### PR TITLE
Implement production factory timing parity

### DIFF
--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -27,7 +27,7 @@ use crate::rules::radar_event_config::RadarEventConfig;
 use crate::rules::terrain_rules::TerrainRules;
 use crate::rules::warhead_type::WarheadType;
 use crate::rules::weapon_type::WeaponType;
-use crate::util::fixed_math::{sim_from_f32, SimFixed};
+use crate::util::fixed_math::{SimFixed, sim_from_f32};
 
 /// Registry section names in rules.ini and their corresponding category.
 const TYPE_REGISTRIES: &[(&str, ObjectCategory)] = &[
@@ -65,6 +65,9 @@ pub struct ProductionRules {
     pub max_low_power_production_speed_ppm: u64,
     /// `build_speed` pre-scaled ×1000 for deterministic build-time computation.
     pub build_speed_x1000: u64,
+    /// Speed coefficient applied to wall building production after all other
+    /// queue time scaling. Parsed from `WallBuildSpeedCoefficient=` in [General].
+    pub wall_build_speed_coefficient: f32,
 }
 
 /// PPM scale constant (1_000_000 = 1.0×) used for f32→integer conversion at parse time.
@@ -88,6 +91,7 @@ impl Default for ProductionRules {
             min_low_power_production_speed_ppm: f32_to_ppm(0.5, 0.0),
             max_low_power_production_speed_ppm: f32_to_ppm(0.9, 0.0),
             build_speed_x1000: (0.05f64 * 1000.0) as u64,
+            wall_build_speed_coefficient: 1.0,
         }
     }
 }
@@ -644,7 +648,10 @@ impl GeneralRules {
                         .collect()
                 })
                 .unwrap_or_default(),
-            cliff_back_impassability: general.get_i32("CliffBackImpassability").unwrap_or(2).clamp(0, 2) as u8,
+            cliff_back_impassability: general
+                .get_i32("CliffBackImpassability")
+                .unwrap_or(2)
+                .clamp(0, 2) as u8,
         }
     }
 
