### PR TITLE
Track agent skills and project contract files

### DIFF
--- a/.agents/skills/architecture-scan/SKILL.md
+++ b/.agents/skills/architecture-scan/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: architecture-scan
+description: "Project-scoped, read-only VERA20k review of repository organization, module ownership, dependency direction, API visibility, naming, cohesion, change locality, test placement, and Cargo target boundaries. Use only when explicitly invoked as $architecture-scan to assess where existing Rust code belongs or whether current repository boundaries are healthy. Reports evidence-backed findings and options; never edits, auto-refactors, performs gameplay parity research, or imposes generic Rust layout preferences."
+---
+
+# Architecture Scan
+
+Review the current repository architecture without editing it. Read `ENGINE.md`
+completely before scanning. A scan samples current structure; it does not certify
+that the repository is well organized.
+
+Judge architecture by whether ownership is predictable, dependencies flow in the
+declared direction, APIs protect invariants, and ordinary changes remain reasonably
+local. Do not judge it by a preferred folder tree, crate count, nesting depth, or
+one-type-per-file rule.
+
+Treat all bundled material as evidence lenses, not implementation requirements.
+Its imperatives govern what this read-only review must inspect and prove; they do
+not authorize moves, renames, API changes, crate splits, or refactors. Only a later,
+explicitly authorized task may change code, with `ENGINE.md` remaining authoritative.
+
+Apply this priority when recommendations compete:
+
+1. explicit `ENGINE.md` boundaries and parity/determinism safety;
+2. state and behavior ownership plus dependency direction;
+3. API visibility, invariant enforcement, and lifecycle seams;
+4. cohesion, change locality, testability, and discoverability;
+5. naming consistency and aesthetic preference.
+
+## Inputs
+
+Preserve these forms:
+
+- `$architecture-scan` — review the current package, beginning with `Cargo.toml`,
+  `src/lib.rs`, `src/main.rs`, and the top-level module roots.
+- `$architecture-scan <path>` — review one repository-relative file, module, or
+  directory in its surrounding architecture.
+- `--changed [--base <revision>]` — review structural effects of changed Rust and
+  manifest files; default the base to `main`.
+- `--focus <name>` — repeat as needed. Names are `boundaries`, `ownership`, `api`,
+  `layout`, `naming`, `tests`, and `packages`.
+
+Without `--focus`, use `boundaries,ownership,api,layout`. Include `packages` when
+manifests or targets are in scope and `tests` when test placement affects the
+question. Resolve paths under the repository root and record HEAD, dirty state,
+active worktrees, target, focus, and exclusions. Do not assess another task's
+half-finished move as settled architecture; identify the active migration and
+inspect both its old and new seams.
+
+## Resources
+
+Read [the architecture review lenses](references/review-lenses.md) completely.
+They contain project-aware questions plus the primary Rust sources behind them.
+No candidate collector is bundled: imports, visibility, macros, and module paths
+must be resolved from the live source rather than treated as a reliable regex graph.
+
+## Workflow
+
+1. **Establish the declared shape.** Read the relevant Cargo manifests,
+   `src/lib.rs`, `src/main.rs`, module roots, and their `//!` contracts. Identify
+   package targets, layer rules, public facades, and any in-progress migration.
+2. **Build a factual boundary map.** For each responsibility in scope, record its
+   current owner, mutable state, public or crate-visible seam, direct callers,
+   upstream inputs, and downstream dependencies. Keep this map small enough to
+   explain the question; do not create a permanent architecture ledger.
+3. **Trace real access.** Read definitions, imports, re-exports, constructors,
+   mutation sites, trait implementations, macro expansions when relevant, tests,
+   and representative callers. Distinguish production, test-only, tool-only,
+   generated, and presentation paths.
+4. **Apply only relevant lenses.** Check explicit project boundaries first, then
+   ownership, dependency direction, API surface, cohesion, placement, naming,
+   tests, and package boundaries as selected. A count or lexical match is only a
+   route to inspect.
+5. **Prove concrete cost.** Confirm either an explicit project-contract violation
+   or a bounded effect: duplicated authority, a wrong-way dependency, bypassable
+   invariants, split lifecycle, unwanted API coupling, recurring cross-module
+   change fanout, an untestable seam, or materially misleading placement/name.
+   Use focused git history only when claiming recurring churn; do not infer design
+   merely from co-change counts.
+6. **Check Rust indirection contextually.** Resolve the consumers and implementors
+   of a trait and the generated surface of a macro. More traits, generics, facades,
+   or macros are not inherently better architecture. Recommend them only when an
+   observed variation or boundary benefits.
+7. **Bound the direction.** State the smallest safe improvement direction and its
+   compatibility, parity, determinism, ordering, persistence, build, and migration
+   risks. Do not turn the scan into a design spec or implementation plan.
+8. **Report and stop.** Never move files, change visibility, add wrappers, split a
+   crate, run automatic fixes, or chain into another skill.
+
+Use `cargo metadata --no-deps` only when manifest topology is ambiguous. Before
+any Cargo command, check for active `cargo` or `rustc` processes and follow the
+repository's Cargo coordination rules. Do not run Clippy or compile merely to
+produce an architecture opinion.
+
+## Confirmation gate
+
+A candidate becomes a finding only when the report can state:
+
+- exact source locations and representative consumers;
+- the current responsibility owner and dependency/API boundary;
+- the violated project rule or concrete engineering/player consequence;
+- the triggering kind of change or runtime path and expected frequency;
+- why the proposed direction improves that boundary without speculative layers.
+
+File length, folder depth, `pub`, re-exports, prefixes, traits, macros, many
+binaries, or a single large crate are not findings by themselves. Generic Rust
+taste is never a project defect.
+
+Use these categories:
+
+- **BOUNDARY** — declared dependency direction or layer ownership is violated;
+- **OWNERSHIP** — authoritative state or behavior has competing/bypass owners;
+- **API** — visibility or a facade exposes/bypasses more than its contract needs;
+- **COHESION** — unrelated responsibilities create verified change amplification;
+- **PLACEMENT** — location materially obscures ownership or dependency direction;
+- **NAMING** — terminology causes demonstrated ambiguity at a real seam;
+- **PACKAGE** — package, crate, binary, feature, or dependency topology is at issue;
+- **TESTABILITY** — placement or visibility prevents the right boundary from being tested.
+
+Assign severity from verified impact and always state trigger/change frequency:
+
+- **CRITICAL** — explicit hard boundary violation, duplicated authoritative owner,
+  or structural path that threatens deterministic/player-visible correctness;
+- **WARNING** — confirmed coupling, invariant bypass, change amplification, or
+  test barrier with a recurring or bounded maintenance effect;
+- **INFO** — a demonstrated low-risk discoverability or API improvement.
+
+## Report
+
+Lead with a one-sentence verdict, then use:
+
+### Coverage
+
+- Target, HEAD, dirty/worktree state, focuses, and files or edges inspected.
+- Explicit contracts and tools used, skipped, or incomplete.
+
+### Current architecture map
+
+| Responsibility | Current owner | Public seam | Inputs / consumers | Evidence |
+|---|---|---|---|---|
+
+### Confirmed findings
+
+| Severity | Confidence | Category | File:line | Evidence | Trigger / frequency | Effect | Improvement direction |
+|---|---|---|---|---|---|---|---|
+
+If none were confirmed, say: `No confirmed architecture findings in the sampled
+scope; this is not certification.`
+
+### Unresolved candidates
+
+List only candidates whose missing caller, owner, history, or boundary evidence
+could materially change the verdict. State the exact next check.
+
+### Supported boundaries
+
+Record a few important boundaries that current evidence shows are healthy so a
+later cleanup does not erase them accidentally.
+
+### Limits
+
+State excluded areas, unresolved macro/trait paths, uninspected history, and other
+unknowns. End after reporting; implementation begins only under a separate request.
+
+## Non-goals
+
+- Do not perform a gameplay parity audit, broad Rust correctness/safety scan,
+  performance profile, feature design, design-document review, or implementation.
+- Do not produce an architecture score, ideal directory tree, parity ledger, or
+  repository-wide cleanup backlog.
+- Do not prescribe traits everywhere, one type per file, shallow/deep nesting,
+  arbitrary line limits, universal `pub(crate)`, or a workspace split by size.
+- Do not replace working project boundaries solely to resemble another engine or
+  a generic "clean architecture" diagram.

--- a/.agents/skills/architecture-scan/agents/openai.yaml
+++ b/.agents/skills/architecture-scan/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "VERA Architecture Scan"
+  short_description: "Review repository architecture and boundaries"
+  default_prompt: "Use $architecture-scan to review the repository module ownership, dependency direction, API visibility, and code placement."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/architecture-scan/references/review-lenses.md
+++ b/.agents/skills/architecture-scan/references/review-lenses.md
@@ -1,0 +1,151 @@
+# Architecture review lenses
+
+These are questions for gathering evidence, not universal coding standards. A
+rule word such as "prefer" or "require" describes what the scan must establish
+before reporting a finding; it does not authorize a rewrite. `ENGINE.md` owns
+project policy and overrides generic Rust guidance.
+
+## Contents
+
+- [Packages and targets](#packages-and-targets)
+- [Modules, files, and placement](#modules-files-and-placement)
+- [Ownership and dependency direction](#ownership-and-dependency-direction)
+- [Visibility and API seams](#visibility-and-api-seams)
+- [Cohesion and change locality](#cohesion-and-change-locality)
+- [Names and navigation](#names-and-navigation)
+- [Traits and macros](#traits-and-macros)
+- [Tests and tools](#tests-and-tools)
+- [Parity-preserving structural work](#parity-preserving-structural-work)
+- [Primary sources](#primary-sources)
+
+## Packages and targets
+
+- Start from Cargo's actual package and target model. One package with a library
+  and several binaries is valid. Conventional `src/lib.rs`, `src/main.rs`,
+  `src/bin/`, `tests/`, `examples/`, and `benches/` placement improves navigation,
+  but compatibility and project-specific target declarations can justify variants.
+- Consider a new package/crate only when it creates a useful compilation,
+  dependency, reuse, testing, platform, or stable-API boundary. Size alone does
+  not justify a workspace split. Account for dependency cycles, duplicated types,
+  build cost, feature unification, and migration burden.
+- Treat feature flags as additive capability choices where practical. Confirm the
+  production surface affected before reporting package or feature topology.
+
+## Modules, files, and placement
+
+- Remember that modules define namespace, privacy, and paths; files store module
+  bodies. A file move or split can improve navigation without changing architecture.
+- Place code with the responsibility that owns its state, invariants, lifecycle,
+  or externally meaningful contract. A shared location is appropriate only for a
+  genuinely lower-level concept with multiple independent consumers.
+- Read the crate root, parent module, `//!` contract, definitions, and callers.
+  Folder depth, sibling count, and filename prefixes are discovery signals only.
+- Check whether a facade offers one coherent entry point while keeping its
+  implementation private. Do not add a facade merely to reduce import length.
+- Recognize active migrations from dirty state and recent focused commits. Mixed
+  old/new placement during a bounded move is not automatically architectural debt.
+
+## Ownership and dependency direction
+
+- Identify one truthful owner for mutable or authoritative state and for the
+  operations that maintain its invariants. Confirm all mutation paths, including
+  constructors, commands, callbacks, tests, macros, and trait methods.
+- Compare actual imports and calls with `ENGINE.md`'s layer direction. Separate
+  production edges from test-only, diagnostic, generated, and tool edges.
+- Prefer communication through the owning layer's command, DTO, event, query, or
+  narrow method when direct access would bypass ordering or lifecycle. Do not add
+  messaging abstractions where a direct lower-level dependency is already valid.
+- Flag a "common", "shared", "manager", or "helpers" module only when it has
+  become a second owner, a dependency dumping ground, or a material navigation trap.
+
+## Visibility and API seams
+
+- Rust items are private by default and support restricted visibility such as
+  `pub(super)`, `pub(in ...)`, and `pub(crate)`. Inspect actual consumers and use
+  the narrowest visibility that truthfully serves them; `pub` alone is not a defect.
+- Treat `pub use` as an architectural facade: verify that it exposes the intended
+  concept without making implementation placement or an internal dependency part
+  of the calling contract.
+- Distinguish an application crate's test-facing surface from a published stable
+  library API. Apply semver-oriented Rust API guidance only where compatibility is
+  an actual project requirement.
+- Prefer private fields for invariant-bearing types and public fields for honest
+  passive data when that is the intended contract. Accessors that merely mirror
+  every field do not create encapsulation.
+- Trace dependency types in public signatures. A third-party type, concrete
+  container, trait bound, or error type can become part of the boundary, but this
+  matters only to real consumers.
+
+## Cohesion and change locality
+
+- Ask whether a module has one coherent reason to change and whether common work
+  stays near the owning code. Confirm unrelated responsibility or repeated fanout
+  before reporting; line count is only a cue.
+- Use focused git history when claiming chronic co-change, but inspect why files
+  changed together. A one-time migration, generated update, or parity slice is not
+  evidence of permanent coupling.
+- A large cohesive table, parser, state machine, or test corpus may be easier to
+  reason about together. A short file can still be misplaced or split an invariant.
+- Prefer the smallest boundary improvement. Moving files without tightening
+  ownership, visibility, dependencies, or navigation may add churn with no gain.
+
+## Names and navigation
+
+- Follow Rust casing and Cargo target conventions unless compatibility requires
+  otherwise. More importantly, use the repository's verified domain vocabulary.
+- A name should let a maintainer predict the responsibility and likely owner.
+  Demonstrate ambiguity through conflicting concepts, imports, or callers before
+  reporting a rename; unfamiliar or long names alone are not findings.
+- Keep conversion and iterator names consistent with established Rust meanings
+  (`as_`, `to_`, `into_`; `iter`, `iter_mut`, `into_iter`) when those APIs exist.
+- Module documentation should state purpose and important dependencies. It should
+  not become a hand-maintained completion ledger or duplicate implementation detail.
+
+## Traits and macros
+
+- Introduce or retain a trait for a real behavioral contract, multiple meaningful
+  implementations, a test seam, or an intentional static/dynamic dispatch boundary.
+  A single implementation is neither proof of needless abstraction nor proof that
+  a trait is useful.
+- Resolve implementors, consumers, associated types, blanket/default methods, and
+  object use before judging placement. Sealing is appropriate only when external
+  implementations are deliberately excluded.
+- Place macros with the domain or infrastructure that owns the generated contract.
+  Inspect the expansion that actually compiles when it affects visibility,
+  dependencies, state ownership, serialization, or tests. Macro use is not itself
+  an architecture smell.
+
+## Tests and tools
+
+- Colocated unit tests may exercise private details. `tests/` integration crates
+  should exercise the public boundary. Rustdoc examples document and compile API
+  use; `examples/` provides runnable programs. Choose placement by the seam tested,
+  not by a universal rule.
+- Keep binary entry points thin when logic can be owned and tested by the library,
+  but do not expose internals publicly merely to satisfy a test.
+- Separate tool-only dependencies and code paths from the production game when
+  they would otherwise expand runtime boundaries or compile cost. Many declared
+  binaries are not automatically evidence that separate packages are needed.
+
+## Parity-preserving structural work
+
+- A structural move is not behavior-neutral merely because the function bodies
+  look unchanged. Check feature/`cfg` reachability, caller order, error routing,
+  constructors, serialization, registration, tests, and public paths.
+- For authoritative simulation, preserve scheduler and tie order, RNG ownership
+  and draw count, lifecycle effects, same-tick visibility, snapshot/hash coverage,
+  and gamemd provenance. Report a behavioral question as out of scope and name
+  `$rust-scan` or the appropriate parity workflow for a separate explicit request;
+  never invoke it automatically or resolve it by architectural taste.
+- Do not recommend translating gamemd's C++ class hierarchy literally. Preserve
+  verified behavior contracts while using Rust-native modules, ownership, and APIs.
+
+## Primary sources
+
+- [Rust Book: packages, crates, and modules](https://doc.rust-lang.org/book/ch07-00-managing-growing-projects-with-packages-crates-and-modules.html)
+- [Cargo Book: package layout](https://doc.rust-lang.org/cargo/guide/project-layout.html)
+- [Cargo Book: workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)
+- [Rust Reference: visibility and privacy](https://doc.rust-lang.org/reference/visibility-and-privacy.html)
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) — recommendations,
+  explicitly not universal mandates
+- [Rust Book: test organization](https://doc.rust-lang.org/book/ch11-03-test-organization.html)

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: audit
+description: "Verify and correct one existing VERA20k research document against active Yuri's Revenge gamemd.exe evidence. Use only when the user explicitly asks to audit and fix/correct a research doc; for read-only review use verify-doc or verify-doc-swarm."
+---
+
+# Audit And Correct A Research Document
+
+Use this skill to correct one named document under
+`<main-checkout>/docs/research/`. The result is a smaller,
+more trustworthy document, not a fresh parallel report.
+
+Read `AGENTS.md` first. Active `gamemd.exe` behavior is the specification. Local
+labels, prior prose, inferred names, YRpp, and agreement between documents are
+navigation aids rather than proof.
+
+## Authorization And Scope
+
+- Require explicit user intent to edit or correct the document. A request to
+  inspect, review, or diagnose is read-only and belongs to `verify-doc`.
+- Own exactly one research document unless the user names more.
+- Do not edit Rust, INI, assets, other documents, or git history.
+- Keep evidence gathering read-only and report Ghidra annotation candidates separately.
+  This skill does not synchronize them by default. A root/standalone run may do so only
+  with `--sync-ghidra-labels` or a direct user request, following ENGINE.md. Workers
+  remain read-only.
+- Use `apply_patch` for document edits and preserve unrelated correct material.
+
+## Preflight
+
+1. Resolve the requested path and read the entire document.
+2. Check its modification time and nearby claim/lock files. If another session
+   changed or claimed it recently, stop rather than racing the moving target.
+3. Use the research-index MCP first (`research_validate`, `research_map`,
+   `research_brief`, or `research_graph` as appropriate). Use the repo CLI only
+   when the corresponding MCP capability is unavailable.
+4. Record the exact active-YR binary/project being queried. Do not silently audit
+   a different executable or a dormant TS path.
+
+## Two-Pass Audit
+
+### Pass 1: Enumerate Claims
+
+Build a private checklist of every load-bearing claim, including:
+
+- function identity, address, owner, caller, and active-YR reachability;
+- field offsets, widths, signedness, constants, and sentinel values;
+- branch conditions, formulas, rounding, clamps, iteration order, and timing;
+- vtable ownership and slot identity;
+- INI keys, asset names, and Rust-facing implementation conclusions.
+
+Do not begin rewriting after finding the first error. First establish the claim
+surface so one correction does not leave dependent prose contradictory.
+
+### Pass 2: Verify And Classify
+
+Classify each claim as `VERIFIED`, `WRONG`, `STALE`, `MISLEADING`, or `UNCHECKED`.
+Use the function body, assembly/raw bytes, callers, receiver flow, data references,
+and active-YR reachability as needed. When evidence conflicts, report the conflict
+instead of forcing a clean answer.
+
+For vtable claims, use the complete protocol:
+
+1. Resolve the table's Complete Object Locator.
+2. Resolve the COL TypeDescriptor to prove the owning class/subobject.
+3. Compute the entry at `slot_index * 4` for this 32-bit binary.
+4. Follow any adjustor thunk and verify the destination body and callsites.
+
+A plausible local label or a decompiler-assigned name does not complete this
+proof.
+
+Record any Ghidra annotation candidate separately with its address/source, current
+metadata, proposed label/comment/reference, and the exact live proof required by
+ENGINE.md. Otherwise record no candidate.
+
+## Optional Ghidra Metadata Sync
+
+By default, stop after reporting the candidate queue. If `--sync-ghidra-labels` was
+provided or the user directly requested synchronization, the root/standalone agent
+waits for every reader to stop and follows ENGINE.md's serial sync protocol. A read-only
+request or `--no-sync-ghidra-labels` disables synchronization.
+
+## Correct The Document
+
+- Correct only claims supported by the evidence gathered in this audit.
+- Never silently delete a load-bearing claim that cannot be re-established. Move
+  or mark it as `UNKNOWN`/`UNCHECKED`, preserve enough original wording for
+  provenance, and record the verification calls/evidence paths attempted. Never
+  invent a replacement address, field, slot, or label.
+- Keep verified findings separate from inference and implementation suggestions.
+- Add a compact inline citation beside every corrected binary claim. The citation
+  must identify the address/symbol plus the exact MCP method and material
+  arguments (or equivalent artifact) used, so another investigator can reproduce
+  it.
+- Update dependent summaries, tables, and implementation handoffs when their
+  premise changed.
+- Do not inflate the document with raw decompiler dumps. Preserve the evidence
+  chain and the exact behavior contract.
+
+## Final Response
+
+Lead with the verdict. Name the corrected document, summarize the material
+corrections, list remaining `UNCHECKED` blockers, and report Ghidra annotation counts
+as applied/deferred/none. Link the edited file with its absolute path.

--- a/.agents/skills/brainstorm/SKILL.md
+++ b/.agents/skills/brainstorm/SKILL.md
@@ -1,0 +1,404 @@
+---
+name: brainstorm
+description: >
+  Architecture-aware brainstorming before any feature work, new component,
+  refactor, or behavioral change. Explores user intent, maps existing
+  architecture, evaluates fit, and produces a design spec before any code
+  is written. Usage: '/brainstorm topic', e.g. '/brainstorm ore refinery
+  docking system' or '/brainstorm refactor movement into sub-modules'.
+---
+
+# Brainstorm — Architecture-Aware Design Skill
+
+Brainstorm a design for: **$ARGUMENTS**
+
+If `$ARGUMENTS` is empty, ask the user what they want to brainstorm.
+
+---
+
+## Hard Gate
+
+**NO code, scaffolding, or implementation until the design is approved.** In an
+interactive task, approval comes from the user. In an autonomous `/goal` that
+explicitly grants self-approval, the coordinator may approve its own design
+after an adversarial review that asks why it should be approved, what could
+still make ordinary skirmish feel wrong, and what could create expensive later
+rework. Record the decision; do not pause for routine approval.
+
+Do NOT invoke any implementation, editing, or code-writing tools during this skill.
+Research and read tools only.
+
+Native-to-Rust translation rule: do not design raw pointer vectors,
+COM/vtable plumbing, global mutable singleton style, or the full native
+inheritance tree just because the binary uses them. Design Rust-native
+ownership boundaries that preserve retail-convincing behavior and load-bearing
+semantics: storage owners, scheduler/order owners, lifecycle helper APIs, plain
+subsystem functions, and ordered commit points. Explain where deterministic
+state, authority, lifecycle, and important player-visible effects live.
+
+Current delivery target: an experienced YR player should be able to play an
+ordinary 30–60 minute stock skirmish without repeatedly noticing differences.
+Exact findings remain honest residuals, but only milestone-blocking or
+compounding differences block the design.
+
+Label-adversarial Ghidra rule: local Ghidra names, labels, comments, xref
+labels, and decompiler-assigned symbol names are navigation hints only. This
+project may contain polluted or stale labels from earlier scripts. Do not let a
+convenient Ghidra name become the design premise unless the function body,
+callsites, receiver/`this` pointer, vtable/data references, and active-YR
+reachability prove that role. Designs should use address plus verified role when
+labels are suspect.
+
+---
+
+## Process — Follow these 8 steps in order
+
+### Step 1: Explore Project Context
+
+- Read AGENTS.md, recent git log (last 10 commits), and any relevant docs/ files
+- Use the research-index MCP before broad manual doc search. Prefer
+  `research_brief(query=<topic>, system=<system>)`; use the repo-local CLI only
+  when the corresponding MCP capability is unavailable:
+
+  ```text
+  python tools/research_index/brief.py "<topic>" --limit 8
+  ```
+
+  If the exact system is known, add `--system <system>` (examples: `bridges`,
+  `miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun
+  without `--system`, then rerun with the inferred exact system. Use
+  `graph.py implementation`, `handoff.py`, and `search.py` for focused Rust
+  touchpoints and mechanism anchors. Treat index output as navigation; verified
+  docs, Ghidra, INI/assets, current Rust reads, and tests still decide parity.
+- Search `<main-checkout>/docs/research/` for any relevant
+  existing `*_SYSTEM_MODEL_SYNTHESIS.md` files.
+  Use them as orientation maps for current understanding, stale-doc warnings,
+  implementation-safe facts, and unresolved research gaps.
+- Do not treat synthesis files as primary evidence. For parity constraints,
+  follow their source ledger back to the cited Ghidra report, trace, INI key,
+  address, or Rust surface and cite that underlying source in the design.
+- Treat contradictions as primary evidence. If a screenshot, runtime result, test
+  failure, trace, asset dump, or user observation disagrees with the current
+  model, mark the design input incomplete and resolve the contradiction before
+  proposing implementation approaches.
+- Stale docs are warnings and source maps, not blockers. If old research conflicts
+  with primary evidence, design from the primary evidence and call out the stale
+  claim as documentation follow-up.
+- Identify relevant parts of the tech stack for this feature
+- Note project conventions that apply (architecture rules, module size limits, etc.)
+
+### Step 2: Map Existing Architecture
+
+This is the most important step. Understand before proposing.
+
+- Identify the major components/modules the proposed work touches
+- Map the dependency graph — what calls what, what imports what
+- Identify **boundaries** — where does this system end and another begin?
+- Identify **interfaces/contracts** — public APIs, data formats, event flow
+- Identify **patterns already in use** — how are similar things done in this codebase?
+  (e.g., how other sim systems are structured, how INI data flows, how entities interact)
+- Locate where the proposed work would **fit** in this picture
+
+Use local search/read tools such as `rg` and direct file reads. Only use Codex
+subagents if the user explicitly asked for delegated or
+parallel work. Be thorough — read the actual code, don't guess from file names.
+
+**Output:** an "Architecture Context" section summarizing what you found. Can be a few
+sentences for small features, a proper component map for larger ones.
+
+### Step 3: Ask Clarifying Questions
+
+Present questions to the user **one at a time** (or in small focused batches).
+
+- Prefer multiple choice when possible
+- Focus on: purpose, constraints, success criteria, edge cases
+- Ask about **scope** — is this one thing or should it be decomposed?
+- Ask about **priorities** — what matters most (correctness, performance, simplicity)?
+- If the gamemd.exe binary is relevant, ask whether RE investigation is needed first
+- If the feature involves gamemd.exe RE findings, ask: **has the TS vs YR distinction
+  been verified?** gamemd.exe serves both Tiberian Sun and YR — systems, fields, and
+  code paths may be TS legacy (disabled/repurposed in YR). Don't design around a
+  mechanic that isn't actually active in a standard YR skirmish.
+
+**Scope-recommendation rule.** Never narrow scope in a way that leaves the
+selected ordinary-skirmish loop visibly broken, changes outcomes, creates
+determinism/authority/lifecycle debt, or pushes the defect into a neighboring
+common path.
+
+A difference may be deferred when it is TS-legacy/inactive, blocked by an
+external prerequisite, or classified as an `EXACTIFICATION-RESIDUAL`: bounded,
+uncommon in ordinary play, mainly expert-probed, non-compounding, and safe for
+later architecture. Record its trigger, player effect, expected frequency, and
+downstream risk. If those are unknown, classify it `UNKNOWN-RISK` and
+investigate only enough to decide whether it blocks the milestone.
+
+Do not proceed while a material ambiguity remains. In an interactive task, ask
+the user. In an explicitly autonomous goal, resolve discoverable questions,
+choose the smallest robust assumption for the representative scenario, record
+it, and continue; stop only when the choice would materially change intent and
+cannot be recovered safely.
+
+### Step 4: Dependency & Impact Analysis
+
+Based on Steps 1-3, analyze:
+
+- What existing code does this feature **touch or depend on**?
+- What existing code **depends on what we're changing**?
+- What might **break**? What is the blast radius?
+- Are there migration concerns (data format changes, config, API compatibility)?
+- For sim/ changes: does this affect tick ordering, determinism, or state hashing?
+
+**Output:** an "Impact Analysis" section listing touched files/modules and risk areas.
+
+### Step 4.5: Player-Experience Detail Ledger
+
+**Before proposing approaches**, list details that could silently make the
+selected ordinary-skirmish scenario feel wrong or create expensive later
+rework. Include timing, constants, ordering, RNG, state/lifecycle, asset lookup,
+draw composition, audio triggers, and edge results in proportion to their risk.
+
+Classify each item:
+
+- `MILESTONE-BLOCKING`
+- `COMPOUNDING`
+- `EXACTIFICATION-RESIDUAL`
+- `UNKNOWN-RISK`
+
+Pull evidence from research docs, synthesis outputs as source maps, INI/assets,
+current Rust, production observations, and Ghidra when needed. Do not invent
+details. An unknown does not automatically block design: investigate enough to
+learn whether it can affect the representative scenario, deterministic state,
+shared architecture, or downstream systems.
+
+Trace from the behavior owner, not a helper. For UI, start at the paint/message/
+render owner; for gameplay, start at the tick/update/action owner; for audio,
+start at the event trigger path; for parsing, start at the actual load/apply
+path; for input, start at dispatch and follow through to command effect. A helper
+belongs in the design only after the target owner is proven to call it.
+
+Always prove activation for the target scenario. Record the game, mode, dialog,
+map, unit, house, difficulty, or setting that the design targets, plus the
+flag/key/case/default that enables the behavior. Code existing in gamemd.exe is
+not enough to make it a design constraint for standard YR.
+
+Inspect variants required by the representative scenario before generalizing.
+Check relevant SHP frames, YR `*md` overrides, dialog cases, difficulty,
+faction, map, and optional branches. Uninspected variants outside the current
+match matrix become named residuals rather than automatic blockers.
+
+Format as a bulleted ledger. Examples of what belongs in it:
+
+- Exact timing: "trigger fires on tick T; effect applies on tick T+0
+  (same tick), not T+1"
+- Exact constants: clamps, thresholds, frame counts, ROT values, ROF
+  cooldowns, animation lengths
+- Order of operations within a tick (which write happens before which)
+- Rounding direction for any fixed-point / integer math
+- Inclusive vs exclusive bounds in range checks
+- Signed vs unsigned comparisons
+- Default values when a field is uninitialized
+- Edge cases: what happens at zero, at max, at empty container, at null
+- Which animation frame an effect starts on (0 vs 1)
+- Sub-tick ordering between paired events (sound vs visual, write vs read)
+- Z-order tie-breakers between overlapping sprites
+- Pixel-level draw offsets / anchor points
+- Side effects: writes that look dead but are read by another system
+
+For UI, shell, sidebar, menu, viewport, sprite, and other visual work, the
+ledger must be a composition ledger, not a summary. Start from the full top-level
+paint/message/render path and include:
+
+- Draw order from entry point to return, including post-background and optional
+  helper calls
+- Per-dialog or per-mode flags that enable each optional draw layer
+- Exact asset names and frames; dump or inspect all SHP frames before choosing a
+  design around an asset
+- Source and destination rects, anchors, clipping/scissor, palette/convert path,
+  and z-order
+- Asset role classification: content/preview, chrome/container, overlay,
+  transition-only, loaded-but-inactive, or not used for the scoped role
+
+If a user screenshot, reference capture, or asset dump contradicts the current
+research conclusion, the research is incomplete. Do not design around the
+contradictory conclusion; reopen the paint path and find the missing layer,
+frame, flag, rect, or palette first.
+
+Each line cites a source: `[GHIDRA <addr>]`, `[doc: X_GHIDRA_REPORT.md §3]`,
+`[ini: rulesmd.ini Speed=]`, or `[UNKNOWN — needs RE]`.
+
+The ledger does not need to be exhaustive of everything the system does. It
+must cover details that could break the representative scenario, compound
+through a normal match, or create costly architecture debt. Every approach
+must explain how it preserves blocking/compounding items and where it records
+exactification residuals.
+
+### Step 5: Propose 2-3 Approaches
+
+For each approach, include:
+
+- **How it works** — brief description
+- **Architectural fit** — does it follow existing patterns or introduce new ones?
+- **Experience fit** — does this make the selected production scenario
+  retail-convincing without unsafe shortcuts?
+- **Detail coverage** — state where every milestone-blocking or compounding
+  item lives and list residuals explicitly.
+- **Trade-offs** — complexity, performance, maintainability, tech debt
+- **What it touches** — which modules/files/interfaces change
+- **Risk areas** — what could go wrong
+
+**Retail-convincing behavior is a first-class evaluation criterion.** For each
+approach, answer:
+
+- What active-gamemd mechanisms does the original have here? (branching,
+  state bytes, timing, visuals, input feel, draw order, audio cues, cursor
+  behavior near boundaries)
+- Which details are required for the representative production path,
+  deterministic state, and shared architecture?
+- Which differences remain honest DRIFT but are safe exactification residuals?
+- Would any small difference be frequent, noticeable, compounding, or
+  outcome-changing? If so, keep it in scope regardless of implementation size.
+- **Be suspicious of "clean" designs that don't mention any of the
+  ledger items.** Cleanness is often achieved by abstracting away exactly
+  the details that drive behavior. If an approach reads as elegant but its
+  player-experience ledger is empty, that's a red flag, not a strength.
+
+Lead with your recommendation and explain why. Call out if an approach introduces
+architectural inconsistency, tech debt, OR parity drift — and whether that's acceptable.
+
+In interactive work, present these to the user and wait for a choice. In an
+explicitly autonomous goal, choose the recommendation after adversarial
+self-review and continue.
+
+### Step 6: Present Design
+
+Scale each section to the complexity of the task. A small feature might need a few
+paragraphs; a major system needs full treatment.
+
+Cover as appropriate:
+- Architecture / component layout
+- Data structures and flow
+- Interfaces and contracts
+- Integration points with existing code
+- Error handling strategy
+- Testing strategy
+- Determinism considerations (for sim/ work)
+
+**Explicitly state:**
+- How the design integrates with existing architecture
+- Which existing patterns it follows or deviates from (and why)
+
+Present in sections and get approval after each major section during interactive
+work. Under an explicitly autonomous goal, review each section internally,
+record load-bearing objections and their resolution, then continue.
+
+### Step 7: Write Design Doc
+
+Save to `docs/plans/YYYY-MM-DD-<topic>-design.md` using this structure:
+
+```markdown
+# [Feature Name] Design
+
+## Goal
+One sentence.
+
+## Architecture Context
+How the existing system works in the area this feature touches.
+Key components, interfaces, data flow.
+
+## Impact Analysis
+What this changes, what depends on it, risk areas.
+
+## Chosen Approach
+What we're building and why this approach over alternatives.
+
+## Player-Experience Detail Ledger
+Milestone-blocking, compounding, residual, and unknown-risk details. Cite the
+source for claims and state why each item does or does not block the selected
+ordinary-skirmish scenario.
+
+## Design
+
+### Components
+### Interfaces / Contracts
+### Data Flow
+### Error Handling
+### Testing Strategy
+
+## Architectural Decisions
+Patterns followed, patterns deviated from (and why).
+Tech debt introduced (if any) and plan to address it.
+
+## Alternatives Considered
+Brief summary of rejected approaches and why.
+```
+
+### Step 8: Hand Off
+
+For interactive work, tell the user the design is ready and ask whether to plan,
+refine, or park it. Under an explicitly autonomous goal, hand the approved
+design directly into proportional planning and implementation.
+
+---
+
+## Anti-Patterns to Flag
+
+During brainstorming, actively call out these anti-patterns if you spot them in a
+proposed design (including your own proposals):
+
+- **"Just bolt it on"** — adding a feature without considering where it fits
+  architecturally. Ask: where does this belong in the module hierarchy?
+- **"New pattern for no reason"** — introducing a different way of doing something
+  the codebase already has a convention for. Ask: how is this done elsewhere?
+- **"Hidden coupling"** — a design that looks clean but creates invisible dependencies
+  between modules. Ask: what breaks if we change X?
+- **"Scope creep"** — the feature quietly growing beyond what was asked for.
+  Apply YAGNI ruthlessly. Ask: do we actually need this part?
+- **"Testing afterthought"** — a design where testability wasn't considered upfront.
+  Ask: how do we test this without spinning up the whole engine?
+- **"TS ghost"** — designing around a mechanic found in gamemd.exe that is actually
+  dormant Tiberian Sun legacy, not active in Yuri's Revenge. Ask: is this code
+  actually executed in a standard YR skirmish? Don't trust field names — verify
+  what they gate in the binary. (Example: WarheadTypeClass `Tiberium=` does NOT
+  control ore destruction — it only gates vein destruction.)
+- **"Convenience-disguised deferral"** — labelling an item "edge case", "rare",
+  or "low priority" without naming its trigger, ordinary-play frequency, player
+  effect, compounding risk, and downstream consumers. Effort is not a valid
+  impact measure.
+- **"First-helper fallacy"** - treating one helper's draw stack as the whole UI
+  composition. Ask: what does the parent paint handler draw after this returns?
+- **"Frame-zero tunnel vision"** - assuming SHP frame 0 is the relevant visual.
+  Ask: were all frames dumped or did Ghidra prove the exact frame?
+- **"Negative-role overreach"** - converting "not used as X" into "not visible at
+  all." Ask: which visual roles were actually ruled out?
+- **"Literal C++ port reflex"** - proposing to recreate native inheritance,
+  raw pointer vectors, COM/vtable plumbing, or global singleton mutation in Rust
+  just because gamemd uses those mechanisms internally. Ask: what exact behavior
+  contract must be preserved, and which Rust-native owner should preserve it?
+- **"Clean-Rust behavior loss"** - proposing an elegant Rust abstraction that drops
+  native ordering, lifecycle, RNG, timer, or same-tick consequences. Ask: where
+  does each native tiny-detail ledger item live in the design?
+
+---
+
+## Key Principles
+
+- **One question at a time** — don't overwhelm the user with 10 questions
+- **Architecture first** — understand the system before proposing changes
+- **YAGNI for speculative and out-of-matrix work** — preserve known residuals
+  in the ledger instead of implementing every possible native branch now.
+- **Complete player loops beat exhaustive local scope** — a smaller slice is
+  wrong when it leaves the selected production journey visibly broken or
+  creates deterministic/architectural debt. Expert-only exactification may
+  remain recorded for later.
+- **Visual parity requires composition closure** - for UI/render work, trace from
+  the paint/render entry point to return before deciding what the player sees.
+- **Explore alternatives** — always propose 2-3 approaches, never just one
+- **Name the trade-offs** — especially architectural ones
+- **Incremental validation** — present design in chunks, get approval
+- **Patterns matter** — follow existing conventions unless there's a good reason not to,
+  and document the deviation
+- **Determinism is sacred** — for any sim/ work, prove the design preserves lockstep
+  correctness
+- **Rust-native structure, retail-convincing behavior** - preserve verified
+  authority, deterministic state, common-path ordering, RNG use, lifecycle, and
+  player-visible effects; record bounded exact residuals honestly

--- a/.agents/skills/design-review/SKILL.md
+++ b/.agents/skills/design-review/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: design-review
+description: >
+  Review a brainstorm/design doc before implementation. Audits whether behavior
+  claims are grounded in cited research docs, INI/assets, source, or explicit
+  UNKNOWN/UNCHECKED status; checks that the chosen approach covers its
+  player-experience ledger without architecture drift. Usage: '/design-review design-doc-path'
+  or 'review this brainstorm design doc'.
+---
+
+# Design Review - Pre-Implementation Readiness Audit
+
+Review the design doc: **$ARGUMENTS**
+
+If `$ARGUMENTS` is empty, use the most recent `docs/plans/*-design.md`. If none
+exists, ask for a design doc path.
+
+## Hard Gate
+
+- Do not implement code.
+- Do not edit Rust.
+- Do not revise the design doc unless explicitly asked.
+- Findings first, ordered by severity.
+- Review against the retail-convincing ordinary-skirmish bar in `AGENTS.md`.
+  Preserve exact truth labels, but do not block implementation solely for a
+  bounded, documented expert-only residual.
+
+## Verdicts
+
+- `APPROVE`: implementation-ready; remaining unknowns are named, bounded, and not
+  blocking the chosen change.
+- `REVISE`: design needs citation, wording, approach, or test-plan fixes before
+  implementation.
+- `BLOCK`: design contradicts load-bearing evidence, guesses about consequential
+  behavior, leaves the representative loop broken, or creates
+  determinism/authority/lifecycle/architecture debt.
+
+## Review Workflow
+
+### 1. Load Grounding
+
+Read:
+
+1. `AGENTS.md`.
+2. The design doc.
+3. Every cited `docs/research/...` file section needed to verify its claims.
+4. Relevant Rust files named by the design.
+
+For parity-sensitive topics, request a compact `research_brief` from the
+research-index MCP first. If that capability is unavailable, run the CLI fallback
+from the repo root:
+
+```text
+python tools/research_index/brief.py --system <system> "<topic>" --limit 8
+```
+
+Use synthesis docs only as maps. Cite underlying Ghidra reports, traces, INI keys,
+or source files for verdicts.
+
+### 2. Extract Claims
+
+Extract only claims that matter to implementation readiness:
+
+- Active-YR gates and INI/default applicability.
+- Branch order, predicates, field reads/writes, clear/set paths, side effects, and
+  skipped side effects.
+- Rust architecture claims: modules, fields, callers, state flow, boundaries.
+- Chosen approach claims.
+- Test-plan claims.
+- Unknowns/deferred items.
+
+### 3. Verify Evidence
+
+For each parity claim:
+
+- `CONFIRMED`: cited source says this.
+- `MISMATCHED`: cited source says something else.
+- `UNCITED`: no usable citation.
+- `STALE`: source is superseded or contradicted by newer evidence.
+- `UNCHECKED`: design correctly marks this as not yet known.
+
+Rules:
+
+- An uncited parity claim is a finding.
+- A synthesis citation alone is not enough for a mechanism claim.
+- Runtime-only facts must not be inferred from static decompilation.
+- "Rare", "visually masked", "internal-only", and "probably equivalent" never
+  prove exact equivalence. They may support delivery deferral only when trigger,
+  ordinary-play frequency, player effect, compounding, and downstream risk are
+  documented.
+
+### 4. Ledger Coverage
+
+Check the player-experience ledger:
+
+- Every milestone-blocking and compounding item has an owner and production test.
+- Exactification residuals name trigger, frequency, player effect, and downstream
+  risk.
+- Unknown-risk items are investigated enough to determine whether they block.
+
+### 5. Architecture And Tests
+
+Verify:
+
+- `sim/` does not gain render/ui/audio/net dependency.
+- The design fits existing module boundaries.
+- It does not broaden scope into unrelated systems.
+- Tests cover the representative production path, negative side effects,
+  neighboring common paths, and deterministic state that could affect outcomes.
+
+## Output Format
+
+```text
+Verdict: APPROVE | REVISE | BLOCK
+
+Findings
+- [P1] ...
+- [P2] ...
+
+Open Questions
+- ...
+
+Implementation Readiness
+- ...
+```
+
+If there are no findings, say so explicitly and still list residual risks or test
+gaps.

--- a/.agents/skills/disparity-scan/SKILL.md
+++ b/.agents/skills/disparity-scan/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: disparity-scan
+description: >
+  Find disparities between active Yuri's Revenge gamemd.exe evidence and the
+  Rust implementation of a named system. Use research docs to discover
+  candidate behaviors, verify Rust state directly, and selectively verify
+  stale, ambiguous, conflicting, or load-bearing claims against the active
+  binary. Produce a structured list that separates verified gaps from
+  doc-derived candidates and fix priority from parity verdict. Trigger on
+  parity audits, requests to find disparities, or questions about what
+  gamemd has that Rust does not.
+---
+
+# Disparity Scan - Evidence vs Rust Implementation
+
+Find behaviors, visuals, sounds, INI keys, and edge cases for **`$ARGUMENTS`**
+that differ between active Yuri's Revenge evidence and the current Rust
+implementation.
+
+Use `docs/research/` for fast discovery and navigation. Research prose is not
+the specification: it supplies candidate claims, addresses, terminology, and
+prior interpretations. The active YR binary and observed retail behavior are
+authoritative. A doc-only claim must remain a candidate until its active-YR
+binding is verified.
+
+Keep the scan proportional. Verify current Rust directly for every finding.
+Escalate candidate gamemd claims when they conflict, are stale or ambiguous,
+would drive a high-impact fix, or concern load-bearing state, ordering,
+authority, RNG, determinism, bytes, or pixels. Leave lower-risk unverified
+claims clearly labeled instead of pretending they are confirmed gaps.
+
+Report exact truth separately from delivery priority. Rank verified gaps for
+the retail-convincing stock-skirmish milestone by normal-play frequency,
+player noticeability, loop breadth, compounding, outcome/determinism risk, and
+unblock value. Bounded expert-only differences remain visible as
+exactification residuals.
+
+If `$ARGUMENTS` is empty, ask the user what system to scan.
+
+---
+
+## Hard Gate - Read-Only Analysis, Candidate Handoff
+
+Modify no source or research input. The only ordinary write is the disparity
+report requested by this workflow.
+
+- Do not edit Rust, tests, INI data, or research docs.
+- Use Ghidra read-only during analysis.
+- Record research corrections and certainty-gated Ghidra metadata candidates
+  in the report rather than applying them.
+- Treat Ghidra metadata synchronization as a separate, explicitly authorized
+  mutation under ENGINE.md, never as part of a nominally read-only scan.
+
+By default, stop after reporting annotation candidates. Synchronize only when
+the user directly requests it or passes `--sync-ghidra-labels`. Child workers
+never mutate Ghidra.
+
+If the user asks to implement a fix during the scan, explain that this skill
+only identifies and verifies disparities. Hand implementation off as a
+separate task.
+
+---
+
+## Research Index Preflight
+
+Use the research-index MCP before manual searching. Prefer
+`research_brief(query=<system-or-topic>, system=<system>)`; if unavailable, use:
+
+```text
+python tools/research_index/brief.py "<system-or-topic>" --limit 8
+```
+
+If the exact system is known, add `--system <system>` (for example `bridges`,
+`miner`, `skirmish-ui`, or `chrono`). If it reports zero docs, retry without
+`--system`, then with the inferred exact system. Use `validate.py`, `map.py`,
+`handoff.py`, `graph.py implementation`, and `search.py` as needed to collect
+verified docs, stale warnings, Rust-status chunks, and likely touched files.
+
+The index is a locator, not proof. Read every cited source directly before
+using it in a finding.
+
+## Evidence Laws
+
+```text
+ACTIVE YR EVIDENCE IS AUTHORITATIVE.
+DOCS ARE DISCOVERY POINTERS AND INTERPRETATIONS, NOT THE SPEC.
+EVERY RUST-STATE CLAIM MUST COME FROM READING CURRENT CODE.
+```
+
+Apply this authority order:
+
+1. Active `gamemd.exe` bytes and reproducible observed retail behavior.
+2. Live Ghidra interpretation tied to the active binary.
+3. Research docs whose relevant claims were verified against that binary and
+   have no newer contradictory evidence.
+4. Stale, unverified, or provenance-unclear docs, used only as candidate leads.
+
+Prose alone never upgrades a claim to verified. If evidence conflicts, prefer
+the higher-authority source and report the conflict. Do not choose the claim
+that merely sounds plausible.
+
+Use these evidence states consistently:
+
+- **ACTIVE-YR VERIFIED** - supported by active-binary evidence, a reproducible
+  retail observation, or a still-current binary-verified doc with precise
+  provenance.
+- **DOC-DERIVED CANDIDATE** - supported only by research prose or an uncertain
+  active-YR binding. It may justify investigation, not implementation.
+- **RUST-STATE UNKNOWN** - current code could not be resolved confidently.
+- **INACTIVE / TS-LEGACY** - present in shared engine code but not active in
+  standard YR under the relevant defaults.
+
+```text
+TIBERIAN SUN != YURI'S REVENGE.
+```
+
+Filter TS-only mechanisms from active-YR gaps only after verifying their gate.
+Do not infer inactivity from a filename or an old doc label.
+
+```text
+EXACT VERDICT AND DELIVERY PRIORITY ARE SEPARATE.
+```
+
+For a verified active-YR difference, keep the exact verdict as DRIFT even when
+delivery priority is low. A different mechanism with one sampled same-output
+result remains DRIFT or UNCHECKED until exact equivalence is proven. Never turn
+a scan into a parity percentage or completion certification.
+
+---
+
+## Procedure
+
+### S1 - Resolve scope
+
+Parse `$ARGUMENTS`:
+
+- A system name such as `miner`, `garrison`, or `ore growth`: scan that system.
+- A specific function or file: scan only that boundary.
+- An ambiguous term: ask the user to narrow it.
+
+State the scope before continuing. Do not silently broaden it.
+
+### S2 - Inventory documented candidate behaviors
+
+Read every relevant document under `docs/research/` top to bottom. For each
+claim, record:
+
+- behavior, state transition, formula, timing, or decision logic;
+- visual, animation, opacity, particle, or sprite behavior;
+- audio cue or voice line;
+- INI key and claimed semantics;
+- edge case, constant, threshold, or ordering constraint;
+- doc path and exact section or line;
+- verification status, date/provenance when present, and any stale warning;
+- disagreement with other docs or known retail behavior.
+
+Build a flat numbered inventory. This is a candidate set, not a baseline that
+has already been proven and not yet a list of gaps.
+
+### S3 - Read the current Rust implementation directly
+
+For every candidate, locate the current implementation, including:
+
+- `src/sim/<system>/` for simulation behavior;
+- `src/render/` for visuals;
+- `src/rules/` for INI parsing and authority;
+- `src/sim/world/` and `app_*` for cross-cutting behavior.
+
+For each Rust-state claim:
+
+1. Open the current file.
+2. Read the relevant control flow and callers, not just a matching symbol.
+3. Record the exact file and line.
+4. Classify Rust as present, partial, missing, different, or unknown relative
+   to the candidate claim.
+
+If subagents are used, spot-check at least five returned Rust-state claims. If
+one is wrong, independently re-verify all claims from that worker.
+
+Do not promote the comparison result until the gamemd side also has an evidence
+state:
+
+- **VERIFIED MATCH** - active-YR behavior and current Rust are proven equivalent
+  at the audited boundary. Omit from the main gaps but retain in the appendix.
+- **VERIFIED GAP** - active-YR behavior is verified and Rust is missing,
+  partial, or different.
+- **DOC-DERIVED CANDIDATE** - Rust differs from a doc claim that has not been
+  sufficiently verified. Keep it out of confirmed gaps.
+- **RUST-STATE UNKNOWN** - the implementation side could not be established.
+
+### S4 - Verify gamemd claims proportionally
+
+Use live active-YR evidence before promoting a candidate when any of these
+conditions applies:
+
+- docs conflict, are ambiguous, stale, superseded, or lack an active-YR tie;
+- the finding would rank HIGH or materially drive an implementation decision;
+- it concerns state ownership, ordering, RNG, determinism, lifecycle,
+  irreversible transitions, byte layout, or pixel/result exactness;
+- the cited address, caller, flag gate, or mechanism identity is uncertain;
+- observed retail behavior contradicts the docs or Rust-side interpretation.
+
+Prefer the smallest decisive check: inspect active bytes, decompile the named
+function and callers, verify the gate, or reproduce the retail observation.
+Record exact evidence. If live verification is unavailable or inconclusive,
+keep the item as `DOC-DERIVED CANDIDATE` or `UNCHECKED`; do not guess.
+
+Do not exhaustively decompile every low-risk behavior by default. Use
+`re-investigate` for fresh mechanism research or `trace-action` for a concrete
+end-to-end behavior when the user needs deeper verification.
+
+When a doc is wrong, add it to **Doc errors discovered**. Do not edit it during
+this workflow.
+
+### S5 - Classify inactive and prerequisite-blocked items
+
+- **TS-legacy / inactive in YR:** exclude from active-YR gaps only with evidence
+  for the gate and relevant default. Record important filtered cases in the
+  appendix.
+- **Blocked by an unimplemented prerequisite:** retain the exact result. A
+  verified missing gamemd behavior remains a `VERIFIED GAP - BLOCKED`; an
+  unverified one remains a blocked candidate. Put it in the deferred section
+  and do not recommend implementing it before its prerequisite.
+- **Outside the stated scope:** record as a residual without expanding the scan.
+
+Never call a missing behavior "correctly absent" merely because its dependency
+has not been built yet.
+
+### S6 - Categorize and rank
+
+Group verified gaps by:
+
+- Visual / VFX
+- Behavior and state machines
+- Audio
+- INI integration
+- Edge cases
+- Determinism / multiplayer
+
+Rank delivery priority independently of evidence confidence:
+
+- **HIGH** - frequent, immediately player-visible, compounding, outcome-changing,
+  determinism-critical, or a broad unblocker.
+- **MEDIUM** - visible in a narrower ordinary-play situation.
+- **LOW** - rare or boundary-condition visibility but still real drift.
+
+Do not use code size as a priority proxy. Keep doc-derived candidates in their
+own section; do not let severity wording make them sound verified.
+
+### S7 - Write the report
+
+Save to `docs/gap-scans/YYYY-MM-DD-disparity-scan-<system>.md`:
+
+```markdown
+---
+title: Disparity Scan - <system>
+date: YYYY-MM-DD
+scope: <one-line scope statement>
+methodology: docs-first discovery, direct Rust verification, selective active-YR verification
+---
+
+# Disparity Scan - <system>
+
+## Scope and evidence basis
+
+<What was scanned, excluded, which docs were read, and what live binary or
+retail evidence was available.>
+
+## Summary
+
+- N documented candidate behaviors inventoried
+- N active-YR claims verified
+- N verified gaps
+- N doc-derived candidates awaiting verification
+- N verified matches / false positives
+- N deferred or prerequisite-blocked gaps/candidates
+
+This report is a dated disparity snapshot, not a parity percentage or
+completion certificate.
+
+## Verified gaps
+
+### HIGH priority
+
+**G<n>. <one-line description>**
+- **Active-YR evidence:** <binary address/caller, retail observation, or precise
+  verified-doc provenance>
+- **Research pointer:** <doc path and section/line>
+- **Rust state:** <missing/partial/different with file:line, or no equivalent found>
+- **Exact verdict:** DRIFT
+- **Priority rationale:** <frequency/player impact/compounding/unblock value>
+
+### MEDIUM priority
+<same structure>
+
+### LOW priority / exactification residuals
+<same structure>
+
+## Doc-derived candidates needing verification
+
+These are not confirmed gaps and must not be handed directly to implementation.
+
+**C<n>. <one-line candidate>**
+- **Doc claim:** <path and section/line>
+- **Rust state:** <directly verified file:line, or unknown>
+- **Missing proof:** <specific active-YR evidence needed>
+- **Potential impact:** <why verification may or may not be worth doing>
+
+## Deferred / blocked by prerequisites
+
+- **<gap or candidate>** - <evidence state>; blocked by <prerequisite>. The
+  disparity remains recorded, but implementation is not yet recommended.
+
+## Doc errors discovered
+
+- **<doc path and section>** - <incorrect claim and higher-authority evidence>
+
+## Appendix - verified matches and false positives
+
+| Preliminary claim | Evidence state | Actual Rust state |
+|-------------------|----------------|-------------------|
+| ... | ... | Implemented at <file:line> |
+
+## Ghidra annotation candidates
+
+| Address/source | Current metadata | Proposed metadata | Kind | Live proof | Status |
+|----------------|------------------|-------------------|------|------------|--------|
+| ... | ... | ... | label/comment/reference | ... | deferred/conflict |
+
+Write `None` when no candidate passes ENGINE.md's certainty gate.
+
+## Recommendations
+
+<Which verified gaps cluster, what deserves a separate brainstorm, which
+candidates need verification, and what should remain deferred.>
+```
+
+Lead with the summary and HIGH verified gaps. Every verified gap must cite:
+
+- decisive active-YR evidence;
+- the research pointer, when one exists;
+- current Rust state with file and line or explicit `no equivalent found`;
+- a player-impact rationale separate from the exact verdict.
+
+Never fabricate paths, addresses, or verification status.
+
+### S7.5 - Optional Ghidra metadata sync
+
+Stop after reporting candidates unless explicitly authorized to synchronize.
+If authorized, wait for all readers to stop and follow ENGINE.md's serial sync
+protocol. `--no-sync-ghidra-labels` or a read-only request prohibits syncing.
+
+### S8 - Hand off
+
+Tell the user where the report was saved and summarize verified gaps separately
+from unverified candidates. Offer appropriate next actions without choosing one:
+
+- brainstorm one verified HIGH gap;
+- run `/verify-doc` on a suspect document;
+- run `/re-investigate <subsystem>` when the research basis is weak;
+- run `/re-investigate <subsystem>` or `/trace-action <mechanic>` when deeper
+  verification is needed;
+- stay focused on the user's current task.
+
+---
+
+## Anti-patterns
+
+- **Treating docs as the specification.** A doc is a pointer or interpretation
+  until its active-YR claim is verified.
+- **Trusting delegated Rust-state claims.** Read current code and callers.
+- **Calling doc-vs-Rust disagreement a confirmed gap.** Without sufficient
+  gamemd evidence it is only a candidate.
+- **Skipping high-impact verification to stay fast.** Proportional does not mean
+  avoiding the decisive check.
+- **Decompiling every low-risk line by default.** Escalate based on uncertainty
+  and impact; use a deeper skill when exhaustive proof is requested.
+- **Restating docs instead of reporting differences.** Keep the inventory
+  internal and report matches only in the appendix.
+- **Treating blocked behavior as absent by design.** Preserve it as a blocked
+  gap or candidate.
+- **Treating TS legacy as active YR without checking its gate.**
+- **Severity-ranking by code size.** Rank player impact, frequency, and risk.
+- **Using a parity percentage.** A scoped scan cannot certify completion.
+- **Implementing during the scan.** Hand verified findings to a separate
+  brainstorm and implementation task.
+
+---
+
+## Distinction from sibling skills
+
+- **`disparity-scan`** - focused docs-first candidate inventory plus direct Rust
+  cross-check and proportional active-YR verification. Use for a faster bounded
+  sweep without treating docs as authority.
+- **`re-investigate <system>`** - fresh active-binary research with a durable
+  implementation handoff when existing evidence is insufficient.
+- **`verify-doc <doc>`** - verify one research document against the binary.
+- **`trace-action <mechanic>`** - verify one player action end to end through
+  simulation, rendering, and audio.
+
+---
+
+## Key principles
+
+- Surface disparities; let the user choose priorities.
+- Verify current Rust state for every reported comparison.
+- Separate verified gaps from doc-derived candidates visibly and consistently.
+- Preserve blocked and low-priority drift without promoting it prematurely.
+- Treat the report as a dated evidence snapshot, not a permanent source of truth
+  or a completion ledger.
+- Keep verified matches and false positives so later scans do not rediscover
+  them without checking whether the code or evidence has changed.

--- a/.agents/skills/implementation-contract/SKILL.md
+++ b/.agents/skills/implementation-contract/SKILL.md
@@ -1,0 +1,481 @@
+---
+name: implementation-contract
+description: >
+  Project-scoped for VERA20k/RA2 Yuri's Revenge only. Use after research,
+  synthesis, disparity scans, traces, or audits when the user wants to prove
+  exactly what Rust must implement or change to close a specific exact-mechanism
+  parity gap. Distills verified gamemd.exe behavior plus current Rust evidence
+  into a sourced `*_IMPLEMENTATION_CONTRACT.md` with required deltas, blockers,
+  and acceptance tests. Never writes Rust code.
+---
+
+# Implementation Contract
+
+Create an implementation contract for: **$ARGUMENTS**
+
+This skill is a distillation step between research/synthesis and
+brainstorming, planning, or implementation. It does not discover an entire
+system from scratch. It proves which Rust changes are actually required to close
+a bounded parity gap.
+
+For the current retail-convincing skirmish milestone, exact truth and delivery
+priority are separate columns. A proven exact delta remains `REQUIRED_FIX` as a
+truth statement, but may be an `EXACTIFICATION-RESIDUAL` rather than required
+now. Never soften the evidence verdict; never make a bounded expert-only delta
+block common-path implementation merely because it exists.
+
+Core proof:
+
+```text
+verified gamemd.exe behavior
++ verified current Rust behavior
++ mechanism, byte, pixel, timing, or downstream-result mismatch
+= required Rust delta
+```
+
+And the inverse:
+
+```text
+verified gamemd.exe behavior
++ verified current Rust behavior
++ proven byte-identical state and pixel/result-identical output over the relevant input space
+= test-only or documentation-only delta
+```
+
+Native-to-Rust translation rule:
+
+```text
+verified gamemd.exe mechanism
++ Rust-native ownership boundary that preserves the same semantics
+= acceptable implementation shape
+```
+
+Do not require literal C++ architecture ports. Do not recreate raw pointer
+vectors, global singleton mutation, COM/vtable plumbing, or the full native
+inheritance tree unless the evidence proves that no Rust-native structure can
+preserve the semantics. The contract must state the behavior to preserve and the
+Rust-native owner likely responsible for it: storage (`EntityStore`), active
+order (`LogicScheduler` or equivalent), lifecycle helpers, subsystem functions,
+or app/render consumers. The required delta is exact gamemd semantics in clean
+Rust, not C++ body shape in Rust syntax.
+
+Label-adversarial Ghidra rule: local Ghidra names, labels, comments, xref
+labels, and decompiler-assigned symbol names are navigation hints only. This
+project may contain polluted or stale labels from earlier scripts. Any contract
+claim that depends on function identity, caller identity, vtable slot identity,
+field role, or active-YR reachability must be verified from body/callsites/bytes
+or marked `BLOCKED`. Prefer address plus verified role over label name.
+
+---
+
+## Hard Gates
+
+- Do not write Rust, INI, asset, or research-doc patches.
+- The only filesystem artifact this skill may create or modify is its own contract under
+  `docs/contracts/`. Report Ghidra annotation candidates; synchronization requires
+  `--sync-ghidra-labels` or a direct user request.
+- Do not call something wrong unless both sides are proven:
+  - original gamemd behavior is sourced;
+  - current Rust behavior is verified by reading code;
+  - the difference affects mechanism, consumed bytes, pixels, timing, audio, UI,
+    or downstream results, or exact equivalence is unproven.
+- Do not treat synthesis docs as primary evidence. Use them as maps to the
+  underlying report, trace, Ghidra address, INI key, asset, or Rust surface.
+- Treat contradictions as primary evidence. If a screenshot, runtime result, test
+  failure, trace, asset dump, or user observation disagrees with the current
+  explanation, mark the row `BLOCKED` or `UNKNOWN` until the contradiction is
+  resolved with primary evidence.
+- Trace from the behavior owner, not a helper. UI contracts start from the
+  paint/message/render owner; gameplay contracts start from the tick/action
+  owner; parsing contracts start from the actual load/apply path; audio
+  contracts start from the event trigger path.
+- Prove activation in the target scenario before classifying a row as
+  `REQUIRED_FIX` or `TEST_ONLY`. Existing code in gamemd.exe is not
+  enough; record the target mode/dialog/map/unit/setting and the flag/key/case
+  that enables the behavior.
+- Inspect the relevant variant set before generalizing: SHP frames, YR `*md`
+  overrides, base INI fallback, dialog IDs, game-mode/difficulty branches,
+  house/faction overrides, map overrides, and optional flags.
+- Do not run broad reverse engineering. If evidence is missing, mark the item
+  `BLOCKED` and recommend `/re-investigate` or `/re-swarm`.
+- Use bounded live Ghidra spot-checks only when resolving a handoff-critical
+  contradiction or confirming a cited address.
+- A live spot-check may report a Ghidra annotation candidate only with its
+  address/source, current metadata, proposed label/comment/reference, and exact proof.
+  Workers and parallel readers remain read-only.
+- Do not spawn subagents unless the user explicitly requested delegated or
+  parallel work.
+
+---
+
+## When To Use
+
+Use this skill when the user asks for:
+
+- an implementation contract;
+- proof of what Rust needs to change;
+- a contract to close a parity gap;
+- turning a synthesis doc into concrete Rust deltas and tests;
+- proving whether suspected gaps are real before implementation.
+
+Do not use this skill for:
+
+- broad "what should we work on next" or backlog scans: keep outside this skill;
+- docs-vs-Rust disparity discovery across a whole system: use `/disparity-scan`;
+- new binary research: use `/re-investigate` or `/re-swarm`;
+- architecture option design: use `/brainstorm`;
+- task-by-task coding plans: use `/write-plan`.
+
+---
+
+## Classification Labels
+
+Every contract row must use one of these labels:
+
+- `REQUIRED_FIX` - Proven active-gamemd mechanism, byte, pixel, timing, audio,
+  UI, or downstream-result mismatch. Rust must change.
+- `TEST_ONLY` - Rust appears to match, but regression coverage is missing or
+  stale.
+- `DOC_ONLY` - Code behavior is acceptable; comments, tests, plans, or research
+  prose are stale or misleading.
+- `BLOCKED` - gamemd behavior is not verified enough for implementation.
+- `UNKNOWN` - current Rust behavior or source mapping could not be proven in the
+  time/scope available.
+
+Only `REQUIRED_FIX`, `TEST_ONLY`, and `DOC_ONLY` may become implementation work.
+`BLOCKED` and `UNKNOWN` require more investigation. There is no internal-only
+`NO_DELTA` classification for active YR behavior; if exact equivalence is not
+proven, classify the row as `REQUIRED_FIX`, `BLOCKED`, or `UNKNOWN`.
+
+Every row also receives one delivery class:
+
+- `MILESTONE-BLOCKING`
+- `COMPOUNDING`
+- `EXACTIFICATION-RESIDUAL`
+- `UNKNOWN-RISK`
+
+`BLOCKED` or `UNKNOWN` evidence blocks current implementation only when its
+delivery class is unknown-risk for the selected common scenario or it could
+affect deterministic/shared architecture.
+
+---
+
+## Step 0: Scope The Gap
+
+Parse `$ARGUMENTS` into one bounded parity target.
+
+State:
+
+- system name;
+- exact active-gamemd mechanism, byte, pixel/result, or suspected gap;
+- included surfaces;
+- explicit non-scope;
+- whether this is based on an existing synthesis doc, disparity scan, trace, or
+  direct user claim.
+
+If the scope is broad, narrow it before continuing. A good contract target is
+"CABHUT bridge collapse footprint", not "bridges".
+
+## Research Index Preflight
+
+Before manual doc gathering, use the research-index MCP first. Prefer
+`research_brief` and `research_handoff`; if unavailable, use the repo-local CLI
+fallback:
+
+```text
+python tools/research_index/brief.py "<topic>" --limit 8
+```
+
+If the exact system is known, add `--system <system>` (examples: `bridges`,
+`miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun without
+`--system`, then rerun with the inferred exact system. Use `validate.py`,
+`map.py`, `handoff.py`, `graph.py implementation`, and `search.py` for focused
+follow-up. Treat index output as navigation and evidence discovery; verified
+Ghidra docs, live binary checks, INI/assets, current Rust reads, and tests still
+decide parity.
+
+---
+
+## Step 1: Gather Evidence Baseline
+
+Search in this order:
+
+1. `<main-checkout>/docs/research/` for relevant
+   `*_SYSTEM_MODEL_SYNTHESIS.md`.
+2. Source reports cited by the synthesis:
+   - `*_GHIDRA_REPORT.md`
+   - trace docs
+   - verify-doc audit notes
+   - re-swarm / re-investigate outputs
+3. INI and art data:
+   - `ini/rulesmd.ini`, `ini/artmd.ini`
+   - base fallback `ini/rules.ini`, `ini/art.ini`
+4. Current Rust:
+   - use `rg` and direct file reads for symbol navigation;
+   - verify current behavior by reading actual lines.
+5. Existing plans, disparity scans, and gap scans as derivative context only.
+
+For every source, classify its role:
+
+- `PRIMARY`: direct binary, trace, INI, asset, or current Rust evidence.
+- `SYNTHESIS`: map/reconciliation source.
+- `DERIVATIVE`: plan, queue, scan, or old overview.
+- `STALE_OR_CONFLICTED`: useful only as a warning.
+
+---
+
+## Step 2: Establish The gamemd Baseline
+
+Extract only behavior that is safe enough to implement:
+
+- active in standard YR or explicitly scoped to a conditional path;
+- not TS legacy unless the user intentionally asked for that path;
+- backed by primary evidence or a synthesis claim pointing to primary evidence;
+- concrete enough to affect active function semantics, consumed bytes,
+  downstream values, pixels, audio, UI, or timing.
+
+For each behavior, capture:
+
+- exact mechanism and result;
+- timing/order within the tick or state flow;
+- constants, bounds, clamps, signedness, and rounding;
+- field reads/writes, state bytes, iteration order, and call order;
+- INI/asset source and fallback rule;
+- animation/audio/RNG order;
+- edge cases and stop conditions;
+- source citation.
+
+If a behavior matters but lacks evidence, mark it `BLOCKED`; do not infer it.
+
+For UI, menu, shell, sidebar, viewport, sprite, or other visual contracts, also
+require a visual asset role table before declaring any row implementation-safe:
+
+```markdown
+| Asset | Exact frame | Loaded | Drawn | Visible in target | Content/preview | Chrome/container | Overlay | Transition-only | Inactive | Evidence |
+|---|---|---|---|---|---|---|---|---|---|---|
+```
+
+Rules for visual baselines:
+
+- `REQUIRED_FIX` must cite complete paint order and target-mode/dialog flag state,
+  not just a loaded asset, a filename, or one helper function.
+- Multi-frame SHP evidence must name the exact frame. Frame 0 is not assumed.
+- Optional draw helpers must have their target-mode flag setters verified before
+  becoming implementation-safe.
+- Negative claims must be role-scoped. "Not used as preview backing" cannot be
+  converted into "not visible" unless the paint path proves that broader claim.
+- Stale negative docs become `DOC_ONLY` or `BLOCKED` until primary evidence proves
+  the specific visual role.
+
+---
+
+## Step 3: Verify Current Rust
+
+For each gamemd behavior candidate, find the current Rust owner or absence.
+
+Requirements:
+
+- Read the actual Rust files before claiming `missing`, `partial`, or `matches`.
+- Cite file paths and line numbers in notes.
+- Distinguish behavior from comments. A stale comment is not a behavior bug.
+- Treat internal implementation differences as DRIFT unless exact byte/pixel
+  equivalence is proven for the relevant input space.
+- For sim changes, check deterministic ownership and architecture boundaries.
+
+Do not trust filenames, TODOs, previous agent summaries, or synthesis Rust
+handoffs without reading the code.
+
+---
+
+## Step 4: Build The Parity Delta Table
+
+The table is the contract's core. Every row must be evidence-backed.
+
+Use this format:
+
+```markdown
+| Evidence class | Delivery class | Mechanism/result | gamemd.exe behavior | Current Rust behavior | Required Rust delta | Evidence | Acceptance test |
+|---|---|---|---|---|---|---|---|
+```
+
+Rules:
+
+- `REQUIRED_FIX` rows must have a specific required Rust delta and a test.
+- `TEST_ONLY` rows must say why behavior appears correct and what regression test
+  preserves it.
+- `DOC_ONLY` rows must name the stale prose/test wording and the correction.
+- `BLOCKED` rows must name the missing evidence and the recommended investigation.
+- `UNKNOWN` rows must name what Rust or source mapping could not be proven.
+- Visual/UI rows must include the relevant asset role, exact frame, paint-order
+  position, and target-mode flag state in either the row or its evidence note.
+
+If a row cannot be classified, the scope is not ready for an implementation
+contract.
+
+---
+
+## Step 5: Required Rust Changes
+
+Summarize current implementation work from rows classified
+`MILESTONE-BLOCKING` or `COMPOUNDING`. List exactification residuals separately
+without turning them into current tasks.
+
+For each required change, state:
+
+- owning module/function/type;
+- exact behavior to add, preserve, or correct;
+- data source to use instead of hardcoding;
+- architecture boundary constraints;
+- determinism/state-hash considerations for `sim/`;
+- risk area and likely dependent tests.
+
+This section is not a task-by-task implementation plan. Leave task breakdown to
+`/write-plan`.
+
+---
+
+## Step 6: Acceptance Tests
+
+Every `REQUIRED_FIX` must have at least one proof mechanism:
+
+- unit test for pure logic;
+- integration test or fixture for world behavior;
+- INI parse/default test;
+- trace/fidelity scenario for rendering, audio, UI, or gameplay timing;
+- explicit manual comparison only when automated verification is not currently
+  possible.
+- screenshot/pixel/manual parity scenario for UI/visual contracts, plus unit
+  coverage for rect/frame/order where the renderer exposes testable surfaces.
+
+Each test must say:
+
+- setup;
+- action;
+- expected mechanism, state bytes, downstream values, pixels, audio, UI, or
+  timing result;
+- which contract row it proves.
+
+Do not write "add tests" without concrete scenarios.
+
+---
+
+## Step 7: Known Non-Requirements
+
+List tempting changes that must not be implemented now:
+
+- stale-doc behavior contradicted by newer evidence;
+- TS legacy or inactive YR paths;
+- changes outside active-gamemd exact-mechanism parity;
+- behavior with proven byte-identical and pixel/result-identical equivalence;
+- broad refactors outside the gap.
+
+This section prevents over-implementation.
+
+---
+
+## Step 8: Blockers And Follow-Ups
+
+List all `BLOCKED` and `UNKNOWN` items with the next appropriate skill:
+
+- `/re-investigate` for one narrow binary question;
+- `/re-swarm` for several independent binary questions;
+- `/disparity-scan` when current Rust comparison is still too broad;
+- `/brainstorm` when behavior is proven but architecture placement is unclear;
+- `/write-plan` when the contract is approved and implementation tasks are next.
+
+---
+
+## Step 9: Write The Contract
+
+Save to:
+
+```text
+docs/contracts/YYYY-MM-DD-<topic>-implementation-contract.md
+```
+
+Use this template:
+
+```markdown
+# [System] Implementation Contract
+
+Date: YYYY-MM-DD
+Scope: <bounded scope>
+Status: <READY_FOR_PLAN | PARTIAL_READY | BLOCKED>
+
+## Gap Being Closed
+One sentence describing the mechanism, byte, pixel, timing, or downstream-result mismatch or suspected mismatch.
+
+## Scope
+Included:
+- ...
+
+Excluded:
+- ...
+
+## Evidence Baseline
+| Source | Role | Use |
+|---|---|---|
+
+## Parity Delta Table
+| Class | Mechanism/result | gamemd.exe behavior | Current Rust behavior | Required Rust delta | Evidence | Acceptance test |
+|---|---|---|---|---|---|---|
+
+## Required Rust Changes
+- ...
+
+## Acceptance Tests
+- ...
+
+## Known Non-Requirements
+- ...
+
+## Blockers And Follow-Ups
+- ...
+
+## Source Ledger
+- ...
+
+## Ghidra Annotation Candidates
+- None | <address/source, current metadata, proposed mutation, proof, status>
+```
+
+Set status:
+
+- `READY_FOR_PLAN` when all required behavior is proven and deltas/tests are
+  concrete.
+- `PARTIAL_READY` when some rows are ready but bounded blockers remain.
+- `BLOCKED` when the core gap cannot be proven yet.
+
+## Step 9.5: Optional Ghidra Annotation Sync
+
+By default, stop after reporting candidates in the contract. If
+`--sync-ghidra-labels` was provided or the user directly requested synchronization, the
+root/standalone run waits for every reader to stop and follows ENGINE.md's serial sync
+protocol. A read-only request or `--no-sync-ghidra-labels` disables synchronization.
+
+---
+
+## Quality Checklist
+
+Before finishing, verify:
+
+- Every `REQUIRED_FIX` row proves gamemd behavior, Rust behavior, mechanism or
+  byte/pixel/result mismatch, required delta, and test.
+- No row cites only a synthesis doc when primary evidence is available.
+- Stale docs are treated as warnings and source maps, not blockers. If primary
+  evidence contradicts an old report, the contract follows primary evidence and
+  records the stale claim as `DOC_ONLY` or a follow-up correction.
+- No `NEEDS_REINVESTIGATE` claim is treated as implementation-safe.
+- No TS-legacy or inactive path is listed as required for standard YR.
+- No active-gamemd mechanism difference is dismissed as internal-only unless
+  exact byte/pixel equivalence is proven.
+- Every test maps to at least one table row.
+- The contract names what *not* to implement.
+- The handoff clearly says whether to run `/brainstorm`, `/write-plan`, or more
+  research next.
+- Ghidra annotation candidates are listed with applied/deferred/conflicted status, or
+  explicitly `None`; no uncertainty was converted into metadata.
+- Every visual/UI `REQUIRED_FIX` row has exact asset role, frame, paint-order
+  position, and target-mode flag proof.
+- No visual/UI row generalizes a scoped negative claim into a broader negative.
+- Any optional visual helper without verified flag setter evidence is `BLOCKED`.

--- a/.agents/skills/re-investigate/SKILL.md
+++ b/.agents/skills/re-investigate/SKILL.md
@@ -1,0 +1,804 @@
+---
+name: re-investigate
+description: "Use when studying, researching, or reverse-engineering a gamemd.exe system before implementation. Produces a verified research document with an implementation handoff, but never writes Rust code. Usage: '/re-investigate chrono miner teleport' or '/re-investigate garrison fire logic' or '/re-investigate power drain formula'"
+---
+
+# RE Investigate — Structured Reverse Engineering
+
+Research `$ARGUMENTS` in gamemd.exe using a structured, evidence-based process. Produce a verified research document. Do NOT write any Rust code.
+
+<HARD-GATE>
+Do NOT implement anything. Do NOT modify any .rs file. Do NOT write Rust code or
+patches. The research report MUST include an implementation handoff that names
+affected Rust surfaces and acceptance scenarios, but it must not contain patch
+text or code snippets. The ONLY filesystem artifact is a research document saved
+to `<main-checkout>/docs/research/`. Report Ghidra annotation
+candidates, but do not synchronize them unless the invocation includes
+`--sync-ghidra-labels` or the user directly requests it. If you catch yourself writing
+Rust code, STOP and delete it. This applies regardless of how "simple" the
+implementation seems.
+</HARD-GATE>
+
+**What we are extracting and why.** Research truth remains exact: record scoped
+active-gamemd branches, constants, field reads/writes, ordering, rounding, RNG,
+assets, draw/audio timing, and uncertainty precisely. Do not label an
+approximation as verified. The implementation handoff must separately classify
+which findings are milestone-blocking, compounding, exactification residuals,
+or unknown-risk for ordinary stock skirmish.
+
+## Iron Laws
+
+```
+CONTRADICTIONS ARE PRIMARY EVIDENCE
+```
+
+If a screenshot, runtime result, test failure, trace, asset dump, or user
+observation contradicts the current explanation, assume the explanation is
+incomplete. Do not defend the model and do not implement from it. Reopen the
+investigation, name the contradiction in the Open Questions Log, and resolve it
+with binary, asset, INI, runtime, or source evidence.
+
+```
+TRACE FROM THE OWNER, NOT THE HELPER
+```
+
+Start from the behavior owner for the target scenario before trusting a helper:
+paint/message/render handlers for UI, tick/update/action pipelines for gameplay,
+event trigger paths for audio, actual load/apply paths for parsing, and input
+dispatch paths for commands. A helper only proves behavior after you prove the
+target owner calls it under the target conditions.
+
+```
+PROVE TARGET ACTIVATION
+```
+
+Code existing in gamemd.exe is not enough. For every claimed behavior, prove it
+is active in the target game, mode, dialog, map, unit, house, difficulty, or
+setting. Record the enabling flag/key/case, its default value in standard YR
+where applicable, and whether the target scenario actually reaches it.
+
+```
+INSPECT THE VARIANT SET
+```
+
+Before choosing a conclusion from one variant, inspect the relevant variant set:
+all active SHP frames, YR `*md` overrides before base INI fallback, dialog IDs or
+switch cases, difficulty/game-mode branches, house/faction overrides, map
+overrides, and optional flags. If the full set is too large, state the bounded
+subset and mark the rest `deferred` instead of generalizing.
+
+```
+STALE DOCS ARE WARNINGS, NOT BLOCKERS
+```
+
+Older reports and synthesis docs are maps to evidence, not final authority. When
+they conflict with binary, runtime, asset, INI, screenshot, or current Rust
+evidence, the primary evidence wins. Record the stale claim and update or hand
+off the correction instead of letting the old prose block the investigation.
+
+```
+GHIDRA LABELS ARE HINTS, NOT TRUTH
+```
+
+Local Ghidra names, labels, comments, xref labels, and decompiler-assigned symbol
+names are navigation aids only. This project may contain polluted or stale labels
+from earlier scripts. For every load-bearing claim, verify from the function body,
+assembly/decompile, callsites, receiver/`this` pointer, argument flow, vtable slot
+bytes, data references, and active-YR reachability. Prefer address plus verified
+role over label name. If a label is wrong or ambiguous, record the label drift and
+do not let the old name drive architecture or implementation.
+
+Every vtable claim requires a CompleteObjectLocator walk (`vtable-4` →
+`COL+0x0C` → TypeDescriptor mangled name), a slot read at `vtable+N*4`, and a
+decompile of the resulting function body. Cite all three inline. Ghidra display
+labels are not identity evidence; if the owner or body is unproven, mark the
+claim `UNCHECKED` rather than inferring it from a name.
+
+```
+THE TINY DETAILS ARE THE WHOLE POINT — NOTHING ELSE COMES CLOSE
+```
+
+**By far the most important output of this skill is the tiny details you would
+normally dismiss as not worth writing down.** Not the high-level summary. Not the
+algorithm overview. Not the "main flow." Those are the easy parts and they are not
+why we are here.
+
+We are here for:
+
+- The `+1` after a multiply that nobody would notice
+- The `if (x == 0) return` that handles one specific frame
+- The constant `0x67` that turns out to be the cell size in a different unit
+- The order in which two writes to the same field happen in the same tick
+- The flag bit that's checked once and only matters when another flag is set
+- The early-out condition three calls deep in a helper
+- The clamp that saturates at `0xFF` instead of `0x100`
+- The fact that the function reads the field BEFORE the caller has updated it
+- The `<` that should obviously be `<=` and isn't
+- The branch that looks dead but writes a side-effect read elsewhere
+- The default value a field holds when nothing has touched it yet
+- The signed-vs-unsigned comparison that flips behavior at the boundary
+
+If your report describes the system at the level of "it does X, then Y, then Z,"
+**you have failed**, no matter how clean the prose is. The summary is the cheap
+part. The summary is what a 10-minute skim of the function gives you. We are paying
+the cost of a full investigation **specifically to surface the things a skim would
+miss**. If the report does not contain at least a dozen findings of the form "this
+specific tiny thing, in this specific place, with this specific value, and here's
+why it matters" — keep digging. You are not done.
+
+A reader of the final report should think: *"I would never have noticed any of this
+on my own."* That feeling is the success criterion. If they instead think *"yeah,
+that's roughly what I'd have guessed,"* the report is worthless — it has told them
+nothing they didn't already know.
+
+**Default to over-recording.** When you are unsure whether a detail is worth noting,
+the answer is yes. The cost of an extra noted constant or branch is one line in the
+report. The cost of a missing one is a parity bug nobody can find later. Err
+massively toward over-recording. Tiny details cost almost nothing to document and
+are almost impossible to recover later without redoing the whole investigation.
+
+```
+NO CLAIMS WITHOUT BINARY EVIDENCE
+```
+
+Every finding must state its evidence source and confidence level. "I think it works like X" is not a finding — it's a guess. Guesses go in an "Open Questions" section, not in findings.
+
+```
+DETAILS COMPOUND — THE INVISIBLE ONES MATTER MOST
+```
+
+Most parity-breaking details are **not directly visible** — a one-tick delay before
+a turret starts rotating, an off-by-one in a damage clamp, a flag that only matters
+on one frame of an animation. These don't jump out to the player, but they compound.
+Two "invisible" 5%-off details interacting produce a behavior the player feels but
+can't articulate. **If a detail exists in the binary, assume it matters until proven
+otherwise.** Document it. Don't filter findings by "will this be visible?" — filter
+by "is this what the binary actually does?"
+
+The temptation to skip a detail because "it probably doesn't matter" is the single
+biggest failure mode of this skill. Resist it every time. The whole point of the
+skill is to capture exactly the details that "probably don't matter" — because in
+aggregate, they're what separates exact byte/pixel parity from drift.
+
+This skill exists because details are hard to catch. That is the job. If your report
+lists the happy path and skips the edge cases, constants, clamps, and off-by-ones,
+you have not done the job — regardless of how clean the report looks.
+
+```
+DECLARE THE INVESTIGATION MODE BEFORE YOU DIG
+```
+
+Half-investigating a system is worse than not investigating it when the output
+pretends to be complete. For an `exhaustive-slice`, decompile every relevant
+function, examine every branch, explain every magic number, check every flag
+default, and trace every edge case. For a `coverage-map`, do not pretend to
+complete the system; make the unknowns and follow-up queue the primary output.
+"Ran out of steam" is not a stopping condition. Either drain the slice, or label
+the report as partial/coverage-map and show exactly what remains.
+
+There are two valid modes:
+
+- **coverage-map**: use for broad systems, vague user prompts, global architecture,
+  tick loops, "overall" behavior, or any topic where the first honest job is to
+  discover entry points and unknowns. The output is a coverage map, not a completed
+  proof. It must say which areas were verified, touched, not touched, and deferred.
+- **exhaustive-slice**: use only for a bounded subsystem small enough to drain every
+  open question in the current session. The output may claim completeness only for
+  that exact slice, never for the parent system.
+
+Default to **coverage-map** when the scope is broad. Do not ask the user to narrow
+unless the request cannot be made useful; instead, make the mode explicit and
+produce an honest map of what remains. Never use filenames, headings, summaries, or
+phrases like "completion", "fully investigated", "entire system", or "all covered"
+unless the Open Questions Log is drained and the Coverage Ledger has no material
+unknowns for the stated slice.
+
+```
+EXHAUSTION, NOT COVERAGE — THE OPEN QUESTIONS LOG IS THE GATE
+```
+
+The single biggest failure mode of this skill is declaring "done" because the
+**topic feels covered** — the main flow is described, the report reads well,
+the summary makes sense. That is coverage, not exhaustion. Coverage is when a
+reader cannot tell what's missing. Exhaustion is when **you** cannot name what's
+missing — because you've maintained an explicit list of unknowns and driven it
+to zero.
+
+You MUST maintain an **Open Questions Log** throughout the investigation. It is
+seeded in Step 0.5, grown in Step 2 every time you encounter a new unknown, and
+drained in Step 3. The investigation is not complete until **every entry in the
+log is either resolved with evidence or explicitly deferred with a stated reason
+and category** (e.g., "deferred — requires runtime debugger to observe"). A
+non-empty log with un-deferred items means you are not done — regardless of how
+many functions you've decompiled or how polished the report looks.
+
+"Covered the topic" is not a stopping criterion. "Open Questions Log has zero
+un-deferred items AND I added no new items in my last full pass" is. This is the
+single check that converts the skill from breadth-by-feel to breadth-by-construction.
+
+```
+TIBERIAN SUN ≠ YURI'S REVENGE
+```
+
+gamemd.exe is the engine for BOTH Tiberian Sun and Yuri's Revenge. It inherited a massive
+TS codebase. Many systems, fields, and code paths exist in the binary but are **disabled,
+repurposed, or irrelevant** in YR. Before reporting any finding:
+
+1. **Verify the code is active in YR** — not gated behind a TS-only flag, not a dead code
+   path, not overridden by a YR-specific implementation.
+2. **Don't trust field/flag names at face value.** TS-era names persist in the binary but
+   may gate something completely different in YR context. Example: `Tiberium=yes` on a
+   WarheadTypeClass does NOT gate ore destruction — it only gates **vein** destruction.
+   The name misleads because "Tiberium" is TS terminology. Always trace what the flag
+   actually controls in the code, not what the name implies.
+3. **Check default values.** A feature may exist in code but default to off in YR
+   (e.g., `FogOfWar` defaults false — it's TS legacy).
+4. **When documenting, always state "Active in YR: Yes/No/Conditional"** for each finding.
+   If conditional, state the exact condition and its default value in a standard YR skirmish.
+
+## Step 0 — Scope, prior work, and duplication check
+
+1. Parse `$ARGUMENTS` into a specific system, mechanic, or class to investigate.
+
+2. Classify the request as `coverage-map` or `exhaustive-slice` and state that mode
+   to the user before proceeding.
+
+   Use `coverage-map` for broad prompts such as "global timing", "the combat
+   system", "movement overall", "find disparities", "entire system", or any request
+   whose entry points are not already bounded. The deliverable is a coverage ledger
+   and a follow-up investigation queue.
+
+   Use `exhaustive-slice` only when the target is narrow enough to resolve every
+   open question in one pass, such as one helper function, one INI key's read/use
+   chain, one state transition, or one specific gameplay action.
+
+3. If `$ARGUMENTS` is so broad that even a useful coverage map cannot be scoped,
+   ask the user to narrow scope before proceeding.
+
+4. **Plan-path check (do this first, before anything else).** If `$ARGUMENTS` references an investigation plan at `docs/plans/YYYY-MM-DD-<topic>-investigation-plan.md`, OR the wording matches a recent plan in `docs/plans/`:
+   - Read the plan's frontmatter and locate the **Expected Output** path (typically `<main-checkout>/docs/research/<TOPIC>_GHIDRA_REPORT.md`).
+   - `ls` that path. If the file exists AND its mtime is newer than the plan's mtime, a parallel/earlier session already executed the plan. Go to step 5.
+
+5. Use the research-index MCP before broad manual doc search:
+
+   ```text
+   research_brief(query="<topic>", limit=8)
+   ```
+
+   If MCP is unavailable, use the equivalent repo-local `brief.py` CLI.
+
+   If the exact system is known, add `--system <system>` (examples: `bridges`,
+   `miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun
+   without `--system`, then rerun with the inferred exact system. Use
+   `validate.py`, `map.py`, `search.py`, and `graph.py evidence` to identify
+   existing verified docs, stale warnings, and likely Rust touchpoints. Treat the
+   index as navigation; live Ghidra/binary evidence still decides new findings.
+
+6. Check for existing research — search BOTH locations:
+   - `docs/` (in-repo)
+   - `<main-checkout>/docs/research/` (ignored in-repo research corpus)
+
+   Sort matches by mtime descending. Read any matching report modified in the
+   last 6 hours before proceeding; it may be a parallel session's output.
+
+7. **Decide before starting the investigation work.** Apply this table and tell the user which row fires:
+
+   | Prior state | Action |
+   |-------------|--------|
+    | No relevant research exists | Proceed to Step 1 — full investigation. |
+    | Matching report modified in the last 6 hours | **STOP.** Read it fully, compare it to the requested scope, and report covered/partial/open before any duplicate work. |
+   | Partial / LOW–MEDIUM confidence report exists | Proceed to Step 1 — scope to **gaps + verification only**, do not re-cover ground. |
+   | Recent HIGH-confidence report covers the topic | **STOP.** Recommend `/verify-doc <report>` for audit, or `/re-investigate <topic> --extend <specific gap>` if the user wants a targeted follow-up. Do not silently re-execute. |
+   | **Expected-output file from a plan already exists and is newer than the plan** | **STOP.** A parallel session executed it. Read the report, diff against the plan's Success Criteria, and report to the user: "covered / partial / open" per criterion. Do not re-execute. |
+   | Recent report has explicit open questions or "Phase 2/3 deferred" markers | Proceed to Step 1 — scope to **those specific gaps**, cite the parent report. |
+
+   When proceeding, state which row applied and what's in-scope vs. out-of-scope.
+
+8. If proceeding, read any existing report fully before Step 1. Your job is to **extend or verify** it, not duplicate it.
+
+## Step 1 — Parallel research
+
+Gather these inputs as three local workstreams. Run independent filesystem
+searches in parallel when practical. Use internal Codex subagents only when the
+active session instructions permit; never create a user-owned task/thread without
+an explicit request. Each input returns structured findings.
+
+When subagents are used, require each return to stay at 150 lines or fewer, name
+every artifact path, and include at most five load-bearing verified facts with
+one-line evidence. Raw decompilation, assembly, INI dumps, source bodies, and full
+struct tables belong in artifacts, not the return.
+
+**Workstream A — Doc search:**
+- Search `docs/` and `<main-checkout>/docs/research/` for ALL reports related to the topic. Search broadly — related systems, not just exact name matches.
+- For each relevant report: extract verified findings (formulas, state machines, offsets, constants, conditions).
+- Note any conflicting claims between reports.
+- Return: list of findings with source file for each.
+
+**Workstream B — INI data extraction:**
+- Grep `ini/rulesmd.ini` and `ini/artmd.ini` for all keys related to the target system.
+- Also check `ini/rules.ini` and `ini/art.ini` for base RA2 values (YR `*md` overrides take priority).
+- For each relevant key: extract the key name, default value, section it appears in, and what it likely controls.
+- Return: structured list of INI keys with values and sections.
+
+**Workstream C — Rust implementation scan:**
+- Search `src/` for the current Rust implementation of this system.
+- Extract: what's implemented, what state machine states exist, what formulas are used, what INI keys are read.
+- Do NOT judge correctness — just document what exists.
+- Return: file paths, function names, current logic summary.
+
+## Step 1.5 — Seed the Open Questions Log
+
+Before touching Ghidra, write the initial Open Questions Log. This is the
+investigation's spine. Maintain it with Codex `update_plan` when that is useful,
+or as a working `<TOPIC>_OPEN_QUESTIONS.md` file in your scratch space,
+whichever keeps it visible across tool calls. The final state lives in Section 7
+of the report.
+
+Start the log with the selected investigation mode:
+
+```
+[MODE] coverage-map | exhaustive-slice
+[SCOPE] exact slice being claimed
+[NON-SCOPE] related areas intentionally not claimed
+```
+
+If the selected mode is `coverage-map`, deferred entries are expected, but they
+must become the follow-up queue. If the selected mode is `exhaustive-slice`, any
+material deferred entry downgrades the final report to partial/coverage-map.
+
+**Required seed entries (every investigation must include all of these):**
+
+1. **Entry points** — every function/vtable slot/string xref that could plausibly
+   enter this system. Each one becomes an open question: "Is FUN_XXXXXX actually
+   on a live path in YR? What does it do?"
+2. **Every INI key from Workstream B** — each one becomes: "Where is this key read in
+   the binary? What does it gate? What's the default-vs-override behavior?"
+3. **Every existing claim from Workstream A** — each prior-doc finding becomes: "Is
+   this still true in the current binary? What's the address that proves it?"
+4. **Every Rust function from Workstream C** — each one becomes: "Does this match
+   gamemd's behavior, and what specific output does it produce vs the binary?"
+5. **Tick-cycle integration** — "When in the tick does this system run? What
+   reads its output? What writes to its inputs?"
+6. **TS legacy filter** — "Which fields/flags/branches in this system are TS
+   holdovers vs. live in YR? What's the default for each gate?"
+7. **Edge / corner cases** — explicitly enumerate at least: null pointer, zero
+   value, max value, empty container, first-tick, last-tick, paused, replay/save
+   restore. Each is an open question until proven irrelevant or handled.
+
+**Format for each entry** (keep terse — one line per question):
+
+```
+[OPEN] <id> — <question>
+[RESOLVED] <id> — <one-line answer> (evidence: <address / doc / INI key>)
+[DEFERRED] <id> — <one-line reason> (category: out-of-scope | needs-runtime-debugger | requires-different-system-context | bounded-cost-too-high)
+```
+
+A seed log with fewer than ~15 entries for a non-trivial system means you have
+not thought hard enough about what could be unknown. Add more before proceeding.
+
+## Step 2 — Ghidra deep dive (THE CORE — spend most of your time here)
+
+After collecting parallel results, go to Ghidra MCP for the authoritative binary analysis.
+This step is the entire point of the investigation. Do NOT shortcut it.
+
+Keep evidence collection read-only while any parallel reader is active. A
+child/worker never mutates Ghidra; it reports candidates for the parent with address,
+current metadata, proposed mutation, and the live binary calls that prove it. This
+skill stops at that candidate ledger by default. An explicitly authorized root sync
+follows ENGINE.md after every reader has stopped.
+
+**Time budget:** Spend at least 70% of your total effort in this step. If you've only
+decompiled 2-3 functions, you almost certainly haven't gone deep enough. A typical
+investigation should decompile **5-15+ functions** depending on system complexity.
+
+**Finding the entry point:**
+1. Search for relevant string constants (INI key names, error messages, class names)
+2. Follow xrefs from strings into the functions that read/use them
+3. If searching for a class method, find the class vtable first, then locate the method
+4. If Ghidra missed a function boundary, do not create it under metadata-sync
+   authorization. Inspect bytes/reachable callers read-only or record the
+   boundary uncertainty unless the user explicitly authorized function creation.
+
+**For each function you decompile:**
+1. Note the address and check `param_1` type:
+   - `param_1` is `int` → offsets like `*(param_1 + 0x98)` are direct byte offsets
+   - `param_1` is `int *` → `param_1[0xac]` means byte offset = `0xac * 4`
+   - `*(type *)((int)param_1 + 0x372)` is always a direct byte offset regardless
+2. Extract: conditions, formulas, constants, state transitions, branching logic
+3. **Follow ALL callees** — decompile every helper function, not just "non-trivial" ones.
+   A 5-line helper can contain the critical detail that makes the whole system make sense.
+   The only exception is obvious utility functions (memset, strlen, etc.)
+4. Check xrefs to understand who calls this function and when
+5. **Read the branch you DIDN'T expect.** When you see an if/else or switch, don't just
+   follow the "normal" path — examine the error path, the edge case path, the fallback.
+   These are where the important behavioral details live.
+6. Record an annotation candidate only when the evidence meets ENGINE.md's label or
+   synthetic-xref certainty gate. Otherwise explicitly record `annotation: none`.
+
+**Depth requirements — follow the chain:**
+- When you find the primary function, decompile it fully.
+- For each callee in that function: decompile it too.
+- For important callees (state machines, formulas, lookups): go one MORE level deep.
+- For the primary function's callers: decompile at least the immediate caller to understand
+  when/how this system is invoked and what context is passed in.
+- **If you see a vtable dispatch** (call through a function pointer), resolve which concrete
+  method is being called. Don't just note "calls vtable+0x48" — find the actual implementation.
+- **If you see a global variable or static array**, inspect its contents or initialization.
+  These often contain lookup tables, default values, or state that changes behavior.
+
+**Branching rule — every unknown spawns a new Open Questions entry.**
+
+This is mandatory and load-bearing. The skill cannot be exploratory if you do
+not externalize unknowns the instant you encounter them. Every time you hit
+ANY of the following while decompiling, **add a new `[OPEN]` entry to the log
+before continuing the current function**:
+
+- A **callee** you haven't decompiled yet (even "obvious" helpers — log it,
+  decide later)
+- A **caller** of the current function you haven't traced
+- A **struct field** read or written at an offset you haven't documented
+- A **global variable** or static array referenced
+- A **flag bit** checked or set (each bit is its own entry unless already covered)
+- A **vtable slot** dispatched through — log "which concrete method is bound here?"
+- A **constant** whose meaning is not immediately obvious
+- A **branch** (if/switch) where you haven't yet examined both/all paths
+- A **string xref** the function uses
+- An **INI key** read by this function that wasn't in the Workstream B list
+
+You may not close a parent open question until **every child entry it spawned
+is resolved or explicitly deferred**. A function is not "done" because you
+read it top to bottom — it is done when its open questions are drained.
+
+**Pass discipline.** Work in passes. A pass = decompile-until-no-new-callees-or-
+unknowns-pop-up. Between passes, re-read the Open Questions Log top to bottom
+and pick the next `[OPEN]` item. The investigation may not exit Step 2 until
+**you have completed a full pass that added zero new entries to the log**.
+That zero-add pass is the empirical signal of exhaustion. If your last pass
+added even one entry, do another pass.
+
+**Detail extraction — the things that matter most:**
+
+The details below are the *primary deliverable* of the investigation. A report that
+describes the overall algorithm but misses the constants, clamps, orderings, and edge
+cases is a failed report — even if the summary reads well. Many of these details are
+invisible at a glance but load-bearing for parity. Treat every one as non-optional.
+
+- **Magic numbers**: Every constant in the code (0x100, 0x600, 256, etc.) — document what
+  it represents. Don't just note the value; figure out WHY that value.
+- **Bit flags and masks**: When you see `& 0x1F` or `| 0x40`, document each bit's meaning.
+  Check if other functions use the same flags — build the complete flag set.
+- **Timing and ordering**: Note the exact order of operations. "A happens before B" is a
+  finding. "A and B happen but I didn't check the order" is incomplete.
+- **Edge cases**: What happens when a value is 0? When a pointer is null? When an array
+  index is out of bounds? The original engine has specific behavior for these — document it.
+- **Clamping and bounds**: Does the code clamp values? What are the min/max? Is it
+  saturating or wrapping? These details affect gameplay.
+- **Off-by-ones and inclusive/exclusive ranges**: `<` vs `<=`, `i < n` vs `i <= n`, ranges
+  that include or exclude their endpoints. These are invisible bugs that cause 1-tick or
+  1-cell drift from gamemd.exe. Always check.
+- **Rounding and truncation**: When the code converts between types or divides, does it
+  round, truncate, or floor? Which direction? This matters for fixed-point sim math.
+- **Default values and initialization**: What does a field hold before the system touches
+  it? Zero-init, constructor-set, copied from a template? This decides edge-case behavior.
+- **Sign, overflow, saturation**: Signed vs unsigned comparisons, whether arithmetic can
+  wrap, whether the code catches it. An unsigned underflow on a counter changes behavior.
+- **"Dead" assignments and side effects**: A write that looks dead may be read by another
+  system later in the tick. Note it; don't skip it because "nothing uses this here."
+
+**UI / visual paint-path completeness:**
+
+For UI, menu, shell, sidebar, and render parity, the first draw helper is not the
+composition. Trace from the top-level paint/message/render entry point until the
+handler returns, including every draw call that runs after the parent background,
+base chrome, or "main" helper. A visual report is incomplete unless it can explain
+the full ordered composition for the target mode/dialog.
+
+Required for every UI/visual investigation:
+
+- **Paint-path closure**: Start at the top-level paint/message handler and follow all
+  active draw callees to return. Do not stop at `RightPanel__Draw`, a background
+  helper, or the first plausible owner-draw function.
+- **Ordered composition ledger**: Record draw order, function/address, condition,
+  asset/file, exact frame/index, source/destination rect, palette/convert path,
+  clipping/scissor if present, and z-order role.
+- **Per-dialog flag proof**: For optional helpers, resolve the target dialog/mode's
+  flag setters. Record setter function, allow-list/switch case, written byte/bit,
+  shifted byte read in the paint handler, and whether the target dialog activates it.
+- **All-frame SHP inspection**: Dump or inspect every frame of SHP assets involved
+  before making a visual claim. If a call draws frame 1, frame 2, or any nonzero
+  frame, name it explicitly.
+- **Asset role matrix**: Classify every relevant asset as `Loaded`, `Drawn`,
+  `Visible in target`, `Content/preview`, `Chrome/container`, `Overlay`,
+  `Transition-only`, or `Inactive in target`. Assets can have multiple roles.
+- **Scoped negative claims**: "Not used as preview backing" does not mean "not
+  visible." Every negative claim must name the role it excludes and the role it
+  does not exclude.
+- **Screenshot contradiction trigger**: If a user screenshot, reference capture, or
+  asset dump contradicts the current conclusion, treat the research as incomplete.
+  Reopen the paint path and look for a missing layer, frame, flag, rect, or palette.
+
+**Verify YR activity (CRITICAL — do this for every function you decompile):**
+- Is this code actually active in Yuri's Revenge, or is it dormant Tiberian Sun legacy?
+- Check if it's gated behind a flag/setting — if so, what's the default in YR?
+- If gated behind `SpecialFlags & 0x1000` or similar, note it as TS-legacy/optional
+- Trace what flags/fields actually gate in the code — don't infer from the name.
+  TS-era field names are often misleading in YR context (e.g., "Tiberium" fields
+  that control vein behavior, not ore behavior).
+- When you find a bool/flag being checked, read the INI key it maps to, confirm
+  the default value, and check if any standard YR content actually sets it to a
+  non-default value.
+
+**Do NOT stop the Ghidra dive early.** Common traps:
+- "I think I have enough to write the report" → No. Follow one more call chain.
+- "This helper probably just does X" → Decompile it. Verify. "Probably" is not evidence.
+- "The main function is clear, I'll skip the edge cases" → The edge cases ARE the details.
+- "I've been at this a while" → Good. That means you're being thorough.
+
+After the deep dive, you should be able to answer: "If someone asked me an obscure
+corner-case question about this system, could I answer it from what I found?" If not,
+keep digging.
+
+## Step 3 — Exhaustion gate (the Open Questions Log must drain)
+
+This is the hard gate, not a soft checklist. You may not proceed to Step 4
+until **every** entry in the Open Questions Log is either `[RESOLVED]` with
+evidence or `[DEFERRED]` with an explicit reason and category.
+
+**Procedure — execute in order, do not skip:**
+
+1. **Re-read the entire Open Questions Log top to bottom.** For each `[OPEN]`
+   entry: either go back to Ghidra and resolve it (preferred), or write an
+   explicit `[DEFERRED]` line with reason + category. "Not relevant" is not a
+   reason — say *why* it's not relevant. "Too deep to follow" requires a
+   category (`bounded-cost-too-high`) and an estimate of what would resolve it.
+
+2. **Run the zero-add pass test.** Do one more full Ghidra pass over the
+   primary function and its top-level callees. If this pass causes you to
+   add even one new `[OPEN]` entry, you are not done — resolve it and repeat
+   the pass. The investigation exits Step 3 only after a pass that adds zero
+   entries.
+
+3. **Adversarial reader test.** Write down 5 specific corner-case questions a
+   sharp reader might ask about this system (e.g., "what happens if the unit
+   is destroyed mid-animation?", "what's the order if two of these fire on
+   the same tick?"). For each, either answer from evidence in your notes or
+   add it to the log as `[OPEN]` and resolve it. If you cannot generate 5
+   non-trivial questions, you do not understand the system well enough yet.
+
+4. **Spot-check at least 2 findings** by going back to Ghidra and re-reading
+   the decompilation cold. Fresh eyes often catch things you glossed over.
+
+5. **Sanity-check the deferral pile.** If more than ~25% of your log entries
+   ended up `[DEFERRED]`, the report is not a complete investigation — it's a
+   partial one. Either resolve more, or rescope the report's title/scope to
+   honestly reflect what was covered (e.g., "Phase 1 — entry points only").
+   Do not hide partial coverage behind confident-sounding prose.
+
+**Anti-checkbox rule.** Do not satisfy this gate by adding the literal words
+"resolved" or "deferred" without doing the work. Each `[RESOLVED]` line MUST
+cite a Ghidra address, doc path, or INI key as evidence. Each `[DEFERRED]`
+line MUST state a category from the allowed set and a one-line reason a
+future reader can act on.
+
+## Step 4 — Synthesize findings
+
+Cross-reference all sources. For each finding:
+
+| Field | Content |
+|-------|---------|
+| **What** | The behavior, formula, or state machine |
+| **Evidence** | Which source confirmed it (Ghidra address, doc name, INI key) |
+| **Confidence** | HIGH (verified from binary), MEDIUM (consistent across docs + INI), LOW (inferred/single source) |
+| **Active in YR?** | Yes / No / Conditional (state the condition) |
+
+**Resolve conflicts:**
+- If docs say X but Ghidra says Y → Ghidra wins, flag the stale doc
+- If two docs conflict → go to Ghidra to settle it
+- If INI has a key but no code reads it → note as potentially unused
+
+**Build the Coverage Ledger from the log.** Every planned function, discovered
+function, major branch, INI key, and Rust comparison point must appear exactly once
+with one of the allowed statuses. Do not collapse "touched" into "verified".
+
+**Build the Implementation Handoff.** This is required even for research-only
+work. The handoff is not a patch plan; it is the minimum bridge from verified
+binary behavior to a future Rust implementation without making the implementer
+rediscover the same facts. Each handoff item must use this shape:
+
+```
+Verified behavior -> binary evidence -> current Rust delta -> affected surface -> acceptance scenario -> risk / do-not-do note
+```
+
+Rules:
+- If Rust already matches, say `current Rust delta: none observed` and give the
+  verification surface.
+- If Rust was not scanned deeply enough, say `current Rust delta: unchecked` and
+  cite the file/function search that remains.
+- Do not invent code structure. Name existing files/functions when found; otherwise
+  say what kind of surface is needed.
+- Every handoff item needs an exact-mechanism, byte/pixel, player-visible, or
+  deterministic acceptance scenario.
+- A report with no implementation handoff is PARTIAL unless the target is purely
+  documentary and has no Rust-facing implication.
+
+## Step 5 — Write research document
+
+Save to `<main-checkout>/docs/research/<TOPIC>_GHIDRA_REPORT.md` (or update existing). This is the canonical ignored research archive; do not save research reports into tracked/published `docs/` locations outside `docs/research/`. Follow this structure:
+
+```markdown
+# <System Name> — Ghidra Research Report
+
+**Address(es):** `0x00XXXXXX` (primary function)
+**Investigation Mode:** coverage-map | exhaustive-slice
+**Claimed Scope:** exact slice this report actually verifies
+**Non-Scope:** related areas this report does not claim to cover
+**Confidence:** High/Medium/Low (overall)
+**Active in YR:** Yes/No/Conditional
+
+## 1. Overview
+What this system does in 2-3 sentences.
+
+## 2. Class Layout / Key Offsets
+Table of struct fields with byte offsets, types, and purpose.
+
+## 3. Core Logic
+The main algorithm, state machine, or formula. Use pseudocode, not C.
+Include actual constants from the binary.
+
+## 4. INI Keys
+Table of relevant INI keys, their types, defaults, and effects.
+
+## 5. Integration Points
+What calls this system? What does it call? When does it run in the tick cycle?
+
+## 6. Current Rust Implementation Status
+What we have vs what's missing. File paths and line numbers.
+
+## 7. Coverage Ledger
+Use this table. Do not omit it.
+
+| Area / function / branch | Status | Evidence | What remains |
+|--------------------------|--------|----------|--------------|
+| <name> | verified | <address/doc/INI> | none |
+| <name> | touched-not-exhausted | <address/doc/INI> | <specific gap> |
+| <name> | not-touched | none | <why it matters> |
+| <name> | deferred | <reason> | <next investigation> |
+
+Status values: `verified`, `touched-not-exhausted`, `not-touched`, `deferred`,
+`conflict-needs-resolution`.
+
+## 8. Open Questions — Final State of the Investigation Log
+The canonical final state of the Open Questions Log from Step 1.5 / Step 3.
+Every entry MUST be `[RESOLVED]` or `[DEFERRED]` — no `[OPEN]` items may
+ship in a completed report. Use this exact format:
+
+- `[RESOLVED] <id> — <question> → <answer>` (evidence: `<address / doc / INI>`)
+- `[DEFERRED] <id> — <question>` (category: `out-of-scope` | `needs-runtime-debugger` | `requires-different-system-context` | `bounded-cost-too-high`; reason: `<one line>`; next-step-if-pursued: `<one line>`)
+
+If the deferred pile is large, also include a short paragraph stating which
+parts of the system are NOT covered by this report and what a follow-up
+investigation would need to do.
+
+## 9. Visual/UI Composition Ledger
+Required when the report covers UI, shell, sidebar, menu, viewport, sprite,
+or other visual composition. Omit only when the investigated system has no
+visual surface.
+
+| Order | Function / address | Condition / flag proof | Asset / frame | Rect / anchor | Palette / convert | Active for target? | Role |
+|-------|--------------------|------------------------|---------------|---------------|-------------------|--------------------|------|
+| 1 | <function> | <always / flag setter evidence> | <file#frame> | <src->dst> | <palette path> | yes/no/conditional | <chrome/content/overlay/etc.> |
+
+Also include an asset role matrix:
+
+| Asset | Loaded | Drawn | Visible in target | Content/preview | Chrome/container | Overlay | Transition-only | Inactive | Evidence |
+|-------|--------|-------|-------------------|-----------------|------------------|---------|-----------------|----------|----------|
+
+## 10. Implementation Handoff
+Use this table. Keep it concrete and implementation-facing, but do not include
+Rust code or patch text.
+
+| Verified behavior | Evidence | Current Rust delta | Affected Rust surface | Required implementation effect | Acceptance scenario | Risk / do-not-do |
+|-------------------|----------|--------------------|-----------------------|--------------------------------|---------------------|------------------|
+| <binary behavior> | <address/doc/INI> | <missing/mismatch/none/unchecked> | <file/function or needed surface> | <mechanism/byte/pixel effect to reproduce> | <exact-mechanism, byte/pixel, or deterministic test> | <wrong implementation to avoid> |
+
+If this report extends or corrects prior work, include a short `Stale Docs /
+Follow-up Docs` list after the table with exact replacement wording for any
+known stale claim.
+
+## 11. Ghidra Annotation Candidates
+
+| Address/source | Current metadata | Proposed metadata | Kind | Live proof | Status |
+|----------------|------------------|-------------------|------|------------|--------|
+| <address> | <FUN_*/DAT_*/missing ref> | <label/comment/reference> | <rename/create_label/comment/add_memory_reference> | <body + binding or source bytes + target> | <applied/deferred/conflict/worker-report-only> |
+
+Write `None` when no candidate passes ENGINE.md's certainty gate. Do not turn
+uncertainty into a cleanup candidate.
+
+## Sources
+- Ghidra addresses decompiled
+- Doc files referenced
+- INI files checked
+```
+
+## Step 5.5 — Optional Ghidra annotation sync
+
+By default, stop after reporting Section 11. If `--sync-ghidra-labels` was provided or
+the user directly requested synchronization, the root/standalone investigator waits
+until every reader has stopped and follows ENGINE.md's serial sync protocol. A read-only
+request or `--no-sync-ghidra-labels` disables synchronization. A child/worker always
+stops after reporting candidates.
+
+## Confidence levels
+
+- **HIGH** — You decompiled the function, read the assembly context, traced the call chain, and confirmed the behavior. You would bet money on it.
+- **MEDIUM** — Multiple docs agree, INI keys are consistent, but you didn't verify every detail in the binary. Or you decompiled but the decompilation was ambiguous.
+- **LOW** — Single source, inferred from naming/context, or extrapolated from similar systems. Mark clearly and add to Open Questions.
+
+## Red Flags — STOP
+
+If you catch yourself:
+- Writing Rust code → DELETE IT. You are researching, not implementing.
+- Omitting the Implementation Handoff → the report is PARTIAL. Future
+  implementers need verified behavior translated into affected Rust surfaces,
+  acceptance scenarios, and risks.
+- Claiming a finding without stating the evidence source → add the source.
+- Saying "probably" or "likely" in a finding → move it to Open Questions or go verify in Ghidra.
+- Skipping Ghidra because "the docs seem complete" → the docs could be wrong. Spot-check at minimum.
+- Copy-pasting a doc's claims without verifying → that's summarizing, not investigating.
+- Guessing what a helper function does instead of decompiling it → decompile it.
+- Assuming code is active in YR without checking → verify it's not TS-legacy.
+- Skipping a detail because it "probably isn't visible to the player" → details drive
+  parity. Invisibility is not a filter. Document it.
+- Stopping early because the report "has enough" → the job is complete investigation,
+  not adequate investigation. Go one more level.
+- Leaving a branch, constant, or flag unexplained because "it doesn't look important" →
+  if it's in the binary and on an active path, it's important until proven otherwise.
+- Declaring the investigation done while the Open Questions Log still has `[OPEN]`
+  items → not done. Resolve or explicitly defer (with category + reason) every entry.
+- Skipping a Ghidra pass because "the report seems complete" → you don't know if it's
+  complete until a full pass adds zero new log entries. Run the pass.
+- Marking entries `[RESOLVED]` without citing an address, doc, or INI key as evidence
+  → that's a checkbox, not a resolution. Add the evidence or move it to `[DEFERRED]`.
+- Generating fewer than 5 adversarial corner-case questions in Step 3 → you don't
+  understand the system well enough to gate on exhaustion yet. Keep digging.
+- Calling a broad coverage-map "complete" → rename/reframe it. A broad map is useful
+  only if it exposes what remains unknown.
+- Saying planned/touched functions were "investigated" without a coverage status →
+  list each as verified, touched-not-exhausted, not-touched, or deferred.
+- Omitting the Coverage Ledger → the report is invalid. Future implementers need to
+  know what not to trust yet.
+- Stopping UI visual research at the first helper or background draw: incomplete.
+  Trace the full paint/message handler through every later active draw call.
+- Dumping only SHP frame 0: incomplete for visual parity. Multi-frame SHPs must be
+  inspected until the exact drawn frame is proven.
+- Turning a role-scoped negative into a global negative: misleading. "Not preview
+  backing" does not prove "not visible chrome."
+- Ignoring a screenshot/reference contradiction because the current call stack seems
+  plausible: reopen the paint path. The contradiction is evidence of missing scope.
+
+## Rationalization table
+
+| Excuse | Reality |
+|--------|---------|
+| "The docs already cover this" | Docs can be stale or wrong. Verify critical claims in Ghidra. |
+| "I can see from the function name what it does" | Ghidra labels can be wrong. YRpp labels are not ground truth. Decompile. |
+| "This is simple enough to just implement" | You are researching. Provide a handoff, not a patch. |
+| "I'll just note the address and come back later" | Decompile now while you have context. Addresses without analysis are useless. |
+| "The INI key name makes the behavior obvious" | INI keys don't tell you edge cases, defaults, or interaction with other systems. |
+| "I already know how this works from a previous session" | Verify. Memory is not evidence. |
+| "Just a quick code fix while I'm here" | NO. Hard gate. Research only. |
+| "The log has open items but they're minor" | Then they take 30 seconds to resolve. Resolve them. |
+| "I've covered the main flow, the rest is edge cases" | Edge cases ARE the deliverable. The main flow is what a skim already gives. |
+| "The zero-add pass test is overkill for this system" | It's the only objective signal of exhaustion. Run it. |
+| "Generating 5 corner-case questions feels artificial" | If you can't generate them, you don't know the system. The exercise is the test. |
+
+## After completion
+
+Present a brief summary to the user:
+1. What system was investigated
+2. Key findings (3-5 bullets, most important first)
+3. What's already implemented vs what's missing
+4. Open questions that need more work
+5. Highest-leverage implementation handoff item
+6. Path to the saved research document
+7. Ghidra annotations: candidates / applied / deferred / conflicted

--- a/.agents/skills/re-swarm/SKILL.md
+++ b/.agents/skills/re-swarm/SKILL.md
@@ -1,0 +1,472 @@
+---
+name: re-swarm
+description: "Project-scoped for VERA20k/RA2 Yuri's Revenge only. Use when the user invokes '/re-swarm', asks to orchestrate parallel reverse-engineering investigations, wants detail-level gamemd.exe research gaps scanned, wants parity-blocker research, or wants multiple /re-investigate reports reconciled into implementation handoffs. Dispatches at most 3 read-only subagents per wave, each investigating one narrow target, then checks reports for cross-doc contradictions and Rust-facing handoff quality. Unless the user opts out, the parent serially syncs only certainty-gated Ghidra metadata after all workers stop. Never auto-applies doc or code patches."
+---
+
+# Re-Swarm
+
+Coordinate up to 3 parallel reverse-engineering investigations per wave for detail-level
+`gamemd.exe` gaps, then reconcile their reports. This skill is detection and
+research only: do not edit Rust, INI files, tracked/published docs outside
+`docs/research/`, or Ghidra state while any worker/reader is active. The final
+parent-only serial metadata sync is the sole Ghidra exception. Reports must include
+implementation handoffs, but the swarm never implements them.
+
+Research truth bar: record active-gamemd mechanism, state, pixels/results, and
+uncertainty precisely; no approximation may be labelled exact parity. This does
+not make every finding current implementation priority. Reconciliation must
+also classify retail-skirmish impact and separate exactification residuals.
+
+Native-to-Rust translation rule: do not recommend literal C++ architecture ports
+unless the user explicitly asks. Research must identify the verified gamemd
+behavior contract, then hand it off as Rust-native ownership boundaries: storage
+can remain in `EntityStore`, scheduler/order can live in a Rust `LogicScheduler`
+or equivalent owner, lifecycle effects can be helper APIs, and systems can stay
+plain functions. What must match is the native semantics: ordering, membership,
+state reads/writes, RNG use, frame visibility, same-tick consequences, and
+downstream bytes/pixels. Avoid both bad shortcuts: copying raw pointer/vtable
+architecture verbatim, or proposing clean Rust that changes behavior.
+
+Label-adversarial Ghidra rule: local Ghidra names, labels, comments, xref
+labels, and decompiler-assigned symbol names are navigation hints only. This
+project may contain polluted or stale labels from earlier scripts. Handoff-critical
+identity claims must be verified from function body, assembly/decompile, callsites,
+receiver/`this` pointer, argument flow, vtable slot bytes, data references, and
+active-YR reachability. Prefer address plus verified role over label name, and
+record label drift explicitly.
+
+## Hard Gates
+
+- Dispatch at most 3 subagents at once, or fewer when collaboration slots are
+  unavailable. Larger queues run as sequential waves.
+- Use subagents only after the user explicitly invokes `/re-swarm` or otherwise
+  asks for parallel/delegated reverse-engineering work.
+- Each subagent must use Ghidra MCP read-only. Use the full mutating-tool blacklist in
+  the worker prompt below; do not duplicate it here.
+- Each subagent must return Ghidra annotation candidates separately: address,
+  current name/reference, proposed label/comment/reference, and exact live-binary
+  proof. A worker never applies a candidate.
+- Each subagent may write exactly one research report under
+  `<main-checkout>/docs/research/` plus the shared claims file.
+  Nothing else.
+- The parent may write only the coverage index and claims file. Reconciliation
+  never applies code or docs fixes. After all readers stop, the parent may apply
+  only ENGINE.md certainty-gated Ghidra metadata serially.
+- If more than half of a wave fails, stop before reconciliation and ask the user
+  whether to retry failed slots, review successes only, or abort.
+- Every returned finding must distinguish verified binary evidence from inference
+  and must label whether the path is active in standard YR.
+- Handoff-critical claims require stronger evidence than ordinary report facts:
+  cite decompile plus assembly/disassembly address range, decompile plus
+  xref/caller evidence, or INI/default source plus the binary reader address.
+  Do not mark a handoff COMPLETE from decompiler prose alone when the claim
+  depends on inclusive/exclusive bounds, signedness, argument order, struct
+  offsets, default values, path liveness, or TS-vs-YR activity.
+
+## Invocation Modes
+
+- `/re-swarm`: scan for detail-level research gaps, propose up to 3 targets, wait for
+  confirmation.
+- `/re-swarm <t1>, <t2>, ...`: validate explicit targets, wait for confirmation.
+- `/re-swarm --area <area>`: scan only one area, propose up to 3 targets, wait for
+  confirmation.
+- `/re-swarm --parity-blocker <area>`: propose targets ranked by what blocks
+  player-visible parity or screenshot parity for the named area.
+- `/re-swarm --dry-run`: scan/validate and print the dispatch plan, then stop.
+- `/re-swarm --refresh-index`: rebuild the coverage index before ranking.
+- `/re-swarm --handoff-plan`: after normal reconciliation, add a non-editing
+  implementation bridge plan: patch order, files likely touched, tests to
+  add/update, risk ordering, and facts that must remain unchanged.
+- `/re-swarm --no-sync-ghidra-labels`: keep the complete run read-only in Ghidra
+  and report annotation candidates only.
+
+If an explicit list has one entry, use a single investigator unless parallelism
+adds a concrete independent check. If it has more than 3 entries, split it into
+sequential waves. Do not dispatch broad targets like `BuildingClass` or `combat`;
+narrow them to one function, field, INI key, vtable slot, or behavior.
+
+## Research Index Preflight
+
+Before rebuilding the swarm coverage index or proposing slots, use the
+research-index MCP first. Prefer `research_brief`, `research_map`, and
+`research_validate`; use the repo-local CLI only for a missing MCP capability:
+
+```text
+python tools/research_index/brief.py "<topic>" --limit 8
+python tools/research_index/map.py "<topic>" --limit 12
+```
+
+If the exact system is known, add `--system <system>` (examples: `bridges`,
+`miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun without
+`--system`, then rerun with the inferred exact system. Use `validate.py` for stale
+or missing docs and `graph.py evidence` / `graph.py implementation` for candidate
+anchors and Rust-facing handoff clues. The index informs target selection; it does
+not replace read-only Ghidra investigation.
+
+## Step 1: Build Or Read The Coverage Index
+
+For auto, scoped, and refresh modes, use
+`<main-checkout>/docs/research/.swarm-coverage-index.md`.
+
+- If absent, rebuild it.
+- If present and modified within 7 days, use it and tell the user the cache date.
+- If older than 7 days or `--refresh-index` was passed, rebuild it and tell the
+  user.
+
+When rebuilding, walk every `*_GHIDRA_REPORT.md` in
+`<main-checkout>/docs/research/` and collect detail-level candidates:
+
+- `[DEFERRED]` entries from open-question sections.
+- "Phase 2/3 deferred", "future work", or equivalent markers.
+- Function addresses mentioned in passing but not analyzed in detail.
+- Struct fields whose purpose is unknown or only typed at an offset.
+- Vtable slots marked unknown, unused, or omitted from a documented table.
+- INI keys referenced by docs, then inverse coverage against `ini/rulesmd.ini` and
+  `ini/artmd.ini` for undocumented keys.
+- Existing reports missing an `Implementation Handoff` section, or handoffs marked
+  `current Rust delta: unchecked` for player-visible behavior.
+- Stale-doc markers found during recent implementation work: reports whose claims
+  contradict current docs, current Rust, or sibling reports.
+- Optional vtable coverage checks against Ghidra only if they require no more than
+  50 read-only Ghidra calls.
+
+Write one flat Markdown bullet per gap:
+
+```markdown
+- DEFERRED | RADIO_PROTOCOL | Q-12 | "Is FUN_0050AB10 the resend handler?" | category: bounded-cost-too-high
+- HINTED_FN | FOOT_MOVEMENT | FUN_005A1C30 mentioned 3x | no dedicated investigation
+- UNDOC_FIELD | BUILDING_CLASS | offset 0x6A4 | type uint32 | purpose unknown
+- VTABLE_SLOT | AIRCRAFT_CLASS | slot 0x48 | unknown per doc; binary has FUN_004C8800
+- UNDOC_INI | rulesmd.ini | [General] AllowableVehicleHijackerCounts= | no doc citation
+- MISSING_HANDOFF | BUILDING_BRACKETS | exact Z-buffer predicate known | no Rust-facing acceptance scenario
+```
+
+## Step 1.5: Summarize Recent Work And Known Settled Facts
+
+Before ranking targets, write a short current-state note for the dispatch prompt.
+Use only cheap local evidence: recent conversation context, relevant report
+headings, `git diff --stat`, and focused `rg` over `src/` and docs. Do not run a
+mini-investigation here.
+
+The note must contain:
+
+- `Already settled`: facts agents must not rediscover unless resolving a conflict.
+- `Current Rust shape`: files/functions already touched or clearly involved.
+- `Known remaining gaps`: specific questions that still block parity.
+- `Stale docs suspected`: exact doc paths or claims, if known.
+
+For `--parity-blocker`, also include one player-visible target scenario such as
+"selected building partly behind cliff under gap re-shroud".
+
+## Step 2: Rank And Propose Targets
+
+Filter by area if requested, then rank candidates:
+
+- HIGH: referenced from 3+ docs, controls player-visible thresholds/formulas, is
+  on an active YR tick path, or blocks a known player-visible/screenshot parity
+  scenario.
+- MEDIUM: referenced from 1-2 docs, fills a deferred item from a high-confidence
+  report, covers an INI key in a default-enabled section, or turns an existing
+  high-confidence report into an implementation-ready handoff.
+- LOW: isolated curiosity, no downstream consumer, or likely TS-only/disabled code.
+
+Break ties by cross-reference count, then smallest scope, then subsystem diversity.
+For `--parity-blocker`, break ties by highest player visibility, then smallest
+scope. Print a dispatch table with slot, target, one-line scope, source, tier, and
+expected handoff. Wait for explicit confirmation such as `go`. Prior confirmation
+in the same thread does not count for a new swarm. For `--dry-run`, stop after
+printing the plan.
+
+Example:
+
+```markdown
+Proposed /re-swarm dispatch:
+
+| Slot | Target | Scope | Source | Tier | Expected handoff |
+|---|---|---|---|---|---|
+| 1 | FUN_0050AB10 radio resend handler | Decompile state and confirm YR live path | RADIO_PROTOCOL Q-12 | HIGH | resend timing acceptance scenario |
+| 2 | BuildingClass+0x6A4 field | Identify type, accessor, and behavior | BUILDING_POWER UNDOC_FIELD | MEDIUM | Rust field mapping or no-op proof |
+| 3 | [General] AllowableVehicleHijackerCounts= | Find reader, struct offset, default behavior | rulesmd.ini UNDOC_INI | MEDIUM | rules parser delta + test |
+```
+
+## Step 3: Write Claims
+
+Path: `<main-checkout>/docs/research/.swarm-claims.md`
+
+Append one block per swarm invocation. Do not overwrite old rows.
+
+```markdown
+## Swarm 2026-05-18T11:42
+
+- 2026-05-18T11:42 - slot-1 - FUN_0050AB10_RadioResendHandler - claimed
+- 2026-05-18T11:42 - slot-2 - BuildingClass_field_0x6A4 - claimed
+```
+
+Statuses are `claimed`, `done`, and `failed`. A `claimed` row older than 4 hours is
+stale and may be re-claimed by a future swarm, but do not delete it.
+
+## Citation discipline
+
+Every material worker claim must cite the exact verification call or local source.
+Match evidence to claim type:
+
+| Claim | Minimum evidence |
+|---|---|
+| Function behavior | `decompile_function` at the entry |
+| Caller/callee relation | callers/callees query |
+| Vtable owner | COL→TypeDescriptor mangled-name walk |
+| Vtable slot | `read_memory vtable+N*4` plus decompile of the result |
+| Struct offset/type | assembly context showing displacement and access width |
+| Constant/default | decompile/assembly showing the literal |
+| INI reader/default | string xref, reader decompile, and default literal |
+| YR activity/TS legacy | caller trace plus gate and stock default |
+
+Bare or wrong-kind citations do not enter reconciliation. Put unresolved claims
+in a YELLOW `Unverified` section instead of mixing them into verified findings.
+
+## Step 4: Dispatch Subagents
+
+Use parallel `spawn_agent` calls where available. Do not set an unavailable model
+override; inherit the active model unless the user explicitly requested a supported
+model. Each subagent receives one narrow target and a self-contained prompt.
+
+Do not assume subagents will automatically load this skill. Include the relevant
+`/re-investigate` constraints directly in each prompt:
+
+```text
+You are subagent slot {{SLOT}} of a /re-swarm batch. Your single target is:
+
+{{TARGET}}
+
+Scope, do not expand: {{SCOPE}}
+
+Recent work context from the parent:
+{{RECENT_WORK_CONTEXT}}
+
+Use the VERA20k /re-investigate workflow for this target, with these added
+constraints:
+
+Hard constraints:
+- Ghidra MCP is read-only. Do not call rename_function,
+  rename_function_by_address, rename_data, rename_variable, create_label,
+  create_function, add_struct_field, modify_struct_field,
+  set_decompiler_comment, set_plate_comment, set_disassembly_comment,
+  add_memory_reference, remove_reference, save_program, or any mutating tool.
+- In swarm mode, `/re-investigate` guidance to create missing functions is
+  overridden by this read-only rule. If Ghidra missed a function boundary, do not
+  create it; inspect bytes/reachable callers read-only where possible, or record
+  the missing boundary as Remaining Uncertainty.
+- You may write exactly one research report:
+  <main-checkout>/docs/research/<TARGET_SLUG>_GHIDRA_REPORT.md
+- You may update only the shared claims file in addition to that report.
+- Do not modify Rust files, INI files, tracked/published docs outside
+  `docs/research/`, or any other location.
+- Follow AGENTS.md project rules: gamemd.exe is the behavior spec, verified binary
+  findings must be separated from inference, offsets and addresses must not be
+  invented, and TS legacy paths must be checked before being treated as standard YR.
+- Every material finding must say: Active in YR: Yes / No / Conditional, with
+  evidence.
+- Before investigating, write these four lines in your working notes and satisfy
+  them in the report: `Target question`, `Non-goals`, `Evidence needed to mark
+  COMPLETE`, and `Stop conditions`.
+- Handoff-critical claims need stronger evidence than normal facts. Cite either
+  decompile plus assembly/disassembly address range, decompile plus xref/caller
+  evidence, or INI/default source plus the binary reader address. This is required
+  for claims involving inclusive/exclusive bounds, signedness, argument order,
+  struct offsets, default values, path liveness, or TS-vs-YR activity.
+- Do not rediscover facts listed under `Already settled` unless you find a direct
+  contradiction. Spend the slot on the unknowns and the implementation handoff.
+- Keep the scope narrow. If related gaps appear, list them as open questions but do
+  not investigate them in this slot.
+- Your report must include `/re-investigate`'s `Implementation Handoff` section.
+  COMPLETE requires at least one handoff item unless the target proves there is no
+  Rust-facing or doc-facing implication.
+- Include a `Negative Facts / Do Not Do` subsection when the investigation rules
+  out an attractive but wrong implementation shortcut. Example:
+  `Do not use AddOccupy/RemoveOccupy for real foundation occupancy`.
+- Each implementation handoff acceptance scenario must include one concrete Rust
+  test-name proposal, e.g. `test_garefn_addoccupy_does_not_block_real_foundation`.
+- Include a `Remaining Uncertainty` subsection for any unresolved condition,
+  missing caller, inactive-path doubt, or partial Rust-facing implication.
+- Include a `Ghidra Annotation Candidates` subsection. For each candidate give
+  address, current metadata, proposed label/comment/reference, mutation kind,
+  and the exact live-binary calls proving that it passes ENGINE.md's certainty
+  gate. Write `None` when no candidate is certain enough. Do not apply it.
+
+Return only:
+1. A Markdown summary no longer than 150 lines.
+2. The exact report path written.
+3. Up to 5 load-bearing verified facts, one line each, with evidence such as Ghidra
+   address, offset, INI key path, or file:line.
+4. Up to 3 implementation handoff bullets in the form:
+   `verified behavior -> Rust delta -> affected surface -> acceptance scenario -> proposed test name -> risk`.
+5. Up to 5 negative facts / do-not-do notes, each with evidence.
+6. Remaining uncertainty bullets, or `None`.
+7. Any stale-doc replacement wording found, with exact doc path.
+8. Ghidra annotation candidates, or `None`.
+9. Status: COMPLETE, PARTIAL (reason), or FAILED (reason).
+
+Do not return raw decompilation, assembly listings, raw INI dumps, full struct
+tables, or the full open questions log.
+```
+
+After dispatching, wait for all returns before reconciliation unless a tool-level
+timeout makes a slot failed.
+
+## Step 5: Collect Returns
+
+For each returned summary:
+
+1. Verify the report path exists.
+2. Update that slot in `.swarm-claims.md` to `done` or `failed`.
+3. Treat malformed returns as PARTIAL: over 150 lines, missing report path, missing
+   facts list, missing implementation handoff, or no status.
+4. Open each report and enforce the citation discipline above. Bare claims or
+   wrong-kind evidence make the slot PARTIAL and are excluded from reconciliation.
+   If more than ~20% of load-bearing claims fail this gate, mark the slot FAILED.
+5. If 0-2 slots failed, continue and flag failures clearly.
+6. If 3+ slots failed, stop and ask the user how to proceed.
+
+A slot may only be marked COMPLETE if it returns at least one item in this chain:
+`verified behavior -> evidence -> Rust implication -> acceptance scenario -> proposed test name`.
+If the slot proves no implementation is needed, that proof must be explicit and
+evidenced. Missing negative facts are acceptable only if the slot explicitly says
+`Negative Facts / Do Not Do: None`.
+If a slot's handoff depends on bounds, signedness, argument order, struct offsets,
+defaults, path liveness, or TS-vs-YR activity, COMPLETE also requires the stronger
+evidence form described above. Otherwise mark it PARTIAL and name the missing
+verification.
+
+## Step 6: Reconcile In Parent
+
+For each successful or partial slot:
+
+1. Read the written report.
+2. Extract the 5-10 most load-bearing claims: offsets, addresses, formulas, INI
+   mappings, call relationships, and YR-activity labels.
+3. Cross-reference each claim against sibling docs in
+   `<main-checkout>/docs/research/`.
+   - If the sibling matches, record it as corroborated.
+   - If it conflicts, record both claims and both evidence citations.
+   - If it appears nowhere else, record it as novel.
+4. Spot-check at least 2 load-bearing claims by re-reading the cited Ghidra address
+   or cited source material.
+   - Spot-check every claim that directly gates an implementation handoff when it
+     involves bounds, signedness, argument order, struct offsets, defaults, path
+     liveness, or TS-vs-YR activity.
+5. Check YR-activity claims against AGENTS.md, existing TS-legacy notes, and sibling
+   docs. Flag any suspicious "Active in YR: Yes" claim.
+6. Reconcile implementation handoffs:
+   - Merge duplicate handoffs that point at the same Rust surface.
+   - Flag contradictions between sibling handoffs.
+   - For each handoff, run a mandatory focused Rust scan before ranking:
+     `rg` likely target symbols/INI keys/type names in `src/`, collect file
+     references, existing tests, and likely ownership/module boundary.
+   - Record the Rust scan as: `target symbols -> file refs -> existing tests ->
+     likely ownership`. This is reconnaissance only; do not edit Rust.
+   - Rank handoffs by player visibility, certainty, and smallest implementation
+     surface.
+   - Preserve `do-not-do` risks; these are often the most useful output.
+7. Consolidate negative facts / do-not-do notes:
+   - Keep evidenced notes even if they are not direct implementation tasks.
+   - Prefer short imperative wording: `Do not ... because ...`.
+   - Attach the evidence source and affected Rust surface when known.
+8. Extract remaining uncertainty:
+   - Include unresolved caller questions, conditional YR activity, missing Rust
+     threading, unverified stock/mod split, or partial handoff risks.
+   - Do not bury uncertainty inside prose; make it a distinct final-report list.
+9. Extract stale-doc fixes separately from implementation handoffs. Include exact
+   replacement wording, but do not apply it unless the user asks.
+
+## Step 6.5: Serial Ghidra Annotation Sync
+
+This skill's description advertises parent synchronization, so run it after every
+worker stops unless `--no-sync-ghidra-labels` or a read-only request disables it.
+Collect and deduplicate candidates, then follow ENGINE.md's serial certainty, save,
+and readback protocol. If write tools are unavailable, report the queue and finish
+the research normally.
+
+If `--handoff-plan` was requested, add a non-editing bridge plan after the normal
+reconciliation:
+
+1. Group handoffs by likely Rust ownership/module boundary.
+2. Produce a patch order that starts with data model/parser/test fixtures, then
+   shared helpers, then gameplay call sites, then UI/render consumers if any.
+3. List files likely touched and tests to add/update, using exact paths when the
+   Rust scan found them.
+4. Rank risks by player visibility, regression surface, determinism risk, and
+   stock-frequency.
+5. List `must remain unchanged` facts, especially negative facts and known
+   gamemd-compatible exceptions.
+6. Stop at the plan. Do not implement, stage, commit, or edit docs.
+
+Do not edit docs during reconciliation.
+
+## Step 7: Report To User
+
+Keep the final report concise and structured:
+
+```markdown
+## /re-swarm Results - 2026-05-18T11:42
+
+Status: 4 of 5 complete, 4 reports written, 1 contradiction found.
+
+Ghidra annotations: 6 candidates, 3 applied serially, 2 uncertain, 1 conflicted.
+
+### Reports Written
+1. slot-1 - RADIO_RESEND_HANDLER_GHIDRA_REPORT.md - COMPLETE - one-line finding
+2. slot-2 - BUILDING_FIELD_6A4_GHIDRA_REPORT.md - PARTIAL - reason
+
+### Cross-Doc Contradictions
+1. slot-2 vs BUILDING_POWER_GHIDRA_REPORT.md:
+   - slot-2 claim and evidence
+   - sibling claim and evidence
+   - recommended next check
+
+### Novel Findings
+- slot-1: finding with evidence.
+
+### Implementation Handoffs
+1. slot-2: verified behavior -> affected Rust surface -> acceptance scenario -> proposed test name -> risk.
+
+### Focused Rust Scan
+- slot-2: target symbols -> file refs -> existing tests -> likely ownership.
+
+### Negative Facts / Do Not Do
+- slot-2: do-not-do note with evidence and affected Rust surface.
+
+### Remaining Uncertainty
+- slot-3: unresolved caller, inactive-path doubt, missing Rust threading, or `None`.
+
+### Handoff Plan
+Only include when `--handoff-plan` was requested.
+- Patch order: data/parser -> helper -> call sites -> consumers.
+- Files likely touched: exact paths from focused Rust scan.
+- Tests to add/update: proposed test names and target files.
+- Risk ordering: highest player-visible/frequent risk first.
+- Must remain unchanged: negative facts and verified exceptions.
+
+### Stale Doc Fixes Suggested
+- `path/to/report.md`: replace "<old claim>" with "<new claim>".
+
+### YR-Activity Flags
+- slot-3: conditional or suspicious active-path claim.
+
+### Contract Violations
+- slot-4 returned 187 lines, treated as PARTIAL.
+
+### Failed Slots
+- slot-5 failed because Ghidra MCP timed out. Suggested single-target retry:
+  /re-investigate "target".
+```
+
+End after reporting. Do not start a follow-up swarm, run `/verify-doc`, or edit docs
+unless the user explicitly asks.
+
+## Stop Conditions
+
+- More than 2 slots fail.
+- A subagent writes outside its allowed locations.
+- A target expands into a whole system instead of one detail.
+- Ghidra MCP read-only access is not available.
+- The user has not confirmed dispatch after seeing the proposed slot list.

--- a/.agents/skills/review-plan/SKILL.md
+++ b/.agents/skills/review-plan/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: review-plan
+description: >
+  Review an implementation plan for correctness before execution.
+  Verifies codebase assumptions (struct fields, signatures, line numbers),
+  binary claims (gamemd.exe addresses, behavior), and internal consistency.
+  Catches false positives before reporting. Usage: '/review-plan plan-file'
+  or '/review-plan' (auto-detects latest plan doc).
+---
+
+# Review Plan — Pre-Execution Correctness Audit
+
+Review the implementation plan: **$ARGUMENTS**
+
+If `$ARGUMENTS` is empty or just a filename, look for the most recent
+`docs/plans/*-plan.md` file. If none exists, tell the user there's nothing
+to review.
+
+**Purpose:** Catch plan errors BEFORE execution — wrong assumptions, stale
+line numbers, incorrect binary claims, missing edge cases. Every finding
+must survive a self-verification step before being reported.
+
+**Delivery framing.** Review against the retail-convincing ordinary-skirmish
+bar in `AGENTS.md`. Verify consequential binary claims and preserve honest
+DRIFT/UNCHECKED labels, but do not reject a plan solely because Rust internals
+or an expert-only edge differ. Block when the plan guesses about common
+behavior, leaves the representative production loop wrong, or risks
+determinism, authority, lifecycle, RNG, persistence, commands, or shared
+architecture. Record bounded exactification residuals separately.
+
+Do NOT implement any code. Do NOT modify the plan. Report findings only.
+
+---
+
+## Phase 0 — Extract Plan Grounding
+
+Before extracting generic claims, pull out the plan's grounding artifacts
+(produced by `/write-plan`). These drive verification priority.
+
+### 0.1 Grounding Summary
+
+Locate the **Grounding Summary** section. Confirm it's present and
+non-empty. A missing or empty summary is itself a finding — the plan
+was written without the grounding phase.
+
+### 0.2 Confidence-Tagged Decisions
+
+Locate the **Key Technical Decisions** section. For each decision,
+extract:
+- The decision itself
+- **Confidence:** high | medium | low
+- **Source:** (docs/research/... | Ghidra FUN_... | repo pattern ... | inferred)
+
+Build a verification priority list:
+1. **low-confidence decisions** — verify first, most likely to be wrong
+2. **medium-confidence decisions** — verify second
+3. **high-confidence decisions** — verify last, spot-check only
+
+A decision tagged high-confidence but citing `inferred` is suspicious —
+promote it to medium for verification purposes.
+
+### 0.3 Sources & References Inventory
+
+Locate the **Sources & References** section. Extract:
+- Every `docs/research/*.md` filename cited
+- Every gamemd.exe address listed (FUN_..., 0x...)
+- Every INI key referenced (`[Section]` Key=)
+- Every Rust file path listed
+
+These entries get verified in Phase 2.5 — missing sources invalidate
+decisions that depend on them.
+
+### 0.4 Deferred Questions
+
+Locate **Open Questions → Deferred to Implementation**. For each entry,
+ask: is this genuinely un-resolvable at planning time, or was it punted?
+Flag any question that could plausibly be answered by reading the code
+or decompiling — those are planning failures disguised as deferrals.
+
+---
+
+## Phase 1 — Extract Claims
+
+Read the full plan document and extract verifiable factual claims that drive
+the implementation, representative production test, or risk classification
+into three categories. Do not spend the review proving decorative background
+prose.
+
+### A. Codebase claims
+- Struct/enum definitions and their fields
+- Function signatures (name, parameters, return type)
+- Line numbers and file locations ("lines 543-574", "after the NEIGHBORS constant")
+- Constants and their values
+- Existing behavior ("the old function does X")
+- What callers exist and whether they need changes
+
+### B. Binary claims
+- Addresses ("AStar_main_loop at 0x00429a90")
+- Behavioral descriptions ("matches binary inline check at 0x00429e38")
+- Thresholds, formulas, decision trees attributed to gamemd.exe
+- Struct field offsets in the binary
+
+### C. Logical claims
+- "No callers need changes" — is this actually true?
+- "Tests check properties not exact sequences" — do they?
+- "Same practical effect" — is it really?
+- Risk assessments ("no test breakage expected")
+
+**Output:** A numbered list of claims to verify. Group by category. Don't
+verify yet — just extract.
+
+---
+
+## Phase 2 — Verify Codebase Claims
+
+For each codebase claim from Phase 1A, read the actual file and check:
+
+1. **Struct/enum fields** — do they match? Any fields missing from or added
+   to the plan's description?
+2. **Function signatures** — exact parameter types and return type?
+3. **Line numbers** — are they still accurate? (Files shift as edits accumulate.)
+   Tolerance: +/- 10 lines is fine. Off by 50+ is a problem.
+4. **Constants** — correct names, types, and values?
+5. **Existing behavior** — read the actual function. Does it do what the plan
+   says it does?
+6. **Caller analysis** — grep for all callers. Are there callers the plan missed?
+
+**For each claim, record:** CONFIRMED / STALE / WRONG / SHIFTED (with actual value).
+
+Do NOT skip this phase. Plans written against a moving codebase accumulate
+drift. Line numbers are the most common casualty.
+
+**Ordering:** Verify codebase claims that back low-confidence decisions
+(from Phase 0.2) first. A low-confidence decision citing `src/sim/foo.rs`
+gets checked before a high-confidence one.
+
+---
+
+## Phase 2.5 — Verify Source Citations
+
+Check every item extracted in Phase 0.3:
+
+1. **docs/research/*.md** — does the file exist? Read it and confirm
+   it actually covers what the plan claims it covers. A citation to a
+   report that doesn't say what the plan says is a fabricated source.
+2. **gamemd.exe addresses** — decompile addresses that support a
+   milestone-blocking, compounding, authority, lifecycle, RNG, persistence, or
+   architecture decision. For residual/background citations, verify existence
+   and flag uncertainty without expanding the review.
+3. **INI keys** — grep `ini/rulesmd.ini` and `ini/artmd.ini` for each
+   cited `[Section]` Key. Missing keys are plan errors.
+4. **Rust file paths** — do the files exist? If line ranges are cited,
+   are they within the file's actual length?
+
+**For each item, record:** EXISTS / MISSING / MISMATCHED.
+
+**Any MISSING source invalidates every decision that cited it.** Surface
+those decisions explicitly in the report.
+
+---
+
+## Phase 3 — Verify Binary Claims
+
+For each implementation-changing binary claim from Phase 1B, decompile via
+Ghidra MCP and check. Exactification-residual claims may remain explicitly
+unverified when they do not affect the selected plan.
+**Prioritize claims that back low-confidence or medium-confidence
+decisions from Phase 0.2.**
+
+1. **Does the function exist at the claimed address?** Decompile it.
+2. **Does the behavior match the plan's description?** Read the actual
+   decompiled code — don't trust summaries.
+3. **Are thresholds/operators correct?** Check exact comparisons:
+   - `>` vs `>=` (the `CMP + JG` vs `CMP + JGE` distinction)
+   - `< 2` vs `<= 2` vs `>= 2` (off-by-one in threshold claims)
+   - signed vs unsigned arithmetic
+4. **Are there prerequisite checks the plan omits?** The binary often has
+   flag checks before the "interesting" logic. Missing a prerequisite
+   means the plan's function fires in cases the binary wouldn't (or
+   vice versa).
+5. **Is the code active in YR?** Trace callers to confirm this isn't
+   dormant TS legacy code.
+
+**Ghidra pitfalls to watch for:**
+- `param_1` as `int` → direct byte offsets. `param_1` as `int *` → multiply
+  index by 4 for byte offset.
+- `DAT_` globals may need `read_memory` to verify actual values.
+- Decompiler may fold or reorder conditions — compare semantics, not syntax.
+
+**For each claim, record:** CONFIRMED / WRONG (with what the binary actually
+does) / PARTIALLY CORRECT (with the nuance).
+
+---
+
+## Phase 4 — Verify Logical Claims
+
+For each logical claim from Phase 1C:
+
+1. **"No callers need changes"** — grep for every call site of every function
+   the plan modifies. Verify the claim exhaustively.
+2. **"Tests won't break"** — read the actual test assertions. Are they really
+   checking properties (start, end, length) or exact sequences? A test that
+   asserts `path[2] == (5, 3)` WILL break if tiebreakers change.
+3. **"Same practical effect"** — construct concrete scenarios with real values
+   and trace both the old and new logic. Do they preserve the same mechanism,
+   consumed bytes, downstream values, pixels, audio, UI, and timing?
+4. **Risk assessments** — for each "no breakage expected" claim, ask: what's
+   the simplest scenario that WOULD break? If you can construct one easily,
+   the risk is higher than claimed.
+
+---
+
+## Phase 5 — Self-Verification (MANDATORY)
+
+**This is the most important phase.** Before reporting ANY finding as a
+discrepancy, re-verify it from the primary source.
+
+For each potential discrepancy found in Phases 2-4:
+
+1. **Re-read the source.** Not your notes — the actual file or decompilation.
+2. **Ask: "Am I comparing the right things?"** A common false positive is
+   comparing two operations that serve different purposes (e.g., a start-height
+   init threshold vs a per-cell routing threshold).
+3. **Ask: "Does this actually fire in practice?"** A discrepancy that only
+   triggers with pathological inputs (values that never occur in real RA2 data)
+   is not worth reporting as a real issue.
+4. **Ask: "Is this an existing discrepancy or one introduced by the plan?"**
+   If the plan preserves an existing architectural difference (e.g., caller
+   provides start_layer vs binary computes it internally), require proof that
+   the difference is byte/pixel equivalent before treating it as acceptable.
+5. **Construct a concrete scenario** where the discrepancy produces a different
+   result. If you can't construct one with real RA2 values, downgrade it.
+
+**Classification after self-verification:**
+- **CONFIRMED ISSUE** — re-verified from source, concrete scenario constructed
+- **FALSE POSITIVE** — initially looked like a discrepancy but isn't on
+  re-examination. State why.
+- **THEORETICAL** — real logical difference but cannot construct a scenario
+  with standard RA2 data. Note what data would trigger it.
+
+---
+
+## Phase 6 — Report
+
+### Structure
+
+```
+## Plan Review: [plan filename]
+
+### Grounding Audit
+- Grounding Summary present? yes/no
+- Deferred questions that could have been resolved: [list, if any]
+
+### Confidence Audit
+[Table of each Key Technical Decision:]
+| Decision | Plan confidence | Verified as | Source check |
+|----------|-----------------|-------------|--------------|
+| ... | low | CONFIRMED / WRONG / INFERRED | docs/research/XYZ.md EXISTS |
+
+### Source Citations
+[Table of items from Phase 2.5:]
+| Citation | Status | Notes |
+|----------|--------|-------|
+| docs/research/XYZ.md | EXISTS | covers claim |
+| FUN_00abcdef | MISMATCHED | address is a different function |
+| [General] Key= | MISSING | not present in rulesmd.ini |
+
+### Codebase Accuracy
+[Table of shifted line numbers, stale references, wrong field names — if any]
+
+### Binary Fidelity
+[Table of confirmed vs wrong behavioral claims — if any]
+
+### Confirmed Issues
+[For each CONFIRMED ISSUE from Phase 5:]
+- What the plan claims
+- What the source actually shows (with address / file:line)
+- Concrete scenario demonstrating the difference
+- Suggested fix (one sentence)
+
+### False Positives Caught
+[For each FALSE POSITIVE from Phase 5:]
+- What initially looked wrong
+- Why it's actually fine (one sentence)
+
+### Theoretical Concerns
+[For each THEORETICAL from Phase 5:]
+- The logical difference
+- Why it doesn't fire with real data
+- What would trigger it (for awareness)
+
+### Verdict
+[One of:]
+- READY — no confirmed issues, plan can be executed as-is
+- FIX FIRST — N confirmed issues that should be addressed before execution
+- NEEDS REWORK — fundamental assumptions are wrong
+- GROUNDING GAP — plan is missing Grounding Summary, has MISSING source
+  citations, or has low-confidence decisions with no verifying evidence.
+  Send back to `/write-plan` to ground properly before execution.
+```
+
+### Rules
+
+- **Lead with confirmed issues.** Don't bury them under tables of passing checks.
+- **Include false positives caught.** This builds confidence that the review
+  was thorough — "we looked at X and it's fine" is valuable signal.
+- **No match tables.** Don't list every claim that checked out. Only report
+  deviations and interesting non-deviations (things that looked wrong but
+  aren't).
+- **Concrete scenarios for every confirmed issue.** "This might differ" is
+  not a finding. "Tank at height 2 on bridge cell with ground_level=0 would
+  route to ground list instead of bridge list" is a finding.
+- **One-sentence suggested fixes.** Don't write implementation code — just
+  point the direction.
+
+---
+
+## Anti-Patterns in Plan Reviews
+
+Avoid these common review failures:
+
+- **Threshold telephone** — claiming a threshold is wrong because you compared
+  two different operations that use different thresholds for different reasons
+- **Architecture-vs-fidelity confusion** — flagging that "the plan does X
+  differently from the binary" when X is an intentional architectural choice
+  (e.g., caller-provided layer vs internally-computed layer)
+- **Ghidra misread** — forgetting to check param_1 type, misinterpreting
+  `JG` vs `JGE`, not accounting for sign extension
+- **Stale-doc amplification** — treating a research doc claim as ground truth
+  without verifying in the binary, then flagging a "discrepancy" that's
+  actually a doc error
+- **Missing the forest** — spending all review effort on helper functions
+  while ignoring the main loop's correctness
+- **Over-reporting** — listing 10 "potential issues" that are really 1
+  confirmed + 9 theoretical. This wastes the user's time and erodes trust.

--- a/.agents/skills/rust-scan/SKILL.md
+++ b/.agents/skills/rust-scan/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: rust-scan
+description: "Project-scoped, read-only VERA20k Rust review for confirmed determinism/desync, authoritative-state and lifecycle, architecture, correctness/safety, and measured hot-path risks. Use for /rust-scan [path], changed-Rust reviews, Rust anti-pattern audits, determinism reviews, or code-health scans, including macro-expanded and trait-dispatched behavior when relevant. Defaults to src/sim/; reports evidence and never edits or auto-fixes."
+---
+
+# Rust Scan
+
+Review Rust code without editing it. Treat `ENGINE.md` as authoritative and read it
+completely before scanning. A scan samples risk; it never certifies parity, correctness,
+or cleanliness.
+
+Treat the bundled references as review lenses, not implementation requirements. Their
+imperatives govern what this read-only scan must inspect, prove, classify, and report;
+they do not prescribe production rewrites or grant permission to change code. A heuristic
+or failed lexical check is not a finding until it passes the confirmation gate. Only a
+later, explicitly authorized implementation task may change code, and `ENGINE.md` remains
+authoritative.
+
+Apply this priority when recommendations compete:
+
+1. verified `gamemd.exe` behavior and player-visible parity;
+2. deterministic authority, ordering, lifecycle, persistence, and RNG;
+3. required architecture boundaries and 20,000-unit scale;
+4. measured performance within an explicit budget;
+5. API polish, idiom, and style.
+
+Do not report less-idiomatic Rust merely because a cleaner abstraction exists. Confirm a
+concrete parity, correctness, safety, scale, or maintenance effect first.
+
+## Inputs
+
+Preserve these forms:
+
+- `/rust-scan` — scan `src/sim/`.
+- `/rust-scan <path>` or `/rust-scan scan <path>` — scan one repository-relative
+  Rust file or directory.
+- `--changed [--base <revision>]` — restrict the target to changed Rust files;
+  default the base to `main`.
+- `--focus <name>` — repeat as needed. Names are `determinism`,
+  `architecture`, `state`, `safety`, `performance`, `ownership`, and
+  `structure`.
+- `--include-tests` — include named and probable inline-test candidates.
+- `--clippy` — run the scoped Clippy wrapper after static review.
+
+Without `--focus`, use `determinism,architecture,state,safety,performance` for
+targets intersecting `src/sim/` and `safety,structure` elsewhere.
+Ownership/API-shape review is opt-in; it must not crowd out parity or correctness work.
+Use `$architecture-scan` instead for repository-wide module placement, dependency
+direction, public-surface, naming, cohesion, or Cargo-boundary review. The
+`architecture` focus here remains limited to hard boundaries that affect the Rust
+target being scanned, especially authoritative simulation isolation.
+
+Resolve the target under the repository root, accept only `.rs` files, respect
+ignore rules, and reject paths outside the repository. Record the current HEAD,
+dirty state, target, selected focus, and file count. Never modify code, apply
+Clippy fixes, create scan ledgers, or update Ghidra.
+
+## Resources
+
+- Always use [general review rules](references/general-review.md).
+- For `src/sim/` or any code feeding authoritative simulation, also use
+  [simulation risk rules](references/sim-risks.md).
+- Use [the candidate collector](scripts/collect_candidates.py) for deterministic
+  lexical discovery. Its output is evidence to inspect, never a verdict.
+- Use [the Clippy wrapper](scripts/run_clippy.ps1) only when `--clippy` was
+  requested.
+
+Read the confirmation gates plus only the reference sections needed for the selected
+focus and surfaced rule IDs. Some high-value checks are contextual and intentionally have
+no repository-wide regex.
+
+## Workflow
+
+1. **Establish scope.** Inspect `src/lib.rs`, `src/sim/mod.rs`, the target module
+   headers, and relevant callers. For simulation work, locate the current
+   `World::advance_tick` / master-frame spine and its `SPINE REGION` comments
+   from live code; do not trust a hardcoded filename or line.
+2. **Collect candidates.** Run a summary first:
+
+       python .agents/skills/rust-scan/scripts/collect_candidates.py --target <path> --profile auto --format summary
+
+   Add `--changed --base <revision>`, `--include-tests`, and repeated
+   `--focus <name>` as requested. Rerun with `--format jsonl --rule <RULE_ID>`
+   only for rules worth inspecting. Never silently truncate a large rule. Narrow
+   by changed files or an owning module when practical; otherwise mark that rule
+   `PARTIAL` with its candidate count and do not infer cleanliness from examples.
+3. **Verify context and Rust indirection.** Read the complete containing item and enough callers to
+   establish compiled production reachability, resolved types and ranges,
+   ownership, authority, and test/setup/presentation boundaries. Search results,
+   comments, names, and lint text alone are not findings. When relevant behavior is
+   generated by a declarative/procedural macro or derive, inspect the definition or
+   expansion that actually compiles. At trait calls, resolve the reachable concrete impl,
+   default or blanket method, associated types, and dispatch boundary. Macro or trait use
+   alone is never an anti-pattern.
+4. **Apply project semantics.** For outcome-bearing simulation code, verify
+   scheduler order, equal-key tie-breakers, RNG stream and draw order, lifecycle
+   ownership, same-tick visibility, serialization/hash/snapshot coverage,
+   coordinate frames, and nearby gamemd provenance where applicable.
+5. **Verify performance claims in two stages.** First prove a live call chain and
+   multiplicity or identify the item in a representative optimized-build capture. Then
+   inspect allocation, growth, copying, data access, and algorithmic cost inside that hot
+   item. `Vec::new()` alone does not allocate; capacity-sensitive `push`, `insert`,
+   `extend`, `reserve`, string append, and map insertion may allocate only at the actual
+   call-site capacity. For budget, cache, bandwidth, or contention claims, record the
+   scenario, entity count, target hardware, sampling window, subsystem time in
+   milliseconds, explicit budget, and relevant counters. Without that evidence, report a
+   profiling candidate rather than a confirmed performance finding. If no capture or
+   budget was supplied or already exists, do not create profiling infrastructure or
+   broaden the scan: confirm only bounded algorithmic multiplicity visible in code,
+   state the exact measurement needed under unresolved candidates, and stop. Recommend
+   reusable scratch only after proving reentrancy, clearing, ordering, snapshot/hash
+   exclusion, and memory-retention safety.
+6. **Run Clippy when requested.** First confirm no `cargo` or `rustc` process is
+   active. Run the wrapper once and never kill it mid-build. Preserve all output
+   and the exit code; for a file scan, filter diagnostics to that file only
+   after Clippy exits. An unrelated build failure means `Clippy incomplete`,
+   not a target finding.
+7. **Deduplicate and classify.** Merge overlapping candidates by root cause.
+   Keep unresolved items explicitly `CANDIDATE/UNCHECKED`. For large scopes,
+   bounded read-only delegation is allowed when host policy permits, but the
+   root agent must reread every reported finding and reconcile duplicates.
+
+For authoritative determinism findings, prefer a fix-direction test that exposes the first
+divergent tick: twin simulations, varied insertion or worker order, replay through the live
+command path, or save/load continuation as appropriate. Rust-vs-Rust agreement is regression
+evidence, not `gamemd.exe` parity evidence.
+
+## Classification
+
+A candidate becomes a confirmed finding only when the report can state:
+
+- the compiled, reachable code and authority boundary;
+- the concrete behavior, state, safety, or cost affected;
+- the trigger and expected frequency;
+- the evidence supporting the claim and what remains unknown.
+
+Use severity from verified impact, never from the scan category:
+
+- **CRITICAL** — confirmed production desync/canonical-state corruption,
+  outcome-changing correctness fault, or forbidden architecture dependency.
+- **WARNING** — confirmed safety, error-boundary, hot-path, ownership, or
+  maintainability risk with a bounded player or engineering effect.
+- **INFO** — low-risk improvement with demonstrated benefit.
+
+Test-only, comment-only, setup-only, presentation-only, lookup-only, dormant, and
+diagnostic cases must be labeled as such. Exact-only drift remains separate from
+ordinary-play impact. Do not cap or promote severity merely because Clippy found
+the issue.
+
+## Report
+
+Lead with a one-sentence verdict, then use:
+
+### Coverage
+
+- Target, HEAD, dirty state, profiles, files scanned.
+- Checks completed, skipped, or incomplete, including Clippy status.
+- For performance work, the release scenario, measurements, hardware, and budget—or an
+  explicit statement that the result remains an unmeasured profiling candidate.
+
+### Confirmed findings
+
+| Severity | Confidence | Rule | File:line | Evidence | Trigger / frequency | Effect | Fix direction |
+|---|---|---|---|---|---|---|---|
+
+If none were confirmed, say: `No confirmed findings in the sampled checks; this
+is not certification.`
+
+### Unresolved candidates
+
+List only candidates whose missing type, caller, authority, or runtime evidence
+could materially change the verdict. State the exact next check.
+
+### Notable rejected candidates
+
+Briefly record high-signal false positives that would otherwise be rediscovered,
+such as test-only code or membership-only `HashMap` use.
+
+### Limits
+
+State excluded files, candidate truncation, unrun tools, and remaining unknowns.
+
+End after reporting. Do not auto-fix findings; implementation is a separate,
+explicitly authorized task.

--- a/.agents/skills/rust-scan/agents/openai.yaml
+++ b/.agents/skills/rust-scan/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "VERA Rust Scan"
+  short_description: "Parity-first Rust determinism and safety review"
+  default_prompt: "Use $rust-scan to review src/sim/ for confirmed parity, determinism, authoritative-state, safety, and measured performance risks."
+
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/rust-scan/references/general-review.md
+++ b/.agents/skills/rust-scan/references/general-review.md
@@ -1,0 +1,208 @@
+# General Rust review rules
+
+Use these rules for every target. Confirm context before reporting; token matches
+are candidates only.
+
+Interpret these as evidence lenses for a requested review, not as an independent
+coding standard. Words such as "inspect," "require," and "prefer" describe the
+proof needed to classify a candidate or evaluate a fix direction; they neither
+authorize nor require a production rewrite.
+
+## Contents
+
+- [Safety and failure behavior](#safety-and-failure-behavior)
+- [Ownership, allocation, and hot-path cost](#ownership-allocation-and-hot-path-cost)
+- [Macros and trait dispatch](#macros-and-trait-dispatch)
+- [Structure and modern Rust](#structure-and-modern-rust)
+- [Clippy interpretation](#clippy-interpretation)
+
+## Safety and failure behavior
+
+### SAFE-001 — unsafe contract
+
+Inspect `unsafe` blocks/functions/traits/impls, FFI blocks, raw pointer
+operations, `transmute`, `from_raw_parts`, `set_len`, unchecked indexing,
+`assume_init*`, and manual `Send`/`Sync`. Inventory every reachable unsafe site;
+do not sample them. Require a nearby `SAFETY:` rationale that proves the relevant
+alignment, validity, initialization, aliasing, lifetime, allocation-provenance,
+and thread-safety obligations. Comment presence alone is not proof. Check
+`# Safety` docs for public unsafe functions and edition-2024 unsafe
+attributes/extern blocks. `unsafe_op_in_unsafe_fn` is a lint requirement, not
+evidence that an operation is unsound. Targeted Miri on pure, unsafe-heavy tests
+can add evidence when supported, but a pass is not a proof and FFI/GPU paths may
+be outside its model.
+
+### SAFE-002 — reachable panic or placeholder
+
+Inspect production `panic!`, `assert!`/`assert_eq!`, `todo!`,
+`unimplemented!`, `unreachable!`, indexing, and other panic paths. Accept a
+proved internal invariant and test-only assertions. Never skip reachable
+`todo!` or `unimplemented!`. Classify by the input and player trigger, not by
+macro name.
+
+### ERR-001 — fallible input handling
+
+For `unwrap`/`expect`, trace the value source. External/user/retail data, file
+I/O, decoded assets, network input, and configurable INI/map values require a
+real error boundary unless validation proves the invariant first. Test code and
+documented post-validation invariants are normally acceptable. Also inspect
+ignored `Result`, `let _ =`, `.ok()`, and fallback/defaulting when they can erase
+a production failure; `Result` being `must_use` does not make an explicit discard
+correct.
+
+### ERR-002 — error-layer boundary
+
+Use `thiserror` for typed library/domain errors and `anyhow` for application
+propagation. Report `anyhow` in library code only after confirming the function
+is not an app facade/boundary. Also inspect discarded errors (`.ok()`, ignored
+results, broad fallback/default) when they can hide malformed production input.
+
+### SAFE-003 — lint suppression
+
+Do not flag every `allow`. Review new, broad, stale, or unexplained
+suppressions. Prefer `expect(lint, reason = "...")` for a local condition that
+should disappear, while retaining documented persistent/generated/platform
+allows when appropriate. Severity comes from the hidden issue.
+
+### SAFE-004 — arithmetic, conversion, and portable width
+
+At parser, serialization, indexing, coordinate, and simulation boundaries,
+inspect narrowing or signedness-changing `as`, unchecked shifts/division, and
+ordinary arithmetic whose overflow behavior matters. `usize`/`isize` and default
+Rust layout are target-dependent; do not let them silently define portable save,
+network, replay, or canonical-state formats. Choose `checked_*`, `wrapping_*`,
+`saturating_*`, `overflowing_*`, or `TryFrom` only after establishing the required
+domain or native behavior. A cast is not wrong by syntax alone.
+
+## Ownership, allocation, and hot-path cost
+
+Apply API-shape rules OWN-001 and OWN-002 only when the user selects the
+`ownership` focus or a concrete finding requires ownership analysis. They are
+not default performance findings. OWN-003 remains a default state check in
+authoritative simulation because aliasing and borrow-panics can cross lifecycle
+and tick boundaries.
+
+### OWN-001 — borrowed versus consumed API
+
+`&String` and `&Vec<T>` are candidates for `&str` and `&[T]` only when callers
+need no concrete-container semantics. An owned parameter may intentionally be
+stored, transferred, normalized, or dropped. Resolve use before suggesting a
+signature change.
+
+### OWN-002 — string identity and indirection
+
+Do not recommend `&'static str` for runtime INI, map, mod, or player-provided
+identifiers. Use the project's `InternedId`/newtype when repeated identity or
+hot cloning justifies interning; otherwise ordinary owned strings may be right.
+`Arc<str>`/`Box<str>` are options only when immutable ownership and lost spare
+capacity fit the API.
+
+### OWN-003 — shared interior mutability
+
+`Rc<RefCell<T>>` in authoritative simulation is an ownership and reentrancy
+candidate, not automatic nondeterminism. Inspect aliasing, borrow-panic
+reachability, lifecycle ownership, and whether the value crosses tick or hash
+boundaries. A documented thread-local `RefCell` used only for non-hashed
+scratch is a different pattern and must not be reported under this rule.
+
+### PERF-001 — allocation on a proved hot path
+
+Use two stages. First trace from the current tick/frame spine and state the
+multiplicity, or identify the item in a representative optimized-build capture.
+Then inspect allocations inside that hot item. `Vec::new()` does not allocate;
+growth, `with_capacity`, `vec!`, `collect::<Vec<_>>()`, `to_vec`,
+strings/formatting, boxes, and cloning owned buffers may. Capacity-sensitive
+`push`, `insert`, `extend`, `reserve`, string append, and map insertion require
+call-site capacity evidence before claiming an allocation. Confirm the resolved
+type and branch frequency. Suggest scratch reuse only after checking reentrancy,
+clearing, retained memory, ordering, and authoritative-state exclusion.
+
+### PERF-002 — clone cost
+
+Never use a per-file clone-count threshold. Resolve the cloned type: a Copy-like
+ID or `Arc` bump differs from a `String`/`Vec`/map clone. One clone inside a
+20,000-entity loop can matter more than many setup clones. Report performance
+only with a hot call path or measurement; report ownership confusion only when
+the API makes it concrete.
+
+### PERF-003 — measured cache and data-layout cost
+
+Require a proved hot phase plus traversal order, fields touched, working-set size,
+indirection, and cache/bandwidth evidence before recommending a layout change.
+Report the representative release scenario, target hardware, sampling window,
+milliseconds against an explicit subsystem budget, and relevant counters. Never
+infer “AoS bad,” require an ECS/SoA rewrite, or replace the mandated `BTreeMap`
+authority from syntax alone.
+
+### PERF-004 — spatial-query and pathfinding scaling
+
+In proved hot simulation items, inspect per-entity global scans, nested entity
+loops, repeated nearest/overlap queries, full path recomputation, frontier growth,
+index rebuild frequency and freshness, and query backlog. Record entity count,
+candidate count per query, and update frequency. Broadphases, batching, tiles, or
+sliced work are only fix directions after preserving verified tie order, same-tick
+visibility, index rebuild semantics, and deterministic commit order.
+
+### PERF-005 — observability cost and evidence
+
+Stable phase spans and counters for tick duration, active entities, allocations,
+spatial-query count, path backlog, and job wait/commit time can make a performance
+claim reproducible. Inspect dynamic trace strings, formatting, and per-entity
+events in hot loops. Instrumentation must remain outside canonical state, and
+wall-clock values must never govern authoritative work. Missing instrumentation is
+not itself a finding unless it blocks an explicit budget or regression contract.
+
+## Macros and trait dispatch
+
+Do not report declarative macros, procedural macros, derives, generics, trait
+objects, or blanket impls merely because they obscure a text search.
+
+- When a selected-focus behavior is generated, inspect the macro definition or
+  compiler expansion that actually builds. Check argument evaluation count/order,
+  hidden allocation or iteration, generated unsafe, `cfg` branches, and generated
+  serialization/hash/state behavior as applicable.
+- At a trait call, resolve the reachable concrete impl, default or blanket method,
+  associated types/constants, and dispatch boundary. Review an `unsafe trait` or
+  manual `Send`/`Sync` under SAFE-001. Treat dynamic dispatch as a performance issue
+  only on a proved hot path with demonstrated cost.
+- If expansion or monomorphization cannot be established, keep the result
+  `CANDIDATE/UNCHECKED`; do not guess from the call-site name.
+
+## Structure and modern Rust
+
+### STRUCT-001 — module documentation
+
+Module files should open with a `//!` purpose/dependency comment. Account for
+shebangs, inner attributes, generated files, and intentionally included test
+modules before reporting.
+
+### STRUCT-002 — file growth and cohesion
+
+Around 600 lines is a review cue, not a violation. Check continued growth and
+mixed responsibilities; exempt cohesive data-heavy files and tests. Prefer
+diff-aware reporting of newly crossed thresholds or materially enlarged
+outliers over a repository-wide wall of size warnings.
+
+### MODERN-001 — lazy initialization
+
+Map by semantics: lazy static initialization normally maps to `LazyLock`;
+one-time explicit initialization to `OnceLock`; unsynchronized variants to an
+appropriate `std::cell` type. Inspect direct crate use only, not transitive
+lockfile entries.
+
+### STYLE-001 — optional idioms
+
+Generic rewrites such as iterator chains, `matches!`, let chains,
+`derive(Default)`, `From`/`Into`, `is_multiple_of`, and `div_ceil` are INFO-only
+and opt-in. Prove evaluation order, eagerness, overflow/zero behavior, ownership,
+and domain meaning. Do not rewrite clear order-sensitive game logic merely to
+look modern; rely on selected Clippy groups for routine style discovery.
+
+## Clippy interpretation
+
+Run only through `scripts/run_clippy.ps1` when requested. A diagnostic is still
+a candidate: read its span and caller. Do not suppress compile errors or confuse
+an unrelated build failure with a target issue. Severity follows verified
+impact, not the Clippy group. Prefer the default correctness/suspicious/perf
+groups plus targeted unsafe-contract lints. Do not enable `restriction` or
+`nursery` wholesale; cherry-pick a lint only when its contract matches the scan.

--- a/.agents/skills/rust-scan/references/sim-risks.md
+++ b/.agents/skills/rust-scan/references/sim-risks.md
@@ -1,0 +1,228 @@
+# Simulation risk rules
+
+Use these rules for `src/sim/` and for parsers, bootstrap code, commands, or
+other code that feeds authoritative simulation. `ENGINE.md` wins if this file
+ever conflicts with it.
+
+Interpret these as evidence lenses for a requested review, not as independent
+implementation policy. They identify questions the scan must resolve; verified
+`gamemd.exe` evidence, `ENGINE.md`, and the explicitly authorized task govern any
+later code change.
+
+## Contents
+
+- [Confirmation gate](#confirmation-gate)
+- [Determinism and ordering](#determinism-and-ordering)
+- [Authoritative state and lifecycle](#authoritative-state-and-lifecycle)
+- [Architecture](#architecture)
+- [Coordinates and provenance](#coordinates-and-provenance)
+- [Validation direction](#validation-direction)
+
+## Confirmation gate
+
+Treat every lexical hit as a candidate. Before assigning severity:
+
+1. Exclude comments, strings, test-only items, setup-only paths, diagnostics, and
+   presentation-only data where the rule does not apply.
+2. Resolve source and destination types, guards, callers, and the owning state.
+3. Establish whether the path can affect commands, RNG draws, ordering,
+   canonical state, serialization, hashing, persistence, or same-tick reads.
+4. State the player trigger and frequency. A rare deterministic-state risk may
+   still be critical, but must not be described as common.
+5. For behavior changes, identify the gamemd evidence or label the equivalent
+   `UNCHECKED`. Never invent the native correction.
+
+## Determinism and ordering
+
+### DET-001 — host floating point
+
+Candidate signal: `f32`/`f64` types, literals, arithmetic, transcendental
+functions, or fixed-to-float conversions in the simulation authority cone.
+
+Confirm whether the value can affect gameplay or canonical state. Comments,
+reference-only tests, and hash-excluded presentation state are not desync
+findings, though presentation state living in `sim/` may be ARCH-002. A native
+float/double mechanism does not silently override VERA's fixed-point contract;
+record the contract conflict and required evidence. Do not replace math until
+native conversion, rounding, overflow, and boundary behavior are known.
+
+### DET-002 — unordered collections
+
+Candidate signal: `HashMap`, `HashSet`, unordered collection, or upstream data
+with unspecified order.
+
+Membership and keyed lookup alone are deterministic. Confirm a risk only when
+iteration, serialization, reduction, selection, command generation, RNG
+consumption, insertion order, or a downstream sort exposes unordered order.
+`BTreeMap` is not a universal fix: key order can itself drift from gamemd's
+insertion/scheduler order. Preserve the explicit `EntityStore = BTreeMap`
+invariant and otherwise require the verified ordering contract. Standard
+`Hash`/`DefaultHasher` output is not a stable save, replay, network, or canonical
+digest contract across toolchains and platforms; require an explicitly specified
+canonical encoding and digest where stability matters.
+
+### DET-003 — external entropy, clock, environment, or filesystem order
+
+Candidate signal: `rand::rng`, `thread_rng`, `rand::random`, `OsRng`,
+`getrandom`, entropy seeding, `SystemTime::now`, `Instant::now`, environment
+reads, locale, or directory enumeration.
+
+Confirm whether the result enters authoritative decisions. App-owned logging,
+debug assertions, and evidence sinks are not desyncs when they cannot feed back
+into simulation. Filesystem iteration must be explicitly sorted before it
+selects canonical input.
+
+### DET-004 — casts, ranges, and native-width arithmetic
+
+Candidate signal: `as` conversion to integer types, especially narrowing,
+signed/unsigned, float/integer, or `usize`/`isize` conversions.
+
+Resolve the actual source type and prove its range. `i32 as usize` is unsafe for
+negative values; it is not widening. A modulo after a narrowing cast does not
+make the cast safe because truncation already occurred. Cover all widths, not
+only 8/16/32-bit targets. Separate arithmetic overflow from cast truncation.
+Do not automatically suggest clamp, saturate, or `TryFrom`: first establish
+gamemd's wrap/truncate/clamp behavior and the supported-platform contract.
+
+### DET-005 — conditional production behavior
+
+Candidate signal: `cfg`, `cfg_attr`, `cfg!`, target OS/architecture/pointer
+width, feature, or debug-only branches.
+
+Test-only helpers are normally fine. Confirm a risk when configuration changes
+production structs, serialization, phase logic, RNG use, commands, or canonical
+results between supported peers/builds. Check aliases and macro-expanded gates
+when a direct hit is ambiguous.
+
+### DET-006 — concurrency, atomics, and uninitialized storage
+
+Candidate signal: spawned work, Rayon/parallel iterators, async tasks, atomics,
+`MaybeUninit`, or unsafe initialization.
+
+Parallelism is allowed when work is pure/read-only or commits in a proved
+deterministic order without changing RNG or same-tick visibility. Atomics,
+including `Relaxed`, are not inherently nondeterministic; confirm that
+inter-thread timing can affect authoritative state. For `MaybeUninit`, inspect
+initialization coverage and each `assume_init*`/raw read rather than flagging
+the type itself. Explicitly inspect Rayon `reduce*`, `sum`, `product`, equal-key
+min/max, `find_any`, `par_bridge`, channel/completion-order collection, and
+parallel mutation buffers. Race-free output is not necessarily deterministic.
+Outcome-bearing work requires schedule-independent unique ordering keys and a
+single deterministic commit in the verified authoritative order; thread index or
+completion order is not such a key.
+
+### DET-007 — scheduler, sort, heap, and tie order
+
+Candidate signal: `sort*`, `BinaryHeap`, priority queues, entity snapshots,
+stable-ID walks, insertion/removal, or equal-key comparators.
+
+Trace the order into effects. Require a total, deterministic tie-breaker when
+equal elements can change damage, lifecycle, commands, or RNG. Do not replace
+native/live-object insertion order with stable-ID or sorted-key order merely
+because it is deterministic. Also inspect equal-key min/max/find selection and
+non-associative reductions: stable sorting cannot repair a nondeterministic input
+order, and a deterministic key can still be the wrong native order.
+
+### DET-008 — RNG ownership and draw order
+
+Candidate signal: `SimRng`, `main_rng`, `scenario_rng`, `mapgen_rng`, stream
+cloning, helper draws, or branch-dependent draws.
+
+Verify the owning stream, caller order, draw count, rejected-draw behavior, and
+same-tick state commit. New direct stream access outside an owning/routing seam
+requires evidence. A deterministic PRNG algorithm can still desync when draw
+order differs.
+
+## Authoritative state and lifecycle
+
+### STATE-001 — serialization, hash, and snapshot coverage
+
+For every added or changed authoritative field in `Simulation`, `GameEntity`,
+RNG, scheduler, production, house, trigger, or mission state, verify:
+
+- serialization/deserialization or a justified `serde(skip)`;
+- inclusion in the canonical state hash, or an explicit proof that it cannot
+  feed future simulation;
+- snapshot-version and compatibility impact;
+- initialization/default and save/load/replay/hash mutation tests.
+
+A `serde(skip)` field is high risk if its value can influence a later decision.
+Do not infer coverage from `derive(Serialize)` alone when hashing is manual.
+Classify state as authoritative, deterministically derived, or presentation-only.
+Derived state must rebuild deterministically and should remain diagnosable by a
+canonical dump/hash when it can expose a divergence.
+
+### STATE-002 — lifecycle and authority ownership
+
+Inspect direct entity-store insertion/removal, pending-delete writes, scheduler
+or LogicVector edits, owner changes, reveal/conceal, limbo/unlimbo, occupancy,
+radio links, and reservations. Confirm that the owning lifecycle/helper performs
+side effects in native order. A direct mutation is not automatically wrong, but
+must not bypass registration, hashing, occupancy, or same-tick consequences.
+
+### STATE-003 — tick-spine and phase changes
+
+Elevate changes around command ingress, master-frame phases, live-object
+snapshots, combat/projectile resolution, pending deletion, and frame commit.
+Read the current `SPINE REGION` comments and relevant closed loop. Verify
+ordering and same-tick visibility even if ordinary lint checks pass.
+
+### STATE-004 — command and replay path
+
+Inspect player/network commands, AI intentions, delayed work, and replay records
+as ordered data entering the live simulation path. Verify tick assignment,
+ordering, duplicate and missing-target behavior, rejection semantics, RNG effects,
+and same-tick visibility. Replay-only callbacks or alternate mutation paths are
+candidates because they can hide divergence. Do not import another engine's
+command delay, rollback window, or phase boundary; `gamemd.exe` evidence owns the
+exact contract.
+
+## Architecture
+
+### ARCH-001 — forbidden dependency
+
+Production `sim/` must not depend on `render/`, `ui/`, `sidebar/`, `audio/`, or
+`net/`. Search direct imports, fully qualified paths, grouped imports, aliases,
+re-exports, and indirect module edges. Separate genuine test-only references.
+A confirmed production edge is critical even when it currently appears harmless.
+
+### ARCH-002 — presentation ownership leaked into simulation
+
+Candidate signal: screen/pixel coordinates, sprites, textures, GPU/UI types,
+audio handles, or render-only animation state stored under `sim/`.
+
+Confirm ownership and feedback direction. Hash-excluded presentation data is
+not automatically a determinism fault, but it may violate the headless/replay
+boundary or let presentation state feed authoritative logic.
+
+## Coordinates and provenance
+
+### COORD-001 — frame, unit, sign, and rounding boundary
+
+For cell/lepton/screen, foundation-anchor, facing-byte, height, and isometric
+conversions, require named source and destination frames/units plus exact
+shift/divide/round/clamp/sign semantics. Walk one concrete boundary fixture.
+Literal `256` or bit shifts are candidates, not proof of a bug.
+
+### PROV-001 — gamemd-derived behavior provenance
+
+When simulation semantics are derived in any way from gamemd, verify the nearby
+canonical provenance comment naming the mechanism, native class/function, and
+exact verified address. Absence is a finding only after establishing derivation;
+pure Rust architecture glue does not need invented provenance.
+
+## Validation direction
+
+Match the proposed validation to the confirmed risk rather than adding a generic
+certification matrix:
+
+- arithmetic, parser, lifecycle, and command boundary tests for local contracts;
+- twin simulations comparing canonical state at every tick, including varied
+  insertion or worker order when ordering is at risk;
+- uninterrupted versus save/load/continue for snapshot coverage;
+- repeated replay through the live command path for command/RNG/order risks;
+- the first divergent tick plus canonical human-readable state dumps for diagnosis.
+
+Cross-toolchain, architecture, optimization, or worker-count runs are appropriate
+only when the finding crosses those boundaries. Rust-vs-Rust agreement is a
+regression check; it does not verify parity with `gamemd.exe`.

--- a/.agents/skills/rust-scan/scripts/collect_candidates.py
+++ b/.agents/skills/rust-scan/scripts/collect_candidates.py
@@ -1,0 +1,877 @@
+#!/usr/bin/env python3
+"""Collect lexical Rust review candidates without assigning verdicts.
+
+The collector is intentionally conservative: it discovers stable, sorted
+candidates and leaves type, call-path, authority, and severity decisions to the
+reviewing agent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+FOCUS_NAMES = (
+    "determinism",
+    "architecture",
+    "state",
+    "safety",
+    "performance",
+    "ownership",
+    "structure",
+)
+
+
+@dataclass(frozen=True)
+class Rule:
+    rule_id: str
+    category: str
+    focus: str
+    scope: str
+    pattern: str
+    description: str
+
+    @property
+    def regex(self) -> re.Pattern[str]:
+        return re.compile(self.pattern)
+
+
+RULES: tuple[Rule, ...] = (
+    Rule(
+        "DET-001",
+        "determinism",
+        "determinism",
+        "sim",
+        r"\b(?:f32|f64)\b|(?<![\w.])\d+\.\d+(?:[eE][+-]?\d+)?(?:f32|f64)?\b",
+        "Host floating-point type or conversion in simulation scope",
+    ),
+    Rule(
+        "DET-002",
+        "determinism",
+        "determinism",
+        "sim",
+        r"\b(?:HashMap|HashSet|DefaultHasher)\b",
+        "Unordered collection or unstable standard hash; verify observable use",
+    ),
+    Rule(
+        "DET-003",
+        "determinism",
+        "determinism",
+        "sim",
+        (
+            r"\b(?:thread_rng|OsRng|getrandom|from_entropy)\b"
+            r"|rand\s*::\s*(?:random|rng)\b"
+            r"|(?:SystemTime|Instant|Utc|Local)\s*::\s*now\b"
+            r"|std\s*::\s*(?:env|fs\s*::\s*read_dir)\b"
+        ),
+        "External entropy, clock, environment, or filesystem-order source",
+    ),
+    Rule(
+        "DET-004",
+        "determinism",
+        "determinism",
+        "sim",
+        (
+            r"\bas\s+(?:u8|u16|u32|u64|u128|usize"
+            r"|i8|i16|i32|i64|i128|isize)\b"
+        ),
+        "Integer cast requiring source-type and range verification",
+    ),
+    Rule(
+        "DET-005",
+        "determinism",
+        "determinism",
+        "sim",
+        (
+            r"#\s*\[\s*cfg(?:_attr)?\s*\([^\]]*"
+            r"\b(?:target_arch|target_os|target_env|target_pointer_width"
+            r"|target_endian|debug_assertions|feature)\b"
+            r"|\bcfg!\s*\([^\)]*\b(?:target_arch|target_os|target_env"
+            r"|target_pointer_width|target_endian|debug_assertions|feature)\b"
+        ),
+        "Production-relevant conditional behavior in simulation scope",
+    ),
+    Rule(
+        "DET-006",
+        "determinism",
+        "determinism",
+        "sim",
+        (
+            r"(?:std\s*::\s*)?thread\s*::\s*spawn\b"
+            r"|\b(?:rayon|par_iter|par_iter_mut|into_par_iter|par_bridge"
+            r"|find_any|reduce_with|tokio\s*::\s*spawn)\b"
+            r"|\b(?:AtomicBool|AtomicI(?:8|16|32|64|128|size)"
+            r"|AtomicU(?:8|16|32|64|128|size)|Ordering\s*::\s*Relaxed)\b"
+            r"|\b(?:MaybeUninit|assume_init(?:_read|_drop|_mut|_ref)?)\b"
+        ),
+        "Concurrency, atomic, or initialization primitive needing semantic review",
+    ),
+    Rule(
+        "DET-007",
+        "determinism",
+        "determinism",
+        "sim",
+        r"\bBinaryHeap\b|\.sort(?:_unstable)?(?:_by|_by_key)?\s*\(",
+        "Ordering operation requiring tie-break and downstream-order review",
+    ),
+    Rule(
+        "DET-008",
+        "determinism",
+        "state",
+        "sim",
+        r"\b(?:SimRng|main_rng|scenario_rng|mapgen_rng)\b",
+        "Simulation RNG ownership or draw-order touchpoint",
+    ),
+    Rule(
+        "STATE-001",
+        "state",
+        "state",
+        "sim",
+        r"#\s*\[\s*serde\s*\([^\]]*\bskip\b|SNAPSHOT_VERSION\b",
+        "Serialization/hash/snapshot coverage touchpoint",
+    ),
+    Rule(
+        "STATE-002",
+        "state",
+        "state",
+        "sim",
+        (
+            r"\b(?:LogicVector|logic_vector|pending_delete|unlimbo|limbo"
+            r"|reveal|conceal)\b"
+            r"|(?:entities|occupancy)\s*\.\s*(?:insert|remove)\s*\("
+        ),
+        "Lifecycle, scheduler, entity-store, or occupancy authority touchpoint",
+    ),
+    Rule(
+        "STATE-003",
+        "state",
+        "state",
+        "sim",
+        r"\b(?:advance_tick|advance_master_frame|commit_frame|flush_pending)\b",
+        "Tick-spine or phase-boundary touchpoint",
+    ),
+    Rule(
+        "ARCH-001",
+        "architecture",
+        "architecture",
+        "sim",
+        (
+            r"crate\s*::\s*(?:(?:render|ui|sidebar|audio|net)\b"
+            r"|\{[^\}]*\b(?:render|ui|sidebar|audio|net)\b)"
+            r"|(?:super\s*::\s*)+(?:render|ui|sidebar|audio|net)\b"
+            r"|(?:super\s*::\s*)+\{[^\}]*\b(?:render|ui|sidebar|audio|net)\b"
+        ),
+        "Reference to a layer forbidden beneath simulation",
+    ),
+    Rule(
+        "ARCH-002",
+        "architecture",
+        "architecture",
+        "sim",
+        (
+            r"\b(?:screen_[xy]|pixel_[xy]|shp_name|wgpu|egui|glam"
+            r"|Texture|Sprite|AudioSink)\b"
+        ),
+        "Presentation-oriented state or type under simulation",
+    ),
+    Rule(
+        "COORD-001",
+        "determinism",
+        "determinism",
+        "sim",
+        (
+            r"\b(?:lepton|facing_byte|screen_[xy]|pixel_[xy])\b"
+            r"|(?:<<|>>)\s*8\b|(?:\*|/)\s*256\b|\b256\s*(?:\*|/)"
+        ),
+        "Coordinate, unit, sign, shift, or rounding boundary",
+    ),
+    Rule(
+        "SAFE-001",
+        "safety",
+        "safety",
+        "all",
+        (
+            r"\bunsafe\s*(?:\{|fn\b|impl\b|trait\b|extern\b)"
+            r"|#\s*\[\s*unsafe\s*\("
+            r"|#\s*\[\s*(?:no_mangle|link_section|export_name)\b"
+            r"|\bextern\s+\{"
+            r"|\b(?:transmute|from_raw_parts|get_unchecked|set_len"
+            r"|assume_init(?:_read|_drop|_mut|_ref)?)\b"
+        ),
+        "Unsafe operation or contract requiring invariant verification",
+    ),
+    Rule(
+        "SAFE-002",
+        "safety",
+        "safety",
+        "all",
+        r"\b(?:panic|todo|unimplemented|unreachable)!\s*\(",
+        "Production panic or placeholder candidate",
+    ),
+    Rule(
+        "ERR-001",
+        "error-handling",
+        "safety",
+        "all",
+        r"\.(?:unwrap|expect)\s*\(",
+        "Fallible value requiring input-boundary verification",
+    ),
+    Rule(
+        "ERR-002",
+        "error-handling",
+        "safety",
+        "all",
+        r"\banyhow\s*::|use\s+anyhow\b",
+        "Anyhow use requiring application-versus-library boundary review",
+    ),
+    Rule(
+        "OWN-001",
+        "ownership",
+        "ownership",
+        "all",
+        r"&\s*(?:String|Vec\s*<)",
+        "Borrowed concrete container; verify whether a view type is sufficient",
+    ),
+    Rule(
+        "OWN-002",
+        "ownership",
+        "ownership",
+        "all",
+        r"^\s*(?:pub(?:\s*\([^\)]*\))?\s+)?[A-Za-z_]\w*\s*:\s*String\b",
+        "Owned string field; inspect identity, mutability, and clone frequency",
+    ),
+    Rule(
+        "OWN-003",
+        "ownership",
+        "state",
+        "sim",
+        r"\bRc\s*<\s*RefCell\b|\bRc\s*::\s*new\s*\(\s*RefCell\b",
+        "Shared interior mutability; inspect ownership and reentrancy",
+    ),
+    Rule(
+        "PERF-001",
+        "performance",
+        "performance",
+        "all",
+        (
+            r"\bVec\s*::\s*with_capacity\s*\(|\bvec!\s*\["
+            r"|\.collect\s*::\s*<\s*Vec\b|\.to_vec\s*\("
+            r"|\.to_(?:string|owned)\s*\(|\bString\s*::\s*from\s*\("
+            r"|\bformat!\s*\(|\bBox\s*::\s*new\s*\("
+        ),
+        "Possible allocation; prove hot-path reachability and multiplicity",
+    ),
+    Rule(
+        "PERF-002",
+        "performance",
+        "performance",
+        "all",
+        r"\.clone\s*\(",
+        "Clone candidate; resolve cloned type and call frequency",
+    ),
+    Rule(
+        "MODERN-001",
+        "structure",
+        "structure",
+        "all",
+        r"\b(?:lazy_static|once_cell)\b",
+        "Legacy lazy/once initialization dependency or macro",
+    ),
+)
+
+SPECIAL_RULE_DESCRIPTIONS = {
+    "STRUCT-001": "Module does not open with an inner doc comment",
+    "STRUCT-002": "File exceeds the cohesion review cue",
+}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    rule_id: str
+    category: str
+    path: str
+    line: int
+    text: str
+    hints: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "kind": "candidate",
+            "rule_id": self.rule_id,
+            "category": self.category,
+            "path": self.path,
+            "line": self.line,
+            "text": self.text,
+            "hints": list(self.hints),
+        }
+
+
+def run_checked(
+    args: Sequence[str], cwd: Path, *, allow_failure: bool = False
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0 and not allow_failure:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"{' '.join(args)} failed ({result.returncode}): {detail}")
+    return result
+
+
+def find_repo_root(start: Path) -> Path:
+    result = run_checked(("git", "rev-parse", "--show-toplevel"), start)
+    return Path(result.stdout.strip()).resolve()
+
+
+def is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_target(root: Path, raw_target: str) -> Path:
+    candidate = Path(raw_target)
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    candidate = candidate.resolve()
+    if not is_within(candidate, root):
+        raise ValueError(f"target escapes repository root: {raw_target}")
+    if not candidate.exists():
+        raise ValueError(f"target does not exist: {raw_target}")
+    if candidate.is_file() and candidate.suffix != ".rs":
+        raise ValueError(f"target file is not Rust: {raw_target}")
+    return candidate
+
+
+def rel_posix(path: Path, root: Path) -> str:
+    return path.resolve().relative_to(root).as_posix()
+
+
+def discover_rust_files(root: Path, target: Path) -> list[Path]:
+    if shutil.which("rg") is None:
+        raise RuntimeError("ripgrep (rg) is required for Rust file discovery")
+    if target.is_file():
+        return [target]
+
+    result = run_checked(
+        ("rg", "--files", "-g", "*.rs", str(target)),
+        root,
+        allow_failure=True,
+    )
+    if result.returncode == 1 and not result.stderr.strip():
+        return []
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"rg file discovery failed ({result.returncode}): {detail}")
+    paths: list[Path] = []
+    for raw in result.stdout.splitlines():
+        path = Path(raw)
+        if not path.is_absolute():
+            path = root / path
+        path = path.resolve()
+        if path.is_file() and path.suffix == ".rs" and is_within(path, target):
+            paths.append(path)
+    return sorted(set(paths), key=lambda item: rel_posix(item, root).casefold())
+
+
+def changed_rust_paths(root: Path, base: str) -> set[str]:
+    diff = run_checked(
+        ("git", "diff", "--name-only", "--diff-filter=ACMR", base, "--"),
+        root,
+    )
+    untracked = run_checked(
+        ("git", "ls-files", "--others", "--exclude-standard", "--", "*.rs"),
+        root,
+    )
+    changed: set[str] = set()
+    for raw in (*diff.stdout.splitlines(), *untracked.stdout.splitlines()):
+        normalized = raw.strip().replace("\\", "/")
+        if normalized.endswith(".rs"):
+            changed.add(normalized)
+    return changed
+
+
+def is_named_test_file(relative: str) -> bool:
+    path = Path(relative)
+    lowered = [part.casefold() for part in path.parts]
+    stem = path.stem.casefold()
+    return (
+        "tests" in lowered
+        or stem in {"test", "tests"}
+        or stem.endswith("_test")
+        or stem.endswith("_tests")
+    )
+
+
+def sanitize_lines(lines: Sequence[str]) -> list[str]:
+    """Remove ordinary comments and string bodies while retaining line shape."""
+
+    sanitized: list[str] = []
+    block_depth = 0
+    for line in lines:
+        output: list[str] = []
+        index = 0
+        in_string = False
+        escaped = False
+        while index < len(line):
+            char = line[index]
+            nxt = line[index + 1] if index + 1 < len(line) else ""
+
+            if block_depth:
+                if char == "/" and nxt == "*":
+                    block_depth += 1
+                    output.extend((" ", " "))
+                    index += 2
+                elif char == "*" and nxt == "/":
+                    block_depth -= 1
+                    output.extend((" ", " "))
+                    index += 2
+                else:
+                    output.append(" ")
+                    index += 1
+                continue
+
+            if in_string:
+                output.append(" ")
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                index += 1
+                continue
+
+            if char == "/" and nxt == "/":
+                output.extend(" " * (len(line) - index))
+                break
+            if char == "/" and nxt == "*":
+                block_depth = 1
+                output.extend((" ", " "))
+                index += 2
+                continue
+            if char == '"':
+                in_string = True
+                output.append(" ")
+                index += 1
+                continue
+
+            output.append(char)
+            index += 1
+        sanitized.append("".join(output))
+    return sanitized
+
+
+TEST_ATTRIBUTE_RE = re.compile(r"#\s*\[\s*(?:cfg\s*\(\s*test\s*\)|test)\s*\]")
+
+
+def probable_test_flags(
+    relative: str, raw_lines: Sequence[str], code_lines: Sequence[str]
+) -> list[bool]:
+    if is_named_test_file(relative):
+        return [True] * len(raw_lines)
+
+    flags = [False] * len(raw_lines)
+    depth = 0
+    test_scope_bases: list[int] = []
+    pending_test_item = False
+
+    for index, code in enumerate(code_lines):
+        active_before = bool(test_scope_bases)
+        if TEST_ATTRIBUTE_RE.search(code):
+            pending_test_item = True
+            flags[index] = True
+
+        if active_before or pending_test_item:
+            flags[index] = True
+
+        opens = code.count("{")
+        closes = code.count("}")
+        if pending_test_item and opens:
+            test_scope_bases.append(depth)
+            pending_test_item = False
+        elif pending_test_item and ";" in code:
+            pending_test_item = False
+
+        depth += opens - closes
+        while test_scope_bases and depth <= test_scope_bases[-1]:
+            test_scope_bases.pop()
+
+    return flags
+
+
+def rule_applies(rule: Rule, relative: str, profile: str) -> bool:
+    if rule.scope == "all":
+        return True
+    if profile == "sim":
+        return True
+    if profile == "general":
+        return False
+    return relative.startswith("src/sim/")
+
+
+def collect_regex_candidates(
+    root: Path,
+    files: Iterable[Path],
+    rules: Sequence[Rule],
+    profile: str,
+) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    compiled = [(rule, rule.regex) for rule in rules]
+
+    for path in files:
+        relative = rel_posix(path, root)
+        raw_lines = path.read_text(encoding="utf-8-sig", errors="replace").splitlines()
+        code_lines = sanitize_lines(raw_lines)
+        test_flags = probable_test_flags(relative, raw_lines, code_lines)
+        multiline_rules = [
+            (rule, regex)
+            for rule, regex in compiled
+            if rule.rule_id == "ARCH-001"
+            and rule_applies(rule, relative, profile)
+        ]
+        line_rules = [
+            (rule, regex)
+            for rule, regex in compiled
+            if rule.rule_id != "ARCH-001"
+        ]
+
+        for line_number, (raw, code) in enumerate(
+            zip(raw_lines, code_lines), start=1
+        ):
+            if not code.strip():
+                continue
+            for rule, regex in line_rules:
+                if not rule_applies(rule, relative, profile):
+                    continue
+                if regex.search(code):
+                    hints: list[str] = []
+                    if test_flags[line_number - 1]:
+                        hints.append("probable-test-context")
+                    candidates.append(
+                        Candidate(
+                            rule.rule_id,
+                            rule.category,
+                            relative,
+                            line_number,
+                            raw.strip()[:500],
+                            tuple(hints),
+                        )
+                    )
+
+        joined_code = "\n".join(code_lines)
+        for rule, regex in multiline_rules:
+            for match in regex.finditer(joined_code):
+                start_line = joined_code.count("\n", 0, match.start()) + 1
+                end_line = joined_code.count("\n", 0, match.end()) + 1
+                hints: list[str] = []
+                if any(test_flags[start_line - 1 : end_line]):
+                    hints.append("probable-test-context")
+                excerpt = " ".join(
+                    line.strip()
+                    for line in raw_lines[start_line - 1 : end_line]
+                    if line.strip()
+                )
+                candidates.append(
+                    Candidate(
+                        rule.rule_id,
+                        rule.category,
+                        relative,
+                        start_line,
+                        excerpt[:500],
+                        tuple(hints),
+                    )
+                )
+
+    return candidates
+
+
+def collect_structure_candidates(
+    root: Path, files: Iterable[Path]
+) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    for path in files:
+        relative = rel_posix(path, root)
+        lines = path.read_text(encoding="utf-8-sig", errors="replace").splitlines()
+        code_lines = sanitize_lines(lines)
+        test_flags = probable_test_flags(relative, lines, code_lines)
+        first_line = 1
+        first_text = ""
+        for index, line in enumerate(lines, start=1):
+            if line.strip():
+                first_line = index
+                first_text = line.strip()
+                break
+        if first_text and not first_text.startswith("//!"):
+            candidates.append(
+                Candidate(
+                    "STRUCT-001",
+                    "structure",
+                    relative,
+                    first_line,
+                    first_text[:500],
+                    ("verify-generated-or-special-module",),
+                )
+            )
+        production_scope_lines = sum(
+            1 for is_probable_test in test_flags if not is_probable_test
+        )
+        if production_scope_lines > 600:
+            candidates.append(
+                Candidate(
+                    "STRUCT-002",
+                    "structure",
+                    relative,
+                    1,
+                    (
+                        f"{production_scope_lines} probable production-scope lines "
+                        f"({len(lines)} total); review growth and cohesion, not size alone"
+                    ),
+                    (
+                        "size-is-review-cue",
+                        "inline-test-scope-detection-is-approximate",
+                    ),
+                )
+            )
+    return candidates
+
+
+def deduplicate_and_sort(candidates: Iterable[Candidate]) -> list[Candidate]:
+    unique = {
+        (item.rule_id, item.path, item.line, item.text, item.hints): item
+        for item in candidates
+    }
+    return sorted(
+        unique.values(),
+        key=lambda item: (
+            item.path.casefold(),
+            item.line,
+            item.rule_id,
+            item.text,
+        ),
+    )
+
+
+def filter_test_candidates(
+    candidates: Iterable[Candidate], include_tests: bool
+) -> list[Candidate]:
+    if include_tests:
+        return list(candidates)
+    return [
+        item
+        for item in candidates
+        if "probable-test-context" not in item.hints
+    ]
+
+
+def repo_snapshot(root: Path) -> tuple[str, bool]:
+    head = run_checked(("git", "rev-parse", "--short=12", "HEAD"), root)
+    status = run_checked(("git", "status", "--porcelain"), root)
+    return head.stdout.strip(), bool(status.stdout.strip())
+
+
+def selected_rules(
+    focuses: Sequence[str], requested_ids: Sequence[str]
+) -> tuple[Rule, ...]:
+    requested = set(requested_ids)
+    if requested:
+        known = {rule.rule_id for rule in RULES} | set(SPECIAL_RULE_DESCRIPTIONS)
+        unknown = sorted(requested - known)
+        if unknown:
+            raise ValueError(f"unknown rule id(s): {', '.join(unknown)}")
+        return tuple(rule for rule in RULES if rule.rule_id in requested)
+    focus_set = set(focuses)
+    return tuple(rule for rule in RULES if rule.focus in focus_set)
+
+
+def make_summary(
+    *,
+    root: Path,
+    target: Path,
+    head: str,
+    dirty: bool,
+    profile: str,
+    focuses: Sequence[str],
+    changed_only: bool,
+    base: str,
+    include_tests: bool,
+    files: Sequence[Path],
+    selected_rule_ids: Sequence[str],
+    candidates: Sequence[Candidate],
+) -> dict[str, object]:
+    by_rule: dict[str, list[Candidate]] = {}
+    for candidate in candidates:
+        by_rule.setdefault(candidate.rule_id, []).append(candidate)
+
+    rule_rows: list[dict[str, object]] = []
+    descriptions = {rule.rule_id: rule.description for rule in RULES}
+    descriptions.update(SPECIAL_RULE_DESCRIPTIONS)
+
+    for rule_id in sorted(set(selected_rule_ids)):
+        matches = by_rule.get(rule_id, [])
+        rule_rows.append(
+            {
+                "rule_id": rule_id,
+                "description": descriptions.get(rule_id, ""),
+                "candidate_count": len(matches),
+                "examples": [
+                    {
+                        "path": item.path,
+                        "line": item.line,
+                        "hints": list(item.hints),
+                    }
+                    for item in matches[:3]
+                ],
+            }
+        )
+
+    target_display = (
+        "." if target == root else target.resolve().relative_to(root).as_posix()
+    )
+    return {
+        "kind": "summary",
+        "repository": str(root),
+        "head": head,
+        "dirty": dirty,
+        "target": target_display,
+        "profile": profile,
+        "focus": list(focuses),
+        "changed_only": changed_only,
+        "base": base if changed_only else None,
+        "include_tests": include_tests,
+        "files_scanned": len(files),
+        "candidate_total": len(candidates),
+        "rules": rule_rows,
+        "note": (
+            "Counts are lexical candidates, not findings. "
+            "Inline test-context detection is intentionally approximate."
+        ),
+    }
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Collect sorted lexical candidates for the VERA20k rust-scan skill."
+    )
+    parser.add_argument("--target", default="src/sim")
+    parser.add_argument(
+        "--profile", choices=("auto", "sim", "general"), default="auto"
+    )
+    parser.add_argument("--focus", action="append", choices=FOCUS_NAMES)
+    parser.add_argument("--rule", action="append", default=[])
+    parser.add_argument("--changed", action="store_true")
+    parser.add_argument("--base", default="main")
+    parser.add_argument("--include-tests", action="store_true")
+    parser.add_argument("--format", choices=("summary", "jsonl"), default="summary")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    try:
+        root = find_repo_root(Path.cwd())
+        target = resolve_target(root, args.target)
+        files = discover_rust_files(root, target)
+        if args.changed:
+            changed = changed_rust_paths(root, args.base)
+            files = [path for path in files if rel_posix(path, root) in changed]
+        if not args.include_tests:
+            files = [
+                path
+                for path in files
+                if not is_named_test_file(rel_posix(path, root))
+            ]
+
+        if args.focus:
+            focuses = tuple(dict.fromkeys(args.focus))
+        elif is_within(target, root / "src" / "sim") or any(
+            rel_posix(path, root).startswith("src/sim/") for path in files
+        ):
+            focuses = (
+                "determinism",
+                "architecture",
+                "state",
+                "safety",
+                "performance",
+            )
+        else:
+            focuses = ("safety", "structure")
+
+        rules = selected_rules(focuses, args.rule)
+        candidates = collect_regex_candidates(root, files, rules, args.profile)
+        candidates = filter_test_candidates(candidates, args.include_tests)
+        requested_special = set(args.rule) & set(SPECIAL_RULE_DESCRIPTIONS)
+        if requested_special:
+            candidates.extend(
+                item
+                for item in collect_structure_candidates(root, files)
+                if item.rule_id in requested_special
+            )
+        elif "structure" in focuses and not args.rule:
+            candidates.extend(collect_structure_candidates(root, files))
+        candidates = deduplicate_and_sort(candidates)
+        selected_rule_ids = [rule.rule_id for rule in rules]
+        if requested_special:
+            selected_rule_ids.extend(sorted(requested_special))
+        elif "structure" in focuses and not args.rule:
+            selected_rule_ids.extend(sorted(SPECIAL_RULE_DESCRIPTIONS))
+        head, dirty = repo_snapshot(root)
+        summary = make_summary(
+            root=root,
+            target=target,
+            head=head,
+            dirty=dirty,
+            profile=args.profile,
+            focuses=focuses,
+            changed_only=args.changed,
+            base=args.base,
+            include_tests=args.include_tests,
+            files=files,
+            selected_rule_ids=selected_rule_ids,
+            candidates=candidates,
+        )
+
+        if args.format == "summary":
+            print(json.dumps(summary, indent=2, ensure_ascii=False))
+        else:
+            print(
+                json.dumps(
+                    {
+                        "kind": "metadata",
+                        "repository": str(root),
+                        "head": head,
+                        "dirty": dirty,
+                        "files_scanned": len(files),
+                        "focus": list(focuses),
+                    },
+                    ensure_ascii=False,
+                )
+            )
+            for candidate in candidates:
+                print(json.dumps(candidate.as_dict(), ensure_ascii=False))
+            print(json.dumps(summary, ensure_ascii=False))
+        return 0
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"rust-scan candidate collection failed: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/rust-scan/scripts/run_clippy.ps1
+++ b/.agents/skills/rust-scan/scripts/run_clippy.ps1
@@ -1,0 +1,77 @@
+[CmdletBinding()]
+param(
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+$activeBuilds = @(
+    Get-Process cargo, rustc -ErrorAction SilentlyContinue |
+        Select-Object -Property Id, ProcessName, StartTime
+)
+
+if ($activeBuilds.Count -gt 0) {
+    Write-Error (
+        'Cargo or rustc is already active; rust-scan will not compete with another build. ' +
+        ($activeBuilds | Format-Table -AutoSize | Out-String).Trim()
+    )
+    exit 3
+}
+
+$repoRoot = (& git rev-parse --show-toplevel 2>$null).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repoRoot)) {
+    Write-Error 'run_clippy.ps1 must run from inside the VERA20k repository.'
+    exit 2
+}
+
+$manifestPath = Join-Path -Path $repoRoot -ChildPath 'Cargo.toml'
+if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    Write-Error "Cargo.toml was not found at repository root: $repoRoot"
+    exit 2
+}
+
+$cargoArgs = @(
+    'clippy'
+    '-p'
+    'vera20k'
+    '--lib'
+    '--no-deps'
+    '--locked'
+    '--message-format=short'
+    '--'
+    '-A'
+    'clippy::all'
+    '-W'
+    'clippy::correctness'
+    '-W'
+    'clippy::suspicious'
+    '-W'
+    'clippy::perf'
+    '-W'
+    'clippy::undocumented_unsafe_blocks'
+    '-W'
+    'clippy::missing_safety_doc'
+    '-W'
+    'unsafe_op_in_unsafe_fn'
+)
+
+Write-Output ('cargo ' + ($cargoArgs -join ' '))
+if ($DryRun) {
+    exit 0
+}
+
+Push-Location -LiteralPath $repoRoot
+try {
+    & cargo @cargoArgs 2>&1
+    $cargoExitCode = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+
+if ($null -eq $cargoExitCode) {
+    Write-Error 'Cargo did not return an exit code.'
+    exit 2
+}
+
+exit $cargoExitCode

--- a/.agents/skills/rust-scan/scripts/tests/test_collect_candidates.py
+++ b/.agents/skills/rust-scan/scripts/tests/test_collect_candidates.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "collect_candidates.py"
+SPEC = importlib.util.spec_from_file_location("rust_scan_collect_candidates", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+COLLECTOR = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = COLLECTOR
+SPEC.loader.exec_module(COLLECTOR)
+
+
+class CandidateCollectorTests(unittest.TestCase):
+    def test_sanitizer_ignores_comments_and_string_bodies(self) -> None:
+        lines = [
+            "// HashMap f64",
+            'let label = "HashSet f32";',
+            "let live: f64 = 1.0;",
+            "/* unsafe { */ let index = value as usize;",
+        ]
+        sanitized = COLLECTOR.sanitize_lines(lines)
+        self.assertNotIn("HashMap", sanitized[0])
+        self.assertNotIn("HashSet", sanitized[1])
+        self.assertIn("f64", sanitized[2])
+        self.assertNotIn("unsafe", sanitized[3])
+        self.assertIn("as usize", sanitized[3])
+
+    def test_inline_test_scope_is_tagged(self) -> None:
+        lines = [
+            "fn production() {}",
+            "#[cfg(test)]",
+            "mod tests {",
+            "    fn helper() {",
+            "        let value: f64 = 1.0;",
+            "    }",
+            "}",
+            "fn production_again() {}",
+        ]
+        sanitized = COLLECTOR.sanitize_lines(lines)
+        flags = COLLECTOR.probable_test_flags(
+            "src/sim/example.rs", lines, sanitized
+        )
+        self.assertFalse(flags[0])
+        self.assertTrue(all(flags[1:7]))
+        self.assertFalse(flags[7])
+
+    def test_grouped_architecture_path_and_cast_are_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            source = root / "src" / "sim" / "example.rs"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "\n".join(
+                    (
+                        "//! Example.",
+                        "use crate::{",
+                        "    map::Map,",
+                        "    render::Thing,",
+                        "};",
+                        "fn index(value: i32) -> usize { value as usize }",
+                        "fn bucket(value: u32) -> u8 { (value as u8) % 10 }",
+                        "#[cfg(test)]",
+                        "mod tests {",
+                        "    fn oracle() { let _: f64 = 1.0; }",
+                        "}",
+                    )
+                ),
+                encoding="utf-8",
+            )
+            rules = tuple(
+                rule
+                for rule in COLLECTOR.RULES
+                if rule.rule_id in {"ARCH-001", "DET-001", "DET-004"}
+            )
+            candidates = COLLECTOR.collect_regex_candidates(
+                root, [source], rules, "auto"
+            )
+            by_rule = {}
+            for candidate in candidates:
+                by_rule.setdefault(candidate.rule_id, []).append(candidate)
+
+            self.assertEqual(by_rule["ARCH-001"][0].line, 2)
+            self.assertEqual(
+                [item.line for item in by_rule["DET-004"]],
+                [6, 7],
+            )
+            self.assertIn(
+                "probable-test-context",
+                by_rule["DET-001"][0].hints,
+            )
+            self.assertNotIn("severity", by_rule["DET-004"][0].as_dict())
+
+    def test_cfg_rule_ignores_plain_test_gate_but_finds_feature_gate(self) -> None:
+        rule = next(rule for rule in COLLECTOR.RULES if rule.rule_id == "DET-005")
+        self.assertIsNone(rule.regex.search("#[cfg(test)]"))
+        self.assertIsNotNone(rule.regex.search('#[cfg(feature = "parallel")]'))
+        self.assertIsNotNone(
+            rule.regex.search('#[cfg(target_pointer_width = "32")]')
+        )
+
+    def test_parallel_hash_and_unsafe_signals_are_candidates(self) -> None:
+        rules = {rule.rule_id: rule for rule in COLLECTOR.RULES}
+        self.assertIsNotNone(
+            rules["DET-002"].regex.search("DefaultHasher::new()")
+        )
+        self.assertIsNotNone(
+            rules["DET-006"].regex.search("values.par_bridge().find_any(predicate)")
+        )
+        self.assertIsNotNone(
+            rules["DET-006"].regex.search("values.into_par_iter().reduce_with(merge)")
+        )
+        self.assertIsNotNone(
+            rules["SAFE-001"].regex.search("unsafe { values.set_len(count); }")
+        )
+
+    def test_api_ownership_rules_are_opt_in(self) -> None:
+        default_rules = COLLECTOR.selected_rules(
+            (
+                "determinism",
+                "architecture",
+                "state",
+                "safety",
+                "performance",
+            ),
+            (),
+        )
+        default_ids = {rule.rule_id for rule in default_rules}
+        self.assertNotIn("OWN-001", default_ids)
+        self.assertNotIn("OWN-002", default_ids)
+        self.assertIn("OWN-003", default_ids)
+
+        ownership_rules = COLLECTOR.selected_rules(("ownership",), ())
+        self.assertEqual(
+            {rule.rule_id for rule in ownership_rules},
+            {"OWN-001", "OWN-002"},
+        )
+
+    def test_float_literal_and_bare_extern_block_are_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            source = root / "src" / "sim" / "ffi_math.rs"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "//! Example.\n"
+                "fn ratio() { let value = 1.25; }\n"
+                'extern "C" { fn native(); }\n',
+                encoding="utf-8",
+            )
+            rules = tuple(
+                rule
+                for rule in COLLECTOR.RULES
+                if rule.rule_id in {"DET-001", "SAFE-001"}
+            )
+            candidates = COLLECTOR.collect_regex_candidates(
+                root, [source], rules, "auto"
+            )
+            self.assertEqual(
+                {(candidate.rule_id, candidate.line) for candidate in candidates},
+                {("DET-001", 2), ("SAFE-001", 3)},
+            )
+
+    def test_candidate_order_is_stable_and_deduplicated(self) -> None:
+        candidate_a = COLLECTOR.Candidate(
+            "DET-004", "determinism", "src/sim/z.rs", 9, "x as u8", ()
+        )
+        candidate_b = COLLECTOR.Candidate(
+            "ARCH-001",
+            "architecture",
+            "src/sim/a.rs",
+            2,
+            "crate::render::Thing",
+            (),
+        )
+        ordered = COLLECTOR.deduplicate_and_sort(
+            [candidate_a, candidate_b, candidate_a]
+        )
+        self.assertEqual([item.path for item in ordered], ["src/sim/a.rs", "src/sim/z.rs"])
+
+    def test_crlf_input_keeps_posix_path_and_line_number(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            source = root / "src" / "sim" / "nested" / "crlf.rs"
+            source.parent.mkdir(parents=True)
+            source.write_bytes(b"//! Example.\r\nfn value() -> f64 { 1.0 }\r\n")
+            rule = next(rule for rule in COLLECTOR.RULES if rule.rule_id == "DET-001")
+            candidates = COLLECTOR.collect_regex_candidates(
+                root, [source], (rule,), "auto"
+            )
+            self.assertEqual(len(candidates), 1)
+            self.assertEqual(candidates[0].path, "src/sim/nested/crlf.rs")
+            self.assertEqual(candidates[0].line, 2)
+
+    def test_named_test_files_are_detected(self) -> None:
+        self.assertTrue(COLLECTOR.is_named_test_file("src/sim/world/world_tests.rs"))
+        self.assertTrue(COLLECTOR.is_named_test_file("tests/replay.rs"))
+        self.assertFalse(COLLECTOR.is_named_test_file("src/sim/world/mod.rs"))
+
+    def test_probable_inline_test_candidates_are_opt_in(self) -> None:
+        production = COLLECTOR.Candidate(
+            "DET-004", "determinism", "src/sim/a.rs", 1, "x as u8", ()
+        )
+        test_only = COLLECTOR.Candidate(
+            "DET-004",
+            "determinism",
+            "src/sim/a.rs",
+            9,
+            "x as u8",
+            ("probable-test-context",),
+        )
+        self.assertEqual(
+            COLLECTOR.filter_test_candidates([production, test_only], False),
+            [production],
+        )
+        self.assertEqual(
+            COLLECTOR.filter_test_candidates([production, test_only], True),
+            [production, test_only],
+        )
+
+    def test_file_size_cue_excludes_probable_inline_test_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            source = root / "src" / "sim" / "mostly_inline.rs"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "\n".join(
+                    [
+                        "//! Example.",
+                        "fn production() {}",
+                        "#[cfg(test)]",
+                        "mod tests {",
+                        *(f"fn case_{index}() {{}}" for index in range(700)),
+                        "}",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            candidates = COLLECTOR.collect_structure_candidates(root, [source])
+            self.assertNotIn(
+                "STRUCT-002",
+                {candidate.rule_id for candidate in candidates},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.agents/skills/sync/SKILL.md
+++ b/.agents/skills/sync/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: sync
+description: >
+  Audit and safely synchronize this repository's GitHub Flow branches:
+  protected main plus short-lived feature/* branches. Use for branch drift,
+  safe fast-forward pulls, branch or worktree cleanup, or questions about what
+  is out of date. Never force-pushes, rewrites history, deletes unmerged work,
+  or removes unprotected local-only data.
+---
+
+# Sync — GitHub Flow Branch Audit
+
+Audit branch state first, then perform only explicitly authorized safe actions.
+The standard lifecycle is `main` → `feature/<topic>` → PR → `main` → cleanup.
+There is no long-lived `dev` branch.
+
+## Safety rules
+
+- Require a clean working tree before switching branches or updating refs.
+- Fetch with pruning before drawing conclusions.
+- Use fast-forward-only pulls and merges. Never rebase, reset, amend, or force-push.
+- Never commit or push directly to `main`; it moves through reviewed PRs or an
+  explicit user-owned GitHub action.
+- Never push an unpublished/local-ahead feature branch without user authorization.
+- Branch deletion requires explicit user confirmation after the audit identifies
+  the exact local/remote refs and proves where their unique commits remain.
+- Use `git branch -d`, never `-D`. If safe deletion refuses, stop and explain why.
+- Do not switch or delete a branch checked out by another worktree or active task.
+- Before removing a worktree or cleaning ignored files, run
+  `powershell -NoProfile -File .agents/skills/sync/scripts/check_worktree_cleanup.ps1 -Worktree <absolute-path>`
+  from the primary checkout. Treat an external junction/symlink as a hard stop,
+  and classify every ignored path as backed up, uniquely valuable, or
+  regenerable before proceeding.
+- Never run root-wide `git clean -fdX`. Ignored project contracts, skills,
+  research, INIs, and tool source are authoritative local data, not build litter.
+
+## 1. Preflight and fetch
+
+For a normal sync run, use:
+
+```text
+git status --porcelain
+git worktree list --porcelain
+git fetch --all --prune
+```
+
+If the user explicitly requests a read-only/no-ref-mutation audit, do not fetch or
+prune. Use `git ls-remote --heads origin` for live remote tips, label local
+remote-tracking refs as cached, and make no changes.
+
+If the tree is dirty, another task owns the checkout, or Cargo/worktree ownership is
+unclear, stop before mutation and report the conflict.
+
+### Local-only backup preflight
+
+Before an authorized action could remove a checkout or local-only data, refresh
+the adjacent private backup with:
+
+```text
+powershell -NoProfile -File ..\vera20k-docs-backup\backup.ps1
+```
+
+Require a successful backup commit before continuing. If the backup script is
+missing, refuses because source files disappeared, or reports unapproved
+deletions, stop. Do not bypass it by copying a few visible files or by passing
+the deletion override without separately reviewing the exact stale paths.
+
+## 2. Audit
+
+Collect:
+
+```text
+git branch --format='%(refname:short)|%(upstream:short)|%(upstream:track)|%(objectname:short)'
+git rev-list --left-right --count <branch>...main
+git ls-remote --heads origin
+```
+
+For `main` and every relevant feature branch report:
+
+- local tip and upstream tip;
+- ahead/behind relative to upstream;
+- commits unique to the branch versus `main`;
+- whether it is checked out in any worktree;
+- whether it is unpublished, active, merged, or a cleanup candidate.
+
+Treat a legacy `dev` ref like any other obsolete branch. Never recreate or
+fast-forward it. It is deletable only when it has zero unique commits versus `main`
+and the user explicitly confirms local/remote deletion.
+
+Present the audit before changing refs. A compact example:
+
+```text
+main                    [origin/main] sync
+feature/current-task    (local only)  4 unique commits — keep
+feature/merged-task     [origin/...]  0 unique commits — delete candidate
+```
+
+## 3. Classify actions
+
+- **NO ACTION** — synchronized or legitimate unique work.
+- **PULL MAIN** — local `main` is behind `origin/main` and can fast-forward.
+- **PULL FEATURE** — a clean feature branch is behind its upstream and can fast-forward.
+- **PUBLISH CANDIDATE** — local branch has unpushed commits; report only unless the
+  user asked to push or open/update a PR.
+- **DELETE CANDIDATE** — branch has zero unique commits versus `main`, or the user
+  explicitly wants a remote-only deletion while retaining a proven local copy.
+- **ANOMALY** — divergence, missing commits, unclear ownership, dirty state, or a
+  protected-branch mismatch. Stop and request direction.
+
+## 4. Execute safe catch-up
+
+For an authorized pull:
+
+```text
+git switch main
+git pull --ff-only origin main
+```
+
+or:
+
+```text
+git switch feature/<topic>
+git pull --ff-only
+```
+
+If `--ff-only` refuses, stop. Do not substitute a merge commit or rebase.
+
+## 5. Clean up confirmed branches
+
+After rechecking unique commits and worktree ownership:
+
+```text
+git branch -d feature/<topic>
+git push origin --delete feature/<topic>
+git fetch origin --prune
+```
+
+For a confirmed remote-only deletion that keeps the local branch:
+
+```text
+git push origin --delete feature/<topic>
+git branch --unset-upstream feature/<topic>
+```
+
+If stale upstream metadata makes `git branch -d` refuse even though the branch is
+merged into the current protected history, remove only that upstream association and
+retry `-d`; never escalate to `-D`.
+
+For worktree removal, first run the local-only backup preflight and the bundled
+cleanup check. `git worktree remove --force` is forbidden while the check reports
+external reparse points, dirty files, or unclassified ignored content.
+
+## 6. Verify and report
+
+Verify exact local/remote tips, absence of deleted refs, a clean working tree, and no
+unexpected branch switch. Report kept, updated, deleted, skipped, and unpublished
+branches in one screen. Zero mutations is a valid result when nothing is safely
+actionable.
+
+## Never do
+
+- `git push --force` or `--force-with-lease`
+- `git rebase`, `git reset --hard`, or `git commit --amend`
+- `git branch -D`
+- direct commits or pushes to `main`
+- automatic publication of local feature work
+- deletion of an unmerged or worktree-owned branch
+- root-wide ignored-file cleanup
+- forced removal of a worktree containing external junctions or symlinks
+- recreation of a long-lived `dev` branch

--- a/.agents/skills/sync/scripts/check_worktree_cleanup.ps1
+++ b/.agents/skills/sync/scripts/check_worktree_cleanup.ps1
@@ -1,0 +1,85 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Worktree
+)
+
+$ErrorActionPreference = "Stop"
+
+function ConvertTo-NormalizedPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    return [System.IO.Path]::GetFullPath($Path).TrimEnd([char]92, [char]47)
+}
+
+$resolvedWorktree = (Resolve-Path -LiteralPath $Worktree).Path
+$worktreeRoot = ConvertTo-NormalizedPath $resolvedWorktree
+if (-not (Get-Item -LiteralPath $worktreeRoot).PSIsContainer) {
+    throw "Worktree path is not a directory: $worktreeRoot"
+}
+
+$gitRootOutput = & git -C $worktreeRoot rev-parse --show-toplevel 2>$null
+if ($LASTEXITCODE -ne 0) {
+    throw "Not a Git worktree: $worktreeRoot"
+}
+$gitRoot = ConvertTo-NormalizedPath ($gitRootOutput | Select-Object -First 1)
+if (-not $gitRoot.Equals($worktreeRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Pass the worktree root, not a subdirectory: $gitRoot"
+}
+
+$externalLinks = @()
+$reparsePoints = @(Get-ChildItem -LiteralPath $worktreeRoot -Force -Recurse `
+    -Attributes ReparsePoint -ErrorAction Stop)
+foreach ($link in $reparsePoints) {
+    $targets = @($link.Target)
+    if ($targets.Count -eq 0 -or [string]::IsNullOrWhiteSpace([string]$targets[0])) {
+        $externalLinks += $link.FullName
+        Write-Output "reparse=$($link.FullName)|target=UNKNOWN|inside_worktree=False"
+        continue
+    }
+
+    foreach ($target in $targets) {
+        $targetPath = if ([System.IO.Path]::IsPathRooted($target)) {
+            ConvertTo-NormalizedPath $target
+        } else {
+            ConvertTo-NormalizedPath (Join-Path $link.DirectoryName $target)
+        }
+        $insideWorktree = $targetPath.Equals(
+            $worktreeRoot,
+            [System.StringComparison]::OrdinalIgnoreCase
+        ) -or $targetPath.StartsWith(
+            "$worktreeRoot\",
+            [System.StringComparison]::OrdinalIgnoreCase
+        )
+        Write-Output "reparse=$($link.FullName)|target=$targetPath|inside_worktree=$insideWorktree"
+        if (-not $insideWorktree) {
+            $externalLinks += $link.FullName
+        }
+    }
+}
+
+if ($externalLinks.Count -gt 0) {
+    throw "Unsafe external reparse point(s): $($externalLinks -join ', ')"
+}
+
+$dirty = @(& git -C $worktreeRoot status --porcelain=v1 --untracked-files=all)
+if ($LASTEXITCODE -ne 0) {
+    throw "Unable to inspect worktree status: $worktreeRoot"
+}
+if ($dirty.Count -gt 0) {
+    $preview = ($dirty | Select-Object -First 20) -join [Environment]::NewLine
+    throw "Worktree has tracked or untracked changes:`n$preview"
+}
+
+$ignored = @(& git -C $worktreeRoot clean -ndX)
+if ($LASTEXITCODE -ne 0) {
+    throw "Unable to preview ignored-file cleanup: $worktreeRoot"
+}
+
+Write-Output "worktree=$worktreeRoot"
+Write-Output "external_reparse_points=0"
+Write-Output "ignored_cleanup_candidates=$($ignored.Count)"
+$ignored | Select-Object -First 50
+if ($ignored.Count -gt 50) {
+    Write-Output "ignored_cleanup_candidates_omitted=$($ignored.Count - 50)"
+}

--- a/.agents/skills/trace-action/SKILL.md
+++ b/.agents/skills/trace-action/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: trace-action
+description: "Trace a game mechanic or player action end-to-end through the engine pipeline, verifying each stage against gamemd.exe. Usage: '/trace-action shroud reveal when unit moves' or '/trace-action attack Grizzly vs Rhino at 5 cells' or '/trace-action ore growth spread' or '/trace-action power goes offline'"
+---
+
+# Trace Action — End-to-End Pipeline Diagnostic
+
+Trace `$ARGUMENTS` through every stage of the engine — from trigger to sim state to render to screen. At each stage, compute the concrete values our code produces and verify them against gamemd.exe.
+
+**The goal: "Does this complete production path behave convincingly in an
+ordinary stock skirmish, where does it diverge from gamemd.exe, and which
+divergences actually block the milestone?"**
+
+This covers ANY game mechanic — not just player clicks. Shroud updates, power calculations, ore spreading, building placement rules, superweapon charging, veterancy, crate pickups, etc.
+
+Use active gamemd behavior, retail inputs, and production Rust to trace every
+load-bearing boundary. Preserve honest exact verdicts: an unproven internal
+difference may remain DRIFT/UNCHECKED. Delivery impact is separate. Focus exact
+mechanism work on differences that can affect common behavior, outcomes,
+determinism, authority, lifecycle, RNG, persistence, or shared architecture.
+
+---
+
+## Iron Law — FOLLOW EVERY LOAD-BEARING STAGE
+
+The point of an end-to-end trace is to find where the player journey actually
+breaks or begins to feel wrong. Do not stop at helper functions or a
+high-level summary. Check details in proportion to how they are consumed:
+
+- The 1-tick delay between trigger and effect (does our code apply on the
+  same tick or the next one?)
+- The order of two writes to the same field within one tick
+- The fixed-point rounding direction (truncate? floor? round-to-nearest?
+  banker's rounding?)
+- The `<` vs `<=` in a range check that flips behavior at the boundary
+  cell
+- The clamp that saturates one unit short of where gamemd's clamps
+- The signed-vs-unsigned compare that flips at the wraparound
+- The animation frame that gamemd starts at frame 1, not frame 0
+- The sound cue that fires *before* the visual, not after
+- The pixel offset that shifts the sprite by 1 in screen Y
+- The Z-order tie-breaker when two sprites are on the same cell
+- The field read that picks up the *previous* tick's value instead of
+  this tick's (because it's read before its writer ran)
+
+For every stage ask: what enters, what state changes, who consumes it next, what
+the player experiences, and whether a difference is milestone-blocking,
+compounding, an exactification residual, or unknown-risk. Literal equality is
+required only for an exact `MATCH` claim. A stage may be `MILESTONE-PASS` from
+production evidence while retaining named exact residuals.
+
+## Step 0 — Parse the scenario
+
+Interpret `$ARGUMENTS` as a game mechanic or scenario. If unclear, ask the user to clarify.
+
+Examples of valid inputs:
+- `shroud reveal when unit moves` — trace vision/shroud update pipeline
+- `attack Grizzly vs Rhino at 5 cells` — trace the full combat sequence
+- `move Harvester from (50,50) to (55,55)` — trace movement pipeline
+- `power goes offline` — trace what happens when power drops below demand
+- `ore growth spread` — trace ore growth tick logic + render
+- `deploy MCV` — trace the deploy state machine
+- `building placement GAWEAP` — trace placement validation
+- `chrono miner teleport` — trace the teleport movement system
+- `prism tower chain` — trace prism forwarding logic
+- `gap generator shroud` — trace gap generator shroud re-covering
+- `bridge repair` — trace bridge HP and state transitions
+- `paradrop over target` — trace paradrop spawning + parachute descent
+
+Extract what's needed:
+- Any unit/building types involved — look up in `ini/rulesmd.ini` and `ini/artmd.ini`
+- Relevant INI values for the mechanic (Speed, ROT, ROF, Sight, Power, etc.)
+- Initial conditions (positions, health, power state, etc.)
+- Use the research-index MCP first to find prior trace/research docs and Rust
+  touchpoints. Prefer `research_brief`; if unavailable, use the repo-local CLI
+  fallback:
+
+  ```text
+  python tools/research_index/brief.py "<scenario>" --limit 8
+  ```
+
+  If the exact system is known, add `--system <system>` (examples: `bridges`,
+  `miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun
+  without `--system`, then rerun with the inferred exact system. Use `search.py`,
+  `graph.py evidence`, and `graph.py implementation` for focused anchors. The
+  index is a source map; the trace verdict still requires concrete Rust values
+  and gamemd evidence.
+
+## Step 1 — Identify the trigger and trace the full chain
+
+**What causes this mechanic to activate?** Map from the trigger event all the way to the visual result.
+
+Every mechanic has a pipeline. Identify each stage by reading the code:
+
+```
+TRIGGER:     What initiates it (player click, tick timer, state change, etc.)
+DATA:        What INI/rules values feed into it
+SIM LOGIC:   The core computation (formulas, state machines, conditions)
+STATE CHANGE: What sim state gets modified (entity fields, map state, etc.)
+PROPAGATION: Does the state change trigger further effects? (chain reactions, updates)
+RENDER:      How the state change becomes visual (sprites, animations, overlays)
+SCREEN:      What the player actually sees
+```
+
+**Adapt the stages to the mechanic.** A shroud system has different stages than combat:
+
+Shroud example:
+```
+TRIGGER:     Unit moves to new cell -> vision system runs
+DATA:        Sight= from rules.ini, cell positions, height levels
+SIM LOGIC:   Vision radius calculation, cell iteration, LOS checks
+STATE CHANGE: ShroudMap cells marked as revealed
+PROPAGATION: Revealed cells expose enemy units, update minimap
+RENDER:      Shroud overlay sprites updated (black -> visible)
+SCREEN:      Terrain/units appear where black shroud was
+```
+
+Power example:
+```
+TRIGGER:     Building destroyed / sold / built -> power recalculated
+DATA:        Power= from rules.ini per building
+SIM LOGIC:   Sum all Power values, compare drain vs supply
+STATE CHANGE: House power state (normal/low), building powered flags
+PROPAGATION: Unpowered buildings lose abilities (radar, production speed)
+RENDER:      Powered anims stop, sidebar power bar updates
+SCREEN:      Buildings go dark, radar goes offline
+```
+
+Identify the actual functions in our codebase for each stage. Note file and line.
+
+## Step 1.5 — Enumerate ALL entry points (lifecycle coverage)
+
+**This step prevents missed code paths.** For the mechanic's trigger event, grep/search the codebase for EVERY code path that can cause it. Don't rely on the task description or your assumptions — search exhaustively.
+
+Ask: **"What are ALL the ways this state change can happen?"**
+
+Examples:
+- "Building enters the world" → search for `spawn_object`, `spawn_from_map`, `spawn_at_height`, `entities.insert` — find ALL spawn paths
+- "Building leaves the world" → search for `entities.remove`, `dying = true`, `despawn`, `sell_building` — find ALL removal paths
+- "Entity changes owner" → search for `owner =`, `capture`, ownership transfer paths
+- "Power balance changes" → building placed, sold, destroyed, captured, powered on/off
+
+**Format:**
+```
+ENTRY POINTS for "<trigger event>":
+  1. <path> — <file>:<line> — <when it fires>
+  2. <path> — <file>:<line> — <when it fires>
+  ...
+  COVERAGE: Which paths have the hook? Which are missing?
+```
+
+If any path is missing the necessary hook/call, flag it as a gap BEFORE implementation begins. This is the #1 source of "it works for production buildings but not map buildings" bugs.
+
+## Step 2 — Trace concrete values through each stage
+
+For the specific scenario, compute the actual value at each pipeline stage with real numbers.
+
+**Format each stage as:**
+```
+STAGE N — <name> (<file>:<line>)
+  Input:   <what enters this stage>
+  Formula: <the computation, with actual numbers>
+  Output:  <what this stage produces>
+  gamemd:  <what the original produces — from Ghidra or docs>
+  Verdict: PASS / FAIL / UNCHECKED
+```
+
+**Rules:**
+- Use actual INI values from `ini/rulesmd.ini` and `ini/artmd.ini`, not hypothetical ones.
+- Compute with real numbers — show `Sight=8, radius=8 cells, area checked=201 cells`.
+- For gamemd verification, search in this order (exhaust each before the next):
+  1. **`docs/`** and **`<main-checkout>/docs/research/`** — written research reports, including the ignored in-repo research corpus
+  2. **INI files** — `ini/rulesmd.ini`, `ini/artmd.ini`
+  3. **Ghidra MCP** — last resort, only for gaps or spot-checks the docs don't cover
+- Include intermediate values that could diverge (fixed-point truncation, integer division, rounding).
+- **Show the tiny stuff explicitly.** For each stage, write down — even if
+  "obviously the same":
+  - Which tick the stage runs on, relative to the trigger (`tick T` or
+    `tick T+1`)
+  - Order of operations within the stage (which field is read or written
+    first, second, third)
+  - Rounding mode for any division or fixed-point conversion
+  - Clamp bounds, inclusive vs exclusive
+  - Whether comparisons are signed or unsigned
+  - Whether the stage reads pre-update or post-update values from the
+    fields it depends on
+  These are the things that look "obvious" and are wrong half the time.
+  Listing them forces you to actually check.
+- If a stage is **not implemented** in our engine, mark it explicitly: `NOT IMPLEMENTED`.
+- If you didn't actually compute both numbers (ours AND gamemd's), the
+  stage is `UNCHECKED`, not `PASS`. Don't fill in `PASS` from intuition.
+
+## Step 3 — Verify critical logic against gamemd.exe (targeted)
+
+**Ghidra MCP is the last resort.** Most answers should already be in the research docs from Step 2. Only use Ghidra when:
+- The docs don't cover a specific formula or threshold
+- A doc's claim seems suspect and needs spot-checking
+- The 1-2 most gameplay-critical computations need hard confirmation
+
+When you do use Ghidra:
+- Decompile the relevant function, extract constants and branching
+- Compute the expected output for the scenario's inputs
+- Compare against our code's output
+- Check `param_1` type: if `int` offsets are direct bytes; if `int *` multiply by 4
+- **TS vs YR:** gamemd.exe serves both Tiberian Sun and Yuri's Revenge. Verify that
+  code you're tracing is actually active in YR, not dormant TS legacy. Don't trust
+  field/flag names — trace what they actually gate. TS-era names like "Tiberium"
+  may control something different in YR context (e.g., `Tiberium=` on warheads only
+  gates vein destruction, not ore destruction).
+- **Labels are navigation hints.** Confirm a cited function from its body, callers,
+  receiver flow, and vtable binding. Vtable identity requires a
+  COL→TypeDescriptor owner walk plus slot read and body decompile. If identity is
+  unproven, cite the address and mark the stage `UNCHECKED`, not PASS/FAIL.
+- When live Ghidra is used, record annotation candidates separately. Include the
+  address/source, current metadata, proposed label/comment/reference, and exact proof.
+  A worker reports candidates only; it never mutates Ghidra.
+
+A single matching trace is evidence, not proof of equivalence. Downgrade a
+different mechanism from DRIFT only with algebraic proof, exhaustive vectors over
+a finite domain, or a suitable gamemd/retail-derived executable oracle.
+
+## Step 4 — Check the visual result
+
+Trace from sim state to what the player sees:
+
+- **Does the right thing appear on screen?** (shroud clears, building goes dark, unit moves, etc.)
+- **At the right position?** (coordinate conversion, offsets, anchoring)
+- **At the right time?** (immediate vs delayed, animation timing)
+- **With the right appearance?** (correct sprite/overlay/color, correct animation frame)
+
+If any part of the render pipeline is missing or wrong, note it.
+
+## Step 5 — Timing and sequencing
+
+For mechanics that unfold over time:
+
+- **How many ticks from trigger to visible result?** (Is there a 1-tick delay? A multi-second animation?)
+- **What's the sequence of events?** (What happens first, second, third?)
+- **Does timing feel and behave correctly in the representative scenario?**
+  Record exact tick/frame/order differences and classify their milestone impact.
+
+For instantaneous mechanics (like shroud reveal), verify it happens on the same tick as the trigger, not a tick later.
+
+## Step 5.5 — Optional Ghidra annotation sync
+
+By default, stop after reporting annotation candidates. If `--sync-ghidra-labels` was
+provided or the user directly requested synchronization, the root/standalone trace waits
+for every reader to stop and follows ENGINE.md's serial sync protocol. A read-only
+request or `--no-sync-ghidra-labels` disables synchronization. Workers remain read-only.
+
+## Step 6 — Report
+
+Present:
+
+1. **Pipeline diagram** — the full chain from trigger to screen, one line per stage
+2. **Milestone failures** — stages that break or repeatedly distort ordinary play
+3. **Not implemented** — stages gamemd has that we're missing entirely
+4. **Residuals** — exact differences and unknowns that do not currently block
+5. **Timing** — noticeable/compounding timing errors first, then bounded residuals
+
+6. **Ghidra annotations** — candidate/applied/deferred count and exact addresses, or `None`
+
+For each failure state:
+- Which stage, what our code does vs gamemd
+- Root cause
+- What consumed state, rendered pixel, sound, decision, or timing can differ
+
+**Keep it concise.** Lead with milestone failures and their earliest root cause.
+Preserve exact differences in the residual section without letting them bury the
+production result.
+
+Do NOT implement gameplay/source fixes — only report findings unless the user explicitly
+asks. Ghidra synchronization is optional under Step 5.5, not a default side effect.

--- a/.agents/skills/trace-swarm/SKILL.md
+++ b/.agents/skills/trace-swarm/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: trace-swarm
+description: "Project-scoped for VERA20k/RA2 Yuri's Revenge only. Use when the user invokes '/trace-swarm', asks to orchestrate parallel end-to-end parity traces, wants a bounded multi-mechanic audit across mature movement/combat/vision/power/production/placement/sidebar/audio/render-order systems, or asks to reconcile multiple /trace-action reports. Dispatches at most 3 read-only subagents per wave, each running /trace-action on one concrete player-visible scenario, then ranks FAIL/UNCHECKED results by player visibility and frequency. Reports Ghidra annotation candidates but does not synchronize them unless explicitly requested. Do not use first for broad, under-implemented UI/menu/setup surfaces. Never auto-applies gameplay fixes."
+---
+
+# Trace Swarm
+
+Coordinate up to 3 parallel `/trace-action` investigations per wave for concrete RA2/YR mechanics, then reconcile their reports into a ranked disparity list. This skill is source-fix detection-only: do not edit Rust, INI, or tracked/published docs outside `docs/research/`. Workers and readers do not mutate Ghidra; the parent reports their annotation candidates by default.
+
+Exact trace verdict bar: active-gamemd mechanism, byte state, and
+pixel/result output. Keep DRIFT honest, then assign the separate milestone
+delivery class.
+
+For the current retail-convincing milestone, default candidate selection to
+concrete ordinary-skirmish interactions with high frequency, player
+noticeability, loop breadth, compounding, or unblock value. Keep the exact trace
+verdict, but reconcile bounded expert-only findings under exactification
+residuals unless the user explicitly requests an exact audit wave.
+
+## Hard Gates
+
+- Run the Suitability Gate below before proposing or dispatching any swarm, even when the user explicitly asks for trace-swarm.
+- Dispatch at most 3 subagents at once, or fewer when collaboration slots are
+  unavailable. Split larger queues into sequential waves.
+- Use subagents only after the user explicitly invokes `/trace-swarm` or otherwise asks for parallel/delegated tracing.
+- Each subagent must use Ghidra MCP read-only and report annotation candidates only.
+  Use the full mutating-tool blacklist in the worker prompt below.
+- Each subagent may write exactly one trace report under `<main-checkout>/docs/research/traces/` plus the shared claims file. Nothing else.
+- The parent's only filesystem write is the claims file. Reconciliation never applies code
+  or docs fixes. Ghidra synchronization requires `--sync-ghidra-labels` or a direct user
+  request and follows ENGINE.md after every reader stops.
+- If more than 2 of 5 subagents fail, stop before reconciliation and ask the user whether to retry failed slots, review successes only, or abort.
+- If a subagent returns all-PASS on a non-trivial trace, treat it as suspicious until spot-checked. PASS requires literal computed equality, not intuition.
+
+## Suitability Gate
+
+Trace-swarm is for parallel confirmation of several independent, concrete, player-visible mechanics. It is the wrong first tool for broad feature surfaces, especially UI/menu/setup screens where many slots will only rediscover the same missing parent system.
+
+Before Step 1, do a quick read-only triage:
+
+1. Restate the user's target as either:
+   - **Concrete trace set**: 2-3 independent actions with implemented Rust surfaces and gamemd evidence to compare.
+   - **Broad feature surface**: a screen/system area such as "skirmish UI", "main menu", "sidebar", "lobby", "save/load", or "options" without concrete interactions.
+2. Inspect recent code/docs enough to answer:
+   - Is the feature on the normal player path, or dev-gated/stubbed?
+   - Are the likely slots independent, or do they share one parent missing system?
+   - Would at least 3 slots probably return mostly `NOT-IMPLEMENTED` for the same root cause?
+3. If the answer is "broad feature surface" and either dev-gated/stubbed or dominated by one parent missing system, stop before dispatch. Report that trace-swarm is not ideal, summarize the root reason in 3-6 bullets, and recommend one of:
+   - `/disparity-scan <surface>` for docs-vs-Rust gap inventory.
+   - `/re-investigate <surface>` when active-YR behavior itself is not established.
+   - `/brainstorm <surface>` then `/write-plan` when the next useful step is implementation design.
+   - One focused `/trace-action <concrete action>` when a single interaction needs binary confirmation.
+4. Only continue with trace-swarm if the user explicitly confirms after this warning with wording like `trace it anyway`, or if the triage finds 2-3 concrete, independent, implemented interactions.
+
+For UI/menu/setup surfaces, default to **one of the alternatives** unless the target is narrow and mature. Good trace-swarm UI targets: "sidebar Repair/Sell button flash cadence", "power bar low-power blink", "main-menu owner-draw button pressed offset". Poor trace-swarm UI targets: "skirmish UI", "main menu screen", "options dialog", "lobby UI".
+
+During this triage, use the research-index MCP first. Prefer `research_brief`; if
+unavailable, use the repo-local CLI fallback:
+
+```text
+python tools/research_index/brief.py "<target>" --limit 8
+```
+
+If the exact system is known, add `--system <system>` (examples: `bridges`,
+`miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun without
+`--system`, then rerun with the inferred exact system. Use `map.py`, `search.py`,
+and `graph.py implementation` to decide whether the target is a mature concrete
+interaction or a broad surface better handled by another skill.
+
+## Invocation Modes
+
+- `/trace-swarm`: auto-scan candidate mechanics, propose up to 3 targets, wait for confirmation.
+- `/trace-swarm <m1>, <m2>, ...`: validate explicit mechanics, restate each as a concrete scenario, wait for confirmation.
+- `/trace-swarm --area <area>`: scan only one area, propose up to 3 targets, wait for confirmation.
+- `/trace-swarm --dry-run`: scan/validate and print the dispatch plan, then stop.
+- `/trace-swarm --refresh-index`: rebuild the trace coverage index before ranking.
+- `/trace-swarm --sync-ghidra-labels`: after all workers stop, explicitly request
+  ENGINE.md-gated parent synchronization of accepted metadata candidates.
+- `/trace-swarm --no-sync-ghidra-labels`: force candidate-only Ghidra handling.
+
+Valid areas include `combat`, `movement`, `vision`, `power`, `production`, `placement`, `ui`, `sidebar`, `audio`, and `render-order`.
+
+`ui` is valid only for mature, concrete interactions. Broad setup/menu screen requests must pass the Suitability Gate first and usually route to disparity-scan/re-investigate/planning instead.
+
+If an explicit list has fewer than 5 mechanics, ask whether to run fewer slots (minimum 2) or pad with scanner picks. If it has more than 5, ask which entries to drop. Do not trace abstract targets like `movement` or broad surfaces like `skirmish UI`; ask for a concrete scenario such as `Conscript walks from (50,50) to (55,55) around a wall` or `click Choose Map on dialog 0x102 at 800x600`.
+
+## Step 1: Build Or Read The Candidate Index
+
+For auto, scoped, and refresh modes, use `<main-checkout>/docs/research/traces/.trace-coverage-index.md`.
+
+- If absent, rebuild it.
+- If present and modified within 7 days, use it and tell the user the cache date.
+- If older than 7 days or `--refresh-index` was passed, rebuild it and tell the user.
+
+When rebuilding, collect candidate player-visible mechanics from:
+
+- Canonical mechanics: combat damage/range/splash/retaliation; ground/air/harvester/chrono/transport/scatter movement; shroud, gap, spy, minimap vision; power supply/demand and low-power transitions; queue/placement/sidebar production feedback; placement terrain/adjacency/foundation; sidebar/ui hit testing and flash cadence; EVA/sound cue ordering and panning; render order, brackets, health bars, cliff redraw.
+- Recent code changes: `git log --since="14 days ago" --name-only -- src/sim src/render src/sidebar src/ui src/audio`, mapped back to player-visible mechanics.
+- Existing trace reports: `*_TRACE.md` files, prioritizing prior FAIL/UNCHECKED reports not clearly re-traced and deprioritizing recently traced or NOT IMPLEMENTED reports.
+- Open follow-ups: grep `<main-checkout>/docs/research/` and `docs/plans/` for `TODO: re-trace`, `deferred from trace report`, and similar markers.
+
+Write one flat Markdown bullet per candidate:
+
+```markdown
+- CANONICAL | combat | "Grizzly vs Rhino at edge of range" | last traced: never | recent code: combat_aoe.rs (2d ago)
+- PRIOR_FAIL | power | "power goes offline" | last traced: 2026-02-15 (UNCHECKED on radar disable timing) | recent code: none
+```
+
+Rank candidates by player visibility times frequency:
+
+- HIGH: visible/audible/behavioral result, fires in most matches, or has unresolved prior FAIL.
+- MEDIUM: highly visible but conditional, or subtle but frequent.
+- LOW: niche edge cases, intact recent traces, or no relevant code drift.
+
+Break ties by most recent touched code, oldest prior trace, then subsystem diversity.
+
+## Step 2: Propose And Confirm
+
+Before dispatching, print a table with slot, mechanic, concrete scenario, source, and tier. Wait for an explicit confirmation such as `go`. A previous confirmation in the same thread does not count for a new swarm. For `--dry-run`, stop after printing the plan.
+
+Example:
+
+```markdown
+Proposed trace swarm dispatch (5 slots):
+
+| Slot | Mechanic | Scenario | Source | Tier |
+|------|----------|----------|--------|------|
+| 1 | Combat - point blank | Grizzly vs Rhino at 1 cell, no cover | CANONICAL | HIGH |
+| 2 | Vision - shroud reveal | Conscript walks 5 cells through unexplored shroud | CANONICAL | HIGH |
+```
+
+## Step 3: Append Work Claims
+
+Append to `<main-checkout>/docs/research/traces/.trace-swarm-claims.md`. Create it if missing with:
+
+```markdown
+# Trace-Swarm Work Claims
+
+Active and historical claims from /trace-swarm invocations. Prevents parallel
+sessions from duplicating work. Append-only; stale claims (>4h `claimed`)
+may be re-claimed but rows are not deleted.
+```
+
+Append one block per swarm:
+
+```markdown
+## Trace Swarm 2026-05-20T11:42 (session <short-id>)
+
+- 2026-05-20T11:42 - slot-1 - combat_grizzly_vs_rhino_pointblank - claimed
+```
+
+Statuses are `claimed`, `done`, and `failed`. Do not delete stale claims; a `claimed` row older than 4 hours may be re-claimed by appending a new row.
+
+## Step 4: Dispatch Subagents
+
+Use parallel `spawn_agent` calls where available. Do not set an unavailable model override; inherit the active model unless the user explicitly requested a supported model. Each subagent receives one concrete scenario and a self-contained prompt:
+
+```text
+You are subagent slot {{SLOT}} of a /trace-swarm batch. Your single mechanic is:
+
+  {{MECHANIC}}
+
+Concrete scenario (do not generalize, do not expand): {{SCENARIO}}
+
+Run /trace-action on this exact scenario with these added constraints:
+
+HARD CONSTRAINTS:
+- Ghidra MCP is READ-ONLY. Do NOT call rename_function, rename_function_by_address,
+  rename_data, rename_variable, create_label, create_function, add_struct_field,
+  modify_struct_field, set_decompiler_comment, set_plate_comment,
+  set_disassembly_comment, add_memory_reference, remove_reference, save_program, or any
+  other mutating tool. Report annotation candidates for the parent; do not apply them.
+- You may write EXACTLY ONE file: {{REPORT_PATH}}. Do NOT modify .rs files, INI
+  files, tracked/published docs outside `docs/research/`, or any other location.
+- PASS at any stage requires literal numerical equality between our output and
+  gamemd's. If you did not compute both, mark UNCHECKED, not PASS.
+- Confirm every gamemd reference is active in standard YR, not dormant TS legacy.
+- Ghidra display names/labels are NAVIGATION HINTS ONLY and may be stale or polluted.
+  Before citing a function as gamemd evidence, confirm its identity from the body /
+  callers / vtable (COL→TypeDescriptor read for any vtable claim). A wrong label
+  yields a false FAIL or false PASS. If you cannot confirm identity, mark UNCHECKED
+  and cite the address, not the name.
+- Trace one mechanic and one concrete scenario only. Put adjacent findings in the
+  report's Adjacent Findings section; do not trace them this run.
+
+RETURN VALUE CONTRACT:
+1. Markdown summary, no more than 150 lines.
+2. Exact report file path.
+3. Verdict tally: PASS: <n> | FAIL: <n> | UNCHECKED: <n> | NOT-IMPLEMENTED: <n>
+4. Top 5 most player-visible FAIL or NOT-IMPLEMENTED findings, one line each,
+   with stage, player-visible difference, our file:line, and gamemd evidence.
+5. Ghidra annotation candidates: address/source, current metadata, proposed
+   label/comment/reference, exact live proof, or `None`.
+6. One-line status: COMPLETE | PARTIAL (reason) | FAILED (reason).
+
+Do not include the full stage table, raw decompilation, raw INI dumps, or adjacent
+findings in the return. If blocked, write what you have and return PARTIAL or FAILED.
+```
+
+Wait for all returns, unless a timeout produces a failed slot. Do not start reconciliation until every slot is complete, partial, or failed.
+
+## Step 5: Intake Returns
+
+For each slot:
+
+- Verify the report exists.
+- Update the matching claims row to `done` or `failed`.
+- Treat malformed returns as PARTIAL: over 150 lines, no report path, missing tally, or missing status.
+- Flag all-PASS/non-trivial traces for spot-checking.
+
+If 3 or more slots failed, stop and ask the user how to proceed.
+
+## Step 6: Reconcile
+
+For each successful or partial report:
+
+1. Read the report.
+2. Tally PASS, FAIL, UNCHECKED, and NOT IMPLEMENTED stages.
+3. Spot-check at least one PASS by rereading cited Rust/INI/research/Ghidra evidence and confirming both values were computed.
+4. Spot-check at least one FAIL where present and confirm the gamemd value is cited, not invented.
+5. Re-rank all failures by player visibility times frequency, not by count.
+6. Detect cross-trace patterns: facing convention drift, shared render-stage UNCHECKED gaps, adjacent NOT IMPLEMENTED systems, or common parser/rules data errors.
+
+Do not edit code or docs during reconciliation.
+
+## Step 6.5: Optional Ghidra Annotation Sync
+
+Collect and deduplicate worker candidates. By default, report the queue without mutating
+Ghidra. If `--sync-ghidra-labels` was provided or the user directly requested
+synchronization, the parent waits for every worker to stop and follows ENGINE.md's
+serial sync protocol. A read-only request or `--no-sync-ghidra-labels` disables it.
+
+## Step 7: Report
+
+Return a concise report with:
+
+- Status: complete/partial/failed counts, reports written, disparity count, high-priority count.
+- Reports written: one line per slot with path, status, and tally.
+- Disparities ranked HIGH, MEDIUM, LOW by visibility times frequency, with evidence and trigger frequency.
+- Cross-trace patterns worth investigating before isolated fixes.
+- Pad-PASS audits and what was spot-checked.
+- Subagent contract violations.
+- Ghidra annotation candidates/applied/deferred/conflicted, with addresses and counts.
+- Failed slots and proposed single-slot retry commands.
+- Next steps for the user to choose from.
+
+Stop after the report. Do not start another swarm, re-trace a failed slot, or patch code unless the user asks.

--- a/.agents/skills/trace-swarm/agents/openai.yaml
+++ b/.agents/skills/trace-swarm/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Trace Swarm"
+  short_description: "Run bounded parallel parity traces and reconcile disparities."
+  default_prompt: "/trace-swarm"

--- a/.agents/skills/verify-doc-swarm/SKILL.md
+++ b/.agents/skills/verify-doc-swarm/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: verify-doc-swarm
+description: "Project-scoped for VERA20k/RA2 Yuri's Revenge only. Use when the user invokes '/verify-doc-swarm', asks to orchestrate parallel research-doc audits, wants the highest-leverage stale or never-audited docs checked against gamemd.exe, or asks to reconcile multiple /verify-doc GREEN/YELLOW/RED results. Dispatches at most 3 read-only subagents per wave, each running /verify-doc on one research doc, then ranks staleness, WRONG/MISLEADING findings, cross-doc contradictions, and correction-fact bundles for a later patch pass. Never auto-applies doc or code patches."
+---
+
+# Verify Doc Swarm
+
+Coordinate up to 3 parallel `/verify-doc` audits per wave for research documents in `<main-checkout>/docs/research/`, then reconcile the bounded GREEN/YELLOW/RED summaries into a ranked staleness, contradiction, and correction-fact report. This skill is detection-only: it may make the next doc-patch pass easy, but it never edits audited docs itself and does not write replacement prose for audited docs.
+
+Documentation truth bar: verified mismatches in fields, offsets, operators,
+ordering, bytes, or pixels remain wrong and must not be rewritten as exact
+equivalence. This audit verdict is separate from current skirmish fix priority.
+
+Label-adversarial Ghidra rule: local Ghidra names, labels, comments, xref
+labels, and decompiler-assigned symbol names are navigation hints only. This
+project may contain polluted or stale labels from earlier scripts. Dispatch and
+reconciliation must treat address plus verified role as stronger than label name,
+and must surface label drift clusters as a root-cause pattern.
+
+## Hard Gates
+
+- Dispatch at most 3 subagents at once, or fewer when collaboration slots are
+  unavailable. Split larger queues into sequential waves.
+- Use subagents only after the user explicitly invokes `/verify-doc-swarm` or otherwise asks for parallel/delegated doc audits.
+- Each subagent must use Ghidra MCP read-only. Forbid `rename_function`, `rename_function_by_address`, `rename_data`, `rename_variable`, `create_label`, `create_function`, `add_struct_field`, `modify_struct_field`, `set_decompiler_comment`, `set_plate_comment`, `set_disassembly_comment`, `save_program`, and any mutating operation.
+- Each subagent may write exactly one file: append one line to `<main-checkout>/docs/research/AUDIT_LOG.md`, matching `/verify-doc` rules.
+- Subagents must not modify the audited doc, create corrected copies, write `.rs` files, touch INI files, or modify any other location.
+- The parent may write only `<main-checkout>/docs/research/.audit-swarm-claims.md` and `<main-checkout>/docs/research/.audit-coverage-index.md`.
+- Reconciliation never applies doc rewrites or code fixes.
+- If more than half of a wave fails, stop before reconciliation and ask the user whether to retry failed slots, review successes only, or abort.
+- Treat GREEN on a large/high-risk doc with suspicion until spot-checked.
+- Every returned finding must distinguish verified binary evidence from inference, and every YR-activity assertion must say `Active in YR: Yes / No / Conditional` with evidence or default-gate context.
+- If an audit discovers that the target is structurally wrong enough to require rebuilding the analysis rather than patching isolated claims, recommend a bounded `/re-investigate` target. Do not let `/verify-doc-swarm` silently become a re-investigation.
+- Before and after dispatch, check that only allowed files changed: `AUDIT_LOG.md`, `.audit-swarm-claims.md`, and `.audit-coverage-index.md`. Any audited-doc edit, Rust edit, INI edit, or Ghidra mutation is a contract violation and must be reported before continuing.
+
+## Status Rubric
+
+Use the `/verify-doc` status meanings consistently across all slots:
+
+- `GREEN`: zero WRONG, zero MISLEADING, and less than 5% UNVERIFIABLE among audited load-bearing claims. Safe to rely on for the audited scope.
+- `YELLOW`: isolated wrong/stale/unverifiable claims, or a partial audit, but the doc remains usable with the listed caveats.
+- `RED`: structural errors such as wrong primary function, wrong struct base/layout family, TS-legacy framed as standard YR, or broad pseudocode that would mislead implementation work. Recommend targeted rewrite or `/re-investigate`.
+
+Tiny mismatches are never downgraded: off-by-one, `<` vs `<=`, signedness, wrong offset, wrong clamp, wrong default value, or wrong order-of-operations is `WRONG`.
+
+## Invocation Modes
+
+- `/verify-doc-swarm`: scan candidate docs, propose up to 3 targets, wait for confirmation.
+- `/verify-doc-swarm <d1>, <d2>, ...`: validate explicit docs, then wait for confirmation.
+- `/verify-doc-swarm --area <area>`: scan only one area, propose up to 3 targets, wait for confirmation.
+- `/verify-doc-swarm --dry-run`: scan/validate and print the dispatch plan, then stop.
+- `/verify-doc-swarm --refresh-index`: rebuild the audit coverage index before ranking.
+- `/verify-doc-swarm --patch-plan`: run the normal audit swarm, then group findings into correction-fact bundles for a later patch pass. This still does not edit docs or generate replacement prose.
+
+Valid areas include `combat`, `movement`, `locomotion`, `pathfinding`, `vision`, `shroud`, `power`, `production`, `placement`, `harvester`, `miner`, `building`, `infantry`, `unit`, `aircraft`, `sidebar`, `shell`, `audio`, `animation`, `weapon`, `superweapon`, `terrain`, `map`, `ai`, `radio`, `timer`, `core-engine`, and `ini-parsing`. Treat area names as aliases: for example `harvester` and `miner` both include `miner/` docs and refinery-dock reports.
+
+If an explicit list has more than 3 docs, split it into sequential waves. If the
+user supplies a system name like `garrison`, resolve it to concrete research docs
+before dispatching.
+
+## Step 0: Preflight
+
+Before scanning or proposing slots:
+
+1. Confirm `<main-checkout>/docs/research/` exists.
+2. Confirm `AUDIT_LOG.md` exists or can be created by `/verify-doc` rules.
+3. Confirm Ghidra MCP read-only access is available. If unavailable, stop and report the blocker.
+4. Confirm a subagent tool is available. If unavailable, offer to run serial `/verify-doc` audits instead of pretending to swarm.
+5. Read `.audit-swarm-claims.md` if present and identify active `claimed` rows less than 4 hours old. Do not propose the same doc while a fresh claim exists unless the user explicitly overrides.
+6. Capture a cheap write-integrity baseline for `docs/research/`, repo `src/`, repo `ini/`, and the Ghidra mutating-tools ban. A simple `git diff --stat` plus doc mtimes is enough; this is to catch unexpected writes after dispatch, not to police unrelated pre-existing changes.
+7. Use the research-index MCP as the first candidate/source map. Prefer
+   `research_validate`, `research_map`, and `research_related`; use the repo-local
+   CLI only for a missing MCP capability:
+
+   ```text
+   python tools/research_index/validate.py --system <system> "<topic>" --limit 12
+   python tools/research_index/map.py --system <system> "<topic>" --limit 12
+   ```
+
+   If the exact system is unclear or returns zero docs, rerun without
+   `--system`, then use the inferred exact system (for example `skirmish-ui`,
+   `bridges`, `miner`, `chrono`). Use stale/unknown docs, missing links, and
+   contradiction signals as candidate-ranking inputs. The index does not replace
+   `/verify-doc`; it only chooses better audit targets.
+
+## Step 1: Build Or Read The Audit Index
+
+For auto, scoped, and refresh modes, use `<main-checkout>/docs/research/.audit-coverage-index.md`.
+
+- If absent, rebuild it.
+- If present and modified within 7 days, use it and tell the user the cache date.
+- If older than 7 days or `--refresh-index` was passed, rebuild it and tell the user.
+
+When rebuilding, recursively walk every `*GHIDRA_REPORT.md` and other RE/research docs in `docs/research/`, including subdirectories such as `miner/`, `units/`, and `traces/`. Exclude plans, design specs, generated correction-only files such as `*_VERIFY_DOC_AMENDMENTS.md`, and patch-cluster notes unless explicitly requested. For each doc, extract:
+
+- Last audit: most recent `AUDIT_LOG.md` entry for the filename, with date and GREEN/YELLOW/RED status. No entry means never audited.
+- Patch status: most recent PATCHED/PATCHED-to-GREEN/PATCHED-to-YELLOW line for the filename, if any. Treat a doc patched after its last YELLOW/RED audit as `POST_PATCH_NEEDS_VERIFY` unless a later GREEN audit exists.
+- Doc mtime: if the doc was edited after its last audit, it is post-audit drift.
+- Cross-reference count: grep the rest of `docs/research/` for the filename, and grep repo `src/` for citations across `sim`, `rules`, `map`, `assets`, `render`, `sidebar`, `ui`, and `audio`.
+- Surface-area proxy: count address citations like `0x00XXXXXX`, `+0x` offsets, `FUN_` references, function-name references, vtable-slot mentions, and INI key mappings.
+- TS-legacy density: count callouts like `inherited from Tiberian Sun`, `SpecialFlags`, `FogOfWar`, `Tunnel`, `Subterranean`, and `Veins`.
+- Implementation-load proxy: count references to `src/`, `Implementation Handoff`, `Current Rust`, `Required implementation effect`, and proposed test names.
+- Recent edit signal: edited in the last 14 days and last audit predates the edit.
+
+Write one flat Markdown bullet per doc:
+
+```markdown
+- NEVER_AUDITED | RADIO_PROTOCOL_GHIDRA_REPORT.md | mtime=2026-04-12 | xref=6 | offsets=38 | ts-density=2
+- POST_AUDIT_DRIFT | BUILDING_POWER_GHIDRA_REPORT.md | last=2026-04-20 GREEN | mtime=2026-05-15 | xref=4 | offsets=29
+- POST_PATCH_NEEDS_VERIFY | POWER_SYSTEM_GHIDRA_REPORT.md | last=2026-05-20 YELLOW | patched=2026-05-20 | xref=5 | offsets=52
+```
+
+Categories, highest leverage first:
+
+- `STALE_RED`: last audit was RED.
+- `POST_PATCH_NEEDS_VERIFY`: patched after a non-GREEN audit and not yet re-audited GREEN.
+- `POST_AUDIT_DRIFT`: doc edited after its last audit.
+- `NEVER_AUDITED`: no `AUDIT_LOG.md` entry.
+- `STALE_YELLOW`: last audit YELLOW and older than 30 days.
+- `STALE_GREEN_90D`: last audit GREEN and older than 90 days.
+- `FRESH_GREEN`: audited GREEN within 30 days.
+
+Rank candidates:
+
+- HIGH: `STALE_RED`, `POST_PATCH_NEEDS_VERIFY`, `POST_AUDIT_DRIFT` with xref >= 3, `NEVER_AUDITED` with xref >= 5, implementation-load >= 3, or ts-density >= 3.
+- MEDIUM: `NEVER_AUDITED` with xref 1-4, `STALE_YELLOW`, or `STALE_GREEN_90D` with xref >= 5.
+- LOW: isolated `STALE_GREEN_90D` or xref 0-1 docs.
+
+Break ties by highest xref count, highest implementation-load, highest offset/address count, then newest mtime when last audit predates it. Spread picks across 3-5 subsystems unless `--area` was passed. Prefer canonical report docs over amendment-only docs; prefer docs with implementation handoffs when the user is preparing implementation work.
+
+## Step 1.5: Validate Explicit Targets
+
+For each explicit target:
+
+1. Resolve it to a concrete file under `docs/research/`. If ambiguous, list candidates and ask.
+2. Confirm it is a research/RE doc, not a plan or design spec. Ask whether to drop questionable slots.
+3. Grep `AUDIT_LOG.md` for an entry from today. If found, ask whether to skip, re-audit, or scope to a subsection.
+4. If the doc was edited in the last 6 hours, confirm before auditing a moving target.
+5. If the target is an amendment, patch-cluster note, or audit-index file, ask whether the user meant the canonical source report instead.
+
+## Step 2: Propose And Confirm
+
+Print a table with slot, doc, category, last audit, patch status, xref, offsets, implementation-load, and tier. Wait for explicit confirmation such as `go`. A previous confirmation in the same thread does not count for a new swarm. For `--dry-run`, stop after printing the plan.
+
+```markdown
+Proposed audit-swarm dispatch (5 slots):
+
+| Slot | Doc | Category | Last Audit | Patch | xref | offsets | impl | Tier |
+|------|-----|----------|------------|-------|------|---------|------|------|
+| 1 | MISSION_ENTER_REFINERY_DOCK_GHIDRA_REPORT.md | STALE_RED | 2025-12-03 RED | none | 11 | 51 | 4 | HIGH |
+```
+
+## Step 3: Append Work Claims
+
+Append to `<main-checkout>/docs/research/.audit-swarm-claims.md`. Create it if missing with:
+
+```markdown
+# Verify-Doc-Swarm Work Claims
+
+Active and historical claims from /verify-doc-swarm invocations. Prevents parallel
+sessions from duplicating audit work. Append-only; stale claims (>4h `claimed`)
+may be re-claimed but rows are not deleted.
+```
+
+Append one block per swarm:
+
+```markdown
+## Audit-Swarm 2026-05-20T14:22 (session <short-id>)
+
+- 2026-05-20T14:22 - slot-1 - MISSION_ENTER_REFINERY_DOCK_GHIDRA_REPORT.md - claimed
+```
+
+Statuses are append-only events: `claimed`, `done`, and `failed`. Do not edit or delete old rows. A `claimed` row older than 4 hours is stale and may be re-claimed by appending a new `claimed` row. Completion is recorded by appending a new row, not by rewriting the old row:
+
+```markdown
+- 2026-05-20T14:22 - slot-1 - MISSION_ENTER_REFINERY_DOCK_GHIDRA_REPORT.md - claimed
+- 2026-05-20T15:03 - slot-1 - MISSION_ENTER_REFINERY_DOCK_GHIDRA_REPORT.md - done (YELLOW, 2 WRONG)
+```
+
+## Step 4: Dispatch Subagents
+
+Use parallel `spawn_agent` calls where available. Do not set an unavailable model override; inherit the active model unless the user explicitly requested a supported model. Each subagent receives one concrete doc path and a self-contained prompt:
+
+```text
+You are subagent slot {{SLOT}} of a /verify-doc-swarm batch. Your single target is:
+
+  {{DOC_PATH}}
+
+Run /verify-doc on this document with these added constraints:
+
+HARD CONSTRAINTS:
+- Ghidra MCP is READ-ONLY. Do NOT call rename_function, rename_function_by_address,
+  rename_data, rename_variable, create_label, create_function, add_struct_field,
+  modify_struct_field, set_decompiler_comment, set_plate_comment,
+  set_disassembly_comment, save_program, or any other mutating tool.
+- You may write EXACTLY ONE file: append one line to
+  <main-checkout>/docs/research/AUDIT_LOG.md.
+  Do NOT modify the audited research doc. Do NOT create a corrected copy. Do NOT
+  write .rs files. Do NOT touch INI files. Do NOT modify any other location.
+- Tiny mismatches count as WRONG. A < vs <= mismatch is WRONG. An off-by-one is
+  WRONG. An offset or clamp mismatch is WRONG.
+- Read literally: compare operators character-by-character, constants digit-by-digit,
+  offsets byte-by-byte.
+- Apply the TS-vs-YR filter: every Active in YR assertion must be re-verified
+  against default gating flags and live YR caller paths.
+- Do not audit sibling docs. Note contradictions for the parent; do not chase them.
+- Use `/verify-doc` claim-selection rules: audit roughly 15-25 load-bearing claims
+  unless the doc is smaller, and name any deliberately scoped-out sections.
+- If the doc is structurally broken enough that isolated corrections would be
+  misleading, mark it RED and recommend a bounded `/re-investigate` target instead
+  of rebuilding the doc inside this audit.
+
+RETURN VALUE CONTRACT:
+1. A YAML front matter block:
+   ```yaml
+   slot: {{SLOT}}
+   doc: {{DOC_FILENAME}}
+   status: GREEN | YELLOW | RED
+   result: COMPLETE | PARTIAL | FAILED
+   audit_log_appended: true | false
+   load_bearing_audited: N
+   confirmed: X
+   wrong: Y
+   stale: Z
+   unverifiable: W
+   misleading: V
+   needs_reinvestigate: true | false
+   ```
+2. Exact AUDIT_LOG.md line appended, verbatim.
+3. Bounded Markdown summary, no more than 150 lines:
+   - Doc filename and status.
+   - Load-bearing claim count: N audited (CONFIRMED: X, WRONG: Y, STALE: Z,
+     UNVERIFIABLE: W, MISLEADING: V).
+   - Top 5 most-impactful WRONG/MISLEADING findings with evidence: Ghidra address,
+     offset, exact quoted doc text, exact binary value.
+   - For each WRONG/MISLEADING finding, classify: verified binary fact / inference,
+     player-visible impact, likely downstream docs, and whether it is patchable or
+     needs `/re-investigate`.
+   - Correction facts when safe: section or quote anchor, exact verified binary
+     fact, and evidence. Do not write replacement prose and do not edit the doc.
+   - Sibling-doc contradictions noticed in passing.
+   - Subsections deliberately scoped out.
+4. One-line status: COMPLETE | PARTIAL (reason) | FAILED (reason).
+
+Do not include full claim tables, raw decompilation, raw INI dumps, or narrative
+doc recaps. If blocked, append a FAILED AUDIT_LOG line and return FAILED.
+```
+
+Wait for all returns, unless a timeout produces a failed slot. Do not reconcile until every slot is complete, partial, or failed.
+
+## Step 5: Intake Returns
+
+For each slot:
+
+- Verify the returned `AUDIT_LOG.md` line was actually appended.
+- Append a new `.audit-swarm-claims.md` row marking the matching slot `done` or `failed`; do not rewrite the original `claimed` row.
+- Tally success/failure counts and GREEN/YELLOW/RED status counts.
+- Treat malformed returns as PARTIAL: over 150 lines, missing YAML front matter, missing audit-log line, missing status, missing findings list, or missing scoped-out section list.
+- Flag GREEN-on-fat-target when xref >= 5, offset count >= 30, or ts-density >= 2 and there are zero WRONG/MISLEADING findings.
+- Flag RED-needs-reinvestigate when `needs_reinvestigate: true`, when the primary function/address family is wrong, or when a struct-table sample invalidates the whole table.
+- Run the post-dispatch write-integrity check. If any audited doc, Rust file, INI file, or disallowed docs file changed, stop and report the contract violation before reconciliation.
+
+If 3 or more slots failed, stop and ask the user how to proceed.
+
+## Step 6: Reconcile
+
+For each successful or partial audit:
+
+1. Read the bounded summary carefully.
+2. Cross-reference WRONG/MISLEADING findings against sibling docs by grepping `docs/research/` for the same address, offset, INI key, or function.
+3. Pattern-match across slots: TS-legacy mislabels, vtable slot shifts, offsets off by a constant, `param_1` `int` vs `int *` confusion, same-address collisions, function-entry vs interior-address confusion, stale Ghidra labels, and repeated Rust-status drift.
+4. Spot-check one GREEN slot by reading its `AUDIT_LOG.md` line and independently verifying one load-bearing function or claim against Ghidra/docs. If it disagrees, demote to flagged YELLOW in the report.
+5. Check `AUDIT_LOG.md` history for oscillating docs such as RED -> GREEN -> RED or YELLOW -> PATCHED -> YELLOW.
+6. Build a correction-fact queue from safe findings only:
+   - Include exact doc quote or section anchor.
+   - Include exact verified binary fact.
+   - Include binary evidence and whether the parent spot-checked it.
+   - Group related fixes by target doc.
+   - Mark `needs_reinvestigate` instead of patch-ready when the correction requires rebuilding a model, tracing a new caller chain, or resolving a broad YR-activity question.
+7. If `--patch-plan` was requested, add an ordered non-editing patch plan: docs to patch first, findings that need parent spot-check before patching, sibling docs to verify afterward, and single-doc `/verify-doc` commands to rerun. Do not include replacement prose.
+
+Do not edit audited docs during reconciliation.
+
+## Step 7: Report
+
+Return a concise report with:
+
+- Status: complete count, failed count, GREEN/YELLOW/RED mix, contradiction count.
+- Audits completed: one line per slot with doc, status, and key finding.
+- Highest-impact WRONG/MISLEADING findings ranked by player visibility times downstream load.
+- Cross-doc contradictions, without resolving them unless the evidence was directly checked.
+- Correction-fact queue grouped by doc, with evidence and spot-check state.
+- RED docs that should go to `/re-investigate` instead of isolated patching.
+- Cross-slot patterns worth investigating before isolated doc edits.
+- Suspicion flags such as GREEN-on-fat-target and whether the spot-check passed.
+- Subagent contract violations.
+- Failed slots and proposed single-doc `/verify-doc` retry commands.
+- Verbatim `AUDIT_LOG.md` lines appended.
+- Next steps for the user to choose from.
+
+Stop after the report. Do not start another swarm, run `/verify-doc` on contradictions, or edit docs unless the user asks.
+
+## Fit Notes For This Project
+
+- Prefer verifying canonical `*_GHIDRA_REPORT.md` files before derivative amendment files. Amendment docs are useful evidence, but they can hide whether the source report is now safe.
+- Many local docs are patch-cluster workflows: YELLOW audit -> PATCHED-to-GREEN -> disparity scan. The swarm should preserve that cadence by outputting correction facts and anchors, not by editing docs itself.
+- Re-investigation reports include `Coverage Ledger`, `Open Questions`, and `Implementation Handoff`. When auditing those docs, treat all three as load-bearing: a stale handoff or open-question state can mislead implementation just as much as a wrong offset.
+- Typical high-risk local failure patterns are `param_1` pointer-index offsets, function-entry vs interior-address citations, TS legacy treated as live YR, same field given different names across sibling docs, Ghidra label drift, and Rust status sections drifting after implementation work. Bias candidate ranking and reconciliation toward those patterns.
+- For implementation-facing docs, a GREEN audit is not enough if the Rust-status section was not checked. Either spot-check the cited Rust surface or mark Rust status as deliberately out of scope.

--- a/.agents/skills/verify-doc-swarm/agents/openai.yaml
+++ b/.agents/skills/verify-doc-swarm/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Verify Doc Swarm"
+  short_description: "Run parallel research-doc audits."
+  default_prompt: "/verify-doc-swarm"

--- a/.agents/skills/verify-doc/SKILL.md
+++ b/.agents/skills/verify-doc/SKILL.md
@@ -1,0 +1,484 @@
+---
+name: verify-doc
+description: >
+  Audit an existing gamemd.exe research document against the live binary.
+  Verifies every factual claim (addresses, offsets, field names, formulas,
+  thresholds, state transitions, INI key mappings) in the doc by decompiling
+  in Ghidra. Flags stale, wrong, or unverifiable claims without modifying
+  the doc. Usage: '/verify-doc doc-path-or-name' or '/verify-doc' (prompts
+  for selection).
+---
+
+# Verify Doc — Research Document vs Binary Audit
+
+Audit the research document **$ARGUMENTS** against gamemd.exe. Every
+factual claim in the doc must be re-verified from the live binary via
+Ghidra MCP. Do NOT modify the document. Do NOT implement any Rust code.
+The only output is an audit report.
+
+**Why we audit research docs.** Research claims must remain exact and honest:
+wrong thresholds, offsets, formulas, ordering, or active-YR reachability poison
+future decisions. Correctness of the document is separate from whether the
+finding is current retail-skirmish implementation priority.
+
+<HARD-GATE — DETECTION ONLY>
+This skill is read-only against the filesystem. It CANNOT change anything unless
+the user explicitly asks to save the report or append an audit-log entry.
+
+- Do NOT modify the research document being audited.
+- Do NOT create a "corrected copy" of the doc at a new path.
+- Do NOT write or edit any .rs file.
+- Do NOT update INI files.
+- Do NOT save the audit report to a file. The full report is chat output
+  only, unless the user explicitly asks you to save it AFTER seeing it.
+- Do NOT rename functions / add labels / save_program in Ghidra. Ghidra
+  MCP is used only for read-only decompilation and memory inspection.
+
+An `AUDIT_LOG.md` entry is optional and requires explicit user authorization; a
+request to inspect or audit the document alone does not authorize the write.
+
+If the user asks you to "fix" the doc or "apply the corrections", reply
+that this skill only detects — they should review the report and run a
+separate edit pass (manual or a different skill) to apply any changes.
+
+Self-check before every tool call: "Does this tool modify state?" If yes and the
+user did not explicitly authorize that exact output, do not call it.
+</HARD-GATE>
+
+## Iron Laws
+
+```
+GHIDRA LABELS ARE UNTRUSTED HINTS
+```
+
+Local Ghidra names, labels, comments, xref labels, and decompiler-assigned symbol
+names are navigation aids only. This project may contain polluted or stale labels
+from earlier scripts. Verify load-bearing identity claims from function body,
+assembly/decompile, callsites, receiver/`this` pointer, argument flow, vtable slot
+bytes, data references, and active-YR reachability. Prefer address plus verified
+role over label name. If a doc's label is wrong or ambiguous, flag label drift as
+a finding instead of treating the label as authority.
+
+```
+TINY MISMATCHES COUNT AS WRONG — "CLOSE ENOUGH" IS A FAIL
+```
+
+The whole purpose of this audit is to catch the tiny silent errors. Big
+errors are easy — anyone re-reading the doc would notice the function
+address is wrong. The mismatches we exist to catch are the ones that
+look like nothing:
+
+- `<` where the binary has `<=` (or vice versa)
+- A clamp at `0xFF` documented as `0x100`
+- A constant of `0x67` documented as `0x68`
+- "Checks A then B" when the binary checks B then A
+- "Returns 0 on error" when the binary returns -1
+- A signed comparison documented as unsigned
+- An off-by-one in a loop bound
+- A field listed at offset `0x40` when it's actually `0x44`
+- A flag bit position one off (`0x10` vs `0x20`)
+- A "happens every tick" that's actually "every other tick"
+- A "post-increment" that's actually a "pre-increment"
+- A field updated **before** another field that the doc lists in the
+  opposite order
+- A default value the doc rounds to "~256" when the binary uses 255
+
+**Every one of these is WRONG, not STALE, not "minor"**. Flag it.
+Treat them with the same severity as a wrong function address — because
+downstream consumers (`/write-plan`, implementation work) will copy the
+doc's value verbatim. A 1-bit error here becomes a 1-bit error in the
+engine.
+
+When picking load-bearing claims in Step 1, **do not skip a claim because
+it looks small**. The constants, clamps, and orderings are exactly where
+docs rot fastest, because authors retype them from memory and skim past
+them on review. They are first-class load-bearing claims — pick them.
+
+When verifying in Step 2, **read literally, not approximately.** Compare
+operators character-by-character, constants digit-by-digit, offsets
+byte-by-byte. If your eye glosses past a constant because "yeah, that's
+roughly right," go back and read the actual digits.
+
+```
+THE BINARY IS GROUND TRUTH. THE DOC IS A HYPOTHESIS.
+```
+
+Research docs accumulate drift. A doc that was correct when written can
+be wrong now because: Ghidra re-analysis shifted addresses, annotations
+were renamed, the author misread `param_1` type, or the finding was
+TS-legacy misidentified as active YR behavior. Treat every claim as
+unverified until re-checked from the binary.
+
+```
+TIBERIAN SUN ≠ YURI'S REVENGE
+```
+
+gamemd.exe hosts both engines. A claim that is technically true about
+the binary ("FUN_X checks SpecialFlags bit 0x1000") may be **misleading**
+if the doc implies the code is active in standard YR. Every active-in-YR
+assertion must be re-verified: check default flag values, trace callers,
+confirm the code path is reachable in a normal skirmish.
+
+## Step 0 — Resolve the target doc
+
+1. Parse `$ARGUMENTS`:
+   - Absolute path → read directly
+   - Relative path → try `docs/`, then `<main-checkout>/docs/research/`
+   - Bare name (e.g., "garrison") → search both directories for matching `*GHIDRA_REPORT.md` / `*GARRISON*.md`
+   - If target resolution is broad or ambiguous, use the research-index MCP first:
+
+     ```text
+     research_search(query="<doc-or-topic>", limit=10)
+     research_validate(topic="<doc-or-topic>", limit=10)
+     ```
+
+     If the MCP tools are unavailable, use the equivalent repo-local CLI
+     `search.py` and `validate.py` commands.
+
+     If the exact system is known, add `--system <system>` (examples:
+     `bridges`, `miner`, `skirmish-ui`, `chrono`). If that returns zero docs,
+     rerun without `--system` and use the inferred exact system. The index helps
+     choose the doc; the audit itself still verifies claims against the binary.
+2. If no match or multiple matches, list candidates and ask the user to pick one.
+3. **Check the audit log and moving-target window.** Read `<main-checkout>/docs/research/AUDIT_LOG.md`
+   if it exists. If the target doc has an entry from the last ~30 days with status
+   GREEN, mention it to the user and ask whether to re-audit or skip — recent
+   GREEN audits rarely drift. YELLOW/RED entries are worth re-checking since the
+   user may have patched the doc; just note the prior finding so you can confirm
+   it was addressed. If it was audited today or within the last few hours, do not
+   silently repeat the audit. Also inspect the target doc's mtime; if it changed in
+   the last 6 hours, a parallel session may be rewriting it. Read the recent work
+   first and get explicit confirmation before auditing a moving target.
+4. Read the full doc. Confirm it's a research/RE document (not a plan, not a design spec).
+   If it's not a research doc, say so and stop — this skill is for RE reports only.
+
+## Step 1 — Identify the load-bearing claims
+
+Don't try to enumerate every fact in the doc. Long research docs have
+hundreds of restatements, examples, and derivative claims, and exhaustive
+enumeration burns context without improving the audit. Instead, pick the
+**~15-25 load-bearing claims** — the ones downstream consumers (other
+docs, /write-plan, implementation code) will actually rely on. Output a
+numbered list grouped by bucket below; every later verification step
+refers back to these numbers.
+
+**A claim is load-bearing if** any of these are true:
+- It anchors other claims (a function entry address that pseudocode walks through; a struct base offset that field offsets are computed from)
+- It's a public-interface fact (INI key → struct offset mapping, vtable slot dispatch)
+- It's a behavioral primitive (state-machine transition condition, damage formula, threshold value)
+- It's gating-active-in-YR (the doc claims a code path runs in standard YR — high-blast-radius if wrong)
+- It contradicts a sibling doc (any time two docs make different claims about the same thing, both are load-bearing)
+
+**A claim is NOT load-bearing** (skip it) if it's:
+- A restated fact already verified upstream in the same doc
+- A natural-language summary of pseudocode you'll verify directly
+- A "what this code does at a high level" narrative
+- A claim about the doc's own conclusions or confidence
+
+### Buckets to draw load-bearing claims from
+
+#### A. Binary-location claims
+- Function addresses (e.g., `0x00429a90`, `FUN_00abcdef`)
+- Function names assigned to addresses (e.g., "AStar_main_loop at 0x...")
+- Vtable offsets and the methods they dispatch to
+- Global/static data addresses (`DAT_...`) and what they hold
+- Callers and callees asserted for a given function
+
+#### B. Struct layout claims
+- Class/struct name → byte offset → field name → type
+- Struct total size
+- Inheritance layout (base class offset within derived class)
+- Flag/bitfield layouts and which bits mean what
+
+#### C. Behavioral claims
+- Formulas (damage, speed, ROT, ore growth, etc.)
+- State machines (states, transitions, triggering conditions)
+- Thresholds, clamps, min/max bounds
+- Order of operations ("A before B", "checked in this sequence")
+- Magic constants and their stated meaning
+
+#### D. INI mapping claims
+- "[Section] Key= maps to struct offset 0x...."
+- Default values claimed for INI keys
+- Claims about whether a key is read, ignored, or superseded
+
+#### E. YR-activity claims
+- "Active in YR: Yes/No/Conditional"
+- Flag gating ("behind SpecialFlags & 0x1000")
+- Default values for gating flags in standard YR
+
+#### F. Cross-reference claims
+- References to other docs ("see X_GHIDRA_REPORT.md for Y")
+- References to Rust files ("implemented in src/sim/..." — Rust claims are
+  lower priority but should be spot-checked since they rot fastest)
+
+**Output of Step 1:** a numbered list grouped by bucket, ~15-25 entries
+total. If the doc is so terse that fewer than ~10 load-bearing claims
+exist, audit them all and note in the report that the doc's surface area
+is small. If the doc is so dense that ~25 doesn't cover the load-bearing
+claims, pick the ~25 highest-impact ones and explicitly flag in the
+report which areas you did NOT cover.
+
+## Step 2 — Verify against the binary (THE CORE)
+
+Work through the numbered claim list. Use Ghidra MCP as the primary tool.
+Verification order: **A (addresses) → B (struct layouts) → C (behavior) →
+D (INI mapping) → E (YR activity) → F (cross-refs)**. Earlier buckets
+invalidate later ones — if the address is wrong, every behavioral claim
+attached to it is moot.
+
+### Per-claim verification protocol
+
+For each claim:
+
+1. **State what you're checking** (one sentence, referencing claim number).
+2. **Go to the binary.** Decompile the function, read the memory region,
+   or dump the struct layout — whatever the claim demands.
+3. **Compare literally.** Exact addresses, exact offsets, exact operators
+   (`>` vs `>=`, `<` vs `<=`), exact constants.
+4. **Classify the result:**
+   - **CONFIRMED** — binary matches the doc exactly
+   - **WRONG** — binary contradicts the doc (include actual value)
+   - **STALE** — doc was correct for an earlier Ghidra state but
+     addresses/labels have since shifted (note the new address)
+   - **UNVERIFIABLE** — cannot resolve from binary alone (e.g., doc claims
+     a design intent that leaves no runtime signature)
+   - **MISLEADING** — technically accurate but omits critical context
+     (most commonly: TS-legacy code presented as YR behavior)
+
+### Ghidra pitfalls to re-check (the ones that produce silently-wrong docs)
+
+- **`param_1` type** — `int` means byte offsets; `int *` means index × 4.
+  This is the #1 source of wrong struct offsets. Re-verify type for every
+  function whose offsets the doc cites.
+- **AnimTypeClass uses `int *`** — doc may have `int *` offsets multiplied
+  correctly OR raw. Check before accepting.
+- **`DAT_` globals** — if the doc cites a value from a data table, re-read
+  memory at that address with `read_memory`. Values may differ from what
+  the decompiler's comment suggested.
+- **Vtable dispatch** — if the doc names a method called "virtually", confirm
+  the concrete implementation at the claimed vtable slot. Vtable indices
+  shift when RTTI labeler reruns. Follow the full protocol below.
+- **Signed vs unsigned** — a claim like "clamped to 0-255" is different from
+  "sign-extended to int". Check the MOVZX vs MOVSX.
+
+### Vtable claim verification
+
+Every claim that slot N of class C's vtable is method M requires all three:
+
+1. **Owner:** read the CompleteObjectLocator pointer at `vtable-4`, then the
+   TypeDescriptor at `COL+0x0C`, then its mangled name at `TypeDescriptor+0x08`.
+   It must name class C; a Ghidra display label is not evidence.
+2. **Slot:** read the function pointer at `vtable + N*4`. gamemd is 32-bit, so
+   slot 17 is byte offset `0x44`, not `0x11`.
+3. **Body:** decompile the resulting function address and verify that its body
+   implements M's claimed behavior.
+
+Cite all three calls inline. Owner or body mismatch is `WRONG`; `__purecall` in
+a construction snapshot is `STALE` only when the live vtable is independently
+verified; an unreachable TypeDescriptor is `UNVERIFIABLE`. Mangled RTTI identity
+wins over a conflicting display label.
+
+### TS-vs-YR re-check (mandatory for every E-bucket claim)
+
+For every "Active in YR" assertion:
+
+1. **Find the gating flag.** Re-trace in the binary — don't trust the doc
+   to have identified the right flag.
+2. **Read the default value.** Check `ini/rulesmd.ini`, `ini/rules.ini`,
+   and any hardcoded default in the binary. TS defaults still appear in
+   the binary but YR ships different defaults.
+3. **Trace callers.** Is the code path reachable from standard YR game
+   setup? Some functions are only called by TS-era mission triggers that
+   no YR map uses.
+4. **Flag misidentification.** Field/flag names may be TS-era. "Tiberium"
+   on a warhead gates veins, not ore. Doc claims that trust the name are
+   suspect.
+
+### Struct layout sanity check
+
+When the doc publishes a struct layout table:
+
+1. Pick 3-5 fields at random (not just the first few — authors often get
+   early offsets right and drift later).
+2. Find a function that reads/writes each picked field. Decompile it.
+   Confirm the offset in the decompilation matches the doc's table.
+3. Check the struct's total size claim against an allocation site
+   (constructor call, array stride).
+
+If any random pick is wrong, treat the entire table as SUSPECT and
+re-verify all fields the doc's consumers actually care about.
+
+## Step 3 — Cross-reference pass
+
+Skim the doc one more time for claims you might have missed because they
+weren't phrased as obvious facts:
+
+- "Obviously the engine must do X" — verify it does.
+- "We infer that..." — re-classify as UNVERIFIABLE or verify it.
+- Pseudocode blocks — compare each line to the decompilation.
+- Tables with "Purpose" columns — the offset+type may be right but the
+  purpose narrative can be fabricated. Spot-check.
+
+## Step 4 — Cross-doc consistency (optional, if time permits)
+
+If the doc references sibling docs (e.g., "See ARMOR_TYPES_GHIDRA_REPORT.md"),
+check the sibling for contradictions. Two docs disagreeing is worth flagging
+even if both are internally consistent — it means at least one is wrong.
+
+Do NOT expand the audit into those sibling docs. Just note the contradiction
+and which doc the binary supports.
+
+## Step 5 — Report
+
+Structure:
+
+```
+## Doc Audit: <doc path>
+
+**Doc status:** GREEN / YELLOW / RED
+  - GREEN: 0 WRONG, 0 MISLEADING, <5% UNVERIFIABLE — safe to rely on
+  - YELLOW: minor staleness or a few wrong offsets — usable with flagged caveats
+  - RED: structural errors (wrong struct base address, TS-legacy framed as
+    YR behavior, wrong primary function) — consumers should not trust this doc
+    until rewritten
+
+### Summary
+- Load-bearing claims audited: N (out of the ~15-25 selected in Step 1)
+- CONFIRMED: N
+- WRONG: N
+- STALE: N
+- UNVERIFIABLE: N
+- MISLEADING: N
+- (If applicable) Areas NOT covered: <one-line list of long pseudocode blocks
+  / sub-systems you deliberately scoped out — be honest, don't pretend
+  uncovered areas were verified>
+
+Be honest about scope. If you only got through 12 of the 22 claims you
+listed, the count is 12 — don't fabricate. The user reads this number
+to decide whether to trust the GREEN/YELLOW/RED status.
+
+### Wrong Claims
+[For each WRONG:]
+- **Claim #N (section "..."):** doc says X
+- **Binary shows:** Y (address/offset/evidence)
+- **Impact:** what downstream code/decisions would this mislead?
+
+### Stale Claims
+[For each STALE:]
+- **Claim #N:** address/label in doc is `OLD`; current Ghidra state shows `NEW`
+- **Still semantically correct?** yes/no
+- **Suggested update:** one-line pointer (not a rewrite)
+
+### Misleading Claims (TS-legacy framed as YR)
+[For each MISLEADING:]
+- **Claim #N:** doc implies behavior is active in YR
+- **Actual gating:** flag / default value / caller analysis
+- **Real YR status:** inactive / conditional / degenerate
+
+### Unverifiable Claims
+[For each UNVERIFIABLE:]
+- **Claim #N:** what the doc asserts
+- **Why it can't be verified from binary:** (design intent, author inference,
+  historical context, etc.)
+- **Treat as:** informational / remove / flag as inference
+
+### Contradictions With Sibling Docs
+[If any — list the conflict and which doc the binary supports.]
+
+### Verdict
+One paragraph: is this doc safe to use as input for /write-plan,
+/trace-action, or new implementation work? If RED, what's the shortest
+path to making it safe (targeted rewrite vs full /re-investigate)?
+```
+
+### Rules for the report
+
+- **Lead with the status and WRONG claims.** Don't bury errors under
+  tables of confirmations.
+- **No match tables.** Don't list every claim that checked out.
+- **Every WRONG / STALE / MISLEADING needs binary evidence** — an address,
+  an offset, a decompiled line. "Seems wrong" is not a finding.
+- **No fixes.** Do not propose doc rewrites. The user decides whether to
+  re-investigate, patch, or deprecate the doc.
+- **Quote the doc verbatim** when flagging a specific claim, so the user
+  can Ctrl-F to the exact line they need to edit.
+
+## Anti-patterns
+
+- **Summarizing the doc instead of auditing it.** If your report restates
+  what the doc says without checking the binary, you did Step 1 and skipped
+  Step 2. Start over.
+- **Accepting addresses without decompiling.** An address in a doc is a
+  claim, not a fact. Decompile it.
+- **Trusting the struct table's first few entries.** Authors get the head
+  right and the tail wrong. Random-sample deeper into the table.
+- **Flagging everything as UNVERIFIABLE.** If most claims land in this bucket,
+  you're not using Ghidra hard enough. Re-read Step 2.
+- **Turning the audit into a re-investigation.** If the doc is RED, STOP
+  and recommend `/re-investigate`. Don't silently rebuild the doc in the
+  audit report.
+- **Ignoring the YR/TS distinction.** Every behavioral claim the doc makes
+  needs an active-in-YR check, even if the doc didn't explicitly frame it
+  that way.
+- **Fabricating coverage counts.** If you didn't enumerate the claim list
+  in Step 1, don't make up a number for "Total claims audited". Either go
+  back and enumerate, or write "smoke check" in the report and mark the
+  status conservatively.
+- **Downgrading a tiny mismatch to "STALE" or "minor".** An off-by-one is
+  WRONG, not stale. A clamp value off by 1 is WRONG, not minor. STALE means
+  "the address shifted but the semantics still hold". A wrong constant or
+  wrong operator is a semantic change — that's WRONG.
+- **Skimming past constants because they "look right".** The pattern is:
+  eye sees `0xFF`, brain reads "byte max", check passes. Then later the
+  binary turns out to use `0x7F` (signed byte max) and a parity bug ships.
+  Read the digits. Every time.
+
+## Step 6 — Optional audit-log entry
+
+After delivering the report in chat, append one line to
+`<main-checkout>/docs/research/AUDIT_LOG.md` only if the user
+explicitly requested logging. Otherwise stop after the chat report.
+
+### Line format
+
+```
+- **YYYY-MM-DD** — `<doc-filename>` — STATUS — <one-line key finding>
+```
+
+Examples:
+```
+- **2026-05-05** — `CHRONO_MINER_TELEPORT_GHIDRA_REPORT.md` — YELLOW — slot-18 vtable label wrong; teleport-vs-drive decision oversimplified (BuildingTypeClass+0x16B3 = DockUnload, gating omitted)
+- **2026-05-05** — `MISSION_ENTER_REFINERY_DOCK_GHIDRA_REPORT.md` — GREEN — CLSID_TeleportLocomotion byte error ({4A582790} → {4A582747}); FootClass__PerCellProcess mislabeled as "dock state transition"
+- **2026-05-05** — `HARVESTER_MISSION_HARVEST_GHIDRA_REPORT.md` — GREEN — 0x4D6AA0 mislabeled as Mission_Harvest (actually Mission_AreaGuard)
+```
+
+If the doc is GREEN with no notable findings, write `clean` for the
+finding field.
+
+### File creation
+
+If `AUDIT_LOG.md` doesn't exist yet, create it with this header and a
+blank line, then add your entry:
+
+```
+# Verify-Doc Audit Log
+
+A running log of /verify-doc runs. One line per audit. See chat history
+or git log for the full reports.
+
+```
+
+### Constraints
+
+- One line per audit. Don't paste the full report into the log.
+- Don't edit prior entries. Append-only.
+- Don't write any other file. The full audit report stays in chat.
+
+### Why this matters
+
+Chat reports vanish after compaction. Without the log, the next session
+auditing the same doc cluster will rediscover the same findings from
+scratch, and cross-doc contradictions found in earlier audits get lost.
+The log is a 30-second cost that pays back the next time you (or
+another session) needs to know "has this doc been verified recently?"

--- a/.agents/skills/write-plan/SKILL.md
+++ b/.agents/skills/write-plan/SKILL.md
@@ -1,0 +1,483 @@
+---
+name: write-plan
+description: >
+  Use when you have an approved design spec and need to create an
+  implementation plan before writing code. Breaks specs into
+  bite-sized tasks with exact file paths, complete code, and
+  verification steps. Usage: '/write-plan topic' or '/write-plan'
+  (auto-detects latest design doc). Trigger only on an explicit request to write,
+  create, or review an implementation plan after design approval; do not chain it
+  automatically after brainstorming.
+---
+
+# Write Plan — Architecture-Aware Implementation Planning
+
+Create an implementation plan for: **$ARGUMENTS**
+
+If `$ARGUMENTS` is empty, look for the most recent `docs/plans/*-design.md` file.
+If none exists, tell the user to run `/brainstorm` first.
+
+Do NOT write any implementation code during this skill. Plans and research only.
+
+Current delivery lens: plan for a retail-convincing ordinary stock-skirmish
+scenario. Preserve deterministic architecture and evidence honesty, but do not
+turn bounded expert-only exactification residuals into implementation blockers.
+Use Ghidra and exhaustive detail when an uncertainty can change common behavior,
+authority, lifecycle, RNG, persistence, or shared architecture.
+
+---
+
+## Hard Gate
+
+- Do NOT start writing the plan until you have read and understood the full design doc.
+- If no design doc exists, tell the user to run `/brainstorm` first and stop.
+- If the design doc is missing **Architecture Context** or **Impact Analysis**, flag it
+  and ask whether to proceed or go back to brainstorming.
+- Under an explicitly autonomous `/goal`, a design with recorded adversarial
+  self-approval satisfies the approval gate. Repair missing grounding directly
+  when it is discoverable; pause only for a material unrecoverable ambiguity.
+
+---
+
+## Research Grounding Phase
+
+Use the research-index MCP first as the source map. Prefer `research_brief` and
+`research_handoff`; if unavailable, use the repo-local CLI fallback:
+
+```text
+python tools/research_index/brief.py "<topic>" --limit 8
+```
+
+If the exact system is known, add `--system <system>` (examples: `bridges`,
+`miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun without
+`--system`, then rerun with the inferred exact system. Use `validate.py`,
+`handoff.py`, `map.py`, `graph.py implementation`, and `search.py` to find
+verified docs, stale warnings, handoff rows, and Rust touchpoints. The plan must
+still cite primary evidence and current Rust lines; index output is navigation.
+
+Before Pre-Planning, gather grounding from the sources below, following
+AGENTS.md priority order for behavioral truth. Skipping this is the #1 cause of
+plans that get rewritten after `/review-plan`.
+
+### R1. docs/research/ — existing RE research
+
+Search `docs/research/` for prior Ghidra reports on this system. You
+have 1,700+ files there; most systems already have struct layouts, field
+offsets, and behavioral analysis documented.
+
+- List every relevant report by filename
+- Extract confidence levels the original report stated (verified / inferred)
+- Note any TS-legacy warnings flagged in the report
+- Every cited report goes in the plan's **Sources & References** section
+
+**Do not redo research that's already been done.**
+
+### R2. gamemd.exe via Ghidra MCP — live binary verification
+
+Use Ghidra MCP to fill gaps in the docs and verify claims:
+
+- Decompile functions referenced in the docs to confirm they still match
+- Trace xrefs for any function you plan to reimplement — confirm the code
+  path is actually reachable in a standard YR skirmish (watch for TS ghosts)
+- Check param_1 types before extracting struct offsets (int vs int* —
+  see AGENTS.md "Decompilation pitfall")
+- Capture binary addresses here; they go in the plan's Sources section,
+  not in Rust code comments
+
+State confidence for every claim: **verified-from-binary** vs **inferred**.
+
+### R3. Repo code — existing patterns to mirror
+
+Find the closest existing pattern in the repo for what you're building:
+
+- Which module owns similar behavior today?
+- Which structs/traits does new code need to integrate with?
+- List specific files + line ranges the new code should mirror
+
+### R4. INI files — constants and source of truth
+
+Grep `ini/rulesmd.ini` and `ini/artmd.ini` for every constant the feature
+needs. Never hardcode values the INI defines.
+
+- List the `[Section]` Key=Value entries the plan depends on
+- Flag any INI keys not currently parsed by `src/rules/` — those become
+  plan tasks
+
+### Grounding Summary
+
+Produce a short summary (~10-20 lines) before Pre-Planning that the plan
+will reference. It should answer:
+
+- What do the docs already tell us? (cite reports)
+- What did Ghidra verification confirm or contradict? (cite addresses)
+- What existing repo pattern does this follow?
+- What INI keys drive the behavior?
+- What's still unknown after grounding? (→ Deferred Open Questions)
+
+---
+
+## Pre-Planning Phase
+
+Complete all four steps before writing any tasks.
+
+### A. Read the Design Doc
+
+Load the design spec from `docs/plans/YYYY-MM-DD-<topic>-design.md`. Extract:
+- Goal, architecture context, impact analysis
+- Chosen approach, interfaces/contracts, testing strategy
+
+### A.1. Re-verify the design's premise against current git state
+
+Design docs go stale. Parallel sessions or background commits can land
+between the brainstorm and the plan, silently invalidating chunks of the
+design. Catch this BEFORE writing tasks against a stale view.
+
+For every file the design names as "modify" or "depend on":
+
+```
+git log --oneline -10 -- <path>
+```
+
+Read the commit subjects. Any commit landed since the design doc's date
+that touches the same system is a red flag — re-read the file and confirm
+the design's "current state" claims still hold. If the system has been
+restructured, refactored, or partially implemented since the design,
+**stop and re-scope**: most of the plan's tasks may now be obsolete or
+wrong-direction.
+
+This step takes seconds and catches the single most common failure mode:
+writing a plan against the world as the design saw it, not the world as
+it is now.
+
+### B. Map the File Structure
+
+From the design, list every file that will be created or modified. For each file:
+- What is its single responsibility?
+- Does it land in the right place in the project structure?
+  - `sim/` — deterministic game logic only, never depends on render/ui/audio/net
+  - `render/`, `sidebar/`, `ui/` — presentation, sits above sim
+  - `assets/`, `util/` — low-level, reusable
+  - `rules/`, `map/` — data used by gameplay and rendering
+- Does it stay within its current responsibility (for modifications)?
+- Does it follow existing patterns for file organization?
+- Will any file exceed ~600 lines? If so, plan submodule splits.
+
+### C. Identify Interface Boundaries and Risk Areas
+
+- Which tasks create or modify public interfaces (APIs, exports, contracts, event
+  handlers, config schemas)? These need extra care — order them before implementations.
+- Pull risk areas from the Impact Analysis. Which files have the highest blast radius?
+  Which tasks are most likely to break existing functionality? Plan regression tests.
+
+**For sim/ changes, additionally flag:**
+- Does this affect tick ordering in `Simulation::advance_tick`?
+- Does this add new state that must be included in the deterministic state hash?
+- Does any new math use `fixed`-point types? (f32/f64 forbidden in sim logic)
+- Does the EntityStore (`BTreeMap<u64, GameEntity>`) iteration order matter here?
+
+---
+
+## Task Design Rules
+
+### Granularity
+
+Keep tasks bounded and independently verifiable. One action per step:
+- "Define the struct/types" — step
+- "Write the implementation" — step
+- "Add tests" — step
+- "Run `cargo test`, verify pass" — step
+- "Commit" appears only when the user explicitly requested commits; otherwise
+  omit all staging/commit steps.
+
+### Ordering Principles
+
+1. **Interfaces and types first** — define structs, traits, and contracts before implementations
+2. **Foundation before features** — infrastructure/plumbing before business logic
+3. **Tests where testable** — unit tests for pure logic and data transforms;
+   for RE-driven behavior, verification against gamemd.exe replaces traditional TDD
+4. **Independent tasks early** — things with no dependencies get done first
+5. **High-risk changes early** — surface problems before building on top
+6. **Integration tasks last** — wire things together after the pieces work
+
+### Verification Strategy
+
+Not all tasks can be TDD'd. Use the right verification for the task type:
+
+- **Pure logic / data transforms** — unit tests with `#[cfg(test)] mod tests`
+  in the same file (Rust convention for unit tests)
+- **INI parsing** — test that parsed values match expected INI entries from
+  `rules(md).ini` / `art(md).ini`
+- **RE-driven behavior** — verify against gamemd.exe via Ghidra decompilation,
+  verified research, in-game observation, or `/trace-action`. State the expected behavior and
+  how to confirm it matches the original.
+- **Rendering / visual** — describe the expected visual result and how to verify
+  by running the game and comparing to original YR
+- **Integration tests** — `tests/` directory for cross-module tests if needed
+
+### No Placeholders — Ever
+
+These are plan failures. Never write:
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without actual test code)
+- "Similar to Task N" (repeat the content — tasks must be self-contained)
+- "See the design doc for details" (the task must contain everything needed)
+- Steps that describe *what* to do without showing *how* (code required)
+
+### Architecture Compliance
+
+Each task must note:
+- Which existing pattern it follows (if any)
+- If it creates a new pattern, call that out explicitly
+- If it modifies an interface/contract, list what depends on it and confirm nothing breaks
+
+**Sim/ boundary rule:** If a task touches `sim/`, verify it introduces NO dependency on
+`render/`, `ui/`, `sidebar/`, `audio/`, or `net/`. This is the #1 architectural invariant.
+
+### Code Style Checklist
+
+All code written in plan tasks must follow these patterns:
+
+- **Ownership in signatures** — `&str` not `&String`, `&[T]` not `&Vec<T>`, `Arc<str>` not `Arc<String>`
+- **Hot path** — no per-tick allocations (Vec::new, String::from, .clone() on non-Copy).
+  Prefer reusable scratch buffers, interned IDs, or pre-allocated collections.
+- **Edition 2024** — `#[unsafe(no_mangle)]`, `#[expect(lint)]` over `#[allow(lint)]`,
+  inner `unsafe {}` blocks inside `unsafe fn`, `let-else` for early returns,
+  let chains for nested `if let`
+- **Iterators over index loops** — `.iter().filter().map()` over `for i in 0..vec.len()`
+- **Error handling** — `?` for propagation, `.unwrap()` only on internal invariants,
+  never on external input (INI, assets, files)
+- **Every `unsafe` block** gets a `// SAFETY:` comment
+
+---
+
+## Plan Document Template
+
+Save to `docs/plans/YYYY-MM-DD-<topic>-plan.md`:
+
+````markdown
+# [Feature Name] Implementation Plan
+
+> **For Codex:** Execute this plan task-by-task. Each task is self-contained.
+
+**Goal:** [One sentence from design doc]
+
+**Architecture:** [2-3 sentences — how this fits into the existing system]
+
+**Design Doc:** [path to the design spec]
+
+---
+
+## Grounding Summary
+
+[~10-20 lines — what the docs say, what Ghidra confirmed, which repo
+pattern this mirrors, which INI keys drive behavior, what's still unknown]
+
+## Key Technical Decisions
+
+- [Decision]: [Rationale] — **Confidence:** high | medium | low
+  - **Source:** docs/research/XYZ.md | Ghidra FUN_00abcdef | repo pattern src/sim/foo.rs | inferred
+
+Low-confidence decisions MUST be flagged for `/review-plan` to verify
+before implementation starts.
+
+## Open Questions
+
+### Resolved During Planning
+
+- [Question]: [Resolution + source]
+
+### Deferred to Implementation
+
+- [Question]: [Why it can't be answered until we run the code — e.g.,
+  "exact tick count depends on frame rate we observe in-game"]
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `src/sim/new_module.rs` | Handles X |
+| Modify | `src/sim/existing.rs` | Add Y interface |
+
+## Interface Changes
+
+List any public APIs, traits, structs, or config schemas that are created or
+modified. Note what depends on them.
+
+## Sim Checklist
+
+(Include only for tasks touching sim/)
+
+- [ ] All math uses `fixed`-point — no f32/f64 in game logic
+- [ ] New state included in deterministic state hash
+- [ ] No dependencies on render/ui/sidebar/audio/net
+- [ ] Tick ordering impact noted (if any)
+- [ ] BTreeMap iteration order considered (if relevant)
+
+## Risk Areas
+
+From impact analysis — what might break, what needs regression tests.
+
+## Player-Experience Critical Items
+
+List milestone-blocking, compounding, exactification-residual, and unknown-risk
+details from the design. Include the representative production scenario and why
+each item does or does not block it.
+
+| Task # | Class | Item | Why it matters | Verification |
+|--------|-------|------|----------------|--------------|
+| e.g. Task 5 | COMPOUNDING | Scroll pan interpolation | Visible repeatedly during radar navigation | Production side-by-side and focused timing check |
+| e.g. Task 8 | MILESTONE-BLOCKING | Completed cameo becomes selectable | Blocks ordinary production commands | Retail-input production test |
+
+The section may be compact, but it cannot omit authority, lifecycle,
+determinism, command, or common player-visible risks. Exactification residuals
+must state trigger, frequency, player effect, and downstream risk.
+
+---
+
+## Tasks
+
+### Task 1: [Component/Interface Name]
+
+**Why:** [One sentence — what this accomplishes and why it's ordered here]
+
+**Files:**
+- Create: `src/sim/new_module.rs`
+- Modify: `src/sim/existing.rs:123-145`
+
+**Pattern:** [Which existing codebase pattern this follows, or "new pattern"]
+
+**Step 1: Define types**
+```rust
+// src/sim/new_module.rs
+pub struct NewThing {
+    pub field: FixedI32<U16>,
+}
+```
+
+**Step 2: Write implementation**
+```rust
+impl NewThing {
+    pub fn new(value: FixedI32<U16>) -> Self {
+        Self { field: value }
+    }
+}
+```
+
+**Step 3: Add tests**
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_thing_creation() {
+        let thing = NewThing::new(FixedI32::from_num(42));
+        assert_eq!(thing.field, FixedI32::from_num(42));
+    }
+}
+```
+
+**Step 4: Verify**
+Run: `cargo test new_thing -- --nocapture`
+Expected: PASS
+
+**Step 5: Optional commit (only when explicitly requested by the user)**
+
+### Task N: [Integration / Wiring]
+
+(Later tasks wire components together and run full regression)
+
+### Task N+1: [Verification against gamemd.exe]
+
+**Why:** Confirm the implementation matches original engine behavior.
+
+**Verify:**
+- [Specific behavior to check against gamemd.exe]
+- [How to verify — Ghidra decompilation, in-game test, /trace-action]
+- [Expected result from original engine]
+
+## Sources & References
+
+- **Design doc:** docs/plans/YYYY-MM-DD-<topic>-design.md
+- **Ghidra reports:** docs/research/XYZ.md, docs/research/ABC.md
+- **gamemd.exe addresses:** FUN_00abcdef (name), 0x00123456 (struct offset)
+  — kept here, not in Rust code comments
+- **INI keys:** rulesmd.ini `[Section]` Key=..., artmd.ini `[Section]` Key=...
+- **Related code:** src/sim/path.rs, src/rules/parse.rs
+- **Prior PRs / commits:** [sha or PR #] if relevant
+````
+
+---
+
+## Post-Plan Self-Review (mandatory)
+
+Run this 10-point checklist before presenting to the user. Fix any gaps.
+
+1. **Spec coverage** — every requirement in the design doc traceable to a task?
+2. **Placeholder scan** — any TBD/TODO/vague steps? (search the plan text)
+3. **Architecture check** — do tasks follow the patterns from the design doc?
+4. **Interface ordering** — are contracts defined before they're consumed?
+5. **Risk coverage** — do high-risk areas from impact analysis have regression tests?
+6. **Self-containment** — could each task be done by someone with zero codebase context?
+7. **Sim/ compliance** — if any task touches sim/, does the sim checklist pass?
+8. **Grounding coverage** — did the plan cite the relevant combination of
+   current code, production observation, research, INI/assets, and Ghidra?
+   Ghidra is required when a consequential native uncertainty remains, not as
+   ritual for every localized fix.
+9. **Confidence tagging** — every Key Technical Decision has a confidence level
+   and a source? Low-confidence decisions flagged for /review-plan?
+10. **Deferred questions** — execution-time unknowns explicitly listed, not
+    hidden as fake certainty in tasks?
+11. **Player-experience items populated** — did you classify blocking,
+    compounding, residual, and unknown-risk details and include a real production
+    scenario?
+
+---
+
+## Present to User
+
+In interactive work, show the plan and ask for review. Under an explicitly
+autonomous goal, run the skeptical plan review, repair load-bearing findings,
+record approval, and proceed without a routine user pause.
+
+After approval, offer execution options:
+- **Subagent-driven** — dispatch one task at a time to fresh subagents, review between
+  tasks (recommended for complex plans)
+- **Batch execution** — execute in this session in batches of 3-5 tasks with human
+  checkpoints
+- **Manual** — user takes the plan and runs it themselves or in a separate session
+
+Do NOT start implementing. The user decides what happens next.
+
+---
+
+## Anti-Patterns to Flag
+
+- **"God task"** — a task that does too many things (split it)
+- **"Implicit dependency"** — Task 5 assumes something Task 3 did but doesn't say so
+  (make it explicit)
+- **"Test desert"** — a stretch of pure-logic tasks with no tests (add them)
+- **"Architecture drift"** — the plan quietly deviates from design doc patterns
+  (flag it, get approval)
+- **"Interface surprise"** — a task changes a public interface without listing what
+  depends on it (add the impact)
+- **"Float in sim"** — any f32/f64 usage in sim/ code (must be fixed-point)
+- **"Sim depends on render"** — any sim/ task that imports from render/ui/sidebar/audio/net
+
+---
+
+## Key Principles
+
+- **Plans are for dumb executors** — assume zero codebase context, zero taste, zero
+  judgment. Spell everything out.
+- **Architecture-aware** — every task knows where it fits and which patterns it follows
+- **Interfaces first** — define structs, traits, and contracts before implementations
+- **Test where testable, verify where not** — unit tests for pure logic; gamemd.exe
+  comparison for RE-driven behavior
+- **YAGNI** — if it's not in the design doc, it's not in the plan
+- **Self-contained tasks** — repeat information across tasks; they must stand alone
+- **Intentional commits** — include commit steps only when the user explicitly
+  requested commits; keep them small and atomic when authorized.
+- **Risk-aware ordering** — surface problems early, don't build on a shaky foundation
+- **Determinism is sacred** — sim/ tasks must preserve lockstep correctness

--- a/.claude/skills/architecture-scan/SKILL.md
+++ b/.claude/skills/architecture-scan/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: architecture-scan
+description: >
+  Project-scoped, read-only VERA20k review of repository organization, module
+  ownership, dependency direction, API visibility, naming, cohesion, change
+  locality, test placement, and Cargo target boundaries. Use only when
+  explicitly invoked as /architecture-scan to assess where existing Rust code
+  belongs or whether current repository boundaries are healthy. Reports
+  evidence-backed findings and options; never edits, auto-refactors, performs
+  gameplay parity research, or imposes generic Rust layout preferences.
+---
+
+# Architecture Scan
+
+Read and follow `../../../.agents/skills/architecture-scan/SKILL.md`
+completely. It is the canonical procedure shared by both agent frontends; its
+bundled `references/` lenses resolve relative to that canonical directory.
+Where it writes `$architecture-scan`, read `/architecture-scan`.
+
+If the relative path does not exist (worktree checkout), read
+`<main-checkout>/.agents/skills/architecture-scan/SKILL.md` instead.

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: audit
+description: "Verify and correct one existing VERA20k research document against active Yuri's Revenge gamemd.exe evidence. Use only when the user explicitly asks to audit and fix/correct a research doc; for read-only review use verify-doc or verify-doc-swarm."
+---
+
+# Audit And Correct A Research Document
+
+Use this skill to correct one named document under
+`<main-checkout>/docs/research/`. The result is a smaller,
+more trustworthy document, not a fresh parallel report.
+
+Read `ENGINE.md` first. Active `gamemd.exe` behavior is the specification. Local
+labels, prior prose, inferred names, YRpp, and agreement between documents are
+navigation aids rather than proof.
+
+## Authorization And Scope
+
+- Require explicit user intent to edit or correct the document. A request to
+  inspect, review, or diagnose is read-only and belongs to `verify-doc`.
+- Own exactly one research document unless the user names more.
+- Do not edit Rust, INI, assets, other documents, or git history.
+- Keep Ghidra read-only. Never rename symbols, change prototypes, edit comments,
+  patch bytes, or otherwise mutate the program database unless the user separately
+  authorizes that exact mutation.
+- Use the Edit tool for document edits and preserve unrelated correct material.
+
+## Preflight
+
+1. Resolve the requested path and read the entire document.
+2. Check its modification time and nearby claim/lock files. If another session
+   changed or claimed it recently, stop rather than racing the moving target.
+3. Use the research-index MCP first (`research_validate`, `research_map`,
+   `research_brief`, or `research_graph` as appropriate). Use the repo CLI only
+   when the corresponding MCP capability is unavailable.
+4. Record the exact active-YR binary/project being queried. Do not silently audit
+   a different executable or a dormant TS path.
+
+## Two-Pass Audit
+
+### Pass 1: Enumerate Claims
+
+Build a private checklist of every load-bearing claim, including:
+
+- function identity, address, owner, caller, and active-YR reachability;
+- field offsets, widths, signedness, constants, and sentinel values;
+- branch conditions, formulas, rounding, clamps, iteration order, and timing;
+- vtable ownership and slot identity;
+- INI keys, asset names, and Rust-facing implementation conclusions.
+
+Do not begin rewriting after finding the first error. First establish the claim
+surface so one correction does not leave dependent prose contradictory.
+
+### Pass 2: Verify And Classify
+
+Classify each claim as `VERIFIED`, `WRONG`, `STALE`, `MISLEADING`, or `UNCHECKED`.
+Use the function body, assembly/raw bytes, callers, receiver flow, data references,
+and active-YR reachability as needed. When evidence conflicts, report the conflict
+instead of forcing a clean answer.
+
+For vtable claims, use the complete protocol:
+
+1. Resolve the table's Complete Object Locator.
+2. Resolve the COL TypeDescriptor to prove the owning class/subobject.
+3. Compute the entry at `slot_index * 4` for this 32-bit binary.
+4. Follow any adjustor thunk and verify the destination body and callsites.
+
+A plausible local label or a decompiler-assigned name does not complete this
+proof.
+
+## Correct The Document
+
+- Correct only claims supported by the evidence gathered in this audit.
+- Never silently delete a load-bearing claim that cannot be re-established. Move
+  or mark it as `UNKNOWN`/`UNCHECKED`, preserve enough original wording for
+  provenance, and record the verification calls/evidence paths attempted. Never
+  invent a replacement address, field, slot, or label.
+- Keep verified findings separate from inference and implementation suggestions.
+- Add a compact inline citation beside every corrected binary claim. The citation
+  must identify the address/symbol plus the exact MCP method and material
+  arguments (or equivalent artifact) used, so another investigator can reproduce
+  it.
+- Update dependent summaries, tables, and implementation handoffs when their
+  premise changed.
+- Do not inflate the document with raw decompiler dumps. Preserve the evidence
+  chain and the exact behavior contract.
+
+## Final Response
+
+Lead with the verdict. Name the corrected document, summarize the material
+corrections, list remaining `UNCHECKED` blockers, and state that Ghidra remained
+read-only. Link the edited file with its absolute path.

--- a/.claude/skills/brainstorm/SKILL.md
+++ b/.claude/skills/brainstorm/SKILL.md
@@ -1,0 +1,404 @@
+---
+name: brainstorm
+description: >
+  Architecture-aware brainstorming before any feature work, new component,
+  refactor, or behavioral change. Explores user intent, maps existing
+  architecture, evaluates fit, and produces a design spec before any code
+  is written. Usage: '/brainstorm topic', e.g. '/brainstorm ore refinery
+  docking system' or '/brainstorm refactor movement into sub-modules'.
+---
+
+# Brainstorm — Architecture-Aware Design Skill
+
+Brainstorm a design for: **$ARGUMENTS**
+
+If `$ARGUMENTS` is empty, ask the user what they want to brainstorm.
+
+---
+
+## Hard Gate
+
+**NO code, scaffolding, or implementation until the design is approved.** In an
+interactive task, approval comes from the user. In an autonomous `/goal` that
+explicitly grants self-approval, the coordinator may approve its own design
+after an adversarial review that asks why it should be approved, what could
+still make ordinary skirmish feel wrong, and what could create expensive later
+rework. Record the decision; do not pause for routine approval.
+
+Do NOT invoke any implementation, editing, or code-writing tools during this skill.
+Research and read tools only.
+
+Native-to-Rust translation rule: do not design raw pointer vectors,
+COM/vtable plumbing, global mutable singleton style, or the full native
+inheritance tree just because the binary uses them. Design Rust-native
+ownership boundaries that preserve retail-convincing behavior and load-bearing
+semantics: storage owners, scheduler/order owners, lifecycle helper APIs, plain
+subsystem functions, and ordered commit points. Explain where deterministic
+state, authority, lifecycle, and important player-visible effects live.
+
+Current delivery target: an experienced YR player should be able to play an
+ordinary 30–60 minute stock skirmish without repeatedly noticing differences.
+Exact findings remain honest residuals, but only milestone-blocking or
+compounding differences block the design.
+
+Label-adversarial Ghidra rule: local Ghidra names, labels, comments, xref
+labels, and decompiler-assigned symbol names are navigation hints only. This
+project may contain polluted or stale labels from earlier scripts. Do not let a
+convenient Ghidra name become the design premise unless the function body,
+callsites, receiver/`this` pointer, vtable/data references, and active-YR
+reachability prove that role. Designs should use address plus verified role when
+labels are suspect.
+
+---
+
+## Process — Follow these 8 steps in order
+
+### Step 1: Explore Project Context
+
+- Read CLAUDE.md and ENGINE.md (the project contract), recent git log (last 10 commits), and any relevant docs/ files
+- Use the research-index MCP before broad manual doc search. Prefer
+  `research_brief(query=<topic>, system=<system>)`; use the repo-local CLI only
+  when the corresponding MCP capability is unavailable:
+
+  ```text
+  python tools/research_index/brief.py "<topic>" --limit 8
+  ```
+
+  If the exact system is known, add `--system <system>` (examples: `bridges`,
+  `miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun
+  without `--system`, then rerun with the inferred exact system. Use
+  `graph.py implementation`, `handoff.py`, and `search.py` for focused Rust
+  touchpoints and mechanism anchors. Treat index output as navigation; verified
+  docs, Ghidra, INI/assets, current Rust reads, and tests still decide parity.
+- Search `<main-checkout>/docs/research/` for any relevant
+  existing `*_SYSTEM_MODEL_SYNTHESIS.md` files.
+  Use them as orientation maps for current understanding, stale-doc warnings,
+  implementation-safe facts, and unresolved research gaps.
+- Do not treat synthesis files as primary evidence. For parity constraints,
+  follow their source ledger back to the cited Ghidra report, trace, INI key,
+  address, or Rust surface and cite that underlying source in the design.
+- Treat contradictions as primary evidence. If a screenshot, runtime result, test
+  failure, trace, asset dump, or user observation disagrees with the current
+  model, mark the design input incomplete and resolve the contradiction before
+  proposing implementation approaches.
+- Stale docs are warnings and source maps, not blockers. If old research conflicts
+  with primary evidence, design from the primary evidence and call out the stale
+  claim as documentation follow-up.
+- Identify relevant parts of the tech stack for this feature
+- Note project conventions that apply (architecture rules, module size limits, etc.)
+
+### Step 2: Map Existing Architecture
+
+This is the most important step. Understand before proposing.
+
+- Identify the major components/modules the proposed work touches
+- Map the dependency graph — what calls what, what imports what
+- Identify **boundaries** — where does this system end and another begin?
+- Identify **interfaces/contracts** — public APIs, data formats, event flow
+- Identify **patterns already in use** — how are similar things done in this codebase?
+  (e.g., how other sim systems are structured, how INI data flows, how entities interact)
+- Locate where the proposed work would **fit** in this picture
+
+Use the Grep and Glob tools plus direct Read calls. Only use
+subagents (the Agent tool) if the user explicitly asked for delegated or
+parallel work. Be thorough — read the actual code, don't guess from file names.
+
+**Output:** an "Architecture Context" section summarizing what you found. Can be a few
+sentences for small features, a proper component map for larger ones.
+
+### Step 3: Ask Clarifying Questions
+
+Present questions to the user **one at a time** (or in small focused batches).
+
+- Prefer multiple choice when possible
+- Focus on: purpose, constraints, success criteria, edge cases
+- Ask about **scope** — is this one thing or should it be decomposed?
+- Ask about **priorities** — what matters most (correctness, performance, simplicity)?
+- If the gamemd.exe binary is relevant, ask whether RE investigation is needed first
+- If the feature involves gamemd.exe RE findings, ask: **has the TS vs YR distinction
+  been verified?** gamemd.exe serves both Tiberian Sun and YR — systems, fields, and
+  code paths may be TS legacy (disabled/repurposed in YR). Don't design around a
+  mechanic that isn't actually active in a standard YR skirmish.
+
+**Scope-recommendation rule.** Never narrow scope in a way that leaves the
+selected ordinary-skirmish loop visibly broken, changes outcomes, creates
+determinism/authority/lifecycle debt, or pushes the defect into a neighboring
+common path.
+
+A difference may be deferred when it is TS-legacy/inactive, blocked by an
+external prerequisite, or classified as an `EXACTIFICATION-RESIDUAL`: bounded,
+uncommon in ordinary play, mainly expert-probed, non-compounding, and safe for
+later architecture. Record its trigger, player effect, expected frequency, and
+downstream risk. If those are unknown, classify it `UNKNOWN-RISK` and
+investigate only enough to decide whether it blocks the milestone.
+
+Do not proceed while a material ambiguity remains. In an interactive task, ask
+the user. In an explicitly autonomous goal, resolve discoverable questions,
+choose the smallest robust assumption for the representative scenario, record
+it, and continue; stop only when the choice would materially change intent and
+cannot be recovered safely.
+
+### Step 4: Dependency & Impact Analysis
+
+Based on Steps 1-3, analyze:
+
+- What existing code does this feature **touch or depend on**?
+- What existing code **depends on what we're changing**?
+- What might **break**? What is the blast radius?
+- Are there migration concerns (data format changes, config, API compatibility)?
+- For sim/ changes: does this affect tick ordering, determinism, or state hashing?
+
+**Output:** an "Impact Analysis" section listing touched files/modules and risk areas.
+
+### Step 4.5: Player-Experience Detail Ledger
+
+**Before proposing approaches**, list details that could silently make the
+selected ordinary-skirmish scenario feel wrong or create expensive later
+rework. Include timing, constants, ordering, RNG, state/lifecycle, asset lookup,
+draw composition, audio triggers, and edge results in proportion to their risk.
+
+Classify each item:
+
+- `MILESTONE-BLOCKING`
+- `COMPOUNDING`
+- `EXACTIFICATION-RESIDUAL`
+- `UNKNOWN-RISK`
+
+Pull evidence from research docs, synthesis outputs as source maps, INI/assets,
+current Rust, production observations, and Ghidra when needed. Do not invent
+details. An unknown does not automatically block design: investigate enough to
+learn whether it can affect the representative scenario, deterministic state,
+shared architecture, or downstream systems.
+
+Trace from the behavior owner, not a helper. For UI, start at the paint/message/
+render owner; for gameplay, start at the tick/update/action owner; for audio,
+start at the event trigger path; for parsing, start at the actual load/apply
+path; for input, start at dispatch and follow through to command effect. A helper
+belongs in the design only after the target owner is proven to call it.
+
+Always prove activation for the target scenario. Record the game, mode, dialog,
+map, unit, house, difficulty, or setting that the design targets, plus the
+flag/key/case/default that enables the behavior. Code existing in gamemd.exe is
+not enough to make it a design constraint for standard YR.
+
+Inspect variants required by the representative scenario before generalizing.
+Check relevant SHP frames, YR `*md` overrides, dialog cases, difficulty,
+faction, map, and optional branches. Uninspected variants outside the current
+match matrix become named residuals rather than automatic blockers.
+
+Format as a bulleted ledger. Examples of what belongs in it:
+
+- Exact timing: "trigger fires on tick T; effect applies on tick T+0
+  (same tick), not T+1"
+- Exact constants: clamps, thresholds, frame counts, ROT values, ROF
+  cooldowns, animation lengths
+- Order of operations within a tick (which write happens before which)
+- Rounding direction for any fixed-point / integer math
+- Inclusive vs exclusive bounds in range checks
+- Signed vs unsigned comparisons
+- Default values when a field is uninitialized
+- Edge cases: what happens at zero, at max, at empty container, at null
+- Which animation frame an effect starts on (0 vs 1)
+- Sub-tick ordering between paired events (sound vs visual, write vs read)
+- Z-order tie-breakers between overlapping sprites
+- Pixel-level draw offsets / anchor points
+- Side effects: writes that look dead but are read by another system
+
+For UI, shell, sidebar, menu, viewport, sprite, and other visual work, the
+ledger must be a composition ledger, not a summary. Start from the full top-level
+paint/message/render path and include:
+
+- Draw order from entry point to return, including post-background and optional
+  helper calls
+- Per-dialog or per-mode flags that enable each optional draw layer
+- Exact asset names and frames; dump or inspect all SHP frames before choosing a
+  design around an asset
+- Source and destination rects, anchors, clipping/scissor, palette/convert path,
+  and z-order
+- Asset role classification: content/preview, chrome/container, overlay,
+  transition-only, loaded-but-inactive, or not used for the scoped role
+
+If a user screenshot, reference capture, or asset dump contradicts the current
+research conclusion, the research is incomplete. Do not design around the
+contradictory conclusion; reopen the paint path and find the missing layer,
+frame, flag, rect, or palette first.
+
+Each line cites a source: `[GHIDRA <addr>]`, `[doc: X_GHIDRA_REPORT.md §3]`,
+`[ini: rulesmd.ini Speed=]`, or `[UNKNOWN — needs RE]`.
+
+The ledger does not need to be exhaustive of everything the system does. It
+must cover details that could break the representative scenario, compound
+through a normal match, or create costly architecture debt. Every approach
+must explain how it preserves blocking/compounding items and where it records
+exactification residuals.
+
+### Step 5: Propose 2-3 Approaches
+
+For each approach, include:
+
+- **How it works** — brief description
+- **Architectural fit** — does it follow existing patterns or introduce new ones?
+- **Experience fit** — does this make the selected production scenario
+  retail-convincing without unsafe shortcuts?
+- **Detail coverage** — state where every milestone-blocking or compounding
+  item lives and list residuals explicitly.
+- **Trade-offs** — complexity, performance, maintainability, tech debt
+- **What it touches** — which modules/files/interfaces change
+- **Risk areas** — what could go wrong
+
+**Retail-convincing behavior is a first-class evaluation criterion.** For each
+approach, answer:
+
+- What active-gamemd mechanisms does the original have here? (branching,
+  state bytes, timing, visuals, input feel, draw order, audio cues, cursor
+  behavior near boundaries)
+- Which details are required for the representative production path,
+  deterministic state, and shared architecture?
+- Which differences remain honest DRIFT but are safe exactification residuals?
+- Would any small difference be frequent, noticeable, compounding, or
+  outcome-changing? If so, keep it in scope regardless of implementation size.
+- **Be suspicious of "clean" designs that don't mention any of the
+  ledger items.** Cleanness is often achieved by abstracting away exactly
+  the details that drive behavior. If an approach reads as elegant but its
+  player-experience ledger is empty, that's a red flag, not a strength.
+
+Lead with your recommendation and explain why. Call out if an approach introduces
+architectural inconsistency, tech debt, OR parity drift — and whether that's acceptable.
+
+In interactive work, present these to the user and wait for a choice. In an
+explicitly autonomous goal, choose the recommendation after adversarial
+self-review and continue.
+
+### Step 6: Present Design
+
+Scale each section to the complexity of the task. A small feature might need a few
+paragraphs; a major system needs full treatment.
+
+Cover as appropriate:
+- Architecture / component layout
+- Data structures and flow
+- Interfaces and contracts
+- Integration points with existing code
+- Error handling strategy
+- Testing strategy
+- Determinism considerations (for sim/ work)
+
+**Explicitly state:**
+- How the design integrates with existing architecture
+- Which existing patterns it follows or deviates from (and why)
+
+Present in sections and get approval after each major section during interactive
+work. Under an explicitly autonomous goal, review each section internally,
+record load-bearing objections and their resolution, then continue.
+
+### Step 7: Write Design Doc
+
+Save to `docs/plans/YYYY-MM-DD-<topic>-design.md` using this structure:
+
+```markdown
+# [Feature Name] Design
+
+## Goal
+One sentence.
+
+## Architecture Context
+How the existing system works in the area this feature touches.
+Key components, interfaces, data flow.
+
+## Impact Analysis
+What this changes, what depends on it, risk areas.
+
+## Chosen Approach
+What we're building and why this approach over alternatives.
+
+## Player-Experience Detail Ledger
+Milestone-blocking, compounding, residual, and unknown-risk details. Cite the
+source for claims and state why each item does or does not block the selected
+ordinary-skirmish scenario.
+
+## Design
+
+### Components
+### Interfaces / Contracts
+### Data Flow
+### Error Handling
+### Testing Strategy
+
+## Architectural Decisions
+Patterns followed, patterns deviated from (and why).
+Tech debt introduced (if any) and plan to address it.
+
+## Alternatives Considered
+Brief summary of rejected approaches and why.
+```
+
+### Step 8: Hand Off
+
+For interactive work, tell the user the design is ready and ask whether to plan,
+refine, or park it. Under an explicitly autonomous goal, hand the approved
+design directly into proportional planning and implementation.
+
+---
+
+## Anti-Patterns to Flag
+
+During brainstorming, actively call out these anti-patterns if you spot them in a
+proposed design (including your own proposals):
+
+- **"Just bolt it on"** — adding a feature without considering where it fits
+  architecturally. Ask: where does this belong in the module hierarchy?
+- **"New pattern for no reason"** — introducing a different way of doing something
+  the codebase already has a convention for. Ask: how is this done elsewhere?
+- **"Hidden coupling"** — a design that looks clean but creates invisible dependencies
+  between modules. Ask: what breaks if we change X?
+- **"Scope creep"** — the feature quietly growing beyond what was asked for.
+  Apply YAGNI ruthlessly. Ask: do we actually need this part?
+- **"Testing afterthought"** — a design where testability wasn't considered upfront.
+  Ask: how do we test this without spinning up the whole engine?
+- **"TS ghost"** — designing around a mechanic found in gamemd.exe that is actually
+  dormant Tiberian Sun legacy, not active in Yuri's Revenge. Ask: is this code
+  actually executed in a standard YR skirmish? Don't trust field names — verify
+  what they gate in the binary. (Example: WarheadTypeClass `Tiberium=` does NOT
+  control ore destruction — it only gates vein destruction.)
+- **"Convenience-disguised deferral"** — labelling an item "edge case", "rare",
+  or "low priority" without naming its trigger, ordinary-play frequency, player
+  effect, compounding risk, and downstream consumers. Effort is not a valid
+  impact measure.
+- **"First-helper fallacy"** - treating one helper's draw stack as the whole UI
+  composition. Ask: what does the parent paint handler draw after this returns?
+- **"Frame-zero tunnel vision"** - assuming SHP frame 0 is the relevant visual.
+  Ask: were all frames dumped or did Ghidra prove the exact frame?
+- **"Negative-role overreach"** - converting "not used as X" into "not visible at
+  all." Ask: which visual roles were actually ruled out?
+- **"Literal C++ port reflex"** - proposing to recreate native inheritance,
+  raw pointer vectors, COM/vtable plumbing, or global singleton mutation in Rust
+  just because gamemd uses those mechanisms internally. Ask: what exact behavior
+  contract must be preserved, and which Rust-native owner should preserve it?
+- **"Clean-Rust behavior loss"** - proposing an elegant Rust abstraction that drops
+  native ordering, lifecycle, RNG, timer, or same-tick consequences. Ask: where
+  does each native tiny-detail ledger item live in the design?
+
+---
+
+## Key Principles
+
+- **One question at a time** — don't overwhelm the user with 10 questions
+- **Architecture first** — understand the system before proposing changes
+- **YAGNI for speculative and out-of-matrix work** — preserve known residuals
+  in the ledger instead of implementing every possible native branch now.
+- **Complete player loops beat exhaustive local scope** — a smaller slice is
+  wrong when it leaves the selected production journey visibly broken or
+  creates deterministic/architectural debt. Expert-only exactification may
+  remain recorded for later.
+- **Visual parity requires composition closure** - for UI/render work, trace from
+  the paint/render entry point to return before deciding what the player sees.
+- **Explore alternatives** — always propose 2-3 approaches, never just one
+- **Name the trade-offs** — especially architectural ones
+- **Incremental validation** — present design in chunks, get approval
+- **Patterns matter** — follow existing conventions unless there's a good reason not to,
+  and document the deviation
+- **Determinism is sacred** — for any sim/ work, prove the design preserves lockstep
+  correctness
+- **Rust-native structure, retail-convincing behavior** - preserve verified
+  authority, deterministic state, common-path ordering, RNG use, lifecycle, and
+  player-visible effects; record bounded exact residuals honestly

--- a/.claude/skills/design-review/SKILL.md
+++ b/.claude/skills/design-review/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: design-review
+description: >
+  Review a brainstorm/design doc before implementation. Audits whether behavior
+  claims are grounded in cited research docs, INI/assets, source, or explicit
+  UNKNOWN/UNCHECKED status; checks that the chosen approach covers its
+  player-experience ledger without architecture drift. Usage: '/design-review design-doc-path'
+  or 'review this brainstorm design doc'.
+---
+
+# Design Review - Pre-Implementation Readiness Audit
+
+Review the design doc: **$ARGUMENTS**
+
+If `$ARGUMENTS` is empty, use the most recent `docs/plans/*-design.md`. If none
+exists, ask for a design doc path.
+
+## Hard Gate
+
+- Do not implement code.
+- Do not edit Rust.
+- Do not revise the design doc unless explicitly asked.
+- Findings first, ordered by severity.
+- Review against the retail-convincing ordinary-skirmish bar in `ENGINE.md`.
+  Preserve exact truth labels, but do not block implementation solely for a
+  bounded, documented expert-only residual.
+
+## Verdicts
+
+- `APPROVE`: implementation-ready; remaining unknowns are named, bounded, and not
+  blocking the chosen change.
+- `REVISE`: design needs citation, wording, approach, or test-plan fixes before
+  implementation.
+- `BLOCK`: design contradicts load-bearing evidence, guesses about consequential
+  behavior, leaves the representative loop broken, or creates
+  determinism/authority/lifecycle/architecture debt.
+
+## Review Workflow
+
+### 1. Load Grounding
+
+Read:
+
+1. `ENGINE.md`.
+2. The design doc.
+3. Every cited `docs/research/...` file section needed to verify its claims.
+4. Relevant Rust files named by the design.
+
+For parity-sensitive topics, request a compact `research_brief` from the
+research-index MCP first. If that capability is unavailable, run the CLI fallback
+from the repo root:
+
+```text
+python tools/research_index/brief.py --system <system> "<topic>" --limit 8
+```
+
+Use synthesis docs only as maps. Cite underlying Ghidra reports, traces, INI keys,
+or source files for verdicts.
+
+### 2. Extract Claims
+
+Extract only claims that matter to implementation readiness:
+
+- Active-YR gates and INI/default applicability.
+- Branch order, predicates, field reads/writes, clear/set paths, side effects, and
+  skipped side effects.
+- Rust architecture claims: modules, fields, callers, state flow, boundaries.
+- Chosen approach claims.
+- Test-plan claims.
+- Unknowns/deferred items.
+
+### 3. Verify Evidence
+
+For each parity claim:
+
+- `CONFIRMED`: cited source says this.
+- `MISMATCHED`: cited source says something else.
+- `UNCITED`: no usable citation.
+- `STALE`: source is superseded or contradicted by newer evidence.
+- `UNCHECKED`: design correctly marks this as not yet known.
+
+Rules:
+
+- An uncited parity claim is a finding.
+- A synthesis citation alone is not enough for a mechanism claim.
+- Runtime-only facts must not be inferred from static decompilation.
+- "Rare", "visually masked", "internal-only", and "probably equivalent" never
+  prove exact equivalence. They may support delivery deferral only when trigger,
+  ordinary-play frequency, player effect, compounding, and downstream risk are
+  documented.
+
+### 4. Ledger Coverage
+
+Check the player-experience ledger:
+
+- Every milestone-blocking and compounding item has an owner and production test.
+- Exactification residuals name trigger, frequency, player effect, and downstream
+  risk.
+- Unknown-risk items are investigated enough to determine whether they block.
+
+### 5. Architecture And Tests
+
+Verify:
+
+- `sim/` does not gain render/ui/audio/net dependency.
+- The design fits existing module boundaries.
+- It does not broaden scope into unrelated systems.
+- Tests cover the representative production path, negative side effects,
+  neighboring common paths, and deterministic state that could affect outcomes.
+
+## Output Format
+
+```text
+Verdict: APPROVE | REVISE | BLOCK
+
+Findings
+- [P1] ...
+- [P2] ...
+
+Open Questions
+- ...
+
+Implementation Readiness
+- ...
+```
+
+If there are no findings, say so explicitly and still list residual risks or test
+gaps.

--- a/.claude/skills/re-investigate/SKILL.md
+++ b/.claude/skills/re-investigate/SKILL.md
@@ -1,0 +1,788 @@
+---
+name: re-investigate
+description: "Use when studying, researching, or reverse-engineering a gamemd.exe system before implementation. Produces a verified research document with an implementation handoff, but never writes Rust code. Usage: '/re-investigate chrono miner teleport' or '/re-investigate garrison fire logic' or '/re-investigate power drain formula'"
+---
+
+# RE Investigate — Structured Reverse Engineering
+
+Research `$ARGUMENTS` in gamemd.exe using a structured, evidence-based process. Produce a verified research document. Do NOT write any Rust code.
+
+<HARD-GATE>
+Do NOT implement anything. Do NOT modify any .rs file. Do NOT write Rust code or
+patches. The research report MUST include an implementation handoff that names
+affected Rust surfaces and acceptance scenarios, but it must not contain patch
+text or code snippets. The ONLY output is a research document saved to
+`<main-checkout>/docs/research/`. If you catch yourself
+writing Rust code, STOP and delete it. This applies regardless of how "simple"
+the implementation seems.
+</HARD-GATE>
+
+**What we are extracting and why.** Research truth remains exact: record scoped
+active-gamemd branches, constants, field reads/writes, ordering, rounding, RNG,
+assets, draw/audio timing, and uncertainty precisely. Do not label an
+approximation as verified. The implementation handoff must separately classify
+which findings are milestone-blocking, compounding, exactification residuals,
+or unknown-risk for ordinary stock skirmish.
+
+## Iron Laws
+
+```
+CONTRADICTIONS ARE PRIMARY EVIDENCE
+```
+
+If a screenshot, runtime result, test failure, trace, asset dump, or user
+observation contradicts the current explanation, assume the explanation is
+incomplete. Do not defend the model and do not implement from it. Reopen the
+investigation, name the contradiction in the Open Questions Log, and resolve it
+with binary, asset, INI, runtime, or source evidence.
+
+```
+TRACE FROM THE OWNER, NOT THE HELPER
+```
+
+Start from the behavior owner for the target scenario before trusting a helper:
+paint/message/render handlers for UI, tick/update/action pipelines for gameplay,
+event trigger paths for audio, actual load/apply paths for parsing, and input
+dispatch paths for commands. A helper only proves behavior after you prove the
+target owner calls it under the target conditions.
+
+```
+PROVE TARGET ACTIVATION
+```
+
+Code existing in gamemd.exe is not enough. For every claimed behavior, prove it
+is active in the target game, mode, dialog, map, unit, house, difficulty, or
+setting. Record the enabling flag/key/case, its default value in standard YR
+where applicable, and whether the target scenario actually reaches it.
+
+```
+INSPECT THE VARIANT SET
+```
+
+Before choosing a conclusion from one variant, inspect the relevant variant set:
+all active SHP frames, YR `*md` overrides before base INI fallback, dialog IDs or
+switch cases, difficulty/game-mode branches, house/faction overrides, map
+overrides, and optional flags. If the full set is too large, state the bounded
+subset and mark the rest `deferred` instead of generalizing.
+
+```
+STALE DOCS ARE WARNINGS, NOT BLOCKERS
+```
+
+Older reports and synthesis docs are maps to evidence, not final authority. When
+they conflict with binary, runtime, asset, INI, screenshot, or current Rust
+evidence, the primary evidence wins. Record the stale claim and update or hand
+off the correction instead of letting the old prose block the investigation.
+
+```
+GHIDRA LABELS ARE HINTS, NOT TRUTH
+```
+
+Local Ghidra names, labels, comments, xref labels, and decompiler-assigned symbol
+names are navigation aids only. This project may contain polluted or stale labels
+from earlier scripts. For every load-bearing claim, verify from the function body,
+assembly/decompile, callsites, receiver/`this` pointer, argument flow, vtable slot
+bytes, data references, and active-YR reachability. Prefer address plus verified
+role over label name. If a label is wrong or ambiguous, record the label drift and
+do not let the old name drive architecture or implementation.
+
+Every vtable claim requires a CompleteObjectLocator walk (`vtable-4` →
+`COL+0x0C` → TypeDescriptor mangled name), a slot read at `vtable+N*4`, and a
+decompile of the resulting function body. Cite all three inline. Ghidra display
+labels are not identity evidence; if the owner or body is unproven, mark the
+claim `UNCHECKED` rather than inferring it from a name.
+
+```
+THE TINY DETAILS ARE THE WHOLE POINT — NOTHING ELSE COMES CLOSE
+```
+
+**By far the most important output of this skill is the tiny details you would
+normally dismiss as not worth writing down.** Not the high-level summary. Not the
+algorithm overview. Not the "main flow." Those are the easy parts and they are not
+why we are here.
+
+We are here for:
+
+- The `+1` after a multiply that nobody would notice
+- The `if (x == 0) return` that handles one specific frame
+- The constant `0x67` that turns out to be the cell size in a different unit
+- The order in which two writes to the same field happen in the same tick
+- The flag bit that's checked once and only matters when another flag is set
+- The early-out condition three calls deep in a helper
+- The clamp that saturates at `0xFF` instead of `0x100`
+- The fact that the function reads the field BEFORE the caller has updated it
+- The `<` that should obviously be `<=` and isn't
+- The branch that looks dead but writes a side-effect read elsewhere
+- The default value a field holds when nothing has touched it yet
+- The signed-vs-unsigned comparison that flips behavior at the boundary
+
+If your report describes the system at the level of "it does X, then Y, then Z,"
+**you have failed**, no matter how clean the prose is. The summary is the cheap
+part. The summary is what a 10-minute skim of the function gives you. We are paying
+the cost of a full investigation **specifically to surface the things a skim would
+miss**. If the report does not contain at least a dozen findings of the form "this
+specific tiny thing, in this specific place, with this specific value, and here's
+why it matters" — keep digging. You are not done.
+
+A reader of the final report should think: *"I would never have noticed any of this
+on my own."* That feeling is the success criterion. If they instead think *"yeah,
+that's roughly what I'd have guessed,"* the report is worthless — it has told them
+nothing they didn't already know.
+
+**Default to over-recording.** When you are unsure whether a detail is worth noting,
+the answer is yes. The cost of an extra noted constant or branch is one line in the
+report. The cost of a missing one is a parity bug nobody can find later. Err
+massively toward over-recording. Tiny details cost almost nothing to document and
+are almost impossible to recover later without redoing the whole investigation.
+
+```
+NO CLAIMS WITHOUT BINARY EVIDENCE
+```
+
+Every finding must state its evidence source and confidence level. "I think it works like X" is not a finding — it's a guess. Guesses go in an "Open Questions" section, not in findings.
+
+```
+DETAILS COMPOUND — THE INVISIBLE ONES MATTER MOST
+```
+
+Most parity-breaking details are **not directly visible** — a one-tick delay before
+a turret starts rotating, an off-by-one in a damage clamp, a flag that only matters
+on one frame of an animation. These don't jump out to the player, but they compound.
+Two "invisible" 5%-off details interacting produce a behavior the player feels but
+can't articulate. **If a detail exists in the binary, assume it matters until proven
+otherwise.** Document it. Don't filter findings by "will this be visible?" — filter
+by "is this what the binary actually does?"
+
+The temptation to skip a detail because "it probably doesn't matter" is the single
+biggest failure mode of this skill. Resist it every time. The whole point of the
+skill is to capture exactly the details that "probably don't matter" — because in
+aggregate, they're what separates exact byte/pixel parity from drift.
+
+This skill exists because details are hard to catch. That is the job. If your report
+lists the happy path and skips the edge cases, constants, clamps, and off-by-ones,
+you have not done the job — regardless of how clean the report looks.
+
+```
+DECLARE THE INVESTIGATION MODE BEFORE YOU DIG
+```
+
+Half-investigating a system is worse than not investigating it when the output
+pretends to be complete. For an `exhaustive-slice`, decompile every relevant
+function, examine every branch, explain every magic number, check every flag
+default, and trace every edge case. For a `coverage-map`, do not pretend to
+complete the system; make the unknowns and follow-up queue the primary output.
+"Ran out of steam" is not a stopping condition. Either drain the slice, or label
+the report as partial/coverage-map and show exactly what remains.
+
+There are two valid modes:
+
+- **coverage-map**: use for broad systems, vague user prompts, global architecture,
+  tick loops, "overall" behavior, or any topic where the first honest job is to
+  discover entry points and unknowns. The output is a coverage map, not a completed
+  proof. It must say which areas were verified, touched, not touched, and deferred.
+- **exhaustive-slice**: use only for a bounded subsystem small enough to drain every
+  open question in the current session. The output may claim completeness only for
+  that exact slice, never for the parent system.
+
+Default to **coverage-map** when the scope is broad. Do not ask the user to narrow
+unless the request cannot be made useful; instead, make the mode explicit and
+produce an honest map of what remains. Never use filenames, headings, summaries, or
+phrases like "completion", "fully investigated", "entire system", or "all covered"
+unless the Open Questions Log is drained and the Coverage Ledger has no material
+unknowns for the stated slice.
+
+```
+EXHAUSTION, NOT COVERAGE — THE OPEN QUESTIONS LOG IS THE GATE
+```
+
+The single biggest failure mode of this skill is declaring "done" because the
+**topic feels covered** — the main flow is described, the report reads well,
+the summary makes sense. That is coverage, not exhaustion. Coverage is when a
+reader cannot tell what's missing. Exhaustion is when **you** cannot name what's
+missing — because you've maintained an explicit list of unknowns and driven it
+to zero.
+
+You MUST maintain an **Open Questions Log** throughout the investigation. It is
+seeded in Step 0.5, grown in Step 2 every time you encounter a new unknown, and
+drained in Step 3. The investigation is not complete until **every entry in the
+log is either resolved with evidence or explicitly deferred with a stated reason
+and category** (e.g., "deferred — requires runtime debugger to observe"). A
+non-empty log with un-deferred items means you are not done — regardless of how
+many functions you've decompiled or how polished the report looks.
+
+"Covered the topic" is not a stopping criterion. "Open Questions Log has zero
+un-deferred items AND I added no new items in my last full pass" is. This is the
+single check that converts the skill from breadth-by-feel to breadth-by-construction.
+
+```
+TIBERIAN SUN ≠ YURI'S REVENGE
+```
+
+gamemd.exe is the engine for BOTH Tiberian Sun and Yuri's Revenge. It inherited a massive
+TS codebase. Many systems, fields, and code paths exist in the binary but are **disabled,
+repurposed, or irrelevant** in YR. Before reporting any finding:
+
+1. **Verify the code is active in YR** — not gated behind a TS-only flag, not a dead code
+   path, not overridden by a YR-specific implementation.
+2. **Don't trust field/flag names at face value.** TS-era names persist in the binary but
+   may gate something completely different in YR context. Example: `Tiberium=yes` on a
+   WarheadTypeClass does NOT gate ore destruction — it only gates **vein** destruction.
+   The name misleads because "Tiberium" is TS terminology. Always trace what the flag
+   actually controls in the code, not what the name implies.
+3. **Check default values.** A feature may exist in code but default to off in YR
+   (e.g., `FogOfWar` defaults false — it's TS legacy).
+4. **When documenting, always state "Active in YR: Yes/No/Conditional"** for each finding.
+   If conditional, state the exact condition and its default value in a standard YR skirmish.
+
+## Step 0 — Scope, prior work, and duplication check
+
+1. Parse `$ARGUMENTS` into a specific system, mechanic, or class to investigate.
+
+2. Classify the request as `coverage-map` or `exhaustive-slice` and state that mode
+   to the user before proceeding.
+
+   Use `coverage-map` for broad prompts such as "global timing", "the combat
+   system", "movement overall", "find disparities", "entire system", or any request
+   whose entry points are not already bounded. The deliverable is a coverage ledger
+   and a follow-up investigation queue.
+
+   Use `exhaustive-slice` only when the target is narrow enough to resolve every
+   open question in one pass, such as one helper function, one INI key's read/use
+   chain, one state transition, or one specific gameplay action.
+
+3. If `$ARGUMENTS` is so broad that even a useful coverage map cannot be scoped,
+   ask the user to narrow scope before proceeding.
+
+4. **Plan-path check (do this first, before anything else).** If `$ARGUMENTS` references an investigation plan at `docs/plans/YYYY-MM-DD-<topic>-investigation-plan.md`, OR the wording matches a recent plan in `docs/plans/`:
+   - Read the plan's frontmatter and locate the **Expected Output** path (typically `<main-checkout>/docs/research/<TOPIC>_GHIDRA_REPORT.md`).
+   - `ls` that path. If the file exists AND its mtime is newer than the plan's mtime, a parallel/earlier session already executed the plan. Go to step 5.
+
+5. Use the research-index MCP before broad manual doc search:
+
+   ```text
+   research_brief(query="<topic>", limit=8)
+   ```
+
+   If MCP is unavailable, use the equivalent repo-local `brief.py` CLI.
+
+   If the exact system is known, add `--system <system>` (examples: `bridges`,
+   `miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun
+   without `--system`, then rerun with the inferred exact system. Use
+   `validate.py`, `map.py`, `search.py`, and `graph.py evidence` to identify
+   existing verified docs, stale warnings, and likely Rust touchpoints. Treat the
+   index as navigation; live Ghidra/binary evidence still decides new findings.
+
+6. Check for existing research — search BOTH locations:
+   - `docs/` (in-repo)
+   - `<main-checkout>/docs/research/` (ignored in-repo research corpus)
+
+   Sort matches by mtime descending. Read any matching report modified in the
+   last 6 hours before proceeding; it may be a parallel session's output.
+
+7. **Decide before starting the investigation work.** Apply this table and tell the user which row fires:
+
+   | Prior state | Action |
+   |-------------|--------|
+    | No relevant research exists | Proceed to Step 1 — full investigation. |
+    | Matching report modified in the last 6 hours | **STOP.** Read it fully, compare it to the requested scope, and report covered/partial/open before any duplicate work. |
+   | Partial / LOW–MEDIUM confidence report exists | Proceed to Step 1 — scope to **gaps + verification only**, do not re-cover ground. |
+   | Recent HIGH-confidence report covers the topic | **STOP.** Recommend `/verify-doc <report>` for audit, or `/re-investigate <topic> --extend <specific gap>` if the user wants a targeted follow-up. Do not silently re-execute. |
+   | **Expected-output file from a plan already exists and is newer than the plan** | **STOP.** A parallel session executed it. Read the report, diff against the plan's Success Criteria, and report to the user: "covered / partial / open" per criterion. Do not re-execute. |
+   | Recent report has explicit open questions or "Phase 2/3 deferred" markers | Proceed to Step 1 — scope to **those specific gaps**, cite the parent report. |
+
+   When proceeding, state which row applied and what's in-scope vs. out-of-scope.
+
+8. If proceeding, read any existing report fully before Step 1. Your job is to **extend or verify** it, not duplicate it.
+
+## Step 1 — Parallel research
+
+Gather these inputs as three local workstreams. Run independent filesystem
+searches in parallel when practical. Use subagents (the Agent tool, `subagent_type: general-purpose`) for the three workstreams
+when the scope justifies it; each runs in the background and reports back. Do not fan out
+more than 3 at once. Each input returns structured findings.
+
+When subagents are used, require each return to stay at 150 lines or fewer, name
+every artifact path, and include at most five load-bearing verified facts with
+one-line evidence. Raw decompilation, assembly, INI dumps, source bodies, and full
+struct tables belong in artifacts, not the return.
+
+**Workstream A — Doc search:**
+- Search `docs/` and `<main-checkout>/docs/research/` for ALL reports related to the topic. Search broadly — related systems, not just exact name matches.
+- For each relevant report: extract verified findings (formulas, state machines, offsets, constants, conditions).
+- Note any conflicting claims between reports.
+- Return: list of findings with source file for each.
+
+**Workstream B — INI data extraction:**
+- Grep `ini/rulesmd.ini` and `ini/artmd.ini` for all keys related to the target system.
+- Also check `ini/rules.ini` and `ini/art.ini` for base RA2 values (YR `*md` overrides take priority).
+- For each relevant key: extract the key name, default value, section it appears in, and what it likely controls.
+- Return: structured list of INI keys with values and sections.
+
+**Workstream C — Rust implementation scan:**
+- Search `src/` for the current Rust implementation of this system.
+- Extract: what's implemented, what state machine states exist, what formulas are used, what INI keys are read.
+- Do NOT judge correctness — just document what exists.
+- Return: file paths, function names, current logic summary.
+
+## Step 1.5 — Seed the Open Questions Log
+
+Before touching Ghidra, write the initial Open Questions Log. This is the
+investigation's spine. Maintain it with the task tools (TaskCreate/TaskUpdate) when that is useful,
+or as a working `<TOPIC>_OPEN_QUESTIONS.md` file in your scratch space,
+whichever keeps it visible across tool calls. The final state lives in Section 7
+of the report.
+
+Start the log with the selected investigation mode:
+
+```
+[MODE] coverage-map | exhaustive-slice
+[SCOPE] exact slice being claimed
+[NON-SCOPE] related areas intentionally not claimed
+```
+
+If the selected mode is `coverage-map`, deferred entries are expected, but they
+must become the follow-up queue. If the selected mode is `exhaustive-slice`, any
+material deferred entry downgrades the final report to partial/coverage-map.
+
+**Required seed entries (every investigation must include all of these):**
+
+1. **Entry points** — every function/vtable slot/string xref that could plausibly
+   enter this system. Each one becomes an open question: "Is FUN_XXXXXX actually
+   on a live path in YR? What does it do?"
+2. **Every INI key from Workstream B** — each one becomes: "Where is this key read in
+   the binary? What does it gate? What's the default-vs-override behavior?"
+3. **Every existing claim from Workstream A** — each prior-doc finding becomes: "Is
+   this still true in the current binary? What's the address that proves it?"
+4. **Every Rust function from Workstream C** — each one becomes: "Does this match
+   gamemd's behavior, and what specific output does it produce vs the binary?"
+5. **Tick-cycle integration** — "When in the tick does this system run? What
+   reads its output? What writes to its inputs?"
+6. **TS legacy filter** — "Which fields/flags/branches in this system are TS
+   holdovers vs. live in YR? What's the default for each gate?"
+7. **Edge / corner cases** — explicitly enumerate at least: null pointer, zero
+   value, max value, empty container, first-tick, last-tick, paused, replay/save
+   restore. Each is an open question until proven irrelevant or handled.
+
+**Format for each entry** (keep terse — one line per question):
+
+```
+[OPEN] <id> — <question>
+[RESOLVED] <id> — <one-line answer> (evidence: <address / doc / INI key>)
+[DEFERRED] <id> — <one-line reason> (category: out-of-scope | needs-runtime-debugger | requires-different-system-context | bounded-cost-too-high)
+```
+
+A seed log with fewer than ~15 entries for a non-trivial system means you have
+not thought hard enough about what could be unknown. Add more before proceeding.
+
+## Step 2 — Ghidra deep dive (THE CORE — spend most of your time here)
+
+After collecting parallel results, go to Ghidra MCP for the authoritative binary analysis.
+This step is the entire point of the investigation. Do NOT shortcut it.
+
+Default to read-only Ghidra work. Do not mutate the Ghidra project unless the
+user explicitly approved mutating reverse-engineering actions for this
+investigation. Mutating actions include `rename_function`,
+`rename_function_by_address`, `rename_data`, `rename_variable`,
+`create_label`, `create_function`, `add_struct_field`, `modify_struct_field`,
+`set_decompiler_comment`, `set_plate_comment`, `set_disassembly_comment`,
+`save_program`, and any equivalent operation that changes the Ghidra database.
+If a missing function boundary blocks analysis and mutation was not approved,
+inspect bytes/reachable callers read-only where possible, or record the missing
+boundary as `[DEFERRED]` with the category `requires-different-system-context`
+or `bounded-cost-too-high`.
+
+**Time budget:** Spend at least 70% of your total effort in this step. If you've only
+decompiled 2-3 functions, you almost certainly haven't gone deep enough. A typical
+investigation should decompile **5-15+ functions** depending on system complexity.
+
+**Finding the entry point:**
+1. Search for relevant string constants (INI key names, error messages, class names)
+2. Follow xrefs from strings into the functions that read/use them
+3. If searching for a class method, find the class vtable first, then locate the method
+4. If Ghidra missed a function boundary, use `create_function` only when the user
+   explicitly approved mutating Ghidra state for this investigation; otherwise
+   keep the analysis read-only and record any remaining boundary uncertainty.
+
+**For each function you decompile:**
+1. Note the address and check `param_1` type:
+   - `param_1` is `int` → offsets like `*(param_1 + 0x98)` are direct byte offsets
+   - `param_1` is `int *` → `param_1[0xac]` means byte offset = `0xac * 4`
+   - `*(type *)((int)param_1 + 0x372)` is always a direct byte offset regardless
+2. Extract: conditions, formulas, constants, state transitions, branching logic
+3. **Follow ALL callees** — decompile every helper function, not just "non-trivial" ones.
+   A 5-line helper can contain the critical detail that makes the whole system make sense.
+   The only exception is obvious utility functions (memset, strlen, etc.)
+4. Check xrefs to understand who calls this function and when
+5. **Read the branch you DIDN'T expect.** When you see an if/else or switch, don't just
+   follow the "normal" path — examine the error path, the edge case path, the fallback.
+   These are where the important behavioral details live.
+
+**Depth requirements — follow the chain:**
+- When you find the primary function, decompile it fully.
+- For each callee in that function: decompile it too.
+- For important callees (state machines, formulas, lookups): go one MORE level deep.
+- For the primary function's callers: decompile at least the immediate caller to understand
+  when/how this system is invoked and what context is passed in.
+- **If you see a vtable dispatch** (call through a function pointer), resolve which concrete
+  method is being called. Don't just note "calls vtable+0x48" — find the actual implementation.
+- **If you see a global variable or static array**, inspect its contents or initialization.
+  These often contain lookup tables, default values, or state that changes behavior.
+
+**Branching rule — every unknown spawns a new Open Questions entry.**
+
+This is mandatory and load-bearing. The skill cannot be exploratory if you do
+not externalize unknowns the instant you encounter them. Every time you hit
+ANY of the following while decompiling, **add a new `[OPEN]` entry to the log
+before continuing the current function**:
+
+- A **callee** you haven't decompiled yet (even "obvious" helpers — log it,
+  decide later)
+- A **caller** of the current function you haven't traced
+- A **struct field** read or written at an offset you haven't documented
+- A **global variable** or static array referenced
+- A **flag bit** checked or set (each bit is its own entry unless already covered)
+- A **vtable slot** dispatched through — log "which concrete method is bound here?"
+- A **constant** whose meaning is not immediately obvious
+- A **branch** (if/switch) where you haven't yet examined both/all paths
+- A **string xref** the function uses
+- An **INI key** read by this function that wasn't in the Workstream B list
+
+You may not close a parent open question until **every child entry it spawned
+is resolved or explicitly deferred**. A function is not "done" because you
+read it top to bottom — it is done when its open questions are drained.
+
+**Pass discipline.** Work in passes. A pass = decompile-until-no-new-callees-or-
+unknowns-pop-up. Between passes, re-read the Open Questions Log top to bottom
+and pick the next `[OPEN]` item. The investigation may not exit Step 2 until
+**you have completed a full pass that added zero new entries to the log**.
+That zero-add pass is the empirical signal of exhaustion. If your last pass
+added even one entry, do another pass.
+
+**Detail extraction — the things that matter most:**
+
+The details below are the *primary deliverable* of the investigation. A report that
+describes the overall algorithm but misses the constants, clamps, orderings, and edge
+cases is a failed report — even if the summary reads well. Many of these details are
+invisible at a glance but load-bearing for parity. Treat every one as non-optional.
+
+- **Magic numbers**: Every constant in the code (0x100, 0x600, 256, etc.) — document what
+  it represents. Don't just note the value; figure out WHY that value.
+- **Bit flags and masks**: When you see `& 0x1F` or `| 0x40`, document each bit's meaning.
+  Check if other functions use the same flags — build the complete flag set.
+- **Timing and ordering**: Note the exact order of operations. "A happens before B" is a
+  finding. "A and B happen but I didn't check the order" is incomplete.
+- **Edge cases**: What happens when a value is 0? When a pointer is null? When an array
+  index is out of bounds? The original engine has specific behavior for these — document it.
+- **Clamping and bounds**: Does the code clamp values? What are the min/max? Is it
+  saturating or wrapping? These details affect gameplay.
+- **Off-by-ones and inclusive/exclusive ranges**: `<` vs `<=`, `i < n` vs `i <= n`, ranges
+  that include or exclude their endpoints. These are invisible bugs that cause 1-tick or
+  1-cell drift from gamemd.exe. Always check.
+- **Rounding and truncation**: When the code converts between types or divides, does it
+  round, truncate, or floor? Which direction? This matters for fixed-point sim math.
+- **Default values and initialization**: What does a field hold before the system touches
+  it? Zero-init, constructor-set, copied from a template? This decides edge-case behavior.
+- **Sign, overflow, saturation**: Signed vs unsigned comparisons, whether arithmetic can
+  wrap, whether the code catches it. An unsigned underflow on a counter changes behavior.
+- **"Dead" assignments and side effects**: A write that looks dead may be read by another
+  system later in the tick. Note it; don't skip it because "nothing uses this here."
+
+**UI / visual paint-path completeness:**
+
+For UI, menu, shell, sidebar, and render parity, the first draw helper is not the
+composition. Trace from the top-level paint/message/render entry point until the
+handler returns, including every draw call that runs after the parent background,
+base chrome, or "main" helper. A visual report is incomplete unless it can explain
+the full ordered composition for the target mode/dialog.
+
+Required for every UI/visual investigation:
+
+- **Paint-path closure**: Start at the top-level paint/message handler and follow all
+  active draw callees to return. Do not stop at `RightPanel__Draw`, a background
+  helper, or the first plausible owner-draw function.
+- **Ordered composition ledger**: Record draw order, function/address, condition,
+  asset/file, exact frame/index, source/destination rect, palette/convert path,
+  clipping/scissor if present, and z-order role.
+- **Per-dialog flag proof**: For optional helpers, resolve the target dialog/mode's
+  flag setters. Record setter function, allow-list/switch case, written byte/bit,
+  shifted byte read in the paint handler, and whether the target dialog activates it.
+- **All-frame SHP inspection**: Dump or inspect every frame of SHP assets involved
+  before making a visual claim. If a call draws frame 1, frame 2, or any nonzero
+  frame, name it explicitly.
+- **Asset role matrix**: Classify every relevant asset as `Loaded`, `Drawn`,
+  `Visible in target`, `Content/preview`, `Chrome/container`, `Overlay`,
+  `Transition-only`, or `Inactive in target`. Assets can have multiple roles.
+- **Scoped negative claims**: "Not used as preview backing" does not mean "not
+  visible." Every negative claim must name the role it excludes and the role it
+  does not exclude.
+- **Screenshot contradiction trigger**: If a user screenshot, reference capture, or
+  asset dump contradicts the current conclusion, treat the research as incomplete.
+  Reopen the paint path and look for a missing layer, frame, flag, rect, or palette.
+
+**Verify YR activity (CRITICAL — do this for every function you decompile):**
+- Is this code actually active in Yuri's Revenge, or is it dormant Tiberian Sun legacy?
+- Check if it's gated behind a flag/setting — if so, what's the default in YR?
+- If gated behind `SpecialFlags & 0x1000` or similar, note it as TS-legacy/optional
+- Trace what flags/fields actually gate in the code — don't infer from the name.
+  TS-era field names are often misleading in YR context (e.g., "Tiberium" fields
+  that control vein behavior, not ore behavior).
+- When you find a bool/flag being checked, read the INI key it maps to, confirm
+  the default value, and check if any standard YR content actually sets it to a
+  non-default value.
+
+**Do NOT stop the Ghidra dive early.** Common traps:
+- "I think I have enough to write the report" → No. Follow one more call chain.
+- "This helper probably just does X" → Decompile it. Verify. "Probably" is not evidence.
+- "The main function is clear, I'll skip the edge cases" → The edge cases ARE the details.
+- "I've been at this a while" → Good. That means you're being thorough.
+
+After the deep dive, you should be able to answer: "If someone asked me an obscure
+corner-case question about this system, could I answer it from what I found?" If not,
+keep digging.
+
+## Step 3 — Exhaustion gate (the Open Questions Log must drain)
+
+This is the hard gate, not a soft checklist. You may not proceed to Step 4
+until **every** entry in the Open Questions Log is either `[RESOLVED]` with
+evidence or `[DEFERRED]` with an explicit reason and category.
+
+**Procedure — execute in order, do not skip:**
+
+1. **Re-read the entire Open Questions Log top to bottom.** For each `[OPEN]`
+   entry: either go back to Ghidra and resolve it (preferred), or write an
+   explicit `[DEFERRED]` line with reason + category. "Not relevant" is not a
+   reason — say *why* it's not relevant. "Too deep to follow" requires a
+   category (`bounded-cost-too-high`) and an estimate of what would resolve it.
+
+2. **Run the zero-add pass test.** Do one more full Ghidra pass over the
+   primary function and its top-level callees. If this pass causes you to
+   add even one new `[OPEN]` entry, you are not done — resolve it and repeat
+   the pass. The investigation exits Step 3 only after a pass that adds zero
+   entries.
+
+3. **Adversarial reader test.** Write down 5 specific corner-case questions a
+   sharp reader might ask about this system (e.g., "what happens if the unit
+   is destroyed mid-animation?", "what's the order if two of these fire on
+   the same tick?"). For each, either answer from evidence in your notes or
+   add it to the log as `[OPEN]` and resolve it. If you cannot generate 5
+   non-trivial questions, you do not understand the system well enough yet.
+
+4. **Spot-check at least 2 findings** by going back to Ghidra and re-reading
+   the decompilation cold. Fresh eyes often catch things you glossed over.
+
+5. **Sanity-check the deferral pile.** If more than ~25% of your log entries
+   ended up `[DEFERRED]`, the report is not a complete investigation — it's a
+   partial one. Either resolve more, or rescope the report's title/scope to
+   honestly reflect what was covered (e.g., "Phase 1 — entry points only").
+   Do not hide partial coverage behind confident-sounding prose.
+
+**Anti-checkbox rule.** Do not satisfy this gate by adding the literal words
+"resolved" or "deferred" without doing the work. Each `[RESOLVED]` line MUST
+cite a Ghidra address, doc path, or INI key as evidence. Each `[DEFERRED]`
+line MUST state a category from the allowed set and a one-line reason a
+future reader can act on.
+
+## Step 4 — Synthesize findings
+
+Cross-reference all sources. For each finding:
+
+| Field | Content |
+|-------|---------|
+| **What** | The behavior, formula, or state machine |
+| **Evidence** | Which source confirmed it (Ghidra address, doc name, INI key) |
+| **Confidence** | HIGH (verified from binary), MEDIUM (consistent across docs + INI), LOW (inferred/single source) |
+| **Active in YR?** | Yes / No / Conditional (state the condition) |
+
+**Resolve conflicts:**
+- If docs say X but Ghidra says Y → Ghidra wins, flag the stale doc
+- If two docs conflict → go to Ghidra to settle it
+- If INI has a key but no code reads it → note as potentially unused
+
+**Build the Coverage Ledger from the log.** Every planned function, discovered
+function, major branch, INI key, and Rust comparison point must appear exactly once
+with one of the allowed statuses. Do not collapse "touched" into "verified".
+
+**Build the Implementation Handoff.** This is required even for research-only
+work. The handoff is not a patch plan; it is the minimum bridge from verified
+binary behavior to a future Rust implementation without making the implementer
+rediscover the same facts. Each handoff item must use this shape:
+
+```
+Verified behavior -> binary evidence -> current Rust delta -> affected surface -> acceptance scenario -> risk / do-not-do note
+```
+
+Rules:
+- If Rust already matches, say `current Rust delta: none observed` and give the
+  verification surface.
+- If Rust was not scanned deeply enough, say `current Rust delta: unchecked` and
+  cite the file/function search that remains.
+- Do not invent code structure. Name existing files/functions when found; otherwise
+  say what kind of surface is needed.
+- Every handoff item needs an exact-mechanism, byte/pixel, player-visible, or
+  deterministic acceptance scenario.
+- A report with no implementation handoff is PARTIAL unless the target is purely
+  documentary and has no Rust-facing implication.
+
+## Step 5 — Write research document
+
+Save to `<main-checkout>/docs/research/<TOPIC>_GHIDRA_REPORT.md` (or update existing). This is the canonical ignored research archive; do not save research reports into tracked/published `docs/` locations outside `docs/research/`. Follow this structure:
+
+```markdown
+# <System Name> — Ghidra Research Report
+
+**Address(es):** `0x00XXXXXX` (primary function)
+**Investigation Mode:** coverage-map | exhaustive-slice
+**Claimed Scope:** exact slice this report actually verifies
+**Non-Scope:** related areas this report does not claim to cover
+**Confidence:** High/Medium/Low (overall)
+**Active in YR:** Yes/No/Conditional
+
+## 1. Overview
+What this system does in 2-3 sentences.
+
+## 2. Class Layout / Key Offsets
+Table of struct fields with byte offsets, types, and purpose.
+
+## 3. Core Logic
+The main algorithm, state machine, or formula. Use pseudocode, not C.
+Include actual constants from the binary.
+
+## 4. INI Keys
+Table of relevant INI keys, their types, defaults, and effects.
+
+## 5. Integration Points
+What calls this system? What does it call? When does it run in the tick cycle?
+
+## 6. Current Rust Implementation Status
+What we have vs what's missing. File paths and line numbers.
+
+## 7. Coverage Ledger
+Use this table. Do not omit it.
+
+| Area / function / branch | Status | Evidence | What remains |
+|--------------------------|--------|----------|--------------|
+| <name> | verified | <address/doc/INI> | none |
+| <name> | touched-not-exhausted | <address/doc/INI> | <specific gap> |
+| <name> | not-touched | none | <why it matters> |
+| <name> | deferred | <reason> | <next investigation> |
+
+Status values: `verified`, `touched-not-exhausted`, `not-touched`, `deferred`,
+`conflict-needs-resolution`.
+
+## 8. Open Questions — Final State of the Investigation Log
+The canonical final state of the Open Questions Log from Step 1.5 / Step 3.
+Every entry MUST be `[RESOLVED]` or `[DEFERRED]` — no `[OPEN]` items may
+ship in a completed report. Use this exact format:
+
+- `[RESOLVED] <id> — <question> → <answer>` (evidence: `<address / doc / INI>`)
+- `[DEFERRED] <id> — <question>` (category: `out-of-scope` | `needs-runtime-debugger` | `requires-different-system-context` | `bounded-cost-too-high`; reason: `<one line>`; next-step-if-pursued: `<one line>`)
+
+If the deferred pile is large, also include a short paragraph stating which
+parts of the system are NOT covered by this report and what a follow-up
+investigation would need to do.
+
+## 9. Visual/UI Composition Ledger
+Required when the report covers UI, shell, sidebar, menu, viewport, sprite,
+or other visual composition. Omit only when the investigated system has no
+visual surface.
+
+| Order | Function / address | Condition / flag proof | Asset / frame | Rect / anchor | Palette / convert | Active for target? | Role |
+|-------|--------------------|------------------------|---------------|---------------|-------------------|--------------------|------|
+| 1 | <function> | <always / flag setter evidence> | <file#frame> | <src->dst> | <palette path> | yes/no/conditional | <chrome/content/overlay/etc.> |
+
+Also include an asset role matrix:
+
+| Asset | Loaded | Drawn | Visible in target | Content/preview | Chrome/container | Overlay | Transition-only | Inactive | Evidence |
+|-------|--------|-------|-------------------|-----------------|------------------|---------|-----------------|----------|----------|
+
+## 10. Implementation Handoff
+Use this table. Keep it concrete and implementation-facing, but do not include
+Rust code or patch text.
+
+| Verified behavior | Evidence | Current Rust delta | Affected Rust surface | Required implementation effect | Acceptance scenario | Risk / do-not-do |
+|-------------------|----------|--------------------|-----------------------|--------------------------------|---------------------|------------------|
+| <binary behavior> | <address/doc/INI> | <missing/mismatch/none/unchecked> | <file/function or needed surface> | <mechanism/byte/pixel effect to reproduce> | <exact-mechanism, byte/pixel, or deterministic test> | <wrong implementation to avoid> |
+
+If this report extends or corrects prior work, include a short `Stale Docs /
+Follow-up Docs` list after the table with exact replacement wording for any
+known stale claim.
+
+## Sources
+- Ghidra addresses decompiled
+- Doc files referenced
+- INI files checked
+```
+
+## Confidence levels
+
+- **HIGH** — You decompiled the function, read the assembly context, traced the call chain, and confirmed the behavior. You would bet money on it.
+- **MEDIUM** — Multiple docs agree, INI keys are consistent, but you didn't verify every detail in the binary. Or you decompiled but the decompilation was ambiguous.
+- **LOW** — Single source, inferred from naming/context, or extrapolated from similar systems. Mark clearly and add to Open Questions.
+
+## Red Flags — STOP
+
+If you catch yourself:
+- Writing Rust code → DELETE IT. You are researching, not implementing.
+- Omitting the Implementation Handoff → the report is PARTIAL. Future
+  implementers need verified behavior translated into affected Rust surfaces,
+  acceptance scenarios, and risks.
+- Claiming a finding without stating the evidence source → add the source.
+- Saying "probably" or "likely" in a finding → move it to Open Questions or go verify in Ghidra.
+- Skipping Ghidra because "the docs seem complete" → the docs could be wrong. Spot-check at minimum.
+- Copy-pasting a doc's claims without verifying → that's summarizing, not investigating.
+- Guessing what a helper function does instead of decompiling it → decompile it.
+- Assuming code is active in YR without checking → verify it's not TS-legacy.
+- Skipping a detail because it "probably isn't visible to the player" → details drive
+  parity. Invisibility is not a filter. Document it.
+- Stopping early because the report "has enough" → the job is complete investigation,
+  not adequate investigation. Go one more level.
+- Leaving a branch, constant, or flag unexplained because "it doesn't look important" →
+  if it's in the binary and on an active path, it's important until proven otherwise.
+- Declaring the investigation done while the Open Questions Log still has `[OPEN]`
+  items → not done. Resolve or explicitly defer (with category + reason) every entry.
+- Skipping a Ghidra pass because "the report seems complete" → you don't know if it's
+  complete until a full pass adds zero new log entries. Run the pass.
+- Marking entries `[RESOLVED]` without citing an address, doc, or INI key as evidence
+  → that's a checkbox, not a resolution. Add the evidence or move it to `[DEFERRED]`.
+- Generating fewer than 5 adversarial corner-case questions in Step 3 → you don't
+  understand the system well enough to gate on exhaustion yet. Keep digging.
+- Calling a broad coverage-map "complete" → rename/reframe it. A broad map is useful
+  only if it exposes what remains unknown.
+- Saying planned/touched functions were "investigated" without a coverage status →
+  list each as verified, touched-not-exhausted, not-touched, or deferred.
+- Omitting the Coverage Ledger → the report is invalid. Future implementers need to
+  know what not to trust yet.
+- Stopping UI visual research at the first helper or background draw: incomplete.
+  Trace the full paint/message handler through every later active draw call.
+- Dumping only SHP frame 0: incomplete for visual parity. Multi-frame SHPs must be
+  inspected until the exact drawn frame is proven.
+- Turning a role-scoped negative into a global negative: misleading. "Not preview
+  backing" does not prove "not visible chrome."
+- Ignoring a screenshot/reference contradiction because the current call stack seems
+  plausible: reopen the paint path. The contradiction is evidence of missing scope.
+
+## Rationalization table
+
+| Excuse | Reality |
+|--------|---------|
+| "The docs already cover this" | Docs can be stale or wrong. Verify critical claims in Ghidra. |
+| "I can see from the function name what it does" | Ghidra labels can be wrong. YRpp labels are not ground truth. Decompile. |
+| "This is simple enough to just implement" | You are researching. Provide a handoff, not a patch. |
+| "I'll just note the address and come back later" | Decompile now while you have context. Addresses without analysis are useless. |
+| "The INI key name makes the behavior obvious" | INI keys don't tell you edge cases, defaults, or interaction with other systems. |
+| "I already know how this works from a previous session" | Verify. Memory is not evidence. |
+| "Just a quick code fix while I'm here" | NO. Hard gate. Research only. |
+| "The log has open items but they're minor" | Then they take 30 seconds to resolve. Resolve them. |
+| "I've covered the main flow, the rest is edge cases" | Edge cases ARE the deliverable. The main flow is what a skim already gives. |
+| "The zero-add pass test is overkill for this system" | It's the only objective signal of exhaustion. Run it. |
+| "Generating 5 corner-case questions feels artificial" | If you can't generate them, you don't know the system. The exercise is the test. |
+
+## After completion
+
+Present a brief summary to the user:
+1. What system was investigated
+2. Key findings (3-5 bullets, most important first)
+3. What's already implemented vs what's missing
+4. Open questions that need more work
+5. Highest-leverage implementation handoff item
+6. Path to the saved research document

--- a/.claude/skills/re-swarm/SKILL.md
+++ b/.claude/skills/re-swarm/SKILL.md
@@ -1,0 +1,453 @@
+---
+name: re-swarm
+description: "Project-scoped for VERA20k/RA2 Yuri's Revenge only. Use when the user invokes '/re-swarm', asks to orchestrate parallel reverse-engineering investigations, wants detail-level gamemd.exe research gaps scanned, wants parity-blocker research, or wants multiple /re-investigate reports reconciled into implementation handoffs. Dispatches at most 3 read-only subagents per wave, each investigating one narrow target, then checks reports for cross-doc contradictions and Rust-facing handoff quality. Never auto-applies doc or code patches."
+---
+
+# Re-Swarm
+
+Coordinate up to 3 parallel reverse-engineering investigations per wave for detail-level
+`gamemd.exe` gaps, then reconcile their reports. This skill is detection and
+research only: do not edit Rust, INI files, tracked/published docs outside
+`docs/research/`, or Ghidra state while
+running a swarm. Reports must include implementation handoffs, but the swarm never
+implements them.
+
+Research truth bar: record active-gamemd mechanism, state, pixels/results, and
+uncertainty precisely; no approximation may be labelled exact parity. This does
+not make every finding current implementation priority. Reconciliation must
+also classify retail-skirmish impact and separate exactification residuals.
+
+Native-to-Rust translation rule: do not recommend literal C++ architecture ports
+unless the user explicitly asks. Research must identify the verified gamemd
+behavior contract, then hand it off as Rust-native ownership boundaries: storage
+can remain in `EntityStore`, scheduler/order can live in a Rust `LogicScheduler`
+or equivalent owner, lifecycle effects can be helper APIs, and systems can stay
+plain functions. What must match is the native semantics: ordering, membership,
+state reads/writes, RNG use, frame visibility, same-tick consequences, and
+downstream bytes/pixels. Avoid both bad shortcuts: copying raw pointer/vtable
+architecture verbatim, or proposing clean Rust that changes behavior.
+
+Label-adversarial Ghidra rule: local Ghidra names, labels, comments, xref
+labels, and decompiler-assigned symbol names are navigation hints only. This
+project may contain polluted or stale labels from earlier scripts. Handoff-critical
+identity claims must be verified from function body, assembly/decompile, callsites,
+receiver/`this` pointer, argument flow, vtable slot bytes, data references, and
+active-YR reachability. Prefer address plus verified role over label name, and
+record label drift explicitly.
+
+## Hard Gates
+
+- Dispatch at most 3 subagents at once. Split larger queues into sequential waves.
+- Use subagents only after the user explicitly invokes `/re-swarm` or otherwise
+  asks for parallel/delegated reverse-engineering work.
+- Each subagent must use Ghidra MCP read-only. The prompt must forbid
+  `rename_function`, `rename_function_by_address`, `rename_data`,
+  `rename_variable`, `create_label`, `create_function`, `add_struct_field`,
+  `modify_struct_field`, `set_decompiler_comment`, `set_plate_comment`,
+  `set_disassembly_comment`, `save_program`, and any mutating operation.
+- Each subagent may write exactly one research report under
+  `<main-checkout>/docs/research/` plus the shared claims file.
+  Nothing else.
+- The parent may write only the coverage index and claims file. Reconciliation
+  never applies code or docs fixes.
+- If 2 or more slots in a wave fail, stop before reconciliation and ask the user
+  whether to retry failed slots, review successes only, or abort.
+- Every returned finding must distinguish verified binary evidence from inference
+  and must label whether the path is active in standard YR.
+- Handoff-critical claims require stronger evidence than ordinary report facts:
+  cite decompile plus assembly/disassembly address range, decompile plus
+  xref/caller evidence, or INI/default source plus the binary reader address.
+  Do not mark a handoff COMPLETE from decompiler prose alone when the claim
+  depends on inclusive/exclusive bounds, signedness, argument order, struct
+  offsets, default values, path liveness, or TS-vs-YR activity.
+
+## Invocation Modes
+
+- `/re-swarm`: scan for detail-level research gaps, propose up to 3 targets, wait for
+  confirmation.
+- `/re-swarm <t1>, <t2>, ...`: validate explicit targets, wait for confirmation.
+- `/re-swarm --area <area>`: scan only one area, propose up to 3 targets, wait for
+  confirmation.
+- `/re-swarm --parity-blocker <area>`: propose targets ranked by what blocks
+  player-visible parity or screenshot parity for the named area.
+- `/re-swarm --dry-run`: scan/validate and print the dispatch plan, then stop.
+- `/re-swarm --refresh-index`: rebuild the coverage index before ranking.
+- `/re-swarm --handoff-plan`: after normal reconciliation, add a non-editing
+  implementation bridge plan: patch order, files likely touched, tests to
+  add/update, risk ordering, and facts that must remain unchanged.
+
+If an explicit list has one entry, use a single investigator unless parallelism
+adds a concrete independent check. If it has more than 3 entries, split it into
+sequential waves. Do not dispatch broad targets like `BuildingClass` or `combat`;
+narrow them to one function, field, INI key, vtable slot, or behavior.
+
+## Research Index Preflight
+
+Before rebuilding the swarm coverage index or proposing slots, use the
+research-index MCP first. Prefer `research_brief`, `research_map`, and
+`research_validate`; use the repo-local CLI only for a missing MCP capability:
+
+```text
+python <main-checkout>/tools/research_index/brief.py "<topic>" --limit 8
+python <main-checkout>/tools/research_index/map.py "<topic>" --limit 12
+```
+
+If the exact system is known, add `--system <system>` (examples: `bridges`,
+`miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun without
+`--system`, then rerun with the inferred exact system. Use `validate.py` for stale
+or missing docs and `graph.py evidence` / `graph.py implementation` for candidate
+anchors and Rust-facing handoff clues. The index informs target selection; it does
+not replace read-only Ghidra investigation.
+
+## Step 1: Build Or Read The Coverage Index
+
+For auto, scoped, and refresh modes, use
+`<main-checkout>/docs/research/.swarm-coverage-index.md`.
+
+- If absent, rebuild it.
+- If present and modified within 7 days, use it and tell the user the cache date.
+- If older than 7 days or `--refresh-index` was passed, rebuild it and tell the
+  user.
+
+When rebuilding, walk every `*_GHIDRA_REPORT.md` in
+`<main-checkout>/docs/research/` and collect detail-level candidates:
+
+- `[DEFERRED]` entries from open-question sections.
+- "Phase 2/3 deferred", "future work", or equivalent markers.
+- Function addresses mentioned in passing but not analyzed in detail.
+- Struct fields whose purpose is unknown or only typed at an offset.
+- Vtable slots marked unknown, unused, or omitted from a documented table.
+- INI keys referenced by docs, then inverse coverage against `ini/rulesmd.ini` and
+  `ini/artmd.ini` for undocumented keys.
+- Existing reports missing an `Implementation Handoff` section, or handoffs marked
+  `current Rust delta: unchecked` for player-visible behavior.
+- Stale-doc markers found during recent implementation work: reports whose claims
+  contradict current docs, current Rust, or sibling reports.
+- Optional vtable coverage checks against Ghidra only if they require no more than
+  50 read-only Ghidra calls.
+
+Write one flat Markdown bullet per gap:
+
+```markdown
+- DEFERRED | RADIO_PROTOCOL | Q-12 | "Is FUN_0050AB10 the resend handler?" | category: bounded-cost-too-high
+- HINTED_FN | FOOT_MOVEMENT | FUN_005A1C30 mentioned 3x | no dedicated investigation
+- UNDOC_FIELD | BUILDING_CLASS | offset 0x6A4 | type uint32 | purpose unknown
+- VTABLE_SLOT | AIRCRAFT_CLASS | slot 0x48 | unknown per doc; binary has FUN_004C8800
+- UNDOC_INI | rulesmd.ini | [General] AllowableVehicleHijackerCounts= | no doc citation
+- MISSING_HANDOFF | BUILDING_BRACKETS | exact Z-buffer predicate known | no Rust-facing acceptance scenario
+```
+
+## Step 1.5: Summarize Recent Work And Known Settled Facts
+
+Before ranking targets, write a short current-state note for the dispatch prompt.
+Use only cheap local evidence: recent conversation context, relevant report
+headings, `git diff --stat`, and focused `rg` over `src/` and docs. Do not run a
+mini-investigation here.
+
+The note must contain:
+
+- `Already settled`: facts agents must not rediscover unless resolving a conflict.
+- `Current Rust shape`: files/functions already touched or clearly involved.
+- `Known remaining gaps`: specific questions that still block parity.
+- `Stale docs suspected`: exact doc paths or claims, if known.
+
+For `--parity-blocker`, also include one player-visible target scenario such as
+"selected building partly behind cliff under gap re-shroud".
+
+## Step 2: Rank And Propose Targets
+
+Filter by area if requested, then rank candidates:
+
+- HIGH: referenced from 3+ docs, controls player-visible thresholds/formulas, is
+  on an active YR tick path, or blocks a known player-visible/screenshot parity
+  scenario.
+- MEDIUM: referenced from 1-2 docs, fills a deferred item from a high-confidence
+  report, covers an INI key in a default-enabled section, or turns an existing
+  high-confidence report into an implementation-ready handoff.
+- LOW: isolated curiosity, no downstream consumer, or likely TS-only/disabled code.
+
+Break ties by cross-reference count, then smallest scope, then subsystem diversity.
+For `--parity-blocker`, break ties by highest player visibility, then smallest
+scope. Print a dispatch table with slot, target, one-line scope, source, tier, and
+expected handoff. Wait for explicit confirmation such as `go`. Prior confirmation
+in the same thread does not count for a new swarm. For `--dry-run`, stop after
+printing the plan.
+
+Example:
+
+```markdown
+Proposed /re-swarm dispatch:
+
+| Slot | Target | Scope | Source | Tier | Expected handoff |
+|---|---|---|---|---|---|
+| 1 | FUN_0050AB10 radio resend handler | Decompile state and confirm YR live path | RADIO_PROTOCOL Q-12 | HIGH | resend timing acceptance scenario |
+| 2 | BuildingClass+0x6A4 field | Identify type, accessor, and behavior | BUILDING_POWER UNDOC_FIELD | MEDIUM | Rust field mapping or no-op proof |
+| 3 | [General] AllowableVehicleHijackerCounts= | Find reader, struct offset, default behavior | rulesmd.ini UNDOC_INI | MEDIUM | rules parser delta + test |
+```
+
+## Step 3: Write Claims
+
+Path: `<main-checkout>/docs/research/.swarm-claims.md`
+
+Append one block per swarm invocation. Do not overwrite old rows.
+
+```markdown
+## Swarm 2026-05-18T11:42
+
+- 2026-05-18T11:42 - slot-1 - FUN_0050AB10_RadioResendHandler - claimed
+- 2026-05-18T11:42 - slot-2 - BuildingClass_field_0x6A4 - claimed
+```
+
+Statuses are `claimed`, `done`, and `failed`. A `claimed` row older than 4 hours is
+stale and may be re-claimed by a future swarm, but do not delete it.
+
+## Citation discipline
+
+Every material worker claim must cite the exact verification call or local source.
+Match evidence to claim type:
+
+| Claim | Minimum evidence |
+|---|---|
+| Function behavior | `decompile_function` at the entry |
+| Caller/callee relation | callers/callees query |
+| Vtable owner | COL→TypeDescriptor mangled-name walk |
+| Vtable slot | `read_memory vtable+N*4` plus decompile of the result |
+| Struct offset/type | assembly context showing displacement and access width |
+| Constant/default | decompile/assembly showing the literal |
+| INI reader/default | string xref, reader decompile, and default literal |
+| YR activity/TS legacy | caller trace plus gate and stock default |
+
+Bare or wrong-kind citations do not enter reconciliation. Put unresolved claims
+in a YELLOW `Unverified` section instead of mixing them into verified findings.
+
+## Step 4: Dispatch Subagents
+
+Use parallel Agent tool calls with `subagent_type: general-purpose` - Explore agents cannot write the report file. Agents run in the background and report back on completion; dispatch all slots before waiting. Do not set an unavailable model
+override; inherit the active model unless the user explicitly requested a supported
+model. Each subagent receives one narrow target and a self-contained prompt.
+
+Do not assume subagents will automatically load this skill. Include the relevant
+`/re-investigate` constraints directly in each prompt:
+
+```text
+You are subagent slot {{SLOT}} of a /re-swarm batch. Your single target is:
+
+{{TARGET}}
+
+Scope, do not expand: {{SCOPE}}
+
+Recent work context from the parent:
+{{RECENT_WORK_CONTEXT}}
+
+Use the VERA20k /re-investigate workflow for this target, with these added
+constraints:
+
+Hard constraints:
+- Ghidra MCP is read-only. Do not call rename_function,
+  rename_function_by_address, rename_data, rename_variable, create_label,
+  create_function, add_struct_field, modify_struct_field,
+  set_decompiler_comment, set_plate_comment, set_disassembly_comment,
+  save_program, or any mutating tool.
+- In swarm mode, `/re-investigate` guidance to create missing functions is
+  overridden by this read-only rule. If Ghidra missed a function boundary, do not
+  create it; inspect bytes/reachable callers read-only where possible, or record
+  the missing boundary as Remaining Uncertainty.
+- You may write exactly one research report:
+  <main-checkout>/docs/research/<TARGET_SLUG>_GHIDRA_REPORT.md
+- You may update only the shared claims file in addition to that report.
+- Do not modify Rust files, INI files, tracked/published docs outside
+  `docs/research/`, or any other location.
+- Follow CLAUDE.md and ENGINE.md project rules: gamemd.exe is the behavior spec, verified binary
+  findings must be separated from inference, offsets and addresses must not be
+  invented, and TS legacy paths must be checked before being treated as standard YR.
+- Every material finding must say: Active in YR: Yes / No / Conditional, with
+  evidence.
+- Before investigating, write these four lines in your working notes and satisfy
+  them in the report: `Target question`, `Non-goals`, `Evidence needed to mark
+  COMPLETE`, and `Stop conditions`.
+- Handoff-critical claims need stronger evidence than normal facts. Cite either
+  decompile plus assembly/disassembly address range, decompile plus xref/caller
+  evidence, or INI/default source plus the binary reader address. This is required
+  for claims involving inclusive/exclusive bounds, signedness, argument order,
+  struct offsets, default values, path liveness, or TS-vs-YR activity.
+- Do not rediscover facts listed under `Already settled` unless you find a direct
+  contradiction. Spend the slot on the unknowns and the implementation handoff.
+- Keep the scope narrow. If related gaps appear, list them as open questions but do
+  not investigate them in this slot.
+- Your report must include `/re-investigate`'s `Implementation Handoff` section.
+  COMPLETE requires at least one handoff item unless the target proves there is no
+  Rust-facing or doc-facing implication.
+- Include a `Negative Facts / Do Not Do` subsection when the investigation rules
+  out an attractive but wrong implementation shortcut. Example:
+  `Do not use AddOccupy/RemoveOccupy for real foundation occupancy`.
+- Each implementation handoff acceptance scenario must include one concrete Rust
+  test-name proposal, e.g. `test_garefn_addoccupy_does_not_block_real_foundation`.
+- Include a `Remaining Uncertainty` subsection for any unresolved condition,
+  missing caller, inactive-path doubt, or partial Rust-facing implication.
+
+Return only:
+1. A Markdown summary no longer than 150 lines.
+2. The exact report path written.
+3. Up to 5 load-bearing verified facts, one line each, with evidence such as Ghidra
+   address, offset, INI key path, or file:line.
+4. Up to 3 implementation handoff bullets in the form:
+   `verified behavior -> Rust delta -> affected surface -> acceptance scenario -> proposed test name -> risk`.
+5. Up to 5 negative facts / do-not-do notes, each with evidence.
+6. Remaining uncertainty bullets, or `None`.
+7. Any stale-doc replacement wording found, with exact doc path.
+8. Status: COMPLETE, PARTIAL (reason), or FAILED (reason).
+
+Do not return raw decompilation, assembly listings, raw INI dumps, full struct
+tables, or the full open questions log.
+```
+
+After dispatching, wait for all returns before reconciliation unless a tool-level
+timeout makes a slot failed.
+
+## Step 5: Collect Returns
+
+For each returned summary:
+
+1. Verify the report path exists.
+2. Update that slot in `.swarm-claims.md` to `done` or `failed`.
+3. Treat malformed returns as PARTIAL: over 150 lines, missing report path, missing
+   facts list, missing implementation handoff, or no status.
+4. Open each report and enforce the citation discipline above. Bare claims or
+   wrong-kind evidence make the slot PARTIAL and are excluded from reconciliation.
+   If more than ~20% of load-bearing claims fail this gate, mark the slot FAILED.
+5. If 0-2 slots failed, continue and flag failures clearly.
+6. If 2 or more slots failed, stop and ask the user how to proceed.
+
+A slot may only be marked COMPLETE if it returns at least one item in this chain:
+`verified behavior -> evidence -> Rust implication -> acceptance scenario -> proposed test name`.
+If the slot proves no implementation is needed, that proof must be explicit and
+evidenced. Missing negative facts are acceptable only if the slot explicitly says
+`Negative Facts / Do Not Do: None`.
+If a slot's handoff depends on bounds, signedness, argument order, struct offsets,
+defaults, path liveness, or TS-vs-YR activity, COMPLETE also requires the stronger
+evidence form described above. Otherwise mark it PARTIAL and name the missing
+verification.
+
+## Step 6: Reconcile In Parent
+
+For each successful or partial slot:
+
+1. Read the written report.
+2. Extract the 5-10 most load-bearing claims: offsets, addresses, formulas, INI
+   mappings, call relationships, and YR-activity labels.
+3. Cross-reference each claim against sibling docs in
+   `<main-checkout>/docs/research/`.
+   - If the sibling matches, record it as corroborated.
+   - If it conflicts, record both claims and both evidence citations.
+   - If it appears nowhere else, record it as novel.
+4. Spot-check at least 2 load-bearing claims by re-reading the cited Ghidra address
+   or cited source material.
+   - Spot-check every claim that directly gates an implementation handoff when it
+     involves bounds, signedness, argument order, struct offsets, defaults, path
+     liveness, or TS-vs-YR activity.
+5. Check YR-activity claims against ENGINE.md, existing TS-legacy notes, and sibling
+   docs. Flag any suspicious "Active in YR: Yes" claim.
+6. Reconcile implementation handoffs:
+   - Merge duplicate handoffs that point at the same Rust surface.
+   - Flag contradictions between sibling handoffs.
+   - For each handoff, run a mandatory focused Rust scan before ranking:
+     `rg` likely target symbols/INI keys/type names in `src/`, collect file
+     references, existing tests, and likely ownership/module boundary.
+   - Record the Rust scan as: `target symbols -> file refs -> existing tests ->
+     likely ownership`. This is reconnaissance only; do not edit Rust.
+   - Rank handoffs by player visibility, certainty, and smallest implementation
+     surface.
+   - Preserve `do-not-do` risks; these are often the most useful output.
+7. Consolidate negative facts / do-not-do notes:
+   - Keep evidenced notes even if they are not direct implementation tasks.
+   - Prefer short imperative wording: `Do not ... because ...`.
+   - Attach the evidence source and affected Rust surface when known.
+8. Extract remaining uncertainty:
+   - Include unresolved caller questions, conditional YR activity, missing Rust
+     threading, unverified stock/mod split, or partial handoff risks.
+   - Do not bury uncertainty inside prose; make it a distinct final-report list.
+9. Extract stale-doc fixes separately from implementation handoffs. Include exact
+   replacement wording, but do not apply it unless the user asks.
+
+If `--handoff-plan` was requested, add a non-editing bridge plan after the normal
+reconciliation:
+
+1. Group handoffs by likely Rust ownership/module boundary.
+2. Produce a patch order that starts with data model/parser/test fixtures, then
+   shared helpers, then gameplay call sites, then UI/render consumers if any.
+3. List files likely touched and tests to add/update, using exact paths when the
+   Rust scan found them.
+4. Rank risks by player visibility, regression surface, determinism risk, and
+   stock-frequency.
+5. List `must remain unchanged` facts, especially negative facts and known
+   gamemd-compatible exceptions.
+6. Stop at the plan. Do not implement, stage, commit, or edit docs.
+
+Do not edit docs during reconciliation.
+
+## Step 7: Report To User
+
+Keep the final report concise and structured:
+
+```markdown
+## /re-swarm Results - 2026-05-18T11:42
+
+Status: 4 of 5 complete, 4 reports written, 1 contradiction found.
+
+### Reports Written
+1. slot-1 - RADIO_RESEND_HANDLER_GHIDRA_REPORT.md - COMPLETE - one-line finding
+2. slot-2 - BUILDING_FIELD_6A4_GHIDRA_REPORT.md - PARTIAL - reason
+
+### Cross-Doc Contradictions
+1. slot-2 vs BUILDING_POWER_GHIDRA_REPORT.md:
+   - slot-2 claim and evidence
+   - sibling claim and evidence
+   - recommended next check
+
+### Novel Findings
+- slot-1: finding with evidence.
+
+### Implementation Handoffs
+1. slot-2: verified behavior -> affected Rust surface -> acceptance scenario -> proposed test name -> risk.
+
+### Focused Rust Scan
+- slot-2: target symbols -> file refs -> existing tests -> likely ownership.
+
+### Negative Facts / Do Not Do
+- slot-2: do-not-do note with evidence and affected Rust surface.
+
+### Remaining Uncertainty
+- slot-3: unresolved caller, inactive-path doubt, missing Rust threading, or `None`.
+
+### Handoff Plan
+Only include when `--handoff-plan` was requested.
+- Patch order: data/parser -> helper -> call sites -> consumers.
+- Files likely touched: exact paths from focused Rust scan.
+- Tests to add/update: proposed test names and target files.
+- Risk ordering: highest player-visible/frequent risk first.
+- Must remain unchanged: negative facts and verified exceptions.
+
+### Stale Doc Fixes Suggested
+- `path/to/report.md`: replace "<old claim>" with "<new claim>".
+
+### YR-Activity Flags
+- slot-3: conditional or suspicious active-path claim.
+
+### Contract Violations
+- slot-4 returned 187 lines, treated as PARTIAL.
+
+### Failed Slots
+- slot-5 failed because Ghidra MCP timed out. Suggested single-target retry:
+  /re-investigate "target".
+```
+
+End after reporting. Do not start a follow-up swarm, run `/verify-doc`, or edit docs
+unless the user explicitly asks.
+
+## Stop Conditions
+
+- 2 or more slots fail.
+- A subagent writes outside its allowed locations.
+- A target expands into a whole system instead of one detail.
+- Ghidra MCP read-only access is not available.
+- The user has not confirmed dispatch after seeing the proposed slot list.

--- a/.claude/skills/rust-scan/SKILL.md
+++ b/.claude/skills/rust-scan/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: rust-scan
+description: >
+  Project-scoped, read-only VERA20k Rust review for confirmed
+  determinism/desync, authoritative-state and lifecycle, architecture,
+  correctness/safety, and measured hot-path risks. Use for /rust-scan [path],
+  changed-Rust reviews, Rust anti-pattern audits, determinism reviews, or
+  code-health scans, including macro-expanded and trait-dispatched behavior
+  when relevant. Defaults to src/sim/; reports evidence and never edits or
+  auto-fixes.
+---
+
+# Rust Scan
+
+Read and follow `../../../.agents/skills/rust-scan/SKILL.md` completely. It is
+the canonical procedure shared by both agent frontends; its bundled
+`references/` lenses and `scripts/` helpers resolve relative to that canonical
+directory. Where it writes `$rust-scan`, read `/rust-scan`.
+
+If the relative path does not exist (worktree checkout), read
+`<main-checkout>/.agents/skills/rust-scan/SKILL.md` instead.

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: sync
+description: >
+  Audit and safely synchronize this repository's protected main and short-lived
+  feature branches. Use for drift, fast-forward pulls, branch or worktree
+  cleanup, and out-of-date questions. Never rewrite history or remove
+  unprotected local-only data.
+---
+
+# Sync
+
+Read and follow `../../../.agents/skills/sync/SKILL.md` completely. It is the
+canonical GitHub Flow workflow and owns the cleanup guard used by both agent
+frontends. Do not substitute this older frontend's former `dev`-branch flow.

--- a/.claude/skills/trace-action/SKILL.md
+++ b/.claude/skills/trace-action/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: trace-action
+description: "Trace a game mechanic or player action end-to-end through the engine pipeline, verifying each stage against gamemd.exe. Usage: '/trace-action shroud reveal when unit moves' or '/trace-action attack Grizzly vs Rhino at 5 cells' or '/trace-action ore growth spread' or '/trace-action power goes offline'"
+---
+
+# Trace Action — End-to-End Pipeline Diagnostic
+
+Trace `$ARGUMENTS` through every stage of the engine — from trigger to sim state to render to screen. At each stage, compute the concrete values our code produces and verify them against gamemd.exe.
+
+**The goal: "Does this complete production path behave convincingly in an
+ordinary stock skirmish, where does it diverge from gamemd.exe, and which
+divergences actually block the milestone?"**
+
+This covers ANY game mechanic — not just player clicks. Shroud updates, power calculations, ore spreading, building placement rules, superweapon charging, veterancy, crate pickups, etc.
+
+Use active gamemd behavior, retail inputs, and production Rust to trace every
+load-bearing boundary. Preserve honest exact verdicts: an unproven internal
+difference may remain DRIFT/UNCHECKED. Delivery impact is separate. Focus exact
+mechanism work on differences that can affect common behavior, outcomes,
+determinism, authority, lifecycle, RNG, persistence, or shared architecture.
+
+---
+
+## Iron Law — FOLLOW EVERY LOAD-BEARING STAGE
+
+The point of an end-to-end trace is to find where the player journey actually
+breaks or begins to feel wrong. Do not stop at helper functions or a
+high-level summary. Check details in proportion to how they are consumed:
+
+- The 1-tick delay between trigger and effect (does our code apply on the
+  same tick or the next one?)
+- The order of two writes to the same field within one tick
+- The fixed-point rounding direction (truncate? floor? round-to-nearest?
+  banker's rounding?)
+- The `<` vs `<=` in a range check that flips behavior at the boundary
+  cell
+- The clamp that saturates one unit short of where gamemd's clamps
+- The signed-vs-unsigned compare that flips at the wraparound
+- The animation frame that gamemd starts at frame 1, not frame 0
+- The sound cue that fires *before* the visual, not after
+- The pixel offset that shifts the sprite by 1 in screen Y
+- The Z-order tie-breaker when two sprites are on the same cell
+- The field read that picks up the *previous* tick's value instead of
+  this tick's (because it's read before its writer ran)
+
+For every stage ask: what enters, what state changes, who consumes it next, what
+the player experiences, and whether a difference is milestone-blocking,
+compounding, an exactification residual, or unknown-risk. Literal equality is
+required only for an exact `MATCH` claim. A stage may be `MILESTONE-PASS` from
+production evidence while retaining named exact residuals.
+
+## Step 0 — Parse the scenario
+
+Interpret `$ARGUMENTS` as a game mechanic or scenario. If unclear, ask the user to clarify.
+
+Examples of valid inputs:
+- `shroud reveal when unit moves` — trace vision/shroud update pipeline
+- `attack Grizzly vs Rhino at 5 cells` — trace the full combat sequence
+- `move Harvester from (50,50) to (55,55)` — trace movement pipeline
+- `power goes offline` — trace what happens when power drops below demand
+- `ore growth spread` — trace ore growth tick logic + render
+- `deploy MCV` — trace the deploy state machine
+- `building placement GAWEAP` — trace placement validation
+- `chrono miner teleport` — trace the teleport movement system
+- `prism tower chain` — trace prism forwarding logic
+- `gap generator shroud` — trace gap generator shroud re-covering
+- `bridge repair` — trace bridge HP and state transitions
+- `paradrop over target` — trace paradrop spawning + parachute descent
+
+Extract what's needed:
+- Any unit/building types involved — look up in `ini/rulesmd.ini` and `ini/artmd.ini`
+- Relevant INI values for the mechanic (Speed, ROT, ROF, Sight, Power, etc.)
+- Initial conditions (positions, health, power state, etc.)
+- Use the research-index MCP first to find prior trace/research docs and Rust
+  touchpoints. Prefer `research_brief`; if unavailable, use the repo-local CLI
+  fallback:
+
+  ```text
+  python tools/research_index/brief.py "<scenario>" --limit 8
+  ```
+
+  If the exact system is known, add `--system <system>` (examples: `bridges`,
+  `miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun
+  without `--system`, then rerun with the inferred exact system. Use `search.py`,
+  `graph.py evidence`, and `graph.py implementation` for focused anchors. The
+  index is a source map; the trace verdict still requires concrete Rust values
+  and gamemd evidence.
+
+## Step 1 — Identify the trigger and trace the full chain
+
+**What causes this mechanic to activate?** Map from the trigger event all the way to the visual result.
+
+Every mechanic has a pipeline. Identify each stage by reading the code:
+
+```
+TRIGGER:     What initiates it (player click, tick timer, state change, etc.)
+DATA:        What INI/rules values feed into it
+SIM LOGIC:   The core computation (formulas, state machines, conditions)
+STATE CHANGE: What sim state gets modified (entity fields, map state, etc.)
+PROPAGATION: Does the state change trigger further effects? (chain reactions, updates)
+RENDER:      How the state change becomes visual (sprites, animations, overlays)
+SCREEN:      What the player actually sees
+```
+
+**Adapt the stages to the mechanic.** A shroud system has different stages than combat:
+
+Shroud example:
+```
+TRIGGER:     Unit moves to new cell -> vision system runs
+DATA:        Sight= from rules.ini, cell positions, height levels
+SIM LOGIC:   Vision radius calculation, cell iteration, LOS checks
+STATE CHANGE: ShroudMap cells marked as revealed
+PROPAGATION: Revealed cells expose enemy units, update minimap
+RENDER:      Shroud overlay sprites updated (black -> visible)
+SCREEN:      Terrain/units appear where black shroud was
+```
+
+Power example:
+```
+TRIGGER:     Building destroyed / sold / built -> power recalculated
+DATA:        Power= from rules.ini per building
+SIM LOGIC:   Sum all Power values, compare drain vs supply
+STATE CHANGE: House power state (normal/low), building powered flags
+PROPAGATION: Unpowered buildings lose abilities (radar, production speed)
+RENDER:      Powered anims stop, sidebar power bar updates
+SCREEN:      Buildings go dark, radar goes offline
+```
+
+Identify the actual functions in our codebase for each stage. Note file and line.
+
+## Step 1.5 — Enumerate ALL entry points (lifecycle coverage)
+
+**This step prevents missed code paths.** For the mechanic's trigger event, grep/search the codebase for EVERY code path that can cause it. Don't rely on the task description or your assumptions — search exhaustively.
+
+Ask: **"What are ALL the ways this state change can happen?"**
+
+Examples:
+- "Building enters the world" → search for `spawn_object`, `spawn_from_map`, `spawn_at_height`, `entities.insert` — find ALL spawn paths
+- "Building leaves the world" → search for `entities.remove`, `dying = true`, `despawn`, `sell_building` — find ALL removal paths
+- "Entity changes owner" → search for `owner =`, `capture`, ownership transfer paths
+- "Power balance changes" → building placed, sold, destroyed, captured, powered on/off
+
+**Format:**
+```
+ENTRY POINTS for "<trigger event>":
+  1. <path> — <file>:<line> — <when it fires>
+  2. <path> — <file>:<line> — <when it fires>
+  ...
+  COVERAGE: Which paths have the hook? Which are missing?
+```
+
+If any path is missing the necessary hook/call, flag it as a gap BEFORE implementation begins. This is the #1 source of "it works for production buildings but not map buildings" bugs.
+
+## Step 2 — Trace concrete values through each stage
+
+For the specific scenario, compute the actual value at each pipeline stage with real numbers.
+
+**Format each stage as:**
+```
+STAGE N — <name> (<file>:<line>)
+  Input:   <what enters this stage>
+  Formula: <the computation, with actual numbers>
+  Output:  <what this stage produces>
+  gamemd:  <what the original produces — from Ghidra or docs>
+  Verdict: PASS / FAIL / UNCHECKED
+```
+
+**Rules:**
+- Use actual INI values from `ini/rulesmd.ini` and `ini/artmd.ini`, not hypothetical ones.
+- Compute with real numbers — show `Sight=8, radius=8 cells, area checked=201 cells`.
+- For gamemd verification, search in this order (exhaust each before the next):
+  1. **`docs/`** and **`<main-checkout>/docs/research/`** — written research reports, including the ignored in-repo research corpus
+  2. **INI files** — `ini/rulesmd.ini`, `ini/artmd.ini`
+  3. **Ghidra MCP** — decompile live for any value a stage verdict rests on; docs and INI say which function to read, not what it does. If the bridge is down, invoke `/ghidra-up` and retry rather than downgrading the stage to a doc claim.
+- Include intermediate values that could diverge (fixed-point truncation, integer division, rounding).
+- **Show the tiny stuff explicitly.** For each stage, write down — even if
+  "obviously the same":
+  - Which tick the stage runs on, relative to the trigger (`tick T` or
+    `tick T+1`)
+  - Order of operations within the stage (which field is read or written
+    first, second, third)
+  - Rounding mode for any division or fixed-point conversion
+  - Clamp bounds, inclusive vs exclusive
+  - Whether comparisons are signed or unsigned
+  - Whether the stage reads pre-update or post-update values from the
+    fields it depends on
+  These are the things that look "obvious" and are wrong half the time.
+  Listing them forces you to actually check.
+- If a stage is **not implemented** in our engine, mark it explicitly: `NOT IMPLEMENTED`.
+- If you didn't actually compute both numbers (ours AND gamemd's), the
+  stage is `UNCHECKED`, not `PASS`. Don't fill in `PASS` from intuition.
+
+## Step 3 — Verify critical logic against gamemd.exe (targeted)
+
+**Ghidra MCP is the arbiter, not a last resort** - CLAUDE.md: prefer live decompilation over static reports. Most answers should already be in the research docs from Step 2. Only use Ghidra when:
+- The docs don't cover a specific formula or threshold
+- A doc's claim seems suspect and needs spot-checking
+- The 1-2 most gameplay-critical computations need hard confirmation
+
+When you do use Ghidra:
+- Decompile the relevant function, extract constants and branching
+- Compute the expected output for the scenario's inputs
+- Compare against our code's output
+- Check `param_1` type: if `int` offsets are direct bytes; if `int *` multiply by 4
+- **TS vs YR:** gamemd.exe serves both Tiberian Sun and Yuri's Revenge. Verify that
+  code you're tracing is actually active in YR, not dormant TS legacy. Don't trust
+  field/flag names — trace what they actually gate. TS-era names like "Tiberium"
+  may control something different in YR context (e.g., `Tiberium=` on warheads only
+  gates vein destruction, not ore destruction).
+- **Labels are navigation hints.** Confirm a cited function from its body, callers,
+  receiver flow, and vtable binding. Vtable identity requires a
+  COL→TypeDescriptor owner walk plus slot read and body decompile. If identity is
+  unproven, cite the address and mark the stage `UNCHECKED`, not PASS/FAIL.
+
+A single matching trace is evidence, not proof of equivalence. Downgrade a
+different mechanism from DRIFT only with algebraic proof, exhaustive vectors over
+a finite domain, or a suitable gamemd/retail-derived executable oracle.
+
+## Step 4 — Check the visual result
+
+Trace from sim state to what the player sees:
+
+- **Does the right thing appear on screen?** (shroud clears, building goes dark, unit moves, etc.)
+- **At the right position?** (coordinate conversion, offsets, anchoring)
+- **At the right time?** (immediate vs delayed, animation timing)
+- **With the right appearance?** (correct sprite/overlay/color, correct animation frame)
+
+If any part of the render pipeline is missing or wrong, note it.
+
+## Step 5 — Timing and sequencing
+
+For mechanics that unfold over time:
+
+- **How many ticks from trigger to visible result?** (Is there a 1-tick delay? A multi-second animation?)
+- **What's the sequence of events?** (What happens first, second, third?)
+- **Does timing feel and behave correctly in the representative scenario?**
+  Record exact tick/frame/order differences and classify their milestone impact.
+
+For instantaneous mechanics (like shroud reveal), verify it happens on the same tick as the trigger, not a tick later.
+
+## Step 6 — Report
+
+Present:
+
+1. **Pipeline diagram** — the full chain from trigger to screen, one line per stage
+2. **Milestone failures** — stages that break or repeatedly distort ordinary play
+3. **Not implemented** — stages gamemd has that we're missing entirely
+4. **Residuals** — exact differences and unknowns that do not currently block
+5. **Timing** — noticeable/compounding timing errors first, then bounded residuals
+
+For each failure state:
+- Which stage, what our code does vs gamemd
+- Root cause
+- What consumed state, rendered pixel, sound, decision, or timing can differ
+
+**Keep it concise.** Lead with milestone failures and their earliest root cause.
+Preserve exact differences in the residual section without letting them bury the
+production result.
+
+Do NOT implement fixes — only report findings unless the user explicitly asks.

--- a/.claude/skills/trace-swarm/SKILL.md
+++ b/.claude/skills/trace-swarm/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: trace-swarm
+description: "Project-scoped for VERA20k/RA2 Yuri's Revenge only. Use when the user invokes '/trace-swarm', asks to orchestrate parallel end-to-end parity traces, wants a bounded multi-mechanic audit across mature movement/combat/vision/power/production/placement/sidebar/audio/render-order systems, or asks to reconcile multiple /trace-action reports. Dispatches at most 3 read-only subagents per wave, each running /trace-action on one concrete player-visible scenario, then ranks FAIL/UNCHECKED results by player visibility and frequency. Do not use first for broad, under-implemented UI/menu/setup surfaces. Never auto-applies fixes."
+---
+
+# Trace Swarm
+
+Coordinate up to 3 parallel `/trace-action` investigations per wave for concrete RA2/YR mechanics, then reconcile their reports into a ranked disparity list. This skill is detection-only: do not edit Rust, INI, tracked/published docs outside `docs/research/`, or Ghidra state while running a swarm.
+
+Exact trace verdict bar: active-gamemd mechanism, byte state, and
+pixel/result output. Keep DRIFT honest, then assign the separate milestone
+delivery class.
+
+For the current retail-convincing milestone, default candidate selection to
+concrete ordinary-skirmish interactions with high frequency, player
+noticeability, loop breadth, compounding, or unblock value. Keep the exact trace
+verdict, but reconcile bounded expert-only findings under exactification
+residuals unless the user explicitly requests an exact audit wave.
+
+## Hard Gates
+
+- Run the Suitability Gate below before proposing or dispatching any swarm, even when the user explicitly asks for trace-swarm.
+- Dispatch at most 3 subagents at once. Split larger queues into sequential waves.
+- Use subagents only after the user explicitly invokes `/trace-swarm` or otherwise asks for parallel/delegated tracing.
+- Each subagent must use Ghidra MCP read-only. The prompt must forbid `rename_function`, `rename_function_by_address`, `rename_data`, `rename_variable`, `create_label`, `create_function`, `add_struct_field`, `modify_struct_field`, `set_decompiler_comment`, `set_plate_comment`, `set_disassembly_comment`, `save_program`, and any other mutating operation.
+- Each subagent may write exactly one trace report under `<main-checkout>/docs/research/traces/` plus the shared claims file. Nothing else.
+- The parent may write only the claims file. Reconciliation never applies code or docs fixes.
+- If 2 or more subagents in a wave fail, stop before reconciliation and ask the user whether to retry failed slots, review successes only, or abort.
+- If a subagent returns all-PASS on a non-trivial trace, treat it as suspicious until spot-checked. PASS requires literal computed equality, not intuition.
+
+## Suitability Gate
+
+Trace-swarm is for parallel confirmation of several independent, concrete, player-visible mechanics. It is the wrong first tool for broad feature surfaces, especially UI/menu/setup screens where many slots will only rediscover the same missing parent system.
+
+Before Step 1, do a quick read-only triage:
+
+1. Restate the user's target as either:
+   - **Concrete trace set**: 2-3 independent actions with implemented Rust surfaces and gamemd evidence to compare.
+   - **Broad feature surface**: a screen/system area such as "skirmish UI", "main menu", "sidebar", "lobby", "save/load", or "options" without concrete interactions.
+2. Inspect recent code/docs enough to answer:
+   - Is the feature on the normal player path, or dev-gated/stubbed?
+   - Are the likely slots independent, or do they share one parent missing system?
+   - Would at least 3 slots probably return mostly `NOT-IMPLEMENTED` for the same root cause?
+3. If the answer is "broad feature surface" and either dev-gated/stubbed or dominated by one parent missing system, stop before dispatch. Report that trace-swarm is not ideal, summarize the root reason in 3-6 bullets, and recommend one of:
+   - `/re-investigate <surface>` when active-YR behavior itself is not established.
+   - `/brainstorm <surface>` then `/write-plan` when the next useful step is implementation design.
+   - One focused `/trace-action <concrete action>` when a single interaction needs binary confirmation.
+4. Only continue with trace-swarm if the user explicitly confirms after this warning with wording like `trace it anyway`, or if the triage finds 2-3 concrete, independent, implemented interactions.
+
+For UI/menu/setup surfaces, default to **one of the alternatives** unless the target is narrow and mature. Good trace-swarm UI targets: "sidebar Repair/Sell button flash cadence", "power bar low-power blink", "main-menu owner-draw button pressed offset". Poor trace-swarm UI targets: "skirmish UI", "main menu screen", "options dialog", "lobby UI".
+
+During this triage, use the research-index MCP first. Prefer `research_brief`; if
+unavailable, use the repo-local CLI fallback:
+
+```text
+python tools/research_index/brief.py "<target>" --limit 8
+```
+
+If the exact system is known, add `--system <system>` (examples: `bridges`,
+`miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun without
+`--system`, then rerun with the inferred exact system. Use `map.py`, `search.py`,
+and `graph.py implementation` to decide whether the target is a mature concrete
+interaction or a broad surface better handled by another skill.
+
+## Invocation Modes
+
+- `/trace-swarm`: auto-scan candidate mechanics, propose up to 3 targets, wait for confirmation.
+- `/trace-swarm <m1>, <m2>, ...`: validate explicit mechanics, restate each as a concrete scenario, wait for confirmation.
+- `/trace-swarm --area <area>`: scan only one area, propose up to 3 targets, wait for confirmation.
+- `/trace-swarm --dry-run`: scan/validate and print the dispatch plan, then stop.
+- `/trace-swarm --refresh-index`: rebuild the trace coverage index before ranking.
+
+Valid areas include `combat`, `movement`, `vision`, `power`, `production`, `placement`, `ui`, `sidebar`, `audio`, and `render-order`.
+
+`ui` is valid only for mature, concrete interactions. Broad setup/menu screen requests must pass the Suitability Gate first and usually route to re-investigate/planning instead.
+
+If an explicit list has one entry, use a single `/trace-action` unless a second slot adds an independent check. If it has more than 3 entries, split it into sequential waves of 3. Do not trace abstract targets like `movement` or broad surfaces like `skirmish UI`; ask for a concrete scenario such as `Conscript walks from (50,50) to (55,55) around a wall` or `click Choose Map on dialog 0x102 at 800x600`.
+
+## Step 1: Build Or Read The Candidate Index
+
+For auto, scoped, and refresh modes, use `<main-checkout>/docs/research/traces/.trace-coverage-index.md`.
+
+- If absent, rebuild it.
+- If present and modified within 7 days, use it and tell the user the cache date.
+- If older than 7 days or `--refresh-index` was passed, rebuild it and tell the user.
+
+When rebuilding, collect candidate player-visible mechanics from:
+
+- Canonical mechanics: combat damage/range/splash/retaliation; ground/air/harvester/chrono/transport/scatter movement; shroud, gap, spy, minimap vision; power supply/demand and low-power transitions; queue/placement/sidebar production feedback; placement terrain/adjacency/foundation; sidebar/ui hit testing and flash cadence; EVA/sound cue ordering and panning; render order, brackets, health bars, cliff redraw.
+- Recent code changes: `git log --since="14 days ago" --name-only -- src/sim src/render src/sidebar src/ui src/audio`, mapped back to player-visible mechanics.
+- Existing trace reports: `*_TRACE.md` files, prioritizing prior FAIL/UNCHECKED reports not clearly re-traced and deprioritizing recently traced or NOT IMPLEMENTED reports.
+- Open follow-ups: grep `<main-checkout>/docs/research/` and `docs/plans/` for `TODO: re-trace`, `deferred from trace report`, and similar markers.
+
+Write one flat Markdown bullet per candidate:
+
+```markdown
+- CANONICAL | combat | "Grizzly vs Rhino at edge of range" | last traced: never | recent code: combat_aoe.rs (2d ago)
+- PRIOR_FAIL | power | "power goes offline" | last traced: 2026-02-15 (UNCHECKED on radar disable timing) | recent code: none
+```
+
+Rank candidates by player visibility times frequency:
+
+- HIGH: visible/audible/behavioral result, fires in most matches, or has unresolved prior FAIL.
+- MEDIUM: highly visible but conditional, or subtle but frequent.
+- LOW: niche edge cases, intact recent traces, or no relevant code drift.
+
+Break ties by most recent touched code, oldest prior trace, then subsystem diversity.
+
+## Step 2: Propose And Confirm
+
+Before dispatching, print a table with slot, mechanic, concrete scenario, source, and tier. Wait for an explicit confirmation such as `go`. A previous confirmation in the same thread does not count for a new swarm. For `--dry-run`, stop after printing the plan.
+
+Example:
+
+```markdown
+Proposed trace swarm dispatch (3 slots):
+
+| Slot | Mechanic | Scenario | Source | Tier |
+|------|----------|----------|--------|------|
+| 1 | Combat - point blank | Grizzly vs Rhino at 1 cell, no cover | CANONICAL | HIGH |
+| 2 | Vision - shroud reveal | Conscript walks 5 cells through unexplored shroud | CANONICAL | HIGH |
+```
+
+## Step 3: Append Work Claims
+
+Append to `<main-checkout>/docs/research/traces/.trace-swarm-claims.md`. Create it if missing with:
+
+```markdown
+# Trace-Swarm Work Claims
+
+Active and historical claims from /trace-swarm invocations. Prevents parallel
+sessions from duplicating work. Append-only; stale claims (>4h `claimed`)
+may be re-claimed but rows are not deleted.
+```
+
+Append one block per swarm:
+
+```markdown
+## Trace Swarm 2026-05-20T11:42 (session <short-id>)
+
+- 2026-05-20T11:42 - slot-1 - combat_grizzly_vs_rhino_pointblank - claimed
+```
+
+Statuses are `claimed`, `done`, and `failed`. Do not delete stale claims; a `claimed` row older than 4 hours may be re-claimed by appending a new row.
+
+## Step 4: Dispatch Subagents
+
+Use parallel Agent tool calls with `subagent_type: general-purpose` - Explore agents cannot write the report file. Agents run in the background and report back on completion; dispatch all slots before waiting. Do not set an unavailable model override; inherit the active model unless the user explicitly requested a supported model. Each subagent receives one concrete scenario and a self-contained prompt:
+
+```text
+You are subagent slot {{SLOT}} of a /trace-swarm batch. Your single mechanic is:
+
+  {{MECHANIC}}
+
+Concrete scenario (do not generalize, do not expand): {{SCENARIO}}
+
+Run /trace-action on this exact scenario with these added constraints:
+
+HARD CONSTRAINTS:
+- Ghidra MCP is READ-ONLY. Do NOT call rename_function, rename_function_by_address,
+  rename_data, rename_variable, create_label, create_function, add_struct_field,
+  modify_struct_field, set_decompiler_comment, set_plate_comment,
+  set_disassembly_comment, save_program, or any other mutating tool.
+- You may write EXACTLY ONE file: {{REPORT_PATH}}. Do NOT modify .rs files, INI
+  files, tracked/published docs outside `docs/research/`, or any other location.
+- PASS at any stage requires literal numerical equality between our output and
+  gamemd's. If you did not compute both, mark UNCHECKED, not PASS.
+- Confirm every gamemd reference is active in standard YR, not dormant TS legacy.
+- Ghidra display names/labels are NAVIGATION HINTS ONLY and may be stale or polluted.
+  Before citing a function as gamemd evidence, confirm its identity from the body /
+  callers / vtable (COL→TypeDescriptor read for any vtable claim). A wrong label
+  yields a false FAIL or false PASS. If you cannot confirm identity, mark UNCHECKED
+  and cite the address, not the name.
+- Trace one mechanic and one concrete scenario only. Put adjacent findings in the
+  report's Adjacent Findings section; do not trace them this run.
+
+RETURN VALUE CONTRACT:
+1. Markdown summary, no more than 150 lines.
+2. Exact report file path.
+3. Verdict tally: PASS: <n> | FAIL: <n> | UNCHECKED: <n> | NOT-IMPLEMENTED: <n>
+4. Top 5 most player-visible FAIL or NOT-IMPLEMENTED findings, one line each,
+   with stage, player-visible difference, our file:line, and gamemd evidence.
+5. One-line status: COMPLETE | PARTIAL (reason) | FAILED (reason).
+
+Do not include the full stage table, raw decompilation, raw INI dumps, or adjacent
+findings in the return. If blocked, write what you have and return PARTIAL or FAILED.
+```
+
+Wait for all returns, unless a timeout produces a failed slot. Do not start reconciliation until every slot is complete, partial, or failed.
+
+## Step 5: Intake Returns
+
+For each slot:
+
+- Verify the report exists.
+- Update the matching claims row to `done` or `failed`.
+- Treat malformed returns as PARTIAL: over 150 lines, no report path, missing tally, or missing status.
+- Flag all-PASS/non-trivial traces for spot-checking.
+
+If 2 or more slots failed, stop and ask the user how to proceed.
+
+## Step 6: Reconcile
+
+For each successful or partial report:
+
+1. Read the report.
+2. Tally PASS, FAIL, UNCHECKED, and NOT IMPLEMENTED stages.
+3. Spot-check at least one PASS by rereading cited Rust/INI/research/Ghidra evidence and confirming both values were computed.
+4. Spot-check at least one FAIL where present and confirm the gamemd value is cited, not invented.
+5. Re-rank all failures by player visibility times frequency, not by count.
+6. Detect cross-trace patterns: facing convention drift, shared render-stage UNCHECKED gaps, adjacent NOT IMPLEMENTED systems, or common parser/rules data errors.
+
+Do not edit code or docs during reconciliation.
+
+## Step 7: Report
+
+Return a concise report with:
+
+- Status: complete/partial/failed counts, reports written, disparity count, high-priority count.
+- Reports written: one line per slot with path, status, and tally.
+- Disparities ranked HIGH, MEDIUM, LOW by visibility times frequency, with evidence and trigger frequency.
+- Cross-trace patterns worth investigating before isolated fixes.
+- Pad-PASS audits and what was spot-checked.
+- Subagent contract violations.
+- Failed slots and proposed single-slot retry commands.
+- Next steps for the user to choose from.
+
+Stop after the report. Do not start another swarm, re-trace a failed slot, or patch code unless the user asks.

--- a/.claude/skills/verify-doc-swarm/SKILL.md
+++ b/.claude/skills/verify-doc-swarm/SKILL.md
@@ -1,0 +1,700 @@
+---
+name: verify-doc-swarm
+description: "Project-scoped for VERA20k/RA2 Yuri's Revenge only. Use when the user invokes '/verify-doc-swarm' (with any flags), asks to orchestrate parallel research-doc audits, wants the highest-leverage stale or never-audited docs checked against gamemd.exe, or asks to reconcile multiple /verify-doc GREEN/YELLOW/RED results. Default mode is detection-only: at most 3 read-only subagents per wave, each running /verify-doc on one research doc, then ranks staleness, WRONG/MISLEADING findings, cross-doc contradictions, and correction-fact bundles; never edits docs. Also use, in '--fix' mode, when the user asks for a corpus/area/list doc-FIX swarm, says 'audit and correct these docs', or wants drifted research docs repaired in place: one doc per worker with disjoint write ownership, workers keep Ghidra read-only, at most 3 workers per wave, and the parent reconciles, spot-checks, and reports the verified in-place corrections."
+---
+
+# Verify Doc Swarm
+
+Coordinate up to 3 parallel `/verify-doc` audits per wave for research documents in
+`<main-checkout>/docs/research/`, then reconcile the bounded
+GREEN/YELLOW/RED summaries into a ranked staleness, contradiction, and correction report.
+
+Two modes:
+
+- **DETECT (default):** detection-only. Workers audit; they never edit the audited doc or
+  write replacement prose. Output is a ranked findings report plus a correction-fact queue
+  that makes a later patch pass easy.
+- **FIX (`--fix`):** audit **and correct**. Each worker owns exactly one doc, repairs the
+  WRONG/STALE/MISLEADING claims it verified against the live binary — after diagnosing why
+  each one drifted — and edits the doc in place with an inline Ghidra-call citation per
+  correction. Disjoint ownership is what makes concurrent correction safe.
+
+**Documentation truth bar:** a verified mismatch in fields, offsets, operators, ordering,
+bytes, or pixels (off-by-one, `<` vs `<=`, offset off by 4, clamp `0xFF` vs `0x100`, wrong
+order-of-operations, TS-legacy framed as live YR) is WRONG — never downgraded to "minor" or
+"internal-only" — and in FIX mode gets corrected. The audit verdict is separate from current
+skirmish fix priority.
+
+**Label-adversarial Ghidra rule:** local Ghidra names, labels, comments, xref labels, and
+decompiler-assigned symbol names are navigation hints only; this project may contain
+polluted or stale labels from earlier scripts. Treat address plus verified role as stronger
+than label name, surface label drift clusters as a root-cause pattern, and (FIX mode)
+correct docs only from body/callsites/bytes/data refs/active-YR reachability — never from a
+current display label alone.
+
+## Iron Laws (FIX mode)
+
+```
+THE BINARY IS GROUND TRUTH. THE DOC IS A HYPOTHESIS. THE FIX IS A NEW CLAIM.
+```
+A correction can be wrong too. Every edit carries its binary evidence inline so the next
+audit can re-check the fix the way it re-checks the original. An unsourced correction is
+worse than the original drift — it launders a guess into apparent ground truth.
+
+```
+DIAGNOSE THE WHY, NOT JUST THE WHAT
+```
+Docs drift for mechanical reasons (see the root-cause taxonomy). Naming the root cause
+tells you whether the fix is safe (a verified address shift is patchable; a
+"probably-equivalent mechanism" is not) and predicts which sibling docs carry the same rot —
+the swarm's marginal value over fixing docs one at a time.
+
+```
+DISJOINT OWNERSHIP OR NO SWARM
+```
+Concurrent *writes* are safe only because no two agents touch the same file. Dedupe the
+queue, assign one doc per agent, never let an agent wander into a sibling doc.
+
+```
+STRUCTURAL-RED IS A STOP, NOT A REWRITE
+```
+The fix step repairs isolated, verified claims. A doc wrong at the foundation is left
+untouched and routed to `/re-investigate` — patching its surface produces a doc that passes
+a skim but still misleads.
+
+```
+TINY MISMATCHES COUNT — THEY ARE THE WHOLE POINT
+```
+The drift this swarm exists to catch is the silent kind nobody re-reads docs to find. An
+agent that returns a fat doc with zero WRONG is suspect — spot-check it.
+
+## Hard Gates
+
+Both modes:
+
+- **Dispatch at most 3 subagents at once.** Split larger queues into sequential waves of ≤3.
+  The cap is a deliberate Ghidra-MCP and review-load bound.
+- Use subagents only after the user explicitly invokes `/verify-doc-swarm` or otherwise asks
+  for parallel/delegated doc audits or doc fixes.
+- **Every worker's Ghidra MCP access is READ-ONLY.** Forbid `rename_function`,
+  `rename_function_by_address`, `rename_data`, `rename_variable`, `create_label`,
+  `create_function`, `add_struct_field`, `modify_struct_field`, `set_decompiler_comment`,
+  `set_plate_comment`, `set_disassembly_comment`, `save_program`, and any other mutating
+  operation. Concurrent Ghidra mutations race on global state; 25 read-only decompile
+  clients are well inside the MCP server's concurrency budget, 3 mutating clients are not.
+- Workers must not write `.rs` files, touch INI files, create "corrected copies" at new
+  paths, edit sibling research docs, or modify any other location. Contradictions noticed in
+  sibling docs are reported for the parent's reconciliation, never chased or edited.
+- The parent may write only `docs/research/.audit-swarm-claims.md` and
+  `docs/research/.audit-coverage-index.md`. The parent never edits audited docs; in FIX mode
+  corrections happen only inside the owning worker (single exception: the parent reverting
+  or repairing a spot-check failure it caught itself, noted in the report).
+- **Write-integrity check before and after each wave.** The only files that may have
+  changed: `AUDIT_LOG.md`, `.audit-swarm-claims.md`, `.audit-coverage-index.md`, and (FIX
+  mode) the wave's owned docs. Any other doc edit, any `.rs`/INI edit, or any Ghidra
+  mutation outside the explicit post-wave parent label-sync phase is a contract violation —
+  stop and report before continuing.
+- If 2 or more slots in a wave fail (more than 1/3 of a full wave), stop before
+  reconciliation or the next wave and ask the user whether to retry failed slots, review
+  successes only, or abort.
+- Treat GREEN on a large/high-risk doc with suspicion until spot-checked.
+- Every returned finding must distinguish verified binary evidence from inference, and every
+  YR-activity assertion must say `Active in YR: Yes / No / Conditional` with evidence or
+  default-gate context.
+- **Structural-RED is not patched in place.** If a doc is wrong at the foundation (wrong
+  primary function, wrong struct base/layout family, TS-legacy framed as YR across multiple
+  sections), the worker makes NO edits, marks it RED with `needs_reinvestigate: true`, and
+  recommends a bounded `/re-investigate` target. Do not let this swarm silently become a
+  re-investigation.
+
+DETECT mode only:
+
+- Each worker may write **exactly one** file: append one line to
+  `docs/research/AUDIT_LOG.md`, matching `/verify-doc` rules. It must not modify the audited
+  doc.
+- Reconciliation never applies doc rewrites or code fixes.
+
+FIX mode only:
+
+- **One doc per worker — disjoint write ownership, no exceptions.** Two workers must never
+  be assigned the same doc, and a worker may edit ONLY its one owned doc. If the scan or the
+  user list contains the same doc twice, dedupe before dispatch.
+- Each worker may write **exactly two** files: (a) its one owned research doc (in-place
+  corrections) and (b) one appended line to `docs/research/AUDIT_LOG.md`.
+- **Correct only verified-binary-backed claims.** A worker may edit a claim ONLY when it has
+  the correct value directly from the live binary this session, with the exact Ghidra MCP
+  call recorded. Inference, "probably," YRpp labels, or a sibling doc's value are NOT
+  grounds to edit. Unverifiable findings stay flagged in the report, not patched.
+- **Diagnose before correcting.** Every edit names the root cause of the error (taxonomy
+  below). "It's wrong, here's the right value" is not enough.
+- **Ghidra label sync, if requested, is parent-only and serial.** Workers only report
+  rename/label/comment candidates with the verifying Ghidra calls. The parent may apply them
+  after all waves only when the user explicitly opted in (`--sync-ghidra-labels`), the
+  mutating tools are available, and the parent has re-verified the exact address/target.
+  Never mutate Ghidra while workers are running.
+- Do NOT stage, commit, or push. Corrected docs are left in the worktree for the user to
+  review with `git diff`.
+
+If you catch yourself about to violate any of these, STOP and surface it to the user.
+
+## Status Rubric
+
+Use the `/verify-doc` status meanings consistently across all slots:
+
+- `GREEN`: zero WRONG, zero MISLEADING, and less than 5% UNVERIFIABLE among audited
+  load-bearing claims. Safe to rely on for the audited scope.
+- `YELLOW`: isolated wrong/stale/unverifiable claims, or a partial audit, but the doc
+  remains usable with the listed caveats.
+- `RED`: structural errors such as wrong primary function, wrong struct base/layout family,
+  TS-legacy framed as standard YR, or broad pseudocode that would mislead implementation
+  work. Recommend targeted rewrite or `/re-investigate`.
+
+Tiny mismatches are never downgraded: off-by-one, `<` vs `<=`, signedness, wrong offset,
+wrong clamp, wrong default value, or wrong order-of-operations is `WRONG`.
+
+## Invocation Modes
+
+- `/verify-doc-swarm`: scan candidate docs, propose up to 3 targets, wait for confirmation.
+- `/verify-doc-swarm <d1>, <d2>, ...`: validate explicit docs, then wait for confirmation.
+- `/verify-doc-swarm --area <area>`: scan only one area, propose up to 3 targets, wait for
+  confirmation.
+- `/verify-doc-swarm --all`: corpus sweep — scan everything, propose a multi-wave plan
+  (waves of 3, HIGH tier first), await one confirmation covering the whole run.
+- `/verify-doc-swarm --dry-run`: scan/validate and print the dispatch plan, then stop.
+- `/verify-doc-swarm --refresh-index`: rebuild the audit coverage index before ranking.
+- `/verify-doc-swarm --patch-plan` (DETECT mode): after the audit swarm, group findings into
+  correction-fact bundles for a later patch pass. Still does not edit docs or generate
+  replacement prose.
+- `/verify-doc-swarm --fix`: FIX mode. Combine with an explicit list, `--area`, or `--all`.
+  Workers correct their owned doc in place. Without `--fix`, the swarm is detection-only.
+- `/verify-doc-swarm --fix --sync-ghidra-labels`: FIX-mode modifier. After all doc-fix waves
+  complete, collect worker-reported label candidates, re-verify them in the parent, and
+  apply Ghidra renames/labels/comments serially if mutating tools are available.
+
+Valid areas include `combat`, `movement`, `locomotion`, `pathfinding`, `vision`, `shroud`,
+`power`, `production`, `placement`, `harvester`, `miner`, `building`, `infantry`, `unit`,
+`aircraft`, `sidebar`, `shell`, `audio`, `animation`, `weapon`, `superweapon`, `terrain`,
+`map`, `ai`, `radio`, `timer`, `core-engine`, `ini-parsing`, `bridges`, `chrono`, and
+`skirmish-ui`. Treat area names as aliases where the corpus uses them: for example
+`harvester` and `miner` both include `miner/` docs and refinery-dock reports.
+
+If an explicit list has more than 3 docs, split it into sequential waves. If the user
+supplies a system name like `garrison`, resolve it to concrete research docs before
+dispatching.
+
+## Step 0: Preflight
+
+Before scanning or proposing slots:
+
+1. Confirm `<main-checkout>/docs/research/` exists.
+2. Confirm `AUDIT_LOG.md` exists or can be created by `/verify-doc` rules.
+3. Confirm Ghidra MCP read-only access is available. If unavailable, stop and report the
+   blocker.
+4. If `--sync-ghidra-labels` is requested, confirm the relevant mutating Ghidra tools are
+   available before promising label sync. If unavailable, run the fix swarm normally and
+   report the label-candidate queue without applying it.
+5. Confirm Ghidra MCP answers from a subagent. If the bridge is down, run `/ghidra-up`
+   before dispatch, or offer serial `/verify-doc` audits instead of pretending to swarm.
+6. Read `.audit-swarm-claims.md` if present and identify active `claimed` rows less than 4
+   hours old. Do not propose the same doc while a fresh claim exists unless the user
+   explicitly overrides.
+7. Capture a cheap write-integrity baseline for `docs/research/`, repo `src/`, repo `ini/`,
+   and the Ghidra mutating-tools ban. `git status --short` / `git diff --stat` plus doc
+   mtimes is enough; this catches unexpected writes after dispatch, not pre-existing dirty
+   state.
+8. Use the research-index MCP as the first candidate/source map (preferred over raw grep at
+   the 2000+ doc scale): `research_map` (filter by `system`) for a system/topic inventory,
+   `research_validate` for freshness/staleness signals, `research_search` +
+   `research_related` to enumerate a cluster. Use the repo-local CLI only for a missing MCP
+   capability:
+
+   ```text
+   python tools/research_index/validate.py --system <system> "<topic>" --limit 12
+   python tools/research_index/map.py --system <system> "<topic>" --limit 12
+   ```
+
+   If the exact system is unclear or returns zero docs, rerun without `--system`, then use
+   the inferred exact system (for example `skirmish-ui`, `bridges`, `miner`, `chrono`). Use
+   stale/unknown docs, missing links, and contradiction signals as candidate-ranking inputs.
+   The index chooses better targets; it does not replace per-doc `/verify-doc` verification.
+
+## Step 1: Build Or Read The Audit Index
+
+For auto, scoped, `--all`, and refresh modes (skip for explicit lists), use
+`docs/research/.audit-coverage-index.md`:
+
+- If absent, rebuild it.
+- If present and modified within 7 days, use it and tell the user the cache date.
+- If older than 7 days or `--refresh-index` was passed, rebuild it and tell the user.
+
+When rebuilding, recursively walk every `*GHIDRA_REPORT.md` and other RE/research docs in
+`docs/research/`, including subdirectories such as `miner/`, `units/`, and `traces/`.
+Exclude plans, design specs, generated correction-only files such as
+`*_VERIFY_DOC_AMENDMENTS.md`, and patch-cluster notes unless explicitly requested. For each
+doc, extract:
+
+- Last audit: most recent `AUDIT_LOG.md` entry for the filename, with date and
+  GREEN/YELLOW/RED status. No entry means never audited.
+- Patch status: most recent PATCHED/PATCHED-to-GREEN/PATCHED-to-YELLOW line for the
+  filename, if any. Treat a doc patched after its last YELLOW/RED audit as
+  `POST_PATCH_NEEDS_VERIFY` unless a later GREEN audit exists.
+- Doc mtime: if the doc was edited after its last audit, it is post-audit drift.
+- Cross-reference count: grep the rest of `docs/research/` for the filename, and grep repo
+  `src/` for citations across `sim`, `rules`, `map`, `assets`, `render`, `sidebar`, `ui`,
+  and `audio`.
+- Surface-area proxy: count address citations like `0x00XXXXXX`, `+0x` offsets, `FUN_`
+  references, function-name references, vtable-slot mentions, and INI key mappings.
+- TS-legacy density: count callouts like `inherited from Tiberian Sun`, `SpecialFlags`,
+  `FogOfWar`, `Tunnel`, `Subterranean`, and `Veins`.
+- Implementation-load proxy: count references to `src/`, `Implementation Handoff`,
+  `Current Rust`, `Required implementation effect`, and proposed test names.
+- Recent edit signal: edited in the last 14 days and last audit predates the edit.
+
+Write one flat Markdown bullet per doc:
+
+```markdown
+- NEVER_AUDITED | RADIO_PROTOCOL_GHIDRA_REPORT.md | mtime=2026-04-12 | xref=6 | offsets=38 | ts-density=2
+- POST_AUDIT_DRIFT | BUILDING_POWER_GHIDRA_REPORT.md | last=2026-04-20 GREEN | mtime=2026-05-15 | xref=4 | offsets=29
+- POST_PATCH_NEEDS_VERIFY | POWER_SYSTEM_GHIDRA_REPORT.md | last=2026-05-20 YELLOW | patched=2026-05-20 | xref=5 | offsets=52
+```
+
+Categories, highest leverage first: `STALE_RED`, `POST_PATCH_NEEDS_VERIFY`,
+`POST_AUDIT_DRIFT`, `NEVER_AUDITED`, `STALE_YELLOW` (last audit YELLOW, older than 30 days),
+`STALE_GREEN_90D` (last audit GREEN, older than 90 days), `FRESH_GREEN` (GREEN within 30
+days).
+
+Rank candidates:
+
+- HIGH: `STALE_RED`, `POST_PATCH_NEEDS_VERIFY`, `POST_AUDIT_DRIFT` with xref >= 3,
+  `NEVER_AUDITED` with xref >= 5, implementation-load >= 3, or ts-density >= 3.
+- MEDIUM: `NEVER_AUDITED` with xref 1-4, `STALE_YELLOW`, or `STALE_GREEN_90D` with
+  xref >= 5.
+- LOW: isolated `STALE_GREEN_90D` or xref 0-1 docs.
+
+Break ties by highest xref count, highest implementation-load, highest offset/address count,
+then newest mtime when last audit predates it. Prefer canonical report docs over
+amendment-only docs; prefer docs with implementation handoffs when the user is preparing
+implementation work.
+
+Building waves:
+
+- **Default / `--area`:** take the top ≤3 by tier. That is wave 1. Propose it and stop;
+  don't pre-plan further waves unless the user asks.
+- **`--all`:** order the entire ranked corpus and split into waves of 3 (HIGH, then MEDIUM,
+  then LOW). Present the full wave count and wave-1 contents; the user approves the run,
+  then each wave gets a one-line "dispatching wave N/M" notice but not a fresh full
+  confirmation.
+- **Spread within a wave** when not `--area`: spread picks across 3-5 subsystems so a single
+  root cause doesn't dominate a wave.
+- **Dedupe.** A doc appears in at most one slot across the whole run.
+
+## Step 1.5: Validate Explicit Targets
+
+For each explicit target:
+
+1. Resolve it to a concrete file under `docs/research/`. If ambiguous, list candidates and
+   ask.
+2. Confirm it is a research/RE doc, not a plan or design spec. Ask whether to drop
+   questionable slots.
+3. Grep `AUDIT_LOG.md` for an entry from today. If found, ask whether to skip, re-audit, or
+   scope to a subsection.
+4. If the doc was edited in the last 6 hours, a parallel session may be rewriting it —
+   confirm before auditing a moving target.
+5. If the target is an amendment, patch-cluster note, or audit-index file, ask whether the
+   user meant the canonical source report instead.
+6. Dedupe. If the list exceeds 3, split into waves and show the plan.
+
+## Step 2: Propose And Confirm
+
+Print a table with slot, doc, category, last audit, patch status, xref, offsets,
+implementation-load, and tier, plus the mode line:
+
+```markdown
+Proposed swarm dispatch — wave 1 of M (N slots, mode: DETECT | FIX):
+
+| Slot | Doc | Category | Last Audit | Patch | xref | offsets | impl | Tier |
+|------|-----|----------|------------|-------|------|---------|------|------|
+| 1 | MISSION_ENTER_REFINERY_DOCK_GHIDRA_REPORT.md | STALE_RED | 2025-12-03 RED | none | 11 | 51 | 4 | HIGH |
+
+Mode: DETECT (audit only, no doc edits) | FIX (agents edit their owned doc in place).
+Ghidra label sync: OFF by default; ON only when --sync-ghidra-labels was requested and
+mutating tools are available. Workers always remain read-only.
+Confirm to dispatch, or list slot numbers to drop/replace.
+```
+
+**Wait for explicit confirmation such as "go" before Step 3.** A previous confirmation in
+the same thread does not count for a new swarm. For `--dry-run`, stop after printing the
+plan. For `--all`, the "go" authorizes the whole multi-wave run.
+
+## Step 3: Append Work Claims
+
+Append (never overwrite) to `docs/research/.audit-swarm-claims.md`. Create it if missing
+with:
+
+```markdown
+# Verify-Doc-Swarm Work Claims
+
+Active and historical claims from /verify-doc-swarm invocations. Prevents parallel
+sessions from duplicating audit work. Append-only; stale claims (>4h `claimed`)
+may be re-claimed but rows are not deleted.
+```
+
+Append one block per wave, naming the mode:
+
+```markdown
+## Swarm 2026-05-28T14:22 wave 1/3 (session abc123, mode FIX)
+
+- 2026-05-28T14:22 - w1-slot-1 - MISSION_ENTER_REFINERY_DOCK_GHIDRA_REPORT.md - claimed
+```
+
+Statuses are append-only events: `claimed`, `done` (returned + `AUDIT_LOG.md` updated + doc
+edited if FIX mode), `failed`. Do not edit or delete old rows; record completion by
+appending a new row. A `claimed` row older than 4 hours is stale and may be re-claimed by
+appending a new `claimed` row:
+
+```markdown
+- 2026-05-28T15:03 - w1-slot-1 - MISSION_ENTER_REFINERY_DOCK_GHIDRA_REPORT.md - done (RED, no edits, needs_reinvestigate)
+- 2026-05-28T15:03 - w1-slot-2 - RADIO_PROTOCOL_GHIDRA_REPORT.md - done (YELLOW→corrected, 3 fixes)
+```
+
+## Step 4: Dispatch A Wave (≤3 Subagents)
+
+Use parallel Agent tool calls with `subagent_type: general-purpose` — workers write files
+(the audit-log line, and in FIX mode their owned doc), so read-only Explore agents will not
+work. Spawn every slot before waiting so the wave runs concurrently. Do not create
+user-visible background tasks for internal swarm work. Do not set an unavailable model
+override; inherit the active model unless the user explicitly requested a supported model.
+
+### Worker prompt template
+
+Self-contained (workers do not auto-load this skill). Substitute `{{DOC_PATH}}`,
+`{{DOC_FILENAME}}`, `{{SLOT}}`, and `{{MODE}}` (`DETECT` or `CORRECT`):
+
+```
+You are agent {{SLOT}} of a /verify-doc-swarm wave. Your single owned document is:
+
+  {{DOC_PATH}}
+
+You OWN this file exclusively. No other agent will touch it. Mode: {{MODE}}.
+
+PHASE 1 — AUDIT (always). Run the /verify-doc procedure against gamemd.exe:
+- Pick the ~15-25 load-bearing claims (addresses, struct offsets, formulas, thresholds,
+  operators, orderings, vtable slots, INI mappings, "Active in YR" assertions, cross-refs)
+  unless the doc is smaller; name any deliberately scoped-out sections.
+- Verify each against the LIVE binary via Ghidra MCP. Read literally: operators
+  character-by-character, constants digit-by-digit, offsets byte-by-byte.
+- Classify each: CONFIRMED / WRONG / STALE / UNVERIFIABLE / MISLEADING.
+- Tiny mismatches are WRONG, never "minor": off-by-one, `<` vs `<=`, signedness, offset
+  off by 4, clamp 0xFF vs 0x100, wrong order-of-operations, pre- vs post-increment.
+- For every "Active in YR" claim: re-trace the gating flag, read its default in
+  ini/rulesmd.ini + the binary, trace live YR caller paths. TS-legacy framed as live YR
+  is MISLEADING.
+- Vtable claims: verify owner via COL→TypeDescriptor mangled name, verify slot at
+  vtable+N*4, decompile the slot and confirm behavior. Ghidra's display label is NOT
+  evidence; the mangled name wins.
+
+PHASE 2 — DIAGNOSE (always, for each WRONG/STALE/MISLEADING finding). Classify: verified
+binary fact vs inference, player-visible impact, likely downstream docs, and patchable vs
+needs /re-investigate. Name the ROOT CAUSE from this taxonomy (or state a more specific
+one):
+  - GHIDRA_ADDRESS_SHIFT — re-analysis moved the address/label; semantics unchanged.
+  - RTTI_LABEL_DRIFT — labeler rerun renamed a function/vtable slot since the doc was written.
+  - PARAM1_TYPE_MISREAD — author read param_1 as int vs int* (×4 offset error), or vice versa.
+  - OFFSET_RETYPED_WRONG — a constant/offset transcribed from memory, off by a small delta.
+  - OPERATOR_OR_ORDER_DRIFT — `<`/`<=`, signedness, or A-before-B order misdocumented.
+  - TS_LEGACY_AS_YR — a TS-only/flag-gated path documented as active in standard YR.
+  - STRUCT_FAMILY_CASCADE — a base-class size change shifted many offsets by a constant.
+  - INFERENCE_HARDENED — a "we infer / probably" guess written as a verified fact.
+The root cause decides safety: a verified ADDRESS_SHIFT/RETYPE/OPERATOR fix is patchable;
+an INFERENCE or "probably-equivalent mechanism" is NOT — flag it, do not edit.
+
+PHASE 2.5 — GHIDRA LABEL CANDIDATES (always, report-only). If verification proves a
+Ghidra function/data label/comment is stale or misleading, emit a parent-action candidate:
+address, current display label/comment, proposed name/comment, candidate kind
+(`rename_function`, `rename_data`, `create_label`, `set_comment`, etc.), root cause, and
+the exact Ghidra calls that prove it. Do NOT apply it. Your Ghidra access stays read-only;
+the parent decides later whether to mutate Ghidra serially.
+
+PHASE 3 — CORRECT (only if MODE is CORRECT; skip entirely if DETECT).
+- Edit ONLY {{DOC_PATH}}. Fix each WRONG/STALE/MISLEADING claim whose correct value you
+  read directly from the binary THIS session.
+- For each edit, replace the wrong text with the verified-correct text and append an inline
+  citation in the form the doc already uses, e.g.:
+    `(corrected 2026-05-28: was 0x16B3; binary shows vtable+0x16B7 via
+     decompile_function 0x00521A40 — RTTI_LABEL_DRIFT)`
+  Keep the doc's existing voice and structure; do not reflow unrelated prose.
+- Do NOT invent. If you could not read the correct value from the binary, do NOT edit that
+  claim — leave it and flag it UNVERIFIABLE in your return.
+- STRUCTURAL-RED STOP: if the doc is wrong at the foundation (wrong primary function, wrong
+  struct base/layout family, TS-legacy framed as YR across multiple sections), make NO
+  edits, set needs_reinvestigate: true, and recommend a bounded /re-investigate target
+  instead of rebuilding the doc inside this audit.
+
+HARD CONSTRAINTS (non-negotiable):
+- Ghidra MCP is READ-ONLY. NO rename_function, rename_function_by_address, rename_data,
+  rename_variable, create_label, create_function, add_struct_field, modify_struct_field,
+  set_decompiler_comment, set_plate_comment, set_disassembly_comment, save_program, or any
+  other mutating tool. Decompile, read xrefs, read memory — that's all. You may only
+  REPORT Ghidra label/rename/comment candidates for the parent.
+- File-write budget: in DETECT mode you may write EXACTLY ONE file — one appended line to
+  <main-checkout>/docs/research/AUDIT_LOG.md; do NOT modify the
+  audited doc. In CORRECT mode you may write EXACTLY TWO files — {{DOC_PATH}} (in-place
+  corrections) and that one AUDIT_LOG.md line. Touch NOTHING else: no other research doc,
+  no "corrected copy" at a new path, no .rs file, no INI file, no other location.
+- Do NOT chase, audit, or edit sibling docs. Note contradictions for the parent.
+- Distinguish verified binary fact from inference in every finding.
+- Scope is ONE doc. Do not expand.
+
+RETURN-VALUE CONTRACT (mandatory, ≤150 lines):
+1. YAML front matter:
+   ```yaml
+   slot: {{SLOT}}
+   doc: {{DOC_FILENAME}}
+   status_before: GREEN | YELLOW | RED
+   status_after: GREEN | YELLOW | RED      # equals status_before in DETECT mode
+   mode: DETECT | CORRECT
+   result: COMPLETE | PARTIAL | FAILED
+   doc_edited: true | false
+   edits_applied: N
+   audit_log_appended: true | false
+   load_bearing_audited: N
+   confirmed: X
+   wrong: Y
+   stale: Z
+   unverifiable: W
+   misleading: V
+   needs_reinvestigate: true | false
+   ghidra_label_candidates: N
+   ```
+2. The exact AUDIT_LOG.md line you appended, verbatim.
+3. Top 5 most-impactful WRONG/MISLEADING findings with evidence: Ghidra address, offset,
+   exact quoted doc text, exact binary value — plus the Phase-2 classification and
+   root-cause tag for each.
+4. CORRECT mode — edits applied: one line each with section/quote anchor, was→now,
+   root-cause tag, and the Ghidra MCP call that verified the new value. Then findings NOT
+   corrected: each WRONG/MISLEADING left unpatched with why (UNVERIFIABLE, structural-RED,
+   inference), one line each.
+   DETECT mode — correction facts when safe: section or quote anchor, exact verified
+   binary fact, and evidence. Do not write replacement prose and do not edit the doc.
+5. Sibling-doc contradictions noticed in passing (do not chase) — for the parent.
+6. Ghidra label/rename/comment candidates (do not apply): one line each with address,
+   current label/comment, proposed label/comment, candidate kind, root-cause tag, and the
+   proving Ghidra MCP call(s). Write `None` if none.
+7. Subsections deliberately scoped out (honesty about coverage).
+8. One-line status: COMPLETE | PARTIAL (reason) | FAILED (reason).
+
+Do NOT return: full claim tables, raw decompilation/assembly, raw INI dumps, narrative doc
+recaps, or replacement prose beyond the one-line was→now anchors.
+
+If you hit a hard blocker (Ghidra MCP outage, doc unreadable, target isn't a research doc,
+scope too broad), append a FAILED line to AUDIT_LOG.md noting why, return status FAILED,
+and stop. Do not retry indefinitely. Do not edit the doc on a FAILED audit.
+
+REMINDERS:
+- A `>` vs `>=` swap is WRONG. A 0x68 documented as 0x67 is WRONG. A field at 0x44
+  documented as 0x40 is WRONG (and probably means the whole layout drifted — check the
+  STRUCT_FAMILY_CASCADE root cause before patching one field).
+- "Active in YR: Yes" on code gated by SpecialFlags & 0x1000 (FogOfWar) is MISLEADING.
+- Vtable slot indices shift when the RTTI labeler reruns — re-confirm via the mangled name.
+- Your correction is a new claim. Cite the binary, or do not make it.
+```
+
+After dispatching the wave, **wait for all N returns** before the per-wave integrity check.
+Do not reconcile until every slot is complete, partial, or failed.
+
+## Step 5: Collect Wave Returns, Integrity Check, Handle Failures
+
+For each return:
+
+1. Verify the returned `AUDIT_LOG.md` line was actually appended (grep date+filename).
+2. FIX mode: if `doc_edited: true`, confirm via `git diff --stat` that ONLY that owned doc
+   changed for this slot — never a sibling.
+3. Append a `done`/`failed` row to `.audit-swarm-claims.md` (new row, don't rewrite).
+4. Tally success/failure counts, GREEN/YELLOW/RED mix (FIX mode: status_before→status_after
+   flips), edits_applied, needs_reinvestigate count, and `ghidra_label_candidates` count.
+5. Run the write-integrity check vs the Step-0 baseline (allowed files per the Hard Gates).
+   Any violation: STOP, report, do not start the next wave or reconciliation.
+
+Treat malformed returns as PARTIAL: over 150 lines, missing YAML front matter, missing
+audit-log line, missing status, missing edits/findings list, missing label-candidate
+section, or missing scoped-out section list. Note it.
+
+Failure-threshold gate (per wave): 2 or more slots failed (>1/3 of a full wave) → STOP,
+print the failure list, do not dispatch remaining waves, ask the user how to proceed (retry
+failed slots, review successes, or abort). One failure → proceed, flagged clearly.
+
+Suspicion gates:
+
+- **GREEN-on-fat-target.** A doc with xref >= 5 OR offsets >= 30 OR ts-density >= 2 that
+  returns GREEN with zero WRONG/MISLEADING findings (FIX mode: `status_after: GREEN` with
+  `edits_applied: 0`) — treat with suspicion, queue for parent spot-check.
+- **Edit-without-citation (FIX mode).** Any `edits_applied` line missing a Ghidra MCP call
+  is a contract violation — the parent must re-verify that specific edit before trusting
+  it, and flag it.
+- **RED-needs-reinvestigate.** Flag separately when `needs_reinvestigate: true`, the primary
+  function/address family is wrong, or a struct-table sample invalidates the whole table;
+  routes to `/re-investigate`, not to a patch.
+
+## Step 6: Reconcile (after all waves, in parent)
+
+For each successful or partial slot, read the bounded summary carefully, then:
+
+1. **Spot-check.** DETECT mode: pick one GREEN slot, read its `AUDIT_LOG.md` line, and
+   independently verify one load-bearing claim against Ghidra/docs; if it disagrees, demote
+   to flagged YELLOW in the report. FIX mode: additionally pick 1-2 corrected claims per
+   wave (bias toward fat targets and edits with weak evidence), re-decompile the cited
+   address yourself, and confirm the edit matches the binary. If a spot-checked edit is
+   wrong, the correction introduced new drift — revert or fix it directly (the parent's one
+   allowed edit), and treat that worker's whole batch as suspect (spot-check more of it).
+2. **Cross-doc contradiction sweep.** For every WRONG/MISLEADING finding (and every FIX-mode
+   correction), grep the rest of `docs/research/` for the same address, offset, INI key, or
+   function. A sibling citing a different value is now a high-priority queue item — it
+   likely shares the root cause. Do NOT auto-edit the sibling; it was not owned by any
+   worker this run. Queue it for the next wave or a follow-up.
+3. **Cross-slot/root-cause patterns.** Pattern-match across slots: TS-legacy mislabels,
+   vtable slot shifts, offsets off by a constant, `param_1` `int` vs `int *` confusion,
+   same-address collisions, function-entry vs interior-address confusion, stale Ghidra
+   labels, repeated Rust-status drift. FIX mode: aggregate root-cause tags — a cluster is a
+   finding bigger than any single fix:
+   - Many `RTTI_LABEL_DRIFT` / vtable-slot fixes → the labeler was re-run; sweep all docs
+     older than that rerun.
+   - Many `STRUCT_FAMILY_CASCADE` (+constant offset) fixes → a base-class size changed;
+     every doc citing that struct family is suspect.
+   - Many `PARAM1_TYPE_MISREAD` fixes → a systemic authoring error; grep for the same.
+   - Many `TS_LEGACY_AS_YR` fixes → run `--area shroud` / the relevant gate sweep next.
+4. **AUDIT_LOG oscillation check.** Grep `AUDIT_LOG.md` history for docs oscillating
+   RED→GREEN→RED or YELLOW→PATCHED→YELLOW — a recurring incomplete fix or an upstream label
+   that keeps flipping; a fresh patch may not stick.
+5. **Build the correction-fact / residual queue.** DETECT mode — correction facts from safe
+   findings only: exact doc quote or section anchor, exact verified binary fact, binary
+   evidence and whether the parent spot-checked it, grouped by target doc; mark
+   `needs_reinvestigate` instead of patch-ready when the correction requires rebuilding a
+   model, tracing a new caller chain, or resolving a broad YR-activity question. FIX mode —
+   residual queue: UNVERIFIABLE findings left unpatched, structural-RED docs routed to
+   `/re-investigate`, contradicting siblings, and suspicion-flagged GREENs; input for a
+   follow-up run.
+6. **Ghidra label-candidate queue (FIX mode).** Collect worker-reported
+   rename/label/comment candidates, dedupe by address and kind, discard any candidate
+   without direct binary evidence. If two candidates conflict, apply neither; report the
+   conflict and route it to `/re-investigate` or a focused manual check.
+7. If `--patch-plan` was requested (DETECT mode), add an ordered non-editing patch plan:
+   docs to patch first, findings that need parent spot-check before patching, sibling docs
+   to verify afterward, and single-doc `/verify-doc` commands to rerun. No replacement
+   prose.
+
+The parent does not edit audited docs during reconciliation (sole exception: the FIX-mode
+spot-check revert in item 1).
+
+## Step 6.5: Optional Serial Ghidra Label-Sync (FIX mode)
+
+Run only when the user explicitly requested `--sync-ghidra-labels` or otherwise clearly
+asked to update Ghidra names/labels/comments, and only after all workers have finished.
+
+- Apply candidates **serially in the parent only**. Never ask workers to mutate Ghidra and
+  never mutate Ghidra while a wave is running.
+- Re-verify each candidate immediately before applying it: address, function/data identity,
+  current label/comment, proposed label/comment, and the body/callsite/data-ref evidence.
+- Apply only low-risk metadata fixes: clearly stale function names, misleading data labels,
+  missing labels at already-known addresses, or comments that record verified behavior.
+- Do not create functions, edit structs, change variable types, rename variables, or save
+  broad analysis state unless the user explicitly requested that operation and the current
+  tool supports it safely.
+- After each mutation, read back the label/comment when the tool allows it and append an
+  event to `.audit-swarm-claims.md` with address, old label/comment, new label/comment,
+  tool call, and evidence source.
+- If mutating Ghidra tools are unavailable, report the verified label-candidate queue and
+  stop; do not simulate the mutation in docs.
+
+## Step 7: Report
+
+Return a concise report with:
+
+- Status header: docs processed, failed count, GREEN/YELLOW/RED mix, contradiction count;
+  FIX mode adds corrected count, RED→re-investigate count, total edits, status flips
+  (e.g. `A YELLOW→GREEN, B RED→YELLOW`), and label candidates reported/applied/deferred.
+- One line per slot: doc, status (FIX mode: status flip + edit count + root-cause tags),
+  and key finding.
+- Highest-impact WRONG/MISLEADING findings — FIX mode: highest-impact corrections with
+  was→now, root cause, and verifying call — ranked by player visibility × downstream load.
+- Docs NOT corrected / routed to `/re-investigate`, each with the recommended bounded
+  target and "no edits applied".
+- Cross-doc contradictions surfaced (NOT auto-edited), without resolving them unless the
+  evidence was directly checked; queued siblings.
+- Cross-wave root-cause patterns and the recommended sweep wave(s).
+- Parent spot-checks: what was re-verified and the outcome, including any reverted edit.
+- DETECT mode: correction-fact queue grouped by doc, with evidence and spot-check state;
+  `--patch-plan` output if requested.
+- FIX mode with label sync: applied renames (with the re-verification call), deferred
+  conflicts, or "mutating tools unavailable — candidates listed only".
+- Suspicion flags (GREEN-on-fat-target and whether the spot-check passed, oversize returns)
+  and subagent contract violations.
+- Failed slots and proposed single-slot retry commands.
+- Verbatim `AUDIT_LOG.md` lines appended.
+- Next steps for the user to choose from — FIX mode: review corrected docs with `git diff`
+  before committing (this swarm never commits), run the recommended root-cause sweeps,
+  route RED docs to `/re-investigate`, re-run failed slots.
+
+Stop after the report. Do not start another swarm or follow-up wave the user didn't
+authorize, do not run `/verify-doc` on contradictions, do not commit, do not edit further
+docs unless the user asks. The user reviews `git diff` and decides what to run next.
+
+## Anti-patterns — STOP
+
+- **Editing a claim you could not verify from the binary this session.** No inference, no
+  YRpp label, no sibling-doc value as the source of a correction. Flag it instead.
+- **Patching surface claims on a structurally-RED doc.** Makes it look fixed while it still
+  misleads. Stop and route to `/re-investigate`.
+- **Two agents owning the same doc.** Dedupe before dispatch. Concurrent edits race and
+  corrupt corrections.
+- **Letting an agent edit (or audit) a sibling doc** it noticed was wrong. Only the owned
+  doc. Queue the sibling for the parent.
+- **Exceeding 3 concurrent agents.** Split into waves. The cap is a deliberate Ghidra-MCP
+  and review-load bound.
+- **A correction without a root cause.** "Wrong → right" with no *why* skips the diagnosis
+  that tells you the fix is safe and predicts sibling rot.
+- **A correction without an inline citation.** The fix is a new claim; it must carry the
+  binary evidence for the next audit to re-check.
+- **Skipping the parent spot-check of corrections.** A swarm that auto-fixes without the
+  parent re-verifying any edit can launder 3 confident guesses into the corpus.
+- **Mutating Ghidra "to clean up while there" from a worker.** Worker read-only is
+  non-negotiable. Ghidra metadata cleanup happens only in the optional parent serial
+  label-sync phase after all workers finish.
+- **Committing/pushing the corrections.** Leave them in the worktree for `git diff` review.
+
+## Rationalization table
+
+| Excuse | Reality |
+|---|---|
+| "The right value is obvious from the sibling doc, I'll just copy it" | A sibling is a hypothesis too. Verify from the binary or don't edit. |
+| "This doc is mostly wrong, I'll rewrite it while I'm here" | Structural-RED is a STOP. Route to /re-investigate; don't rebuild in a fix pass. |
+| "30 agents would clear the corpus faster" | 3 is the cap. Wave the rest. Ghidra MCP and review load are the bound. |
+| "I corrected it, no need for the parent to re-check" | Auto-fix without spot-check launders guesses into ground truth. Spot-check. |
+| "The fix is small, skip the citation" | Small fixes rot fastest and are hardest to re-find. Cite every edit. |
+| "Same offset is wrong in three docs, I'll fix all three from this agent" | One doc per agent. Queue the others; the parent dispatches them owned. |
+| "It's probably an equivalent mechanism, close enough to leave/patch" | DRIFT by default. Equivalence needs proof. Flag, don't hand-wave. |
+| "All GREEN, no edits — clean corpus" | GREEN-on-fat-target with zero edits is the suspicion gate. Spot-check it. |
+
+## Fit Notes For This Project
+
+- Prefer verifying/correcting canonical `*_GHIDRA_REPORT.md` files before derivative
+  amendment files. Amendment docs are useful evidence, but they can hide whether the source
+  report is now safe; a corrected source report may make an amendment file redundant — note
+  it, don't delete it.
+- This project's patch-cluster workflow is YELLOW audit → PATCH → targeted
+  `/trace-action` or `/re-investigate` follow-up. DETECT mode preserves that
+  cadence by outputting correction facts and anchors, not edits. FIX
+  mode collapses the first two steps for *verified, isolated* drift while preserving the
+  STOP for structural cases; the inline `(corrected YYYY-MM-DD: was X; binary shows Y via
+  <call> — ROOT_CAUSE)` annotation is the durable trace per the project's "cite the
+  verification call inline" rule.
+- Re-investigation reports include `Coverage Ledger`, `Open Questions`, and
+  `Implementation Handoff`. When auditing those docs, treat all three as load-bearing: a
+  stale handoff or open-question state can mislead implementation just as much as a wrong
+  offset.
+- High-risk local failure patterns to bias ranking and diagnosis toward: `param_1`
+  int-vs-int* (×4 offset bugs), function-entry vs interior-address citations, TS legacy
+  treated as live YR, the same field named differently across siblings, RTTI/Ghidra label
+  drift after labeler reruns, and Rust-status sections drifting after implementation work.
+- For implementation-facing docs, a GREEN audit (or `status_after: GREEN`) is not enough if
+  the Rust-status section was not checked. Either spot-check the cited Rust surface or mark
+  Rust status as deliberately out of scope.

--- a/.claude/skills/verify-doc/SKILL.md
+++ b/.claude/skills/verify-doc/SKILL.md
@@ -1,0 +1,488 @@
+---
+name: verify-doc
+description: >
+  Audit an existing gamemd.exe research document against the live binary.
+  Verifies every factual claim (addresses, offsets, field names, formulas,
+  thresholds, state transitions, INI key mappings) in the doc by decompiling
+  in Ghidra. Flags stale, wrong, or unverifiable claims without modifying
+  the doc. Usage: '/verify-doc doc-path-or-name' or '/verify-doc' (prompts
+  for selection).
+---
+
+# Verify Doc — Research Document vs Binary Audit
+
+Audit the research document **$ARGUMENTS** against gamemd.exe. Every
+factual claim in the doc must be re-verified from the live binary via
+Ghidra MCP. Do NOT modify the document. Do NOT implement any Rust code.
+The only output is an audit report.
+
+**Why we audit research docs.** Research claims must remain exact and honest:
+wrong thresholds, offsets, formulas, ordering, or active-YR reachability poison
+future decisions. Correctness of the document is separate from whether the
+finding is current retail-skirmish implementation priority.
+
+<HARD-GATE — DETECTION ONLY>
+This skill is read-only against the filesystem. It CANNOT change anything unless
+the user explicitly asks to save the report or append an audit-log entry.
+
+- Do NOT modify the research document being audited.
+- Do NOT create a "corrected copy" of the doc at a new path.
+- Do NOT write or edit any .rs file.
+- Do NOT update INI files.
+- Do NOT save the audit report to a file. The full report is chat output
+  only, unless the user explicitly asks you to save it AFTER seeing it.
+- Do NOT rename functions / add labels / save_program in Ghidra. Ghidra
+  MCP is used only for read-only decompilation and memory inspection.
+
+An `AUDIT_LOG.md` entry is optional and requires explicit user authorization; a
+request to inspect or audit the document alone does not authorize the write.
+
+If the user asks you to "fix" the doc or "apply the corrections", reply
+that this skill only detects — they should review the report and run a
+separate edit pass to apply any changes: `/audit` for a single doc, `/verify-doc-swarm --fix` for several.
+
+Self-check before every tool call: "Does this tool modify state?" If yes and the
+user did not explicitly authorize that exact output, do not call it.
+</HARD-GATE>
+
+## Iron Laws
+
+```
+GHIDRA LABELS ARE UNTRUSTED HINTS
+```
+
+Local Ghidra names, labels, comments, xref labels, and decompiler-assigned symbol
+names are navigation aids only. This project may contain polluted or stale labels
+from earlier scripts. Verify load-bearing identity claims from function body,
+assembly/decompile, callsites, receiver/`this` pointer, argument flow, vtable slot
+bytes, data references, and active-YR reachability. Prefer address plus verified
+role over label name. If a doc's label is wrong or ambiguous, flag label drift as
+a finding instead of treating the label as authority.
+
+```
+TINY MISMATCHES COUNT AS WRONG — "CLOSE ENOUGH" IS A FAIL
+```
+
+The whole purpose of this audit is to catch the tiny silent errors. Big
+errors are easy — anyone re-reading the doc would notice the function
+address is wrong. The mismatches we exist to catch are the ones that
+look like nothing:
+
+- `<` where the binary has `<=` (or vice versa)
+- A clamp at `0xFF` documented as `0x100`
+- A constant of `0x67` documented as `0x68`
+- "Checks A then B" when the binary checks B then A
+- "Returns 0 on error" when the binary returns -1
+- A signed comparison documented as unsigned
+- An off-by-one in a loop bound
+- A field listed at offset `0x40` when it's actually `0x44`
+- A flag bit position one off (`0x10` vs `0x20`)
+- A "happens every tick" that's actually "every other tick"
+- A "post-increment" that's actually a "pre-increment"
+- A field updated **before** another field that the doc lists in the
+  opposite order
+- A default value the doc rounds to "~256" when the binary uses 255
+
+**Every one of these is WRONG, not STALE, not "minor"**. Flag it.
+Treat them with the same severity as a wrong function address — because
+downstream consumers (`/write-plan`, implementation work) will copy the
+doc's value verbatim. A 1-bit error here becomes a 1-bit error in the
+engine.
+
+When picking load-bearing claims in Step 1, **do not skip a claim because
+it looks small**. The constants, clamps, and orderings are exactly where
+docs rot fastest, because authors retype them from memory and skim past
+them on review. They are first-class load-bearing claims — pick them.
+
+When verifying in Step 2, **read literally, not approximately.** Compare
+operators character-by-character, constants digit-by-digit, offsets
+byte-by-byte. If your eye glosses past a constant because "yeah, that's
+roughly right," go back and read the actual digits.
+
+```
+THE BINARY IS GROUND TRUTH. THE DOC IS A HYPOTHESIS.
+```
+
+Research docs accumulate drift. A doc that was correct when written can
+be wrong now because: Ghidra re-analysis shifted addresses, annotations
+were renamed, the author misread `param_1` type, or the finding was
+TS-legacy misidentified as active YR behavior. Treat every claim as
+unverified until re-checked from the binary.
+
+```
+TIBERIAN SUN ≠ YURI'S REVENGE
+```
+
+gamemd.exe hosts both engines. A claim that is technically true about
+the binary ("FUN_X checks SpecialFlags bit 0x1000") may be **misleading**
+if the doc implies the code is active in standard YR. Every active-in-YR
+assertion must be re-verified: check default flag values, trace callers,
+confirm the code path is reachable in a normal skirmish.
+
+## Step 0 — Resolve the target doc
+
+1. Parse `$ARGUMENTS`:
+   - Absolute path → read directly
+   - Relative path → try `docs/`, then `<main-checkout>/docs/research/`
+   - Bare name (e.g., "garrison") → search both directories for matching `*GHIDRA_REPORT.md` / `*GARRISON*.md`
+   - If target resolution is broad or ambiguous, use the research-index MCP first:
+
+     ```text
+     research_search(query="<doc-or-topic>", limit=10)
+     research_validate(topic="<doc-or-topic>", limit=10)
+     ```
+
+     If the MCP tools are unavailable, use the equivalent repo-local CLI
+     `search.py` and `validate.py` commands.
+
+     If the exact system is known, add `--system <system>` (examples:
+     `bridges`, `miner`, `skirmish-ui`, `chrono`). If that returns zero docs,
+     rerun without `--system` and use the inferred exact system. The index helps
+     choose the doc; the audit itself still verifies claims against the binary.
+2. If no match or multiple matches, list candidates and ask the user to pick one.
+3. **Check the audit log and moving-target window.** Read `<main-checkout>/docs/research/AUDIT_LOG.md`
+   if it exists. If the target doc has an entry from the last ~30 days with status
+   GREEN, mention it to the user and ask whether to re-audit or skip — recent
+   GREEN audits rarely drift. YELLOW/RED entries are worth re-checking since the
+   user may have patched the doc; just note the prior finding so you can confirm
+   it was addressed. If it was audited today or within the last few hours, do not
+   silently repeat the audit. Also inspect the target doc's mtime; if it changed in
+   the last 6 hours, a parallel session may be rewriting it. Read the recent work
+   first and get explicit confirmation before auditing a moving target.
+4. Read the full doc. Confirm it's a research/RE document (not a plan, not a design spec).
+   If it's not a research doc, say so and stop — this skill is for RE reports only.
+
+## Step 1 — Identify the load-bearing claims
+
+Don't try to enumerate every fact in the doc. Long research docs have
+hundreds of restatements, examples, and derivative claims, and exhaustive
+enumeration burns context without improving the audit. Instead, pick the
+**~15-25 load-bearing claims** — the ones downstream consumers (other
+docs, /write-plan, implementation code) will actually rely on. Output a
+numbered list grouped by bucket below; every later verification step
+refers back to these numbers.
+
+**A claim is load-bearing if** any of these are true:
+- It anchors other claims (a function entry address that pseudocode walks through; a struct base offset that field offsets are computed from)
+- It's a public-interface fact (INI key → struct offset mapping, vtable slot dispatch)
+- It's a behavioral primitive (state-machine transition condition, damage formula, threshold value)
+- It's gating-active-in-YR (the doc claims a code path runs in standard YR — high-blast-radius if wrong)
+- It contradicts a sibling doc (any time two docs make different claims about the same thing, both are load-bearing)
+
+**A claim is NOT load-bearing** (skip it) if it's:
+- A restated fact already verified upstream in the same doc
+- A natural-language summary of pseudocode you'll verify directly
+- A "what this code does at a high level" narrative
+- A claim about the doc's own conclusions or confidence
+
+### Buckets to draw load-bearing claims from
+
+#### A. Binary-location claims
+- Function addresses (e.g., `0x00429a90`, `FUN_00abcdef`)
+- Function names assigned to addresses (e.g., "AStar_main_loop at 0x...")
+- Vtable offsets and the methods they dispatch to
+- Global/static data addresses (`DAT_...`) and what they hold
+- Callers and callees asserted for a given function
+
+#### B. Struct layout claims
+- Class/struct name → byte offset → field name → type
+- Struct total size
+- Inheritance layout (base class offset within derived class)
+- Flag/bitfield layouts and which bits mean what
+
+#### C. Behavioral claims
+- Formulas (damage, speed, ROT, ore growth, etc.)
+- State machines (states, transitions, triggering conditions)
+- Thresholds, clamps, min/max bounds
+- Order of operations ("A before B", "checked in this sequence")
+- Magic constants and their stated meaning
+
+#### D. INI mapping claims
+- "[Section] Key= maps to struct offset 0x...."
+- Default values claimed for INI keys
+- Claims about whether a key is read, ignored, or superseded
+
+#### E. YR-activity claims
+- "Active in YR: Yes/No/Conditional"
+- Flag gating ("behind SpecialFlags & 0x1000")
+- Default values for gating flags in standard YR
+
+#### F. Cross-reference claims
+- References to other docs ("see X_GHIDRA_REPORT.md for Y")
+- References to Rust files ("implemented in src/sim/..." — Rust claims are
+  lower priority but should be spot-checked since they rot fastest)
+
+**Output of Step 1:** a numbered list grouped by bucket, ~15-25 entries
+total. If the doc is so terse that fewer than ~10 load-bearing claims
+exist, audit them all and note in the report that the doc's surface area
+is small. If the doc is so dense that ~25 doesn't cover the load-bearing
+claims, pick the ~25 highest-impact ones and explicitly flag in the
+report which areas you did NOT cover.
+
+## Step 2 — Verify against the binary (THE CORE)
+
+Work through the numbered claim list. Use Ghidra MCP as the primary tool.
+Verification order: **A (addresses) → B (struct layouts) → C (behavior) →
+D (INI mapping) → E (YR activity) → F (cross-refs)**. Earlier buckets
+invalidate later ones — if the address is wrong, every behavioral claim
+attached to it is moot.
+
+**If Ghidra MCP is unreachable** (connection-refused, empty `list_instances`, or "No program
+loaded"), invoke the `/ghidra-up` skill before auditing anything. Do not classify claims as
+UNVERIFIABLE because the bridge is down - that produces a false RED.
+
+### Per-claim verification protocol
+
+For each claim:
+
+1. **State what you're checking** (one sentence, referencing claim number).
+2. **Go to the binary.** Decompile the function, read the memory region,
+   or dump the struct layout — whatever the claim demands.
+3. **Compare literally.** Exact addresses, exact offsets, exact operators
+   (`>` vs `>=`, `<` vs `<=`), exact constants.
+4. **Classify the result:**
+   - **CONFIRMED** — binary matches the doc exactly
+   - **WRONG** — binary contradicts the doc (include actual value)
+   - **STALE** — doc was correct for an earlier Ghidra state but
+     addresses/labels have since shifted (note the new address)
+   - **UNVERIFIABLE** — cannot resolve from binary alone (e.g., doc claims
+     a design intent that leaves no runtime signature)
+   - **MISLEADING** — technically accurate but omits critical context
+     (most commonly: TS-legacy code presented as YR behavior)
+
+### Ghidra pitfalls to re-check (the ones that produce silently-wrong docs)
+
+- **`param_1` type** — `int` means byte offsets; `int *` means index × 4.
+  This is the #1 source of wrong struct offsets. Re-verify type for every
+  function whose offsets the doc cites.
+- **AnimTypeClass uses `int *`** — doc may have `int *` offsets multiplied
+  correctly OR raw. Check before accepting.
+- **`DAT_` globals** — if the doc cites a value from a data table, re-read
+  memory at that address with `read_memory`. Values may differ from what
+  the decompiler's comment suggested.
+- **Vtable dispatch** — if the doc names a method called "virtually", confirm
+  the concrete implementation at the claimed vtable slot. Vtable indices
+  shift when RTTI labeler reruns. Follow the full protocol below.
+- **Signed vs unsigned** — a claim like "clamped to 0-255" is different from
+  "sign-extended to int". Check the MOVZX vs MOVSX.
+
+### Vtable claim verification
+
+Every claim that slot N of class C's vtable is method M requires all three:
+
+1. **Owner:** read the CompleteObjectLocator pointer at `vtable-4`, then the
+   TypeDescriptor at `COL+0x0C`, then its mangled name at `TypeDescriptor+0x08`.
+   It must name class C; a Ghidra display label is not evidence.
+2. **Slot:** read the function pointer at `vtable + N*4`. gamemd is 32-bit, so
+   slot 17 is byte offset `0x44`, not `0x11`.
+3. **Body:** decompile the resulting function address and verify that its body
+   implements M's claimed behavior.
+
+Cite all three calls inline. Owner or body mismatch is `WRONG`; `__purecall` in
+a construction snapshot is `STALE` only when the live vtable is independently
+verified; an unreachable TypeDescriptor is `UNVERIFIABLE`. Mangled RTTI identity
+wins over a conflicting display label.
+
+### TS-vs-YR re-check (mandatory for every E-bucket claim)
+
+For every "Active in YR" assertion:
+
+1. **Find the gating flag.** Re-trace in the binary — don't trust the doc
+   to have identified the right flag.
+2. **Read the default value.** Check `ini/rulesmd.ini`, `ini/rules.ini`,
+   and any hardcoded default in the binary. TS defaults still appear in
+   the binary but YR ships different defaults.
+3. **Trace callers.** Is the code path reachable from standard YR game
+   setup? Some functions are only called by TS-era mission triggers that
+   no YR map uses.
+4. **Flag misidentification.** Field/flag names may be TS-era. "Tiberium"
+   on a warhead gates veins, not ore. Doc claims that trust the name are
+   suspect.
+
+### Struct layout sanity check
+
+When the doc publishes a struct layout table:
+
+1. Pick 3-5 fields at random (not just the first few — authors often get
+   early offsets right and drift later).
+2. Find a function that reads/writes each picked field. Decompile it.
+   Confirm the offset in the decompilation matches the doc's table.
+3. Check the struct's total size claim against an allocation site
+   (constructor call, array stride).
+
+If any random pick is wrong, treat the entire table as SUSPECT and
+re-verify all fields the doc's consumers actually care about.
+
+## Step 3 — Cross-reference pass
+
+Skim the doc one more time for claims you might have missed because they
+weren't phrased as obvious facts:
+
+- "Obviously the engine must do X" — verify it does.
+- "We infer that..." — re-classify as UNVERIFIABLE or verify it.
+- Pseudocode blocks — compare each line to the decompilation.
+- Tables with "Purpose" columns — the offset+type may be right but the
+  purpose narrative can be fabricated. Spot-check.
+
+## Step 4 — Cross-doc consistency (optional, if time permits)
+
+If the doc references sibling docs (e.g., "See ARMOR_TYPES_GHIDRA_REPORT.md"),
+check the sibling for contradictions. Two docs disagreeing is worth flagging
+even if both are internally consistent — it means at least one is wrong.
+
+Do NOT expand the audit into those sibling docs. Just note the contradiction
+and which doc the binary supports.
+
+## Step 5 — Report
+
+Structure:
+
+```
+## Doc Audit: <doc path>
+
+**Doc status:** GREEN / YELLOW / RED
+  - GREEN: 0 WRONG, 0 MISLEADING, <5% UNVERIFIABLE — safe to rely on
+  - YELLOW: minor staleness or a few wrong offsets — usable with flagged caveats
+  - RED: structural errors (wrong struct base address, TS-legacy framed as
+    YR behavior, wrong primary function) — consumers should not trust this doc
+    until rewritten
+
+### Summary
+- Load-bearing claims audited: N (out of the ~15-25 selected in Step 1)
+- CONFIRMED: N
+- WRONG: N
+- STALE: N
+- UNVERIFIABLE: N
+- MISLEADING: N
+- (If applicable) Areas NOT covered: <one-line list of long pseudocode blocks
+  / sub-systems you deliberately scoped out — be honest, don't pretend
+  uncovered areas were verified>
+
+Be honest about scope. If you only got through 12 of the 22 claims you
+listed, the count is 12 — don't fabricate. The user reads this number
+to decide whether to trust the GREEN/YELLOW/RED status.
+
+### Wrong Claims
+[For each WRONG:]
+- **Claim #N (section "..."):** doc says X
+- **Binary shows:** Y (address/offset/evidence)
+- **Impact:** what downstream code/decisions would this mislead?
+
+### Stale Claims
+[For each STALE:]
+- **Claim #N:** address/label in doc is `OLD`; current Ghidra state shows `NEW`
+- **Still semantically correct?** yes/no
+- **Suggested update:** one-line pointer (not a rewrite)
+
+### Misleading Claims (TS-legacy framed as YR)
+[For each MISLEADING:]
+- **Claim #N:** doc implies behavior is active in YR
+- **Actual gating:** flag / default value / caller analysis
+- **Real YR status:** inactive / conditional / degenerate
+
+### Unverifiable Claims
+[For each UNVERIFIABLE:]
+- **Claim #N:** what the doc asserts
+- **Why it can't be verified from binary:** (design intent, author inference,
+  historical context, etc.)
+- **Treat as:** informational / remove / flag as inference
+
+### Contradictions With Sibling Docs
+[If any — list the conflict and which doc the binary supports.]
+
+### Verdict
+One paragraph: is this doc safe to use as input for /write-plan
+or new implementation work? If RED, what's the shortest
+path to making it safe (targeted rewrite vs full /re-investigate)?
+```
+
+### Rules for the report
+
+- **Lead with the status and WRONG claims.** Don't bury errors under
+  tables of confirmations.
+- **No match tables.** Don't list every claim that checked out.
+- **Every WRONG / STALE / MISLEADING needs binary evidence** — an address,
+  an offset, a decompiled line. "Seems wrong" is not a finding.
+- **No fixes.** Do not propose doc rewrites. The user decides whether to
+  re-investigate, patch, or deprecate the doc.
+- **Quote the doc verbatim** when flagging a specific claim, so the user
+  can Ctrl-F to the exact line they need to edit.
+
+## Anti-patterns
+
+- **Summarizing the doc instead of auditing it.** If your report restates
+  what the doc says without checking the binary, you did Step 1 and skipped
+  Step 2. Start over.
+- **Accepting addresses without decompiling.** An address in a doc is a
+  claim, not a fact. Decompile it.
+- **Trusting the struct table's first few entries.** Authors get the head
+  right and the tail wrong. Random-sample deeper into the table.
+- **Flagging everything as UNVERIFIABLE.** If most claims land in this bucket,
+  you're not using Ghidra hard enough. Re-read Step 2.
+- **Turning the audit into a re-investigation.** If the doc is RED, STOP
+  and recommend `/re-investigate`. Don't silently rebuild the doc in the
+  audit report.
+- **Ignoring the YR/TS distinction.** Every behavioral claim the doc makes
+  needs an active-in-YR check, even if the doc didn't explicitly frame it
+  that way.
+- **Fabricating coverage counts.** If you didn't enumerate the claim list
+  in Step 1, don't make up a number for "Total claims audited". Either go
+  back and enumerate, or write "smoke check" in the report and mark the
+  status conservatively.
+- **Downgrading a tiny mismatch to "STALE" or "minor".** An off-by-one is
+  WRONG, not stale. A clamp value off by 1 is WRONG, not minor. STALE means
+  "the address shifted but the semantics still hold". A wrong constant or
+  wrong operator is a semantic change — that's WRONG.
+- **Skimming past constants because they "look right".** The pattern is:
+  eye sees `0xFF`, brain reads "byte max", check passes. Then later the
+  binary turns out to use `0x7F` (signed byte max) and a parity bug ships.
+  Read the digits. Every time.
+
+## Step 6 — Optional audit-log entry
+
+After delivering the report in chat, append one line to
+`<main-checkout>/docs/research/AUDIT_LOG.md` only if the user
+explicitly requested logging. Otherwise stop after the chat report.
+
+### Line format
+
+```
+- **YYYY-MM-DD** — `<doc-filename>` — STATUS — <one-line key finding>
+```
+
+Examples:
+```
+- **2026-05-05** — `CHRONO_MINER_TELEPORT_GHIDRA_REPORT.md` — YELLOW — slot-18 vtable label wrong; teleport-vs-drive decision oversimplified (BuildingTypeClass+0x16B3 = DockUnload, gating omitted)
+- **2026-05-05** — `MISSION_ENTER_REFINERY_DOCK_GHIDRA_REPORT.md` — GREEN — CLSID_TeleportLocomotion byte error ({4A582790} → {4A582747}); FootClass__PerCellProcess mislabeled as "dock state transition"
+- **2026-05-05** — `HARVESTER_MISSION_HARVEST_GHIDRA_REPORT.md` — GREEN — 0x4D6AA0 mislabeled as Mission_Harvest (actually Mission_AreaGuard)
+```
+
+If the doc is GREEN with no notable findings, write `clean` for the
+finding field.
+
+### File creation
+
+If `AUDIT_LOG.md` doesn't exist yet, create it with this header and a
+blank line, then add your entry:
+
+```
+# Verify-Doc Audit Log
+
+A running log of /verify-doc runs. One line per audit. See chat history
+or git log for the full reports.
+
+```
+
+### Constraints
+
+- One line per audit. Don't paste the full report into the log.
+- Don't edit prior entries. Append-only.
+- Don't write any other file. The full audit report stays in chat.
+
+### Why this matters
+
+Chat reports vanish after compaction. Without the log, the next session
+auditing the same doc cluster will rediscover the same findings from
+scratch, and cross-doc contradictions found in earlier audits get lost.
+The log is a 30-second cost that pays back the next time you (or
+another session) needs to know "has this doc been verified recently?"

--- a/.claude/skills/write-plan/SKILL.md
+++ b/.claude/skills/write-plan/SKILL.md
@@ -1,0 +1,824 @@
+---
+name: write-plan
+description: >
+  Implementation-plan skill with two modes. Write mode (default): use when you
+  have an approved design spec and need to create an implementation plan before
+  writing code. Breaks specs into bite-sized tasks with exact file paths,
+  complete code, and verification steps. Usage: '/write-plan topic' or
+  '/write-plan' (auto-detects latest design doc). Trigger only on an explicit
+  request to write or create an implementation plan after design approval; do
+  not chain it automatically after brainstorming. Review mode: use when asked
+  to review, audit, or verify an existing implementation plan before execution
+  — 'review this plan', '/review-plan plan-file', or '/review-plan'
+  (auto-detects latest plan doc). Verifies codebase assumptions (struct fields,
+  signatures, line numbers), binary claims (gamemd.exe addresses, behavior),
+  and internal consistency, catching false positives before reporting.
+---
+
+# Write Plan — Implementation Planning and Pre-Execution Plan Review
+
+One skill, two modes:
+
+- **Write mode (default):** create an implementation plan for **$ARGUMENTS**.
+  If `$ARGUMENTS` is empty, look for the most recent `docs/plans/*-design.md`
+  file. If none exists, tell the user to run `/brainstorm` first.
+- **Review mode:** entered when the request is to review, audit, or verify an
+  existing plan ("review this plan", `/review-plan <file>`), or when
+  `$ARGUMENTS` names an existing `docs/plans/*-plan.md`. If `$ARGUMENTS` is
+  empty or just a filename, look for the most recent `docs/plans/*-plan.md`
+  file. If none exists, tell the user there's nothing to review.
+
+Do NOT write any implementation code in either mode. Plans, research, and
+review findings only.
+
+---
+---
+
+# WRITE MODE — Architecture-Aware Implementation Planning
+
+Current delivery lens: plan for a retail-convincing ordinary stock-skirmish
+scenario. Preserve deterministic architecture and evidence honesty, but do not
+turn bounded expert-only exactification residuals into implementation blockers.
+Use Ghidra and exhaustive detail when an uncertainty can change common behavior,
+authority, lifecycle, RNG, persistence, or shared architecture.
+
+---
+
+## Hard Gate
+
+- Do NOT start writing the plan until you have read and understood the full design doc.
+- If no design doc exists, tell the user to run `/brainstorm` first and stop.
+- If the design doc is missing **Architecture Context** or **Impact Analysis**, flag it
+  and ask whether to proceed or go back to brainstorming.
+- Under an explicitly autonomous `/goal`, a design with recorded adversarial
+  self-approval satisfies the approval gate. Repair missing grounding directly
+  when it is discoverable; pause only for a material unrecoverable ambiguity.
+
+---
+
+## Research Grounding Phase
+
+Use the research-index MCP first as the source map. Prefer `research_brief` and
+`research_handoff`; if unavailable, use the repo-local CLI fallback:
+
+```text
+python tools/research_index/brief.py "<topic>" --limit 8
+```
+
+If the exact system is known, add `--system <system>` (examples: `bridges`,
+`miner`, `skirmish-ui`, `chrono`). If the result reports zero docs, rerun without
+`--system`, then rerun with the inferred exact system. Use `validate.py`,
+`handoff.py`, `map.py`, `graph.py implementation`, and `search.py` to find
+verified docs, stale warnings, handoff rows, and Rust touchpoints. The plan must
+still cite primary evidence and current Rust lines; index output is navigation.
+
+Before Pre-Planning, gather grounding from the sources below, following
+ENGINE.md priority order for behavioral truth. Skipping this is the #1 cause of
+plans that get rewritten after review mode.
+
+### R1. docs/research/ — existing RE research
+
+Search `docs/research/` for prior Ghidra reports on this system. You
+have 1,700+ files there; most systems already have struct layouts, field
+offsets, and behavioral analysis documented.
+
+- List every relevant report by filename
+- Extract confidence levels the original report stated (verified / inferred)
+- Note any TS-legacy warnings flagged in the report
+- Every cited report goes in the plan's **Sources & References** section
+
+**Do not redo research that's already been done.**
+
+### R2. gamemd.exe via Ghidra MCP — live binary verification
+
+Use Ghidra MCP to fill gaps in the docs and verify claims:
+
+- Decompile functions referenced in the docs to confirm they still match
+- Trace xrefs for any function you plan to reimplement — confirm the code
+  path is actually reachable in a standard YR skirmish (watch for TS ghosts)
+- Check param_1 types before extracting struct offsets (int vs int* —
+  see docs/research/ghidra-workflow.md, the param_1 pointer-arithmetic pitfall)
+- Capture binary addresses here; they go in the plan's Sources section,
+  not in Rust code comments
+
+State confidence for every claim: **verified-from-binary** vs **inferred**.
+
+### R3. Repo code — existing patterns to mirror
+
+Find the closest existing pattern in the repo for what you're building:
+
+- Which module owns similar behavior today?
+- Which structs/traits does new code need to integrate with?
+- List specific files + line ranges the new code should mirror
+
+### R4. INI files — constants and source of truth
+
+Grep `ini/rulesmd.ini` and `ini/artmd.ini` for every constant the feature
+needs. Never hardcode values the INI defines.
+
+- List the `[Section]` Key=Value entries the plan depends on
+- Flag any INI keys not currently parsed by `src/rules/` — those become
+  plan tasks
+
+### Grounding Summary
+
+Produce a short summary (~10-20 lines) before Pre-Planning that the plan
+will reference. It should answer:
+
+- What do the docs already tell us? (cite reports)
+- What did Ghidra verification confirm or contradict? (cite addresses)
+- What existing repo pattern does this follow?
+- What INI keys drive the behavior?
+- What's still unknown after grounding? (→ Deferred Open Questions)
+
+---
+
+## Pre-Planning Phase
+
+Complete all four steps before writing any tasks.
+
+### A. Read the Design Doc
+
+Load the design spec from `docs/plans/YYYY-MM-DD-<topic>-design.md`. Extract:
+- Goal, architecture context, impact analysis
+- Chosen approach, interfaces/contracts, testing strategy
+
+### A.1. Re-verify the design's premise against current git state
+
+Design docs go stale. Parallel sessions or background commits can land
+between the brainstorm and the plan, silently invalidating chunks of the
+design. Catch this BEFORE writing tasks against a stale view.
+
+For every file the design names as "modify" or "depend on":
+
+```
+git log --oneline -10 -- <path>
+```
+
+Read the commit subjects. Any commit landed since the design doc's date
+that touches the same system is a red flag — re-read the file and confirm
+the design's "current state" claims still hold. If the system has been
+restructured, refactored, or partially implemented since the design,
+**stop and re-scope**: most of the plan's tasks may now be obsolete or
+wrong-direction.
+
+This step takes seconds and catches the single most common failure mode:
+writing a plan against the world as the design saw it, not the world as
+it is now.
+
+### B. Map the File Structure
+
+From the design, list every file that will be created or modified. For each file:
+- What is its single responsibility?
+- Does it land in the right place in the project structure?
+  - `sim/` — deterministic game logic only, never depends on render/ui/audio/net
+  - `render/`, `sidebar/`, `ui/` — presentation, sits above sim
+  - `assets/`, `util/` — low-level, reusable
+  - `rules/`, `map/` — data used by gameplay and rendering
+- Does it stay within its current responsibility (for modifications)?
+- Does it follow existing patterns for file organization?
+- Will any file exceed ~600 lines? If so, plan submodule splits.
+
+### C. Identify Interface Boundaries and Risk Areas
+
+- Which tasks create or modify public interfaces (APIs, exports, contracts, event
+  handlers, config schemas)? These need extra care — order them before implementations.
+- Pull risk areas from the Impact Analysis. Which files have the highest blast radius?
+  Which tasks are most likely to break existing functionality? Plan regression tests.
+
+**For sim/ changes, additionally flag:**
+- Does this affect tick ordering in `Simulation::advance_tick`?
+- Does this add new state that must be included in the deterministic state hash?
+- Does any new math use `fixed`-point types? (f32/f64 forbidden in sim logic)
+- Does the EntityStore (`BTreeMap<u64, GameEntity>`) iteration order matter here?
+
+---
+
+## Task Design Rules
+
+### Granularity
+
+Keep tasks bounded and independently verifiable. One action per step:
+- "Define the struct/types" — step
+- "Write the implementation" — step
+- "Add tests" — step
+- "Run `cargo test -p vera20k --lib <module_path>::`, verify pass" — step
+- "Commit" appears only when the user explicitly requested commits; otherwise
+  omit all staging/commit steps.
+
+### Ordering Principles
+
+1. **Interfaces and types first** — define structs, traits, and contracts before implementations
+2. **Foundation before features** — infrastructure/plumbing before business logic
+3. **Tests where testable** — unit tests for pure logic and data transforms;
+   for RE-driven behavior, verification against gamemd.exe replaces traditional TDD
+4. **Independent tasks early** — things with no dependencies get done first
+5. **High-risk changes early** — surface problems before building on top
+6. **Integration tasks last** — wire things together after the pieces work
+
+### Verification Strategy
+
+Not all tasks can be TDD'd. Use the right verification for the task type:
+
+- **Pure logic / data transforms** — unit tests with `#[cfg(test)] mod tests`
+  in the same file (Rust convention for unit tests)
+- **INI parsing** — test that parsed values match expected INI entries from
+  `rules(md).ini` / `art(md).ini`
+- **RE-driven behavior** — verify against gamemd.exe via Ghidra decompilation,
+  in-game observation, or `/trace-action`. State the expected behavior and
+  how to confirm it matches the original.
+- **Rendering / visual** — describe the expected visual result and how to verify
+  by running the game and comparing to original YR
+- **Integration tests** — `tests/` directory for cross-module tests if needed
+
+### No Placeholders — Ever
+
+These are plan failures. Never write:
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" (without actual test code)
+- "Similar to Task N" (repeat the content — tasks must be self-contained)
+- "See the design doc for details" (the task must contain everything needed)
+- Steps that describe *what* to do without showing *how* (code required)
+
+### Architecture Compliance
+
+Each task must note:
+- Which existing pattern it follows (if any)
+- If it creates a new pattern, call that out explicitly
+- If it modifies an interface/contract, list what depends on it and confirm nothing breaks
+
+**Sim/ boundary rule:** If a task touches `sim/`, verify it introduces NO dependency on
+`render/`, `ui/`, `sidebar/`, `audio/`, or `net/`. This is the #1 architectural invariant.
+
+### Code Style Checklist
+
+All code written in plan tasks must follow these patterns:
+
+- **Ownership in signatures** — `&str` not `&String`, `&[T]` not `&Vec<T>`, `Arc<str>` not `Arc<String>`
+- **Hot path** — no per-tick allocations (Vec::new, String::from, .clone() on non-Copy).
+  Prefer reusable scratch buffers, interned IDs, or pre-allocated collections.
+- **Edition 2024** — `#[unsafe(no_mangle)]`, `#[expect(lint)]` over `#[allow(lint)]`,
+  inner `unsafe {}` blocks inside `unsafe fn`, `let-else` for early returns,
+  let chains for nested `if let`
+- **Iterators over index loops** — `.iter().filter().map()` over `for i in 0..vec.len()`
+- **Error handling** — `?` for propagation, `.unwrap()` only on internal invariants,
+  never on external input (INI, assets, files)
+- **Every `unsafe` block** gets a `// SAFETY:` comment
+
+---
+
+## Plan Document Template
+
+Save to `docs/plans/YYYY-MM-DD-<topic>-plan.md`:
+
+````markdown
+# [Feature Name] Implementation Plan
+
+> **For the executing agent:** Execute this plan task-by-task. Each task is self-contained.
+
+**Goal:** [One sentence from design doc]
+
+**Architecture:** [2-3 sentences — how this fits into the existing system]
+
+**Design Doc:** [path to the design spec]
+
+---
+
+## Grounding Summary
+
+[~10-20 lines — what the docs say, what Ghidra confirmed, which repo
+pattern this mirrors, which INI keys drive behavior, what's still unknown]
+
+## Key Technical Decisions
+
+- [Decision]: [Rationale] — **Confidence:** high | medium | low
+  - **Source:** docs/research/XYZ.md | Ghidra FUN_00abcdef | repo pattern src/sim/foo.rs | inferred
+
+Low-confidence decisions MUST be flagged for review mode to verify
+before implementation starts.
+
+## Open Questions
+
+### Resolved During Planning
+
+- [Question]: [Resolution + source]
+
+### Deferred to Implementation
+
+- [Question]: [Why it can't be answered until we run the code — e.g.,
+  "exact tick count depends on frame rate we observe in-game"]
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `src/sim/new_module.rs` | Handles X |
+| Modify | `src/sim/existing.rs` | Add Y interface |
+
+## Interface Changes
+
+List any public APIs, traits, structs, or config schemas that are created or
+modified. Note what depends on them.
+
+## Sim Checklist
+
+(Include only for tasks touching sim/)
+
+- [ ] All math uses `fixed`-point — no f32/f64 in game logic
+- [ ] New state included in deterministic state hash
+- [ ] No dependencies on render/ui/sidebar/audio/net
+- [ ] Tick ordering impact noted (if any)
+- [ ] BTreeMap iteration order considered (if relevant)
+
+## Risk Areas
+
+From impact analysis — what might break, what needs regression tests.
+
+## Player-Experience Critical Items
+
+List milestone-blocking, compounding, exactification-residual, and unknown-risk
+details from the design. Include the representative production scenario and why
+each item does or does not block it.
+
+| Task # | Class | Item | Why it matters | Verification |
+|--------|-------|------|----------------|--------------|
+| e.g. Task 5 | COMPOUNDING | Scroll pan interpolation | Visible repeatedly during radar navigation | Production side-by-side and focused timing check |
+| e.g. Task 8 | MILESTONE-BLOCKING | Completed cameo becomes selectable | Blocks ordinary production commands | Retail-input production test |
+
+The section may be compact, but it cannot omit authority, lifecycle,
+determinism, command, or common player-visible risks. Exactification residuals
+must state trigger, frequency, player effect, and downstream risk.
+
+---
+
+## Tasks
+
+### Task 1: [Component/Interface Name]
+
+**Why:** [One sentence — what this accomplishes and why it's ordered here]
+
+**Files:**
+- Create: `src/sim/new_module.rs`
+- Modify: `src/sim/existing.rs:123-145`
+
+**Pattern:** [Which existing codebase pattern this follows, or "new pattern"]
+
+**Step 1: Define types**
+```rust
+// src/sim/new_module.rs
+pub struct NewThing {
+    pub field: FixedI32<U16>,
+}
+```
+
+**Step 2: Write implementation**
+```rust
+impl NewThing {
+    pub fn new(value: FixedI32<U16>) -> Self {
+        Self { field: value }
+    }
+}
+```
+
+**Step 3: Add tests**
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_thing_creation() {
+        let thing = NewThing::new(FixedI32::from_num(42));
+        assert_eq!(thing.field, FixedI32::from_num(42));
+    }
+}
+```
+
+**Step 4: Verify**
+Run: `cargo test -p vera20k --lib new_thing -- --nocapture`
+Expected: PASS
+
+**Step 5: Optional commit (only when explicitly requested by the user)**
+
+### Task N: [Integration / Wiring]
+
+(Later tasks wire components together and run full regression)
+
+### Task N+1: [Verification against gamemd.exe]
+
+**Why:** Confirm the implementation matches original engine behavior.
+
+**Verify:**
+- [Specific behavior to check against gamemd.exe]
+- [How to verify — Ghidra decompilation, in-game test, /trace-action]
+- [Expected result from original engine]
+
+## Sources & References
+
+- **Design doc:** docs/plans/YYYY-MM-DD-<topic>-design.md
+- **Ghidra reports:** docs/research/XYZ.md, docs/research/ABC.md
+- **gamemd.exe addresses:** FUN_00abcdef (name), 0x00123456 (struct offset)
+  — kept here, not in Rust code comments
+- **INI keys:** rulesmd.ini `[Section]` Key=..., artmd.ini `[Section]` Key=...
+- **Related code:** src/sim/path.rs, src/rules/parse.rs
+- **Prior PRs / commits:** [sha or PR #] if relevant
+````
+
+---
+
+## Post-Plan Self-Review (mandatory)
+
+Run this checklist before presenting to the user. Fix any gaps.
+
+1. **Spec coverage** — every requirement in the design doc traceable to a task?
+2. **Placeholder scan** — any TBD/TODO/vague steps? (search the plan text)
+3. **Architecture check** — do tasks follow the patterns from the design doc?
+4. **Interface ordering** — are contracts defined before they're consumed?
+5. **Risk coverage** — do high-risk areas from impact analysis have regression tests?
+6. **Self-containment** — could each task be done by someone with zero codebase context?
+7. **Sim/ compliance** — if any task touches sim/, does the sim checklist pass?
+8. **Grounding coverage** — did the plan cite the relevant combination of
+   current code, production observation, research, INI/assets, and Ghidra?
+   Ghidra is required when a consequential native uncertainty remains, not as
+   ritual for every localized fix.
+9. **Confidence tagging** — every Key Technical Decision has a confidence level
+   and a source? Low-confidence decisions flagged for review mode?
+10. **Deferred questions** — execution-time unknowns explicitly listed, not
+    hidden as fake certainty in tasks?
+11. **Player-experience items populated** — did you classify blocking,
+    compounding, residual, and unknown-risk details and include a real production
+    scenario?
+
+---
+
+## Present to User
+
+In interactive work, show the plan and ask for review. Under an explicitly
+autonomous goal, run the skeptical plan review (review mode below), repair
+load-bearing findings, record approval, and proceed without a routine user
+pause.
+
+After approval, offer execution options:
+- **Subagent-driven** — dispatch one task at a time to fresh subagents, review between
+  tasks (recommended for complex plans)
+- **Batch execution** — execute in this session in batches of 3-5 tasks with human
+  checkpoints
+- **Manual** — user takes the plan and runs it themselves or in a separate session
+
+Do NOT start implementing. The user decides what happens next.
+
+---
+
+## Write-Mode Anti-Patterns to Flag
+
+- **"God task"** — a task that does too many things (split it)
+- **"Implicit dependency"** — Task 5 assumes something Task 3 did but doesn't say so
+  (make it explicit)
+- **"Test desert"** — a stretch of pure-logic tasks with no tests (add them)
+- **"Architecture drift"** — the plan quietly deviates from design doc patterns
+  (flag it, get approval)
+- **"Interface surprise"** — a task changes a public interface without listing what
+  depends on it (add the impact)
+- **"Float in sim"** — any f32/f64 usage in sim/ code (must be fixed-point)
+- **"Sim depends on render"** — any sim/ task that imports from render/ui/sidebar/audio/net
+
+---
+
+## Key Principles
+
+- **Plans are for dumb executors** — assume zero codebase context, zero taste, zero
+  judgment. Spell everything out.
+- **Architecture-aware** — every task knows where it fits and which patterns it follows
+- **Interfaces first** — define structs, traits, and contracts before implementations
+- **Test where testable, verify where not** — unit tests for pure logic; gamemd.exe
+  comparison for RE-driven behavior
+- **YAGNI** — if it's not in the design doc, it's not in the plan
+- **Self-contained tasks** — repeat information across tasks; they must stand alone
+- **Intentional commits** — include commit steps only when the user explicitly
+  requested commits; keep them small and atomic when authorized.
+- **Risk-aware ordering** — surface problems early, don't build on a shaky foundation
+- **Determinism is sacred** — sim/ tasks must preserve lockstep correctness
+
+---
+---
+
+# REVIEW MODE — Pre-Execution Correctness Audit
+
+**Purpose:** Catch plan errors BEFORE execution — wrong assumptions, stale
+line numbers, incorrect binary claims, missing edge cases. Every finding
+must survive a self-verification step before being reported.
+
+**Delivery framing.** Review against the retail-convincing ordinary-skirmish
+bar in `ENGINE.md`. Verify consequential binary claims and preserve honest
+DRIFT/UNCHECKED labels, but do not reject a plan solely because Rust internals
+or an expert-only edge differ. Block when the plan guesses about common
+behavior, leaves the representative production loop wrong, or risks
+determinism, authority, lifecycle, RNG, persistence, commands, or shared
+architecture. Record bounded exactification residuals separately.
+
+Do NOT implement any code. Do NOT modify the plan. Report findings only.
+
+---
+
+## Phase 0 — Extract Plan Grounding
+
+Before extracting generic claims, pull out the plan's grounding artifacts
+(produced by write mode). These drive verification priority.
+
+### 0.1 Grounding Summary
+
+Locate the **Grounding Summary** section. Confirm it's present and
+non-empty. A missing or empty summary is itself a finding — the plan
+was written without the grounding phase.
+
+### 0.2 Confidence-Tagged Decisions
+
+Locate the **Key Technical Decisions** section. For each decision,
+extract:
+- The decision itself
+- **Confidence:** high | medium | low
+- **Source:** (docs/research/... | Ghidra FUN_... | repo pattern ... | inferred)
+
+Build a verification priority list:
+1. **low-confidence decisions** — verify first, most likely to be wrong
+2. **medium-confidence decisions** — verify second
+3. **high-confidence decisions** — verify last, spot-check only
+
+A decision tagged high-confidence but citing `inferred` is suspicious —
+promote it to medium for verification purposes.
+
+### 0.3 Sources & References Inventory
+
+Locate the **Sources & References** section. Extract:
+- Every `docs/research/*.md` filename cited
+- Every gamemd.exe address listed (FUN_..., 0x...)
+- Every INI key referenced (`[Section]` Key=)
+- Every Rust file path listed
+
+These entries get verified in Phase 2.5 — missing sources invalidate
+decisions that depend on them.
+
+### 0.4 Deferred Questions
+
+Locate **Open Questions → Deferred to Implementation**. For each entry,
+ask: is this genuinely un-resolvable at planning time, or was it punted?
+Flag any question that could plausibly be answered by reading the code
+or decompiling — those are planning failures disguised as deferrals.
+
+---
+
+## Phase 1 — Extract Claims
+
+Read the full plan document and extract verifiable factual claims that drive
+the implementation, representative production test, or risk classification
+into three categories. Do not spend the review proving decorative background
+prose.
+
+### A. Codebase claims
+- Struct/enum definitions and their fields
+- Function signatures (name, parameters, return type)
+- Line numbers and file locations ("lines 543-574", "after the NEIGHBORS constant")
+- Constants and their values
+- Existing behavior ("the old function does X")
+- What callers exist and whether they need changes
+
+### B. Binary claims
+- Addresses ("AStar_main_loop at 0x00429a90")
+- Behavioral descriptions ("matches binary inline check at 0x00429e38")
+- Thresholds, formulas, decision trees attributed to gamemd.exe
+- Struct field offsets in the binary
+
+### C. Logical claims
+- "No callers need changes" — is this actually true?
+- "Tests check properties not exact sequences" — do they?
+- "Same practical effect" — is it really?
+- Risk assessments ("no test breakage expected")
+
+**Output:** A numbered list of claims to verify. Group by category. Don't
+verify yet — just extract.
+
+---
+
+## Phase 2 — Verify Codebase Claims
+
+For each codebase claim from Phase 1A, read the actual file and check:
+
+1. **Struct/enum fields** — do they match? Any fields missing from or added
+   to the plan's description?
+2. **Function signatures** — exact parameter types and return type?
+3. **Line numbers** — are they still accurate? (Files shift as edits accumulate.)
+   Tolerance: +/- 10 lines is fine. Off by 50+ is a problem.
+4. **Constants** — correct names, types, and values?
+5. **Existing behavior** — read the actual function. Does it do what the plan
+   says it does?
+6. **Caller analysis** — grep for all callers. Are there callers the plan missed?
+
+**For each claim, record:** CONFIRMED / STALE / WRONG / SHIFTED (with actual value).
+
+Do NOT skip this phase. Plans written against a moving codebase accumulate
+drift. Line numbers are the most common casualty.
+
+**Ordering:** Verify codebase claims that back low-confidence decisions
+(from Phase 0.2) first. A low-confidence decision citing `src/sim/foo.rs`
+gets checked before a high-confidence one.
+
+---
+
+## Phase 2.5 — Verify Source Citations
+
+Check every item extracted in Phase 0.3:
+
+1. **docs/research/*.md** — does the file exist? Read it and confirm
+   it actually covers what the plan claims it covers. A citation to a
+   report that doesn't say what the plan says is a fabricated source.
+2. **gamemd.exe addresses** — decompile addresses that support a
+   milestone-blocking, compounding, authority, lifecycle, RNG, persistence, or
+   architecture decision. For residual/background citations, verify existence
+   and flag uncertainty without expanding the review.
+3. **INI keys** — grep `ini/rulesmd.ini` and `ini/artmd.ini` for each
+   cited `[Section]` Key. Missing keys are plan errors.
+4. **Rust file paths** — do the files exist? If line ranges are cited,
+   are they within the file's actual length?
+
+**For each item, record:** EXISTS / MISSING / MISMATCHED.
+
+**Any MISSING source invalidates every decision that cited it.** Surface
+those decisions explicitly in the report.
+
+---
+
+## Phase 3 — Verify Binary Claims
+
+For each implementation-changing binary claim from Phase 1B, decompile via
+Ghidra MCP and check. Exactification-residual claims may remain explicitly
+unverified when they do not affect the selected plan.
+**Prioritize claims that back low-confidence or medium-confidence
+decisions from Phase 0.2.**
+
+1. **Does the function exist at the claimed address?** Decompile it.
+2. **Does the behavior match the plan's description?** Read the actual
+   decompiled code — don't trust summaries.
+3. **Are thresholds/operators correct?** Check exact comparisons:
+   - `>` vs `>=` (the `CMP + JG` vs `CMP + JGE` distinction)
+   - `< 2` vs `<= 2` vs `>= 2` (off-by-one in threshold claims)
+   - signed vs unsigned arithmetic
+4. **Are there prerequisite checks the plan omits?** The binary often has
+   flag checks before the "interesting" logic. Missing a prerequisite
+   means the plan's function fires in cases the binary wouldn't (or
+   vice versa).
+5. **Is the code active in YR?** Trace callers to confirm this isn't
+   dormant TS legacy code.
+
+**Ghidra pitfalls to watch for:**
+- `param_1` as `int` → direct byte offsets. `param_1` as `int *` → multiply
+  index by 4 for byte offset.
+- `DAT_` globals may need `read_memory` to verify actual values.
+- Decompiler may fold or reorder conditions — compare semantics, not syntax.
+
+**For each claim, record:** CONFIRMED / WRONG (with what the binary actually
+does) / PARTIALLY CORRECT (with the nuance).
+
+---
+
+## Phase 4 — Verify Logical Claims
+
+For each logical claim from Phase 1C:
+
+1. **"No callers need changes"** — grep for every call site of every function
+   the plan modifies. Verify the claim exhaustively.
+2. **"Tests won't break"** — read the actual test assertions. Are they really
+   checking properties (start, end, length) or exact sequences? A test that
+   asserts `path[2] == (5, 3)` WILL break if tiebreakers change.
+3. **"Same practical effect"** — construct concrete scenarios with real values
+   and trace both the old and new logic. Do they preserve the same mechanism,
+   consumed bytes, downstream values, pixels, audio, UI, and timing?
+4. **Risk assessments** — for each "no breakage expected" claim, ask: what's
+   the simplest scenario that WOULD break? If you can construct one easily,
+   the risk is higher than claimed.
+
+---
+
+## Phase 5 — Self-Verification (MANDATORY)
+
+**This is the most important phase.** Before reporting ANY finding as a
+discrepancy, re-verify it from the primary source.
+
+For each potential discrepancy found in Phases 2-4:
+
+1. **Re-read the source.** Not your notes — the actual file or decompilation.
+2. **Ask: "Am I comparing the right things?"** A common false positive is
+   comparing two operations that serve different purposes (e.g., a start-height
+   init threshold vs a per-cell routing threshold).
+3. **Ask: "Does this actually fire in practice?"** A discrepancy that only
+   triggers with pathological inputs (values that never occur in real RA2 data)
+   is not worth reporting as a real issue.
+4. **Ask: "Is this an existing discrepancy or one introduced by the plan?"**
+   If the plan preserves an existing architectural difference (e.g., caller
+   provides start_layer vs binary computes it internally), require proof that
+   the difference is byte/pixel equivalent before treating it as acceptable.
+5. **Construct a concrete scenario** where the discrepancy produces a different
+   result. If you can't construct one with real RA2 values, downgrade it.
+
+**Classification after self-verification:**
+- **CONFIRMED ISSUE** — re-verified from source, concrete scenario constructed
+- **FALSE POSITIVE** — initially looked like a discrepancy but isn't on
+  re-examination. State why.
+- **THEORETICAL** — real logical difference but cannot construct a scenario
+  with standard RA2 data. Note what data would trigger it.
+
+---
+
+## Phase 6 — Report
+
+### Structure
+
+```
+## Plan Review: [plan filename]
+
+### Grounding Audit
+- Grounding Summary present? yes/no
+- Deferred questions that could have been resolved: [list, if any]
+
+### Confidence Audit
+[Table of each Key Technical Decision:]
+| Decision | Plan confidence | Verified as | Source check |
+|----------|-----------------|-------------|--------------|
+| ... | low | CONFIRMED / WRONG / INFERRED | docs/research/XYZ.md EXISTS |
+
+### Source Citations
+[Table of items from Phase 2.5:]
+| Citation | Status | Notes |
+|----------|--------|-------|
+| docs/research/XYZ.md | EXISTS | covers claim |
+| FUN_00abcdef | MISMATCHED | address is a different function |
+| [General] Key= | MISSING | not present in rulesmd.ini |
+
+### Codebase Accuracy
+[Table of shifted line numbers, stale references, wrong field names — if any]
+
+### Binary Fidelity
+[Table of confirmed vs wrong behavioral claims — if any]
+
+### Confirmed Issues
+[For each CONFIRMED ISSUE from Phase 5:]
+- What the plan claims
+- What the source actually shows (with address / file:line)
+- Concrete scenario demonstrating the difference
+- Suggested fix (one sentence)
+
+### False Positives Caught
+[For each FALSE POSITIVE from Phase 5:]
+- What initially looked wrong
+- Why it's actually fine (one sentence)
+
+### Theoretical Concerns
+[For each THEORETICAL from Phase 5:]
+- The logical difference
+- Why it doesn't fire with real data
+- What would trigger it (for awareness)
+
+### Verdict
+[One of:]
+- READY — no confirmed issues, plan can be executed as-is
+- FIX FIRST — N confirmed issues that should be addressed before execution
+- NEEDS REWORK — fundamental assumptions are wrong
+- GROUNDING GAP — plan is missing Grounding Summary, has MISSING source
+  citations, or has low-confidence decisions with no verifying evidence.
+  Send back to write mode to ground properly before execution.
+```
+
+### Rules
+
+- **Lead with confirmed issues.** Don't bury them under tables of passing checks.
+- **Include false positives caught.** This builds confidence that the review
+  was thorough — "we looked at X and it's fine" is valuable signal.
+- **No match tables.** Don't list every claim that checked out. Only report
+  deviations and interesting non-deviations (things that looked wrong but
+  aren't).
+- **Concrete scenarios for every confirmed issue.** "This might differ" is
+  not a finding. "Tank at height 2 on bridge cell with ground_level=0 would
+  route to ground list instead of bridge list" is a finding.
+- **One-sentence suggested fixes.** Don't write implementation code — just
+  point the direction.
+
+---
+
+## Review-Mode Anti-Patterns
+
+Avoid these common review failures:
+
+- **Threshold telephone** — claiming a threshold is wrong because you compared
+  two different operations that use different thresholds for different reasons
+- **Architecture-vs-fidelity confusion** — flagging that "the plan does X
+  differently from the binary" when X is an intentional architectural choice
+  (e.g., caller-provided layer vs internally-computed layer)
+- **Ghidra misread** — forgetting to check param_1 type, misinterpreting
+  `JG` vs `JGE`, not accounting for sign extension
+- **Stale-doc amplification** — treating a research doc claim as ground truth
+  without verifying in the binary, then flagging a "discrepancy" that's
+  actually a doc error
+- **Missing the forest** — spending all review effort on helper functions
+  while ignoring the main loop's correctness
+- **Over-reporting** — listing 10 "potential issues" that are really 1
+  confirmed + 9 theoretical. This wastes the user's time and erodes trust.

--- a/.gitignore
+++ b/.gitignore
@@ -30,11 +30,13 @@ Thumbs.db
 !/docs/system-map/
 !/docs/system-map/**
 
-CLAUDE.md
-AGENTS.md
 .mcp.json
-/.claude/
-/.agents/
+/.claude/*
+!/.claude/skills/
+/.claude/skills/ghidra-up/
+/.agents/*
+!/.agents/skills/
+/.agents/skills/ghidra-up/
 /todo/
 /logs/
 /saves/
@@ -45,6 +47,9 @@ tools/research_index/
 
 /*.md
 !/README.md
+!/CLAUDE.md
+!/ENGINE.md
+!/AGENTS.md
 
 /*.js
 /*.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# VERA20k Agent Instructions
+
+**Read `ENGINE.md` completely before any work.** It is the shared project contract —
+delivery bar, evidence rules, native-to-Rust translation, architecture boundaries,
+coordinate frames, INI authority, reverse-engineering discipline, Tiberian Sun legacy,
+System Map rules, change management, parallel-session coordination, git, and cargo. This
+file adds only what is specific to autonomous runs.
+
+## Autonomous runs
+
+- **Own one slice at a time.** Finish it and hand off. Do not select another system, start
+  another feature, or expand into a new dependency chain because it looks adjacent.
+- Promote a prerequisite only when its behavior is necessary to locate, implement, or
+  validate the current slice's first divergence *and* it is missing, disconnected, or
+  unverified. Close the smallest prerequisite the parent needs — not that system's whole
+  backlog. Record indirect dependencies as residuals.
+- Newly discovered expert-only or scheduler-tail differences become recorded residuals
+  unless they are required for correctness, determinism, architecture, or the ordinary
+  player-visible loop being closed.
+- Every sim-behavior commit names its gamemd source or labels the rule UNCHECKED — the
+  full rule is in `ENGINE.md` (Evidence); it applies doubly to mid-run bug fixes.
+- Proceed without an approval pause unless ambiguity would materially change the result.
+  Resolve discoverable questions from current evidence, choose the smallest reversible
+  in-scope assumption, record it, and continue.
+- **Verify with the test tiers in `ENGINE.md`:** scoped `--lib` module tests while working;
+  the full suite exactly once, before the PR is declared ready for `main`. Do not rerun
+  the full suite per slice or per iteration, and do not add extra certification matrices
+  beyond what the goal explicitly asks for. **Every `cargo test` MUST carry `--lib`** — a bare
+  `cargo test -p vera20k` (with or without `--no-fail-fast`) also compiles and links 13
+  unrelated side binaries and is never the right command; the full-suite form is
+  `cargo test -p vera20k --lib`. Check `Get-Process cargo,rustc` before starting any
+  cargo command; if another session owns Cargo, wait.
+- **All implementation work uses a short-lived `feature/<topic>` branch from current `main`.**
+  Never commit or push directly to `main`. A sole owner may use this checkout; concurrent tasks
+  must use separate worktrees and branches. Continue an existing task-owned branch rather than
+  splitting one task across branches. PRs target `main`; do not recreate a long-lived `dev`
+  branch. Push/open a PR only when the user or goal authorizes publication.
+- **Commit incrementally during implementation.** After each coherent, evidence-backed slice
+  passes its focused `--lib` validation, create a descriptive commit before starting the next
+  slice. Keep commits reviewable and buildable where practical; do not commit every edit or
+  temporary WIP, and do not defer a multi-slice task into one giant end-of-run commit. When
+  slices overlap in shared files, use exact hunk staging or finish the coupled dependency as one
+  clearly named commit. The full `--lib` suite still runs exactly once at the end, and pushing
+  remains authorization-gated by the rule above.
+- **Bookkeeping caps.** The state file is ONE page, replaced each update, never appended —
+  history lives in git, not the state file. Update the System Map only when verified work
+  changed a mapped connection. Produce capture/evidence bundles only for pixel- or
+  frame-parity work, not for ordinary behavior fixes. Time spent on bookkeeping an
+  ordinary slice should be minutes, not a rival of the implementation itself.
+- **Before any pause:** leave the current feature branch stable with no merge in progress,
+  release Cargo and leave no build running, and write a handoff recording branch and commit SHAs, literal
+  validation output, changed files, remaining residuals, and the exact next safe action.
+  Do not select a new owner after a handoff.
+- Reconcile actual state before mutating anything — git status, branches, worktrees, recent
+  commits, running processes. Actual state wins over journals and prose. Never modify
+  another task's files, branch, worktree, dirty checkout, or running process.
+
+## Communication
+
+- **Read for intent, not literal wording** — resolve ambiguity toward retail-convincing
+  stock skirmish. Exact INI keys, offsets, addresses, and parity numbers stay literal.
+- **The user's observed symptom is evidence; a proposed cause or fix is a hypothesis.**
+  When an observation contradicts the analysis, investigate — don't defend the analysis.
+- **Verdict first**, short first answers, plain language, severity always with a
+  trigger-frequency clause.
+
+## GitHub issues
+
+Short and human-written — `## Player-visible problem` then `## Current Rust mismatch`.
+No binary addresses, research dumps, or checklists unless asked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# RA2 Engine — CLAUDE.md
+
+@ENGINE.md
+@LOCAL.md
+
+**Read `ENGINE.md` completely before any work.** It is the shared project contract —
+delivery bar, evidence rules, architecture, INI authority, coordinate frames, Tiberian Sun
+legacy, reverse-engineering discipline, git, and cargo. This file adds only what is
+specific to working with me in Claude Code.
+
+## Working with me
+
+- **gamemd-native semantics is the product.** When I report a behavior problem or ask for
+  a sim change, the deliverable begins with what gamemd does (cited from decompile or
+  research doc), then the Rust that matches it. A fix that merely makes the symptom go
+  away is not a fix here.
+- **Read for intent, not literal wording.** I'm not always precise — I may say "harvester"
+  for "miner" or "refinery" for "war factory". Follow the obvious intent and note the
+  substitution in a clause. Ask one focused question only when the wrong reading would
+  waste real work or change behavior. Exact INI keys, offsets, addresses, and parity
+  numbers are still taken literally.
+- **I can be wrong — argue back.** My observations are ground truth ("the miner exits
+  facing the wrong way"); my explanations and proposed fixes are hypotheses, so check them,
+  including whether the premise holds at all. When evidence contradicts me, say so in one
+  sentence *before* building on the premise. Make the case for a better alternative once,
+  concretely; after I've seen the evidence and decided, execute without relitigating.
+  Defer to me on game feel and priorities; push back on mechanisms, architecture, and
+  process.
+- **Verdict first** on evaluative questions ("is X useful?", "should we?"). If you can't
+  decide, say "insufficient evidence" and list what's missing — don't hide a non-answer in
+  a neutral overview.
+- **Be brief.** A few sentences by default. No preamble, no recap, no closing summary, no
+  tables or multi-section breakdowns in chat unless I ask. Thoroughness goes into the work
+  and saved artifacts, not the message. One follow-up suggestion max. This does not apply
+  inside `docs/research/`.
+- **Plain language.** Lead with the symptom, then why it matters in player terms. No
+  addresses or struct offsets in a first answer — "the harvester's dock logic," not a
+  function address. One line of plain meaning the first time an unavoidable term appears.
+- **Severity needs a frequency clause.** Never "low priority" or "narrow" without one
+  sentence on how often it fires in normal play. Severity = player-visibility × frequency,
+  not lines of code or effort. If you can't name the trigger frequency, you don't know the
+  severity.
+- No filler adjectives ("major", "core", "significant") unless backed by a concrete metric.
+- Don't propose style or cleanup edits while fixing a substantive bug.
+
+## Loops and swarms
+
+I run `/loop` and `/re-swarm` heavily and I'm the domain expert on when an investigation
+has produced enough value.
+
+- **Don't argue diminishing returns.** When I ask for another iteration or pass, execute.
+  State one concrete concern in a sentence, then proceed unless I say stop.
+- **Preserve `/loop` framing in adapted prompts** — the invocation goes inline, verbatim, at
+  the top. Don't write it to a file unless asked.
+- **My screenshot beats your analysis.** An in-game observation that contradicts a binary
+  finding is ground truth — dig harder on the binary side, don't defend the analysis.
+
+## Codex sessions
+
+Long phase-walk work often runs in the Codex desktop app, not here, so "where are we"
+frequently cannot be answered from this session's history. How to inspect Codex goal/session
+state on this machine is documented in `LOCAL.md` (gitignored, machine-local).
+
+## Ghidra
+
+The Ghidra MCP server is connected to `gamemd.exe`; prefer live decompilation over static
+reports. If the bridge is down — connection-refused, empty `list_instances`, or "No program
+loaded" — invoke the `/ghidra-up` skill to relaunch Ghidra and reopen the program, then
+retry the failed call. The MCP only connects; it cannot launch Ghidra itself.
+
+## Memory
+
+Save only durable preferences and decisions; never status snapshots, task trackers, or
+"system X is complete" claims — those rot within days. Before citing a memory that names a
+system, file, or plan, verify it against `git log --grep` or current code.

--- a/ENGINE.md
+++ b/ENGINE.md
@@ -1,0 +1,273 @@
+# VERA20k — Engine Instructions
+
+Shared project contract. `CLAUDE.md` and `AGENTS.md` point here; anything true of the engine
+regardless of which tool is driving belongs here and nowhere else.
+
+## What this project is
+
+A from-scratch Rust engine that runs **Yuri's Revenge** — a faithful, playable replacement for
+`gamemd.exe`, not a mod tool or viewer. Parses retail `.mix` and every asset format from scratch,
+reads `.mmx`/`.map` from WAE, simulates from `rules(md).ini` / `art(md).ini`, renders with wgpu
+(egui overlays, custom-drawn sidebar). Lockstep correctness is a hard requirement — all sim math
+is fixed-point. YR (`*md`) takes priority; RA2 is the fallback.
+
+Scale is the intentional exception to native storage limits: **20,000 units, 30 players**.
+Replace any native structure that caps scale, preserving deterministic and player-visible
+behavior.
+
+## The delivery bar
+
+> An experienced Yuri's Revenge player should be able to play ordinary stock skirmish matches for
+> 30–60 minutes, using any faction on representative retail maps, without repeatedly noticing that
+> the game behaves, looks, sounds, or responds differently from `gamemd.exe`. An expert
+> deliberately testing edge cases may still find differences.
+
+Resolve ambiguous intent toward it. Fix what a player notices often; ten-second screens and edge
+cases wait while ordinary-play gaps remain. Exact byte/pixel/frame/audio equivalence is a future
+aspiration, not the current gate. **Internals are not the spec — the production experience is.**
+Investigate binary internals when they can change common behavior, RNG, ordering, persistence, or
+architecture; not to make every helper resemble the original.
+
+## Evidence
+
+Active YR `gamemd.exe`, retail INIs/assets, and observed production behavior are the reference.
+Never guess when uncertainty could change common gameplay, deterministic state, authority,
+lifecycle, persistence, commands, or shared architecture. Use evidence proportionally — a
+localized observable fix needs no exhaustive binary proof.
+
+- **DRIFT is the default verdict** for any difference in formula, mechanism, ordering, field,
+  byte, or render composition — not equivalent because it looks internal, rare, sub-pixel, or
+  matched one sampled trace. Downgrade only with algebraic proof, a bit-identical test across the
+  input space including boundaries, or exhaustive caller verification.
+- **`VERIFIED` names a gamemd-derived executable check** ("verified by `test_x`") or exhaustive
+  proof; otherwise `UNCHECKED`/`UNVERIFIED`. Prose never upgrades a status. This governs *claims*,
+  not commits — ordinary fixes land with ordinary tests.
+- **Goldens are machine-derived** — binary emulation, live capture, retail bytes. Hand-computed
+  goldens have produced wrong references here. Rust-vs-prior-Rust hashes and replay fixtures are
+  regression ratchets, not parity evidence.
+- **Hand-maintained parity ledgers and completion trackers are forbidden** — they rot. Derive
+  status from current code, git history, named checks, machine-generated evidence.
+- A deferred DRIFT still gets its trigger, player effect, frequency and downstream risk recorded —
+  never hidden, never called verified. It is non-deferrable when it repeatedly affects ordinary
+  skirmish, changes outcomes or commands, breaks a loop or handoff, threatens deterministic state,
+  or forces architectural rework; one-cell/pixel/frame/lepton/tick differences count when
+  noticeable, frequent, compounding, or load-bearing.
+- Scans and traces sample; a pass with no findings certifies nothing.
+- **Every commit changing sim behavior names its gamemd source** — a live decompile citation, a
+  named research doc, or an explicit "VERA-internal, gamemd equivalent UNCHECKED".
+- State what was observed, what was tested, what remains unknown. Never declare exact victory from
+  approximate evidence.
+
+## Sources of truth
+
+Order: `docs/research/` → live Ghidra decompilation → repo `ini/` → retail assets. Authority for
+any conflict: **binary → Ghidra → docs**.
+
+Skill instructions write `<main-checkout>` for the primary repository root. Gitignored
+corpora (`docs/`, `ini/`, `tools/research_index/`) exist only there — never in worktrees;
+from a worktree, resolve the main checkout with `git worktree list`.
+
+Grep the INI files before implementing; never hardcode animation names, frame counts, timing, or
+constants. `rules(md).ini` = gameplay data, `art(md).ini` = all visual/animation data including
+`Foundation=`. YR loads standalone `RULESMD.INI`/`ARTMD.INI`/`AIMD.INI` — it does *not* merge the
+RA2 base INIs beneath them — then optional `LANGRULE.INI`, the mode INI, and the map INI in that
+order. Use the in-repo `ini/`, never an external mod repo.
+
+Inspect retail assets with the `asset` CLI (`cargo run -q --release --bin asset -- <verb>`,
+`--help` lists verbs) or the `asset-browser` MCP server, not another one-off binary. Its palette
+choice is inferred, so a plausible render is not evidence it is right; voxels render body-only;
+`parse-check` "ok" means only that `from_bytes` returned Ok. Navigate research with the
+`research-index` MCP server — top-N search ranks for triage and does not enumerate, so find the
+anchor, expand, and read cited sections before editing. Check modification times for a parallel
+session's in-progress output and extend it rather than duplicating.
+
+**Do not create a research document unless code or a test lands in the same session.** Prose rots
+silently while a test goes red. Convert a doc into a test only while already touching that system;
+never run a corpus-wide cleanup pass.
+
+## Native-to-Rust translation
+
+**Rust-native structure, gamemd-native semantics.**
+
+**The first question of every sim change — including bug fixes — is "what does gamemd do here?"**,
+answered from research docs or live decompilation *before* designing the Rust. Never introduce a
+gate, sentinel, clamp, fallback, or heuristic in `sim/` that gamemd lacks unless labeled
+VERA-internal with the gamemd equivalent UNCHECKED. When debugging, the question is never "what
+check would suppress this symptom".
+
+Don't copy the C++ architecture literally — no raw pointer vectors, global mutable singletons,
+COM/vtable plumbing, or the inheritance tree. Do copy the verified behavior contract carrying
+player-visible or downstream meaning: ordering, state reads/writes, RNG consumption, timer
+semantics, same-tick consequences, registration/removal.
+
+- `EntityStore` owns storage; a scheduler owns active-object order; lifecycle helpers own reveal,
+  conceal, limbo, unlimbo, uninit, delete, and scheduler registration effects.
+- Plain functions implement behavior but commit state in verified native order.
+- Recurring primitives — radio links, mission state machines, locomotor piggybacking, dock
+  reservations, authority handoffs — are **modeled as mechanisms**, not replaced by constants for
+  their common cases. Approximate locally only when the behavior is clear, the trigger bounded, no
+  deterministic or architectural debt is created, and the residual is recorded.
+- Parallel helpers must be pure/read-only, or commit deterministically without changing
+  player-visible ordering, RNG consumption, or same-tick visibility.
+
+For native authority systems (`LogicClass`, `ObjectClass`, `TechnoClass`, `MissionClass`,
+`RadioClass`, `MapClass`, `FactoryClass`, `HouseClass`), identify the behavior contract the
+production loop needs, then map it to clean Rust — neither "C++ classes ported to Rust" nor "clean
+Rust that visibly changes the game."
+
+## Architecture boundaries
+
+**The #1 invariant:** `sim/` must never depend on `render/`, `ui/`, `sidebar/`, `audio/`, or
+`net/`. This enables headless servers, spectator views, and deterministic replay.
+
+`assets/` + `util/` stay low-level and reusable; `rules/` + `map/` build data; `sim/` owns
+deterministic state and gameplay; `render/`, `sidebar/`, `ui/`, `audio/`, `net/` sit above it; app
+code orchestrates without absorbing gameplay logic. `src/lib.rs`, `src/sim/mod.rs`, and each
+module's `//!` header are the source of truth for layout; the `SPINE REGION` / phase comments in
+`World::advance_tick` are authoritative for tick order.
+
+**Coordinates.** All `sim/` coordinates are **cell-grid `(u16, u16)`**, **+X = east, +Y = south**,
+anchored at the building footprint NW corner. Porting an offset between the original's five
+reference frames is a recurring bug class: name the source frame and unit (leptons ÷ 256, signed),
+preserve conversion/shift/round/clamp semantics, and walk a concrete fixture through it before
+trusting the math. Facing bytes (`0x00`=N, `0x40`=E, `0x80`=S, `0xC0`=W) are NOT drive-track curve
+indices; isometric screen direction ≠ cell axes. Full reference:
+`docs/research/coordinate-reference-frames.md`.
+
+## Rust conventions
+
+- Modules open with a `//!` doc comment: purpose and dependencies.
+- Comment the *why*, not the what. Named constants for all magic numbers.
+- Split files around ~600 lines when growth continues, except cohesive data-heavy files and tests.
+- `thiserror` for library errors, `anyhow` for application propagation.
+- **All sim math uses `fixed`-point types — never `f32`/`f64` in game logic.** Float is fine for
+  rendering math in `glam`.
+- `EntityStore` is `BTreeMap<u64, GameEntity>` — no ECS crate; deterministic sorted iteration is
+  required for replay and lockstep.
+- Asset parsers (.mix, .shp, .vxl, .pal, .tmp, .hva, .csf, .aud) are written from scratch with
+  `nom`. No obscure or RA2-specific crates.
+- `Cargo.toml` versions are pinned deliberately; don't upgrade without checking egui-wgpu
+  compatibility.
+- **Every Rust behavior whose semantics are derived in any way from `gamemd.exe` carries
+  a nearby provenance comment.** Put it on the nearest owning item or behavior block; one
+  comment may cover a cohesive implementation, while pure Rust architecture glue need not
+  repeat it. It names the system/mechanism, the verified native class and function, and
+  the exact Ghidra address. Never invent an identity to complete the format. Use the
+  canonical one-line form and verified-identity fallback in
+  `docs/research/ghidra-workflow.md`.
+
+## Reverse engineering
+
+Full rules — evidence discipline, label and save protocol, drift causes, the `param_1`
+pointer-arithmetic pitfall, Tiberian Sun legacy — live in `docs/research/ghidra-workflow.md`. Read
+it before any binary work. The rules that bind everywhere:
+
+- **Asked to study, research, inspect, or investigate → analysis only**, no implementation unless
+  explicitly requested.
+- **Porting a system starts with a bounded mapping pass** — identify the functions and globals the
+  port actually needs, and record evidence-backed annotation candidates before writing Rust. Do not
+  expand to transitive closure. The mapped set is the port's scope; synchronizing that set into
+  Ghidra follows the authorization rule below.
+- **Ghidra annotation is candidate-first, not a default side effect of analysis.** Every
+  reverse-engineering workflow may report candidates. Applying them is authorized only when the
+  selected skill's description explicitly promises Ghidra synchronization, the invocation includes
+  `--sync-ghidra-labels`, or the user directly requests synchronization. `--no-sync-ghidra-labels`
+  or any read-only request disables it. Workers are always read-only; after all readers stop, only
+  the root or sole agent may mutate Ghidra, serially.
+- **Apply only certain, low-risk metadata.** A function label requires the exact boundary, behavior,
+  owner/receiver, and relevant active caller binding. A global/data label requires the exact storage
+  boundary and size, verified role, writer/initializer, consuming use, and active data binding. If
+  identity or binding is uncertain, keep `FUN_*`/`DAT_*`; an evidence comment may record only the
+  verified partial fact and must state the uncertainty. A synthetic memory reference requires proved
+  source instruction/table-slot bytes, exact target, operand, reference kind, and confirmed absence
+  of an equivalent reference. Never infer metadata from Rust comments, research prose, YRpp,
+  neighboring patterns, or an existing Ghidra name, and never remove analyzer references
+  automatically. After every authorized mutation: `save_program`, read it back, then continue. If
+  write tools are unavailable, report the queue without claiming application. Function creation,
+  prototypes, structs, field/type edits, variable renames, and byte patches require separate explicit
+  per-task authorization.
+- **Never invent** offsets, addresses, vtable slots, fields, enum values, or labels; not verified
+  this session → `UNKNOWN`/`UNCHECKED`. Cite the decompile call inline for anything written into a
+  doc, and treat your own prior claims as unverified.
+- **TS legacy is the most frequent error from decompilation.** Before implementing any behavior
+  found in the binary, confirm it is reachable and visible in a normal YR skirmish. Known dormant,
+  do NOT implement as default: **fog of war** (`FogOfWar` defaults to `false` — shroud only),
+  **subterranean locomotion** (absent from RA2/YR; not the same as low-bridge `TubeClass`
+  movement, which *is* active), and most `SpecialFlags`-gated features.
+
+## System Map
+
+`docs/system-map/` is navigation — not parity proof, completion ledger, or work queue, and the
+surface is frozen (2026-07-27). Use `loop` and `mechanism` lookups *after* you have a symptom;
+never select work from missing fields or unmapped rows. Extend a loop only when verified work
+touches that system, updating just the affected nodes/edges, then run
+`python -m tools.system_map check --require-sources`. Never bulk-import call adjacency,
+bulk-annotate, or hand-edit generated files.
+
+## Change management
+
+- Reduce the request to a compact task contract — player scenario, scope, non-deferrable
+  constraints, smallest production validation, residual risk, stop condition — then take the
+  simplest robust Rust-native solution.
+- Read the relevant code and data before editing; generate multiple hypotheses before a
+  non-trivial fix.
+- **Debug end-to-end first** — log each pipeline stage (lookup → transform → output) and run once
+  before deep-diving any stage statically.
+- **Verify the end-to-end result**, not just compilation. When removing or refactoring, trace all
+  consumers — the removed system may have masked bugs elsewhere.
+- **Read the whole closed loop before fixing one stage** (harvest/return/dock/exit,
+  build/place/sell, dock approach/link/deposit/depart); a symptom in one stage often originates in
+  another.
+- **If a fix makes things worse, stop and reassess** instead of layering more changes.
+- No autonomous bulk refactors, renames, or rewrites without explicit approval.
+- **A shadow-mode slice flips to authoritative within two sessions or gets reverted.**
+
+## Parallel sessions
+
+- A build failing in files you did NOT modify is another session's work. Don't fix, revert, or
+  stash it.
+- **Pending re-baselines.** If your change legitimately shifts a committed golden but the tree also
+  carries another session's unmerged shifts, do NOT re-baseline — record one line in
+  `docs/scans/PENDING_REBASELINES.md` and leave the test red. Whoever later finds the tree clean
+  folds all pending entries into one commit citing them.
+- Scan findings decay in days; check `git log --grep` and the live code before implementing one.
+
+## Git
+
+- Start development from an up-to-date `main` and commit every change on a short-lived
+  `feature/<topic>` branch. Never commit or push directly to `main`; `main` moves only through a
+  reviewed PR (or an explicit user-owned GitHub action).
+- When this checkout has a sole owner, create or switch the feature branch here. When another
+  task owns the checkout, use a separate worktree and feature branch. Continue an existing
+  task-owned feature branch rather than creating a second branch for the same work.
+- Push a feature branch or open/update its PR only when the user or goal authorizes publication.
+  Every PR targets `main`. Delete merged feature branches when safe. Do not create a long-lived
+  `dev` branch; use a temporary integration branch only when the user explicitly requests one.
+- Gitignored, local-only — never write commit steps for these: `docs/` (except `_config.yml`,
+  `index.md`, and `system-map/`), `ini/`, `tools/research_index/`, `.mcp.json`, `.claude/` and
+  `.agents/` (except their `skills/` trees, which are tracked — `ghidra-up` alone stays local),
+  `todo/`, and root `*.md` other than `README.md`, `CLAUDE.md`, `ENGINE.md`, and `AGENTS.md`
+  (`LOCAL.md` stays local).
+
+## Cargo and environment
+
+- Package is `vera20k`; a wrong `-p` exits 101 without running anything. Read and report the
+  literal `test result:` line rather than inferring success from completion.
+- **Run the cheapest test tier that answers the question.** *Working:* `cargo check -p vera20k`
+  plus the touched module only, `cargo test -p vera20k --lib <module_path>::` — always `--lib`, or
+  you also link 13 unrelated side binaries. *PR integration/merge certification:* one full
+  `cargo test -p vera20k --lib`, run once before the PR is declared ready for `main`, not per
+  slice or per commit. *Nightly:* full suite plus
+  slow/ignored retail certification; a red nightly is stop-the-line.
+- **Never run cargo commands in parallel** from one session; check first with
+  `Get-Process cargo,rustc -ErrorAction SilentlyContinue` and wait if another session owns Cargo. A
+  full build takes minutes — start it once in the background, then wait on the `test result:` line
+  with a single polling loop.
+- **Never kill a cargo build mid-compile** — interrupted codegen corrupts
+  `target/debug/incremental` and the *next* build fails to link with `unresolved external symbol
+  anon.*.llvm.*` in untouched files. Recovery: delete that directory and rebuild.
+- **Never run crate-wide `cargo fmt`** — the repo isn't uniformly rustfmt-clean. Format only leaf
+  files you edited (`rustfmt --edition 2024 <file>`), never a `mod.rs` (it recurses).
+- Coordinate `SNAPSHOT_VERSION` changes and golden re-baselines; one session at a time.
+- GPU, linker toolchain, retail-asset location, and other machine-local environment notes
+  live in `LOCAL.md` (gitignored, machine-local).


### PR DESCRIPTION
## What

Stops gitignoring the agent workflow toolkit and project contract so every checkout — including worktrees and fresh clones — carries them:

- `.claude/skills/` (13 skills) and `.agents/skills/` (16 skills); `ghidra-up` stays machine-local via explicit ignore entries
- `CLAUDE.md`, `ENGINE.md`, `AGENTS.md` — the shared project contract

## Confidentiality screening

- All absolute machine paths rewritten to a `<main-checkout>` placeholder, defined in ENGINE.md (gitignored corpora exist only in the primary checkout, not worktrees)
- Machine-specific environment notes and Codex session internals moved to gitignored `LOCAL.md` (imported by CLAUDE.md, absent in clones by design)
- Staged diff grep-gated for usernames, machine names, private repo names, and local paths: clean

## Post-merge note for existing checkouts

Checkouts holding untracked copies of these files will refuse the pull ("untracked working tree file would be overwritten"). From such a checkout, the local copies are identical or older — resolve with:

```
git stash -u   # or delete the untracked .claude/skills, .agents/skills, CLAUDE.md, ENGINE.md, AGENTS.md copies
git pull
```

`LOCAL.md`, `ghidra-up`, `.claude/skills-removed/`, and all other local-only state are unaffected.