### PR TITLE
Improve renderer ordering and hot paths

### DIFF
--- a/src/app_render/build_instances.rs
+++ b/src/app_render/build_instances.rs
@@ -198,10 +198,10 @@ pub(super) fn build_world_instances(state: &mut AppState, sw: f32, sh: f32) -> W
     // Garrison muzzle flashes (OccupantAnim) at fire port positions.
     app_instances::build_garrison_muzzle_flash_instances(state, &mut shp_paged);
     for page in &mut shp_paged {
-        sort_by_y_asc(page);
+        sort_by_depth_desc(page);
     }
     for page in &mut bridge_shp_paged {
-        sort_by_y_asc(page);
+        sort_by_depth_desc(page);
     }
 
     // One-time first-frame statistics.
@@ -275,6 +275,7 @@ pub(super) fn update_minimap(state: &mut AppState, local_owner: &Option<String>)
             &state.batch_renderer,
             &sim.entities,
             &state.house_color_map,
+            sim.tick,
             if state.sandbox_full_visibility {
                 None
             } else {
@@ -605,15 +606,6 @@ fn sort_by_depth_desc(instances: &mut [SpriteInstance]) {
     instances.sort_by(|a, b| {
         b.depth
             .partial_cmp(&a.depth)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-}
-
-/// Sort instances by Y position ascending (used for SHP pages where Y = screen row).
-fn sort_by_y_asc(instances: &mut [SpriteInstance]) {
-    instances.sort_by(|a, b| {
-        a.position[1]
-            .partial_cmp(&b.position[1])
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 }

--- a/src/app_render/merge_passes.rs
+++ b/src/app_render/merge_passes.rs
@@ -17,14 +17,36 @@ use crate::render::unit_atlas::UnitAtlas;
 ///
 /// Each group represents one GPU buffer + texture pair (e.g., VXL units, one SHP page,
 /// wall overlays). The `cursor` advances through the buffer as sub-ranges are drawn.
-/// `depths` are extracted from CPU-side instance data to avoid lifetime entanglement
-/// between GPU resources and function parameters.
-struct DrawGroup<'a> {
-    texture: &'a BatchTexture,
-    buffer: &'a wgpu::Buffer,
-    depths: Vec<f32>,
+struct DrawGroup<'tex, 'inst> {
+    texture: &'tex BatchTexture,
+    buffer: &'tex wgpu::Buffer,
+    instances: &'inst [SpriteInstance],
     cursor: u32,
     total: u32,
+}
+
+impl<'tex, 'inst> DrawGroup<'tex, 'inst> {
+    fn new(
+        texture: &'tex BatchTexture,
+        buffer: &'tex wgpu::Buffer,
+        instances: &'inst [SpriteInstance],
+        total: u32,
+    ) -> Self {
+        Self {
+            texture,
+            buffer,
+            instances,
+            cursor: 0,
+            total,
+        }
+    }
+
+    fn depth_at(&self, index: u32) -> f32 {
+        self.instances
+            .get(index as usize)
+            .map(|instance| instance.depth)
+            .unwrap_or(f32::NEG_INFINITY)
+    }
 }
 
 /// Multi-way merge for bridge entities: interleaves VXL units and SHP sprites on bridges.
@@ -40,16 +62,10 @@ pub(super) fn draw_merged_bridge_occluded_pass<'a>(
     unit_atlas: Option<&'a UnitAtlas>,
     sprite_atlas: Option<&'a SpriteAtlas>,
 ) {
-    let mut groups: Vec<DrawGroup<'a>> = Vec::new();
+    let mut groups: Vec<DrawGroup<'a, '_>> = Vec::new();
     if let (Some(ua), Some((buf, count))) = (unit_atlas, pool.get("unit_bridge")) {
         if count > 0 {
-            groups.push(DrawGroup {
-                texture: &ua.texture,
-                buffer: buf,
-                depths: unit_instances.iter().map(|s| s.depth).collect(),
-                cursor: 0,
-                total: count,
-            });
+            groups.push(DrawGroup::new(&ua.texture, buf, unit_instances, count));
         }
     }
 
@@ -64,16 +80,8 @@ pub(super) fn draw_merged_bridge_occluded_pass<'a>(
             if let Some(key) = SHP_BRIDGE_KEYS.get(i) {
                 if let Some((buf, count)) = pool.get(key) {
                     if count > 0 {
-                        groups.push(DrawGroup {
-                            texture: &page.texture,
-                            buffer: buf,
-                            depths: shp_paged
-                                .get(i)
-                                .map(|v| v.iter().map(|s| s.depth).collect())
-                                .unwrap_or_default(),
-                            cursor: 0,
-                            total: count,
-                        });
+                        let instances = shp_paged.get(i).map_or(&[][..], Vec::as_slice);
+                        groups.push(DrawGroup::new(&page.texture, buf, instances, count));
                     }
                 }
             }
@@ -91,7 +99,7 @@ pub(super) fn draw_merged_bridge_occluded_pass<'a>(
             if group.cursor >= group.total {
                 continue;
             }
-            let depth = group.depths[group.cursor as usize];
+            let depth = group.depth_at(group.cursor);
             if depth > best_depth {
                 best_depth = depth;
                 best_idx = Some(i);
@@ -101,7 +109,7 @@ pub(super) fn draw_merged_bridge_occluded_pass<'a>(
         let start = groups[best_idx].cursor;
         let mut end = start + 1;
         while end < groups[best_idx].total {
-            let depth = groups[best_idx].depths[end as usize];
+            let depth = groups[best_idx].depth_at(end);
             if depth < best_depth {
                 break;
             }
@@ -142,19 +150,12 @@ pub(super) fn draw_merged_object_pass<'a>(
     // Sort is by depth DESCENDING (largest depth = furthest back = draw first).
     // Depth is based on iso_row (elevation-independent): GetYSort = X + Y
     // (which ignores Z elevation).
-    let mut groups: Vec<DrawGroup<'a>> = Vec::new();
+    let mut groups: Vec<DrawGroup<'a, '_>> = Vec::new();
 
     // VXL units draw group -- passthrough (no depth test).
     if let (Some(ua), Some((buf, count))) = (unit_atlas, pool.get("unit")) {
         if count > 0 {
-            let ds: Vec<f32> = unit_instances.iter().map(|s| s.depth).collect();
-            groups.push(DrawGroup {
-                texture: &ua.texture,
-                buffer: buf,
-                depths: ds,
-                cursor: 0,
-                total: count,
-            });
+            groups.push(DrawGroup::new(&ua.texture, buf, unit_instances, count));
         }
     }
 
@@ -165,17 +166,8 @@ pub(super) fn draw_merged_object_pass<'a>(
             if let Some(key) = SHP_KEYS.get(i) {
                 if let Some((buf, count)) = pool.get(key) {
                     if count > 0 {
-                        let ds: Vec<f32> = shp_paged
-                            .get(i)
-                            .map(|v| v.iter().map(|s| s.depth).collect())
-                            .unwrap_or_default();
-                        groups.push(DrawGroup {
-                            texture: &page.texture,
-                            buffer: buf,
-                            depths: ds,
-                            cursor: 0,
-                            total: count,
-                        });
+                        let instances = shp_paged.get(i).map_or(&[][..], Vec::as_slice);
+                        groups.push(DrawGroup::new(&page.texture, buf, instances, count));
                     }
                 }
             }
@@ -188,14 +180,7 @@ pub(super) fn draw_merged_object_pass<'a>(
     // in front of units at closer iso rows.
     if let (Some(oa), Some((buf, count))) = (overlay_atlas, pool.get("overlay_wall")) {
         if count > 0 {
-            let ds: Vec<f32> = wall_instances.iter().map(|s| s.depth).collect();
-            groups.push(DrawGroup {
-                texture: &oa.texture,
-                buffer: buf,
-                depths: ds,
-                cursor: 0,
-                total: count,
-            });
+            groups.push(DrawGroup::new(&oa.texture, buf, wall_instances, count));
         }
     }
 
@@ -216,7 +201,7 @@ pub(super) fn draw_merged_object_pass<'a>(
             if g.cursor >= g.total {
                 continue;
             }
-            let d = g.depths.get(g.cursor as usize).copied().unwrap_or(-1.0);
+            let d = g.depth_at(g.cursor);
             // Larger depth = further back = should draw first.
             // At equal depth, prefer SHP (gi > 0) over VXL (gi == 0).
             if d > best_d || (d == best_d && gi > 0) {
@@ -232,14 +217,14 @@ pub(super) fn draw_merged_object_pass<'a>(
         let run_start = g.cursor;
         let mut run_end = run_start + 1;
         while run_end < g.total {
-            let next_d = g.depths.get(run_end as usize).copied().unwrap_or(-1.0);
+            let next_d = g.depth_at(run_end);
             // Check if any other group has a larger depth (further back, should draw first).
             let mut other_has_larger = false;
             for (oi, og) in groups.iter().enumerate() {
                 if oi == gi || og.cursor >= og.total {
                     continue;
                 }
-                let other_d = og.depths.get(og.cursor as usize).copied().unwrap_or(-1.0);
+                let other_d = og.depth_at(og.cursor);
                 if other_d > next_d || (other_d == next_d && oi > gi) {
                     other_has_larger = true;
                     break;

--- a/src/map/terrain.rs
+++ b/src/map/terrain.rs
@@ -470,6 +470,16 @@ pub struct TerrainInstances {
     pub cliff_redraw: Vec<SpriteInstance>,
 }
 
+fn visible_cell_slice(grid: &TerrainGrid, view_top: f32, view_bottom: f32) -> &[TerrainCell] {
+    let start = grid
+        .cells
+        .partition_point(|cell| cell.screen_y + TILE_HEIGHT < view_top);
+    let end = grid
+        .cells
+        .partition_point(|cell| cell.screen_y <= view_bottom);
+    &grid.cells[start..end]
+}
+
 /// Generate SpriteInstance data for all tiles visible in the current viewport.
 ///
 /// Single-layer rendering: each cell draws exactly one tile. LAT transition
@@ -498,7 +508,7 @@ pub fn build_visible_instances(
         cliff_redraw: Vec::new(),
     };
 
-    for cell in &grid.cells {
+    for cell in visible_cell_slice(grid, view_top, view_bottom) {
         // AABB visibility test against viewport.
         let right: f32 = cell.screen_x + TILE_WIDTH;
         let bottom: f32 = cell.screen_y + TILE_HEIGHT;

--- a/src/render/minimap.rs
+++ b/src/render/minimap.rs
@@ -6,8 +6,8 @@
 //!
 //! ## Implementation
 //! - Terrain image is generated once at map load from TerrainGrid data.
-//! - Unit dots are overlaid each frame by copying the base image and stamping dots.
-//! - The combined image is re-uploaded to the GPU each frame (200x200 = 160KB, negligible).
+//! - Unit dots are overlaid on demand by copying the base image and stamping dots.
+//! - The combined image is only re-uploaded when sim/fog state changes.
 //! - A separate 2x2 white pixel texture is used for the viewport rectangle lines.
 //!
 //! ## Screen-space rendering trick
@@ -26,6 +26,7 @@ use crate::map::terrain::TerrainGrid;
 use crate::render::batch::{BatchRenderer, BatchTexture, SpriteInstance};
 use crate::render::gpu::GpuContext;
 use crate::rules::ruleset::RuleSet;
+use crate::sim::intern::InternedId;
 use crate::sim::vision::FogState;
 
 use super::minimap_helpers::{
@@ -45,7 +46,7 @@ pub struct MinimapRenderer {
     map_texture: BatchTexture,
     /// Raw GPU texture handle for `write_texture()` reuse (avoids per-frame alloc).
     map_texture_raw: wgpu::Texture,
-    /// Reusable RGBA scratch buffer for building the minimap each frame.
+    /// Reusable RGBA scratch buffer for rebuilding the minimap texture.
     rgba_scratch: Vec<u8>,
     /// Tiny 2x2 white pixel texture for drawing the viewport rectangle lines.
     white_texture: BatchTexture,
@@ -62,6 +63,12 @@ pub struct MinimapRenderer {
     map_offset_y: f32,
     map_pixel_w: f32,
     map_pixel_h: f32,
+    /// Last simulation tick used to refresh the texture.
+    last_sim_tick: u64,
+    /// Last fog generation used to refresh the texture.
+    last_fog_generation: u64,
+    /// Last local owner used for fog-aware refresh.
+    last_visibility_owner: Option<InternedId>,
 }
 
 impl MinimapRenderer {
@@ -189,6 +196,9 @@ impl MinimapRenderer {
             map_offset_y,
             map_pixel_w,
             map_pixel_h,
+            last_sim_tick: u64::MAX,
+            last_fog_generation: u64::MAX,
+            last_visibility_owner: None,
         }
     }
 
@@ -196,18 +206,32 @@ impl MinimapRenderer {
     ///
     /// Copies the base terrain image, stamps overlay pixels (ore, gems, walls,
     /// bridges, trees), then stamps a colored dot for each entity with
-    /// Position + Owner, and re-uploads to the GPU.
+    /// Position + Owner, and re-uploads to the GPU. If sim tick, owner, and
+    /// fog generation are unchanged, the existing texture is reused.
     pub fn update_unit_dots(
         &mut self,
         gpu: &GpuContext,
         _batch: &BatchRenderer,
         entities: &crate::sim::entity_store::EntityStore,
         house_colors: &HouseColorMap,
+        sim_tick: u64,
         visibility: Option<(crate::sim::intern::InternedId, &FogState)>,
         rules: Option<&RuleSet>,
         radar_events: Option<&crate::sim::radar::RadarEventQueue>,
         interner: Option<&crate::sim::intern::StringInterner>,
     ) {
+        let fog_generation = visibility.map_or(0, |(_, fog)| fog.generation);
+        let visibility_owner = visibility.map(|(owner, _)| owner);
+        if sim_tick == self.last_sim_tick
+            && fog_generation == self.last_fog_generation
+            && visibility_owner == self.last_visibility_owner
+        {
+            return;
+        }
+        self.last_sim_tick = sim_tick;
+        self.last_fog_generation = fog_generation;
+        self.last_visibility_owner = visibility_owner;
+
         let size: u32 = MINIMAP_SIZE;
         let rgba: &mut Vec<u8> = &mut self.rgba_scratch;
 

--- a/src/render/shroud_buffer.rs
+++ b/src/render/shroud_buffer.rs
@@ -12,7 +12,7 @@
 //! ## Dependency rules
 //! - Part of render/ — reads FogState (no mutation), uses GpuContext.
 
-use crate::map::terrain::iso_to_screen;
+use crate::map::terrain::{HEIGHT_STEP, iso_to_screen, screen_to_iso};
 use crate::render::gpu::GpuContext;
 use crate::sim::vision::FogState;
 
@@ -26,6 +26,8 @@ const BLACK: u8 = 0x00;
 
 /// SHP transparent pixel marker — skip (don't overwrite buffer).
 const TRANSPARENT: u8 = 0xFE;
+const SHROUD_CELL_PAD: i32 = 8;
+const SHROUD_HEIGHT_PAD_LEVELS: f32 = 16.0;
 
 /// Shroud edge frame lookup table.
 ///
@@ -134,7 +136,63 @@ fn align_up(n: u32, align: u32) -> u32 {
     (n + align - 1) / align * align
 }
 
+fn clamp_cell_range(min_v: i32, max_v: i32, limit: u16) -> Option<(u16, u16)> {
+    if limit == 0 {
+        return None;
+    }
+    let upper = i32::from(limit) - 1;
+    let start = min_v.clamp(0, upper);
+    let end = max_v.clamp(0, upper);
+    if start > end {
+        return None;
+    }
+    Some((start as u16, end as u16))
+}
 impl ShroudBuffer {
+    fn visible_cell_bounds(
+        &self,
+        cam_x: f32,
+        cam_y: f32,
+        vp_w: i32,
+        vp_h: i32,
+    ) -> Option<((u16, u16), (u16, u16))> {
+        let pad_x = self.canvas_w as f32;
+        let pad_y = self.canvas_h as f32 + HEIGHT_STEP * SHROUD_HEIGHT_PAD_LEVELS;
+        let left = cam_x - pad_x;
+        let right = cam_x + vp_w as f32 + pad_x;
+        let top = cam_y - pad_y;
+        let bottom = cam_y + vp_h as f32 + pad_y;
+        let corners = [
+            screen_to_iso(left, top),
+            screen_to_iso(right, top),
+            screen_to_iso(left, bottom),
+            screen_to_iso(right, bottom),
+        ];
+
+        let mut min_rx = f32::INFINITY;
+        let mut max_rx = f32::NEG_INFINITY;
+        let mut min_ry = f32::INFINITY;
+        let mut max_ry = f32::NEG_INFINITY;
+        for (rx, ry) in corners {
+            min_rx = min_rx.min(rx);
+            max_rx = max_rx.max(rx);
+            min_ry = min_ry.min(ry);
+            max_ry = max_ry.max(ry);
+        }
+
+        let rx_range = clamp_cell_range(
+            min_rx.floor() as i32 - SHROUD_CELL_PAD,
+            max_rx.ceil() as i32 + SHROUD_CELL_PAD,
+            self.map_width,
+        )?;
+        let ry_range = clamp_cell_range(
+            min_ry.floor() as i32 - SHROUD_CELL_PAD,
+            max_ry.ceil() as i32 + SHROUD_CELL_PAD,
+            self.map_height,
+        )?;
+        Some((rx_range, ry_range))
+    }
+
     /// Create a new shroud buffer for the given screen and map dimensions.
     ///
     /// `frame_pixels` is the raw SHROUD.SHP brightness data per frame,
@@ -249,8 +307,14 @@ impl ShroudBuffer {
         let cam_xi = cam_x_r as i32;
         let cam_yi = cam_y_r as i32;
 
-        for ry in 0..self.map_height {
-            for rx in 0..self.map_width {
+        let Some(((rx_start, rx_end), (ry_start, ry_end))) =
+            self.visible_cell_bounds(cam_x_r, cam_y_r, vp_w, vp_h)
+        else {
+            return;
+        };
+
+        for ry in ry_start..=ry_end {
+            for rx in rx_start..=rx_end {
                 // Position shroud diamond at the cell's actual terrain height so
                 // the brightness buffer aligns with where the terrain renders.
                 // Fully shrouded cells aren't rendered as terrain at all (filtered


### PR DESCRIPTION
Adds a first renderer pipeline pass focused on cheap, low-risk improvements.

- fixes SHP page ordering to use render depth and removes the stray building-status debug injection
- avoids per-frame depth vector cloning in merged object passes
- rebuilds the minimap texture only when sim or fog state changes
- limits terrain and shroud work to visible cell ranges instead of scanning the whole map
