### PR TITLE
Complete clean-slate Phase 1 retail substrate

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -236,7 +236,8 @@ pub(crate) struct AppState {
     /// Registry of overlay types from rules.ini — needed at runtime to look up
     /// overlay_id by name when a wall is placed via production.
     pub(crate) overlay_registry: Option<OverlayTypeRegistry>,
-    /// Loaded GameConfig — None when config.toml is missing or invalid.
+    /// Loaded GameConfig — missing config.toml falls back to the executable root;
+    /// None only when config loading or executable-root discovery fails.
     /// Read at render time for cosmetic toggles (extra_animations) and other
     /// per-session user preferences. Set in AppState::new() from the existing
     /// GameConfig::load() call; not mutated afterwards.

--- a/src/app.rs
+++ b/src/app.rs
@@ -244,7 +244,7 @@ pub(crate) struct AppState {
     pub(crate) game_config: Option<GameConfig>,
     /// GPU depth texture for back-to-front depth ordering. Recreated on window resize.
     pub(crate) depth_view: wgpu::TextureView,
-    /// Shell-only encoded-byte RGB565 presentation boundary for dialog 0xE2.
+    /// Encoded-byte RGB565 presentation boundary for stock shell/loading surfaces.
     pub(crate) shell_surface_presenter: crate::render::shell_surface_present::ShellSurfacePresenter,
     /// Optional Catmull-Rom bicubic upscale pass (render at lower res, upscale to window).
     pub(crate) upscale_pass: Option<crate::render::upscale_pass::UpscalePass>,
@@ -1994,7 +1994,10 @@ impl App {
         let rgb: Vec<u8> = preview
             .rgba
             .chunks_exact(4)
-            .flat_map(|px| [px[0], px[1], px[2]])
+            .flat_map(|px| {
+                crate::render::native_surface_format::ACTIVE_RETAIL_RGB565_PRESENTATION
+                    .storage_roundtrip_rgb8([px[0], px[1], px[2]])
+            })
             .collect();
         match crate::assets::pcx_file::encode_direct_rgb(width, height, &rgb) {
             Ok(encoded) => {
@@ -4823,7 +4826,7 @@ impl App {
                     crate::app_skirmish_shell_render::render_skirmish_shell(
                         state,
                         &mut encoder,
-                        &view,
+                        &output.texture,
                     )?;
                 } else if Self::single_player_shell_active(state) {
                     match crate::app_single_player_shell_render::render_single_player_shell(
@@ -4919,7 +4922,11 @@ impl App {
                 }
             }
             GameScreen::Loading => {
-                match crate::app_loading::render_loading_screen(state, &mut encoder, &view) {
+                match crate::app_loading::render_loading_screen(
+                    state,
+                    &mut encoder,
+                    &output.texture,
+                ) {
                     crate::app_loading::LoadingRenderResult::NativeRendered => {}
                     crate::app_loading::LoadingRenderResult::GenericFallback => {
                         let map_name_display = crate::app_loading::loading_map_name(state)

--- a/src/app_building_anim.rs
+++ b/src/app_building_anim.rs
@@ -1239,7 +1239,8 @@ mod tests {
     fn garrison_occupant_anim_rate_uses_animtype_default_logic_tick_when_rate_missing() {
         let mut sim = Simulation::new();
         let ucflash = sim.interner.intern("UCFLASH");
-        let art = ArtRegistry::from_ini(&IniFile::from_str("[UCFLASH]\n"));
+        let art =
+            ArtRegistry::from_ini(&IniFile::from_str("[UCFLASH]\nFixtureOnly=1\n"));
 
         assert_eq!(
             garrison_occupant_anim_rate_logic_frames(&sim, &art, ucflash),
@@ -1295,7 +1296,8 @@ mod tests {
         let mut sim = Simulation::new();
         let ucflash = sim.interner.intern("UCFLASH");
         sim.effect_frame_counts.insert(ucflash, 3);
-        let art = ArtRegistry::from_ini(&IniFile::from_str("[UCFLASH]\n"));
+        let art =
+            ArtRegistry::from_ini(&IniFile::from_str("[UCFLASH]\nFixtureOnly=1\n"));
         let config = art.anim_runtime_config("UCFLASH").unwrap();
         let mut flash = GarrisonMuzzleFlash {
             building_id: 1,

--- a/src/app_init_helpers.rs
+++ b/src/app_init_helpers.rs
@@ -1023,9 +1023,11 @@ mod tests {
     /// verified offset map to flip to).
     #[test]
     fn ported_defaults_match_ctor_csv() {
-        // Sections present but empty: every key below is absent, so each field
-        // takes its fallback default (the realistic "key missing" path).
-        let rules = RuleSet::from_ini(&IniFile::from_str("[General]\n[CombatDamage]\n"))
+        // Sections contain only an inert fixture key: every recognized key
+        // below is absent, so each field takes its fallback default.
+        let rules = RuleSet::from_ini(&IniFile::from_str(
+            "[General]\nFixtureOnly=1\n[CombatDamage]\nFixtureOnly=1\n",
+        ))
             .expect("empty-section rules parse");
 
         // [General] scalar fallbacks == ctor defaults.

--- a/src/app_instances/overlays.rs
+++ b/src/app_instances/overlays.rs
@@ -1355,7 +1355,7 @@ mod tests {
              [WAKELIKE]\n\
              Translucent=yes\n\
              End=10\n\
-             [PLAIN]\n",
+             [PLAIN]\nFixtureOnly=1\n",
         );
         let reg = ArtRegistry::from_ini(&ini);
 

--- a/src/app_instances/overlays.rs
+++ b/src/app_instances/overlays.rs
@@ -1100,13 +1100,14 @@ mod tests {
     fn gsi_04_10_render_visibility_distinguishes_unregistered_live_and_destroyed() {
         let ini = IniFile::from_str(
             "[General]\n\
+             FixtureOnly=1\n\
              [InfantryTypes]\n\
              [VehicleTypes]\n0=DUMMY\n\
              [AircraftTypes]\n\
              [BuildingTypes]\n\
              [TerrainTypes]\n0=TREE01\n\
              [DUMMY]\nStrength=100\n\
-             [TREE01]\n",
+             [TREE01]\nFixtureOnly=1\n",
         );
         let rules = RuleSet::from_ini(&ini).expect("rules");
         let registered = TerrainObject {

--- a/src/app_list_maps.rs
+++ b/src/app_list_maps.rs
@@ -205,56 +205,65 @@ fn append_loose_yro_records(
         if file_name.eq_ignore_ascii_case(MISSIONS_YRO_FILE_NAME) {
             continue;
         }
-        let owned_archive;
-        let archive: &MixArchive;
-        let fallback_assets: Option<&AssetManager>;
+        let Some(pkt_name) = Path::new(&file_name)
+            .with_extension("PKT")
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(str::to_string)
+        else {
+            continue;
+        };
+
         if let Some(manager) = assets.as_deref_mut() {
             if manager.register_loose_yro_archive(&path).is_err() {
                 continue;
             }
-            let Some(registered) = manager.archive(&file_name) else {
+
+            // Retail provenance: global YRO-derived PKT/map resolution —
+            // `SessionClass::ScanMultiplayerMapFiles` @ `0x00699980`.
+            let Some(pkt) = manager
+                .get_ref(&pkt_name)
+                .and_then(|bytes| IniFile::from_bytes(bytes).ok())
+            else {
                 continue;
             };
-            archive = registered;
-            fallback_assets = Some(manager);
+            append_pkt_records(
+                records,
+                &pkt,
+                SkirmishScenarioSource::LooseYro(file_name),
+                csf,
+                PktTitleStyle::YroPlayerCountSuffix,
+                |map_file| {
+                    manager
+                        .get_ref(map_file)
+                        .and_then(|bytes| IniFile::from_bytes(bytes).ok())
+                },
+            );
         } else {
-            owned_archive = match MixArchive::load(&path) {
+            let archive = match MixArchive::load(&path) {
                 Ok(archive) => archive,
                 Err(_) => continue,
             };
-            archive = &owned_archive;
-            fallback_assets = None;
-        };
-        let pkt_name = Path::new(&file_name)
-            .with_extension("PKT")
-            .file_name()
-            .and_then(|name| name.to_str())
-            .map(str::to_string);
-        let Some(pkt) = pkt_name
-            .as_deref()
-            .and_then(|name| archive.get_by_name(name))
-            .and_then(|bytes| IniFile::from_bytes(bytes).ok())
-        else {
-            continue;
-        };
-        append_pkt_records(
-            records,
-            &pkt,
-            SkirmishScenarioSource::LooseYro(file_name),
-            csf,
-            PktTitleStyle::YroPlayerCountSuffix,
-            |map_file| {
-                archive
-                    .get_by_name(map_file)
-                    .and_then(|bytes| IniFile::from_bytes(bytes).ok())
-                    .or_else(|| {
-                        fallback_assets
-                            .and_then(|assets| assets.get_ref(map_file))
-                            .and_then(|bytes| IniFile::from_bytes(bytes).ok())
-                    })
-                    .or_else(|| read_map_ini_for_metadata(&ra2_dir.join(map_file)))
-            },
-        );
+            let Some(pkt) = archive
+                .get_by_name(&pkt_name)
+                .and_then(|bytes| IniFile::from_bytes(bytes).ok())
+            else {
+                continue;
+            };
+            append_pkt_records(
+                records,
+                &pkt,
+                SkirmishScenarioSource::LooseYro(file_name),
+                csf,
+                PktTitleStyle::YroPlayerCountSuffix,
+                |map_file| {
+                    archive
+                        .get_by_name(map_file)
+                        .and_then(|bytes| IniFile::from_bytes(bytes).ok())
+                        .or_else(|| read_map_ini_for_metadata(&ra2_dir.join(map_file)))
+                },
+            );
+        }
     }
     Ok(())
 }
@@ -664,6 +673,71 @@ pub(crate) fn try_load_mmx(ra2_dir: &Path, names: &[&str]) -> Result<LoadedMap> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::assets::mix_hash::mix_hash;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+    struct TestDirectory(PathBuf);
+
+    impl TestDirectory {
+        fn new(label: &str) -> Self {
+            let sequence = TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "vera20k-app-list-maps-{label}-{}-{sequence}",
+                std::process::id()
+            ));
+            std::fs::create_dir(&path).expect("create test directory");
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+
+        fn write(&self, name: &str, bytes: &[u8]) {
+            std::fs::write(self.0.join(name), bytes).expect("write test file");
+        }
+    }
+
+    impl Drop for TestDirectory {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn make_new_format_mix_bytes(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let body_size: usize = entries.iter().map(|(_, body)| body.len()).sum();
+        let mut data = Vec::new();
+        data.extend_from_slice(&0u16.to_le_bytes());
+        data.extend_from_slice(&0u16.to_le_bytes());
+        data.extend_from_slice(
+            &u16::try_from(entries.len())
+                .expect("test MIX entry count")
+                .to_le_bytes(),
+        );
+        data.extend_from_slice(
+            &u32::try_from(body_size)
+                .expect("test MIX body size")
+                .to_le_bytes(),
+        );
+
+        let mut offset = 0u32;
+        for (name, body) in entries {
+            data.extend_from_slice(&mix_hash(name).to_le_bytes());
+            data.extend_from_slice(&offset.to_le_bytes());
+            data.extend_from_slice(
+                &u32::try_from(body.len())
+                    .expect("test MIX entry size")
+                    .to_le_bytes(),
+            );
+            offset += u32::try_from(body.len()).expect("test MIX entry offset");
+        }
+        for (_, body) in entries {
+            data.extend_from_slice(body);
+        }
+        data
+    }
 
     #[test]
     fn menu_entry_exposes_sorted_multiplayer_start_waypoints() {
@@ -913,6 +987,43 @@ mod tests {
         );
 
         assert_eq!(records[0].display_name.chars().count(), 43);
+    }
+
+    #[test]
+    fn yro_discovery_uses_global_loose_winners_and_retains_registered_archive() {
+        let directory = TestDirectory::new("yro-global-collisions");
+        let embedded_pkt = b"[MultiMaps]\n1=Arena\n[Arena]\nDescriptionText=Embedded PKT\nMinPlayers=2\nMaxPlayers=2\n";
+        let embedded_map = b"[Basic]\nName=Embedded Map\nAuthor=Embedded Author\n";
+        let yro = make_new_format_mix_bytes(&[
+            ("COLLIDE.PKT", &embedded_pkt[..]),
+            ("Arena.MAP", &embedded_map[..]),
+            ("YROONLY.BIN", &b"retained"[..]),
+        ]);
+        directory.write("COLLIDE.YRO", &yro);
+        directory.write(
+            "COLLIDE.PKT",
+            b"[MultiMaps]\n1=Arena\n[Arena]\nDescriptionText=Loose PKT\nMinPlayers=2\nMaxPlayers=4\n",
+        );
+        directory.write(
+            "Arena.MAP",
+            b"[Basic]\nName=Loose Map\nAuthor=Loose Author\n",
+        );
+
+        let mut manager = AssetManager::from_loose_root_for_test(directory.path());
+        let mut records = Vec::new();
+        append_loose_yro_records(&mut records, directory.path(), Some(&mut manager), None)
+            .expect("scan loose YRO");
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].file_name, "Arena.MAP");
+        assert_eq!(records[0].display_name, "Loose PKT (2-4)");
+        assert_eq!(records[0].author.as_deref(), Some("Loose Author"));
+        assert_eq!(
+            records[0].source,
+            SkirmishScenarioSource::LooseYro("COLLIDE.YRO".to_string())
+        );
+        assert_eq!(manager.registered_archive_names(), ["COLLIDE.YRO"]);
+        assert_eq!(manager.get_ref("YROONLY.BIN"), Some(&b"retained"[..]));
     }
 
     #[test]

--- a/src/app_loading.rs
+++ b/src/app_loading.rs
@@ -29,6 +29,7 @@ use crate::render::loading_screen_chrome::{
     LoadingScreenWidth, MmpbMarkerRemap, PreparedLoadingPreviewRgba,
     build_loading_screen_atlas_with_composition,
 };
+use crate::render::shell_surface_present::ShellSurfacePresenter;
 use crate::render::shell_text::{ScissorRect, ShellAlign, ShellTextDraw, TextRect, draw_in_rect};
 use crate::rules::color_scheme::{
     ColorSchemeEntry, hsv_to_rgb, scheme_entry_by_name, scheme_entry_for_priority,
@@ -681,6 +682,7 @@ pub(crate) fn pump_loading_after_present(state: &mut AppState) -> LoadingPump {
             {
                 advance_and_present_native_progress(
                     &state.gpu,
+                    &state.shell_surface_presenter,
                     &state.depth_view,
                     &state.batch_renderer,
                     &state.bit_font,
@@ -711,6 +713,7 @@ pub(crate) fn pump_loading_after_present(state: &mut AppState) -> LoadingPump {
                     let composition = native.composition.as_ref();
                     let mut sink = RenderingProgressSink {
                         gpu: &state.gpu,
+                        presenter: &state.shell_surface_presenter,
                         depth_view: &state.depth_view,
                         batch: &state.batch_renderer,
                         font: &state.bit_font,
@@ -781,6 +784,7 @@ pub(crate) fn pump_loading_after_present(state: &mut AppState) -> LoadingPump {
                         let terminal_raw_percent = native.progress_cadence.terminal_raw_percent();
                         advance_and_present_native_progress(
                             &state.gpu,
+                            &state.shell_surface_presenter,
                             &state.depth_view,
                             &state.batch_renderer,
                             &state.bit_font,
@@ -1205,7 +1209,7 @@ pub(crate) fn ensure_native_loading_atlas(state: &mut AppState) -> anyhow::Resul
 pub(crate) fn render_loading_screen(
     state: &mut AppState,
     encoder: &mut wgpu::CommandEncoder,
-    target: &wgpu::TextureView,
+    destination: &wgpu::Texture,
 ) -> LoadingRenderResult {
     if !is_native_loading_session(state) {
         return LoadingRenderResult::GenericFallback;
@@ -1236,6 +1240,7 @@ pub(crate) fn render_loading_screen(
             "native Skirmish loading atlas was not available for render"
         ));
     };
+    let target = state.shell_surface_presenter.source_render_view();
 
     let frame_plan = build_native_loading_frame_plan(
         &state.bit_font,
@@ -1286,7 +1291,7 @@ pub(crate) fn render_loading_screen(
     let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
         label: Some("Native Loading Screen"),
         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-            view: target,
+            view: &target,
             depth_slice: None,
             resolve_target: None,
             ops: wgpu::Operations {
@@ -1340,6 +1345,10 @@ pub(crate) fn render_loading_screen(
         );
     }
     pass.set_scissor_rect(0, 0, state.gpu.config.width, state.gpu.config.height);
+    drop(pass);
+    state
+        .shell_surface_presenter
+        .encode_present(encoder, destination);
     LoadingRenderResult::NativeRendered
 }
 
@@ -1720,6 +1729,7 @@ fn build_native_loading_frame_plan(
 /// Returns an error on acquire/upload failure; the caller treats it as non-fatal.
 fn present_native_loading(
     gpu: &GpuContext,
+    presenter: &ShellSurfacePresenter,
     depth_view: &wgpu::TextureView,
     batch: &BatchRenderer,
     font: &BitFont,
@@ -1735,7 +1745,7 @@ fn present_native_loading(
         .surface
         .get_current_texture()
         .map_err(|e| anyhow::anyhow!("loading repaint surface texture: {e}"))?;
-    let view = output.texture.create_view(&Default::default());
+    let view = presenter.source_render_view();
     let mut encoder = gpu
         .device
         .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -1822,6 +1832,7 @@ fn present_native_loading(
         pass.set_scissor_rect(0, 0, gpu.config.width, gpu.config.height);
     }
 
+    presenter.encode_present(&mut encoder, &output.texture);
     gpu.queue.submit(std::iter::once(encoder.finish()));
     output.present();
     Ok(())
@@ -1829,6 +1840,7 @@ fn present_native_loading(
 
 fn advance_and_present_native_progress(
     gpu: &GpuContext,
+    presenter: &ShellSurfacePresenter,
     depth_view: &wgpu::TextureView,
     batch: &BatchRenderer,
     font: &BitFont,
@@ -1845,6 +1857,7 @@ fn advance_and_present_native_progress(
     };
     if let Err(err) = present_native_loading(
         gpu,
+        presenter,
         depth_view,
         batch,
         font,
@@ -1869,6 +1882,7 @@ fn advance_and_present_native_progress(
 /// they never abort the map load.
 struct RenderingProgressSink<'a> {
     gpu: &'a GpuContext,
+    presenter: &'a ShellSurfacePresenter,
     depth_view: &'a wgpu::TextureView,
     batch: &'a BatchRenderer,
     font: &'a BitFont,
@@ -1888,6 +1902,7 @@ impl LoadingProgressSink for RenderingProgressSink<'_> {
         if self.progress.advance_progress(effective_percent) {
             if let Err(err) = present_native_loading(
                 self.gpu,
+                self.presenter,
                 self.depth_view,
                 self.batch,
                 self.font,

--- a/src/app_score_shell_render.rs
+++ b/src/app_score_shell_render.rs
@@ -236,6 +236,17 @@ fn build_labels<'a>(
     out
 }
 
+/// Bind the score screen's otherwise shared paint labels to native ScoreFont
+/// glyph selection without changing the shared shell/BitFont text path.
+///
+/// Retail provenance: post-match score-font binding — `ScoreFontClass__Constructor @ 0x00690580`.
+fn bind_score_font_text(labels: &mut [PaintLabel<'_>]) {
+    for label in labels {
+        let converted = crate::util::native_string::score_font_text(label.text.as_ref());
+        label.text = std::borrow::Cow::Owned(converted);
+    }
+}
+
 /// One row's five cells rendered to strings, kept alive for the paint pass.
 pub(crate) struct RowCellText {
     rgb: [u8; 3],
@@ -382,7 +393,8 @@ fn render_score_shell_to_target(
     let cells = row_cell_text(&model);
     let game_text = format_game_number(&model, resolve_csf(state, "TXT_GAME").as_ref());
     let time_text = format_elapsed(&model, resolve_csf(state, "TXT_TIME_FORMAT_HOURS").as_ref());
-    let labels = build_labels(state, &layout, &model, &cells, &game_text, &time_text);
+    let mut labels = build_labels(state, &layout, &model, &cells, &game_text, &time_text);
+    bind_score_font_text(&mut labels);
     let text_draws = shell_paint::paint_labels(&state.bit_font, &labels);
     drop(labels);
 

--- a/src/app_shell_transition.rs
+++ b/src/app_shell_transition.rs
@@ -435,16 +435,20 @@ pub(crate) fn render_shell_first_paint_slide(
                 state.shell_first_paint_slide = None;
                 return Ok(ShellFirstPaintRenderResult::NotRendered);
             }
+            let color = state.shell_surface_presenter.source_render_view();
             let depth = state.depth_view.clone();
             crate::app_skirmish_shell_render::render_skirmish_shell_to_target(
                 state,
                 encoder,
                 crate::render::shell_transition_pass::ShellRenderTarget {
-                    color: target,
+                    color: &color,
                     depth: &depth,
                 },
                 crate::app_skirmish_shell_render::ShellRenderMode::TransitionPreview,
             )?;
+            state
+                .shell_surface_presenter
+                .encode_present(encoder, destination);
             true
         }
         ShellSlideKind::SinglePlayer => matches!(

--- a/src/app_sim_tick.rs
+++ b/src/app_sim_tick.rs
@@ -2045,7 +2045,7 @@ mod tests {
     fn gsi_04_07_wall_sell_sound_is_global_only_for_local_receiver() {
         let rules =
             crate::rules::ruleset::RuleSet::from_ini(&crate::rules::ini_parser::IniFile::from_str(
-                "[General]\n[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
+                "[General]\nFixtureOnly=1\n[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
                  [AudioVisual]\nSellSound=SellBuilding\n",
             ))
             .unwrap();

--- a/src/app_skirmish_shell_render.rs
+++ b/src/app_skirmish_shell_render.rs
@@ -430,18 +430,23 @@ fn update_owner_draw_button_paint_sound(state: &mut AppState, mode: ShellRenderM
 pub(crate) fn render_skirmish_shell(
     state: &mut AppState,
     encoder: &mut wgpu::CommandEncoder,
-    target: &wgpu::TextureView,
+    destination: &wgpu::Texture,
 ) -> anyhow::Result<SkirmishShellAction> {
+    let color = state.shell_surface_presenter.source_render_view();
     let depth = state.depth_view.clone();
-    render_skirmish_shell_to_target(
+    let action = render_skirmish_shell_to_target(
         state,
         encoder,
         ShellRenderTarget {
-            color: target,
+            color: &color,
             depth: &depth,
         },
         ShellRenderMode::Visible,
-    )
+    )?;
+    state
+        .shell_surface_presenter
+        .encode_present(encoder, destination);
+    Ok(action)
 }
 
 /// Render the active in-game Options (`0xBBB`) overlay over the frozen

--- a/src/assets/asset_manager.rs
+++ b/src/assets/asset_manager.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::assets::error::AssetError;
 use crate::assets::mix_archive::MixArchive;
-use crate::assets::mix_hash::{mix_hash, westwood_hash};
+use crate::assets::mix_hash::mix_hash;
 
 /// A MIX archive with a human-readable name for logging and diagnostics.
 struct NamedArchive {
@@ -360,12 +360,11 @@ impl AssetManager {
     }
 
     /// Load through retail's `LoadFileFromMIX @ 0x005B40B0` boundary.
-    ///
-    /// This intentionally differs from [`Self::resolve_ref`]:
-    ///
-    /// - the uppercase-normalized filename CRC is checked first;
-    /// - a cache miss searches registered MIXes before the raw filesystem;
-    /// - the first payload for a CRC remains cached even after archive remounts.
+    /// Retail provenance: Sticky CRC file cache — `LoadFileFromMIX` @ `0x005B40B0`.
+    /// Retail provenance: Availability probing — `CCFileClass__IsAvailable_MixThenRaw` @ `0x00473C50`.
+    /// Retail provenance: Raw-before-MIX size selection — `CCFileClass__GetSize_RawThenMix` @ `0x00473C00`.
+    /// Retail provenance: Raw-before-MIX byte selection — `CCFileClass__Open_RawThenMix` @ `0x00473D10`.
+    /// A cache miss takes loose bytes before registered MIX bytes; that first CRC winner is sticky.
     pub fn load_file_from_mix(&self, name: &str) -> Option<MixFileLoad> {
         let cache_key = mix_hash(name);
         if let Some(cached) = self
@@ -378,18 +377,18 @@ impl AssetManager {
             return Some(cached);
         }
 
-        let candidate = if let Some((named, entry_id)) = self.lookup_asset_entry(name) {
-            MixFileLoad {
-                bytes: Arc::from(named.archive.get_by_id(entry_id)?),
-                source_archive: Arc::from(named.name.as_str()),
-                entry_id,
-            }
-        } else {
-            let loose = self.loose_asset(name)?;
+        let candidate = if let Some(loose) = self.loose_asset(name) {
             MixFileLoad {
                 bytes: Arc::from(loose.bytes.as_slice()),
                 source_archive: Arc::from(loose.source_name.as_str()),
                 entry_id: cache_key,
+            }
+        } else {
+            let (named, entry_id) = self.lookup_asset_entry(name)?;
+            MixFileLoad {
+                bytes: Arc::from(named.archive.get_by_id(entry_id)?),
+                source_archive: Arc::from(named.name.as_str()),
+                entry_id,
             }
         };
 
@@ -539,9 +538,9 @@ impl AssetManager {
         Ok(loaded_count)
     }
 
-    /// Check if a file exists in any loaded archive.
+    /// Check if a file is available through a registered MIX or the loose root.
+    /// Retail provenance: MIX-then-raw availability — `CCFileClass__IsAvailable_MixThenRaw` @ `0x00473C50`.
     pub fn contains(&self, name: &str) -> bool {
-        // Native availability checks MIX before raw. Only the boolean escapes.
         self.lookup_location_for_name(name).is_some() || self.loose_asset(name).is_some()
     }
 
@@ -607,30 +606,13 @@ impl AssetManager {
         Some((archive, location.entry_id))
     }
 
+    /// Retail provenance: First-match MIX filename resolution — `MixFileSystem__Resolve_First` @ `0x005B4430`.
+    /// Retail provenance: Padded filename CRC — `CRCEngine__AddData` @ `0x004A1DE0`.
     fn lookup_location_for_name(&self, name: &str) -> Option<AssetLocation> {
-        let primary_id = mix_hash(name);
-        let alternate_id = westwood_hash(name);
-        let primary = self.lookup_index.get(&primary_id).copied();
-        let alternate = if alternate_id == primary_id {
-            None
-        } else {
-            self.lookup_index.get(&alternate_id).copied()
-        };
-
-        match (primary, alternate) {
-            (Some(primary), Some(alternate)) => {
-                if primary.archive_index <= alternate.archive_index {
-                    Some(primary)
-                } else {
-                    Some(alternate)
-                }
-            }
-            (Some(primary), None) => Some(primary),
-            (None, Some(alternate)) => Some(alternate),
-            (None, None) => None,
-        }
+        self.lookup_index.get(&mix_hash(name)).copied()
     }
 
+    /// Retail provenance: Append-before-tail registration — `MixFileClass` registered constructor @ `0x005B3C20`.
     fn append_registered_archive(&mut self, named: NamedArchive) {
         let archive_index = self.archives.len();
         for entry in named.archive.entries() {
@@ -1136,20 +1118,6 @@ mod tests {
             .expect("new-format test mix should parse")
     }
 
-    fn make_old_format_mix(name: &str, body: &[u8]) -> MixArchive {
-        let mut data = Vec::new();
-        let entry_id = westwood_hash(name);
-
-        data.extend_from_slice(&1u16.to_le_bytes());
-        data.extend_from_slice(&(body.len() as u32).to_le_bytes());
-        data.extend_from_slice(&entry_id.to_le_bytes());
-        data.extend_from_slice(&0u32.to_le_bytes());
-        data.extend_from_slice(&(body.len() as u32).to_le_bytes());
-        data.extend_from_slice(body);
-
-        MixArchive::from_bytes(data).expect("old-format test mix should parse")
-    }
-
     #[test]
     fn media_mode_matches_native_uppercase_substring_command_line_test() {
         assert_eq!(
@@ -1401,40 +1369,30 @@ mod tests {
     }
 
     #[test]
-    fn indexed_lookup_prefers_earliest_archive_across_hash_fallbacks() {
-        let mut manager = AssetManager {
-            archives: vec![
-                NamedArchive {
-                    name: "theme.mix".to_string(),
-                    archive: make_old_format_mix("audio.idx", b"westwood"),
-                },
-                NamedArchive {
-                    name: "audio.mix".to_string(),
-                    archive: make_new_format_mix("audio.idx", b"crc32"),
-                },
-            ],
-            archive_catalog: Vec::new(),
-            lookup_index: HashMap::new(),
-            mix_file_cache: Mutex::new(HashMap::new()),
-            loose_files: HashMap::new(),
-            active_theater: None,
-            active_theater_archives: Vec::new(),
-            ra2_dir: PathBuf::new(),
-        };
-        manager.rebuild_indexes();
+    fn first_registered_crc_duplicate_wins() {
+        let directory = TestDirectory::new("first-registered-crc-duplicate");
+        let mut manager = empty_manager(directory.path());
+        manager.append_registered_archive(NamedArchive {
+            name: "first.mix".to_string(),
+            archive: make_new_format_mix("audio.idx", b"first"),
+        });
+        manager.append_registered_archive(NamedArchive {
+            name: "second.mix".to_string(),
+            archive: make_new_format_mix("audio.idx", b"second"),
+        });
 
         let (bytes, source) = manager
             .get_with_source("audio.idx")
             .expect("indexed lookup should find audio.idx");
-        assert_eq!(bytes, b"westwood");
-        assert_eq!(source, "theme.mix");
+        assert_eq!(bytes, b"first");
+        assert_eq!(source, "first.mix");
 
         let resolved = manager
             .resolve_ref("audio.idx")
             .expect("observational resolution should preserve first match");
-        assert_eq!(resolved.bytes, b"westwood");
-        assert_eq!(resolved.source_archive, "theme.mix");
-        assert_eq!(resolved.entry_id, westwood_hash("audio.idx"));
+        assert_eq!(resolved.bytes, b"first");
+        assert_eq!(resolved.source_archive, "first.mix");
+        assert_eq!(resolved.entry_id, mix_hash("audio.idx"));
     }
 
     #[test]
@@ -1595,7 +1553,7 @@ mod tests {
     }
 
     #[test]
-    fn loose_mixed_case_file_supplies_bytes_before_registered_mix() {
+    fn load_file_from_mix_fills_from_loose_before_mix_and_stays_sticky() {
         let mut manager = AssetManager {
             archives: vec![NamedArchive {
                 name: "first.mix".to_string(),
@@ -1625,48 +1583,24 @@ mod tests {
         assert_eq!(bytes, b"loose");
         assert_eq!(source, "loose:RA2MD.CSF");
 
-        let mix_only = manager
-            .load_file_from_mix("RA2MD.CSF")
-            .expect("LoadFileFromMIX checks MIX before the loose fallback");
-        assert_eq!(&*mix_only.bytes, b"archived");
-        assert_eq!(mix_only.source_archive.as_ref(), "first.mix");
-    }
-
-    #[test]
-    fn load_file_from_mix_caches_raw_fallback_before_later_mix_registration() {
-        let mut manager = AssetManager {
-            archives: Vec::new(),
-            archive_catalog: Vec::new(),
-            lookup_index: HashMap::new(),
-            mix_file_cache: Mutex::new(HashMap::new()),
-            loose_files: HashMap::from([(
-                "weather.bin".to_string(),
-                LooseAsset {
-                    path: PathBuf::from("WEATHER.BIN"),
-                    source_name: "loose:WEATHER.BIN".to_string(),
-                    bytes: LooseBytes::Owned(Box::from(&b"raw-first"[..])),
-                },
-            )]),
-            active_theater: None,
-            active_theater_archives: Vec::new(),
-            ra2_dir: PathBuf::new(),
-        };
-
         let first = manager
-            .load_file_from_mix("Weather.Bin")
-            .expect("raw fallback");
-        assert_eq!(&*first.bytes, b"raw-first");
-        assert_eq!(first.source_archive.as_ref(), "loose:WEATHER.BIN");
+            .load_file_from_mix("RA2MD.CSF")
+            .expect("loose file should fill cache before registered MIX");
+        assert_eq!(&*first.bytes, b"loose");
+        assert_eq!(first.source_archive.as_ref(), "loose:RA2MD.CSF");
+        assert_eq!(first.entry_id, mix_hash("RA2MD.CSF"));
 
-        manager.append_registered_archive(NamedArchive {
-            name: "later.mix".to_string(),
-            archive: make_new_format_mix("WEATHER.BIN", b"later-mix"),
-        });
+        manager.loose_files.clear();
+        assert_eq!(
+            manager.resolve_ref("RA2MD.CSF").map(|found| found.bytes),
+            Some(&b"archived"[..])
+        );
         let cached = manager
-            .load_file_from_mix("WEATHER.BIN")
-            .expect("cached raw winner");
-        assert_eq!(&*cached.bytes, b"raw-first");
-        assert_eq!(cached.source_archive.as_ref(), "loose:WEATHER.BIN");
+            .load_file_from_mix("ra2md.csf")
+            .expect("cached loose winner");
+        assert_eq!(&*cached.bytes, b"loose");
+        assert!(Arc::ptr_eq(&first.bytes, &cached.bytes));
+        assert_eq!(cached.source_archive.as_ref(), "loose:RA2MD.CSF");
     }
 
     #[test]

--- a/src/assets/asset_manager.rs
+++ b/src/assets/asset_manager.rs
@@ -440,11 +440,11 @@ impl AssetManager {
         self.mount_named_archive(name, true).map(|_| ())
     }
 
-    /// Replace retail's one active theater archive group.
+    /// Retail provenance: theater archive-group lifecycle — `Init_Theater` @ `0x005349C0`.
     ///
-    /// `Init_Theater @ 0x005349C0` destroys the previous group, appends the
-    /// new group's named archives, and does nothing when the theater identity
-    /// is unchanged.
+    /// The previous group is destroyed, every optional slot is attempted in
+    /// caller order, successful slots are retained, and an unchanged theater
+    /// identity is a no-op.
     pub fn activate_theater_archives(
         &mut self,
         theater_name: &str,
@@ -476,8 +476,14 @@ impl AssetManager {
         }
 
         for &name in archive_names {
-            if self.mount_named_archive(name, false)? {
-                self.active_theater_archives.push(name.to_string());
+            match self.mount_named_archive(name, false) {
+                Ok(true) => self.active_theater_archives.push(name.to_string()),
+                Ok(false) => {}
+                Err(err) => {
+                    log::warn!(
+                        "Theater {theater_name}: skipping optional archive {name}: {err}"
+                    );
+                }
             }
         }
         self.active_theater = Some(theater_name.to_string());
@@ -1646,6 +1652,50 @@ mod tests {
         assert!(!manager.contains("snow.bin"));
         assert!(manager.contains("temperate.bin"));
         assert_eq!(manager.archives.len(), 2);
+    }
+
+    #[test]
+    fn theater_group_skips_malformed_middle_slot_and_commits_new_identity() {
+        let directory = TestDirectory::new("theater-middle-failure");
+        directory.write_mix("snow.mix", "snow.bin", b"snow");
+        directory.write_mix("temperat.mix", "temperate.bin", b"temperate");
+        std::fs::write(directory.path().join("tem.mix"), b"not a MIX")
+            .expect("write malformed middle archive");
+        directory.write_mix("isotemmd.mix", "iso-md.bin", b"iso-md");
+
+        let mut manager = empty_manager(directory.path());
+        manager
+            .activate_theater_archives("SNOW", &["snow.mix"])
+            .expect("activate initial snow group");
+        manager
+            .activate_theater_archives(
+                "TEMPERATE",
+                &["temperat.mix", "tem.mix", "isotemmd.mix", "isotemp.mix"],
+            )
+            .expect("malformed optional slot is skipped");
+
+        assert_eq!(manager.active_theater.as_deref(), Some("TEMPERATE"));
+        assert_eq!(
+            manager.active_theater_archives,
+            ["temperat.mix", "isotemmd.mix"]
+        );
+        assert_eq!(
+            manager.registered_archive_names(),
+            ["temperat.mix", "isotemmd.mix"]
+        );
+        assert!(!manager.contains("snow.bin"));
+        assert_eq!(manager.get_ref("iso-md.bin"), Some(&b"iso-md"[..]));
+
+        manager
+            .activate_theater_archives(
+                "temperate",
+                &["temperat.mix", "tem.mix", "isotemmd.mix", "isotemp.mix"],
+            )
+            .expect("same theater is a no-op");
+        assert_eq!(
+            manager.registered_archive_names(),
+            ["temperat.mix", "isotemmd.mix"]
+        );
     }
 
     #[test]

--- a/src/assets/mix_archive.rs
+++ b/src/assets/mix_archive.rs
@@ -14,7 +14,7 @@
 //!           if not encrypted → file index header
 //! ```
 //!
-//! ### Old format (Tiberian Dawn, Red Alert 1, theme.mix):
+//! ### Old-header layout (also used by YR theme archives):
 //! ```text
 //! Offset 0: u16 = file_count (non-zero — this IS the count, no flags)
 //! Offset 2: u32 = body_size
@@ -45,7 +45,7 @@ use std::sync::Arc;
 
 use crate::assets::error::AssetError;
 use crate::assets::mix_crypto;
-use crate::assets::mix_hash::{mix_hash, westwood_hash};
+use crate::assets::mix_hash::mix_hash;
 use crate::util::read_helpers::{read_i32_le, read_u16_le, read_u32_le};
 
 /// MIX flags bit: file index is Blowfish-encrypted (with RSA key block).
@@ -83,19 +83,11 @@ pub struct MixEntry {
 pub struct MixArchive {
     /// The file index entries, sorted by id for binary search lookup.
     entries: Vec<MixEntry>,
-    /// Filename hash algorithm used by this archive format.
-    hash_kind: MixHashKind,
     /// Byte offset where the body section starts in the raw data.
     body_offset: usize,
     /// The raw archive bytes. Top-level archives can stay memory-mapped;
     /// nested archives can share a sub-view into parent archive storage.
     data: MixData,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum MixHashKind {
-    Crc32,
-    Westwood,
 }
 
 #[derive(Clone)]
@@ -161,7 +153,7 @@ impl MixArchive {
     ///
     /// Detects old vs new format by checking the first u16:
     /// - 0x0000 → new format (RA2/TS): real flags at offset 2
-    /// - Non-zero → old format (TD/RA1): that value IS the file_count
+    /// - Non-zero → old-header layout: that value IS the file_count
     pub fn from_bytes(data: Vec<u8>) -> Result<Self, AssetError> {
         Self::from_data(MixData::from_owned(data))
     }
@@ -221,9 +213,9 @@ impl MixArchive {
 
         // The first u16 distinguishes old vs new MIX format.
         // New format (RA2/TS): offset 0 is always 0x0000 as a format marker.
-        // Old format (TD/RA1): offset 0 is file_count (always non-zero).
+        // Old-header layout: offset 0 is file_count (always non-zero).
         let first_word: u16 = read_u16_le(bytes, 0);
-        let (mut entries, hash_kind, body_offset) = if first_word == 0 {
+        let (mut entries, body_offset) = if first_word == 0 {
             // New format: actual flags are at offset 2.
             let flags: u16 = read_u16_le(bytes, 2);
             let is_encrypted: bool = (flags & FLAG_ENCRYPTED) != 0;
@@ -234,14 +226,13 @@ impl MixArchive {
                 Self::parse_unencrypted_new_format(bytes)?
             }
         } else {
-            // Old format: first_word IS the file_count. No flags, no encryption.
+            // Old-header layout: first_word IS the file_count. No flags, no encryption.
             Self::parse_old_format(bytes, first_word)?
         };
         entries.sort_by_key(|e| e.id);
 
         Ok(Self {
             entries,
-            hash_kind,
             body_offset,
             data,
         })
@@ -255,25 +246,11 @@ impl MixArchive {
     }
 
     /// Look up a file by name. Returns the raw bytes if found.
-    ///
-    /// MIX archives in the wild are not perfectly format-segregated by hash style:
-    /// some old-format archives (notably `theme.mix` / `thememd.mix`) still use the
-    /// CRC-style filename hash. Try the archive's primary hash first, then fall back
-    /// to the alternate hash before giving up.
+    /// Retail provenance: MIX filename resolution — `MixFileSystem__Resolve_First` @ `0x005B4430`.
+    /// Retail provenance: Padded filename CRC — `CRCEngine__AddData` @ `0x004A1DE0`.
+    /// Header layout affects parsing only; active YR resolves every archive with one CRC ID.
     pub fn get_by_name(&self, name: &str) -> Option<&[u8]> {
-        let primary: i32 = match self.hash_kind {
-            MixHashKind::Crc32 => mix_hash(name),
-            MixHashKind::Westwood => westwood_hash(name),
-        };
-        if let Some(data) = self.get_by_id(primary) {
-            return Some(data);
-        }
-
-        let alternate: i32 = match self.hash_kind {
-            MixHashKind::Crc32 => westwood_hash(name),
-            MixHashKind::Westwood => mix_hash(name),
-        };
-        self.get_by_id(alternate)
+        self.get_by_id(mix_hash(name))
     }
 
     /// Look up a file by its pre-computed hash ID.
@@ -326,9 +303,7 @@ impl MixArchive {
     ///
     /// Layout: [marker:2][flags:2][RSA block:80][encrypted index...][body...]
     /// The RSA block starts at offset 4 (after the 2-byte marker + 2-byte flags).
-    fn parse_encrypted_new_format(
-        data: &[u8],
-    ) -> Result<(Vec<MixEntry>, MixHashKind, usize), AssetError> {
+    fn parse_encrypted_new_format(data: &[u8]) -> Result<(Vec<MixEntry>, usize), AssetError> {
         // RSA key block starts after the 4-byte new-format header.
         let rsa_start: usize = NEW_FORMAT_HEADER_SIZE;
         let rsa_end: usize = rsa_start + mix_crypto::RSA_KEY_BLOCK_SIZE;
@@ -393,16 +368,14 @@ impl MixArchive {
         // Body data starts right after the encrypted index.
         let body_offset: usize = encrypted_start + encrypted_size;
 
-        Ok((entries, MixHashKind::Crc32, body_offset))
+        Ok((entries, body_offset))
     }
 
     /// Parse a new-format unencrypted MIX file (flags has no encryption bit).
     ///
     /// Layout: [marker:2][flags:2][file_count:2][body_size:4][entries...][body...]
     /// The index header starts at offset 4.
-    fn parse_unencrypted_new_format(
-        data: &[u8],
-    ) -> Result<(Vec<MixEntry>, MixHashKind, usize), AssetError> {
+    fn parse_unencrypted_new_format(data: &[u8]) -> Result<(Vec<MixEntry>, usize), AssetError> {
         if data.len() < NEW_FORMAT_HEADER_SIZE + INDEX_HEADER_SIZE {
             return Err(AssetError::InvalidMixHeader {
                 reason: "File too small for new-format unencrypted header".to_string(),
@@ -427,20 +400,20 @@ impl MixArchive {
         let entries: Vec<MixEntry> = Self::parse_entries(&data, index_start, file_count)?;
         let body_offset: usize = index_end;
 
-        Ok((entries, MixHashKind::Crc32, body_offset))
+        Ok((entries, body_offset))
     }
 
-    /// Parse an old-format MIX file (TD/RA1/theme.mix — no format marker).
+    /// Parse an old-header MIX file (no format marker).
     ///
     /// Layout: [file_count:2][body_size:4][entries...][body...]
     /// The first u16 at offset 0 is already the file_count (passed in).
     fn parse_old_format(
         data: &[u8],
         file_count: u16,
-    ) -> Result<(Vec<MixEntry>, MixHashKind, usize), AssetError> {
+    ) -> Result<(Vec<MixEntry>, usize), AssetError> {
         if data.len() < INDEX_HEADER_SIZE {
             return Err(AssetError::InvalidMixHeader {
-                reason: "File too small for old-format header".to_string(),
+                reason: "File too small for old-header MIX header".to_string(),
             });
         }
 
@@ -453,7 +426,7 @@ impl MixArchive {
         if data.len() < index_end {
             return Err(AssetError::InvalidMixHeader {
                 reason: format!(
-                    "File too small for {} old-format index entries: need {} bytes",
+                    "File too small for {} old-header index entries: need {} bytes",
                     file_count, index_end
                 ),
             });
@@ -462,7 +435,7 @@ impl MixArchive {
         let entries: Vec<MixEntry> = Self::parse_entries(&data, index_start, file_count)?;
         let body_offset: usize = index_end;
 
-        Ok((entries, MixHashKind::Westwood, body_offset))
+        Ok((entries, body_offset))
     }
 
     /// Parse file index entries from a buffer starting at the given offset.
@@ -517,6 +490,7 @@ impl MixArchive {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::assets::mix_hash::westwood_hash;
 
     /// Build a minimal new-format unencrypted MIX file with one entry.
     ///
@@ -545,18 +519,18 @@ mod tests {
         data
     }
 
-    /// Build a minimal old-format MIX file (like theme.mix).
+    /// Build a minimal old-header MIX file (like thememd.mix).
     ///
     /// Layout: [file_count:1][body_size:5][index entry: 12 bytes][body: "world"]
-    fn make_test_mix_old_format() -> Vec<u8> {
+    fn make_test_mix_old_header() -> Vec<u8> {
         let mut data: Vec<u8> = Vec::new();
 
-        // Old format: file_count directly at offset 0 (non-zero).
+        // Old-header layout: file_count directly at offset 0 (non-zero).
         data.extend_from_slice(&1u16.to_le_bytes()); // file_count=1
         data.extend_from_slice(&5u32.to_le_bytes()); // body_size=5
 
         // Index entry
-        let test_id: i32 = westwood_hash("data.bin");
+        let test_id: i32 = 0x0CFB_D6C3;
         data.extend_from_slice(&test_id.to_le_bytes());
         data.extend_from_slice(&0u32.to_le_bytes()); // offset
         data.extend_from_slice(&5u32.to_le_bytes()); // size
@@ -592,15 +566,15 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_old_format() {
-        let data: Vec<u8> = make_test_mix_old_format();
+    fn parses_old_header_layout() {
+        let data: Vec<u8> = make_test_mix_old_header();
         let archive: MixArchive =
-            MixArchive::from_bytes(data).expect("Should parse old-format MIX");
+            MixArchive::from_bytes(data).expect("Should parse old-header MIX");
         assert_eq!(archive.entry_count(), 1);
     }
 
     #[test]
-    fn test_get_by_name_new_format() {
+    fn get_by_name_uses_one_crc_id_without_rolling_fallback() {
         let data: Vec<u8> = make_test_mix_new_format();
         let archive: MixArchive = MixArchive::from_bytes(data).expect("Should parse");
 
@@ -608,16 +582,26 @@ mod tests {
             .get_by_name("test.txt")
             .expect("Should find test.txt");
         assert_eq!(content, b"hello");
+
+        let mut rolling_only = make_test_mix_new_format();
+        let crc_id = mix_hash("test.txt");
+        let rolling_id = westwood_hash("test.txt");
+        assert_ne!(crc_id, rolling_id);
+        let index_start = NEW_FORMAT_HEADER_SIZE + INDEX_HEADER_SIZE;
+        rolling_only[index_start..index_start + 4].copy_from_slice(&rolling_id.to_le_bytes());
+        let rolling_only = MixArchive::from_bytes(rolling_only).expect("Should parse");
+        assert!(rolling_only.get_by_name("test.txt").is_none());
     }
 
     #[test]
-    fn test_get_by_name_old_format() {
-        let data: Vec<u8> = make_test_mix_old_format();
+    fn old_header_get_by_name_uses_crc_id() {
+        assert_eq!(mix_hash("BRAINfre.wav"), 0x0CFB_D6C3);
+        let data: Vec<u8> = make_test_mix_old_header();
         let archive: MixArchive = MixArchive::from_bytes(data).expect("Should parse");
 
         let content: &[u8] = archive
-            .get_by_name("data.bin")
-            .expect("Should find data.bin");
+            .get_by_name("brainfre.wav")
+            .expect("Should find BRAINfre.wav");
         assert_eq!(content, b"world");
     }
 
@@ -641,7 +625,7 @@ mod tests {
     #[test]
     fn test_looks_like_mix_accepts_valid_headers() {
         assert!(MixArchive::looks_like_mix(&make_test_mix_new_format()));
-        assert!(MixArchive::looks_like_mix(&make_test_mix_old_format()));
+        assert!(MixArchive::looks_like_mix(&make_test_mix_old_header()));
     }
 
     #[test]

--- a/src/map/lighting.rs
+++ b/src/map/lighting.rs
@@ -1029,7 +1029,7 @@ mod tests {
 
     #[test]
     fn test_parse_lighting_uses_yr_defaults() {
-        let ini = IniFile::from_str("[Lighting]\n");
+        let ini = IniFile::from_str("[Lighting]\nFixtureOnly=1\n");
         let config = parse_lighting(&ini);
         assert!((config.ambient - 1.0).abs() < 0.001);
         assert!((config.red - 1.0).abs() < 0.001);

--- a/src/map/map_file.rs
+++ b/src/map/map_file.rs
@@ -737,7 +737,7 @@ LocalSize=2,4,96,92
 
     #[test]
     fn gsi_04_01_loaded_empty_rect_values_are_omitted_and_become_missing_zeros() {
-        let ini = IniFile::from_str("[Map]\nSize=\nLocalSize= \t \n");
+        let ini = IniFile::from_str("[Map]\nTheater=TEMPERATE\nSize=\nLocalSize= \t \n");
         let map_section = ini.section("Map").expect("Map section");
 
         assert!(map_section.get("Size").is_none());

--- a/src/map/rmg/tech_catalog.rs
+++ b/src/map/rmg/tech_catalog.rs
@@ -101,7 +101,7 @@ mod tests {
     fn absent_section_or_key_yields_an_empty_catalog() {
         let art = IniFile::from_str("[CAOILD]\nFoundation=2x2\n");
         assert!(resolve(&IniFile::from_str(""), &art).is_empty());
-        assert!(resolve(&IniFile::from_str("[AI]\n"), &art).is_empty());
+        assert!(resolve(&IniFile::from_str("[AI]\nFixtureOnly=1\n"), &art).is_empty());
     }
 
     #[test]

--- a/src/render/loading_screen_chrome.rs
+++ b/src/render/loading_screen_chrome.rs
@@ -13,6 +13,7 @@ use crate::assets::pcx_file::PcxFile;
 use crate::assets::shp_file::ShpFile;
 use crate::render::batch::{BatchRenderer, BatchTexture};
 use crate::render::gpu::GpuContext;
+use crate::render::native_surface_format::ACTIVE_RETAIL_RGB565_PRESENTATION;
 
 const ATLAS_PADDING: u32 = 2;
 
@@ -471,7 +472,9 @@ fn render_pcx_entry(assets: &AssetManager, file_name: &str) -> Option<RenderedLo
             err
         })
         .ok()?;
-    let rgba = pcx.to_rgba_with_color_key(SIDE_ICON_TRANSPARENT_RGB);
+    let mut rgba = pcx.to_rgba(None);
+    ACTIVE_RETAIL_RGB565_PRESENTATION
+        .apply_packed_color_key_rgba8(&mut rgba, SIDE_ICON_TRANSPARENT_RGB);
     Some(RenderedLoadingEntry {
         label: file_name.to_ascii_lowercase(),
         width: pcx.width as u32,

--- a/src/render/native_surface_format.rs
+++ b/src/render/native_surface_format.rs
@@ -60,6 +60,36 @@ impl NativeSurfacePresentationProfile {
         ]
     }
 
+    /// Apply a transparent RGB key after both colors have been packed into the
+    /// active DirectDraw word. Non-key pixels retain their incoming alpha.
+    ///
+    /// Retail provenance: packed flag-image transparency — `OwnerDraw_Static_006153E0` @ `0x006153E0`.
+    pub(crate) fn apply_packed_color_key_rgba8(
+        self,
+        rgba: &mut [u8],
+        transparent_rgb: [u8; 3],
+    ) {
+        assert_eq!(rgba.len() % 4, 0, "RGBA8 input must contain whole pixels");
+        let transparent_word = self.pack_rgb8(transparent_rgb);
+        for pixel in rgba.chunks_exact_mut(4) {
+            if self.pack_rgb8([pixel[0], pixel[1], pixel[2]]) == transparent_word {
+                pixel[3] = 0;
+            }
+        }
+    }
+
+    /// Recover the component bytes that native emits after a packed-surface
+    /// round trip: discarded low bits are zero-filled, not replicated.
+    ///
+    /// Retail provenance: RandMap.img packed-surface RGB extraction — `WriteSurfaceAsPCX` @ `0x007B05C0`.
+    pub(crate) fn storage_roundtrip_rgb8(self, rgb: [u8; 3]) -> [u8; 3] {
+        [
+            (rgb[0] >> self.format.red_loss) << self.format.red_loss,
+            (rgb[1] >> self.format.green_loss) << self.format.green_loss,
+            (rgb[2] >> self.format.blue_loss) << self.format.blue_loss,
+        ]
+    }
+
     /// Flatten the exact codebooks for the read-only shader buffer.
     pub(crate) fn shader_words(self) -> [u32; 96] {
         let mut words = [0; 96];
@@ -78,6 +108,12 @@ impl NativeSurfacePresentationProfile {
             2 => self.six_bit[usize::from(channel >> 2)],
             _ => panic!("presentation profile supports only five- and six-bit channels"),
         }
+    }
+
+    fn pack_rgb8(self, rgb: [u8; 3]) -> u16 {
+        ((u16::from(rgb[0]) >> self.format.red_loss) << self.format.red_shift)
+            | ((u16::from(rgb[1]) >> self.format.green_loss) << self.format.green_shift)
+            | ((u16::from(rgb[2]) >> self.format.blue_loss) << self.format.blue_shift)
     }
 }
 
@@ -163,6 +199,30 @@ mod tests {
                 alpha
             );
         }
+    }
+
+    #[test]
+    fn rgb565_packed_color_key_accepts_low_bit_aliases_and_preserves_other_alpha() {
+        let mut rgba = [
+            255, 0, 255, 255, // exact magenta
+            248, 3, 249, 127, // same R5G6B5 word
+            247, 3, 249, 37, // adjacent red word
+        ];
+
+        ACTIVE_RETAIL_RGB565_PRESENTATION
+            .apply_packed_color_key_rgba8(&mut rgba, [255, 0, 255]);
+
+        assert_eq!(&rgba[0..4], &[255, 0, 255, 0]);
+        assert_eq!(&rgba[4..8], &[248, 3, 249, 0]);
+        assert_eq!(&rgba[8..12], &[247, 3, 249, 37]);
+    }
+
+    #[test]
+    fn rgb565_storage_roundtrip_zero_fills_discarded_channel_bits() {
+        assert_eq!(
+            ACTIVE_RETAIL_RGB565_PRESENTATION.storage_roundtrip_rgb8([17, 101, 249]),
+            [16, 100, 248]
+        );
     }
 
     #[test]

--- a/src/render/shell_surface_present.rs
+++ b/src/render/shell_surface_present.rs
@@ -1,9 +1,11 @@
-//! Encoded-byte RGB565 presentation for the stock main-menu shell.
+//! Encoded-byte RGB565 presentation for stock shell and loading surfaces.
 //!
 //! The native shell composes into a 16-bit DirectDraw surface. Rust keeps its
-//! existing sRGB shell painters, then this shell-only boundary samples the
+//! existing sRGB shell/loading painters, then this boundary samples the
 //! stored encoded bytes through a compatible unorm view, applies the guarded
 //! presentation codebooks, and copies the resulting bytes into the swapchain.
+//!
+//! Retail provenance: DirectDraw surface-format derivation — `DSurface__Constructor` @ `0x004BA770`.
 
 use std::num::NonZeroU64;
 

--- a/src/render/skirmish_shell_chrome.rs
+++ b/src/render/skirmish_shell_chrome.rs
@@ -13,6 +13,7 @@ use crate::assets::pcx_file::PcxFile;
 use crate::assets::shp_file::ShpFile;
 use crate::render::batch::{BatchRenderer, BatchTexture};
 use crate::render::gpu::GpuContext;
+use crate::render::native_surface_format::ACTIVE_RETAIL_RGB565_PRESENTATION;
 
 const ATLAS_PADDING: u32 = 2;
 const OWNER_DRAW_FLAG_TRANSPARENT_RGB: [u8; 3] = [255, 0, 255];
@@ -697,11 +698,14 @@ fn render_pcx_entry(assets: &AssetManager, file_name: &str) -> Option<RenderedSh
 fn render_flag_pcx_entry(assets: &AssetManager, file_name: &str) -> Option<RenderedShellEntry> {
     let bytes = assets.get_ref(file_name)?;
     let pcx = PcxFile::from_bytes(bytes).ok()?;
+    let mut rgba = pcx.to_rgba(None);
+    ACTIVE_RETAIL_RGB565_PRESENTATION
+        .apply_packed_color_key_rgba8(&mut rgba, OWNER_DRAW_FLAG_TRANSPARENT_RGB);
     Some(RenderedShellEntry {
         label: file_name.to_ascii_lowercase(),
         width: pcx.width as u32,
         height: pcx.height as u32,
-        rgba: pcx.to_rgba_with_color_key(OWNER_DRAW_FLAG_TRANSPARENT_RGB),
+        rgba,
     })
 }
 

--- a/src/rules/art_data.rs
+++ b/src/rules/art_data.rs
@@ -1973,7 +1973,8 @@ mod anim_runtime_metadata_tests {
              Translucency=50\n\
              [SEVENTY_FIVE]\n\
              Translucency=75\n\
-             [OMITTED]\n",
+             [OMITTED]\n\
+             FixtureOnly=1\n",
         );
         let reg = ArtRegistry::from_ini(&ini);
 
@@ -2249,6 +2250,7 @@ mod anim_runtime_metadata_tests {
     fn anim_bounds_preserve_omission_explicit_zero_and_negative_one() {
         let ini = IniFile::from_str(
             "[OMITTED]\n\
+             FixtureOnly=1\n\
              [ZERO]\nEnd=0\nLoopEnd=0\n\
              [LAST]\nEnd=-1\nLoopEnd=-1\n",
         );

--- a/src/rules/art_data_tests.rs
+++ b/src/rules/art_data_tests.rs
@@ -106,7 +106,7 @@ fn test_from_ini_parses_entries() {
 #[test]
 fn gsi_04_05_hidden_absent_occupy_height_inherits_resolved_height() {
     let ini: IniFile = IniFile::from_str(
-        "[GAREFN]\nCanHideThings=no\nOccupyHeight=4\n\n[GAPOWR]\nHeight=3\n\n[NAPOWR]\n",
+        "[GAREFN]\nCanHideThings=no\nOccupyHeight=4\n\n[GAPOWR]\nHeight=3\n\n[NAPOWR]\nFixtureOnly=1\n",
     );
     let reg: ArtRegistry = ArtRegistry::from_ini(&ini);
 
@@ -139,7 +139,9 @@ fn parses_anim_start_sound_and_report() {
 
 #[test]
 fn parses_generic_animtype_rate_with_constructor_default() {
-    let ini: IniFile = IniFile::from_str("[UCFAST]\nRate=300\n\n[UCDEFAULT]\n\n[UCSTOP]\nRate=0\n");
+    let ini: IniFile = IniFile::from_str(
+        "[UCFAST]\nRate=300\n\n[UCDEFAULT]\nFixtureOnly=1\n\n[UCSTOP]\nRate=0\n",
+    );
     let reg: ArtRegistry = ArtRegistry::from_ini(&ini);
 
     assert_eq!(reg.rate_ms("UCFAST"), Some(200));
@@ -157,7 +159,9 @@ fn parses_generic_animtype_rate_with_constructor_default() {
 
 #[test]
 fn test_resolve_effective_image_id_chain() {
-    let ini: IniFile = IniFile::from_str("[NACNST]\nImage=CIVNC\n\n[E1]\n\n[MTNK]\nImage=MTNK\n");
+    let ini: IniFile = IniFile::from_str(
+        "[NACNST]\nImage=CIVNC\n\n[E1]\nFixtureOnly=1\n\n[MTNK]\nImage=MTNK\n",
+    );
     let reg: ArtRegistry = ArtRegistry::from_ini(&ini);
 
     assert_eq!(reg.resolve_effective_image_id("NACNST", "NACNST"), "CIVNC");
@@ -545,7 +549,8 @@ fn parses_anim_smudge_flags() {
           Crater=yes\n\
           ForceBigCraters=yes\n\
           \n\
-          [ANIMC]\n",
+          [ANIMC]\n\
+          FixtureOnly=1\n",
     )
     .unwrap();
     let reg = ArtRegistry::from_ini(&ini);

--- a/src/rules/bridge_warheads.rs
+++ b/src/rules/bridge_warheads.rs
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn missing_keys_fall_back_to_defaults() {
-        let ini = IniFile::from_str("[CombatDamage]\n");
+        let ini = IniFile::from_str("[CombatDamage]\nFixtureOnly=1\n");
         let section = ini.section("CombatDamage").unwrap();
         let bw = BridgeWarheads::from_ini_section(section);
         assert_eq!(bw.ion_cannon_name, "IonCannonWH");

--- a/src/rules/combat_damage.rs
+++ b/src/rules/combat_damage.rs
@@ -152,8 +152,8 @@ mod tests {
     }
 
     #[test]
-    fn empty_section_yields_all_none() {
-        let ini = IniFile::from_str("[CombatDamage]\n");
+    fn section_without_recognized_keys_yields_all_none() {
+        let ini = IniFile::from_str("[CombatDamage]\nFixtureOnly=1\n");
         let section = ini.section("CombatDamage").unwrap();
         let cd = CombatDamageDefaults::from_ini_section(section);
         assert!(cd.default_large_grey_smoke_system.is_none());
@@ -164,7 +164,8 @@ mod tests {
 
     #[test]
     fn whitespace_only_value_treated_as_none() {
-        let ini = IniFile::from_str("[CombatDamage]\nDefaultSparkSystem=   \n");
+        let ini =
+            IniFile::from_str("[CombatDamage]\nFixtureOnly=1\nDefaultSparkSystem=   \n");
         let section = ini.section("CombatDamage").unwrap();
         let cd = CombatDamageDefaults::from_ini_section(section);
         assert!(cd.default_spark_system.is_none());

--- a/src/rules/ini_parser.rs
+++ b/src/rules/ini_parser.rs
@@ -1,8 +1,9 @@
 //! Parser and layer composer for Westwood INI data.
 //!
 //! Active `gamemd.exe` treats raw section and key names as case-sensitive.
-//! A fresh load retains duplicate section bodies, while public name lookup
-//! resolves the first matching body. Empty keys and values are not inserted.
+//! A fresh load retains duplicate nonempty section bodies. Empty keys, values,
+//! and physical section bodies are not inserted. Arbitrary duplicate-name
+//! lookup remains a native CRC/qsort exactification residual.
 //! Rules layers are processed separately: ordinary values update live fields,
 //! while numbered type registries find-or-allocate by their value.
 
@@ -22,6 +23,11 @@ pub struct IniSection {
     entries: HashMap<String, String>,
     /// Exact keys in their first insertion order.
     key_order: Vec<String>,
+    /// Values presented by successive `RulesClass::Process` passes.
+    ///
+    /// Raw INIs leave this empty. The compatibility projection retains it so
+    /// typed readers can use the current live field as the next pass default.
+    projected_values: HashMap<String, Vec<String>>,
 }
 
 impl IniSection {
@@ -30,19 +36,32 @@ impl IniSection {
             name,
             entries: HashMap::new(),
             key_order: Vec::new(),
+            projected_values: HashMap::new(),
         }
     }
 
-    fn overlay_from(&mut self, patch: &IniSection) {
+    fn overlay_rules_pass(&mut self, patch: &IniSection) {
         for key in patch.keys() {
             if let Some(value) = patch.get(key) {
-                self.set(key, value);
+                self.set_projected(key, value);
             }
         }
     }
 
-    /// Insert during a fresh file load. Native lookup resolves the original
-    /// first exact duplicate key.
+    fn set_projected(&mut self, key: &str, value: &str) {
+        if !self.entries.contains_key(key) {
+            self.key_order.push(key.to_string());
+        }
+        self.entries.insert(key.to_string(), value.to_string());
+        self.projected_values
+            .entry(key.to_string())
+            .or_default()
+            .push(value.to_string());
+    }
+
+    /// Insert during a fresh file load. The Rust compatibility lookup keeps
+    /// the first exact duplicate; native multi-duplicate CRC/qsort selection
+    /// is intentionally outside the ordinary-retail contract.
     fn insert_initial(&mut self, key: &str, value: &str) {
         if self.entries.contains_key(key) {
             return;
@@ -58,6 +77,7 @@ impl IniSection {
             self.key_order.push(key.to_string());
         }
         self.entries.insert(key.to_string(), value.to_string());
+        self.projected_values.remove(key);
     }
 
     /// Get an exact-case key.
@@ -67,18 +87,17 @@ impl IniSection {
 
     /// Integer reader with native `$FF`, `FFh`, and C `atoi` prefix behavior.
     pub fn get_i32(&self, key: &str) -> Option<i32> {
-        let value = trim_ascii_controls(self.get(key)?);
-        if let Some(hex) = value.strip_prefix('$') {
-            return crate::rules::ini_value::parse_leading_hex(hex);
+        if let Some(values) = self.projected_values.get(key) {
+            let mut resolved = None;
+            for value in values {
+                if let Some(parsed) = crate::rules::ini_value::parse_read_int_value(value) {
+                    resolved = Some(parsed);
+                }
+            }
+            resolved
+        } else {
+            crate::rules::ini_value::parse_read_int_value(self.get(key)?)
         }
-        if value
-            .as_bytes()
-            .last()
-            .is_some_and(|byte| byte.eq_ignore_ascii_case(&b'h'))
-        {
-            return crate::rules::ini_value::parse_leading_hex(&value[..value.len() - 1]);
-        }
-        Some(self.read_int(key, 0))
     }
 
     /// Native float read: parse as `f32`, then return that value.
@@ -108,16 +127,25 @@ impl IniSection {
     }
 
     /// Native boolean reads inspect only the first trimmed character.
+    ///
+    /// Retail provenance: current-field default — `WeaponTypeClass__ReadINI` @
+    /// `0x00772080`, calling `CCINIClass__ReadBool` @ `0x005295F0`.
     pub fn get_bool(&self, key: &str) -> Option<bool> {
-        let first = trim_ascii_controls(self.get(key)?)
-            .bytes()
-            .next()?
-            .to_ascii_uppercase();
-        match first {
-            b'1' | b'T' | b'Y' => Some(true),
-            b'0' | b'F' | b'N' => Some(false),
-            _ => None,
+        let mut resolved = None;
+        if let Some(values) = self.projected_values.get(key) {
+            for value in values {
+                if let Some(parsed) = parse_bool_value(value) {
+                    resolved = Some(parsed);
+                }
+            }
+            resolved
+        } else {
+            parse_bool_value(self.get(key)?)
         }
+    }
+
+    pub(crate) fn projected_values(&self, key: &str) -> Option<&[String]> {
+        self.projected_values.get(key).map(Vec::as_slice)
     }
 
     pub fn get_list(&self, key: &str) -> Option<Vec<&str>> {
@@ -174,7 +202,8 @@ impl IniSection {
     }
 }
 
-/// Parsed INI section occurrences plus the native first-winner name index.
+/// Parsed section occurrences plus Rust's deterministic exact-name lookup index
+/// for the supported ordinary INI contract.
 #[derive(Debug, Clone)]
 pub struct IniFile {
     sections: Vec<IniSection>,
@@ -224,7 +253,21 @@ impl IniFile {
             Self::parse_line(&mut ini, &mut current_section, visible);
         }
 
+        // Retail provenance: INI lexical loading — `INIClass__LoadFromStraw` @ `0x00525A60`.
+        // Active read mode destroys a candidate section unless at least one
+        // accepted nonempty entry was linked into it.
+        ini.discard_entryless_sections();
         ini
+    }
+
+    fn discard_entryless_sections(&mut self) {
+        self.sections.retain(|section| section.entry_count() != 0);
+        self.first_section.clear();
+        for (index, section) in self.sections.iter().enumerate() {
+            self.first_section
+                .entry(section.name.clone())
+                .or_insert(index);
+        }
     }
 
     fn parse_line(ini: &mut Self, current_section: &mut Option<usize>, raw_line: &str) {
@@ -286,6 +329,26 @@ impl IniFile {
                 continue;
             }
             self.overlay_section(patch_section);
+        }
+    }
+
+    /// Build the typed-reader compatibility view for one ordered rules pass.
+    ///
+    /// Retail provenance: sequential typed defaults — `RulesClass__Process` @ `0x00668BF0`.
+    fn merge_rules_projection(&mut self, patch: &IniFile) {
+        for (patch_index, patch_section) in patch.sections.iter().enumerate() {
+            if patch.first_section.get(&patch_section.name) != Some(&patch_index) {
+                continue;
+            }
+            if let Some(index) = self.first_section.get(&patch_section.name).copied() {
+                self.sections[index].overlay_rules_pass(patch_section);
+            } else {
+                let mut section = IniSection::new(patch_section.name.clone());
+                section.overlay_rules_pass(patch_section);
+                let index = self.sections.len();
+                self.first_section.insert(section.name.clone(), index);
+                self.sections.push(section);
+            }
         }
     }
 
@@ -580,10 +643,10 @@ struct RulesPassProcessor {
 impl RulesPassProcessor {
     fn apply_pass(&mut self, pass: &IniFile) {
         if let Some(ordinary) = self.ordinary.as_mut() {
-            ordinary.merge(pass);
+            ordinary.merge_rules_projection(pass);
         } else {
             let mut ordinary = IniFile::empty();
-            ordinary.merge(pass);
+            ordinary.merge_rules_projection(pass);
             self.ordinary = Some(ordinary);
         }
         // RulesClass::Process allocates every explicit registry before the
@@ -878,7 +941,7 @@ impl RulesPassProcessor {
             };
             let canonical_name = self.tiberiums[index].canonical_name.clone();
             if let Some(section) = pass.section(&canonical_name) {
-                self.tiberiums[index].body.overlay_from(section);
+                self.tiberiums[index].body.overlay_rules_pass(section);
             }
         }
     }
@@ -889,7 +952,7 @@ impl RulesPassProcessor {
         };
         for member in members {
             if let Some(section) = pass.section(&member.canonical_name) {
-                member.body.overlay_from(section);
+                member.body.overlay_rules_pass(section);
             }
         }
     }
@@ -1125,6 +1188,18 @@ impl RulesPassProcessor {
 
 fn trim_ascii_controls(value: &str) -> &str {
     value.trim_matches(|character| u32::from(character) <= 0x20)
+}
+
+fn parse_bool_value(value: &str) -> Option<bool> {
+    match trim_ascii_controls(value)
+        .bytes()
+        .next()?
+        .to_ascii_uppercase()
+    {
+        b'1' | b'T' | b'Y' => Some(true),
+        b'0' | b'F' | b'N' => Some(false),
+        _ => None,
+    }
 }
 
 const RULE_TYPE_REGISTRIES: &[&str] = &[

--- a/src/rules/ini_parser_tests.rs
+++ b/src/rules/ini_parser_tests.rs
@@ -42,6 +42,32 @@ fn empty_section_name_is_retained() {
 }
 
 #[test]
+fn entryless_physical_sections_are_discarded() {
+    let ini = IniFile::from_str(
+        "[HeaderOnly]\n[CommentOnly]\n; no accepted entries\n\
+         [EmptyValueOnly]\nKey=\n[Kept]\nKey=Value\n",
+    );
+
+    assert!(ini.section("HeaderOnly").is_none());
+    assert!(ini.section("CommentOnly").is_none());
+    assert!(ini.section("EmptyValueOnly").is_none());
+    assert_eq!(ini.section_names(), vec!["Kept"]);
+}
+
+#[test]
+fn retail_parabomb_empty_body_does_not_hide_later_definition() {
+    // ARTMD has an entryless PARABOMB occurrence before this populated body.
+    let ini = IniFile::from_str(
+        "[PARABOMB]\n\n[PARABOMB]\nRate=200\nLoopStart=7\nLoopCount=15\n",
+    );
+
+    let parabomb = ini.section("PARABOMB").expect("populated PARABOMB body");
+    assert_eq!(parabomb.get("Rate"), Some("200"));
+    assert_eq!(parabomb.get("LoopStart"), Some("7"));
+    assert_eq!(parabomb.get("LoopCount"), Some("15"));
+}
+
+#[test]
 fn malformed_header_falls_through_to_key_value_parsing() {
     let ini = IniFile::from_str("[S]\n[foo=bar\n");
 
@@ -146,7 +172,7 @@ fn test_get_list() {
 }
 
 #[test]
-fn test_duplicate_sections_are_retained_and_first_body_wins_lookup() {
+fn duplicate_nonempty_section_bodies_are_retained_in_source_order() {
     let text: &str = "\
 [General]
 Key1=First
@@ -160,15 +186,13 @@ Key3=New
 
     assert_eq!(ini.section_count(), 2);
 
-    let section: &IniSection = ini.section("General").unwrap();
-    assert_eq!(section.get("Key1"), Some("First"));
-    assert_eq!(section.get("Key2"), Some("Original"));
-    assert_eq!(section.get("Key3"), None);
     assert_eq!(ini.section_names(), vec!["General", "General"]);
+    assert_eq!(ini.sections[0].get("Key1"), Some("First"));
+    assert_eq!(ini.sections[1].get("Key3"), Some("New"));
 }
 
 #[test]
-fn duplicate_key_in_fresh_section_keeps_first_definition() {
+fn duplicate_key_compatibility_lookup_keeps_first_definition() {
     let ini = IniFile::from_str("[General]\nBuildSpeed=.7\nBuildSpeed=.58\n");
     assert_eq!(
         ini.section("General").unwrap().get("BuildSpeed"),
@@ -188,7 +212,8 @@ fn semicolon_truncates_before_equals_and_empty_entries_are_omitted() {
 
 #[test]
 fn test_section_names_order() {
-    let ini: IniFile = IniFile::from_str("[Zebra]\n[Alpha]\n[Middle]\n");
+    let ini: IniFile =
+        IniFile::from_str("[Zebra]\nKey=Z\n[Alpha]\nKey=A\n[Middle]\nKey=M\n");
 
     let names: Vec<&str> = ini.section_names();
     assert_eq!(names, vec!["Zebra", "Alpha", "Middle"]);
@@ -344,6 +369,20 @@ fn process_rules_passes(root: &str, later: &str) -> ProcessedRulesLayers {
     let mut layers = RulesLayerStack::new(IniFile::from_str(root));
     layers.push(RulesLayerKind::Scenario, IniFile::from_str(later));
     layers.process()
+}
+
+#[test]
+fn later_malformed_weapon_bool_preserves_current_field_default() {
+    use crate::rules::weapon_type::WeaponType;
+
+    let processed = process_rules_passes(
+        "[VehicleTypes]\n0=TANK\n[TANK]\nPrimary=Gun\n[Gun]\nRevealOnFire=yes\n",
+        "[Gun]\nRevealOnFire=maybe\n",
+    );
+    let section = processed.ini().section("Gun").expect("allocated Gun body");
+
+    assert_eq!(section.get("RevealOnFire"), Some("maybe"));
+    assert!(WeaponType::from_ini_section("Gun", section).reveal_on_fire);
 }
 
 #[test]

--- a/src/rules/ini_value.rs
+++ b/src/rules/ini_value.rs
@@ -20,43 +20,32 @@ use crate::rules::ini_parser::IniSection;
 const STRTRIM_MAX: u8 = 0x20;
 
 impl IniSection {
+    fn fold_rules_values<T: Copy>(
+        &self,
+        key: &str,
+        default: T,
+        mut apply: impl FnMut(T, &str) -> T,
+    ) -> T {
+        if let Some(values) = self.projected_values(key) {
+            values
+                .iter()
+                .fold(default, |current, raw| apply(current, raw))
+        } else {
+            self.get(key).map_or(default, |raw| apply(default, raw))
+        }
+    }
+
     /// ReadInt (P1–P4, P18): `$xx`/`xxh` (case-insensitive `h`) hex, else C-atoi
     /// leniency. Default ONLY on absent key. Present-but-nonnumeric -> atoi (0).
     pub fn read_int(&self, key: &str, default: i32) -> i32 {
-        match self.get(key) {
-            None => default,
-            Some(raw) => {
-                // strtrim ≤0x20 both ends (P5), matching the value gamemd parses.
-                let v = strtrim_ascii(raw);
-                if let Some(rest) = v.strip_prefix('$') {
-                    // "$%x": parse hex; junk after digits stops the C scan -> take
-                    // the leading hex run (sscanf "$%x" stops at first non-hex).
-                    parse_leading_hex(rest).unwrap_or(default)
-                } else if ends_with_h(v) {
-                    // "%xh": leading hex run, ignore the trailing 'h'/'H'.
-                    parse_leading_hex(&v[..v.len() - 1]).unwrap_or(default)
-                } else {
-                    atoi_lenient(v)
-                }
-            }
-        }
+        self.fold_rules_values(key, default, parse_read_int)
     }
 
     /// ReadBool (P6, P18): `toupper(first char)` in {'1','T','Y'}=true,
     /// {'0','F','N'}=false, else default. `on`/`off` (first char 'o') -> default.
     /// Present-empty (no first char) -> default.
     pub fn read_bool(&self, key: &str, default: bool) -> bool {
-        match self.get(key) {
-            None => default,
-            Some(raw) => {
-                let v = strtrim_ascii(raw);
-                match v.bytes().next().map(|b| b.to_ascii_uppercase()) {
-                    Some(b'1') | Some(b'T') | Some(b'Y') => true,
-                    Some(b'0') | Some(b'F') | Some(b'N') => false,
-                    _ => default, // present-empty or any other first char
-                }
-            }
-        }
+        self.fold_rules_values(key, default, parse_read_bool)
     }
 
     /// ReadDouble (P7): sscanf "%f" (leading float, single-precision) widened to
@@ -67,19 +56,7 @@ impl IniSection {
     /// 32-bit ABI argument bits on failed `%f`, while Rust deterministically
     /// returns zero rather than importing that non-portable accident.
     pub fn read_double(&self, key: &str, default: f64) -> f64 {
-        match self.get(key) {
-            None => default,
-            Some(raw) => {
-                let v = strtrim_ascii(raw);
-                let leading: f32 = parse_leading_f32(v); // f32 first (mantissa narrow)
-                let widened: f64 = leading as f64;
-                if v.as_bytes().contains(&b'%') {
-                    widened * 0.01_f64
-                } else {
-                    widened
-                }
-            }
-        }
+        self.fold_rules_values(key, default, |_current, raw| parse_read_double(raw))
     }
 
     /// ReadString (P5, P18): copy at most `capacity - 1` bytes, force the final
@@ -97,30 +74,22 @@ impl IniSection {
     /// Read3Int (P8): comma "%d,%d,%d". All-defaults on ABSENT key. Each field
     /// atoi-lenient; missing trailing fields keep the corresponding default.
     pub fn read_3int(&self, key: &str, default: [i32; 3]) -> [i32; 3] {
-        match self.get(key) {
-            None => default,
-            Some(raw) => {
-                let mut out = default;
-                for (i, tok) in strtrim_ascii(raw).split(',').enumerate().take(3) {
-                    out[i] = atoi_lenient(strtrim_ascii(tok));
-                }
-                out
+        self.fold_rules_values(key, default, |mut current, raw| {
+            for (index, token) in strtrim_ascii(raw).split(',').enumerate().take(3) {
+                current[index] = atoi_lenient(strtrim_ascii(token));
             }
-        }
+            current
+        })
     }
 
     /// ReadMinMax (P8): comma "%d,%d". All-defaults on ABSENT key.
     pub fn read_minmax(&self, key: &str, default: [i32; 2]) -> [i32; 2] {
-        match self.get(key) {
-            None => default,
-            Some(raw) => {
-                let mut out = default;
-                for (i, tok) in strtrim_ascii(raw).split(',').enumerate().take(2) {
-                    out[i] = atoi_lenient(strtrim_ascii(tok));
-                }
-                out
+        self.fold_rules_values(key, default, |mut current, raw| {
+            for (index, token) in strtrim_ascii(raw).split(',').enumerate().take(2) {
+                current[index] = atoi_lenient(strtrim_ascii(token));
             }
-        }
+            current
+        })
     }
 
     /// ReadPoint/ReadSize (P9, COMMA): "%d,%d". All-defaults on ABSENT key.
@@ -132,16 +101,14 @@ impl IniSection {
     /// ReadRect (P9, COMMA): "%d,%d,%d,%d". gamemd seeds "0,0,0,0" so missing
     /// fields keep the default component; all-defaults on ABSENT key.
     pub fn read_rect(&self, key: &str, default: (i32, i32, i32, i32)) -> (i32, i32, i32, i32) {
-        match self.get(key) {
-            None => default,
-            Some(raw) => {
-                let mut out = [default.0, default.1, default.2, default.3];
-                for (i, tok) in strtrim_ascii(raw).split(',').enumerate().take(4) {
-                    out[i] = atoi_lenient(strtrim_ascii(tok));
-                }
-                (out[0], out[1], out[2], out[3])
+        let current = [default.0, default.1, default.2, default.3];
+        let out = self.fold_rules_values(key, current, |mut current, raw| {
+            for (index, token) in strtrim_ascii(raw).split(',').enumerate().take(4) {
+                current[index] = atoi_lenient(strtrim_ascii(token));
             }
-        }
+            current
+        });
+        (out[0], out[1], out[2], out[3])
     }
 
     /// ReadColorRGB (P21): COMMA "%d,%d,%d" -> [u8;3]. Per-component plain %d
@@ -154,33 +121,34 @@ impl IniSection {
     /// triplet components (plan-review C-R3). The `$`/`h` hex lives in `read_int`,
     /// NOT in `atoi_lenient`, so reusing it here stays faithful to `%d`.
     pub fn read_color_rgb(&self, key: &str, default: [u8; 3]) -> [u8; 3] {
-        match self.get(key) {
-            None => default,
-            Some(raw) => {
-                let mut out = default;
-                for (i, tok) in strtrim_ascii(raw).split(',').enumerate().take(3) {
-                    out[i] = atoi_lenient(strtrim_ascii(tok)) as u8;
-                }
-                out
+        self.fold_rules_values(key, default, |mut current, raw| {
+            for (index, token) in strtrim_ascii(raw).split(',').enumerate().take(3) {
+                current[index] = atoi_lenient(strtrim_ascii(token)) as u8;
             }
-        }
+            current
+        })
     }
 
-    /// ReadSpeed (P19): `read_int(-1)` sentinel; -1 -> default; else clamp100,
+    /// ReadSpeed (P19): `read_int(-1)` sentinel; -1 -> default; else clamp 0..100,
     /// `(v<<8)/100` truncate-toward-zero (Rust i32 `/` truncates toward 0),
     /// clamp255. `100→255`, `50→128`, `7→17`, `0→0`. (ledger #18)
     ///
     /// NB present-empty `Speed=` -> `read_int("")` = atoi("") = 0 (NOT the -1
     /// sentinel) -> `(0<<8)/100` = 0, NOT the call-site default. Correct per
     /// P4/P18; corpus harness scans stock for present-empty Speed/Range.
+    ///
+    /// Retail provenance: INI speed conversion — `CCINIClass__ReadSpeed` @ `0x00474810`.
     pub fn read_speed(&self, key: &str, default: i32) -> i32 {
-        let raw = self.read_int(key, -1);
-        if raw == -1 {
-            return default;
-        }
-        let capped = raw.min(100);
-        let scaled = (capped << 8) / 100; // i32 / truncates toward zero (ledger #18)
-        scaled.min(255)
+        self.fold_rules_values(key, default, |current, raw| {
+            let parsed = parse_read_int(-1, raw);
+            if parsed == -1 {
+                current
+            } else {
+                let capped = parsed.clamp(0, 100);
+                let scaled = (capped << 8) / 100;
+                scaled.min(255)
+            }
+        })
     }
 
     /// ReadRange (P20): `read_double(-1.0)` sentinel; ==-1.0 -> default; else ftol
@@ -188,11 +156,51 @@ impl IniSection {
     /// on negatives, ledger #18). `f64 as i32` truncates toward zero (saturating,
     /// NaN->0), matching gamemd ftol RC=11. `5.9→5`.
     pub fn read_range(&self, key: &str, default: i32) -> i32 {
-        let raw = self.read_double(key, -1.0);
-        if raw == -1.0 {
-            return default;
-        }
-        raw as i32 // truncate toward zero (gamemd ftol RC=11)
+        self.fold_rules_values(key, default, |current, raw| {
+            let parsed = parse_read_double(raw);
+            if parsed == -1.0 {
+                current
+            } else {
+                parsed as i32
+            }
+        })
+    }
+}
+
+fn parse_read_int(default: i32, raw: &str) -> i32 {
+    parse_read_int_value(raw).unwrap_or(default)
+}
+
+pub(crate) fn parse_read_int_value(raw: &str) -> Option<i32> {
+    let value = strtrim_ascii(raw);
+    if let Some(rest) = value.strip_prefix('$') {
+        parse_leading_hex(rest)
+    } else if ends_with_h(value) {
+        parse_leading_hex(&value[..value.len() - 1])
+    } else {
+        Some(atoi_lenient(value))
+    }
+}
+
+fn parse_read_bool(default: bool, raw: &str) -> bool {
+    match strtrim_ascii(raw)
+        .bytes()
+        .next()
+        .map(|byte| byte.to_ascii_uppercase())
+    {
+        Some(b'1') | Some(b'T') | Some(b'Y') => true,
+        Some(b'0') | Some(b'F') | Some(b'N') => false,
+        _ => default,
+    }
+}
+
+fn parse_read_double(raw: &str) -> f64 {
+    let value = strtrim_ascii(raw);
+    let widened = f64::from(parse_leading_f32(value));
+    if value.as_bytes().contains(&b'%') {
+        widened * 0.01_f64
+    } else {
+        widened
     }
 }
 
@@ -462,12 +470,13 @@ mod tests {
 
     #[test] // P19
     fn test_read_speed_clamp() {
-        let ini = sec("[S]\nA=100\nB=50\nC=7\nD=0\n");
+        let ini = sec("[S]\nA=100\nB=50\nC=7\nD=0\nE=-2\n");
         let s = ini.section("S").unwrap();
         assert_eq!(s.read_speed("A", -1), 255); // (100<<8)/100=256 -> clamp 255
         assert_eq!(s.read_speed("B", -1), 128); // (50<<8)/100=128
         assert_eq!(s.read_speed("C", -1), 17); // (7<<8)/100=17 (trunc)
         assert_eq!(s.read_speed("D", -1), 0);
+        assert_eq!(s.read_speed("E", 42), 0); // negative non-sentinel clamps to zero
         assert_eq!(s.read_speed("MISSING", 42), 42); // absent -> default (sentinel -1)
     }
 

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -1693,7 +1693,7 @@ mod tests {
         assert_eq!(absent.ui_name, None);
 
         // Empty UIName= also yields None.
-        let empty_ini = IniFile::from_str("[E1]\nUIName=\n");
+        let empty_ini = IniFile::from_str("[E1]\nUIName=\nCost=0\n");
         let empty = ObjectType::from_ini_section(
             "E1",
             empty_ini.section("E1").unwrap(),
@@ -1720,7 +1720,7 @@ mod tests {
         );
         assert!(!disabled.allowed_to_start_in_multiplayer);
 
-        let default_ini = IniFile::from_str("[E1]\n");
+        let default_ini = IniFile::from_str("[E1]\nFixtureOnly=1\n");
         let defaulted = ObjectType::from_ini_section(
             "E1",
             default_ini.section("E1").unwrap(),
@@ -1751,7 +1751,7 @@ mod tests {
 
     #[test]
     fn test_light_visibility_defaults_to_5000_without_intensity() {
-        let ini: IniFile = IniFile::from_str("[GALITE]\n");
+        let ini: IniFile = IniFile::from_str("[GALITE]\nFixtureOnly=1\n");
         let section: &IniSection = ini.section("GALITE").unwrap();
         let obj: ObjectType =
             ObjectType::from_ini_section("GALITE", section, ObjectCategory::Building);
@@ -1783,7 +1783,8 @@ mod tests {
 
     #[test]
     fn parse_bridge_repair_hut_flag() {
-        let ini: IniFile = IniFile::from_str("[CABHUT]\nBridgeRepairHut=yes\n[NACABH]\n");
+        let ini: IniFile =
+            IniFile::from_str("[CABHUT]\nBridgeRepairHut=yes\n[NACABH]\nFixtureOnly=1\n");
         let obj_on: ObjectType = ObjectType::from_ini_section(
             "CABHUT",
             ini.section("CABHUT").unwrap(),
@@ -1800,7 +1801,8 @@ mod tests {
 
     #[test]
     fn parse_laser_fence_flag() {
-        let ini: IniFile = IniFile::from_str("[FENCE]\nLaserFence=yes\n[OTHER]\n");
+        let ini: IniFile =
+            IniFile::from_str("[FENCE]\nLaserFence=yes\n[OTHER]\nFixtureOnly=1\n");
         let fence = ObjectType::from_ini_section(
             "FENCE",
             ini.section("FENCE").unwrap(),
@@ -1817,7 +1819,8 @@ mod tests {
 
     #[test]
     fn parse_no_force_shield_flag() {
-        let ini: IniFile = IniFile::from_str("[TST1]\nNoForceShield=yes\n[TST2]\n");
+        let ini: IniFile =
+            IniFile::from_str("[TST1]\nNoForceShield=yes\n[TST2]\nFixtureOnly=1\n");
         let obj_on: ObjectType = ObjectType::from_ini_section(
             "TST1",
             ini.section("TST1").unwrap(),
@@ -1834,7 +1837,7 @@ mod tests {
 
     #[test]
     fn test_defaults_for_missing_keys() {
-        let ini: IniFile = IniFile::from_str("[BARE]\n");
+        let ini: IniFile = IniFile::from_str("[BARE]\nFixtureOnly=1\n");
         let section: &IniSection = ini.section("BARE").unwrap();
         let obj: ObjectType =
             ObjectType::from_ini_section("BARE", section, ObjectCategory::Infantry);
@@ -1897,7 +1900,7 @@ mod tests {
 
     #[test]
     fn test_bridge_render_flags_default() {
-        let ini: IniFile = IniFile::from_str("[BOAT]\n");
+        let ini: IniFile = IniFile::from_str("[BOAT]\nFixtureOnly=1\n");
         let section: &IniSection = ini.section("BOAT").unwrap();
         let obj: ObjectType =
             ObjectType::from_ini_section("BOAT", section, ObjectCategory::Vehicle);
@@ -1933,7 +1936,7 @@ mod tests {
         assert!(obj.construction_yard);
         assert_eq!(obj.deploy_facing, 0x40);
 
-        let default_ini = IniFile::from_str("[GAPOWR]\n");
+        let default_ini = IniFile::from_str("[GAPOWR]\nFixtureOnly=1\n");
         let default_obj = ObjectType::from_ini_section(
             "GAPOWR",
             default_ini.section("GAPOWR").unwrap(),
@@ -2062,6 +2065,7 @@ mod tests {
     fn weapons_factory_parses_independently_from_factory_type() {
         let ini = IniFile::from_str(
             "[MISSING]\n\
+             FixtureOnly=1\n\
              [EXPLICIT_NO]\nWeaponsFactory=no\n\
              [EXPLICIT_YES]\nWeaponsFactory=yes\n\
              [FACTORY_ONLY]\nFactory=UnitType\n\
@@ -2252,13 +2256,13 @@ mod tests {
     #[test]
     fn test_size_defaults_by_category() {
         // Infantry defaults to Size=1
-        let ini: IniFile = IniFile::from_str("[INF]\n");
+        let ini: IniFile = IniFile::from_str("[INF]\nFixtureOnly=1\n");
         let section: &IniSection = ini.section("INF").unwrap();
         let obj = ObjectType::from_ini_section("INF", section, ObjectCategory::Infantry);
         assert_eq!(obj.size, 1);
 
         // Vehicle defaults to Size=3
-        let ini2: IniFile = IniFile::from_str("[VEH]\n");
+        let ini2: IniFile = IniFile::from_str("[VEH]\nFixtureOnly=1\n");
         let section2: &IniSection = ini2.section("VEH").unwrap();
         let obj2 = ObjectType::from_ini_section("VEH", section2, ObjectCategory::Vehicle);
         assert_eq!(obj2.size, 3);
@@ -2274,7 +2278,7 @@ mod tests {
 
     #[test]
     fn c4_defaults_to_false() {
-        let ini = IniFile::from_str("[E1]\n");
+        let ini = IniFile::from_str("[E1]\nFixtureOnly=1\n");
         let section = ini.section("E1").unwrap();
         let obj = ObjectType::from_ini_section("E1", section, ObjectCategory::Infantry);
         assert!(!obj.c4);
@@ -2282,7 +2286,7 @@ mod tests {
 
     #[test]
     fn can_c4_defaults_to_true_for_buildings() {
-        let ini = IniFile::from_str("[GAPILE]\n");
+        let ini = IniFile::from_str("[GAPILE]\nFixtureOnly=1\n");
         let section = ini.section("GAPILE").unwrap();
         let obj = ObjectType::from_ini_section("GAPILE", section, ObjectCategory::Building);
         assert!(obj.can_c4);
@@ -2290,7 +2294,7 @@ mod tests {
 
     #[test]
     fn can_c4_defaults_to_false_for_non_buildings() {
-        let ini = IniFile::from_str("[E1]\n");
+        let ini = IniFile::from_str("[E1]\nFixtureOnly=1\n");
         let section = ini.section("E1").unwrap();
         let obj = ObjectType::from_ini_section("E1", section, ObjectCategory::Infantry);
         assert!(!obj.can_c4);
@@ -2327,7 +2331,7 @@ mod tests {
 
     #[test]
     fn bunkerable_defaults_true_for_vehicles_only() {
-        let ini = IniFile::from_str("[TEST]\n");
+        let ini = IniFile::from_str("[TEST]\nFixtureOnly=1\n");
         let section = ini.section("TEST").unwrap();
 
         let vehicle = ObjectType::from_ini_section("TEST", section, ObjectCategory::Vehicle);
@@ -2351,7 +2355,7 @@ mod tests {
 
     #[test]
     fn invisible_in_game_defaults_to_false() {
-        let ini = IniFile::from_str("[GAPILE]\n");
+        let ini = IniFile::from_str("[GAPILE]\nFixtureOnly=1\n");
         let section = ini.section("GAPILE").unwrap();
         let obj = ObjectType::from_ini_section("GAPILE", section, ObjectCategory::Building);
         assert!(!obj.invisible);
@@ -2384,7 +2388,7 @@ mod tests {
 
     #[test]
     fn techno_type_particle_fields_default_to_empty() {
-        let ini: IniFile = IniFile::from_str("[E1]\n");
+        let ini: IniFile = IniFile::from_str("[E1]\nFixtureOnly=1\n");
         let section = ini.section("E1").unwrap();
         let obj = ObjectType::from_ini_section("E1", section, ObjectCategory::Infantry);
 
@@ -2446,7 +2450,7 @@ mod tests {
             !ObjectType::from_ini_section("X", s, ObjectCategory::Aircraft).emits_damage_spark()
         );
         // Default (no Cyborg key) → false even for infantry (dormant in stock YR).
-        let plain = IniFile::from_str("[E1]\n");
+        let plain = IniFile::from_str("[E1]\nFixtureOnly=1\n");
         let ps = plain.section("E1").unwrap();
         let plain_inf = ObjectType::from_ini_section("E1", ps, ObjectCategory::Infantry);
         assert!(!plain_inf.cyborg);
@@ -2458,7 +2462,7 @@ mod tests {
         // Absent keys: OpportunityFire defaults off, CanRetaliate defaults on
         // (the gamemd TechnoType defaults — passive acquire opt-in, retaliate
         // opt-out).
-        let ini: IniFile = IniFile::from_str("[E1]\n");
+        let ini: IniFile = IniFile::from_str("[E1]\nFixtureOnly=1\n");
         let section = ini.section("E1").unwrap();
         let obj = ObjectType::from_ini_section("E1", section, ObjectCategory::Infantry);
         assert!(!obj.opportunity_fire, "OpportunityFire defaults to no");
@@ -2483,7 +2487,7 @@ mod tests {
         // Absent key → yes (the gamemd TechnoType constructor default). The INI
         // spelling is "CanPassiveAquire"; the correctly-spelled variant is NOT a
         // key the original reads, so it must not turn the flag off.
-        let plain = IniFile::from_str("[E1]\n");
+        let plain = IniFile::from_str("[E1]\nFixtureOnly=1\n");
         let obj = ObjectType::from_ini_section(
             "E1",
             plain.section("E1").unwrap(),
@@ -2513,7 +2517,7 @@ mod tests {
 
     #[test]
     fn techno_type_distributed_fire_defaults_no_and_parses() {
-        let plain = IniFile::from_str("[MTNK]\n");
+        let plain = IniFile::from_str("[MTNK]\nFixtureOnly=1\n");
         let obj = ObjectType::from_ini_section(
             "MTNK",
             plain.section("MTNK").unwrap(),
@@ -2563,7 +2567,7 @@ mod tests {
 
     #[test]
     fn techno_type_refinery_smoke_frames_defaults_to_zero() {
-        let ini: IniFile = IniFile::from_str("[FOO]\n");
+        let ini: IniFile = IniFile::from_str("[FOO]\nFixtureOnly=1\n");
         let section = ini.section("FOO").expect("section");
         let obj = ObjectType::from_ini_section("FOO", section, ObjectCategory::Building);
         assert_eq!(obj.refinery_smoke_frames, 0);

--- a/src/rules/particle_system_type.rs
+++ b/src/rules/particle_system_type.rs
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn defaults_match_binary_constructor() {
-        let ini = IniFile::from_str("[Foo]\n");
+        let ini = IniFile::from_str("[Foo]\nFixtureOnly=1\n");
         let section = ini.section("Foo").unwrap();
         let pst = ParticleSystemType::from_ini_section("Foo", section);
 

--- a/src/rules/particle_type.rs
+++ b/src/rules/particle_type.rs
@@ -395,7 +395,7 @@ mod tests {
 
     #[test]
     fn from_ini_uses_documented_defaults() {
-        let ini = IniFile::from_str("[Foo]\n");
+        let ini = IniFile::from_str("[Foo]\nFixtureOnly=1\n");
         let section = ini.section("Foo").unwrap();
         let pt = ParticleType::from_ini_section("Foo", section);
         assert_eq!(pt.state_ai_advance, 4);

--- a/src/rules/projectile_type.rs
+++ b/src/rules/projectile_type.rs
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_defaults() {
-        let ini: IniFile = IniFile::from_str("[Empty]\n");
+        let ini: IniFile = IniFile::from_str("[Empty]\nFixtureOnly=1\n");
         let section: &IniSection = ini.section("Empty").unwrap();
         let proj: ProjectileType = ProjectileType::from_ini_section("Empty", section, None);
 
@@ -345,7 +345,7 @@ mod tests {
         // Rotates is an art Image key. The binary stores its inverse, and this
         // field intentionally exposes that stored form.
         let ini: IniFile = IniFile::from_str(
-            "[Rules]\nRotates=yes\n[RotYesImage]\nRotates=yes\n[RotNoImage]\nRotates=no\n[NoKey]\n",
+            "[Rules]\nRotates=yes\n[RotYesImage]\nRotates=yes\n[RotNoImage]\nRotates=no\n[NoKey]\nFixtureOnly=1\n",
         );
         let rules_section = ini.section("Rules").unwrap();
 
@@ -396,7 +396,7 @@ mod tests {
 
     #[test]
     fn parse_rocker_scale_default_one() {
-        let ini: IniFile = IniFile::from_str("[TestBullet]\n");
+        let ini: IniFile = IniFile::from_str("[TestBullet]\nFixtureOnly=1\n");
         let section = ini.section("TestBullet").unwrap();
         let p = ProjectileType::from_ini_section("TestBullet", section, None);
         assert_eq!(p.rocker_scale, I8F8::ONE);

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -4348,6 +4348,7 @@ BarrelParticle=SmallGreySSys
         // Verify the parser doesn't accidentally accept it elsewhere.
         let ini_str = "\
 [General]
+FixtureOnly=1
 [AudioVisual]
 BarrelParticle=SmallGreySSys
 ";
@@ -4360,6 +4361,7 @@ BarrelParticle=SmallGreySSys
     fn test_building_garrisoned_sound_default_none() {
         let ini_str = "\
 [General]
+FixtureOnly=1
 [AudioVisual]
 ";
         let ini = IniFile::from_str(ini_str);
@@ -4489,6 +4491,7 @@ ParachuteMaxFallRate=-1
     fn test_building_garrisoned_sound_empty_treated_as_none() {
         let ini_str = "\
 [General]
+FixtureOnly=1
 [AudioVisual]
 BuildingGarrisonedSound=
 ";
@@ -5011,16 +5014,16 @@ ZAdjust=-10
              [GHOST]\nC4=yes\n\
              [TANY]\nC4=yes\n\
              [PTROOP]\nC4=yes\n\
-             [E1]\n\
-             [ENGINEER]\n\
-             [CCOMAND]\n\
+             [E1]\nFixtureOnly=1\n\
+             [ENGINEER]\nFixtureOnly=1\n\
+             [CCOMAND]\nFixtureOnly=1\n\
              [CAMISC01]\nCanC4=no\n\
              [CAMISC02]\nCanC4=no\n\
              [CAMISC06]\nCanC4=no\n\
              [AMMOCRAT]\nCanC4=no\n\
-             [GAPILE]\n\
-             [NAHAND]\n\
-             [GAREFN]\n",
+             [GAPILE]\nFixtureOnly=1\n\
+             [NAHAND]\nFixtureOnly=1\n\
+             [GAREFN]\nFixtureOnly=1\n",
         );
         let rules = RuleSet::from_ini(&ini).expect("parse C4 stock-contract fixture");
 

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -3565,7 +3565,7 @@ CellSpread=0
         );
 
         let src = format!(
-            "{}\n[Countries]\n0=Americans\n1=Russia\n[Americans]\nIncomeMult=1.2\n[Russia]\n",
+            "{}\n[Countries]\n0=Americans\n1=Russia\n[Americans]\nIncomeMult=1.2\n[Russia]\nFixtureOnly=1\n",
             make_test_rules()
         );
         let ini = IniFile::from_str(&src);
@@ -3754,7 +3754,9 @@ MutateWarhead=MyMutate\n\
     fn parse_rules_rocking_coefficients_defaults() {
         // [General] must be present, otherwise GeneralRules::from_ini bails to
         // Self::default(). Missing AudioVisual keys then fall back to defaults.
-        let ini = IniFile::from_str("[General]\n[AudioVisual]\n");
+        let ini = IniFile::from_str(
+            "[General]\nFixtureOnly=1\n[AudioVisual]\nFixtureOnly=1\n",
+        );
         let r = GeneralRules::from_ini(&ini);
         assert_eq!(r.direct_rocking_coefficient, SimFixed::lit("1.5"));
         assert_eq!(r.fallback_coefficient, SimFixed::lit("0.1"));
@@ -3764,11 +3766,13 @@ MutateWarhead=MyMutate\n\
     fn parse_spark_gravity_preserves_signed_integer_storage() {
         assert_eq!(GeneralRules::default().gravity, 3);
         // Gravity lives in [AudioVisual] (stock rulesmd.ini), NOT [General].
-        let stock =
-            GeneralRules::from_ini(&IniFile::from_str("[General]\n[AudioVisual]\nGravity=6\n"));
+        let stock = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\nGravity=6\n",
+        ));
         assert_eq!(stock.gravity, 6);
-        let signed =
-            GeneralRules::from_ini(&IniFile::from_str("[General]\n[AudioVisual]\nGravity=-7\n"));
+        let signed = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\nGravity=-7\n",
+        ));
         assert_eq!(signed.gravity, -7);
         // A [General] Gravity is ignored (the engine reads it in ReadAudioVisual).
         let misplaced = GeneralRules::from_ini(&IniFile::from_str("[General]\nGravity=9\n"));
@@ -3779,17 +3783,19 @@ MutateWarhead=MyMutate\n\
     fn item82_scroll_multiplier_parses_from_audio_visual_with_stock_default() {
         assert_eq!(GeneralRules::default().scroll_multiplier, 0.07);
         let parsed = GeneralRules::from_ini(&IniFile::from_str(
-            "[General]\n[AudioVisual]\nScrollMultiplier=.125\n",
+            "[General]\nFlightLevel=500\n[AudioVisual]\nScrollMultiplier=.125\n",
         ));
         assert_eq!(parsed.scroll_multiplier, 0.125);
-        let absent = GeneralRules::from_ini(&IniFile::from_str("[General]\n[AudioVisual]\n"));
+        let absent = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\n",
+        ));
         assert_eq!(absent.scroll_multiplier, 0.07);
     }
 
     #[test]
     fn parse_rules_rocking_coefficients_explicit() {
         let ini = IniFile::from_str(
-            "[General]\n[AudioVisual]\nDirectRockingCoefficient=2.0\nFallBackCoefficient=0.05\n",
+            "[General]\nFlightLevel=500\n[AudioVisual]\nDirectRockingCoefficient=2.0\nFallBackCoefficient=0.05\n",
         );
         let r = GeneralRules::from_ini(&ini);
         assert_eq!(r.direct_rocking_coefficient, SimFixed::lit("2"));
@@ -3988,7 +3994,8 @@ MutateWarhead=MyMutate\n\
              [VehicleTypes]\n\
              [AircraftTypes]\n\
              [BuildingTypes]\n\
-             [General]\n",
+             [General]\n\
+             FixtureOnly=1\n",
         );
         let rules = RuleSet::from_ini(&ini).expect("Should parse");
         assert_eq!(rules.general.tiberium_short_scan, 6);
@@ -4150,6 +4157,7 @@ MutateWarhead=MyMutate\n\
     fn test_building_garrisoned_sound_parsed() {
         let ini_str = "\
 [General]
+FlightLevel=500
 [AudioVisual]
 BuildingGarrisonedSound=BuildingGarrisoned
 ";
@@ -4165,6 +4173,7 @@ BuildingGarrisonedSound=BuildingGarrisoned
     fn test_chute_sound_parsed() {
         let ini_str = "\
 [General]
+FlightLevel=500
 [AudioVisual]
 ChuteSound=CustomDrop
 ";
@@ -4177,6 +4186,7 @@ ChuteSound=CustomDrop
     fn test_stock_chute_sound_parsed() {
         let ini_str = "\
 [General]
+FlightLevel=500
 [AudioVisual]
 ChuteSound=ParachuteDrop
 ";
@@ -4190,6 +4200,7 @@ ChuteSound=ParachuteDrop
         // Stock ships both keys under [AudioVisual] with value ChronoMinerTeleport.
         let ini_str = "\
 [General]
+FlightLevel=500
 [AudioVisual]
 ChronoInSound=ChronoMinerTeleport
 ChronoOutSound=ChronoMinerTeleport
@@ -4213,6 +4224,7 @@ ChronoOutSound=ChronoMinerTeleport
         // hardcoded default. [General] present so from_ini does not early-return.
         let ini_str = "\
 [General]
+FlightLevel=500
 [AudioVisual]
 ";
         let ini = IniFile::from_str(ini_str);
@@ -4255,6 +4267,7 @@ ChronoOutSound=ChronoMinerTeleport
     fn test_gui_main_button_sound_parsed() {
         let ini_str = "\
 [General]
+FlightLevel=500
 [AudioVisual]
 GUIMainButtonSound=MenuClick
 ";
@@ -4267,6 +4280,7 @@ GUIMainButtonSound=MenuClick
     fn shell_ui_sound_keys_parse_independently() {
         let ini_str = "\
 [General]
+FlightLevel=500
 [AudioVisual]
 GUIMainButtonSound=MainButtonClick
 GenericClick=GenericPress
@@ -4289,7 +4303,7 @@ GUIComboCloseSound=ComboClose
     #[test]
     fn shell_ui_sound_keys_trim_and_ignore_empty_values() {
         let ini_str = concat!(
-            "[General]\n",
+            "[General]\nFixtureOnly=1\n",
             "[AudioVisual]\n",
             "ChuteSound=  ParachuteDrop  \n",
             "GenericClick=  MenuClick  \n",
@@ -4322,7 +4336,7 @@ BarrelParticle=SmallGreySSys
 
     #[test]
     fn barrel_particle_default_none() {
-        let ini_str = "[General]\n";
+        let ini_str = "[General]\nFixtureOnly=1\n";
         let ini = IniFile::from_str(ini_str);
         let general = GeneralRules::from_ini(&ini);
         assert!(general.barrel_particle.is_none());
@@ -4357,6 +4371,7 @@ BarrelParticle=SmallGreySSys
     fn test_chute_sound_empty_treated_as_none() {
         let ini_str = "\
 [General]
+FixtureOnly=1
 [AudioVisual]
 ChuteSound=
 ";
@@ -4370,20 +4385,22 @@ ChuteSound=
         // PlayerScatter is a [CombatDamage] key and Scatter an [IQ] key; neither
         // lives in [General], so a [General]-only file must fall back to the
         // RulesClass constructor values (no / 3).
-        let ini = IniFile::from_str("[General]\n");
+        let ini = IniFile::from_str("[General]\nFixtureOnly=1\n");
         let general = GeneralRules::from_ini(&ini);
         assert!(!general.player_scatter);
         assert_eq!(general.iq_scatter, 3);
 
         // Stock values.
-        let ini =
-            IniFile::from_str("[General]\n[CombatDamage]\nPlayerScatter=no\n[IQ]\nScatter=2\n");
+        let ini = IniFile::from_str(
+            "[General]\nFlightLevel=500\n[CombatDamage]\nPlayerScatter=no\n[IQ]\nScatter=2\n",
+        );
         let general = GeneralRules::from_ini(&ini);
         assert!(!general.player_scatter);
         assert_eq!(general.iq_scatter, 2);
 
-        let ini =
-            IniFile::from_str("[General]\n[CombatDamage]\nPlayerScatter=yes\n[IQ]\nScatter=4\n");
+        let ini = IniFile::from_str(
+            "[General]\nFlightLevel=500\n[CombatDamage]\nPlayerScatter=yes\n[IQ]\nScatter=4\n",
+        );
         let general = GeneralRules::from_ini(&ini);
         assert!(general.player_scatter);
         assert_eq!(general.iq_scatter, 4);
@@ -4398,7 +4415,7 @@ ChuteSound=
 
     #[test]
     fn base_unit_types_default_to_stock_yr() {
-        let ini = IniFile::from_str("[General]\n");
+        let ini = IniFile::from_str("[General]\nFixtureOnly=1\n");
         let general = GeneralRules::from_ini(&ini);
         assert_eq!(general.base_unit_types, vec!["AMCV", "SMCV", "PCV"]);
     }
@@ -4416,7 +4433,7 @@ ParachuteMaxFallRate=-3
 
     #[test]
     fn test_parachute_max_fall_rate_default_when_missing() {
-        let ini_str = "[General]\n";
+        let ini_str = "[General]\nFixtureOnly=1\n";
         let ini = IniFile::from_str(ini_str);
         let general = GeneralRules::from_ini(&ini);
         assert_eq!(
@@ -4439,7 +4456,7 @@ ParachuteMaxFallRate=-1
 
     #[test]
     fn test_missile_rot_var_missing_key_falls_back_to_one() {
-        let ini = IniFile::from_str("[General]\n");
+        let ini = IniFile::from_str("[General]\nFixtureOnly=1\n");
         let general = GeneralRules::from_ini(&ini);
         assert_eq!(general.missile_rot_var, sim_from_f32(1.0));
     }

--- a/src/rules/smudge_type.rs
+++ b/src/rules/smudge_type.rs
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn defaults_apply() {
-        let ini = parse_ini("[SmudgeTypes]\n1=X\n[X]\n");
+        let ini = parse_ini("[SmudgeTypes]\n1=X\n[X]\nFixtureOnly=1\n");
         let reg = SmudgeTypeRegistry::from_rules_ini(&ini);
         let x = reg.get(0).unwrap();
         assert!(!x.crater);

--- a/src/rules/terrain_object_type.rs
+++ b/src/rules/terrain_object_type.rs
@@ -174,7 +174,7 @@ mod tests {
     #[test]
     fn gsi_04_10_strength_preserves_signed_explicit_and_fallback_values() {
         for (body, tree_strength, expected) in [
-            ("", -375, -375),
+            ("AnimationRate=0\n", -375, -375),
             ("Strength=0\n", 200, 0),
             ("Strength=-27\n", 200, -27),
             ("Strength=450\n", -375, 450),
@@ -192,7 +192,7 @@ mod tests {
 
     #[test]
     fn art_foundation_is_normalized() {
-        let ini = IniFile::from_str("[TREE01]\n");
+        let ini = IniFile::from_str("[TREE01]\nFixtureOnly=1\n");
         let section = ini.section("TREE01").expect("section");
         let mut t = TerrainObjectType::from_ini_section("TREE01", section);
         t.merge_art_foundation("2x2");

--- a/src/rules/warhead_type.rs
+++ b/src/rules/warhead_type.rs
@@ -366,7 +366,7 @@ mod tests {
 
     #[test]
     fn verses_f64_defaults_to_all_full_when_absent() {
-        let ini: IniFile = IniFile::from_str("[Empty]\n");
+        let ini: IniFile = IniFile::from_str("[Empty]\nFixtureOnly=1\n");
         let wh = WarheadType::from_ini_section("Empty", ini.section("Empty").unwrap());
         // gamemd default is all-100% (1.0), NOT empty.
         assert_eq!(wh.verses_f64, [1.0; 11]);
@@ -389,7 +389,7 @@ mod tests {
 
     #[test]
     fn test_warhead_defaults() {
-        let ini: IniFile = IniFile::from_str("[Empty]\n");
+        let ini: IniFile = IniFile::from_str("[Empty]\nFixtureOnly=1\n");
         let section: &IniSection = ini.section("Empty").unwrap();
         let wh: WarheadType = WarheadType::from_ini_section("Empty", section);
 
@@ -465,7 +465,7 @@ mod tests {
 
     #[test]
     fn parse_rocker_default_false() {
-        let ini: IniFile = IniFile::from_str("[TestWH]\n");
+        let ini: IniFile = IniFile::from_str("[TestWH]\nFixtureOnly=1\n");
         let wh = WarheadType::from_ini_section("TestWH", ini.section("TestWH").unwrap());
         assert!(!wh.rocker);
         assert!(!wh.direct_rocker);

--- a/src/rules/weapon_type.rs
+++ b/src/rules/weapon_type.rs
@@ -317,7 +317,7 @@ mod tests {
 
     #[test]
     fn test_weapon_defaults() {
-        let ini: IniFile = IniFile::from_str("[Empty]\n");
+        let ini: IniFile = IniFile::from_str("[Empty]\nFixtureOnly=1\n");
         let section: &IniSection = ini.section("Empty").unwrap();
         let weapon: WeaponType = WeaponType::from_ini_section("Empty", section);
 

--- a/src/sim/combat/combat_aoe.rs
+++ b/src/sim/combat/combat_aoe.rs
@@ -3158,7 +3158,7 @@ mod tests {
     #[test]
     fn gsi_04_07_damage_prone_raw_scaling_precedes_area_receiver_pipeline() {
         let ini = IniFile::from_str(
-            "[General]\n\
+            "[General]\nFixtureOnly=1\n\
              [Normal]\nArmor=1.0\n\
              [Easy]\nArmor=1.2\n\
              [InfantryTypes]\n0=E1\n\

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -5372,7 +5372,7 @@ fn two_inviso_attackers_consume_consecutive_draws_in_live_order() {
 
 fn emit_helper_test_warhead(animlist: &[&str]) -> crate::rules::warhead_type::WarheadType {
     let animlist_csv = animlist.join(",");
-    let ini_text = format!("[WH]\nAnimList={}\n", animlist_csv);
+    let ini_text = format!("[WH]\nFixtureOnly=1\nAnimList={}\n", animlist_csv);
     let ini = IniFile::from_str(&ini_text);
     let section = ini.section("WH").expect("section parses");
     crate::rules::warhead_type::WarheadType::from_ini_section("WH", section)
@@ -5858,6 +5858,7 @@ fn gsi_04_07_damage_periodic_radiation_enters_direct_receiver_once() {
 fn gsi_04_07_damage_hostile_building_hit_latches_was_attacked_for_ai_repair() {
     let rules = RuleSet::from_ini(&IniFile::from_str(
         "[General]\n\
+         FixtureOnly=1\n\
          [AI]\nCreditReserve=100\n\
          [IQ]\nMaxIQLevels=5\nRepairSell=2\nSellBack=2\n\
          [AudioVisual]\nConditionYellow=50%\nConditionRed=25%\n\

--- a/src/sim/miner/miner_tests.rs
+++ b/src/sim/miner/miner_tests.rs
@@ -2098,6 +2098,7 @@ fn stock_dock_exit_does_not_emit_refinery_exit_sfx() {
          [BuildingTypes]\n\
          0=GAREFN\n\
          [General]\n\
+         FixtureOnly=1\n\
          [AudioVisual]\n\
          BunkerWallsDownSound=TankBunkerDown\n\
          [HARV]\n\
@@ -2161,6 +2162,7 @@ fn stock_dock_exit_does_not_emit_refinery_exit_sfx() {
 fn miner_rules_fallback_only() -> RuleSet {
     let ini = IniFile::from_str(
         "[General]\n\
+         FixtureOnly=1\n\
          [AudioVisual]\n\
          ChronoInSound=FALLBACKIN\n\
          ChronoOutSound=FALLBACKOUT\n\
@@ -2221,6 +2223,7 @@ fn mission_base_frames_reads_rate_table_stock_identical() {
 
     let ini = IniFile::from_str(
         "[General]\n\
+         FixtureOnly=1\n\
          [AudioVisual]\n\
          ChronoInSound=FALLBACKIN\n\
          ChronoOutSound=FALLBACKOUT\n\

--- a/src/sim/miner/mod.rs
+++ b/src/sim/miner/mod.rs
@@ -720,7 +720,7 @@ mod tests {
 
         let non_harvester = ObjectType::from_ini_section(
             "E1",
-            &crate::rules::ini_parser::IniFile::from_str("[E1]\n")
+            &crate::rules::ini_parser::IniFile::from_str("[E1]\nFixtureOnly=1\n")
                 .section("E1")
                 .expect("section"),
             crate::rules::object_type::ObjectCategory::Infantry,

--- a/src/sim/particles/spark_world.rs
+++ b/src/sim/particles/spark_world.rs
@@ -501,7 +501,7 @@ mod tests {
         let rules = RuleSet::from_ini(&IniFile::from_str(
             "[VehicleTypes]\n1=Vehicle\n\
              [BuildingTypes]\n1=Deployable\n2=Solid\n3=Fence\n\
-             [Vehicle]\n\
+             [Vehicle]\nFixtureOnly=1\n\
              [Deployable]\nUndeploysInto=Vehicle\nFoundation=1x1\n\
              [Solid]\nFoundation=2x2\n\
              [Fence]\nLaserFence=yes\nFoundation=1x1\n",

--- a/src/sim/particles/system_ai.rs
+++ b/src/sim/particles/system_ai.rs
@@ -270,7 +270,7 @@ mod tests {
 
     fn spark_rules(gravity: i32) -> RuleSet {
         let ini = IniFile::from_str(&format!(
-            "[General]\n[AudioVisual]\nGravity={gravity}\n\
+            "[General]\nFixtureOnly=1\n[AudioVisual]\nGravity={gravity}\n\
              [Particles]\n1=SparkP\n\
              [SparkP]\nBehavesLike=Spark\nColorList=255,255,255,128,128,64\nColorSpeed=.13\n"
         ));

--- a/src/sim/passenger.rs
+++ b/src/sim/passenger.rs
@@ -1267,6 +1267,7 @@ MultiplayPassive=true
 MultiplayPassive=true
 
 [General]
+FixtureOnly=1
 [AudioVisual]
 BuildingGarrisonedSound=BuildingGarrisoned
 ConditionRed=25%
@@ -1302,6 +1303,7 @@ SizeLimit=2
 OpenTopped=yes
 
 [General]
+FixtureOnly=1
 [AudioVisual]
 ConditionRed=25%
 ConditionYellow=50%
@@ -2324,6 +2326,7 @@ Speed=8
 Passengers=5
 
 [General]
+FixtureOnly=1
 [AudioVisual]
 ConditionRed=25%
 ConditionYellow=50%

--- a/src/sim/terrain_object.rs
+++ b/src/sim/terrain_object.rs
@@ -600,7 +600,7 @@ mod tests {
               [DUMMY]\nPrimary=Gun\nStrength=100\nArmor=heavy\n\
               [Gun]\nDamage=10\nWarhead=WH\n\
               [WH]\nWood={}\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,0%,0%\n\
-              [{}]\n{}",
+              [{}]\nFixtureOnly=1\n{}",
             type_name, wood, type_name, type_section
         ));
         RuleSet::from_ini(&ini).expect("rules")

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -49,7 +49,7 @@ fn gsi_04_07_wall_sell_rules(
     with_sound: bool,
 ) -> (RuleSet, crate::map::overlay_types::OverlayTypeRegistry) {
     let ini = IniFile::from_str(&format!(
-        "[General]\n[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n\
+        "[General]\nFixtureOnly=1\n[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n\
          [BuildingTypes]\n0=FIRSTWALL\n1=SECONDWALL\n\
          [OverlayTypes]\n0=DUMMY0\n1=DUMMY1\n2=GAWALL\n\
          [FIRSTWALL]\nWall=yes\nCost=100\nUnsellable={}\nClickRepairable=no\n\

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -168,6 +168,7 @@ fn default_input_delay_ticks() -> u32 {
 impl GameConfig {
     /// Load the optional host override, otherwise use the retail module directory.
     ///
+    /// Retail provenance: Executable-root path discovery — `WinMain` @ `0x006BB9A0`.
     /// Active `gamemd.exe` `WinMain @ 0x006BB9A0` calls
     /// `GetModuleFileNameA`, splits/rebuilds its drive and directory, and calls
     /// `SetCurrentDirectoryA` before opening `RA2MD.INI` or any MIX archive.

--- a/src/util/native_string.rs
+++ b/src/util/native_string.rs
@@ -8,6 +8,45 @@ pub fn widen_bytes(bytes: &[u8]) -> String {
     bytes.iter().map(|byte| char::from(*byte)).collect()
 }
 
+#[cfg(windows)]
+#[link(name = "user32")]
+unsafe extern "system" {
+    fn CharToOemBuffA(source: *const u8, destination: *mut u8, length: u32) -> i32;
+}
+
+#[cfg(windows)]
+fn ansi_byte_to_oem(byte: u8) -> u8 {
+    let mut converted = byte;
+    // SAFETY: source and destination are distinct live one-byte objects, and
+    // the explicit length keeps Win32 from reading either as a C string.
+    let succeeded = unsafe { CharToOemBuffA(&byte, &mut converted, 1) };
+    if succeeded == 0 { byte } else { converted }
+}
+
+#[cfg(not(windows))]
+fn ansi_byte_to_oem(byte: u8) -> u8 {
+    byte
+}
+
+/// Convert score-screen text to the byte-valued glyph string used by ScoreFont.
+///
+/// Each UTF-16 unit is truncated independently before ANSI-to-OEM conversion;
+/// this is intentionally unrelated to the ordinary byte widening, player-edit
+/// ACP boundary, CSF Unicode, and shared BitFont paths. An original wide NUL
+/// terminates the input, while a zero low byte from a nonzero unit remains a
+/// valid converted glyph value.
+///
+/// Retail provenance: ScoreFont low-byte ANSI-to-OEM glyph selection — ScoreFont width slot @ `0x006907E0`.
+/// Retail provenance: ScoreFont low-byte ANSI-to-OEM glyph selection — ScoreFont draw slot @ `0x00690850`.
+/// Retail provenance: ScoreFont low-byte ANSI-to-OEM glyph selection — ScoreFont draw slot @ `0x00690910`.
+pub fn score_font_text(text: &str) -> String {
+    let mut converted = String::with_capacity(text.len());
+    for unit in text.encode_utf16().take_while(|unit| *unit != 0) {
+        converted.push(char::from(ansi_byte_to_oem(unit as u8)));
+    }
+    converted
+}
+
 /// Encode UTF-16 text through the Windows active ANSI code page.
 #[cfg(windows)]
 pub fn acp_encode(text: &str) -> Vec<u8> {
@@ -142,4 +181,42 @@ pub fn acp_round_trip(text: &str) -> String {
 #[cfg(not(windows))]
 pub fn acp_round_trip(text: &str) -> String {
     text.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn score_font_ascii_is_identity() {
+        let ascii: String = (0x20u8..=0x7E).map(char::from).collect();
+        assert_eq!(score_font_text(&ascii), ascii);
+    }
+
+    #[test]
+    fn score_font_truncates_euro_before_oem_mapping() {
+        let expected = char::from(ansi_byte_to_oem(0xAC)).to_string();
+        assert_eq!(score_font_text("\u{20AC}"), expected);
+    }
+
+    #[test]
+    fn score_font_stops_at_an_original_wide_nul() {
+        assert_eq!(score_font_text("A\0ignored"), "A");
+        assert_eq!(score_font_text("\u{100}"), "\0");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn score_font_e_acute_matches_one_byte_char_to_oem_buff() {
+        let source = 0xE9u8;
+        let mut expected = source;
+        // SAFETY: this independently exercises the native one-byte call with
+        // distinct source and destination objects, matching the verified ABI.
+        let succeeded = unsafe { CharToOemBuffA(&source, &mut expected, 1) };
+        if succeeded == 0 {
+            expected = source;
+        }
+
+        assert_eq!(score_font_text("\u{E9}"), char::from(expected).to_string());
+    }
 }


### PR DESCRIPTION
## What changed

- Derive the retail asset root from the executable directory while keeping explicit Rust path ownership.
- Match active YR MIX/VFS behavior: one padded Westwood CRC, registered-order duplicate selection, raw-first initial loads, and sticky CRC caching.
- Route language, theater, loose YRO/PKT, and map-pack discovery through the retail-resolution order.
- Preserve verified LCW/LZO/Format80 behavior and reproduce RGB565 PCX presentation, packed color keys, and RandMap storage bytes.
- Match active INI loading: discard entryless physical sections, preserve typed current-field defaults across ordered rule passes, and clamp ReadSpeed to its native domain.
- Preserve active ra2md.csf behavior and add the score-only UTF-16 low-byte to CharToOemBuffA glyph boundary.
- Update affected fixtures so tests that require physical INI sections contain accepted inert entries.

## Why

This completes rows 22–27 of the clean-slate implementation order against active retail Yuri's Revenge behavior proven from gamemd.exe bodies, callsites, receivers, active reachability, and installed retail INI/archive data.

## Player and developer impact

Retail assets now resolve in the same effective order as YR, packed shell/loading colors follow native RGB565 behavior, layered rules retain native typed defaults, and non-ASCII score text crosses the same score-font OEM boundary. The implementation keeps explicit ownership and Unicode-safe host paths rather than copying unsafe process-global or fixed-buffer details.

## Root causes corrected

The prior implementation admitted a non-retail rolling MIX hash, selected MIX bytes before loose bytes on first cache fill, retained physical INI sections that retail destroys, collapsed invalid later typed values onto constructor defaults, and sent score text directly through shared Unicode glyph lookup.

## Validation

```text
cargo test -p vera20k --lib
test result: ok. 6625 passed; 0 failed; 28 ignored; 0 measured; 0 filtered out; finished in 10.22s
```

Each meaningful implementation batch also passed focused module tests and a fresh read-only critic review.

## Integration note

The branch was cut from `5ea53fd4`; `main` subsequently advanced to `187e0a88`. A read-only merge-tree check found no textual conflict markers. This PR is draft so GitHub CI can validate the combined result before merge.
