### PR TITLE
Publish contributor roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
 
 # VERA20K
 
-[![Discord](https://img.shields.io/badge/Discord-Join%20Server-5865F2?logo=discord&logoColor=white)](https://discord.gg/kmjRUn5m5F)![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)[![Docs](https://img.shields.io/badge/Docs-GitHub%20Pages-blue)](https://yrvera.github.io/vera20k/)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Server-5865F2?logo=discord&logoColor=white)](https://discord.gg/kmjRUn5m5F) ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg) [![Docs](https://img.shields.io/badge/Docs-GitHub%20Pages-blue)](https://yrvera.github.io/vera20k/)
 
 <img src="docs/images/new-conscirpt-hero-image.png" alt="VERA20k hero image" width="600">
 
-Red Alert 2: Yuri's Revenge — rebuilt from scratch in Rust for large multiplayer battles.
+Red Alert 2: Yuri's Revenge - rebuilt from scratch in Rust for large multiplayer battles.
 
 
-This project stands on the shoulders of giants. Thanks to OpenRA, XCC mixer, ModEnc website, PPM website, EA for open source RA1, World Altering Editor, Final Alert,YRpp, Ares, Phobos and much more.
+This project stands on the shoulders of giants. Thanks to OpenRA, XCC Mixer, ModEnc, Project Perfect Mod, EA's open-source Command & Conquer release, World-Altering Editor, FinalAlert 2, YRpp, Ares, Phobos, and many others.
 
 VERA20K operates after contributor-owned cooperative principles. Contributors earn equity shares through contributions or donations. Those shares give automatically income rights and governance weight.
 
 ---
 
 ## Project Goals
-
-<small>
 
 **1.**
 A drop-in replacement for `gamemd.exe` focused first on retail-convincing stock
@@ -25,20 +23,22 @@ matches without repeatedly noticing differences in gameplay, visuals, sound, or
 response.
 
 **2.**
-Constructed from the ground up for large multiplayer — targeting support for up to **30 players** and **20,000 units** on significantly bigger maps.
+Constructed from the ground up for large multiplayer - targeting support for up to **30 players** and **20,000 units** on significantly bigger maps.
 
 **3.**
-Offer known old and new rts feautures never seen before to enhance the cnc ra2 experience.
+Offer carefully bounded classic and new RTS features that expand the Command & Conquer: Red Alert 2 experience.
 
 ## Current Status
 
-**Early development** — Work is focused on the core engine. Approximately 35% complete.
+**Early development** - Work is focused on the retail-convincing stock-skirmish path. Progress is reported through observable roadmap outcomes and current tests rather than a hand-maintained completion percentage.
 
 
 ## Requirements
 
-- [Rust](https://rustup.rs/) 1.85+ (edition 2024)
+- [Current stable Rust](https://rustup.rs/) (minimum 1.88; selected by `rust-toolchain.toml`)
 - A copy of **Red Alert 2: Yuri's Revenge** (the engine reads .mix files from your install)
+- Linux: `libasound2-dev` and `libudev-dev`
+- Windows: an MSVC Rust toolchain and Visual Studio C++ Build Tools
 
 
 ## Setup
@@ -62,7 +62,7 @@ Offer known old and new rts feautures never seen before to enhance the cnc ra2 e
 
 ## Contributing
 
-Read the [architecture overview](https://yrvera.github.io/vera20k/) before diving in.
+Start with the [contributor roadmap](https://yrvera.github.io/vera20k/). It explains where different skills fit, how to choose a bounded contribution, and what evidence and validation each kind of change needs.
 
 1. Fork the repo
 2. Create a feature branch (`git checkout -b feature/my-feature`)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,102 +1,84 @@
 ---
 layout: default
-title: VERA20k Engine
+title: VERA20k Contributor Roadmap
 ---
 
-# VERA20k
+# VERA20k Contributor Roadmap
 
-Red Alert 2: Yuri's Revenge — rebuilt from scratch in Rust.
+**Rebuild Yuri's Revenge faithfully in Rust, then take it beyond the original engine's limits.**
 
-The entire engine is built from two things: structs and functions. There are zero abstraction layers. Code is logically organized in files and folders. The codebase is therefore very machine and human friendly.
+> **North star:** an experienced Yuri's Revenge player can complete an ordinary 30-60 minute stock skirmish, with any faction on representative retail maps, without repeatedly noticing differences in gameplay, visuals, sound, or response.
 
-The top-level layout under `src/`, roughly bottom-up:
+These are target outcomes, not current-status claims or completion percentages.
 
-- `assets/` — format parsers for `.mix`, `.shp`, `.vxl`, `.pal`, `.tmp`, `.hva`, `.csf`, `.aud`. Written from scratch with `nom`, no third-party RA2 libs.
-- `util/` — low-level helpers: fixed-point math, bit utilities. Reusable everywhere.
-- `rules/` — parses `rulesmd.ini` / `artmd.ini` and exposes the resolved game rules.
-- `map/` — `.mmx` / `.map` parsing, theater handling (temperate / snow / urban), resolved terrain.
-- `sim/` — game state and deterministic behavior. Owns `Simulation`. Never depends on render / audio / ui / net. Major subsystems sit in their own subdirs: `combat/`, `movement/`, `pathfinding/`, `aircraft/`, `production/`, `miner/`, `superweapon/`, `vision/`, `docking/`, `world/`.
-- `render/` — wgpu sprite renderer, atlases, draw passes. Reads from sim, never writes back.
-- `sidebar/` — custom-drawn build / cameo sidebar.
-- `ui/` — egui overlays (debug panels, save/load, lobby).
-- `audio/` — sound playback through `rodio`; drains events produced by sim.
-- `net/` — multiplayer transport and lockstep.
-- `bin/` — auxiliary tools: mix browser, BIK video player, INI extractor.
-- `app_*.rs` files at the root of `src/` — the app layer that wires sim, render, ui, audio, and net together.
+## Where we are going
 
-When adding a new file, ask which of those concerns it belongs to. If it's gameplay logic, it goes in `sim/`. If it touches the GPU, it goes in `render/`. If it talks to both, it's app layer.
+1. **Trust retail content.** Load the player's legally owned archives, standalone MD INIs and verified overrides, maps, text, graphics, audio, and movies correctly.
 
-To learn what a specific file does, read its `//!` header — every module starts with a short comment stating its purpose and what it depends on.
+2. **Finish a convincing stock skirmish.** Go from skirmish setup to battlefield to result, with familiar control, combat, economy, AI, presentation, and sound.
 
-All game state lives in one struct: `Simulation`.
+3. **Complete the Yuri's Revenge battlefield.** Support Allied, Soviet, and Yuri identity, specialist units, naval and aircraft play, superweapons, stock scripts, and common map mechanics.
 
-It contains:
+4. **Preserve and connect matches.** Save, restore, replay, diagnose, and play across real machines without changing deterministic game state.
 
-- `entities: EntityStore` — every unit/building/aircraft in the game
-- `production: ProductionState` — build queues, credits, rally points per player
-- `fog: FogState` — shroud/visibility per player
-- `power_states` — per-player power grid (output, drain, blackout)
-- `super_weapons` — per-player superweapon countdowns
-- `occupancy: OccupancyGrid` — which entity occupies which cell
-- `houses` — per-player state (alliances, defeat status)
-- `terrain_costs` — pathfinding cost grids
-- `zone_grid` — zone connectivity for unreachability checks
-- `overlay_grid` — ore, gems, walls on the map
-- `bridge_state` — bridge health and connectivity
-- `rng: SimRng` — single deterministic random number generator
-- `tick: u64` — current game tick counter
+5. **Reach VERA scale.** Prove responsive, deterministic battles at up to 30 players and 20,000 units with measured benchmarks.
 
-Each of those is a plain struct or a map of structs. No behavior attached to them.
+6. **Go beyond retail.** Add new modes and features only behind explicit boundaries that cannot silently change stock behavior.
 
-Each `GameEntity` is one struct with optional fields.
+The first two outcomes are the main delivery path. Persistence, multiplayer, presentation, and performance work can advance independently when their boundaries are clear.
 
-Every object in the game — tank, soldier, building, aircraft — is the same struct. Always-present fields: `stable_id`, `position`, `health`, `owner`, `facing`, `type_ref`, `category`. Optional fields are `Option<T>`: a tank has `locomotor` + `turret_facing` + `drive_track`, a building has `production`, a harvester has `miner`. No component has methods — they're all data.
+## The first complete skirmish
 
-Behavior is plain functions.
+Close this journey in order:
 
-(Example functions below)
-- `tick_movement()` — reads entity positions and locomotor data, writes new positions
-- `tick_combat()` — reads attack targets and weapon stats, applies damage
-- `tick_production()` — advances build queues, spawns finished units
-- `tick_power_states()` — recalculates per-player power from buildings
-- `tick_superweapons()` — counts down timers, fires effects
-- `tick_ore_growth()` — spreads ore across the map
+1. **Choose and load** - select a stock setup, load the scenario, and create houses, starts, and forces.
+2. **Advance a stable first frame** - preserve native-compatible command, scheduler, presentation, and late-frame timing.
+3. **Move and reveal** - select, command, path, locomote, update occupancy, and reveal terrain.
+4. **Attack and die** - target, fire, apply damage, resolve lifecycle consequences, and present feedback.
+5. **Harvest and earn** - choose work, collect, return, dock, deposit, and release.
+6. **Build and recover power** - fund production incrementally, place or exit the result, and update power and radar.
+7. **Finish and return** - let AI, teams, scripts, and triggers reach a result and return through the skirmish shell.
 
-These functions all read and write to the same `Simulation` struct. 45 times a second at 45 FPS(standard multiplayer FPS) There is no message buses, no event systems.
+The gate is one production-route stock skirmish that runs for 30-60 minutes with deterministically reproducible state evolution and no repeatedly noticeable ordinary-play divergence.
 
-The game loop is one function calling the others in order.
+## Pick a contribution
 
-`Simulation::advance_tick()` calls: commands → movement → combat → vision → power → superweapons → production → AI → defeat check → state hash. Every tick, same order.
+- **Good first contributions:** documentation, setup, diagnostics, tools, legal synthetic fixtures, parser boundaries, and focused tests.
+- **With engine experience:** maps, UI, rendering, audio, rules, and one reproduced gameplay divergence.
+- **Advanced:** persistence, replay, AI, specialist mechanics, and cross-system behavior.
+- **Maintainer-paired:** scheduler order, lifecycle ownership, synchronized randomness, networking, hashes, and hot-path optimization.
 
-Current foundational scheduler TODO.
+If the curated issue lists are empty, agree on one bounded slice in Discord before coding.
 
-The repo-local roadmap for native `LogicClass`-style timing and scheduler work is
-stored at `docs/plans/2026-05-28-foundational-scheduler-roadmap-todo.md`. It
-covers the contract stack for native frame timing, active object scheduling,
-ObjectClass/TechnoClass lifecycle, global tick spine order, factory/house tail
-order, and projectile/AnimClass same-tick behavior.
+## Work one small slice
 
-Rendering.
+1. Start from an observed player problem or an accepted contributor issue.
+2. Reproduce one route and find the smallest Rust owner.
+3. Establish retail data, native evidence, or an explicit **unverified** label.
+4. Create a short-lived `feature/<topic>` branch before editing.
+5. Fix the first player-visible or determinism-relevant divergence.
+6. Run the focused check and the production route, record what remains unknown, then stop.
 
-A 2D sprite renderer using wgpu. At map load, all sprites (buildings, infantry, terrain tiles, overlays) are packed into atlas textures — big images containing many sprites side by side. Voxel models (vehicles, aircraft) are pre-rendered into 2D sprites and packed into atlases the same way.
+### Ready for review
 
-Each frame, the renderer walks through all entities in `Simulation`, reads their position, facing, health, and animation frame, looks up the matching sprite in the atlas, and tells the GPU where to draw it on screen. Isometric depth is handled by draw order and depth values — there's no 3D geometry.
+- The outcome is stated in plain language.
+- The change preserves deterministic order, identity, randomness, and native same-frame/tick consequence timing where relevant.
+- Behavioral work has a focused regression test; visible work exercises the production path.
+- Pixel/frame-parity visual work has a capture, parser work a boundary fixture, and performance work a profile.
+- No retail binary, archive, map, key, or extracted asset is committed.
 
-The render code only reads from `Simulation`. It never writes back. You can change rendering without touching game logic, and vice versa.
+### Useful commands
 
-App layer.
+```bash
+cargo check -p vera20k
+cargo test -p vera20k --lib module_path::
+cargo run --bin vera20k
+```
 
-The app layer wires everything together. It contains no game logic and no rendering logic — just the connections between them.
+### Start here
 
-When you click on a unit, the app layer handles that. It figures out which entity you clicked, translates it into a command, and passes it to the simulation. The app layer is the translator between "what the player did" and "what the simulation understands."
-
-The simulation runs at a fixed 45 ticks per second, independent of frame rate. The app layer keeps track of elapsed time and runs the right number of sim ticks each frame — sometimes one, sometimes two if the frame was slow, never more than eight to prevent spiral-of-death lag.
-
-After each tick, the app layer hands the updated simulation state to the renderer, which draws the frame. It also drains sound events that the simulation produced (weapon fired, unit died, construction complete) and plays them through the audio system.
-
-Like everything else, it's split into files by concern — `app_input.rs`, `app_camera.rs`, `app_commands.rs`, `app_sidebar_build.rs` — but they're all just functions operating on one shared `AppState` struct. 
-
-Everything in `Simulation` is deterministic. All sim math uses `fixed`-point types — never `f32` / `f64`, since floats drift across CPUs. There is exactly one RNG (`SimRng`); any code that needs randomness pulls from it. `EntityStore` is a `BTreeMap<u64, GameEntity>` so iteration order is stable. At the end of every tick the simulation produces a state hash — two clients on the same inputs must agree on it. That's what makes lockstep multiplayer and replays work, and it's why nothing in `sim/` is allowed to call into `render/`, `audio/`, `ui/`, or `net/`.
-
----
-
+- [Good first issues](https://github.com/Yrvera/vera20k/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22)
+- [Discord](https://discord.gg/kmjRUn5m5F)
+- [README and setup](https://github.com/Yrvera/vera20k/blob/main/README.md)
+- [Authoritative Rust module map](https://github.com/Yrvera/vera20k/blob/main/src/lib.rs)
+- [Current pull requests](https://github.com/Yrvera/vera20k/pulls)


### PR DESCRIPTION
## What changed

- replace the stale completion percentage and outdated architecture essay with an outcome-oriented contributor roadmap
- document that the repository tracks stable Rust, with 1.88 as the current dependency floor
- clarify contribution boundaries, review evidence, setup requirements, and useful entry points

## Why

The previous landing page contained architecture claims that no longer matched the codebase, while the README carried a hand-maintained completion percentage. The replacement describes target outcomes without presenting them as current completion claims.

## Validation

- `git diff --check -- README.md docs/index.md`
- independent read-only review of the final two-file diff
- docs-only change; Cargo tests were not run
