### PR TITLE
walls: wire combat damage to overlay destruction with neighbor cleanup

### DIFF
--- a/src/app_sim_tick.rs
+++ b/src/app_sim_tick.rs
@@ -265,6 +265,7 @@ pub(crate) fn advance_fixed_simulation(state: &mut AppState, elapsed_ms: u64) {
                 state.rules.as_ref(),
                 &state.height_map,
                 state.path_grid.as_ref(),
+                state.overlay_registry.as_ref(),
                 SIM_TICK_MS,
             );
             let death_finished = animation::tick_animations(

--- a/src/sim/ai.rs
+++ b/src/sim/ai.rs
@@ -976,7 +976,7 @@ mod tests {
             "MODPROC"
         ));
         for _ in 0..240 {
-            let _ = sim.advance_tick(&[], Some(&rules), &height_map, Some(&grid), 33);
+            let _ = sim.advance_tick(&[], Some(&rules), &height_map, Some(&grid), None, 33);
             if !production::ready_buildings_for_owner(&sim, &rules, "Americans").is_empty() {
                 break;
             }
@@ -1052,7 +1052,7 @@ mod tests {
         // Needs enough ticks for: harvest + return + unload.
         // Unload alone: up to 20 bales × 57 ticks/bale = 1140 ticks at 60Hz.
         for _ in 0..2000 {
-            let _ = sim.advance_tick(&[], Some(&rules), &height_map, Some(&grid), 33);
+            let _ = sim.advance_tick(&[], Some(&rules), &height_map, Some(&grid), None, 33);
 
             let miner = sim
                 .entities

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -184,12 +184,18 @@ fn test_tick_combat_only_emits_bridge_damage_for_wall_warheads() {
         &BTreeMap::<InternedId, PowerState>::new(),
         None,
         &mut BTreeMap::new(),
+        None,
+        None,
         0u64,
         100,
     );
     assert!(
         result.bridge_damage_events.is_empty(),
         "non-wall warheads must not emit bridge damage"
+    );
+    assert!(
+        result.wall_damage_events.is_empty(),
+        "non-wall warheads must not emit wall damage"
     );
 
     let bridge_rules = RuleSet::from_ini(&IniFile::from_str(
@@ -215,6 +221,8 @@ fn test_tick_combat_only_emits_bridge_damage_for_wall_warheads() {
         &BTreeMap::<InternedId, PowerState>::new(),
         None,
         &mut BTreeMap::new(),
+        None,
+        None,
         0u64,
         100,
     );
@@ -226,6 +234,10 @@ fn test_tick_combat_only_emits_bridge_damage_for_wall_warheads() {
             damage: 65
         }]
     );
+    // Without an overlay grid+registry, the discriminator can't identify a wall
+    // cell — events fall through to bridge_damage_events. wall_damage_events
+    // requires both a grid lookup and Wall=yes in the registry.
+    assert!(wall_result.wall_damage_events.is_empty());
 }
 
 #[test]
@@ -477,6 +489,8 @@ fn test_tick_combat_visibility_blocks_fire() {
         &BTreeMap::<InternedId, PowerState>::new(),
         None,
         &mut BTreeMap::new(),
+        None,
+        None,
         0u64,
         100,
     );
@@ -511,6 +525,8 @@ fn test_tick_combat_retargets_by_distance_then_stable_id() {
         &BTreeMap::<InternedId, PowerState>::new(),
         None,
         &mut BTreeMap::new(),
+        None,
+        None,
         0u64,
         100,
     );
@@ -552,6 +568,8 @@ fn test_tick_combat_retargets_prefers_threat_class_when_distance_equal() {
         &BTreeMap::<InternedId, PowerState>::new(),
         None,
         &mut BTreeMap::new(),
+        None,
+        None,
         0u64,
         100,
     );
@@ -622,6 +640,8 @@ fn test_weapon_fire_destroys_ore_in_spread() {
         &BTreeMap::<InternedId, PowerState>::new(),
         None,
         &mut resource_nodes,
+        None,
+        None,
         0u64,
         100,
     );
@@ -674,6 +694,8 @@ fn test_direct_hit_weapon_destroys_center_ore() {
         &BTreeMap::<InternedId, PowerState>::new(),
         None,
         &mut resource_nodes,
+        None,
+        None,
         0u64,
         100,
     );
@@ -721,6 +743,8 @@ fn test_weak_weapon_partial_ore_reduction() {
         &BTreeMap::<InternedId, PowerState>::new(),
         None,
         &mut resource_nodes,
+        None,
+        None,
         0u64,
         100,
     );
@@ -732,4 +756,193 @@ fn test_weak_weapon_partial_ore_reduction() {
         960,
         "should reduce by 2 density levels (25/10=2)"
     );
+}
+
+// ---- Wall damage integration tests ----------------------------------------
+
+use crate::map::overlay_types::OverlayTypeRegistry;
+use crate::sim::overlay_grid::{OverlayGrid, WallDamageEvent};
+use crate::sim::world::Simulation;
+
+/// INI containing GAWALL as both a [BuildingTypes] entry (so it has an
+/// ObjectType with Wall=yes) and an [OverlayTypes] entry (so the overlay
+/// registry knows it as a wall overlay). Strength=400, DamageLevels=4 are
+/// representative of the real GAWALL.
+fn wall_test_ini() -> &'static str {
+    "[InfantryTypes]\n\
+     [VehicleTypes]\n\
+     [AircraftTypes]\n\
+     [BuildingTypes]\n0=GAWALL\n\
+     [OverlayTypes]\n0=GASAND\n1=CYCL\n2=GAWALL\n\
+     [GAWALL]\nStrength=400\nArmor=concrete\nWall=yes\n\
+     [GASAND]\nWall=yes\nStrength=400\n\
+     [CYCL]\nWall=yes\nStrength=400\n"
+}
+
+/// Build a Simulation with a 10x10 OverlayGrid and a GAWALL placed at (rx, ry)
+/// with both an OverlayCell entry and a matching wall GameEntity. Returns the
+/// sim, ruleset, and registry tied to the same INI.
+fn build_minimal_sim_with_gawall(rx: u16, ry: u16) -> (Simulation, RuleSet, OverlayTypeRegistry) {
+    let ini = IniFile::from_str(wall_test_ini());
+    let rules = RuleSet::from_ini(&ini).expect("wall rules parse");
+    let registry = OverlayTypeRegistry::from_ini(&ini, None);
+
+    let mut sim = Simulation::new();
+    let mut grid = OverlayGrid::new(10, 10);
+    // Place GAWALL (overlay_id=2). Initial frame = 0 (isolated, stage 0).
+    grid.place_overlay(rx, ry, 2, 0);
+    sim.overlay_grid = Some(grid);
+
+    // Spawn a wall GameEntity at the same cell. Intern the type_ref and owner
+    // through sim.interner so later lookups via sim.interner.resolve() succeed.
+    let owner_id = sim.interner.intern("Test");
+    let type_id = sim.interner.intern("GAWALL");
+    let mut entity = GameEntity::test_default(1, "GAWALL", "Test", rx, ry);
+    entity.owner = owner_id;
+    entity.type_ref = type_id;
+    entity.health = Health { current: 400, max: 400 };
+    sim.entities.insert(entity);
+    sim.entities.rebuild_owner_index();
+
+    (sim, rules, registry)
+}
+
+#[test]
+fn wall_warhead_damages_and_destroys_wall_overlay() {
+    let (mut sim, rules, registry) = build_minimal_sim_with_gawall(5, 5);
+
+    let initial_wall_entities = sim
+        .entities
+        .iter_sorted()
+        .filter(|(_, e)| {
+            rules
+                .object(sim.interner.resolve(e.type_ref))
+                .is_some_and(|o| o.wall)
+        })
+        .count();
+    assert_eq!(initial_wall_entities, 1, "fixture must place exactly one wall entity");
+
+    // Forced destruction (u16::MAX bypasses the probabilistic gate).
+    let events = [WallDamageEvent { rx: 5, ry: 5, damage: u16::MAX }];
+    sim.apply_wall_damage_events(&events, &rules, &registry);
+
+    // Overlay cleared.
+    let grid = sim.overlay_grid.as_ref().expect("grid should still be present");
+    assert!(grid.cell(5, 5).overlay_id.is_none(), "overlay should be cleared");
+
+    // Wall entity removed.
+    let remaining = sim
+        .entities
+        .iter_sorted()
+        .filter(|(_, e)| {
+            rules
+                .object(sim.interner.resolve(e.type_ref))
+                .is_some_and(|o| o.wall)
+        })
+        .count();
+    assert_eq!(remaining, 0, "wall entity should be despawned after overlay destruction");
+}
+
+/// Build a Simulation with a row of GAWALL at `(rx_range, ry)`. Each cell gets
+/// both an OverlayCell entry and a matching wall GameEntity.
+fn build_minimal_sim_with_gawall_row(
+    ry: u16,
+    rx_range: std::ops::Range<u16>,
+) -> (Simulation, RuleSet, OverlayTypeRegistry) {
+    let ini = IniFile::from_str(wall_test_ini());
+    let rules = RuleSet::from_ini(&ini).expect("wall rules parse");
+    let registry = OverlayTypeRegistry::from_ini(&ini, None);
+
+    let mut sim = Simulation::new();
+    let mut grid = OverlayGrid::new(10, 10);
+    let owner_id = sim.interner.intern("Test");
+    let type_id = sim.interner.intern("GAWALL");
+    let mut next_id: u64 = 1;
+    for rx in rx_range {
+        grid.place_overlay(rx, ry, 2, 0);
+        let mut entity = GameEntity::test_default(next_id, "GAWALL", "Test", rx, ry);
+        entity.owner = owner_id;
+        entity.type_ref = type_id;
+        entity.health = Health { current: 400, max: 400 };
+        sim.entities.insert(entity);
+        next_id += 1;
+    }
+    sim.overlay_grid = Some(grid);
+    sim.entities.rebuild_owner_index();
+
+    (sim, rules, registry)
+}
+
+#[test]
+fn concrete_wall_chain_reaction_runs_without_panic() {
+    // Row of 4 GAWALL at (4..8, 5).
+    let (mut sim, rules, registry) = build_minimal_sim_with_gawall_row(5, 4..8);
+    // Pre-set (5,5) to stage 2 with E+W connectivity so a single damage event
+    // pushes it through the penultimate-stage chain trigger (stage 3 of
+    // DamageLevels=4). Connectivity nibble 0b1010 = E+W = 0xA, byte = 0x2A.
+    sim.overlay_grid
+        .as_mut()
+        .unwrap()
+        .set_overlay_data(5, 5, 0x2A);
+
+    // damage = Strength (400) — gate `damage < strength` is false, so the
+    // probabilistic check is skipped and the damage applies. Stage advances
+    // to 3 → chain triggers 200-damage events on pristine same-type cardinal
+    // neighbors. Outcome of those events depends on RNG roll vs strength=400.
+    let events = [WallDamageEvent { rx: 5, ry: 5, damage: 400 }];
+    sim.apply_wall_damage_events(&events, &rules, &registry);
+
+    // The chain code path ran (no panic). Assert (5,5) is at stage ≥ 3 or
+    // gone — either outcome is consistent with the binary's behavior at the
+    // penultimate damage level.
+    let grid = sim.overlay_grid.as_ref().unwrap();
+    let cell = grid.cell(5, 5);
+    if let Some(id) = cell.overlay_id {
+        assert_eq!(id, 2, "if not destroyed, must still be GAWALL");
+        assert!(
+            cell.overlay_data >> 4 >= 3,
+            "stage should have advanced to ≥3 after applied damage"
+        );
+    }
+    // No assertion about pristine neighbors — their fate depends on RNG.
+}
+
+/// Seeded variant of `build_minimal_sim_with_gawall` — used for determinism
+/// replay tests where two sims must produce byte-identical state given the
+/// same input event sequence.
+fn build_minimal_sim_with_gawall_seeded(
+    rx: u16,
+    ry: u16,
+    seed: u64,
+) -> (Simulation, RuleSet, OverlayTypeRegistry) {
+    let (mut sim, rules, registry) = build_minimal_sim_with_gawall(rx, ry);
+    sim.rng = crate::sim::rng::SimRng::new(seed);
+    (sim, rules, registry)
+}
+
+#[test]
+fn wall_damage_deterministic_across_replays() {
+    let seed: u64 = 0x1234_5678;
+    let events = [
+        WallDamageEvent { rx: 5, ry: 5, damage: 100 },
+        WallDamageEvent { rx: 5, ry: 5, damage: 100 },
+        WallDamageEvent { rx: 5, ry: 5, damage: 100 },
+        WallDamageEvent { rx: 5, ry: 5, damage: 100 },
+        WallDamageEvent { rx: 5, ry: 5, damage: 100 },
+    ];
+
+    let snapshot_a: (Option<u8>, u8) = {
+        let (mut sim, rules, registry) = build_minimal_sim_with_gawall_seeded(5, 5, seed);
+        sim.apply_wall_damage_events(&events, &rules, &registry);
+        let cell = sim.overlay_grid.as_ref().unwrap().cell(5, 5);
+        (cell.overlay_id, cell.overlay_data)
+    };
+    let snapshot_b: (Option<u8>, u8) = {
+        let (mut sim, rules, registry) = build_minimal_sim_with_gawall_seeded(5, 5, seed);
+        sim.apply_wall_damage_events(&events, &rules, &registry);
+        let cell = sim.overlay_grid.as_ref().unwrap().cell(5, 5);
+        (cell.overlay_id, cell.overlay_data)
+    };
+
+    assert_eq!(snapshot_a, snapshot_b, "wall damage must be RNG-deterministic");
 }

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -37,7 +37,9 @@ use crate::rules::object_type::ObjectType;
 use crate::rules::ruleset::RuleSet;
 use crate::rules::warhead_type::WarheadType;
 use crate::sim::animation::animation_is_prone;
