### PR TITLE
Apply RE-backed pathfinding zoning fixes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -309,9 +309,7 @@ impl AppState {
     /// Whether the software cursor (mouse.shp) should be active this frame.
     /// Returns false when an egui interactive panel is open so the OS cursor shows.
     pub(crate) fn use_software_cursor(&self) -> bool {
-        self.software_cursor.is_some()
-            && !self.paused
-            && !self.show_save_load_panel
+        self.software_cursor.is_some() && !self.paused && !self.show_save_load_panel
     }
 }
 

--- a/src/app_selection_brackets.rs
+++ b/src/app_selection_brackets.rs
@@ -247,8 +247,6 @@ pub(crate) fn build_selection_bracket_instances(
         ) {
             continue;
         }
-
-
         // --- 12 edges of the isometric bounding box ---
         // Indices: FL=0, FR=1, BL=2, BR=3
 

--- a/src/app_target_lines.rs
+++ b/src/app_target_lines.rs
@@ -186,14 +186,7 @@ pub(crate) fn build_target_line_instances(
             LineKind::Move => MOVE_COLOR,
         };
 
-        emit_colored_line(
-            &mut instances,
-            src_x,
-            src_y,
-            dst_x,
-            dst_y,
-            color,
-        );
+        emit_colored_line(&mut instances, src_x, src_y, dst_x, dst_y, color);
     }
 
     instances

