### PR TITLE
Add RE-backed bridge helper specs and fallout fix

### DIFF
--- a/src/bridge_re.rs
+++ b/src/bridge_re.rs
@@ -1,0 +1,640 @@
+//! Pure RE-backed bridge helpers.
+//!
+//! This file mirrors the closed bridge-related canon specs as small,
+//! deterministic helpers with no dependency on the rest of the game code.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BridgeOverlayTriple {
+    pub a: i32,
+    pub center: i32,
+    pub b: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowBridgeOverlayDamageStepReason {
+    NotBridgeOverlay,
+    GateFailed,
+    NoTransition,
+    Changed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LowBridgeOverlayDamageStepResult {
+    pub ok: bool,
+    pub reason: LowBridgeOverlayDamageStepReason,
+    pub changed: bool,
+    pub triple_out: BridgeOverlayTriple,
+}
+
+fn in_range_inclusive(x: i32, lo: i32, hi: i32) -> bool {
+    x >= lo && x <= hi
+}
+
+fn pattern_a_new_index_or_null(center_overlay_type_index: i32) -> Option<i32> {
+    match center_overlay_type_index {
+        0x60 => Some(0x61),
+        0x62 => Some(0x63),
+        x if x < 0x59 => Some(0x59),
+        x if x < 0x5c => Some(0x65),
+        _ => None,
+    }
+}
+
+fn pattern_b_new_index_or_null(center_overlay_type_index: i32) -> Option<i32> {
+    match center_overlay_type_index {
+        0xe3 => Some(0xe4),
+        0xe5 => Some(0xe6),
+        x if x < 0xdc => Some(0xdc),
+        x if x < 0xdf => Some(0xe8),
+        _ => None,
+    }
+}
+
+pub fn low_bridge_overlay_damage_step_ra2(
+    triple: BridgeOverlayTriple,
+    damage: i32,
+    bridge_strength: i32,
+    atom_damage: i32,
+    random_ranged_1_bridge_strength: i32,
+) -> LowBridgeOverlayDamageStepResult {
+    let center = triple.center;
+    let in_wood = in_range_inclusive(center, 0x4a, 0x63);
+    let in_concrete = in_range_inclusive(center, 0xcd, 0xe6);
+
+    if !in_wood && !in_concrete {
+        return LowBridgeOverlayDamageStepResult {
+            ok: true,
+            reason: LowBridgeOverlayDamageStepReason::NotBridgeOverlay,
+            changed: false,
+            triple_out: triple,
+        };
+    }
+
+    if damage != atom_damage {
+        if bridge_strength <= 0 || random_ranged_1_bridge_strength >= damage {
+            return LowBridgeOverlayDamageStepResult {
+                ok: true,
+                reason: LowBridgeOverlayDamageStepReason::GateFailed,
+                changed: false,
+                triple_out: triple,
+            };
+        }
+    }
+
+    let new_index = if in_wood {
+        pattern_a_new_index_or_null(center)
+    } else {
+        pattern_b_new_index_or_null(center)
+    };
+
+    let Some(new_index) = new_index else {
+        return LowBridgeOverlayDamageStepResult {
+            ok: true,
+            reason: LowBridgeOverlayDamageStepReason::NoTransition,
+            changed: false,
+            triple_out: triple,
+        };
+    };
+
+    LowBridgeOverlayDamageStepResult {
+        ok: true,
+        reason: LowBridgeOverlayDamageStepReason::Changed,
+        changed: true,
+        triple_out: BridgeOverlayTriple {
+            a: new_index,
+            center: new_index,
+            b: new_index,
+        },
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowBridgeConnectedBand {
+    WoodBand1,
+    WoodBand2,
+    ConcreteBand1,
+    ConcreteBand2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowBridgeConnectedAnchor {
+    OppositeAdjacent,
+    Center,
+    PrimaryAdjacent,
+    ConnectedChainHelper,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LowBridgeConnectedSelectorResult {
+    pub handled: bool,
+    pub reason: LowBridgeConnectedSectionSelectorReason,
+    pub pattern: Option<LowBridgePattern>,
+    pub band: Option<LowBridgeConnectedBand>,
+    pub anchor: Option<LowBridgeConnectedAnchor>,
+    pub neighbor_range_lo: Option<i32>,
+    pub neighbor_range_hi: Option<i32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowBridgeConnectedSectionSelectorReason {
+    NotBridgeOverlay,
+    Selected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowBridgePattern {
+    A,
+    B,
+}
+
+fn classify_low_bridge_band(center_overlay_type_index: i32) -> Option<LowBridgeConnectedBand> {
+    let x = center_overlay_type_index;
+
+    if in_range_inclusive(x, 0x4a, 0x52) || in_range_inclusive(x, 0x5c, 0x5f) || x == 0x64 {
+        return Some(LowBridgeConnectedBand::WoodBand1);
+    }
+    if in_range_inclusive(x, 0x53, 0x5b) || in_range_inclusive(x, 0x60, 0x63) || x == 0x65 {
+        return Some(LowBridgeConnectedBand::WoodBand2);
+    }
+    if in_range_inclusive(x, 0xcd, 0xd5) || in_range_inclusive(x, 0xdf, 0xe2) || x == 0xe7 {
+        return Some(LowBridgeConnectedBand::ConcreteBand1);
+    }
+    if in_range_inclusive(x, 0xd6, 0xde) || in_range_inclusive(x, 0xe3, 0xe6) || x == 0xe8 {
+        return Some(LowBridgeConnectedBand::ConcreteBand2);
+    }
+
+    None
+}
+
+fn low_bridge_neighbor_range_for_band(
+    band: LowBridgeConnectedBand,
+) -> (LowBridgePattern, i32, i32) {
+    match band {
+        LowBridgeConnectedBand::WoodBand1 | LowBridgeConnectedBand::WoodBand2 => {
+            (LowBridgePattern::A, 0x4a, 0x65)
+        }
+        LowBridgeConnectedBand::ConcreteBand1 | LowBridgeConnectedBand::ConcreteBand2 => {
+            (LowBridgePattern::B, 0xcd, 0xe8)
+        }
+    }
+}
+
+pub fn low_bridge_connected_section_selector_yr(
+    center_overlay_type_index: i32,
+    primary_probe_in_family_range: bool,
+    secondary_probe_in_family_range: bool,
+) -> LowBridgeConnectedSelectorResult {
+    let Some(band) = classify_low_bridge_band(center_overlay_type_index) else {
+        return LowBridgeConnectedSelectorResult {
+            handled: false,
+            reason: LowBridgeConnectedSectionSelectorReason::NotBridgeOverlay,
+            pattern: None,
+            band: None,
+            anchor: None,
+            neighbor_range_lo: None,
+            neighbor_range_hi: None,
+        };
+    };
+
+    let (pattern, neighbor_range_lo, neighbor_range_hi) = low_bridge_neighbor_range_for_band(band);
+
+    let anchor = if !primary_probe_in_family_range {
+        LowBridgeConnectedAnchor::OppositeAdjacent
+    } else if !secondary_probe_in_family_range {
+        LowBridgeConnectedAnchor::Center
+    } else {
+        match band {
+            LowBridgeConnectedBand::WoodBand1 | LowBridgeConnectedBand::ConcreteBand1 => {
+                LowBridgeConnectedAnchor::PrimaryAdjacent
+            }
+            LowBridgeConnectedBand::WoodBand2 | LowBridgeConnectedBand::ConcreteBand2 => {
+                LowBridgeConnectedAnchor::ConnectedChainHelper
+            }
+        }
+    };
+
+    LowBridgeConnectedSelectorResult {
+        handled: true,
+        reason: LowBridgeConnectedSectionSelectorReason::Selected,
+        pattern: Some(pattern),
+        band: Some(band),
+        anchor: Some(anchor),
+        neighbor_range_lo: Some(neighbor_range_lo),
+        neighbor_range_hi: Some(neighbor_range_hi),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Cell {
+    pub x: i32,
+    pub y: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ZoneConnectionRecord {
+    pub cell_a: Cell,
+    pub cell_b: Cell,
+    pub flags: u32,
+    pub flags_byte8: u8,
+    pub skip_if_nonzero: u32,
+}
+
+fn read_u8(bytes: &[u8], off: usize) -> u8 {
+    bytes.get(off).copied().unwrap_or(0)
+}
+
+fn read_i16_le(bytes: &[u8], off: usize) -> i16 {
+    i16::from_le_bytes([read_u8(bytes, off), read_u8(bytes, off + 1)])
+}
+
+fn read_u32_le(bytes: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes([
+        read_u8(bytes, off),
+        read_u8(bytes, off + 1),
+        read_u8(bytes, off + 2),
+        read_u8(bytes, off + 3),
+    ])
+}
+
+pub fn decode_zone_connection_record(record: &[u8]) -> Result<ZoneConnectionRecord, String> {
+    if record.len() != 16 {
+        return Err(format!("expected 16-byte record, got len={}", record.len()));
+    }
+
+    let cell_a = Cell {
+        x: read_i16_le(record, 0x00) as i32,
+        y: read_i16_le(record, 0x02) as i32,
+    };
+    let cell_b = Cell {
+        x: read_i16_le(record, 0x04) as i32,
+        y: read_i16_le(record, 0x06) as i32,
+    };
+    let flags = read_u32_le(record, 0x08);
+    let skip_if_nonzero = read_u32_le(record, 0x0c);
+
+    Ok(ZoneConnectionRecord {
+        cell_a,
+        cell_b,
+        flags,
+        flags_byte8: (flags & 0xff) as u8,
+        skip_if_nonzero,
+    })
+}
+
+pub fn zone_connection_matches_cell(record: &[u8], cell: Cell, dist: i32) -> bool {
+    let Ok(decoded) = decode_zone_connection_record(record) else {
+        return false;
+    };
+    if decoded.skip_if_nonzero != 0 {
+        return false;
+    }
+
+    let d = dist.max(0);
+    let a = decoded.cell_a;
+    let b = decoded.cell_b;
+
+    if a.x == b.x {
+        let y_min = a.y.min(b.y);
+        let y_max = a.y.max(b.y);
+        return cell.y >= y_min && cell.y <= y_max && (cell.x - a.x).abs() <= d;
+    }
+
+    let x_min = a.x.min(b.x);
+    let x_max = a.x.max(b.x);
+    cell.x >= x_min && cell.x <= x_max && (cell.y - a.y).abs() <= d
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeZonePolicyTarget {
+    Ra2_1006,
+    Yr_1001,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GetCellZoneIdBridgePolicyResult {
+    pub use_bridge_path: bool,
+    pub call_bridge_remap_fallback: bool,
+    pub return_no_zone: bool,
+}
+
+const BRIDGE_GATE_BIT: u32 = 0x0100;
+const NO_ZONE_CONNECTION: i32 = -1;
+
+pub fn get_cell_zone_id_bridge_policy_decision(
+    target: BridgeZonePolicyTarget,
+    on_bridge: bool,
+    cell_flags_dword: u32,
+    zone_connection_index: i32,
+) -> GetCellZoneIdBridgePolicyResult {
+    let use_bridge_path = on_bridge && (cell_flags_dword & BRIDGE_GATE_BIT) != 0;
+    if !use_bridge_path {
+        return GetCellZoneIdBridgePolicyResult {
+            use_bridge_path: false,
+            call_bridge_remap_fallback: false,
+            return_no_zone: false,
+        };
+    }
+
+    if zone_connection_index != NO_ZONE_CONNECTION {
+        return GetCellZoneIdBridgePolicyResult {
+            use_bridge_path: true,
+            call_bridge_remap_fallback: false,
+            return_no_zone: false,
+        };
+    }
+
+    if matches!(target, BridgeZonePolicyTarget::Yr_1001) {
+        return GetCellZoneIdBridgePolicyResult {
+            use_bridge_path: true,
+            call_bridge_remap_fallback: true,
+            return_no_zone: false,
+        };
+    }
+
+    GetCellZoneIdBridgePolicyResult {
+        use_bridge_path: true,
+        call_bridge_remap_fallback: false,
+        return_no_zone: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn low_bridge_overlay_damage_step_branches() {
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 1,
+                center: 1234,
+                b: 2,
+            },
+            50,
+            150,
+            999,
+            1,
+        );
+        assert_eq!(
+            out.reason,
+            LowBridgeOverlayDamageStepReason::NotBridgeOverlay
+        );
+        assert!(!out.changed);
+        assert_eq!(
+            out.triple_out,
+            BridgeOverlayTriple {
+                a: 1,
+                center: 1234,
+                b: 2,
+            }
+        );
+
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 96,
+                center: 96,
+                b: 96,
+            },
+            10,
+            150,
+            999,
+            10,
+        );
+        assert_eq!(out.reason, LowBridgeOverlayDamageStepReason::GateFailed);
+        assert!(!out.changed);
+
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 96,
+                center: 96,
+                b: 96,
+            },
+            999,
+            150,
+            999,
+            150,
+        );
+        assert_eq!(out.reason, LowBridgeOverlayDamageStepReason::Changed);
+        assert!(out.changed);
+        assert_eq!(
+            out.triple_out,
+            BridgeOverlayTriple {
+                a: 97,
+                center: 97,
+                b: 97,
+            }
+        );
+
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 74,
+                center: 74,
+                b: 74,
+            },
+            2,
+            150,
+            999,
+            1,
+        );
+        assert_eq!(out.triple_out.center, 89);
+        assert!(out.changed);
+
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 89,
+                center: 89,
+                b: 90,
+            },
+            2,
+            150,
+            999,
+            1,
+        );
+        assert_eq!(out.triple_out.center, 101);
+        assert!(out.changed);
+
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 227,
+                center: 227,
+                b: 227,
+            },
+            2,
+            150,
+            999,
+            1,
+        );
+        assert_eq!(out.triple_out.center, 228);
+        assert!(out.changed);
+
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 223,
+                center: 223,
+                b: 223,
+            },
+            2,
+            150,
+            999,
+            1,
+        );
+        assert_eq!(out.reason, LowBridgeOverlayDamageStepReason::NoTransition);
+        assert!(!out.changed);
+    }
+
+    #[test]
+    fn low_bridge_connected_section_selector_branches() {
+        let out = low_bridge_connected_section_selector_yr(1, false, false);
+        assert!(!out.handled);
+        assert_eq!(
+            out.reason,
+            LowBridgeConnectedSectionSelectorReason::NotBridgeOverlay
+        );
+
+        let out = low_bridge_connected_section_selector_yr(74, false, false);
+        assert_eq!(
+            out.reason,
+            LowBridgeConnectedSectionSelectorReason::Selected
+        );
+        assert_eq!(out.pattern, Some(LowBridgePattern::A));
+        assert_eq!(out.band, Some(LowBridgeConnectedBand::WoodBand1));
+        assert_eq!(out.anchor, Some(LowBridgeConnectedAnchor::OppositeAdjacent));
+        assert_eq!(out.neighbor_range_lo, Some(0x4a));
+        assert_eq!(out.neighbor_range_hi, Some(0x65));
+
+        let out = low_bridge_connected_section_selector_yr(74, true, false);
+        assert_eq!(out.anchor, Some(LowBridgeConnectedAnchor::Center));
+
+        let out = low_bridge_connected_section_selector_yr(74, true, true);
+        assert_eq!(out.anchor, Some(LowBridgeConnectedAnchor::PrimaryAdjacent));
+
+        let out = low_bridge_connected_section_selector_yr(83, true, true);
+        assert_eq!(out.band, Some(LowBridgeConnectedBand::WoodBand2));
+        assert_eq!(
+            out.anchor,
+            Some(LowBridgeConnectedAnchor::ConnectedChainHelper)
+        );
+
+        let out = low_bridge_connected_section_selector_yr(205, false, false);
+        assert_eq!(out.pattern, Some(LowBridgePattern::B));
+        assert_eq!(out.band, Some(LowBridgeConnectedBand::ConcreteBand1));
+        assert_eq!(out.anchor, Some(LowBridgeConnectedAnchor::OppositeAdjacent));
+        assert_eq!(out.neighbor_range_lo, Some(0xcd));
+        assert_eq!(out.neighbor_range_hi, Some(0xe8));
+
+        let out = low_bridge_connected_section_selector_yr(214, true, true);
+        assert_eq!(out.band, Some(LowBridgeConnectedBand::ConcreteBand2));
+        assert_eq!(
+            out.anchor,
+            Some(LowBridgeConnectedAnchor::ConnectedChainHelper)
+        );
+    }
+
+    #[test]
+    fn zone_connection_record_layout_decode_basic() {
+        let record = vec![10, 0, 254, 255, 10, 0, 5, 0, 1, 0, 0, 0, 0, 0, 0, 0];
+        let decoded = decode_zone_connection_record(&record).expect("decode");
+        assert_eq!(decoded.cell_a, Cell { x: 10, y: -2 });
+        assert_eq!(decoded.cell_b, Cell { x: 10, y: 5 });
+        assert_eq!(decoded.flags, 1);
+        assert_eq!(decoded.flags_byte8, 1);
+        assert_eq!(decoded.skip_if_nonzero, 0);
+    }
+
+    #[test]
+    fn zone_connection_record_layout_match_vertical_segment() {
+        let record = vec![10, 0, 254, 255, 10, 0, 5, 0, 1, 0, 0, 0, 0, 0, 0, 0];
+        assert!(zone_connection_matches_cell(
+            &record,
+            Cell { x: 9, y: 0 },
+            1
+        ));
+        assert!(!zone_connection_matches_cell(
+            &record,
+            Cell { x: 8, y: 0 },
+            1
+        ));
+        assert!(!zone_connection_matches_cell(
+            &record,
+            Cell { x: 10, y: 6 },
+            1
+        ));
+    }
+
+    #[test]
+    fn zone_connection_record_layout_match_skip_if_nonzero() {
+        let record = vec![10, 0, 254, 255, 10, 0, 5, 0, 1, 0, 0, 0, 1, 0, 0, 0];
+        assert!(!zone_connection_matches_cell(
+            &record,
+            Cell { x: 10, y: 0 },
+            1
+        ));
+    }
+
+    #[test]
+    fn zone_id_bridge_policy_decisions() {
+        let out = get_cell_zone_id_bridge_policy_decision(
+            BridgeZonePolicyTarget::Yr_1001,
+            false,
+            256,
+            -1,
+        );
+        assert_eq!(
+            out,
+            GetCellZoneIdBridgePolicyResult {
+                use_bridge_path: false,
+                call_bridge_remap_fallback: false,
+                return_no_zone: false,
+            }
+        );
+
+        let out =
+            get_cell_zone_id_bridge_policy_decision(BridgeZonePolicyTarget::Ra2_1006, true, 0, -1);
+        assert_eq!(
+            out,
+            GetCellZoneIdBridgePolicyResult {
+                use_bridge_path: false,
+                call_bridge_remap_fallback: false,
+                return_no_zone: false,
+            }
+        );
+
+        let out =
+            get_cell_zone_id_bridge_policy_decision(BridgeZonePolicyTarget::Ra2_1006, true, 256, 3);
+        assert_eq!(
+            out,
+            GetCellZoneIdBridgePolicyResult {
+                use_bridge_path: true,
+                call_bridge_remap_fallback: false,
+                return_no_zone: false,
+            }
+        );
+
+        let out = get_cell_zone_id_bridge_policy_decision(
+            BridgeZonePolicyTarget::Ra2_1006,
+            true,
+            256,
+            -1,
+        );
+        assert_eq!(
+            out,
+            GetCellZoneIdBridgePolicyResult {
+                use_bridge_path: true,
+                call_bridge_remap_fallback: false,
+                return_no_zone: true,
+            }
+        );
+
+        let out =
+            get_cell_zone_id_bridge_policy_decision(BridgeZonePolicyTarget::Yr_1001, true, 256, -1);
+        assert_eq!(
+            out,
+            GetCellZoneIdBridgePolicyResult {
+                use_bridge_path: true,
+                call_bridge_remap_fallback: true,
+                return_no_zone: false,
+            }
+        );
+    }
+}

