### PR TITLE
Implement prone damage scaling

### DIFF
--- a/src/rules/warhead_type.rs
+++ b/src/rules/warhead_type.rs
@@ -57,9 +57,9 @@ pub struct WarheadType {
     pub tiberium: bool,
     /// Bright flash on detonation. Offset +0x14F.
     pub bright: bool,
-    /// Damage multiplier against prone infantry. Offset +0x150 in-game as a double.
-    /// Examples: `50%` -> `0.5`, `100%` -> `1.0`, `300%` -> `3.0`.
-    pub prone_damage: f64,
+    /// Damage multiplier against prone infantry, stored as 1.0 = 10_000 basis points.
+    /// Examples: `50%` -> `5_000`, `100%` -> `10_000`, `300%` -> `30_000`.
+    pub prone_damage_basis_points: u32,
     /// Instantly destroys any wall. Offset +0x151.
     pub wall_absolute_destroyer: bool,
     /// Chrono legionnaire erase effect. Offset +0x152.
@@ -153,7 +153,7 @@ impl WarheadType {
             rocker: section.get_bool("Rocker").unwrap_or(false),
             tiberium: section.get_bool("Tiberium").unwrap_or(false),
             bright: section.get_bool("Bright").unwrap_or(false),
-            prone_damage: section.get_percent("ProneDamage").map(f64::from).unwrap_or(1.0),
+            prone_damage_basis_points: parse_prone_damage_basis_points(section),
             wall_absolute_destroyer: section.get_bool("WallAbsoluteDestroyer").unwrap_or(false),
             temporal: section.get_bool("Temporal").unwrap_or(false),
             is_locomotor: section.get_bool("IsLocomotor").unwrap_or(false),
@@ -200,6 +200,29 @@ fn parse_verses(raw: &str) -> Vec<u8> {
         .collect()
 }
 
+fn parse_prone_damage_basis_points(section: &IniSection) -> u32 {
+    let Some(raw) = section.get("ProneDamage") else {
+        return 10_000;
+    };
+
+    let value = raw.trim();
+    let basis_points = if let Some(stripped) = value.strip_suffix('%') {
+        stripped.trim().parse::<f64>().ok().map(|v| v * 100.0)
+    } else {
+        value.parse::<f64>().ok().map(|v| v * 10_000.0)
+    };
+
+    let Some(basis_points) = basis_points else {
+        return 10_000;
+    };
+
+    if !basis_points.is_finite() || basis_points < 0.0 {
+        return 10_000;
+    }
+
+    basis_points.round().clamp(0.0, u32::MAX as f64) as u32
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,7 +257,7 @@ mod tests {
         assert!(wh.verses.is_empty());
         assert_eq!(wh.cell_spread, SIM_ZERO);
         assert_eq!(wh.percent_at_max, 100);
-        assert_eq!(wh.prone_damage, 1.0);
+        assert_eq!(wh.prone_damage_basis_points, 10_000);
         assert!(!wh.wall);
     }
 
@@ -265,15 +288,31 @@ mod tests {
 
     #[test]
     fn test_prone_damage_parses_as_multiplier() {
-        let ini: IniFile =
-            IniFile::from_str("[AP]\nProneDamage=50%\n[Gas]\nProneDamage=300%\n[Raw]\nProneDamage=1.25\n");
+        let ini: IniFile = IniFile::from_str(
+            "[AP]\nProneDamage=50%\n[Gas]\nProneDamage=300%\n[Raw]\nProneDamage=1.25\n",
+        );
 
         let ap = WarheadType::from_ini_section("AP", ini.section("AP").unwrap());
         let gas = WarheadType::from_ini_section("Gas", ini.section("Gas").unwrap());
         let raw = WarheadType::from_ini_section("Raw", ini.section("Raw").unwrap());
 
-        assert!((ap.prone_damage - 0.5).abs() < f64::EPSILON);
-        assert!((gas.prone_damage - 3.0).abs() < f64::EPSILON);
-        assert!((raw.prone_damage - 1.25).abs() < f64::EPSILON);
+        assert_eq!(ap.prone_damage_basis_points, 5_000);
+        assert_eq!(gas.prone_damage_basis_points, 30_000);
+        assert_eq!(raw.prone_damage_basis_points, 12_500);
+    }
+
+    #[test]
+    fn test_prone_damage_invalid_values_fall_back_to_default() {
+        let ini: IniFile = IniFile::from_str(
+            "[Neg]\nProneDamage=-1\n[Bad]\nProneDamage=wat\n[Huge]\nProneDamage=inf\n",
+        );
+
+        let neg = WarheadType::from_ini_section("Neg", ini.section("Neg").unwrap());
+        let bad = WarheadType::from_ini_section("Bad", ini.section("Bad").unwrap());
+        let huge = WarheadType::from_ini_section("Huge", ini.section("Huge").unwrap());
+
+        assert_eq!(neg.prone_damage_basis_points, 10_000);
+        assert_eq!(bad.prone_damage_basis_points, 10_000);
+        assert_eq!(huge.prone_damage_basis_points, 10_000);
     }
 }

--- a/src/rules/warhead_type.rs
+++ b/src/rules/warhead_type.rs
@@ -57,8 +57,9 @@ pub struct WarheadType {
     pub tiberium: bool,
     /// Bright flash on detonation. Offset +0x14F.
     pub bright: bool,
-    /// Extra damage to prone infantry. Offset +0x150.
-    pub prone_damage: bool,
+    /// Damage multiplier against prone infantry. Offset +0x150 in-game as a double.
+    /// Examples: `50%` -> `0.5`, `100%` -> `1.0`, `300%` -> `3.0`.
+    pub prone_damage: f64,
     /// Instantly destroys any wall. Offset +0x151.
     pub wall_absolute_destroyer: bool,
     /// Chrono legionnaire erase effect. Offset +0x152.
@@ -152,7 +153,7 @@ impl WarheadType {
             rocker: section.get_bool("Rocker").unwrap_or(false),
             tiberium: section.get_bool("Tiberium").unwrap_or(false),
             bright: section.get_bool("Bright").unwrap_or(false),
-            prone_damage: section.get_bool("ProneDamage").unwrap_or(false),
+            prone_damage: section.get_percent("ProneDamage").map(f64::from).unwrap_or(1.0),
             wall_absolute_destroyer: section.get_bool("WallAbsoluteDestroyer").unwrap_or(false),
             temporal: section.get_bool("Temporal").unwrap_or(false),
             is_locomotor: section.get_bool("IsLocomotor").unwrap_or(false),
@@ -233,6 +234,7 @@ mod tests {
         assert!(wh.verses.is_empty());
         assert_eq!(wh.cell_spread, SIM_ZERO);
         assert_eq!(wh.percent_at_max, 100);
+        assert_eq!(wh.prone_damage, 1.0);
         assert!(!wh.wall);
     }
 
@@ -259,5 +261,19 @@ mod tests {
         assert_eq!(result[0], 100);
         assert_eq!(result[1], 50);
         assert_eq!(result[2], 25);
+    }
+
+    #[test]
+    fn test_prone_damage_parses_as_multiplier() {
+        let ini: IniFile =
+            IniFile::from_str("[AP]\nProneDamage=50%\n[Gas]\nProneDamage=300%\n[Raw]\nProneDamage=1.25\n");
+
+        let ap = WarheadType::from_ini_section("AP", ini.section("AP").unwrap());
+        let gas = WarheadType::from_ini_section("Gas", ini.section("Gas").unwrap());
+        let raw = WarheadType::from_ini_section("Raw", ini.section("Raw").unwrap());
+
+        assert!((ap.prone_damage - 0.5).abs() < f64::EPSILON);
+        assert!((gas.prone_damage - 3.0).abs() < f64::EPSILON);
+        assert!((raw.prone_damage - 1.25).abs() < f64::EPSILON);
     }
 }

--- a/src/sim/animation.rs
+++ b/src/sim/animation.rs
@@ -226,6 +226,11 @@ pub fn sequence_is_prone(sequence: SequenceKind) -> bool {
 }
 
 /// Whether the current animation represents a prone stance.
+///
+/// TODO(RE): The sim does not yet enter these sequences during live infantry
+/// combat because prone-entry behavior has not been reverse engineered yet.
+/// This helper only recognizes prone once some other system explicitly switches
+/// the animation into one of the prone-related sequences.
 pub fn animation_is_prone(animation: Option<&Animation>) -> bool {
     animation.is_some_and(|anim| sequence_is_prone(anim.sequence))
 }

--- a/src/sim/animation.rs
+++ b/src/sim/animation.rs
@@ -211,6 +211,25 @@ impl Animation {
     }
 }
 
+/// Whether a sequence represents the infantry being in a prone stance.
+///
+/// This is a temporary stance proxy until the sim carries an explicit prone bit.
+pub fn sequence_is_prone(sequence: SequenceKind) -> bool {
+    matches!(
+        sequence,
+        SequenceKind::Prone
+            | SequenceKind::Crawl
+            | SequenceKind::FireProne
+            | SequenceKind::SecondaryProne
+            | SequenceKind::Down
+    )
+}
+
+/// Whether the current animation represents a prone stance.
+pub fn animation_is_prone(animation: Option<&Animation>) -> bool {
+    animation.is_some_and(|anim| sequence_is_prone(anim.sequence))
+}
+
 /// Collection of sequence definitions for one object type.
 ///
 /// Maps `SequenceKind` → `SequenceDef`. Not all kinds need to be present;

--- a/src/sim/animation_tests.rs
+++ b/src/sim/animation_tests.rs
@@ -409,3 +409,13 @@ fn test_tick_dying_entity_returns_finished_id() {
     let dead = tick_animations(&mut store, &sequences, 16, &interner);
     assert_eq!(dead, vec![1]);
 }
+
+#[test]
+fn test_sequence_is_prone_helper() {
+    assert!(sequence_is_prone(SequenceKind::Prone));
+    assert!(sequence_is_prone(SequenceKind::Crawl));
+    assert!(sequence_is_prone(SequenceKind::FireProne));
+    assert!(sequence_is_prone(SequenceKind::Down));
+    assert!(!sequence_is_prone(SequenceKind::Stand));
+    assert!(!sequence_is_prone(SequenceKind::Up));
+}

--- a/src/sim/combat/combat_aoe.rs
+++ b/src/sim/combat/combat_aoe.rs
@@ -14,8 +14,10 @@
 //! - sim/ NEVER depends on render/, ui/, sidebar/, audio/, net/.
 
 use super::{apply_prone_damage_modifier, armor_index, lepton_distance_sq_raw};
+use crate::map::entities::EntityCategory;
 use crate::rules::ruleset::RuleSet;
 use crate::rules::warhead_type::WarheadType;
+use crate::sim::animation::animation_is_prone;
 use crate::sim::entity_store::EntityStore;
 use crate::sim::intern::StringInterner;
 use crate::util::fixed_math::{SIM_ZERO, SimFixed, isqrt_i64};
@@ -94,7 +96,9 @@ pub(crate) fn apply_aoe_damage(
             warhead.percent_at_max,
             verses_pct,
         );
-        let dmg: u16 = apply_prone_damage_modifier(entity, warhead, raw_damage as i32);
+        let prone_infantry = entity.category == EntityCategory::Infantry
+            && animation_is_prone(entity.animation.as_ref());
+        let dmg: u16 = apply_prone_damage_modifier(prone_infantry, warhead, raw_damage as i32);
 
         if dmg > 0 {
             damage_list.push((entity.stable_id, dmg));

--- a/src/sim/combat/combat_aoe.rs
+++ b/src/sim/combat/combat_aoe.rs
@@ -13,7 +13,7 @@
 //! - Part of sim/ — depends on rules/ (RuleSet, WarheadType) and sim/components.
 //! - sim/ NEVER depends on render/, ui/, sidebar/, audio/, net/.
 
-use super::{armor_index, lepton_distance_sq_raw};
+use super::{apply_prone_damage_modifier, armor_index, lepton_distance_sq_raw};
 use crate::rules::ruleset::RuleSet;
 use crate::rules::warhead_type::WarheadType;
 use crate::sim::entity_store::EntityStore;
@@ -87,13 +87,14 @@ pub(crate) fn apply_aoe_damage(
         let idx: usize = armor_index(armor_str);
         let verses_pct: u8 = warhead.verses.get(idx).copied().unwrap_or(100);
 
-        let dmg: u16 = aoe_damage_at_distance(
+        let raw_damage: u16 = aoe_damage_at_distance(
             base_damage,
             distance,
             cell_spread,
             warhead.percent_at_max,
             verses_pct,
         );
+        let dmg: u16 = apply_prone_damage_modifier(entity, warhead, raw_damage as i32);
 
         if dmg > 0 {
             damage_list.push((entity.stable_id, dmg));

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -5,8 +5,10 @@
 use std::collections::BTreeMap;
 
 use super::*;
+use crate::map::entities::EntityCategory;
 use crate::rules::ini_parser::IniFile;
 use crate::rules::ruleset::RuleSet;
+use crate::sim::animation::{Animation, SequenceKind};
 use crate::sim::components::Health;
 use crate::sim::entity_store::EntityStore;
 use crate::sim::game_entity::GameEntity;
@@ -55,6 +57,14 @@ fn make_entity_owned(
         current: hp,
         max: hp,
     };
+    e
+}
+
+fn make_infantry_entity(id: u64, type_ref: &str, rx: u16, ry: u16, hp: u16) -> GameEntity {
+    let mut e = make_entity(id, type_ref, rx, ry, hp);
+    e.category = EntityCategory::Infantry;
+    e.is_voxel = false;
+    e.animation = Some(Animation::new(SequenceKind::Stand));
     e
 }
 
@@ -258,6 +268,70 @@ fn test_infantry_vs_heavy_armor() {
         300 - 6,
         "Infantry vs heavy armor should do 6 damage (25 * 25 / 100)"
     );
+}
+
+#[test]
+fn test_prone_infantry_takes_scaled_direct_damage() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=E1\n1=E2\n\n\
+         [VehicleTypes]\n0=MTNK\n\n\
+         [AircraftTypes]\n\n\
+         [BuildingTypes]\n\n\
+         [E1]\nStrength=125\nArmor=flak\nSpeed=4\nPrimary=M60\n\n\
+         [E2]\nStrength=125\nArmor=flak\nSpeed=4\n\n\
+         [MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nPrimary=105mm\n\n\
+         [M60]\nDamage=25\nROF=20\nRange=5\nWarhead=SA\n\n\
+         [105mm]\nDamage=100\nROF=50\nRange=6\nWarhead=AP\n\n\
+         [SA]\nVerses=100%,100%,100%,90%,70%,25%,100%,25%,25%,0%,0%\n\n\
+         [AP]\nVerses=100%,100%,90%,75%,75%,75%,60%,30%,20%,0%,0%\nProneDamage=50%\n",
+    ))
+    .expect("prone combat rules should parse");
+
+    let mut store = EntityStore::new();
+    store.insert(make_entity(1, "MTNK", 5, 5, 300));
+    let mut target = make_infantry_entity(2, "E2", 8, 5, 125);
+    target.animation = Some(Animation::new(SequenceKind::Prone));
+    store.insert(target);
+
+    let mut interner = test_interner();
+    issue_attack_command(&mut store, 1, 2, None, &interner);
+
+    tick_combat(&mut store, &rules, &mut interner, &mut BTreeMap::new(), 100);
+
+    let target_health = store.get(2).expect("target alive").health.current;
+    assert_eq!(target_health, 75, "100 damage with ProneDamage=50% should deal 50");
+}
+
+#[test]
+fn test_prone_infantry_takes_scaled_aoe_damage() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=E1\n1=E2\n\n\
+         [VehicleTypes]\n0=MTNK\n\n\
+         [AircraftTypes]\n\n\
+         [BuildingTypes]\n\n\
+         [E1]\nStrength=125\nArmor=flak\nSpeed=4\nPrimary=M60\n\n\
+         [E2]\nStrength=125\nArmor=flak\nSpeed=4\n\n\
+         [MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nPrimary=105mm\n\n\
+         [M60]\nDamage=25\nROF=20\nRange=5\nWarhead=SA\n\n\
+         [105mm]\nDamage=100\nROF=50\nRange=6\nWarhead=AP\n\n\
+         [SA]\nVerses=100%,100%,100%,90%,70%,25%,100%,25%,25%,0%,0%\n\n\
+         [AP]\nCellSpread=1\nPercentAtMax=1\nVerses=100%,100%,90%,75%,75%,75%,60%,30%,20%,0%,0%\nProneDamage=50%\n",
+    ))
+    .expect("prone aoe combat rules should parse");
+
+    let mut store = EntityStore::new();
+    store.insert(make_entity(1, "MTNK", 5, 5, 300));
+    let mut target = make_infantry_entity(2, "E2", 8, 5, 125);
+    target.animation = Some(Animation::new(SequenceKind::Prone));
+    store.insert(target);
+
+    let mut interner = test_interner();
+    issue_attack_command(&mut store, 1, 2, None, &interner);
+
+    tick_combat(&mut store, &rules, &mut interner, &mut BTreeMap::new(), 100);
+
+    let target_health = store.get(2).expect("target alive").health.current;
+    assert_eq!(target_health, 75, "AoE center hit should also respect ProneDamage=50%");
 }
 
 #[test]

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -299,7 +299,10 @@ fn test_prone_infantry_takes_scaled_direct_damage() {
     tick_combat(&mut store, &rules, &mut interner, &mut BTreeMap::new(), 100);
 
     let target_health = store.get(2).expect("target alive").health.current;
-    assert_eq!(target_health, 75, "100 damage with ProneDamage=50% should deal 50");
+    assert_eq!(
+        target_health, 75,
+        "100 damage with ProneDamage=50% should deal 50"
+    );
 }
 
 #[test]
@@ -331,7 +334,10 @@ fn test_prone_infantry_takes_scaled_aoe_damage() {
     tick_combat(&mut store, &rules, &mut interner, &mut BTreeMap::new(), 100);
 
     let target_health = store.get(2).expect("target alive").health.current;
-    assert_eq!(target_health, 75, "AoE center hit should also respect ProneDamage=50%");
+    assert_eq!(
+        target_health, 75,
+        "AoE center hit should also respect ProneDamage=50%"
+    );
 }
 
 #[test]

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -35,6 +35,8 @@ use self::combat_weapon::select_weapon_with_ifv;
 use crate::map::entities::EntityCategory;
 use crate::rules::object_type::ObjectType;
 use crate::rules::ruleset::RuleSet;
+use crate::rules::warhead_type::WarheadType;
+use crate::sim::animation::animation_is_prone;
 use crate::sim::bridge_state::BridgeDamageEvent;
 use crate::sim::entity_store::EntityStore;
 use crate::sim::intern::{InternedId, StringInterner};
@@ -84,6 +86,24 @@ const ARMOR_NAMES: &[&str] = &[
 pub fn armor_index(armor: &str) -> usize {
     let lower: String = armor.to_ascii_lowercase();
     ARMOR_NAMES.iter().position(|&a| a == lower).unwrap_or(0)
+}
+
+pub(crate) fn apply_prone_damage_modifier(
+    target: &GameEntity,
+    warhead: &WarheadType,
+    damage: i32,
+) -> u16 {
+    if damage <= 0 {
+        return 0;
+    }
+
+    let scaled = if target.category == EntityCategory::Infantry && animation_is_prone(target.animation.as_ref()) {
+        (damage as f64 * warhead.prone_damage).trunc() as i32
+    } else {
+        damage
+    };
+
+    scaled.clamp(0, u16::MAX as i32) as u16
 }
 
 /// Component: this entity is attacking a specific target entity.
@@ -1074,7 +1094,10 @@ pub fn tick_combat_with_fog(
             // Integer damage: base_damage * verses_pct / 100.
             // base_damage already includes OccupyDamageMultiplier for garrison.
             let raw_damage: i32 = base_damage * selected.verses_pct as i32 / 100;
-            let actual_damage: u16 = raw_damage.max(0) as u16;
+            let actual_damage: u16 = entities
+                .get(snap.target)
+                .map(|target| apply_prone_damage_modifier(target, warhead, raw_damage))
+                .unwrap_or(0);
             if actual_damage > 0 {
                 let wh_iid = interner.intern(&warhead.id);
                 damage_events.push((snap.target, actual_damage, snap.stable_id, wh_iid));

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -89,7 +89,7 @@ pub fn armor_index(armor: &str) -> usize {
 }
 
 pub(crate) fn apply_prone_damage_modifier(
-    target: &GameEntity,
+    target_prone_infantry: bool,
     warhead: &WarheadType,
     damage: i32,
 ) -> u16 {
@@ -97,8 +97,8 @@ pub(crate) fn apply_prone_damage_modifier(
         return 0;
     }
 
-    let scaled = if target.category == EntityCategory::Infantry && animation_is_prone(target.animation.as_ref()) {
-        (damage as f64 * warhead.prone_damage).trunc() as i32
+    let scaled = if target_prone_infantry {
+        (damage as u64 * warhead.prone_damage_basis_points as u64 / 10_000) as i32
     } else {
         damage
     };
@@ -891,6 +891,12 @@ pub fn tick_combat_with_fog(
                 t.category,
                 t.type_ref,
                 t.owner,
+                // TODO(RE): This currently keys off prone animation sequences because
+                // the runtime has no separate prone-state bit yet. Reverse engineer
+                // and implement the real infantry prone-entry conditions so
+                // ProneDamage applies during normal gameplay instead of only when
+                // prone sequences are explicitly driven.
+                t.category == EntityCategory::Infantry && animation_is_prone(t.animation.as_ref()),
             )
         });
 
@@ -903,9 +909,10 @@ pub fn tick_combat_with_fog(
             target_cat,
             target_type_ref,
             target_owner,
+            target_prone_infantry,
         ) = match target_data {
-            Some((rx, ry, sx, sy, hp, cat, tr, own)) if hp > 0 => {
-                (rx, ry, sx, sy, hp, cat, tr, own)
+            Some((rx, ry, sx, sy, hp, cat, tr, own, prone)) if hp > 0 => {
+                (rx, ry, sx, sy, hp, cat, tr, own, prone)
             }
             _ => {
                 if let Some(new_target) = acquire_best_target(
@@ -1094,10 +1101,8 @@ pub fn tick_combat_with_fog(
             // Integer damage: base_damage * verses_pct / 100.
             // base_damage already includes OccupyDamageMultiplier for garrison.
             let raw_damage: i32 = base_damage * selected.verses_pct as i32 / 100;
-            let actual_damage: u16 = entities
-                .get(snap.target)
-                .map(|target| apply_prone_damage_modifier(target, warhead, raw_damage))
-                .unwrap_or(0);
+            let actual_damage: u16 =
+                apply_prone_damage_modifier(target_prone_infantry, warhead, raw_damage);
             if actual_damage > 0 {
                 let wh_iid = interner.intern(&warhead.id);
                 damage_events.push((snap.target, actual_damage, snap.stable_id, wh_iid));


### PR DESCRIPTION
- parse `ProneDamage` as a numeric multiplier using deterministic fixed-point scaling
- apply that multiplier for direct-hit and AoE damage when the target is infantry already in a prone animation state
- add focused tests for parser behavior and both damage paths

## Scope
This PR does not implement full prone state transitions or broader infantry stance behavior. It is limited to parsing and damage scaling for targets that are already in a prone sequence, and leaves the runtime prone-entry behavior as a follow-up.
