### PR TITLE
Improve renderer ordering and hot paths

### DIFF
--- a/src/app_render/build_instances.rs
+++ b/src/app_render/build_instances.rs
@@ -198,10 +198,10 @@ pub(super) fn build_world_instances(state: &mut AppState, sw: f32, sh: f32) -> W
     // Garrison muzzle flashes (OccupantAnim) at fire port positions.
     app_instances::build_garrison_muzzle_flash_instances(state, &mut shp_paged);
     for page in &mut shp_paged {
-        sort_by_y_asc(page);
+        sort_by_depth_desc(page);
     }
     for page in &mut bridge_shp_paged {
-        sort_by_y_asc(page);
+        sort_by_depth_desc(page);
     }
 
     // One-time first-frame statistics.
@@ -275,6 +275,7 @@ pub(super) fn update_minimap(state: &mut AppState, local_owner: &Option<String>)
             &state.batch_renderer,
             &sim.entities,
             &state.house_color_map,
+            sim.tick,
             if state.sandbox_full_visibility {
                 None
             } else {
@@ -294,9 +295,7 @@ pub(super) fn update_minimap(state: &mut AppState, local_owner: &Option<String>)
 pub(super) fn build_ui_instances(state: &AppState, sw: f32, sh: f32) -> UiInstances {
     let bracket: Vec<SpriteInstance> =
         crate::app_selection_brackets::build_selection_bracket_instances(state, sw, sh);
-    let mut building_status: Vec<SpriteInstance> = build_building_status_instances(state, sw, sh);
-    // DEBUG: append bracket instances into building_status pool to test rendering.
-    building_status.extend_from_slice(&bracket);
+    let building_status: Vec<SpriteInstance> = build_building_status_instances(state, sw, sh);
     let occupant_pip = build_occupant_pip_instances(state, sw, sh);
     let unit_status_bg = build_unit_status_bg_instances(state, sw, sh);
     let unit_status_fill = build_unit_status_fill_instances(state, sw, sh);
@@ -607,15 +606,6 @@ fn sort_by_depth_desc(instances: &mut [SpriteInstance]) {
     instances.sort_by(|a, b| {
         b.depth
             .partial_cmp(&a.depth)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-}
-
-/// Sort instances by Y position ascending (used for SHP pages where Y = screen row).
-fn sort_by_y_asc(instances: &mut [SpriteInstance]) {
-    instances.sort_by(|a, b| {
-        a.position[1]
-            .partial_cmp(&b.position[1])
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 }

--- a/src/app_render/merge_passes.rs
+++ b/src/app_render/merge_passes.rs
@@ -17,14 +17,36 @@ use crate::render::unit_atlas::UnitAtlas;
 ///
 /// Each group represents one GPU buffer + texture pair (e.g., VXL units, one SHP page,
 /// wall overlays). The `cursor` advances through the buffer as sub-ranges are drawn.
-/// `depths` are extracted from CPU-side instance data to avoid lifetime entanglement
-/// between GPU resources and function parameters.
-struct DrawGroup<'a> {
-    texture: &'a BatchTexture,
-    buffer: &'a wgpu::Buffer,
-    depths: Vec<f32>,
+struct DrawGroup<'tex, 'inst> {
+    texture: &'tex BatchTexture,
+    buffer: &'tex wgpu::Buffer,
+    instances: &'inst [SpriteInstance],
     cursor: u32,
     total: u32,
+}
+
+impl<'tex, 'inst> DrawGroup<'tex, 'inst> {
+    fn new(
+        texture: &'tex BatchTexture,
+        buffer: &'tex wgpu::Buffer,
+        instances: &'inst [SpriteInstance],
+        total: u32,
+    ) -> Self {
+        Self {
+            texture,
+            buffer,
+            instances,
+            cursor: 0,
+            total,
+        }
+    }
+
+    fn depth_at(&self, index: u32) -> f32 {
+        self.instances
+            .get(index as usize)
+            .map(|instance| instance.depth)
+            .unwrap_or(f32::NEG_INFINITY)
+    }
 }
 
 /// Multi-way merge for bridge entities: interleaves VXL units and SHP sprites on bridges.
@@ -40,16 +62,10 @@ pub(super) fn draw_merged_bridge_occluded_pass<'a>(
     unit_atlas: Option<&'a UnitAtlas>,
     sprite_atlas: Option<&'a SpriteAtlas>,
 ) {
-    let mut groups: Vec<DrawGroup<'a>> = Vec::new();
+    let mut groups: Vec<DrawGroup<'a, '_>> = Vec::new();
     if let (Some(ua), Some((buf, count))) = (unit_atlas, pool.get("unit_bridge")) {
         if count > 0 {
-            groups.push(DrawGroup {
-                texture: &ua.texture,
-                buffer: buf,
-                depths: unit_instances.iter().map(|s| s.depth).collect(),
-                cursor: 0,
-                total: count,
-            });
+            groups.push(DrawGroup::new(&ua.texture, buf, unit_instances, count));
         }
     }
 
@@ -64,16 +80,8 @@ pub(super) fn draw_merged_bridge_occluded_pass<'a>(
             if let Some(key) = SHP_BRIDGE_KEYS.get(i) {
                 if let Some((buf, count)) = pool.get(key) {
                     if count > 0 {
-                        groups.push(DrawGroup {
-                            texture: &page.texture,
-                            buffer: buf,
-                            depths: shp_paged
-                                .get(i)
-                                .map(|v| v.iter().map(|s| s.depth).collect())
-                                .unwrap_or_default(),
-                            cursor: 0,
-                            total: count,
-                        });
+                        let instances = shp_paged.get(i).map_or(&[][..], Vec::as_slice);
+                        groups.push(DrawGroup::new(&page.texture, buf, instances, count));
                     }
                 }
             }
@@ -91,7 +99,7 @@ pub(super) fn draw_merged_bridge_occluded_pass<'a>(
             if group.cursor >= group.total {
                 continue;
             }
-            let depth = group.depths[group.cursor as usize];
+            let depth = group.depth_at(group.cursor);
             if depth > best_depth {
                 best_depth = depth;
                 best_idx = Some(i);
@@ -101,7 +109,7 @@ pub(super) fn draw_merged_bridge_occluded_pass<'a>(
         let start = groups[best_idx].cursor;
         let mut end = start + 1;
         while end < groups[best_idx].total {
-            let depth = groups[best_idx].depths[end as usize];
+            let depth = groups[best_idx].depth_at(end);
             if depth < best_depth {
                 break;
             }
@@ -142,19 +150,12 @@ pub(super) fn draw_merged_object_pass<'a>(
     // Sort is by depth DESCENDING (largest depth = furthest back = draw first).
     // Depth is based on iso_row (elevation-independent): GetYSort = X + Y
     // (which ignores Z elevation).
-    let mut groups: Vec<DrawGroup<'a>> = Vec::new();
+    let mut groups: Vec<DrawGroup<'a, '_>> = Vec::new();
 
     // VXL units draw group -- passthrough (no depth test).
     if let (Some(ua), Some((buf, count))) = (unit_atlas, pool.get("unit")) {
         if count > 0 {
-            let ds: Vec<f32> = unit_instances.iter().map(|s| s.depth).collect();
-            groups.push(DrawGroup {
-                texture: &ua.texture,
-                buffer: buf,
-                depths: ds,
-                cursor: 0,
-                total: count,
-            });
+            groups.push(DrawGroup::new(&ua.texture, buf, unit_instances, count));
         }
     }
 
@@ -165,17 +166,8 @@ pub(super) fn draw_merged_object_pass<'a>(
             if let Some(key) = SHP_KEYS.get(i) {
                 if let Some((buf, count)) = pool.get(key) {
                     if count > 0 {
-                        let ds: Vec<f32> = shp_paged
-                            .get(i)
-                            .map(|v| v.iter().map(|s| s.depth).collect())
-                            .unwrap_or_default();
-                        groups.push(DrawGroup {
-                            texture: &page.texture,
-                            buffer: buf,
-                            depths: ds,
-                            cursor: 0,
-                            total: count,
-                        });
+                        let instances = shp_paged.get(i).map_or(&[][..], Vec::as_slice);
+                        groups.push(DrawGroup::new(&page.texture, buf, instances, count));
                     }
                 }
             }
@@ -188,14 +180,7 @@ pub(super) fn draw_merged_object_pass<'a>(
     // in front of units at closer iso rows.
     if let (Some(oa), Some((buf, count))) = (overlay_atlas, pool.get("overlay_wall")) {
         if count > 0 {
-            let ds: Vec<f32> = wall_instances.iter().map(|s| s.depth).collect();
-            groups.push(DrawGroup {
-                texture: &oa.texture,
-                buffer: buf,
-                depths: ds,
-                cursor: 0,
-                total: count,
-            });
+            groups.push(DrawGroup::new(&oa.texture, buf, wall_instances, count));
         }
     }
 
@@ -216,7 +201,7 @@ pub(super) fn draw_merged_object_pass<'a>(
             if g.cursor >= g.total {
                 continue;
             }
-            let d = g.depths.get(g.cursor as usize).copied().unwrap_or(-1.0);
+            let d = g.depth_at(g.cursor);
             // Larger depth = further back = should draw first.
             // At equal depth, prefer SHP (gi > 0) over VXL (gi == 0).
             if d > best_d || (d == best_d && gi > 0) {
@@ -232,14 +217,14 @@ pub(super) fn draw_merged_object_pass<'a>(
         let run_start = g.cursor;
         let mut run_end = run_start + 1;
         while run_end < g.total {
-            let next_d = g.depths.get(run_end as usize).copied().unwrap_or(-1.0);
+            let next_d = g.depth_at(run_end);
             // Check if any other group has a larger depth (further back, should draw first).
             let mut other_has_larger = false;
             for (oi, og) in groups.iter().enumerate() {
                 if oi == gi || og.cursor >= og.total {
                     continue;
                 }
-                let other_d = og.depths.get(og.cursor as usize).copied().unwrap_or(-1.0);
+                let other_d = og.depth_at(og.cursor);
                 if other_d > next_d || (other_d == next_d && oi > gi) {
                     other_has_larger = true;
                     break;

--- a/src/map/terrain.rs
+++ b/src/map/terrain.rs
@@ -470,6 +470,16 @@ pub struct TerrainInstances {
     pub cliff_redraw: Vec<SpriteInstance>,
 }
 
+fn visible_cell_slice(grid: &TerrainGrid, view_top: f32, view_bottom: f32) -> &[TerrainCell] {
+    let start = grid
+        .cells
+        .partition_point(|cell| cell.screen_y + TILE_HEIGHT < view_top);
+    let end = grid
+        .cells
+        .partition_point(|cell| cell.screen_y <= view_bottom);
+    &grid.cells[start..end]
+}
+
 /// Generate SpriteInstance data for all tiles visible in the current viewport.
 ///
 /// Single-layer rendering: each cell draws exactly one tile. LAT transition
@@ -498,7 +508,7 @@ pub fn build_visible_instances(
         cliff_redraw: Vec::new(),
     };
 
-    for cell in &grid.cells {
+    for cell in visible_cell_slice(grid, view_top, view_bottom) {
         // AABB visibility test against viewport.
         let right: f32 = cell.screen_x + TILE_WIDTH;
         let bottom: f32 = cell.screen_y + TILE_HEIGHT;

--- a/src/render/minimap.rs
+++ b/src/render/minimap.rs
@@ -6,8 +6,8 @@
 //!
 //! ## Implementation
 //! - Terrain image is generated once at map load from TerrainGrid data.
-//! - Unit dots are overlaid each frame by copying the base image and stamping dots.
-//! - The combined image is re-uploaded to the GPU each frame (200x200 = 160KB, negligible).
+//! - Unit dots are overlaid on demand by copying the base image and stamping dots.
+//! - The combined image is only re-uploaded when sim/fog state changes.
 //! - A separate 2x2 white pixel texture is used for the viewport rectangle lines.
 //!
 //! ## Screen-space rendering trick
@@ -26,6 +26,7 @@ use crate::map::terrain::TerrainGrid;
 use crate::render::batch::{BatchRenderer, BatchTexture, SpriteInstance};
 use crate::render::gpu::GpuContext;
 use crate::rules::ruleset::RuleSet;
+use crate::sim::intern::InternedId;
 use crate::sim::vision::FogState;
 
 use super::minimap_helpers::{
@@ -45,7 +46,7 @@ pub struct MinimapRenderer {
     map_texture: BatchTexture,
     /// Raw GPU texture handle for `write_texture()` reuse (avoids per-frame alloc).
     map_texture_raw: wgpu::Texture,
-    /// Reusable RGBA scratch buffer for building the minimap each frame.
+    /// Reusable RGBA scratch buffer for rebuilding the minimap texture.
     rgba_scratch: Vec<u8>,
     /// Tiny 2x2 white pixel texture for drawing the viewport rectangle lines.
     white_texture: BatchTexture,
@@ -62,6 +63,12 @@ pub struct MinimapRenderer {
     map_offset_y: f32,
     map_pixel_w: f32,
     map_pixel_h: f32,
+    /// Last simulation tick used to refresh the texture.
+    last_sim_tick: u64,
+    /// Last fog generation used to refresh the texture.
+    last_fog_generation: u64,
+    /// Last local owner used for fog-aware refresh.
+    last_visibility_owner: Option<InternedId>,
 }
 
 impl MinimapRenderer {
@@ -189,6 +196,9 @@ impl MinimapRenderer {
             map_offset_y,
             map_pixel_w,
             map_pixel_h,
+            last_sim_tick: u64::MAX,
+            last_fog_generation: u64::MAX,
+            last_visibility_owner: None,
         }
     }
 
@@ -196,18 +206,32 @@ impl MinimapRenderer {
     ///
     /// Copies the base terrain image, stamps overlay pixels (ore, gems, walls,
     /// bridges, trees), then stamps a colored dot for each entity with
-    /// Position + Owner, and re-uploads to the GPU.
+    /// Position + Owner, and re-uploads to the GPU. If sim tick, owner, and
+    /// fog generation are unchanged, the existing texture is reused.
     pub fn update_unit_dots(
         &mut self,
         gpu: &GpuContext,
         _batch: &BatchRenderer,
         entities: &crate::sim::entity_store::EntityStore,
         house_colors: &HouseColorMap,
+        sim_tick: u64,
         visibility: Option<(crate::sim::intern::InternedId, &FogState)>,
         rules: Option<&RuleSet>,
         radar_events: Option<&crate::sim::radar::RadarEventQueue>,
         interner: Option<&crate::sim::intern::StringInterner>,
     ) {
+        let fog_generation = visibility.map_or(0, |(_, fog)| fog.generation);
+        let visibility_owner = visibility.map(|(owner, _)| owner);
+        if sim_tick == self.last_sim_tick
+            && fog_generation == self.last_fog_generation
+            && visibility_owner == self.last_visibility_owner
+        {
+            return;
+        }
+        self.last_sim_tick = sim_tick;
+        self.last_fog_generation = fog_generation;
+        self.last_visibility_owner = visibility_owner;
+
         let size: u32 = MINIMAP_SIZE;
         let rgba: &mut Vec<u8> = &mut self.rgba_scratch;
 

--- a/src/render/shroud_buffer.rs
+++ b/src/render/shroud_buffer.rs
@@ -12,7 +12,7 @@
 //! ## Dependency rules
 //! - Part of render/ — reads FogState (no mutation), uses GpuContext.
 
-use crate::map::terrain::iso_to_screen;
+use crate::map::terrain::{HEIGHT_STEP, iso_to_screen, screen_to_iso};
 use crate::render::gpu::GpuContext;
 use crate::sim::vision::FogState;
 
@@ -26,6 +26,8 @@ const BLACK: u8 = 0x00;
 
 /// SHP transparent pixel marker — skip (don't overwrite buffer).
 const TRANSPARENT: u8 = 0xFE;
+const SHROUD_CELL_PAD: i32 = 8;
+const SHROUD_HEIGHT_PAD_LEVELS: f32 = 16.0;
 
 /// Shroud edge frame lookup table.
 ///
@@ -134,7 +136,63 @@ fn align_up(n: u32, align: u32) -> u32 {
     (n + align - 1) / align * align
 }
 
+fn clamp_cell_range(min_v: i32, max_v: i32, limit: u16) -> Option<(u16, u16)> {
+    if limit == 0 {
+        return None;
+    }
+    let upper = i32::from(limit) - 1;
+    let start = min_v.clamp(0, upper);
+    let end = max_v.clamp(0, upper);
+    if start > end {
+        return None;
+    }
+    Some((start as u16, end as u16))
+}
 impl ShroudBuffer {
+    fn visible_cell_bounds(
+        &self,
+        cam_x: f32,
+        cam_y: f32,
+        vp_w: i32,
+        vp_h: i32,
+    ) -> Option<((u16, u16), (u16, u16))> {
+        let pad_x = self.canvas_w as f32;
+        let pad_y = self.canvas_h as f32 + HEIGHT_STEP * SHROUD_HEIGHT_PAD_LEVELS;
+        let left = cam_x - pad_x;
+        let right = cam_x + vp_w as f32 + pad_x;
+        let top = cam_y - pad_y;
+        let bottom = cam_y + vp_h as f32 + pad_y;
+        let corners = [
+            screen_to_iso(left, top),
+            screen_to_iso(right, top),
+            screen_to_iso(left, bottom),
+            screen_to_iso(right, bottom),
+        ];
+
+        let mut min_rx = f32::INFINITY;
+        let mut max_rx = f32::NEG_INFINITY;
+        let mut min_ry = f32::INFINITY;
+        let mut max_ry = f32::NEG_INFINITY;
+        for (rx, ry) in corners {
+            min_rx = min_rx.min(rx);
+            max_rx = max_rx.max(rx);
+            min_ry = min_ry.min(ry);
+            max_ry = max_ry.max(ry);
+        }
+
+        let rx_range = clamp_cell_range(
+            min_rx.floor() as i32 - SHROUD_CELL_PAD,
+            max_rx.ceil() as i32 + SHROUD_CELL_PAD,
+            self.map_width,
+        )?;
+        let ry_range = clamp_cell_range(
+            min_ry.floor() as i32 - SHROUD_CELL_PAD,
+            max_ry.ceil() as i32 + SHROUD_CELL_PAD,
+            self.map_height,
+        )?;
+        Some((rx_range, ry_range))
+    }
+
     /// Create a new shroud buffer for the given screen and map dimensions.
     ///
     /// `frame_pixels` is the raw SHROUD.SHP brightness data per frame,
@@ -249,8 +307,14 @@ impl ShroudBuffer {
         let cam_xi = cam_x_r as i32;
         let cam_yi = cam_y_r as i32;
 
-        for ry in 0..self.map_height {
-            for rx in 0..self.map_width {
+        let Some(((rx_start, rx_end), (ry_start, ry_end))) =
+            self.visible_cell_bounds(cam_x_r, cam_y_r, vp_w, vp_h)
+        else {
+            return;
+        };
+
+        for ry in ry_start..=ry_end {
+            for rx in rx_start..=rx_end {
                 // Position shroud diamond at the cell's actual terrain height so
                 // the brightness buffer aligns with where the terrain renders.
                 // Fully shrouded cells aren't rendered as terrain at all (filtered

--- a/src/rules/warhead_type.rs
+++ b/src/rules/warhead_type.rs
@@ -57,8 +57,9 @@ pub struct WarheadType {
     pub tiberium: bool,
     /// Bright flash on detonation. Offset +0x14F.
     pub bright: bool,
-    /// Extra damage to prone infantry. Offset +0x150.
-    pub prone_damage: bool,
+    /// Damage multiplier against prone infantry. Offset +0x150 in-game as a double.
+    /// Examples: `50%` -> `0.5`, `100%` -> `1.0`, `300%` -> `3.0`.
+    pub prone_damage: f64,
     /// Instantly destroys any wall. Offset +0x151.
     pub wall_absolute_destroyer: bool,
     /// Chrono legionnaire erase effect. Offset +0x152.
@@ -152,7 +153,7 @@ impl WarheadType {
             rocker: section.get_bool("Rocker").unwrap_or(false),
             tiberium: section.get_bool("Tiberium").unwrap_or(false),
             bright: section.get_bool("Bright").unwrap_or(false),
-            prone_damage: section.get_bool("ProneDamage").unwrap_or(false),
+            prone_damage: section.get_percent("ProneDamage").map(f64::from).unwrap_or(1.0),
             wall_absolute_destroyer: section.get_bool("WallAbsoluteDestroyer").unwrap_or(false),
             temporal: section.get_bool("Temporal").unwrap_or(false),
             is_locomotor: section.get_bool("IsLocomotor").unwrap_or(false),
@@ -233,6 +234,7 @@ mod tests {
         assert!(wh.verses.is_empty());
         assert_eq!(wh.cell_spread, SIM_ZERO);
         assert_eq!(wh.percent_at_max, 100);
+        assert_eq!(wh.prone_damage, 1.0);
         assert!(!wh.wall);
     }
 
@@ -259,5 +261,19 @@ mod tests {
         assert_eq!(result[0], 100);
         assert_eq!(result[1], 50);
         assert_eq!(result[2], 25);
+    }
+
+    #[test]
+    fn test_prone_damage_parses_as_multiplier() {
+        let ini: IniFile =
+            IniFile::from_str("[AP]\nProneDamage=50%\n[Gas]\nProneDamage=300%\n[Raw]\nProneDamage=1.25\n");
+
+        let ap = WarheadType::from_ini_section("AP", ini.section("AP").unwrap());
+        let gas = WarheadType::from_ini_section("Gas", ini.section("Gas").unwrap());
+        let raw = WarheadType::from_ini_section("Raw", ini.section("Raw").unwrap());
+
+        assert!((ap.prone_damage - 0.5).abs() < f64::EPSILON);
+        assert!((gas.prone_damage - 3.0).abs() < f64::EPSILON);
+        assert!((raw.prone_damage - 1.25).abs() < f64::EPSILON);
     }
 }

--- a/src/sim/animation.rs
+++ b/src/sim/animation.rs
@@ -211,6 +211,25 @@ impl Animation {
     }
 }
 
+/// Whether a sequence represents the infantry being in a prone stance.
+///
+/// This is a temporary stance proxy until the sim carries an explicit prone bit.
+pub fn sequence_is_prone(sequence: SequenceKind) -> bool {
+    matches!(
+        sequence,
+        SequenceKind::Prone
+            | SequenceKind::Crawl
+            | SequenceKind::FireProne
+            | SequenceKind::SecondaryProne
+            | SequenceKind::Down
+    )
+}
+
+/// Whether the current animation represents a prone stance.
+pub fn animation_is_prone(animation: Option<&Animation>) -> bool {
+    animation.is_some_and(|anim| sequence_is_prone(anim.sequence))
+}
+
 /// Collection of sequence definitions for one object type.
 ///
 /// Maps `SequenceKind` → `SequenceDef`. Not all kinds need to be present;

--- a/src/sim/animation_tests.rs
+++ b/src/sim/animation_tests.rs
@@ -409,3 +409,13 @@ fn test_tick_dying_entity_returns_finished_id() {
     let dead = tick_animations(&mut store, &sequences, 16, &interner);
     assert_eq!(dead, vec![1]);
 }
+
+#[test]
+fn test_sequence_is_prone_helper() {
+    assert!(sequence_is_prone(SequenceKind::Prone));
+    assert!(sequence_is_prone(SequenceKind::Crawl));
+    assert!(sequence_is_prone(SequenceKind::FireProne));
+    assert!(sequence_is_prone(SequenceKind::Down));
+    assert!(!sequence_is_prone(SequenceKind::Stand));
+    assert!(!sequence_is_prone(SequenceKind::Up));
+}

--- a/src/sim/combat/combat_aoe.rs
+++ b/src/sim/combat/combat_aoe.rs
@@ -13,7 +13,7 @@
 //! - Part of sim/ — depends on rules/ (RuleSet, WarheadType) and sim/components.
 //! - sim/ NEVER depends on render/, ui/, sidebar/, audio/, net/.
 
-use super::{armor_index, lepton_distance_sq_raw};
+use super::{apply_prone_damage_modifier, armor_index, lepton_distance_sq_raw};
 use crate::rules::ruleset::RuleSet;
 use crate::rules::warhead_type::WarheadType;
 use crate::sim::entity_store::EntityStore;
@@ -87,13 +87,14 @@ pub(crate) fn apply_aoe_damage(
         let idx: usize = armor_index(armor_str);
         let verses_pct: u8 = warhead.verses.get(idx).copied().unwrap_or(100);
 
-        let dmg: u16 = aoe_damage_at_distance(
+        let raw_damage: u16 = aoe_damage_at_distance(
             base_damage,
             distance,
             cell_spread,
             warhead.percent_at_max,
             verses_pct,
         );
+        let dmg: u16 = apply_prone_damage_modifier(entity, warhead, raw_damage as i32);
 
         if dmg > 0 {
             damage_list.push((entity.stable_id, dmg));

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -5,8 +5,10 @@
 use std::collections::BTreeMap;
 
 use super::*;
+use crate::map::entities::EntityCategory;
 use crate::rules::ini_parser::IniFile;
 use crate::rules::ruleset::RuleSet;
+use crate::sim::animation::{Animation, SequenceKind};
 use crate::sim::components::Health;
 use crate::sim::entity_store::EntityStore;
 use crate::sim::game_entity::GameEntity;
@@ -55,6 +57,14 @@ fn make_entity_owned(
         current: hp,
         max: hp,
     };
+    e
+}
+
+fn make_infantry_entity(id: u64, type_ref: &str, rx: u16, ry: u16, hp: u16) -> GameEntity {
+    let mut e = make_entity(id, type_ref, rx, ry, hp);
+    e.category = EntityCategory::Infantry;
+    e.is_voxel = false;
+    e.animation = Some(Animation::new(SequenceKind::Stand));
     e
 }
 
@@ -258,6 +268,70 @@ fn test_infantry_vs_heavy_armor() {
         300 - 6,
         "Infantry vs heavy armor should do 6 damage (25 * 25 / 100)"
     );
+}
+
+#[test]
+fn test_prone_infantry_takes_scaled_direct_damage() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=E1\n1=E2\n\n\
+         [VehicleTypes]\n0=MTNK\n\n\
+         [AircraftTypes]\n\n\
+         [BuildingTypes]\n\n\
+         [E1]\nStrength=125\nArmor=flak\nSpeed=4\nPrimary=M60\n\n\
+         [E2]\nStrength=125\nArmor=flak\nSpeed=4\n\n\
+         [MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nPrimary=105mm\n\n\
+         [M60]\nDamage=25\nROF=20\nRange=5\nWarhead=SA\n\n\
+         [105mm]\nDamage=100\nROF=50\nRange=6\nWarhead=AP\n\n\
+         [SA]\nVerses=100%,100%,100%,90%,70%,25%,100%,25%,25%,0%,0%\n\n\
+         [AP]\nVerses=100%,100%,90%,75%,75%,75%,60%,30%,20%,0%,0%\nProneDamage=50%\n",
+    ))
+    .expect("prone combat rules should parse");
+
+    let mut store = EntityStore::new();
+    store.insert(make_entity(1, "MTNK", 5, 5, 300));
+    let mut target = make_infantry_entity(2, "E2", 8, 5, 125);
+    target.animation = Some(Animation::new(SequenceKind::Prone));
+    store.insert(target);
+
+    let mut interner = test_interner();
+    issue_attack_command(&mut store, 1, 2, None, &interner);
+
+    tick_combat(&mut store, &rules, &mut interner, &mut BTreeMap::new(), 100);
+
+    let target_health = store.get(2).expect("target alive").health.current;
+    assert_eq!(target_health, 75, "100 damage with ProneDamage=50% should deal 50");
+}
+
+#[test]
+fn test_prone_infantry_takes_scaled_aoe_damage() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=E1\n1=E2\n\n\
+         [VehicleTypes]\n0=MTNK\n\n\
+         [AircraftTypes]\n\n\
+         [BuildingTypes]\n\n\
+         [E1]\nStrength=125\nArmor=flak\nSpeed=4\nPrimary=M60\n\n\
+         [E2]\nStrength=125\nArmor=flak\nSpeed=4\n\n\
+         [MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nPrimary=105mm\n\n\
+         [M60]\nDamage=25\nROF=20\nRange=5\nWarhead=SA\n\n\
+         [105mm]\nDamage=100\nROF=50\nRange=6\nWarhead=AP\n\n\
+         [SA]\nVerses=100%,100%,100%,90%,70%,25%,100%,25%,25%,0%,0%\n\n\
+         [AP]\nCellSpread=1\nPercentAtMax=1\nVerses=100%,100%,90%,75%,75%,75%,60%,30%,20%,0%,0%\nProneDamage=50%\n",
+    ))
+    .expect("prone aoe combat rules should parse");
+
+    let mut store = EntityStore::new();
+    store.insert(make_entity(1, "MTNK", 5, 5, 300));
+    let mut target = make_infantry_entity(2, "E2", 8, 5, 125);
+    target.animation = Some(Animation::new(SequenceKind::Prone));
+    store.insert(target);
+
+    let mut interner = test_interner();
+    issue_attack_command(&mut store, 1, 2, None, &interner);
+
+    tick_combat(&mut store, &rules, &mut interner, &mut BTreeMap::new(), 100);
+
+    let target_health = store.get(2).expect("target alive").health.current;
+    assert_eq!(target_health, 75, "AoE center hit should also respect ProneDamage=50%");
 }
 
 #[test]

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -35,6 +35,8 @@ use self::combat_weapon::select_weapon_with_ifv;
 use crate::map::entities::EntityCategory;
 use crate::rules::object_type::ObjectType;
 use crate::rules::ruleset::RuleSet;
+use crate::rules::warhead_type::WarheadType;
+use crate::sim::animation::animation_is_prone;
 use crate::sim::bridge_state::BridgeDamageEvent;
 use crate::sim::entity_store::EntityStore;
 use crate::sim::intern::{InternedId, StringInterner};
@@ -84,6 +86,24 @@ const ARMOR_NAMES: &[&str] = &[
 pub fn armor_index(armor: &str) -> usize {
     let lower: String = armor.to_ascii_lowercase();
     ARMOR_NAMES.iter().position(|&a| a == lower).unwrap_or(0)
+}
+
+pub(crate) fn apply_prone_damage_modifier(
+    target: &GameEntity,
+    warhead: &WarheadType,
+    damage: i32,
+) -> u16 {
+    if damage <= 0 {
+        return 0;
+    }
+
+    let scaled = if target.category == EntityCategory::Infantry && animation_is_prone(target.animation.as_ref()) {
+        (damage as f64 * warhead.prone_damage).trunc() as i32
+    } else {
+        damage
+    };
+
+    scaled.clamp(0, u16::MAX as i32) as u16
 }
 
 /// Component: this entity is attacking a specific target entity.
@@ -1074,7 +1094,10 @@ pub fn tick_combat_with_fog(
             // Integer damage: base_damage * verses_pct / 100.
             // base_damage already includes OccupyDamageMultiplier for garrison.
             let raw_damage: i32 = base_damage * selected.verses_pct as i32 / 100;
-            let actual_damage: u16 = raw_damage.max(0) as u16;
+            let actual_damage: u16 = entities
+                .get(snap.target)
+                .map(|target| apply_prone_damage_modifier(target, warhead, raw_damage))
+                .unwrap_or(0);
             if actual_damage > 0 {
                 let wh_iid = interner.intern(&warhead.id);
                 damage_events.push((snap.target, actual_damage, snap.stable_id, wh_iid));


### PR DESCRIPTION
Adds a first renderer pipeline pass focused on cheap, low-risk improvements.

- fixes SHP page ordering to use render depth and removes the stray building-status debug injection
- avoids per-frame depth vector cloning in merged object passes
- rebuilds the minimap texture only when sim or fog state changes
- limits terrain and shroud work to visible cell ranges instead of scanning the whole map
