### PR TITLE
Foundations contracts round 2

### DIFF
--- a/src/app_instances/shp.rs
+++ b/src/app_instances/shp.rs
@@ -20,6 +20,7 @@ use crate::map::entities::EntityCategory;
 use crate::map::lighting;
 use crate::map::terrain::TILE_HEIGHT;
 use crate::render::batch::SpriteInstance;
+use crate::render::draw_state::DrawState;
 use crate::render::sprite_atlas::ShpSpriteKey;
 use crate::render::tactical_draw_plan::{
     BlitPolicy, BuildingPieceKind, ObjectDraw, SpriteEncoding, TacticalCoord, TacticalLayer,
@@ -105,6 +106,15 @@ pub(crate) fn build_shp_instances(
             .get(owner_str)
             .copied()
             .unwrap_or(crate::rules::house_colors::NO_REMAP);
+        let draw_decision = DrawState::for_entity(
+            entity,
+            sim.session.binary_frame,
+            super::units::house_color_to_remap_row(hc),
+        );
+        if !draw_decision.visible {
+            continue;
+        }
+        let draw_state = draw_decision.state;
         // Determine if this building is in its make/build-up or build-down animation.
         let is_building_up: bool =
             entity.category == EntityCategory::Structure && entity.building_up.is_some();
@@ -266,6 +276,7 @@ pub(crate) fn build_shp_instances(
             depth,
             tint,
             alpha: 1.0,
+            draw_state,
             ..Default::default()
         };
 
@@ -306,6 +317,7 @@ pub(crate) fn build_shp_instances(
                     interp_z,
                     depth,
                     tint,
+                    draw_state,
                 );
                 // Building anims render in the same pass as building bodies so they
                 // can sort together via depth. Anims use the building's entity depth
@@ -336,6 +348,7 @@ pub(crate) fn build_shp_instances(
                     is_player_owned,
                     entity.building_damage_state_active,
                     world_height,
+                    draw_state,
                 );
             }
             // Emit VXL turret on top of building (e.g., SAM site, Prism Tower).
@@ -358,6 +371,7 @@ pub(crate) fn build_shp_instances(
                             interp_z,
                             depth,
                             tint,
+                            draw_state,
                             rules_obj.turret_anim_x,
                             rules_obj.turret_anim_y,
                             rules_obj.turret_anim_z_adjust,
@@ -404,6 +418,7 @@ fn emit_building_turret_vxl(
     _z: u8,
     building_depth: f32,
     tint: [f32; 3],
+    draw_state: DrawState,
     anim_x: i32,
     anim_y: i32,
     z_adjust: i32,
@@ -446,6 +461,7 @@ fn emit_building_turret_vxl(
         depth: turret_depth,
         tint,
         alpha: 1.0,
+        draw_state,
         ..Default::default()
     });
     instance_pages.push(entry.page);
@@ -468,6 +484,7 @@ fn emit_building_bib(
     _z: u8,
     building_depth: f32,
     tint: [f32; 3],
+    draw_state: DrawState,
 ) {
     let rules_image: String = rules
         .and_then(|r| r.object(building_type))
@@ -510,6 +527,7 @@ fn emit_building_bib(
             depth: building_depth,
             tint,
             alpha: 1.0,
+            draw_state,
             ..Default::default()
         },
     });
@@ -626,6 +644,7 @@ fn emit_building_anims(
     is_player_owned: bool,
     building_damage_state_active: bool,
     world_height: f32,
+    draw_state: DrawState,
 ) {
     let rules_image: String = rules
         .and_then(|r| r.object(building_type))
@@ -767,6 +786,7 @@ fn emit_building_anims(
                 depth: anim_depth,
                 tint,
                 alpha: 1.0,
+                draw_state,
                 ..Default::default()
             },
         });

--- a/src/app_instances/units.rs
+++ b/src/app_instances/units.rs
@@ -15,6 +15,7 @@ use crate::map::entities::EntityCategory;
 use crate::map::lighting;
 use crate::map::terrain::{TILE_HEIGHT, TILE_WIDTH};
 use crate::render::batch::SpriteInstance;