+use crate::map::overlay_types::OverlayTypeRegistry;
 use crate::sim::bridge_state::BridgeDamageEvent;
+use crate::sim::overlay_grid::{OverlayGrid, WallDamageEvent};
 use crate::sim::entity_store::EntityStore;
 use crate::sim::intern::{InternedId, StringInterner};
 use crate::sim::passenger::PassengerRole;
@@ -87,6 +89,24 @@ const ARMOR_NAMES: &[&str] = &[
 pub fn armor_index(armor: &str) -> usize {
     let lower: String = armor.to_ascii_lowercase();
     ARMOR_NAMES.iter().position(|&a| a == lower).unwrap_or(0)
+}
+
+/// True iff the cell at `(rx, ry)` has an overlay whose type is flagged `Wall=yes`.
+/// Used to discriminate wall-damage events from bridge-damage events at warhead
+/// emission sites. Returns false when grid or registry is missing.
+fn cell_has_wall_overlay(
+    overlay_grid: Option<&OverlayGrid>,
+    overlay_registry: Option<&OverlayTypeRegistry>,
+    rx: u16,
+    ry: u16,
+) -> bool {
+    let (Some(grid), Some(registry)) = (overlay_grid, overlay_registry) else {
+        return false;
+    };
+    grid.cell(rx, ry)
+        .overlay_id
+        .and_then(|id| registry.flags(id))
+        .is_some_and(|f| f.wall)
 }
 
 pub(crate) fn apply_prone_damage_modifier(
@@ -274,6 +294,8 @@ pub fn tick_combat(
         &BTreeMap::new(),
         None,
         resource_nodes,
+        None,
+        None,
         current_tick,
         tick_ms,
     )
@@ -330,6 +352,8 @@ pub struct CombatTickResult {
     pub spy_sat_reshroud_owners: Vec<InternedId>,
     /// Bridge impact cells that should apply terrain damage after combat resolution.
     pub bridge_damage_events: Vec<BridgeDamageEvent>,
+    /// Wall overlay impact cells that should apply wall damage after combat resolution.
+    pub wall_damage_events: Vec<WallDamageEvent>,
     /// Fire events for render-side muzzle flash / projectile origin computation.
     pub fire_events: Vec<SimFireEvent>,
     /// Crewed buildings destroyed this tick — survivors should be ejected by the caller.
@@ -371,6 +395,7 @@ struct DeathEffects {
     destroyed_garrison_buildings: Vec<DestroyedGarrisonBuilding>,
     explosion_effects: Vec<ExplosionEffect>,
     bridge_damage_events: Vec<BridgeDamageEvent>,
+    wall_damage_events: Vec<WallDamageEvent>,
     death_sounds: Vec<(InternedId, u16, u16)>,
 }
 
@@ -386,6 +411,8 @@ fn handle_entity_deaths(
     dead_entities: &[u64],
     damage_events: &[(u64, u16, u64, InternedId)],
     resource_nodes: &mut BTreeMap<(u16, u16), ResourceNode>,
+    overlay_grid: Option<&OverlayGrid>,
+    overlay_registry: Option<&OverlayTypeRegistry>,
     current_tick: u64,
 ) -> DeathEffects {
     let mut death_sounds: Vec<(InternedId, u16, u16)> = Vec::new();
@@ -396,6 +423,7 @@ fn handle_entity_deaths(
     let mut destroyed_garrison_buildings: Vec<DestroyedGarrisonBuilding> = Vec::new();
     let mut explosion_effects: Vec<ExplosionEffect> = Vec::new();
     let mut bridge_damage_events: Vec<BridgeDamageEvent> = Vec::new();
+    let mut wall_damage_events: Vec<WallDamageEvent> = Vec::new();
     let mut structure_destroyed: bool = false;
     // Step size for selecting explosion anim from AnimList (damage / 25).
     const ANIM_LIST_DAMAGE_STEP: u16 = 25;
@@ -559,16 +587,27 @@ fn handle_entity_deaths(
     for (rx, ry, dmg, wh_id, owner_id) in &death_aoe {
         if let Some(warhead) = rules.warhead(interner.resolve(*wh_id)) {
             if warhead.wall && *dmg > 0 {
-                // TODO(RE): Low-bridge overlay damage is not a raw "damage bridge cell" event.
-                // The recovered engine uses a BridgeStrength RNG gate, AtomDamage bypass,
-                // and 3-cell overlay pattern transitions before the pathfinding side-effects.
-                // Keep these events scoped to the current elevated-bridge runtime until
-                // mutable overlay bridge state is wired through the sim.
-                bridge_damage_events.push(BridgeDamageEvent {
-                    rx: *rx,
-                    ry: *ry,
-                    damage: (*dmg).max(0) as u16,
-                });
+                // Wall cells produce WallDamageEvent; remaining cells (bridges
+                // or unaffiliated) keep the legacy bridge_damage_events path.
+                let damage_u16 = (*dmg).max(0) as u16;
+                if cell_has_wall_overlay(overlay_grid, overlay_registry, *rx, *ry) {
+                    wall_damage_events.push(WallDamageEvent {
+                        rx: *rx,
+                        ry: *ry,
+                        damage: damage_u16,
+                    });
+                } else {
+                    // TODO(RE): Low-bridge overlay damage is not a raw "damage bridge cell" event.
+                    // The recovered engine uses a BridgeStrength RNG gate, AtomDamage bypass,
+                    // and 3-cell overlay pattern transitions before the pathfinding side-effects.
+                    // Keep these events scoped to the current elevated-bridge runtime until
+                    // mutable overlay bridge state is wired through the sim.
+                    bridge_damage_events.push(BridgeDamageEvent {
+                        rx: *rx,
+                        ry: *ry,
+                        damage: damage_u16,
+                    });
+                }
             }
             let aoe_hits = self::combat_aoe::apply_aoe_damage(
                 entities,
@@ -604,6 +643,7 @@ fn handle_entity_deaths(
         destroyed_garrison_buildings,
         explosion_effects,
         bridge_damage_events,
+        wall_damage_events,
         death_sounds,
     }
 }
@@ -655,6 +695,11 @@ fn destroy_ore_at_impact(
 
 /// Advance combat with optional owner visibility gating and sound event sink.
 /// Returns reveal events and stable IDs of entities despawned this tick.
+///
+/// `overlay_grid` and `overlay_registry` are used to discriminate wall-overlay
+/// cells from bridge cells when a wall-warhead detonates (so the right event
+/// stream — WallDamageEvent vs BridgeDamageEvent — gets populated). Pass
+/// `None` to skip wall-cell discrimination (legacy bridge-only routing).
 pub fn tick_combat_with_fog(
     entities: &mut EntityStore,
     occupancy: &mut OccupancyGrid,
@@ -664,6 +709,8 @@ pub fn tick_combat_with_fog(
     power_states: &BTreeMap<InternedId, PowerState>,
     sound_sink: Option<&mut Vec<SimSoundEvent>>,
     resource_nodes: &mut BTreeMap<(u16, u16), ResourceNode>,
+    overlay_grid: Option<&OverlayGrid>,
+    overlay_registry: Option<&OverlayTypeRegistry>,
     current_tick: u64,
     tick_ms: u32,
 ) -> CombatTickResult {
@@ -674,6 +721,7 @@ pub fn tick_combat_with_fog(
             structure_destroyed: false,
             spy_sat_reshroud_owners: Vec::new(),
             bridge_damage_events: Vec::new(),
+            wall_damage_events: Vec::new(),
             fire_events: Vec::new(),
             destroyed_crewed_buildings: Vec::new(),
             destroyed_garrison_buildings: Vec::new(),
@@ -952,6 +1000,7 @@ pub fn tick_combat_with_fog(
     let mut fire_events: Vec<SimFireEvent> = Vec::new();
     let mut reveal_events: Vec<RevealEvent> = Vec::new();
     let mut bridge_damage_events: Vec<BridgeDamageEvent> = Vec::new();
+    let mut wall_damage_events: Vec<WallDamageEvent> = Vec::new();
     let mut burst_updates: Vec<(u64, u8, u8, u16)> = Vec::new(); // (id, burst_rem, burst_delay, rof_cd)
     let mut ammo_deduct: Vec<u64> = Vec::new(); // aircraft that fired this tick
     let mut garrison_advance: Vec<u64> = Vec::new(); // building IDs to advance fire index
@@ -1184,14 +1233,23 @@ pub fn tick_combat_with_fog(
                 damage_events.push((target_id, dmg, snap.stable_id, wh_iid));
             }
             if warhead.wall && weapon.damage > 0 {
-                // TODO(RE): Low-bridge overlay damage still needs the recovered overlay-step
-                // logic and connected-section selection. These events currently feed only the
-                // elevated-bridge runtime state.
-                bridge_damage_events.push(BridgeDamageEvent {
-                    rx: target_rx,
-                    ry: target_ry,
-                    damage: weapon.damage.max(0) as u16,
-                });
+                let damage_u16 = weapon.damage.max(0) as u16;
+                if cell_has_wall_overlay(overlay_grid, overlay_registry, target_rx, target_ry) {
+                    wall_damage_events.push(WallDamageEvent {
+                        rx: target_rx,
+                        ry: target_ry,
+                        damage: damage_u16,
+                    });
+                } else {
+                    // TODO(RE): Low-bridge overlay damage still needs the recovered overlay-step
+                    // logic and connected-section selection. These events currently feed only the
+                    // elevated-bridge runtime state.
+                    bridge_damage_events.push(BridgeDamageEvent {
+                        rx: target_rx,
+                        ry: target_ry,
+                        damage: damage_u16,
+                    });
+                }
             }
         } else {
             // Integer damage: base_damage * verses_pct / 100.
@@ -1204,14 +1262,23 @@ pub fn tick_combat_with_fog(
                 damage_events.push((snap.target, actual_damage, snap.stable_id, wh_iid));
             }
             if warhead.wall && weapon.damage > 0 {
-                // TODO(RE): Low-bridge overlay damage still needs the recovered overlay-step
-                // logic and connected-section selection. These events currently feed only the
-                // elevated-bridge runtime state.
-                bridge_damage_events.push(BridgeDamageEvent {
-                    rx: target_rx,
-                    ry: target_ry,
-                    damage: weapon.damage.max(0) as u16,
-                });
+                let damage_u16 = weapon.damage.max(0) as u16;
+                if cell_has_wall_overlay(overlay_grid, overlay_registry, target_rx, target_ry) {
+                    wall_damage_events.push(WallDamageEvent {
+                        rx: target_rx,
+                        ry: target_ry,
+                        damage: damage_u16,
+                    });
+                } else {
+                    // TODO(RE): Low-bridge overlay damage still needs the recovered overlay-step
+                    // logic and connected-section selection. These events currently feed only the
+                    // elevated-bridge runtime state.
+                    bridge_damage_events.push(BridgeDamageEvent {
+                        rx: target_rx,
+                        ry: target_ry,
+                        damage: damage_u16,
+                    });
+                }
             }
         }
 
@@ -1363,9 +1430,12 @@ pub fn tick_combat_with_fog(
         &dead_entities,
         &damage_events,
         resource_nodes,
+        overlay_grid,
+        overlay_registry,
         current_tick,
     );
     bridge_damage_events.extend(death.bridge_damage_events);
+    wall_damage_events.extend(death.wall_damage_events);
 
     // Phase 7: push sound events to the sink.
     if let Some(sink) = sound_sink {
@@ -1399,6 +1469,7 @@ pub fn tick_combat_with_fog(
         structure_destroyed: death.structure_destroyed,
         spy_sat_reshroud_owners: death.spy_sat_reshroud_owners,
         bridge_damage_events,
+        wall_damage_events,
         fire_events,
         destroyed_crewed_buildings: death.destroyed_crewed_buildings,
         destroyed_garrison_buildings: death.destroyed_garrison_buildings,

--- a/src/sim/deploy_tests.rs
+++ b/src/sim/deploy_tests.rs
@@ -146,7 +146,7 @@ fn dispatch(sim: &mut Simulation, _owner: &str, cmd: Command, rules: &RuleSet) {
     let height_map: BTreeMap<(u16, u16), u8> = BTreeMap::new();
     let owner_id = sim.interner.intern(_owner);
     let cmds = vec![CommandEnvelope::new(owner_id, sim.tick + 1, cmd)];
-    sim.advance_tick(&cmds, Some(rules), &height_map, None, 22);
+    sim.advance_tick(&cmds, Some(rules), &height_map, None, None, 22);
 }
 
 /// Apply a command directly via `apply_command` (no tick advance, no combat
@@ -163,7 +163,7 @@ fn apply(sim: &mut Simulation, owner: &str, cmd: &Command, rules: &RuleSet) -> b
 fn tick_n(sim: &mut Simulation, rules: &RuleSet, n: u32) {
     let height_map: BTreeMap<(u16, u16), u8> = BTreeMap::new();
     for _ in 0..n {
-        sim.advance_tick(&[], Some(rules), &height_map, None, 22);
+        sim.advance_tick(&[], Some(rules), &height_map, None, None, 22);
     }
 }
 

--- a/src/sim/overlay_grid.rs
+++ b/src/sim/overlay_grid.rs
@@ -236,6 +236,17 @@ pub fn recalc_overlay_passability(
     old_blocks != new_blocks || old_zone != final_zone_type
 }
 
+/// A combat-emitted request to damage a wall overlay at a specific cell.
+///
+/// Sentinel value `damage == u16::MAX` represents forced destruction (bypasses
+/// the probabilistic gate inside `damage_wall_overlay`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct WallDamageEvent {
+    pub rx: u16,
+    pub ry: u16,
+    pub damage: u16,
+}
+
 /// Result of a wall damage attempt.
 #[derive(Debug, Clone, Default)]
 pub struct WallDamageResult {
@@ -328,6 +339,135 @@ fn damage_wall_recursive(
     // Full destruction.
     grid.clear_overlay(rx, ry);
     result.destroyed_cells.push((rx, ry));
+}
+
+/// Outcome of `recompute_wall_connectivity_at`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecomputeResult {
+    /// Cell was not a wall, or no nibble change.
+    NoChange,
+    /// Connectivity nibble changed; cell remains.
+    Updated,
+    /// Auto-destruct threshold tripped; cell cleared.
+    Destroyed,
+}
+
+/// Per-overlay-type byte-value thresholds at which neighbor cleanup destroys an
+/// already-damaged isolated wall.
+fn auto_destruct_threshold(overlay_id: u8, full_byte: u8) -> bool {
+    match overlay_id {
+        0x00 => matches!(full_byte, 0x10 | 0x20), // GASAND
+        0x01 => full_byte == 0x20,                // CYCL
+        0x02 => matches!(full_byte, 0x20 | 0x30), // GAWALL
+        0x03 => full_byte == 0x10,                // BARB
+        0x16 => matches!(full_byte, 0x10 | 0x20),
+        0x1A => matches!(full_byte, 0x20 | 0x30), // NAWALL
+        _ => false,
+    }
+}
+
+/// Refresh one cell's connectivity nibble against its 4 cardinal neighbors,
+/// then apply the per-type auto-destruct safety net.
+///
+/// Same-type-only matching.
+pub fn recompute_wall_connectivity_at(
+    grid: &mut OverlayGrid,
+    registry: &OverlayTypeRegistry,
+    rx: u16,
+    ry: u16,
+) -> RecomputeResult {
+    let cell = *grid.cell(rx, ry);
+    let Some(overlay_id) = cell.overlay_id else {
+        return RecomputeResult::NoChange;
+    };
+    let Some(flags) = registry.flags(overlay_id) else {
+        return RecomputeResult::NoChange;
+    };
+    if !flags.wall {
+        return RecomputeResult::NoChange;
+    }
+
+    // Cardinal neighbor connectivity scan. Bit assignment matches existing
+    // compute_wall_connectivity: N=0, E=1, S=2, W=3.
+    const CARDINAL: [(i32, i32); 4] = [(0, -1), (1, 0), (0, 1), (-1, 0)];
+    let mut connectivity: u8 = 0;
+    for (bit, (dx, dy)) in CARDINAL.iter().enumerate() {
+        let nx = rx as i32 + dx;
+        let ny = ry as i32 + dy;
+        if nx < 0 || ny < 0 {
+            continue;
+        }
+        let neighbor = grid.cell(nx as u16, ny as u16);
+        if neighbor.overlay_id == Some(overlay_id) {
+            connectivity |= 1 << bit;
+        }
+    }
+
+    let damage_nibble = cell.overlay_data & 0xF0;
+    let new_byte = damage_nibble | connectivity;
+
+    // Auto-destruct threshold fires whenever cleanup runs over an already-
+    // damaged isolated wall, even if the connectivity nibble itself is
+    // unchanged. Mirrors PostDestructionWallCleanup §5.2.
+    if auto_destruct_threshold(overlay_id, new_byte) {
+        grid.clear_overlay(rx, ry);
+        return RecomputeResult::Destroyed;
+    }
+
+    if new_byte == cell.overlay_data {
+        return RecomputeResult::NoChange;
+    }
+
+    grid.set_overlay_data(rx, ry, new_byte);
+    RecomputeResult::Updated
+}
+
+/// Refresh connectivity on the 4 cardinal neighbors of `(rx, ry)`, recursively
+/// extending into any neighbor that gets auto-destructed by the safety net.
+///
+/// Returns the list of cells destroyed by the cleanup pass (caller is responsible
+/// for removing the corresponding wall entities).
+///
+/// Bounded by a visited set so each cell is recomputed at most once per call.
+pub fn cleanup_wall_neighbors(
+    grid: &mut OverlayGrid,
+    registry: &OverlayTypeRegistry,
+    rx: u16,
+    ry: u16,
+) -> Vec<(u16, u16)> {
+    use std::collections::{HashSet, VecDeque};
+    const CARDINAL: [(i32, i32); 4] = [(0, -1), (1, 0), (0, 1), (-1, 0)];
+
+    let mut destroyed: Vec<(u16, u16)> = Vec::new();
+    let mut visited: HashSet<(u16, u16)> = HashSet::new();
+    let mut worklist: VecDeque<(u16, u16)> = VecDeque::new();
+    worklist.push_back((rx, ry));
+
+    while let Some((cx, cy)) = worklist.pop_front() {
+        for (dx, dy) in CARDINAL {
+            let nx = cx as i32 + dx;
+            let ny = cy as i32 + dy;
+            if nx < 0 || ny < 0 {
+                continue;
+            }
+            let nx = nx as u16;
+            let ny = ny as u16;
+            if nx >= grid.width() || ny >= grid.height() {
+                continue;
+            }
+            if !visited.insert((nx, ny)) {
+                continue;
+            }
+            if let RecomputeResult::Destroyed =
+                recompute_wall_connectivity_at(grid, registry, nx, ny)
+            {
+                destroyed.push((nx, ny));
+                worklist.push_back((nx, ny));
+            }
+        }
+    }
+
+    destroyed
 }
 
 /// 8-direction offsets: N, NE, E, SE, S, SW, W, NW.
@@ -493,5 +633,137 @@ mod tests {
         grid.place_overlay(0, 0, 2, 0);
         grid.place_overlay(9, 3, 3, 0);
         assert_eq!(grid.take_dirty_cells(), vec![(5, 5), (0, 0), (9, 3)]);
+    }
+}
+
+#[cfg(test)]
+mod recompute_tests {
+    use super::*;
+    use crate::rules::ini_parser::IniFile;
+
+    /// Build a registry whose overlay_id=2 maps to GAWALL (for auto-destruct
+    /// threshold matching). Filler entries at id 0 and 1 get Wall=yes too so
+    /// tests can exercise other ids if needed.
+    fn make_wall_registry() -> OverlayTypeRegistry {
+        let text = "\
+[OverlayTypes]
+0=GASAND
+1=CYCL
+2=GAWALL
+[GASAND]
+Wall=yes
+Strength=400
+[CYCL]
+Wall=yes
+Strength=400
+[GAWALL]
+Wall=yes
+Strength=400
+";
+        let ini = IniFile::from_str(text);
+        OverlayTypeRegistry::from_ini(&ini, None)
+    }
+
+    #[test]
+    fn recompute_no_op_for_non_wall_cell() {
+        let mut grid = OverlayGrid::new(10, 10);
+        let reg = OverlayTypeRegistry::empty();
+        let r = recompute_wall_connectivity_at(&mut grid, &reg, 5, 5);
+        assert_eq!(r, RecomputeResult::NoChange);
+    }
+
+    #[test]
+    fn recompute_updates_nibble_when_neighbor_changes() {
+        let mut grid = OverlayGrid::new(10, 10);
+        let reg = make_wall_registry();
+        // Place two adjacent GAWALL at (5,5) and (6,5). Initialize (5,5) with
+        // stale connectivity (0b0001 = N) so the recompute changes it to
+        // 0b0010 (E neighbor only).
+        grid.place_overlay(5, 5, 2, 0b0001);
+        grid.place_overlay(6, 5, 2, 0);
+        let r = recompute_wall_connectivity_at(&mut grid, &reg, 5, 5);
+        assert_eq!(r, RecomputeResult::Updated);
+        assert_eq!(grid.cell(5, 5).overlay_data, 0b0010);
+    }
+
+    #[test]
+    fn recompute_destroys_isolated_max_damage_gawall() {
+        let mut grid = OverlayGrid::new(10, 10);
+        let reg = make_wall_registry();
+        // Isolated GAWALL with damage stage 3 (= 0x30) and connectivity 0 → 0x30
+        // matches the auto-destruct threshold.
+        grid.place_overlay(5, 5, 2, 0x30);
+        let r = recompute_wall_connectivity_at(&mut grid, &reg, 5, 5);
+        assert_eq!(r, RecomputeResult::Destroyed);
+        assert_eq!(grid.cell(5, 5).overlay_id, None);
+    }
+
+    #[test]
+    fn recompute_keeps_max_damage_wall_when_connected() {
+        let mut grid = OverlayGrid::new(10, 10);
+        let reg = make_wall_registry();
+        // GAWALL at (5,5) with damage stage 3 PLUS connection to E neighbor.
+        // Connected → byte = 0x30 | 0b0010 = 0x32 → not in auto-destruct set → kept.
+        grid.place_overlay(5, 5, 2, 0x30);
+        grid.place_overlay(6, 5, 2, 0);
+        let r = recompute_wall_connectivity_at(&mut grid, &reg, 5, 5);
+        assert_eq!(r, RecomputeResult::Updated);
+        assert_eq!(grid.cell(5, 5).overlay_data, 0x32);
+        assert!(grid.cell(5, 5).overlay_id.is_some());
+    }
+
+    #[test]
+    fn cleanup_chain_does_not_destroy_intact_segment() {
+        let mut grid = OverlayGrid::new(10, 10);
+        let reg = make_wall_registry();
+        // Row of 3 GAWALL at (4,5), (5,5), (6,5), all at max damage stage 3.
+        // Connectivity nibbles: (4,5)=0b0010 (E only), (5,5)=0b1010 (E+W),
+        // (6,5)=0b1000 (W only). Full bytes: 0x32, 0x3A, 0x38.
+        grid.place_overlay(4, 5, 2, 0x32);
+        grid.place_overlay(5, 5, 2, 0x3A);
+        grid.place_overlay(6, 5, 2, 0x38);
+        // Destroy the leftmost cell directly (simulating damage_wall_overlay's destroy).
+        grid.clear_overlay(4, 5);
+        // Run cleanup starting from (4, 5).
+        let destroyed = cleanup_wall_neighbors(&mut grid, &reg, 4, 5);
+        // (5,5) loses W connection → byte = 0x32 → not in {0x20, 0x30} → keeps.
+        // (6,5) keeps W connection (5,5 still present) → byte = 0x38 → keeps.
+        assert!(destroyed.is_empty());
+        assert!(grid.cell(5, 5).overlay_id.is_some());
+        assert!(grid.cell(6, 5).overlay_id.is_some());
+    }
+
+    #[test]
+    fn cleanup_chain_terminates_via_visited_set() {
+        let mut grid = OverlayGrid::new(10, 10);
+        let reg = make_wall_registry();
+        // 5-cell row of GAWALL at max damage; recompute initial connectivity
+        // via the helper to set up coherent state, then destroy the leftmost
+        // cell and run cleanup. Test passes if it returns in finite time.
+        let cells: [(u16, u16); 5] = [(2, 5), (3, 5), (4, 5), (5, 5), (6, 5)];
+        for &(rx, ry) in &cells {
+            grid.place_overlay(rx, ry, 2, 0x30);
+        }
+        for &(rx, ry) in &cells {
+            let _ = recompute_wall_connectivity_at(&mut grid, &reg, rx, ry);
+        }
+        // After initial recompute, cells with neighbors survive; isolated ones
+        // would already be gone. The endpoints had only one neighbor → byte
+        // 0x32 or 0x38, both kept. Middle three: 0x3A, kept.
+        // Now destroy (2,5) and trigger cleanup.
+        grid.clear_overlay(2, 5);
+        let _ = cleanup_wall_neighbors(&mut grid, &reg, 2, 5);
+        // No assertion: termination is the test.
+    }
+
+    #[test]
+    fn cleanup_handles_oob_neighbors() {
+        let mut grid = OverlayGrid::new(10, 10);
+        let reg = make_wall_registry();
+        grid.place_overlay(0, 0, 2, 0x30);
+        grid.clear_overlay(0, 0);
+        // Cleanup at (0,0) — neighbors include (-1, 0) and (0, -1) which are OOB.
+        let _ = cleanup_wall_neighbors(&mut grid, &reg, 0, 0);
+        // No panic = pass.
     }
 }

--- a/src/sim/production/production_tests.rs
+++ b/src/sim/production/production_tests.rs
@@ -802,7 +802,7 @@ fn harvester_moves_to_ore_and_back_with_path_grid() {
     // harvest bales → return to refinery → dock → unload. HarvestRate=37
     // ticks/bale, 40 bales = ~1500 ticks harvest + movement + dock time.
     for _ in 0..3000 {
-        let _ = sim.advance_tick(&[], Some(&rules), &height_map, Some(&grid), 33);
+        let _ = sim.advance_tick(&[], Some(&rules), &height_map, Some(&grid), None, 33);
         let pos = sim
             .entities
             .get(harvester_sid)

--- a/src/sim/replay.rs
+++ b/src/sim/replay.rs
@@ -83,7 +83,8 @@ impl ReplayRunner {
     ) -> Vec<u64> {
         let mut hashes: Vec<u64> = Vec::with_capacity(replay.ticks.len());
         for entry in &replay.ticks {
-            let result = sim.advance_tick(&entry.commands, rules, height_map, path_grid, tick_ms);
+            let result =
+                sim.advance_tick(&entry.commands, rules, height_map, path_grid, None, tick_ms);
             hashes.push(result.state_hash);
         }
         hashes

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -133,7 +133,7 @@ mod tests {
     /// Helper: advance a sim by one tick with empty inputs.
     fn tick(sim: &mut Simulation) {
         let height_map = BTreeMap::new();
-        sim.advance_tick(&[], None, &height_map, None, 67);
+        sim.advance_tick(&[], None, &height_map, None, None, 67);
     }
 
     /// Prove snapshot round-trip preserves all authoritative state.

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -28,6 +28,9 @@ use crate::rules::locomotor_type::SpeedType;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::ai::{self, AiPlayerState};
 use crate::sim::bridge_state::{BridgeDamageEvent, BridgeRuntimeState, BridgeStateChange};
+use crate::sim::overlay_grid::{
+    cleanup_wall_neighbors, damage_wall_overlay, WallDamageEvent,
+};
 use crate::sim::combat;
 use crate::sim::combat::combat_weapon::WeaponSlot;
 use crate::sim::command::{Command, CommandEnvelope};
@@ -663,6 +666,86 @@ impl Simulation {
         changes
     }
 
+    /// Apply combat-emitted wall damage events: drives the per-cell damage
+    /// progression in `damage_wall_overlay`, runs the cardinal-neighbor cleanup
+    /// for any cells the damage destroys, and despawns the wall GameEntity at
+    /// each destroyed cell.
+    ///
+    /// `rules` and `overlay_registry` are required because the wall damage
+    /// pipeline reads per-overlay-type Strength/DamageLevels and identifies
+    /// wall entities via the `Wall=yes` flag on their ObjectType.
+    pub(crate) fn apply_wall_damage_events(
+        &mut self,
+        events: &[WallDamageEvent],
+        rules: &RuleSet,
+        overlay_registry: &crate::map::overlay_types::OverlayTypeRegistry,
+    ) {
+        if events.is_empty() {
+            return;
+        }
+        let Some(grid) = self.overlay_grid.as_mut() else {
+            return;
+        };
+
+        let mut destroyed_cells: Vec<(u16, u16)> = Vec::new();
+
+        for event in events {
+            let result = damage_wall_overlay(
+                grid,
+                overlay_registry,
+                event.rx,
+                event.ry,
+                event.damage,
+                &mut self.rng,
+            );
+
+            for &cell in &result.destroyed_cells {
+                destroyed_cells.push(cell);
+                let chained = cleanup_wall_neighbors(grid, overlay_registry, cell.0, cell.1);
+                destroyed_cells.extend(chained);
+            }
+        }
+
+        if destroyed_cells.is_empty() {
+            return;
+        }
+
+        destroyed_cells.sort_unstable();
+        destroyed_cells.dedup();
+
+        for (rx, ry) in destroyed_cells {
+            self.remove_wall_entity_at(rx, ry, rules);
+        }
+    }
+
+    /// Despawn the GameEntity backing a wall overlay cell, if one exists.
+    /// Walls have a paired `GameEntity` for HP/ownership and an OverlayCell for
+    /// rendering/passability. When the overlay is destroyed via wall-damage
+    /// events, the entity must be removed too. Mod-loaded maps may have stale
+    /// state with no matching entity; in that case a warn is logged and the
+    /// caller continues without panicking.
+    fn remove_wall_entity_at(&mut self, rx: u16, ry: u16, rules: &RuleSet) {
+        let interner = &self.interner;
+        let to_remove: Option<u64> = self.entities.iter_sorted().find_map(|(id, e)| {
+            if e.position.rx == rx
+                && e.position.ry == ry
+                && rules
+                    .object(interner.resolve(e.type_ref))
+                    .is_some_and(|o| o.wall)
+            {
+                Some(id)
+            } else {
+                None
+            }
+        });
+
+        if let Some(id) = to_remove {
+            self.entities.remove(id);
+        } else {
+            log::warn!("apply_wall_damage_events: no wall entity at ({rx}, {ry})");
+        }
+    }
+
     pub(crate) fn resolve_bridge_state_changes(
         &mut self,
         changes: &[BridgeStateChange],
@@ -1011,6 +1094,7 @@ impl Simulation {
         rules: Option<&RuleSet>,
         height_map: &BTreeMap<(u16, u16), u8>,
         path_grid: Option<&PathGrid>,
+        overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
         tick_ms: u32,
     ) -> TickResult {
         let execute_tick = self.tick.saturating_add(1);
@@ -1211,6 +1295,8 @@ impl Simulation {
                 &self.power_states,
                 Some(&mut self.sound_events),
                 &mut self.production.resource_nodes,
+                self.overlay_grid.as_ref(),
+                overlay_registry,
                 self.tick,
                 tick_ms,
             );
@@ -1227,6 +1313,13 @@ impl Simulation {
                 self.apply_bridge_damage_events(&combat_result.bridge_damage_events);
             // resolve_bridge_state_changes calls despawn_entity() internally.
             let _bridge_fallout_ids = self.resolve_bridge_state_changes(&bridge_changes);
+            // Wall damage: feed combat-emitted wall hits through the per-cell damage
+            // pipeline and despawn destroyed wall entities. Requires overlay_registry
+            // (wall flag on OverlayType plus per-type Strength/DamageLevels); rules
+            // is already unwrapped in this block.
+            if let Some(reg) = overlay_registry {
+                self.apply_wall_damage_events(&combat_result.wall_damage_events, rules, reg);
+            }
             // Apply RevealOnFire events from combat.
             for ev in &combat_result.reveal_events {
                 vision::reveal_radius(&mut self.fog, ev.owner, ev.rx, ev.ry, ev.radius);

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -657,7 +657,7 @@ fn test_water_mover_lookahead_does_not_attach_bridge_occupancy_under_bridge() {
     });
 
     let path_grid = PathGrid::new(2, 1);
-    let _ = sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&path_grid), 33);
+    let _ = sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&path_grid), None, 33);
 
     let boat = sim.entities.get(boat_id).expect("boat still exists");
     assert!(
@@ -704,7 +704,7 @@ fn test_too_big_ship_can_move_under_bridge_route() {
     // Use tick_ms=1000 so the ship crosses the cell boundary in 1 tick
     // (speed=256 * dt=1.0 = 256 leptons = 1 cell).
     let path_grid = PathGrid::new(2, 1);
-    let _ = sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&path_grid), 1000);
+    let _ = sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&path_grid), None, 1000);
 
     let ship = sim.entities.get(ship_id).expect("ship still exists");
     assert!(
@@ -743,7 +743,7 @@ fn test_ship_turn_path_completes_without_drive_track_stall() {
 
     let path_grid = PathGrid::new(3, 3);
     for _ in 0..10 {
-        let _ = sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&path_grid), 100);
+        let _ = sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&path_grid), None, 100);
     }
 
     let boat = sim.entities.get(boat_id).expect("boat still exists");
@@ -795,10 +795,11 @@ fn test_real_ship_locomotor_move_command_crosses_water_cells() {
         Some(&rules),
         &BTreeMap::new(),
         Some(&path_grid),
+        None,
         100,
     );
     for _ in 0..80 {
-        let _ = sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&path_grid), 100);
+        let _ = sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&path_grid), None, 100);
     }
 
     let ship = sim.entities.get(ship_id).expect("ship still exists");
@@ -852,10 +853,11 @@ fn test_real_ship_locomotor_crosses_water_surface_cells_with_non_water_land_type
         Some(&rules),
         &BTreeMap::new(),
         Some(&path_grid),
+        None,
         100,
     );
     for _ in 0..80 {
-        let _ = sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&path_grid), 100);
+        let _ = sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&path_grid), None, 100);
     }
 
     let ship = sim.entities.get(ship_id).expect("ship still exists");
@@ -911,6 +913,7 @@ fn test_real_ship_move_command_can_path_under_bridge_when_too_big() {
         Some(&rules),
         &BTreeMap::new(),
         Some(&path_grid),
+        None,
         100,
     );
     let initial_path = sim
@@ -920,7 +923,7 @@ fn test_real_ship_move_command_can_path_under_bridge_when_too_big() {
         .map(|mt| mt.path.clone())
         .expect("ship should have an initial path");
     for _ in 0..120 {
-        let _ = sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&path_grid), 100);
+        let _ = sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&path_grid), None, 100);
     }
 
     let ship = sim.entities.get(ship_id).expect("ship still exists");
