### PR TITLE
Improve asset loading hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3737,6 +3737,7 @@ dependencies = [
  "glam",
  "image",
  "log",
+ "memmap2",
  "nom 7.1.3",
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ toml = "0.8"
 # nom parses RA2's binary asset formats (.mix, .shp, .vxl, .pal, .tmp, .hva).
 # All parsers are written from scratch — no third-party RA2-specific crates.
 nom = "7"
+memmap2 = "0.9"
 
 # --- Error handling ---
 # thiserror for structured library errors (AssetError, RulesError, etc.)

--- a/src/app_init.rs
+++ b/src/app_init.rs
@@ -36,7 +36,6 @@ use crate::map::tags::TagMap;
 use crate::map::terrain::{self, LocalBounds, TerrainGrid};
 use crate::map::theater;
 use crate::map::trigger_graph::TriggerGraph;
-use crate::sim::trigger_runtime::TriggerRuntime;
 use crate::map::triggers::TriggerMap;
 use crate::map::waypoints::{self, Waypoint};
 use crate::render::batch::BatchRenderer;
@@ -54,6 +53,7 @@ use crate::rules::ini_parser::IniFile;
 use crate::rules::ruleset::{GeneralRules, RuleSet};
 use crate::sim::pathfinding::PathGrid;
 use crate::sim::production;
+use crate::sim::trigger_runtime::TriggerRuntime;
 use crate::sim::world::Simulation;
 use crate::util::config::GameConfig;
 
@@ -137,10 +137,10 @@ fn load_csf(asset_manager: &AssetManager) -> Option<crate::assets::csf_file::Csf
         "stringtablemd.csf",
         "stringtable.csf",
     ] {
-        let Some(bytes) = asset_manager.get(name) else {
+        let Some(bytes) = asset_manager.get_ref(name) else {
             continue;
         };
-        match crate::assets::csf_file::CsfFile::from_bytes(&bytes) {
+        match crate::assets::csf_file::CsfFile::from_bytes(bytes) {
             Ok(csf) => {
                 log::info!("Loaded CSF string table: {name}");
                 return Some(csf);
@@ -393,8 +393,7 @@ pub fn load_map(
         sim.house_alliances = house_roster.alliance_map();
         // Populate per-player HouseState from the map's house roster.
         for house in &house_roster.houses {
-            let side_idx =
-                crate::sim::house_state::side_index_from_name(house.side.as_deref());
+            let side_idx = crate::sim::house_state::side_index_from_name(house.side.as_deref());
             let is_human = house.player_control == Some(true);
             let name_id = sim.interner.intern(&house.name);
             let country_id = house.country.as_deref().map(|c| sim.interner.intern(c));
@@ -662,8 +661,8 @@ pub fn load_map(
         build_sidebar_cameo_atlas(gpu, batch, &asset_manager, rules.as_ref(), art.as_ref());
     let sidebar_chrome =
         crate::render::sidebar_chrome::build_sidebar_chrome_set(gpu, batch, &asset_manager);
-    let fnt_file = asset_manager.get("GAME.FNT").and_then(|data| {
-        crate::assets::fnt_file::FntFile::from_bytes(&data)
+    let fnt_file = asset_manager.get_ref("GAME.FNT").and_then(|data| {
+        crate::assets::fnt_file::FntFile::from_bytes(data)
             .map_err(|e| log::warn!("Failed to parse GAME.FNT: {e}"))
             .ok()
     });
@@ -746,7 +745,8 @@ fn setup_ai_players(
         if house.name.eq_ignore_ascii_case(local_owner) {
             continue;
         }
-        sim.ai_players.push(AiPlayerState::new(sim.interner.intern(&house.name)));
+        sim.ai_players
+            .push(AiPlayerState::new(sim.interner.intern(&house.name)));
         log::info!("AI player registered: {}", house.name);
     }
 }

--- a/src/app_init_helpers.rs
+++ b/src/app_init_helpers.rs
@@ -86,8 +86,8 @@ pub(crate) fn load_sidebar_cameo_palette(asset_manager: &AssetManager) -> Option
         "temperat.pal",
     ];
     for name in palette_names {
-        if let Some(data) = asset_manager.get(name) {
-            if let Ok(palette) = Palette::from_bytes(&data) {
+        if let Some(data) = asset_manager.get_ref(name) {
+            if let Ok(palette) = Palette::from_bytes(data) {
                 log::info!("Sidebar cameos using palette {}", name);
                 return Some(palette);
             }
@@ -173,11 +173,7 @@ pub(crate) fn parse_debug_spawn_units_env() -> Option<Vec<String>> {
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
         .collect();
-    if items.is_empty() {
-        None
-    } else {
-        Some(items)
-    }
+    if items.is_empty() { None } else { Some(items) }
 }
 
 /// Build a texture atlas from pre-loaded theater data and the terrain grid.
@@ -364,7 +360,9 @@ pub(crate) fn spawn_entities(
     );
     sim.bridge_explosions = rules
         .map(|r| {
-            r.bridge_rules.explosions.iter()
+            r.bridge_rules
+                .explosions
+                .iter()
                 .map(|s| sim.interner.intern(s))
                 .collect()
         })
@@ -441,7 +439,8 @@ pub(crate) fn build_entity_atlases(
         )
     });
     // Pre-load building types that can be spawned at runtime (e.g., ConYards from MCV deploy).
-    let extra_buildings: Vec<&str> = deployable_building_types(&sim.entities, rules, Some(&sim.interner));
+    let extra_buildings: Vec<&str> =
+        deployable_building_types(&sim.entities, rules, Some(&sim.interner));
     let shp_atlas: Option<SpriteAtlas> = palette.as_ref().and_then(|pal| {
         sprite_atlas::build_sprite_atlas(
             gpu,

--- a/src/app_transitions.rs
+++ b/src/app_transitions.rs
@@ -12,10 +12,10 @@ use crate::map::basic::BasicSection;
 use crate::map::houses::HouseRoster;
 use crate::map::overlay_types::OverlayTypeRegistry;
 use crate::map::trigger_graph::TriggerGraph;
-use crate::sim::trigger_runtime::TriggerRuntime;
 use crate::render::minimap::MinimapRenderer;
 use crate::render::selection_overlay::SelectionOverlay;
 use crate::sidebar::SidebarTab;
+use crate::sim::trigger_runtime::TriggerRuntime;
 use crate::ui::game_screen::GameScreen;
 
 use crate::app::AppState;
@@ -217,8 +217,8 @@ pub(crate) fn transition_to_in_game(state: &mut AppState) {
     // Loads SHROUD.SHP brightness data and the 256-byte edge LUT.
     if let Some(ref am) = state.asset_manager {
         if let Some(ref grid) = state.path_grid {
-            if let Some(shp_data) = am.get("shroud.shp") {
-                if let Ok(shp) = crate::assets::shp_file::ShpFile::from_bytes(&shp_data) {
+            if let Some(shp_data) = am.get_ref("shroud.shp") {
+                if let Ok(shp) = crate::assets::shp_file::ShpFile::from_bytes(shp_data) {
                     let (frame_pixels, cw, ch) =
                         crate::render::shroud_buffer::extract_shp_brightness(&shp);
                     state.shroud_buffer = Some(crate::render::shroud_buffer::ShroudBuffer::new(
@@ -262,9 +262,7 @@ pub(crate) fn transition_to_in_game(state: &mut AppState) {
     }
 
     // Start music playback: prefer map's Theme= field, otherwise play first playlist track.
-    if let (Some(player), Some(assets)) =
-        (&mut state.music_player, &state.asset_manager)
-    {
+    if let (Some(player), Some(assets)) = (&mut state.music_player, &state.asset_manager) {
         let started: bool = if let Some(ref theme) = state.map_basic.theme {
             player.play_track(theme, assets)
         } else {
@@ -322,28 +320,19 @@ fn load_audio_indices(
     assets: &crate::assets::asset_manager::AssetManager,
 ) -> Vec<crate::assets::audio_bag::AudioIndex> {
     use crate::assets::audio_bag::AudioIndex;
-    use crate::assets::mix_archive::MixArchive;
 
     let mut indices = Vec::new();
 
     // Both AUDIO.MIX and AUDIOMD.MIX contain entries named "audio.idx" and "audio.bag"
     // internally. We need to load each MIX explicitly and extract from within, because
-    // the AssetManager's first-match behavior would return the base RA2 version for both.
+    // the generic first-match lookup would conflate the shared internal filenames.
     // YR (AUDIOMD.MIX) is loaded first so its sounds take priority in the search.
     for mix_name in ["AUDIOMD.MIX", "AUDIO.MIX"] {
-        let mix_data = match assets.get(mix_name) {
-            Some(d) => d,
-            None => continue,
-        };
-        let mix = match MixArchive::from_bytes(mix_data) {
-            Ok(m) => m,
-            Err(e) => {
-                log::warn!("Failed to parse {}: {}", mix_name, e);
-                continue;
-            }
+        let Some(mix) = assets.archive(mix_name) else {
+            continue;
         };
         let idx_data = match mix.get_by_name("audio.idx") {
-            Some(d) => d.to_vec(),
+            Some(d) => d,
             None => {
                 log::warn!("{} has no audio.idx entry", mix_name);
                 continue;
@@ -356,7 +345,7 @@ fn load_audio_indices(
                 continue;
             }
         };
-        match AudioIndex::from_idx_bag(&idx_data, bag_data) {
+        match AudioIndex::from_idx_bag(idx_data, bag_data) {
             Some(index) => {
                 log::info!(
                     "Loaded audio.idx/bag from {}: {} entries",

--- a/src/assets/asset_manager.rs
+++ b/src/assets/asset_manager.rs
@@ -35,8 +35,8 @@ pub struct AssetManager {
     archives: Vec<NamedArchive>,
     /// Precomputed first-match lookup across all archives.
     lookup_index: HashMap<i32, AssetLocation>,
-    /// Case-insensitive display-name index for direct archive access.
-    archive_name_index: HashMap<String, usize>,
+    /// Case-insensitive archive lookup index for full names and leaf aliases.
+    archive_lookup_index: HashMap<String, usize>,
     /// Path to the RA2 installation directory.
     ra2_dir: PathBuf,
 }
@@ -101,7 +101,7 @@ impl AssetManager {
         let mut manager = Self {
             archives: Vec::new(),
             lookup_index: HashMap::new(),
-            archive_name_index: HashMap::new(),
+            archive_lookup_index: HashMap::new(),
             ra2_dir: ra2_dir.to_path_buf(),
         };
 
@@ -263,18 +263,34 @@ impl AssetManager {
 
     /// Look up a file by name across all loaded archives.
     pub fn get(&self, name: &str) -> Option<Vec<u8>> {
-        let (named, entry_id) = self.lookup_archive_entry(name)?;
+        let (named, entry_id) = self.lookup_asset_entry(name)?;
         log::trace!("Found '{}' in {}", name, named.name);
         named.archive.get_by_id(entry_id).map(|data| data.to_vec())
     }
 
+    /// Look up a file by name without copying the asset bytes.
+    pub fn get_ref(&self, name: &str) -> Option<&[u8]> {
+        let (named, entry_id) = self.lookup_asset_entry(name)?;
+        log::trace!("Found '{}' in {}", name, named.name);
+        named.archive.get_by_id(entry_id)
+    }
+
     /// Look up a file by name and return both the bytes and source archive name.
     pub fn get_with_source(&self, name: &str) -> Option<(Vec<u8>, String)> {
-        let (named, entry_id) = self.lookup_archive_entry(name)?;
+        let (named, entry_id) = self.lookup_asset_entry(name)?;
         named
             .archive
             .get_by_id(entry_id)
             .map(|data| (data.to_vec(), named.name.clone()))
+    }
+
+    /// Look up a file by name and return both the borrowed bytes and source archive name.
+    pub fn get_with_source_ref(&self, name: &str) -> Option<(&[u8], &str)> {
+        let (named, entry_id) = self.lookup_asset_entry(name)?;
+        named
+            .archive
+            .get_by_id(entry_id)
+            .map(|data| (data, named.name.as_str()))
     }
 
     /// Load an additional nested archive from within already-loaded archives.
@@ -369,7 +385,7 @@ impl AssetManager {
 
     /// Look up a loaded archive by its display/debug name.
     pub fn archive(&self, name: &str) -> Option<&MixArchive> {
-        let index = self.archive_name_index.get(&name.to_ascii_lowercase())?;
+        let index = self.archive_lookup_index.get(&name.to_ascii_lowercase())?;
         self.archives.get(*index).map(|archive| &archive.archive)
     }
 
@@ -402,7 +418,7 @@ impl AssetManager {
         &self.ra2_dir
     }
 
-    fn lookup_archive_entry(&self, name: &str) -> Option<(&NamedArchive, i32)> {
+    fn lookup_asset_entry(&self, name: &str) -> Option<(&NamedArchive, i32)> {
         let location = self.lookup_location_for_name(name)?;
         let archive = self.archives.get(location.archive_index)?;
         Some((archive, location.entry_id))
@@ -434,12 +450,14 @@ impl AssetManager {
 
     fn rebuild_indexes(&mut self) {
         self.lookup_index.clear();
-        self.archive_name_index.clear();
+        self.archive_lookup_index.clear();
 
         for (archive_index, named) in self.archives.iter().enumerate() {
-            self.archive_name_index
-                .entry(named.name.to_ascii_lowercase())
-                .or_insert(archive_index);
+            for key in archive_lookup_keys(&named.name) {
+                self.archive_lookup_index
+                    .entry(key)
+                    .or_insert(archive_index);
+            }
             for entry in named.archive.entries() {
                 self.lookup_index.entry(entry.id).or_insert(AssetLocation {
                     archive_index,
@@ -455,6 +473,22 @@ fn guess_nested_mix_name(entry_id: i32) -> Option<&'static str> {
         .iter()
         .copied()
         .find(|name| mix_hash(name) == entry_id)
+}
+
+fn archive_lookup_keys(name: &str) -> Vec<String> {
+    let mut keys = Vec::with_capacity(3);
+    keys.push(name.to_ascii_lowercase());
+
+    if let Some(rest) = name.strip_prefix("nested:") {
+        keys.push(rest.trim().to_ascii_lowercase());
+    }
+    if let Some((_, leaf)) = name.rsplit_once("->") {
+        keys.push(leaf.trim().to_ascii_lowercase());
+    }
+
+    keys.sort();
+    keys.dedup();
+    keys
 }
 
 #[cfg(test)]
@@ -505,7 +539,7 @@ mod tests {
                 },
             ],
             lookup_index: HashMap::new(),
-            archive_name_index: HashMap::new(),
+            archive_lookup_index: HashMap::new(),
             ra2_dir: PathBuf::new(),
         };
         manager.rebuild_indexes();
@@ -525,12 +559,29 @@ mod tests {
                 archive: make_new_format_mix("rules.ini", b"test"),
             }],
             lookup_index: HashMap::new(),
-            archive_name_index: HashMap::new(),
+            archive_lookup_index: HashMap::new(),
             ra2_dir: PathBuf::new(),
         };
         manager.rebuild_indexes();
 
         assert!(manager.archive("ra2.mix").is_some());
         assert!(manager.archive("RA2.MIX").is_some());
+    }
+
+    #[test]
+    fn archive_lookup_matches_nested_leaf_aliases() {
+        let mut manager = AssetManager {
+            archives: vec![NamedArchive {
+                name: "language.mix -> audio.mix".to_string(),
+                archive: make_new_format_mix("audio.idx", b"test"),
+            }],
+            lookup_index: HashMap::new(),
+            archive_lookup_index: HashMap::new(),
+            ra2_dir: PathBuf::new(),
+        };
+        manager.rebuild_indexes();
+
+        assert!(manager.archive("audio.mix").is_some());
+        assert!(manager.archive("language.mix -> audio.mix").is_some());
     }
 }

--- a/src/assets/asset_manager.rs
+++ b/src/assets/asset_manager.rs
@@ -5,12 +5,13 @@
 //! search path. Callers ask for filenames and do not need to know where an
 //! asset physically lives.
 
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use crate::assets::error::AssetError;
 use crate::assets::mix_archive::MixArchive;
-use crate::assets::mix_hash::mix_hash;
+use crate::assets::mix_hash::{mix_hash, westwood_hash};
 
 /// A MIX archive with a human-readable name for logging and diagnostics.
 struct NamedArchive {
@@ -20,12 +21,22 @@ struct NamedArchive {
     archive: MixArchive,
 }
 
+#[derive(Clone, Copy)]
+struct AssetLocation {
+    archive_index: usize,
+    entry_id: i32,
+}
+
 /// Manages loaded MIX archives and provides name-based lookups.
 ///
 /// Archives are searched in priority order. Earlier archives win.
 pub struct AssetManager {
     /// Loaded MIX archives in search priority order.
     archives: Vec<NamedArchive>,
+    /// Precomputed first-match lookup across all archives.
+    lookup_index: HashMap<i32, AssetLocation>,
+    /// Case-insensitive display-name index for direct archive access.
+    archive_name_index: HashMap<String, usize>,
     /// Path to the RA2 installation directory.
     ra2_dir: PathBuf,
 }
@@ -89,6 +100,8 @@ impl AssetManager {
     pub fn new(ra2_dir: &Path) -> Result<Self, AssetError> {
         let mut manager = Self {
             archives: Vec::new(),
+            lookup_index: HashMap::new(),
+            archive_name_index: HashMap::new(),
             ra2_dir: ra2_dir.to_path_buf(),
         };
 
@@ -177,6 +190,7 @@ impl AssetManager {
                 named.archive.entry_count()
             );
         }
+        manager.rebuild_indexes();
 
         Ok(manager)
     }
@@ -193,6 +207,9 @@ impl AssetManager {
             let Some(data) = parent.get_by_id(entry.id) else {
                 continue;
             };
+            if !MixArchive::looks_like_mix(data) {
+                continue;
+            }
 
             match MixArchive::from_bytes(data.to_vec()) {
                 Ok(nested) if nested.entry_count() > 0 => {
@@ -246,23 +263,18 @@ impl AssetManager {
 
     /// Look up a file by name across all loaded archives.
     pub fn get(&self, name: &str) -> Option<Vec<u8>> {
-        for named in &self.archives {
-            if let Some(data) = named.archive.get_by_name(name) {
-                log::trace!("Found '{}' in {}", name, named.name);
-                return Some(data.to_vec());
-            }
-        }
-        None
+        let (named, entry_id) = self.lookup_archive_entry(name)?;
+        log::trace!("Found '{}' in {}", name, named.name);
+        named.archive.get_by_id(entry_id).map(|data| data.to_vec())
     }
 
     /// Look up a file by name and return both the bytes and source archive name.
     pub fn get_with_source(&self, name: &str) -> Option<(Vec<u8>, String)> {
-        for named in &self.archives {
-            if let Some(data) = named.archive.get_by_name(name) {
-                return Some((data.to_vec(), named.name.clone()));
-            }
-        }
-        None
+        let (named, entry_id) = self.lookup_archive_entry(name)?;
+        named
+            .archive
+            .get_by_id(entry_id)
+            .map(|data| (data.to_vec(), named.name.clone()))
     }
 
     /// Load an additional nested archive from within already-loaded archives.
@@ -285,6 +297,7 @@ impl AssetManager {
                 archive,
             },
         );
+        self.rebuild_indexes();
 
         Ok(())
     }
@@ -342,23 +355,22 @@ impl AssetManager {
             });
             loaded_count += 1;
         }
+        if loaded_count > 0 {
+            self.rebuild_indexes();
+        }
 
         Ok(loaded_count)
     }
 
     /// Check if a file exists in any loaded archive.
     pub fn contains(&self, name: &str) -> bool {
-        self.archives
-            .iter()
-            .any(|archive| archive.archive.get_by_name(name).is_some())
+        self.lookup_location_for_name(name).is_some()
     }
 
     /// Look up a loaded archive by its display/debug name.
     pub fn archive(&self, name: &str) -> Option<&MixArchive> {
-        self.archives
-            .iter()
-            .find(|archive| archive.name.eq_ignore_ascii_case(name))
-            .map(|archive| &archive.archive)
+        let index = self.archive_name_index.get(&name.to_ascii_lowercase())?;
+        self.archives.get(*index).map(|archive| &archive.archive)
     }
 
     /// Read one entry from a specific archive by entry hash.
@@ -389,6 +401,53 @@ impl AssetManager {
     pub fn ra2_dir(&self) -> &Path {
         &self.ra2_dir
     }
+
+    fn lookup_archive_entry(&self, name: &str) -> Option<(&NamedArchive, i32)> {
+        let location = self.lookup_location_for_name(name)?;
+        let archive = self.archives.get(location.archive_index)?;
+        Some((archive, location.entry_id))
+    }
+
+    fn lookup_location_for_name(&self, name: &str) -> Option<AssetLocation> {
+        let primary_id = mix_hash(name);
+        let alternate_id = westwood_hash(name);
+        let primary = self.lookup_index.get(&primary_id).copied();
+        let alternate = if alternate_id == primary_id {
+            None
+        } else {
+            self.lookup_index.get(&alternate_id).copied()
+        };
+
+        match (primary, alternate) {
+            (Some(primary), Some(alternate)) => {
+                if primary.archive_index <= alternate.archive_index {
+                    Some(primary)
+                } else {
+                    Some(alternate)
+                }
+            }
+            (Some(primary), None) => Some(primary),
+            (None, Some(alternate)) => Some(alternate),
+            (None, None) => None,
+        }
+    }
+
+    fn rebuild_indexes(&mut self) {
+        self.lookup_index.clear();
+        self.archive_name_index.clear();
+
+        for (archive_index, named) in self.archives.iter().enumerate() {
+            self.archive_name_index
+                .entry(named.name.to_ascii_lowercase())
+                .or_insert(archive_index);
+            for entry in named.archive.entries() {
+                self.lookup_index.entry(entry.id).or_insert(AssetLocation {
+                    archive_index,
+                    entry_id: entry.id,
+                });
+            }
+        }
+    }
 }
 
 fn guess_nested_mix_name(entry_id: i32) -> Option<&'static str> {
@@ -396,4 +455,82 @@ fn guess_nested_mix_name(entry_id: i32) -> Option<&'static str> {
         .iter()
         .copied()
         .find(|name| mix_hash(name) == entry_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_new_format_mix(name: &str, body: &[u8]) -> MixArchive {
+        let mut data = Vec::new();
+        let entry_id = mix_hash(name);
+
+        data.extend_from_slice(&0u16.to_le_bytes());
+        data.extend_from_slice(&0u16.to_le_bytes());
+        data.extend_from_slice(&1u16.to_le_bytes());
+        data.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        data.extend_from_slice(&entry_id.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes());
+        data.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        data.extend_from_slice(body);
+
+        MixArchive::from_bytes(data).expect("new-format test mix should parse")
+    }
+
+    fn make_old_format_mix(name: &str, body: &[u8]) -> MixArchive {
+        let mut data = Vec::new();
+        let entry_id = westwood_hash(name);
+
+        data.extend_from_slice(&1u16.to_le_bytes());
+        data.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        data.extend_from_slice(&entry_id.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes());
+        data.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        data.extend_from_slice(body);
+
+        MixArchive::from_bytes(data).expect("old-format test mix should parse")
+    }
+
+    #[test]
+    fn indexed_lookup_prefers_earliest_archive_across_hash_fallbacks() {
+        let mut manager = AssetManager {
+            archives: vec![
+                NamedArchive {
+                    name: "theme.mix".to_string(),
+                    archive: make_old_format_mix("audio.idx", b"westwood"),
+                },
+                NamedArchive {
+                    name: "audio.mix".to_string(),
+                    archive: make_new_format_mix("audio.idx", b"crc32"),
+                },
+            ],
+            lookup_index: HashMap::new(),
+            archive_name_index: HashMap::new(),
+            ra2_dir: PathBuf::new(),
+        };
+        manager.rebuild_indexes();
+
+        let (bytes, source) = manager
+            .get_with_source("audio.idx")
+            .expect("indexed lookup should find audio.idx");
+        assert_eq!(bytes, b"westwood");
+        assert_eq!(source, "theme.mix");
+    }
+
+    #[test]
+    fn archive_lookup_is_case_insensitive() {
+        let mut manager = AssetManager {
+            archives: vec![NamedArchive {
+                name: "RA2.MIX".to_string(),
+                archive: make_new_format_mix("rules.ini", b"test"),
+            }],
+            lookup_index: HashMap::new(),
+            archive_name_index: HashMap::new(),
+            ra2_dir: PathBuf::new(),
+        };
+        manager.rebuild_indexes();
+
+        assert!(manager.archive("ra2.mix").is_some());
+        assert!(manager.archive("RA2.MIX").is_some());
+    }
 }

--- a/src/assets/asset_manager.rs
+++ b/src/assets/asset_manager.rs
@@ -211,8 +211,8 @@ impl AssetManager {
                 continue;
             }
 
-            match MixArchive::from_bytes(data.to_vec()) {
-                Ok(nested) if nested.entry_count() > 0 => {
+            match parent.nested_archive_by_id(entry.id) {
+                Ok(Some(nested)) if nested.entry_count() > 0 => {
                     let nested_name = guess_nested_mix_name(entry.id)
                         .map(|name| format!("{parent_name} -> {name}"))
                         .unwrap_or_else(|| {
@@ -229,8 +229,11 @@ impl AssetManager {
                         archive: nested,
                     });
                 }
-                _ => {
+                Ok(_) => {
                     // Not a MIX archive or empty.
+                }
+                Err(_) => {
+                    // Not a MIX archive or malformed.
                 }
             }
         }
@@ -295,11 +298,19 @@ impl AssetManager {
 
     /// Load an additional nested archive from within already-loaded archives.
     pub fn load_nested(&mut self, name: &str) -> Result<(), AssetError> {
-        let data = self.get(name).ok_or_else(|| AssetError::AssetNotFound {
-            name: name.to_string(),
-        })?;
-
-        let archive = MixArchive::from_bytes(data)?;
+        let archive = {
+            let (named, entry_id) =
+                self.lookup_asset_entry(name)
+                    .ok_or_else(|| AssetError::AssetNotFound {
+                        name: name.to_string(),
+                    })?;
+            named
+                .archive
+                .nested_archive_by_id(entry_id)?
+                .ok_or_else(|| AssetError::AssetNotFound {
+                    name: name.to_string(),
+                })?
+        };
         log::info!(
             "Loaded nested archive: {} ({} entries)",
             name,

--- a/src/assets/mix_archive.rs
+++ b/src/assets/mix_archive.rs
@@ -39,6 +39,7 @@
 //! - Part of assets/ — no dependencies on game modules.
 //! - Uses mix_crypto for decryption and mix_hash for filename lookup.
 
+use std::fs::File;
 use std::path::Path;
 
 use crate::assets::error::AssetError;
@@ -78,12 +79,6 @@ pub struct MixEntry {
 ///
 /// Holds the entire MIX file data in memory and provides
 /// methods to look up and extract files by name or hash ID.
-///
-/// ## Why keep everything in memory?
-/// RA2's MIX files are typically 100-300 MB total. Modern systems
-/// have plenty of RAM, and keeping the data in memory avoids repeated
-/// disk I/O when extracting multiple files. Memory-mapping could be
-/// added as an optimization later if needed.
 pub struct MixArchive {
     /// The file index entries, sorted by id for binary search lookup.
     entries: Vec<MixEntry>,
@@ -91,14 +86,33 @@ pub struct MixArchive {
     hash_kind: MixHashKind,
     /// Byte offset where the body section starts in the raw data.
     body_offset: usize,
-    /// The raw file data (entire MIX file kept in memory).
-    data: Vec<u8>,
+    /// The raw archive bytes. Disk archives can stay memory-mapped; nested
+    /// archives copied out of parent MIXes stay owned.
+    data: MixData,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MixHashKind {
     Crc32,
     Westwood,
+}
+
+enum MixData {
+    Owned(Vec<u8>),
+    Mapped(memmap2::Mmap),
+}
+
+impl MixData {
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Owned(data) => data,
+            Self::Mapped(map) => map,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.as_slice().len()
+    }
 }
 
 impl MixArchive {
@@ -108,37 +122,95 @@ impl MixArchive {
     /// - 0x0000 → new format (RA2/TS): real flags at offset 2
     /// - Non-zero → old format (TD/RA1): that value IS the file_count
     pub fn from_bytes(data: Vec<u8>) -> Result<Self, AssetError> {
-        if data.len() < 4 {
+        Self::from_data(MixData::Owned(data))
+    }
+
+    /// Cheap format sniff used before cloning candidate nested MIX payloads.
+    pub fn looks_like_mix(data: &[u8]) -> bool {
+        if data.len() < INDEX_HEADER_SIZE {
+            return false;
+        }
+
+        let first_word: u16 = read_u16_le(data, 0);
+
+        if first_word == 0 {
+            if data.len() < NEW_FORMAT_HEADER_SIZE + INDEX_HEADER_SIZE {
+                return false;
+            }
+
+            let flags: u16 = read_u16_le(data, 2);
+            if (flags & FLAG_ENCRYPTED) != 0 {
+                let min_header = NEW_FORMAT_HEADER_SIZE
+                    + mix_crypto::RSA_KEY_BLOCK_SIZE
+                    + mix_crypto::BLOWFISH_BLOCK_SIZE;
+                return data.len() >= min_header;
+            }
+
+            let file_count: u16 = read_u16_le(data, NEW_FORMAT_HEADER_SIZE);
+            let body_size: u32 = read_u32_le(data, NEW_FORMAT_HEADER_SIZE + 2);
+            let Some(index_bytes) = (file_count as usize).checked_mul(INDEX_ENTRY_SIZE) else {
+                return false;
+            };
+            let Some(body_offset) =
+                (NEW_FORMAT_HEADER_SIZE + INDEX_HEADER_SIZE).checked_add(index_bytes)
+            else {
+                return false;
+            };
+            return Self::header_bounds_are_sane(data, body_offset, body_size);
+        }
+
+        let file_count: u16 = first_word;
+        let body_size: u32 = read_u32_le(data, 2);
+        let Some(index_bytes) = (file_count as usize).checked_mul(INDEX_ENTRY_SIZE) else {
+            return false;
+        };
+        let Some(body_offset) = INDEX_HEADER_SIZE.checked_add(index_bytes) else {
+            return false;
+        };
+        Self::header_bounds_are_sane(data, body_offset, body_size)
+    }
+
+    fn from_data(data: MixData) -> Result<Self, AssetError> {
+        let bytes = data.as_slice();
+        if bytes.len() < 4 {
             return Err(AssetError::InvalidMixHeader {
-                reason: format!("File too small: {} bytes (need at least 4)", data.len()),
+                reason: format!("File too small: {} bytes (need at least 4)", bytes.len()),
             });
         }
 
         // The first u16 distinguishes old vs new MIX format.
         // New format (RA2/TS): offset 0 is always 0x0000 as a format marker.
         // Old format (TD/RA1): offset 0 is file_count (always non-zero).
-        let first_word: u16 = read_u16_le(&data, 0);
-
-        if first_word == 0 {
+        let first_word: u16 = read_u16_le(bytes, 0);
+        let (mut entries, hash_kind, body_offset) = if first_word == 0 {
             // New format: actual flags are at offset 2.
-            let flags: u16 = read_u16_le(&data, 2);
+            let flags: u16 = read_u16_le(bytes, 2);
             let is_encrypted: bool = (flags & FLAG_ENCRYPTED) != 0;
 
             if is_encrypted {
-                Self::parse_encrypted_new_format(data)
+                Self::parse_encrypted_new_format(bytes)?
             } else {
-                Self::parse_unencrypted_new_format(data)
+                Self::parse_unencrypted_new_format(bytes)?
             }
         } else {
             // Old format: first_word IS the file_count. No flags, no encryption.
-            Self::parse_old_format(data, first_word)
-        }
+            Self::parse_old_format(bytes, first_word)?
+        };
+        entries.sort_by_key(|e| e.id);
+
+        Ok(Self {
+            entries,
+            hash_kind,
+            body_offset,
+            data,
+        })
     }
 
     /// Load a MIX archive from a file path.
     pub fn load(path: &Path) -> Result<Self, AssetError> {
-        let data: Vec<u8> = std::fs::read(path)?;
-        Self::from_bytes(data)
+        let file = File::open(path)?;
+        let data = unsafe { memmap2::MmapOptions::new().map(&file)? };
+        Self::from_data(MixData::Mapped(data))
     }
 
     /// Look up a file by name. Returns the raw bytes if found.
@@ -169,16 +241,17 @@ impl MixArchive {
     pub fn get_by_id(&self, id: i32) -> Option<&[u8]> {
         let index: usize = self.entries.binary_search_by_key(&id, |e| e.id).ok()?;
         let entry: &MixEntry = &self.entries[index];
+        let data = self.data.as_slice();
 
         let start: usize = self.body_offset + entry.offset as usize;
         let end: usize = start + entry.size as usize;
 
         // Bounds check to prevent panics on corrupt data.
-        if end > self.data.len() {
+        if end > data.len() {
             return None;
         }
 
-        Some(&self.data[start..end])
+        Some(&data[start..end])
     }
 
     /// Number of files in this archive.
@@ -200,7 +273,9 @@ impl MixArchive {
     ///
     /// Layout: [marker:2][flags:2][RSA block:80][encrypted index...][body...]
     /// The RSA block starts at offset 4 (after the 2-byte marker + 2-byte flags).
-    fn parse_encrypted_new_format(data: Vec<u8>) -> Result<Self, AssetError> {
+    fn parse_encrypted_new_format(
+        data: &[u8],
+    ) -> Result<(Vec<MixEntry>, MixHashKind, usize), AssetError> {
         // RSA key block starts after the 4-byte new-format header.
         let rsa_start: usize = NEW_FORMAT_HEADER_SIZE;
         let rsa_end: usize = rsa_start + mix_crypto::RSA_KEY_BLOCK_SIZE;
@@ -265,22 +340,16 @@ impl MixArchive {
         // Body data starts right after the encrypted index.
         let body_offset: usize = encrypted_start + encrypted_size;
 
-        let mut archive: Self = Self {
-            entries,
-            hash_kind: MixHashKind::Crc32,
-            body_offset,
-            data,
-        };
-        archive.entries.sort_by_key(|e| e.id);
-
-        Ok(archive)
+        Ok((entries, MixHashKind::Crc32, body_offset))
     }
 
     /// Parse a new-format unencrypted MIX file (flags has no encryption bit).
     ///
     /// Layout: [marker:2][flags:2][file_count:2][body_size:4][entries...][body...]
     /// The index header starts at offset 4.
-    fn parse_unencrypted_new_format(data: Vec<u8>) -> Result<Self, AssetError> {
+    fn parse_unencrypted_new_format(
+        data: &[u8],
+    ) -> Result<(Vec<MixEntry>, MixHashKind, usize), AssetError> {
         if data.len() < NEW_FORMAT_HEADER_SIZE + INDEX_HEADER_SIZE {
             return Err(AssetError::InvalidMixHeader {
                 reason: "File too small for new-format unencrypted header".to_string(),
@@ -305,22 +374,17 @@ impl MixArchive {
         let entries: Vec<MixEntry> = Self::parse_entries(&data, index_start, file_count)?;
         let body_offset: usize = index_end;
 
-        let mut archive: Self = Self {
-            entries,
-            hash_kind: MixHashKind::Crc32,
-            body_offset,
-            data,
-        };
-        archive.entries.sort_by_key(|e| e.id);
-
-        Ok(archive)
+        Ok((entries, MixHashKind::Crc32, body_offset))
     }
 
     /// Parse an old-format MIX file (TD/RA1/theme.mix — no format marker).
     ///
     /// Layout: [file_count:2][body_size:4][entries...][body...]
     /// The first u16 at offset 0 is already the file_count (passed in).
-    fn parse_old_format(data: Vec<u8>, file_count: u16) -> Result<Self, AssetError> {
+    fn parse_old_format(
+        data: &[u8],
+        file_count: u16,
+    ) -> Result<(Vec<MixEntry>, MixHashKind, usize), AssetError> {
         if data.len() < INDEX_HEADER_SIZE {
             return Err(AssetError::InvalidMixHeader {
                 reason: "File too small for old-format header".to_string(),
@@ -345,15 +409,7 @@ impl MixArchive {
         let entries: Vec<MixEntry> = Self::parse_entries(&data, index_start, file_count)?;
         let body_offset: usize = index_end;
 
-        let mut archive: Self = Self {
-            entries,
-            hash_kind: MixHashKind::Westwood,
-            body_offset,
-            data,
-        };
-        archive.entries.sort_by_key(|e| e.id);
-
-        Ok(archive)
+        Ok((entries, MixHashKind::Westwood, body_offset))
     }
 
     /// Parse file index entries from a buffer starting at the given offset.
@@ -386,6 +442,13 @@ impl MixArchive {
         }
 
         Ok(entries)
+    }
+
+    fn header_bounds_are_sane(data: &[u8], body_offset: usize, body_size: u32) -> bool {
+        if body_offset > data.len() {
+            return false;
+        }
+        body_size as usize <= data.len().saturating_sub(body_offset)
     }
 }
 
@@ -495,6 +558,17 @@ mod tests {
         let archive: MixArchive = MixArchive::from_bytes(data).expect("Should parse");
 
         assert!(archive.get_by_name("nonexistent.dat").is_none());
+    }
+
+    #[test]
+    fn test_looks_like_mix_accepts_valid_headers() {
+        assert!(MixArchive::looks_like_mix(&make_test_mix_new_format()));
+        assert!(MixArchive::looks_like_mix(&make_test_mix_old_format()));
+    }
+
+    #[test]
+    fn test_looks_like_mix_rejects_non_mix_data() {
+        assert!(!MixArchive::looks_like_mix(b"not a mix archive"));
     }
 
     #[test]

--- a/src/assets/mix_archive.rs
+++ b/src/assets/mix_archive.rs
@@ -41,6 +41,7 @@
 
 use std::fs::File;
 use std::path::Path;
+use std::sync::Arc;
 
 use crate::assets::error::AssetError;
 use crate::assets::mix_crypto;
@@ -86,8 +87,8 @@ pub struct MixArchive {
     hash_kind: MixHashKind,
     /// Byte offset where the body section starts in the raw data.
     body_offset: usize,
-    /// The raw archive bytes. Disk archives can stay memory-mapped; nested
-    /// archives copied out of parent MIXes stay owned.
+    /// The raw archive bytes. Top-level archives can stay memory-mapped;
+    /// nested archives can share a sub-view into parent archive storage.
     data: MixData,
 }
 
@@ -97,21 +98,61 @@ enum MixHashKind {
     Westwood,
 }
 
-enum MixData {
-    Owned(Vec<u8>),
-    Mapped(memmap2::Mmap),
+#[derive(Clone)]
+enum MixBytes {
+    Owned(Arc<[u8]>),
+    Mapped(Arc<memmap2::Mmap>),
+}
+
+#[derive(Clone)]
+struct MixData {
+    bytes: MixBytes,
+    start: usize,
+    len: usize,
 }
 
 impl MixData {
-    fn as_slice(&self) -> &[u8] {
-        match self {
-            Self::Owned(data) => data,
-            Self::Mapped(map) => map,
+    fn from_owned(data: Vec<u8>) -> Self {
+        let bytes: Arc<[u8]> = data.into();
+        let len = bytes.len();
+        Self {
+            bytes: MixBytes::Owned(bytes),
+            start: 0,
+            len,
         }
     }
 
+    fn from_mapped(map: memmap2::Mmap) -> Self {
+        let bytes = Arc::new(map);
+        let len = bytes.len();
+        Self {
+            bytes: MixBytes::Mapped(bytes),
+            start: 0,
+            len,
+        }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        let bytes = match &self.bytes {
+            MixBytes::Owned(data) => &data[..],
+            MixBytes::Mapped(map) => &map[..],
+        };
+        &bytes[self.start..self.start + self.len]
+    }
+
+    fn subrange(&self, start: usize, end: usize) -> Option<Self> {
+        if start > end || end > self.len {
+            return None;
+        }
+        Some(Self {
+            bytes: self.bytes.clone(),
+            start: self.start + start,
+            len: end - start,
+        })
+    }
+
     fn len(&self) -> usize {
-        self.as_slice().len()
+        self.len
     }
 }
 
@@ -122,7 +163,7 @@ impl MixArchive {
     /// - 0x0000 → new format (RA2/TS): real flags at offset 2
     /// - Non-zero → old format (TD/RA1): that value IS the file_count
     pub fn from_bytes(data: Vec<u8>) -> Result<Self, AssetError> {
-        Self::from_data(MixData::Owned(data))
+        Self::from_data(MixData::from_owned(data))
     }
 
     /// Cheap format sniff used before cloning candidate nested MIX payloads.
@@ -210,7 +251,7 @@ impl MixArchive {
     pub fn load(path: &Path) -> Result<Self, AssetError> {
         let file = File::open(path)?;
         let data = unsafe { memmap2::MmapOptions::new().map(&file)? };
-        Self::from_data(MixData::Mapped(data))
+        Self::from_data(MixData::from_mapped(data))
     }
 
     /// Look up a file by name. Returns the raw bytes if found.
@@ -252,6 +293,18 @@ impl MixArchive {
         }
 
         Some(&data[start..end])
+    }
+
+    /// Parse a child MIX archive directly from an entry without copying its bytes.
+    pub fn nested_archive_by_id(&self, id: i32) -> Result<Option<Self>, AssetError> {
+        let index: usize = match self.entries.binary_search_by_key(&id, |e| e.id) {
+            Ok(index) => index,
+            Err(_) => return Ok(None),
+        };
+        let Some(data) = self.entry_view(&self.entries[index]) else {
+            return Ok(None);
+        };
+        Self::from_data(data).map(Some)
     }
 
     /// Number of files in this archive.
@@ -450,6 +503,15 @@ impl MixArchive {
         }
         body_size as usize <= data.len().saturating_sub(body_offset)
     }
+
+    fn entry_view(&self, entry: &MixEntry) -> Option<MixData> {
+        let start: usize = self.body_offset + entry.offset as usize;
+        let end: usize = start + entry.size as usize;
+        if end > self.data.len() {
+            return None;
+        }
+        self.data.subrange(start, end)
+    }
 }
 
 #[cfg(test)]
@@ -501,6 +563,22 @@ mod tests {
 
         // Body data
         data.extend_from_slice(b"world");
+
+        data
+    }
+
+    fn make_test_mix_with_entry(name: &str, body: &[u8]) -> Vec<u8> {
+        let mut data: Vec<u8> = Vec::new();
+        let entry_id: i32 = mix_hash(name);
+
+        data.extend_from_slice(&0u16.to_le_bytes());
+        data.extend_from_slice(&0u16.to_le_bytes());
+        data.extend_from_slice(&1u16.to_le_bytes());
+        data.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        data.extend_from_slice(&entry_id.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes());
+        data.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        data.extend_from_slice(body);
 
         data
     }
@@ -569,6 +647,26 @@ mod tests {
     #[test]
     fn test_looks_like_mix_rejects_non_mix_data() {
         assert!(!MixArchive::looks_like_mix(b"not a mix archive"));
+    }
+
+    #[test]
+    fn test_nested_archive_by_id_parses_child_without_copying_interface() {
+        let child = make_test_mix_with_entry("child.txt", b"nested");
+        let parent = MixArchive::from_bytes(make_test_mix_with_entry("child.mix", &child))
+            .expect("parent mix should parse");
+        let child_id = mix_hash("child.mix");
+
+        let nested = parent
+            .nested_archive_by_id(child_id)
+            .expect("nested parse should succeed")
+            .expect("child entry should exist");
+
+        assert_eq!(
+            nested
+                .get_by_name("child.txt")
+                .expect("child asset should exist"),
+            b"nested"
+        );
     }
 
     #[test]

--- a/src/audio/music.rs
+++ b/src/audio/music.rs
@@ -223,17 +223,17 @@ impl MusicPlayer {
 /// Returns (samples, sample_rate) or None if not found / decode fails.
 fn load_track(track_name: &str, assets: &AssetManager) -> Option<(Vec<f32>, u32)> {
     for filename in [format!("{}.wav", track_name), format!("{}.aud", track_name)] {
-        let Some(data) = assets.get(&filename) else {
+        let Some(data) = assets.get_ref(&filename) else {
             continue;
         };
 
         if data.len() >= 44 && &data[0..4] == b"RIFF" {
-            if let Some(decoded) = decode_wav(&data, &filename) {
+            if let Some(decoded) = decode_wav(data, &filename) {
                 return Some((decoded.samples, decoded.sample_rate));
             }
         }
 
-        let (header, samples) = match aud_file::decode_aud(&data) {
+        let (header, samples) = match aud_file::decode_aud(data) {
             Some(decoded) => decoded,
             None => continue,
         };
@@ -272,8 +272,8 @@ fn load_track(track_name: &str, assets: &AssetManager) -> Option<(Vec<f32>, u32)
 }
 
 fn load_theme_ini(assets: &AssetManager, name: &str) -> Option<IniFile> {
-    let bytes = assets.get(name)?;
-    IniFile::from_bytes(&bytes).ok()
+    let bytes = assets.get_ref(name)?;
+    IniFile::from_bytes(bytes).ok()
 }
 
 fn merge_theme_aliases(into: &mut HashMap<String, String>, ini: &IniFile) {

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -93,11 +93,7 @@ pub fn calc_spatial_volume(
         vol = min_vol;
     }
 
-    if vol < MIN_VOLUME_CUTOFF {
-        0.0
-    } else {
-        vol
-    }
+    if vol < MIN_VOLUME_CUTOFF { 0.0 } else { vol }
 }
 
 const FADE_MS: u32 = 3;
@@ -375,17 +371,18 @@ fn load_sfx(
     }
 
     // Try MIX asset lookup (exact name, then with .wav extension).
-    let data: Vec<u8> = assets
-        .get(filename)
-        .or_else(|| assets.get(&format!("{}.wav", filename)))?;
+    let exact_name = format!("{}.wav", filename);
+    let data: &[u8] = assets
+        .get_ref(filename)
+        .or_else(|| assets.get_ref(&exact_name))?;
 
     // Try WAV first (most SFX are .wav).
     if data.len() >= 44 && &data[0..4] == b"RIFF" {
-        return decode_wav(&data, filename);
+        return decode_wav(data, filename);
     }
 
     // Fall back to .aud format.
-    let (header, samples) = aud_file::decode_aud(&data)?;
+    let (header, samples) = aud_file::decode_aud(data)?;
     if samples.is_empty() {
         return None;
     }
@@ -542,12 +539,11 @@ pub(crate) fn decode_wav(data: &[u8], filename: &str) -> Option<DecodedAudio> {
 
 /// IMA ADPCM step size table — standard IMA/DVI specification.
 const IMA_STEP_TABLE: [i32; 89] = [
-    7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41, 45, 50, 55, 60,
-    66, 73, 80, 88, 97, 107, 118, 130, 143, 157, 173, 190, 209, 230, 253, 279, 307, 337, 371,
-    408, 449, 494, 544, 598, 658, 724, 796, 876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878,
-    2066, 2272, 2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484, 7132, 7845,
-    8630, 9493, 10442, 11487, 12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623, 27086,
-    29794, 32767,
+    7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41, 45, 50, 55, 60, 66,
+    73, 80, 88, 97, 107, 118, 130, 143, 157, 173, 190, 209, 230, 253, 279, 307, 337, 371, 408, 449,
+    494, 544, 598, 658, 724, 796, 876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066, 2272,
+    2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484, 7132, 7845, 8630, 9493,
+    10442, 11487, 12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767,
 ];
 
 /// IMA ADPCM index adjustment table for each nibble value.
@@ -584,8 +580,7 @@ fn decode_ima_adpcm(data: &[u8], channels: u16, block_align: u16) -> Vec<f32> {
         let mut step_index = [0i32; 2];
         for c in 0..ch {
             let base = c * 4;
-            predictor[c] =
-                i16::from_le_bytes([block[base], block[base + 1]]) as i32;
+            predictor[c] = i16::from_le_bytes([block[base], block[base + 1]]) as i32;
             step_index[c] = block[base + 2] as i32;
             step_index[c] = step_index[c].clamp(0, 88);
             // First sample from header.
@@ -608,9 +603,15 @@ fn decode_ima_adpcm(data: &[u8], channels: u16, block_align: u16) -> Vec<f32> {
                     let nibble = ((byte >> shift) & 0x0F) as usize;
                     let step = IMA_STEP_TABLE[step_index[0] as usize];
                     let mut diff = step >> 3;
-                    if nibble & 4 != 0 { diff += step; }
-                    if nibble & 2 != 0 { diff += step >> 1; }
-                    if nibble & 1 != 0 { diff += step >> 2; }
+                    if nibble & 4 != 0 {
+                        diff += step;
+                    }
+                    if nibble & 2 != 0 {
+                        diff += step >> 1;
+                    }
+                    if nibble & 1 != 0 {
+                        diff += step >> 2;
+                    }
                     if nibble & 8 != 0 {
                         predictor[0] -= diff;
                     } else {
@@ -635,9 +636,15 @@ fn decode_ima_adpcm(data: &[u8], channels: u16, block_align: u16) -> Vec<f32> {
                             let nibble = ((byte >> shift) & 0x0F) as usize;
                             let step = IMA_STEP_TABLE[step_index[c] as usize];
                             let mut diff = step >> 3;
-                            if nibble & 4 != 0 { diff += step; }
-                            if nibble & 2 != 0 { diff += step >> 1; }
-                            if nibble & 1 != 0 { diff += step >> 2; }
+                            if nibble & 4 != 0 {
+                                diff += step;
+                            }
+                            if nibble & 2 != 0 {
+                                diff += step >> 1;
+                            }
+                            if nibble & 1 != 0 {
+                                diff += step >> 2;
+                            }
                             if nibble & 8 != 0 {
                                 predictor[c] -= diff;
                             } else {

--- a/src/map/theater.rs
+++ b/src/map/theater.rs
@@ -570,7 +570,7 @@ pub fn load_tile_images(
             }
         };
 
-        let tmp_data: Vec<u8> = match asset_manager.get(filename) {
+        let tmp_data: &[u8] = match asset_manager.get_ref(filename) {
             Some(d) => d,
             None => {
                 missing_file_count += sub_tiles.len() as u32;
@@ -579,7 +579,7 @@ pub fn load_tile_images(
             }
         };
 
-        let tmp: TmpFile = match TmpFile::from_bytes(&tmp_data) {
+        let tmp: TmpFile = match TmpFile::from_bytes(tmp_data) {
             Ok(t) => t,
             Err(e) => {
                 parse_error_count += sub_tiles.len() as u32;
@@ -646,10 +646,10 @@ pub fn load_tile_images(
             continue;
         }
         for (var_idx, var_name) in var_names.iter().enumerate() {
-            let Some(var_data) = asset_manager.get(var_name) else {
+            let Some(var_data) = asset_manager.get_ref(var_name) else {
                 break; // Stop at first missing variant (same as FA2)
             };
-            let Ok(var_tmp) = TmpFile::from_bytes(&var_data) else {
+            let Ok(var_tmp) = TmpFile::from_bytes(var_data) else {
                 break;
             };
             let var_cell_count = (var_tmp.template_width * var_tmp.template_height) as usize;

--- a/src/render/bridge_atlas.rs
+++ b/src/render/bridge_atlas.rs
@@ -135,8 +135,8 @@ fn render_bridge_sprite(
     }
 
     let shp: ShpFile = candidates.iter().find_map(|name| {
-        let data = asset_manager.get(name)?;
-        let shp = ShpFile::from_bytes(&data).ok()?;
+        let data = asset_manager.get_ref(name)?;
+        let shp = ShpFile::from_bytes(data).ok()?;
         let has_drawable = shp
             .frames
             .iter()

--- a/src/render/cursor_atlas.rs
+++ b/src/render/cursor_atlas.rs
@@ -347,12 +347,12 @@ pub(crate) fn build_software_cursor(
     asset_manager: &AssetManager,
 ) -> Option<crate::app_render::SoftwareCursor> {
     let palette = asset_manager
-        .get("mousepal.pal")
-        .and_then(|data| Palette::from_bytes(&data).ok())?;
+        .get_ref("mousepal.pal")
+        .and_then(|data| Palette::from_bytes(data).ok())?;
     let shp_data = asset_manager
-        .get("mouse.sha")
-        .or_else(|| asset_manager.get("mouse.shp"))?;
-    let shp = ShpFile::from_bytes(&shp_data).ok()?;
+        .get_ref("mouse.sha")
+        .or_else(|| asset_manager.get_ref("mouse.shp"))?;
+    let shp = ShpFile::from_bytes(shp_data).ok()?;
     if shp.frames.is_empty() {
         return None;
     }

--- a/src/render/overlay_atlas.rs
+++ b/src/render/overlay_atlas.rs
@@ -18,7 +18,7 @@ use crate::assets::pal_file::Palette;
 use crate::assets::shp_file::ShpFile;
 use crate::map::overlay::{OverlayEntry, TerrainObject};
 use crate::map::overlay_types::{
-    resolve_overlay_name_for_render, OverlayTypeFlags, OverlayTypeRegistry,
+    OverlayTypeFlags, OverlayTypeRegistry, resolve_overlay_name_for_render,
 };
 use crate::render::batch::{BatchRenderer, BatchTexture};
 use crate::render::gpu::GpuContext;
@@ -166,7 +166,12 @@ pub fn build_overlay_atlas(
     // need all frames loaded; static objects just need frame 0.
     let mut terrain_anim_frames: HashMap<String, u8> = HashMap::new();
     for obj in terrain_objects {
-        if terrain_anim_frames.contains_key(&obj.name) || needed.contains(&OverlaySpriteKey { name: obj.name.clone(), frame: 0 }) {
+        if terrain_anim_frames.contains_key(&obj.name)
+            || needed.contains(&OverlaySpriteKey {
+                name: obj.name.clone(),
+                frame: 0,
+            })
+        {
             // Already processed this terrain type.
             continue;
         }
@@ -288,7 +293,12 @@ pub fn build_overlay_atlas(
         );
     }
 
-    Some(pack_overlay_sprites(gpu, batch, &rendered, terrain_anim_frames))
+    Some(pack_overlay_sprites(
+        gpu,
+        batch,
+        &rendered,
+        terrain_anim_frames,
+    ))
 }
 
 /// Load and render a single overlay SHP sprite to RGBA pixels.
@@ -342,10 +352,10 @@ fn render_overlay_sprite(
     let mut found_name: String = String::new();
     let mut shp_opt: Option<ShpFile> = None;
     for name in &candidates {
-        let Some(data) = asset_manager.get(name) else {
+        let Some(data) = asset_manager.get_ref(name) else {
             continue;
         };
-        let Ok(shp) = ShpFile::from_bytes(&data) else {
+        let Ok(shp) = ShpFile::from_bytes(data) else {
             continue;
         };
         // Skip template files with no drawable frames (e.g. some bridge stubs).
@@ -565,10 +575,10 @@ pub fn compute_tiberium_radar_colors(
         );
 
         for candidate in &candidates {
-            let Some(data) = asset_manager.get(candidate) else {
+            let Some(data) = asset_manager.get_ref(candidate) else {
                 continue;
             };
-            let Ok(shp) = ShpFile::from_bytes(&data) else {
+            let Ok(shp) = ShpFile::from_bytes(data) else {
                 continue;
             };
             shp_cache.insert(overlay_id, shp);
@@ -626,10 +636,10 @@ fn probe_terrain_shp_frame_count(
         theater_name,
     );
     for candidate in &candidates {
-        let Some(data) = asset_manager.get(candidate) else {
+        let Some(data) = asset_manager.get_ref(candidate) else {
             continue;
         };
-        let Ok(shp) = ShpFile::from_bytes(&data) else {
+        let Ok(shp) = ShpFile::from_bytes(data) else {
             continue;
         };
         // Terrain SHPs store shadow frames in the second half (same layout
@@ -761,5 +771,9 @@ fn pack_overlay_sprites(
     );
 
     let texture: BatchTexture = batch.create_texture(gpu, &rgba, atlas_width, atlas_height);
-    OverlayAtlas { texture, entries, terrain_anim_frames }
+    OverlayAtlas {
+        texture,
+        entries,
+        terrain_anim_frames,
+    }
 }

--- a/src/render/sidebar_cameo_atlas.rs
+++ b/src/render/sidebar_cameo_atlas.rs
@@ -110,10 +110,10 @@ pub fn export_debug_palette_sheet(
     let mut max_cameo_w = 1u32;
     let mut max_cameo_h = 1u32;
     for &palette_name in palette_names {
-        let Some(data) = asset_manager.get(palette_name) else {
+        let Some(data) = asset_manager.get_ref(palette_name) else {
             continue;
         };
-        let Ok(palette) = Palette::from_bytes(&data) else {
+        let Ok(palette) = Palette::from_bytes(data) else {
             continue;
         };
         let mut row: Vec<RenderedCameo> = Vec::new();
@@ -212,8 +212,8 @@ fn render_cameo(
 
     let (data, file_name) = candidates
         .iter()
-        .find_map(|name| asset_manager.get(name).map(|data| (data, name.clone())))?;
-    let shp = ShpFile::from_bytes(&data).ok()?;
+        .find_map(|name| asset_manager.get_ref(name).map(|data| (data, name.clone())))?;
+    let shp = ShpFile::from_bytes(data).ok()?;
     if shp.frames.is_empty() {
         return None;
     }

--- a/src/render/sidebar_chrome.rs
+++ b/src/render/sidebar_chrome.rs
@@ -165,15 +165,14 @@ fn build_theme_atlas(
     radar_name: &str,
     background_names: Option<(&str, &str, &str)>,
 ) -> Option<SidebarChromeAtlas> {
-    let mix_bytes = asset_manager.get(mix_name)?;
-    let mix = MixArchive::from_bytes(mix_bytes).ok()?;
+    let mix = asset_manager.archive(mix_name)?;
     let palette = mix
         .get_by_name(palette_name)
         .and_then(|bytes| Palette::from_bytes(bytes).ok())
         .or_else(|| {
             asset_manager
-                .get(palette_name)
-                .and_then(|bytes| Palette::from_bytes(&bytes).ok())
+                .get_ref(palette_name)
+                .and_then(|bytes| Palette::from_bytes(bytes).ok())
         })?;
     // For sidebar inspection/fidelity work, decode every sidebar-side MIX SHP
     // with the theme's main sidebar palette so unknown pieces are comparable
@@ -547,8 +546,10 @@ fn render_all_radar_frames(
     radar_name: &str,
     palette: &Palette,
 ) -> (Vec<Vec<u8>>, [u32; 2], [u32; 4]) {
-    let owned_bytes = asset_manager.get(radar_name);
-    let shp_bytes = match mix.get_by_name(radar_name).or(owned_bytes.as_deref()) {
+    let shp_bytes = match mix
+        .get_by_name(radar_name)
+        .or_else(|| asset_manager.get_ref(radar_name))
+    {
         Some(b) => b,
         None => return (Vec::new(), [0, 0], [0; 4]),
     };
@@ -707,8 +708,9 @@ fn render_entry(
     palette: &Palette,
     frame_index: usize,
 ) -> Option<RenderedChromeEntry> {
-    let owned_bytes = asset_manager.get(shp_name);
-    let shp_bytes = mix.get_by_name(shp_name).or(owned_bytes.as_deref())?;
+    let shp_bytes = mix
+        .get_by_name(shp_name)
+        .or_else(|| asset_manager.get_ref(shp_name))?;
     let shp = ShpFile::from_bytes(shp_bytes).ok()?;
     render_shp(&shp, palette, frame_index)
 }

--- a/src/render/sprite_atlas.rs
+++ b/src/render/sprite_atlas.rs
@@ -186,9 +186,10 @@ pub fn collect_needed_base_keys(
         }
         let owner_str = interner.map_or("", |i| i.resolve(entity.owner));
         let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
-        let color_idx: HouseColorIndex =
-            house_colors.get(owner_str).copied()
-                .unwrap_or(crate::rules::house_colors::NO_REMAP);
+        let color_idx: HouseColorIndex = house_colors
+            .get(owner_str)
+            .copied()
+            .unwrap_or(crate::rules::house_colors::NO_REMAP);
         base_keys.insert((type_str.to_string(), color_idx));
     }
     // Include extra building types (deployable ConYards etc.).
@@ -275,9 +276,10 @@ pub fn build_sprite_atlas(
         }
         let owner_str = interner.map_or("", |i| i.resolve(entity.owner));
         let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
-        let color_idx: HouseColorIndex =
-            house_colors.get(owner_str).copied()
-                .unwrap_or(crate::rules::house_colors::NO_REMAP);
+        let color_idx: HouseColorIndex = house_colors
+            .get(owner_str)
+            .copied()
+            .unwrap_or(crate::rules::house_colors::NO_REMAP);
         match entity.category {
             EntityCategory::Structure => {
                 needed.insert(ShpSpriteKey {
@@ -434,9 +436,10 @@ pub fn build_sprite_atlas(
                                 theater_ext,
                                 theater_name,
                             );
-                            if let Some(data) = candidates.iter().find_map(|c| asset_manager.get(c))
+                            if let Some(data) =
+                                candidates.iter().find_map(|c| asset_manager.get_ref(c))
                             {
-                                if let Ok(shp) = ShpFile::from_bytes(&data) {
+                                if let Ok(shp) = ShpFile::from_bytes(data) {
                                     // RA2 anim SHPs have shadow frames in second half.
                                     let real: u16 = (shp.frames.len() as u16) / 2;
                                     // Ensure we load at least loop_end frames so every
@@ -488,9 +491,10 @@ pub fn build_sprite_atlas(
                                 theater_ext,
                                 theater_name,
                             );
-                            if let Some(data) = candidates.iter().find_map(|c| asset_manager.get(c))
+                            if let Some(data) =
+                                candidates.iter().find_map(|c| asset_manager.get_ref(c))
                             {
-                                if let Ok(shp) = ShpFile::from_bytes(&data) {
+                                if let Ok(shp) = ShpFile::from_bytes(data) {
                                     let real: u16 = (shp.frames.len() as u16) / 2;
                                     // Same loop_end guard as ActiveAnim above.
                                     let count: u16 = if real >= anim.loop_end {
@@ -587,9 +591,9 @@ pub fn build_sprite_atlas(
             let image: String = art_reg.resolve_effective_image_id(type_id, &rules_image);
             let candidates: Vec<String> =
                 art_data::make_shp_candidates(Some(art_reg), &image, theater_ext, theater_name);
-            let shp_data: Option<Vec<u8>> = candidates.iter().find_map(|c| asset_manager.get(c));
+            let shp_data: Option<&[u8]> = candidates.iter().find_map(|c| asset_manager.get_ref(c));
             if let Some(data) = shp_data {
-                if let Ok(shp) = ShpFile::from_bytes(&data) {
+                if let Ok(shp) = ShpFile::from_bytes(data) {
                     // RA2 make SHPs have shadow frames in the second half — only use the first half.
                     let real_frames: u16 = (shp.frames.len() as u16) / 2;
                     let frame_count: u16 = if real_frames > 0 {
@@ -603,7 +607,7 @@ pub fn build_sprite_atlas(
                         frame_count,
                         candidates
                             .iter()
-                            .find(|c| asset_manager.get(c).is_some())
+                            .find(|c| asset_manager.get_ref(c).is_some())
                             .unwrap_or(&String::new()),
                     );
                     make_frame_counts.insert(make_key.clone(), frame_count);
@@ -666,8 +670,8 @@ pub fn build_sprite_atlas(
         for name in &effect_names {
             let lower: String = name.to_ascii_lowercase();
             let candidates: Vec<String> = vec![format!("{}.shp", lower), format!("{}.SHP", name)];
-            if let Some(data) = candidates.iter().find_map(|c| asset_manager.get(c)) {
-                if let Ok(shp) = ShpFile::from_bytes(&data) {
+            if let Some(data) = candidates.iter().find_map(|c| asset_manager.get_ref(c)) {
+                if let Ok(shp) = ShpFile::from_bytes(data) {
                     let real: u16 = (shp.frames.len() as u16) / 2;
                     let count: u16 = if real > 0 {
                         real
@@ -714,8 +718,8 @@ pub fn build_sprite_atlas(
     // Load anim.pal for world effect SHPs. Anim types (explosions, warp flashes,
     // etc.) are drawn with anim.pal, not unit.pal.
     let effect_palette: Option<Palette> = asset_manager
-        .get("anim.pal")
-        .and_then(|d| Palette::from_bytes(&d).ok());
+        .get_ref("anim.pal")
+        .and_then(|d| Palette::from_bytes(d).ok());
     if effect_palette.is_none() && !effect_type_ids.is_empty() {
         log::warn!("anim.pal not found — world effect SHPs will use unit.pal (wrong colors)");
     }
@@ -760,8 +764,7 @@ pub fn build_sprite_atlas(
         house_color: HouseColorIndex::default(),
     });
     if has_harvesters && !oregath_cached {
-        let oregath_sprites: Vec<RenderedShpSprite> =
-            render_harvest_overlay_frames(asset_manager);
+        let oregath_sprites: Vec<RenderedShpSprite> = render_harvest_overlay_frames(asset_manager);
         if !oregath_sprites.is_empty() {
             log::info!(
                 "Rendered {} oregath.shp harvest overlay frames",
@@ -932,9 +935,9 @@ fn render_shp_sprite(
     };
 
     // Try each candidate in order until one is found.
-    let mut lookup_result: Option<(Vec<u8>, String)> = None;
+    let mut lookup_result: Option<(&[u8], String)> = None;
     for name in &candidates {
-        if let Some(data) = asset_manager.get(name) {
+        if let Some(data) = asset_manager.get_ref(name) {
             lookup_result = Some((data, name.clone()));
             break;
         }
@@ -957,7 +960,7 @@ fn render_shp_sprite(
         );
     }
     log::trace!("Loaded SHP: {} ({} bytes)", found_name, shp_data.len());
-    let shp: ShpFile = match ShpFile::from_bytes(&shp_data) {
+    let shp: ShpFile = match ShpFile::from_bytes(shp_data) {
         Ok(s) => s,
         Err(e) => {
             log::warn!("Failed to parse {}: {}", found_name, e);
@@ -1094,14 +1097,14 @@ pub fn canonical_infantry_facing(facing: u8) -> u8 {
 /// At render time, the correct frame is: `facing_index * 15 + anim_frame`.
 fn render_harvest_overlay_frames(asset_manager: &AssetManager) -> Vec<RenderedShpSprite> {
     // Load effect palette (anim.pal).
-    let pal_data: Vec<u8> = match asset_manager.get("anim.pal") {
+    let pal_data: &[u8] = match asset_manager.get_ref("anim.pal") {
         Some(d) => d,
         None => {
             log::warn!("anim.pal not found — skipping harvest overlay");
             return Vec::new();
         }
     };
-    let palette: Palette = match Palette::from_bytes(&pal_data) {
+    let palette: Palette = match Palette::from_bytes(pal_data) {
         Ok(p) => p,
         Err(e) => {
             log::warn!("Failed to parse anim.pal: {} — skipping harvest overlay", e);
@@ -1110,14 +1113,14 @@ fn render_harvest_overlay_frames(asset_manager: &AssetManager) -> Vec<RenderedSh
     };
 
     // Load oregath.shp.
-    let shp_data: Vec<u8> = match asset_manager.get("oregath.shp") {
+    let shp_data: &[u8] = match asset_manager.get_ref("oregath.shp") {
         Some(d) => d,
         None => {
             log::warn!("oregath.shp not found — skipping harvest overlay");
             return Vec::new();
         }
     };
-    let shp: ShpFile = match ShpFile::from_bytes(&shp_data) {
+    let shp: ShpFile = match ShpFile::from_bytes(shp_data) {
         Ok(s) => s,
         Err(e) => {
             log::warn!(

--- a/src/render/unit_atlas.rs
+++ b/src/render/unit_atlas.rs
@@ -183,8 +183,7 @@ pub fn collect_needed_unit_keys(
         }
         let owner_str = interner.map_or("", |i| i.resolve(entity.owner));
         let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
-        let color_idx: HouseColorIndex =
-            house_colors.get(owner_str).copied().unwrap_or_default();
+        let color_idx: HouseColorIndex = house_colors.get(owner_str).copied().unwrap_or_default();
         // Ground vehicles can drive onto any ramp, so pre-render all 9 slope
         // variants (0=flat, 1-8=ramps) upfront. Aircraft never tilt on slopes.
         let is_ground_vehicle: bool = entity.category != EntityCategory::Aircraft;
@@ -200,8 +199,7 @@ pub fn collect_needed_unit_keys(
         for &layer in layers {
             let fc_key: (String, VxlLayer) = (type_str.to_string(), layer);
             if !frame_counts.contains_key(&fc_key) {
-                let fc: u32 =
-                    detect_hva_frame_count(asset_manager, type_str, layer, rules, art);
+                let fc: u32 = detect_hva_frame_count(asset_manager, type_str, layer, rules, art);
                 frame_counts.insert(fc_key.clone(), fc);
             }
             let num_frames: u32 = frame_counts[&fc_key];
@@ -209,11 +207,8 @@ pub fn collect_needed_unit_keys(
             // Ground vehicles: generate all 9 slope variants (0-8) so no
             // atlas rebuild is needed when driving onto ramps.
             // Aircraft: only slope_type=0 (flat).
-            let slope_range: std::ops::RangeInclusive<u8> = if is_ground_vehicle {
-                0..=8
-            } else {
-                0..=0
-            };
+            let slope_range: std::ops::RangeInclusive<u8> =
+                if is_ground_vehicle { 0..=8 } else { 0..=0 };
             for bucket in 0..buckets {
                 let facing: u8 = bucket.saturating_mul(step);
                 for frame in 0..num_frames {
@@ -252,8 +247,7 @@ pub fn collect_needed_unit_keys(
                 Some(id) => id,
                 None => continue,
             };
-            let hc: HouseColorIndex =
-                house_colors.get(bowner_str).copied().unwrap_or_default();
+            let hc: HouseColorIndex = house_colors.get(bowner_str).copied().unwrap_or_default();
             for bucket in 0..TURRET_FACING_BUCKETS {
                 let facing: u8 = bucket.saturating_mul(TURRET_FACING_STEP);
                 needed.insert(UnitSpriteKey {
@@ -309,8 +303,7 @@ pub fn build_unit_atlas(
         }
         let owner_str = interner.map_or("", |i| i.resolve(entity.owner));
         let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
-        let color_idx: HouseColorIndex =
-            house_colors.get(owner_str).copied().unwrap_or_default();
+        let color_idx: HouseColorIndex = house_colors.get(owner_str).copied().unwrap_or_default();
         let is_ground_vehicle: bool = entity.category != EntityCategory::Aircraft;
         let has_turret: bool = rules
             .and_then(|r| r.object(type_str))
@@ -324,8 +317,7 @@ pub fn build_unit_atlas(
         for &layer in layers {
             let fc_key: (String, VxlLayer) = (type_str.to_string(), layer);
             if !frame_counts.contains_key(&fc_key) {
-                let fc: u32 =
-                    detect_hva_frame_count(asset_manager, type_str, layer, rules, art);
+                let fc: u32 = detect_hva_frame_count(asset_manager, type_str, layer, rules, art);
                 if fc > 1 {
                     log::info!(
                         "VXL {}/{:?} has {} HVA frames — rendering all",
@@ -338,11 +330,8 @@ pub fn build_unit_atlas(
             }
             let num_frames: u32 = frame_counts[&fc_key];
             let (step, buckets) = facing_config_for_layer(layer);
-            let slope_range: std::ops::RangeInclusive<u8> = if is_ground_vehicle {
-                0..=8
-            } else {
-                0..=0
-            };
+            let slope_range: std::ops::RangeInclusive<u8> =
+                if is_ground_vehicle { 0..=8 } else { 0..=0 };
             for bucket in 0..buckets {
                 let facing: u8 = bucket.saturating_mul(step);
                 for frame in 0..num_frames {
@@ -381,8 +370,7 @@ pub fn build_unit_atlas(
                 Some(id) => id,
                 None => continue,
             };
-            let hc: HouseColorIndex =
-                house_colors.get(bowner_str).copied().unwrap_or_default();
+            let hc: HouseColorIndex = house_colors.get(bowner_str).copied().unwrap_or_default();
             for bucket in 0..TURRET_FACING_BUCKETS {
                 let facing: u8 = bucket.saturating_mul(TURRET_FACING_STEP);
                 needed.insert(UnitSpriteKey {
@@ -427,8 +415,8 @@ pub fn build_unit_atlas(
         // Load VPL file for Blinn-Phong lighting lookup (optional).
         let vpl: Option<VplFile> =
             asset_manager
-                .get("VOXELS.VPL")
-                .and_then(|data| match VplFile::from_bytes(&data) {
+                .get_ref("VOXELS.VPL")
+                .and_then(|data| match VplFile::from_bytes(data) {
                     Ok(v) => {
                         log::info!("Loaded VOXELS.VPL ({} lighting sections)", v.num_sections);
                         Some(v)
@@ -530,8 +518,8 @@ fn render_unit_sprite(
 
     let (vxl_name, hva_name): (String, String) = art_data::voxel_asset_names(&image);
 
-    let vxl_data: Vec<u8> = asset_manager.get(&vxl_name)?;
-    let vxl: VxlFile = match VxlFile::from_bytes(&vxl_data) {
+    let vxl_data = asset_manager.get_ref(&vxl_name)?;
+    let vxl: VxlFile = match VxlFile::from_bytes(vxl_data) {
         Ok(v) => v,
         Err(e) => {
             log::warn!("Failed to parse {}: {}", vxl_name, e);
@@ -542,8 +530,8 @@ fn render_unit_sprite(
     // HVA is optional — some models don't have animation files.
     let hva: Option<HvaFile> =
         asset_manager
-            .get(&hva_name)
-            .and_then(|data| match HvaFile::from_bytes(&data) {
+            .get_ref(&hva_name)
+            .and_then(|data| match HvaFile::from_bytes(data) {
                 Ok(h) => Some(h),
                 Err(e) => {
                     log::trace!("No HVA for {} ({}), using default pose", key.type_id, e);
@@ -586,12 +574,12 @@ fn render_unit_sprite(
 
         // Turret VXL.
         let tur_vxl_name = format!("{}TUR.VXL", image);
-        if let Some(tur_data) = asset_manager.get(&tur_vxl_name) {
-            if let Ok(tur_vxl) = VxlFile::from_bytes(&tur_data) {
+        if let Some(tur_data) = asset_manager.get_ref(&tur_vxl_name) {
+            if let Ok(tur_vxl) = VxlFile::from_bytes(tur_data) {
                 let tur_hva_name = format!("{}TUR.HVA", image);
                 let tur_hva = asset_manager
-                    .get(&tur_hva_name)
-                    .and_then(|d| HvaFile::from_bytes(&d).ok());
+                    .get_ref(&tur_hva_name)
+                    .and_then(|d| HvaFile::from_bytes(d).ok());
                 let (tur_limbs, _) =
                     vxl_raster::prepare_limb_data(&tur_vxl, tur_hva.as_ref(), &params);
                 all_limb_data.extend(tur_limbs);
@@ -602,16 +590,16 @@ fn render_unit_sprite(
         let barl_vxl_name = format!("{}BARL.VXL", image);
         let barrel_vxl_name = format!("{}BARREL.VXL", image);
         let barl_data = asset_manager
-            .get(&barl_vxl_name)
-            .or_else(|| asset_manager.get(&barrel_vxl_name));
+            .get_ref(&barl_vxl_name)
+            .or_else(|| asset_manager.get_ref(&barrel_vxl_name));
         if let Some(bd) = barl_data {
-            if let Ok(barl_vxl) = VxlFile::from_bytes(&bd) {
+            if let Ok(barl_vxl) = VxlFile::from_bytes(bd) {
                 let barl_hva_name = format!("{}BARL.HVA", image);
                 let barrel_hva_name = format!("{}BARREL.HVA", image);
                 let barl_hva = asset_manager
-                    .get(&barl_hva_name)
-                    .or_else(|| asset_manager.get(&barrel_hva_name))
-                    .and_then(|d| HvaFile::from_bytes(&d).ok());
+                    .get_ref(&barl_hva_name)
+                    .or_else(|| asset_manager.get_ref(&barrel_hva_name))
+                    .and_then(|d| HvaFile::from_bytes(d).ok());
                 let (barl_limbs, _) =
                     vxl_raster::prepare_limb_data(&barl_vxl, barl_hva.as_ref(), &params);
                 all_limb_data.extend(barl_limbs);
@@ -800,8 +788,8 @@ fn detect_hva_frame_count(
     };
 
     let frame_count: u32 = asset_manager
-        .get(&hva_name)
-        .and_then(|data| HvaFile::from_bytes(&data).ok())
+        .get_ref(&hva_name)
+        .and_then(|data| HvaFile::from_bytes(data).ok())
         .map(|h| h.frame_count)
         .unwrap_or(1);
 
@@ -809,8 +797,8 @@ fn detect_hva_frame_count(
     if layer == VxlLayer::Barrel && frame_count <= 1 {
         let alt_name: String = format!("{}BARREL.HVA", image);
         let alt_count: u32 = asset_manager
-            .get(&alt_name)
-            .and_then(|data| HvaFile::from_bytes(&data).ok())
+            .get_ref(&alt_name)
+            .and_then(|data| HvaFile::from_bytes(data).ok())
             .map(|h| h.frame_count)
             .unwrap_or(1);
         if alt_count > 1 {
@@ -829,12 +817,12 @@ fn render_optional_layer(
     vpl: Option<&VplFile>,
 ) -> Option<VxlSprite> {
     let vxl_name = format!("{}.VXL", layer_base);
-    let vxl_data = asset_manager.get(&vxl_name)?;
-    let vxl = VxlFile::from_bytes(&vxl_data).ok()?;
+    let vxl_data = asset_manager.get_ref(&vxl_name)?;
+    let vxl = VxlFile::from_bytes(vxl_data).ok()?;
     let hva_name = format!("{}.HVA", layer_base);
     let hva = asset_manager
-        .get(&hva_name)
-        .and_then(|data| HvaFile::from_bytes(&data).ok());
+        .get_ref(&hva_name)
+        .and_then(|data| HvaFile::from_bytes(data).ok());
     Some(vxl_raster::render_vxl(
         &vxl,
         hva.as_ref(),


### PR DESCRIPTION
- memory-map top-level MIX archives instead of always copying them into RAM
- add a first-match asset index so lookups stop scanning the full archive stack
- cheap-check candidate nested MIX payloads before cloning and parsing them