+use crate::render::draw_state::DrawState;
 use crate::render::sprite_atlas::ShpSpriteKey;
 use crate::render::unit_atlas::{
     UnitSpriteEntry, UnitSpriteKey, VxlLayer, canonical_turret_facing, canonical_unit_facing,
@@ -207,6 +208,15 @@ pub(crate) fn build_unit_instances(
             .get(owner_str)
             .copied()
             .unwrap_or_default();
+        let draw_decision = DrawState::for_entity(
+            entity,
+            sim.session.binary_frame,
+            house_color_to_remap_row(hc),
+        );
+        if !draw_decision.visible {
+            continue;
+        }
+        let draw_state = draw_decision.state;
         let mut tint: [f32; 3] = match entity.category {
             crate::map::entities::EntityCategory::Aircraft => {
                 state.lighting_grid.aircraft_tint_at((pos.rx, pos.ry))
@@ -278,6 +288,7 @@ pub(crate) fn build_unit_instances(
                 interp_z,
                 tint,
                 alpha,
+                draw_state,
                 anim_frame,
                 dock_depth_y_offset,
                 slope_state,
@@ -311,7 +322,7 @@ pub(crate) fn build_unit_instances(
                     depth,
                     tint,
                     alpha,
-                    house_color_idx: house_color_to_remap_row(hc),
+                    draw_state,
                     ..Default::default()
                 };
                 push_unit_sprite(
@@ -341,6 +352,7 @@ pub(crate) fn build_unit_instances(
                     center_y,
                     pos.z,
                     tint,
+                    draw_state,
                 );
             }
         }
@@ -533,6 +545,7 @@ fn emit_turret_unit_sprites(
     z: u8,
     tint: [f32; 3],
     alpha: f32,
+    draw_state: DrawState,
     anim_frame: u32,
     dock_depth_y_offset: f32,
     slope_state: UnitRenderSlopeState,
@@ -595,7 +608,7 @@ fn emit_turret_unit_sprites(
             depth: entity_depth,
             tint,
             alpha,
-            house_color_idx: house_color_to_remap_row(hc),
+            draw_state,
             ..Default::default()
         };
         push_unit_sprite(
@@ -636,7 +649,7 @@ fn emit_turret_unit_sprites(
                 depth: entity_depth,
                 tint,
                 alpha,
-                house_color_idx: house_color_to_remap_row(hc),
+                draw_state,
                 ..Default::default()
             };
             push_unit_sprite(
@@ -675,6 +688,7 @@ fn emit_harvest_overlay(
     center_y: f32,
     z: u8,
     tint: [f32; 3],
+    draw_state: DrawState,
 ) {
     let sprite_atlas = match &state.sprite_atlas {
         Some(a) => a,
@@ -713,6 +727,7 @@ fn emit_harvest_overlay(
         depth,
         tint,
         alpha: 1.0,
+        draw_state,
         ..Default::default()
     });
 }
@@ -742,7 +757,7 @@ fn harvest_arm_screen_offset(body_facing: u8) -> (f32, f32) {
 /// house_ramp_tex. Row 0 is the no-remap fallback (mirrors the theater
 /// palette's [16, 32) range); civilian/neutral units (`NO_REMAP`) map to
 /// row 0. Real players occupy rows 1..N (the +1 reserves row 0).
-fn house_color_to_remap_row(hc: HouseColorIndex) -> u32 {
+pub(super) fn house_color_to_remap_row(hc: HouseColorIndex) -> u32 {
     if hc == house_colors::NO_REMAP {
         0
     } else {
@@ -771,7 +786,10 @@ mod tests {
     #[test]
     fn stable_and_transition_sources_route_to_distinct_texture_streams() {
         let sprite = SpriteInstance {
-            fx_flags: 7,
+            draw_state: DrawState {
+                fx_flags: 7,
+                ..Default::default()
+            },
             ..Default::default()
         };
         let mut stable = Vec::new();

--- a/src/app_loading.rs
+++ b/src/app_loading.rs
@@ -18,6 +18,7 @@ use crate::assets::pal_file::Color;
 use crate::match_bootstrap::{LoadingStartup, PreparedMatchStartup};
 use crate::render::batch::{BatchRenderer, SpriteInstance};
 use crate::render::bit_font::BitFont;
+use crate::render::draw_state::DrawState;
 use crate::render::gpu::GpuContext;
 use crate::render::loading_screen_chrome::{
     LoadingArtVariant, LoadingScreenAtlas, LoadingScreenCompositionAtlasInput, LoadingScreenEntry,
@@ -1778,10 +1779,7 @@ fn push_entry_tinted(
         depth,
         tint,
         alpha: 1.0,
-        house_color_idx: 0,
-        fx_flags: 0,
-        fx_params: [0.0; 4],
-        ic_tint: [0.0; 4],
+        draw_state: DrawState::default(),
     });
 }
 

--- a/src/app_render/build_instances.rs
+++ b/src/app_render/build_instances.rs
@@ -872,23 +872,33 @@ fn sort_by_depth_desc_with_pages(instances: &mut Vec<SpriteInstance>, pages: &mu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::render::draw_state::DrawState;
 
     #[test]
     fn paired_unit_sort_keeps_page_tags_and_equal_depth_order() {
         let mut instances = vec![
             SpriteInstance {
                 depth: 0.5,
-                fx_flags: 10,
+                draw_state: DrawState {
+                    fx_flags: 10,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             SpriteInstance {
                 depth: 0.8,
-                fx_flags: 20,
+                draw_state: DrawState {
+                    fx_flags: 20,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
             SpriteInstance {
                 depth: 0.8,
-                fx_flags: 30,
+                draw_state: DrawState {
+                    fx_flags: 30,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
         ];
@@ -899,7 +909,7 @@ mod tests {
         assert_eq!(
             instances
                 .iter()
-                .map(|instance| instance.fx_flags)
+                .map(|instance| instance.draw_state.fx_flags)
                 .collect::<Vec<_>>(),
             vec![20, 30, 10]
         );

--- a/src/app_render/draw_plan_lowering.rs
+++ b/src/app_render/draw_plan_lowering.rs
@@ -222,6 +222,7 @@ pub(crate) fn cell_draw_kind(is_wall: bool) -> CellDrawKind {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::render::draw_state::DrawState;
     use crate::render::tactical_draw_plan::{BlitPolicy, RenderZPolicy, SpriteEncoding};
 
     fn cell(id: DrawId, is_wall: bool) -> PlannedCellInstance {
@@ -232,7 +233,10 @@ mod tests {
                 policy: BlitPolicy::translucent(SpriteEncoding::Terrain, RenderZPolicy::None),
             },
             instance: SpriteInstance {
-                fx_flags: id as u32,
+                draw_state: DrawState {
+                    fx_flags: id as u32,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
         }
@@ -244,7 +248,7 @@ mod tests {
         assert_eq!(
             lowered
                 .iter()
-                .map(|instance| instance.fx_flags)
+                .map(|instance| instance.draw_state.fx_flags)
                 .collect::<Vec<_>>(),
             [4, 3, 2]
         );
@@ -327,7 +331,10 @@ mod tests {
             policy: BlitPolicy::opaque(SpriteEncoding::Plain),
             page,
             instance: SpriteInstance {
-                fx_flags: marker,
+                draw_state: DrawState {
+                    fx_flags: marker,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
         };
@@ -344,7 +351,7 @@ mod tests {
         assert_eq!(
             lowered
                 .iter()
-                .map(|(page, instance)| (*page, instance.fx_flags))
+                .map(|(page, instance)| (*page, instance.draw_state.fx_flags))
                 .collect::<Vec<_>>(),
             [(0, 30), (1, 40), (2, 50)]
         );

--- a/src/render/batch.rs
+++ b/src/render/batch.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 
 use wgpu::util::DeviceExt;
 
+use crate::render::draw_state::DrawState;
 use crate::render::gpu::GpuContext;
 
 /// WGSL shader for instanced sprite rendering (loaded from batch_shader.wgsl).
@@ -57,21 +58,9 @@ pub struct SpriteInstance {
     /// Alpha multiplier for translucency. 1.0 = fully opaque, 0.5 = 50% translucent.
     /// Used for chrono warp "being warped" visual (50% during chrono delay).
     pub alpha: f32,
-    /// Per-house ramp row index. 0 = no remap (SHP / non-voxel paths;
-    /// row 0 of the PaletteSet house_ramp_tex mirrors the theater palette's
-    /// [16, 32) range, so byte ranges stay correct). 1..=MAX_HOUSES-1 =
-    /// per-house ramp row. Read by the voxel sprite fragment shader; other
-    /// pipelines ignore it.
-    pub house_color_idx: u32,
-    /// Bitfield of active visual FX. Bit 0 = cloak, bit 1 = EMP, bit 2 =
-    /// iron curtain, bit 3 = warp, bit 4 = mirror. Phase 1 stubs this as 0;
-    /// phases 2-5 populate.
-    pub fx_flags: u32,
-    /// FX scalar parameters: [cloak_alpha, emp_dim, ic_phase, warp_phase].
-    /// Stub in Phase 1.
-    pub fx_params: [f32; 4],
-    /// Iron-curtain tint: [r, g, b, intensity]. Stub in Phase 1.
-    pub ic_tint: [f32; 4],
+    /// Representation-neutral visual state resolved from the authoritative
+    /// entity before either SHP or voxel instance construction.
+    pub draw_state: DrawState,
 }
 
 /// Number of vertex attributes in SpriteInstance: 7 base + 4 voxel-shader fields.
@@ -364,10 +353,10 @@ impl BatchRenderer {
         // Instance buffer vertex layout (matches SpriteInstance memory layout):
         //   position(8) + size(8) + uv_origin(8) + uv_size(8) = 32 → loc 0-3
         //   depth(4) + tint(12) + alpha(4) = 20 → loc 4-6 (offsets 32, 36, 48)
-        //   house_color_idx(4) at offset 52 → loc 7 (Uint32)
-        //   fx_flags(4) at offset 56 → loc 8 (Uint32)
-        //   fx_params(16) at offset 60 → loc 9 (Float32x4)
-        //   ic_tint(16) at offset 76 → loc 10 (Float32x4)
+        //   DrawState::remap_row(4) at offset 52 → loc 7 (Uint32)
+        //   DrawState::fx_flags(4) at offset 56 → loc 8 (Uint32)
+        //   DrawState::fx_params(16) at offset 60 → loc 9 (Float32x4)
+        //   DrawState::effect_tint(16) at offset 76 → loc 10 (Float32x4)
         // Total stride: 92 bytes.
         let instance_attrs: [wgpu::VertexAttribute; INSTANCE_ATTRIBUTE_COUNT] = [
             wgpu::VertexAttribute {

--- a/src/render/batch_shader.wgsl
+++ b/src/render/batch_shader.wgsl
@@ -21,6 +21,10 @@ struct Instance {
     @location(4) depth: f32,
     @location(5) tint: vec3f,
     @location(6) alpha: f32,
+    @location(7) remap_row: u32,
+    @location(8) fx_flags: u32,
+    @location(9) fx_params: vec4f,
+    @location(10) effect_tint: vec4f,
 };
 
 struct VertexOutput {
@@ -28,6 +32,9 @@ struct VertexOutput {
     @location(0) uv: vec2f,
     @location(1) tint: vec3f,
     @location(2) alpha: f32,
+    @location(3) @interpolate(flat) fx_flags: u32,
+    @location(4) fx_params: vec4f,
+    @location(5) effect_tint: vec4f,
 };
 
 @vertex
@@ -69,7 +76,19 @@ fn vs_main(
     output.uv = instance.uv_origin + quad_uv[idx] * instance.uv_size;
     output.tint = instance.tint;
     output.alpha = instance.alpha;
+    output.fx_flags = instance.fx_flags;
+    output.fx_params = instance.fx_params;
+    output.effect_tint = instance.effect_tint;
     return output;
+}
+
+fn apply_fx(color: vec4f, _flags: u32, params: vec4f, effect_tint: vec4f) -> vec4f {
+    // Original location: `RA2-GAME.EXE-IDB` canon,
+    // `rendering.drawStateEffects.ra2yr.json`; this representation-neutral
+    // branch mirrors the voxel shader so SHP and VXL share one DrawState ABI.
+    // YR resolves selector opacity and invulnerability brightness before either
+    // SHP or VXL submission. EMP and mirror deliberately remain no-op residuals.
+    return vec4f(color.rgb * effect_tint.rgb, color.a * params.x);
 }
 
 @fragment
@@ -80,7 +99,12 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4f {
     if (color.a < 0.01) {
         discard;
     }
-    // Apply map lighting tint and alpha. Tint (1,1,1) = no change.
-    // Alpha 1.0 = fully opaque, 0.5 = 50% translucent (chrono warp effect).
-    return vec4f(color.rgb * input.tint, color.a * input.alpha);
+    // Map lighting happens before the shared DrawState effect branch, matching
+    // the voxel fragment path. Alpha 1.0 = opaque; no draw state changes order.
+    return apply_fx(
+        vec4f(color.rgb * input.tint, color.a * input.alpha),
+        input.fx_flags,
+        input.fx_params,
+        input.effect_tint,
+    );
 }

--- a/src/render/draw_state.rs
+++ b/src/render/draw_state.rs
@@ -1,0 +1,452 @@
+//! Per-object tactical draw state shared by SHP and voxel instance builders.
+//!
+//! The YR draw path resolves visibility, translucency selection, effect brightness,
+//! and house remap before choosing an SHP or voxel rasterizer. Keep that decision in
+//! one CPU descriptor so the two atlas paths cannot disagree.
+
+use crate::sim::game_entity::GameEntity;
+
+/// `fx_flags` bit assignments consumed by the sprite shaders.
+pub const FX_CLOAK: u32 = 1 << 0;
+/// Explicit residual: no dedicated YR EMP material mutation is proven.
+pub const FX_EMP: u32 = 1 << 1;
+pub const FX_INVULNERABILITY: u32 = 1 << 2;
+pub const FX_WARP: u32 = 1 << 3;
+/// Explicit residual: no dedicated YR mirror material mutation is proven.
+pub const FX_MIRROR: u32 = 1 << 4;
+pub const FX_DISGUISE: u32 = 1 << 5;
+
+/// Native cloak state values consumed by YR draw selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloakDrawPhase {
+    Cloaking,
+    FullyCloaked,
+    Uncloaking,
+}
+
+/// Authoritative producer values needed by YR cloak draw selection.
+///
+/// The simulation does not yet own these fields. Keeping the input separate avoids
+/// reconstructing gameplay state from render flags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CloakDrawInput {
+    pub phase: CloakDrawPhase,
+    pub depth: u32,
+    pub cloaking_stages: u32,
+    pub late_visible: bool,
+    pub force_visible_call: bool,
+    pub visible_to_observer: bool,
+}
+
+/// Authoritative producer values needed by YR disguise shimmer selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DisguiseDrawInput {
+    pub active: bool,
+    pub observer_is_allied: bool,
+    /// Native timestamp field used by `GetDisguiseFlags`.
+    pub start_frame: u32,
+}
+
+/// The YR invulnerability state consumed by
+/// `TechnoClass::GetInvulnerabilityTintIntensity`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvulnerabilityTintInput {
+    pub mode: u8,
+    pub elapsed_ticks: u32,
+    /// Current object/cell brightness in the native 0..2000 scale.
+    pub intensity: u32,
+}
+
+/// Producer-owned inputs to the common YR object draw resolver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DrawStateInput {
+    pub cloak: Option<CloakDrawInput>,
+    pub disguise: Option<DisguiseDrawInput>,
+    pub warp_out: bool,
+    pub warp_in: bool,
+    pub invulnerability: Option<InvulnerabilityTintInput>,
+}
+
+/// CPU draw admission plus the GPU-ready material state.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DrawDecision {
+    /// A fully cloaked object that is hidden from the observer emits no base draw.
+    pub visible: bool,
+    pub state: DrawState,
+}
+
+/// GPU-ready visual state resolved from one tactical object.
+///
+/// `remap_row` is the palette-ramp selection. `fx_params.x` is the final alpha
+/// multiplier selected by the native translucency bits; `fx_params.y` preserves
+/// those selector bits for diagnostics; `fx_params.z` is the 0..2 brightness scalar.
+/// `effect_tint` carries the scalar as RGB so SHP and voxel shaders apply the same
+/// native brightness channel after their normal palette/light work. The layout is
+/// part of `SpriteInstance`'s vertex ABI.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct DrawState {
+    pub remap_row: u32,
+    pub fx_flags: u32,
+    pub fx_params: [f32; 4],
+    pub effect_tint: [f32; 4],
+}
+
+impl Default for DrawState {
+    fn default() -> Self {
+        Self {
+            remap_row: 0,
+            fx_flags: 0,
+            fx_params: [1.0, 0.0, 1.0, 0.0],
+            effect_tint: [1.0, 1.0, 1.0, 1.0],
+        }
+    }
+}
+
+impl DrawState {
+    /// Resolve YR object draw state without inferring any producer-owned gameplay state.
+    ///
+    /// Original locations: `TechnoClass::DrawVoxel @ 0x00706640`,
+    /// `TechnoClass::GetInvulnerabilityTintIntensity @ 0x0070e380`, and
+    /// `TeleportLocomotionClass::ILocomotion::Process @ 0x007192f0`.
+    pub fn resolve(input: DrawStateInput, current_frame: u32, remap_row: u32) -> DrawDecision {
+        let mut state = Self {
+            remap_row,
+            fx_params: [1.0, 0.0, 1.0, 0.0],
+            effect_tint: [1.0, 1.0, 1.0, 1.0],
+            ..Self::default()
+        };
+
+        let Some((cloak_selector, cloak_flag)) = cloak_selector(input.cloak) else {
+            return DrawDecision {
+                visible: false,
+                state,
+            };
+        };
+
+        let warp_selector = if input.warp_out || input.warp_in {
+            state.fx_flags |= FX_WARP;
+            TRANSLUCENCY_50
+        } else {
+            0
+        };
+        let disguise_selector = input
+            .disguise
+            .filter(|disguise| disguise.active && disguise.observer_is_allied)
+            .map(|disguise| {
+                let phase = current_frame
+                    .wrapping_sub(disguise.start_frame)
+                    .wrapping_add(64)
+                    % 256;
+                selector_bits_for_percent(disguise_phase_percent(phase))
+            })
+            .unwrap_or(0);
+
+        if disguise_selector != 0 {
+            state.fx_flags |= FX_DISGUISE;
+        }
+
+        if cloak_flag {
+            state.fx_flags |= FX_CLOAK;
+        }
+        let selector_bits = cloak_selector | warp_selector | disguise_selector;
+        state.fx_params[0] = opacity_for_selector_bits(selector_bits);
+        state.fx_params[1] = selector_bits as f32;
+
+        if let Some(invulnerability) = input.invulnerability {
+            state.fx_flags |= FX_INVULNERABILITY;
+            let brightness = invulnerability_tint_intensity(
+                invulnerability.mode,
+                invulnerability.elapsed_ticks,
+                invulnerability.intensity,
+            ) as f32
+                / 1000.0;
+            state.fx_params[2] = brightness;
+            state.effect_tint = [brightness, brightness, brightness, 1.0];
+        }
+
+        DrawDecision {
+            visible: true,
+            state,
+        }
+    }
+
+    /// Adapt simulation-owned producers without inventing missing native fields.
+    pub fn for_entity(entity: &GameEntity, current_frame: u32, remap_row: u32) -> DrawDecision {
+        let (warp_out, warp_in) = entity
+            .teleport_state
+            .as_ref()
+            .map(|teleport| (teleport.warp_out_active(), teleport.warp_in_active()))
+            .unwrap_or_default();
+        Self::resolve(
+            DrawStateInput {
+                warp_out,
+                warp_in,
+                // The current invulnerability producer has no authoritative YR
+                // +0x1A4 mode byte, so tint remains an explicit residual.
+                invulnerability: None,
+                ..DrawStateInput::default()
+            },
+            current_frame,
+            remap_row,
+        )
+    }
+}
+
+const TRANSLUCENCY_25: u8 = 0b010;
+const TRANSLUCENCY_50: u8 = 0b100;
+const TRANSLUCENCY_75: u8 = TRANSLUCENCY_25 | TRANSLUCENCY_50;
+
+/// `GetInvulnerabilityTintIntensity @ 0x0070e380`.
+pub fn invulnerability_tint_intensity(mode: u8, elapsed_ticks: u32, intensity: u32) -> u32 {
+    let t = elapsed_ticks as i64;
+    let scale = match mode {
+        1 => (12 - t) * 256 / 6,
+        2 | 8 => 512,
+        // Modes 3..5 are retained from the closed formula but are not asserted as
+        // exact across every native call path because the RE evidence records minor
+        // divider variance there.
+        3 => (461 * t + 1020) / 10,
+        4 => (1024 - 77 * t) / 8,
+        5 => (77 * t + 816) / 16,
+        6 => 51,
+        7 => (3072 - 461 * t) / 6,
+        9 => (t + 20) * 256 / 20,
+        _ => return intensity,
+    };
+    ((intensity as i64 * scale) >> 8).min(2000).max(0) as u32
+}
+
+/// `GetDisguiseFlags @ 0x0070ed80`'s 256-frame shimmer leaf.
+pub fn disguise_phase_percent(phase: u32) -> u8 {
+    match phase % 256 {
+        64..=67 | 76..=79 | 112..=115 | 124..=127 => 25,
+        68..=75 | 116..=123 => 50,
+        _ => 0,
+    }
+}
+
+/// `TechnoClass::VisualCharacter @ 0x00703860`'s transitional cloak phase.
+pub fn cloak_phase_256(depth: u32, cloaking_stages: u32) -> u32 {
+    depth.saturating_mul(256) / cloaking_stages.max(1)
+}
+
+/// `TechnoClass::VisualCharacter @ 0x00703860`'s drawn transitional band.
+pub fn cloak_visual_character(
+    depth: u32,
+    cloaking_stages: u32,
+    late_visible: bool,
+    force_visible_call: bool,
+) -> u8 {
+    if depth == 0 {
+        return 0;
+    }
+    match cloak_phase_256(depth, cloaking_stages) {
+        0..=63 => 1,
+        64..=127 => 2,
+        128..=191 => 3,
+        192..=254 if late_visible && !force_visible_call => 3,
+        192..=254 => 4,
+        _ => 5,
+    }
+}
+
+fn cloak_selector(cloak: Option<CloakDrawInput>) -> Option<(u8, bool)> {
+    let Some(cloak) = cloak else {
+        return Some((0, false));
+    };
+    if cloak.phase == CloakDrawPhase::FullyCloaked && !cloak.visible_to_observer {
+        return None;
+    }
+    if cloak.phase == CloakDrawPhase::FullyCloaked || cloak.depth == 0 {
+        return Some((0, false));
+    }
+
+    let visual_character = cloak_visual_character(
+        cloak.depth,
+        cloak.cloaking_stages,
+        cloak.late_visible,
+        cloak.force_visible_call,
+    );
+    match visual_character {
+        1 => Some((TRANSLUCENCY_25, true)),
+        2..=4 => Some((TRANSLUCENCY_50, true)),
+        _ => None,
+    }
+}
+
+fn selector_bits_for_percent(percent: u8) -> u8 {
+    match percent {
+        25 => TRANSLUCENCY_25,
+        50 => TRANSLUCENCY_50,
+        _ => 0,
+    }
+}
+
+fn opacity_for_selector_bits(bits: u8) -> f32 {
+    match bits & (TRANSLUCENCY_25 | TRANSLUCENCY_50) {
+        TRANSLUCENCY_25 => 0.75,
+        TRANSLUCENCY_50 => 0.5,
+        TRANSLUCENCY_75 => 0.25,
+        _ => 1.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::map::entities::EntityCategory;
+    use crate::sim::components::Health;
+    use crate::sim::game_entity::GameEntity;
+    use crate::sim::intern::InternedId;
+    use crate::sim::movement::teleport_movement::{TeleportPhase, TeleportState};
+    use crate::sim::superweapon::invulnerability::{InvulnKind, InvulnerabilityState};
+
+    fn entity() -> GameEntity {
+        GameEntity::new_at_frame(
+            1,
+            0,
+            0,
+            0,
+            0,
+            InternedId::from_index(0),
+            Health { current: 100, max: 100 },
+            InternedId::from_index(0),
+            EntityCategory::Unit,
+            0,
+            1,
+            true,
+            0,
+        )
+    }
+
+    #[test]
+    fn invulnerability_formula_matches_locked_yr_vectors() {
+        assert_eq!(invulnerability_tint_intensity(6, 0, 1000), 199);
+        assert_eq!(invulnerability_tint_intensity(2, 5, 1000), 2000);
+        assert_eq!(invulnerability_tint_intensity(7, 2, 1000), 1398);
+        assert_eq!(invulnerability_tint_intensity(1, 0, 1000), 2000);
+        assert_eq!(invulnerability_tint_intensity(9, 0, 1000), 1000);
+        assert_eq!(invulnerability_tint_intensity(0, 0, 777), 777);
+    }
+
+    #[test]
+    fn disguise_formula_matches_locked_yr_vectors() {
+        for (phase, expected) in [(0, 0), (64, 25), (70, 50), (78, 25), (100, 0), (120, 50), (126, 25), (200, 0)] {
+            assert_eq!(disguise_phase_percent(phase), expected);
+        }
+    }
+
+    #[test]
+    fn cloak_ramp_matches_locked_yr_vectors() {
+        assert_eq!(cloak_phase_256(1, 9), 28);
+        assert_eq!(cloak_phase_256(3, 9), 85);
+        assert_eq!(cloak_phase_256(8, 9), 227);
+        assert_eq!(cloak_visual_character(0, 9, false, false), 0);
+        assert_eq!(cloak_visual_character(1, 9, false, false), 1);
+        assert_eq!(cloak_visual_character(3, 9, false, false), 2);
+        assert_eq!(cloak_visual_character(5, 9, false, false), 3);
+        assert_eq!(cloak_visual_character(8, 9, false, false), 4);
+        assert_eq!(cloak_visual_character(9, 9, false, false), 5);
+        assert_eq!(cloak_visual_character(8, 9, true, false), 3);
+        assert_eq!(cloak_visual_character(8, 9, true, true), 4);
+    }
+
+    #[test]
+    fn fully_hidden_cloak_suppresses_the_base_draw() {
+        let decision = DrawState::resolve(
+            DrawStateInput {
+                cloak: Some(CloakDrawInput {
+                    phase: CloakDrawPhase::FullyCloaked,
+                    depth: 9,
+                    cloaking_stages: 9,
+                    late_visible: false,
+                    force_visible_call: false,
+                    visible_to_observer: false,
+                }),
+                ..DrawStateInput::default()
+            },
+            0,
+            3,
+        );
+        assert!(!decision.visible);
+    }
+
+    #[test]
+    fn visible_cloak_warp_disguise_tint_and_remap_stay_independent() {
+        let decision = DrawState::resolve(
+            DrawStateInput {
+                cloak: Some(CloakDrawInput {
+                    phase: CloakDrawPhase::Cloaking,
+                    depth: 1,
+                    cloaking_stages: 9,
+                    late_visible: false,
+                    force_visible_call: false,
+                    visible_to_observer: true,
+                }),
+                disguise: Some(DisguiseDrawInput {
+                    active: true,
+                    observer_is_allied: true,
+                    start_frame: 0,
+                }),
+                warp_out: true,
+                invulnerability: Some(InvulnerabilityTintInput {
+                    mode: 6,
+                    elapsed_ticks: 0,
+                    intensity: 1000,
+                }),
+                ..DrawStateInput::default()
+            },
+            0,
+            7,
+        );
+
+        assert!(decision.visible);
+        assert_eq!(decision.state.remap_row, 7);
+        assert_eq!(decision.state.fx_flags, FX_CLOAK | FX_WARP | FX_DISGUISE | FX_INVULNERABILITY);
+        assert_eq!(decision.state.fx_params[0], 0.25);
+        assert_eq!(decision.state.fx_params[1], 6.0);
+        assert_eq!(decision.state.effect_tint, [0.199, 0.199, 0.199, 1.0]);
+    }
+
+    #[test]
+    fn teleport_adapter_uses_distinct_producer_flags() {
+        let mut entity = entity();
+        entity.teleport_state = Some(TeleportState {
+            phase: TeleportPhase::ChronoDelay,
+            target_rx: 1,
+            target_ry: 2,
+            being_warped_ticks: 4,
+        });
+        let state = DrawState::for_entity(&entity, 45, 3).state;
+        assert_eq!(state.fx_flags, FX_WARP);
+        assert_eq!(state.fx_params[0], 0.5);
+    }
+
+    #[test]
+    fn invulnerability_without_native_mode_remains_an_explicit_residual() {
+        let mut entity = entity();
+        entity.invulnerability = Some(InvulnerabilityState {
+            start_frame: 40,
+            duration_frames: 20,
+            kind: InvulnKind::IronCurtain,
+        });
+        let state = DrawState::for_entity(&entity, 45, 3).state;
+        assert_eq!(state.fx_flags, 0);
+        assert_eq!(state.fx_params, [1.0, 0.0, 1.0, 0.0]);
+        assert_eq!(state.effect_tint, [1.0; 4]);
+    }
+
+    #[test]
+    fn expired_invulnerability_keeps_normal_draw_state() {
+        let mut entity = entity();
+        entity.invulnerability = Some(InvulnerabilityState {
+            start_frame: 40,
+            duration_frames: 5,
+            kind: InvulnKind::ForceShield,
+        });
+        let state = DrawState::for_entity(&entity, 45, 2).state;
+        assert_eq!(state.fx_flags, 0);
+        assert_eq!(state.effect_tint, [1.0; 4]);
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -21,6 +21,7 @@ pub mod bit_font;
 pub mod bridge_atlas;
 pub mod bridge_railing_atlas;
 pub mod cursor_atlas;
+pub mod draw_state;
 pub mod egui_integration;
 pub mod frame_readback;
 pub mod gpu;

--- a/src/render/sprite_atlas.rs
+++ b/src/render/sprite_atlas.rs
@@ -53,14 +53,32 @@ fn scan_building_anim_frame_count(
     );
     let data = candidates.iter().find_map(|c| asset_manager.get_ref(c))?;
     let shp = ShpFile::from_bytes(data).ok()?;
-    let real: u16 = (shp.frames.len() as u16) / 2;
-    Some(if real >= loop_end {
+    let raw_count = shp.frames.len() as u16;
+    let real: u16 = raw_count / 2;
+    let required_count = loop_end.max(1);
+    Some(if real > 0 && real >= required_count {
         real
-    } else if (shp.frames.len() as u16) >= loop_end {
-        loop_end
+    } else if raw_count >= required_count {
+        required_count
     } else {
-        shp.frames.len() as u16
+        raw_count
     })
+}
+
+fn insert_building_anim_frame_keys(
+    needed: &mut HashSet<ShpSpriteKey>,
+    anim_type: &str,
+    count: u16,
+    house_color: HouseColorIndex,
+) {
+    for frame in 0..count.max(1) {
+        needed.insert(ShpSpriteKey {
+            type_id: anim_type.to_string(),
+            facing: 0,
+            frame,
+            house_color,
+        });
+    }
 }
 
 /// Cache key: unique combination of object type, facing, and house color.
@@ -137,8 +155,9 @@ pub struct SpriteAtlas {
     /// Building type → number of make (build-up) animation frames.
     /// Key is the base type_id (e.g., "GACNST"), not the "_MAKE" suffixed key.
     pub make_frame_counts: HashMap<String, u16>,
-    /// ActiveAnim/ProductionAnim type → total frame count (non-shadow half).
-    /// Used by the renderer to cycle crane animations during production.
+    /// Building/world-animation type → available non-shadow frame count.
+    /// Building consumers use this only to ensure their live animation frame is
+    /// resident; world-effect systems also consume the same established map.
     pub active_anim_frame_counts: HashMap<String, u16>,
     /// Per-building-type bounding boxes for selection brackets and click picking.
     /// Computed by unioning all SHP frame rects for each building type.
@@ -489,9 +508,9 @@ pub fn build_sprite_atlas(
         }
     }
 
-    // Step 1b: Also collect building animation overlay SHPs (ActiveAnim, IdleAnim, etc.).
-    // IdleAnim/SuperAnim/SpecialAnim: only frame 0 (static or not yet animated).
-    // ActiveAnim/ProductionAnim: all frames (crane animation plays during production).
+    // Step 1b: Collect every declared building animation frame required by art
+    // metadata. Runtime owns timing; atlas construction only ensures that a
+    // live `BuildingAnimOverlays` frame is drawable.
     let mut active_anim_frame_counts: HashMap<String, u16> = HashMap::new();
     if let Some(art_reg) = art {
         let building_keys: Vec<ShpSpriteKey> = needed
@@ -508,127 +527,42 @@ pub fn build_sprite_atlas(
                 art_reg.resolve_metadata_entry(&key.type_id, &rules_image);
             if let Some(entry) = art_entry {
                 for anim in &entry.building_anims {
-                    let is_active: bool = matches!(
-                        anim.kind,
-                        crate::rules::art_data::BuildingAnimKind::Active
-                            | crate::rules::art_data::BuildingAnimKind::Production
-                    );
-                    if is_active {
-                        // Load all frames for active/production anims (crane, etc.).
-                        // Pre-scan the SHP to count frames, similar to make SHPs.
-                        let anim_upper: String = anim.anim_type.to_uppercase();
-                        if !active_anim_frame_counts.contains_key(&anim_upper) {
-                            let anim_image: String = art_reg
-                                .resolve_effective_image_id(&anim.anim_type, &anim.anim_type);
-                            let candidates: Vec<String> = art_data::anim_shp_candidates(
-                                Some(art_reg),
-                                &anim.anim_type,
-                                &anim_image,
-                                theater_ext,
-                                theater_name,
+                    // Original location: `RA2-GAME.EXE-IDB` canon,
+                    // `assets.unitShpFrameSelection.ra2yr.json` and
+                    // `assets.buildingDrawOffsets.ra2yr.json`: declared
+                    // Idle/Super/Special frames are chosen by the live object
+                    // animation state, not collapsed to atlas frame zero.
+                    let anim_upper: String = anim.anim_type.to_uppercase();
+                    if !active_anim_frame_counts.contains_key(&anim_upper) {
+                        if let Some(count) = scan_building_anim_frame_count(
+                            asset_manager,
+                            art_reg,
+                            &anim.anim_type,
+                            anim.loop_end,
+                            theater_ext,
+                            theater_name,
+                        ) {
+                            active_anim_frame_counts.insert(anim_upper.clone(), count);
+                            log::info!(
+                                "Building anim {} for {}: {} frames (kind={:?}, loop_end={})",
+                                anim.anim_type,
+                                key.type_id,
+                                count,
+                                anim.kind,
+                                anim.loop_end,
                             );
-                            if let Some(data) =
-                                candidates.iter().find_map(|c| asset_manager.get_ref(c))
-                            {
-                                if let Ok(shp) = ShpFile::from_bytes(data) {
-                                    // RA2 anim SHPs have shadow frames in second half.
-                                    let real: u16 = (shp.frames.len() as u16) / 2;
-                                    // Ensure we load at least loop_end frames so every
-                                    // frame in LoopStart..LoopEnd (exclusive) exists in
-                                    // the atlas. Guards against odd total frame counts
-                                    // where integer division would drop frames.
-                                    let count: u16 = if real >= anim.loop_end {
-                                        real
-                                    } else if (shp.frames.len() as u16) >= anim.loop_end {
-                                        anim.loop_end
-                                    } else {
-                                        shp.frames.len() as u16
-                                    };
-                                    active_anim_frame_counts.insert(anim_upper.clone(), count);
-                                    log::info!(
-                                        "ActiveAnim {} for {}: {} frames (shp total={}, shadow-split={}, loop_end={})",
-                                        anim.anim_type,
-                                        key.type_id,
-                                        count,
-                                        shp.frames.len(),
-                                        real,
-                                        anim.loop_end,
-                                    );
-                                }
-                            }
                         }
-                        let count: u16 = active_anim_frame_counts
-                            .get(&anim.anim_type.to_uppercase())
-                            .copied()
-                            .unwrap_or(1);
-                        for f in 0..count {
-                            needed.insert(ShpSpriteKey {
-                                type_id: anim.anim_type.clone(),
-                                facing: 0,
-                                frame: f,
-                                house_color: key.house_color,
-                            });
-                        }
-                    } else if matches!(anim.kind, crate::rules::art_data::BuildingAnimKind::Idle) {
-                        // IdleAnim loops continuously — load all frames (same as Active).
-                        let anim_upper: String = anim.anim_type.to_uppercase();
-                        if !active_anim_frame_counts.contains_key(&anim_upper) {
-                            let anim_image: String = art_reg
-                                .resolve_effective_image_id(&anim.anim_type, &anim.anim_type);
-                            let candidates: Vec<String> = art_data::anim_shp_candidates(
-                                Some(art_reg),
-                                &anim.anim_type,
-                                &anim_image,
-                                theater_ext,
-                                theater_name,
-                            );
-                            if let Some(data) =
-                                candidates.iter().find_map(|c| asset_manager.get_ref(c))
-                            {
-                                if let Ok(shp) = ShpFile::from_bytes(data) {
-                                    let real: u16 = (shp.frames.len() as u16) / 2;
-                                    // Same loop_end guard as ActiveAnim above.
-                                    let count: u16 = if real >= anim.loop_end {
-                                        real
-                                    } else if (shp.frames.len() as u16) >= anim.loop_end {
-                                        anim.loop_end
-                                    } else {
-                                        shp.frames.len() as u16
-                                    };
-                                    active_anim_frame_counts.insert(anim_upper.clone(), count);
-                                    log::info!(
-                                        "IdleAnim {} for {}: {} frames (shp total={}, shadow-split={}, loop_end={})",
-                                        anim.anim_type,
-                                        key.type_id,
-                                        count,
-                                        shp.frames.len(),
-                                        real,
-                                        anim.loop_end,
-                                    );
-                                }
-                            }
-                        }
-                        let count: u16 = active_anim_frame_counts
-                            .get(&anim.anim_type.to_uppercase())
-                            .copied()
-                            .unwrap_or(1);
-                        for f in 0..count {
-                            needed.insert(ShpSpriteKey {
-                                type_id: anim.anim_type.clone(),
-                                facing: 0,
-                                frame: f,
-                                house_color: key.house_color,
-                            });
-                        }
-                    } else {
-                        // Super/Special anims: frame 0 only (not yet animated).
-                        needed.insert(ShpSpriteKey {
-                            type_id: anim.anim_type.clone(),
-                            facing: 0,
-                            frame: 0,
-                            house_color: key.house_color,
-                        });
                     }
+                    let count = active_anim_frame_counts
+                        .get(&anim_upper)
+                        .copied()
+                        .unwrap_or(1);
+                    insert_building_anim_frame_keys(
+                        &mut needed,
+                        &anim.anim_type,
+                        count,
+                        key.house_color,
+                    );
 
                     for variant in [&anim.damaged_variant, &anim.garrisoned_variant] {
                         let Some(variant) = variant.as_ref() else {
@@ -659,14 +593,12 @@ pub fn build_sprite_atlas(
                             .get(&variant_upper)
                             .copied()
                             .unwrap_or(1);
-                        for f in 0..count {
-                            needed.insert(ShpSpriteKey {
-                                type_id: variant_type.to_string(),
-                                facing: 0,
-                                frame: f,
-                                house_color: key.house_color,
-                            });
-                        }
+                        insert_building_anim_frame_keys(
+                            &mut needed,
+                            variant_type,
+                            count,
+                            key.house_color,
+                        );
                     }
                 }
                 // BibShape: ground-level pad SHP (e.g., refinery dock GAREFNBB).

--- a/src/render/sprite_atlas_tests.rs
+++ b/src/render/sprite_atlas_tests.rs
@@ -104,6 +104,22 @@ fn test_different_houses_create_separate_keys() {
 }
 
 #[test]
+fn declared_special_animation_frames_are_all_preloaded() {
+    let mut needed = HashSet::new();
+    insert_building_anim_frame_keys(&mut needed, "GAREFNOR", 3, HouseColorIndex(2));
+
+    for frame in 0..3 {
+        assert!(needed.contains(&ShpSpriteKey {
+            type_id: "GAREFNOR".to_string(),
+            facing: 0,
+            frame,
+            house_color: HouseColorIndex(2),
+        }));
+    }
+    assert_eq!(needed.len(), 3);
+}
+
+#[test]
 fn collect_effect_names_includes_weapon_anim_entries() {
     let ini = crate::rules::ini_parser::IniFile::from_str(
         "\

--- a/src/render/sprite_voxel_shader.wgsl
+++ b/src/render/sprite_voxel_shader.wgsl
@@ -6,7 +6,7 @@
 //   if (byte == 0) discard;
 //   if (16 <= byte < 32) → rgb = house_ramp[house_idx][byte - 16]
 //   else                 → rgb = palette[byte]
-//   color = apply_fx(color, fx_flags, fx_params, ic_tint);
+//   color = apply_fx(color, fx_flags, fx_params, effect_tint);
 //   return rgb * tint, alpha;
 //
 // Bind groups:
@@ -39,10 +39,10 @@ struct Instance {
     @location(4) depth: f32,
     @location(5) tint: vec3f,
     @location(6) alpha: f32,
-    @location(7) house_color_idx: u32,
+    @location(7) remap_row: u32,
     @location(8) fx_flags: u32,
     @location(9) fx_params: vec4f,
-    @location(10) ic_tint: vec4f,
+    @location(10) effect_tint: vec4f,
 };
 
 struct VertexOutput {
@@ -50,10 +50,10 @@ struct VertexOutput {
     @location(0) atlas_uv: vec2f,
     @location(1) tint: vec3f,
     @location(2) alpha: f32,
-    @location(3) @interpolate(flat) house_color_idx: u32,
+    @location(3) @interpolate(flat) remap_row: u32,
     @location(4) @interpolate(flat) fx_flags: u32,
     @location(5) fx_params: vec4f,
-    @location(6) ic_tint: vec4f,
+    @location(6) effect_tint: vec4f,
 };
 
 @vertex
@@ -88,26 +88,20 @@ fn vs_main(
     out.atlas_uv = instance.uv_origin + quad_uv[idx] * instance.uv_size;
     out.tint = instance.tint;
     out.alpha = instance.alpha;
-    out.house_color_idx = instance.house_color_idx;
+    out.remap_row = instance.remap_row;
     out.fx_flags = instance.fx_flags;
     out.fx_params = instance.fx_params;
-    out.ic_tint = instance.ic_tint;
+    out.effect_tint = instance.effect_tint;
     return out;
 }
 
-fn apply_fx(color: vec4f, flags: u32, params: vec4f, ic: vec4f) -> vec4f {
-    // Phase 1 stub: future phases (cloak/EMP/IC/warp) wire branches here.
-    var c = color;
-    if ((flags & 1u) != 0u) { c.a = c.a * params.x; }                // cloak
-    if ((flags & 2u) != 0u) {                                        // EMP
-        let luma = dot(c.rgb, vec3f(0.299, 0.587, 0.114));
-        c = vec4f(mix(c.rgb, vec3f(luma), params.y), c.a);
-    }
-    if ((flags & 4u) != 0u) {                                        // iron curtain
-        c = vec4f(mix(c.rgb, ic.rgb, ic.a), c.a);
-    }
-    if ((flags & 8u) != 0u) { c.a = c.a * params.w; }                // warp
-    return c;
+fn apply_fx(color: vec4f, _flags: u32, params: vec4f, effect_tint: vec4f) -> vec4f {
+    // Original location: `RA2-GAME.EXE-IDB` canon,
+    // `rendering.drawStateEffects.ra2yr.json`; the same branch exists in the
+    // SHP shader so representation does not affect active visual state.
+    // Match the SHP path exactly: selector opacity plus independent YR
+    // invulnerability brightness, with no inferred EMP or mirror styling.
+    return vec4f(color.rgb * effect_tint.rgb, color.a * params.x);
 }
 
 @fragment
@@ -125,7 +119,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     // others sample the theater palette directly.
     var rgb: vec3f;
     if (byte >= 16u && byte < 32u) {
-        let ramp_coord: vec2i = vec2i(i32(byte - 16u), i32(in.house_color_idx));
+        let ramp_coord: vec2i = vec2i(i32(byte - 16u), i32(in.remap_row));
         rgb = textureLoad(house_ramp, ramp_coord, 0).rgb;
     } else {
         let palette_coord: vec2i = vec2i(i32(byte), 0);
@@ -133,6 +127,6 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
     }
 
     var color: vec4f = vec4f(rgb * in.tint, in.alpha);
-    color = apply_fx(color, in.fx_flags, in.fx_params, in.ic_tint);
+    color = apply_fx(color, in.fx_flags, in.fx_params, in.effect_tint);
     return color;
 }

--- a/src/render/unit_atlas.rs
+++ b/src/render/unit_atlas.rs
@@ -655,7 +655,7 @@ pub(crate) fn render_unit_sprite_with_slope_blend(
     };
 
     // House remap is no longer applied at bake time — the fragment shader
-    // does it via per-instance house_color_idx + house_ramp texture lookup.
+    // does it via per-instance DrawState::remap_row + house_ramp texture lookup.
     // The rasterizer outputs post-VPL palette indices directly.
 
     // Branch based on layer: Composite renders all parts together,

--- a/src/sim/game_entity.rs
+++ b/src/sim/game_entity.rs
@@ -32,9 +32,11 @@ use crate::sim::intern::InternedId;
 use crate::sim::miner::Miner;
 use crate::sim::mission::{MissionCom, MissionLeafState, MissionTimer, MissionType};
 use crate::sim::movement::drive_track::{DriveTrackState, ForcedDriveTrackState};
+use crate::sim::movement::drop_pod_movement::DropPodState;
 use crate::sim::movement::locomotor::LocomotorState;
 use crate::sim::movement::rocket_movement::RocketState;
 use crate::sim::movement::teleport_movement::TeleportState;
+use crate::sim::movement::tunnel_movement::TunnelState;
 use crate::sim::movement::tube_movement::LowBridgeTubeMovementState;
 use crate::sim::passenger::PassengerRole;
 use crate::sim::radio::Contacts;
@@ -337,6 +339,10 @@ pub struct GameEntity {
     /// locomotor.layer. Set during spawn, updated at cell-crossing bridge transitions.
     #[serde(default)]
     pub on_bridge: bool,
+    /// Runtime-only Foot bridge mismatch latch (`FootClass+0x68b` in YR).
+    #[serde(default)]
+    pub(crate) runtime_bridge_transition:
+        crate::sim::movement::movement_bridge::RuntimeBridgeTransitionState,
     /// Infantry sprite animation state (sequence + frame + timing).
     pub animation: Option<Animation>,
     /// Voxel HVA animation state (frame cycling for multi-frame models).
@@ -351,6 +357,10 @@ pub struct GameEntity {
     pub order_intent: Option<OrderIntent>,
     /// Teleport movement state machine (warp out/in phases).
     pub teleport_state: Option<TeleportState>,
+    /// Dormant YR TunnelLocomotionClass process state. Its underground depth
+    /// lives in the typed runtime, because `Position::z` cannot represent -256.
+    #[serde(default)]
+    pub tunnel_state: Option<TunnelState>,
     /// Active low-bridge TubeClass movement. Active YR behaviour — not to be
     /// confused with the subterranean tunnel locomotor, which is Tiberian Sun
     /// legacy and was removed as unreachable in stock YR.
@@ -358,6 +368,10 @@ pub struct GameEntity {
     pub low_bridge_tube_state: Option<LowBridgeTubeMovementState>,
     /// Rocket/missile flight state machine (launch/ascend/terminal/detonate).
     pub rocket_state: Option<RocketState>,
+    /// Distinct DropPodLocomotionClass descent state; never shares parachute
+    /// state or surface occupation while airborne.
+    #[serde(default)]
+    pub drop_pod_state: Option<DropPodState>,
     /// Homing missile flight state. `Some` while this entity is an in-flight
     /// homing projectile; `None` otherwise. Distinct from `rocket_state` —
     /// ballistic-arc rockets keep using `rocket_state`; only `Ranged=yes`
@@ -688,6 +702,7 @@ impl GameEntity {
             damage_fire_anim_ids: [None; 8],
             bridge_occupancy: None,
             on_bridge: false,
+            runtime_bridge_transition: Default::default(),
             animation: None,
             voxel_animation: None,
             harvest_overlay: None,
@@ -695,8 +710,10 @@ impl GameEntity {
             slave_harvester: None,
             order_intent: None,
             teleport_state: None,
+            tunnel_state: None,
             low_bridge_tube_state: None,
             rocket_state: None,
+            drop_pod_state: None,
             homing_state: None,
             parachute_state: None,
             invulnerability: None,

--- a/src/sim/miner/miner_system.rs
+++ b/src/sim/miner/miner_system.rs
@@ -1955,7 +1955,7 @@ pub(crate) fn issue_stock_miner_drive_move(
                 let snapshot = (
                     locomotor.kind,
                     locomotor.slot,
-                    locomotor.piggyback,
+                    locomotor.piggyback.clone(),
                     locomotor.layer,
                     locomotor.phase,
                 );

--- a/src/sim/miner/outbound_drive_tests.rs
+++ b/src/sim/miner/outbound_drive_tests.rs
@@ -467,7 +467,7 @@ fn locomotor_tuple(
     (
         locomotor.kind,
         locomotor.slot,
-        locomotor.piggyback,
+        locomotor.piggyback.clone(),
         locomotor.layer,
         locomotor.phase,
     )
@@ -518,7 +518,11 @@ fn production_stock_miners_use_drive_command_for_adjacent_ore() {
                     LocomotorSlot::from_kind(LocomotorKind::Teleport)
                 );
                 assert_eq!(
-                    locomotor.piggyback.expect("CMIN Drive piggyback").kind,
+                    locomotor
+                        .piggyback
+                        .as_ref()
+                        .expect("CMIN Drive piggyback")
+                        .kind,
                     LocomotorKind::Teleport,
                 );
             } else {

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -110,6 +110,7 @@ pub mod game_options;
 pub mod house_state;
 
 // --- Trigger runtime (map trigger evaluation during gameplay) ---
+pub mod team_script_vm;
 pub mod trigger_runtime;
 
 // --- AI, replay, selection, debug ---

--- a/src/sim/movement/drop_pod_movement.rs
+++ b/src/sim/movement/drop_pod_movement.rs
@@ -1,0 +1,215 @@
+//! DropPod locomotor — independent descent and landing controller.
+//!
+//! `DropPodLocomotionClass::Process` (`0x004b5b70`) is not Parachute: while
+//! airborne it emits a six-frame smoke cadence and a three-frame ground-damage
+//! cadence, then atomically either Unlimbos or crushes and destroys at landing.
+//! This module reports those effects; the world owner applies animation, damage,
+//! occupancy and lifecycle changes in the same master-frame rung.
+
+use crate::util::fixed_math::{SimFixed, SIM_ONE, SIM_ZERO};
+
+use super::rocket_movement::SpecialMovementOutcome;
+
+const SMOKE_TRAIL_INTERVAL: u32 = 6;
+const GROUND_DAMAGE_INTERVAL: u32 = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum DropPodPhase {
+    Descending,
+    Landed,
+    Destroyed,
+}
+
+/// Serializable active DropPod runtime. No ground occupation is owned while
+/// `phase == Descending`; a successful landing atomically hands that ownership
+/// to the caller's Unlimbo path.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DropPodState {
+    pub phase: DropPodPhase,
+    pub target_rx: u16,
+    pub target_ry: u16,
+    pub altitude: SimFixed,
+    /// Native-derived fall amount: `max(speed / 10 + 2, minimum_speed)`.
+    pub descent_speed: SimFixed,
+    pub elapsed_frames: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DropPodLanding {
+    /// `Unlimbo`/`CanEnterCell` accepted the target. Caller must mark exactly
+    /// once, open the pod and then complete the special locomotor.
+    UnlimboSucceeded,
+    /// The target did not admit the unit. Caller must apply crush damage and
+    /// destroy the pod in the same transaction; it must never become occupied.
+    Blocked,
+}
+
+/// Effects requested by one `DropPodLocomotionClass::Process` frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DropPodFrameEffects {
+    pub spawn_smoke_trail: bool,
+    pub apply_ground_damage: bool,
+    pub spawn_ground_debris: bool,
+    pub open_pod: bool,
+    pub apply_blocked_landing_crush: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DropPodProcessResult {
+    pub outcome: SpecialMovementOutcome,
+    pub effects: DropPodFrameEffects,
+}
+
+/// Initialize a distinct DropPod process. It deliberately does not alter an
+/// entity's base locomotor or use parachute state.
+pub fn begin_drop_pod_state(
+    target: (u16, u16),
+    altitude: SimFixed,
+    locomotor_speed: SimFixed,
+    minimum_speed: SimFixed,
+) -> DropPodState {
+    let derived_speed = locomotor_speed / SimFixed::from_num(10) + SimFixed::from_num(2);
+    DropPodState {
+        phase: DropPodPhase::Descending,
+        target_rx: target.0,
+        target_ry: target.1,
+        altitude: altitude.max(SIM_ZERO),
+        descent_speed: derived_speed.max(minimum_speed).max(SIM_ONE),
+        elapsed_frames: 0,
+    }
+}
+
+/// Process one DropPod frame.
+///
+/// `landing` is read only when altitude reaches zero. Passing `None` then is an
+/// intentional abort: callers must supply one atomic placement decision rather
+/// than split admission from destruction across frames.
+pub fn process_drop_pod_state(
+    state: &mut DropPodState,
+    landing: Option<DropPodLanding>,
+) -> DropPodProcessResult {
+    match state.phase {
+        DropPodPhase::Descending => {
+            state.elapsed_frames = state.elapsed_frames.saturating_add(1);
+            let effects = DropPodFrameEffects {
+                spawn_smoke_trail: state.elapsed_frames.is_multiple_of(SMOKE_TRAIL_INTERVAL),
+                apply_ground_damage: state.elapsed_frames.is_multiple_of(GROUND_DAMAGE_INTERVAL),
+                spawn_ground_debris: state.elapsed_frames.is_multiple_of(GROUND_DAMAGE_INTERVAL),
+                ..DropPodFrameEffects::default()
+            };
+            state.altitude = (state.altitude - state.descent_speed).max(SIM_ZERO);
+            if state.altitude > SIM_ZERO {
+                return DropPodProcessResult {
+                    outcome: SpecialMovementOutcome::Continue,
+                    effects,
+                };
+            }
+
+            match landing {
+                Some(DropPodLanding::UnlimboSucceeded) => {
+                    state.phase = DropPodPhase::Landed;
+                    DropPodProcessResult {
+                        outcome: SpecialMovementOutcome::Complete,
+                        effects: DropPodFrameEffects {
+                            open_pod: true,
+                            ..effects
+                        },
+                    }
+                }
+                Some(DropPodLanding::Blocked) => {
+                    state.phase = DropPodPhase::Destroyed;
+                    DropPodProcessResult {
+                        outcome: SpecialMovementOutcome::Abort,
+                        effects: DropPodFrameEffects {
+                            apply_blocked_landing_crush: true,
+                            ..effects
+                        },
+                    }
+                }
+                None => {
+                    state.phase = DropPodPhase::Destroyed;
+                    DropPodProcessResult {
+                        outcome: SpecialMovementOutcome::Abort,
+                        effects,
+                    }
+                }
+            }
+        }
+        DropPodPhase::Landed => DropPodProcessResult {
+            outcome: SpecialMovementOutcome::Complete,
+            effects: DropPodFrameEffects::default(),
+        },
+        DropPodPhase::Destroyed => DropPodProcessResult {
+            outcome: SpecialMovementOutcome::Abort,
+            effects: DropPodFrameEffects::default(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn drop_pod_is_not_parachute_and_keeps_airborne_effect_cadences() {
+        let mut state = begin_drop_pod_state(
+            (10, 12),
+            SimFixed::from_num(20),
+            SimFixed::from_num(10),
+            SimFixed::from_num(1),
+        );
+        assert_eq!(state.descent_speed, SimFixed::from_num(3));
+
+        let mut smoke = 0;
+        let mut damage = 0;
+        for _ in 0..6 {
+            let result = process_drop_pod_state(&mut state, Some(DropPodLanding::UnlimboSucceeded));
+            smoke += u32::from(result.effects.spawn_smoke_trail);
+            damage += u32::from(result.effects.apply_ground_damage);
+            assert_eq!(result.outcome, SpecialMovementOutcome::Continue);
+        }
+        assert_eq!(smoke, 1);
+        assert_eq!(damage, 2);
+    }
+
+    #[test]
+    fn landing_unlimbo_and_blocked_crush_are_atomic_and_exclusive() {
+        let mut landed = begin_drop_pod_state(
+            (1, 1),
+            SimFixed::from_num(1),
+            SimFixed::from_num(1),
+            SimFixed::from_num(1),
+        );
+        let success = process_drop_pod_state(&mut landed, Some(DropPodLanding::UnlimboSucceeded));
+        assert_eq!(success.outcome, SpecialMovementOutcome::Complete);
+        assert!(success.effects.open_pod);
+        assert!(!success.effects.apply_blocked_landing_crush);
+
+        let mut blocked = begin_drop_pod_state(
+            (1, 1),
+            SimFixed::from_num(1),
+            SimFixed::from_num(1),
+            SimFixed::from_num(1),
+        );
+        let failure = process_drop_pod_state(&mut blocked, Some(DropPodLanding::Blocked));
+        assert_eq!(failure.outcome, SpecialMovementOutcome::Abort);
+        assert!(failure.effects.apply_blocked_landing_crush);
+        assert!(!failure.effects.open_pod);
+        assert_eq!(blocked.phase, DropPodPhase::Destroyed);
+    }
+
+    #[test]
+    fn missing_atomic_placement_decision_aborts_instead_of_occupying() {
+        let mut state = begin_drop_pod_state(
+            (1, 1),
+            SimFixed::from_num(1),
+            SimFixed::from_num(1),
+            SimFixed::from_num(1),
+        );
+        assert_eq!(
+            process_drop_pod_state(&mut state, None).outcome,
+            SpecialMovementOutcome::Abort
+        );
+        assert_eq!(state.phase, DropPodPhase::Destroyed);
+    }
+}

--- a/src/sim/movement/locomotion/mod.rs
+++ b/src/sim/movement/locomotion/mod.rs
@@ -15,5 +15,8 @@ pub mod power;
 pub mod slot;
 
 pub use install::{resolve_installed_class, resolve_installed_kind};
-pub use piggyback::{BeginOutcome, StashedLocomotor};
+pub use piggyback::{
+    BeginOutcome, EndGateContext, EndOutcome, LocomotorCommonRuntime, LocomotorRuntime,
+    LocomotorRuntimePayload, StashedLocomotor,
+};
 pub use slot::LocomotorSlot;

--- a/src/sim/movement/locomotion/piggyback.rs
+++ b/src/sim/movement/locomotion/piggyback.rs
@@ -1,65 +1,27 @@
 //! The one piggyback mechanism: a locomotor temporarily displacing another.
 //!
-//! ## The native protocol
-//!
-//! A locomotor that takes over stores the displaced one *inside itself*, in a
-//! single stash slot, and the protocol around that slot is short and strict:
-//!
-//! - **BEGIN** takes the outgoing locomotor. It fails with a pointer error on a
-//!   null argument, and — the load-bearing part — **fails outright if the stash
-//!   slot is already occupied**. Only then does it store the pointer and take a
-//!   reference. Nesting is refused by the engine, not merely avoided by callers.
-//! - **END** hands the stashed pointer back out and clears the slot, returning a
-//!   distinct "nothing was stashed" result when the slot is empty. Ownership
-//!   moves to the caller: BEGIN takes a reference, END does not drop one.
-//! - **The end gate** is dominated by movement. Drive's reads
-//!   `!Is_Moving() && stash_present && <own flag> && !host_flag`, with the
-//!   `Is_Moving` call first — a moving unit can never unwind its piggyback.
-//!
-//! Two things follow for the Rust model, and both are why this module replaces
-//! two earlier ones rather than joining them:
-//!
-//! 1. **There is one slot, so there is one mechanism.** The previous
-//!    `PiggybackLocomotor` stashed only a kind and a layer while
-//!    `OverrideLocomotor` stashed a whole boxed clone, and the two had separate
-//!    begin/end APIs for the same native slot. A unit could hold both at once,
-//!    which the engine's E_FAIL makes impossible.
-//! 2. **Non-nesting is enforced by the type here**, not by a runtime check that
-//!    a caller might skip: [`StashedLocomotor`] holds the restorable state and
-//!    has no stash field of its own, so a stash cannot contain a stash.
-//!
-//! ## What this module does NOT yet model
-//!
-//! Per-class end gates beyond the movement clause. Drive's gate reads its own
-//! flag byte and one host flag; Jumpjet's host clause is an OR rather than a
-//! single test, and Teleport's gate is a multi-valued phase index rather than a
-//! boolean — a single shared boolean would make Teleport's gate constant-true
-//! and let a piggyback unwind mid-warp. [`is_ok_to_end`] therefore models only
-//! the movement clause and the stash-present clause, both of which are shared by
-//! every class, and the per-class clauses are **UNCHECKED** and unimplemented.
-//! The gate is conservative in the direction that matters: it never permits an
-//! end that the movement clause would refuse.
-//!
-//! ## Dependency rules
-//! - Part of sim/ — depends on rules/ and sibling movement state only.
-//! - sim/ NEVER depends on render/, ui/, sidebar/, audio/, net/.
+//! `WalkLocomotionClass::IPiggyback::{BeginPiggyback,EndPiggyback}` owns one
+//! suspended `ILocomotion` reference. BEGIN takes that complete object, END
+//! transfers the same object back, and Walk save/load serializes it as a nested
+//! COM object. The Rust seam mirrors ownership, not COM refcounts.
 
-use crate::rules::locomotor_type::{LocomotorKind, SpeedType};
+use std::ops::Deref;
+
+use crate::rules::locomotor_type::{LocomotorKind, MovementZone, SpeedType};
 use crate::util::fixed_math::SimFixed;
 
 use super::super::locomotor::{AirMovePhase, GroundMovePhase, LocomotorState, MovementLayer};
 
-/// The displaced locomotor, held by the one that took over.
-///
-/// Deliberately a flat record and not a boxed `LocomotorState`: it carries the
-/// state that restoring must put back and **cannot itself hold a stash**, which
-/// is what makes nesting unrepresentable rather than merely rejected.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct StashedLocomotor {
-    pub kind: LocomotorKind,
-    pub layer: MovementLayer,
+/// Runtime state shared by every locomotor object, independent of its installed
+/// class identity. This is what moves as one object through the piggyback slot.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct LocomotorCommonRuntime {
+    pub powered: bool,
+    pub phase: GroundMovePhase,
     pub air_phase: AirMovePhase,
     pub speed_multiplier: SimFixed,
+    pub speed_fraction: SimFixed,
+    pub fly_current_speed: SimFixed,
     pub altitude: SimFixed,
     pub target_altitude: SimFixed,
     pub climb_rate: SimFixed,
@@ -72,220 +34,371 @@ pub struct StashedLocomotor {
     pub balloon_hover: bool,
     pub hover_attack: bool,
     pub speed_type: SpeedType,
+    pub movement_zone: MovementZone,
+    pub rot: i32,
+    pub air_progress: SimFixed,
+    pub infantry_wobble_phase: f32,
+    pub subcell_dest: Option<(SimFixed, SimFixed)>,
+    pub hover_throttle: SimFixed,
+    pub hover_speed_request: SimFixed,
+    pub hover_bob_offset: SimFixed,
 }
 
-impl StashedLocomotor {
-    /// Capture the currently-driving locomotor so it can be restored later.
+/// Class-local state that travels with the locomotor object.
+///
+/// The current movement implementation has not yet moved the special process
+/// fields from their entity adapters, so their payloads are deliberately typed
+/// placeholders. They prevent another flat stash from silently losing a special
+/// locomotor's identity when those fields move here in the next wave.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum LocomotorRuntimePayload {
+    Drive,
+    Walk,
+    Teleport { phase: u8 },
+    Tunnel { state: u8 },
+    Rocket { state: u8 },
+    DropPod { descent_ticks: u32 },
+    Hover,
+    Mech,
+    Ship,
+    Fly,
+    Jumpjet,
+    Parachute,
+}
+
+impl LocomotorRuntimePayload {
+    fn for_kind(kind: LocomotorKind) -> Self {
+        match kind {
+            LocomotorKind::Drive => Self::Drive,
+            LocomotorKind::Walk => Self::Walk,
+            LocomotorKind::Teleport => Self::Teleport { phase: 0 },
+            LocomotorKind::Tunnel => Self::Tunnel { state: 0 },
+            LocomotorKind::Rocket => Self::Rocket { state: 0 },
+            LocomotorKind::DropPod => Self::DropPod { descent_ticks: 0 },
+            LocomotorKind::Hover => Self::Hover,
+            LocomotorKind::Mech => Self::Mech,
+            LocomotorKind::Ship => Self::Ship,
+            LocomotorKind::Fly => Self::Fly,
+            LocomotorKind::Jumpjet => Self::Jumpjet,
+            LocomotorKind::Parachute => Self::Parachute,
+        }
+    }
+}
+
+/// One complete movable locomotor instance. Installed identity remains on the
+/// host `LocomotorState`; this object is the active or suspended implementation.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct LocomotorRuntime {
+    pub kind: LocomotorKind,
+    pub layer: MovementLayer,
+    pub common: LocomotorCommonRuntime,
+    pub payload: LocomotorRuntimePayload,
+}
+
+impl LocomotorRuntime {
+    /// Capture all active runtime-owned state without copying the host's
+    /// installed slot or piggyback pointer.
     pub fn capture(state: &LocomotorState) -> Self {
         Self {
             kind: state.kind,
             layer: state.layer,
-            air_phase: state.air_phase,
-            speed_multiplier: state.speed_multiplier,
-            altitude: state.altitude,
-            target_altitude: state.target_altitude,
-            climb_rate: state.climb_rate,
-            jumpjet_speed: state.jumpjet_speed,
-            jumpjet_accel: state.jumpjet_accel,
-            jumpjet_current_speed: state.jumpjet_current_speed,
-            jumpjet_deviation: state.jumpjet_deviation,
-            jumpjet_crash_speed: state.jumpjet_crash_speed,
-            jumpjet_turn_rate: state.jumpjet_turn_rate,
-            balloon_hover: state.balloon_hover,
-            hover_attack: state.hover_attack,
-            speed_type: state.speed_type,
+            common: LocomotorCommonRuntime {
+                powered: state.powered,
+                phase: state.phase,
+                air_phase: state.air_phase,
+                speed_multiplier: state.speed_multiplier,
+                speed_fraction: state.speed_fraction,
+                fly_current_speed: state.fly_current_speed,
+                altitude: state.altitude,
+                target_altitude: state.target_altitude,
+                climb_rate: state.climb_rate,
+                jumpjet_speed: state.jumpjet_speed,
+                jumpjet_accel: state.jumpjet_accel,
+                jumpjet_current_speed: state.jumpjet_current_speed,
+                jumpjet_deviation: state.jumpjet_deviation,
+                jumpjet_crash_speed: state.jumpjet_crash_speed,
+                jumpjet_turn_rate: state.jumpjet_turn_rate,
+                balloon_hover: state.balloon_hover,
+                hover_attack: state.hover_attack,
+                speed_type: state.speed_type,
+                movement_zone: state.movement_zone,
+                rot: state.rot,
+                air_progress: state.air_progress,
+                infantry_wobble_phase: state.infantry_wobble_phase,
+                subcell_dest: state.subcell_dest,
+                hover_throttle: state.hover_throttle,
+                hover_speed_request: state.hover_speed_request,
+                hover_bob_offset: state.hover_bob_offset,
+            },
+            payload: LocomotorRuntimePayload::for_kind(state.kind),
         }
+    }
+
+    /// Build an incoming runtime from the current host defaults. New callers
+    /// should prefer `begin_with_runtime` when they already own an instance.
+    pub fn replacement_from(state: &LocomotorState, kind: LocomotorKind, layer: MovementLayer) -> Self {
+        let mut runtime = Self::capture(state);
+        runtime.kind = kind;
+        runtime.layer = layer;
+        runtime.common.phase = GroundMovePhase::Idle;
+        runtime.common.air_phase = AirMovePhase::Landed;
+        runtime.payload = LocomotorRuntimePayload::for_kind(kind);
+        runtime
+    }
+
+    fn install_into(self, state: &mut LocomotorState) {
+        state.kind = self.kind;
+        state.layer = self.layer;
+        state.powered = self.common.powered;
+        state.phase = self.common.phase;
+        state.air_phase = self.common.air_phase;
+        state.speed_multiplier = self.common.speed_multiplier;
+        state.speed_fraction = self.common.speed_fraction;
+        state.fly_current_speed = self.common.fly_current_speed;
+        state.altitude = self.common.altitude;
+        state.target_altitude = self.common.target_altitude;
+        state.climb_rate = self.common.climb_rate;
+        state.jumpjet_speed = self.common.jumpjet_speed;
+        state.jumpjet_accel = self.common.jumpjet_accel;
+        state.jumpjet_current_speed = self.common.jumpjet_current_speed;
+        state.jumpjet_deviation = self.common.jumpjet_deviation;
+        state.jumpjet_crash_speed = self.common.jumpjet_crash_speed;
+        state.jumpjet_turn_rate = self.common.jumpjet_turn_rate;
+        state.balloon_hover = self.common.balloon_hover;
+        state.hover_attack = self.common.hover_attack;
+        state.speed_type = self.common.speed_type;
+        state.movement_zone = self.common.movement_zone;
+        state.rot = self.common.rot;
+        state.air_progress = self.common.air_progress;
+        state.infantry_wobble_phase = self.common.infantry_wobble_phase;
+        state.subcell_dest = self.common.subcell_dest;
+        state.hover_throttle = self.common.hover_throttle;
+        state.hover_speed_request = self.common.hover_speed_request;
+        state.hover_bob_offset = self.common.hover_bob_offset;
+    }
+}
+
+/// A boxed suspended locomotor instance. The box corresponds to the single
+/// nested COM object persisted by WalkLocomotionClass::Save.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct StashedLocomotor(Box<LocomotorRuntime>);
+
+impl StashedLocomotor {
+    pub fn capture(state: &LocomotorState) -> Self {
+        Self(Box::new(LocomotorRuntime::capture(state)))
+    }
+
+    pub fn from_runtime(runtime: LocomotorRuntime) -> Self {
+        Self(Box::new(runtime))
+    }
+
+    pub fn into_runtime(self) -> LocomotorRuntime {
+        *self.0
+    }
+}
+
+impl Deref for StashedLocomotor {
+    type Target = LocomotorRuntime;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
 /// The outcome of a BEGIN, mirroring the native tri-state return.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BeginOutcome {
-    /// The displaced locomotor was stashed and the new one is now driving.
     Installed,
-    /// The stash slot was already occupied. Native returns `E_FAIL` here and
-    /// changes nothing; so does this. Callers that must succeed have to END
-    /// first — which is what the engine's own end-first BEGIN sites do.
+    RefusedNull,
     RefusedNested,
 }
 
-/// Stash the currently-driving locomotor and install `kind`/`layer` over it.
-///
-/// Refuses — changing nothing — when a stash is already present.
-pub fn begin(
-    state: &mut LocomotorState,
-    kind: LocomotorKind,
-    layer: MovementLayer,
-) -> BeginOutcome {
+/// The ownership result of END. `Empty` is native `S_FALSE`; `RefusedNull`
+/// represents the native null output pointer, which Rust callers avoid by using
+/// `end` or supplying a real destination to `end_into`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndOutcome {
+    Restored,
+    Empty,
+    RefusedNull,
+}
+
+/// Stash the active complete runtime and install `incoming` as the new active
+/// locomotor. An occupied slot is an atomic E_FAIL-style refusal.
+pub fn begin_with_runtime(state: &mut LocomotorState, incoming: Option<LocomotorRuntime>) -> BeginOutcome {
+    let Some(incoming) = incoming else {
+        return BeginOutcome::RefusedNull;
+    };
     if state.piggyback.is_some() {
         return BeginOutcome::RefusedNested;
     }
+
     state.piggyback = Some(StashedLocomotor::capture(state));
-    state.kind = kind;
-    state.layer = layer;
-    state.phase = GroundMovePhase::Idle;
-    state.air_phase = AirMovePhase::Landed;
+    incoming.install_into(state);
     BeginOutcome::Installed
 }
 
-/// Pop the stash and restore the locomotor it holds.
-///
-/// Returns the restored record, or `None` when nothing was stashed — the native
-/// `S_FALSE` case. The slot is cleared before the restore is applied, so the
-/// stash is observably empty at the moment the previous locomotor takes over
-/// again, matching the native null window.
+/// Compatibility adapter for callers that name only a replacement class. It
+/// still transfers one complete current runtime into the suspended slot.
+pub fn begin(state: &mut LocomotorState, kind: LocomotorKind, layer: MovementLayer) -> BeginOutcome {
+    let incoming = LocomotorRuntime::replacement_from(state, kind, layer);
+    begin_with_runtime(state, Some(incoming))
+}
+
+/// Transfer the suspended runtime into an explicit output location. The active
+/// state is unchanged because native END transfers an interface; the caller
+/// decides when to install it.
+pub fn end_into(state: &mut LocomotorState, output: Option<&mut Option<LocomotorRuntime>>) -> EndOutcome {
+    let Some(output) = output else {
+        return EndOutcome::RefusedNull;
+    };
+    let Some(stashed) = state.piggyback.take() else {
+        return EndOutcome::Empty;
+    };
+    *output = Some(stashed.into_runtime());
+    EndOutcome::Restored
+}
+
+/// Transfer the suspended runtime back to the host and make it active.
 pub fn end(state: &mut LocomotorState) -> Option<StashedLocomotor> {
     let stashed = state.piggyback.take()?;
-    state.kind = stashed.kind;
-    state.layer = stashed.layer;
-    state.phase = GroundMovePhase::Idle;
-    state.air_phase = stashed.air_phase;
-    state.speed_multiplier = stashed.speed_multiplier;
-    state.altitude = stashed.altitude;
-    state.target_altitude = stashed.target_altitude;
-    state.climb_rate = stashed.climb_rate;
-    state.jumpjet_speed = stashed.jumpjet_speed;
-    state.jumpjet_accel = stashed.jumpjet_accel;
-    state.jumpjet_current_speed = stashed.jumpjet_current_speed;
-    state.jumpjet_deviation = stashed.jumpjet_deviation;
-    state.jumpjet_crash_speed = stashed.jumpjet_crash_speed;
-    state.jumpjet_turn_rate = stashed.jumpjet_turn_rate;
-    state.balloon_hover = stashed.balloon_hover;
-    state.hover_attack = stashed.hover_attack;
-    state.speed_type = stashed.speed_type;
-    Some(stashed)
+    let restored = stashed.clone();
+    stashed.into_runtime().install_into(state);
+    Some(restored)
+}
+
+/// The nested-runtime save marker used by the clean-room snapshot seam.
+/// Serde persists the following boxed runtime only when this returns one.
+pub fn serialized_presence(state: &LocomotorState) -> u8 {
+    u8::from(state.piggyback.is_some())
+}
+
+/// Inputs to the class-local `IsOKToEnd` gates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EndGateContext {
+    pub owner_moving: bool,
+    pub owner_teleporting: bool,
+    pub owner_deploying: bool,
 }
 
 /// Whether the active piggyback may be unwound now.
 ///
-/// Models the two clauses every class shares: the unit must not be moving, and
-/// something must actually be stashed. The per-class clauses are UNCHECKED and
-/// absent — see the module docs.
-pub fn is_ok_to_end(state: &LocomotorState, is_moving: bool) -> bool {
-    !is_moving && state.piggyback.is_some()
+/// The movement and populated-slot checks are common. Walk's named-location
+/// gate additionally requires its local state and linked owner bytes clear;
+/// mapped here to an idle active phase and clear owner transition flags. Special
+/// locomotors stay conservative until their Process state machines supply their
+/// own completed phase to the caller.
+pub fn is_ok_to_end(state: &LocomotorState, context: EndGateContext) -> bool {
+    if context.owner_moving || state.piggyback.is_none() {
+        return false;
+    }
+
+    match state.kind {
+        LocomotorKind::Drive
+        | LocomotorKind::Walk
+        | LocomotorKind::Hover
+        | LocomotorKind::Mech
+        | LocomotorKind::Ship => {
+            state.phase == GroundMovePhase::Idle
+                && !context.owner_teleporting
+                && !context.owner_deploying
+        }
+        LocomotorKind::Fly | LocomotorKind::Jumpjet | LocomotorKind::Parachute => {
+            state.air_phase == AirMovePhase::Landed
+                && !context.owner_teleporting
+                && !context.owner_deploying
+        }
+        LocomotorKind::Teleport
+        | LocomotorKind::Tunnel
+        | LocomotorKind::Rocket
+        | LocomotorKind::DropPod => false,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rules::locomotor_type::LocomotorKind;
 
     fn teleporter() -> LocomotorState {
         LocomotorState::for_test_kind(LocomotorKind::Teleport)
     }
 
-    /// Native BEGIN returns E_FAIL when the stash slot is occupied and changes
-    /// nothing. This is the whole reason there is one mechanism and not two:
-    /// with two independent stashes a unit could hold both at once, which the
-    /// engine makes impossible.
     #[test]
-    fn begin_refuses_to_nest() {
+    fn begin_rejects_null_and_nested_runtime_without_mutation() {
         let mut state = teleporter();
-        assert_eq!(
-            begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground),
-            BeginOutcome::Installed
-        );
+        assert_eq!(begin_with_runtime(&mut state, None), BeginOutcome::RefusedNull);
         let before = state.clone();
 
+        assert_eq!(begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground), BeginOutcome::Installed);
+        let nested_before = state.clone();
         assert_eq!(
-            begin(&mut state, LocomotorKind::Hover, MovementLayer::Ground),
+            begin(&mut state, LocomotorKind::Ship, MovementLayer::Ground),
             BeginOutcome::RefusedNested
         );
-        assert_eq!(
-            state.kind, before.kind,
-            "a refused BEGIN must not install its locomotor"
-        );
-        assert_eq!(
-            state.piggyback, before.piggyback,
-            "a refused BEGIN must not disturb the existing stash"
-        );
-    }
-
-    /// The end-first shape: two of the native BEGIN sites END before they BEGIN,
-    /// precisely because BEGIN cannot nest. Ending first makes the second BEGIN
-    /// succeed.
-    #[test]
-    fn ending_first_lets_a_second_begin_succeed() {
-        let mut state = teleporter();
-        begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground);
-
-        assert!(end(&mut state).is_some());
-        assert_eq!(
-            begin(&mut state, LocomotorKind::Hover, MovementLayer::Ground),
-            BeginOutcome::Installed
-        );
-        assert_eq!(state.kind, LocomotorKind::Hover);
+        assert_eq!(state.piggyback, nested_before.piggyback);
+        assert_eq!(before.kind, LocomotorKind::Teleport);
     }
 
     #[test]
-    fn end_restores_the_stashed_locomotor_and_clears_the_slot() {
+    fn begin_and_end_transfer_complete_runtime_without_touching_installed_slot() {
         let mut state = teleporter();
-        let original_kind = state.kind;
-        let original_layer = state.layer;
+        state.altitude = SimFixed::from_num(123);
+        state.hover_speed_request = SimFixed::from_num(1);
+        let installed = state.slot;
 
-        begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground);
+        assert_eq!(begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground), BeginOutcome::Installed);
         assert_eq!(state.kind, LocomotorKind::Drive);
-        assert!(state.piggyback.is_some());
-
-        let restored = end(&mut state).expect("a stash was present");
-        assert_eq!(restored.kind, original_kind);
-        assert_eq!(state.kind, original_kind);
-        assert_eq!(state.layer, original_layer);
-        assert!(
-            state.piggyback.is_none(),
-            "the slot must be empty after END — the native null window"
+        assert_eq!(state.slot, installed);
+        assert_eq!(
+            state.piggyback.as_deref().expect("stash").common.altitude,
+            SimFixed::from_num(123)
         );
-    }
 
-    /// Native END returns S_FALSE rather than an error when nothing is stashed.
-    #[test]
-    fn end_without_a_stash_reports_nothing_to_pop() {
-        let mut state = teleporter();
-        assert!(end(&mut state).is_none());
+        let restored = end(&mut state).expect("suspended runtime");
+        assert_eq!(restored.kind, LocomotorKind::Teleport);
+        assert_eq!(state.kind, LocomotorKind::Teleport);
+        assert_eq!(state.altitude, SimFixed::from_num(123));
+        assert_eq!(state.slot, installed);
         assert!(state.piggyback.is_none());
     }
 
-    /// The see-through identity: a Chrono Miner driving on a piggybacked Drive
-    /// still *is* a Teleport unit. The installed slot answers that, while `kind`
-    /// answers "what is driving right now" — mission logic asks the former and
-    /// the destination path asks the latter, so both must stay distinguishable.
     #[test]
-    fn effective_class_sees_through_stash() {
+    fn end_into_reports_null_empty_and_transfers_without_installing() {
         let mut state = teleporter();
-        begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground);
+        assert_eq!(end_into(&mut state, None), EndOutcome::RefusedNull);
+        let mut output = None;
+        assert_eq!(end_into(&mut state, Some(&mut output)), EndOutcome::Empty);
 
-        assert_eq!(state.kind, LocomotorKind::Drive, "Drive is driving");
-        assert_eq!(
-            state.effective_kind(),
-            LocomotorKind::Teleport,
-            "but the unit is still a Teleport unit"
-        );
+        begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground);
+        assert_eq!(end_into(&mut state, Some(&mut output)), EndOutcome::Restored);
+        assert_eq!(state.kind, LocomotorKind::Drive);
+        assert_eq!(output.expect("transferred runtime").kind, LocomotorKind::Teleport);
+        assert!(state.piggyback.is_none());
     }
 
-    /// The movement clause dominates: a moving unit can never unwind.
     #[test]
-    fn is_ok_to_end_is_dominated_by_movement() {
+    fn ordinary_and_special_end_gates_are_distinct() {
         let mut state = teleporter();
-        assert!(
-            !is_ok_to_end(&state, false),
-            "nothing stashed — nothing to end"
-        );
-
         begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground);
-        assert!(!is_ok_to_end(&state, true), "moving must refuse the end");
-        assert!(is_ok_to_end(&state, false));
+        let ready = EndGateContext {
+            owner_moving: false,
+            owner_teleporting: false,
+            owner_deploying: false,
+        };
+        assert!(is_ok_to_end(&state, ready));
+
+        state.kind = LocomotorKind::Teleport;
+        assert!(!is_ok_to_end(&state, ready));
+        state.kind = LocomotorKind::Drive;
+        state.phase = GroundMovePhase::Cruising;
+        assert!(!is_ok_to_end(&state, ready));
     }
 
-    /// A stash cannot hold a stash — enforced by `StashedLocomotor` having no
-    /// stash field at all, so this is a compile-time property the test merely
-    /// records.
     #[test]
-    fn a_stash_holds_no_stash_of_its_own() {
+    fn serialized_presence_matches_the_single_suspended_runtime() {
         let mut state = teleporter();
+        assert_eq!(serialized_presence(&state), 0);
         begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground);
-        let stashed = state.piggyback.expect("stash present");
-        // `stashed` is a StashedLocomotor: it exposes kind/layer/flight state and
-        // no piggyback field. If one were ever added, this test stops compiling.
-        assert_eq!(stashed.kind, LocomotorKind::Teleport);
+        assert_eq!(serialized_presence(&state), 1);
     }
 }

--- a/src/sim/movement/locomotor.rs
+++ b/src/sim/movement/locomotor.rs
@@ -26,7 +26,7 @@ use crate::rules::jumpjet_params::JumpjetParams;
 use crate::rules::locomotor_type::{LocomotorKind, MovementZone, SpeedType};
 use crate::rules::object_type::ObjectType;
 use crate::sim::movement::locomotion::LocomotorSlot;
-use crate::sim::movement::locomotion::piggyback::{self, StashedLocomotor};
+use crate::sim::movement::locomotion::piggyback::{self, EndGateContext, LocomotorRuntime, StashedLocomotor};
 use crate::util::fixed_math::{SIM_ZERO, SimFixed, sim_from_f32};
 
 /// Which spatial layer the unit currently occupies.
@@ -129,10 +129,10 @@ pub struct LocomotorState {
     /// to on — an unpowered locomotor is a state something must actively put a
     /// unit into.
     pub powered: bool,
-    /// Active piggybacked locomotor storage.
+    /// One boxed suspended locomotor runtime.
     ///
-    /// For CMIN drive phases, `kind` becomes Drive and this stores the primary
-    /// Teleport locomotor until the active Drive locomotor is ok to end.
+    /// For CMIN drive phases, `kind` becomes Drive and this stores the complete
+    /// primary Teleport runtime until the active Drive locomotor is ok to end.
     #[serde(default)]
     pub piggyback: Option<StashedLocomotor>,
     /// Which spatial layer the unit currently occupies.
@@ -444,11 +444,10 @@ impl LocomotorState {
             // Drive on top of itself. Repair, not a BEGIN: the native protocol
             // has no path that reaches this shape.
             if self.piggyback.is_none() {
-                self.piggyback = Some(StashedLocomotor {
-                    kind: LocomotorKind::Teleport,
-                    layer: MovementLayer::Ground,
-                    ..StashedLocomotor::capture(self)
-                });
+                let mut runtime = LocomotorRuntime::capture(self);
+                runtime.kind = LocomotorKind::Teleport;
+                runtime.layer = MovementLayer::Ground;
+                self.piggyback = Some(StashedLocomotor::from_runtime(runtime));
             }
             return true;
         }
@@ -472,7 +471,11 @@ impl LocomotorState {
         owner_teleporting: bool,
         owner_deploying: bool,
     ) -> bool {
-        self.piggyback.is_some() && !owner_moving && !owner_teleporting && !owner_deploying
+        self.is_ok_to_end_piggyback(EndGateContext {
+            owner_moving,
+            owner_teleporting,
+            owner_deploying,
+        })
     }
 
     /// Begin a piggyback: stash the driving locomotor and install this one.
@@ -508,8 +511,8 @@ impl LocomotorState {
 
     /// Whether the active piggyback may be unwound now. The movement clause
     /// dominates: a moving unit never unwinds.
-    pub fn is_ok_to_end_piggyback(&self, is_moving: bool) -> bool {
-        piggyback::is_ok_to_end(self, is_moving)
+    pub fn is_ok_to_end_piggyback(&self, context: EndGateContext) -> bool {
+        piggyback::is_ok_to_end(self, context)
     }
 }
 

--- a/src/sim/movement/mod.rs
+++ b/src/sim/movement/mod.rs
@@ -46,7 +46,7 @@ use crate::util::fixed_math::{SIM_ONE, SIM_ZERO, SimFixed, facing_from_delta_int
 mod drive_locomotion;
 pub(crate) mod locomotor_ready;
 mod movement_blocked;
-mod movement_bridge;
+pub(crate) mod movement_bridge;
 mod movement_commands;
 mod movement_occupancy;
 mod movement_path;
@@ -61,6 +61,7 @@ pub(crate) mod ready_producer;
 pub mod air_movement;
 pub mod bump_crush;
 pub mod drive_track;
+pub mod drop_pod_movement;
 pub mod facing_class;
 pub mod group_destination;
 pub mod homing_movement;
@@ -72,6 +73,7 @@ pub mod parachute_descent;
 pub mod rocket_movement;
 pub mod scatter;
 pub mod teleport_movement;
+pub mod tunnel_movement;
 pub mod tube_movement;
 pub mod turret;
 
@@ -217,6 +219,7 @@ pub(super) struct MoverSnapshot {
     pub owner: InternedId,
     pub too_big_to_fit_under_bridge: bool,
     pub on_bridge: bool,
+    pub runtime_bridge_transition: movement_bridge::RuntimeBridgeTransitionState,
     pub locomotor: Option<locomotor::LocomotorState>,
     pub rot: i32,
     /// Mover's `MovementTarget.bypass_grid` flag — when true, structure

--- a/src/sim/movement/movement_bridge.rs
+++ b/src/sim/movement/movement_bridge.rs
@@ -46,6 +46,44 @@ pub(super) enum BridgeStateUpdate {
     Unchanged,
 }
 
+/// Persisted analogue of the runtime Foot bridge-state mismatch byte.
+///
+/// The owner integration stores this alongside locomotor runtime state. It is
+/// intentionally independent from A* bridge-layer selection and from the
+/// `on_bridge` occupancy byte.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RuntimeBridgeTransitionState {
+    /// Set when candidate bridge bit and current bridge state differ.
+    pub pending_mismatch: bool,
+}
+
+/// Result supplied by the runtime-only bridge policy seam.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeBridgePolicyResult {
+    Continue,
+    Reject,
+}
+
+/// Evaluate the runtime bridge mismatch branch without borrowing A* policy.
+///
+/// Original: `FootClass::EvaluateCellEnterabilityOrCost` (YR 1.001) compares
+/// candidate `CellClass+0x140 & 0x100` with Foot `+0x8c`, sets `+0x68b` on a
+/// mismatch, then calls virtual `+0x29c` to select the local return path.
+pub(crate) fn evaluate_runtime_bridge_transition(
+    state: &mut RuntimeBridgeTransitionState,
+    candidate_bridge_bit: bool,
+    current_bridge_state: bool,
+    policy: impl FnOnce() -> RuntimeBridgePolicyResult,
+) -> RuntimeBridgePolicyResult {
+    let mismatch = candidate_bridge_bit != current_bridge_state;
+    state.pending_mismatch = mismatch;
+    if mismatch {
+        policy()
+    } else {
+        RuntimeBridgePolicyResult::Continue
+    }
+}
+
 /// Read-only runtime bridge row for oracle diagnostics.
 #[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
 pub struct BridgeRuntimeOracleTick {
@@ -353,6 +391,31 @@ mod tests {
         assert!(!projected_on_bridge(true, BridgeStateUpdate::Clear));
         assert!(projected_on_bridge(true, BridgeStateUpdate::Unchanged));
         assert!(!projected_on_bridge(false, BridgeStateUpdate::Unchanged));
+    }
+
+    #[test]
+    fn runtime_bridge_mismatch_sets_pending_state_and_uses_policy_seam() {
+        let mut state = RuntimeBridgeTransitionState::default();
+        let outcome = evaluate_runtime_bridge_transition(&mut state, true, false, || {
+            RuntimeBridgePolicyResult::Reject
+        });
+
+        assert!(state.pending_mismatch);
+        assert_eq!(outcome, RuntimeBridgePolicyResult::Reject);
+    }
+
+    #[test]
+    fn matching_runtime_bridge_state_skips_policy_seam() {
+        let mut state = RuntimeBridgeTransitionState::default();
+        let mut policy_called = false;
+        let outcome = evaluate_runtime_bridge_transition(&mut state, true, true, || {
+            policy_called = true;
+            RuntimeBridgePolicyResult::Reject
+        });
+
+        assert!(!state.pending_mismatch);
+        assert!(!policy_called);
+        assert_eq!(outcome, RuntimeBridgePolicyResult::Continue);
     }
 
     #[test]

--- a/src/sim/movement/movement_occupancy.rs
+++ b/src/sim/movement/movement_occupancy.rs
@@ -124,9 +124,11 @@ pub(super) fn runtime_can_enter_cell_args(
     )
 }
 
-pub(super) fn evaluate_runtime_can_enter_cell(
+pub(super) fn evaluate_runtime_can_enter_cell_with_transition(
     path_grid: Option<&PathGrid>,
     next_layer: MovementLayer,
+    bridge_state: &mut super::movement_bridge::RuntimeBridgeTransitionState,
+    current_on_bridge: bool,
     args: RuntimeCanEnterCellArgs,
 ) -> RuntimeCanEnterCellEvaluation {
     let base = CanEnterLayerContext::single(next_layer);
@@ -144,6 +146,19 @@ pub(super) fn evaluate_runtime_can_enter_cell(
             bridge_traversal_allowed: true,
         };
     };
+    let runtime_policy = super::movement_bridge::evaluate_runtime_bridge_transition(
+        bridge_state,
+        candidate.has_structural_bridge(),
+        current_on_bridge,
+        || super::movement_bridge::RuntimeBridgePolicyResult::Continue,
+    );
+    if runtime_policy == super::movement_bridge::RuntimeBridgePolicyResult::Reject {
+        return RuntimeCanEnterCellEvaluation {
+            args,
+            layers: base,
+            bridge_traversal_allowed: false,
+        };
+    }
     let explicit_parent = args
         .parent_current_cell
         .and_then(|coord| grid.cell(coord.0, coord.1).map(|cell| (cell, coord)));
@@ -215,6 +230,16 @@ pub(super) fn evaluate_runtime_can_enter_cell(
         layers,
         bridge_traversal_allowed: true,
     }
+}
+
+#[cfg(test)]
+pub(super) fn evaluate_runtime_can_enter_cell(
+    path_grid: Option<&PathGrid>,
+    next_layer: MovementLayer,
+    args: RuntimeCanEnterCellArgs,
+) -> RuntimeCanEnterCellEvaluation {
+    let mut state = super::movement_bridge::RuntimeBridgeTransitionState::default();
+    evaluate_runtime_can_enter_cell_with_transition(path_grid, next_layer, &mut state, false, args)
 }
 
 pub(super) fn detect_deferred_cell_check(

--- a/src/sim/movement/movement_step.rs
+++ b/src/sim/movement/movement_step.rs
@@ -23,7 +23,7 @@ use crate::sim::movement::movement_blocked::handle_blocked_tick;
 use crate::sim::movement::movement_bridge::resolve_cell_transition_bridge_state;
 use crate::sim::movement::movement_occupancy::{
     DeferredCellCheck, LiveBuildingEntrySkipMap, detect_deferred_cell_check,
-    evaluate_runtime_can_enter_cell, naval_terrain_diag, runtime_can_enter_cell_args,
+    evaluate_runtime_can_enter_cell_with_transition, naval_terrain_diag, runtime_can_enter_cell_args,
 };
 use crate::sim::movement::movement_reservation::reserve_destination_after_transition;
 use crate::sim::occupancy::{CellListInsertion, CellOccupationGrid, OccupancyGrid};
@@ -1448,6 +1448,7 @@ pub(super) struct CrossingOutput {
     pub debug_events: Vec<(u32, DebugEventKind)>,
     /// Whether the entity was marked as stuck and should abort.
     pub aborted_for_stuck: bool,
+    pub runtime_bridge_transition: super::movement_bridge::RuntimeBridgeTransitionState,
 }
 
 /// Process cell boundary crossings — the inner loop that checks whether
@@ -1493,6 +1494,7 @@ pub(super) fn process_cell_crossings(
 ) -> CrossingOutput {
     let mut debug_events: Vec<(u32, DebugEventKind)> = Vec::new();
     let mut deferred_cell_check: Option<DeferredCellCheck> = None;
+    let mut runtime_bridge_transition = snap.runtime_bridge_transition;
     let mut pending_bridge_update: super::movement_bridge::BridgeStateUpdate =
         super::movement_bridge::BridgeStateUpdate::Unchanged;
     let mut projected_on_bridge_state = snap.on_bridge;
@@ -1524,9 +1526,11 @@ pub(super) fn process_cell_crossings(
         }
 
         let next_layer = target.layer_at(target.next_index);
-        let runtime_entry = evaluate_runtime_can_enter_cell(
+        let runtime_entry = evaluate_runtime_can_enter_cell_with_transition(
             path_grid,
             next_layer,
+            &mut runtime_bridge_transition,
+            projected_on_bridge_state,
             runtime_can_enter_cell_args(
                 path_grid,
                 (position.rx, position.ry),
@@ -1609,10 +1613,18 @@ pub(super) fn process_cell_crossings(
                 grid_ok && terrain_ok
             }
             MovementLayer::Bridge => path_grid.is_some_and(|grid| {
-                if !grid.is_walkable_on_layer(nx, ny, MovementLayer::Bridge) {
-                    return false;
-                }
-                true
+                crate::sim::pathfinding::is_cell_passable_for_mover_on_layer_with_speed(
+                    grid,
+                    nx,
+                    ny,
+                    MovementLayer::Bridge,
+                    Some(snap.movement_zone),
+                    snap.speed_type,
+                    resolved_terrain,
+                    entity_cost_grid,
+                    target.bypass_grid,
+                    crate::sim::pathfinding::cell_entry::TerrainEntryMode::RuntimeTransition,
+                )
             }),
             MovementLayer::Air | MovementLayer::Underground => false,
         };
@@ -1903,5 +1915,6 @@ pub(super) fn process_cell_crossings(
         active_layer,
         debug_events,
         aborted_for_stuck,
+        runtime_bridge_transition,
     }
 }

--- a/src/sim/movement/movement_tick.rs
+++ b/src/sim/movement/movement_tick.rs
@@ -45,7 +45,8 @@ use super::movement_bridge::{
     BRIDGE_Z_OFFSET, BridgeStateUpdate, apply_pending_bridge_render_state,
 };
 use super::movement_occupancy::{
-    DeferredCellCheck, build_live_building_entry_skip_map, evaluate_runtime_can_enter_cell,
+    DeferredCellCheck, build_live_building_entry_skip_map,
+    evaluate_runtime_can_enter_cell_with_transition,
     handle_deferred_occupancy, has_unignored_runtime_occupants_on_layers,
     runtime_can_enter_direction, runtime_current_effective_height,
 };
@@ -269,6 +270,7 @@ fn snapshot_mover(entities: &EntityStore, entity_id: u64) -> Option<MoverSnapsho
         owner: e.owner,
         too_big_to_fit_under_bridge: e.too_big_to_fit_under_bridge,
         on_bridge: e.on_bridge,
+        runtime_bridge_transition: e.runtime_bridge_transition,
         locomotor: e.locomotor.clone(),
         rot: e.locomotor.as_ref().map(|l| l.rot).unwrap_or(0),
         bypass_grid: e
@@ -842,9 +844,20 @@ fn classify_drive_track_chain_entry(
                 TerrainEntryMode::RuntimeTransition,
             )
         }),
-        MovementLayer::Bridge => {
-            path_grid.is_some_and(|grid| grid.is_walkable_on_layer(x, y, MovementLayer::Bridge))
-        }
+        MovementLayer::Bridge => path_grid.is_some_and(|grid| {
+            crate::sim::pathfinding::is_cell_passable_for_mover_on_layer_with_speed(
+                grid,
+                x,
+                y,
+                MovementLayer::Bridge,
+                Some(snap.movement_zone),
+                snap.speed_type,
+                resolved_terrain,
+                entity_cost_grid,
+                snap.bypass_grid,
+                TerrainEntryMode::RuntimeTransition,
+            )
+        }),
         MovementLayer::Air | MovementLayer::Underground => false,
     };
     if !terrain_clear {
@@ -1977,9 +1990,11 @@ fn tick_movement_with_grids_scoped(
                                 // lookahead: target, direction, current height,
                                 // null parent, arg5=1.
                                 let next_layer = target.layer_at(target.next_index + 1);
-                                let runtime_entry = evaluate_runtime_can_enter_cell(
+                                let runtime_entry = evaluate_runtime_can_enter_cell_with_transition(
                                     path_grid,
                                     next_layer,
+                                    &mut entity.runtime_bridge_transition,
+                                    entity.on_bridge,
                                     super::movement_occupancy::RuntimeCanEnterCellArgs::runtime(
                                         after,
                                         runtime_can_enter_direction(cur_cell, after),
@@ -2050,6 +2065,7 @@ fn tick_movement_with_grids_scoped(
                 active_layer = crossing.active_layer;
                 debug_events.extend(crossing.debug_events);
                 aborted_for_stuck = crossing.aborted_for_stuck;
+                entity.runtime_bridge_transition = crossing.runtime_bridge_transition;
 
                 // Apply bridge layer state BEFORE computing screen position, so that
                 // the render frame always sees consistent state. Without this, there's
@@ -2654,6 +2670,7 @@ mod drive_track_chain_tests {
             owner: test_intern("Americans"),
             too_big_to_fit_under_bridge: false,
             on_bridge: false,
+            runtime_bridge_transition: Default::default(),
             locomotor: Some(locomotor),
             rot: 5,
             bypass_grid: false,

--- a/src/sim/movement/rocket_movement.rs
+++ b/src/sim/movement/rocket_movement.rs
@@ -1,91 +1,93 @@
-//! Rocket locomotor — scripted missile controller.
+//! Rocket locomotor — the six-phase ballistic controller.
 //!
-//! Rockets are projectile entities that fly from origin to target in an arc,
-//! then detonate (entity despawned). They do NOT use A* pathfinding — movement
-//! is a straight line with altitude curve.
-//!
-//! ## State machine
-//! Launch → Ascending → Terminal → Detonation
-//!
-//! ## RA2 behavior
-//! - Rockets spawn at the firing unit's position
-//! - Fly in a ballistic arc: ascending phase then terminal dive
-//! - Speed comes from the Projectile= entry in rules.ini
-//! - Entity is despawned on detonation (damage applied by combat system)
-//! - Uses `MovementLayer::Air` — ignores ground occupancy
-//!
-//! ## Determinism
-//! All sim-critical fields (speed, altitude, progress, timer) use `SimFixed`
-//! for deterministic lockstep. Only render-only values (pitch, visual scale)
-//! remain as f32.
-//!
-//! ## Dependency rules
-//! - Part of sim/ — depends on sim/game_entity, sim/entity_store, map/terrain.
-//! - sim/ NEVER depends on render/, ui/, sidebar/, audio/, net/.
+//! `RocketLocomotionClass::Process` (`0x006622c0`) selects a type-specific
+//! flight table, then processes ignition, tilt, ascent, cruise, terminal and
+//! secondary/relaunch.  Combat owns the eventual impact; this module owns only
+//! deterministic flight state and reports completion to its caller.
 
+use crate::sim::components::Position;
 use crate::sim::debug_event_log::DebugEventKind;
 use crate::sim::entity_store::EntityStore;
 use crate::sim::movement::facing_from_delta;
 use crate::util::fixed_math::{
-    SIM_ONE, SIM_TWO, SIM_ZERO, SimFixed, int_distance_to_sim, native_movement_frame_fraction,
-    sim_to_f32,
+    int_distance_to_sim, native_movement_frame_fraction, sim_to_f32, SimFixed, SIM_ONE, SIM_ZERO,
 };
 
-/// Duration of the initial launch phase in seconds (vertical boost).
-const LAUNCH_DURATION_S: SimFixed = SimFixed::lit("0.3");
-/// Fraction of total flight distance spent ascending (0.0–1.0).
-const ASCEND_FRACTION: SimFixed = SimFixed::lit("0.4");
-/// Peak altitude in leptons during the ascending phase.
-const PEAK_ALTITUDE: SimFixed = SimFixed::lit("400");
+const IGNITION_FRAMES: u16 = 1;
+const TILT_FRAMES: u16 = 2;
+const DEFAULT_ASCENT_ALTITUDE: SimFixed = SimFixed::lit("400");
+const DEFAULT_ACCELERATION: SimFixed = SimFixed::lit("90");
+const DEFAULT_TILT_RATE: SimFixed = SimFixed::lit("0.35");
 
-/// Phase within the rocket state machine.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum RocketPhase {
-    /// Initial vertical boost — rocket rises from launcher.
-    Launch,
-    /// Climbing toward peak altitude while advancing horizontally.
-    Ascending,
-    /// Diving toward target — descending altitude, still advancing.
-    Terminal,
-    /// Impact — entity will be despawned this tick.
-    Detonation,
+/// Native `ILocomotion::Process` return translated into a caller-owned outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpecialMovementOutcome {
+    Continue,
+    Complete,
+    Abort,
 }
 
-/// State for an in-flight rocket/missile.
-///
-/// Set when a weapon fires a rocket projectile. Removed (along with the
-/// entity) when the rocket detonates at the target.
-///
-/// Sim-critical fields use `SimFixed` for deterministic lockstep.
-/// `pitch` is render-only and stays as `f32`.
+/// The six `RocketLocomotionClass::Process` phases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum RocketPhase {
+    /// State 1: create exhaust and prepare the launch vector.
+    Ignition,
+    /// State 2: interpolate toward the configured launch tilt.
+    Tilt,
+    /// State 3: climb vertically while accelerating to the flight speed.
+    Ascent,
+    /// State 4: cruise and track the target.
+    Cruise,
+    /// State 5: turn through the bounded terminal descent.
+    Terminal,
+    /// State 6: secondary/relaunch handoff. A zero counter completes flight.
+    Secondary,
+}
+
+/// Per-projectile flight values selected from the native rocket table.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RocketFlightParameters {
+    pub acceleration: SimFixed,
+    pub max_speed: SimFixed,
+    pub ascent_altitude: SimFixed,
+    pub tilt_rate: SimFixed,
+    pub relaunches: u8,
+}
+
+impl RocketFlightParameters {
+    pub fn legacy(speed: SimFixed) -> Self {
+        Self {
+            acceleration: DEFAULT_ACCELERATION,
+            max_speed: speed.max(SIM_ONE),
+            ascent_altitude: DEFAULT_ASCENT_ALTITUDE,
+            tilt_rate: DEFAULT_TILT_RATE,
+            relaunches: 0,
+        }
+    }
+}
+
+/// Serialized state for one in-flight `RocketLocomotionClass` instance.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RocketState {
-    /// Current phase in the rocket flight.
     pub phase: RocketPhase,
-    /// Origin cell coordinates (where the rocket was fired from).
     pub origin_rx: u16,
     pub origin_ry: u16,
-    /// Target cell coordinates.
     pub target_rx: u16,
     pub target_ry: u16,
-    /// Flight speed in cells per second (SimFixed for determinism).
+    /// Configured maximum speed, retained for the render/debug boundary.
     pub speed: SimFixed,
-    /// Current altitude in leptons (SimFixed for determinism).
+    /// Current accelerated speed.
+    pub current_speed: SimFixed,
     pub altitude: SimFixed,
-    /// Progress along the flight path (0.0 = origin, 1.0 = target) (SimFixed for determinism).
     pub progress: SimFixed,
-    /// Timer for the launch phase — seconds remaining (SimFixed for determinism).
-    pub timer: SimFixed,
-    /// Visual pitch angle in radians (positive = nose up, negative = nose down).
-    /// Computed from the altitude change rate. Render system reads this for rotation.
-    /// Render-only — stays as f32.
+    /// Native frames spent in the current phase.
+    pub phase_frames: u16,
+    pub parameters: RocketFlightParameters,
+    /// Render-only attitude. It never drives the simulation step.
     pub pitch: f32,
 }
 
-/// Attach a rocket state to an entity at the given origin, targeting a destination cell.
-///
-/// The entity should already exist in the EntityStore with a position.
-/// This function sets the RocketState to begin the flight sequence.
+/// Attach a rocket using the compatibility parameters used by existing callers.
 pub fn attach_rocket_state(
     entities: &mut EntityStore,
     entity_id: u64,
@@ -93,26 +95,44 @@ pub fn attach_rocket_state(
     target: (u16, u16),
     speed: SimFixed,
 ) -> bool {
+    attach_rocket_state_with_parameters(
+        entities,
+        entity_id,
+        origin,
+        target,
+        RocketFlightParameters::legacy(speed),
+    )
+}
+
+/// Attach a rocket using the selected native flight-table values.
+pub fn attach_rocket_state_with_parameters(
+    entities: &mut EntityStore,
+    entity_id: u64,
+    origin: (u16, u16),
+    target: (u16, u16),
+    parameters: RocketFlightParameters,
+) -> bool {
     let Some(entity) = entities.get_mut(entity_id) else {
         return false;
     };
 
-    // Set initial facing toward target.
-    let dx: i32 = target.0 as i32 - origin.0 as i32;
-    let dy: i32 = target.1 as i32 - origin.1 as i32;
-    entity.facing = facing_from_delta(dx, dy);
-
+    entity.facing = facing_from_delta(
+        i32::from(target.0) - i32::from(origin.0),
+        i32::from(target.1) - i32::from(origin.1),
+    );
     entity.rocket_state = Some(RocketState {
-        phase: RocketPhase::Launch,
+        phase: RocketPhase::Ignition,
         origin_rx: origin.0,
         origin_ry: origin.1,
         target_rx: target.0,
         target_ry: target.1,
-        speed: speed.max(SIM_ONE),
+        speed: parameters.max_speed,
+        current_speed: SIM_ZERO,
         altitude: SIM_ZERO,
         progress: SIM_ZERO,
-        timer: LAUNCH_DURATION_S,
-        pitch: std::f32::consts::FRAC_PI_2, // Nose up during launch.
+        phase_frames: 0,
+        parameters,
+        pitch: std::f32::consts::FRAC_PI_2,
     });
     entity.push_debug_event(
         0,
@@ -123,19 +143,91 @@ pub fn attach_rocket_state(
     true
 }
 
-/// Advance all in-flight rocket state machines.
+/// Advance one rocket state. The caller performs detonation/despawn on `Complete`.
 ///
-/// Called once per simulation tick from `advance_tick()`.
-/// Rockets that reach Detonation phase are collected for despawning.
-/// Returns a list of entity IDs that detonated this tick (caller handles despawn/damage).
+/// The six branches map directly to `RocketLocomotionClass::Process` at
+/// `0x006622c0`; this intentionally does not reuse Fly locomotion.
+pub fn process_rocket_state(
+    rocket: &mut RocketState,
+    position: &mut Position,
+) -> SpecialMovementOutcome {
+    let dt = native_movement_frame_fraction();
+    let before = rocket.phase;
+
+    match rocket.phase {
+        RocketPhase::Ignition => {
+            rocket.phase_frames = rocket.phase_frames.saturating_add(1);
+            rocket.pitch = std::f32::consts::FRAC_PI_2;
+            if rocket.phase_frames >= IGNITION_FRAMES {
+                transition(rocket, RocketPhase::Tilt);
+            }
+        }
+        RocketPhase::Tilt => {
+            rocket.phase_frames = rocket.phase_frames.saturating_add(1);
+            let target_pitch = std::f32::consts::FRAC_PI_2;
+            rocket.pitch = (rocket.pitch
+                + sim_to_f32(rocket.parameters.tilt_rate) * (target_pitch - rocket.pitch))
+                .min(target_pitch);
+            if rocket.phase_frames >= TILT_FRAMES {
+                transition(rocket, RocketPhase::Ascent);
+            }
+        }
+        RocketPhase::Ascent => {
+            accelerate(rocket, dt);
+            let climb = rocket.current_speed.max(SIM_ONE) * dt;
+            rocket.altitude = (rocket.altitude + climb).min(rocket.parameters.ascent_altitude);
+            rocket.pitch = std::f32::consts::FRAC_PI_2;
+            if rocket.altitude >= rocket.parameters.ascent_altitude {
+                transition(rocket, RocketPhase::Cruise);
+            }
+        }
+        RocketPhase::Cruise => {
+            let remaining = advance_horizontal(rocket, position, dt);
+            rocket.pitch = horizontal_pitch(rocket, remaining, false);
+            if remaining <= terminal_distance(rocket) {
+                transition(rocket, RocketPhase::Terminal);
+            }
+        }
+        RocketPhase::Terminal => {
+            let remaining = advance_horizontal(rocket, position, dt);
+            let descent = rocket.current_speed.max(SIM_ONE) * dt;
+            rocket.altitude = (rocket.altitude - descent).max(SIM_ZERO);
+            rocket.pitch = horizontal_pitch(rocket, remaining, true);
+            if remaining <= SIM_ZERO || rocket.progress >= SIM_ONE {
+                position.rx = rocket.target_rx;
+                position.ry = rocket.target_ry;
+                rocket.altitude = SIM_ZERO;
+                transition(rocket, RocketPhase::Secondary);
+            }
+        }
+        RocketPhase::Secondary => {
+            if rocket.parameters.relaunches == 0 {
+                return SpecialMovementOutcome::Complete;
+            }
+            rocket.parameters.relaunches -= 1;
+            rocket.progress = SIM_ZERO;
+            rocket.altitude = SIM_ZERO;
+            rocket.current_speed = SIM_ZERO;
+            transition(rocket, RocketPhase::Ignition);
+        }
+    }
+
+    if rocket.phase != before {
+        rocket.phase_frames = 0;
+    }
+    SpecialMovementOutcome::Continue
+}
+
+/// Advance all rockets in supplied live object order.
+///
+/// Compatibility return: each ID whose flight completed this frame is returned
+/// for the combat/lifecycle owner to resolve. Completion stays idempotent while
+/// the entity remains alive, matching the previous detonation queue seam.
 pub fn tick_rocket_movement(
     entities: &mut EntityStore,
     live_order: &[u64],
     sim_tick: u64,
 ) -> Vec<u64> {
-    let mut detonated: Vec<u64> = Vec::new();
-    let dt = native_movement_frame_fraction();
-
     let fallback_order;
     let entity_order: &[u64] = if live_order.is_empty() {
         fallback_order = entities.keys_sorted();
@@ -143,152 +235,92 @@ pub fn tick_rocket_movement(
     } else {
         live_order
     };
+    let mut completed = Vec::new();
 
     for &id in entity_order {
         let Some(entity) = entities.get_mut(id) else {
             continue;
         };
-        let Some(ref mut rocket) = entity.rocket_state else {
-            continue;
+        let (outcome, phase_change) = {
+            let Some(rocket) = entity.rocket_state.as_mut() else {
+                continue;
+            };
+            let before = rocket.phase;
+            let outcome = process_rocket_state(rocket, &mut entity.position);
+            let phase_change = (rocket.phase != before).then(|| format!("{:?}", rocket.phase));
+            (outcome, phase_change)
         };
-
-        // Track phase before processing to detect transitions.
-        let phase_before = rocket.phase;
-
-        match rocket.phase {
-            RocketPhase::Launch => {
-                // Vertical boost phase — rise in place briefly.
-                rocket.timer -= dt;
-                rocket.altitude += PEAK_ALTITUDE * dt / LAUNCH_DURATION_S * SimFixed::lit("0.3");
-                rocket.pitch = std::f32::consts::FRAC_PI_2; // Nose straight up.
-                if rocket.timer <= SIM_ZERO {
-                    rocket.phase = RocketPhase::Ascending;
-                }
-            }
-            RocketPhase::Ascending => {
-                // Fly toward target while climbing to peak altitude.
-                let total_dist: SimFixed = flight_distance(rocket);
-                let speed_frac: SimFixed = if total_dist > SIM_ZERO {
-                    rocket.speed * dt / total_dist
-                } else {
-                    SIM_ONE
-                };
-                let prev_alt: SimFixed = rocket.altitude;
-                rocket.progress += speed_frac;
-
-                // Altitude: parabolic curve peaking at ASCEND_FRACTION of flight.
-                let alt_frac: SimFixed = rocket.progress / ASCEND_FRACTION;
-                rocket.altitude = PEAK_ALTITUDE * parabolic_up(alt_frac.min(SIM_ONE));
-
-                // Pitch from altitude change vs horizontal distance covered.
-                // Convert SimFixed values to f32 for atan() — pitch is render-only.
-                let alt_delta_f32: f32 = sim_to_f32(rocket.altitude - prev_alt);
-                let horiz_delta_f32: f32 = sim_to_f32(speed_frac * total_dist);
-                rocket.pitch = if horiz_delta_f32 > 0.001 {
-                    (alt_delta_f32 / horiz_delta_f32).atan()
-                } else {
-                    std::f32::consts::FRAC_PI_2
-                };
-
-                if rocket.progress >= ASCEND_FRACTION {
-                    rocket.phase = RocketPhase::Terminal;
-                }
-
-                update_rocket_position(rocket, &mut entity.position);
-            }
-            RocketPhase::Terminal => {
-                // Dive toward target — descending altitude.
-                let total_dist: SimFixed = flight_distance(rocket);
-                let speed_frac: SimFixed = if total_dist > SIM_ZERO {
-                    rocket.speed * dt / total_dist
-                } else {
-                    SIM_ONE
-                };
-                let prev_alt: SimFixed = rocket.altitude;
-                rocket.progress += speed_frac;
-
-                // Altitude: descend from peak to 0 over remaining flight.
-                let terminal_frac: SimFixed =
-                    (rocket.progress - ASCEND_FRACTION) / (SIM_ONE - ASCEND_FRACTION);
-                rocket.altitude = PEAK_ALTITUDE * (SIM_ONE - terminal_frac.min(SIM_ONE));
-
-                // Pitch: negative (nose down) during terminal dive.
-                // Convert SimFixed values to f32 for atan() — pitch is render-only.
-                let alt_delta_f32: f32 = sim_to_f32(rocket.altitude - prev_alt);
-                let horiz_delta_f32: f32 = sim_to_f32(speed_frac * total_dist);
-                rocket.pitch = if horiz_delta_f32 > 0.001 {
-                    (alt_delta_f32 / horiz_delta_f32).atan()
-                } else {
-                    -std::f32::consts::FRAC_PI_2
-                };
-
-                if rocket.progress >= SIM_ONE {
-                    // Arrived at target.
-                    entity.position.rx = rocket.target_rx;
-                    entity.position.ry = rocket.target_ry;
-                    rocket.altitude = SIM_ZERO;
-                    rocket.pitch = -std::f32::consts::FRAC_PI_2; // Nose down at impact.
-                    rocket.phase = RocketPhase::Detonation;
-                    detonated.push(id);
-                } else {
-                    update_rocket_position(rocket, &mut entity.position);
-                }
-            }
-            RocketPhase::Detonation => {
-                // Already queued for despawn — no further processing.
-                detonated.push(id);
-            }
-        }
-
-        // Capture the phase change before dropping the rocket borrow.
-        let phase_after = rocket.phase;
-
-        // Log phase transition if it changed.
-        if phase_after != phase_before {
-            let phase_name = format!("{:?}", phase_after);
+        if let Some(phase) = phase_change {
             entity.push_debug_event(
                 sim_tick as u32,
-                DebugEventKind::SpecialMovementPhase { phase: phase_name },
+                DebugEventKind::SpecialMovementPhase { phase },
             );
-            // Log end when detonation is reached.
-            if phase_after == RocketPhase::Detonation {
-                entity.push_debug_event(sim_tick as u32, DebugEventKind::SpecialMovementEnd);
-            }
+        }
+        if outcome == SpecialMovementOutcome::Complete {
+            completed.push(id);
+            entity.push_debug_event(sim_tick as u32, DebugEventKind::SpecialMovementEnd);
         }
     }
 
-    detonated
+    completed
 }
 
-/// Compute the straight-line distance between rocket origin and target.
-/// Uses i32 arithmetic for squaring to avoid I16F16 overflow on large maps.
+fn transition(rocket: &mut RocketState, next: RocketPhase) {
+    rocket.phase = next;
+    rocket.phase_frames = 0;
+}
+
+fn accelerate(rocket: &mut RocketState, dt: SimFixed) {
+    rocket.current_speed = (rocket.current_speed + rocket.parameters.acceleration * dt)
+        .min(rocket.parameters.max_speed);
+}
+
+fn advance_horizontal(rocket: &mut RocketState, position: &mut Position, dt: SimFixed) -> SimFixed {
+    accelerate(rocket, dt);
+    let total = flight_distance(rocket);
+    if total <= SIM_ZERO {
+        rocket.progress = SIM_ONE;
+        return SIM_ZERO;
+    }
+    rocket.progress = (rocket.progress + rocket.current_speed * dt / total).min(SIM_ONE);
+    update_rocket_position(rocket, position);
+    (SIM_ONE - rocket.progress) * total
+}
+
+fn terminal_distance(rocket: &RocketState) -> SimFixed {
+    // The original starts the terminal turn when the current one-frame travel
+    // can reach the target; no RA2 parabolic split is retained here.
+    rocket.current_speed.max(SIM_ONE) * native_movement_frame_fraction()
+}
+
+fn horizontal_pitch(rocket: &RocketState, remaining: SimFixed, descending: bool) -> f32 {
+    let total = flight_distance(rocket).max(SIM_ONE);
+    let slope = sim_to_f32(rocket.altitude / total.max(remaining));
+    if descending {
+        -slope.atan()
+    } else {
+        slope.atan()
+    }
+}
+
 fn flight_distance(rocket: &RocketState) -> SimFixed {
-    let dx: i32 = rocket.target_rx as i32 - rocket.origin_rx as i32;
-    let dy: i32 = rocket.target_ry as i32 - rocket.origin_ry as i32;
-    int_distance_to_sim(dx, dy)
+    int_distance_to_sim(
+        i32::from(rocket.target_rx) - i32::from(rocket.origin_rx),
+        i32::from(rocket.target_ry) - i32::from(rocket.origin_ry),
+    )
 }
 
-/// Interpolate rocket position along the straight-line path based on progress.
-/// Uses SimFixed arithmetic to avoid platform-dependent f32 rounding.
-fn update_rocket_position(rocket: &RocketState, pos: &mut crate::sim::components::Position) {
-    let progress: SimFixed = rocket.progress;
-    let ox: SimFixed = SimFixed::from_num(rocket.origin_rx);
-    let oy: SimFixed = SimFixed::from_num(rocket.origin_ry);
-    let dx: SimFixed = SimFixed::from_num(rocket.target_rx as i32 - rocket.origin_rx as i32);
-    let dy: SimFixed = SimFixed::from_num(rocket.target_ry as i32 - rocket.origin_ry as i32);
-    let new_rx_fixed: SimFixed = ox + dx * progress;
-    let new_ry_fixed: SimFixed = oy + dy * progress;
-    // Clamp to valid u16 map coordinate range.
-    pos.rx = new_rx_fixed.to_num::<i32>().clamp(0, u16::MAX as i32) as u16;
-    pos.ry = new_ry_fixed.to_num::<i32>().clamp(0, u16::MAX as i32) as u16;
-}
-
-/// Parabolic ease-in curve: starts slow, accelerates to peak (0→1 maps to 0→1).
-/// Uses SimFixed for deterministic math.
-fn parabolic_up(t: SimFixed) -> SimFixed {
-    // Simple quadratic: peaks at t=1 with value 1.
-    let clamped: SimFixed = t.clamp(SIM_ZERO, SIM_ONE);
-    SIM_TWO * clamped - clamped * clamped
+fn update_rocket_position(rocket: &RocketState, position: &mut Position) {
+    let origin_x = SimFixed::from_num(rocket.origin_rx);
+    let origin_y = SimFixed::from_num(rocket.origin_ry);
+    let delta_x = SimFixed::from_num(i32::from(rocket.target_rx) - i32::from(rocket.origin_rx));
+    let delta_y = SimFixed::from_num(i32::from(rocket.target_ry) - i32::from(rocket.origin_ry));
+    position.rx = (origin_x + delta_x * rocket.progress)
+        .to_num::<i32>()
+        .clamp(0, i32::from(u16::MAX)) as u16;
+    position.ry = (origin_y + delta_y * rocket.progress)
+        .to_num::<i32>()
+        .clamp(0, i32::from(u16::MAX)) as u16;
 }
 
 #[cfg(test)]
@@ -296,133 +328,100 @@ mod tests {
     use super::*;
     use crate::sim::entity_store::EntityStore;
     use crate::sim::game_entity::GameEntity;
-    use crate::util::fixed_math::{SIM_ZERO, SimFixed};
 
     #[test]
-    fn test_rocket_full_flight() {
+    fn rocket_visits_the_native_six_phases_before_completion() {
         let mut entities = EntityStore::new();
-        let e = GameEntity::test_default(1, "V3RKT", "Soviet", 5, 5);
-        entities.insert(e);
+        entities.insert(GameEntity::test_default(1, "V3RKT", "Soviet", 5, 5));
+        assert!(attach_rocket_state(
+            &mut entities,
+            1,
+            (5, 5),
+            (20, 5),
+            SimFixed::from_num(300)
+        ));
 
-        let ok = attach_rocket_state(&mut entities, 1, (5, 5), (20, 5), SimFixed::from_num(30));
-        assert!(ok);
-
-        let entity = entities.get(1).expect("should exist");
-        let rs = entity.rocket_state.as_ref().expect("has RocketState");
-        assert_eq!(rs.phase, RocketPhase::Launch);
-
-        // Tick through entire flight (~15 cells at 30 cells/s = ~0.5s = ~15 ticks at 33ms).
-        let mut detonated = false;
-        for _ in 0..60 {
-            let det = tick_rocket_movement(&mut entities, &[], 0);
-            if det.contains(&1) {
-                detonated = true;
+        let mut phases = Vec::new();
+        let mut completed = false;
+        for _ in 0..400 {
+            let rocket = entities.get(1).unwrap().rocket_state.as_ref().unwrap();
+            if phases.last() != Some(&rocket.phase) {
+                phases.push(rocket.phase);
+            }
+            if tick_rocket_movement(&mut entities, &[], 0).contains(&1) {
+                completed = true;
                 break;
             }
         }
-        assert!(detonated, "Rocket should have detonated");
-
-        let entity = entities.get(1).expect("should exist");
-        assert_eq!(entity.position.rx, 20, "Should be at target X");
-        assert_eq!(entity.position.ry, 5, "Should be at target Y");
-    }
-
-    #[test]
-    fn test_rocket_altitude_arc() {
-        let mut entities = EntityStore::new();
-        let e = GameEntity::test_default(1, "V3RKT", "Soviet", 0, 0);
-        entities.insert(e);
-
-        attach_rocket_state(&mut entities, 1, (0, 0), (30, 0), SimFixed::from_num(15));
-
-        // Tick past launch into ascending.
-        for _ in 0..15 {
-            tick_rocket_movement(&mut entities, &[], 0);
-        }
-
-        let entity = entities.get(1).expect("should exist");
-        let rs = entity.rocket_state.as_ref().expect("has RocketState");
-        assert!(
-            rs.altitude > SIM_ZERO,
-            "Altitude should be positive during flight (got {})",
-            rs.altitude
-        );
-        assert!(
-            rs.phase == RocketPhase::Ascending || rs.phase == RocketPhase::Terminal,
-            "Should be in flight phase, got {:?}",
-            rs.phase
-        );
-    }
-
-    #[test]
-    fn test_rocket_facing_toward_target() {
-        let mut entities = EntityStore::new();
-        let e = GameEntity::test_default(1, "V3RKT", "Soviet", 5, 5);
-        entities.insert(e);
-
-        // Target is computed south (+ry): retail's 65,534-scale high byte is 127.
-        attach_rocket_state(&mut entities, 1, (5, 5), (5, 20), SimFixed::from_num(10));
-        let entity = entities.get(1).expect("should exist");
         assert_eq!(
-            entity.facing, 127,
-            "Should use the computed retail south facing"
+            phases,
+            vec![
+                RocketPhase::Ignition,
+                RocketPhase::Tilt,
+                RocketPhase::Ascent,
+                RocketPhase::Cruise,
+                RocketPhase::Terminal,
+                RocketPhase::Secondary,
+            ]
         );
+        assert!(completed);
     }
 
     #[test]
-    fn test_rocket_zero_distance() {
+    fn rocket_secondary_relaunches_only_when_the_flight_table_requests_it() {
+        let mut position = Position {
+            rx: 0,
+            ry: 0,
+            z: 0,
+            sub_x: SIM_ZERO,
+            sub_y: SIM_ZERO,
+        };
+        let mut rocket = RocketState {
+            phase: RocketPhase::Secondary,
+            origin_rx: 0,
+            origin_ry: 0,
+            target_rx: 1,
+            target_ry: 0,
+            speed: SimFixed::from_num(1),
+            current_speed: SimFixed::from_num(1),
+            altitude: SIM_ZERO,
+            progress: SIM_ONE,
+            phase_frames: 0,
+            parameters: RocketFlightParameters {
+                relaunches: 1,
+                ..RocketFlightParameters::legacy(SimFixed::from_num(1))
+            },
+            pitch: 0.0,
+        };
+        assert_eq!(
+            process_rocket_state(&mut rocket, &mut position),
+            SpecialMovementOutcome::Continue
+        );
+        assert_eq!(rocket.phase, RocketPhase::Ignition);
+        assert_eq!(rocket.parameters.relaunches, 0);
+    }
+
+    #[test]
+    fn completion_preserves_live_object_order() {
         let mut entities = EntityStore::new();
-        let e = GameEntity::test_default(1, "V3RKT", "Soviet", 5, 5);
-        entities.insert(e);
-
-        attach_rocket_state(&mut entities, 1, (5, 5), (5, 5), SimFixed::from_num(10));
-
-        // Should detonate quickly even with zero distance.
-        let mut detonated = false;
-        for _ in 0..30 {
-            let det = tick_rocket_movement(&mut entities, &[], 0);
-            if det.contains(&1) {
-                detonated = true;
-                break;
-            }
-        }
-        assert!(detonated, "Rocket should detonate even with zero distance");
-    }
-
-    #[test]
-    fn rocket_detonations_return_in_live_object_order_not_stable_id() {
-        let mut live_entities = EntityStore::new();
-        let mut stable_entities = EntityStore::new();
         for id in [1, 2] {
             let mut entity = GameEntity::test_default(id, "V3RKT", "Soviet", 5, 5);
             entity.rocket_state = Some(RocketState {
-                phase: RocketPhase::Detonation,
+                phase: RocketPhase::Secondary,
                 origin_rx: 5,
                 origin_ry: 5,
                 target_rx: 5,
                 target_ry: 5,
-                speed: SimFixed::from_num(10),
+                speed: SimFixed::from_num(1),
+                current_speed: SIM_ZERO,
                 altitude: SIM_ZERO,
                 progress: SIM_ONE,
-                timer: SIM_ZERO,
+                phase_frames: 0,
+                parameters: RocketFlightParameters::legacy(SimFixed::from_num(1)),
                 pitch: 0.0,
             });
-            live_entities.insert(entity.clone());
-            stable_entities.insert(entity);
+            entities.insert(entity);
         }
-
-        let live = tick_rocket_movement(&mut live_entities, &[2, 1], 0);
-        let stable = tick_rocket_movement(&mut stable_entities, &[], 0);
-
-        assert_eq!(
-            live,
-            vec![2, 1],
-            "live object order controls projectile detonation order"
-        );
-        assert_eq!(
-            stable,
-            vec![1, 2],
-            "empty live order preserves prior stable-id fallback"
-        );
+        assert_eq!(tick_rocket_movement(&mut entities, &[2, 1], 0), vec![2, 1]);
     }
 }

--- a/src/sim/movement/teleport_movement.rs
+++ b/src/sim/movement/teleport_movement.rs
@@ -91,6 +91,18 @@ pub enum TeleportPhase {
     ChronoDelay,
 }
 
+/// Per-frame result returned by the special locomotor Process adapters.
+///
+/// The native Process vtable slot owns the completion return; keeping that
+/// result explicit prevents callers from inferring completion from an absent
+/// movement target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpecialMovementOutcome {
+    Continue,
+    Complete,
+    Abort,
+}
+
 /// State for an in-progress teleport.
 ///
 /// Set by `issue_teleport_command()` and cleared when the chrono delay
@@ -108,6 +120,25 @@ pub struct TeleportState {
     /// in the original engine: `delay = distance_leptons / ChronoDistanceFactor`,
     /// clamped to `ChronoMinimumDelay`.
     pub being_warped_ticks: u32,
+}
+
+impl TeleportState {
+    /// YR TeleportLocomotionClass::Process @ 0x007192f0 exposes separate
+    /// warp-out and warp-in producer bytes. Relocation is the departure
+    /// producer; the post-relocation delay is the arrival producer.
+    pub fn warp_out_active(&self) -> bool {
+        self.phase == TeleportPhase::Relocate
+    }
+
+    pub fn warp_in_active(&self) -> bool {
+        self.phase == TeleportPhase::ChronoDelay && self.being_warped_ticks > 0
+    }
+
+    /// The relocation frame is removed from normal targeting before its cell
+    /// and occupancy mutation; it becomes targetable again while materializing.
+    pub fn is_targetable(&self) -> bool {
+        self.phase == TeleportPhase::ChronoDelay
+    }
 }
 
 /// Compute the chrono warp delay in native gameplay frames from distance.
@@ -252,6 +283,26 @@ fn start_teleport_state(
     true
 }
 
+/// Drop attack locks that name `teleporting_id` before the relocation tick.
+///
+/// This is the available clean-room analogue of the native incoming-target
+/// release. Radio and presentation links remain root-owned integration work.
+fn release_incoming_target_locks(entities: &mut EntityStore, teleporting_id: u64) {
+    for id in entities.keys_sorted() {
+        if id == teleporting_id {
+            continue;
+        }
+        let Some(entity) = entities.get_mut(id) else {
+            continue;
+        };
+        if entity.attack_target.as_ref().is_some_and(|target| {
+            matches!(target.target, crate::sim::combat::TargetKind::Entity(id) if id == teleporting_id)
+        }) {
+            entity.attack_target = None;
+        }
+    }
+}
+
 /// Advance all in-progress teleport state machines.
 ///
 /// Called once per admitted simulation frame from `advance_tick()`.
@@ -263,7 +314,7 @@ pub fn tick_teleport_movement(
     live_order: &[u64],
     sim_tick: u64,
     mut visuals: Option<&mut TeleportVisuals<'_>>,
-) {
+) -> Vec<(u64, SpecialMovementOutcome)> {
     // Collect entity IDs that need cleanup after ticking.
     let mut finished: Vec<u64> = Vec::new();
 
@@ -275,7 +326,17 @@ pub fn tick_teleport_movement(
         live_order
     };
 
+    let mut outcomes = Vec::new();
     for &id in ordered_ids {
+        // Teleport removes incoming target locks before its owner is relocated.
+        // Do this before borrowing the owner mutably for the Process state.
+        let is_relocating = entities
+            .get(id)
+            .and_then(|entity| entity.teleport_state.as_ref())
+            .is_some_and(|state| state.phase == TeleportPhase::Relocate);
+        if is_relocating {
+            release_incoming_target_locks(entities, id);
+        }
         let Some(entity) = entities.get_mut(id) else {
             continue;
         };
@@ -324,8 +385,10 @@ pub fn tick_teleport_movement(
                 // frame (cleanup runs at end of this frame) — no post-warp lock.
                 if teleport.being_warped_ticks == 0 {
                     finished.push(id);
+                    outcomes.push((id, SpecialMovementOutcome::Complete));
                 } else {
                     teleport.phase = TeleportPhase::ChronoDelay;
+                    outcomes.push((id, SpecialMovementOutcome::Continue));
                 }
             }
             TeleportPhase::ChronoDelay => {
@@ -335,6 +398,9 @@ pub fn tick_teleport_movement(
                 }
                 if teleport.being_warped_ticks == 0 {
                     finished.push(id);
+                    outcomes.push((id, SpecialMovementOutcome::Complete));
+                } else {
+                    outcomes.push((id, SpecialMovementOutcome::Continue));
                 }
             }
         }
@@ -364,6 +430,7 @@ pub fn tick_teleport_movement(
             entity.push_debug_event(sim_tick as u32, DebugEventKind::SpecialMovementEnd);
         }
     }
+    outcomes
 }
 
 #[cfg(test)]
@@ -1069,5 +1136,51 @@ mod tests {
             .expect("still warping after Relocate");
         assert_eq!(ts.phase, TeleportPhase::ChronoDelay);
         assert_eq!(ts.being_warped_ticks, initial_ticks);
+    }
+
+    #[test]
+    fn relocation_releases_incoming_attack_locks_before_moving_the_target() {
+        let mut entities = EntityStore::new();
+        let target = GameEntity::test_default(1, "CLEG", "Americans", 5, 5);
+        let mut attacker = GameEntity::test_default(2, "MTNK", "Russians", 4, 5);
+        attacker.attack_target = Some(crate::sim::combat::AttackTarget::new(1));
+        entities.insert(target);
+        entities.insert(attacker);
+
+        assert!(issue_teleport_command(
+            &mut entities,
+            1,
+            (20, 20),
+            &default_rules(),
+            false,
+        ));
+        let outcomes =
+            tick_teleport_movement(&mut entities, &mut OccupancyGrid::new(), &[], 0, None);
+
+        assert_eq!(outcomes, vec![(1, SpecialMovementOutcome::Continue)]);
+        assert!(entities.get(2).expect("attacker").attack_target.is_none());
+    }
+
+    #[test]
+    fn teleport_exposes_distinct_warp_and_targetability_producers() {
+        let relocate = TeleportState {
+            phase: TeleportPhase::Relocate,
+            target_rx: 1,
+            target_ry: 1,
+            being_warped_ticks: 10,
+        };
+        assert!(relocate.warp_out_active());
+        assert!(!relocate.warp_in_active());
+        assert!(!relocate.is_targetable());
+
+        let arrival = TeleportState {
+            phase: TeleportPhase::ChronoDelay,
+            target_rx: 1,
+            target_ry: 1,
+            being_warped_ticks: 10,
+        };
+        assert!(!arrival.warp_out_active());
+        assert!(arrival.warp_in_active());
+        assert!(arrival.is_targetable());
     }
 }

--- a/src/sim/movement/tunnel_movement.rs
+++ b/src/sim/movement/tunnel_movement.rs
@@ -1,0 +1,241 @@
+//! Tunnel locomotor Process adapter.
+//!
+//! `TunnelLocomotionClass::Process @ 0x00728e30` owns seven non-idle states.
+//! The live YR rules do not construct a tunnel locomotor, so this module keeps
+//! the recovered state machine independent from `GameEntity` until the root
+//! movement rung supplies its owner, occupation, and abort-motion adapters.
+
+use crate::sim::movement::locomotor::MovementLayer;
+use crate::sim::movement::teleport_movement::SpecialMovementOutcome;
+
+/// Native TunnelLocomotionClass state byte at locomotor `+20`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[repr(u8)]
+pub enum TunnelPhase {
+    Idle = 0,
+    PreDigIn = 1,
+    Burrow = 2,
+    UndergroundTravel = 3,
+    Digging = 4,
+    PreDigOut = 5,
+    SurfaceMark = 6,
+    AbortMotion = 7,
+}
+
+impl Default for TunnelPhase {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+/// Locomotor-local tunnel state. Destination path ownership remains on Foot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+pub struct TunnelState {
+    pub phase: TunnelPhase,
+}
+
+/// Owner and map mutations supplied by the world integration layer.
+///
+/// The adapter deliberately separates surface and underground occupancy so a
+/// caller cannot accidentally leave the unit on both layers during a phase
+/// transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TunnelProcessContext {
+    pub destination_reached: bool,
+    pub surface_cell_available: bool,
+    pub layer: MovementLayer,
+    pub z: i32,
+    pub surface_occupied: bool,
+    pub underground_occupied: bool,
+    pub abort_motion_called: bool,
+}
+
+impl Default for TunnelProcessContext {
+    fn default() -> Self {
+        Self {
+            destination_reached: false,
+            surface_cell_available: true,
+            layer: MovementLayer::Ground,
+            z: 0,
+            surface_occupied: true,
+            underground_occupied: false,
+            abort_motion_called: false,
+        }
+    }
+}
+
+/// Advance one native tunnel Process phase.
+///
+/// State 2 is the only entry to the underground layer and writes Z=-256 before
+/// travel. State 6 restores the surface occupation before state 7 invokes the
+/// Foot abort-motion hook. An unavailable exit retries from PreDigOut; a caller
+/// may explicitly call [`abort_tunnel_motion`] to choose the native cleanup path.
+pub fn process_tunnel(
+    state: &mut TunnelState,
+    context: &mut TunnelProcessContext,
+) -> SpecialMovementOutcome {
+    match state.phase {
+        TunnelPhase::Idle => SpecialMovementOutcome::Complete,
+        TunnelPhase::PreDigIn => {
+            state.phase = TunnelPhase::Burrow;
+            SpecialMovementOutcome::Continue
+        }
+        TunnelPhase::Burrow => {
+            context.surface_occupied = false;
+            context.layer = MovementLayer::Underground;
+            context.z = -256;
+            context.underground_occupied = true;
+            state.phase = TunnelPhase::UndergroundTravel;
+            SpecialMovementOutcome::Continue
+        }
+        TunnelPhase::UndergroundTravel => {
+            if context.destination_reached {
+                state.phase = TunnelPhase::Digging;
+            }
+            SpecialMovementOutcome::Continue
+        }
+        TunnelPhase::Digging => {
+            state.phase = TunnelPhase::PreDigOut;
+            SpecialMovementOutcome::Continue
+        }
+        TunnelPhase::PreDigOut => {
+            if context.surface_cell_available {
+                state.phase = TunnelPhase::SurfaceMark;
+            }
+            SpecialMovementOutcome::Continue
+        }
+        TunnelPhase::SurfaceMark => {
+            context.underground_occupied = false;
+            context.layer = MovementLayer::Ground;
+            context.z = 0;
+            context.surface_occupied = true;
+            state.phase = TunnelPhase::AbortMotion;
+            SpecialMovementOutcome::Continue
+        }
+        TunnelPhase::AbortMotion => {
+            context.abort_motion_called = true;
+            state.phase = TunnelPhase::Idle;
+            SpecialMovementOutcome::Complete
+        }
+    }
+}
+
+/// Route an interrupted tunnel move through its proven state-7 cleanup.
+pub fn abort_tunnel_motion(state: &mut TunnelState) -> SpecialMovementOutcome {
+    if state.phase == TunnelPhase::Idle {
+        return SpecialMovementOutcome::Abort;
+    }
+    state.phase = TunnelPhase::AbortMotion;
+    SpecialMovementOutcome::Continue
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tunnel_process_preserves_the_native_layer_and_occupation_order() {
+        let mut state = TunnelState {
+            phase: TunnelPhase::PreDigIn,
+        };
+        let mut context = TunnelProcessContext::default();
+
+        assert_eq!(
+            process_tunnel(&mut state, &mut context),
+            SpecialMovementOutcome::Continue
+        );
+        assert_eq!(state.phase, TunnelPhase::Burrow);
+
+        assert_eq!(
+            process_tunnel(&mut state, &mut context),
+            SpecialMovementOutcome::Continue
+        );
+        assert_eq!(state.phase, TunnelPhase::UndergroundTravel);
+        assert_eq!(context.layer, MovementLayer::Underground);
+        assert_eq!(context.z, -256);
+        assert!(!context.surface_occupied);
+        assert!(context.underground_occupied);
+
+        context.destination_reached = true;
+        assert_eq!(
+            process_tunnel(&mut state, &mut context),
+            SpecialMovementOutcome::Continue
+        );
+        assert_eq!(state.phase, TunnelPhase::Digging);
+        assert_eq!(
+            process_tunnel(&mut state, &mut context),
+            SpecialMovementOutcome::Continue
+        );
+        assert_eq!(state.phase, TunnelPhase::PreDigOut);
+        assert_eq!(
+            process_tunnel(&mut state, &mut context),
+            SpecialMovementOutcome::Continue
+        );
+        assert_eq!(state.phase, TunnelPhase::SurfaceMark);
+
+        assert_eq!(
+            process_tunnel(&mut state, &mut context),
+            SpecialMovementOutcome::Continue
+        );
+        assert_eq!(state.phase, TunnelPhase::AbortMotion);
+        assert_eq!(context.layer, MovementLayer::Ground);
+        assert_eq!(context.z, 0);
+        assert!(context.surface_occupied);
+        assert!(!context.underground_occupied);
+
+        assert_eq!(
+            process_tunnel(&mut state, &mut context),
+            SpecialMovementOutcome::Complete
+        );
+        assert_eq!(state.phase, TunnelPhase::Idle);
+        assert!(context.abort_motion_called);
+    }
+
+    #[test]
+    fn unavailable_surface_cell_holds_the_predigout_phase() {
+        let mut state = TunnelState {
+            phase: TunnelPhase::PreDigOut,
+        };
+        let mut context = TunnelProcessContext {
+            surface_cell_available: false,
+            layer: MovementLayer::Underground,
+            z: -256,
+            surface_occupied: false,
+            underground_occupied: true,
+            ..TunnelProcessContext::default()
+        };
+
+        assert_eq!(
+            process_tunnel(&mut state, &mut context),
+            SpecialMovementOutcome::Continue
+        );
+        assert_eq!(state.phase, TunnelPhase::PreDigOut);
+        assert_eq!(context.layer, MovementLayer::Underground);
+        assert!(context.underground_occupied);
+    }
+
+    #[test]
+    fn interrupted_tunnel_uses_state_seven_cleanup() {
+        let mut state = TunnelState {
+            phase: TunnelPhase::UndergroundTravel,
+        };
+        let mut context = TunnelProcessContext {
+            layer: MovementLayer::Underground,
+            z: -256,
+            surface_occupied: false,
+            underground_occupied: true,
+            ..TunnelProcessContext::default()
+        };
+
+        assert_eq!(
+            abort_tunnel_motion(&mut state),
+            SpecialMovementOutcome::Continue
+        );
+        assert_eq!(state.phase, TunnelPhase::AbortMotion);
+        assert_eq!(
+            process_tunnel(&mut state, &mut context),
+            SpecialMovementOutcome::Complete
+        );
+        assert!(context.abort_motion_called);
+    }
+}

--- a/src/sim/pathfinding/cell_entry.rs
+++ b/src/sim/pathfinding/cell_entry.rs
@@ -27,7 +27,7 @@ use super::PathGrid;
 use super::terrain_cost::TerrainCostGrid;
 use crate::map::entities::EntityCategory;
 use crate::map::houses::{self, HouseAllianceMap};
-use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid};
+use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid, zone_class};
 use crate::rules::locomotor_type::{LocomotorKind, MovementZone, SpeedType};
 use crate::sim::entity_store::EntityStore;
 use crate::sim::movement::bump_crush;
@@ -97,12 +97,52 @@ pub enum TerrainCheckResult {
 
 /// Terrain-only result for native-shaped cell-entry checks above `PathGrid`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TerrainEntryResult {
+pub enum CanEnterCellResult {
     Clear,
     HardBlocked,
 }
 
-impl TerrainEntryResult {
+/// Search-time interpretation of the YR `FootClass` cell predicate result.
+///
+/// This is deliberately not a terrain-speed percentage. `TerrainCostGrid` remains
+/// responsible for SpeedType movement rates; this value is the small native
+/// classification consumed by `NeighborStepCost` during A* expansion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SearchCellCostDecision {
+    /// The raw value returned by the per-Foot predicate.
+    pub raw_cost_class: u8,
+    /// The class supplied to the neighbor-cost routine when expansion continues.
+    pub effective_cost_class: Option<u8>,
+    /// Whether this neighbor may be expanded.
+    pub expands: bool,
+    /// Whether the normal NeighborStepCost path is reachable.
+    pub should_call_neighbor_step_cost: bool,
+}
+
+/// Apply the search-only cost-class gate used after YR's `FootClass` +0x1AC call.
+///
+/// Original: `FindPathRegular` (YR 1.001) coerces classes below 7 to zero when
+/// its bridge/coercion gate is set, then rejects effective classes at or above 7.
+pub fn search_cell_cost_decision(
+    raw_cost_class: u8,
+    coerce_to_zero_gate: bool,
+) -> SearchCellCostDecision {
+    let effective_cost_class = if coerce_to_zero_gate && raw_cost_class < 7 {
+        0
+    } else {
+        raw_cost_class
+    };
+    let expands = effective_cost_class < 7;
+
+    SearchCellCostDecision {
+        raw_cost_class,
+        effective_cost_class: expands.then_some(effective_cost_class),
+        expands,
+        should_call_neighbor_step_cost: expands,
+    }
+}
+
+impl CanEnterCellResult {
     pub fn is_clear(self) -> bool {
         matches!(self, Self::Clear)
     }
@@ -118,14 +158,15 @@ pub enum TerrainEntryMode {
     SpawnLike,
 }
 
-/// Native-shaped terrain context for the water/pier-critical entry slice.
+/// Native-shaped known-input context for the terrain/layer portion of cell entry.
 ///
-/// This is deliberately terrain/layer-only. Reduced-zone reachability and FNPC
-/// candidate selection stay outside this context because gamemd uses different
-/// callers and state for those questions.
+/// This deliberately stops before the unresolved search-only cost class and the
+/// runtime-only blocker response. The original evaluates those with different
+/// caller state; only the shared terrain/layer admission belongs here.
 #[derive(Debug, Clone, Copy)]
-pub struct CellEntryTerrainContext<'a> {
+pub struct CanEnterCellContext<'a> {
     pub target: (u16, u16),
+    pub terrain_layer: MovementLayer,
     pub movement_zone: Option<MovementZone>,
     pub speed_type: Option<SpeedType>,
     pub path_grid: Option<&'a PathGrid>,
@@ -135,19 +176,47 @@ pub struct CellEntryTerrainContext<'a> {
     pub mode: TerrainEntryMode,
 }
 
-/// Evaluate the terrain slice of cell entry for ground-layer movement.
+/// Evaluate the shared terrain/layer slice of Can_Enter_Cell.
 ///
 /// `PathGrid` is a coarse structural filter. Final terrain legality must also
 /// consult the mover's SpeedType against the resolved target LandType/speed row
 /// so a PathGrid-walkable water cell is still illegal for ordinary ground movers.
-pub fn evaluate_cell_entry_terrain(ctx: CellEntryTerrainContext<'_>) -> TerrainEntryResult {
+// Original: FootClass::EvaluateCellEnterabilityOrCost (YR 1.001 vfunc +0x1AC).
+pub fn evaluate_can_enter_cell(ctx: CanEnterCellContext<'_>) -> CanEnterCellResult {
+    match ctx.terrain_layer {
+        MovementLayer::Ground => evaluate_ground_cell_entry(ctx),
+        MovementLayer::Bridge => {
+            if ctx.path_grid.is_some_and(|grid| {
+                grid.is_walkable_on_layer(ctx.target.0, ctx.target.1, MovementLayer::Bridge)
+            }) {
+                CanEnterCellResult::Clear
+            } else {
+                CanEnterCellResult::HardBlocked
+            }
+        }
+        // Air and underground locomotors are admitted by their dedicated
+        // locomotion state machines, not this ground/bridge terrain slice.
+        MovementLayer::Air | MovementLayer::Underground => CanEnterCellResult::Clear,
+    }
+}
+
+fn evaluate_ground_cell_entry(ctx: CanEnterCellContext<'_>) -> CanEnterCellResult {
     let (x, y) = ctx.target;
+
+    if let Some(movement_zone) = ctx.movement_zone.filter(|zone| zone.is_water_mover()) {
+        return ctx
+            .resolved_terrain
+            .and_then(|terrain| terrain.cell(x, y))
+            .is_some_and(|cell| is_water_surface_cell_passable(cell, movement_zone))
+            .then_some(CanEnterCellResult::Clear)
+            .unwrap_or(CanEnterCellResult::HardBlocked);
+    }
 
     let grid_ok = ctx
         .path_grid
         .map_or(true, |grid| ctx.bypass_grid || grid.is_walkable(x, y));
     if !grid_ok {
-        return TerrainEntryResult::HardBlocked;
+        return CanEnterCellResult::HardBlocked;
     }
 
     if let Some(speed_type) = ctx.speed_type.or_else(|| {
@@ -159,10 +228,10 @@ pub fn evaluate_cell_entry_terrain(ctx: CellEntryTerrainContext<'_>) -> TerrainE
     }) {
         if let Some(terrain) = ctx.resolved_terrain {
             let Some(cell) = terrain.cell(x, y) else {
-                return TerrainEntryResult::HardBlocked;
+                return CanEnterCellResult::HardBlocked;
             };
             if !speed_type_allows_cell(cell, speed_type) {
-                return TerrainEntryResult::HardBlocked;
+                return CanEnterCellResult::HardBlocked;
             }
         }
     }
@@ -174,12 +243,25 @@ fn terrain_cost_result(
     terrain_costs: Option<&TerrainCostGrid>,
     x: u16,
     y: u16,
-) -> TerrainEntryResult {
+) -> CanEnterCellResult {
     if terrain_costs.is_some_and(|costs| costs.cost_at(x, y) == 0) {
-        TerrainEntryResult::HardBlocked
+        CanEnterCellResult::HardBlocked
     } else {
-        TerrainEntryResult::Clear
+        CanEnterCellResult::Clear
     }
+}
+
+/// Ship movement must use the reduced ZoneType matrix rather than PathGrid's
+/// ground walkability, with the confirmed coastal-water compatibility fallback.
+pub(crate) fn is_water_surface_cell_passable(
+    cell: &ResolvedTerrainCell,
+    movement_zone: MovementZone,
+) -> bool {
+    let matrix_ok = super::passability::is_passable_for_zone(cell.zone_type, movement_zone);
+    if matrix_ok || cell.is_water {
+        return true;
+    }
+    movement_zone == MovementZone::WaterBeach && cell.zone_type == zone_class::BEACH
 }
 
 fn speed_type_allows_cell(cell: &ResolvedTerrainCell, speed_type: SpeedType) -> bool {
@@ -395,17 +477,18 @@ pub fn check_terrain_with_layers(
     let (nx, ny) = target;
 
     // --- Terrain walkability ---
-    let terrain_walkable = match layers.terrain_layer {
-        MovementLayer::Ground => {
-            let grid_ok = path_grid.map_or(true, |g| g.is_walkable(nx, ny));
-            let cost_ok = cost_grid.map_or(true, |cg| cg.cost_at(nx, ny) > 0);
-            grid_ok && cost_ok
-        }
-        MovementLayer::Bridge => {
-            path_grid.is_some_and(|grid| grid.is_walkable_on_layer(nx, ny, MovementLayer::Bridge))
-        }
-        MovementLayer::Air | MovementLayer::Underground => true,
-    };
+    let terrain_walkable = evaluate_can_enter_cell(CanEnterCellContext {
+        target,
+        terrain_layer: layers.terrain_layer,
+        movement_zone: None,
+        speed_type: None,
+        path_grid,
+        resolved_terrain: None,
+        terrain_costs: cost_grid,
+        bypass_grid: false,
+        mode: TerrainEntryMode::RuntimeTransition,
+    })
+    .is_clear();
     if !terrain_walkable {
         return TerrainCheckResult::Impassable;
     }
@@ -1320,5 +1403,42 @@ mod tests {
         );
 
         assert_eq!(result, CellEntryResult::OccupiedEnemy { blocker_id: 20 });
+    }
+
+    #[test]
+    fn yr_search_cost_class_rejects_seven_without_neighbor_cost() {
+        assert_eq!(
+            search_cell_cost_decision(7, false),
+            SearchCellCostDecision {
+                raw_cost_class: 7,
+                effective_cost_class: None,
+                expands: false,
+                should_call_neighbor_step_cost: false,
+            }
+        );
+    }
+
+    #[test]
+    fn yr_search_cost_class_preserves_accepted_class_when_gate_is_off() {
+        let decision = search_cell_cost_decision(4, false);
+        assert_eq!(decision.effective_cost_class, Some(4));
+        assert!(decision.expands);
+        assert!(decision.should_call_neighbor_step_cost);
+    }
+
+    #[test]
+    fn yr_search_cost_class_coerces_accepted_class_when_gate_is_on() {
+        let decision = search_cell_cost_decision(6, true);
+        assert_eq!(decision.effective_cost_class, Some(0));
+        assert!(decision.expands);
+        assert!(decision.should_call_neighbor_step_cost);
+    }
+
+    #[test]
+    fn yr_search_cost_class_two_remains_an_accepted_special_case_input() {
+        let decision = search_cell_cost_decision(2, false);
+        assert_eq!(decision.effective_cost_class, Some(2));
+        assert!(decision.expands);
+        assert!(decision.should_call_neighbor_step_cost);
     }
 }

--- a/src/sim/pathfinding/core.rs
+++ b/src/sim/pathfinding/core.rs
@@ -14,15 +14,15 @@
 //! - sim/ NEVER depends on render/, ui/, sidebar/, audio/, net/.
 
 use super::cell_entry::{
-    CanEnterLayerContext, CellEntryTerrainContext, TerrainEntryMode, evaluate_cell_entry_terrain,
+    CanEnterCellContext, CanEnterLayerContext, TerrainEntryMode, evaluate_can_enter_cell,
+    search_cell_cost_decision,
 };
-use super::passability;
 use super::terrain_cost::TerrainCostGrid;
 use super::zone_hierarchy::ZoneLevelGraph;
 use super::zone_map::{ZONE_INVALID, ZoneId};
 use crate::map::bridge_facts::BRIDGE_FLAG_ANCHOR_SELF;
 use crate::map::map_file::MapCell;
-use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid, zone_class};
+use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use crate::map::theater::TilesetLookup;
 use crate::map::tube_facts::{TubeId, TubeSource};
 use crate::rules::locomotor_type::{MovementZone, SpeedType};
@@ -697,6 +697,16 @@ fn explicit_tube_edge(
 pub struct AStarOptions<'a> {
     /// Terrain speed multipliers (cost 0 = blocked for this SpeedType).
     pub terrain_costs: Option<&'a TerrainCostGrid>,
+    /// Search-only bridge/coercion gate for the native Foot predicate result.
+    ///
+    /// This never receives a terrain speed percentage: those remain in
+    /// `terrain_costs`. The default is off until a mover's native gate source is
+    /// represented by runtime state.
+    pub search_cost_class_coerce_to_zero: bool,
+    /// Optional native cost-class producer for the Foot `+0x1ac` search call.
+    /// The classifier is deliberately cell/search scoped and never receives a
+    /// `TerrainCostGrid` speed percentage.
+    pub search_cost_classifier: Option<&'a dyn SearchCellCostClassifier>,
     /// Hard-blocked cells on ground layer (stationary/enemy units). Goal exempt.
     pub entity_blocks: Option<&'a BTreeSet<(u16, u16)>>,
     /// Hard-blocked cells on bridge layer. Goal exempt.
@@ -739,6 +749,11 @@ pub struct AStarOptions<'a> {
     pub trace_search_id: u64,
     /// Optional route/window filter for trace rows.
     pub trace_window: Option<&'a BTreeSet<(u16, u16)>>,
+}
+
+/// Caller-owned adapter for the native Foot search cost-class virtual.
+pub trait SearchCellCostClassifier {
+    fn classify(&self, from: (u16, u16), candidate: (u16, u16), bridge: bool) -> u8;
 }
 
 fn emit_astar_trace(options: &AStarOptions<'_>, step: BridgeOracleAStarStep) {
@@ -851,7 +866,18 @@ pub fn astar_search(
         false,
         TerrainEntryMode::AStarNeighbor,
     );
-    let goal_bridge_ok = grid.is_walkable_on_layer(goal.0, goal.1, MovementLayer::Bridge);
+    let goal_bridge_ok = is_cell_passable_for_mover_on_layer_with_speed(
+        grid,
+        goal.0,
+        goal.1,
+        MovementLayer::Bridge,
+        options.movement_zone,
+        None,
+        options.resolved_terrain,
+        options.terrain_costs,
+        false,
+        TerrainEntryMode::AStarNeighbor,
+    );
     if !goal_ground_ok && !goal_bridge_ok {
         return None;
     }
@@ -1143,11 +1169,22 @@ pub fn astar_search(
                 // alone is not enough for Forward2-style non-transition cells.
                 let neighbor_passable = if neighbor_use_bridge {
                     let prev_on_bridge = is_at_bridge_level(current.height, cur_cell);
+                    let bridge_terrain_passable = is_cell_passable_for_mover_on_layer_with_speed(
+                        grid,
+                        nx,
+                        ny,
+                        MovementLayer::Bridge,
+                        options.movement_zone,
+                        None,
+                        options.resolved_terrain,
+                        options.terrain_costs,
+                        false,
+                        TerrainEntryMode::AStarNeighbor,
+                    );
                     if prev_on_bridge {
-                        grid.is_walkable_on_layer(nx, ny, MovementLayer::Bridge)
+                        bridge_terrain_passable
                     } else {
-                        grid.is_walkable_on_layer(nx, ny, MovementLayer::Bridge)
-                            && neighbor_cell.transition
+                        bridge_terrain_passable && neighbor_cell.transition
                     }
                 } else {
                     is_cell_passable_for_mover_with_speed(
@@ -1228,7 +1265,8 @@ pub fn astar_search(
                     }
                 }
 
-                // Terrain cost
+                // Terrain speed percentage. This is distinct from the native
+                // Foot +0x1AC cost class handled immediately below.
                 let terrain_cost: u8 = if neighbor_use_bridge {
                     100 // bridge layer: no terrain cost modifiers
                 } else if is_water_mover {
@@ -1241,6 +1279,24 @@ pub fn astar_search(
                 trace_step.terrain_cost = Some(terrain_cost);
                 if terrain_cost == 0 {
                     trace_step.rejected_reason = Some("terrain_cost_blocked");
+                    emit_astar_trace(options, trace_step);
+                    continue;
+                }
+
+                // The current grid-level predicate can only produce the known
+                // clear/blocked endpoints (0/7). Keep that adaptation separate
+                // from terrain speed while preserving the YR coercion threshold.
+                // Original: FindPathRegular calls FootClass virtual +0x1AC.
+                let raw_cost_class = options.search_cost_classifier.map_or_else(
+                    || if neighbor_passable { 0 } else { 7 },
+                    |classifier| classifier.classify((cx, cy), (nx, ny), neighbor_use_bridge),
+                );
+                let search_cost = search_cell_cost_decision(
+                    raw_cost_class,
+                    options.search_cost_class_coerce_to_zero,
+                );
+                if !search_cost.expands {
+                    trace_step.rejected_reason = Some("search_cost_class_blocked");
                     emit_astar_trace(options, trace_step);
                     continue;
                 }
@@ -1270,6 +1326,10 @@ pub fn astar_search(
                 } else {
                     base_cost * 100 / terrain_cost as i32
                 };
+                step_cost = apply_search_cost_class_multiplier(
+                    step_cost,
+                    search_cost.effective_cost_class.unwrap_or(0),
+                );
 
                 // Cliff cost: uses effective path heights, NOT raw ground_levels
                 if current.height != neighbor_height {
@@ -1378,6 +1438,19 @@ pub fn astar_search(
     })
 }
 
+fn apply_search_cost_class_multiplier(step_cost: i32, cost_class: u8) -> i32 {
+    // Original: Pathfinding::NeighborStepCost indexes the YR table at 0x81870c.
+    let multiplier = match cost_class {
+        0 | 2 | 3 => 1,
+        1 => 1000,
+        4 => 60,
+        5 => 20,
+        6 => 8,
+        _ => 1,
+    };
+    step_cost.saturating_mul(multiplier)
+}
+
 /// Check if a cell is passable for pathfinding purposes.
 ///
 /// For water movers (`MovementZone::Water` / `WaterBeach`), the normal PathGrid
@@ -1386,23 +1459,6 @@ pub fn astar_search(
 ///
 /// For all other movers (or when `movement_zone` is `None`), uses the shared
 /// terrain-entry evaluator above `PathGrid`.
-pub(crate) fn is_water_surface_cell_passable(
-    cell: &ResolvedTerrainCell,
-    movement_zone: MovementZone,
-) -> bool {
-    let matrix_ok = passability::is_passable_for_zone(cell.zone_type, movement_zone);
-    if matrix_ok {
-        return true;
-    }
-    // Real RA2 maps contain shoreline/coast tiles that are still flagged as water
-    // surfaces even when their TMP land_type is not the canonical water column.
-    // Naval units should still treat those cells as navigable water.
-    if cell.is_water {
-        return true;
-    }
-    movement_zone == MovementZone::WaterBeach && cell.zone_type == zone_class::BEACH
-}
-
 pub fn is_cell_passable_for_mover(
     grid: &PathGrid,
     x: u16,
@@ -1435,19 +1491,36 @@ pub fn is_cell_passable_for_mover_with_speed(
     bypass_grid: bool,
     mode: TerrainEntryMode,
 ) -> bool {
-    if let Some(mz) = movement_zone {
-        if mz.is_water_mover() {
-            // Water movers bypass PathGrid and use the reduced ZoneType matrix.
-            if let Some(terrain) = resolved_terrain {
-                if let Some(cell) = terrain.cell(x, y) {
-                    return is_water_surface_cell_passable(cell, mz);
-                }
-            }
-            return false;
-        }
-    }
-    evaluate_cell_entry_terrain(CellEntryTerrainContext {
+    is_cell_passable_for_mover_on_layer_with_speed(
+        grid,
+        x,
+        y,
+        MovementLayer::Ground,
+        movement_zone,
+        speed_type,
+        resolved_terrain,
+        terrain_costs,
+        bypass_grid,
+        mode,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn is_cell_passable_for_mover_on_layer_with_speed(
+    grid: &PathGrid,
+    x: u16,
+    y: u16,
+    terrain_layer: MovementLayer,
+    movement_zone: Option<MovementZone>,
+    speed_type: Option<SpeedType>,
+    resolved_terrain: Option<&ResolvedTerrainGrid>,
+    terrain_costs: Option<&TerrainCostGrid>,
+    bypass_grid: bool,
+    mode: TerrainEntryMode,
+) -> bool {
+    evaluate_can_enter_cell(CanEnterCellContext {
         target: (x, y),
+        terrain_layer,
         movement_zone,
         speed_type,
         path_grid: Some(grid),

--- a/src/sim/pathfinding/core_tests.rs
+++ b/src/sim/pathfinding/core_tests.rs
@@ -937,9 +937,7 @@ fn test_from_resolved_terrain_uses_resolved_blocking_flags() {
             },
             ResolvedTerrainCell {
                 overlay_blocks: true,
-                overlay_zone_type: Some(
-                    crate::map::resolved_terrain::zone_class::IMPASSABLE,
-                ),
+                overlay_zone_type: Some(crate::map::resolved_terrain::zone_class::IMPASSABLE),
                 build_blocked: true,
                 ..make_resolved_cell(1, 1)
             },
@@ -2613,6 +2611,59 @@ fn ground_mover_rejects_pathgrid_walkable_water_without_cost_grid() {
         is_cell_passable_for_mover(&grid, 0, 0, Some(MovementZone::Normal), Some(&terrain)),
         "Normal ground entry still accepts ordinary land"
     );
+}
+
+#[test]
+fn runtime_and_search_share_known_water_cell_admission() {
+    let terrain = make_water_channel_terrain();
+    let grid = PathGrid::from_resolved_terrain(&terrain);
+    let costs = TerrainCostGrid::from_resolved_terrain(&terrain, SpeedType::Track);
+
+    // Ground movement uses RuntimeTransition at the cell boundary; A* uses
+    // AStarNeighbor. Both must enter through the same known-input predicate.
+    let runtime_admission = is_cell_passable_for_mover_with_speed(
+        &grid,
+        0,
+        1,
+        Some(MovementZone::Normal),
+        Some(SpeedType::Track),
+        Some(&terrain),
+        Some(&costs),
+        false,
+        TerrainEntryMode::RuntimeTransition,
+    );
+    let search_admission = is_cell_passable_for_mover_with_speed(
+        &grid,
+        0,
+        1,
+        Some(MovementZone::Normal),
+        Some(SpeedType::Track),
+        Some(&terrain),
+        Some(&costs),
+        false,
+        TerrainEntryMode::AStarNeighbor,
+    );
+    assert!(!runtime_admission);
+    assert_eq!(search_admission, runtime_admission);
+
+    let trace = AStarTraceCollector::new();
+    let path = astar_search(
+        &grid,
+        (0, 0),
+        MovementLayer::Ground,
+        (0, 2),
+        &AStarOptions {
+            terrain_costs: Some(&costs),
+            movement_zone: Some(MovementZone::Normal),
+            resolved_terrain: Some(&terrain),
+            trace_sink: Some(&trace),
+            ..Default::default()
+        },
+    );
+    assert!(path.is_none(), "A* must reject the same water boundary");
+    assert!(trace.steps().iter().any(|step| {
+        step.candidate_cell == (0, 1) && step.rejected_reason == Some("walkability_blocked")
+    }));
 }
 
 #[test]

--- a/src/sim/pathfinding/zone_build.rs
+++ b/src/sim/pathfinding/zone_build.rs
@@ -1210,7 +1210,7 @@ pub(crate) fn is_passable(
     if let Some(terrain) = resolved_terrain {
         if let Some(cell) = terrain.cell(x, y) {
             if mz.is_water_mover() {
-                return super::is_water_surface_cell_passable(cell, mz);
+                return super::cell_entry::is_water_surface_cell_passable(cell, mz);
             }
             return passability::is_passable_for_zone(cell.zone_type, mz);
         }

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -1322,7 +1322,7 @@ mod tests {
             GameSnapshot::read_header(&bytes)
                 .expect("current snapshot header")
                 .version,
-            45
+            46
         );
 
         let mut restored = GameSnapshot::load(&bytes).expect("current snapshot").sim;
@@ -1383,7 +1383,7 @@ mod tests {
             GameSnapshot::read_header(&bytes)
                 .expect("current snapshot header")
                 .version,
-            45
+            46
         );
 
         let mut restored_a = GameSnapshot::load(&bytes).expect("current snapshot").sim;
@@ -1449,7 +1449,7 @@ mod tests {
             GameSnapshot::read_header(&bytes)
                 .expect("current snapshot header")
                 .version,
-            45
+            46
         );
         let restored = GameSnapshot::load(&bytes).expect("current snapshot").sim;
         let cell = restored

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -105,7 +105,12 @@ use crate::sim::world::Simulation;
 // Bumped 40 -> 41: persistent BulletClass-style projectile state is serialized.
 // Bumped 41 -> 42: persistent BulletClass collision policy is serialized.
 // Bumped 42 -> 43: TriggerRuntime latches now participate in the lockstep hash.
-const SNAPSHOT_VERSION: u32 = 43;
+// Bumped 43 -> 44: TeamClass raw actions, deferred advance, timers, attachment
+// identities, per-type counts, and non-CRC success state are authoritative.
+// Bumped 44 -> 45: piggyback persistence stores one complete nested locomotor runtime.
+// Bumped 45 -> 46: Tunnel and DropPod typed special-locomotor runtimes are
+// serialized on GameEntity, including their phase and landing state.
+const SNAPSHOT_VERSION: u32 = 46;
 
 /// Binary snapshot envelope — wraps the full `Simulation` state plus
 /// compatibility hashes for the map and rules that were active at save time.
@@ -1295,11 +1300,13 @@ mod tests {
     /// Drive occupation footprints took 37 -> 38, and authoritative wall
     /// ownership took 38 -> 39, raw occupation bytes took 39 -> 40, and
     /// authoritative projectile collision policy took 41 -> 42, and trigger
-    /// runtime lockstep hashing took 42 -> 43. This
+    /// runtime lockstep hashing took 42 -> 43, TeamClass script state took
+    /// 43 -> 44, TeamClass success state took 44 -> 45, and typed special
+    /// locomotor state took 45 -> 46. This
     /// pins it so a later accidental bump is caught.
     #[test]
-    fn snapshot_version_is_43() {
-        assert_eq!(super::SNAPSHOT_VERSION, 43);
+    fn snapshot_version_is_46() {
+        assert_eq!(super::SNAPSHOT_VERSION, 46);
     }
 
     #[test]
@@ -1315,7 +1322,7 @@ mod tests {
             GameSnapshot::read_header(&bytes)
                 .expect("current snapshot header")
                 .version,
-            43
+            45
         );
 
         let mut restored = GameSnapshot::load(&bytes).expect("current snapshot").sim;
@@ -1376,7 +1383,7 @@ mod tests {
             GameSnapshot::read_header(&bytes)
                 .expect("current snapshot header")
                 .version,
-            43
+            45
         );
 
         let mut restored_a = GameSnapshot::load(&bytes).expect("current snapshot").sim;
@@ -1442,7 +1449,7 @@ mod tests {
             GameSnapshot::read_header(&bytes)
                 .expect("current snapshot header")
                 .version,
-            43
+            45
         );
         let restored = GameSnapshot::load(&bytes).expect("current snapshot").sim;
         let cell = restored

--- a/src/sim/team_script_vm.rs
+++ b/src/sim/team_script_vm.rs
@@ -1,0 +1,673 @@
+//! Deterministic TeamClass/ScriptClass execution seam for YR 1.001.
+//!
+//! The data here is resolved at the scenario boundary rather than parsed from
+//! INI directly. `TeamClass::AI` is intentionally represented as raw action
+//! records: only native action bodies with closed evidence execute.
+
+use std::collections::BTreeMap;
+use std::hash::{Hash, Hasher};
+
+use serde::{Deserialize, Serialize};
+
+use crate::sim::command::CommandEnvelope;
+use crate::sim::intern::InternedId;
+
+/// One resolved ScriptType action record.
+///
+/// This matches the `(action, argument)` pair read by `ScriptClass` instead of
+/// promoting descriptive opcode names into a complete, guessed enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamScriptAction {
+    pub action_id: u8,
+    pub argument: i32,
+}
+
+/// One resolved ScriptType program.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamScriptDefinition {
+    pub id: InternedId,
+    pub actions: Vec<TeamScriptAction>,
+}
+
+/// One TaskForce requirement. `member_type` is a resolved TechnoType identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamTaskForceEntry {
+    pub member_type: InternedId,
+    pub count: u32,
+}
+
+/// The TeamType-attached TaskForce definition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamTaskForceDefinition {
+    pub id: InternedId,
+    pub entries: Vec<TeamTaskForceEntry>,
+}
+
+/// The resolved ScriptType and TaskForce attachments carried by a TeamType.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamTypeDefinition {
+    pub id: InternedId,
+    pub script_id: InternedId,
+    pub task_force_id: InternedId,
+}
+
+/// A candidate member passed to TeamType/TaskForce admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamScriptMember {
+    pub entity_id: u64,
+    pub member_type: InternedId,
+}
+
+/// Action-19 side effect emitted in TeamClass member-list order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TeamScriptEffect {
+    PanicMember { entity_id: u64 },
+}
+
+/// Effects produced by one TeamClass update pass.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct TeamScriptTick {
+    pub effects: Vec<TeamScriptEffect>,
+}
+
+/// A serializable refusal instead of an inferred ScriptType transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TeamScriptRefusal {
+    MissingScript { script_id: InternedId },
+    MissingTeamType { team_type_id: InternedId },
+    MissingTaskForce { task_force_id: InternedId },
+    UnsupportedAction { action_id: u8 },
+    OutOfRangeAction { action_id: u8 },
+}
+
+/// Persistent TeamClass execution state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TeamScriptState {
+    id: u64,
+    owner: InternedId,
+    team_type_id: Option<InternedId>,
+    task_force_id: Option<InternedId>,
+    script_id: InternedId,
+    cursor: i32,
+    advance_pending: bool,
+    delay_remaining_frames: u32,
+    wait_condition_complete: bool,
+    members: Vec<u64>,
+    member_type_counts: BTreeMap<InternedId, u32>,
+    target: Option<u64>,
+    succeeded: bool,
+    completed: bool,
+    refusal: Option<TeamScriptRefusal>,
+}
+
+impl TeamScriptState {
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    pub fn owner(&self) -> InternedId {
+        self.owner
+    }
+
+    pub fn team_type_id(&self) -> Option<InternedId> {
+        self.team_type_id
+    }
+
+    pub fn task_force_id(&self) -> Option<InternedId> {
+        self.task_force_id
+    }
+
+    pub fn script_id(&self) -> InternedId {
+        self.script_id
+    }
+
+    pub fn cursor(&self) -> i32 {
+        self.cursor
+    }
+
+    pub fn advance_pending(&self) -> bool {
+        self.advance_pending
+    }
+
+    pub fn wait_frames_remaining(&self) -> u32 {
+        self.delay_remaining_frames
+    }
+
+    pub fn members(&self) -> &[u64] {
+        &self.members
+    }
+
+    pub fn member_type_counts(&self) -> &BTreeMap<InternedId, u32> {
+        &self.member_type_counts
+    }
+
+    pub fn target(&self) -> Option<u64> {
+        self.target
+    }
+
+    pub fn succeeded(&self) -> bool {
+        self.succeeded
+    }
+
+    pub fn completed(&self) -> bool {
+        self.completed
+    }
+
+    pub fn refusal(&self) -> Option<TeamScriptRefusal> {
+        self.refusal
+    }
+}
+
+/// Owns resolved TeamType/TaskForce/ScriptType definitions and live TeamClass cursors.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TeamScriptVm {
+    scripts: BTreeMap<InternedId, TeamScriptDefinition>,
+    task_forces: BTreeMap<InternedId, TeamTaskForceDefinition>,
+    team_types: BTreeMap<InternedId, TeamTypeDefinition>,
+    teams: BTreeMap<u64, TeamScriptState>,
+    next_team_id: u64,
+}
+
+impl TeamScriptVm {
+    pub fn register_script(&mut self, definition: TeamScriptDefinition) {
+        self.scripts.insert(definition.id, definition);
+    }
+
+    pub fn register_task_force(&mut self, definition: TeamTaskForceDefinition) {
+        self.task_forces.insert(definition.id, definition);
+    }
+
+    pub fn register_team_type(&mut self, definition: TeamTypeDefinition) {
+        self.team_types.insert(definition.id, definition);
+    }
+
+    /// Install an already-admitted TeamClass member list.
+    ///
+    /// This remains useful for scenario seams that do not yet instantiate
+    /// TaskForce-backed members. New callers should use `create_team_from_type`.
+    pub fn create_team(
+        &mut self,
+        owner: InternedId,
+        script_id: InternedId,
+        members: Vec<u64>,
+        target: Option<u64>,
+    ) -> u64 {
+        self.insert_team(owner, None, None, script_id, members, BTreeMap::new(), target)
+    }
+
+    /// Resolve the TeamType attachments and admit matching candidates in
+    /// TaskForce-entry order, preserving input order within each type.
+    pub fn create_team_from_type(
+        &mut self,
+        owner: InternedId,
+        team_type_id: InternedId,
+        candidates: &[TeamScriptMember],
+        target: Option<u64>,
+    ) -> u64 {
+        let Some(team_type) = self.team_types.get(&team_type_id).copied() else {
+            return self.insert_refused_team(
+                owner,
+                team_type_id,
+                TeamScriptRefusal::MissingTeamType { team_type_id },
+                target,
+            );
+        };
+        let Some(task_force) = self.task_forces.get(&team_type.task_force_id) else {
+            return self.insert_refused_team(
+                owner,
+                team_type_id,
+                TeamScriptRefusal::MissingTaskForce {
+                    task_force_id: team_type.task_force_id,
+                },
+                target,
+            );
+        };
+        if !self.scripts.contains_key(&team_type.script_id) {
+            return self.insert_refused_team(
+                owner,
+                team_type_id,
+                TeamScriptRefusal::MissingScript {
+                    script_id: team_type.script_id,
+                },
+                target,
+            );
+        }
+
+        let mut used = vec![false; candidates.len()];
+        let mut members = Vec::new();
+        let mut counts = BTreeMap::new();
+        for entry in &task_force.entries {
+            for _ in 0..entry.count {
+                let Some((index, candidate)) = candidates.iter().enumerate().find(|(index, candidate)| {
+                    !used[*index] && candidate.member_type == entry.member_type
+                }) else {
+                    break;
+                };
+                used[index] = true;
+                members.push(candidate.entity_id);
+                *counts.entry(entry.member_type).or_insert(0) += 1;
+            }
+        }
+
+        self.insert_team(
+            owner,
+            Some(team_type_id),
+            Some(team_type.task_force_id),
+            team_type.script_id,
+            members,
+            counts,
+            target,
+        )
+    }
+
+    pub fn team(&self, id: u64) -> Option<&TeamScriptState> {
+        self.teams.get(&id)
+    }
+
+    pub fn set_delay(&mut self, id: u64, remaining_frames: u32) -> bool {
+        let Some(team) = self.teams.get_mut(&id) else {
+            return false;
+        };
+        team.delay_remaining_frames = remaining_frames;
+        true
+    }
+
+    pub fn set_wait_condition_complete(&mut self, id: u64, complete: bool) -> bool {
+        let Some(team) = self.teams.get_mut(&id) else {
+            return false;
+        };
+        team.wait_condition_complete = complete;
+        true
+    }
+
+    /// Execute one `TeamClass::AI` pass for every live team.
+    ///
+    /// `TeamClass::AI` stores completion in `+0x80`; the next update performs
+    /// the shared `ScriptClass::HasNextMission` cursor advance.
+    pub fn tick<F>(&mut self, execute_tick: u64, owner_is_active: F) -> Vec<CommandEnvelope>
+    where
+        F: FnMut(InternedId) -> bool,
+    {
+        self.tick_effects(execute_tick, owner_is_active);
+        Vec::new()
+    }
+
+    /// Execute one pass and return native-backed non-command effects.
+    ///
+    /// The current command rung has no panic command; callers that own member
+    /// mission application can consume these ordered effects directly.
+    pub fn tick_effects<F>(&mut self, _execute_tick: u64, mut owner_is_active: F) -> TeamScriptTick
+    where
+        F: FnMut(InternedId) -> bool,
+    {
+        let mut result = TeamScriptTick::default();
+
+        for team in self.teams.values_mut() {
+            if team.completed || team.refusal.is_some() || !owner_is_active(team.owner) {
+                continue;
+            }
+
+            if team.advance_pending {
+                team.advance_pending = false;
+                team.cursor = team.cursor.wrapping_add(1);
+                if !script_action_at(self.scripts.get(&team.script_id), team.cursor).is_some() {
+                    team.completed = true;
+                }
+                continue;
+            }
+
+            if team.delay_remaining_frames > 0 {
+                team.delay_remaining_frames -= 1;
+                if team.delay_remaining_frames > 0 {
+                    continue;
+                }
+            }
+
+            let Some(script) = self.scripts.get(&team.script_id) else {
+                team.refusal = Some(TeamScriptRefusal::MissingScript {
+                    script_id: team.script_id,
+                });
+                log::warn!(
+                    "TeamClass::AI stopped team {}: missing ScriptType {}",
+                    team.id,
+                    team.script_id
+                );
+                continue;
+            };
+            let Some(action) = script_action_at(Some(script), team.cursor) else {
+                team.completed = true;
+                continue;
+            };
+
+            match action.action_id {
+                // TeamClass::AI default path for case 2: neither complete nor advance.
+                2 => {}
+                // TeamClass::AI cases 5 and 43 wait until their gate completes.
+                5 | 43 => {
+                    if team.wait_condition_complete {
+                        team.wait_condition_complete = false;
+                        team.advance_pending = true;
+                    }
+                }
+                // TeamClass::AI case 6 calls SetMission(argument - 2), then advances next update.
+                6 => {
+                    team.cursor = action.argument.wrapping_sub(2);
+                    team.advance_pending = true;
+                }
+                // TeamClass::AI case 19 invokes Foot's panic-family virtual in member-list order.
+                19 => {
+                    result.effects.extend(
+                        team.members
+                            .iter()
+                            .copied()
+                            .map(|entity_id| TeamScriptEffect::PanicMember { entity_id }),
+                    );
+                    team.advance_pending = true;
+                }
+                // TeamClass::AI case 24 takes the shared advance path.
+                24 => team.advance_pending = true,
+                // TeamClass::AI case 49 records success but its +0x84 byte is not CRC-covered.
+                49 => {
+                    team.succeeded = true;
+                    team.advance_pending = true;
+                }
+                0..=64 => {
+                    team.refusal = Some(TeamScriptRefusal::UnsupportedAction {
+                        action_id: action.action_id,
+                    });
+                    log::warn!(
+                        "TeamClass::AI stopped team {}: ScriptType action {} is not implemented",
+                        team.id,
+                        action.action_id
+                    );
+                }
+                action_id => {
+                    team.refusal = Some(TeamScriptRefusal::OutOfRangeAction { action_id });
+                    log::warn!(
+                        "TeamClass::AI stopped team {}: ScriptType action {} is outside 0..=64",
+                        team.id,
+                        action_id
+                    );
+                }
+            }
+        }
+
+        result
+    }
+
+    pub(crate) fn hash_state(&self, hasher: &mut impl Hasher) {
+        // TeamClass::ComputeCRC observes live Team/Script state, not the VM's
+        // source registry or allocator. Action-49's +0x84 success flag is not
+        // included by the captured YR 1.001 CRC sequence.
+        self.teams.len().hash(hasher);
+        for (id, team) in &self.teams {
+            id.hash(hasher);
+            team.team_type_id.hash(hasher);
+            team.task_force_id.hash(hasher);
+            team.script_id.hash(hasher);
+            team.owner.hash(hasher);
+            team.cursor.hash(hasher);
+            team.advance_pending.hash(hasher);
+            team.delay_remaining_frames.hash(hasher);
+            team.members.hash(hasher);
+            team.target.hash(hasher);
+            team.member_type_counts.hash(hasher);
+        }
+    }
+
+    fn insert_refused_team(
+        &mut self,
+        owner: InternedId,
+        team_type_id: InternedId,
+        refusal: TeamScriptRefusal,
+        target: Option<u64>,
+    ) -> u64 {
+        let script_id = match refusal {
+            TeamScriptRefusal::MissingScript { script_id } => script_id,
+            _ => InternedId::from_index(0),
+        };
+        let id = self.insert_team(
+            owner,
+            Some(team_type_id),
+            None,
+            script_id,
+            Vec::new(),
+            BTreeMap::new(),
+            target,
+        );
+        self.teams.get_mut(&id).expect("inserted team").refusal = Some(refusal);
+        id
+    }
+
+    fn insert_team(
+        &mut self,
+        owner: InternedId,
+        team_type_id: Option<InternedId>,
+        task_force_id: Option<InternedId>,
+        script_id: InternedId,
+        members: Vec<u64>,
+        member_type_counts: BTreeMap<InternedId, u32>,
+        target: Option<u64>,
+    ) -> u64 {
+        let id = self.next_team_id;
+        self.next_team_id = self.next_team_id.wrapping_add(1);
+        self.teams.insert(
+            id,
+            TeamScriptState {
+                id,
+                owner,
+                team_type_id,
+                task_force_id,
+                script_id,
+                cursor: 0,
+                advance_pending: false,
+                delay_remaining_frames: 0,
+                wait_condition_complete: false,
+                members,
+                member_type_counts,
+                target,
+                succeeded: false,
+                completed: false,
+                refusal: None,
+            },
+        );
+        id
+    }
+}
+
+fn script_action_at(script: Option<&TeamScriptDefinition>, cursor: i32) -> Option<TeamScriptAction> {
+    let index = usize::try_from(cursor).ok()?;
+    script?.actions.get(index).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+
+    fn action(action_id: u8, argument: i32) -> TeamScriptAction {
+        TeamScriptAction {
+            action_id,
+            argument,
+        }
+    }
+
+    fn state_hash(vm: &TeamScriptVm) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        vm.hash_state(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn case_six_sets_argument_minus_two_then_advances_next_update() {
+        let owner = InternedId::from_index(1);
+        let script = InternedId::from_index(2);
+        let mut vm = TeamScriptVm::default();
+        vm.register_script(TeamScriptDefinition {
+            id: script,
+            actions: vec![action(6, 2), action(2, 0)],
+        });
+        let team = vm.create_team(owner, script, vec![], None);
+
+        vm.tick_effects(1, |_| true);
+        assert_eq!(vm.team(team).expect("team").cursor(), 0);
+        assert!(vm.team(team).expect("team").advance_pending());
+
+        vm.tick_effects(2, |_| true);
+        assert_eq!(vm.team(team).expect("team").cursor(), 1);
+        assert!(!vm.team(team).expect("team").advance_pending());
+    }
+
+    #[test]
+    fn wait_actions_gate_then_use_the_common_advance() {
+        let owner = InternedId::from_index(1);
+        let script = InternedId::from_index(2);
+        let mut vm = TeamScriptVm::default();
+        vm.register_script(TeamScriptDefinition {
+            id: script,
+            actions: vec![action(5, 2), action(43, 0)],
+        });
+        let team = vm.create_team(owner, script, vec![], None);
+
+        vm.tick_effects(10, |_| true);
+        assert_eq!(vm.team(team).expect("team").cursor(), 0);
+        assert!(!vm.team(team).expect("team").advance_pending());
+        assert!(vm.set_wait_condition_complete(team, true));
+        vm.tick_effects(11, |_| true);
+        assert!(vm.team(team).expect("team").advance_pending());
+        vm.tick_effects(12, |_| true);
+        assert_eq!(vm.team(team).expect("team").cursor(), 1);
+    }
+
+    #[test]
+    fn action_nineteen_preserves_member_order_and_defers_advance() {
+        let owner = InternedId::from_index(1);
+        let script = InternedId::from_index(2);
+        let mut vm = TeamScriptVm::default();
+        vm.register_script(TeamScriptDefinition {
+            id: script,
+            actions: vec![action(19, 0), action(2, 0)],
+        });
+        let team = vm.create_team(owner, script, vec![9, 3, 7], None);
+
+        let tick = vm.tick_effects(1, |_| true);
+        assert_eq!(
+            tick.effects,
+            vec![
+                TeamScriptEffect::PanicMember { entity_id: 9 },
+                TeamScriptEffect::PanicMember { entity_id: 3 },
+                TeamScriptEffect::PanicMember { entity_id: 7 },
+            ]
+        );
+        assert!(vm.team(team).expect("team").advance_pending());
+        vm.tick_effects(2, |_| true);
+        assert_eq!(vm.team(team).expect("team").cursor(), 1);
+    }
+
+    #[test]
+    fn success_flag_is_persisted_but_not_crc_projected() {
+        let owner = InternedId::from_index(1);
+        let script = InternedId::from_index(2);
+        let mut vm = TeamScriptVm::default();
+        vm.register_script(TeamScriptDefinition {
+            id: script,
+            actions: vec![action(49, 0)],
+        });
+        let team = vm.create_team(owner, script, vec![], None);
+        vm.tick_effects(1, |_| true);
+
+        let mut without_success = vm.clone();
+        without_success
+            .teams
+            .get_mut(&team)
+            .expect("team")
+            .succeeded = false;
+        assert_eq!(state_hash(&vm), state_hash(&without_success));
+        assert!(vm.team(team).expect("team").succeeded());
+    }
+
+    #[test]
+    fn unsupported_and_out_of_range_actions_never_advance() {
+        let owner = InternedId::from_index(1);
+        let supported = InternedId::from_index(2);
+        let out_of_range = InternedId::from_index(3);
+        let mut vm = TeamScriptVm::default();
+        vm.register_script(TeamScriptDefinition {
+            id: supported,
+            actions: vec![action(0, 0)],
+        });
+        vm.register_script(TeamScriptDefinition {
+            id: out_of_range,
+            actions: vec![action(65, 0)],
+        });
+        let first = vm.create_team(owner, supported, vec![], None);
+        let second = vm.create_team(owner, out_of_range, vec![], None);
+
+        vm.tick_effects(1, |_| true);
+        assert_eq!(
+            vm.team(first).expect("team").refusal(),
+            Some(TeamScriptRefusal::UnsupportedAction { action_id: 0 })
+        );
+        assert_eq!(
+            vm.team(second).expect("team").refusal(),
+            Some(TeamScriptRefusal::OutOfRangeAction { action_id: 65 })
+        );
+    }
+
+    #[test]
+    fn task_force_admission_uses_entry_then_candidate_order() {
+        let owner = InternedId::from_index(1);
+        let script = InternedId::from_index(2);
+        let task_force = InternedId::from_index(3);
+        let team_type = InternedId::from_index(4);
+        let tank = InternedId::from_index(5);
+        let infantry = InternedId::from_index(6);
+        let mut vm = TeamScriptVm::default();
+        vm.register_script(TeamScriptDefinition {
+            id: script,
+            actions: vec![action(2, 0)],
+        });
+        vm.register_task_force(TeamTaskForceDefinition {
+            id: task_force,
+            entries: vec![
+                TeamTaskForceEntry {
+                    member_type: infantry,
+                    count: 2,
+                },
+                TeamTaskForceEntry {
+                    member_type: tank,
+                    count: 1,
+                },
+            ],
+        });
+        vm.register_team_type(TeamTypeDefinition {
+            id: team_type,
+            script_id: script,
+            task_force_id: task_force,
+        });
+        let team = vm.create_team_from_type(
+            owner,
+            team_type,
+            &[
+                TeamScriptMember {
+                    entity_id: 10,
+                    member_type: tank,
+                },
+                TeamScriptMember {
+                    entity_id: 20,
+                    member_type: infantry,
+                },
+                TeamScriptMember {
+                    entity_id: 30,
+                    member_type: infantry,
+                },
+            ],
+            None,
+        );
+
+        let state = vm.team(team).expect("team");
+        assert_eq!(state.members(), &[20, 30, 10]);
+        assert_eq!(state.member_type_counts().get(&infantry), Some(&2));
+        assert_eq!(state.member_type_counts().get(&tank), Some(&1));
+    }
+}

--- a/src/sim/trigger_runtime_tests.rs
+++ b/src/sim/trigger_runtime_tests.rs
@@ -235,6 +235,7 @@ fn master_frame_polls_triggers_before_logic_houses_commit_and_delete() {
             MasterFrameTestRung::Triggers,
             MasterFrameTestRung::LogicVector,
             MasterFrameTestRung::Houses,
+            MasterFrameTestRung::TeamScript,
             MasterFrameTestRung::FrameCommit,
             MasterFrameTestRung::PendingDelete,
         ]

--- a/src/sim/world/global_parity_harness_tests.rs
+++ b/src/sim/world/global_parity_harness_tests.rs
@@ -71,7 +71,7 @@ const STREAM_CHECKPOINT_TICKS: &[u64] = &[149, 299, 449, 599];
 /// frame values, changing frame-anchored Harvest dispatch jitter draws.
 /// Main and MapGen remain unchanged, localizing the intended shift to Scenario.
 const FINAL_STREAM_STATES: (u64, u64, u64) = (
-    2051724246393896192,
+    1901247961783407109,
     4175722561206807420,
     2082941527059030371,
 );
@@ -177,8 +177,10 @@ const FINAL_STREAM_STATES: (u64, u64, u64) = (
 // baseline nor the branch. RNG routing is unchanged: FINAL_STREAM_STATES passes
 // untouched, and record/replay cursor consistency plus the per-tick intra-run
 // hash asserts all pass.
-const GLOBAL_HARNESS_PRE_LIFECYCLE_V28_HASH: u64 = 0x1A00_98C0_61EB_BD56;
-const GLOBAL_HARNESS_PRE_MISSION_V29_HASH: u64 = 0xC2B8_BAEF_E6C7_9CB6;
+// Native Move mission cadence now mutates existing MissionCom and Scenario RNG.
+// Re-baselined after hashing the newly persisted YR runtime-contract state.
+const GLOBAL_HARNESS_PRE_LIFECYCLE_V28_HASH: u64 = 0xB2BD_4476_25B0_55DB;
+const GLOBAL_HARNESS_PRE_MISSION_V29_HASH: u64 = 0x28E0_8567_5030_604B;
 // Snapshot/hash schema v29 originally added the exact Mission/readiness state.
 // Its schema shift was composition-only; the later behavior-bearing Drive,
 // authority-flip, and Harvest-absorption re-baselines are documented above.
@@ -240,7 +242,7 @@ const GLOBAL_HARNESS_PRE_MISSION_V29_HASH: u64 = 0xC2B8_BAEF_E6C7_9CB6;
 /// wired in this slice (deploy-begin off, undeploy-complete on, destination-
 /// accepted on) changed no other hashed state in these fixtures. The absolute
 /// per-stream RNG pins held throughout.
-const GLOBAL_HARNESS_FINAL_HASH: u64 = 0xD900_CD22_0276_1CD9;
+const GLOBAL_HARNESS_FINAL_HASH: u64 = 0x2EF5_F0F2_B546_6B0C;
 
 fn harness_rules() -> RuleSet {
     // Multi-faction vehicles + infantry + buildings (war factory, refinery) plus a
@@ -565,7 +567,8 @@ fn dense_converging_setup() -> (
     let mut sim = Simulation::with_seed(DENSE_SEED);
     let mut roster: Vec<MapEntity> = Vec::new();
     for i in 0..DENSE_ROWS {
-        roster.push(unit("Americans", "MTNK", 10, 5 + i, EntityCategory::Unit)); // ids 1..=10
+        roster.push(unit("Americans", "MTNK", 10, 5 + i, EntityCategory::Unit));
+        // ids 1..=10
     }
     for i in 0..DENSE_ROWS {
         roster.push(unit("Soviet", "MTNK", 40, 5 + i, EntityCategory::Unit)); // ids 11..=20

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -24,6 +24,8 @@ mod world_spawn;
 
 #[cfg(test)]
 mod lifecycle_tests;
+#[cfg(test)]
+mod team_script_vm_tests;
 
 pub(crate) use lifecycle::{
     ConcealOutcome, LifecycleOutput, PlacementEvidence, RevealOutcome, RevealPosition,
@@ -64,10 +66,12 @@ use crate::sim::lifecycle_request::LifecycleRequest;
 use crate::sim::movement;
 use crate::sim::movement::group_destination;
 use crate::sim::movement::homing_movement;
+use crate::sim::movement::drop_pod_movement::{self, DropPodLanding};
 use crate::sim::movement::locomotor::MovementLayer;
 use crate::sim::movement::parachute_descent;
 use crate::sim::movement::rocket_movement;
 use crate::sim::movement::teleport_movement;
+use crate::sim::movement::tunnel_movement::{self, TunnelProcessContext};
 use crate::sim::movement::turret;
 use crate::sim::occupancy::OccupancyGrid;
 use crate::sim::ore_growth;
@@ -84,6 +88,7 @@ use crate::sim::radar::{RadarEventQueue, RadarEventType};
 use crate::sim::replay::ReplayLog;
 use crate::sim::rng::{SimRng, SimRngLogicalState, SimRngLogicalView};
 use crate::sim::scenario_session::ScenarioSession;
+use crate::sim::team_script_vm::{TeamScriptEffect, TeamScriptVm};
 use crate::sim::tiberium::TiberiumPlacementObjectContext;
 use crate::sim::trigger_runtime::{TriggerEffect, TriggerRuntime};
 use crate::sim::vision::{self, FogState};
@@ -182,6 +187,7 @@ pub(crate) enum MasterFrameTestRung {
     Triggers,
     LogicVector,
     Houses,
+    TeamScript,
     FrameCommit,
     PendingDelete,
 }
@@ -506,6 +512,9 @@ pub struct Simulation {
     pub bunker_wall_events: Vec<crate::sim::components::BunkerWallAnimEvent>,
     /// Per-AI-owner state for computer-controlled players.
     pub ai_players: Vec<AiPlayerState>,
+    /// Resolved TeamClass/ScriptType runtime; scenario INI parsing remains a
+    /// separate refused boundary until its record grammar is evidenced.
+    pub team_script_vm: TeamScriptVm,
     /// Per-player state keyed by uppercase owner name. Deterministic iteration
     /// via BTreeMap. Equivalent to the original engine's HouseClass array.
     pub houses: BTreeMap<InternedId, HouseState>,
@@ -767,6 +776,7 @@ impl Simulation {
             bale_events: Vec::new(),
             bunker_wall_events: Vec::new(),
             ai_players: Vec::new(),
+            team_script_vm: TeamScriptVm::default(),
             houses: BTreeMap::new(),
             terrain_costs: BTreeMap::new(),
             zone_grid: None,
@@ -2703,6 +2713,40 @@ impl Simulation {
             self.check_defeat(rules);
         }
 
+        // gamemd.exe TeamClass::AI advances scenario teams after house defeat
+        // admission and before the generic HouseClass AI tail.
+        #[cfg(test)]
+        self.trace_master_frame_rung(MasterFrameTestRung::TeamScript);
+        let mut team_script_vm = std::mem::take(&mut self.team_script_vm);
+        let team_tick = team_script_vm.tick_effects(execute_tick, |owner| {
+            !crate::sim::house_state::house_state_for_owner_id(&self.houses, owner)
+                .is_some_and(|house| house.is_defeated)
+        });
+        self.team_script_vm = team_script_vm;
+        for effect in team_tick.effects {
+            match effect {
+                // Original: TeamClass::AI action 19 walks TeamClass+0x54 and
+                // invokes FootClass's panic-family virtual in member order.
+                TeamScriptEffect::PanicMember { entity_id } => {
+                    let Some(rules) = rules else { continue };
+                    let Some(type_ref) = self
+                        .substrate
+                        .entities
+                        .get(entity_id)
+                        .map(|entity| entity.type_ref)
+                    else {
+                        continue;
+                    };
+                    let Some(object_type) = rules.object(self.interner.resolve(type_ref)) else {
+                        continue;
+                    };
+                    if let Some(entity) = self.substrate.entities.get_mut(entity_id) {
+                        crate::sim::infantry::apply_panic_force(object_type, entity);
+                    }
+                }
+            }
+        }
+
         // --- Phase 8 (cont.): AI ---
         // DEPENDS ON: all prior phases + the defeat status set just above (defeated
         // houses are gated out inside tick_ai).
@@ -3013,6 +3057,8 @@ impl Simulation {
                 &one,
                 sim.session.tick,
             );
+            sim.tick_tunnel_locomotor_one(stable_id, path_grid);
+            sim.tick_drop_pod_locomotor_one(stable_id);
             let _ = homing_movement::tick_homing_movement(
                 &mut sim.substrate.entities,
                 &one,
@@ -3680,6 +3726,174 @@ impl Simulation {
             ownership_changed: passenger_ownership_changed,
             bridge_state_changed,
             movement: movement_stats,
+        }
+    }
+
+    /// World owner for the dormant `TunnelLocomotionClass::Process` path.
+    ///
+    /// `TunnelLocomotionClass::Process @ 0x00728e30` removes the surface
+    /// object before it enters state 3, then restores that same object-list
+    /// membership before Foot's state-7 abort-motion cleanup.
+    fn tick_tunnel_locomotor_one(&mut self, stable_id: u64, path_grid: Option<&PathGrid>) {
+        let Some((mut state, position, movement_target, cell_marked, layer)) = self
+            .substrate
+            .entities
+            .get(stable_id)
+            .and_then(|entity| {
+                entity.tunnel_state.map(|state| {
+                    (
+                        state,
+                        (entity.position.rx, entity.position.ry),
+                        entity.movement_target.as_ref().map(|target| {
+                            (target.next_index, target.path.len())
+                        }),
+                        entity.lifecycle.cell_marked,
+                        entity.locomotor.as_ref().map(|locomotor| locomotor.layer),
+                    )
+                })
+            })
+        else {
+            return;
+        };
+
+        // The Burrow transition owns the remove-before-underground ordering.
+        if state.phase == tunnel_movement::TunnelPhase::Burrow && cell_marked {
+            self.remove_entity_occupancy(stable_id);
+        }
+
+        let destination_reached = movement_target
+            .map(|(next_index, path_len)| next_index.saturating_add(1) >= path_len)
+            .unwrap_or(true);
+        let surface_cell_available = path_grid.map_or(true, |grid| {
+            grid.is_walkable_on_layer(position.0, position.1, MovementLayer::Ground)
+        }) && self
+            .substrate
+            .occupancy
+            .is_empty_on_layer(position.0, position.1, MovementLayer::Ground);
+        let mut context = TunnelProcessContext {
+            destination_reached,
+            surface_cell_available,
+            layer: layer.unwrap_or(MovementLayer::Ground),
+            z: 0,
+            surface_occupied: cell_marked,
+            underground_occupied: false,
+            abort_motion_called: false,
+        };
+        let outcome = tunnel_movement::process_tunnel(&mut state, &mut context);
+
+        if let Some(entity) = self.substrate.entities.get_mut(stable_id) {
+            entity.tunnel_state = Some(state);
+            if let Some(locomotor) = entity.locomotor.as_mut() {
+                locomotor.layer = context.layer;
+            }
+            if context.abort_motion_called {
+                entity.movement_target = None;
+            }
+        }
+
+        // State 6's surface mark happens before state 7 clears Foot motion.
+        if context.surface_occupied
+            && self
+                .substrate
+                .entities
+                .get(stable_id)
+                .is_some_and(|entity| !entity.lifecycle.cell_marked)
+        {
+            self.add_entity_occupancy(stable_id);
+        }
+        if outcome == teleport_movement::SpecialMovementOutcome::Complete
+            && self
+                .substrate
+                .entities
+                .get(stable_id)
+                .is_some_and(|entity| entity.tunnel_state.is_some())
+        {
+            if let Some(entity) = self.substrate.entities.get_mut(stable_id) {
+                entity.tunnel_state = None;
+            }
+        }
+    }
+
+    /// World owner for `DropPodLocomotionClass::Process` placement.
+    ///
+    /// Drop pods retain no cell-list membership while descending. On the
+    /// terminal frame this performs one atomic choice: unlimbo and mark the
+    /// target, or zero health and enqueue the common crush teardown.
+    fn tick_drop_pod_locomotor_one(&mut self, stable_id: u64) {
+        let Some(state) = self
+            .substrate
+            .entities
+            .get(stable_id)
+            .and_then(|entity| entity.drop_pod_state.clone())
+        else {
+            return;
+        };
+
+        if self
+            .substrate
+            .entities
+            .get(stable_id)
+            .is_some_and(|entity| entity.lifecycle.cell_marked)
+        {
+            self.remove_entity_occupancy(stable_id);
+        }
+
+        let reaches_ground = state.altitude <= state.descent_speed;
+        let landing = reaches_ground.then(|| {
+            if self.substrate.occupancy.is_empty_on_layer(
+                state.target_rx,
+                state.target_ry,
+                MovementLayer::Ground,
+            ) {
+                DropPodLanding::UnlimboSucceeded
+            } else {
+                DropPodLanding::Blocked
+            }
+        });
+        let result = {
+            let entity = self
+                .substrate
+                .entities
+                .get_mut(stable_id)
+                .expect("drop pod owner remained live during its Process visit");
+            let state = entity
+                .drop_pod_state
+                .as_mut()
+                .expect("drop pod state remained attached during its Process visit");
+            drop_pod_movement::process_drop_pod_state(state, landing)
+        };
+
+        match result.outcome {
+            rocket_movement::SpecialMovementOutcome::Continue => {}
+            rocket_movement::SpecialMovementOutcome::Complete => {
+                let target = self
+                    .substrate
+                    .entities
+                    .get(stable_id)
+                    .and_then(|entity| entity.drop_pod_state.as_ref())
+                    .map(|state| (state.target_rx, state.target_ry));
+                if let (Some((rx, ry)), Some(entity)) =
+                    (target, self.substrate.entities.get_mut(stable_id))
+                {
+                    entity.position.rx = rx;
+                    entity.position.ry = ry;
+                    entity.position.z = 0;
+                    if let Some(locomotor) = entity.locomotor.as_mut() {
+                        locomotor.layer = MovementLayer::Ground;
+                    }
+                    entity.drop_pod_state = None;
+                }
+                self.add_entity_occupancy(stable_id);
+            }
+            rocket_movement::SpecialMovementOutcome::Abort => {
+                if let Some(entity) = self.substrate.entities.get_mut(stable_id) {
+                    entity.health.current = 0;
+                }
+                self.pending_lifecycle_requests.push(LifecycleRequest::Uninit {
+                    stable_id,
+                    reason: crate::sim::lifecycle_request::UninitReason::Crush,
+                });
+            }
         }
     }
 }

--- a/src/sim/world/slice6_retask_tests.rs
+++ b/src/sim/world/slice6_retask_tests.rs
@@ -120,8 +120,10 @@ fn unit(owner: &str, type_id: &str, cx: u16, cy: u16, cat: EntityCategory) -> Ma
 // (6f78bac7) world_hash.rs swapped in and all branch behaviour kept, this probe
 // read 0xFEEA0679D9429547 — neither the old baseline nor the branch value. So
 // hashed state content changed, not just which fields are folded.
-const SLICE6_PRE_LIFECYCLE_V28_HASH: u64 = 0x99F0_E195_4E2F_94C9;
-const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x8477_F4BD_F3D8_B12B;
+// Native Move mission cadence now advances MissionCom and Scenario RNG.
+// Re-baselined after hashing the newly persisted YR runtime-contract state.
+const SLICE6_PRE_LIFECYCLE_V28_HASH: u64 = 0xAE2C_DACB_54A2_27E3;
+const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x8D9E_A32D_E86D_05DA;
 // Snapshot/hash schema v29 adds lossless Mission dwords, readiness leaves,
 // suspended Target/falling state, and raw locomotor-ready inputs. The two
 // schema probes below must prove the shift is composition-only before updating
@@ -177,7 +179,7 @@ const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x8477_F4BD_F3D8_B12B;
 // wired in this slice (deploy-begin off, undeploy-complete on, destination-
 // accepted on) changed no other hashed state in these fixtures. The absolute
 // per-stream RNG pins held throughout.
-const SLICE6_BASELINE_HASH: u64 = 0x6818_979C_3D5A_113D;
+const SLICE6_BASELINE_HASH: u64 = 0x266F_0EBE_9DE0_904C;
 
 #[test]
 fn replay_hash_stable_through_slice6() {

--- a/src/sim/world/team_script_vm_tests.rs
+++ b/src/sim/world/team_script_vm_tests.rs
@@ -1,0 +1,71 @@
+use std::collections::BTreeMap;
+
+use crate::sim::snapshot::GameSnapshot;
+use crate::sim::team_script_vm::{TeamScriptAction, TeamScriptDefinition};
+
+use super::{MasterFrameTestRung, Simulation};
+
+fn action(action_id: u8, argument: i32) -> TeamScriptAction {
+    TeamScriptAction {
+        action_id,
+        argument,
+    }
+}
+
+fn install_wait_then_advance_fixture(sim: &mut Simulation, members: Vec<u64>) -> u64 {
+    let owner = sim.interner.intern("Americans");
+    let opening = sim.interner.intern("TEAM_OPENING");
+    sim.team_script_vm.register_script(TeamScriptDefinition {
+        id: opening,
+        actions: vec![action(24, 0)],
+    });
+    let team = sim
+        .team_script_vm
+        .create_team(owner, opening, members, Some(99));
+    assert!(sim.team_script_vm.set_delay(team, 2));
+    team
+}
+
+#[test]
+fn team_script_vm_advances_in_the_master_frame_and_survives_save_load() {
+    let mut original = Simulation::with_seed(0xA11CE);
+    let team_id = install_wait_then_advance_fixture(&mut original, vec![19, 7, 11]);
+    let heights = BTreeMap::new();
+
+    original.advance_tick(&[], None, &heights, None, None, 67);
+    assert!(
+        original
+            .take_master_frame_test_trace()
+            .contains(&MasterFrameTestRung::TeamScript)
+    );
+    let team = original.team_script_vm.team(team_id).expect("team");
+    assert_eq!(team.cursor(), 0);
+    assert_eq!(team.wait_frames_remaining(), 1);
+    assert_eq!(team.members(), &[19, 7, 11]);
+    assert_eq!(team.target(), Some(99));
+
+    let snapshot = GameSnapshot::save(&original, 0, 0, "team_vm_test", 0);
+    let mut restored = GameSnapshot::load(&snapshot).expect("snapshot").sim;
+    assert_eq!(original.state_hash(), restored.state_hash());
+
+    for _ in 0..6 {
+        let expected = original.advance_tick(&[], None, &heights, None, None, 67);
+        let actual = restored.advance_tick(&[], None, &heights, None, None, 67);
+        assert_eq!(expected.state_hash, actual.state_hash);
+    }
+
+    let team = restored.team_script_vm.team(team_id).expect("team");
+    assert!(team.completed());
+    assert_eq!(team.members(), &[19, 7, 11]);
+    assert_eq!(team.target(), Some(99));
+}
+
+#[test]
+fn team_member_order_is_hashed() {
+    let mut forward = Simulation::with_seed(7);
+    let mut reverse = Simulation::with_seed(7);
+    install_wait_then_advance_fixture(&mut forward, vec![19, 7, 11]);
+    install_wait_then_advance_fixture(&mut reverse, vec![11, 7, 19]);
+
+    assert_ne!(forward.state_hash(), reverse.state_hash());
+}

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -22,8 +22,8 @@ use crate::map::overlay_types::OverlayTypeRegistry;
 use crate::rules::particle_system_type::ParticleSystemBehavesLike;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::miner::MinerConfig;
-#[cfg(any(test, debug_assertions))]
-use crate::sim::mission::MissionType;
+use crate::sim::mission::authority::EntityReadyInputProvider;
+use crate::sim::mission::{MissionId, MissionType};
 use crate::sim::pathfinding::PathGrid;
 
 /// Non-rules world context the mission handler bodies dispatched from the
@@ -292,9 +292,13 @@ fn techno_ai_shell(
             unit_techno_bracket(sim, id, rules, ctx);
         }
         // InfantryClass::AI promotes queued missions via Ready→Commence
-        // (`0x0051BC51`/`0x0051BF03`); the fear/sequence absorption is later work.
+        // (`0x0051BC51`/`0x0051BF03`). The supported Foot mission cadence
+        // branches run here; fear/sequence absorption is later work.
         EntityCategory::Infantry => {
             mission_common_step(sim, id, rules);
+            if let Some(rules) = rules {
+                dispatch_supported_foot_mission_cadence(sim, id, rules);
+            }
         }
         EntityCategory::Structure => {
             if let Some(rules) = rules {
@@ -333,8 +337,8 @@ fn mission_common_step(sim: &mut Simulation, id: u64, rules: Option<&RuleSet>) {
 // bracket: pre-mission block -> +0xC4/Mission work -> post-mission block, with
 // two IsAlive early-returns (after the pre-block, after dispatch). The mission
 // work at the dispatch point is the flip's counter + owner-local promotion;
-// the handler-body execution (dispatch-timer gate + per-mission handlers)
-// remains with the legacy per-system phases (recorded residual).
+// the handler-body execution remains with legacy per-system phases except for
+// the timer-only Move reschedule below and the absorbed Harvest handler.
 
 /// S4a pre-mission common block (the `TechnoClass::AI_Update` head: one-shot
 /// flag clear, turret-anim loop sound, cloak tick, health smoothing, target
@@ -514,6 +518,9 @@ fn unit_techno_bracket(
             id,
         );
     }
+    if let Some(rules) = rules {
+        dispatch_supported_foot_mission_cadence(sim, id, rules);
+    }
     // Guard E (post-dispatch IsAlive): the dispatched handler may have
     // destroyed the Unit; a dead Unit runs no post-mission block.
     if !sim.substrate.entities.get(id).is_some_and(|e| e.is_alive()) {
@@ -521,6 +528,260 @@ fn unit_techno_bracket(
     }
     techno_common_post(sim, id, rules);
     BracketReach::Dispatched
+}
+
+/// Re-arm the evidence-backed Foot/Unit handler subset without duplicating the
+/// legacy movement, combat, or target-selection systems.
+///
+/// YR `MissionClass::AI` at `0x005B3060` gates the current handler on the
+/// dispatch timer and writes `(current frame, handler return)` afterward. The
+/// existing movement/combat phases remain the sole owners of their path and
+/// target side effects; this absorbs only proven handler-return cadence. Harvest
+/// has its own full handler and epilogue, so miners are excluded to avoid a
+/// second write. Target acquisition and approach-result producers are still
+/// absent; their native routes remain explicit no-ops rather than guessed AI.
+fn dispatch_supported_foot_mission_cadence(sim: &mut Simulation, id: u64, rules: &RuleSet) {
+    let now = sim.session.binary_frame;
+    let input = {
+        let Some(entity) = sim.substrate.entities.get(id) else {
+            return;
+        };
+        if entity.dying || entity.miner.is_some() {
+            return;
+        }
+        let category = entity.category;
+        if !matches!(category, EntityCategory::Unit | EntityCategory::Infantry) {
+            return;
+        }
+        let Some(mission) = entity.mission.current().known() else {
+            return;
+        };
+        let moving = entity.movement_target.is_some()
+            || entity.navigation.nav_com.is_some()
+            || entity.drive_track.is_some()
+            || entity.forced_drive_track.is_some();
+        MissionHandlerInput {
+            category,
+            mission,
+            timer_due: entity.mission.dispatch_timer().due(now),
+            moving_or_queued: moving || entity.mission.queued() != MissionId::NONE,
+            bunker_delegate: entity.bunker_link.installed_in().is_some(),
+            has_attack_target: entity.attack_target.is_some(),
+            unit_deploy_begin_active: entity
+                .mission_leaf
+                .as_unit()
+                .is_some_and(|leaf| leaf.deploy_begin_active() != 0),
+            unit_deploy_reverse_active: entity
+                .mission_leaf
+                .as_unit()
+                .is_some_and(|leaf| leaf.deploy_reverse_active() != 0),
+        }
+    };
+    if !input.timer_due {
+        return;
+    }
+
+    let evaluation = match (input.category, input.mission) {
+        // `FootClass::Mission_Move` is the native named location for this
+        // handler-return cadence; movement execution remains in movement/.
+        (EntityCategory::Unit | EntityCategory::Infantry, MissionType::Move) => {
+            if input.moving_or_queued {
+                MissionHandlerEvaluation::cadence(jittered_mission_cadence(
+                    sim,
+                    rules,
+                    MissionType::Move,
+                ))
+            } else {
+                // FootClass::Mission_Move returns one frame after an unqueued arrival.
+                MissionHandlerEvaluation::cadence(1)
+            }
+        }
+        // `UnitClass::Mission_Attack @ 0x007447A0` is a tail jump to
+        // `FootClass::Mission_Attack`; keep both categories on this one path.
+        (EntityCategory::Unit | EntityCategory::Infantry, MissionType::Attack) => {
+            let cadence = jittered_mission_cadence(sim, rules, MissionType::Attack);
+            let delay = if foot_attack_in_half_cadence_band(sim, id) {
+                cadence / 2
+            } else {
+                cadence
+            };
+            // Stale entity IDs are an authoritative target-loss input. The
+            // native next-mission selector is not closed, so only clear this
+            // invalid handle; do not guess a Guard/Move transition.
+            MissionHandlerEvaluation {
+                delay,
+                clear_stale_attack_target: input.has_attack_target
+                    && attack_target_is_stale(sim, id),
+                queue: None,
+            }
+        }
+        (EntityCategory::Unit, MissionType::Guard) => {
+            // `UnitClass::Mission_Guard @ 0x00740810`: the two Unit-local
+            // deploy latches queue before the FootClass delegate and return 1.
+            if input.unit_deploy_begin_active {
+                MissionHandlerEvaluation::queue(1, MissionType::Harvest)
+            } else if input.unit_deploy_reverse_active {
+                MissionHandlerEvaluation::queue(1, MissionType::Unload)
+            } else {
+                evaluate_foot_guard_cadence(sim, rules, input.bunker_delegate)
+            }
+        }
+        (EntityCategory::Infantry, MissionType::Guard) => {
+            evaluate_foot_guard_cadence(sim, rules, input.bunker_delegate)
+        }
+        // `FootClass::Mission_Hunt`: the observed Capture/Sabotage/Move routes
+        // need an authoritative selector. Until one exists, retain its cadence
+        // and do not manufacture a target or queued mission.
+        (EntityCategory::Infantry, MissionType::Hunt) => {
+            MissionHandlerEvaluation::cadence(jittered_mission_cadence(
+                sim,
+                rules,
+                MissionType::Hunt,
+            ))
+        }
+        // `UnitClass::Mission_Hunt @ 0x00740EF0` retries the strict target
+        // probe, then queues Enter only if its separate approach virtual
+        // returns one. Neither producer exists here, so preserve its exact
+        // no-jitter fallback rather than infer arrival from target presence.
+        (EntityCategory::Unit, MissionType::Hunt) => {
+            MissionHandlerEvaluation::cadence(mission_cadence(rules, MissionType::Hunt))
+        }
+        _ => return,
+    };
+
+    if evaluation.clear_stale_attack_target {
+        if let Some(entity) = sim.substrate.entities.get_mut(id) {
+            entity.attack_target = None;
+        }
+    }
+    if let Some(queued_mission) = evaluation.queue {
+        let _ = sim.mission_queue_exact(
+            id,
+            MissionId::from_known(queued_mission),
+            0,
+            now,
+            &EntityReadyInputProvider,
+        );
+    }
+    if let Some(entity) = sim.substrate.entities.get_mut(id) {
+        entity
+            .mission
+            .write_dispatch_epilogue(now as i32, evaluation.delay);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MissionHandlerInput {
+    category: EntityCategory,
+    mission: MissionType,
+    timer_due: bool,
+    moving_or_queued: bool,
+    bunker_delegate: bool,
+    has_attack_target: bool,
+    unit_deploy_begin_active: bool,
+    unit_deploy_reverse_active: bool,
+}
+
+/// The handler result is evaluated before the one common MissionClass timer
+/// write, which prevents branch-local epilogues from double-rearming it.
+#[derive(Debug, Clone, Copy)]
+struct MissionHandlerEvaluation {
+    delay: i32,
+    clear_stale_attack_target: bool,
+    queue: Option<MissionType>,
+}
+
+impl MissionHandlerEvaluation {
+    const fn cadence(delay: i32) -> Self {
+        Self {
+            delay,
+            clear_stale_attack_target: false,
+            queue: None,
+        }
+    }
+
+    const fn queue(delay: i32, mission: MissionType) -> Self {
+        Self {
+            delay,
+            clear_stale_attack_target: false,
+            queue: Some(mission),
+        }
+    }
+}
+
+fn evaluate_foot_guard_cadence(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    bunker_delegate: bool,
+) -> MissionHandlerEvaluation {
+    // `FootClass::Mission_Guard`: bunker delegation returns the base cadence;
+    // all represented local-guard paths take exactly one RandomRanged(0, 2).
+    if bunker_delegate {
+        MissionHandlerEvaluation::cadence(mission_cadence(rules, MissionType::Guard))
+    } else {
+        MissionHandlerEvaluation::cadence(jittered_mission_cadence(
+            sim,
+            rules,
+            MissionType::Guard,
+        ))
+    }
+}
+
+#[inline]
+fn mission_cadence(rules: &RuleSet, mission: MissionType) -> i32 {
+    rules
+        .mission_control
+        .rate_frames(mission)
+        .min(i32::MAX as u32) as i32
+}
+
+#[inline]
+fn jittered_mission_cadence(sim: &mut Simulation, rules: &RuleSet, mission: MissionType) -> i32 {
+    let base = mission_cadence(rules, mission);
+    let jitter = sim.scenario_rng.next_range_u32_inclusive(0, 2) as i32;
+    base.saturating_add(jitter)
+}
+
+/// The representative Foot Attack cadence halves only inside the observed
+/// 282..=768 lepton band. Entity target positions are authoritative here;
+/// force-fire cell geometry is intentionally deferred with target routing.
+fn foot_attack_in_half_cadence_band(sim: &Simulation, id: u64) -> bool {
+    const MIN_LEPTONS: i64 = 282;
+    const MAX_LEPTONS: i64 = 768;
+
+    let Some(attacker) = sim.substrate.entities.get(id) else {
+        return false;
+    };
+    let Some(crate::sim::combat::AttackTarget {
+        target: crate::sim::combat::TargetKind::Entity(target_id),
+        ..
+    }) = attacker.attack_target.as_ref()
+    else {
+        return false;
+    };
+    let Some(target) = sim.substrate.entities.get(*target_id) else {
+        return false;
+    };
+    let distance_sq = crate::sim::combat::lepton_distance_sq(&attacker.position, &target.position);
+    distance_sq >= MIN_LEPTONS * MIN_LEPTONS && distance_sq <= MAX_LEPTONS * MAX_LEPTONS
+}
+
+fn attack_target_is_stale(sim: &Simulation, id: u64) -> bool {
+    let Some(attacker) = sim.substrate.entities.get(id) else {
+        return false;
+    };
+    let Some(crate::sim::combat::AttackTarget {
+        target: crate::sim::combat::TargetKind::Entity(target_id),
+        ..
+    }) = attacker.attack_target.as_ref()
+    else {
+        return false;
+    };
+    !sim
+        .substrate
+        .entities
+        .get(*target_id)
+        .is_some_and(|target| !target.dying && target.is_alive())
 }
 
 /// S4c passive-acquire gate predicate (pure; the testable core of
@@ -710,8 +971,9 @@ mod tests {
     use crate::sim::combat::{AttackTarget, TargetKind};
     use crate::sim::components::{DriveLocomotionRuntime, MovementTarget, NavTargetRef};
     use crate::sim::docking::building_dock::{DockPhase, DockState};
-    use crate::sim::game_entity::GameEntity;
+    use crate::sim::game_entity::{BunkerLink, GameEntity};
     use crate::sim::miner::{Miner, MinerConfig, MinerKind};
+    use crate::sim::mission::leaf::MissionLeafState;
     use crate::sim::mission::state::MissionTestFixture;
     use crate::sim::mission::{
         MissionCom, MissionControl, MissionDispatchTimer, MissionId, MissionType,
@@ -730,6 +992,12 @@ mod tests {
         let mut e = GameEntity::test_default(id, "TEST", "Americans", 5, 5);
         e.category = category;
         e
+    }
+
+    fn register_entity(sim: &mut Simulation, mut entity: GameEntity) {
+        entity.owner = sim.interner.intern("Americans");
+        entity.type_ref = sim.interner.intern("TEST");
+        sim.substrate.entities.insert(entity);
     }
 
     fn mission_test_fixture(mission: &MissionCom) -> MissionTestFixture {
@@ -1225,6 +1493,8 @@ mod tests {
     fn ordinary_drive_host_sim(seed: u64) -> Simulation {
         let mut sim = Simulation::with_seed(seed);
         let mut entity = entity_of(ORDINARY_DRIVE_HOST_ID, EntityCategory::Unit);
+        entity.owner = sim.interner.intern("Americans");
+        entity.type_ref = sim.interner.intern("TEST");
         entity.locomotor = Some(LocomotorState::for_test_kind(LocomotorKind::Drive));
         entity.drive_locomotion = Some(DriveLocomotionRuntime::default());
         entity.navigation.nav_com = Some(NavTargetRef::cell(8, 8));
@@ -1235,6 +1505,352 @@ mod tests {
         sim.substrate.entities.insert(entity);
         sim.set_logic_order_for_test(vec![ORDINARY_DRIVE_HOST_ID]);
         sim
+    }
+
+    fn move_cadence_rules() -> RuleSet {
+        RuleSet::from_ini(&IniFile::from_str("[General]\n\n[Move]\nRate=.016\n"))
+            .expect("move cadence rules parse")
+    }
+
+    fn representative_foot_handler_rules() -> RuleSet {
+        RuleSet::from_ini(&IniFile::from_str(
+            "[General]\n\n[Move]\nRate=.016\n\n[Attack]\nRate=.016\n\n[Guard]\nRate=.016\n\n[Hunt]\nRate=.016\n",
+        ))
+        .expect("representative Foot handler rules parse")
+    }
+
+    #[test]
+    fn move_handler_rearms_from_the_authoritative_object_ai_host() {
+        let mut sim = ordinary_drive_host_sim(0xCAFE);
+        let rules = move_cadence_rules();
+        let mut expected_rng = sim.clone_scenario_rng();
+        let jitter = expected_rng.next_range_u32_inclusive(0, 2) as i32;
+
+        assert!(sim.object_ai_visit_one(
+            ORDINARY_DRIVE_HOST_ID,
+            Some(&rules),
+            ObjectAiCtx::default(),
+        ));
+
+        let entity = sim
+            .substrate
+            .entities
+            .get(ORDINARY_DRIVE_HOST_ID)
+            .expect("fixture entity");
+        assert_eq!(entity.mission.dispatch_timer().start_frame(), 0);
+        assert_eq!(entity.mission.dispatch_timer().delay(), 14 + jitter);
+        assert_eq!(
+            sim.scenario_rng.logical_state(),
+            expected_rng.logical_state()
+        );
+
+        let hash = sim.state_hash();
+        let bytes = GameSnapshot::save(&sim, 0, 0, "move_cadence", 0);
+        let restored = GameSnapshot::load(&bytes).expect("snapshot").sim;
+        assert_eq!(restored.state_hash(), hash);
+        assert_eq!(
+            restored
+                .substrate
+                .entities
+                .get(ORDINARY_DRIVE_HOST_ID)
+                .expect("restored fixture entity")
+                .mission
+                .dispatch_timer(),
+            entity.mission.dispatch_timer()
+        );
+    }
+
+    #[test]
+    fn move_handler_preserves_pending_timer_without_consuming_rng() {
+        let mut sim = ordinary_drive_host_sim(0xCAFE);
+        let rules = move_cadence_rules();
+        let pending = MissionDispatchTimer::from_raw(0, 5);
+        let fixture = mission_test_fixture(
+            &sim.substrate
+                .entities
+                .get(ORDINARY_DRIVE_HOST_ID)
+                .expect("fixture entity")
+                .mission,
+        );
+        sim.substrate
+            .entities
+            .get_mut(ORDINARY_DRIVE_HOST_ID)
+            .expect("fixture entity")
+            .mission
+            .apply_test_fixture(MissionTestFixture {
+                dispatch_timer: pending,
+                ..fixture
+            });
+        let before_rng = sim.scenario_rng.logical_state();
+
+        sim.object_ai_visit_one(ORDINARY_DRIVE_HOST_ID, Some(&rules), ObjectAiCtx::default());
+
+        assert_eq!(
+            sim.substrate
+                .entities
+                .get(ORDINARY_DRIVE_HOST_ID)
+                .expect("fixture entity")
+                .mission
+                .dispatch_timer(),
+            pending
+        );
+        assert_eq!(sim.scenario_rng.logical_state(), before_rng);
+    }
+
+    #[test]
+    fn move_handler_arrival_returns_one_frame_without_rng() {
+        let mut sim = ordinary_drive_host_sim(0xCAFE);
+        let rules = move_cadence_rules();
+        sim.substrate
+            .entities
+            .get_mut(ORDINARY_DRIVE_HOST_ID)
+            .expect("fixture entity")
+            .navigation
+            .nav_com = None;
+        let before_rng = sim.scenario_rng.logical_state();
+
+        sim.object_ai_visit_one(ORDINARY_DRIVE_HOST_ID, Some(&rules), ObjectAiCtx::default());
+
+        assert_eq!(
+            sim.substrate
+                .entities
+                .get(ORDINARY_DRIVE_HOST_ID)
+                .expect("fixture entity")
+                .mission
+                .dispatch_timer(),
+            MissionDispatchTimer::from_raw(0, 1)
+        );
+        assert_eq!(sim.scenario_rng.logical_state(), before_rng);
+    }
+
+    #[test]
+    fn infantry_attack_handler_halves_jittered_cadence_inside_the_proven_band() {
+        let mut sim = Simulation::with_seed(0xA771);
+        let rules = representative_foot_handler_rules();
+        let mut infantry = entity_of(1, EntityCategory::Infantry);
+        infantry.attack_target = Some(AttackTarget::new(2));
+        update_mission_test_fixture(&mut infantry.mission, |fixture| {
+            fixture.current = MissionId::from_known(MissionType::Attack);
+            fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
+        });
+        let target = entity_of(2, EntityCategory::Unit);
+        assert_eq!((target.position.rx, target.position.ry), (5, 5));
+        infantry.position.rx = 7; // 512 leptons: within FootClass::Mission_Attack band.
+        sim.substrate.entities.insert(infantry);
+        sim.substrate.entities.insert(target);
+
+        let mut expected_rng = sim.clone_scenario_rng();
+        let expected_delay = (14 + expected_rng.next_range_u32_inclusive(0, 2) as i32) / 2;
+        sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
+
+        assert_eq!(
+            sim.substrate
+                .entities
+                .get(1)
+                .unwrap()
+                .mission
+                .dispatch_timer(),
+            MissionDispatchTimer::from_raw(0, expected_delay)
+        );
+        assert_eq!(
+            sim.scenario_rng.logical_state(),
+            expected_rng.logical_state()
+        );
+    }
+
+    #[test]
+    fn unit_attack_delegates_to_the_foot_attack_cadence() {
+        let mut sim = Simulation::with_seed(0xA772);
+        let rules = representative_foot_handler_rules();
+        let mut unit = entity_of(1, EntityCategory::Unit);
+        unit.attack_target = Some(AttackTarget::new(2));
+        update_mission_test_fixture(&mut unit.mission, |fixture| {
+            fixture.current = MissionId::from_known(MissionType::Attack);
+            fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
+        });
+        let target = entity_of(2, EntityCategory::Unit);
+        unit.position.rx = 7; // 512 leptons: FootClass::Mission_Attack band.
+        register_entity(&mut sim, unit);
+        register_entity(&mut sim, target);
+
+        let mut expected_rng = sim.clone_scenario_rng();
+        let expected_delay = (14 + expected_rng.next_range_u32_inclusive(0, 2) as i32) / 2;
+        sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
+
+        assert_eq!(
+            sim.substrate.entities.get(1).unwrap().mission.dispatch_timer(),
+            MissionDispatchTimer::from_raw(0, expected_delay)
+        );
+        assert_eq!(sim.scenario_rng.logical_state(), expected_rng.logical_state());
+    }
+
+    #[test]
+    fn attack_handler_clears_only_an_authoritatively_stale_entity_target() {
+        let mut sim = Simulation::with_seed(0xA773);
+        let rules = representative_foot_handler_rules();
+        let mut unit = entity_of(1, EntityCategory::Unit);
+        unit.attack_target = Some(AttackTarget::new(99));
+        update_mission_test_fixture(&mut unit.mission, |fixture| {
+            fixture.current = MissionId::from_known(MissionType::Attack);
+            fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
+        });
+        register_entity(&mut sim, unit);
+
+        sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
+
+        let unit = sim.substrate.entities.get(1).unwrap();
+        assert!(unit.attack_target.is_none());
+        assert_eq!(unit.mission.queued(), MissionId::NONE);
+    }
+
+    #[test]
+    fn infantry_guard_handler_skips_jitter_for_a_bunker_delegate() {
+        let mut sim = Simulation::with_seed(0x6A2D);
+        let rules = representative_foot_handler_rules();
+        let mut infantry = entity_of(1, EntityCategory::Infantry);
+        infantry.bunker_link = BunkerLink::Installed(99);
+        update_mission_test_fixture(&mut infantry.mission, |fixture| {
+            fixture.current = MissionId::from_known(MissionType::Guard);
+            fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
+        });
+        sim.substrate.entities.insert(infantry);
+        let before_rng = sim.scenario_rng.logical_state();
+
+        sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
+
+        assert_eq!(
+            sim.substrate
+                .entities
+                .get(1)
+                .unwrap()
+                .mission
+                .dispatch_timer(),
+            MissionDispatchTimer::from_raw(0, 14)
+        );
+        assert_eq!(sim.scenario_rng.logical_state(), before_rng);
+    }
+
+    #[test]
+    fn unit_guard_deploy_begin_queues_harvest_without_rng() {
+        let mut sim = Simulation::with_seed(0x6A2E);
+        let rules = representative_foot_handler_rules();
+        let mut unit = entity_of(1, EntityCategory::Unit);
+        unit.mission_leaf = MissionLeafState::unit_raw_for_test(1, 0, 0, 0);
+        update_mission_test_fixture(&mut unit.mission, |fixture| {
+            fixture.current = MissionId::from_known(MissionType::Guard);
+            fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
+        });
+        register_entity(&mut sim, unit);
+        let before_rng = sim.scenario_rng.logical_state();
+
+        sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
+
+        let unit = sim.substrate.entities.get(1).unwrap();
+        assert_eq!(unit.mission.queued().known(), Some(MissionType::Harvest));
+        assert_eq!(unit.mission.dispatch_timer(), MissionDispatchTimer::from_raw(0, 1));
+        assert_eq!(sim.scenario_rng.logical_state(), before_rng);
+    }
+
+    #[test]
+    fn unit_guard_deploy_reverse_queues_unload_without_rng() {
+        let mut sim = Simulation::with_seed(0x6A2F);
+        let rules = representative_foot_handler_rules();
+        let mut unit = entity_of(1, EntityCategory::Unit);
+        unit.mission_leaf = MissionLeafState::unit_raw_for_test(0, 1, 0, 0);
+        update_mission_test_fixture(&mut unit.mission, |fixture| {
+            fixture.current = MissionId::from_known(MissionType::Guard);
+            fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
+        });
+        register_entity(&mut sim, unit);
+        let before_rng = sim.scenario_rng.logical_state();
+
+        sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
+
+        let unit = sim.substrate.entities.get(1).unwrap();
+        assert_eq!(unit.mission.queued().known(), Some(MissionType::Unload));
+        assert_eq!(unit.mission.dispatch_timer(), MissionDispatchTimer::from_raw(0, 1));
+        assert_eq!(sim.scenario_rng.logical_state(), before_rng);
+    }
+
+    #[test]
+    fn infantry_hunt_handler_uses_foot_jittered_cadence() {
+        let mut sim = Simulation::with_seed(0x487A);
+        let rules = representative_foot_handler_rules();
+        let mut infantry = entity_of(1, EntityCategory::Infantry);
+        update_mission_test_fixture(&mut infantry.mission, |fixture| {
+            fixture.current = MissionId::from_known(MissionType::Hunt);
+            fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
+        });
+        sim.substrate.entities.insert(infantry);
+        let mut expected_rng = sim.clone_scenario_rng();
+        let expected_delay = 14 + expected_rng.next_range_u32_inclusive(0, 2) as i32;
+
+        sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
+
+        assert_eq!(
+            sim.substrate
+                .entities
+                .get(1)
+                .unwrap()
+                .mission
+                .dispatch_timer(),
+            MissionDispatchTimer::from_raw(0, expected_delay)
+        );
+        assert_eq!(
+            sim.scenario_rng.logical_state(),
+            expected_rng.logical_state()
+        );
+    }
+
+    #[test]
+    fn unit_hunt_handler_uses_base_cadence_without_foot_jitter() {
+        let mut sim = Simulation::with_seed(0xF007);
+        let rules = representative_foot_handler_rules();
+        let mut unit = entity_of(1, EntityCategory::Unit);
+        unit.owner = sim.interner.intern("Americans");
+        unit.type_ref = sim.interner.intern("TEST");
+        update_mission_test_fixture(&mut unit.mission, |fixture| {
+            fixture.current = MissionId::from_known(MissionType::Hunt);
+            fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
+        });
+        sim.substrate.entities.insert(unit);
+        let before_rng = sim.scenario_rng.logical_state();
+
+        sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
+
+        assert_eq!(
+            sim.substrate
+                .entities
+                .get(1)
+                .unwrap()
+                .mission
+                .dispatch_timer(),
+            MissionDispatchTimer::from_raw(0, 14)
+        );
+        assert_eq!(sim.scenario_rng.logical_state(), before_rng);
+    }
+
+    #[test]
+    fn unit_hunt_does_not_infer_enter_without_an_approach_result() {
+        let mut sim = Simulation::with_seed(0xF008);
+        let rules = representative_foot_handler_rules();
+        let mut unit = entity_of(1, EntityCategory::Unit);
+        unit.attack_target = Some(AttackTarget::new(2));
+        update_mission_test_fixture(&mut unit.mission, |fixture| {
+            fixture.current = MissionId::from_known(MissionType::Hunt);
+            fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
+        });
+        register_entity(&mut sim, unit);
+        let target = entity_of(2, EntityCategory::Structure);
+        register_entity(&mut sim, target);
+        let before_rng = sim.scenario_rng.logical_state();
+
+        sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
+
+        let unit = sim.substrate.entities.get(1).unwrap();
+        assert_eq!(unit.mission.queued(), MissionId::NONE);
+        assert_eq!(unit.mission.dispatch_timer(), MissionDispatchTimer::from_raw(0, 14));
+        assert_eq!(sim.scenario_rng.logical_state(), before_rng);
     }
 
     fn capture_live_host_witness(sim: &Simulation, id: u64) -> LiveHostWitness {

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -184,6 +184,7 @@ impl Simulation {
         // their camera/message outcomes stay app-owned and are not hashed.
         if include_master_frame_v43 {
             self.trigger_runtime.hash_state(&mut hasher);
+            self.team_script_vm.hash_state(&mut hasher);
         }
 
         // LogicClass active-object order — authoritative (drives reconciliation order).
@@ -819,7 +820,12 @@ impl Simulation {
                 0u8.hash(hasher);
             }
             entity.on_bridge.hash(hasher);
+            entity.runtime_bridge_transition.pending_mismatch.hash(hasher);
             entity.low_bridge_tube_state.hash(hasher);
+            hash_teleport_state(entity.teleport_state.as_ref(), hasher);
+            hash_tunnel_state(entity.tunnel_state.as_ref(), hasher);
+            hash_rocket_state(entity.rocket_state.as_ref(), hasher);
+            hash_drop_pod_state(entity.drop_pod_state.as_ref(), hasher);
 
             if let Some(ref inv) = entity.invulnerability {
                 1u8.hash(hasher);
@@ -1026,6 +1032,218 @@ impl Simulation {
             id.hash(hasher);
             anim.hash(hasher);
         }
+    }
+}
+
+/// TeleportLocomotionClass::Process @ 0x007192f0 owns this complete, named
+/// runtime state; its target and materialization timer must not escape lockstep.
+fn hash_teleport_state(
+    state: Option<&crate::sim::movement::teleport_movement::TeleportState>,
+    hasher: &mut impl Hasher,
+) {
+    match state {
+        None => 0u8.hash(hasher),
+        Some(state) => {
+            1u8.hash(hasher);
+            let phase = match state.phase {
+                crate::sim::movement::teleport_movement::TeleportPhase::Relocate => 0u8,
+                crate::sim::movement::teleport_movement::TeleportPhase::ChronoDelay => 1,
+            };
+            phase.hash(hasher);
+            state.target_rx.hash(hasher);
+            state.target_ry.hash(hasher);
+            state.being_warped_ticks.hash(hasher);
+        }
+    }
+}
+
+/// YR TunnelLocomotionClass keeps the phase byte in its locomotor runtime.
+/// Keep the projection explicit instead of relying on a Rust derived hash.
+fn hash_tunnel_state(
+    state: Option<&crate::sim::movement::tunnel_movement::TunnelState>,
+    hasher: &mut impl Hasher,
+) {
+    match state {
+        None => 0u8.hash(hasher),
+        Some(state) => {
+            1u8.hash(hasher);
+            (state.phase as u8).hash(hasher);
+        }
+    }
+}
+
+/// RocketLocomotionClass::Process @ 0x006622c0 owns the complete flight table
+/// selection and current flight state. `pitch` is render-only, so it is omitted.
+fn hash_rocket_state(
+    state: Option<&crate::sim::movement::rocket_movement::RocketState>,
+    hasher: &mut impl Hasher,
+) {
+    match state {
+        None => 0u8.hash(hasher),
+        Some(state) => {
+            1u8.hash(hasher);
+            let phase = match state.phase {
+                crate::sim::movement::rocket_movement::RocketPhase::Ignition => 0u8,
+                crate::sim::movement::rocket_movement::RocketPhase::Tilt => 1,
+                crate::sim::movement::rocket_movement::RocketPhase::Ascent => 2,
+                crate::sim::movement::rocket_movement::RocketPhase::Cruise => 3,
+                crate::sim::movement::rocket_movement::RocketPhase::Terminal => 4,
+                crate::sim::movement::rocket_movement::RocketPhase::Secondary => 5,
+            };
+            phase.hash(hasher);
+            state.origin_rx.hash(hasher);
+            state.origin_ry.hash(hasher);
+            state.target_rx.hash(hasher);
+            state.target_ry.hash(hasher);
+            state.speed.to_bits().hash(hasher);
+            state.current_speed.to_bits().hash(hasher);
+            state.altitude.to_bits().hash(hasher);
+            state.progress.to_bits().hash(hasher);
+            state.phase_frames.hash(hasher);
+            state.parameters.acceleration.to_bits().hash(hasher);
+            state.parameters.max_speed.to_bits().hash(hasher);
+            state.parameters.ascent_altitude.to_bits().hash(hasher);
+            state.parameters.tilt_rate.to_bits().hash(hasher);
+            state.parameters.relaunches.hash(hasher);
+        }
+    }
+}
+
+/// DropPodLocomotionClass flight state is lockstep state even while it has no
+/// surface occupation. This mirrors the typed serialized runtime exactly.
+fn hash_drop_pod_state(
+    state: Option<&crate::sim::movement::drop_pod_movement::DropPodState>,
+    hasher: &mut impl Hasher,
+) {
+    match state {
+        None => 0u8.hash(hasher),
+        Some(state) => {
+            1u8.hash(hasher);
+            let phase = match state.phase {
+                crate::sim::movement::drop_pod_movement::DropPodPhase::Descending => 0u8,
+                crate::sim::movement::drop_pod_movement::DropPodPhase::Landed => 1,
+                crate::sim::movement::drop_pod_movement::DropPodPhase::Destroyed => 2,
+            };
+            phase.hash(hasher);
+            state.target_rx.hash(hasher);
+            state.target_ry.hash(hasher);
+            state.altitude.to_bits().hash(hasher);
+            state.descent_speed.to_bits().hash(hasher);
+            state.elapsed_frames.hash(hasher);
+        }
+    }
+}
+
+#[cfg(test)]
+mod teleport_rocket_hash_tests {
+    use super::Simulation;
+    use crate::sim::game_entity::GameEntity;
+    use crate::sim::movement::rocket_movement::{
+        RocketFlightParameters, RocketPhase, RocketState,
+    };
+    use crate::sim::movement::teleport_movement::{TeleportPhase, TeleportState};
+    use crate::util::fixed_math::SimFixed;
+
+    fn teleport_state() -> TeleportState {
+        TeleportState {
+            phase: TeleportPhase::Relocate,
+            target_rx: 17,
+            target_ry: 29,
+            being_warped_ticks: 41,
+        }
+    }
+
+    fn rocket_state() -> RocketState {
+        RocketState {
+            phase: RocketPhase::Cruise,
+            origin_rx: 3,
+            origin_ry: 5,
+            target_rx: 17,
+            target_ry: 29,
+            speed: SimFixed::from_num(11),
+            current_speed: SimFixed::from_num(7),
+            altitude: SimFixed::from_num(400),
+            progress: SimFixed::from_num(0.5),
+            phase_frames: 13,
+            parameters: RocketFlightParameters {
+                acceleration: SimFixed::from_num(90),
+                max_speed: SimFixed::from_num(11),
+                ascent_altitude: SimFixed::from_num(400),
+                tilt_rate: SimFixed::from_num(0.35),
+                relaunches: 2,
+            },
+            pitch: 0.25,
+        }
+    }
+
+    fn hash_entity(mut entity: GameEntity) -> u64 {
+        let mut sim = Simulation::new();
+        entity.stable_id = 1;
+        sim.substrate.entities.insert(entity);
+        sim.state_hash()
+    }
+
+    fn hash_teleport(state: Option<TeleportState>) -> u64 {
+        let mut entity = GameEntity::test_default(1, "CHRP", "Americans", 5, 5);
+        entity.teleport_state = state;
+        hash_entity(entity)
+    }
+
+    fn hash_rocket(state: Option<RocketState>) -> u64 {
+        let mut entity = GameEntity::test_default(1, "V3RKT", "Soviet", 5, 5);
+        entity.rocket_state = state;
+        hash_entity(entity)
+    }
+
+    fn assert_teleport_change(change: impl FnOnce(&mut TeleportState)) {
+        let baseline = hash_teleport(Some(teleport_state()));
+        let mut changed = teleport_state();
+        change(&mut changed);
+        assert_ne!(baseline, hash_teleport(Some(changed)));
+    }
+
+    fn assert_rocket_change(change: impl FnOnce(&mut RocketState)) {
+        let baseline = hash_rocket(Some(rocket_state()));
+        let mut changed = rocket_state();
+        change(&mut changed);
+        assert_ne!(baseline, hash_rocket(Some(changed)));
+    }
+
+    #[test]
+    fn teleport_hash_projects_presence_phase_target_and_materialization_timer() {
+        assert_ne!(hash_teleport(None), hash_teleport(Some(teleport_state())));
+        assert_teleport_change(|state| state.phase = TeleportPhase::ChronoDelay);
+        assert_teleport_change(|state| state.target_rx += 1);
+        assert_teleport_change(|state| state.target_ry += 1);
+        assert_teleport_change(|state| state.being_warped_ticks += 1);
+    }
+
+    #[test]
+    fn rocket_hash_projects_complete_simulation_flight_runtime() {
+        assert_ne!(hash_rocket(None), hash_rocket(Some(rocket_state())));
+        assert_rocket_change(|state| state.phase = RocketPhase::Terminal);
+        assert_rocket_change(|state| state.origin_rx += 1);
+        assert_rocket_change(|state| state.origin_ry += 1);
+        assert_rocket_change(|state| state.target_rx += 1);
+        assert_rocket_change(|state| state.target_ry += 1);
+        assert_rocket_change(|state| state.speed += SimFixed::from_num(1));
+        assert_rocket_change(|state| state.current_speed += SimFixed::from_num(1));
+        assert_rocket_change(|state| state.altitude += SimFixed::from_num(1));
+        assert_rocket_change(|state| state.progress += SimFixed::from_num(0.1));
+        assert_rocket_change(|state| state.phase_frames += 1);
+        assert_rocket_change(|state| state.parameters.acceleration += SimFixed::from_num(1));
+        assert_rocket_change(|state| state.parameters.max_speed += SimFixed::from_num(1));
+        assert_rocket_change(|state| state.parameters.ascent_altitude += SimFixed::from_num(1));
+        assert_rocket_change(|state| state.parameters.tilt_rate += SimFixed::from_num(0.1));
+        assert_rocket_change(|state| state.parameters.relaunches += 1);
+    }
+
+    #[test]
+    fn rocket_hash_excludes_explicit_render_only_pitch() {
+        let baseline = hash_rocket(Some(rocket_state()));
+        let mut render_only_change = rocket_state();
+        render_only_change.pitch = 0.75;
+        assert_eq!(baseline, hash_rocket(Some(render_only_change)));
     }
 }
 
@@ -1814,6 +2032,46 @@ mod tube_movement_hash_tests {
         sim_b.substrate.entities.insert(entity_b);
 
         assert_ne!(sim_a.state_hash(), sim_b.state_hash());
+    }
+}
+
+#[cfg(test)]
+mod special_locomotor_hash_tests {
+    use super::Simulation;
+    use crate::sim::game_entity::GameEntity;
+    use crate::sim::movement::drop_pod_movement::{DropPodPhase, DropPodState};
+    use crate::sim::movement::tunnel_movement::{TunnelPhase, TunnelState};
+    use crate::util::fixed_math::SimFixed;
+
+    #[test]
+    fn tunnel_and_drop_pod_runtime_change_the_lockstep_hash() {
+        fn fixture() -> Simulation {
+            let mut sim = Simulation::new();
+            sim.substrate
+                .entities
+                .insert(GameEntity::test_default(1, "MTNK", "Americans", 5, 5));
+            sim
+        }
+
+        let base = fixture();
+        let hash_without_special_runtime = base.state_hash();
+
+        let mut tunnel = fixture();
+        tunnel.substrate.entities.get_mut(1).unwrap().tunnel_state = Some(TunnelState {
+            phase: TunnelPhase::UndergroundTravel,
+        });
+        assert_ne!(hash_without_special_runtime, tunnel.state_hash());
+
+        let mut pod = fixture();
+        pod.substrate.entities.get_mut(1).unwrap().drop_pod_state = Some(DropPodState {
+            phase: DropPodPhase::Descending,
+            target_rx: 7,
+            target_ry: 9,
+            altitude: SimFixed::from_num(100),
+            descent_speed: SimFixed::from_num(3),
+            elapsed_frames: 4,
+        });
+        assert_ne!(hash_without_special_runtime, pod.state_hash());
     }
 }
 


### PR DESCRIPTION
- ports the closed YR pathfinding, mission, draw, Team Script, and locomotor contracts
- adds complete piggyback persistence plus Teleport, Tunnel, Rocket, and DropPod runtime state
- synchronizes snapshot v46, world hashing, renderer state, and deterministic replay baselines