@@ -994,7 +997,7 @@ fn test_select_command_applies_snapshot_selection() {
             additive: false,
         },
     );
-    let _ = sim.advance_tick(&[select], None, &empty_heights(), None, 33);
+    let _ = sim.advance_tick(&[select], None, &empty_heights(), None, None, 33);
 
     assert!(!sim.entities.get(1).is_some_and(|e| e.selected));
     assert!(sim.entities.get(2).is_some_and(|e| e.selected));
@@ -1021,7 +1024,7 @@ fn test_select_command_replaces_previous_selection() {
             additive: false,
         },
     );
-    let _ = sim.advance_tick(&[cmd1], None, &empty_heights(), None, 33);
+    let _ = sim.advance_tick(&[cmd1], None, &empty_heights(), None, None, 33);
 
     let cmd2 = cmd_envelope(
         &sim,
@@ -1032,7 +1035,7 @@ fn test_select_command_replaces_previous_selection() {
             additive: true,
         },
     );
-    let _ = sim.advance_tick(&[cmd2], None, &empty_heights(), None, 33);
+    let _ = sim.advance_tick(&[cmd2], None, &empty_heights(), None, None, 33);
 
     assert!(!sim.entities.get(1).is_some_and(|e| e.selected));
     assert!(sim.entities.get(2).is_some_and(|e| e.selected));