@@ -704,12 +711,9 @@ impl ProductionRules {
         let bs = general.get_f32("BuildSpeed").unwrap_or(0.1);
         let mf = general.get_f32("MultipleFactory").unwrap_or(0.8);
         let lpp = general.get_f32("LowPowerPenaltyModifier").unwrap_or(1.0);
-        let min_lp = general
-            .get_f32("MinLowPowerProductionSpeed")
-            .unwrap_or(0.5);
-        let max_lp = general
-            .get_f32("MaxLowPowerProductionSpeed")
-            .unwrap_or(0.9);
+        let min_lp = general.get_f32("MinLowPowerProductionSpeed").unwrap_or(0.5);
+        let max_lp = general.get_f32("MaxLowPowerProductionSpeed").unwrap_or(0.9);
+        let wall_coeff = general.get_f32("WallBuildSpeedCoefficient").unwrap_or(1.0);
         let result = Self {
             build_speed: bs,
             multiple_factory: mf,
@@ -721,6 +725,7 @@ impl ProductionRules {
             min_low_power_production_speed_ppm: f32_to_ppm(min_lp, 0.0),
             max_low_power_production_speed_ppm: f32_to_ppm(max_lp.max(min_lp), 0.0),
             build_speed_x1000: (bs.max(0.01) as f64 * 1000.0) as u64,
+            wall_build_speed_coefficient: wall_coeff,
         };
         log::info!(
             "ProductionRules: BuildSpeed={}, MultipleFactory={}, LowPowerPenalty={}",

--- a/src/sim/production/mod.rs
+++ b/src/sim/production/mod.rs
@@ -18,11 +18,11 @@ mod production_types;
 
 // Re-export everything so external code can still use `production::X`.
 pub use self::production_economy::is_harvester_type;
+pub(crate) use self::production_placement::structure_occupies_cell;
 pub use self::production_placement::{
     active_producer_for_owner_category, cycle_active_producer_for_owner_category,
     place_ready_building, placement_preview_for_owner, toggle_pause_for_owner_category,
 };
-pub(crate) use self::production_placement::structure_occupies_cell;
 pub use self::production_queue::{
     build_options_for_owner, cancel_by_type_for_owner, cancel_last_for_owner, credits_for_owner,
     enqueue_by_type, enqueue_default_unit_for_owner, has_strict_build_option_for_owner,
@@ -47,7 +47,10 @@ pub(in crate::sim) use self::production_queue::credits_entry_for_owner;
 
 // Re-exports used by test sub-modules (via `super::` in test files).
 #[cfg(test)]
-pub(in crate::sim) use self::production_tech::effective_progress_rate_ppm_for_type;
+pub(in crate::sim) use self::production_tech::{
+    build_time_base_frames, effective_progress_rate_ppm_for_type,
+    effective_time_to_build_frames_for_type,
+};
 
 #[cfg(test)]
 #[path = "production_tests.rs"]

--- a/src/sim/production/production_placement_tests.rs
+++ b/src/sim/production/production_placement_tests.rs
@@ -4,10 +4,11 @@
 use std::collections::{BTreeMap, VecDeque};
 
 use super::{
+    BuildQueueItem, BuildQueueState, BuildingPlacementError, ProductionCategory,
     cancel_last_for_owner, credits_for_owner, cycle_active_producer_for_owner_category,
     find_spawn_cell_for_owner, place_ready_building, placement_preview_for_owner,
     producer_candidates_for_owner_category, ready_buildings_for_owner, sell_building,
-    tick_production, BuildQueueItem, BuildQueueState, BuildingPlacementError, ProductionCategory,
+    tick_production,
 };
 use crate::map::resolved_terrain::{RampDirection, ResolvedTerrainCell, ResolvedTerrainGrid};
 use crate::rules::ini_parser::IniFile;
@@ -121,10 +122,7 @@ fn completed_building_moves_into_ready_placement_pool() {
     let gacnst = sim.interner.intern("GACNST");
     sim.production.queues_by_owner.insert(
         americans,
-        BTreeMap::from([(
-            ProductionCategory::Building,
-            VecDeque::from([qi]),
-        )]),
+        BTreeMap::from([(ProductionCategory::Building, VecDeque::from([qi]))]),
     );
 
     let spawned = tick_production(&mut sim, &rules, &height_map, None, 33);
@@ -149,10 +147,9 @@ fn place_ready_building_spawns_and_consumes_ready_item() {
 
     let americans = sim.interner.intern("Americans");
     let gacnst = sim.interner.intern("GACNST");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([gacnst]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([gacnst]));
 
     assert!(place_ready_building(
         &mut sim,
@@ -170,8 +167,13 @@ fn place_ready_building_spawns_and_consumes_ready_item() {
         .entities
         .values()
         .filter(|e| {
-            sim.interner.resolve(e.owner).eq_ignore_ascii_case("Americans")
-                && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("GACNST")
+            sim.interner
+                .resolve(e.owner)
+                .eq_ignore_ascii_case("Americans")
+                && sim
+                    .interner
+                    .resolve(e.type_ref)
+                    .eq_ignore_ascii_case("GACNST")
                 && e.position.rx == 20
                 && e.position.ry == 20
                 && e.category == crate::map::entities::EntityCategory::Structure
@@ -189,10 +191,9 @@ fn refinery_placement_spawns_one_starter_harvester() {
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 18, 18);
     let americans = sim.interner.intern("Americans");
     let garefn = sim.interner.intern("GAREFN");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([garefn]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([garefn]));
 
     assert!(place_ready_building(
         &mut sim,
@@ -209,8 +210,13 @@ fn refinery_placement_spawns_one_starter_harvester() {
         .entities
         .values()
         .filter(|e| {
-            sim.interner.resolve(e.owner).eq_ignore_ascii_case("Americans")
-                && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("HARV")
+            sim.interner
+                .resolve(e.owner)
+                .eq_ignore_ascii_case("Americans")
+                && sim
+                    .interner
+                    .resolve(e.type_ref)
+                    .eq_ignore_ascii_case("HARV")
                 && e.category == crate::map::entities::EntityCategory::Unit
         })
         .map(|e| (e.position.rx, e.position.ry))
@@ -252,10 +258,9 @@ fn modded_refinery_placement_uses_free_unit_from_rules() {
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 18, 18);
     let americans = sim.interner.intern("Americans");
     let modproc = sim.interner.intern("MODPROC");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([modproc]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([modproc]));
 
     assert!(place_ready_building(
         &mut sim,
@@ -272,8 +277,13 @@ fn modded_refinery_placement_uses_free_unit_from_rules() {
         .entities
         .values()
         .filter(|e| {
-            sim.interner.resolve(e.owner).eq_ignore_ascii_case("Americans")
-                && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("MODHARV")
+            sim.interner
+                .resolve(e.owner)
+                .eq_ignore_ascii_case("Americans")
+                && sim
+                    .interner
+                    .resolve(e.type_ref)
+                    .eq_ignore_ascii_case("MODHARV")
                 && e.category == crate::map::entities::EntityCategory::Unit
         })
         .count();
@@ -308,10 +318,9 @@ fn refinery_without_free_unit_spawns_nothing() {
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 18, 18);
     let americans = sim.interner.intern("Americans");
     let modproc = sim.interner.intern("MODPROC");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([modproc]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([modproc]));
 
     assert!(place_ready_building(
         &mut sim,
@@ -328,8 +337,13 @@ fn refinery_without_free_unit_spawns_nothing() {
         .entities
         .values()
         .filter(|e| {
-            sim.interner.resolve(e.owner).eq_ignore_ascii_case("Americans")
-                && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("MODHARV")
+            sim.interner
+                .resolve(e.owner)
+                .eq_ignore_ascii_case("Americans")
+                && sim
+                    .interner
+                    .resolve(e.type_ref)
+                    .eq_ignore_ascii_case("MODHARV")
                 && e.category == crate::map::entities::EntityCategory::Unit
         })
         .count();
@@ -348,10 +362,9 @@ fn place_ready_building_rejects_blocked_or_overlapping_cells() {
 
     let americans = sim.interner.intern("Americans");
     let gacnst = sim.interner.intern("GACNST");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([gacnst, gacnst]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([gacnst, gacnst]));
 
     assert!(!place_ready_building(
         &mut sim,
@@ -390,10 +403,9 @@ fn place_ready_building_requires_base_normal_provider_within_adjacent_range() {
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 10, 10);
     let americans = sim.interner.intern("Americans");
     let gapowr = sim.interner.intern("GAPOWR");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([gapowr]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([gapowr]));
 
     assert!(place_ready_building(
         &mut sim,
@@ -410,10 +422,10 @@ fn place_ready_building_requires_base_normal_provider_within_adjacent_range() {
     spawn_structure(&mut far_sim, 1, "Americans", "GACNST", 10, 10);
     let far_americans = far_sim.interner.intern("Americans");
     let far_gapowr = far_sim.interner.intern("GAPOWR");
-    far_sim.production.ready_by_owner.insert(
-        far_americans,
-        VecDeque::from([far_gapowr]),
-    );
+    far_sim
+        .production
+        .ready_by_owner
+        .insert(far_americans, VecDeque::from([far_gapowr]));
     // GACNST has Adjacent=6 (default), foundation 2x2 at (10,10).
     // Expanded zone: max_x = 10+2-1+7 = 18, so (20,10) is out of range.
     assert!(!place_ready_building(
@@ -438,10 +450,9 @@ fn base_normal_false_structures_do_not_extend_build_area() {
     spawn_structure(&mut sim, 1, "Americans", "GAGAP", 10, 10);
     let americans = sim.interner.intern("Americans");
     let gapowr = sim.interner.intern("GAPOWR");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([gapowr]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([gapowr]));
 
     assert!(!place_ready_building(
         &mut sim,
@@ -464,10 +475,9 @@ fn placement_preview_reports_out_of_build_area() {
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 10, 10);
     let americans = sim.interner.intern("Americans");
     let gapowr = sim.interner.intern("GAPOWR");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([gapowr]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([gapowr]));
 
     let preview = placement_preview_for_owner(
         &sim,
@@ -494,10 +504,9 @@ fn placement_preview_reports_blocked_terrain() {
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 10, 10);
     let americans = sim.interner.intern("Americans");
     let gapowr = sim.interner.intern("GAPOWR");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([gapowr]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([gapowr]));
 
     let preview = placement_preview_for_owner(
         &sim,
@@ -524,10 +533,9 @@ fn place_ready_building_rejects_bridge_deck_cells() {
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 10, 10);
     let americans = sim.interner.intern("Americans");
     let gapowr = sim.interner.intern("GAPOWR");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([gapowr]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([gapowr]));
     sim.resolved_terrain = Some(resolved_clear_grid_with_override(64, 64, |cell| {
         if cell.rx == 12 && cell.ry == 10 {
             cell.build_blocked = true;
@@ -573,10 +581,9 @@ fn place_ready_building_rejects_canonical_ramp_cells() {
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 10, 10);
     let americans = sim.interner.intern("Americans");
     let gapowr = sim.interner.intern("GAPOWR");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([gapowr]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([gapowr]));
     sim.resolved_terrain = Some(resolved_clear_grid_with_override(64, 64, |cell| {
         if cell.rx == 12 && cell.ry == 10 {
             cell.has_ramp = true;
@@ -629,10 +636,9 @@ fn place_ready_building_rejects_destroyed_bridge_over_blocked_ground() {
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 10, 10);
     let americans = sim.interner.intern("Americans");
     let gapowr = sim.interner.intern("GAPOWR");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([gapowr]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([gapowr]));
     let resolved = resolved_clear_grid_with_override(64, 64, |cell| {
         if cell.rx == 12 && cell.ry == 10 {
             cell.ground_walk_blocked = true;
@@ -678,10 +684,9 @@ fn water_bound_building_rejects_beach_like_water_cells() {
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 10, 10);
     let americans = sim.interner.intern("Americans");
     let gayard = sim.interner.intern("GAYARD");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([gayard]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([gayard]));
     sim.resolved_terrain = Some(resolved_clear_grid_with_override(64, 64, |cell| {
         if cell.rx == 20 && cell.ry == 20 {
             cell.is_water = true;
@@ -728,10 +733,9 @@ fn water_bound_building_accepts_true_ship_water_cells() {
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 10, 10);
     let americans = sim.interner.intern("Americans");
     let gayard = sim.interner.intern("GAYARD");
-    sim.production.ready_by_owner.insert(
-        americans,
-        VecDeque::from([gayard]),
-    );
+    sim.production
+        .ready_by_owner
+        .insert(americans, VecDeque::from([gayard]));
     sim.resolved_terrain = Some(resolved_clear_grid_with_override(64, 64, |cell| {
         if cell.rx == 20 && cell.ry == 20 {
             cell.is_water = true;
@@ -898,8 +902,8 @@ fn cancel_last_for_owner_cancels_latest_item_across_categories() {
                     type_id: e1,
                     queue_category: ProductionCategory::Infantry,
                     state: BuildQueueState::Building,
-                    total_base_ms: 100,
-                    remaining_base_ms: 100,
+                    total_base_frames: 100,
+                    remaining_base_frames: 100,
                     progress_carry: 0,
                     enqueue_order: 1,
                 }]),
@@ -911,8 +915,8 @@ fn cancel_last_for_owner_cancels_latest_item_across_categories() {
                     type_id: mtnk,
                     queue_category: ProductionCategory::Vehicle,
                     state: BuildQueueState::Building,
-                    total_base_ms: 100,
-                    remaining_base_ms: 100,
+                    total_base_frames: 100,
+                    remaining_base_frames: 100,
                     progress_carry: 0,
                     enqueue_order: 2,
                 }]),
@@ -955,7 +959,10 @@ fn sell_building_refunds_half_current_value_and_ejects_allied_infantry() {
         .entities
         .values()
         .filter(|e| {
-            sim.interner.resolve(e.owner).eq_ignore_ascii_case("Americans") && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("E1")
+            sim.interner
+                .resolve(e.owner)
+                .eq_ignore_ascii_case("Americans")
+                && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("E1")
         })
         .map(|e| ("E1".to_string(), e.position.rx, e.position.ry))
         .collect();
@@ -999,7 +1006,10 @@ fn sell_building_uses_owner_appropriate_survivor_type_and_caps_count() {
         .entities
         .values()
         .filter(|e| {
-            sim.interner.resolve(e.owner).eq_ignore_ascii_case("Russians") && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("E2")
+            sim.interner
+                .resolve(e.owner)
+                .eq_ignore_ascii_case("Russians")
+                && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("E2")
         })
         .count();
     // RA2 formula: refund = 500 * 50% * 100% = 250, survivors = 250 / 250 = 1.

--- a/src/sim/production/production_queue.rs
+++ b/src/sim/production/production_queue.rs
@@ -13,11 +13,13 @@ use crate::sim::world::Simulation;
 use super::production_economy::tick_resource_economy;
 use super::production_spawn::find_spawn_cell_for_owner;
 use super::production_tech::{
-    build_option_for_owner, build_time_base_ms, effective_progress_rate_ppm_for_category,
-    effective_progress_rate_ppm_for_type, estimated_real_time_ms, production_category_for_object,
-    should_use_relaxed_build_mode, supports_live_production,
+    build_option_for_owner, build_time_base_frames, effective_progress_rate_ppm_for_type,
+    effective_time_to_build_frames_for_type, estimated_real_time_ms,
+    production_category_for_object, should_use_relaxed_build_mode, supports_live_production,
 };
 use super::production_types::*;
+
+const RA2_QUEUE_FRAME_MS: u64 = 66;
 
 /// Set rally point for an owner's production output.
 pub fn set_rally_point_for_owner(sim: &mut Simulation, owner: &InternedId, rx: u16, ry: u16) {
@@ -28,13 +30,15 @@ pub fn set_rally_point_for_owner(sim: &mut Simulation, owner: &InternedId, rx: u
 
 /// Return current rally point for owner, if one has been set.
 pub fn rally_point_for_owner(sim: &Simulation, owner: &str) -> Option<(u16, u16)> {
-    sim.interner.get(owner)
+    sim.interner
+        .get(owner)
         .and_then(|id| sim.houses.get(&id))
         .and_then(|h| h.rally_point)
 }
 
 pub fn credits_for_owner(sim: &Simulation, owner: &str) -> i32 {
-    sim.interner.get(owner)
+    sim.interner
+        .get(owner)
         .and_then(|id| sim.houses.get(&id))
         .map(|h| h.credits)
         .unwrap_or(STARTING_CREDITS)
@@ -73,14 +77,7 @@ pub(in crate::sim) fn credits_entry_for_owner<'a>(
     if !sim.houses.contains_key(&key) {
         sim.houses.insert(
             key,
-            crate::sim::house_state::HouseState::new(
-                key,
-                0,
-                None,
-                false,
-                STARTING_CREDITS,
-                10,
-            ),
+            crate::sim::house_state::HouseState::new(key, 0, None, false, STARTING_CREDITS, 10),
         );
     }
     &mut sim.houses.get_mut(&key).unwrap().credits
@@ -209,7 +206,7 @@ pub fn enqueue_by_type(sim: &mut Simulation, rules: &RuleSet, owner: &str, type_
     if obj.cost <= 0 || owner_credits < obj.cost {
         return false;
     }
-    let total_base_ms: u32 = build_time_base_ms(rules, obj);
+    let total_base_frames: u32 = build_time_base_frames(rules, obj);
     *credits_entry_for_owner(sim, owner) -= obj.cost;
     let owner_id = sim.interner.intern(owner);
     let type_interned = sim.interner.intern(type_id);
@@ -219,8 +216,8 @@ pub fn enqueue_by_type(sim: &mut Simulation, rules: &RuleSet, owner: &str, type_
         type_id: type_interned,
         queue_category,
         state: BuildQueueState::Queued,
-        total_base_ms,
-        remaining_base_ms: total_base_ms,
+        total_base_frames,
+        remaining_base_frames: total_base_frames,
         progress_carry: 0,
         enqueue_order,
     });
@@ -259,7 +256,10 @@ pub fn build_options_for_owner(sim: &Simulation, rules: &RuleSet, owner: &str) -
         }
         log::warn!(
             "[BUILD-DIAG] owner='{}' tick={} total_items={} reasons={:?}",
-            owner, sim.tick, strict.len(), reason_counts
+            owner,
+            sim.tick,
+            strict.len(),
+            reason_counts
         );
         // Log owned structures and their factory status.
         for e in sim.entities.values() {
@@ -269,7 +269,9 @@ pub fn build_options_for_owner(sim: &Simulation, rules: &RuleSet, owner: &str) -
                 let ts = sim.interner.resolve(e.type_ref);
                 log::warn!(
                     "[BUILD-DIAG]   structure '{}' building_up={} factory_type={:?}",
-                    ts, e.building_up.is_some(), rules.factory_type(ts)
+                    ts,
+                    e.building_up.is_some(),
+                    rules.factory_type(ts)
                 );
             }
         }
@@ -278,7 +280,8 @@ pub fn build_options_for_owner(sim: &Simulation, rules: &RuleSet, owner: &str) -
             let type_str = sim.interner.resolve(opt.type_id);
             log::warn!(
                 "[BUILD-DIAG]   sample: '{}' reason={:?}",
-                type_str, opt.reason
+                type_str,
+                opt.reason
             );
         }
     }
@@ -341,7 +344,11 @@ fn dedupe_visible_build_options(
     deduped
 }
 
-fn build_option_sidebar_key(rules: &RuleSet, option: &BuildOption, interner: &crate::sim::intern::StringInterner) -> Option<String> {
+fn build_option_sidebar_key(
+    rules: &RuleSet,
+    option: &BuildOption,
+    interner: &crate::sim::intern::StringInterner,
+) -> Option<String> {
     let type_str = interner.resolve(option.type_id);
     let obj = rules.object(type_str)?;
     let image_key = if obj.image.trim().is_empty() {
@@ -359,10 +366,16 @@ fn prefers_sidebar_variant(
     existing: &BuildOption,
     interner: &crate::sim::intern::StringInterner,
 ) -> bool {
-    sidebar_variant_rank(rules, owner, candidate, interner) > sidebar_variant_rank(rules, owner, existing, interner)
+    sidebar_variant_rank(rules, owner, candidate, interner)
+        > sidebar_variant_rank(rules, owner, existing, interner)
 }
 
-fn sidebar_variant_rank(rules: &RuleSet, owner: &str, option: &BuildOption, interner: &crate::sim::intern::StringInterner) -> (u8, u16, u8) {
+fn sidebar_variant_rank(
+    rules: &RuleSet,
+    owner: &str,
+    option: &BuildOption,
+    interner: &crate::sim::intern::StringInterner,
+) -> (u8, u16, u8) {
     let type_str = interner.resolve(option.type_id);
     let Some(obj) = rules.object(type_str) else {
         return (0, 0, 0);
@@ -440,7 +453,7 @@ pub fn tick_production(
                     None
                 } else {
                     advance_queue_item(front, tick_ms, progress_rate);
-                    if front.remaining_base_ms > 0 {
+                    if front.remaining_base_frames > 0 {
                         None
                     } else {
                         front.state = BuildQueueState::Done;
@@ -465,9 +478,7 @@ pub fn tick_production(
                 .or_default()
                 .push_back(done.type_id);
             sim.sound_events
-                .push(crate::sim::world::SimSoundEvent::BuildingComplete {
-                    owner: done.owner,
-                });
+                .push(crate::sim::world::SimSoundEvent::BuildingComplete { owner: done.owner });
             continue;
         }
         let is_naval: bool = rules.object(&done_type_str).map_or(false, |o| o.naval);
@@ -484,14 +495,11 @@ pub fn tick_production(
         let spawned = sim.spawn_object(&done_type_str, &owner_str, rx, ry, 64, rules, height_map);
         if let Some(stable_id) = spawned {
             sim.sound_events
-                .push(crate::sim::world::SimSoundEvent::UnitComplete {
-                    owner: done.owner,
-                });
+                .push(crate::sim::world::SimSoundEvent::UnitComplete { owner: done.owner });
             // Auto-move newly produced unit to rally point (if set).
-            if let (Some(grid), Some((tx, ty))) = (
-                path_grid,
-                rally_point_for_owner(sim, &owner_str),
-            ) {
+            if let (Some(grid), Some((tx, ty))) =
+                (path_grid, rally_point_for_owner(sim, &owner_str))
+            {
                 let obj = rules.object(&done_type_str);
                 let loco_mult = sim
                     .entities
@@ -551,22 +559,38 @@ pub fn queue_view_for_owner(sim: &Simulation, rules: &RuleSet, owner: &str) -> V
         .into_iter()
         .map(|q| {
             let type_str = sim.interner.resolve(q.type_id);
-            let (display_name, rate_ppm) = rules
+            let (display_name, remaining_frames, total_frames) = rules
                 .object(type_str)
                 .map(|obj| {
                     (
                         obj.name.clone().unwrap_or_else(|| type_str.to_string()),
-                        effective_progress_rate_ppm_for_category(sim, rules, owner, obj.category),
+                        effective_time_to_build_frames_for_type(
+                            sim,
+                            rules,
+                            owner,
+                            type_str,
+                            q.remaining_base_frames,
+                        ),
+                        effective_time_to_build_frames_for_type(
+                            sim,
+                            rules,
+                            owner,
+                            type_str,
+                            q.total_base_frames.max(1),
+                        ),
                     )
                 })
-                .unwrap_or_else(|| (type_str.to_string(), PRODUCTION_RATE_SCALE));
+                .unwrap_or_else(|| {
+                    let frames = q.remaining_base_frames;
+                    (type_str.to_string(), frames, q.total_base_frames.max(1))
+                });
             QueueItemView {
                 type_id: q.type_id,
                 display_name,
                 queue_category: q.queue_category,
                 state: q.state,
-                remaining_ms: estimated_real_time_ms(q.remaining_base_ms, rate_ppm),
-                total_ms: estimated_real_time_ms(q.total_base_ms.max(1), rate_ppm),
+                remaining_ms: estimated_real_time_ms(remaining_frames, PRODUCTION_RATE_SCALE),
+                total_ms: estimated_real_time_ms(total_frames, PRODUCTION_RATE_SCALE),
             }
         })
         .collect()
@@ -726,22 +750,29 @@ fn cancel_ready_by_type_for_owner(
 }
 
 fn advance_queue_item(item: &mut BuildQueueItem, tick_ms: u32, rate_ppm: u64) {
-    if item.remaining_base_ms == 0 || tick_ms == 0 {
+    if item.remaining_base_frames == 0 || tick_ms == 0 {
         return;
     }
-    let scaled_progress = u64::from(tick_ms).saturating_mul(rate_ppm) + item.progress_carry;
-    let progressed_base_ms = (scaled_progress / PRODUCTION_RATE_SCALE) as u32;
-    item.progress_carry = scaled_progress % PRODUCTION_RATE_SCALE;
+    let frame_scale = RA2_QUEUE_FRAME_MS.saturating_mul(PRODUCTION_RATE_SCALE);
+    let scaled_progress = u64::from(tick_ms)
+        .saturating_mul(rate_ppm)
+        .saturating_add(item.progress_carry);
+    let progressed_base_frames = (scaled_progress / frame_scale) as u32;
+    item.progress_carry = scaled_progress % frame_scale;
 
-    if progressed_base_ms >= item.remaining_base_ms {
-        item.remaining_base_ms = 0;
+    if progressed_base_frames >= item.remaining_base_frames {
+        item.remaining_base_frames = 0;
         item.progress_carry = 0;
     } else {
-        item.remaining_base_ms -= progressed_base_ms;
+        item.remaining_base_frames -= progressed_base_frames;
     }
 }
 
-fn pick_default_buildable_unit(sim: &Simulation, rules: &RuleSet, owner: &str) -> Option<InternedId> {
+fn pick_default_buildable_unit(
+    sim: &Simulation,
+    rules: &RuleSet,
+    owner: &str,
+) -> Option<InternedId> {
     let mode = if should_use_relaxed_build_mode(sim, rules, owner) {
         BuildMode::PrototypeRelaxed
     } else {

--- a/src/sim/production/production_queue_tests.rs
+++ b/src/sim/production/production_queue_tests.rs
@@ -4,14 +4,14 @@
 use std::collections::{BTreeMap, VecDeque};
 
 use super::{
-    build_options_for_owner, credits_for_owner, queue_view_for_owner, tick_production,
-    toggle_pause_for_owner_category, BuildQueueState, ProductionCategory,
+    BuildQueueState, ProductionCategory, build_options_for_owner, credits_for_owner,
+    queue_view_for_owner, tick_production, toggle_pause_for_owner_category,
 };
 use crate::rules::ini_parser::IniFile;
 use crate::rules::locomotor_type::SpeedType;
 use crate::rules::ruleset::RuleSet;
-use crate::sim::pathfinding::terrain_cost::TerrainCostGrid;
 use crate::sim::pathfinding::PathGrid;
+use crate::sim::pathfinding::terrain_cost::TerrainCostGrid;
 use crate::sim::world::Simulation;
 
 // Re-use test helpers from the main production_tests module.
@@ -55,22 +55,27 @@ fn build_catalog_exposes_sidebar_categories_and_required_houses() {
             ProductionCategory::Aircraft,
         ]
     );
-    assert!(americans
-        .iter()
-        .filter(|opt| {
-            matches!(
-                opt.queue_category,
-                ProductionCategory::Infantry
-                    | ProductionCategory::Vehicle
-                    | ProductionCategory::Aircraft
-            )
-        })
-        .all(|opt| opt.enabled));
+    assert!(
+        americans
+            .iter()
+            .filter(|opt| {
+                matches!(
+                    opt.queue_category,
+                    ProductionCategory::Infantry
+                        | ProductionCategory::Vehicle
+                        | ProductionCategory::Aircraft
+                )
+            })
+            .all(|opt| opt.enabled)
+    );
 
     // Alliance should NOT see GTUR — it has RequiredHouses=Americans,
     // so it's hidden (not just greyed out) per RA2 behavior.
     assert!(
-        alliance.iter().find(|opt| opt.type_id == sim.interner.intern("GTUR")).is_none(),
+        alliance
+            .iter()
+            .find(|opt| opt.type_id == sim.interner.intern("GTUR"))
+            .is_none(),
         "GTUR should be hidden for Alliance (RequiredHouses=Americans)"
     );
 
@@ -109,8 +114,22 @@ fn queue_view_uses_owner_power_modifier() {
 
     let americans_id = sim.interner.intern("Americans");
     let soviet_id = sim.interner.intern("Soviet");
-    let qi_am = queued_item_via(&mut sim.interner, "Americans", "E1", ProductionCategory::Infantry, 60_000, 60_000);
-    let qi_so = queued_item_via(&mut sim.interner, "Soviet", "E1", ProductionCategory::Infantry, 60_000, 60_000);
+    let qi_am = queued_item_via(
+        &mut sim.interner,
+        "Americans",
+        "E1",
+        ProductionCategory::Infantry,
+        900,
+        900,
+    );
+    let qi_so = queued_item_via(
+        &mut sim.interner,
+        "Soviet",
+        "E1",
+        ProductionCategory::Infantry,
+        900,
+        900,
+    );
     sim.production.queues_by_owner.insert(
         americans_id,
         BTreeMap::from([(ProductionCategory::Infantry, VecDeque::from([qi_am]))]),
@@ -123,8 +142,8 @@ fn queue_view_uses_owner_power_modifier() {
     let americans = queue_view_for_owner(&sim, &rules, "Americans");
     let soviet = queue_view_for_owner(&sim, &rules, "Soviet");
 
-    assert_eq!(americans[0].total_ms, 120_000);
-    assert_eq!(soviet[0].total_ms, 60_000);
+    assert_eq!(americans[0].total_ms, 118_800);
+    assert_eq!(soviet[0].total_ms, 59_400);
 }
 
 #[test]
@@ -144,6 +163,63 @@ fn matching_factory_bonus_is_category_specific() {
 
     assert_eq!(infantry_rate, 1_250_000);
     assert_eq!(vehicle_rate, 1_000_000);
+}
+
+#[test]
+fn base_build_frames_follow_ra2_cost_buildspeed_formula() {
+    let rules = production_modifier_rules();
+    let obj = rules.object("E1").expect("E1 should exist");
+
+    assert_eq!(super::build_time_base_frames(&rules, obj), 900);
+}
+
+#[test]
+fn wall_build_speed_coefficient_applies_after_factory_scaling() {
+    let mut sim = Simulation::new();
+    let ini = IniFile::from_str(
+        "[General]\n\
+             BuildSpeed=1.0\n\
+             MultipleFactory=0.8\n\
+             WallBuildSpeedCoefficient=0.5\n\
+             [InfantryTypes]\n\
+             [VehicleTypes]\n\
+             [AircraftTypes]\n\
+             [BuildingTypes]\n\
+             0=GACNST\n\
+             1=NACNST\n\
+             2=GAWALL\n\
+             [GACNST]\n\
+             Factory=BuildingType\n\
+             Owner=Americans\n\
+             [NACNST]\n\
+             Factory=BuildingType\n\
+             Owner=Americans\n\
+             [GAWALL]\n\
+             Name=Wall\n\
+             Cost=1000\n\
+             Strength=100\n\
+             Armor=wood\n\
+             TechLevel=1\n\
+             Owner=Americans\n\
+             Wall=yes\n",
+    );
+    let rules = RuleSet::from_ini(&ini).expect("wall rules should parse");
+
+    spawn_structure(&mut sim, 1, "Americans", "GACNST", 10, 10);
+    spawn_structure(&mut sim, 2, "Americans", "NACNST", 12, 10);
+
+    let wall = rules.object("GAWALL").expect("wall should exist");
+    let base_frames = super::build_time_base_frames(&rules, wall);
+    let total_frames = super::effective_time_to_build_frames_for_type(
+        &sim,
+        &rules,
+        "Americans",
+        "GAWALL",
+        base_frames,
+    );
+
+    assert_eq!(base_frames, 900);
+    assert_eq!(total_frames, 360);
 }
 
 #[test]
@@ -170,8 +246,22 @@ fn low_power_and_factory_bonus_apply_per_owner_and_category() {
 
     let americans_id = sim.interner.intern("Americans");
     let soviet_id = sim.interner.intern("Soviet");
-    let qi_am = queued_item_via(&mut sim.interner, "Americans", "E1", ProductionCategory::Infantry, 60_000, 60_000);
-    let qi_so = queued_item_via(&mut sim.interner, "Soviet", "MTNK", ProductionCategory::Vehicle, 60_000, 60_000);
+    let qi_am = queued_item_via(
+        &mut sim.interner,
+        "Americans",
+        "E1",
+        ProductionCategory::Infantry,
+        60_000,
+        60_000,
+    );
+    let qi_so = queued_item_via(
+        &mut sim.interner,
+        "Soviet",
+        "MTNK",
+        ProductionCategory::Vehicle,
+        60_000,
+        60_000,
+    );
     sim.production.queues_by_owner.insert(
         americans_id,
         BTreeMap::from([(ProductionCategory::Infantry, VecDeque::from([qi_am]))]),
@@ -189,7 +279,7 @@ fn low_power_and_factory_bonus_apply_per_owner_and_category() {
         .get(&americans_id)
         .and_then(|queues| queues.get(&ProductionCategory::Infantry))
         .and_then(|queue| queue.front())
-        .map(|item| item.remaining_base_ms)
+        .map(|item| item.remaining_base_frames)
         .expect("americans queue should still exist");
     let soviet_remaining = sim
         .production
@@ -197,11 +287,11 @@ fn low_power_and_factory_bonus_apply_per_owner_and_category() {
         .get(&soviet_id)
         .and_then(|queues| queues.get(&ProductionCategory::Vehicle))
         .and_then(|queue| queue.front())
-        .map(|item| item.remaining_base_ms)
+        .map(|item| item.remaining_base_frames)
         .expect("soviet queue should still exist");
 
-    assert_eq!(americans_remaining, 59_375);
-    assert_eq!(soviet_remaining, 59_000);
+    assert_eq!(americans_remaining, 59_991);
+    assert_eq!(soviet_remaining, 59_985);
 }
 
 #[test]
@@ -234,7 +324,14 @@ fn naval_unit_rally_uses_water_pathing_after_spawn() {
     if let Some(h) = sim.houses.get_mut(&americans_key) {
         h.rally_point = Some((26, 21));
     }
-    let qi_naval = queued_item_via(&mut sim.interner, "Americans", "DEST", ProductionCategory::Vehicle, 100, 0);
+    let qi_naval = queued_item_via(
+        &mut sim.interner,
+        "Americans",
+        "DEST",
+        ProductionCategory::Vehicle,
+        100,
+        0,
+    );
     sim.production.queues_by_owner.insert(
         americans_display,
         BTreeMap::from([(ProductionCategory::Vehicle, VecDeque::from([qi_naval]))]),
@@ -246,7 +343,11 @@ fn naval_unit_rally_uses_water_pathing_after_spawn() {
     let ship = sim
         .entities
         .values()
-        .find(|e| sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("DEST"))
+        .find(|e| {
+            sim.interner
+                .resolve(e.type_ref)
+                .eq_ignore_ascii_case("DEST")
+        })
         .expect("spawned destroyer");
     assert!(
         ship.movement_target.is_some(),
@@ -324,8 +425,22 @@ fn tick_production_advances_each_owner_queue() {
 
     let americans_id = sim.interner.intern("Americans");
     let soviet_id = sim.interner.intern("Soviet");
-    let qi_am = queued_item_via(&mut sim.interner, "Americans", "E1", ProductionCategory::Infantry, 100, 10);
-    let qi_so = queued_item_via(&mut sim.interner, "Soviet", "E1", ProductionCategory::Infantry, 100, 10);
+    let qi_am = queued_item_via(
+        &mut sim.interner,
+        "Americans",
+        "E1",
+        ProductionCategory::Infantry,
+        100,
+        10,
+    );
+    let qi_so = queued_item_via(
+        &mut sim.interner,
+        "Soviet",
+        "E1",
+        ProductionCategory::Infantry,
+        100,
+        10,
+    );
     sim.production.queues_by_owner.insert(
         americans_id,
         BTreeMap::from([(ProductionCategory::Infantry, VecDeque::from([qi_am]))]),
@@ -346,13 +461,19 @@ fn tick_production_advances_each_owner_queue() {
         .entities
         .values()
         .filter(|e| {
-            sim.interner.resolve(e.owner).eq_ignore_ascii_case("Americans") && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("E1")
+            sim.interner
+                .resolve(e.owner)
+                .eq_ignore_ascii_case("Americans")
+                && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("E1")
         })
         .count();
     let soviet = sim
         .entities
         .values()
-        .filter(|e| sim.interner.resolve(e.owner).eq_ignore_ascii_case("Soviet") && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("E1"))
+        .filter(|e| {
+            sim.interner.resolve(e.owner).eq_ignore_ascii_case("Soviet")
+                && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("E1")
+        })
         .count();
     assert_eq!(americans, 1);
     assert_eq!(soviet, 1);
@@ -368,8 +489,22 @@ fn tick_production_advances_multiple_queue_categories_for_same_owner() {
     spawn_structure(&mut sim, 2, "Americans", "GAWEAP", 14, 10);
 
     let americans_id = sim.interner.intern("Americans");
-    let qi_inf = queued_item_via(&mut sim.interner, "Americans", "E1", ProductionCategory::Infantry, 100, 10);
-    let qi_veh = queued_item_via(&mut sim.interner, "Americans", "MTNK", ProductionCategory::Vehicle, 100, 10);
+    let qi_inf = queued_item_via(
+        &mut sim.interner,
+        "Americans",
+        "E1",
+        ProductionCategory::Infantry,
+        100,
+        10,
+    );
+    let qi_veh = queued_item_via(
+        &mut sim.interner,
+        "Americans",
+        "MTNK",
+        ProductionCategory::Vehicle,
+        100,
+        10,
+    );
     sim.production.queues_by_owner.insert(
         americans_id,
         BTreeMap::from([
@@ -389,14 +524,23 @@ fn tick_production_advances_multiple_queue_categories_for_same_owner() {
         .entities
         .values()
         .filter(|e| {
-            sim.interner.resolve(e.owner).eq_ignore_ascii_case("Americans") && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("E1")
+            sim.interner
+                .resolve(e.owner)
+                .eq_ignore_ascii_case("Americans")
+                && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("E1")
         })
         .count();
     let vehicles = sim
         .entities
         .values()
         .filter(|e| {
-            sim.interner.resolve(e.owner).eq_ignore_ascii_case("Americans") && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case("MTNK")
+            sim.interner
+                .resolve(e.owner)
+                .eq_ignore_ascii_case("Americans")
+                && sim
+                    .interner
+                    .resolve(e.type_ref)
+                    .eq_ignore_ascii_case("MTNK")
         })
         .count();
     assert_eq!(infantry, 1);
@@ -413,8 +557,22 @@ fn paused_queue_category_does_not_advance_while_other_category_does() {
     spawn_structure(&mut sim, 2, "Americans", "GAWEAP", 14, 10);
 
     let americans_id = sim.interner.intern("Americans");
-    let qi_inf = queued_item_via(&mut sim.interner, "Americans", "E1", ProductionCategory::Infantry, 1000, 1000);
-    let qi_veh = queued_item_via(&mut sim.interner, "Americans", "MTNK", ProductionCategory::Vehicle, 1000, 1000);
+    let qi_inf = queued_item_via(
+        &mut sim.interner,
+        "Americans",
+        "E1",
+        ProductionCategory::Infantry,
+        1000,
+        1000,
+    );
+    let qi_veh = queued_item_via(
+        &mut sim.interner,
+        "Americans",
+        "MTNK",
+        ProductionCategory::Vehicle,
+        1000,
+        1000,
+    );
     sim.production.queues_by_owner.insert(
         americans_id,
         BTreeMap::from([
@@ -445,9 +603,9 @@ fn paused_queue_category_does_not_advance_while_other_category_does() {
         .expect("vehicle queue should remain");
 
     assert_eq!(infantry.state, BuildQueueState::Paused);
-    assert_eq!(infantry.remaining_base_ms, 1000);
+    assert_eq!(infantry.remaining_base_frames, 1000);
     assert_eq!(vehicle.state, BuildQueueState::Building);
-    assert_eq!(vehicle.remaining_base_ms, 900);
+    assert_eq!(vehicle.remaining_base_frames, 899);
 }
 
 #[test]
@@ -501,7 +659,14 @@ fn cancel_by_type_prefers_build_queue_over_ready_queue() {
     // Put GAREFN in both the build queue AND ready queue.
     let americans_id = sim.interner.intern("Americans");
     let garefn_id = sim.interner.intern("GAREFN");
-    let qi = queued_item_via(&mut sim.interner, "Americans", "GAREFN", ProductionCategory::Building, 10000, 5000);
+    let qi = queued_item_via(
+        &mut sim.interner,
+        "Americans",
+        "GAREFN",
+        ProductionCategory::Building,
+        10000,
+        5000,
+    );
     sim.production
         .ready_by_owner
         .entry(americans_id)

--- a/src/sim/production/production_tech.rs
+++ b/src/sim/production/production_tech.rs
@@ -174,7 +174,9 @@ fn count_owned_and_queued(sim: &Simulation, owner: &str, type_id: &str) -> u32 {
     let type_interned = sim.interner.get(type_id);
 
     let owned = match (owner_id, type_interned) {
-        (Some(oid), Some(tid)) => sim.entities.values()
+        (Some(oid), Some(tid)) => sim
+            .entities
+            .values()
             .filter(|e| e.owner == oid && e.type_ref == tid)
             .count() as u32,
         _ => 0,
@@ -183,7 +185,8 @@ fn count_owned_and_queued(sim: &Simulation, owner: &str, type_id: &str) -> u32 {
     let queued = owner_id
         .and_then(|oid| sim.production.queues_by_owner.get(&oid))
         .map(|queues| {
-            queues.values()
+            queues
+                .values()
                 .flat_map(|queue| queue.iter())
                 .filter(|item| type_interned.map_or(false, |tid| item.type_id == tid))
                 .count() as u32
@@ -193,7 +196,8 @@ fn count_owned_and_queued(sim: &Simulation, owner: &str, type_id: &str) -> u32 {
     let ready = owner_id
         .and_then(|oid| sim.production.ready_by_owner.get(&oid))
         .map(|ready| {
-            ready.iter()
+            ready
+                .iter()
                 .filter(|&&tid| type_interned.map_or(false, |expected| tid == expected))
                 .count() as u32
         })
@@ -289,29 +293,36 @@ pub(super) fn is_production_factory(
     }
 }
 
-pub(super) fn build_time_base_ms(
+const RA2_QUEUE_FRAME_MS: u64 = 66;
+const RA2_BUILD_SPEED_TICK_SCALE: f64 = 0.9;
+
+#[inline]
+fn trunc_to_i32(value: f64) -> i32 {
+    value.trunc() as i32
+}
+
+pub(in crate::sim) fn build_time_base_frames(
     rules: &RuleSet,
     obj: &crate::rules::object_type::ObjectType,
 ) -> u32 {
     if obj.cost <= 0 {
         return 0;
     }
-    // Integer-scaled computation: cost * build_speed * build_time_multiplier * 60 ms.
-    // Uses pre-computed ×1000 integer values from INI parse time (no f32 at tick time).
+    // RE-proven base path:
+    //   baseValue = trunc(cost * BuildSpeed * 0.9)
+    //   rawFrames = trunc(baseValue * typeBuildTimeMult) then
+    //   trunc(rawFrames * technoTypeBuildTimeMult)
     //
-    // Formula: base_ms = (cost / 1000) * build_speed * build_time_multiplier * 60000
-    // Rearranged to avoid intermediate fractions:
-    //   base_ms = cost * build_speed_x1000 * btm_x1000 * 60 / 1_000_000
-    let build_speed_x1000: u64 = rules.production.build_speed_x1000;
-    let btm_x1000: u64 = obj.build_time_multiplier_x1000;
-    let cost: u64 = obj.cost.max(0) as u64;
-    // cost * speed * btm * 60, then divide by 1_000_000 (the two x1000 scalings).
-    let millis: u64 = cost * build_speed_x1000 * btm_x1000 * 60 / 1_000_000;
-    let base: u32 = millis.min(u64::from(u32::MAX)).max(1) as u32;
-    // Dev-time speed divisor. If this needs to be configurable, move to
-    // GameOptions so it stays synced across multiplayer peers.
-    const BUILD_SPEED_DIVISOR: u32 = 10;
-    base / BUILD_SPEED_DIVISOR
+    // The local sim does not yet model the separate house/type build-time
+    // multiplier helper, so that term stays at 1.0 here and the per-object
+    // `BuildTimeMultiplier` remains the only type-specific multiplier.
+    let base_value = trunc_to_i32(
+        obj.cost.max(0) as f64
+            * rules.production.build_speed.max(0.0) as f64
+            * RA2_BUILD_SPEED_TICK_SCALE,
+    );
+    let raw_frames = trunc_to_i32(base_value as f64 * obj.build_time_multiplier as f64).max(0);
+    raw_frames as u32
 }
 
 pub(in crate::sim) fn effective_progress_rate_ppm_for_type(
@@ -344,42 +355,97 @@ pub(super) fn effective_progress_rate_ppm_for_category(
     rate.max(1)
 }
 
-pub(super) fn estimated_real_time_ms(base_ms: u32, rate_ppm: u64) -> u32 {
-    if base_ms == 0 {
+pub(super) fn estimated_real_time_ms(base_frames: u32, rate_ppm: u64) -> u32 {
+    if base_frames == 0 {
         return 0;
     }
     let denom = u128::from(rate_ppm.max(1));
-    let numer = u128::from(base_ms) * u128::from(PRODUCTION_RATE_SCALE);
+    let numer = u128::from(base_frames)
+        * u128::from(RA2_QUEUE_FRAME_MS)
+        * u128::from(PRODUCTION_RATE_SCALE);
     let rounded_up = numer.div_ceil(denom);
     rounded_up.min(u128::from(u32::MAX)) as u32
 }
 
-/// Power-speed multiplier scaled by PRODUCTION_RATE_SCALE (1M = 1.0×).
-/// Uses integer arithmetic to avoid platform-dependent f64 rounding.
-fn owner_power_speed_multiplier_ppm(sim: &Simulation, rules: &RuleSet, owner: &str) -> u64 {
-    let (produced, drained) = sim.interner.get(owner)
+pub(in crate::sim) fn effective_time_to_build_frames_for_type(
+    sim: &Simulation,
+    rules: &RuleSet,
+    owner: &str,
+    type_id: &str,
+    base_frames: u32,
+) -> u32 {
+    let Some(obj) = rules.object(type_id) else {
+        return base_frames;
+    };
+    effective_time_to_build_frames_for_object(sim, rules, owner, obj, base_frames)
+}
+
+fn effective_time_to_build_frames_for_object(
+    sim: &Simulation,
+    rules: &RuleSet,
+    owner: &str,
+    obj: &crate::rules::object_type::ObjectType,
+    base_frames: u32,
+) -> u32 {
+    let speed = owner_effective_production_speed(sim, rules, owner);
+    let mut time_to_build = trunc_to_i32(base_frames as f64 / speed.max(0.01));
+    time_to_build = apply_multiple_factory_scaling(
+        time_to_build,
+        rules.production.multiple_factory,
+        matching_factory_count_for_owner(&sim.entities, rules, owner, obj.category, &sim.interner),
+    );
+    if obj.category == ObjectCategory::Building && obj.wall {
+        time_to_build = trunc_to_i32(
+            time_to_build as f64 * rules.production.wall_build_speed_coefficient as f64,
+        );
+    }
+    time_to_build.max(0) as u32
+}
+
+fn apply_multiple_factory_scaling(
+    time_to_build: i32,
+    multiple_factory: f32,
+    queue_factory_count: u32,
+) -> i32 {
+    if multiple_factory <= 0.0 || queue_factory_count <= 1 {
+        return time_to_build;
+    }
+    let mut scaled = time_to_build;
+    for _ in 1..queue_factory_count {
+        scaled = trunc_to_i32(scaled as f64 * multiple_factory as f64);
+    }
+    scaled
+}
+
+fn owner_effective_production_speed(sim: &Simulation, rules: &RuleSet, owner: &str) -> f64 {
+    let power_pct = owner_power_percentage(sim, owner);
+    let mut speed = 1.0 - (1.0 - power_pct) * rules.production.low_power_penalty_modifier as f64;
+    speed = speed.max(rules.production.min_low_power_production_speed as f64);
+    if power_pct < 1.0 {
+        speed = speed.min(rules.production.max_low_power_production_speed as f64);
+    }
+    if speed == 0.0 { 0.01 } else { speed }
+}
+
+fn owner_power_percentage(sim: &Simulation, owner: &str) -> f64 {
+    let (produced, drained) = sim
+        .interner
+        .get(owner)
         .and_then(|id| sim.power_states.get(&id))
         .map(|state| (state.total_output, state.total_drain))
         .unwrap_or((0, 0));
 
-    if drained <= 0 || produced >= drained {
-        return PRODUCTION_RATE_SCALE; // 1.0×
+    if drained <= 0 {
+        return 1.0;
     }
 
-    let shortage: i32 = drained - produced;
-    let drained_pos: u64 = drained.max(1) as u64;
+    ((produced.max(0) as f64) / (drained as f64)).clamp(0.0, 1.0)
+}
 
-    // Use pre-computed PPM values from rules (converted at INI parse time, not tick time).
-    let penalty_mod_ppm: u64 = rules.production.low_power_penalty_modifier_ppm;
-    // shortage_ratio * penalty_modifier, scaled to ppm.
-    let shortage_penalty_ppm: u64 = (shortage as u64) * penalty_mod_ppm / drained_pos;
-    // penalized = 1.0 - shortage_ratio * penalty_modifier (in ppm).
-    let penalized_ppm: u64 = PRODUCTION_RATE_SCALE.saturating_sub(shortage_penalty_ppm);
-
-    let min_ppm: u64 = rules.production.min_low_power_production_speed_ppm;
-    let max_ppm: u64 = rules.production.max_low_power_production_speed_ppm;
-
-    penalized_ppm.clamp(min_ppm, max_ppm)
+/// Power-speed multiplier scaled by PRODUCTION_RATE_SCALE (1M = 1.0×).
+fn owner_power_speed_multiplier_ppm(sim: &Simulation, rules: &RuleSet, owner: &str) -> u64 {
+    (owner_effective_production_speed(sim, rules, owner) * PRODUCTION_RATE_SCALE as f64).trunc()
+        as u64
 }
 
 /// Factory time multiplier scaled by PRODUCTION_RATE_SCALE (1M = 1.0×).
@@ -391,7 +457,8 @@ fn matching_factory_time_multiplier_ppm(
     category: ObjectCategory,
     interner: &crate::sim::intern::StringInterner,
 ) -> u64 {
-    let factory_count: u32 = matching_factory_count_for_owner(entities, rules, owner, category, interner);
+    let factory_count: u32 =
+        matching_factory_count_for_owner(entities, rules, owner, category, interner);
     if factory_count <= 1 {
         return PRODUCTION_RATE_SCALE; // 1.0×
     }

--- a/src/sim/production/production_tests.rs
+++ b/src/sim/production/production_tests.rs
@@ -4,9 +4,9 @@
 use std::collections::BTreeMap;
 
 use super::{
-    credits_for_owner, find_spawn_cell_for_owner, is_matching_factory,
-    seed_resource_nodes_from_overlays, structure_satisfies_prerequisite, BuildQueueItem,
-    BuildQueueState, ProductionCategory, STARTING_CREDITS,
+    BuildQueueItem, BuildQueueState, ProductionCategory, STARTING_CREDITS, credits_for_owner,
+    find_spawn_cell_for_owner, is_matching_factory, seed_resource_nodes_from_overlays,
+    structure_satisfies_prerequisite,
 };
 use crate::map::overlay::OverlayEntry;
 use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid};
@@ -523,16 +523,16 @@ pub(super) fn queued_item_via(
     owner: &str,
     type_id: &str,
     queue_category: ProductionCategory,
-    total_base_ms: u32,
-    remaining_base_ms: u32,
+    total_base_frames: u32,
+    remaining_base_frames: u32,
 ) -> BuildQueueItem {
     BuildQueueItem {
         owner: interner.intern(owner),
         type_id: interner.intern(type_id),
         queue_category,
         state: BuildQueueState::Queued,
-        total_base_ms,
-        remaining_base_ms,
+        total_base_frames,
+        remaining_base_frames,
         progress_carry: 0,
         enqueue_order: 1,
     }

--- a/src/sim/production/production_types.rs
+++ b/src/sim/production/production_types.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::rules::object_type::ObjectCategory;
 use crate::sim::intern::InternedId;
-use crate::sim::miner::miner_dock::DockReservations;
 use crate::sim::miner::ResourceNode;
+use crate::sim::miner::miner_dock::DockReservations;
 use crate::sim::ore_growth::{OreGrowthConfig, OreGrowthState};
 
 /// Initial credits for the local player.
@@ -25,8 +25,10 @@ pub struct BuildQueueItem {
     pub type_id: InternedId,
     pub queue_category: ProductionCategory,
     pub state: BuildQueueState,
-    pub total_base_ms: u32,
-    pub remaining_base_ms: u32,
+    /// Base build time in RA2 production frames before live power/factory/wall scaling.
+    pub total_base_frames: u32,
+    /// Remaining base build time in RA2 production frames before live scaling.
+    pub remaining_base_frames: u32,
     pub progress_carry: u64,
     pub enqueue_order: u64,
 }
@@ -191,7 +193,8 @@ pub(super) enum BuildMode {
 /// Player production state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProductionState {
-    pub queues_by_owner: BTreeMap<InternedId, BTreeMap<ProductionCategory, VecDeque<BuildQueueItem>>>,
+    pub queues_by_owner:
+        BTreeMap<InternedId, BTreeMap<ProductionCategory, VecDeque<BuildQueueItem>>>,
     pub ready_by_owner: BTreeMap<InternedId, VecDeque<InternedId>>,
     pub active_producer_by_owner: BTreeMap<InternedId, BTreeMap<ProductionCategory, u64>>,
     pub next_enqueue_order: u64,

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -98,8 +98,8 @@ impl Simulation {
                     item.type_id.hash(hasher);
                     item.queue_category.hash(hasher);
                     item.state.hash(hasher);
-                    item.total_base_ms.hash(hasher);
-                    item.remaining_base_ms.hash(hasher);
+                    item.total_base_frames.hash(hasher);
+                    item.remaining_base_frames.hash(hasher);
                     item.progress_carry.hash(hasher);
                     item.enqueue_order.hash(hasher);
                 }


### PR DESCRIPTION
- switched production queue internals from pseudo-millisecond build time tracking to RA2-style base build frames
- applied the RE-backed production timing path for `cost * BuildSpeed * 0.9`, per-type build-time multiplier, low-power shaping, iterative multiple-factory scaling, and wall build speed coefficient
- updated queue display timing, queue progression, production-state hashing, and production helper/test fixtures to use the new frame-based model

## Impact
- build queue totals and remaining time now reflect the closed production formula rather than the previous approximate millisecond model
- wall segments can build faster/slower through `WallBuildSpeedCoefficient`
- production queue state is hashed with the new frame fields