--- a/src/sim/bridge_specs.rs
+++ b/src/sim/bridge_specs.rs
@@ -1,0 +1,591 @@
+//! RE-backed bridge helper algorithms not yet fully wired into the live runtime.
+//!
+//! These helpers mirror closed behavior from the RE repo:
+//! - low-bridge overlay damage step (RA2)
+//! - low-bridge connected-section selector (YR)
+//! - ZoneConnection record decode + proximity matching
+//! - bridge-layer zone-id policy gate (RA2/YR)
+//!
+//! They are kept as pure functions so the runtime can adopt them incrementally
+//! once mutable overlay state and ZoneConnection records are available.
+
+const BRIDGE_GATE_BIT: u32 = 0x0100;
+const NO_ZONE_CONNECTION: i16 = -1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BridgeOverlayTriple {
+    pub a: i32,
+    pub center: i32,
+    pub b: i32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowBridgeOverlayDamageReason {
+    NotBridgeOverlay,
+    GateFailed,
+    NoTransition,
+    Changed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LowBridgeOverlayDamageStepResult {
+    pub ok: bool,
+    pub reason: LowBridgeOverlayDamageReason,
+    pub changed: bool,
+    pub triple_out: BridgeOverlayTriple,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowBridgeConnectedBand {
+    WoodBand1,
+    WoodBand2,
+    ConcreteBand1,
+    ConcreteBand2,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowBridgeConnectedAnchor {
+    OppositeAdjacent,
+    Center,
+    PrimaryAdjacent,
+    ConnectedChainHelper,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LowBridgeConnectedPattern {
+    A,
+    B,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LowBridgeConnectedSectionSelectorResult {
+    pub handled: bool,
+    pub reason_not_bridge_overlay: bool,
+    pub pattern: Option<LowBridgeConnectedPattern>,
+    pub band: Option<LowBridgeConnectedBand>,
+    pub anchor: Option<LowBridgeConnectedAnchor>,
+    pub neighbor_range_lo: Option<i32>,
+    pub neighbor_range_hi: Option<i32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ZoneConnectionRecord {
+    pub cell_a: (i16, i16),
+    pub cell_b: (i16, i16),
+    pub flags: u32,
+    pub flags_byte8: u8,
+    pub skip_if_nonzero: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeZoneIdPolicyTarget {
+    Ra21006,
+    Yr1001,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BridgeZoneIdPolicyDecision {
+    pub use_bridge_path: bool,
+    pub call_bridge_remap_fallback: bool,
+    pub return_no_zone: bool,
+}
+
+pub fn low_bridge_overlay_damage_step_ra2(
+    triple: BridgeOverlayTriple,
+    damage: i32,
+    bridge_strength: i32,
+    atom_damage: i32,
+    random_ranged_1_bridge_strength: i32,
+) -> LowBridgeOverlayDamageStepResult {
+    let center = triple.center;
+    let in_a = in_range_inclusive(center, 0x4a, 0x63);
+    let in_b = in_range_inclusive(center, 0xcd, 0xe6);
+
+    if !in_a && !in_b {
+        return LowBridgeOverlayDamageStepResult {
+            ok: true,
+            reason: LowBridgeOverlayDamageReason::NotBridgeOverlay,
+            changed: false,
+            triple_out: triple,
+        };
+    }
+
+    if damage != atom_damage {
+        if bridge_strength <= 0 || random_ranged_1_bridge_strength >= damage {
+            return LowBridgeOverlayDamageStepResult {
+                ok: true,
+                reason: LowBridgeOverlayDamageReason::GateFailed,
+                changed: false,
+                triple_out: triple,
+            };
+        }
+    }
+
+    let new_index = if in_a {
+        pattern_a_new_index(center)
+    } else {
+        pattern_b_new_index(center)
+    };
+
+    match new_index {
+        Some(new_index) => LowBridgeOverlayDamageStepResult {
+            ok: true,
+            reason: LowBridgeOverlayDamageReason::Changed,
+            changed: true,
+            triple_out: BridgeOverlayTriple {
+                a: new_index,
+                center: new_index,
+                b: new_index,
+            },
+        },
+        None => LowBridgeOverlayDamageStepResult {
+            ok: true,
+            reason: LowBridgeOverlayDamageReason::NoTransition,
+            changed: false,
+            triple_out: triple,
+        },
+    }
+}
+
+pub fn low_bridge_connected_section_selector_yr(
+    center_overlay_type_index: i32,
+    primary_probe_in_family_range: bool,
+    secondary_probe_in_family_range: bool,
+) -> LowBridgeConnectedSectionSelectorResult {
+    let Some(band) = classify_low_bridge_band(center_overlay_type_index) else {
+        return LowBridgeConnectedSectionSelectorResult {
+            handled: false,
+            reason_not_bridge_overlay: true,
+            pattern: None,
+            band: None,
+            anchor: None,
+            neighbor_range_lo: None,
+            neighbor_range_hi: None,
+        };
+    };
+
+    let (pattern, neighbor_range_lo, neighbor_range_hi) = match band {
+        LowBridgeConnectedBand::WoodBand1 | LowBridgeConnectedBand::WoodBand2 => {
+            (LowBridgeConnectedPattern::A, 0x4a, 0x65)
+        }
+        LowBridgeConnectedBand::ConcreteBand1 | LowBridgeConnectedBand::ConcreteBand2 => {
+            (LowBridgeConnectedPattern::B, 0xcd, 0xe8)
+        }
+    };
+
+    let anchor = if !primary_probe_in_family_range {
+        LowBridgeConnectedAnchor::OppositeAdjacent
+    } else if !secondary_probe_in_family_range {
+        LowBridgeConnectedAnchor::Center
+    } else if matches!(
+        band,
+        LowBridgeConnectedBand::WoodBand1 | LowBridgeConnectedBand::ConcreteBand1
+    ) {
+        LowBridgeConnectedAnchor::PrimaryAdjacent
+    } else {
+        LowBridgeConnectedAnchor::ConnectedChainHelper
+    };
+
+    LowBridgeConnectedSectionSelectorResult {
+        handled: true,
+        reason_not_bridge_overlay: false,
+        pattern: Some(pattern),
+        band: Some(band),
+        anchor: Some(anchor),
+        neighbor_range_lo: Some(neighbor_range_lo),
+        neighbor_range_hi: Some(neighbor_range_hi),
+    }
+}
+
+pub fn decode_zone_connection_record(record: &[u8]) -> ZoneConnectionRecord {
+    assert_eq!(record.len(), 16, "expected 16-byte ZoneConnection record");
+
+    let flags = read_u32_le(record, 0x08);
+    ZoneConnectionRecord {
+        cell_a: (read_i16_le(record, 0x00), read_i16_le(record, 0x02)),
+        cell_b: (read_i16_le(record, 0x04), read_i16_le(record, 0x06)),
+        flags,
+        flags_byte8: (flags & 0xff) as u8,
+        skip_if_nonzero: read_u32_le(record, 0x0c),
+    }
+}
+
+pub fn zone_connection_matches_cell(record: &[u8], cell: (i16, i16), dist: i16) -> bool {
+    let decoded = decode_zone_connection_record(record);
+    if decoded.skip_if_nonzero != 0 {
+        return false;
+    }
+
+    let dist = dist.max(0);
+    let ((ax, ay), (bx, by)) = (decoded.cell_a, decoded.cell_b);
+
+    if ax == bx {
+        let y_min = ay.min(by);
+        let y_max = ay.max(by);
+        cell.1 >= y_min && cell.1 <= y_max && (cell.0 - ax).abs() <= dist
+    } else {
+        let x_min = ax.min(bx);
+        let x_max = ax.max(bx);
+        cell.0 >= x_min && cell.0 <= x_max && (cell.1 - ay).abs() <= dist
+    }
+}
+
+pub fn get_cell_zone_id_bridge_policy_decision(
+    target: BridgeZoneIdPolicyTarget,
+    on_bridge: bool,
+    cell_flags_dword: u32,
+    zone_connection_index: i16,
+) -> BridgeZoneIdPolicyDecision {
+    let use_bridge_path = on_bridge && (cell_flags_dword & BRIDGE_GATE_BIT) != 0;
+    if !use_bridge_path {
+        return BridgeZoneIdPolicyDecision {
+            use_bridge_path: false,
+            call_bridge_remap_fallback: false,
+            return_no_zone: false,
+        };
+    }
+
+    if zone_connection_index != NO_ZONE_CONNECTION {
+        return BridgeZoneIdPolicyDecision {
+            use_bridge_path: true,
+            call_bridge_remap_fallback: false,
+            return_no_zone: false,
+        };
+    }
+
+    match target {
+        BridgeZoneIdPolicyTarget::Yr1001 => BridgeZoneIdPolicyDecision {
+            use_bridge_path: true,
+            call_bridge_remap_fallback: true,
+            return_no_zone: false,
+        },
+        BridgeZoneIdPolicyTarget::Ra21006 => BridgeZoneIdPolicyDecision {
+            use_bridge_path: true,
+            call_bridge_remap_fallback: false,
+            return_no_zone: true,
+        },
+    }
+}
+
+fn in_range_inclusive(x: i32, lo: i32, hi: i32) -> bool {
+    x >= lo && x <= hi
+}
+
+fn pattern_a_new_index(center_overlay_type_index: i32) -> Option<i32> {
+    match center_overlay_type_index {
+        0x60 => Some(0x61),
+        0x62 => Some(0x63),
+        x if x < 0x59 => Some(0x59),
+        x if x < 0x5c => Some(0x65),
+        _ => None,
+    }
+}
+
+fn pattern_b_new_index(center_overlay_type_index: i32) -> Option<i32> {
+    match center_overlay_type_index {
+        0xe3 => Some(0xe4),
+        0xe5 => Some(0xe6),
+        x if x < 0xdc => Some(0xdc),
+        x if x < 0xdf => Some(0xe8),
+        _ => None,
+    }
+}
+
+fn classify_low_bridge_band(center_overlay_type_index: i32) -> Option<LowBridgeConnectedBand> {
+    let x = center_overlay_type_index;
+
+    if in_range_inclusive(x, 0x4a, 0x52) || in_range_inclusive(x, 0x5c, 0x5f) || x == 0x64 {
+        return Some(LowBridgeConnectedBand::WoodBand1);
+    }
+    if in_range_inclusive(x, 0x53, 0x5b) || in_range_inclusive(x, 0x60, 0x63) || x == 0x65 {
+        return Some(LowBridgeConnectedBand::WoodBand2);
+    }
+    if in_range_inclusive(x, 0xcd, 0xd5) || in_range_inclusive(x, 0xdf, 0xe2) || x == 0xe7 {
+        return Some(LowBridgeConnectedBand::ConcreteBand1);
+    }
+    if in_range_inclusive(x, 0xd6, 0xde) || in_range_inclusive(x, 0xe3, 0xe6) || x == 0xe8 {
+        return Some(LowBridgeConnectedBand::ConcreteBand2);
+    }
+
+    None
+}
+
+fn read_u16_le(bytes: &[u8], off: usize) -> u16 {
+    u16::from_le_bytes([bytes[off], bytes[off + 1]])
+}
+
+fn read_i16_le(bytes: &[u8], off: usize) -> i16 {
+    read_u16_le(bytes, off) as i16
+}
+
+fn read_u32_le(bytes: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes([bytes[off], bytes[off + 1], bytes[off + 2], bytes[off + 3]])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn low_bridge_damage_step_ignores_non_bridge_overlay() {
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 1,
+                center: 1234,
+                b: 2,
+            },
+            50,
+            150,
+            999,
+            1,
+        );
+        assert_eq!(out.reason, LowBridgeOverlayDamageReason::NotBridgeOverlay);
+        assert!(!out.changed);
+        assert_eq!(out.triple_out.center, 1234);
+    }
+
+    #[test]
+    fn low_bridge_damage_step_applies_rng_gate() {
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 96,
+                center: 96,
+                b: 96,
+            },
+            10,
+            150,
+            999,
+            10,
+        );
+        assert_eq!(out.reason, LowBridgeOverlayDamageReason::GateFailed);
+        assert!(!out.changed);
+    }
+
+    #[test]
+    fn low_bridge_damage_step_atom_damage_bypasses_gate() {
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 96,
+                center: 96,
+                b: 96,
+            },
+            999,
+            150,
+            999,
+            150,
+        );
+        assert_eq!(out.reason, LowBridgeOverlayDamageReason::Changed);
+        assert!(out.changed);
+        assert_eq!(
+            out.triple_out,
+            BridgeOverlayTriple {
+                a: 97,
+                center: 97,
+                b: 97,
+            }
+        );
+    }
+
+    #[test]
+    fn low_bridge_damage_step_maps_wood_family() {
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 74,
+                center: 74,
+                b: 74,
+            },
+            2,
+            150,
+            999,
+            1,
+        );
+        assert_eq!(out.triple_out.center, 89);
+
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 89,
+                center: 89,
+                b: 90,
+            },
+            2,
+            150,
+            999,
+            1,
+        );
+        assert_eq!(out.triple_out.center, 101);
+    }
+
+    #[test]
+    fn low_bridge_damage_step_maps_concrete_family_and_no_transition() {
+        let out = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 227,
+                center: 227,
+                b: 227,
+            },
+            2,
+            150,
+            999,
+            1,
+        );
+        assert_eq!(out.triple_out.center, 228);
+
+        let no_change = low_bridge_overlay_damage_step_ra2(
+            BridgeOverlayTriple {
+                a: 223,
+                center: 223,
+                b: 223,
+            },
+            2,
+            150,
+            999,
+            1,
+        );
+        assert_eq!(no_change.reason, LowBridgeOverlayDamageReason::NoTransition);
+        assert!(!no_change.changed);
+    }
+
+    #[test]
+    fn low_bridge_selector_rejects_non_bridge_overlay() {
+        let out = low_bridge_connected_section_selector_yr(1, false, false);
+        assert!(!out.handled);
+        assert!(out.reason_not_bridge_overlay);
+    }
+
+    #[test]
+    fn low_bridge_selector_uses_exact_anchor_policy() {
+        let out = low_bridge_connected_section_selector_yr(74, false, false);
+        assert_eq!(out.pattern, Some(LowBridgeConnectedPattern::A));
+        assert_eq!(out.band, Some(LowBridgeConnectedBand::WoodBand1));
+        assert_eq!(out.anchor, Some(LowBridgeConnectedAnchor::OppositeAdjacent));
+        assert_eq!(out.neighbor_range_lo, Some(74));
+        assert_eq!(out.neighbor_range_hi, Some(101));
+
+        let out = low_bridge_connected_section_selector_yr(74, true, false);
+        assert_eq!(out.anchor, Some(LowBridgeConnectedAnchor::Center));
+
+        let out = low_bridge_connected_section_selector_yr(74, true, true);
+        assert_eq!(out.anchor, Some(LowBridgeConnectedAnchor::PrimaryAdjacent));
+
+        let out = low_bridge_connected_section_selector_yr(83, true, true);
+        assert_eq!(out.band, Some(LowBridgeConnectedBand::WoodBand2));
+        assert_eq!(
+            out.anchor,
+            Some(LowBridgeConnectedAnchor::ConnectedChainHelper)
+        );
+
+        let out = low_bridge_connected_section_selector_yr(205, false, false);
+        assert_eq!(out.pattern, Some(LowBridgeConnectedPattern::B));
+        assert_eq!(out.band, Some(LowBridgeConnectedBand::ConcreteBand1));
+        assert_eq!(out.anchor, Some(LowBridgeConnectedAnchor::OppositeAdjacent));
+        assert_eq!(out.neighbor_range_lo, Some(205));
+        assert_eq!(out.neighbor_range_hi, Some(232));
+
+        let out = low_bridge_connected_section_selector_yr(214, true, true);
+        assert_eq!(out.band, Some(LowBridgeConnectedBand::ConcreteBand2));
+        assert_eq!(
+            out.anchor,
+            Some(LowBridgeConnectedAnchor::ConnectedChainHelper)
+        );
+    }
+
+    #[test]
+    fn zone_connection_record_decodes_layout() {
+        let record = [10, 0, 254, 255, 10, 0, 5, 0, 1, 0, 0, 0, 0, 0, 0, 0];
+        let decoded = decode_zone_connection_record(&record);
+        assert_eq!(decoded.cell_a, (10, -2));
+        assert_eq!(decoded.cell_b, (10, 5));
+        assert_eq!(decoded.flags, 1);
+        assert_eq!(decoded.flags_byte8, 1);
+        assert_eq!(decoded.skip_if_nonzero, 0);
+    }
+
+    #[test]
+    fn zone_connection_match_uses_axis_aligned_segment_proximity() {
+        let record = [10, 0, 254, 255, 10, 0, 5, 0, 1, 0, 0, 0, 0, 0, 0, 0];
+        assert!(zone_connection_matches_cell(&record, (9, 0), 1));
+        assert!(!zone_connection_matches_cell(&record, (8, 0), 1));
+        assert!(!zone_connection_matches_cell(&record, (10, 6), 1));
+    }
+
+    #[test]
+    fn zone_connection_match_respects_skip_flag() {
+        let record = [10, 0, 254, 255, 10, 0, 5, 0, 1, 0, 0, 0, 1, 0, 0, 0];
+        assert!(!zone_connection_matches_cell(&record, (10, 0), 1));
+    }
+
+    #[test]
+    fn bridge_zone_policy_turns_off_when_on_bridge_false() {
+        let out = get_cell_zone_id_bridge_policy_decision(
+            BridgeZoneIdPolicyTarget::Yr1001,
+            false,
+            0x0100,
+            -1,
+        );
+        assert_eq!(
+            out,
+            BridgeZoneIdPolicyDecision {
+                use_bridge_path: false,
+                call_bridge_remap_fallback: false,
+                return_no_zone: false,
+            }
+        );
+    }
+
+    #[test]
+    fn bridge_zone_policy_turns_off_when_bridge_bit_clear() {
+        let out =
+            get_cell_zone_id_bridge_policy_decision(BridgeZoneIdPolicyTarget::Ra21006, true, 0, -1);
+        assert!(!out.use_bridge_path);
+        assert!(!out.call_bridge_remap_fallback);
+        assert!(!out.return_no_zone);
+    }
+
+    #[test]
+    fn bridge_zone_policy_matches_ra2_and_yr_fallback_split() {
+        let hit = get_cell_zone_id_bridge_policy_decision(
+            BridgeZoneIdPolicyTarget::Ra21006,
+            true,
+            0x0100,
+            3,
+        );
+        assert_eq!(
+            hit,
+            BridgeZoneIdPolicyDecision {
+                use_bridge_path: true,
+                call_bridge_remap_fallback: false,
+                return_no_zone: false,
+            }
+        );
+
+        let ra2_miss = get_cell_zone_id_bridge_policy_decision(
+            BridgeZoneIdPolicyTarget::Ra21006,
+            true,
+            0x0100,
+            -1,
+        );
+        assert_eq!(
+            ra2_miss,
+            BridgeZoneIdPolicyDecision {
+                use_bridge_path: true,
+                call_bridge_remap_fallback: false,
+                return_no_zone: true,
+            }
+        );
+
+        let yr_miss = get_cell_zone_id_bridge_policy_decision(
+            BridgeZoneIdPolicyTarget::Yr1001,
+            true,
+            0x0100,
+            -1,
+        );
+        assert_eq!(
+            yr_miss,
+            BridgeZoneIdPolicyDecision {
+                use_bridge_path: true,
+                call_bridge_remap_fallback: true,
+                return_no_zone: false,
+            }
+        );
+    }
+}