@@ -1059,7 +1062,7 @@ fn test_select_command_deduplicates_and_sorts_ids() {
             additive: false,
         },
     );
-    let _ = sim.advance_tick(&[select], None, &empty_heights(), None, 33);
+    let _ = sim.advance_tick(&[select], None, &empty_heights(), None, None, 33);
 
     assert!(sim.entities.get(1).is_some_and(|e| e.selected));
     assert!(sim.entities.get(2).is_some_and(|e| e.selected));
@@ -1078,7 +1081,7 @@ fn test_deploy_mcv_replaces_vehicle_with_conyard() {
     }
 
     let cmd = cmd_envelope(&sim, "Americans", 1, Command::DeployMcv { entity_id: mcv });
-    let _ = sim.advance_tick(&[cmd], Some(&rules), &heights, None, 33);
+    let _ = sim.advance_tick(&[cmd], Some(&rules), &heights, None, None, 33);
 
     assert!(sim.entities.get(mcv).is_none(), "MCV should be removed");
     let gacnst_id = sim
@@ -1127,7 +1130,7 @@ fn test_execute_tick_delay_blocks_early_execution() {
         },
     );
 
-    let _ = sim.advance_tick(&[delayed.clone()], None, &empty_heights(), Some(&grid), 33);
+    let _ = sim.advance_tick(&[delayed.clone()], None, &empty_heights(), Some(&grid), None, 33);
     assert!(
         sim.entities
             .get(1)
@@ -1135,7 +1138,7 @@ fn test_execute_tick_delay_blocks_early_execution() {
             .is_none()
     );
 
-    let _ = sim.advance_tick(&[delayed.clone()], None, &empty_heights(), Some(&grid), 33);
+    let _ = sim.advance_tick(&[delayed.clone()], None, &empty_heights(), Some(&grid), None, 33);
     assert!(
         sim.entities
             .get(1)
@@ -1143,7 +1146,7 @@ fn test_execute_tick_delay_blocks_early_execution() {
             .is_none()
     );
 
-    let _ = sim.advance_tick(&[delayed], None, &empty_heights(), Some(&grid), 33);
+    let _ = sim.advance_tick(&[delayed], None, &empty_heights(), Some(&grid), None, 33);
     assert!(
         sim.entities
             .get(1)
@@ -1198,7 +1201,7 @@ fn test_move_queue_command_appends_waypoint() {
             },
         ),
     ];
-    let _ = sim.advance_tick(&commands, None, &empty_heights(), Some(&grid), 33);
+    let _ = sim.advance_tick(&commands, None, &empty_heights(), Some(&grid), None, 33);
 
     let ge = sim
         .entities
@@ -1246,7 +1249,7 @@ fn test_stop_command_clears_move_and_attack_intent() {
     }
 
     let cmd = cmd_envelope(&sim, "Americans", 1, Command::Stop { entity_id: 1 });
-    let _ = sim.advance_tick(&[cmd], None, &empty_heights(), None, 33);
+    let _ = sim.advance_tick(&[cmd], None, &empty_heights(), None, None, 33);
     assert!(
         sim.entities.get(1).unwrap().movement_target.is_none(),
         "movement target should be cleared by Stop"
@@ -1292,7 +1295,7 @@ fn test_move_command_rejects_non_owned_entity() {
         },
     );
 
-    let _ = sim.advance_tick(&[cmd], None, &empty_heights(), Some(&grid), 33);
+    let _ = sim.advance_tick(&[cmd], None, &empty_heights(), Some(&grid), None, 33);
     assert!(
         sim.entities
             .get(1)
@@ -1322,7 +1325,7 @@ fn test_move_command_chrono_miner_uses_ground_path() {
         },
     );
 
-    let _ = sim.advance_tick(&[cmd], Some(&rules), &heights, Some(&grid), 33);
+    let _ = sim.advance_tick(&[cmd], Some(&rules), &heights, Some(&grid), None, 33);
     assert!(
         sim.entities
             .get(entity)
@@ -1361,7 +1364,7 @@ fn test_move_command_non_harvester_teleporter_uses_teleport() {
         },
     );
 
-    let _ = sim.advance_tick(&[cmd], Some(&rules), &heights, Some(&grid), 33);
+    let _ = sim.advance_tick(&[cmd], Some(&rules), &heights, Some(&grid), None, 33);
     assert!(
         sim.entities
             .get(entity)
@@ -1398,7 +1401,7 @@ fn test_attack_move_command_chrono_miner_uses_ground_path() {
         },
     );
 
-    let _ = sim.advance_tick(&[cmd], Some(&rules), &heights, Some(&grid), 33);
+    let _ = sim.advance_tick(&[cmd], Some(&rules), &heights, Some(&grid), None, 33);
     assert!(
         sim.entities
             .get(entity)
@@ -1468,7 +1471,7 @@ fn test_attack_command_rejects_friendly_target() {
         },
     );
 
-    let _ = sim.advance_tick(&[cmd], None, &empty_heights(), None, 33);
+    let _ = sim.advance_tick(&[cmd], None, &empty_heights(), None, None, 33);
     assert!(
         sim.entities.get(1).unwrap().attack_target.is_none(),
         "Attack on same-owner target should not issue"
@@ -1522,7 +1525,7 @@ fn test_attack_move_auto_acquires_enemy() {
         },
     );
 
-    let _ = sim.advance_tick(&[cmd], Some(&rules), &empty_heights(), Some(&grid), 100);
+    let _ = sim.advance_tick(&[cmd], Some(&rules), &empty_heights(), Some(&grid), None, 100);
     let attack = sim
         .entities
         .get(1)
@@ -1585,7 +1588,7 @@ fn test_attack_move_resumes_after_kill() {
         },
     );
 
