### PR TITLE
Port YR simulation and tactical foundations

### DIFF
--- a/src/app_fire_effects.rs
+++ b/src/app_fire_effects.rs
@@ -406,6 +406,11 @@ fn build_projectile_visuals(
         let Some(projectile) = rules.projectile(projectile_id) else {
             continue;
         };
+        if crate::sim::combat::projectile_uses_authoritative_flight(weapon, rules) {
+            // YR BulletClass::AI linkage: persistent shots render from the
+            // simulation store, never a parallel app-local interpolation.
+            continue;
+        }
         if projectile.inviso {
             continue;
         }

--- a/src/app_instances/overlays.rs
+++ b/src/app_instances/overlays.rs
@@ -15,21 +15,17 @@ use crate::render::batch::SpriteInstance;
 use crate::render::bridge_atlas::is_high_bridge_body_name;
 use crate::render::overlay_atlas::OverlaySpriteKey;
 use crate::render::sprite_atlas::ShpSpriteKey;
+use crate::render::tactical_draw_plan::{BlitPolicy, RenderZPolicy, SpriteEncoding};
 use crate::rules::house_colors::HouseColorIndex;
 use crate::sim::components::WeaponMuzzleFlash;
 use crate::sim::miner::ResourceType;
+use crate::sim::projectile::{Projectile, ProjectileCoord};
 use crate::util::fixed_math::SimFixed;
 
 use super::helpers::{
     ANIM_DRAW_DEPTH_BIAS_PX, apply_shape_z_adjust, compute_sprite_depth,
     compute_sprite_depth_params, in_view,
 };
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OverlayRenderBucket {
-    Generic,
-    Wall,
-}
 
 /// Map terrain entries remain the render metadata source, but once rules-backed
 /// simulation authority exists the live cell index decides whether an instance
@@ -49,10 +45,7 @@ fn terrain_object_is_render_visible(
     {
         return true;
     }
-    let Some(stable_id) = production
-        .terrain_object_cells
-        .get(&(object.rx, object.ry))
-    else {
+    let Some(stable_id) = production.terrain_object_cells.get(&(object.rx, object.ry)) else {
         return false;
     };
     production
@@ -73,14 +66,6 @@ pub(crate) fn world_effect_screen_position(
     z: u8,
 ) -> (f32, f32) {
     crate::util::lepton::lepton_to_screen(rx, ry, sub_x, sub_y, z)
-}
-
-fn classify_overlay_render_bucket(is_wall: bool) -> OverlayRenderBucket {
-    if is_wall {
-        OverlayRenderBucket::Wall
-    } else {
-        OverlayRenderBucket::Generic
-    }
 }
 
 /// Build SpriteInstances for active world-position effects (warp sparkles, etc.).
@@ -256,7 +241,6 @@ pub(crate) fn build_overlay_instances(
     sw: f32,
     sh: f32,
     instances: &mut Vec<SpriteInstance>,
-    wall_instances: &mut Vec<SpriteInstance>,
 ) {
     let atlas = match &state.overlay_atlas {
         Some(a) => a,
@@ -291,7 +275,10 @@ pub(crate) fn build_overlay_instances(
         }
     };
 
-    // Overlay entries from [OverlayPack].
+    // Overlay entries from [OverlayPack]. `YR TacticalClass::Draw` keeps walls
+    // in the fixed cell overlay family, not the `LayerClass` object sort.
+    let mut planned_cells = Vec::new();
+    let mut next_draw_id = 0u64;
     for entry in &state.overlays {
         if let Some((owner_id, fog)) = cell_visibility_fog {
             if !fog.is_cell_revealed(owner_id, entry.rx, entry.ry) {
@@ -376,7 +363,6 @@ pub(crate) fn build_overlay_instances(
             }
         };
 
-        let bucket = classify_overlay_render_bucket(is_wall);
         // FA2 IsoView.cpp:5955-5956: track overlays render +CellHeight (15px) lower.
         let track_y_offset: f32 = if overlay_flags.map(|f| f.track).unwrap_or(false) {
             15.0
@@ -415,55 +401,37 @@ pub(crate) fn build_overlay_instances(
         let spr = atlas.get(&key).or_else(|| atlas.get(&key_fallback));
         let Some(spr) = spr else { continue };
         let depth_z: u8 = z;
-        // Walls use the same NW-corner render coords as buildings:
-        // (Location.X - 128, Location.Y - 128). Apply -TILE_HEIGHT/2 to match.
-        // Without this, a wall one cell behind a building lands at the same
-        // sort depth (the building's own -TILE_HEIGHT/2 shift eats the gap)
-        // and the tie-break nudge below pushes the wall in front.
-        let depth_y: f32 = if is_wall {
-            screen_y - TILE_HEIGHT / 2.0
-        } else {
-            screen_y
-        };
-        let raw_depth: f32 = compute_sprite_depth_params(origin_y, world_height, depth_y, depth_z);
-        // Walls get a tiny depth nudge closer to the camera so they win ties
-        // against building bodies at the same iso row. In the original engine,
-        // walls sort AFTER other buildings at the same YSort (inserted later →
-        // drawn later → in front). Our merge can't replicate insertion-order
-        // tie-breaking, so this nudge ensures walls render in front of building
-        // bibs/bodies at equal depth.
-        let depth: f32 = if is_wall {
-            (raw_depth - 0.00005).clamp(0.001, 0.999)
-        } else {
-            raw_depth
-        };
+        let depth: f32 = compute_sprite_depth_params(origin_y, world_height, screen_y, depth_z);
         let tint: [f32; 3] = state.lighting_grid.overlay_tint_at((entry.rx, entry.ry));
-
-        let target = match bucket {
-            OverlayRenderBucket::Wall => &mut *wall_instances,
-            OverlayRenderBucket::Generic => &mut *instances,
-        };
-        target.push(SpriteInstance {
-            position: [
-                screen_x + TILE_WIDTH / 2.0 + spr.offset_x,
-                screen_y + TILE_HEIGHT / 2.0 + spr.offset_y,
-            ],
-            size: spr.pixel_size,
-            uv_origin: spr.uv_origin,
-            uv_size: spr.uv_size,
-            depth,
-            tint,
-            alpha: 1.0,
-            ..Default::default()
+        planned_cells.push(crate::app_render::draw_plan_lowering::PlannedCellInstance {
+            draw: crate::render::tactical_draw_plan::CellDraw {
+                id: next_draw_id,
+                kind: crate::app_render::draw_plan_lowering::cell_draw_kind(is_wall),
+                policy: BlitPolicy::translucent(SpriteEncoding::Terrain, RenderZPolicy::None),
+            },
+            instance: SpriteInstance {
+                position: [
+                    screen_x + TILE_WIDTH / 2.0 + spr.offset_x,
+                    screen_y + TILE_HEIGHT / 2.0 + spr.offset_y,
+                ],
+                size: spr.pixel_size,
+                uv_origin: spr.uv_origin,
+                uv_size: spr.uv_size,
+                depth,
+                tint,
+                alpha: 1.0,
+                ..Default::default()
+            },
         });
+        next_draw_id += 1;
     }
 
+    instances.extend(crate::app_render::draw_plan_lowering::lower_cell_instances(
+        planned_cells,
+    ));
+
     if std::env::var("RA2_DEBUG_BRIDGE_RENDER_BUCKETS").is_ok() {
-        log::debug!(
-            "Overlay buckets: generic={} walls={}",
-            instances.len(),
-            wall_instances.len()
-        );
+        log::debug!("Cell overlay instances: {}", instances.len());
     }
 
     // Terrain objects from [Terrain] section.
@@ -730,11 +698,107 @@ fn projectile_visual_key(projectile: &ProjectileVisual) -> ShpSpriteKey {
     }
 }
 
+fn projectile_authoritative_screen_position(
+    coordinate: ProjectileCoord,
+) -> Option<(f32, f32, u16, u16, u8)> {
+    let rx = u16::try_from(coordinate.x.div_euclid(256)).ok()?;
+    let ry = u16::try_from(coordinate.y.div_euclid(256)).ok()?;
+    let sub_x = SimFixed::from_num(coordinate.x.rem_euclid(256));
+    let sub_y = SimFixed::from_num(coordinate.y.rem_euclid(256));
+    let z = coordinate.z.clamp(0, i32::from(u8::MAX)) as u8;
+    let (screen_x, screen_y) = crate::util::lepton::lepton_to_screen(rx, ry, sub_x, sub_y, z);
+    Some((screen_x, screen_y, rx, ry, z))
+}
+
+fn authoritative_projectile_frame(projectile: &Projectile, frame_count: u16) -> u16 {
+    if frame_count == 0 {
+        return 0;
+    }
+    let facing = crate::sim::movement::facing_from_delta(
+        projectile.last_target_position.x - projectile.position.x,
+        projectile.last_target_position.y - projectile.position.y,
+    );
+    (((u32::from(facing) * u32::from(frame_count)) / 256) as u16).min(frame_count.saturating_sub(1))
+}
+
+/// Build visible persistent shots from `Simulation::projectiles`.
+///
+/// YR `BulletClass::AI` linkage: rendering reads the same committed CoordStruct
+/// that the next authoritative flight pass will advance.
+fn build_authoritative_projectile_instances(state: &AppState, paged: &mut [Vec<SpriteInstance>]) {
+    let (sim, rules, atlas) = match (&state.simulation, &state.rules, &state.sprite_atlas) {
+        (Some(sim), Some(rules), Some(atlas)) => (sim, rules, atlas),
+        _ => return,
+    };
+    let z = state.zoom_level;
+    let (cam_x, cam_y, sw, sh) = (
+        state.camera_x,
+        state.camera_y,
+        state.render_width() as f32 / z,
+        state.render_height() as f32 / z,
+    );
+    let (origin_y, world_height) = state
+        .terrain_grid
+        .as_ref()
+        .map(|grid| (grid.origin_y, grid.world_height))
+        .unwrap_or((0.0, 1.0));
+
+    for (_, projectile) in sim.projectiles.iter() {
+        let Some(weapon) = rules.weapon(sim.interner.resolve(projectile.payload.weapon)) else {
+            continue;
+        };
+        let Some(projectile_type_id) = weapon.projectile.as_deref() else {
+            continue;
+        };
+        let Some(projectile_type) = rules.projectile(projectile_type_id) else {
+            continue;
+        };
+        let Some(image) = projectile_type.image.as_deref() else {
+            continue;
+        };
+        let Some((screen_x, screen_y, rx, ry, projectile_z)) =
+            projectile_authoritative_screen_position(projectile.position)
+        else {
+            continue;
+        };
+        if !in_view(screen_x, screen_y, 96.0, 96.0, cam_x, cam_y, sw, sh, 96.0) {
+            continue;
+        }
+        let frame_count = sim
+            .interner
+            .get(image)
+            .and_then(|image_id| sim.effect_frame_counts.get(&image_id).copied())
+            .unwrap_or(32);
+        let key = ShpSpriteKey {
+            type_id: image.to_string(),
+            facing: 0,
+            frame: authoritative_projectile_frame(projectile, frame_count),
+            house_color: HouseColorIndex(0),
+        };
+        let Some(entry) = atlas.get(&key) else {
+            continue;
+        };
+        let tint = state.lighting_grid.anim_tint_at((rx, ry));
+        let depth = compute_sprite_depth_params(origin_y, world_height, screen_y, projectile_z);
+        paged[entry.page as usize].push(SpriteInstance {
+            position: [screen_x + entry.offset_x, screen_y + entry.offset_y],
+            size: entry.pixel_size,
+            uv_origin: entry.uv_origin,
+            uv_size: entry.uv_size,
+            depth,
+            tint,
+            alpha: 1.0,
+            ..Default::default()
+        });
+    }
+}
+
 /// Build SpriteInstances for render-only in-flight projectile visuals.
 pub(crate) fn build_projectile_visual_instances(
     state: &AppState,
     paged: &mut [Vec<SpriteInstance>],
 ) {
+    build_authoritative_projectile_instances(state, paged);
     let atlas = match &state.sprite_atlas {
         Some(a) => a,
         None => return,
@@ -894,9 +958,8 @@ pub(crate) fn build_parachute_instances(state: &AppState, paged: &mut [Vec<Sprit
 #[cfg(test)]
 mod tests {
     use super::{
-        ANIM_DRAW_DEPTH_BIAS_PX, OverlayRenderBucket, apply_shape_z_adjust,
-        classify_overlay_render_bucket, garrison_flash_depth, terrain_object_is_render_visible,
-        weapon_muzzle_flash_key, world_effect_screen_position,
+        ANIM_DRAW_DEPTH_BIAS_PX, apply_shape_z_adjust, garrison_flash_depth,
+        terrain_object_is_render_visible, weapon_muzzle_flash_key, world_effect_screen_position,
     };
     use crate::map::overlay::TerrainObject;
     use crate::rules::ini_parser::IniFile;
@@ -976,22 +1039,6 @@ mod tests {
             Some(&rules),
             Some(&production),
         ));
-    }
-
-    #[test]
-    fn wall_routes_to_wall_bucket() {
-        assert_eq!(
-            classify_overlay_render_bucket(true),
-            OverlayRenderBucket::Wall
-        );
-    }
-
-    #[test]
-    fn non_wall_routes_to_generic_bucket() {
-        assert_eq!(
-            classify_overlay_render_bucket(false),
-            OverlayRenderBucket::Generic
-        );
     }
 
     #[test]

--- a/src/app_instances/shp.rs
+++ b/src/app_instances/shp.rs
@@ -13,11 +13,17 @@ use super::helpers::{
     is_under_bridge_render_state,
 };
 use crate::app::AppState;
+use crate::app_render::draw_plan_lowering::{
+    PlannedBuildingPieceInstance, lower_building_piece_instances,
+};
 use crate::map::entities::EntityCategory;
 use crate::map::lighting;
 use crate::map::terrain::TILE_HEIGHT;
 use crate::render::batch::SpriteInstance;
 use crate::render::sprite_atlas::ShpSpriteKey;
+use crate::render::tactical_draw_plan::{
+    BlitPolicy, BuildingPieceKind, ObjectDraw, SpriteEncoding, TacticalCoord, TacticalLayer,
+};
 use crate::render::unit_atlas::{UnitSpriteKey, VxlLayer, canonical_turret_facing};
 use crate::rules::house_colors::HouseColorIndex;
 use crate::sim::animation;
@@ -252,7 +258,7 @@ pub(crate) fn build_shp_instances(
         } else {
             &mut *paged
         };
-        target_pages[entry.page as usize].push(SpriteInstance {
+        let body = SpriteInstance {
             position: [final_x, final_y],
             size: entry.pixel_size,
             uv_origin: entry.uv_origin,
@@ -261,7 +267,24 @@ pub(crate) fn build_shp_instances(
             tint,
             alpha: 1.0,
             ..Default::default()
-        });
+        };
+
+        let mut building_pieces = Vec::new();
+        if entity.category == EntityCategory::Structure {
+            building_pieces.push(PlannedBuildingPieceInstance {
+                kind: if is_building_up || is_building_down {
+                    BuildingPieceKind::BuildupOrSpecial
+                } else {
+                    BuildingPieceKind::Body
+                },
+                z_bias: 0,
+                policy: BlitPolicy::opaque(SpriteEncoding::Plain),
+                page: entry.page as usize,
+                instance: body,
+            });
+        } else {
+            target_pages[entry.page as usize].push(body);
+        }
 
         // Emit building animation overlays and bib — but NOT during build-up/down.
         // Bibs and anims use the raw cell position (sy) — their own SHP offsets
@@ -272,7 +295,7 @@ pub(crate) fn build_shp_instances(
                 // right after the main body sprite, as part of the same object pass.
                 // It overwrites the body's terrain-colored pixels at the ramp area.
                 emit_building_bib(
-                    paged,
+                    &mut building_pieces,
                     atlas,
                     art,
                     state.rules.as_ref(),
@@ -296,7 +319,7 @@ pub(crate) fn build_shp_instances(
                     .map(|g| g.world_height)
                     .unwrap_or(1.0);
                 emit_building_anims(
-                    paged,
+                    &mut building_pieces,
                     atlas,
                     art,
                     state.rules.as_ref(),
@@ -341,6 +364,25 @@ pub(crate) fn build_shp_instances(
                         );
                     }
                 }
+            }
+        }
+
+        if entity.category == EntityCategory::Structure {
+            let coord = TacticalCoord {
+                x: i32::from(pos.rx) * 256 + crate::util::fixed_math::sim_to_i32(pos.sub_x),
+                y: i32::from(pos.ry) * 256 + crate::util::fixed_math::sim_to_i32(pos.sub_y),
+                z: i32::from(pos.z),
+            };
+            let parent = ObjectDraw {
+                id: entity.stable_id,
+                layer: TacticalLayer(2),
+                coord,
+                y_sort_adjust: 0,
+                registration_order: entity.stable_id,
+                policy: BlitPolicy::opaque(SpriteEncoding::Plain),
+            };
+            for (page, instance) in lower_building_piece_instances(parent, building_pieces) {
+                paged[page].push(instance);
             }
         }
     }
@@ -415,7 +457,7 @@ fn emit_building_turret_vxl(
 /// behind the building at the same cell position. It provides the flat ground
 /// surface where harvesters dock or other ground-level detail.
 fn emit_building_bib(
-    paged: &mut [Vec<SpriteInstance>],
+    pieces: &mut Vec<PlannedBuildingPieceInstance>,
     atlas: &crate::render::sprite_atlas::SpriteAtlas,
     art_reg: &crate::rules::art_data::ArtRegistry,
     rules: Option<&crate::rules::ruleset::RuleSet>,
@@ -455,15 +497,21 @@ fn emit_building_bib(
     // building's YSort position. Use the building's depth so bib and body stay
     // together in the Y-sorted merge, preventing bibs from incorrectly
     // overlapping walls at closer iso rows.
-    paged[bib_entry.page as usize].push(SpriteInstance {
-        position: [bx, by],
-        size: bib_entry.pixel_size,
-        uv_origin: bib_entry.uv_origin,
-        uv_size: bib_entry.uv_size,
-        depth: building_depth,
-        tint,
-        alpha: 1.0,
-        ..Default::default()
+    pieces.push(PlannedBuildingPieceInstance {
+        kind: BuildingPieceKind::Bib,
+        z_bias: 0,
+        policy: BlitPolicy::opaque(SpriteEncoding::Plain),
+        page: bib_entry.page as usize,
+        instance: SpriteInstance {
+            position: [bx, by],
+            size: bib_entry.pixel_size,
+            uv_origin: bib_entry.uv_origin,
+            uv_size: bib_entry.uv_size,
+            depth: building_depth,
+            tint,
+            alpha: 1.0,
+            ..Default::default()
+        },
     });
 }
 
@@ -561,7 +609,7 @@ fn selected_building_anim_view<'a>(
 /// in the sprite atlas and positioned at the building's cell center + the
 /// animation's (X, Y) pixel offset from art.ini.
 fn emit_building_anims(
-    paged: &mut [Vec<SpriteInstance>],
+    pieces: &mut Vec<PlannedBuildingPieceInstance>,
     atlas: &crate::render::sprite_atlas::SpriteAtlas,
     art_reg: &crate::rules::art_data::ArtRegistry,
     rules: Option<&crate::rules::ruleset::RuleSet>,
@@ -706,15 +754,21 @@ fn emit_building_anims(
             effective_anim_z_adjust(anim.z_adjust, type_z_adjust) + ANIM_DRAW_DEPTH_BIAS_PX;
         let anim_depth: f32 = apply_shape_z_adjust(building_depth, z_adjust_px, world_height);
 
-        paged[anim_entry.page as usize].push(SpriteInstance {
-            position: [ax, ay],
-            size: anim_entry.pixel_size,
-            uv_origin: anim_entry.uv_origin,
-            uv_size: anim_entry.uv_size,
-            depth: anim_depth,
-            tint,
-            alpha: 1.0,
-            ..Default::default()
+        pieces.push(PlannedBuildingPieceInstance {
+            kind: BuildingPieceKind::PoweredOrActiveOverlay,
+            z_bias: z_adjust_px,
+            policy: BlitPolicy::opaque(SpriteEncoding::Plain),
+            page: anim_entry.page as usize,
+            instance: SpriteInstance {
+                position: [ax, ay],
+                size: anim_entry.pixel_size,
+                uv_origin: anim_entry.uv_origin,
+                uv_size: anim_entry.uv_size,
+                depth: anim_depth,
+                tint,
+                alpha: 1.0,
+                ..Default::default()
+            },
         });
     }
 }

--- a/src/app_render/build_instances.rs
+++ b/src/app_render/build_instances.rs
@@ -38,7 +38,6 @@ pub(super) struct WorldInstances {
     pub bridge_body: Vec<SpriteInstance>,
     pub bridge_body_shadow: Vec<SpriteInstance>,
     pub bridge_railing: Vec<SpriteInstance>,
-    pub wall: Vec<SpriteInstance>,
     pub unit: Vec<SpriteInstance>,
     pub unit_pages: Vec<usize>,
     pub bridge_unit: Vec<SpriteInstance>,
@@ -190,13 +189,13 @@ pub(super) fn build_world_instances(state: &mut AppState, sw: f32, sh: f32) -> W
         }
     };
 
-    // Overlays: map overlays, walls — each sorted by depth descending. Low
-    // bridges (LOBRDG*) ride in `overlay`; high-bridge bodies are emitted by
-    // `app_instances::bridges` instead.
+    // Map overlays and walls are lowered through the fixed per-cell draw plan.
+    // Terrain objects remain an explicit fallback until they carry LayerClass
+    // registration metadata. Low bridges (LOBRDG*) ride in `overlay`; high
+    // bridge bodies are emitted by `app_instances::bridges` instead.
     let mut overlay: Vec<SpriteInstance> = std::mem::take(&mut state.cached_overlay_instances);
     overlay.clear();
-    let mut wall: Vec<SpriteInstance> = Vec::new();
-    app_instances::build_overlay_instances(state, sw, sh, &mut overlay, &mut wall);
+    app_instances::build_overlay_instances(state, sw, sh, &mut overlay);
     // Bridge body, shadow, and railing emission live in app_instances::bridges
     // (Phase D). Read from BridgeRuntimeCell post-tick (NOT OverlayGrid).
     let mut bridge_body: Vec<SpriteInstance> = Vec::new();
@@ -205,11 +204,9 @@ pub(super) fn build_world_instances(state: &mut AppState, sw: f32, sh: f32) -> W
     app_instances::bridges::build_bridge_body_instances(state, sw, sh, &mut bridge_body);
     app_instances::bridges::build_bridge_shadow_instances(state, sw, sh, &mut bridge_body_shadow);
     app_instances::bridges::build_bridge_railing_instances(state, sw, sh, &mut bridge_railing);
-    sort_by_depth_desc(&mut overlay);
     sort_by_depth_desc(&mut bridge_body);
     sort_by_depth_desc(&mut bridge_body_shadow);
     sort_by_depth_desc(&mut bridge_railing);
-    sort_by_depth_desc(&mut wall);
 
     // Smudges: static crater/scorch decals on top of terrain, under entities.
     // Atlas registration for SmudgeType SHPs is a deferred follow-up; until it
@@ -300,6 +297,14 @@ pub(super) fn build_world_instances(state: &mut AppState, sw: f32, sh: f32) -> W
         sort_by_depth_desc(page);
     }
 
+    // `LayerClass` needs integer ObjectClass::GetYSort and registration order.
+    // Existing atlas vectors retain neither, so publish the typed fallback once.
+    super::draw_plan_lowering::report_object_buffer_fallbacks(
+        !unit.is_empty(),
+        unit_transition_paged.iter().any(|page| !page.is_empty()),
+        shp_paged.iter().any(|page| !page.is_empty()),
+    );
+
     // PixelFX water/ore sparkles — per-frame 1-pixel cell dots.
     let cell_sparkles: Vec<SpriteInstance> = build_pixel_fx_sparkle_instances(state, sw, sh);
 
@@ -325,7 +330,6 @@ pub(super) fn build_world_instances(state: &mut AppState, sw: f32, sh: f32) -> W
         bridge_body,
         bridge_body_shadow,
         bridge_railing,
-        wall,
         unit,
         unit_pages,
         bridge_unit,

--- a/src/app_render/draw_passes.rs
+++ b/src/app_render/draw_passes.rs
@@ -32,7 +32,6 @@ pub(super) struct DrawPassData<'a> {
     pub unit_pages: &'a [usize],
     pub unit_transition_paged: &'a [Vec<SpriteInstance>],
     pub shp_paged: &'a [Vec<SpriteInstance>],
-    pub wall_instances: &'a [SpriteInstance],
     pub building_turret_pages: &'a [usize],
     pub particle_paged: &'a [Vec<SpriteInstance>],
     pub ghost_page: u8,
@@ -89,10 +88,7 @@ pub(super) fn dispatch_draw_passes(
     // occlude overlays via LessEqual depth test ("sinking into ground").
     // Cliff occlusion for overlays comes from the cliff redraw pass (step 7).
     //
-    // Walls are NOT drawn here — they participate in the Y-sorted merge
-    // (step 5) so they correctly interleave with buildings by depth.
-
-    // Non-wall overlays (ore, trees, terrain objects, low bridges) — no depth test.
+    // Overlays (including walls) stay in the fixed cell family.
     draw_pooled_passthrough_overlay(
         &mut pass,
         &state.batch_renderer,
@@ -154,9 +150,6 @@ pub(super) fn dispatch_draw_passes(
 
     // --- Step 5: Ground objects (unified multi-way Y-merge) ---
     // All ground objects Y-sorted together (Layer 2).
-    // Walls are included so they correctly appear in front of units at
-    // closer iso rows (walls render in both terrain pass and object pass --
-    // the object pass rendering provides Y-sorted priority).
     merge_passes::draw_merged_object_pass(
         &mut pass,
         &state.batch_renderer,
@@ -165,11 +158,9 @@ pub(super) fn dispatch_draw_passes(
         data.unit_pages,
         data.unit_transition_paged,
         data.shp_paged,
-        data.wall_instances,
         state.unit_atlas.as_ref(),
         &transition_cache,
         state.sprite_atlas.as_ref(),
-        state.overlay_atlas.as_ref(),
         state.palette_set.as_ref(),
     );
 

--- a/src/app_render/draw_plan_lowering.rs
+++ b/src/app_render/draw_plan_lowering.rs
@@ -1,0 +1,352 @@
+//! Safe lowering from native-shaped tactical plans to existing GPU buffers.
+//!
+//! The adapter only reorders families that retain all native ordering metadata.
+//! It refuses lossy atlas vectors rather than inferring coordinates or registration.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+use crate::render::batch::SpriteInstance;
+use crate::render::tactical_draw_plan::{
+    BlitPolicy, BuildingOwnedPlan, BuildingPiece, BuildingPieceKind, CellDraw, CellDrawKind,
+    DrawId, ObjectDraw, TacticalCoord, TacticalDrawInput, TacticalDrawPlan, TacticalLayer,
+};
+
+/// A cell-pass instance paired with the metadata needed by `YR TacticalClass::Draw`.
+pub(crate) struct PlannedCellInstance {
+    pub draw: CellDraw,
+    pub instance: SpriteInstance,
+}
+
+/// One GPU sprite that remains owned by a single building during lowering.
+///
+/// Keeping the atlas page alongside the sprite lets the render submission
+/// preserve `BuildingClass::Draw` piece order without inferring it from floats.
+pub(crate) struct PlannedBuildingPieceInstance {
+    pub kind: BuildingPieceKind,
+    pub z_bias: i32,
+    pub policy: BlitPolicy,
+    pub page: usize,
+    pub instance: SpriteInstance,
+}
+
+/// Families whose existing buffers cannot be safely promoted to `LayerClass` ordering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ObjectOrderFamily {
+    UnitAtlas,
+    ShpAtlas,
+    SlopeTransitionAtlas,
+}
+
+/// A deliberate refusal to guess missing `ObjectClass::GetYSort` inputs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ObjectOrderRefusal {
+    MissingTacticalCoord { family: ObjectOrderFamily },
+    MissingRegistrationOrder { family: ObjectOrderFamily },
+    SplitOwnedBuildingGroup { family: ObjectOrderFamily },
+}
+
+/// Metadata required before a live object can enter the native integer sort.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct NativeObjectOrderMetadata {
+    pub id: DrawId,
+    pub layer: TacticalLayer,
+    pub coord: Option<TacticalCoord>,
+    pub y_sort_adjust: i32,
+    pub registration_order: Option<u64>,
+}
+
+pub(crate) fn object_draw_from_metadata(
+    family: ObjectOrderFamily,
+    metadata: NativeObjectOrderMetadata,
+) -> Result<ObjectDraw, ObjectOrderRefusal> {
+    let coord = metadata
+        .coord
+        .ok_or(ObjectOrderRefusal::MissingTacticalCoord { family })?;
+    let registration_order = metadata
+        .registration_order
+        .ok_or(ObjectOrderRefusal::MissingRegistrationOrder { family })?;
+    Ok(ObjectDraw {
+        id: metadata.id,
+        layer: metadata.layer,
+        coord,
+        y_sort_adjust: metadata.y_sort_adjust,
+        registration_order,
+        policy: crate::render::tactical_draw_plan::BlitPolicy::opaque(
+            crate::render::tactical_draw_plan::SpriteEncoding::Plain,
+        ),
+    })
+}
+
+/// Return explicit fallbacks for the current GPU buffers that lost native keys.
+pub(crate) fn object_buffer_fallbacks(
+    has_units: bool,
+    has_slope_transitions: bool,
+    has_shp: bool,
+) -> Vec<ObjectOrderRefusal> {
+    let mut refusals = Vec::new();
+    if has_units {
+        refusals.push(ObjectOrderRefusal::MissingTacticalCoord {
+            family: ObjectOrderFamily::UnitAtlas,
+        });
+    }
+    if has_slope_transitions {
+        refusals.push(ObjectOrderRefusal::MissingTacticalCoord {
+            family: ObjectOrderFamily::SlopeTransitionAtlas,
+        });
+    }
+    if has_shp {
+        refusals.push(ObjectOrderRefusal::MissingTacticalCoord {
+            family: ObjectOrderFamily::ShpAtlas,
+        });
+    }
+    refusals
+}
+
+/// Report each lossless-lowering refusal once per process, not once per frame.
+pub(crate) fn report_object_buffer_fallbacks(
+    has_units: bool,
+    has_slope_transitions: bool,
+    has_shp: bool,
+) {
+    static REPORTED: AtomicU8 = AtomicU8::new(0);
+    for refusal in object_buffer_fallbacks(has_units, has_slope_transitions, has_shp) {
+        let bit = match refusal {
+            ObjectOrderRefusal::MissingTacticalCoord {
+                family: ObjectOrderFamily::UnitAtlas,
+            } => 1,
+            ObjectOrderRefusal::MissingTacticalCoord {
+                family: ObjectOrderFamily::SlopeTransitionAtlas,
+            } => 2,
+            ObjectOrderRefusal::MissingTacticalCoord {
+                family: ObjectOrderFamily::ShpAtlas,
+            } => 4,
+            _ => 0,
+        };
+        if REPORTED.fetch_or(bit, Ordering::Relaxed) & bit == 0 {
+            log::warn!(
+                "native tactical object ordering fallback: {refusal:?}; retaining existing GPU buffer order"
+            );
+        }
+    }
+}
+
+/// Lower a complete cell family while preserving the existing GPU instance type.
+///
+/// `TacticalDrawPlan` owns the family ordering; this adapter only maps ordered
+/// IDs back to the existing instances. Duplicate IDs are rejected at the source.
+pub(crate) fn lower_cell_instances(entries: Vec<PlannedCellInstance>) -> Vec<SpriteInstance> {
+    let mut instances = BTreeMap::new();
+    let inputs = entries.into_iter().map(|entry| {
+        assert!(
+            instances.insert(entry.draw.id, entry.instance).is_none(),
+            "each planned cell instance must have a unique draw id"
+        );
+        TacticalDrawInput::Cell(entry.draw)
+    });
+    let plan = TacticalDrawPlan::build(inputs);
+    let mut ordered = Vec::with_capacity(instances.len());
+    for draw in plan
+        .cell_pass
+        .terrain
+        .iter()
+        .chain(&plan.cell_pass.smudges)
+        .chain(&plan.cell_pass.overlays)
+        .chain(&plan.cell_pass.primary_objects)
+    {
+        ordered.push(
+            instances
+                .remove(&draw.id)
+                .expect("plan entry must resolve to its existing GPU instance"),
+        );
+    }
+    ordered
+}
+
+/// Lower one intact building group through the native-shaped planner.
+///
+/// `YR BuildingClass::Draw` keeps its owned bib/body/anim draws together after
+/// the parent object wins the TacticalClass layer sort.
+pub(crate) fn lower_building_piece_instances(
+    parent: ObjectDraw,
+    entries: Vec<PlannedBuildingPieceInstance>,
+) -> Vec<(usize, SpriteInstance)> {
+    let mut instances = BTreeMap::new();
+    let pieces = entries
+        .into_iter()
+        .enumerate()
+        .map(|(index, entry)| {
+            let id = index as DrawId;
+            assert!(
+                instances.insert(id, (entry.page, entry.instance)).is_none(),
+                "each planned building piece must have a unique local id"
+            );
+            BuildingPiece {
+                id,
+                kind: entry.kind,
+                z_bias: entry.z_bias,
+                policy: entry.policy,
+            }
+        })
+        .collect();
+    let plan = TacticalDrawPlan::build([TacticalDrawInput::Building(BuildingOwnedPlan {
+        parent,
+        pieces,
+    })]);
+    let mut ordered = Vec::with_capacity(instances.len());
+    for entry in &plan.object_layers {
+        for building in &entry.entries {
+            let crate::render::tactical_draw_plan::LayerEntry::Building(building) = building else {
+                unreachable!("building-only lowering cannot produce an object entry");
+            };
+            for piece in &building.pieces {
+                ordered.push(
+                    instances
+                        .remove(&piece.id)
+                        .expect("plan piece must resolve to its existing GPU instance"),
+                );
+            }
+        }
+    }
+    ordered
+}
+
+pub(crate) fn cell_draw_kind(is_wall: bool) -> CellDrawKind {
+    if is_wall {
+        CellDrawKind::WallOverlay
+    } else {
+        CellDrawKind::FlatOverlay
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::tactical_draw_plan::{BlitPolicy, RenderZPolicy, SpriteEncoding};
+
+    fn cell(id: DrawId, is_wall: bool) -> PlannedCellInstance {
+        PlannedCellInstance {
+            draw: CellDraw {
+                id,
+                kind: cell_draw_kind(is_wall),
+                policy: BlitPolicy::translucent(SpriteEncoding::Terrain, RenderZPolicy::None),
+            },
+            instance: SpriteInstance {
+                fx_flags: id as u32,
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn cell_lowering_keeps_walls_in_the_fixed_overlay_family() {
+        let lowered = lower_cell_instances(vec![cell(4, false), cell(3, true), cell(2, false)]);
+        assert_eq!(
+            lowered
+                .iter()
+                .map(|instance| instance.fx_flags)
+                .collect::<Vec<_>>(),
+            [4, 3, 2]
+        );
+    }
+
+    #[test]
+    fn object_lowering_refuses_missing_integer_coordinates() {
+        let refusal = object_draw_from_metadata(
+            ObjectOrderFamily::ShpAtlas,
+            NativeObjectOrderMetadata {
+                id: 1,
+                layer: TacticalLayer(2),
+                coord: None,
+                y_sort_adjust: 0,
+                registration_order: Some(3),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            refusal,
+            ObjectOrderRefusal::MissingTacticalCoord {
+                family: ObjectOrderFamily::ShpAtlas
+            }
+        );
+    }
+
+    #[test]
+    fn object_lowering_refuses_missing_registration_order() {
+        let refusal = object_draw_from_metadata(
+            ObjectOrderFamily::UnitAtlas,
+            NativeObjectOrderMetadata {
+                id: 1,
+                layer: TacticalLayer(2),
+                coord: Some(TacticalCoord { x: 1, y: 2, z: 0 }),
+                y_sort_adjust: 0,
+                registration_order: None,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            refusal,
+            ObjectOrderRefusal::MissingRegistrationOrder {
+                family: ObjectOrderFamily::UnitAtlas
+            }
+        );
+    }
+
+    #[test]
+    fn non_empty_gpu_families_publish_typed_fallbacks() {
+        assert_eq!(
+            object_buffer_fallbacks(true, false, true),
+            vec![
+                ObjectOrderRefusal::MissingTacticalCoord {
+                    family: ObjectOrderFamily::UnitAtlas,
+                },
+                ObjectOrderRefusal::MissingTacticalCoord {
+                    family: ObjectOrderFamily::ShpAtlas,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn building_lowering_keeps_owned_pieces_together_in_native_order() {
+        let parent = ObjectDraw {
+            id: 9,
+            layer: TacticalLayer(2),
+            coord: TacticalCoord {
+                x: 512,
+                y: 768,
+                z: 0,
+            },
+            y_sort_adjust: 0,
+            registration_order: 9,
+            policy: BlitPolicy::opaque(SpriteEncoding::Plain),
+        };
+        let piece = |kind, page, marker| PlannedBuildingPieceInstance {
+            kind,
+            z_bias: 0,
+            policy: BlitPolicy::opaque(SpriteEncoding::Plain),
+            page,
+            instance: SpriteInstance {
+                fx_flags: marker,
+                ..Default::default()
+            },
+        };
+
+        let lowered = lower_building_piece_instances(
+            parent,
+            vec![
+                piece(BuildingPieceKind::PoweredOrActiveOverlay, 2, 50),
+                piece(BuildingPieceKind::Body, 1, 40),
+                piece(BuildingPieceKind::Bib, 0, 30),
+            ],
+        );
+
+        assert_eq!(
+            lowered
+                .iter()
+                .map(|(page, instance)| (*page, instance.fx_flags))
+                .collect::<Vec<_>>(),
+            [(0, 30), (1, 40), (2, 50)]
+        );
+    }
+}

--- a/src/app_render/merge_passes.rs
+++ b/src/app_render/merge_passes.rs
@@ -1,7 +1,7 @@
 //! Y-sorted multi-way merge passes for interleaving draw calls across atlas textures.
 //!
 //! The original engine renders all ground objects in a single Y-sorted pass (Layer 2).
-//! Our engine has multiple atlas textures (VXL units, SHP pages 0-3, wall overlays),
+//! Our engine has multiple atlas textures (VXL units and SHP pages),
 //! so we interleave draw calls by walking cursors through each Y-sorted buffer and
 //! emitting sub-range draws in depth-descending order (back-to-front).
 //!
@@ -9,7 +9,6 @@
 //! - Internal to app_render — only called from draw_passes.rs.
 
 use crate::render::batch::{BatchRenderer, BatchTexture, InstanceBufferPool, SpriteInstance};
-use crate::render::overlay_atlas::OverlayAtlas;
 use crate::render::palette_textures::PaletteSet;
 use crate::render::sprite_atlas::SpriteAtlas;
 use crate::render::unit_atlas::UnitAtlas;
@@ -35,8 +34,8 @@ enum DrawTexture<'tex, 'inst> {
 
 /// Tracks a single draw group during the multi-way merge.
 ///
-/// Each group represents one GPU buffer + texture pair (e.g., VXL units, one SHP page,
-/// wall overlays). The `cursor` advances through the buffer as sub-ranges are drawn.
+/// Each group represents one GPU buffer + texture pair (e.g., VXL units or one SHP page).
+/// The `cursor` advances through the buffer as sub-ranges are drawn.
 /// `kind` determines which pipeline is used to dispatch the draw.
 struct DrawGroup<'tex, 'inst> {
     texture: DrawTexture<'tex, 'inst>,
@@ -221,12 +220,10 @@ pub(super) fn draw_merged_bridge_occluded_pass<'a>(
     }
 }
 
-/// Unified Y-sorted object pass: multi-way merge of VXL units, SHP entities, and walls.
+/// Unified Y-sorted object pass: multi-way merge of VXL units and SHP entities.
 ///
-/// All ground objects (buildings, infantry, vehicles, walls) are rendered in a
-/// single Y-sorted pass (Layer 2). Walls render in both the terrain overlay pass AND
-/// here -- the second rendering provides correct Y-sorted priority (walls in front of
-/// units at closer iso rows). Our engine has multiple atlas textures, so we interleave
+/// Ground objects (buildings, infantry, vehicles) are rendered in a single
+/// Y-sorted pass (Layer 2). Our engine has multiple atlas textures, so we interleave
 /// draw calls by walking cursors through each Y-sorted buffer and emitting sub-range draws.
 pub(super) fn draw_merged_object_pass<'a>(
     pass: &mut wgpu::RenderPass<'a>,
@@ -236,11 +233,9 @@ pub(super) fn draw_merged_object_pass<'a>(
     unit_pages: &[usize],
     unit_transition_paged: &[Vec<SpriteInstance>],
     shp_paged: &[Vec<SpriteInstance>],
-    wall_instances: &[SpriteInstance],
     unit_atlas: Option<&'a UnitAtlas>,
     transition_cache: &'a VxlSlopeTransitionCache,
     sprite_atlas: Option<&'a SpriteAtlas>,
-    overlay_atlas: Option<&'a OverlayAtlas>,
     palette_set: Option<&'a PaletteSet>,
 ) {
     // Each draw group has a bind group, pool buffer, extracted depth values, and cursor.
@@ -298,16 +293,6 @@ pub(super) fn draw_merged_object_pass<'a>(
         }
     }
 
-    // Wall overlay draw group -- uses passthrough (no depth test).
-    // Walls render in both terrain pass (overlays) and object pass (Layer 2).
-    // The object pass rendering provides Y-sorted priority so walls appear
-    // in front of units at closer iso rows.
-    if let (Some(oa), Some((buf, count))) = (overlay_atlas, pool.get("overlay_wall")) {
-        if count > 0 {
-            groups.push(DrawGroup::new_shp(&oa.texture, buf, wall_instances, count));
-        }
-    }
-
     if groups.is_empty() {
         return;
     }
@@ -361,7 +346,7 @@ pub(super) fn draw_merged_object_pass<'a>(
         }
 
         // Draw the contiguous run. Voxel groups go through the voxel sprite
-        // pipeline (R8Uint atlas + PaletteSet bind group); SHP / wall groups
+        // pipeline (R8Uint atlas + PaletteSet bind group); SHP groups
         // go through passthrough (RGBA atlas, no depth test).
         let count = run_end - run_start;
         let g = &groups[gi];

--- a/src/app_render/mod.rs
+++ b/src/app_render/mod.rs
@@ -21,6 +21,7 @@
 
 mod build_instances;
 mod draw_passes;
+pub(crate) mod draw_plan_lowering;
 mod merge_passes;
 
 use anyhow::Result;
@@ -138,7 +139,6 @@ pub(crate) fn render_game(
             unit_pages: &world.unit_pages,
             unit_transition_paged: &world.unit_transition_paged,
             shp_paged: &world.shp_paged,
-            wall_instances: &world.wall,
             building_turret_pages: &world.building_turret_pages,
             particle_paged: &world.particle_paged,
             ghost_page: ui.ghost_page,
@@ -194,7 +194,6 @@ fn upload_to_gpu(
         &world.bridge_body_shadow,
     );
     pool.upload(&state.gpu, "overlay_bridge_railing", &world.bridge_railing);
-    pool.upload(&state.gpu, "overlay_wall", &world.wall);
     // Smudges: drawn after overlays, before bridge entities. Empty until the
     // SmudgeType SHP atlas registration follow-up lands.
     pool.upload(&state.gpu, "smudge", &world.smudge);

--- a/src/app_sim_tick.rs
+++ b/src/app_sim_tick.rs
@@ -31,7 +31,7 @@ use crate::sim::pathfinding::terrain_cost::build_canonical_terrain_cost_grids;
 use crate::sim::production;
 use crate::sim::replay::{ReplayHeader, ReplayLog};
 use crate::sim::trigger_runtime::TriggerEffect;
-use crate::sim::world::{LifecycleOutput, SimFireEvent, SimSoundEvent, TickLane};
+use crate::sim::world::{LifecycleOutput, SimFireEvent, SimSoundEvent, TickLane, TriggerInputs};
 use crate::ui::game_screen::GameScreen;
 
 /// Directory for Rust-only deterministic diagnostic logs.
@@ -676,11 +676,18 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
     for _ in 0..1 {
         // Compute local owner before mutable borrow of simulation.
         let local_owner_for_fog = preferred_local_owner_name(state);
+        let trigger_inputs = TriggerInputs {
+            graph: &state.trigger_graph,
+            triggers: &state.triggers,
+            events: &state.events,
+            actions: &state.actions,
+        };
 
         // Cache local owner name before mutable sim borrow (avoids borrow conflict).
         let local_owner_name = crate::app_commands::preferred_local_owner_name(state);
         let mut drained_fire_events: Vec<SimFireEvent> = Vec::new();
         let mut drained_lifecycle_outputs: Vec<LifecycleOutput> = Vec::new();
+        let mut trigger_effects: Vec<TriggerEffect> = Vec::new();
         // Carried out of the sim borrow so the census can read `state` freely below.
         let mut census_tick: Option<u64> = None;
         if let Some(sim) = &mut state.simulation {
@@ -695,7 +702,7 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
             } else {
                 Vec::new()
             };
-            let tick_result = sim.advance_tick_in_lane(
+            let tick_result = sim.advance_master_frame(
                 &due_commands,
                 state.rules.as_ref(),
                 &state.height_map,
@@ -704,7 +711,9 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                 SIM_TICK_MS,
                 tick_lane,
                 Some(&state.animation_sequences),
+                Some(trigger_inputs),
             );
+            trigger_effects = sim.drain_trigger_effects();
             frame_committed = tick_result.frame_committed;
             // Parity capture, if requested. Placed directly after the committed tick so
             // it observes the same state the tick hash covers, and before any app-layer
@@ -1229,16 +1238,6 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
             crate::app_input::report_black_cell_causes(state);
         }
 
-        let trigger_effects = if let Some(sim) = &mut state.simulation {
-            sim.advance_triggers(
-                &state.trigger_graph,
-                &state.triggers,
-                &state.events,
-                &state.actions,
-            )
-        } else {
-            Vec::new()
-        };
         apply_trigger_effects(state, &trigger_effects);
 
         // Drain overlay dirty cells and recompute passability. If any cell's
@@ -2071,7 +2070,10 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(upsert_overlay_entries(&mut render_entries, authoritative), 1);
+        assert_eq!(
+            upsert_overlay_entries(&mut render_entries, authoritative),
+            1
+        );
         assert_eq!(render_entries.len(), 2);
         assert_eq!((render_entries[0].rx, render_entries[0].ry), (4, 4));
         assert_eq!(render_entries[0].overlay_id, 3);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -49,6 +49,7 @@ pub mod skirmish_shell_chrome;
 pub mod smudge;
 pub mod sprite_atlas;
 pub mod tactical_compat;
+pub mod tactical_draw_plan;
 pub mod tile_atlas;
 pub mod unit_atlas;
 pub mod unit_slope_transition_cache;

--- a/src/render/tactical_draw_plan.rs
+++ b/src/render/tactical_draw_plan.rs
@@ -1,0 +1,414 @@
+//! Pure tactical draw planning before GPU atlas submission.
+//!
+//! This models the ordering authority only. The app layer lowers the resulting
+//! plan to atlas/page buffers; it does not replace wgpu or asset decoding.
+
+use std::cmp::Ordering;
+
+/// Opaque identifier retained by render planning and its eventual GPU lowering.
+pub type DrawId = u64;
+
+/// Integer tactical coordinate in native world units.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TacticalCoord {
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
+}
+
+/// Coarse `LayerClass` bucket. Lower layers draw first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TacticalLayer(pub u8);
+
+/// Render-Z behavior shared by SHP, VXL, and terrain lowering paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenderZPolicy {
+    /// Submit without reading or writing render Z.
+    None,
+    /// Write a nearer opaque source pixel to the render-Z target.
+    ReadWrite,
+    /// Read render Z without mutating it.
+    ReadOnly,
+    /// Read and write render Z while using an alpha-capable blitter.
+    AlphaReadWrite,
+}
+
+/// Source representation consumed by the eventual blitter or GPU pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpriteEncoding {
+    Plain,
+    Rle,
+    Voxel,
+    Terrain,
+}
+
+/// Typed policy carrier for the native blitter-family boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BlitPolicy {
+    pub encoding: SpriteEncoding,
+    pub render_z: RenderZPolicy,
+    pub translucent: bool,
+}
+
+impl BlitPolicy {
+    pub const fn opaque(encoding: SpriteEncoding) -> Self {
+        Self {
+            encoding,
+            render_z: RenderZPolicy::ReadWrite,
+            translucent: false,
+        }
+    }
+
+    pub const fn translucent(encoding: SpriteEncoding, render_z: RenderZPolicy) -> Self {
+        Self {
+            encoding,
+            render_z,
+            translucent: true,
+        }
+    }
+}
+
+/// Families drawn during the fixed per-cell pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CellDrawKind {
+    Terrain,
+    Smudge,
+    FlatOverlay,
+    WallOverlay,
+    PrimaryCellObject,
+}
+
+/// One already-cell-traversed item. Its order is preserved exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CellDraw {
+    pub id: DrawId,
+    pub kind: CellDrawKind,
+    pub policy: BlitPolicy,
+}
+
+/// Fixed cell-pass families from back to front.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CellPass {
+    pub terrain: Vec<CellDraw>,
+    pub smudges: Vec<CellDraw>,
+    /// Flat overlays and walls keep their original cell traversal order.
+    pub overlays: Vec<CellDraw>,
+    pub primary_objects: Vec<CellDraw>,
+}
+
+impl CellPass {
+    fn push(&mut self, draw: CellDraw) {
+        match draw.kind {
+            CellDrawKind::Terrain => self.terrain.push(draw),
+            CellDrawKind::Smudge => self.smudges.push(draw),
+            CellDrawKind::FlatOverlay | CellDrawKind::WallOverlay => self.overlays.push(draw),
+            CellDrawKind::PrimaryCellObject => self.primary_objects.push(draw),
+        }
+    }
+}
+
+/// An object submitted to the depth-sorted `LayerClass` equivalent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ObjectDraw {
+    pub id: DrawId,
+    pub layer: TacticalLayer,
+    pub coord: TacticalCoord,
+    /// Class-owned adjustment, such as an anim's YSortAdjust.
+    pub y_sort_adjust: i32,
+    /// Registration order resolves equal native Y-sort keys.
+    pub registration_order: u64,
+    pub policy: BlitPolicy,
+}
+
+impl ObjectDraw {
+    /// `ObjectClass::GetYSort`: X + Y, then a caller-supplied class adjustment.
+    pub fn y_sort_key(self) -> i32 {
+        self.coord
+            .x
+            .wrapping_add(self.coord.y)
+            .wrapping_add(self.y_sort_adjust)
+    }
+}
+
+/// Building-owned pieces stay grouped inside their parent's object draw.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildingPieceKind {
+    BuildupOrSpecial,
+    Body,
+    Bib,
+    PoweredOrActiveOverlay,
+    SplitBack,
+    SplitFront,
+}
+
+/// A fixed-order building-owned blit. `z_bias` is interpreted during lowering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BuildingPiece {
+    pub id: DrawId,
+    pub kind: BuildingPieceKind,
+    pub z_bias: i32,
+    pub policy: BlitPolicy,
+}
+
+/// The parent remains globally sortable; its owned pieces never escape this group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildingOwnedPlan {
+    pub parent: ObjectDraw,
+    pub pieces: Vec<BuildingPiece>,
+}
+
+/// One entry in a depth-sorted layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LayerEntry {
+    Object(ObjectDraw),
+    Building(BuildingOwnedPlan),
+}
+
+impl LayerEntry {
+    pub fn object(&self) -> ObjectDraw {
+        match self {
+            Self::Object(object) => *object,
+            Self::Building(building) => building.parent,
+        }
+    }
+}
+
+/// Layer output after native-shaped integer sorting.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectLayerPass {
+    pub layer: TacticalLayer,
+    pub entries: Vec<LayerEntry>,
+}
+
+/// One pure input to the tactical draw planner.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TacticalDrawInput {
+    Cell(CellDraw),
+    Object(ObjectDraw),
+    Building(BuildingOwnedPlan),
+}
+
+/// Pure tactical render authority, modeled after `YR TacticalClass::Draw`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TacticalDrawPlan {
+    pub cell_pass: CellPass,
+    pub object_layers: Vec<ObjectLayerPass>,
+}
+
+impl TacticalDrawPlan {
+    /// Build fixed cell passes plus stable `LayerClass` object ordering.
+    pub fn build(inputs: impl IntoIterator<Item = TacticalDrawInput>) -> Self {
+        let mut plan = Self::default();
+        let mut entries = Vec::new();
+
+        for input in inputs {
+            match input {
+                TacticalDrawInput::Cell(draw) => plan.cell_pass.push(draw),
+                TacticalDrawInput::Object(object) => entries.push(LayerEntry::Object(object)),
+                TacticalDrawInput::Building(building) => {
+                    let mut building = building;
+                    building
+                        .pieces
+                        .sort_by_key(|piece| building_piece_order(piece.kind));
+                    entries.push(LayerEntry::Building(building))
+                }
+            }
+        }
+
+        // LayerClass uses ObjectClass::GetYSort with registration-order ties.
+        entries.sort_by(native_layer_order);
+        for entry in entries {
+            let object = entry.object();
+            if let Some(last) = plan
+                .object_layers
+                .last_mut()
+                .filter(|last| last.layer == object.layer)
+            {
+                last.entries.push(entry);
+            } else {
+                plan.object_layers.push(ObjectLayerPass {
+                    layer: object.layer,
+                    entries: vec![entry],
+                });
+            }
+        }
+
+        plan
+    }
+}
+
+fn building_piece_order(kind: BuildingPieceKind) -> u8 {
+    match kind {
+        BuildingPieceKind::BuildupOrSpecial => 0,
+        BuildingPieceKind::Bib => 1,
+        BuildingPieceKind::SplitBack => 2,
+        BuildingPieceKind::Body => 3,
+        BuildingPieceKind::PoweredOrActiveOverlay => 4,
+        BuildingPieceKind::SplitFront => 5,
+    }
+}
+
+fn native_layer_order(left: &LayerEntry, right: &LayerEntry) -> Ordering {
+    let left = left.object();
+    let right = right.object();
+    left.layer
+        .cmp(&right.layer)
+        .then_with(|| left.y_sort_key().cmp(&right.y_sort_key()))
+        .then_with(|| left.registration_order.cmp(&right.registration_order))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OPAQUE_SHP: BlitPolicy = BlitPolicy::opaque(SpriteEncoding::Plain);
+
+    fn object(id: DrawId, layer: u8, x: i32, y: i32, adjust: i32, registration: u64) -> ObjectDraw {
+        ObjectDraw {
+            id,
+            layer: TacticalLayer(layer),
+            coord: TacticalCoord { x, y, z: 0 },
+            y_sort_adjust: adjust,
+            registration_order: registration,
+            policy: OPAQUE_SHP,
+        }
+    }
+
+    #[test]
+    fn cell_pass_keeps_native_family_order_and_cell_traversal_order() {
+        let plan = TacticalDrawPlan::build([
+            TacticalDrawInput::Cell(CellDraw {
+                id: 4,
+                kind: CellDrawKind::WallOverlay,
+                policy: OPAQUE_SHP,
+            }),
+            TacticalDrawInput::Cell(CellDraw {
+                id: 1,
+                kind: CellDrawKind::Terrain,
+                policy: OPAQUE_SHP,
+            }),
+            TacticalDrawInput::Cell(CellDraw {
+                id: 2,
+                kind: CellDrawKind::Smudge,
+                policy: OPAQUE_SHP,
+            }),
+            TacticalDrawInput::Cell(CellDraw {
+                id: 3,
+                kind: CellDrawKind::FlatOverlay,
+                policy: OPAQUE_SHP,
+            }),
+        ]);
+
+        assert_eq!(
+            plan.cell_pass
+                .terrain
+                .iter()
+                .map(|draw| draw.id)
+                .collect::<Vec<_>>(),
+            [1]
+        );
+        assert_eq!(
+            plan.cell_pass
+                .smudges
+                .iter()
+                .map(|draw| draw.id)
+                .collect::<Vec<_>>(),
+            [2]
+        );
+        assert_eq!(
+            plan.cell_pass
+                .overlays
+                .iter()
+                .map(|draw| draw.id)
+                .collect::<Vec<_>>(),
+            [4, 3]
+        );
+    }
+
+    #[test]
+    fn object_layers_use_integer_ysort_then_registration_order() {
+        let plan = TacticalDrawPlan::build([
+            TacticalDrawInput::Object(object(1, 2, 300, 200, 0, 9)),
+            TacticalDrawInput::Object(object(2, 2, 100, 400, 0, 2)),
+            TacticalDrawInput::Object(object(3, 1, 999, 999, 0, 1)),
+            TacticalDrawInput::Object(object(4, 2, 200, 300, 0, 1)),
+            TacticalDrawInput::Object(object(5, 2, 200, 300, 32, 0)),
+        ]);
+
+        assert_eq!(plan.object_layers.len(), 2);
+        assert_eq!(plan.object_layers[0].layer, TacticalLayer(1));
+        assert_eq!(
+            plan.object_layers[1]
+                .entries
+                .iter()
+                .map(|entry| entry.object().id)
+                .collect::<Vec<_>>(),
+            [4, 2, 1, 5]
+        );
+    }
+
+    #[test]
+    fn building_pieces_remain_grouped_inside_global_parent_order() {
+        let building = BuildingOwnedPlan {
+            parent: object(20, 2, 100, 100, 0, 1),
+            pieces: vec![
+                BuildingPiece {
+                    id: 21,
+                    kind: BuildingPieceKind::Bib,
+                    z_bias: -1,
+                    policy: OPAQUE_SHP,
+                },
+                BuildingPiece {
+                    id: 22,
+                    kind: BuildingPieceKind::Body,
+                    z_bias: 0,
+                    policy: OPAQUE_SHP,
+                },
+            ],
+        };
+        let plan = TacticalDrawPlan::build([
+            TacticalDrawInput::Object(object(10, 2, 50, 50, 0, 0)),
+            TacticalDrawInput::Building(building),
+            TacticalDrawInput::Object(object(30, 2, 200, 200, 0, 2)),
+        ]);
+
+        let entries = &plan.object_layers[0].entries;
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.object().id)
+                .collect::<Vec<_>>(),
+            [10, 20, 30]
+        );
+        let LayerEntry::Building(building) = &entries[1] else {
+            panic!("building stays grouped in the parent slot");
+        };
+        assert_eq!(
+            building
+                .pieces
+                .iter()
+                .map(|piece| piece.kind)
+                .collect::<Vec<_>>(),
+            [BuildingPieceKind::Bib, BuildingPieceKind::Body]
+        );
+        let LayerEntry::Building(building) = &entries[1] else {
+            panic!("building parent must retain its owned draw group");
+        };
+        assert_eq!(
+            building
+                .pieces
+                .iter()
+                .map(|piece| piece.id)
+                .collect::<Vec<_>>(),
+            [21, 22]
+        );
+    }
+
+    #[test]
+    fn alpha_z_policy_is_explicit_for_future_shared_blitter_lowering() {
+        let policy = BlitPolicy::translucent(SpriteEncoding::Rle, RenderZPolicy::AlphaReadWrite);
+        assert_eq!(policy.encoding, SpriteEncoding::Rle);
+        assert_eq!(policy.render_z, RenderZPolicy::AlphaReadWrite);
+        assert!(policy.translucent);
+    }
+}

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -1067,6 +1067,7 @@ fn fatal_sound_selection_uses_human_voice_then_die_sound_main_draws() {
         100,
         0,
         &[1, 2],
+        &[],
         None,
         &mut scenario_rng,
         &mut human_rng,
@@ -1271,7 +1272,8 @@ fn deployed_guardian_gi_vs_rhino_at_six_cells_uses_missilelauncher() {
     let ev = &result.fire_events[0];
     assert_eq!(interner.resolve(ev.weapon_id), "MissileLauncher");
     assert_eq!(ev.weapon_slot, WeaponSlot::Secondary);
-    assert_eq!(store.get(2).unwrap().health.current, 360);
+    assert_eq!(store.get(2).unwrap().health.current, 400);
+    assert_eq!(result.projectile_spawns.len(), 1);
 }
 
 #[test]
@@ -2692,6 +2694,99 @@ Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
         anim_list,
     ));
     RuleSet::from_ini(&ini).expect("Inviso test rules should parse")
+}
+
+fn persistent_projectile_rules() -> RuleSet {
+    RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n\n[VehicleTypes]\n0=SHOOTER\n1=TARGET\n\n[AircraftTypes]\n\n[BuildingTypes]\n\n[SHOOTER]\nStrength=300\nArmor=heavy\nSpeed=6\nPrimary=GUN\n\n[TARGET]\nStrength=500\nArmor=heavy\nSpeed=6\n\n[GUN]\nDamage=10\nROF=20\nRange=10\nSpeed=128\nProjectile=TESTPROJ\nWarhead=TESTWH\n\n[TESTPROJ]\nInviso=no\nImage=TESTBULLET\n\n[TESTWH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("persistent projectile rules should parse")
+}
+
+#[test]
+fn persistent_projectile_delays_damage_across_save_load_continuation() {
+    let rules = persistent_projectile_rules();
+    assert!(matches!(
+        classify_projectile_delivery(rules.weapon("GUN").unwrap(), &rules),
+        ProjectileDelivery::Persistent { .. }
+    ));
+    let mut entities = EntityStore::new();
+    entities.insert(make_entity(1, "SHOOTER", 5, 5, 300));
+    entities.insert(make_entity(2, "TARGET", 8, 5, 500));
+    let mut interner = test_interner();
+    issue_attack_command(&mut entities, 1, 2, None, &interner);
+
+    let mut scenario_rng = SimRng::new(1);
+    let fire = tick_combat(
+        &mut entities,
+        &mut OccupancyGrid::new(),
+        &rules,
+        &mut interner,
+        &mut BTreeMap::new(),
+        0,
+        100,
+        0,
+        &mut scenario_rng,
+    );
+    assert_eq!(entities.get(2).unwrap().health.current, 500);
+    assert_eq!(fire.projectile_spawns.len(), 1);
+
+    let mut sim = crate::sim::world::Simulation::new();
+    sim.projectiles.spawn(fire.projectile_spawns[0]);
+    let target_positions =
+        BTreeMap::from([(2, ProjectileCoord::new(8 * 256 + 128, 5 * 256 + 128, 0))]);
+    assert!(
+        sim.projectiles
+            .advance(&target_positions, |_, _| false)
+            .detonations
+            .is_empty()
+    );
+
+    let snapshot = crate::sim::snapshot::GameSnapshot::save(&sim, 0, 0, "projectile-flight", 0);
+    let mut restored = crate::sim::snapshot::GameSnapshot::load(&snapshot)
+        .expect("pending projectile snapshot should load")
+        .sim;
+    let mut detonations = Vec::new();
+    for _ in 0..8 {
+        detonations = restored
+            .projectiles
+            .advance(&target_positions, |_, _| false)
+            .detonations;
+        if !detonations.is_empty() {
+            break;
+        }
+    }
+    assert_eq!(
+        detonations.len(),
+        1,
+        "resumed projectile should reach target"
+    );
+
+    entities.remove(1);
+    let mut main_rng = SimRng::new(1);
+    tick_combat_with_fog_and_main_rng(
+        &mut entities,
+        &mut OccupancyGrid::new(),
+        &rules,
+        &mut interner,
+        None,
+        &BTreeMap::new(),
+        &BTreeMap::new(),
+        None,
+        &mut BTreeMap::new(),
+        None,
+        None,
+        None,
+        1,
+        100,
+        1,
+        &[2],
+        &detonations,
+        None,
+        &mut scenario_rng,
+        &mut main_rng,
+    );
+    assert_eq!(entities.get(2).unwrap().health.current, 490);
 }
 
 fn explosion_coord(effect: &ExplosionEffect) -> (u16, u16, SimFixed, SimFixed) {

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -61,6 +61,10 @@ use crate::sim::infantry;
 use crate::sim::intern::{InternedId, StringInterner};
 use crate::sim::overlay_grid::{OverlayGrid, WallDamageEvent};
 use crate::sim::power_system::PowerState;
+use crate::sim::projectile::{
+    ProjectileCollisionPolicy, ProjectileCoord, ProjectileDetonation, ProjectilePayload,
+    ProjectileSpawn, ProjectileTarget, TargetExpiryPolicy,
+};
 use crate::sim::rng::SimRng;
 use crate::sim::vision::FogState;
 use crate::sim::world::{FireOriginSnapshot, SimFireEvent, SimSoundEvent};
@@ -77,6 +81,126 @@ use super::production::foundation_dimensions;
 const REVEAL_ON_FIRE_RADIUS: u16 = 3;
 /// Step size for selecting explosion anim from a warhead's AnimList: idx = damage / 25.
 const ANIM_LIST_DAMAGE_STEP: u16 = 25;
+
+/// Explicitly classified delivery decision at weapon fire.
+///
+/// Unsupported projectile behaviors intentionally remain on the established
+/// immediate path until their own native trajectory contracts are ported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProjectileDelivery {
+    Persistent {
+        arm_frames: u16,
+        tracks_target: bool,
+        collision: ProjectileCollisionPolicy,
+    },
+    Immediate(ImmediateProjectileReason),
+}
+
+/// The bounded lifecycle never silently treats an unsupported bullet as a
+/// straight ordinary shot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImmediateProjectileReason {
+    NoProjectile,
+    MissingProjectileType,
+    Invisible,
+    InstantSpeed,
+    Vertical,
+    Ballistic,
+    ObstacleTrajectory,
+    SpecialTrajectory,
+}
+
+fn classify_projectile_delivery(
+    weapon: &crate::rules::weapon_type::WeaponType,
+    rules: &RuleSet,
+) -> ProjectileDelivery {
+    let Some(projectile_id) = weapon.projectile.as_deref() else {
+        return ProjectileDelivery::Immediate(ImmediateProjectileReason::NoProjectile);
+    };
+    let Some(projectile) = rules.projectile(projectile_id) else {
+        return ProjectileDelivery::Immediate(ImmediateProjectileReason::MissingProjectileType);
+    };
+    if projectile.inviso {
+        return ProjectileDelivery::Immediate(ImmediateProjectileReason::Invisible);
+    }
+    if weapon.speed <= 0 {
+        return ProjectileDelivery::Immediate(ImmediateProjectileReason::InstantSpeed);
+    }
+    if projectile.vertical {
+        return ProjectileDelivery::Immediate(ImmediateProjectileReason::Vertical);
+    }
+    if projectile.arcing || weapon.lobber {
+        return ProjectileDelivery::Immediate(ImmediateProjectileReason::Ballistic);
+    }
+    // YR BulletClass::AI linkage: Level's current-cell water predicate and
+    // wall entry are now owned by the world collision rung. Cliff/elevation
+    // kernels still need their native coordinate contracts.
+    if projectile.subject_to_cliffs || projectile.subject_to_elevation {
+        return ProjectileDelivery::Immediate(ImmediateProjectileReason::ObstacleTrajectory);
+    }
+    if projectile.airburst
+        || projectile.dropping
+        || projectile.very_high
+        || projectile.proximity
+        || projectile.flak_scatter
+        || projectile.inaccurate
+        || projectile.degenerates
+        || projectile.bouncy
+        // BulletTypeClass defaults Cluster to one ordinary impact. Only a
+        // value other than that baseline requires the cluster kernel.
+        || projectile.cluster != 1
+        || projectile.shrapnel_count != 0
+    {
+        return ProjectileDelivery::Immediate(ImmediateProjectileReason::SpecialTrajectory);
+    }
+    ProjectileDelivery::Persistent {
+        arm_frames: projectile.arm.max(0).min(u16::MAX as i32) as u16,
+        tracks_target: projectile.rot > 0,
+        collision: ProjectileCollisionPolicy {
+            level_non_water: projectile.level,
+            subject_to_walls: projectile.subject_to_walls,
+        },
+    }
+}
+
+/// Whether a fire event's visible projectile is represented by the serialized
+/// world `ProjectileStore`, rather than the legacy app-local interpolation.
+pub(crate) fn projectile_uses_authoritative_flight(
+    weapon: &crate::rules::weapon_type::WeaponType,
+    rules: &RuleSet,
+) -> bool {
+    matches!(
+        classify_projectile_delivery(weapon, rules),
+        ProjectileDelivery::Persistent { .. }
+    )
+}
+
+#[cfg(test)]
+mod projectile_delivery_tests {
+    use super::*;
+    use crate::rules::ini_parser::IniFile;
+
+    #[test]
+    fn wall_projectile_uses_the_authoritative_collision_path() {
+        let ini = IniFile::from_str(
+            "[VehicleTypes]\n0=TEST\n\n[TEST]\nStrength=100\nArmor=heavy\nPrimary=GUN\n\n[GUN]\nDamage=20\nROF=10\nRange=5\nSpeed=30\nProjectile=SHELL\nWarhead=WH\n\n[SHELL]\nSubjectToWalls=yes\n\n[WH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+        );
+        let rules = RuleSet::from_ini(&ini).expect("projectile rules");
+        let weapon = rules.weapon("GUN").expect("weapon");
+
+        assert_eq!(
+            classify_projectile_delivery(weapon, &rules),
+            ProjectileDelivery::Persistent {
+                arm_frames: 0,
+                tracks_target: false,
+                collision: ProjectileCollisionPolicy {
+                    level_non_water: false,
+                    subject_to_walls: true,
+                },
+            }
+        );
+    }
+}
 
 /// A cell area to reveal due to a RevealOnFire weapon firing.
 pub struct RevealEvent {
@@ -153,9 +277,7 @@ fn warhead_damages_wall(
     warhead: &WarheadType,
     wall_flags: &crate::map::overlay_types::OverlayTypeFlags,
 ) -> bool {
-    warhead.wall
-        || warhead.wall_absolute_destroyer
-        || (warhead.wood && wall_flags.armor_is_wood)
+    warhead.wall || warhead.wall_absolute_destroyer || (warhead.wood && wall_flags.armor_is_wood)
 }
 
 pub(crate) fn apply_prone_damage_modifier(
@@ -742,6 +864,9 @@ pub struct TiberiumReductionRequest {
 
 /// Result of a combat tick: reveal events + stable IDs of despawned entities.
 pub struct CombatTickResult {
+    /// Ordinary projectiles created by fire this frame, to admit after the
+    /// current BulletClass pass. New bullets never advance recursively.
+    pub projectile_spawns: Vec<ProjectileSpawn>,
     pub reveal_events: Vec<RevealEvent>,
     pub despawned_ids: Vec<u64>,
     /// IDs that should enter world-owned UnInit immediately this tick.
@@ -1078,8 +1203,7 @@ fn handle_entity_deaths(
         if let Some(warhead) = rules.warhead(interner.resolve(*wh_id)) {
             if *dmg > 0 {
                 let damage_u16 = (*dmg).max(0) as u16;
-                let wall_flags =
-                    wall_overlay_flags_at(overlay_grid, overlay_registry, *rx, *ry);
+                let wall_flags = wall_overlay_flags_at(overlay_grid, overlay_registry, *rx, *ry);
                 if wall_flags.is_some_and(|flags| warhead_damages_wall(warhead, flags)) {
                     wall_damage_events.push(WallDamageEvent {
                         rx: *rx,
@@ -1214,6 +1338,9 @@ fn destroy_ore_at_impact(
 /// never hashed — destructured back into the named locals after the Phase-2 loop.
 #[derive(Default)]
 pub(crate) struct CombatEmit {
+    /// Persistent ordinary bullets admitted by accepted weapon fire. The world
+    /// inserts them only after this frame's BulletClass pass has completed.
+    pub(crate) projectile_spawns: Vec<ProjectileSpawn>,
     /// (target_id, damage, attacker_id, warhead_id)
     pub(crate) damage_events: Vec<(u64, u16, u64, InternedId)>,
     /// Radiation-emitting detonations (weapon RadLevel > 0), folded into
@@ -1242,6 +1369,155 @@ pub(crate) struct CombatEmit {
     /// per-object window (pre-death state; own-retarget visible), applied
     /// post-batch by `unit_post::apply_unit_facing`.
     pub(crate) unit_facing: Vec<(u64, u16)>,
+}
+
+fn projectile_impact_cell(impact: ProjectileCoord) -> (u16, u16, SimFixed, SimFixed, i32) {
+    let rx = impact.x.div_euclid(256).clamp(0, i32::from(u16::MAX)) as u16;
+    let ry = impact.y.div_euclid(256).clamp(0, i32::from(u16::MAX)) as u16;
+    (
+        rx,
+        ry,
+        SimFixed::from_num(impact.x.rem_euclid(256)),
+        SimFixed::from_num(impact.y.rem_euclid(256)),
+        impact.z,
+    )
+}
+
+/// Reuse the ordinary combat emission paths after a persistent bullet reaches
+/// `BulletClass::Detonate`; this stays before the shared damage/death phases.
+fn emit_projectile_detonations(
+    detonations: &[ProjectileDetonation],
+    entities: &mut EntityStore,
+    occupancy: &OccupancyGrid,
+    rules: &RuleSet,
+    interner: &mut StringInterner,
+    overlay_grid: Option<&OverlayGrid>,
+    overlay_registry: Option<&OverlayTypeRegistry>,
+    terrain: Option<&crate::map::resolved_terrain::ResolvedTerrainGrid>,
+    out: &mut CombatEmit,
+) {
+    for detonation in detonations {
+        let Some(warhead) = rules.warhead(interner.resolve(detonation.payload.warhead)) else {
+            log::warn!(
+                "Projectile {} dropped: missing serialized warhead {}",
+                detonation.projectile_id,
+                detonation.payload.warhead
+            );
+            continue;
+        };
+        let (impact_rx, impact_ry, impact_sub_x, impact_sub_y, impact_z) =
+            projectile_impact_cell(detonation.impact);
+        let direct_target = match detonation.target {
+            ProjectileTarget::Entity(id) => entities
+                .get(id)
+                .filter(|entity| entity.is_alive() && !entity.dying),
+            ProjectileTarget::Cell(_) => None,
+        };
+
+        if warhead.cell_spread > SIM_ZERO {
+            let aoe_hits = self::combat_aoe::apply_aoe_damage(
+                entities,
+                impact_rx,
+                impact_ry,
+                detonation.payload.base_damage,
+                warhead,
+                rules,
+                interner,
+                interner.resolve(detonation.payload.owner),
+                self::combat_aoe::AoELayerContext {
+                    occupancy: Some(occupancy),
+                    terrain,
+                    impact_z,
+                },
+            );
+            for (target_id, damage) in aoe_hits {
+                out.damage_events.push((
+                    target_id,
+                    damage,
+                    detonation.source_id,
+                    detonation.payload.warhead,
+                ));
+            }
+        } else if let Some(target) = direct_target {
+            let armor = rules
+                .object(interner.resolve(target.type_ref))
+                .map(|object| object.armor.as_str())
+                .unwrap_or("none");
+            let raw_damage =
+                detonation.payload.base_damage * warhead.verses[armor_index(armor)] as i32 / 100;
+            let prone = target.category == EntityCategory::Infantry
+                && infantry::is_prone_for_damage(target);
+            let actual_damage = apply_prone_damage_modifier(prone, warhead, raw_damage);
+            if actual_damage > 0 {
+                out.damage_events.push((
+                    target.stable_id,
+                    actual_damage,
+                    detonation.source_id,
+                    detonation.payload.warhead,
+                ));
+            }
+        }
+
+        if detonation.payload.base_damage > 0 {
+            let damage = detonation.payload.base_damage.min(i32::from(u16::MAX)) as u16;
+            let wall_flags =
+                wall_overlay_flags_at(overlay_grid, overlay_registry, impact_rx, impact_ry);
+            if wall_flags.is_some_and(|flags| warhead_damages_wall(warhead, flags)) {
+                out.wall_damage_events.push(WallDamageEvent {
+                    rx: impact_rx,
+                    ry: impact_ry,
+                    damage,
+                });
+            } else if wall_flags.is_none() && warhead.wall {
+                out.bridge_damage_events.push(BridgeDamageEvent {
+                    rx: impact_rx,
+                    ry: impact_ry,
+                    damage,
+                    warhead_ref: detonation.payload.warhead,
+                    is_ion_cannon: detonation.payload.warhead == rules.ion_cannon_warhead_id(),
+                    impact_z,
+                });
+            }
+        }
+        if warhead.wood && detonation.payload.base_damage > 0 {
+            out.terrain_damage_events.push(TerrainDamageEvent {
+                rx: impact_rx,
+                ry: impact_ry,
+                damage: detonation.payload.base_damage,
+                warhead_ref: detonation.payload.warhead,
+            });
+        }
+        destroy_ore_at_impact(
+            &mut out.tiberium_reduction_requests,
+            impact_rx,
+            impact_ry,
+            detonation.payload.base_damage,
+            warhead.cell_spread,
+        );
+        if let Some(weapon) = rules.weapon(interner.resolve(detonation.payload.weapon))
+            && weapon.rad_level > 0
+        {
+            out.rad_detonations
+                .push(crate::sim::radiation::RadDetonation {
+                    rx: impact_rx,
+                    ry: impact_ry,
+                    rad_level: weapon.rad_level,
+                    spread: warhead.cell_spread.to_num::<i32>(),
+                });
+        }
+        emit_warhead_detonation_effects(
+            warhead,
+            detonation.payload.base_damage,
+            impact_rx,
+            impact_ry,
+            impact_sub_x,
+            impact_sub_y,
+            impact_z.clamp(0, i32::from(u8::MAX)) as u8,
+            interner,
+            &mut out.explosion_effects,
+            &mut out.smudge_spawn_requests,
+        );
+    }
 }
 
 /// Advance combat with optional owner visibility gating and sound event sink.
@@ -1292,6 +1568,7 @@ pub fn tick_combat_with_fog(
         tick_ms,
         binary_frame,
         live_order,
+        &[],
         radiation,
         scenario_rng,
         &mut unused_main_rng,
@@ -1319,12 +1596,14 @@ pub fn tick_combat_with_fog_and_main_rng(
     tick_ms: u32,
     binary_frame: u32,
     live_order: &[u64],
+    projectile_detonations: &[ProjectileDetonation],
     radiation: Option<&mut crate::sim::radiation::RadiationState>,
     scenario_rng: &mut SimRng,
     main_rng: &mut SimRng,
 ) -> CombatTickResult {
     if tick_ms == 0 {
         return CombatTickResult {
+            projectile_spawns: Vec::new(),
             reveal_events: Vec::new(),
             despawned_ids: Vec::new(),
             immediate_uninit_ids: Vec::new(),
@@ -1770,8 +2049,22 @@ pub fn tick_combat_with_fog_and_main_rng(
             emit.unit_facing.push((id, desired));
         }
     }
+    // YR BulletClass::Detonate: completed prior-frame bullets enter the same
+    // combat damage/death pipeline as all other authoritative detonations.
+    emit_projectile_detonations(
+        projectile_detonations,
+        entities,
+        occupancy,
+        rules,
+        interner,
+        overlay_grid,
+        overlay_registry,
+        terrain,
+        &mut emit,
+    );
     // Destructure back into the named locals so Phases 3-6 are untouched.
     let CombatEmit {
+        projectile_spawns,
         mut damage_events,
         rad_detonations,
         mut remove_attack,
@@ -2039,6 +2332,7 @@ pub fn tick_combat_with_fog_and_main_rng(
     }
 
     CombatTickResult {
+        projectile_spawns,
         reveal_events,
         despawned_ids: death.despawned_ids,
         immediate_uninit_ids: death.immediate_uninit_ids,
@@ -2492,166 +2786,206 @@ pub(crate) fn resolve_attacker_fire(
     } else {
         weapon.damage
     };
-    let impact_z = attack_impact_z(snap.target, entities);
-    if warhead.cell_spread > SIM_ZERO {
-        let aoe_hits = self::combat_aoe::apply_aoe_damage(
-            entities,
+    let persistent_delivery = classify_projectile_delivery(weapon, rules);
+    if let ProjectileDelivery::Persistent {
+        arm_frames,
+        tracks_target,
+        collision,
+    } = persistent_delivery
+    {
+        let impact = ProjectileCoord::new(
+            i32::from(target_rx) * 256 + target_sub_x.to_num::<i32>(),
+            i32::from(target_ry) * 256 + target_sub_y.to_num::<i32>(),
+            attack_impact_z(snap.target, entities),
+        );
+        let target = match snap.target {
+            TargetKind::Entity(id) => ProjectileTarget::Entity(id),
+            TargetKind::Cell(_, _) => ProjectileTarget::Cell(impact),
+        };
+        out.projectile_spawns.push(ProjectileSpawn {
+            source_id: snap.stable_id,
+            origin: ProjectileCoord::new(
+                i32::from(snap.pos_rx) * 256 + snap.sub_x.to_num::<i32>(),
+                i32::from(snap.pos_ry) * 256 + snap.sub_y.to_num::<i32>(),
+                i32::from(snap.pos_z),
+            ),
+            target,
+            initial_target_position: impact,
+            payload: ProjectilePayload {
+                base_damage,
+                warhead: interner.intern(&warhead.id),
+                weapon: interner.intern(selected.weapon_id),
+                owner: snap.owner,
+            },
+            speed_leptons_per_frame: weapon.speed.clamp(1, i32::from(u16::MAX)) as u16,
+            arm_frames,
+            fuse_frames: None,
+            tracks_target,
+            target_expiry: TargetExpiryPolicy::DetonateAtLastKnown,
+            collision,
+        });
+    } else {
+        let impact_z = attack_impact_z(snap.target, entities);
+        if warhead.cell_spread > SIM_ZERO {
+            let aoe_hits = self::combat_aoe::apply_aoe_damage(
+                entities,
+                target_rx,
+                target_ry,
+                base_damage,
+                warhead,
+                rules,
+                interner,
+                interner.resolve(snap.owner),
+                self::combat_aoe::AoELayerContext {
+                    occupancy: Some(&*occupancy),
+                    terrain,
+                    impact_z,
+                },
+            );
+            for (target_id, dmg) in aoe_hits {
+                let wh_iid = interner.intern(&warhead.id);
+                out.damage_events
+                    .push((target_id, dmg, snap.stable_id, wh_iid));
+            }
+            if base_damage > 0 {
+                let damage_u16 = base_damage as u16;
+                let wall_flags =
+                    wall_overlay_flags_at(overlay_grid, overlay_registry, target_rx, target_ry);
+                if wall_flags.is_some_and(|flags| warhead_damages_wall(warhead, flags)) {
+                    out.wall_damage_events.push(WallDamageEvent {
+                        rx: target_rx,
+                        ry: target_ry,
+                        damage: damage_u16,
+                    });
+                } else if wall_flags.is_none() && warhead.wall {
+                    let wh_iid = interner.intern(&warhead.id);
+                    out.bridge_damage_events.push(BridgeDamageEvent {
+                        rx: target_rx,
+                        ry: target_ry,
+                        damage: damage_u16,
+                        warhead_ref: wh_iid,
+                        is_ion_cannon: wh_iid == rules.ion_cannon_warhead_id(),
+                        impact_z,
+                    });
+                }
+            }
+            if warhead.wood && base_damage > 0 {
+                out.terrain_damage_events.push(TerrainDamageEvent {
+                    rx: target_rx,
+                    ry: target_ry,
+                    damage: base_damage,
+                    warhead_ref: interner.intern(&warhead.id),
+                });
+            }
+        } else {
+            // Integer damage: base_damage * verses_pct / 100.
+            // base_damage already includes OccupyDamageMultiplier for garrison.
+            let raw_damage: i32 = base_damage * selected.verses_pct as i32 / 100;
+            let actual_damage: u16 =
+                apply_prone_damage_modifier(target_prone_infantry, warhead, raw_damage);
+            // Direct-hit damage only applies to Entity targets. For Cell
+            // targets (force-fire on terrain), splash logic via warhead
+            // CellSpread handles AoE damage at the impact cell — there's no
+            // primary target entity to damage.
+            if actual_damage > 0 {
+                if let TargetKind::Entity(target_id) = snap.target {
+                    let wh_iid = interner.intern(&warhead.id);
+                    out.damage_events
+                        .push((target_id, actual_damage, snap.stable_id, wh_iid));
+                }
+            }
+            if base_damage > 0 {
+                let damage_u16 = base_damage as u16;
+                let wall_flags =
+                    wall_overlay_flags_at(overlay_grid, overlay_registry, target_rx, target_ry);
+                if wall_flags.is_some_and(|flags| warhead_damages_wall(warhead, flags)) {
+                    out.wall_damage_events.push(WallDamageEvent {
+                        rx: target_rx,
+                        ry: target_ry,
+                        damage: damage_u16,
+                    });
+                } else if wall_flags.is_none() && warhead.wall {
+                    let wh_iid = interner.intern(&warhead.id);
+                    out.bridge_damage_events.push(BridgeDamageEvent {
+                        rx: target_rx,
+                        ry: target_ry,
+                        damage: damage_u16,
+                        warhead_ref: wh_iid,
+                        is_ion_cannon: wh_iid == rules.ion_cannon_warhead_id(),
+                        impact_z,
+                    });
+                }
+            }
+            if warhead.wood && base_damage > 0 {
+                out.terrain_damage_events.push(TerrainDamageEvent {
+                    rx: target_rx,
+                    ry: target_ry,
+                    damage: base_damage,
+                    warhead_ref: interner.intern(&warhead.id),
+                });
+            }
+        }
+
+        // Ore destruction: all warheads unconditionally destroy ore at impact cells.
+        // CellSpreadTable[0] = 1, so even CellSpread=0 weapons check the center cell.
+        destroy_ore_at_impact(
+            &mut out.tiberium_reduction_requests,
             target_rx,
             target_ry,
             base_damage,
-            warhead,
-            rules,
-            interner,
-            interner.resolve(snap.owner),
-            self::combat_aoe::AoELayerContext {
-                occupancy: Some(&*occupancy),
-                terrain,
-                impact_z,
-            },
+            warhead.cell_spread,
         );
-        for (target_id, dmg) in aoe_hits {
-            let wh_iid = interner.intern(&warhead.id);
-            out.damage_events
-                .push((target_id, dmg, snap.stable_id, wh_iid));
-        }
-        if base_damage > 0 {
-            let damage_u16 = base_damage as u16;
-            let wall_flags =
-                wall_overlay_flags_at(overlay_grid, overlay_registry, target_rx, target_ry);
-            if wall_flags.is_some_and(|flags| warhead_damages_wall(warhead, flags)) {
-                out.wall_damage_events.push(WallDamageEvent {
+
+        // Radiation-emitting detonation: one site request per shot at the impact
+        // cell. Spread is the warhead's CellSpread truncated to whole cells.
+        if weapon.rad_level > 0 {
+            out.rad_detonations
+                .push(crate::sim::radiation::RadDetonation {
                     rx: target_rx,
                     ry: target_ry,
-                    damage: damage_u16,
+                    rad_level: weapon.rad_level,
+                    spread: warhead.cell_spread.to_num::<i32>(),
                 });
-            } else if wall_flags.is_none() && warhead.wall {
-                let wh_iid = interner.intern(&warhead.id);
-                out.bridge_damage_events.push(BridgeDamageEvent {
-                    rx: target_rx,
-                    ry: target_ry,
-                    damage: damage_u16,
-                    warhead_ref: wh_iid,
-                    is_ion_cannon: wh_iid == rules.ion_cannon_warhead_id(),
-                    impact_z,
-                });
-            }
         }
-        if warhead.wood && base_damage > 0 {
-            out.terrain_damage_events.push(TerrainDamageEvent {
-                rx: target_rx,
-                ry: target_ry,
-                damage: base_damage,
-                warhead_ref: interner.intern(&warhead.id),
-            });
-        }
-    } else {
-        // Integer damage: base_damage * verses_pct / 100.
-        // base_damage already includes OccupyDamageMultiplier for garrison.
-        let raw_damage: i32 = base_damage * selected.verses_pct as i32 / 100;
-        let actual_damage: u16 =
-            apply_prone_damage_modifier(target_prone_infantry, warhead, raw_damage);
-        // Direct-hit damage only applies to Entity targets. For Cell
-        // targets (force-fire on terrain), splash logic via warhead
-        // CellSpread handles AoE damage at the impact cell — there's no
-        // primary target entity to damage.
-        if actual_damage > 0 {
-            if let TargetKind::Entity(target_id) = snap.target {
-                let wh_iid = interner.intern(&warhead.id);
-                out.damage_events
-                    .push((target_id, actual_damage, snap.stable_id, wh_iid));
-            }
-        }
-        if base_damage > 0 {
-            let damage_u16 = base_damage as u16;
-            let wall_flags =
-                wall_overlay_flags_at(overlay_grid, overlay_registry, target_rx, target_ry);
-            if wall_flags.is_some_and(|flags| warhead_damages_wall(warhead, flags)) {
-                out.wall_damage_events.push(WallDamageEvent {
-                    rx: target_rx,
-                    ry: target_ry,
-                    damage: damage_u16,
-                });
-            } else if wall_flags.is_none() && warhead.wall {
-                let wh_iid = interner.intern(&warhead.id);
-                out.bridge_damage_events.push(BridgeDamageEvent {
-                    rx: target_rx,
-                    ry: target_ry,
-                    damage: damage_u16,
-                    warhead_ref: wh_iid,
-                    is_ion_cannon: wh_iid == rules.ion_cannon_warhead_id(),
-                    impact_z,
-                });
-            }
-        }
-        if warhead.wood && base_damage > 0 {
-            out.terrain_damage_events.push(TerrainDamageEvent {
-                rx: target_rx,
-                ry: target_ry,
-                damage: base_damage,
-                warhead_ref: interner.intern(&warhead.id),
-            });
-        }
+
+        // Cell-target force-fire on terrain has no entity z; the dispatcher
+        // re-derives ground_z from terrain.cell(rx,ry).level, so 0 is safe.
+        let impact_z: u8 = match snap.target {
+            TargetKind::Entity(eid) => entities.get(eid).map(|e| e.position.z).unwrap_or(0),
+            TargetKind::Cell(_, _) => 0,
+        };
+        // BulletClass::Detonate randomizes only the visible CoordStruct for an
+        // Inviso projectile. The draw happens before AnimList selection, so this
+        // must run even when the warhead has no animation to emit.
+        let (effect_rx, effect_ry, effect_sub_x, effect_sub_y) = if weapon
+            .projectile
+            .as_deref()
+            .and_then(|projectile_id| rules.projectile(projectile_id))
+            .is_some_and(|projectile| projectile.inviso)
+        {
+            inviso_scatter::scatter_inviso_effect_coord(
+                scenario_rng,
+                target_rx,
+                target_ry,
+                target_sub_x,
+                target_sub_y,
+            )
+        } else {
+            (target_rx, target_ry, target_sub_x, target_sub_y)
+        };
+        emit_warhead_detonation_effects(
+            warhead,
+            base_damage,
+            effect_rx,
+            effect_ry,
+            effect_sub_x,
+            effect_sub_y,
+            impact_z,
+            interner,
+            &mut out.explosion_effects,
+            &mut out.smudge_spawn_requests,
+        );
     }
-
-    // Ore destruction: all warheads unconditionally destroy ore at impact cells.
-    // CellSpreadTable[0] = 1, so even CellSpread=0 weapons check the center cell.
-    destroy_ore_at_impact(
-        &mut out.tiberium_reduction_requests,
-        target_rx,
-        target_ry,
-        base_damage,
-        warhead.cell_spread,
-    );
-
-    // Radiation-emitting detonation: one site request per shot at the impact
-    // cell. Spread is the warhead's CellSpread truncated to whole cells.
-    if weapon.rad_level > 0 {
-        out.rad_detonations
-            .push(crate::sim::radiation::RadDetonation {
-                rx: target_rx,
-                ry: target_ry,
-                rad_level: weapon.rad_level,
-                spread: warhead.cell_spread.to_num::<i32>(),
-            });
-    }
-
-    // Cell-target force-fire on terrain has no entity z; the dispatcher
-    // re-derives ground_z from terrain.cell(rx,ry).level, so 0 is safe.
-    let impact_z: u8 = match snap.target {
-        TargetKind::Entity(eid) => entities.get(eid).map(|e| e.position.z).unwrap_or(0),
-        TargetKind::Cell(_, _) => 0,
-    };
-    // BulletClass::Detonate randomizes only the visible CoordStruct for an
-    // Inviso projectile. The draw happens before AnimList selection, so this
-    // must run even when the warhead has no animation to emit.
-    let (effect_rx, effect_ry, effect_sub_x, effect_sub_y) = if weapon
-        .projectile
-        .as_deref()
-        .and_then(|projectile_id| rules.projectile(projectile_id))
-        .is_some_and(|projectile| projectile.inviso)
-    {
-        inviso_scatter::scatter_inviso_effect_coord(
-            scenario_rng,
-            target_rx,
-            target_ry,
-            target_sub_x,
-            target_sub_y,
-        )
-    } else {
-        (target_rx, target_ry, target_sub_x, target_sub_y)
-    };
-    emit_warhead_detonation_effects(
-        warhead,
-        base_damage,
-        effect_rx,
-        effect_ry,
-        effect_sub_x,
-        effect_sub_y,
-        impact_z,
-        interner,
-        &mut out.explosion_effects,
-        &mut out.smudge_spawn_requests,
-    );
 
     let report_sound_id = weapon
         .report

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -52,6 +52,7 @@ pub mod radio; // RadioMessage / RadioResponse / RadioPayload
 //     special locomotors, drive tracks, turret rotation ---
 pub mod movement;
 pub mod pathfinding; // A* search, zone connectivity, terrain costs, path smoothing
+pub mod projectile; // serialized BulletClass-style flight state and detonation handoff
 
 // --- Docking: repair depots and airfield landing pads ---
 pub mod docking;

--- a/src/sim/projectile.rs
+++ b/src/sim/projectile.rs
@@ -1,0 +1,490 @@
+//! Authoritative in-flight projectile state.
+//!
+//! This module deliberately owns only delayed flight, target expiry, collision,
+//! and detonation admission. Combat remains the authority for turning a returned
+//! [`ProjectileDetonation`] into damage, warhead effects, and terrain changes.
+//! Keeping that handoff narrow lets the world phase place this system at the
+//! verified native frame rung without duplicating combat arithmetic here.
+
+use std::collections::BTreeMap;
+
+use crate::sim::intern::InternedId;
+
+/// Lepton-space position for an in-flight projectile.
+///
+/// Cells contain 256 leptons. Keeping the flight state in signed integer
+/// leptons avoids float math and makes the serialized state independent of
+/// render coordinates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct ProjectileCoord {
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
+}
+
+impl ProjectileCoord {
+    pub const fn new(x: i32, y: i32, z: i32) -> Self {
+        Self { x, y, z }
+    }
+}
+
+/// The original target retained by a projectile after weapon fire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum ProjectileTarget {
+    Entity(u64),
+    Cell(ProjectileCoord),
+}
+
+/// What to do when an entity target no longer exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum TargetExpiryPolicy {
+    /// Remove the projectile without a damage handoff.
+    Expire,
+    /// Detonate at the last target coordinate observed by the projectile.
+    DetonateAtLastKnown,
+}
+
+/// Terrain checks admitted for one ordinary `BulletClass` flight.
+///
+/// The cases intentionally stay narrow: special trajectory kernels retain the
+/// typed immediate path until their native coordinate contracts are ported.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ProjectileCollisionPolicy {
+    /// `BulletTypeClass::Level`: detonate after entering a non-water cell.
+    pub level_non_water: bool,
+    /// `BulletTypeClass::SubjectToWalls`: detonate after entering a live wall.
+    pub subject_to_walls: bool,
+}
+
+impl ProjectileCollisionPolicy {
+    pub const NONE: Self = Self {
+        level_non_water: false,
+        subject_to_walls: false,
+    };
+}
+
+/// Stable projectile payload transferred to combat only at detonation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ProjectilePayload {
+    /// Damage after firing-side modifiers, before target/warhead resolution.
+    pub base_damage: i32,
+    pub warhead: InternedId,
+    /// Weapon identity retained for impact-only effects such as radiation.
+    pub weapon: InternedId,
+    /// Firing house retained when the source dies before impact.
+    pub owner: InternedId,
+}
+
+/// Immutable admission data for an ordinary, non-vertical projectile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ProjectileSpawn {
+    pub source_id: u64,
+    pub origin: ProjectileCoord,
+    pub target: ProjectileTarget,
+    /// Target coordinate captured when the weapon fires. Non-homing shots keep
+    /// this destination; homing shots replace it from the live target table.
+    pub initial_target_position: ProjectileCoord,
+    pub payload: ProjectilePayload,
+    /// Native weapon speed expressed by the caller in leptons per logical frame.
+    pub speed_leptons_per_frame: u16,
+    /// A projectile may not detonate until this many frames have elapsed.
+    pub arm_frames: u16,
+    /// Optional fuse duration; zero means the fuse detonates on this advance.
+    pub fuse_frames: Option<u16>,
+    /// Only homing projectiles update their destination from a live target.
+    pub tracks_target: bool,
+    pub target_expiry: TargetExpiryPolicy,
+    pub collision: ProjectileCollisionPolicy,
+}
+
+/// Persistent state corresponding to one native `BulletClass` instance.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Projectile {
+    pub id: u64,
+    pub source_id: u64,
+    pub position: ProjectileCoord,
+    pub target: ProjectileTarget,
+    pub last_target_position: ProjectileCoord,
+    pub payload: ProjectilePayload,
+    pub speed_leptons_per_frame: u16,
+    pub arm_frames_remaining: u16,
+    pub fuse_frames_remaining: Option<u16>,
+    pub tracks_target: bool,
+    pub target_expiry: TargetExpiryPolicy,
+    pub collision: ProjectileCollisionPolicy,
+}
+
+/// Why a projectile reached its combat detonation handoff.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ProjectileDetonationReason {
+    ReachedTarget,
+    Fuse,
+    Collision,
+    TargetExpired,
+}
+
+/// One deferred `BulletClass::Detonate` handoff for combat to apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ProjectileDetonation {
+    pub projectile_id: u64,
+    pub source_id: u64,
+    pub target: ProjectileTarget,
+    pub impact: ProjectileCoord,
+    pub payload: ProjectilePayload,
+    pub reason: ProjectileDetonationReason,
+}
+
+/// Results from one stable-order projectile pass.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ProjectileAdvanceResult {
+    pub detonations: Vec<ProjectileDetonation>,
+    pub expired: Vec<u64>,
+}
+
+/// Serialized, stable-id ordered projectile collection.
+///
+/// `BTreeMap` makes creation-order IDs and processing order explicit. New
+/// projectiles are only advanced by the next call, matching the usual
+/// object-pass boundary instead of recursively advancing a newly fired shot.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ProjectileStore {
+    next_id: u64,
+    projectiles: BTreeMap<u64, Projectile>,
+}
+
+impl ProjectileStore {
+    pub fn new() -> Self {
+        Self {
+            next_id: 1,
+            projectiles: BTreeMap::new(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.projectiles.len()
+    }
+
+    pub(crate) fn next_id(&self) -> u64 {
+        self.next_id
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.projectiles.is_empty()
+    }
+
+    pub fn get(&self, id: u64) -> Option<&Projectile> {
+        self.projectiles.get(&id)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&u64, &Projectile)> {
+        self.projectiles.iter()
+    }
+
+    /// Admit one ordinary projectile. Vertical, airburst, cluster, and other
+    /// special trajectories remain outside this bounded foundation.
+    pub fn spawn(&mut self, spawn: ProjectileSpawn) -> u64 {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1).max(1);
+        self.projectiles.insert(
+            id,
+            Projectile {
+                id,
+                source_id: spawn.source_id,
+                position: spawn.origin,
+                target: spawn.target,
+                last_target_position: spawn.initial_target_position,
+                payload: spawn.payload,
+                speed_leptons_per_frame: spawn.speed_leptons_per_frame,
+                arm_frames_remaining: spawn.arm_frames,
+                fuse_frames_remaining: spawn.fuse_frames,
+                tracks_target: spawn.tracks_target,
+                target_expiry: spawn.target_expiry,
+                collision: spawn.collision,
+            },
+        );
+        id
+    }
+
+    /// Advance every currently admitted projectile in ascending stable id.
+    ///
+    /// `target_positions` must contain live entity targets in lepton space.
+    /// `collides_at` is a world-owned terrain/wall admission predicate for the
+    /// candidate next coordinate; object collision remains a later port.
+    pub fn advance(
+        &mut self,
+        target_positions: &BTreeMap<u64, ProjectileCoord>,
+        mut collides_at: impl FnMut(&Projectile, ProjectileCoord) -> bool,
+    ) -> ProjectileAdvanceResult {
+        let mut result = ProjectileAdvanceResult::default();
+        let ids: Vec<u64> = self.projectiles.keys().copied().collect();
+
+        for id in ids {
+            let Some(projectile) = self.projectiles.get_mut(&id) else {
+                continue;
+            };
+
+            let target_position = match projectile.target {
+                ProjectileTarget::Cell(position) => position,
+                ProjectileTarget::Entity(target_id) => match target_positions.get(&target_id) {
+                    Some(&position) => {
+                        if projectile.tracks_target {
+                            projectile.last_target_position = position;
+                        }
+                        projectile.last_target_position
+                    }
+                    None => match projectile.target_expiry {
+                        TargetExpiryPolicy::Expire => {
+                            result.expired.push(id);
+                            continue;
+                        }
+                        TargetExpiryPolicy::DetonateAtLastKnown => {
+                            if projectile.arm_frames_remaining == 0 {
+                                result.detonations.push(detonation(
+                                    projectile,
+                                    projectile.last_target_position,
+                                    ProjectileDetonationReason::TargetExpired,
+                                ));
+                            } else {
+                                result.expired.push(id);
+                            }
+                            continue;
+                        }
+                    },
+                },
+            };
+
+            if let Some(fuse) = projectile.fuse_frames_remaining.as_mut() {
+                if *fuse == 0 {
+                    result.detonations.push(detonation(
+                        projectile,
+                        projectile.position,
+                        ProjectileDetonationReason::Fuse,
+                    ));
+                    continue;
+                }
+                *fuse -= 1;
+            }
+
+            let candidate = step_toward(
+                projectile.position,
+                target_position,
+                i32::from(projectile.speed_leptons_per_frame),
+            );
+            if collides_at(projectile, candidate) {
+                if projectile.arm_frames_remaining == 0 {
+                    result.detonations.push(detonation(
+                        projectile,
+                        candidate,
+                        ProjectileDetonationReason::Collision,
+                    ));
+                } else {
+                    result.expired.push(id);
+                }
+                continue;
+            }
+
+            projectile.position = candidate;
+            if projectile.arm_frames_remaining > 0 {
+                projectile.arm_frames_remaining -= 1;
+            }
+            if candidate == target_position && projectile.arm_frames_remaining == 0 {
+                result.detonations.push(detonation(
+                    projectile,
+                    candidate,
+                    ProjectileDetonationReason::ReachedTarget,
+                ));
+            }
+        }
+
+        for id in result.expired.iter().chain(
+            result
+                .detonations
+                .iter()
+                .map(|detonation| &detonation.projectile_id),
+        ) {
+            self.projectiles.remove(id);
+        }
+        result
+    }
+}
+
+// YR BulletClass::AI linkage: this is the bounded ordinary-flight rung; exact trajectory kernels remain separate.
+fn step_toward(from: ProjectileCoord, target: ProjectileCoord, speed: i32) -> ProjectileCoord {
+    if speed <= 0 || from == target {
+        return from;
+    }
+    let dx = target.x - from.x;
+    let dy = target.y - from.y;
+    let dz = target.z - from.z;
+    let max_delta = dx.abs().max(dy.abs()).max(dz.abs());
+    if max_delta <= speed {
+        return target;
+    }
+    ProjectileCoord::new(
+        from.x + ((i64::from(dx) * i64::from(speed)) / i64::from(max_delta)) as i32,
+        from.y + ((i64::from(dy) * i64::from(speed)) / i64::from(max_delta)) as i32,
+        from.z + ((i64::from(dz) * i64::from(speed)) / i64::from(max_delta)) as i32,
+    )
+}
+
+// YR BulletClass::Detonate linkage: only this handoff permits combat damage/effects.
+fn detonation(
+    projectile: &Projectile,
+    impact: ProjectileCoord,
+    reason: ProjectileDetonationReason,
+) -> ProjectileDetonation {
+    ProjectileDetonation {
+        projectile_id: projectile.id,
+        source_id: projectile.source_id,
+        target: projectile.target,
+        impact,
+        payload: projectile.payload,
+        reason,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spawn(target: ProjectileTarget) -> ProjectileSpawn {
+        ProjectileSpawn {
+            source_id: 7,
+            origin: ProjectileCoord::new(0, 0, 0),
+            target,
+            initial_target_position: match target {
+                ProjectileTarget::Entity(_) => ProjectileCoord::new(128, 0, 0),
+                ProjectileTarget::Cell(position) => position,
+            },
+            payload: ProjectilePayload {
+                base_damage: 40,
+                warhead: InternedId::from_index(3),
+                weapon: InternedId::from_index(4),
+                owner: InternedId::from_index(5),
+            },
+            speed_leptons_per_frame: 64,
+            arm_frames: 0,
+            fuse_frames: None,
+            tracks_target: true,
+            target_expiry: TargetExpiryPolicy::DetonateAtLastKnown,
+            collision: ProjectileCollisionPolicy::NONE,
+        }
+    }
+
+    #[test]
+    fn advance_preserves_stable_creation_order_and_delays_new_projectiles() {
+        let mut store = ProjectileStore::new();
+        let first = store.spawn(spawn(ProjectileTarget::Cell(ProjectileCoord::new(
+            64, 0, 0,
+        ))));
+        let second = store.spawn(spawn(ProjectileTarget::Cell(ProjectileCoord::new(
+            128, 0, 0,
+        ))));
+
+        let result = store.advance(&BTreeMap::new(), |_, _| false);
+
+        assert_eq!(
+            result
+                .detonations
+                .iter()
+                .map(|detonation| detonation.projectile_id)
+                .collect::<Vec<_>>(),
+            vec![first]
+        );
+        assert!(store.get(first).is_none());
+        assert_eq!(store.get(second).unwrap().position.x, 64);
+    }
+
+    #[test]
+    fn homing_projectile_uses_current_target_position() {
+        let mut store = ProjectileStore::new();
+        let id = store.spawn(spawn(ProjectileTarget::Entity(42)));
+        let targets = BTreeMap::from([(42, ProjectileCoord::new(128, 128, 0))]);
+
+        store.advance(&targets, |_, _| false);
+
+        assert_eq!(
+            store.get(id).unwrap().position,
+            ProjectileCoord::new(64, 64, 0)
+        );
+    }
+
+    #[test]
+    fn target_expiry_detonates_at_last_known_position() {
+        let mut store = ProjectileStore::new();
+        let id = store.spawn(spawn(ProjectileTarget::Entity(42)));
+        let targets = BTreeMap::from([(42, ProjectileCoord::new(128, 0, 0))]);
+        store.advance(&targets, |_, _| false);
+
+        let result = store.advance(&BTreeMap::new(), |_, _| false);
+
+        assert_eq!(result.detonations.len(), 1);
+        assert_eq!(result.detonations[0].projectile_id, id);
+        assert_eq!(
+            result.detonations[0].impact,
+            ProjectileCoord::new(128, 0, 0)
+        );
+        assert_eq!(
+            result.detonations[0].reason,
+            ProjectileDetonationReason::TargetExpired
+        );
+    }
+
+    #[test]
+    fn fuse_and_collision_are_deferred_detonations() {
+        let mut store = ProjectileStore::new();
+        let mut fused = spawn(ProjectileTarget::Cell(ProjectileCoord::new(256, 0, 0)));
+        fused.fuse_frames = Some(0);
+        let fuse_id = store.spawn(fused);
+        let collision_id = store.spawn(spawn(ProjectileTarget::Cell(ProjectileCoord::new(
+            256, 0, 0,
+        ))));
+
+        let result = store.advance(&BTreeMap::new(), |_, coord| coord.x == 64);
+
+        assert_eq!(result.detonations.len(), 2);
+        assert_eq!(result.detonations[0].projectile_id, fuse_id);
+        assert_eq!(
+            result.detonations[0].reason,
+            ProjectileDetonationReason::Fuse
+        );
+        assert_eq!(result.detonations[1].projectile_id, collision_id);
+        assert_eq!(
+            result.detonations[1].reason,
+            ProjectileDetonationReason::Collision
+        );
+    }
+
+    #[test]
+    fn store_round_trips_through_snapshot_serialization() {
+        let mut store = ProjectileStore::new();
+        store.spawn(spawn(ProjectileTarget::Cell(ProjectileCoord::new(
+            256, 64, 0,
+        ))));
+
+        let bytes = bincode::serialize(&store).unwrap();
+        let restored: ProjectileStore = bincode::deserialize(&bytes).unwrap();
+
+        assert_eq!(restored, store);
+    }
+
+    #[test]
+    fn simulation_hash_and_save_preserve_pending_projectile() {
+        let empty = crate::sim::world::Simulation::new();
+        let mut sim = crate::sim::world::Simulation::new();
+        sim.projectiles
+            .spawn(spawn(ProjectileTarget::Cell(ProjectileCoord::new(
+                256, 64, 0,
+            ))));
+        let expected_hash = sim.state_hash();
+
+        assert_ne!(empty.state_hash(), expected_hash);
+        let bytes = crate::sim::snapshot::GameSnapshot::save(&sim, 0, 0, "projectile", 0);
+        let restored = crate::sim::snapshot::GameSnapshot::load(&bytes)
+            .expect("projectile snapshot should load")
+            .sim;
+
+        assert_eq!(restored.state_hash(), expected_hash);
+        assert_eq!(restored.projectiles.len(), 1);
+    }
+}

--- a/src/sim/replay.rs
+++ b/src/sim/replay.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::command::{COMMAND_RECORD_LEN, CommandEnvelope, CommandRecord};
 use crate::sim::pathfinding::PathGrid;
-use crate::sim::world::Simulation;
+use crate::sim::world::{Simulation, TickLane, TriggerInputs};
 
 /// Value written by the retail executable at the start of every recording.
 pub const NATIVE_REPLAY_VERSION: u32 = 10;
@@ -537,6 +537,24 @@ impl ReplayRunner {
         path_grid: Option<&PathGrid>,
         tick_ms: u32,
     ) -> Vec<u64> {
+        Self::run_master_frame(sim, replay, rules, height_map, path_grid, tick_ms, None)
+    }
+
+    /// Replay through the same master-frame admission used by gameplay.
+    ///
+    /// Diagnostic logs own commands and hashes, while the caller owns static
+    /// map trigger definitions. This keeps presentation-free replay faithful
+    /// to the YR LogicClass trigger rung without serializing map data twice.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn run_master_frame(
+        sim: &mut Simulation,
+        replay: &ReplayLog,
+        rules: Option<&RuleSet>,
+        height_map: &BTreeMap<(u16, u16), u8>,
+        path_grid: Option<&PathGrid>,
+        tick_ms: u32,
+        trigger_inputs: Option<TriggerInputs<'_>>,
+    ) -> Vec<u64> {
         // The diagnostic playback must be constructed from the recorded seed.
         // A sim seeded
         // differently than the header it replays is a guaranteed silent
@@ -562,8 +580,19 @@ impl ReplayRunner {
         }
         let mut hashes: Vec<u64> = Vec::with_capacity(replay.ticks.len());
         for entry in &replay.ticks {
-            let result =
-                sim.advance_tick(&entry.commands, rules, height_map, path_grid, None, tick_ms);
+            let result = sim.advance_master_frame(
+                &entry.commands,
+                rules,
+                height_map,
+                path_grid,
+                None,
+                tick_ms,
+                TickLane::Ordinary,
+                None,
+                trigger_inputs,
+            );
+            // Replay has no app layer to consume presentation-only trigger effects.
+            let _ = sim.drain_trigger_effects();
             hashes.push(result.state_hash);
         }
         hashes

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -102,7 +102,10 @@ use crate::sim::world::Simulation;
 // Bumped 38 -> 39: overlay wall ownership became authoritative persisted state.
 // Bumped 39 -> 40: ObjectSubstrate persists the authoritative per-cell raw
 // ground/deck occupation bytes instead of reconstructing them from object lists.
-const SNAPSHOT_VERSION: u32 = 40;
+// Bumped 40 -> 41: persistent BulletClass-style projectile state is serialized.
+// Bumped 41 -> 42: persistent BulletClass collision policy is serialized.
+// Bumped 42 -> 43: TriggerRuntime latches now participate in the lockstep hash.
+const SNAPSHOT_VERSION: u32 = 43;
 
 /// Binary snapshot envelope — wraps the full `Simulation` state plus
 /// compatibility hashes for the map and rules that were active at save time.
@@ -1290,11 +1293,13 @@ mod tests {
     /// lifecycle target/animation identity state took 35 -> 36, and omission
     /// of process-global Main/MapGen RNG state took 36 -> 37, and serialized
     /// Drive occupation footprints took 37 -> 38, and authoritative wall
-    /// ownership took 38 -> 39, and raw occupation bytes took 39 -> 40. This
+    /// ownership took 38 -> 39, raw occupation bytes took 39 -> 40, and
+    /// authoritative projectile collision policy took 41 -> 42, and trigger
+    /// runtime lockstep hashing took 42 -> 43. This
     /// pins it so a later accidental bump is caught.
     #[test]
-    fn snapshot_version_is_40() {
-        assert_eq!(super::SNAPSHOT_VERSION, 40);
+    fn snapshot_version_is_43() {
+        assert_eq!(super::SNAPSHOT_VERSION, 43);
     }
 
     #[test]
@@ -1310,7 +1315,7 @@ mod tests {
             GameSnapshot::read_header(&bytes)
                 .expect("current snapshot header")
                 .version,
-            40
+            43
         );
 
         let mut restored = GameSnapshot::load(&bytes).expect("current snapshot").sim;
@@ -1371,7 +1376,7 @@ mod tests {
             GameSnapshot::read_header(&bytes)
                 .expect("current snapshot header")
                 .version,
-            40
+            43
         );
 
         let mut restored_a = GameSnapshot::load(&bytes).expect("current snapshot").sim;
@@ -1437,7 +1442,7 @@ mod tests {
             GameSnapshot::read_header(&bytes)
                 .expect("current snapshot header")
                 .version,
-            40
+            43
         );
         let restored = GameSnapshot::load(&bytes).expect("current snapshot").sim;
         let cell = restored

--- a/src/sim/trigger_runtime.rs
+++ b/src/sim/trigger_runtime.rs
@@ -14,6 +14,7 @@
 //! committing to a full mission-script system yet.
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::hash::{Hash, Hasher};
 
 use crate::map::actions::{ActionEntry, ActionMap};
 use crate::map::events::{EventCondition, EventMap};
@@ -69,6 +70,38 @@ pub struct TriggerRuntime {
 }
 
 impl TriggerRuntime {
+    /// Fold mutable trigger state into the simulation's lockstep hash.
+    ///
+    /// The map definitions are static input, but these latches decide which
+    /// later YR LogicClass trigger actions may run after a save or replay.
+    pub(crate) fn hash_state(&self, hasher: &mut impl Hasher) {
+        self.globals_set.len().hash(hasher);
+        for value in &self.globals_set {
+            value.hash(hasher);
+        }
+
+        self.locals_set.len().hash(hasher);
+        for value in &self.locals_set {
+            value.hash(hasher);
+        }
+
+        self.disabled_triggers.len().hash(hasher);
+        for value in &self.disabled_triggers {
+            value.hash(hasher);
+        }
+
+        self.fired_one_shot_triggers.len().hash(hasher);
+        for value in &self.fired_one_shot_triggers {
+            value.hash(hasher);
+        }
+
+        match self.last_announcement {
+            None => 0u8.hash(hasher),
+            Some(MissionAnnouncementKind::Victory) => 1u8.hash(hasher),
+            Some(MissionAnnouncementKind::Defeat) => 2u8.hash(hasher),
+        }
+    }
+
     pub fn from_map(triggers: &TriggerMap, local_variables: &LocalVariableMap) -> Self {
         let mut runtime = TriggerRuntime::default();
         for trigger in triggers.values() {

--- a/src/sim/trigger_runtime_tests.rs
+++ b/src/sim/trigger_runtime_tests.rs
@@ -8,7 +8,14 @@ use crate::map::trigger_graph::build_trigger_graph;
 use crate::map::triggers::{MapTrigger, TriggerDifficulty};
 use crate::map::variable_names::{LocalVariable, LocalVariableMap};
 use crate::sim::game_entity::GameEntity;
-use crate::sim::world::Simulation;
+use crate::sim::projectile::{
+    ProjectileCollisionPolicy, ProjectileCoord, ProjectilePayload, ProjectileSpawn,
+    ProjectileTarget, TargetExpiryPolicy,
+};
+use crate::sim::replay::{ReplayHeader, ReplayLog, ReplayRunner};
+use crate::sim::snapshot::GameSnapshot;
+use crate::sim::world::{MasterFrameTestRung, Simulation, TickLane, TriggerInputs};
+use std::collections::BTreeMap;
 
 fn make_trigger(
     id: &str,
@@ -42,7 +49,7 @@ fn make_trigger(
     }
 }
 
-fn spawn_type(sim: &mut Simulation, type_id: &str) {
+fn spawn_type(sim: &mut Simulation, type_id: &str) -> u64 {
     let sid = sim.allocate_stable_id();
     let owner_id = sim.interner.intern("Neutral");
     let type_id_interned = sim.interner.intern(type_id);
@@ -64,6 +71,7 @@ fn spawn_type(sim: &mut Simulation, type_id: &str) {
         false,
     );
     sim.substrate.entities.insert(ge);
+    sid
 }
 
 #[test]
@@ -149,6 +157,252 @@ fn time_trigger_can_center_camera_at_waypoint() {
             .advance_at_frame(46, &graph, &triggers, &events, &actions, None)
             .is_empty()
     );
+}
+
+#[test]
+fn master_frame_polls_triggers_before_logic_houses_commit_and_delete() {
+    let triggers: TriggerMap = [(
+        "TRIG_A".to_string(),
+        make_trigger("TRIG_A", None, "Frame Zero", true, false),
+    )]
+    .into_iter()
+    .collect();
+    let events: EventMap = [(
+        "TRIG_A".to_string(),
+        MapEvent {
+            id: "TRIG_A".to_string(),
+            fields: vec![],
+            conditions: vec![EventCondition {
+                kind: 47,
+                params: vec!["0".to_string(), "0".to_string()],
+            }],
+        },
+    )]
+    .into_iter()
+    .collect();
+    let actions: ActionMap = [(
+        "TRIG_A".to_string(),
+        MapAction {
+            id: "TRIG_A".to_string(),
+            fields: vec![],
+            entries: vec![ActionEntry {
+                kind: 112,
+                params: vec![
+                    "0".to_string(),
+                    "0".to_string(),
+                    "0".to_string(),
+                    "0".to_string(),
+                    "0".to_string(),
+                    "0".to_string(),
+                    "9".to_string(),
+                ],
+            }],
+        },
+    )]
+    .into_iter()
+    .collect();
+    let graph = build_trigger_graph(
+        &HashMap::new(),
+        &HashMap::new(),
+        &triggers,
+        &events,
+        &actions,
+    );
+    let mut sim = Simulation::new();
+    sim.trigger_runtime = TriggerRuntime::from_map(&triggers, &HashMap::new());
+
+    let tick = sim.advance_master_frame(
+        &[],
+        None,
+        &BTreeMap::new(),
+        None,
+        None,
+        67,
+        TickLane::Ordinary,
+        None,
+        Some(TriggerInputs {
+            graph: &graph,
+            triggers: &triggers,
+            events: &events,
+            actions: &actions,
+        }),
+    );
+
+    assert!(tick.frame_committed);
+    assert_eq!(
+        sim.take_master_frame_test_trace(),
+        vec![
+            MasterFrameTestRung::Triggers,
+            MasterFrameTestRung::LogicVector,
+            MasterFrameTestRung::Houses,
+            MasterFrameTestRung::FrameCommit,
+            MasterFrameTestRung::PendingDelete,
+        ]
+    );
+    assert_eq!(
+        sim.drain_trigger_effects(),
+        vec![TriggerEffect::CenterCameraAtWaypoint {
+            waypoint: 9,
+            immediate: true,
+        }]
+    );
+}
+
+#[test]
+fn master_frame_save_load_continues_trigger_projectile_and_delete_state() {
+    let triggers: TriggerMap = [(
+        "TRIG_A".to_string(),
+        make_trigger("TRIG_A", None, "Set Global", true, false),
+    )]
+    .into_iter()
+    .collect();
+    let events: EventMap = [(
+        "TRIG_A".to_string(),
+        MapEvent {
+            id: "TRIG_A".to_string(),
+            fields: vec![],
+            conditions: vec![EventCondition {
+                kind: 47,
+                params: vec!["0".to_string(), "0".to_string()],
+            }],
+        },
+    )]
+    .into_iter()
+    .collect();
+    let actions: ActionMap = [(
+        "TRIG_A".to_string(),
+        MapAction {
+            id: "TRIG_A".to_string(),
+            fields: vec![],
+            entries: vec![ActionEntry {
+                kind: 28,
+                params: vec!["13".to_string()],
+            }],
+        },
+    )]
+    .into_iter()
+    .collect();
+    let graph = build_trigger_graph(
+        &HashMap::new(),
+        &HashMap::new(),
+        &triggers,
+        &events,
+        &actions,
+    );
+    let height_map = BTreeMap::new();
+    let trigger_inputs = TriggerInputs {
+        graph: &graph,
+        triggers: &triggers,
+        events: &events,
+        actions: &actions,
+    };
+
+    let mut original = Simulation::new();
+    original.trigger_runtime = TriggerRuntime::from_map(&triggers, &HashMap::new());
+    original.advance_master_frame(
+        &[],
+        None,
+        &height_map,
+        None,
+        None,
+        67,
+        TickLane::Ordinary,
+        None,
+        Some(trigger_inputs),
+    );
+    assert!(original.trigger_runtime.globals_set.contains(&13));
+
+    original.projectiles.spawn(ProjectileSpawn {
+        source_id: 99,
+        origin: ProjectileCoord::new(0, 0, 0),
+        target: ProjectileTarget::Cell(ProjectileCoord::new(1024, 0, 0)),
+        initial_target_position: ProjectileCoord::new(1024, 0, 0),
+        payload: ProjectilePayload {
+            base_damage: 40,
+            warhead: crate::sim::intern::InternedId::from_index(0),
+            weapon: crate::sim::intern::InternedId::from_index(0),
+            owner: crate::sim::intern::InternedId::from_index(0),
+        },
+        speed_leptons_per_frame: 64,
+        arm_frames: 0,
+        fuse_frames: None,
+        tracks_target: false,
+        target_expiry: TargetExpiryPolicy::Expire,
+        collision: ProjectileCollisionPolicy::NONE,
+    });
+    let deleted_id = spawn_type(&mut original, "GAPOWR");
+    original.uninit(deleted_id);
+    assert_eq!(original.projectiles.len(), 1);
+    assert!(original.substrate.pending_delete.contains(&deleted_id));
+
+    let hash_before_save = original.state_hash();
+    let bytes = GameSnapshot::save(&original, 0, 0, "test_map", 0);
+    let mut restored = GameSnapshot::load(&bytes).expect("snapshot loads").sim;
+    assert_eq!(restored.state_hash(), hash_before_save);
+    assert!(restored.trigger_runtime.globals_set.contains(&13));
+    assert_eq!(restored.projectiles.len(), 1);
+    assert!(restored.substrate.pending_delete.contains(&deleted_id));
+
+    let original_tick = original.advance_master_frame(
+        &[],
+        None,
+        &height_map,
+        None,
+        None,
+        67,
+        TickLane::Ordinary,
+        None,
+        Some(trigger_inputs),
+    );
+    let mut replay_log = ReplayLog::new(ReplayHeader {
+        version: 1,
+        tick_hz: 15,
+        seed: original.session.seed,
+        map_name: original.session.map_name.clone(),
+        rules_hash: 0,
+    });
+    replay_log.record_tick(original_tick.tick, Vec::new(), original_tick.state_hash);
+    let restored_tick = restored.advance_master_frame(
+        &[],
+        None,
+        &height_map,
+        None,
+        None,
+        67,
+        TickLane::Ordinary,
+        None,
+        Some(trigger_inputs),
+    );
+
+    assert!(original_tick.frame_committed);
+    assert!(restored_tick.frame_committed);
+    assert_eq!(original.state_hash(), restored.state_hash());
+    assert_eq!(original.projectiles.len(), 1);
+    assert!(original.substrate.pending_delete.is_empty());
+
+    let mut replayed = GameSnapshot::load(&bytes).expect("snapshot reloads").sim;
+    assert_eq!(
+        ReplayRunner::run_master_frame(
+            &mut replayed,
+            &replay_log,
+            None,
+            &height_map,
+            None,
+            67,
+            Some(trigger_inputs),
+        ),
+        vec![original_tick.state_hash],
+    );
+}
+
+#[test]
+fn trigger_runtime_latches_participate_in_state_hash() {
+    let mut sim = Simulation::new();
+    let before = sim.state_hash();
+
+    sim.trigger_runtime.globals_set.insert(13);
+
+    assert_ne!(sim.state_hash(), before);
 }
 
 #[test]

--- a/src/sim/world/global_parity_harness_tests.rs
+++ b/src/sim/world/global_parity_harness_tests.rs
@@ -240,7 +240,7 @@ const GLOBAL_HARNESS_PRE_MISSION_V29_HASH: u64 = 0xC2B8_BAEF_E6C7_9CB6;
 /// wired in this slice (deploy-begin off, undeploy-complete on, destination-
 /// accepted on) changed no other hashed state in these fixtures. The absolute
 /// per-stream RNG pins held throughout.
-const GLOBAL_HARNESS_FINAL_HASH: u64 = 0xDFA8_E30E_93BC_FEEF;
+const GLOBAL_HARNESS_FINAL_HASH: u64 = 0xD900_CD22_0276_1CD9;
 
 fn harness_rules() -> RuleSet {
     // Multi-faction vehicles + infantry + buildings (war factory, refinery) plus a

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -79,6 +79,7 @@ use crate::sim::pathfinding::terrain_speed;
 use crate::sim::pathfinding::zone_map::ZoneGrid;
 use crate::sim::power_system::{self, PowerState};
 use crate::sim::production::{self, ProductionState};
+use crate::sim::projectile::{Projectile, ProjectileCoord};
 use crate::sim::radar::{RadarEventQueue, RadarEventType};
 use crate::sim::replay::ReplayLog;
 use crate::sim::rng::{SimRng, SimRngLogicalState, SimRngLogicalView};
@@ -91,6 +92,44 @@ use crate::util::fixed_math::SimFixed;
 /// Dev/test fallback seed. Real launches negotiate a per-match seed through
 /// `ScenarioDescriptor`; nothing on the launch path may rely on this value.
 const DEFAULT_SIM_SEED: u64 = 0x5EED_CAFE_D15E_A5E5;
+
+/// Bounded `BulletClass::AI` terrain collision admission.
+///
+/// The verified `Level` path uses the current canonical cell's water identity;
+/// this engine's resolved terrain owns that identity directly. Cliff and
+/// elevation trajectory kernels remain explicitly outside this straight-flight
+/// port rather than being guessed from cell levels.
+fn projectile_collides_at(
+    terrain: Option<&ResolvedTerrainGrid>,
+    overlay_grid: Option<&crate::sim::overlay_grid::OverlayGrid>,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+    projectile: &Projectile,
+    candidate: ProjectileCoord,
+) -> bool {
+    let policy = projectile.collision;
+    if !policy.level_non_water && !policy.subject_to_walls {
+        return false;
+    }
+    let Ok(rx) = u16::try_from(candidate.x.div_euclid(256)) else {
+        return policy.level_non_water;
+    };
+    let Ok(ry) = u16::try_from(candidate.y.div_euclid(256)) else {
+        return policy.level_non_water;
+    };
+
+    if policy.level_non_water
+        && !terrain
+            .and_then(|grid| grid.cell(rx, ry))
+            .is_some_and(|cell| cell.is_water)
+    {
+        return true;
+    }
+    policy.subject_to_walls
+        && overlay_grid
+            .and_then(|grid| grid.cell(rx, ry).overlay_id)
+            .and_then(|overlay_id| overlay_registry.and_then(|registry| registry.flags(overlay_id)))
+            .is_some_and(|flags| flags.wall)
+}
 
 /// Result of one deterministic simulation tick.
 #[derive(Debug, Clone, Copy)]
@@ -123,6 +162,28 @@ pub(crate) enum TickLane {
     Ordinary,
     /// LAN/WOL modal pump: service PerTickUpdate and the late tail only.
     NetworkModal,
+}
+
+/// Static map trigger definitions borrowed for one authoritative frame.
+///
+/// The definitions remain map data; `Simulation` owns the mutable runtime
+/// state and evaluates it in the master-frame spine.
+#[derive(Clone, Copy)]
+pub(crate) struct TriggerInputs<'a> {
+    pub graph: &'a TriggerGraph,
+    pub triggers: &'a TriggerMap,
+    pub events: &'a EventMap,
+    pub actions: &'a ActionMap,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MasterFrameTestRung {
+    Triggers,
+    LogicVector,
+    Houses,
+    FrameCommit,
+    PendingDelete,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -409,6 +470,14 @@ pub struct Simulation {
     #[cfg(test)]
     #[serde(skip)]
     lifecycle_test_events: Vec<LifecycleTestEvent>,
+    /// App-visible outcomes produced by the authoritative trigger rung.
+    /// Trigger actions mutate `trigger_runtime` during the frame; only their
+    /// presentation outcomes are drained by the app after the tick.
+    #[serde(skip)]
+    trigger_effects: Vec<TriggerEffect>,
+    #[cfg(test)]
+    #[serde(skip)]
+    master_frame_test_trace: Vec<MasterFrameTestRung>,
     /// Sound events produced during the current tick — drained by the app layer.
     #[serde(skip)]
     pub sound_events: Vec<SimSoundEvent>,
@@ -416,6 +485,10 @@ pub struct Simulation {
     /// muzzle flash rendering and future projectile origin computation.
     #[serde(skip)]
     pub fire_events: Vec<SimFireEvent>,
+    /// Persistent ordinary shots. This is authoritative save/hash state, not
+    /// the render-side fire-event approximation.
+    #[serde(default)]
+    pub projectiles: crate::sim::projectile::ProjectileStore,
     /// Smudge spawn requests emitted by callsites that don't return through
     /// `CombatTickResult` (superweapons, etc.). Drained alongside combat-emitted
     /// smudge requests in the post-combat drain block. Ephemeral — never
@@ -684,8 +757,12 @@ impl Simulation {
             pending_lifecycle_requests: Vec::new(),
             #[cfg(test)]
             lifecycle_test_events: Vec::new(),
+            trigger_effects: Vec::new(),
+            #[cfg(test)]
+            master_frame_test_trace: Vec::new(),
             sound_events: Vec::new(),
             fire_events: Vec::new(),
+            projectiles: crate::sim::projectile::ProjectileStore::new(),
             pending_smudge_requests: Vec::new(),
             bale_events: Vec::new(),
             bunker_wall_events: Vec::new(),
@@ -1121,7 +1198,7 @@ impl Simulation {
 
     /// Advance map triggers by one tick. Uses `std::mem::take` to avoid
     /// self-borrow conflict (advance reads entity/interner state via `&Simulation`).
-    pub fn advance_triggers(
+    fn advance_triggers(
         &mut self,
         graph: &TriggerGraph,
         triggers: &TriggerMap,
@@ -1139,6 +1216,28 @@ impl Simulation {
         );
         self.trigger_runtime = rt;
         effects
+    }
+
+    fn poll_triggers_for_master_frame(&mut self, inputs: TriggerInputs<'_>) {
+        // YR LogicClass::Update polls scenario triggers before the live-object walk.
+        let effects =
+            self.advance_triggers(inputs.graph, inputs.triggers, inputs.events, inputs.actions);
+        self.trigger_effects.extend(effects);
+    }
+
+    /// Drain app-owned outcomes after their authoritative trigger actions ran.
+    pub(crate) fn drain_trigger_effects(&mut self) -> Vec<TriggerEffect> {
+        std::mem::take(&mut self.trigger_effects)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_master_frame_test_trace(&mut self) -> Vec<MasterFrameTestRung> {
+        std::mem::take(&mut self.master_frame_test_trace)
+    }
+
+    #[cfg(test)]
+    fn trace_master_frame_rung(&mut self, rung: MasterFrameTestRung) {
+        self.master_frame_test_trace.push(rung);
     }
 
     /// Returns true if the given house name is human-controlled.
@@ -2592,6 +2691,8 @@ impl Simulation {
         spawned_entities: &mut bool,
         destroyed_structure: &mut bool,
     ) -> bool {
+        #[cfg(test)]
+        self.trace_master_frame_rung(MasterFrameTestRung::Houses);
         // --- Phase 8: Defeat detection (runs BEFORE AI) ---
         // gamemd evaluates each house's defeat before its AI manage/produce step,
         // so a house that lost its last building/unit this tick can issue NO AI
@@ -2709,11 +2810,15 @@ impl Simulation {
         self.session.total_sim_ms = self.session.total_sim_ms.saturating_add(tick_ms as u64);
         self.session.binary_frame = self.session.binary_frame.wrapping_add(1);
         #[cfg(test)]
+        self.trace_master_frame_rung(MasterFrameTestRung::FrameCommit);
+        #[cfg(test)]
         self.trace_lifecycle_for_test(LifecycleTestEvent::BinaryFrameCommitted);
 
         // The one ordinary ProcessPendingDelete drain follows the native frame
         // commit. Alive queue entries keep their position; ready duplicate IDs
         // collapse and physically finalize exactly once.
+        #[cfg(test)]
+        self.trace_master_frame_rung(MasterFrameTestRung::PendingDelete);
         self.process_pending_delete();
 
         // Debug-mode safety net: rebuild occupancy after the drain so dead
@@ -2739,7 +2844,9 @@ impl Simulation {
         overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
         tick_ms: u32,
     ) -> TickResult {
-        self.advance_tick_in_lane(
+        // Headless callers still enter the complete YR Main_Tick-shaped
+        // transaction; only map-owned trigger definitions are unavailable here.
+        self.advance_master_frame(
             commands,
             rules,
             height_map,
@@ -2748,11 +2855,17 @@ impl Simulation {
             tick_ms,
             TickLane::Ordinary,
             None,
+            None,
         )
     }
 
+    /// Advance exactly one authoritative simulation frame.
+    ///
+    /// This is the sole Main_Tick-shaped entry point. `advance_tick` is the
+    /// ordinary, trigger-definition-free adapter used by headless callers and
+    /// tests; gameplay supplies its map definitions through `trigger_inputs`.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn advance_tick_in_lane(
+    pub(crate) fn advance_master_frame(
         &mut self,
         commands: &[CommandEnvelope],
         rules: Option<&RuleSet>,
@@ -2762,6 +2875,7 @@ impl Simulation {
         tick_ms: u32,
         lane: TickLane,
         animation_sequences: Option<&BTreeMap<String, crate::sim::animation::SequenceSet>>,
+        trigger_inputs: Option<TriggerInputs<'_>>,
     ) -> TickResult {
         // The wrapping native frame counter is committed LATE (end of this fn,
         // beside self.session.tick) so every phase sees the same pre-increment
@@ -2780,6 +2894,14 @@ impl Simulation {
         // aircraft, …) are dying-gated, so a corpse is excluded until that drain.
         let mut bridge_state_changed = false;
         let mut passenger_ownership_changed = false;
+
+        // YR LogicClass::Update establishes trigger state before visiting the
+        // live LogicVector, so object work in this frame observes its actions.
+        #[cfg(test)]
+        self.trace_master_frame_rung(MasterFrameTestRung::Triggers);
+        if let Some(inputs) = trigger_inputs {
+            self.poll_triggers_for_master_frame(inputs);
+        }
 
         // Object-AI stage: the authoritative per-object Mission host, run
         // immediately BEFORE Phase-1 ground movement — gamemd decides each
@@ -2819,6 +2941,8 @@ impl Simulation {
         // --- Phase 1: Ground movement ---
         // DEPENDS ON: commands (may set movement_target), entity positions from prior tick.
         // PRODUCES: updated entity positions, crush/bump effects, drive track state.
+        #[cfg(test)]
+        self.trace_master_frame_rung(MasterFrameTestRung::LogicVector);
         let mut movement_stats = movement::MovementTickStats::default();
         self.for_each_live_object(|sim, stable_id| {
             sim.object_ai_visit_one(stable_id, rules, object_ctx);
@@ -3089,6 +3213,40 @@ impl Simulation {
             // resolution sequence. Snapshot is owned, so it does not conflict
             // with the &mut self.entities borrow below.
             let logic_order = self.live_object_order_snapshot();
+            let projectile_targets = self
+                .substrate
+                .entities
+                .iter_sorted()
+                .filter(|(_, entity)| entity.is_alive() && !entity.dying)
+                .map(|(id, entity)| {
+                    (
+                        id,
+                        crate::sim::projectile::ProjectileCoord::new(
+                            i32::from(entity.position.rx) * 256
+                                + entity.position.sub_x.to_num::<i32>(),
+                            i32::from(entity.position.ry) * 256
+                                + entity.position.sub_y.to_num::<i32>(),
+                            i32::from(entity.position.z),
+                        ),
+                    )
+                })
+                .collect();
+            // YR BulletClass::AI: existing bullets advance before this frame's
+            // newly accepted weapon fire, so a spawn cannot move recursively.
+            let terrain = self.resolved_terrain.as_ref();
+            let overlay_grid = self.overlay_grid.as_ref();
+            let projectile_detonations = self
+                .projectiles
+                .advance(&projectile_targets, |projectile, candidate| {
+                    projectile_collides_at(
+                        terrain,
+                        overlay_grid,
+                        overlay_registry,
+                        projectile,
+                        candidate,
+                    )
+                })
+                .detonations;
             let combat_result = combat::tick_combat_with_fog_and_main_rng(
                 &mut self.substrate.entities,
                 &mut self.substrate.occupancy,
@@ -3106,10 +3264,14 @@ impl Simulation {
                 tick_ms,
                 self.session.binary_frame,
                 &logic_order,
+                &projectile_detonations,
                 Some(&mut self.radiation),
                 &mut self.scenario_rng,
                 &mut self.main_rng,
             );
+            for projectile in combat_result.projectile_spawns.iter().copied() {
+                self.projectiles.spawn(projectile);
+            }
             turret::tick_turret_rotation(
                 &mut self.substrate.entities,
                 rules,

--- a/src/sim/world/slice6_retask_tests.rs
+++ b/src/sim/world/slice6_retask_tests.rs
@@ -177,7 +177,7 @@ const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x8477_F4BD_F3D8_B12B;
 // wired in this slice (deploy-begin off, undeploy-complete on, destination-
 // accepted on) changed no other hashed state in these fixtures. The absolute
 // per-stream RNG pins held throughout.
-const SLICE6_BASELINE_HASH: u64 = 0x64E3_D8E5_D202_8D5C;
+const SLICE6_BASELINE_HASH: u64 = 0x6818_979C_3D5A_113D;
 
 #[test]
 fn replay_hash_stable_through_slice6() {

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -10,6 +10,24 @@ use std::hash::{Hash, Hasher};
 
 use super::Simulation;
 
+fn hash_projectile_target(
+    target: crate::sim::projectile::ProjectileTarget,
+    hasher: &mut impl Hasher,
+) {
+    match target {
+        crate::sim::projectile::ProjectileTarget::Entity(id) => {
+            0u8.hash(hasher);
+            id.hash(hasher);
+        }
+        crate::sim::projectile::ProjectileTarget::Cell(position) => {
+            1u8.hash(hasher);
+            position.x.hash(hasher);
+            position.y.hash(hasher);
+            position.z.hash(hasher);
+        }
+    }
+}
+
 fn hash_drive_track_state(
     state: &crate::sim::movement::drive_track::DriveTrackState,
     hasher: &mut impl Hasher,
@@ -126,7 +144,7 @@ impl Simulation {
     /// Hashes clocks, Scenario RNG, production, fog, alliances, and all entity
     /// components in stable-entity-ID order (EntityStore keys_sorted) for determinism.
     pub fn state_hash(&self) -> u64 {
-        self.state_hash_with_schema(true, true)
+        self.state_hash_with_schema(true, true, true)
     }
 
     /// Test-only provenance probe for the v29 Mission hash rebaseline.
@@ -135,7 +153,7 @@ impl Simulation {
     /// Mission/hash layout from representable final state.
     #[cfg(test)]
     pub(crate) fn state_hash_without_mission_v29(&self) -> u64 {
-        self.state_hash_with_schema(true, false)
+        self.state_hash_with_schema(true, false, false)
     }
 
     /// Test-only provenance probe for the historical pre-v28 baseline.
@@ -144,13 +162,14 @@ impl Simulation {
     /// schema changes do not invalidate that earlier proof.
     #[cfg(test)]
     pub(crate) fn state_hash_before_lifecycle_v28_and_mission_v29(&self) -> u64 {
-        self.state_hash_with_schema(false, false)
+        self.state_hash_with_schema(false, false, false)
     }
 
     fn state_hash_with_schema(
         &self,
         include_lifecycle_v28: bool,
         include_mission_v29: bool,
+        include_master_frame_v43: bool,
     ) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
 
@@ -161,6 +180,11 @@ impl Simulation {
         self.scenario_rng.hash_state(&mut hasher);
         self.substrate.next_stable_object_id.hash(&mut hasher);
         self.substrate.next_occupancy_enter_order.hash(&mut hasher);
+        // YR LogicClass trigger latches are save/lockstep state, even though
+        // their camera/message outcomes stay app-owned and are not hashed.
+        if include_master_frame_v43 {
+            self.trigger_runtime.hash_state(&mut hasher);
+        }
 
         // LogicClass active-object order — authoritative (drives reconciliation order).
         let order = self.substrate.logic.as_slice();
@@ -190,6 +214,9 @@ impl Simulation {
         self.hash_overlay_grid(&mut hasher);
         self.hash_smudge_grid(&mut hasher);
         self.hash_radiation(&mut hasher);
+        if include_master_frame_v43 {
+            self.hash_projectiles(&mut hasher);
+        }
         self.hash_super_weapons(&mut hasher);
         self.hash_entities(&mut hasher, include_lifecycle_v28, include_mission_v29);
         self.hash_anims(&mut hasher);
@@ -197,6 +224,33 @@ impl Simulation {
         self.hash_session_identity(&mut hasher);
 
         hasher.finish()
+    }
+
+    fn hash_projectiles(&self, hasher: &mut impl Hasher) {
+        self.projectiles.next_id().hash(hasher);
+        self.projectiles.len().hash(hasher);
+        for (&id, projectile) in self.projectiles.iter() {
+            id.hash(hasher);
+            projectile.source_id.hash(hasher);
+            projectile.position.x.hash(hasher);
+            projectile.position.y.hash(hasher);
+            projectile.position.z.hash(hasher);
+            hash_projectile_target(projectile.target, hasher);
+            projectile.last_target_position.x.hash(hasher);
+            projectile.last_target_position.y.hash(hasher);
+            projectile.last_target_position.z.hash(hasher);
+            projectile.payload.base_damage.hash(hasher);
+            projectile.payload.warhead.index().hash(hasher);
+            projectile.payload.weapon.index().hash(hasher);
+            projectile.payload.owner.index().hash(hasher);
+            projectile.speed_leptons_per_frame.hash(hasher);
+            projectile.arm_frames_remaining.hash(hasher);
+            projectile.fuse_frames_remaining.hash(hasher);
+            projectile.tracks_target.hash(hasher);
+            projectile.target_expiry.hash(hasher);
+            projectile.collision.level_non_water.hash(hasher);
+            projectile.collision.subject_to_walls.hash(hasher);
+        }
     }
 
     /// Fold the authoritative sparse raw occupation bytes without conflating


### PR DESCRIPTION
- add an authoritative master-frame tick with trigger state hashing and replay/save continuity
- add persistent projectile flight, collision, delayed detonation damage, and simulation-driven visuals
- add native-shaped tactical draw planning for cells, walls, overlays, and grouped building pieces

Special projectile trajectories and cross-atlas unit/effect ordering remain explicit typed fallbacks rather than guessed behavior.