--- a/src/rules/locomotor_type.rs
+++ b/src/rules/locomotor_type.rs
@@ -214,39 +214,40 @@ impl SpeedType {
 /// Parsed from rules.ini `MovementZone=` key. Controls what kind of route
 /// the pathfinder plans — distinct from SpeedType which controls terrain legality.
 ///
-/// The numeric value IS the passability matrix row index -- used directly by the
-/// zone flood-fill and pathfinder.
+/// The numeric value IS the passability-matrix row index used by the original
+/// pathfinding code. Recent RE shows these rows are keyed by derived
+/// `MovementClass8`, not directly by our terrain `LandType` buckets.
 ///
 /// Example: `MovementZone=Subterranean` enables dig-in/dig-out cell search
 /// logic that plain Drive does not have.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[repr(u8)]
 pub enum MovementZone {
-    /// Standard ground pathfinding. Passability row 0: ground only.
+    /// Row 0: only movement class 0 is passable.
     Normal = 0,
-    /// Can crush infantry and fences. Row 1: ground + road.
+    /// Row 1: classes 0 and 1 are passable.
     Crusher = 1,
-    /// Can crush walls (stronger than Crusher). Row 2: ground + road + rough.
+    /// Row 2: classes 0, 1, and 2 are passable.
     Destroyer = 2,
-    /// Amphibious + can crush walls. Row 3: all land + water.
+    /// Row 3: classes 0, 1, 2, 3, 4, and 5 are passable.
     AmphibiousDestroyer = 3,
-    /// Amphibious + can crush infantry/fences. Row 4: ground + road + beach + water.
+    /// Row 4: classes 0, 1, 3, and 4 are passable.
     AmphibiousCrusher = 4,
-    /// Amphibious movement (land + water). Row 5: ground + beach + water.
+    /// Row 5: classes 0, 3, and 4 are passable.
     Amphibious = 5,
-    /// Tunnel dig-in/dig-out logic. Row 6: ground + road + rough + railroad.
+    /// Row 6: classes 0, 1, 2, and 6 are passable.
     Subterranean = 6,
-    /// Infantry-specific pathfinding (sub-cell, garrison entry). Row 7: ground + tiberium.
+    /// Row 7: classes 0 and 5 are passable.
     Infantry = 7,
-    /// Infantry that can crush walls. Row 8: ground + water.
+    /// Row 8: classes 0, 1, 2, and 5 are passable.
     InfantryDestroyer = 8,
-    /// Airborne pathfinding (ignores ground obstacles). Row 9: everything except rock.
+    /// Row 9: classes 0 through 6 are passable.
     Fly = 9,
-    /// Water-only pathfinding. Row 10: water only.
+    /// Row 10: only class 4 is passable.
     Water = 10,
-    /// Water + beach landing allowed. Row 11: water + beach.
+    /// Row 11: classes 3 and 4 are passable.
     WaterBeach = 11,
-    /// Can crush everything (strongest crusher variant). Row 12: ground + road + rough.
+    /// Row 12: classes 0, 1, and 2 are passable.
     CrusherAll = 12,
 }
 

--- a/src/sim/movement/air_movement.rs
+++ b/src/sim/movement/air_movement.rs
@@ -179,23 +179,22 @@ pub fn tick_air_movement(
                 if let Some(ref mut target) = entity.movement_target {
                     use fixed::types::I48F16;
                     let final_goal = target.final_goal.unwrap_or_else(|| {
-                        *target.path.last().unwrap_or(&(entity.position.rx, entity.position.ry))
+                        *target
+                            .path
+                            .last()
+                            .unwrap_or(&(entity.position.rx, entity.position.ry))
                     });
 
                     // Lepton math uses I48F16 to avoid I16F16 overflow on large maps.
                     // Cell coordinates * 256 can exceed SimFixed's 32767 max integer.
                     let lep256 = I48F16::from_num(256);
                     let lep128 = I48F16::from_num(128);
-                    let goal_lx: I48F16 =
-                        I48F16::from_num(final_goal.0) * lep256 + lep128;
-                    let goal_ly: I48F16 =
-                        I48F16::from_num(final_goal.1) * lep256 + lep128;
-                    let cur_lx: I48F16 =
-                        I48F16::from_num(entity.position.rx) * lep256
-                            + I48F16::from(entity.position.sub_x);
-                    let cur_ly: I48F16 =
-                        I48F16::from_num(entity.position.ry) * lep256
-                            + I48F16::from(entity.position.sub_y);
+                    let goal_lx: I48F16 = I48F16::from_num(final_goal.0) * lep256 + lep128;
+                    let goal_ly: I48F16 = I48F16::from_num(final_goal.1) * lep256 + lep128;
+                    let cur_lx: I48F16 = I48F16::from_num(entity.position.rx) * lep256
+                        + I48F16::from(entity.position.sub_x);
+                    let cur_ly: I48F16 = I48F16::from_num(entity.position.ry) * lep256
+                        + I48F16::from(entity.position.sub_y);
 
                     let dlx: I48F16 = goal_lx - cur_lx;
                     let dly: I48F16 = goal_ly - cur_ly;
@@ -207,7 +206,9 @@ pub fn tick_air_movement(
                         let two = I48F16::from_num(2);
                         let mut g = dist_sq / two;
                         for _ in 0..20 {
-                            if g <= I48F16::ZERO { break; }
+                            if g <= I48F16::ZERO {
+                                break;
+                            }
                             g = (g + dist_sq / g) / two;
                         }
                         g
@@ -219,8 +220,7 @@ pub fn tick_air_movement(
                         .as_ref()
                         .map_or(SIM_ONE, |l| l.speed_fraction);
                     // speed is in leptons/sec; multiply by dt to get leptons this tick.
-                    let move_lep: I48F16 =
-                        I48F16::from(target.speed * speed_frac * dt);
+                    let move_lep: I48F16 = I48F16::from(target.speed * speed_frac * dt);
                     let snap_threshold = I48F16::from_num(4);
 
                     if dist <= move_lep || dist < snap_threshold {
@@ -243,10 +243,8 @@ pub fn tick_air_movement(
                         let new_ry: i32 = (new_ly / lep256).to_num::<i32>();
                         entity.position.rx = (new_rx.max(0) as u16).min(511);
                         entity.position.ry = (new_ry.max(0) as u16).min(511);
-                        let sub_x: I48F16 =
-                            new_lx - I48F16::from_num(entity.position.rx) * lep256;
-                        let sub_y: I48F16 =
-                            new_ly - I48F16::from_num(entity.position.ry) * lep256;
+                        let sub_x: I48F16 = new_lx - I48F16::from_num(entity.position.rx) * lep256;
+                        let sub_y: I48F16 = new_ly - I48F16::from_num(entity.position.ry) * lep256;
                         entity.position.sub_x =
                             SimFixed::from_num(sub_x.to_num::<i32>().max(0).min(255));
                         entity.position.sub_y =
@@ -540,7 +538,10 @@ mod tests {
         // Should have a MovementTarget with cell-by-cell waypoints.
         let e = entities.get(1).expect("has entity");
         let target = e.movement_target.as_ref().expect("has target");
-        assert!(target.path.len() > 2, "path should have intermediate waypoints");
+        assert!(
+            target.path.len() > 2,
+            "path should have intermediate waypoints"
+        );
         assert_eq!(target.path[0], (10, 10));
         assert_eq!(*target.path.last().unwrap(), (20, 15));
 

--- a/src/sim/movement/group_destination.rs
+++ b/src/sim/movement/group_destination.rs
@@ -133,8 +133,7 @@ fn find_next_infantry_cell(
     while *start_idx < ring_cells.len() {
         let cell: (u16, u16) = ring_cells[*start_idx];
         *start_idx += 1;
-        if grid.is_any_layer_walkable(cell.0, cell.1) && !claimed_vehicle.contains(&cell)
-        {
+        if grid.is_any_layer_walkable(cell.0, cell.1) && !claimed_vehicle.contains(&cell) {
             let count: usize = infantry_counts.get(&cell).copied().unwrap_or(0);
             if count < MAX_INFANTRY_PER_CELL {
                 return Some(cell);

--- a/src/sim/movement/mod.rs
+++ b/src/sim/movement/mod.rs
@@ -34,10 +34,10 @@ use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use crate::rules::locomotor_type::{MovementZone, SpeedType};
 use crate::sim::entity_store::EntityStore;
 use crate::sim::intern::InternedId;
+use crate::sim::pathfinding::PathGrid;
 use crate::sim::pathfinding::terrain_cost::TerrainCostGrid;
 use crate::sim::pathfinding::terrain_speed::TerrainSpeedConfig;
 use crate::sim::pathfinding::zone_map::ZoneGrid;
-use crate::sim::pathfinding::PathGrid;
 use crate::sim::rng::SimRng;
 use crate::util::fixed_math::{SIM_ZERO, SimFixed, facing_from_delta_int};
 

--- a/src/sim/movement/movement_blocked.rs
+++ b/src/sim/movement/movement_blocked.rs
@@ -89,7 +89,9 @@ pub(super) fn handle_blocked_tick(
         return deferred_events;
     }
 
-    if target.blocked_delay == 0 && !on_bridge {
+    // Bridge movers also need to replan once blockage delay expires. Keeping the
+    // old ground-only gate can leave units permanently stalled on bridge cells.
+    if target.blocked_delay == 0 {
         stats.repath_attempts = stats.repath_attempts.saturating_add(1);
         let layered_pathing_for_repath = locomotor
             .as_ref()

--- a/src/sim/movement/movement_bridge.rs
+++ b/src/sim/movement/movement_bridge.rs
@@ -8,13 +8,11 @@
 //! Path layers are NOT used for bridge state decisions; the unit's Z relative to the
 //! cell's ground height determines everything at runtime.
 //!
-//! TODO: Once the underlying bridge Z issues are fixed, this module should switch
-//! from height heuristics to using the pathfinder's `next_layer` (path_layers) as the
-//! primary bridge/ground decision. The pathfinder already produces correct per-cell
-//! Bridge/Ground layer assignments — the `_next_layer` parameter is passed in at every
-//! call site but currently ignored. Using it would fix ramp-entry edge cases where
-//! the height heuristic fails (unit at ground Z approaching a bridge deck cell with
-//! matching ground_level).
+//! TODO(RE): The stock game keeps explicit bridge-layer state on the unit
+//! (`FootClass+0x79`) and feeds that into bridge-aware zone lookups. This module still
+//! infers bridge state from reactive height heuristics and ignores the pathfinder's
+//! `_next_layer` hints. Keep this conservative until the runtime bridge-layer update
+//! rules are fully wired in.
 
 use crate::rules::locomotor_type::MovementZone;
 use crate::sim::components::{BridgeOccupancy, Position};
@@ -41,7 +39,7 @@ pub(super) const BRIDGE_Z_OFFSET: SimFixed = SimFixed::lit("360");
 ///
 /// Compares the unit's current Z to the destination cell's ground height to decide
 /// ground vs bridge level. The `_next_layer` parameter from path_layers is available
-/// but currently unused — see module-level TODO.
+/// but currently unused — see module-level TODO(RE).
 pub(super) fn resolve_cell_transition_bridge_state(
     position: &mut Position,
     path_grid: Option<&PathGrid>,
@@ -108,18 +106,23 @@ pub(super) fn apply_pending_bridge_render_state(
 /// deck level. Only fires when bridge_occupancy is not already set and the
 /// unit's Z indicates it's at bridge level relative to the next cell.
 ///
-/// The `_next_step_layer` from path_layers is available but currently unused —
-/// see module-level TODO.
+/// The planned next-step layer is only used as a conservative gate here: we
+/// never pre-claim bridge occupancy unless the path already says the next step
+/// is on the bridge layer. Full bridge-state parity is still pending the
+/// runtime layer-state RE noted in the module-level TODO(RE).
 pub(super) fn apply_bridge_lookahead_if_needed(
     position: &mut Position,
     bridge_occupancy: &mut Option<BridgeOccupancy>,
     on_bridge: &mut bool,
     mover_zone: MovementZone,
     next_step: Option<(u16, u16)>,
-    _next_step_layer: MovementLayer,
+    next_step_layer: MovementLayer,
     path_grid: Option<&PathGrid>,
 ) {
-    if mover_zone.is_water_mover() || bridge_occupancy.is_some() {
+    if mover_zone.is_water_mover()
+        || bridge_occupancy.is_some()
+        || next_step_layer != MovementLayer::Bridge
+    {
         return;
     }
 

--- a/src/sim/movement/movement_commands.rs
+++ b/src/sim/movement/movement_commands.rs
@@ -13,9 +13,9 @@ use crate::map::entities::EntityCategory;
 use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use crate::sim::components::MovementTarget;
 use crate::sim::entity_store::EntityStore;
+use crate::sim::pathfinding::PathGrid;
 use crate::sim::pathfinding::terrain_cost::TerrainCostGrid;
 use crate::sim::pathfinding::zone_map::ZoneCategory;
-use crate::sim::pathfinding::PathGrid;
 use crate::util::fixed_math::{SIM_ZERO, SimFixed};
 
 use super::movement_path::{

--- a/src/sim/movement/movement_path.rs
+++ b/src/sim/movement/movement_path.rs
@@ -32,6 +32,9 @@ pub(super) fn merge_path_blocks(
 ) -> BTreeSet<(u16, u16)> {
     let mut blocks = entity_blocks.cloned().unwrap_or_default();
     if too_big_to_fit_under_bridge && movement_zone.is_some_and(|mz| !mz.is_water_mover()) {
+        // TODO(RE): The current under-bridge restriction is a hard path block. The RE notes
+        // still leave open whether RA2/YR treats TooBigToFitUnderBridge as a pure parking/
+        // eviction rule, a navigation restriction, or a mix depending on bridge state.
         if let Some(terrain) = resolved_terrain {
             for cell in terrain.iter().filter(|c| is_under_bridge_blocked_cell(c)) {
                 blocks.insert((cell.rx, cell.ry));
@@ -90,13 +93,7 @@ fn nearest_move_goal(
     resolved_terrain: Option<&ResolvedTerrainGrid>,
 ) -> Option<(u16, u16)> {
     if !movement_zone.is_some_and(|mz| mz.is_water_mover()) {
-        return grid.nearest_walkable_any_layer(
-            goal.0,
-            goal.1,
-            max_radius,
-            blocked_cells,
-            None,
-        );
+        return grid.nearest_walkable_any_layer(goal.0, goal.1, max_radius, blocked_cells, None);
     }
 
     let check = |x: u16, y: u16| {
@@ -188,6 +185,7 @@ pub(super) fn find_move_path(
             zone_grid,
             zone_cat,
             terrain_costs,
+            movement_zone,
         );
         if let Some(path) = layered_result {
             log::trace!(
@@ -203,12 +201,8 @@ pub(super) fn find_move_path(
                     return false;
                 }
                 match layer {
-                    MovementLayer::Ground => {
-                        !ground_blocks.is_some_and(|gb| gb.contains(&(x, y)))
-                    }
-                    MovementLayer::Bridge => {
-                        !bridge_blocks.is_some_and(|bb| bb.contains(&(x, y)))
-                    }
+                    MovementLayer::Ground => !ground_blocks.is_some_and(|gb| gb.contains(&(x, y))),
+                    MovementLayer::Bridge => !bridge_blocks.is_some_and(|bb| bb.contains(&(x, y))),
                     _ => true,
                 }
             };
@@ -216,8 +210,7 @@ pub(super) fn find_move_path(
                 path_smooth::smooth_layered_path(coords, layers, &layered_smooth_walkable);
             let (coords, layers) =
                 path_smooth::optimize_layered_path(coords, layers, &layered_smooth_walkable);
-            let (coords, layers) =
-                truncate_layered_path(coords, layers, MAX_PATH_SEGMENT_STEPS);
+            let (coords, layers) = truncate_layered_path(coords, layers, MAX_PATH_SEGMENT_STEPS);
             return Some((coords, layers));
         } else {
             log::info!(

--- a/src/sim/movement/movement_step.rs
+++ b/src/sim/movement/movement_step.rs
@@ -22,8 +22,8 @@ use crate::sim::movement::movement_occupancy::{
 };
 use crate::sim::movement::movement_reservation::reserve_destination_after_transition;
 use crate::sim::movement::turret::{rot_to_facing_delta, shortest_rotation};
-use crate::sim::pathfinding::terrain_cost::TerrainCostGrid;
 use crate::sim::pathfinding::PathGrid;
+use crate::sim::pathfinding::terrain_cost::TerrainCostGrid;
 use crate::sim::rng::SimRng;
 use crate::util::fixed_math::{
     SIM_HALF, SIM_ONE, SIM_ZERO, SimFixed, facing_from_delta_int as facing_from_delta,

--- a/src/sim/movement/movement_tick.rs
+++ b/src/sim/movement/movement_tick.rs
@@ -23,10 +23,10 @@ use crate::rules::locomotor_type::{MovementZone, SpeedType};
 use crate::sim::components::MovementTarget;
 use crate::sim::debug_event_log::DebugEventKind;
 use crate::sim::entity_store::EntityStore;
+use crate::sim::pathfinding::PathGrid;
 use crate::sim::pathfinding::terrain_cost::TerrainCostGrid;
 use crate::sim::pathfinding::terrain_speed::{self, TerrainSpeedConfig};
 use crate::sim::pathfinding::zone_map::{ZoneCategory, ZoneGrid};
-use crate::sim::pathfinding::PathGrid;
 use crate::sim::rng::SimRng;
 use crate::util::fixed_math::{
     SIM_HALF, SIM_ONE, SIM_ZERO, SimFixed, dt_from_tick_ms, fixed_distance,

--- a/src/sim/movement/scatter.rs
+++ b/src/sim/movement/scatter.rs
@@ -30,8 +30,8 @@ use crate::rules::ruleset::RuleSet;
 use crate::sim::entity_store::EntityStore;
 use crate::sim::movement;
 use crate::sim::movement::bump_crush::{self, OccupancyMap};
-use crate::sim::pathfinding::terrain_cost::TerrainCostGrid;
 use crate::sim::pathfinding::PathGrid;
+use crate::sim::pathfinding::terrain_cost::TerrainCostGrid;
 use crate::sim::rng::SimRng;
 use crate::util::fixed_math::{SimFixed, ra2_speed_to_leptons_per_second};
 
@@ -178,13 +178,7 @@ pub fn tick_idle_scatter(
             .and_then(|l| terrain_costs.get(&l.speed_type));
 
         movement::issue_move_command_with_layered(
-            entities,
-            grid,
-            entity_id,
-            dest,
-            speed,
-            false,
-            cost_grid,
+            entities, grid, entity_id, dest, speed, false, cost_grid,
             None, // no entity blocks for 1-cell scatter
             None, // resolved_terrain
         );

--- a/src/sim/pathfinding/cell_entry.rs
+++ b/src/sim/pathfinding/cell_entry.rs
@@ -9,14 +9,18 @@
 //! - Phase 1 (`check_terrain`): terrain + occupancy presence, no EntityStore needed
 //! - Phase 2 (`classify_occupied_cell`): blocker friendship/crush, needs &EntityStore
 //!
+//! TODO(RE): The stock search-time legality/cost predicate is richer than this runtime
+//! movement-side classification. Bridge legality, more terrain/object cases, and the
+//! exact cost classes still need to be pulled in from the RE corpus.
+//!
 //! ## Dependency rules
 //! - Part of sim/ — depends on sim/bump_crush, sim/entity_store, sim/locomotor,
 //!   sim/pathfinding, map/entities, map/houses, rules/locomotor_type.
 
 use std::collections::BTreeSet;
 
-use super::terrain_cost::TerrainCostGrid;
 use super::PathGrid;
+use super::terrain_cost::TerrainCostGrid;
 use crate::map::entities::EntityCategory;
 use crate::map::houses::{self, HouseAllianceMap};
 use crate::rules::locomotor_type::{LocomotorKind, MovementZone};
@@ -42,7 +46,8 @@ pub enum CellEntryResult {
     /// Code 2: Blocked by a moving friendly unit. Wait, then repath.
     TemporaryBlock { blocker_id: u64 },
     /// Code 3: Bridge ramp transition. Adjust Z, enter with elevation change.
-    /// Initial implementation: treated as Clear (existing bridge code handles Z).
+    /// Current implementation still treats this as Clear because bridge-layer state
+    /// handling is centralized in movement_bridge.rs.
     BridgeRamp,
     /// Code 4: Friendly stationary unit occupying. Try bump/scatter, or wait.
     OccupiedFriendly { blocker_id: u64 },
@@ -146,10 +151,13 @@ pub fn check_terrain(
 /// This is Phase 2 — runs outside the mutable entity borrow so it can read
 /// blocker properties from EntityStore.
 ///
-/// Check order (matching original engine priority):
+/// Check order (current approximation of original engine priority):
 /// 1. Crush: if all occupants are crushable → Crushable
 /// 2. Blocker friendship: enemy → OccupiedEnemy, friendly → moving/stationary
 /// 3. JumpJet override: codes < 7 treated as Clear
+///
+/// TODO(RE): The recovered candidate predicate also folds in bridge legality and
+/// additional terrain/object state before these occupancy outcomes are chosen.
 pub fn classify_occupied_cell(
     target: (u16, u16),
     mover_id: u64,

--- a/src/sim/pathfinding/core.rs
+++ b/src/sim/pathfinding/core.rs
@@ -4,6 +4,11 @@
 //! bridge_walkable, transition, height levels). Flat A* reads ground_walkable;
 //! layered A* reads both layers for bridge-aware routing.
 //!
+//! TODO(RE): The stock neighbor predicate is richer than the grid-level checks in this
+//! module. The RE corpus has closed the existence and numeric shape of the cost/legality
+//! classes, but not yet enough of the surrounding runtime state to replace these local
+//! passability/cost shortcuts end-to-end.
+//!
 //! ## Dependency rules
 //! - Part of sim/ — depends on map/ (MapCell, TilesetLookup for walkability).
 //! - sim/ NEVER depends on render/, ui/, sidebar/, audio/, net/.
@@ -103,6 +108,9 @@ pub fn is_cell_passable_for_mover(
     movement_zone: Option<MovementZone>,
     resolved_terrain: Option<&ResolvedTerrainGrid>,
 ) -> bool {
+    // TODO(RE): This is still the local path-grid legality gate, not the stock
+    // search-time can-enter/cost predicate. Keep the distinction explicit so we
+    // can swap the real evaluator in once the remaining runtime inputs are known.
     if let Some(mz) = movement_zone {
         if mz.is_water_mover() {
             // Water movers bypass PathGrid — use passability matrix directly.
@@ -268,8 +276,7 @@ impl PathGrid {
     }
 
     pub fn bridge_deck_level(&self, x: u16, y: u16) -> Option<u8> {
-        self.cell(x, y)
-            .and_then(PathCell::bridge_deck_level_if_any)
+        self.cell(x, y).and_then(PathCell::bridge_deck_level_if_any)
     }
 
     pub fn can_enter_bridge_layer_from_ground(&self, x: u16, y: u16) -> bool {
@@ -484,7 +491,7 @@ impl PathGrid {
         }
     }
 
-    /// Compute cells whose ground walkability differs between two grids.
+    /// Compute cells whose path-relevant walkability differs between two grids.
     /// Returns `None` if grids have different dimensions (full rebuild needed).
     pub fn diff_cells(&self, other: &PathGrid) -> Option<Vec<(u16, u16)>> {
         if self.width != other.width || self.height != other.height {
@@ -493,7 +500,12 @@ impl PathGrid {
         let w = self.width as usize;
         let mut changed = Vec::new();
         for (idx, (a, b)) in self.cells.iter().zip(other.cells.iter()).enumerate() {
-            if a.ground_walkable != b.ground_walkable {
+            if a.ground_walkable != b.ground_walkable
+                || a.bridge_walkable != b.bridge_walkable
+                || a.transition != b.transition
+                || a.ground_level != b.ground_level
+                || a.bridge_deck_level != b.bridge_deck_level
+            {
                 changed.push(((idx % w) as u16, (idx / w) as u16));
             }
         }

--- a/src/sim/pathfinding/core_tests.rs
+++ b/src/sim/pathfinding/core_tests.rs
@@ -430,8 +430,7 @@ fn test_layered_path_rebuild_blocks_destroyed_bridge_deck() {
         ],
     );
     let mut bridge_state = BridgeRuntimeState::from_resolved_terrain(&terrain, true, 10);
-    let intact_grid =
-        PathGrid::from_resolved_terrain_with_bridges(&terrain, Some(&bridge_state));
+    let intact_grid = PathGrid::from_resolved_terrain_with_bridges(&terrain, Some(&bridge_state));
     assert!(
         find_layered_path(
             &intact_grid,

--- a/src/sim/pathfinding/mod.rs
+++ b/src/sim/pathfinding/mod.rs
@@ -1,7 +1,12 @@
 //! Pathfinding system — A* search, zone connectivity, terrain costs, and path smoothing.
 //!
 //! Combines cell-level A* with zone-aware hierarchical search for fast unreachability
-//! detection and corridor-based pruning, matching the original engine's approach.
+//! detection and corridor-based pruning.
+//!
+//! TODO(RE): The current split is still only partially aligned with RA2/YR. Terrain-aware
+//! zone rebuilds now use recovered nodeIndex -> zoneId semantics, but bridge-layer remap,
+//! full hierarchical subzone support, and the exact regular-vs-hierarchical path entry
+//! behavior are still pending.
 //!
 //! ## Dependency rules
 //! - Part of sim/ — depends on map/ (terrain, resolved_terrain).

--- a/src/sim/pathfinding/zone_build.rs
+++ b/src/sim/pathfinding/zone_build.rs
@@ -9,11 +9,12 @@
 
 use std::collections::VecDeque;
 
+use super::PathGrid;
 use super::passability;
 use super::terrain_cost::TerrainCostGrid;
 use super::zone_map::{ZONE_INVALID, ZoneAdjacency, ZoneCategory, ZoneId, ZoneInfo, ZoneMap};
-use super::PathGrid;
 use crate::map::resolved_terrain::ResolvedTerrainGrid;
+use crate::rules::locomotor_type::MovementZone;
 use crate::sim::movement::locomotor::MovementLayer;
 
 /// 8-directional neighbor offsets: (dx, dy, is_diagonal).
@@ -28,6 +29,33 @@ pub(crate) const NEIGHBORS: [(i32, i32, bool); 8] = [
     (-1, -1, true), // NW
 ];
 
+/// RE-backed MovementClass8 passability rows used by zone/node rebuilding.
+///
+/// This is distinct from the terrain `LandType` matrix used elsewhere. RA2/YR
+/// connectivity is keyed by a derived per-cell movement class, then filtered by
+/// the mover's `MovementZone` row.
+const MOVEMENT_CLASS_PASSABILITY: [[u8; 8]; 13] = [
+    [1, 2, 2, 2, 2, 2, 2, 3], // Normal
+    [1, 1, 2, 2, 2, 2, 2, 3], // Crusher
+    [1, 1, 1, 2, 2, 2, 2, 3], // Destroyer
+    [1, 1, 1, 1, 1, 1, 2, 3], // AmphibiousDestroyer
+    [1, 1, 2, 1, 1, 2, 2, 3], // AmphibiousCrusher
+    [1, 2, 2, 1, 1, 2, 2, 3], // Amphibious
+    [1, 1, 1, 2, 2, 2, 1, 3], // Subterranean
+    [1, 2, 2, 2, 2, 1, 2, 3], // Infantry
+    [1, 1, 1, 2, 2, 1, 2, 3], // InfantryDestroyer
+    [1, 1, 1, 1, 1, 1, 1, 3], // Fly
+    [2, 2, 2, 2, 1, 2, 2, 3], // Water
+    [2, 2, 2, 1, 1, 2, 2, 3], // WaterBeach
+    [1, 1, 1, 2, 2, 2, 2, 3], // CrusherAll
+];
+
+const MOVEMENT_CLASS_OPEN: u8 = 0;
+const MOVEMENT_CLASS_BEACH: u8 = 3;
+const MOVEMENT_CLASS_WATER: u8 = 4;
+const MOVEMENT_CLASS_BLOCKED: u8 = 6;
+const MOVEMENT_CLASS_OUTSIDE: u8 = 7;
+
 /// Build a zone map and adjacency graph for one ZoneCategory.
 #[cfg(test)]
 #[allow(dead_code)]
@@ -41,12 +69,12 @@ pub(crate) fn build_zone_map(
     build_zone_map_with_terrain(path_grid, cost_grid, None, cat, width, height)
 }
 
-/// Build a zone map using the passability matrix when resolved terrain is available.
+/// Build a zone map using recovered movement-class zoning when resolved terrain is available.
 ///
-/// When `resolved_terrain` is provided, uses the original engine's passability matrix
-/// lookups on the cell's `land_type` field — this is the authoritative check
-/// matching the original engine. Falls back to PathGrid + TerrainCostGrid
-/// checks when resolved terrain is not available.
+/// When `resolved_terrain` is provided, rebuilds a coarse `MovementClass8` grid, derives
+/// `nodeIndex` components, then remaps those nodes through the representative movement-zone
+/// row. Falls back to the older direct passable-cell flood-fill when resolved terrain is not
+/// available (primarily tests and non-terrain-aware call sites).
 pub(crate) fn build_zone_map_with_terrain(
     path_grid: &PathGrid,
     cost_grid: Option<&TerrainCostGrid>,
@@ -55,6 +83,10 @@ pub(crate) fn build_zone_map_with_terrain(
     width: u16,
     height: u16,
 ) -> (ZoneMap, ZoneAdjacency) {
+    if let Some(terrain) = resolved_terrain {
+        return build_zone_map_with_movement_classes(path_grid, terrain, cat, width, height);
+    }
+
     let total = width as usize * height as usize;
 
     // -- Ground layer flood-fill --
@@ -158,14 +190,339 @@ pub(crate) fn build_zone_map_with_terrain(
     (zone_map, adj)
 }
 
+fn build_zone_map_with_movement_classes(
+    path_grid: &PathGrid,
+    resolved_terrain: &ResolvedTerrainGrid,
+    cat: ZoneCategory,
+    width: u16,
+    height: u16,
+) -> (ZoneMap, ZoneAdjacency) {
+    let total = width as usize * height as usize;
+    let movement_classes: Vec<u8> = (0..height)
+        .flat_map(|ry| {
+            (0..width).map(move |rx| movement_class_for_cell(path_grid, resolved_terrain, rx, ry))
+        })
+        .collect();
+
+    let (node_indices, node_count) =
+        rebuild_node_indices(&movement_classes, path_grid, width, height);
+    let node_adj = build_node_adjacency(&node_indices, width, height);
+    let movement_zone = cat.representative_movement_zone();
+    let raw_zone_ids = rebuild_zone_ids_for_movement_zone(
+        &movement_classes,
+        &node_indices,
+        node_count,
+        &node_adj,
+        movement_zone,
+    );
+    let (zone_ids, ground_zone_count) = compact_raw_zone_ids(&node_indices, &raw_zone_ids, total);
+
+    // TODO(RE): Ground-layer zone IDs now follow the recovered nodeIndex -> zoneId table shape,
+    // but bridge lookups still use the older standalone bridge flood-fill. Real RA2/YR routes
+    // bridge-layer zone queries through onBridge state plus ZoneConnection remap records.
+    let bridge_zone_ids = if matches!(
+        cat,
+        ZoneCategory::Land | ZoneCategory::Infantry | ZoneCategory::Amphibious
+    ) {
+        let mut bz = vec![ZONE_INVALID; total];
+        let mut next_zone = ground_zone_count + 1;
+        let mut any_bridge = false;
+        for ry in 0..height {
+            for rx in 0..width {
+                let idx = ry as usize * width as usize + rx as usize;
+                if bz[idx] != ZONE_INVALID {
+                    continue;
+                }
+                if !path_grid.is_walkable_on_layer(rx, ry, MovementLayer::Bridge) {
+                    continue;
+                }
+                flood_fill_bridge(rx, ry, next_zone, &mut bz, width, height, path_grid);
+                next_zone += 1;
+                any_bridge = true;
+            }
+        }
+        if any_bridge { Some(bz) } else { None }
+    } else {
+        None
+    };
+
+    let mut zone_count = ground_zone_count;
+    if let Some(bridge_ids) = &bridge_zone_ids {
+        if let Some(max_bridge) = bridge_ids.iter().copied().max() {
+            zone_count = zone_count.max(max_bridge);
+        }
+    }
+
+    let adj = extract_adjacency(
+        &zone_ids,
+        bridge_zone_ids.as_deref(),
+        path_grid,
+        width,
+        height,
+        zone_count,
+    );
+    let zone_info = compute_zone_info(
+        &zone_ids,
+        bridge_zone_ids.as_deref(),
+        width,
+        height,
+        zone_count,
+    );
+    let zone_map = ZoneMap::new(
+        zone_ids,
+        bridge_zone_ids,
+        width,
+        height,
+        zone_count,
+        zone_info,
+    );
+
+    (zone_map, adj)
+}
+
+fn movement_class_for_cell(
+    path_grid: &PathGrid,
+    resolved_terrain: &ResolvedTerrainGrid,
+    x: u16,
+    y: u16,
+) -> u8 {
+    let Some(cell) = resolved_terrain.cell(x, y) else {
+        return MOVEMENT_CLASS_OUTSIDE;
+    };
+
+    if cell.overlay_blocks || cell.terrain_object_blocks {
+        // TODO(RE): exact TerrainType occupation-bit decoding is not wired into the map model
+        // yet, so we cannot distinguish partial-occupancy class 5 from full blockers here.
+        return MOVEMENT_CLASS_BLOCKED;
+    }
+    if (cell.ground_walk_blocked && !cell.is_water)
+        || (!path_grid.is_walkable(x, y) && !cell.is_water)
+    {
+        return MOVEMENT_CLASS_BLOCKED;
+    }
+    if cell.is_water {
+        return MOVEMENT_CLASS_WATER;
+    }
+    if cell.land_type == passability::LandType::Beach.as_index() {
+        return MOVEMENT_CLASS_BEACH;
+    }
+
+    MOVEMENT_CLASS_OPEN
+}
+
+fn rebuild_node_indices(
+    movement_classes: &[u8],
+    path_grid: &PathGrid,
+    width: u16,
+    height: u16,
+) -> (Vec<u16>, u16) {
+    let mut node_indices = vec![0u16; movement_classes.len()];
+    let mut next_node: u16 = 1;
+
+    for ry in 0..height {
+        for rx in 0..width {
+            let idx = ry as usize * width as usize + rx as usize;
+            if movement_classes[idx] == MOVEMENT_CLASS_OUTSIDE || node_indices[idx] != 0 {
+                continue;
+            }
+            flood_fill_node_index(
+                rx,
+                ry,
+                next_node,
+                movement_classes,
+                &mut node_indices,
+                path_grid,
+                width,
+                height,
+            );
+            next_node += 1;
+        }
+    }
+
+    (node_indices, next_node.saturating_sub(1))
+}
+
+fn flood_fill_node_index(
+    start_x: u16,
+    start_y: u16,
+    node_id: u16,
+    movement_classes: &[u8],
+    node_indices: &mut [u16],
+    path_grid: &PathGrid,
+    width: u16,
+    height: u16,
+) {
+    let mut queue = VecDeque::new();
+    let start_idx = start_y as usize * width as usize + start_x as usize;
+    let movement_class = movement_classes[start_idx];
+    node_indices[start_idx] = node_id;
+    queue.push_back((start_x, start_y));
+
+    // TODO(RE): The recovered nodeIndex flood-fill is 8-neighbor and class/height based,
+    // not the same as final movement-time diagonal corner legality. Keep this RE-shaped
+    // connectivity here for now and let the actual A* legality checks remain tighter.
+    // If later runtime evidence proves an additional corner constraint at the node layer,
+    // update this together with the zone fast-reject assumptions.
+    while let Some((cx, cy)) = queue.pop_front() {
+        for &(dx, dy, _) in &NEIGHBORS {
+            let nx = cx as i32 + dx;
+            let ny = cy as i32 + dy;
+            if nx < 0 || ny < 0 || nx >= width as i32 || ny >= height as i32 {
+                continue;
+            }
+            let nx = nx as u16;
+            let ny = ny as u16;
+            let n_idx = ny as usize * width as usize + nx as usize;
+            if node_indices[n_idx] != 0 || movement_classes[n_idx] != movement_class {
+                continue;
+            }
+
+            if movement_class != MOVEMENT_CLASS_BLOCKED {
+                let Some(cur) = path_grid.cell(cx, cy) else {
+                    continue;
+                };
+                let Some(nbr) = path_grid.cell(nx, ny) else {
+                    continue;
+                };
+                if (cur.ground_level as i16 - nbr.ground_level as i16).abs() >= 2 {
+                    continue;
+                }
+            }
+
+            node_indices[n_idx] = node_id;
+            queue.push_back((nx, ny));
+        }
+    }
+}
+
+fn build_node_adjacency(node_indices: &[u16], width: u16, height: u16) -> Vec<Vec<u16>> {
+    let node_count = node_indices.iter().copied().max().unwrap_or(0) as usize;
+    let mut adj = vec![Vec::new(); node_count + 1];
+
+    for y in 0..height {
+        for x in 0..width {
+            let idx = y as usize * width as usize + x as usize;
+            let a = node_indices[idx];
+            if a == 0 {
+                continue;
+            }
+            for &(dx, dy, is_diagonal) in &NEIGHBORS {
+                let nx = x as i32 + dx;
+                let ny = y as i32 + dy;
+                if nx < 0 || ny < 0 || nx >= width as i32 || ny >= height as i32 {
+                    continue;
+                }
+                let nx = nx as u16;
+                let ny = ny as u16;
+                let n_idx = ny as usize * width as usize + nx as usize;
+                let b = node_indices[n_idx];
+                if b == 0 || a == b {
+                    continue;
+                }
+
+                if is_diagonal {
+                    let o = node_indices[y as usize * width as usize + nx as usize];
+                    let p = node_indices[ny as usize * width as usize + x as usize];
+                    if o == 0 && p == 0 {
+                        continue;
+                    }
+                }
+
+                adj[a as usize].push(b);
+            }
+        }
+    }
+
+    for neighbors in &mut adj {
+        neighbors.sort_unstable();
+        neighbors.dedup();
+    }
+
+    adj
+}
+
+fn rebuild_zone_ids_for_movement_zone(
+    movement_classes: &[u8],
+    node_indices: &[u16],
+    node_count: u16,
+    node_adj: &[Vec<u16>],
+    movement_zone: MovementZone,
+) -> Vec<u16> {
+    let mut node_movement_classes = vec![MOVEMENT_CLASS_OUTSIDE; node_count as usize + 1];
+    for (&node, &movement_class) in node_indices.iter().zip(movement_classes.iter()) {
+        if node != 0 && node_movement_classes[node as usize] == MOVEMENT_CLASS_OUTSIDE {
+            node_movement_classes[node as usize] = movement_class;
+        }
+    }
+
+    let row = MOVEMENT_CLASS_PASSABILITY[movement_zone as usize];
+    let mut zone_id_by_node = vec![1u16; node_count as usize + 1];
+    for node in 1..=node_count {
+        let movement_class = node_movement_classes[node as usize] as usize;
+        if row[movement_class] == 1 {
+            zone_id_by_node[node as usize] = 0;
+        }
+    }
+
+    let mut next_label: u16 = 2;
+    for start_node in 1..=node_count {
+        if zone_id_by_node[start_node as usize] != 0 {
+            continue;
+        }
+        let mut queue = VecDeque::new();
+        zone_id_by_node[start_node as usize] = next_label;
+        queue.push_back(start_node);
+
+        while let Some(cur) = queue.pop_front() {
+            for &neighbor in &node_adj[cur as usize] {
+                if zone_id_by_node[neighbor as usize] != 0 {
+                    continue;
+                }
+                zone_id_by_node[neighbor as usize] = next_label;
+                queue.push_back(neighbor);
+            }
+        }
+
+        next_label += 1;
+    }
+
+    zone_id_by_node[0] = u16::MAX;
+    zone_id_by_node
+}
+
+fn compact_raw_zone_ids(
+    node_indices: &[u16],
+    raw_zone_ids: &[u16],
+    total: usize,
+) -> (Vec<ZoneId>, ZoneId) {
+    let mut remap = std::collections::BTreeMap::<u16, ZoneId>::new();
+    let mut next_zone: ZoneId = 1;
+    let mut zone_ids = vec![ZONE_INVALID; total];
+
+    for (idx, &node) in node_indices.iter().enumerate() {
+        if node == 0 {
+            continue;
+        }
+        let raw_zone = raw_zone_ids[node as usize];
+        if raw_zone <= 1 {
+            continue;
+        }
+        let zone = *remap.entry(raw_zone).or_insert_with(|| {
+            let assigned = next_zone;
+            next_zone += 1;
+            assigned
+        });
+        zone_ids[idx] = zone;
+    }
+
+    (zone_ids, next_zone.saturating_sub(1))
+}
+
 /// Check if a cell is passable for a given ZoneCategory.
 ///
-/// When `resolved_terrain` is available, uses the original engine's passability
-/// matrix (land_type → zone layer → passable/blocked/impassable). This is the
-/// authoritative check matching the original engine's zone flood-fill.
-///
-/// Falls back to PathGrid + TerrainCostGrid checks when resolved terrain data
-/// is not available (e.g. in unit tests).
+/// This helper is still the direct passable-cell check used by the fallback and legacy
+/// incremental paths. Terrain-aware full rebuilds now go through `MovementClass8` +
+/// `nodeIndex` reconstruction instead.
 pub(crate) fn is_passable(
     x: u16,
     y: u16,

--- a/src/sim/pathfinding/zone_hierarchy.rs
+++ b/src/sim/pathfinding/zone_hierarchy.rs
@@ -5,6 +5,9 @@
 //! transitively reachable through adjacency edges. This turns the O(V+E) BFS
 //! in `zone_graph_connected()` into an O(1) lookup.
 //!
+//! TODO(RE): This is only a cheap reachability cache. YR's hierarchical pathfinding
+//! uses additional subzone passes and scratch tables that are not represented here yet.
+//!
 //! ## Dependency rules
 //! - Part of sim/ — depends only on sim/zone_map types.
 //! - sim/ NEVER depends on render/, ui/, sidebar/, audio/, net/.

--- a/src/sim/pathfinding/zone_incremental.rs
+++ b/src/sim/pathfinding/zone_incremental.rs
@@ -8,8 +8,8 @@
 //! 3. Re-flood-fills the cleared cells to assign new zone IDs.
 //! 4. Rebuilds adjacency and super-zone labels for affected categories.
 //!
-//! Falls back to full rebuild if too many cells changed or zone IDs are
-//! getting exhausted.
+//! Falls back to full rebuild if too many cells changed, resolved-terrain zoning
+//! is active, or zone IDs are getting exhausted.
 //!
 //! ## Dependency rules
 //! - Part of sim/ — depends on sim/zone_map, sim/zone_build, sim/zone_hierarchy.
@@ -17,13 +17,14 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+use super::PathGrid;
 use super::terrain_cost::TerrainCostGrid;
 use super::zone_build::{
     compute_zone_info, extract_adjacency, flood_fill, flood_fill_bridge, is_passable,
 };
 use super::zone_hierarchy::SuperZoneMap;
 use super::zone_map::{ZONE_INVALID, ZoneCategory, ZoneGrid, ZoneId};
-use super::PathGrid;
+use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use crate::rules::locomotor_type::SpeedType;
 use crate::sim::movement::locomotor::MovementLayer;
 
@@ -45,9 +46,16 @@ pub(crate) fn try_incremental_update(
     changed_cells: &[(u16, u16)],
     path_grid: &PathGrid,
     terrain_costs: &BTreeMap<SpeedType, TerrainCostGrid>,
+    resolved_terrain: Option<&ResolvedTerrainGrid>,
 ) -> bool {
     if changed_cells.is_empty() {
         return true;
+    }
+    if resolved_terrain.is_some() {
+        // TODO(RE): terrain-aware zoning now rebuilds nodeIndex + zoneIdByNodeIndex tables on
+        // full rebuilds. We have not closed the exact localized invalidation/update contract for
+        // that model yet, so dynamic changes conservatively fall back to a full rebuild.
+        return false;
     }
     if changed_cells.len() > INCREMENTAL_THRESHOLD {
         return false;

--- a/src/sim/pathfinding/zone_map.rs
+++ b/src/sim/pathfinding/zone_map.rs
@@ -16,10 +16,10 @@
 
 use std::collections::{BTreeMap, VecDeque};
 
+use super::PathGrid;
 use super::terrain_cost::TerrainCostGrid;
 use super::zone_build;
 use super::zone_hierarchy::SuperZoneMap;
-use super::PathGrid;
 use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use crate::rules::locomotor_type::{MovementZone, SpeedType};
 use crate::sim::movement::locomotor::MovementLayer;
@@ -32,6 +32,10 @@ pub const ZONE_INVALID: ZoneId = 0;
 
 /// Canonical passability class — groups MovementZone variants that share the
 /// same passability rules into a smaller set for zone computation.
+///
+/// TODO(RE): The recovered engine layout is per-MovementZone, not per reduced
+/// ZoneCategory. This canonicalization is a memory/runtime shortcut until the
+/// nodeIndex -> zoneIdByMovementZone tables and YR subzone tracking are wired in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ZoneCategory {
     /// Ground-only units (Normal, Crusher, Destroyer, CrusherAll, Subterranean).
@@ -98,7 +102,7 @@ impl ZoneCategory {
             ZoneCategory::Land => MovementZone::Normal,
             ZoneCategory::Water => MovementZone::Water,
             ZoneCategory::WaterBeach => MovementZone::WaterBeach,
-            ZoneCategory::Amphibious => MovementZone::AmphibiousCrusher,
+            ZoneCategory::Amphibious => MovementZone::Amphibious,
             ZoneCategory::Infantry => MovementZone::Infantry,
             ZoneCategory::Fly => MovementZone::Fly,
         }
@@ -128,8 +132,15 @@ pub struct ZoneInfo {
 #[derive(Debug, Clone)]
 pub struct ZoneMap {
     /// Zone ID per cell, indexed by `y * width + x`. ZONE_INVALID = impassable.
+    ///
+    /// TODO(RE): RA2/YR does not store zone IDs directly per cell. Each cell carries
+    /// a nodeIndex, and each MovementZone has its own zoneIdByNodeIndex table.
     zone_ids: Vec<ZoneId>,
     /// Optional bridge-layer zone IDs (same index space, continuation of zone_count).
+    ///
+    /// TODO(RE): Bridge-layer zone queries in the original engine go through the
+    /// onBridge flag plus ZoneConnection remap records near the cell, not a standalone
+    /// bridge zone grid.
     bridge_zone_ids: Option<Vec<ZoneId>>,
     pub width: u16,
     pub height: u16,
@@ -353,6 +364,9 @@ impl ZoneGrid {
         to_layer: MovementLayer,
     ) -> bool {
         if cat == ZoneCategory::Fly {
+            // TODO(RE): Air/jumpjet navigation is not just "one global zone". The RE queue
+            // still needs to close which movers bypass grid A*, which still do local tests,
+            // and how crowd/yield/replan interacts with those movers.
             return true; // Fly units can reach anywhere
         }
         let Some(zone_map) = self.maps.get(&cat) else {

--- a/src/sim/pathfinding/zone_map_tests.rs
+++ b/src/sim/pathfinding/zone_map_tests.rs
@@ -1,12 +1,12 @@
 //! Tests for zone map flood-fill and adjacency extraction.
 
-use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid};
-use crate::rules::terrain_rules::{SpeedCostProfile, TerrainClass};
-use super::zone_map::*;
 use super::zone_build::build_zone_map;
+use super::zone_map::*;
+use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid};
+use crate::rules::locomotor_type::MovementZone;
+use crate::rules::terrain_rules::{SpeedCostProfile, TerrainClass};
 use crate::sim::movement::locomotor::MovementLayer;
 use crate::sim::pathfinding::{PathCell, PathGrid};
-use crate::rules::locomotor_type::MovementZone;
 use std::collections::BTreeMap;
 
 // Helper: build a PathGrid from a string map where '.' = walkable, '#' = blocked.
@@ -74,13 +74,74 @@ fn water_row_terrain(width: u16) -> ResolvedTerrainGrid {
     ResolvedTerrainGrid::from_cells(width, 1, cells)
 }
 
+fn clear_beach_water_row_terrain() -> ResolvedTerrainGrid {
+    let land_types = [
+        crate::sim::pathfinding::passability::LandType::Clear.as_index(),
+        crate::sim::pathfinding::passability::LandType::Beach.as_index(),
+        crate::sim::pathfinding::passability::LandType::Water.as_index(),
+    ];
+    let cells = land_types
+        .into_iter()
+        .enumerate()
+        .map(|(rx, land_type)| ResolvedTerrainCell {
+            rx: rx as u16,
+            ry: 0,
+            source_tile_index: 0,
+            source_sub_tile: 0,
+            final_tile_index: 0,
+            final_sub_tile: 0,
+            level: 0,
+            filled_clear: false,
+            tileset_index: Some(0),
+            land_type,
+            slope_type: 0,
+            template_height: 0,
+            render_offset_x: 0,
+            render_offset_y: 0,
+            terrain_class: match land_type {
+                x if x == crate::sim::pathfinding::passability::LandType::Water.as_index() => {
+                    TerrainClass::Water
+                }
+                x if x == crate::sim::pathfinding::passability::LandType::Beach.as_index() => {
+                    TerrainClass::Beach
+                }
+                _ => TerrainClass::Clear,
+            },
+            speed_costs: SpeedCostProfile::default(),
+            is_water: land_type == crate::sim::pathfinding::passability::LandType::Water.as_index(),
+            is_cliff_like: false,
+            is_cliff_redraw: false,
+            variant: 0,
+            is_rough: false,
+            is_road: false,
+            has_ramp: false,
+            canonical_ramp: None,
+            ground_walk_blocked: false,
+            terrain_object_blocks: false,
+            overlay_blocks: false,
+            base_build_blocked: false,
+            build_blocked: false,
+            has_bridge_deck: false,
+            bridge_walkable: false,
+            bridge_transition: false,
+            bridge_deck_level: 0,
+            bridge_layer: None,
+            radar_left: [0, 0, 0],
+            radar_right: [0, 0, 0],
+        })
+        .collect();
+    ResolvedTerrainGrid::from_cells(3, 1, cells)
+}
+
 #[test]
 fn single_open_area_one_zone() {
-    let grid = grid_from_str("
+    let grid = grid_from_str(
+        "
         .....
         .....
         .....
-    ");
+    ",
+    );
     let (zm, adj) = land_zones(&grid);
     assert_eq!(zm.zone_count, 1);
     // All cells should be zone 1.
@@ -95,11 +156,13 @@ fn single_open_area_one_zone() {
 
 #[test]
 fn wall_splits_into_two_zones() {
-    let grid = grid_from_str("
+    let grid = grid_from_str(
+        "
         ..#..
         ..#..
         ..#..
-    ");
+    ",
+    );
     let (zm, _adj) = land_zones(&grid);
     assert_eq!(zm.zone_count, 2);
     // Left side should be zone 1, right side zone 2.
@@ -114,11 +177,13 @@ fn wall_splits_into_two_zones() {
 
 #[test]
 fn blocked_cells_are_invalid() {
-    let grid = grid_from_str("
+    let grid = grid_from_str(
+        "
         .#.
         ###
         .#.
-    ");
+    ",
+    );
     let (zm, _adj) = land_zones(&grid);
     // Each corner is isolated (diagonal would need both cardinals passable).
     // (0,0) is passable, (2,0) is passable, but they can't connect diagonally
@@ -138,10 +203,12 @@ fn blocked_cells_are_invalid() {
 #[test]
 fn diagonal_connectivity_requires_cardinal_passable() {
     // Two cells diagonally adjacent but one cardinal blocked → different zones.
-    let grid = grid_from_str("
+    let grid = grid_from_str(
+        "
         .#
         #.
-    ");
+    ",
+    );
     let (zm, _adj) = land_zones(&grid);
     // (0,0) and (1,1) are diagonally adjacent but (1,0)=# and (0,1)=# block the diagonal.
     let z00 = zm.zone_at(0, 0, MovementLayer::Ground);
@@ -152,10 +219,12 @@ fn diagonal_connectivity_requires_cardinal_passable() {
 #[test]
 fn diagonal_connectivity_with_both_cardinals() {
     // Two cells diagonally adjacent with both cardinals passable → same zone.
-    let grid = grid_from_str("
+    let grid = grid_from_str(
+        "
         ..
         ..
-    ");
+    ",
+    );
     let (zm, _adj) = land_zones(&grid);
     assert_eq!(zm.zone_count, 1);
 }
@@ -164,65 +233,93 @@ fn diagonal_connectivity_with_both_cardinals() {
 fn adjacency_between_zones() {
     // Two zones separated by a gap that has adjacent cells.
     // Zones are adjacent when their cells are 8-connected neighbors.
-    let grid = grid_from_str("
+    let grid = grid_from_str(
+        "
         ..#..
         .....
         ..#..
-    ");
-    let (zm, adj) = land_zones(&grid);
+    ",
+    );
+    let (zm, _adj) = land_zones(&grid);
     // The gap at (2,1) connects everything into one zone.
     assert_eq!(zm.zone_count, 1);
 
     // Now create a true split with adjacency:
-    let grid2 = grid_from_str("
+    let grid2 = grid_from_str(
+        "
         ...##
         ...##
         .....
         ##...
         ##...
-    ");
-    let (zm2, adj2) = land_zones(&grid2);
+    ",
+    );
+    let (zm2, _adj2) = land_zones(&grid2);
     // Check that zones exist and might be adjacent via the connecting corridor.
     assert!(zm2.zone_count >= 1);
 }
 
 #[test]
 fn same_zone_check() {
-    let grid = grid_from_str("
+    let grid = grid_from_str(
+        "
         .....
         .....
-    ");
+    ",
+    );
     let (zm, _adj) = land_zones(&grid);
     assert!(zm.same_zone((0, 0), (4, 1), MovementLayer::Ground));
 }
 
 #[test]
 fn different_zones_same_zone_check() {
-    let grid = grid_from_str("
+    let grid = grid_from_str(
+        "
         ..#..
         ..#..
-    ");
+    ",
+    );
     let (zm, _adj) = land_zones(&grid);
     assert!(!zm.same_zone((0, 0), (3, 0), MovementLayer::Ground));
 }
 
 #[test]
 fn zone_category_from_movement_zone() {
-    assert_eq!(ZoneCategory::from_movement_zone(MovementZone::Normal), ZoneCategory::Land);
-    assert_eq!(ZoneCategory::from_movement_zone(MovementZone::Crusher), ZoneCategory::Land);
-    assert_eq!(ZoneCategory::from_movement_zone(MovementZone::Infantry), ZoneCategory::Infantry);
-    assert_eq!(ZoneCategory::from_movement_zone(MovementZone::Fly), ZoneCategory::Fly);
-    assert_eq!(ZoneCategory::from_movement_zone(MovementZone::Water), ZoneCategory::Water);
-    assert_eq!(ZoneCategory::from_movement_zone(MovementZone::AmphibiousCrusher), ZoneCategory::Amphibious);
+    assert_eq!(
+        ZoneCategory::from_movement_zone(MovementZone::Normal),
+        ZoneCategory::Land
+    );
+    assert_eq!(
+        ZoneCategory::from_movement_zone(MovementZone::Crusher),
+        ZoneCategory::Land
+    );
+    assert_eq!(
+        ZoneCategory::from_movement_zone(MovementZone::Infantry),
+        ZoneCategory::Infantry
+    );
+    assert_eq!(
+        ZoneCategory::from_movement_zone(MovementZone::Fly),
+        ZoneCategory::Fly
+    );
+    assert_eq!(
+        ZoneCategory::from_movement_zone(MovementZone::Water),
+        ZoneCategory::Water
+    );
+    assert_eq!(
+        ZoneCategory::from_movement_zone(MovementZone::AmphibiousCrusher),
+        ZoneCategory::Amphibious
+    );
 }
 
 #[test]
 fn deterministic_zone_ids() {
-    let grid = grid_from_str("
+    let grid = grid_from_str(
+        "
         ..#..
         ..#..
         ..#..
-    ");
+    ",
+    );
     let (zm1, _) = land_zones(&grid);
     let (zm2, _) = land_zones(&grid);
     // Zone IDs must be identical across runs.
@@ -231,7 +328,9 @@ fn deterministic_zone_ids() {
             assert_eq!(
                 zm1.zone_at(rx, ry, MovementLayer::Ground),
                 zm2.zone_at(rx, ry, MovementLayer::Ground),
-                "Non-deterministic zone at ({}, {})", rx, ry,
+                "Non-deterministic zone at ({}, {})",
+                rx,
+                ry,
             );
         }
     }
@@ -239,37 +338,55 @@ fn deterministic_zone_ids() {
 
 #[test]
 fn zone_grid_can_reach_same_zone() {
-    let grid = grid_from_str("
+    let grid = grid_from_str(
+        "
         .....
         .....
-    ");
+    ",
+    );
     let zg = ZoneGrid::build(&grid, &BTreeMap::new(), 5, 2);
     assert!(zg.can_reach(
-        ZoneCategory::Land, (0, 0), MovementLayer::Ground, (4, 1), MovementLayer::Ground,
+        ZoneCategory::Land,
+        (0, 0),
+        MovementLayer::Ground,
+        (4, 1),
+        MovementLayer::Ground,
     ));
 }
 
 #[test]
 fn zone_grid_cannot_reach_disconnected() {
-    let grid = grid_from_str("
+    let grid = grid_from_str(
+        "
         ..#..
         ..#..
-    ");
+    ",
+    );
     let zg = ZoneGrid::build(&grid, &BTreeMap::new(), 5, 2);
     assert!(!zg.can_reach(
-        ZoneCategory::Land, (0, 0), MovementLayer::Ground, (4, 0), MovementLayer::Ground,
+        ZoneCategory::Land,
+        (0, 0),
+        MovementLayer::Ground,
+        (4, 0),
+        MovementLayer::Ground,
     ));
 }
 
 #[test]
 fn zone_grid_fly_always_reachable() {
-    let grid = grid_from_str("
+    let grid = grid_from_str(
+        "
         ..#..
         ..#..
-    ");
+    ",
+    );
     let zg = ZoneGrid::build(&grid, &BTreeMap::new(), 5, 2);
     assert!(zg.can_reach(
-        ZoneCategory::Fly, (0, 0), MovementLayer::Ground, (4, 0), MovementLayer::Ground,
+        ZoneCategory::Fly,
+        (0, 0),
+        MovementLayer::Ground,
+        (4, 0),
+        MovementLayer::Ground,
     ));
 }
 
@@ -283,6 +400,27 @@ fn water_zone_grid_uses_resolved_land_type_directly() {
         (0, 0),
         MovementLayer::Ground,
         (4, 0),
+        MovementLayer::Ground,
+    ));
+}
+
+#[test]
+fn waterbeach_zone_grid_connects_beach_to_water_with_resolved_terrain() {
+    let terrain = clear_beach_water_row_terrain();
+    let grid = PathGrid::from_resolved_terrain(&terrain);
+    let zg = ZoneGrid::build_with_terrain(&grid, &BTreeMap::new(), Some(&terrain), 3, 1);
+    assert!(zg.can_reach(
+        ZoneCategory::WaterBeach,
+        (1, 0),
+        MovementLayer::Ground,
+        (2, 0),
+        MovementLayer::Ground,
+    ));
+    assert!(zg.can_reach(
+        ZoneCategory::Amphibious,
+        (0, 0),
+        MovementLayer::Ground,
+        (2, 0),
         MovementLayer::Ground,
     ));
 }
@@ -317,7 +455,10 @@ fn height_cliff_splits_zone() {
     // All cells walkable, but heights jump from 0 to 3 — should split into 2 zones.
     let grid = path_grid_from_heights(&[0, 0, 0, 3, 3, 3], 6, 1);
     let (zm, _adj) = land_zones_with_height(&grid);
-    assert_eq!(zm.zone_count, 2, "Height cliff (0→3) should split into two zones");
+    assert_eq!(
+        zm.zone_count, 2,
+        "Height cliff (0→3) should split into two zones"
+    );
     let z_left = zm.zone_at(0, 0, MovementLayer::Ground);
     let z_right = zm.zone_at(5, 0, MovementLayer::Ground);
     assert_ne!(z_left, ZONE_INVALID);
@@ -338,7 +479,10 @@ fn height_check_skipped_when_all_level_zero() {
     // When all cells have ground_level=0, heights don't split zones — all passable cells merge.
     let grid = grid_from_str("......");
     let (zm, _adj) = land_zones(&grid);
-    assert_eq!(zm.zone_count, 1, "All level-zero cells should merge into one zone");
+    assert_eq!(
+        zm.zone_count, 1,
+        "All level-zero cells should merge into one zone"
+    );
 }
 
 #[test]
@@ -356,7 +500,10 @@ fn height_2d_plateau_isolated() {
     let z_center = zm.zone_at(1, 1, MovementLayer::Ground);
     assert_ne!(z_corner, ZONE_INVALID);
     assert_ne!(z_center, ZONE_INVALID);
-    assert_ne!(z_corner, z_center, "Height-5 plateau should be isolated from height-0 surround");
+    assert_ne!(
+        z_corner, z_center,
+        "Height-5 plateau should be isolated from height-0 surround"
+    );
 }
 
 #[test]
@@ -378,7 +525,11 @@ fn incremental_block_cell_splits_zone() {
     let grid = grid_from_str(".....");
     let mut zg = ZoneGrid::build(&grid, &BTreeMap::new(), 5, 1);
     assert!(zg.can_reach(
-        ZoneCategory::Land, (0, 0), MovementLayer::Ground, (4, 0), MovementLayer::Ground,
+        ZoneCategory::Land,
+        (0, 0),
+        MovementLayer::Ground,
+        (4, 0),
+        MovementLayer::Ground,
     ));
 
     // Block center cell (2,0) → should split into two zones.
@@ -388,19 +539,38 @@ fn incremental_block_cell_splits_zone() {
     assert_eq!(changed.len(), 1);
 
     let result = crate::sim::pathfinding::zone_incremental::try_incremental_update(
-        &mut zg, &changed, &grid2, &BTreeMap::new(),
+        &mut zg,
+        &changed,
+        &grid2,
+        &BTreeMap::new(),
+        None,
     );
     assert!(result, "Incremental update should succeed");
-    assert!(!zg.can_reach(
-        ZoneCategory::Land, (0, 0), MovementLayer::Ground, (4, 0), MovementLayer::Ground,
-    ), "After blocking center, left and right should be disconnected");
+    assert!(
+        !zg.can_reach(
+            ZoneCategory::Land,
+            (0, 0),
+            MovementLayer::Ground,
+            (4, 0),
+            MovementLayer::Ground,
+        ),
+        "After blocking center, left and right should be disconnected"
+    );
     // Left side still connected within itself.
     assert!(zg.can_reach(
-        ZoneCategory::Land, (0, 0), MovementLayer::Ground, (1, 0), MovementLayer::Ground,
+        ZoneCategory::Land,
+        (0, 0),
+        MovementLayer::Ground,
+        (1, 0),
+        MovementLayer::Ground,
     ));
     // Right side still connected within itself.
     assert!(zg.can_reach(
-        ZoneCategory::Land, (3, 0), MovementLayer::Ground, (4, 0), MovementLayer::Ground,
+        ZoneCategory::Land,
+        (3, 0),
+        MovementLayer::Ground,
+        (4, 0),
+        MovementLayer::Ground,
     ));
 }
 
@@ -411,7 +581,11 @@ fn incremental_unblock_cell_merges_zones() {
     let grid1 = grid_from_str("..#..");
     let mut zg = ZoneGrid::build(&grid1, &BTreeMap::new(), 5, 1);
     assert!(!zg.can_reach(
-        ZoneCategory::Land, (0, 0), MovementLayer::Ground, (4, 0), MovementLayer::Ground,
+        ZoneCategory::Land,
+        (0, 0),
+        MovementLayer::Ground,
+        (4, 0),
+        MovementLayer::Ground,
     ));
 
     // Remove wall → should reconnect.
@@ -420,12 +594,23 @@ fn incremental_unblock_cell_merges_zones() {
     assert_eq!(changed.len(), 1);
 
     let result = crate::sim::pathfinding::zone_incremental::try_incremental_update(
-        &mut zg, &changed, &grid2, &BTreeMap::new(),
+        &mut zg,
+        &changed,
+        &grid2,
+        &BTreeMap::new(),
+        None,
     );
     assert!(result);
-    assert!(zg.can_reach(
-        ZoneCategory::Land, (0, 0), MovementLayer::Ground, (4, 0), MovementLayer::Ground,
-    ), "After removing wall, zones should reconnect");
+    assert!(
+        zg.can_reach(
+            ZoneCategory::Land,
+            (0, 0),
+            MovementLayer::Ground,
+            (4, 0),
+            MovementLayer::Ground,
+        ),
+        "After removing wall, zones should reconnect"
+    );
 }
 
 /// Large number of changed cells should trigger fallback (return false).
@@ -437,9 +622,16 @@ fn incremental_fallback_on_large_change() {
     // Simulate > INCREMENTAL_THRESHOLD changed cells.
     let many_changes: Vec<(u16, u16)> = (0..201).map(|i| (i % 5, 0)).collect();
     let result = crate::sim::pathfinding::zone_incremental::try_incremental_update(
-        &mut zg, &many_changes, &grid, &BTreeMap::new(),
+        &mut zg,
+        &many_changes,
+        &grid,
+        &BTreeMap::new(),
+        None,
     );
-    assert!(!result, "Should fall back to full rebuild on > threshold changes");
+    assert!(
+        !result,
+        "Should fall back to full rebuild on > threshold changes"
+    );
 }
 
 /// Empty changeset is a no-op.
@@ -450,11 +642,53 @@ fn incremental_no_change_is_noop() {
     let original_zone_count = zg.map_for(ZoneCategory::Land).unwrap().zone_count;
 
     let result = crate::sim::pathfinding::zone_incremental::try_incremental_update(
-        &mut zg, &[], &grid, &BTreeMap::new(),
+        &mut zg,
+        &[],
+        &grid,
+        &BTreeMap::new(),
+        None,
     );
     assert!(result);
     assert_eq!(
         zg.map_for(ZoneCategory::Land).unwrap().zone_count,
         original_zone_count,
+    );
+}
+
+#[test]
+fn incremental_with_resolved_terrain_falls_back_to_full_rebuild_path() {
+    let terrain = water_row_terrain(3);
+    let grid = PathGrid::from_resolved_terrain(&terrain);
+    let mut zg = ZoneGrid::build_with_terrain(&grid, &BTreeMap::new(), Some(&terrain), 3, 1);
+    let mut grid2 = grid.clone();
+    grid2.set_blocked(1, 0, true);
+    let changed = grid.diff_cells(&grid2).unwrap();
+
+    let result = crate::sim::pathfinding::zone_incremental::try_incremental_update(
+        &mut zg,
+        &changed,
+        &grid2,
+        &BTreeMap::new(),
+        Some(&terrain),
+    );
+    assert!(!result);
+}
+
+#[test]
+fn terrain_aware_incremental_update_requests_full_rebuild() {
+    let terrain = water_row_terrain(5);
+    let grid = PathGrid::from_resolved_terrain(&terrain);
+    let mut zg = ZoneGrid::build_with_terrain(&grid, &BTreeMap::new(), Some(&terrain), 5, 1);
+
+    let result = crate::sim::pathfinding::zone_incremental::try_incremental_update(
+        &mut zg,
+        &[(0, 0)],
+        &grid,
+        &BTreeMap::new(),
+        Some(&terrain),
+    );
+    assert!(
+        !result,
+        "terrain-aware zoning should currently force a full rebuild on dynamic updates"
     );
 }

--- a/src/sim/pathfinding/zone_search.rs
+++ b/src/sim/pathfinding/zone_search.rs
@@ -1,13 +1,17 @@
 //! Zone-aware pathfinding — uses zone connectivity for fast unreachability
 //! detection and hierarchical corridor-based search space reduction.
 //!
-//! Two-tier approach matching the original engine:
+//! Current approximation:
 //! 1. Look up zone IDs for start and goal.
 //! 2. If they are in disconnected zones, return `None` immediately (no A*).
 //! 3. Run Dijkstra on the zone adjacency graph to find a coarse corridor.
 //! 4. Run cell-level A* restricted to the corridor zones.
-//! 5. On failure, retry with zone exclusions (up to 3 retries).
+//! 5. On failure, retry with zone exclusions (up to 5 retries).
 //! 6. Final fallback: run A* without corridor restriction.
+//!
+//! TODO(RE): RA2/YR has distinct regular vs hierarchical entrypoints and a separate
+//! allowHS gate. The recovered entrypoint behavior is precise enough to prove those
+//! modes exist, but not yet enough to replace this corridor-Dijkstra approximation.
 //!
 //! ## Dependency rules
 //! - Part of sim/ — depends on sim/zone_map, sim/pathfinding, sim/locomotor.
@@ -27,14 +31,35 @@ use crate::rules::locomotor_type::MovementZone;
 use crate::sim::movement::locomotor::MovementLayer;
 
 /// Maximum corridor Dijkstra retries with zone exclusions before falling back
-/// to unrestricted A*. Original engine uses 5; we use 3 for simplicity.
-const MAX_CORRIDOR_RETRIES: u8 = 3;
+/// to unrestricted A*. The recovered path entry contract uses a default retry cap of 5.
+const MAX_CORRIDOR_RETRIES: u8 = 5;
+
+fn can_use_reduced_zone_precheck(movement_zone: Option<MovementZone>) -> bool {
+    match movement_zone {
+        None => true,
+        Some(
+            MovementZone::Normal
+            | MovementZone::Amphibious
+            | MovementZone::Infantry
+            | MovementZone::Fly,
+        ) => true,
+        // TODO(RE): naval water/beach surface legality in the current terrain-aware zone
+        // builder is still coarser than the runtime water-surface predicate, so do not
+        // hard-gate those movers on reduced-zone reachability yet.
+        Some(_) => false,
+    }
+}
 
 /// Zone-aware path search for flat (ground-only) paths.
 ///
-/// Uses hierarchical zone Dijkstra to compute a corridor, then runs A*
+/// Uses zone reachability plus a corridor-Dijkstra approximation, then runs A*
 /// restricted to that corridor. Falls back to unrestricted A* if corridor
 /// search fails.
+///
+/// TODO(RE): terrain-aware nodeIndex connectivity can still be a little looser than
+/// final movement legality because the recovered node flood-fill is 8-neighbor while
+/// the actual step predicate also applies tighter per-move checks. Treat zone gating
+/// here as a best-effort reject, not closed parity.
 pub fn find_path_zoned(
     grid: &PathGrid,
     start: (u16, u16),
@@ -46,6 +71,18 @@ pub fn find_path_zoned(
     movement_zone: Option<MovementZone>,
     resolved_terrain: Option<&ResolvedTerrainGrid>,
 ) -> Option<Vec<(u16, u16)>> {
+    if !can_use_reduced_zone_precheck(movement_zone) {
+        return find_path_with_costs(
+            grid,
+            start,
+            goal,
+            costs,
+            entity_blocks,
+            movement_zone,
+            resolved_terrain,
+        );
+    }
+
     let Some(zg) = zone_grid else {
         return find_path_with_costs(
             grid,
@@ -162,9 +199,12 @@ pub fn find_path_zoned(
 /// Zone-aware path search for layered (bridge-capable) paths.
 ///
 /// Checks zone connectivity before invoking the layered A* pathfinder.
-/// Corridor restriction is not applied to layered paths (bridge transitions
-/// make zone corridor semantics complex; the layered A* already benefits
-/// from the increased search budget).
+/// Corridor restriction is not applied to layered paths because the current
+/// bridge-zone model is still conservative.
+///
+/// TODO(RE): The stock game's bridge-layer zone query uses onBridge state plus
+/// ZoneConnection remap records near the cell, not the standalone bridge grid
+/// that this pathfinder currently uses for fast rejects.
 pub fn find_layered_path_zoned(
     grid: &PathGrid,
     ground_blocks: Option<&BTreeSet<(u16, u16)>>,
@@ -175,7 +215,20 @@ pub fn find_layered_path_zoned(
     zone_grid: Option<&ZoneGrid>,
     zone_cat: ZoneCategory,
     terrain_costs: Option<&TerrainCostGrid>,
+    movement_zone: Option<MovementZone>,
 ) -> Option<Vec<LayeredPathStep>> {
+    if !can_use_reduced_zone_precheck(movement_zone) {
+        return find_layered_path(
+            grid,
+            ground_blocks,
+            bridge_blocks,
+            start,
+            start_layer,
+            goal,
+            terrain_costs,
+        );
+    }
+
     // Zone pre-check for layered paths.
     if let Some(zg) = zone_grid {
         let ground_reachable =

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -48,10 +48,10 @@ use crate::sim::movement::tunnel_movement;
 use crate::sim::movement::turret;
 use crate::sim::ore_growth;
 use crate::sim::passenger;
+use crate::sim::pathfinding::PathGrid;
 use crate::sim::pathfinding::terrain_cost::TerrainCostGrid;
 use crate::sim::pathfinding::terrain_speed;
 use crate::sim::pathfinding::zone_map::ZoneGrid;
-use crate::sim::pathfinding::PathGrid;
 use crate::sim::power_system::{self, PowerState};
 use crate::sim::production::{self, ProductionState};
 use crate::sim::radar::{RadarEventQueue, RadarEventType};
@@ -520,6 +520,7 @@ impl Simulation {
                     &changed,
                     path_grid,
                     &self.terrain_costs,
+                    self.resolved_terrain.as_ref(),
                 ) {
                     log::trace!("zone: incremental update ({} cells changed)", changed.len(),);
                     self.prev_path_grid = Some(path_grid.clone());

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -397,10 +397,8 @@ fn test_bridge_damage_rebuilds_path_grid() {
         &resolved, true, 20,
     ));
     // Build PathGrid before damage — bridge should be walkable.
-    let grid_before = PathGrid::from_resolved_terrain_with_bridges(
-        &resolved,
-        sim.bridge_state.as_ref(),
-    );
+    let grid_before =
+        PathGrid::from_resolved_terrain_with_bridges(&resolved, sim.bridge_state.as_ref());
     assert!(grid_before.is_walkable_on_layer(2, 0, MovementLayer::Bridge));
 
     let changes = sim.apply_bridge_damage_events(&[BridgeDamageEvent {
@@ -509,8 +507,6 @@ fn test_water_mover_lookahead_does_not_attach_bridge_occupancy_under_bridge() {
     sim.bridge_state = Some(BridgeRuntimeState::from_resolved_terrain(
         &resolved, true, 15,
     ));
-
-
     let boat_id = sim
         .spawn_object("BOAT", "Americans", 0, 0, 64, &rules, &BTreeMap::new())
         .expect("spawn boat");
@@ -556,8 +552,6 @@ fn test_too_big_ship_can_move_under_bridge_route() {
     sim.bridge_state = Some(BridgeRuntimeState::from_resolved_terrain(
         &resolved, true, 15,
     ));
-
-
     let ship_id = sim
         .spawn_object("DRED", "Americans", 0, 0, 64, &rules, &BTreeMap::new())
         .expect("spawn dreadnought");


### PR DESCRIPTION
## Summary
- rebuild terrain-aware zones from RE-backed movement classes and node connectivity
- align pathfinding fast-reject behavior with known gaps by falling back where parity is still open
- add TODO(RE) markers for unresolved bridge and pathfinding parity details