-    let _ = sim.advance_tick(&[cmd], Some(&rules), &empty_heights(), Some(&grid), 100);
+    let _ = sim.advance_tick(&[cmd], Some(&rules), &empty_heights(), Some(&grid), None, 100);
     assert!(
         sim.entities.get(1).unwrap().attack_target.is_none(),
         "target should die and attack should clear"
@@ -1633,6 +1636,7 @@ fn test_guard_returns_to_anchor_when_displaced() {
         Some(&rules),
         &empty_heights(),
         Some(&grid),
+        None,
         100,
     );
 
@@ -1646,7 +1650,7 @@ fn test_guard_returns_to_anchor_when_displaced() {
         e.attack_target = None;
     }
 
-    let _ = sim.advance_tick(&[], Some(&rules), &empty_heights(), Some(&grid), 100);
+    let _ = sim.advance_tick(&[], Some(&rules), &empty_heights(), Some(&grid), None, 100);
     let ge = sim.entities.get(1).expect("entity 1 should exist");
     let movement = ge
         .movement_target
@@ -1683,7 +1687,7 @@ fn test_fog_revealed_persists_after_unit_moves_away() {
 
     let grid = PathGrid::new(8, 8);
     let americans = sim.interner.get("Americans").expect("Americans interned");
-    let _ = sim.advance_tick(&[], None, &empty_heights(), Some(&grid), 33);
+    let _ = sim.advance_tick(&[], None, &empty_heights(), Some(&grid), None, 33);
     assert!(sim.fog.is_cell_visible(americans, 1, 1));
     assert!(sim.fog.is_cell_revealed(americans, 1, 1));
 
@@ -1695,7 +1699,7 @@ fn test_fog_revealed_persists_after_unit_moves_away() {
         e.position.screen_x = nx;
         e.position.screen_y = ny;
     }
-    let _ = sim.advance_tick(&[], None, &empty_heights(), Some(&grid), 33);
+    let _ = sim.advance_tick(&[], None, &empty_heights(), Some(&grid), None, 33);
     assert!(!sim.fog.is_cell_visible(americans, 1, 1));
     assert!(sim.fog.is_cell_revealed(americans, 1, 1));
     assert!(sim.fog.is_cell_visible(americans, 2, 1));
@@ -1715,7 +1719,7 @@ fn test_undeploy_conyard_spawns_mcv() {
         e.selected = true;
     }
     let deploy_cmd = cmd_envelope(&sim, "Americans", 1, Command::DeployMcv { entity_id: mcv });
-    let _ = sim.advance_tick(&[deploy_cmd], Some(&rules), &heights, None, 33);
+    let _ = sim.advance_tick(&[deploy_cmd], Some(&rules), &heights, None, None, 33);
 
     // Find the ConYard that was spawned.
     let yard_id: u64 = sim
@@ -1738,7 +1742,7 @@ fn test_undeploy_conyard_spawns_mcv() {
         2,
         Command::UndeployBuilding { entity_id: yard_id },
     );
-    let _ = sim.advance_tick(&[undeploy_cmd], Some(&rules), &heights, None, 33);
+    let _ = sim.advance_tick(&[undeploy_cmd], Some(&rules), &heights, None, None, 33);
 
     // ConYard should still exist but have building_down set.
     assert!(
@@ -1752,7 +1756,7 @@ fn test_undeploy_conyard_spawns_mcv() {
 
     // Advance through the 30-tick undeploy animation.
     for _tick in 3..33 {
-        let _ = sim.advance_tick(&[], Some(&rules), &heights, None, 33);
+        let _ = sim.advance_tick(&[], Some(&rules), &heights, None, None, 33);
     }
 
     // ConYard should be gone after animation completes.

--- a/tests/determinism_replay.rs
+++ b/tests/determinism_replay.rs
@@ -77,7 +77,7 @@ fn run_with_frame_profile(total_ms: u32, frame_ms: u32) -> (u64, Vec<u64>, Repla
                 }
             });
 
-            let result = sim.advance_tick(&due, None, &height_map, Some(&grid), TICK_MS);
+            let result = sim.advance_tick(&due, None, &height_map, Some(&grid), None, TICK_MS);
             hashes.push(result.state_hash);
             replay.record_tick(result.tick, due, result.state_hash);
         }


### PR DESCRIPTION
Combat now emits WallDamageEvent (split from BridgeDamageEvent) when a wall-warhead hits a cell with a wall overlay. The world tick consumes these via Simulation::apply_wall_damage_events, which drives the per-cell damage progression, runs cardinal-neighbor cleanup with per-type auto-destruct thresholds (PostDestructionWallCleanup parity), and despawns paired wall GameEntities at destroyed cells.

Threads &OverlayTypeRegistry through advance_tick and tick_combat_with_fog so combat's wall-vs-bridge discriminator can read the Wall=yes flag. ~30 test call sites updated with a trailing None for the new param.

Adds 7 unit tests in overlay_grid (recompute + cleanup) and 3 integration/determinism tests in combat_tests.