--- a/src/sim/bridge_state.rs
+++ b/src/sim/bridge_state.rs
@@ -3,6 +3,11 @@
 //! Bridges are modeled as terrain, not spawned entities. This module owns the
 //! destroyable runtime state used by combat, layered pathing, and bridge-deck
 //! fallout handling.
+//!
+//! TODO(RE): This runtime currently models elevated bridge-deck presence/destruction only.
+//! The recovered low-bridge overlay damage progression now lives in
+//! `sim::bridge_specs`, but wiring it here still needs mutable overlay state,
+//! connected-section selection, and `AtomDamage`/BridgeStrength gate inputs.
 
 use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use std::collections::{BTreeMap, VecDeque};

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -481,6 +481,11 @@ fn handle_entity_deaths(
     for (rx, ry, dmg, wh_id, owner_id) in &death_aoe {
         if let Some(warhead) = rules.warhead(interner.resolve(*wh_id)) {
             if warhead.wall && *dmg > 0 {
+                // TODO(RE): Low-bridge overlay damage is not a raw "damage bridge cell" event.
+                // The recovered engine uses a BridgeStrength RNG gate, AtomDamage bypass,
+                // and 3-cell overlay pattern transitions before the pathfinding side-effects.
+                // Keep these events scoped to the current elevated-bridge runtime until
+                // mutable overlay bridge state is wired through the sim.
                 bridge_damage_events.push(BridgeDamageEvent {
                     rx: *rx,
                     ry: *ry,
@@ -1091,6 +1096,9 @@ pub fn tick_combat_with_fog(
                 damage_events.push((target_id, dmg, snap.stable_id, wh_iid));
             }
             if warhead.wall && weapon.damage > 0 {
+                // TODO(RE): Low-bridge overlay damage still needs the recovered overlay-step
+                // logic and connected-section selection. These events currently feed only the
+                // elevated-bridge runtime state.
                 bridge_damage_events.push(BridgeDamageEvent {
                     rx: target_rx,
                     ry: target_ry,
@@ -1108,6 +1116,9 @@ pub fn tick_combat_with_fog(
                 damage_events.push((snap.target, actual_damage, snap.stable_id, wh_iid));
             }
             if warhead.wall && weapon.damage > 0 {
+                // TODO(RE): Low-bridge overlay damage still needs the recovered overlay-step
+                // logic and connected-section selection. These events currently feed only the
+                // elevated-bridge runtime state.
                 bridge_damage_events.push(BridgeDamageEvent {
                     rx: target_rx,
                     ry: target_ry,

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -51,6 +51,7 @@ pub mod vision;
 
 // --- Animation, building overlays, bridge state ---
 pub mod animation;
+pub mod bridge_specs;
 pub mod bridge_state;
 
 // --- Passengers, transport, slaves ---

--- a/src/sim/pathfinding/zone_map.rs
+++ b/src/sim/pathfinding/zone_map.rs
@@ -140,7 +140,9 @@ pub struct ZoneMap {
     ///
     /// TODO(RE): Bridge-layer zone queries in the original engine go through the
     /// onBridge flag plus ZoneConnection remap records near the cell, not a standalone
-    /// bridge zone grid.
+    /// bridge zone grid. The recovered gate/record helpers now live in
+    /// `sim::bridge_specs`, but the live runtime still lacks stored ZoneConnection
+    /// records and bridge-remap integration.
     bridge_zone_ids: Option<Vec<ZoneId>>,
     pub width: u16,
     pub height: u16,

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -587,6 +587,9 @@ impl Simulation {
             .iter()
             .flat_map(|change| change.destroyed_cells.iter().copied())
             .collect();
+        let fallout_ground_grid = self.resolved_terrain.as_ref().map(|terrain| {
+            PathGrid::from_resolved_terrain_with_bridges(terrain, self.bridge_state.as_ref())
+        });
 
         // Spawn bridge destruction explosions (matches original BlowUpBridge logic):
         // ~95% chance per destroyed cell, random anim from BridgeExplosions list,
@@ -604,11 +607,9 @@ impl Simulation {
             if !on_bridge || !destroyed_cells.contains(&(pos.rx, pos.ry)) {
                 continue;
             }
-            let ground_walkable = self
-                .resolved_terrain
-                .as_ref()
-                .and_then(|terrain| terrain.cell(pos.rx, pos.ry))
-                .is_some_and(|cell| !cell.ground_walk_blocked);
+            let ground_walkable = fallout_ground_grid.as_ref().is_some_and(|grid| {
+                grid.is_walkable_on_layer(pos.rx, pos.ry, MovementLayer::Ground)
+            });
             if ground_walkable {
                 let ground_level = self
                     .resolved_terrain

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -499,6 +499,133 @@ fn test_destroyed_bridge_despawns_unit_over_blocked_ground() {
 }
 
 #[test]
+fn test_destroyed_bridge_despawns_unit_over_overlay_blocked_ground() {
+    let mut sim = Simulation::new();
+    let mut resolved = bridge_cell_with_ground_block(5, 5, 3, false, 0);
+    let idx = resolved.index(5, 5).expect("bridge index");
+    resolved.cells[idx].overlay_blocks = true;
+    sim.resolved_terrain = Some(resolved.clone());
+    sim.bridge_state = Some(BridgeRuntimeState::from_resolved_terrain(
+        &resolved, true, 15,
+    ));
+
+    sim.spawn_from_map_with_resolved(
+        &[MapEntity {
+            owner: "Americans".to_string(),
+            type_id: "MTNK".to_string(),
+            health: 256,
+            cell_x: 5,
+            cell_y: 5,
+            facing: 64,
+            category: EntityCategory::Unit,
+            sub_cell: 0,
+            veterancy: 0,
+            high: true,
+        }],
+        Some(&combat_test_rules()),
+        &BTreeMap::new(),
+        Some(&resolved),
+    );
+
+    let changes = sim.apply_bridge_damage_events(&[BridgeDamageEvent {
+        rx: 5,
+        ry: 5,
+        damage: 15,
+    }]);
+    let fallout = sim.resolve_bridge_state_changes(&changes);
+    assert_eq!(fallout, vec![1]);
+    assert!(sim.entities.get(1).is_none());
+}
+
+#[test]
+fn test_destroyed_bridge_despawns_unit_over_terrain_object_blocked_ground() {
+    let mut sim = Simulation::new();
+    let mut resolved = bridge_cell_with_ground_block(5, 5, 3, false, 0);
+    let idx = resolved.index(5, 5).expect("bridge index");
+    resolved.cells[idx].terrain_object_blocks = true;
+    sim.resolved_terrain = Some(resolved.clone());
+    sim.bridge_state = Some(BridgeRuntimeState::from_resolved_terrain(
+        &resolved, true, 15,
+    ));
+
+    sim.spawn_from_map_with_resolved(
+        &[MapEntity {
+            owner: "Americans".to_string(),
+            type_id: "MTNK".to_string(),
+            health: 256,
+            cell_x: 5,
+            cell_y: 5,
+            facing: 64,
+            category: EntityCategory::Unit,
+            sub_cell: 0,
+            veterancy: 0,
+            high: true,
+        }],
+        Some(&combat_test_rules()),
+        &BTreeMap::new(),
+        Some(&resolved),
+    );
+
+    let changes = sim.apply_bridge_damage_events(&[BridgeDamageEvent {
+        rx: 5,
+        ry: 5,
+        damage: 15,
+    }]);
+    let fallout = sim.resolve_bridge_state_changes(&changes);
+    assert_eq!(fallout, vec![1]);
+    assert!(sim.entities.get(1).is_none());
+}
+
+#[test]
+fn test_destroyed_bridge_fallout_matches_rebuilt_ground_walkability() {
+    let mut sim = Simulation::new();
+    let mut resolved = bridge_cell_with_ground_block(5, 5, 3, false, 0);
+    let idx = resolved.index(5, 5).expect("bridge index");
+    resolved.cells[idx].is_cliff_like = true;
+    sim.resolved_terrain = Some(resolved.clone());
+    sim.bridge_state = Some(BridgeRuntimeState::from_resolved_terrain(
+        &resolved, true, 15,
+    ));
+
+    sim.spawn_from_map_with_resolved(
+        &[MapEntity {
+            owner: "Americans".to_string(),
+            type_id: "MTNK".to_string(),
+            health: 256,
+            cell_x: 5,
+            cell_y: 5,
+            facing: 64,
+            category: EntityCategory::Unit,
+            sub_cell: 0,
+            veterancy: 0,
+            high: true,
+        }],
+        Some(&combat_test_rules()),
+        &BTreeMap::new(),
+        Some(&resolved),
+    );
+
+    let changes = sim.apply_bridge_damage_events(&[BridgeDamageEvent {
+        rx: 5,
+        ry: 5,
+        damage: 15,
+    }]);
+
+    let rebuilt_grid = PathGrid::from_resolved_terrain_with_bridges(
+        sim.resolved_terrain.as_ref().expect("resolved terrain"),
+        sim.bridge_state.as_ref(),
+    );
+    assert!(
+        !rebuilt_grid.is_walkable_on_layer(5, 5, MovementLayer::Ground),
+        "destroyed bridge cell should stay ground-blocked when the rebuilt PathGrid says so"
+    );
+
+    let fallout = sim.resolve_bridge_state_changes(&changes);
+    assert_eq!(fallout, vec![1]);
+    assert!(sim.entities.get(1).is_none());
+}
+
+#[test]
 fn test_water_mover_lookahead_does_not_attach_bridge_occupancy_under_bridge() {
     let rules = naval_bridge_test_rules();
     let mut sim = Simulation::new();


### PR DESCRIPTION
## Summary
- add pure RE-backed bridge helpers for low-bridge overlay damage/selection and bridge zone record/policy logic
- make destroyed-bridge fallout use rebuilt ground walkability instead of a looser direct terrain check
- add focused bridge tests and TODO(RE) markers for the remaining low-bridge runtime wiring