### PR TITLE
Make Claude-side skills self-contained; move backup command to LOCAL.md

### DIFF
--- a/.agents/skills/sync/SKILL.md
+++ b/.agents/skills/sync/SKILL.md
@@ -54,11 +54,8 @@ unclear, stop before mutation and report the conflict.
 ### Local-only backup preflight
 
 Before an authorized action could remove a checkout or local-only data, refresh
-the adjacent private backup with:
-
-```text
-powershell -NoProfile -File ..\vera20k-docs-backup\backup.ps1
-```
+the adjacent private local backup using the machine-local command recorded in
+`LOCAL.md` (section "Local-only backup").
 
 Require a successful backup commit before continuing. If the backup script is
 missing, refuses because source files disappeared, or reports unapproved

--- a/.claude/skills/architecture-scan/SKILL.md
+++ b/.claude/skills/architecture-scan/SKILL.md
@@ -1,21 +1,174 @@
 ---
 name: architecture-scan
-description: >
-  Project-scoped, read-only VERA20k review of repository organization, module
-  ownership, dependency direction, API visibility, naming, cohesion, change
-  locality, test placement, and Cargo target boundaries. Use only when
-  explicitly invoked as /architecture-scan to assess where existing Rust code
-  belongs or whether current repository boundaries are healthy. Reports
-  evidence-backed findings and options; never edits, auto-refactors, performs
-  gameplay parity research, or imposes generic Rust layout preferences.
+description: "Project-scoped, read-only VERA20k review of repository organization, module ownership, dependency direction, API visibility, naming, cohesion, change locality, test placement, and Cargo target boundaries. Use only when explicitly invoked as /architecture-scan to assess where existing Rust code belongs or whether current repository boundaries are healthy. Reports evidence-backed findings and options; never edits, auto-refactors, performs gameplay parity research, or imposes generic Rust layout preferences."
 ---
 
 # Architecture Scan
 
-Read and follow `../../../.agents/skills/architecture-scan/SKILL.md`
-completely. It is the canonical procedure shared by both agent frontends; its
-bundled `references/` lenses resolve relative to that canonical directory.
-Where it writes `$architecture-scan`, read `/architecture-scan`.
+Review the current repository architecture without editing it. Read `ENGINE.md`
+completely before scanning. A scan samples current structure; it does not certify
+that the repository is well organized.
 
-If the relative path does not exist (worktree checkout), read
-`<main-checkout>/.agents/skills/architecture-scan/SKILL.md` instead.
+Judge architecture by whether ownership is predictable, dependencies flow in the
+declared direction, APIs protect invariants, and ordinary changes remain reasonably
+local. Do not judge it by a preferred folder tree, crate count, nesting depth, or
+one-type-per-file rule.
+
+Treat all bundled material as evidence lenses, not implementation requirements.
+Its imperatives govern what this read-only review must inspect and prove; they do
+not authorize moves, renames, API changes, crate splits, or refactors. Only a later,
+explicitly authorized task may change code, with `ENGINE.md` remaining authoritative.
+
+Apply this priority when recommendations compete:
+
+1. explicit `ENGINE.md` boundaries and parity/determinism safety;
+2. state and behavior ownership plus dependency direction;
+3. API visibility, invariant enforcement, and lifecycle seams;
+4. cohesion, change locality, testability, and discoverability;
+5. naming consistency and aesthetic preference.
+
+## Inputs
+
+Preserve these forms:
+
+- `/architecture-scan` — review the current package, beginning with `Cargo.toml`,
+  `src/lib.rs`, `src/main.rs`, and the top-level module roots.
+- `/architecture-scan <path>` — review one repository-relative file, module, or
+  directory in its surrounding architecture.
+- `--changed [--base <revision>]` — review structural effects of changed Rust and
+  manifest files; default the base to `main`.
+- `--focus <name>` — repeat as needed. Names are `boundaries`, `ownership`, `api`,
+  `layout`, `naming`, `tests`, and `packages`.
+
+Without `--focus`, use `boundaries,ownership,api,layout`. Include `packages` when
+manifests or targets are in scope and `tests` when test placement affects the
+question. Resolve paths under the repository root and record HEAD, dirty state,
+active worktrees, target, focus, and exclusions. Do not assess another task's
+half-finished move as settled architecture; identify the active migration and
+inspect both its old and new seams.
+
+## Resources
+
+Read [the architecture review lenses](references/review-lenses.md) completely.
+They contain project-aware questions plus the primary Rust sources behind them.
+No candidate collector is bundled: imports, visibility, macros, and module paths
+must be resolved from the live source rather than treated as a reliable regex graph.
+
+## Workflow
+
+1. **Establish the declared shape.** Read the relevant Cargo manifests,
+   `src/lib.rs`, `src/main.rs`, module roots, and their `//!` contracts. Identify
+   package targets, layer rules, public facades, and any in-progress migration.
+2. **Build a factual boundary map.** For each responsibility in scope, record its
+   current owner, mutable state, public or crate-visible seam, direct callers,
+   upstream inputs, and downstream dependencies. Keep this map small enough to
+   explain the question; do not create a permanent architecture ledger.
+3. **Trace real access.** Read definitions, imports, re-exports, constructors,
+   mutation sites, trait implementations, macro expansions when relevant, tests,
+   and representative callers. Distinguish production, test-only, tool-only,
+   generated, and presentation paths.
+4. **Apply only relevant lenses.** Check explicit project boundaries first, then
+   ownership, dependency direction, API surface, cohesion, placement, naming,
+   tests, and package boundaries as selected. A count or lexical match is only a
+   route to inspect.
+5. **Prove concrete cost.** Confirm either an explicit project-contract violation
+   or a bounded effect: duplicated authority, a wrong-way dependency, bypassable
+   invariants, split lifecycle, unwanted API coupling, recurring cross-module
+   change fanout, an untestable seam, or materially misleading placement/name.
+   Use focused git history only when claiming recurring churn; do not infer design
+   merely from co-change counts.
+6. **Check Rust indirection contextually.** Resolve the consumers and implementors
+   of a trait and the generated surface of a macro. More traits, generics, facades,
+   or macros are not inherently better architecture. Recommend them only when an
+   observed variation or boundary benefits.
+7. **Bound the direction.** State the smallest safe improvement direction and its
+   compatibility, parity, determinism, ordering, persistence, build, and migration
+   risks. Do not turn the scan into a design spec or implementation plan.
+8. **Report and stop.** Never move files, change visibility, add wrappers, split a
+   crate, run automatic fixes, or chain into another skill.
+
+Use `cargo metadata --no-deps` only when manifest topology is ambiguous. Before
+any Cargo command, check for active `cargo` or `rustc` processes and follow the
+repository's Cargo coordination rules. Do not run Clippy or compile merely to
+produce an architecture opinion.
+
+## Confirmation gate
+
+A candidate becomes a finding only when the report can state:
+
+- exact source locations and representative consumers;
+- the current responsibility owner and dependency/API boundary;
+- the violated project rule or concrete engineering/player consequence;
+- the triggering kind of change or runtime path and expected frequency;
+- why the proposed direction improves that boundary without speculative layers.
+
+File length, folder depth, `pub`, re-exports, prefixes, traits, macros, many
+binaries, or a single large crate are not findings by themselves. Generic Rust
+taste is never a project defect.
+
+Use these categories:
+
+- **BOUNDARY** — declared dependency direction or layer ownership is violated;
+- **OWNERSHIP** — authoritative state or behavior has competing/bypass owners;
+- **API** — visibility or a facade exposes/bypasses more than its contract needs;
+- **COHESION** — unrelated responsibilities create verified change amplification;
+- **PLACEMENT** — location materially obscures ownership or dependency direction;
+- **NAMING** — terminology causes demonstrated ambiguity at a real seam;
+- **PACKAGE** — package, crate, binary, feature, or dependency topology is at issue;
+- **TESTABILITY** — placement or visibility prevents the right boundary from being tested.
+
+Assign severity from verified impact and always state trigger/change frequency:
+
+- **CRITICAL** — explicit hard boundary violation, duplicated authoritative owner,
+  or structural path that threatens deterministic/player-visible correctness;
+- **WARNING** — confirmed coupling, invariant bypass, change amplification, or
+  test barrier with a recurring or bounded maintenance effect;
+- **INFO** — a demonstrated low-risk discoverability or API improvement.
+
+## Report
+
+Lead with a one-sentence verdict, then use:
+
+### Coverage
+
+- Target, HEAD, dirty/worktree state, focuses, and files or edges inspected.
+- Explicit contracts and tools used, skipped, or incomplete.
+
+### Current architecture map
+
+| Responsibility | Current owner | Public seam | Inputs / consumers | Evidence |
+|---|---|---|---|---|
+
+### Confirmed findings
+
+| Severity | Confidence | Category | File:line | Evidence | Trigger / frequency | Effect | Improvement direction |
+|---|---|---|---|---|---|---|---|
+
+If none were confirmed, say: `No confirmed architecture findings in the sampled
+scope; this is not certification.`
+
+### Unresolved candidates
+
+List only candidates whose missing caller, owner, history, or boundary evidence
+could materially change the verdict. State the exact next check.
+
+### Supported boundaries
+
+Record a few important boundaries that current evidence shows are healthy so a
+later cleanup does not erase them accidentally.
+
+### Limits
+
+State excluded areas, unresolved macro/trait paths, uninspected history, and other
+unknowns. End after reporting; implementation begins only under a separate request.
+
+## Non-goals
+
+- Do not perform a gameplay parity audit, broad Rust correctness/safety scan,
+  performance profile, feature design, design-document review, or implementation.
+- Do not produce an architecture score, ideal directory tree, parity ledger, or
+  repository-wide cleanup backlog.
+- Do not prescribe traits everywhere, one type per file, shallow/deep nesting,
+  arbitrary line limits, universal `pub(crate)`, or a workspace split by size.
+- Do not replace working project boundaries solely to resemble another engine or
+  a generic "clean architecture" diagram.

--- a/.claude/skills/architecture-scan/references/review-lenses.md
+++ b/.claude/skills/architecture-scan/references/review-lenses.md
@@ -1,0 +1,151 @@
+# Architecture review lenses
+
+These are questions for gathering evidence, not universal coding standards. A
+rule word such as "prefer" or "require" describes what the scan must establish
+before reporting a finding; it does not authorize a rewrite. `ENGINE.md` owns
+project policy and overrides generic Rust guidance.
+
+## Contents
+
+- [Packages and targets](#packages-and-targets)
+- [Modules, files, and placement](#modules-files-and-placement)
+- [Ownership and dependency direction](#ownership-and-dependency-direction)
+- [Visibility and API seams](#visibility-and-api-seams)
+- [Cohesion and change locality](#cohesion-and-change-locality)
+- [Names and navigation](#names-and-navigation)
+- [Traits and macros](#traits-and-macros)
+- [Tests and tools](#tests-and-tools)
+- [Parity-preserving structural work](#parity-preserving-structural-work)
+- [Primary sources](#primary-sources)
+
+## Packages and targets
+
+- Start from Cargo's actual package and target model. One package with a library
+  and several binaries is valid. Conventional `src/lib.rs`, `src/main.rs`,
+  `src/bin/`, `tests/`, `examples/`, and `benches/` placement improves navigation,
+  but compatibility and project-specific target declarations can justify variants.
+- Consider a new package/crate only when it creates a useful compilation,
+  dependency, reuse, testing, platform, or stable-API boundary. Size alone does
+  not justify a workspace split. Account for dependency cycles, duplicated types,
+  build cost, feature unification, and migration burden.
+- Treat feature flags as additive capability choices where practical. Confirm the
+  production surface affected before reporting package or feature topology.
+
+## Modules, files, and placement
+
+- Remember that modules define namespace, privacy, and paths; files store module
+  bodies. A file move or split can improve navigation without changing architecture.
+- Place code with the responsibility that owns its state, invariants, lifecycle,
+  or externally meaningful contract. A shared location is appropriate only for a
+  genuinely lower-level concept with multiple independent consumers.
+- Read the crate root, parent module, `//!` contract, definitions, and callers.
+  Folder depth, sibling count, and filename prefixes are discovery signals only.
+- Check whether a facade offers one coherent entry point while keeping its
+  implementation private. Do not add a facade merely to reduce import length.
+- Recognize active migrations from dirty state and recent focused commits. Mixed
+  old/new placement during a bounded move is not automatically architectural debt.
+
+## Ownership and dependency direction
+
+- Identify one truthful owner for mutable or authoritative state and for the
+  operations that maintain its invariants. Confirm all mutation paths, including
+  constructors, commands, callbacks, tests, macros, and trait methods.
+- Compare actual imports and calls with `ENGINE.md`'s layer direction. Separate
+  production edges from test-only, diagnostic, generated, and tool edges.
+- Prefer communication through the owning layer's command, DTO, event, query, or
+  narrow method when direct access would bypass ordering or lifecycle. Do not add
+  messaging abstractions where a direct lower-level dependency is already valid.
+- Flag a "common", "shared", "manager", or "helpers" module only when it has
+  become a second owner, a dependency dumping ground, or a material navigation trap.
+
+## Visibility and API seams
+
+- Rust items are private by default and support restricted visibility such as
+  `pub(super)`, `pub(in ...)`, and `pub(crate)`. Inspect actual consumers and use
+  the narrowest visibility that truthfully serves them; `pub` alone is not a defect.
+- Treat `pub use` as an architectural facade: verify that it exposes the intended
+  concept without making implementation placement or an internal dependency part
+  of the calling contract.
+- Distinguish an application crate's test-facing surface from a published stable
+  library API. Apply semver-oriented Rust API guidance only where compatibility is
+  an actual project requirement.
+- Prefer private fields for invariant-bearing types and public fields for honest
+  passive data when that is the intended contract. Accessors that merely mirror
+  every field do not create encapsulation.
+- Trace dependency types in public signatures. A third-party type, concrete
+  container, trait bound, or error type can become part of the boundary, but this
+  matters only to real consumers.
+
+## Cohesion and change locality
+
+- Ask whether a module has one coherent reason to change and whether common work
+  stays near the owning code. Confirm unrelated responsibility or repeated fanout
+  before reporting; line count is only a cue.
+- Use focused git history when claiming chronic co-change, but inspect why files
+  changed together. A one-time migration, generated update, or parity slice is not
+  evidence of permanent coupling.
+- A large cohesive table, parser, state machine, or test corpus may be easier to
+  reason about together. A short file can still be misplaced or split an invariant.
+- Prefer the smallest boundary improvement. Moving files without tightening
+  ownership, visibility, dependencies, or navigation may add churn with no gain.
+
+## Names and navigation
+
+- Follow Rust casing and Cargo target conventions unless compatibility requires
+  otherwise. More importantly, use the repository's verified domain vocabulary.
+- A name should let a maintainer predict the responsibility and likely owner.
+  Demonstrate ambiguity through conflicting concepts, imports, or callers before
+  reporting a rename; unfamiliar or long names alone are not findings.
+- Keep conversion and iterator names consistent with established Rust meanings
+  (`as_`, `to_`, `into_`; `iter`, `iter_mut`, `into_iter`) when those APIs exist.
+- Module documentation should state purpose and important dependencies. It should
+  not become a hand-maintained completion ledger or duplicate implementation detail.
+
+## Traits and macros
+
+- Introduce or retain a trait for a real behavioral contract, multiple meaningful
+  implementations, a test seam, or an intentional static/dynamic dispatch boundary.
+  A single implementation is neither proof of needless abstraction nor proof that
+  a trait is useful.
+- Resolve implementors, consumers, associated types, blanket/default methods, and
+  object use before judging placement. Sealing is appropriate only when external
+  implementations are deliberately excluded.
+- Place macros with the domain or infrastructure that owns the generated contract.
+  Inspect the expansion that actually compiles when it affects visibility,
+  dependencies, state ownership, serialization, or tests. Macro use is not itself
+  an architecture smell.
+
+## Tests and tools
+
+- Colocated unit tests may exercise private details. `tests/` integration crates
+  should exercise the public boundary. Rustdoc examples document and compile API
+  use; `examples/` provides runnable programs. Choose placement by the seam tested,
+  not by a universal rule.
+- Keep binary entry points thin when logic can be owned and tested by the library,
+  but do not expose internals publicly merely to satisfy a test.
+- Separate tool-only dependencies and code paths from the production game when
+  they would otherwise expand runtime boundaries or compile cost. Many declared
+  binaries are not automatically evidence that separate packages are needed.
+
+## Parity-preserving structural work
+
+- A structural move is not behavior-neutral merely because the function bodies
+  look unchanged. Check feature/`cfg` reachability, caller order, error routing,
+  constructors, serialization, registration, tests, and public paths.
+- For authoritative simulation, preserve scheduler and tie order, RNG ownership
+  and draw count, lifecycle effects, same-tick visibility, snapshot/hash coverage,
+  and gamemd provenance. Report a behavioral question as out of scope and name
+  `/rust-scan` or the appropriate parity workflow for a separate explicit request;
+  never invoke it automatically or resolve it by architectural taste.
+- Do not recommend translating gamemd's C++ class hierarchy literally. Preserve
+  verified behavior contracts while using Rust-native modules, ownership, and APIs.
+
+## Primary sources
+
+- [Rust Book: packages, crates, and modules](https://doc.rust-lang.org/book/ch07-00-managing-growing-projects-with-packages-crates-and-modules.html)
+- [Cargo Book: package layout](https://doc.rust-lang.org/cargo/guide/project-layout.html)
+- [Cargo Book: workspaces](https://doc.rust-lang.org/cargo/reference/workspaces.html)
+- [Rust Reference: visibility and privacy](https://doc.rust-lang.org/reference/visibility-and-privacy.html)
+- [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) — recommendations,
+  explicitly not universal mandates
+- [Rust Book: test organization](https://doc.rust-lang.org/book/ch11-03-test-organization.html)

--- a/.claude/skills/rust-scan/SKILL.md
+++ b/.claude/skills/rust-scan/SKILL.md
@@ -1,21 +1,184 @@
 ---
 name: rust-scan
-description: >
-  Project-scoped, read-only VERA20k Rust review for confirmed
-  determinism/desync, authoritative-state and lifecycle, architecture,
-  correctness/safety, and measured hot-path risks. Use for /rust-scan [path],
-  changed-Rust reviews, Rust anti-pattern audits, determinism reviews, or
-  code-health scans, including macro-expanded and trait-dispatched behavior
-  when relevant. Defaults to src/sim/; reports evidence and never edits or
-  auto-fixes.
+description: "Project-scoped, read-only VERA20k Rust review for confirmed determinism/desync, authoritative-state and lifecycle, architecture, correctness/safety, and measured hot-path risks. Use for /rust-scan [path], changed-Rust reviews, Rust anti-pattern audits, determinism reviews, or code-health scans, including macro-expanded and trait-dispatched behavior when relevant. Defaults to src/sim/; reports evidence and never edits or auto-fixes."
 ---
 
 # Rust Scan
 
-Read and follow `../../../.agents/skills/rust-scan/SKILL.md` completely. It is
-the canonical procedure shared by both agent frontends; its bundled
-`references/` lenses and `scripts/` helpers resolve relative to that canonical
-directory. Where it writes `$rust-scan`, read `/rust-scan`.
+Review Rust code without editing it. Treat `ENGINE.md` as authoritative and read it
+completely before scanning. A scan samples risk; it never certifies parity, correctness,
+or cleanliness.
 
-If the relative path does not exist (worktree checkout), read
-`<main-checkout>/.agents/skills/rust-scan/SKILL.md` instead.
+Treat the bundled references as review lenses, not implementation requirements. Their
+imperatives govern what this read-only scan must inspect, prove, classify, and report;
+they do not prescribe production rewrites or grant permission to change code. A heuristic
+or failed lexical check is not a finding until it passes the confirmation gate. Only a
+later, explicitly authorized implementation task may change code, and `ENGINE.md` remains
+authoritative.
+
+Apply this priority when recommendations compete:
+
+1. verified `gamemd.exe` behavior and player-visible parity;
+2. deterministic authority, ordering, lifecycle, persistence, and RNG;
+3. required architecture boundaries and 20,000-unit scale;
+4. measured performance within an explicit budget;
+5. API polish, idiom, and style.
+
+Do not report less-idiomatic Rust merely because a cleaner abstraction exists. Confirm a
+concrete parity, correctness, safety, scale, or maintenance effect first.
+
+## Inputs
+
+Preserve these forms:
+
+- `/rust-scan` — scan `src/sim/`.
+- `/rust-scan <path>` or `/rust-scan scan <path>` — scan one repository-relative
+  Rust file or directory.
+- `--changed [--base <revision>]` — restrict the target to changed Rust files;
+  default the base to `main`.
+- `--focus <name>` — repeat as needed. Names are `determinism`,
+  `architecture`, `state`, `safety`, `performance`, `ownership`, and
+  `structure`.
+- `--include-tests` — include named and probable inline-test candidates.
+- `--clippy` — run the scoped Clippy wrapper after static review.
+
+Without `--focus`, use `determinism,architecture,state,safety,performance` for
+targets intersecting `src/sim/` and `safety,structure` elsewhere.
+Ownership/API-shape review is opt-in; it must not crowd out parity or correctness work.
+Use `/architecture-scan` instead for repository-wide module placement, dependency
+direction, public-surface, naming, cohesion, or Cargo-boundary review. The
+`architecture` focus here remains limited to hard boundaries that affect the Rust
+target being scanned, especially authoritative simulation isolation.
+
+Resolve the target under the repository root, accept only `.rs` files, respect
+ignore rules, and reject paths outside the repository. Record the current HEAD,
+dirty state, target, selected focus, and file count. Never modify code, apply
+Clippy fixes, create scan ledgers, or update Ghidra.
+
+## Resources
+
+- Always use [general review rules](references/general-review.md).
+- For `src/sim/` or any code feeding authoritative simulation, also use
+  [simulation risk rules](references/sim-risks.md).
+- Use [the candidate collector](scripts/collect_candidates.py) for deterministic
+  lexical discovery. Its output is evidence to inspect, never a verdict.
+- Use [the Clippy wrapper](scripts/run_clippy.ps1) only when `--clippy` was
+  requested.
+
+Read the confirmation gates plus only the reference sections needed for the selected
+focus and surfaced rule IDs. Some high-value checks are contextual and intentionally have
+no repository-wide regex.
+
+## Workflow
+
+1. **Establish scope.** Inspect `src/lib.rs`, `src/sim/mod.rs`, the target module
+   headers, and relevant callers. For simulation work, locate the current
+   `World::advance_tick` / master-frame spine and its `SPINE REGION` comments
+   from live code; do not trust a hardcoded filename or line.
+2. **Collect candidates.** Run a summary first:
+
+       python .claude/skills/rust-scan/scripts/collect_candidates.py --target <path> --profile auto --format summary
+
+   Add `--changed --base <revision>`, `--include-tests`, and repeated
+   `--focus <name>` as requested. Rerun with `--format jsonl --rule <RULE_ID>`
+   only for rules worth inspecting. Never silently truncate a large rule. Narrow
+   by changed files or an owning module when practical; otherwise mark that rule
+   `PARTIAL` with its candidate count and do not infer cleanliness from examples.
+3. **Verify context and Rust indirection.** Read the complete containing item and enough callers to
+   establish compiled production reachability, resolved types and ranges,
+   ownership, authority, and test/setup/presentation boundaries. Search results,
+   comments, names, and lint text alone are not findings. When relevant behavior is
+   generated by a declarative/procedural macro or derive, inspect the definition or
+   expansion that actually compiles. At trait calls, resolve the reachable concrete impl,
+   default or blanket method, associated types, and dispatch boundary. Macro or trait use
+   alone is never an anti-pattern.
+4. **Apply project semantics.** For outcome-bearing simulation code, verify
+   scheduler order, equal-key tie-breakers, RNG stream and draw order, lifecycle
+   ownership, same-tick visibility, serialization/hash/snapshot coverage,
+   coordinate frames, and nearby gamemd provenance where applicable.
+5. **Verify performance claims in two stages.** First prove a live call chain and
+   multiplicity or identify the item in a representative optimized-build capture. Then
+   inspect allocation, growth, copying, data access, and algorithmic cost inside that hot
+   item. `Vec::new()` alone does not allocate; capacity-sensitive `push`, `insert`,
+   `extend`, `reserve`, string append, and map insertion may allocate only at the actual
+   call-site capacity. For budget, cache, bandwidth, or contention claims, record the
+   scenario, entity count, target hardware, sampling window, subsystem time in
+   milliseconds, explicit budget, and relevant counters. Without that evidence, report a
+   profiling candidate rather than a confirmed performance finding. If no capture or
+   budget was supplied or already exists, do not create profiling infrastructure or
+   broaden the scan: confirm only bounded algorithmic multiplicity visible in code,
+   state the exact measurement needed under unresolved candidates, and stop. Recommend
+   reusable scratch only after proving reentrancy, clearing, ordering, snapshot/hash
+   exclusion, and memory-retention safety.
+6. **Run Clippy when requested.** First confirm no `cargo` or `rustc` process is
+   active. Run the wrapper once and never kill it mid-build. Preserve all output
+   and the exit code; for a file scan, filter diagnostics to that file only
+   after Clippy exits. An unrelated build failure means `Clippy incomplete`,
+   not a target finding.
+7. **Deduplicate and classify.** Merge overlapping candidates by root cause.
+   Keep unresolved items explicitly `CANDIDATE/UNCHECKED`. For large scopes,
+   bounded read-only delegation is allowed when host policy permits, but the
+   root agent must reread every reported finding and reconcile duplicates.
+
+For authoritative determinism findings, prefer a fix-direction test that exposes the first
+divergent tick: twin simulations, varied insertion or worker order, replay through the live
+command path, or save/load continuation as appropriate. Rust-vs-Rust agreement is regression
+evidence, not `gamemd.exe` parity evidence.
+
+## Classification
+
+A candidate becomes a confirmed finding only when the report can state:
+
+- the compiled, reachable code and authority boundary;
+- the concrete behavior, state, safety, or cost affected;
+- the trigger and expected frequency;
+- the evidence supporting the claim and what remains unknown.
+
+Use severity from verified impact, never from the scan category:
+
+- **CRITICAL** — confirmed production desync/canonical-state corruption,
+  outcome-changing correctness fault, or forbidden architecture dependency.
+- **WARNING** — confirmed safety, error-boundary, hot-path, ownership, or
+  maintainability risk with a bounded player or engineering effect.
+- **INFO** — low-risk improvement with demonstrated benefit.
+
+Test-only, comment-only, setup-only, presentation-only, lookup-only, dormant, and
+diagnostic cases must be labeled as such. Exact-only drift remains separate from
+ordinary-play impact. Do not cap or promote severity merely because Clippy found
+the issue.
+
+## Report
+
+Lead with a one-sentence verdict, then use:
+
+### Coverage
+
+- Target, HEAD, dirty state, profiles, files scanned.
+- Checks completed, skipped, or incomplete, including Clippy status.
+- For performance work, the release scenario, measurements, hardware, and budget—or an
+  explicit statement that the result remains an unmeasured profiling candidate.
+
+### Confirmed findings
+
+| Severity | Confidence | Rule | File:line | Evidence | Trigger / frequency | Effect | Fix direction |
+|---|---|---|---|---|---|---|---|
+
+If none were confirmed, say: `No confirmed findings in the sampled checks; this
+is not certification.`
+
+### Unresolved candidates
+
+List only candidates whose missing type, caller, authority, or runtime evidence
+could materially change the verdict. State the exact next check.
+
+### Notable rejected candidates
+
+Briefly record high-signal false positives that would otherwise be rediscovered,
+such as test-only code or membership-only `HashMap` use.
+
+### Limits
+
+State excluded files, candidate truncation, unrun tools, and remaining unknowns.
+
+End after reporting. Do not auto-fix findings; implementation is a separate,
+explicitly authorized task.

--- a/.claude/skills/rust-scan/references/general-review.md
+++ b/.claude/skills/rust-scan/references/general-review.md
@@ -1,0 +1,208 @@
+# General Rust review rules
+
+Use these rules for every target. Confirm context before reporting; token matches
+are candidates only.
+
+Interpret these as evidence lenses for a requested review, not as an independent
+coding standard. Words such as "inspect," "require," and "prefer" describe the
+proof needed to classify a candidate or evaluate a fix direction; they neither
+authorize nor require a production rewrite.
+
+## Contents
+
+- [Safety and failure behavior](#safety-and-failure-behavior)
+- [Ownership, allocation, and hot-path cost](#ownership-allocation-and-hot-path-cost)
+- [Macros and trait dispatch](#macros-and-trait-dispatch)
+- [Structure and modern Rust](#structure-and-modern-rust)
+- [Clippy interpretation](#clippy-interpretation)
+
+## Safety and failure behavior
+
+### SAFE-001 — unsafe contract
+
+Inspect `unsafe` blocks/functions/traits/impls, FFI blocks, raw pointer
+operations, `transmute`, `from_raw_parts`, `set_len`, unchecked indexing,
+`assume_init*`, and manual `Send`/`Sync`. Inventory every reachable unsafe site;
+do not sample them. Require a nearby `SAFETY:` rationale that proves the relevant
+alignment, validity, initialization, aliasing, lifetime, allocation-provenance,
+and thread-safety obligations. Comment presence alone is not proof. Check
+`# Safety` docs for public unsafe functions and edition-2024 unsafe
+attributes/extern blocks. `unsafe_op_in_unsafe_fn` is a lint requirement, not
+evidence that an operation is unsound. Targeted Miri on pure, unsafe-heavy tests
+can add evidence when supported, but a pass is not a proof and FFI/GPU paths may
+be outside its model.
+
+### SAFE-002 — reachable panic or placeholder
+
+Inspect production `panic!`, `assert!`/`assert_eq!`, `todo!`,
+`unimplemented!`, `unreachable!`, indexing, and other panic paths. Accept a
+proved internal invariant and test-only assertions. Never skip reachable
+`todo!` or `unimplemented!`. Classify by the input and player trigger, not by
+macro name.
+
+### ERR-001 — fallible input handling
+
+For `unwrap`/`expect`, trace the value source. External/user/retail data, file
+I/O, decoded assets, network input, and configurable INI/map values require a
+real error boundary unless validation proves the invariant first. Test code and
+documented post-validation invariants are normally acceptable. Also inspect
+ignored `Result`, `let _ =`, `.ok()`, and fallback/defaulting when they can erase
+a production failure; `Result` being `must_use` does not make an explicit discard
+correct.
+
+### ERR-002 — error-layer boundary
+
+Use `thiserror` for typed library/domain errors and `anyhow` for application
+propagation. Report `anyhow` in library code only after confirming the function
+is not an app facade/boundary. Also inspect discarded errors (`.ok()`, ignored
+results, broad fallback/default) when they can hide malformed production input.
+
+### SAFE-003 — lint suppression
+
+Do not flag every `allow`. Review new, broad, stale, or unexplained
+suppressions. Prefer `expect(lint, reason = "...")` for a local condition that
+should disappear, while retaining documented persistent/generated/platform
+allows when appropriate. Severity comes from the hidden issue.
+
+### SAFE-004 — arithmetic, conversion, and portable width
+
+At parser, serialization, indexing, coordinate, and simulation boundaries,
+inspect narrowing or signedness-changing `as`, unchecked shifts/division, and
+ordinary arithmetic whose overflow behavior matters. `usize`/`isize` and default
+Rust layout are target-dependent; do not let them silently define portable save,
+network, replay, or canonical-state formats. Choose `checked_*`, `wrapping_*`,
+`saturating_*`, `overflowing_*`, or `TryFrom` only after establishing the required
+domain or native behavior. A cast is not wrong by syntax alone.
+
+## Ownership, allocation, and hot-path cost
+
+Apply API-shape rules OWN-001 and OWN-002 only when the user selects the
+`ownership` focus or a concrete finding requires ownership analysis. They are
+not default performance findings. OWN-003 remains a default state check in
+authoritative simulation because aliasing and borrow-panics can cross lifecycle
+and tick boundaries.
+
+### OWN-001 — borrowed versus consumed API
+
+`&String` and `&Vec<T>` are candidates for `&str` and `&[T]` only when callers
+need no concrete-container semantics. An owned parameter may intentionally be
+stored, transferred, normalized, or dropped. Resolve use before suggesting a
+signature change.
+
+### OWN-002 — string identity and indirection
+
+Do not recommend `&'static str` for runtime INI, map, mod, or player-provided
+identifiers. Use the project's `InternedId`/newtype when repeated identity or
+hot cloning justifies interning; otherwise ordinary owned strings may be right.
+`Arc<str>`/`Box<str>` are options only when immutable ownership and lost spare
+capacity fit the API.
+
+### OWN-003 — shared interior mutability
+
+`Rc<RefCell<T>>` in authoritative simulation is an ownership and reentrancy
+candidate, not automatic nondeterminism. Inspect aliasing, borrow-panic
+reachability, lifecycle ownership, and whether the value crosses tick or hash
+boundaries. A documented thread-local `RefCell` used only for non-hashed
+scratch is a different pattern and must not be reported under this rule.
+
+### PERF-001 — allocation on a proved hot path
+
+Use two stages. First trace from the current tick/frame spine and state the
+multiplicity, or identify the item in a representative optimized-build capture.
+Then inspect allocations inside that hot item. `Vec::new()` does not allocate;
+growth, `with_capacity`, `vec!`, `collect::<Vec<_>>()`, `to_vec`,
+strings/formatting, boxes, and cloning owned buffers may. Capacity-sensitive
+`push`, `insert`, `extend`, `reserve`, string append, and map insertion require
+call-site capacity evidence before claiming an allocation. Confirm the resolved
+type and branch frequency. Suggest scratch reuse only after checking reentrancy,
+clearing, retained memory, ordering, and authoritative-state exclusion.
+
+### PERF-002 — clone cost
+
+Never use a per-file clone-count threshold. Resolve the cloned type: a Copy-like
+ID or `Arc` bump differs from a `String`/`Vec`/map clone. One clone inside a
+20,000-entity loop can matter more than many setup clones. Report performance
+only with a hot call path or measurement; report ownership confusion only when
+the API makes it concrete.
+
+### PERF-003 — measured cache and data-layout cost
+
+Require a proved hot phase plus traversal order, fields touched, working-set size,
+indirection, and cache/bandwidth evidence before recommending a layout change.
+Report the representative release scenario, target hardware, sampling window,
+milliseconds against an explicit subsystem budget, and relevant counters. Never
+infer “AoS bad,” require an ECS/SoA rewrite, or replace the mandated `BTreeMap`
+authority from syntax alone.
+
+### PERF-004 — spatial-query and pathfinding scaling
+
+In proved hot simulation items, inspect per-entity global scans, nested entity
+loops, repeated nearest/overlap queries, full path recomputation, frontier growth,
+index rebuild frequency and freshness, and query backlog. Record entity count,
+candidate count per query, and update frequency. Broadphases, batching, tiles, or
+sliced work are only fix directions after preserving verified tie order, same-tick
+visibility, index rebuild semantics, and deterministic commit order.
+
+### PERF-005 — observability cost and evidence
+
+Stable phase spans and counters for tick duration, active entities, allocations,
+spatial-query count, path backlog, and job wait/commit time can make a performance
+claim reproducible. Inspect dynamic trace strings, formatting, and per-entity
+events in hot loops. Instrumentation must remain outside canonical state, and
+wall-clock values must never govern authoritative work. Missing instrumentation is
+not itself a finding unless it blocks an explicit budget or regression contract.
+
+## Macros and trait dispatch
+
+Do not report declarative macros, procedural macros, derives, generics, trait
+objects, or blanket impls merely because they obscure a text search.
+
+- When a selected-focus behavior is generated, inspect the macro definition or
+  compiler expansion that actually builds. Check argument evaluation count/order,
+  hidden allocation or iteration, generated unsafe, `cfg` branches, and generated
+  serialization/hash/state behavior as applicable.
+- At a trait call, resolve the reachable concrete impl, default or blanket method,
+  associated types/constants, and dispatch boundary. Review an `unsafe trait` or
+  manual `Send`/`Sync` under SAFE-001. Treat dynamic dispatch as a performance issue
+  only on a proved hot path with demonstrated cost.
+- If expansion or monomorphization cannot be established, keep the result
+  `CANDIDATE/UNCHECKED`; do not guess from the call-site name.
+
+## Structure and modern Rust
+
+### STRUCT-001 — module documentation
+
+Module files should open with a `//!` purpose/dependency comment. Account for
+shebangs, inner attributes, generated files, and intentionally included test
+modules before reporting.
+
+### STRUCT-002 — file growth and cohesion
+
+Around 600 lines is a review cue, not a violation. Check continued growth and
+mixed responsibilities; exempt cohesive data-heavy files and tests. Prefer
+diff-aware reporting of newly crossed thresholds or materially enlarged
+outliers over a repository-wide wall of size warnings.
+
+### MODERN-001 — lazy initialization
+
+Map by semantics: lazy static initialization normally maps to `LazyLock`;
+one-time explicit initialization to `OnceLock`; unsynchronized variants to an
+appropriate `std::cell` type. Inspect direct crate use only, not transitive
+lockfile entries.
+
+### STYLE-001 — optional idioms
+
+Generic rewrites such as iterator chains, `matches!`, let chains,
+`derive(Default)`, `From`/`Into`, `is_multiple_of`, and `div_ceil` are INFO-only
+and opt-in. Prove evaluation order, eagerness, overflow/zero behavior, ownership,
+and domain meaning. Do not rewrite clear order-sensitive game logic merely to
+look modern; rely on selected Clippy groups for routine style discovery.
+
+## Clippy interpretation
+
+Run only through `scripts/run_clippy.ps1` when requested. A diagnostic is still
+a candidate: read its span and caller. Do not suppress compile errors or confuse
+an unrelated build failure with a target issue. Severity follows verified
+impact, not the Clippy group. Prefer the default correctness/suspicious/perf
+groups plus targeted unsafe-contract lints. Do not enable `restriction` or
+`nursery` wholesale; cherry-pick a lint only when its contract matches the scan.

--- a/.claude/skills/rust-scan/references/sim-risks.md
+++ b/.claude/skills/rust-scan/references/sim-risks.md
@@ -1,0 +1,228 @@
+# Simulation risk rules
+
+Use these rules for `src/sim/` and for parsers, bootstrap code, commands, or
+other code that feeds authoritative simulation. `ENGINE.md` wins if this file
+ever conflicts with it.
+
+Interpret these as evidence lenses for a requested review, not as independent
+implementation policy. They identify questions the scan must resolve; verified
+`gamemd.exe` evidence, `ENGINE.md`, and the explicitly authorized task govern any
+later code change.
+
+## Contents
+
+- [Confirmation gate](#confirmation-gate)
+- [Determinism and ordering](#determinism-and-ordering)
+- [Authoritative state and lifecycle](#authoritative-state-and-lifecycle)
+- [Architecture](#architecture)
+- [Coordinates and provenance](#coordinates-and-provenance)
+- [Validation direction](#validation-direction)
+
+## Confirmation gate
+
+Treat every lexical hit as a candidate. Before assigning severity:
+
+1. Exclude comments, strings, test-only items, setup-only paths, diagnostics, and
+   presentation-only data where the rule does not apply.
+2. Resolve source and destination types, guards, callers, and the owning state.
+3. Establish whether the path can affect commands, RNG draws, ordering,
+   canonical state, serialization, hashing, persistence, or same-tick reads.
+4. State the player trigger and frequency. A rare deterministic-state risk may
+   still be critical, but must not be described as common.
+5. For behavior changes, identify the gamemd evidence or label the equivalent
+   `UNCHECKED`. Never invent the native correction.
+
+## Determinism and ordering
+
+### DET-001 — host floating point
+
+Candidate signal: `f32`/`f64` types, literals, arithmetic, transcendental
+functions, or fixed-to-float conversions in the simulation authority cone.
+
+Confirm whether the value can affect gameplay or canonical state. Comments,
+reference-only tests, and hash-excluded presentation state are not desync
+findings, though presentation state living in `sim/` may be ARCH-002. A native
+float/double mechanism does not silently override VERA's fixed-point contract;
+record the contract conflict and required evidence. Do not replace math until
+native conversion, rounding, overflow, and boundary behavior are known.
+
+### DET-002 — unordered collections
+
+Candidate signal: `HashMap`, `HashSet`, unordered collection, or upstream data
+with unspecified order.
+
+Membership and keyed lookup alone are deterministic. Confirm a risk only when
+iteration, serialization, reduction, selection, command generation, RNG
+consumption, insertion order, or a downstream sort exposes unordered order.
+`BTreeMap` is not a universal fix: key order can itself drift from gamemd's
+insertion/scheduler order. Preserve the explicit `EntityStore = BTreeMap`
+invariant and otherwise require the verified ordering contract. Standard
+`Hash`/`DefaultHasher` output is not a stable save, replay, network, or canonical
+digest contract across toolchains and platforms; require an explicitly specified
+canonical encoding and digest where stability matters.
+
+### DET-003 — external entropy, clock, environment, or filesystem order
+
+Candidate signal: `rand::rng`, `thread_rng`, `rand::random`, `OsRng`,
+`getrandom`, entropy seeding, `SystemTime::now`, `Instant::now`, environment
+reads, locale, or directory enumeration.
+
+Confirm whether the result enters authoritative decisions. App-owned logging,
+debug assertions, and evidence sinks are not desyncs when they cannot feed back
+into simulation. Filesystem iteration must be explicitly sorted before it
+selects canonical input.
+
+### DET-004 — casts, ranges, and native-width arithmetic
+
+Candidate signal: `as` conversion to integer types, especially narrowing,
+signed/unsigned, float/integer, or `usize`/`isize` conversions.
+
+Resolve the actual source type and prove its range. `i32 as usize` is unsafe for
+negative values; it is not widening. A modulo after a narrowing cast does not
+make the cast safe because truncation already occurred. Cover all widths, not
+only 8/16/32-bit targets. Separate arithmetic overflow from cast truncation.
+Do not automatically suggest clamp, saturate, or `TryFrom`: first establish
+gamemd's wrap/truncate/clamp behavior and the supported-platform contract.
+
+### DET-005 — conditional production behavior
+
+Candidate signal: `cfg`, `cfg_attr`, `cfg!`, target OS/architecture/pointer
+width, feature, or debug-only branches.
+
+Test-only helpers are normally fine. Confirm a risk when configuration changes
+production structs, serialization, phase logic, RNG use, commands, or canonical
+results between supported peers/builds. Check aliases and macro-expanded gates
+when a direct hit is ambiguous.
+
+### DET-006 — concurrency, atomics, and uninitialized storage
+
+Candidate signal: spawned work, Rayon/parallel iterators, async tasks, atomics,
+`MaybeUninit`, or unsafe initialization.
+
+Parallelism is allowed when work is pure/read-only or commits in a proved
+deterministic order without changing RNG or same-tick visibility. Atomics,
+including `Relaxed`, are not inherently nondeterministic; confirm that
+inter-thread timing can affect authoritative state. For `MaybeUninit`, inspect
+initialization coverage and each `assume_init*`/raw read rather than flagging
+the type itself. Explicitly inspect Rayon `reduce*`, `sum`, `product`, equal-key
+min/max, `find_any`, `par_bridge`, channel/completion-order collection, and
+parallel mutation buffers. Race-free output is not necessarily deterministic.
+Outcome-bearing work requires schedule-independent unique ordering keys and a
+single deterministic commit in the verified authoritative order; thread index or
+completion order is not such a key.
+
+### DET-007 — scheduler, sort, heap, and tie order
+
+Candidate signal: `sort*`, `BinaryHeap`, priority queues, entity snapshots,
+stable-ID walks, insertion/removal, or equal-key comparators.
+
+Trace the order into effects. Require a total, deterministic tie-breaker when
+equal elements can change damage, lifecycle, commands, or RNG. Do not replace
+native/live-object insertion order with stable-ID or sorted-key order merely
+because it is deterministic. Also inspect equal-key min/max/find selection and
+non-associative reductions: stable sorting cannot repair a nondeterministic input
+order, and a deterministic key can still be the wrong native order.
+
+### DET-008 — RNG ownership and draw order
+
+Candidate signal: `SimRng`, `main_rng`, `scenario_rng`, `mapgen_rng`, stream
+cloning, helper draws, or branch-dependent draws.
+
+Verify the owning stream, caller order, draw count, rejected-draw behavior, and
+same-tick state commit. New direct stream access outside an owning/routing seam
+requires evidence. A deterministic PRNG algorithm can still desync when draw
+order differs.
+
+## Authoritative state and lifecycle
+
+### STATE-001 — serialization, hash, and snapshot coverage
+
+For every added or changed authoritative field in `Simulation`, `GameEntity`,
+RNG, scheduler, production, house, trigger, or mission state, verify:
+
+- serialization/deserialization or a justified `serde(skip)`;
+- inclusion in the canonical state hash, or an explicit proof that it cannot
+  feed future simulation;
+- snapshot-version and compatibility impact;
+- initialization/default and save/load/replay/hash mutation tests.
+
+A `serde(skip)` field is high risk if its value can influence a later decision.
+Do not infer coverage from `derive(Serialize)` alone when hashing is manual.
+Classify state as authoritative, deterministically derived, or presentation-only.
+Derived state must rebuild deterministically and should remain diagnosable by a
+canonical dump/hash when it can expose a divergence.
+
+### STATE-002 — lifecycle and authority ownership
+
+Inspect direct entity-store insertion/removal, pending-delete writes, scheduler
+or LogicVector edits, owner changes, reveal/conceal, limbo/unlimbo, occupancy,
+radio links, and reservations. Confirm that the owning lifecycle/helper performs
+side effects in native order. A direct mutation is not automatically wrong, but
+must not bypass registration, hashing, occupancy, or same-tick consequences.
+
+### STATE-003 — tick-spine and phase changes
+
+Elevate changes around command ingress, master-frame phases, live-object
+snapshots, combat/projectile resolution, pending deletion, and frame commit.
+Read the current `SPINE REGION` comments and relevant closed loop. Verify
+ordering and same-tick visibility even if ordinary lint checks pass.
+
+### STATE-004 — command and replay path
+
+Inspect player/network commands, AI intentions, delayed work, and replay records
+as ordered data entering the live simulation path. Verify tick assignment,
+ordering, duplicate and missing-target behavior, rejection semantics, RNG effects,
+and same-tick visibility. Replay-only callbacks or alternate mutation paths are
+candidates because they can hide divergence. Do not import another engine's
+command delay, rollback window, or phase boundary; `gamemd.exe` evidence owns the
+exact contract.
+
+## Architecture
+
+### ARCH-001 — forbidden dependency
+
+Production `sim/` must not depend on `render/`, `ui/`, `sidebar/`, `audio/`, or
+`net/`. Search direct imports, fully qualified paths, grouped imports, aliases,
+re-exports, and indirect module edges. Separate genuine test-only references.
+A confirmed production edge is critical even when it currently appears harmless.
+
+### ARCH-002 — presentation ownership leaked into simulation
+
+Candidate signal: screen/pixel coordinates, sprites, textures, GPU/UI types,
+audio handles, or render-only animation state stored under `sim/`.
+
+Confirm ownership and feedback direction. Hash-excluded presentation data is
+not automatically a determinism fault, but it may violate the headless/replay
+boundary or let presentation state feed authoritative logic.
+
+## Coordinates and provenance
+
+### COORD-001 — frame, unit, sign, and rounding boundary
+
+For cell/lepton/screen, foundation-anchor, facing-byte, height, and isometric
+conversions, require named source and destination frames/units plus exact
+shift/divide/round/clamp/sign semantics. Walk one concrete boundary fixture.
+Literal `256` or bit shifts are candidates, not proof of a bug.
+
+### PROV-001 — gamemd-derived behavior provenance
+
+When simulation semantics are derived in any way from gamemd, verify the nearby
+canonical provenance comment naming the mechanism, native class/function, and
+exact verified address. Absence is a finding only after establishing derivation;
+pure Rust architecture glue does not need invented provenance.
+
+## Validation direction
+
+Match the proposed validation to the confirmed risk rather than adding a generic
+certification matrix:
+
+- arithmetic, parser, lifecycle, and command boundary tests for local contracts;
+- twin simulations comparing canonical state at every tick, including varied
+  insertion or worker order when ordering is at risk;
+- uninterrupted versus save/load/continue for snapshot coverage;
+- repeated replay through the live command path for command/RNG/order risks;
+- the first divergent tick plus canonical human-readable state dumps for diagnosis.
+
+Cross-toolchain, architecture, optimization, or worker-count runs are appropriate
+only when the finding crosses those boundaries. Rust-vs-Rust agreement is a
+regression check; it does not verify parity with `gamemd.exe`.

--- a/.claude/skills/rust-scan/scripts/collect_candidates.py
+++ b/.claude/skills/rust-scan/scripts/collect_candidates.py
@@ -1,0 +1,877 @@
+#!/usr/bin/env python3
+"""Collect lexical Rust review candidates without assigning verdicts.
+
+The collector is intentionally conservative: it discovers stable, sorted
+candidates and leaves type, call-path, authority, and severity decisions to the
+reviewing agent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+FOCUS_NAMES = (
+    "determinism",
+    "architecture",
+    "state",
+    "safety",
+    "performance",
+    "ownership",
+    "structure",
+)
+
+
+@dataclass(frozen=True)
+class Rule:
+    rule_id: str
+    category: str
+    focus: str
+    scope: str
+    pattern: str
+    description: str
+
+    @property
+    def regex(self) -> re.Pattern[str]:
+        return re.compile(self.pattern)
+
+
+RULES: tuple[Rule, ...] = (
+    Rule(
+        "DET-001",
+        "determinism",
+        "determinism",
+        "sim",
+        r"\b(?:f32|f64)\b|(?<![\w.])\d+\.\d+(?:[eE][+-]?\d+)?(?:f32|f64)?\b",
+        "Host floating-point type or conversion in simulation scope",
+    ),
+    Rule(
+        "DET-002",
+        "determinism",
+        "determinism",
+        "sim",
+        r"\b(?:HashMap|HashSet|DefaultHasher)\b",
+        "Unordered collection or unstable standard hash; verify observable use",
+    ),
+    Rule(
+        "DET-003",
+        "determinism",
+        "determinism",
+        "sim",
+        (
+            r"\b(?:thread_rng|OsRng|getrandom|from_entropy)\b"
+            r"|rand\s*::\s*(?:random|rng)\b"
+            r"|(?:SystemTime|Instant|Utc|Local)\s*::\s*now\b"
+            r"|std\s*::\s*(?:env|fs\s*::\s*read_dir)\b"
+        ),
+        "External entropy, clock, environment, or filesystem-order source",
+    ),
+    Rule(
+        "DET-004",
+        "determinism",
+        "determinism",
+        "sim",
+        (
+            r"\bas\s+(?:u8|u16|u32|u64|u128|usize"
+            r"|i8|i16|i32|i64|i128|isize)\b"
+        ),
+        "Integer cast requiring source-type and range verification",
+    ),
+    Rule(
+        "DET-005",
+        "determinism",
+        "determinism",
+        "sim",
+        (
+            r"#\s*\[\s*cfg(?:_attr)?\s*\([^\]]*"
+            r"\b(?:target_arch|target_os|target_env|target_pointer_width"
+            r"|target_endian|debug_assertions|feature)\b"
+            r"|\bcfg!\s*\([^\)]*\b(?:target_arch|target_os|target_env"
+            r"|target_pointer_width|target_endian|debug_assertions|feature)\b"
+        ),
+        "Production-relevant conditional behavior in simulation scope",
+    ),
+    Rule(
+        "DET-006",
+        "determinism",
+        "determinism",
+        "sim",
+        (
+            r"(?:std\s*::\s*)?thread\s*::\s*spawn\b"
+            r"|\b(?:rayon|par_iter|par_iter_mut|into_par_iter|par_bridge"
+            r"|find_any|reduce_with|tokio\s*::\s*spawn)\b"
+            r"|\b(?:AtomicBool|AtomicI(?:8|16|32|64|128|size)"
+            r"|AtomicU(?:8|16|32|64|128|size)|Ordering\s*::\s*Relaxed)\b"
+            r"|\b(?:MaybeUninit|assume_init(?:_read|_drop|_mut|_ref)?)\b"
+        ),
+        "Concurrency, atomic, or initialization primitive needing semantic review",
+    ),
+    Rule(
+        "DET-007",
+        "determinism",
+        "determinism",
+        "sim",
+        r"\bBinaryHeap\b|\.sort(?:_unstable)?(?:_by|_by_key)?\s*\(",
+        "Ordering operation requiring tie-break and downstream-order review",
+    ),
+    Rule(
+        "DET-008",
+        "determinism",
+        "state",
+        "sim",
+        r"\b(?:SimRng|main_rng|scenario_rng|mapgen_rng)\b",
+        "Simulation RNG ownership or draw-order touchpoint",
+    ),
+    Rule(
+        "STATE-001",
+        "state",
+        "state",
+        "sim",
+        r"#\s*\[\s*serde\s*\([^\]]*\bskip\b|SNAPSHOT_VERSION\b",
+        "Serialization/hash/snapshot coverage touchpoint",
+    ),
+    Rule(
+        "STATE-002",
+        "state",
+        "state",
+        "sim",
+        (
+            r"\b(?:LogicVector|logic_vector|pending_delete|unlimbo|limbo"
+            r"|reveal|conceal)\b"
+            r"|(?:entities|occupancy)\s*\.\s*(?:insert|remove)\s*\("
+        ),
+        "Lifecycle, scheduler, entity-store, or occupancy authority touchpoint",
+    ),
+    Rule(
+        "STATE-003",
+        "state",
+        "state",
+        "sim",
+        r"\b(?:advance_tick|advance_master_frame|commit_frame|flush_pending)\b",
+        "Tick-spine or phase-boundary touchpoint",
+    ),
+    Rule(
+        "ARCH-001",
+        "architecture",
+        "architecture",
+        "sim",
+        (
+            r"crate\s*::\s*(?:(?:render|ui|sidebar|audio|net)\b"
+            r"|\{[^\}]*\b(?:render|ui|sidebar|audio|net)\b)"
+            r"|(?:super\s*::\s*)+(?:render|ui|sidebar|audio|net)\b"
+            r"|(?:super\s*::\s*)+\{[^\}]*\b(?:render|ui|sidebar|audio|net)\b"
+        ),
+        "Reference to a layer forbidden beneath simulation",
+    ),
+    Rule(
+        "ARCH-002",
+        "architecture",
+        "architecture",
+        "sim",
+        (
+            r"\b(?:screen_[xy]|pixel_[xy]|shp_name|wgpu|egui|glam"
+            r"|Texture|Sprite|AudioSink)\b"
+        ),
+        "Presentation-oriented state or type under simulation",
+    ),
+    Rule(
+        "COORD-001",
+        "determinism",
+        "determinism",
+        "sim",
+        (
+            r"\b(?:lepton|facing_byte|screen_[xy]|pixel_[xy])\b"
+            r"|(?:<<|>>)\s*8\b|(?:\*|/)\s*256\b|\b256\s*(?:\*|/)"
+        ),
+        "Coordinate, unit, sign, shift, or rounding boundary",
+    ),
+    Rule(
+        "SAFE-001",
+        "safety",
+        "safety",
+        "all",
+        (
+            r"\bunsafe\s*(?:\{|fn\b|impl\b|trait\b|extern\b)"
+            r"|#\s*\[\s*unsafe\s*\("
+            r"|#\s*\[\s*(?:no_mangle|link_section|export_name)\b"
+            r"|\bextern\s+\{"
+            r"|\b(?:transmute|from_raw_parts|get_unchecked|set_len"
+            r"|assume_init(?:_read|_drop|_mut|_ref)?)\b"
+        ),
+        "Unsafe operation or contract requiring invariant verification",
+    ),
+    Rule(
+        "SAFE-002",
+        "safety",
+        "safety",
+        "all",
+        r"\b(?:panic|todo|unimplemented|unreachable)!\s*\(",
+        "Production panic or placeholder candidate",
+    ),
+    Rule(
+        "ERR-001",
+        "error-handling",
+        "safety",
+        "all",
+        r"\.(?:unwrap|expect)\s*\(",
+        "Fallible value requiring input-boundary verification",
+    ),
+    Rule(
+        "ERR-002",
+        "error-handling",
+        "safety",
+        "all",
+        r"\banyhow\s*::|use\s+anyhow\b",
+        "Anyhow use requiring application-versus-library boundary review",
+    ),
+    Rule(
+        "OWN-001",
+        "ownership",
+        "ownership",
+        "all",
+        r"&\s*(?:String|Vec\s*<)",
+        "Borrowed concrete container; verify whether a view type is sufficient",
+    ),
+    Rule(
+        "OWN-002",
+        "ownership",
+        "ownership",
+        "all",
+        r"^\s*(?:pub(?:\s*\([^\)]*\))?\s+)?[A-Za-z_]\w*\s*:\s*String\b",
+        "Owned string field; inspect identity, mutability, and clone frequency",
+    ),
+    Rule(
+        "OWN-003",
+        "ownership",
+        "state",
+        "sim",
+        r"\bRc\s*<\s*RefCell\b|\bRc\s*::\s*new\s*\(\s*RefCell\b",
+        "Shared interior mutability; inspect ownership and reentrancy",
+    ),
+    Rule(
+        "PERF-001",
+        "performance",
+        "performance",
+        "all",
+        (
+            r"\bVec\s*::\s*with_capacity\s*\(|\bvec!\s*\["
+            r"|\.collect\s*::\s*<\s*Vec\b|\.to_vec\s*\("
+            r"|\.to_(?:string|owned)\s*\(|\bString\s*::\s*from\s*\("
+            r"|\bformat!\s*\(|\bBox\s*::\s*new\s*\("
+        ),
+        "Possible allocation; prove hot-path reachability and multiplicity",
+    ),
+    Rule(
+        "PERF-002",
+        "performance",
+        "performance",
+        "all",
+        r"\.clone\s*\(",
+        "Clone candidate; resolve cloned type and call frequency",
+    ),
+    Rule(
+        "MODERN-001",
+        "structure",
+        "structure",
+        "all",
+        r"\b(?:lazy_static|once_cell)\b",
+        "Legacy lazy/once initialization dependency or macro",
+    ),
+)
+
+SPECIAL_RULE_DESCRIPTIONS = {
+    "STRUCT-001": "Module does not open with an inner doc comment",
+    "STRUCT-002": "File exceeds the cohesion review cue",
+}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    rule_id: str
+    category: str
+    path: str
+    line: int
+    text: str
+    hints: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "kind": "candidate",
+            "rule_id": self.rule_id,
+            "category": self.category,
+            "path": self.path,
+            "line": self.line,
+            "text": self.text,
+            "hints": list(self.hints),
+        }
+
+
+def run_checked(
+    args: Sequence[str], cwd: Path, *, allow_failure: bool = False
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if result.returncode != 0 and not allow_failure:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"{' '.join(args)} failed ({result.returncode}): {detail}")
+    return result
+
+
+def find_repo_root(start: Path) -> Path:
+    result = run_checked(("git", "rev-parse", "--show-toplevel"), start)
+    return Path(result.stdout.strip()).resolve()
+
+
+def is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def resolve_target(root: Path, raw_target: str) -> Path:
+    candidate = Path(raw_target)
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    candidate = candidate.resolve()
+    if not is_within(candidate, root):
+        raise ValueError(f"target escapes repository root: {raw_target}")
+    if not candidate.exists():
+        raise ValueError(f"target does not exist: {raw_target}")
+    if candidate.is_file() and candidate.suffix != ".rs":
+        raise ValueError(f"target file is not Rust: {raw_target}")
+    return candidate
+
+
+def rel_posix(path: Path, root: Path) -> str:
+    return path.resolve().relative_to(root).as_posix()
+
+
+def discover_rust_files(root: Path, target: Path) -> list[Path]:
+    if shutil.which("rg") is None:
+        raise RuntimeError("ripgrep (rg) is required for Rust file discovery")
+    if target.is_file():
+        return [target]
+
+    result = run_checked(
+        ("rg", "--files", "-g", "*.rs", str(target)),
+        root,
+        allow_failure=True,
+    )
+    if result.returncode == 1 and not result.stderr.strip():
+        return []
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"rg file discovery failed ({result.returncode}): {detail}")
+    paths: list[Path] = []
+    for raw in result.stdout.splitlines():
+        path = Path(raw)
+        if not path.is_absolute():
+            path = root / path
+        path = path.resolve()
+        if path.is_file() and path.suffix == ".rs" and is_within(path, target):
+            paths.append(path)
+    return sorted(set(paths), key=lambda item: rel_posix(item, root).casefold())
+
+
+def changed_rust_paths(root: Path, base: str) -> set[str]:
+    diff = run_checked(
+        ("git", "diff", "--name-only", "--diff-filter=ACMR", base, "--"),
+        root,
+    )
+    untracked = run_checked(
+        ("git", "ls-files", "--others", "--exclude-standard", "--", "*.rs"),
+        root,
+    )
+    changed: set[str] = set()
+    for raw in (*diff.stdout.splitlines(), *untracked.stdout.splitlines()):
+        normalized = raw.strip().replace("\\", "/")
+        if normalized.endswith(".rs"):
+            changed.add(normalized)
+    return changed
+
+
+def is_named_test_file(relative: str) -> bool:
+    path = Path(relative)
+    lowered = [part.casefold() for part in path.parts]
+    stem = path.stem.casefold()
+    return (
+        "tests" in lowered
+        or stem in {"test", "tests"}
+        or stem.endswith("_test")
+        or stem.endswith("_tests")
+    )
+
+
+def sanitize_lines(lines: Sequence[str]) -> list[str]:
+    """Remove ordinary comments and string bodies while retaining line shape."""
+
+    sanitized: list[str] = []
+    block_depth = 0
+    for line in lines:
+        output: list[str] = []
+        index = 0
+        in_string = False
+        escaped = False
+        while index < len(line):
+            char = line[index]
+            nxt = line[index + 1] if index + 1 < len(line) else ""
+
+            if block_depth:
+                if char == "/" and nxt == "*":
+                    block_depth += 1
+                    output.extend((" ", " "))
+                    index += 2
+                elif char == "*" and nxt == "/":
+                    block_depth -= 1
+                    output.extend((" ", " "))
+                    index += 2
+                else:
+                    output.append(" ")
+                    index += 1
+                continue
+
+            if in_string:
+                output.append(" ")
+                if escaped:
+                    escaped = False
+                elif char == "\\":
+                    escaped = True
+                elif char == '"':
+                    in_string = False
+                index += 1
+                continue
+
+            if char == "/" and nxt == "/":
+                output.extend(" " * (len(line) - index))
+                break
+            if char == "/" and nxt == "*":
+                block_depth = 1
+                output.extend((" ", " "))
+                index += 2
+                continue
+            if char == '"':
+                in_string = True
+                output.append(" ")
+                index += 1
+                continue
+
+            output.append(char)
+            index += 1
+        sanitized.append("".join(output))
+    return sanitized
+
+
+TEST_ATTRIBUTE_RE = re.compile(r"#\s*\[\s*(?:cfg\s*\(\s*test\s*\)|test)\s*\]")
+
+
+def probable_test_flags(
+    relative: str, raw_lines: Sequence[str], code_lines: Sequence[str]
+) -> list[bool]:
+    if is_named_test_file(relative):
+        return [True] * len(raw_lines)
+
+    flags = [False] * len(raw_lines)
+    depth = 0
+    test_scope_bases: list[int] = []
+    pending_test_item = False
+
+    for index, code in enumerate(code_lines):
+        active_before = bool(test_scope_bases)
+        if TEST_ATTRIBUTE_RE.search(code):
+            pending_test_item = True
+            flags[index] = True
+
+        if active_before or pending_test_item:
+            flags[index] = True
+
+        opens = code.count("{")
+        closes = code.count("}")
+        if pending_test_item and opens:
+            test_scope_bases.append(depth)
+            pending_test_item = False
+        elif pending_test_item and ";" in code:
+            pending_test_item = False
+
+        depth += opens - closes
+        while test_scope_bases and depth <= test_scope_bases[-1]:
+            test_scope_bases.pop()
+
+    return flags
+
+
+def rule_applies(rule: Rule, relative: str, profile: str) -> bool:
+    if rule.scope == "all":
+        return True
+    if profile == "sim":
+        return True
+    if profile == "general":
+        return False
+    return relative.startswith("src/sim/")
+
+
+def collect_regex_candidates(
+    root: Path,
+    files: Iterable[Path],
+    rules: Sequence[Rule],
+    profile: str,
+) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    compiled = [(rule, rule.regex) for rule in rules]
+
+    for path in files:
+        relative = rel_posix(path, root)
+        raw_lines = path.read_text(encoding="utf-8-sig", errors="replace").splitlines()
+        code_lines = sanitize_lines(raw_lines)
+        test_flags = probable_test_flags(relative, raw_lines, code_lines)
+        multiline_rules = [
+            (rule, regex)
+            for rule, regex in compiled
+            if rule.rule_id == "ARCH-001"
+            and rule_applies(rule, relative, profile)
+        ]
+        line_rules = [
+            (rule, regex)
+            for rule, regex in compiled
+            if rule.rule_id != "ARCH-001"
+        ]
+
+        for line_number, (raw, code) in enumerate(
+            zip(raw_lines, code_lines), start=1
+        ):
+            if not code.strip():
+                continue
+            for rule, regex in line_rules:
+                if not rule_applies(rule, relative, profile):
+                    continue
+                if regex.search(code):
+                    hints: list[str] = []
+                    if test_flags[line_number - 1]:
+                        hints.append("probable-test-context")
+                    candidates.append(
+                        Candidate(
+                            rule.rule_id,
+                            rule.category,
+                            relative,
+                            line_number,
+                            raw.strip()[:500],
+                            tuple(hints),
+                        )
+                    )
+
+        joined_code = "\n".join(code_lines)
+        for rule, regex in multiline_rules:
+            for match in regex.finditer(joined_code):
+                start_line = joined_code.count("\n", 0, match.start()) + 1
+                end_line = joined_code.count("\n", 0, match.end()) + 1
+                hints: list[str] = []
+                if any(test_flags[start_line - 1 : end_line]):
+                    hints.append("probable-test-context")
+                excerpt = " ".join(
+                    line.strip()
+                    for line in raw_lines[start_line - 1 : end_line]
+                    if line.strip()
+                )
+                candidates.append(
+                    Candidate(
+                        rule.rule_id,
+                        rule.category,
+                        relative,
+                        start_line,
+                        excerpt[:500],
+                        tuple(hints),
+                    )
+                )
+
+    return candidates
+
+
+def collect_structure_candidates(
+    root: Path, files: Iterable[Path]
+) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    for path in files:
+        relative = rel_posix(path, root)
+        lines = path.read_text(encoding="utf-8-sig", errors="replace").splitlines()
+        code_lines = sanitize_lines(lines)
+        test_flags = probable_test_flags(relative, lines, code_lines)
+        first_line = 1
+        first_text = ""
+        for index, line in enumerate(lines, start=1):
+            if line.strip():
+                first_line = index
+                first_text = line.strip()
+                break
+        if first_text and not first_text.startswith("//!"):
+            candidates.append(
+                Candidate(
+                    "STRUCT-001",
+                    "structure",
+                    relative,
+                    first_line,
+                    first_text[:500],
+                    ("verify-generated-or-special-module",),
+                )
+            )
+        production_scope_lines = sum(
+            1 for is_probable_test in test_flags if not is_probable_test
+        )
+        if production_scope_lines > 600:
+            candidates.append(
+                Candidate(
+                    "STRUCT-002",
+                    "structure",
+                    relative,
+                    1,
+                    (
+                        f"{production_scope_lines} probable production-scope lines "
+                        f"({len(lines)} total); review growth and cohesion, not size alone"
+                    ),
+                    (
+                        "size-is-review-cue",
+                        "inline-test-scope-detection-is-approximate",
+                    ),
+                )
+            )
+    return candidates
+
+
+def deduplicate_and_sort(candidates: Iterable[Candidate]) -> list[Candidate]:
+    unique = {
+        (item.rule_id, item.path, item.line, item.text, item.hints): item
+        for item in candidates
+    }
+    return sorted(
+        unique.values(),
+        key=lambda item: (
+            item.path.casefold(),
+            item.line,
+            item.rule_id,
+            item.text,
+        ),
+    )
+
+
+def filter_test_candidates(
+    candidates: Iterable[Candidate], include_tests: bool
+) -> list[Candidate]:
+    if include_tests:
+        return list(candidates)
+    return [
+        item
+        for item in candidates
+        if "probable-test-context" not in item.hints
+    ]
+
+
+def repo_snapshot(root: Path) -> tuple[str, bool]:
+    head = run_checked(("git", "rev-parse", "--short=12", "HEAD"), root)
+    status = run_checked(("git", "status", "--porcelain"), root)
+    return head.stdout.strip(), bool(status.stdout.strip())
+
+
+def selected_rules(
+    focuses: Sequence[str], requested_ids: Sequence[str]
+) -> tuple[Rule, ...]:
+    requested = set(requested_ids)
+    if requested:
+        known = {rule.rule_id for rule in RULES} | set(SPECIAL_RULE_DESCRIPTIONS)
+        unknown = sorted(requested - known)
+        if unknown:
+            raise ValueError(f"unknown rule id(s): {', '.join(unknown)}")
+        return tuple(rule for rule in RULES if rule.rule_id in requested)
+    focus_set = set(focuses)
+    return tuple(rule for rule in RULES if rule.focus in focus_set)
+
+
+def make_summary(
+    *,
+    root: Path,
+    target: Path,
+    head: str,
+    dirty: bool,
+    profile: str,
+    focuses: Sequence[str],
+    changed_only: bool,
+    base: str,
+    include_tests: bool,
+    files: Sequence[Path],
+    selected_rule_ids: Sequence[str],
+    candidates: Sequence[Candidate],
+) -> dict[str, object]:
+    by_rule: dict[str, list[Candidate]] = {}
+    for candidate in candidates:
+        by_rule.setdefault(candidate.rule_id, []).append(candidate)
+
+    rule_rows: list[dict[str, object]] = []
+    descriptions = {rule.rule_id: rule.description for rule in RULES}
+    descriptions.update(SPECIAL_RULE_DESCRIPTIONS)
+
+    for rule_id in sorted(set(selected_rule_ids)):
+        matches = by_rule.get(rule_id, [])
+        rule_rows.append(
+            {
+                "rule_id": rule_id,
+                "description": descriptions.get(rule_id, ""),
+                "candidate_count": len(matches),
+                "examples": [
+                    {
+                        "path": item.path,
+                        "line": item.line,
+                        "hints": list(item.hints),
+                    }
+                    for item in matches[:3]
+                ],
+            }
+        )
+
+    target_display = (
+        "." if target == root else target.resolve().relative_to(root).as_posix()
+    )
+    return {
+        "kind": "summary",
+        "repository": str(root),
+        "head": head,
+        "dirty": dirty,
+        "target": target_display,
+        "profile": profile,
+        "focus": list(focuses),
+        "changed_only": changed_only,
+        "base": base if changed_only else None,
+        "include_tests": include_tests,
+        "files_scanned": len(files),
+        "candidate_total": len(candidates),
+        "rules": rule_rows,
+        "note": (
+            "Counts are lexical candidates, not findings. "
+            "Inline test-context detection is intentionally approximate."
+        ),
+    }
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Collect sorted lexical candidates for the VERA20k rust-scan skill."
+    )
+    parser.add_argument("--target", default="src/sim")
+    parser.add_argument(
+        "--profile", choices=("auto", "sim", "general"), default="auto"
+    )
+    parser.add_argument("--focus", action="append", choices=FOCUS_NAMES)
+    parser.add_argument("--rule", action="append", default=[])
+    parser.add_argument("--changed", action="store_true")
+    parser.add_argument("--base", default="main")
+    parser.add_argument("--include-tests", action="store_true")
+    parser.add_argument("--format", choices=("summary", "jsonl"), default="summary")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    try:
+        root = find_repo_root(Path.cwd())
+        target = resolve_target(root, args.target)
+        files = discover_rust_files(root, target)
+        if args.changed:
+            changed = changed_rust_paths(root, args.base)
+            files = [path for path in files if rel_posix(path, root) in changed]
+        if not args.include_tests:
+            files = [
+                path
+                for path in files
+                if not is_named_test_file(rel_posix(path, root))
+            ]
+
+        if args.focus:
+            focuses = tuple(dict.fromkeys(args.focus))
+        elif is_within(target, root / "src" / "sim") or any(
+            rel_posix(path, root).startswith("src/sim/") for path in files
+        ):
+            focuses = (
+                "determinism",
+                "architecture",
+                "state",
+                "safety",
+                "performance",
+            )
+        else:
+            focuses = ("safety", "structure")
+
+        rules = selected_rules(focuses, args.rule)
+        candidates = collect_regex_candidates(root, files, rules, args.profile)
+        candidates = filter_test_candidates(candidates, args.include_tests)
+        requested_special = set(args.rule) & set(SPECIAL_RULE_DESCRIPTIONS)
+        if requested_special:
+            candidates.extend(
+                item
+                for item in collect_structure_candidates(root, files)
+                if item.rule_id in requested_special
+            )
+        elif "structure" in focuses and not args.rule:
+            candidates.extend(collect_structure_candidates(root, files))
+        candidates = deduplicate_and_sort(candidates)
+        selected_rule_ids = [rule.rule_id for rule in rules]
+        if requested_special:
+            selected_rule_ids.extend(sorted(requested_special))
+        elif "structure" in focuses and not args.rule:
+            selected_rule_ids.extend(sorted(SPECIAL_RULE_DESCRIPTIONS))
+        head, dirty = repo_snapshot(root)
+        summary = make_summary(
+            root=root,
+            target=target,
+            head=head,
+            dirty=dirty,
+            profile=args.profile,
+            focuses=focuses,
+            changed_only=args.changed,
+            base=args.base,
+            include_tests=args.include_tests,
+            files=files,
+            selected_rule_ids=selected_rule_ids,
+            candidates=candidates,
+        )
+
+        if args.format == "summary":
+            print(json.dumps(summary, indent=2, ensure_ascii=False))
+        else:
+            print(
+                json.dumps(
+                    {
+                        "kind": "metadata",
+                        "repository": str(root),
+                        "head": head,
+                        "dirty": dirty,
+                        "files_scanned": len(files),
+                        "focus": list(focuses),
+                    },
+                    ensure_ascii=False,
+                )
+            )
+            for candidate in candidates:
+                print(json.dumps(candidate.as_dict(), ensure_ascii=False))
+            print(json.dumps(summary, ensure_ascii=False))
+        return 0
+    except (OSError, RuntimeError, ValueError) as error:
+        print(f"rust-scan candidate collection failed: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/rust-scan/scripts/run_clippy.ps1
+++ b/.claude/skills/rust-scan/scripts/run_clippy.ps1
@@ -1,0 +1,77 @@
+[CmdletBinding()]
+param(
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+$activeBuilds = @(
+    Get-Process cargo, rustc -ErrorAction SilentlyContinue |
+        Select-Object -Property Id, ProcessName, StartTime
+)
+
+if ($activeBuilds.Count -gt 0) {
+    Write-Error (
+        'Cargo or rustc is already active; rust-scan will not compete with another build. ' +
+        ($activeBuilds | Format-Table -AutoSize | Out-String).Trim()
+    )
+    exit 3
+}
+
+$repoRoot = (& git rev-parse --show-toplevel 2>$null).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($repoRoot)) {
+    Write-Error 'run_clippy.ps1 must run from inside the VERA20k repository.'
+    exit 2
+}
+
+$manifestPath = Join-Path -Path $repoRoot -ChildPath 'Cargo.toml'
+if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    Write-Error "Cargo.toml was not found at repository root: $repoRoot"
+    exit 2
+}
+
+$cargoArgs = @(
+    'clippy'
+    '-p'
+    'vera20k'
+    '--lib'
+    '--no-deps'
+    '--locked'
+    '--message-format=short'
+    '--'
+    '-A'
+    'clippy::all'
+    '-W'
+    'clippy::correctness'
+    '-W'
+    'clippy::suspicious'
+    '-W'
+    'clippy::perf'
+    '-W'
+    'clippy::undocumented_unsafe_blocks'
+    '-W'
+    'clippy::missing_safety_doc'
+    '-W'
+    'unsafe_op_in_unsafe_fn'
+)
+
+Write-Output ('cargo ' + ($cargoArgs -join ' '))
+if ($DryRun) {
+    exit 0
+}
+
+Push-Location -LiteralPath $repoRoot
+try {
+    & cargo @cargoArgs 2>&1
+    $cargoExitCode = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+
+if ($null -eq $cargoExitCode) {
+    Write-Error 'Cargo did not return an exit code.'
+    exit 2
+}
+
+exit $cargoExitCode

--- a/.claude/skills/rust-scan/scripts/tests/test_collect_candidates.py
+++ b/.claude/skills/rust-scan/scripts/tests/test_collect_candidates.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "collect_candidates.py"
+SPEC = importlib.util.spec_from_file_location("rust_scan_collect_candidates", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+COLLECTOR = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = COLLECTOR
+SPEC.loader.exec_module(COLLECTOR)
+
+
+class CandidateCollectorTests(unittest.TestCase):
+    def test_sanitizer_ignores_comments_and_string_bodies(self) -> None:
+        lines = [
+            "// HashMap f64",
+            'let label = "HashSet f32";',
+            "let live: f64 = 1.0;",
+            "/* unsafe { */ let index = value as usize;",
+        ]
+        sanitized = COLLECTOR.sanitize_lines(lines)
+        self.assertNotIn("HashMap", sanitized[0])
+        self.assertNotIn("HashSet", sanitized[1])
+        self.assertIn("f64", sanitized[2])
+        self.assertNotIn("unsafe", sanitized[3])
+        self.assertIn("as usize", sanitized[3])
+
+    def test_inline_test_scope_is_tagged(self) -> None:
+        lines = [
+            "fn production() {}",
+            "#[cfg(test)]",
+            "mod tests {",
+            "    fn helper() {",
+            "        let value: f64 = 1.0;",
+            "    }",
+            "}",
+            "fn production_again() {}",
+        ]
+        sanitized = COLLECTOR.sanitize_lines(lines)
+        flags = COLLECTOR.probable_test_flags(
+            "src/sim/example.rs", lines, sanitized
+        )
+        self.assertFalse(flags[0])
+        self.assertTrue(all(flags[1:7]))
+        self.assertFalse(flags[7])
+
+    def test_grouped_architecture_path_and_cast_are_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            source = root / "src" / "sim" / "example.rs"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "\n".join(
+                    (
+                        "//! Example.",
+                        "use crate::{",
+                        "    map::Map,",
+                        "    render::Thing,",
+                        "};",
+                        "fn index(value: i32) -> usize { value as usize }",
+                        "fn bucket(value: u32) -> u8 { (value as u8) % 10 }",
+                        "#[cfg(test)]",
+                        "mod tests {",
+                        "    fn oracle() { let _: f64 = 1.0; }",
+                        "}",
+                    )
+                ),
+                encoding="utf-8",
+            )
+            rules = tuple(
+                rule
+                for rule in COLLECTOR.RULES
+                if rule.rule_id in {"ARCH-001", "DET-001", "DET-004"}
+            )
+            candidates = COLLECTOR.collect_regex_candidates(
+                root, [source], rules, "auto"
+            )
+            by_rule = {}
+            for candidate in candidates:
+                by_rule.setdefault(candidate.rule_id, []).append(candidate)
+
+            self.assertEqual(by_rule["ARCH-001"][0].line, 2)
+            self.assertEqual(
+                [item.line for item in by_rule["DET-004"]],
+                [6, 7],
+            )
+            self.assertIn(
+                "probable-test-context",
+                by_rule["DET-001"][0].hints,
+            )
+            self.assertNotIn("severity", by_rule["DET-004"][0].as_dict())
+
+    def test_cfg_rule_ignores_plain_test_gate_but_finds_feature_gate(self) -> None:
+        rule = next(rule for rule in COLLECTOR.RULES if rule.rule_id == "DET-005")
+        self.assertIsNone(rule.regex.search("#[cfg(test)]"))
+        self.assertIsNotNone(rule.regex.search('#[cfg(feature = "parallel")]'))
+        self.assertIsNotNone(
+            rule.regex.search('#[cfg(target_pointer_width = "32")]')
+        )
+
+    def test_parallel_hash_and_unsafe_signals_are_candidates(self) -> None:
+        rules = {rule.rule_id: rule for rule in COLLECTOR.RULES}
+        self.assertIsNotNone(
+            rules["DET-002"].regex.search("DefaultHasher::new()")
+        )
+        self.assertIsNotNone(
+            rules["DET-006"].regex.search("values.par_bridge().find_any(predicate)")
+        )
+        self.assertIsNotNone(
+            rules["DET-006"].regex.search("values.into_par_iter().reduce_with(merge)")
+        )
+        self.assertIsNotNone(
+            rules["SAFE-001"].regex.search("unsafe { values.set_len(count); }")
+        )
+
+    def test_api_ownership_rules_are_opt_in(self) -> None:
+        default_rules = COLLECTOR.selected_rules(
+            (
+                "determinism",
+                "architecture",
+                "state",
+                "safety",
+                "performance",
+            ),
+            (),
+        )
+        default_ids = {rule.rule_id for rule in default_rules}
+        self.assertNotIn("OWN-001", default_ids)
+        self.assertNotIn("OWN-002", default_ids)
+        self.assertIn("OWN-003", default_ids)
+
+        ownership_rules = COLLECTOR.selected_rules(("ownership",), ())
+        self.assertEqual(
+            {rule.rule_id for rule in ownership_rules},
+            {"OWN-001", "OWN-002"},
+        )
+
+    def test_float_literal_and_bare_extern_block_are_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            source = root / "src" / "sim" / "ffi_math.rs"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "//! Example.\n"
+                "fn ratio() { let value = 1.25; }\n"
+                'extern "C" { fn native(); }\n',
+                encoding="utf-8",
+            )
+            rules = tuple(
+                rule
+                for rule in COLLECTOR.RULES
+                if rule.rule_id in {"DET-001", "SAFE-001"}
+            )
+            candidates = COLLECTOR.collect_regex_candidates(
+                root, [source], rules, "auto"
+            )
+            self.assertEqual(
+                {(candidate.rule_id, candidate.line) for candidate in candidates},
+                {("DET-001", 2), ("SAFE-001", 3)},
+            )
+
+    def test_candidate_order_is_stable_and_deduplicated(self) -> None:
+        candidate_a = COLLECTOR.Candidate(
+            "DET-004", "determinism", "src/sim/z.rs", 9, "x as u8", ()
+        )
+        candidate_b = COLLECTOR.Candidate(
+            "ARCH-001",
+            "architecture",
+            "src/sim/a.rs",
+            2,
+            "crate::render::Thing",
+            (),
+        )
+        ordered = COLLECTOR.deduplicate_and_sort(
+            [candidate_a, candidate_b, candidate_a]
+        )
+        self.assertEqual([item.path for item in ordered], ["src/sim/a.rs", "src/sim/z.rs"])
+
+    def test_crlf_input_keeps_posix_path_and_line_number(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            source = root / "src" / "sim" / "nested" / "crlf.rs"
+            source.parent.mkdir(parents=True)
+            source.write_bytes(b"//! Example.\r\nfn value() -> f64 { 1.0 }\r\n")
+            rule = next(rule for rule in COLLECTOR.RULES if rule.rule_id == "DET-001")
+            candidates = COLLECTOR.collect_regex_candidates(
+                root, [source], (rule,), "auto"
+            )
+            self.assertEqual(len(candidates), 1)
+            self.assertEqual(candidates[0].path, "src/sim/nested/crlf.rs")
+            self.assertEqual(candidates[0].line, 2)
+
+    def test_named_test_files_are_detected(self) -> None:
+        self.assertTrue(COLLECTOR.is_named_test_file("src/sim/world/world_tests.rs"))
+        self.assertTrue(COLLECTOR.is_named_test_file("tests/replay.rs"))
+        self.assertFalse(COLLECTOR.is_named_test_file("src/sim/world/mod.rs"))
+
+    def test_probable_inline_test_candidates_are_opt_in(self) -> None:
+        production = COLLECTOR.Candidate(
+            "DET-004", "determinism", "src/sim/a.rs", 1, "x as u8", ()
+        )
+        test_only = COLLECTOR.Candidate(
+            "DET-004",
+            "determinism",
+            "src/sim/a.rs",
+            9,
+            "x as u8",
+            ("probable-test-context",),
+        )
+        self.assertEqual(
+            COLLECTOR.filter_test_candidates([production, test_only], False),
+            [production],
+        )
+        self.assertEqual(
+            COLLECTOR.filter_test_candidates([production, test_only], True),
+            [production, test_only],
+        )
+
+    def test_file_size_cue_excludes_probable_inline_test_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            source = root / "src" / "sim" / "mostly_inline.rs"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "\n".join(
+                    [
+                        "//! Example.",
+                        "fn production() {}",
+                        "#[cfg(test)]",
+                        "mod tests {",
+                        *(f"fn case_{index}() {{}}" for index in range(700)),
+                        "}",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            candidates = COLLECTOR.collect_structure_candidates(root, [source])
+            self.assertNotIn(
+                "STRUCT-002",
+                {candidate.rule_id for candidate in candidates},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -1,14 +1,167 @@
 ---
 name: sync
 description: >
-  Audit and safely synchronize this repository's protected main and short-lived
-  feature branches. Use for drift, fast-forward pulls, branch or worktree
-  cleanup, and out-of-date questions. Never rewrite history or remove
-  unprotected local-only data.
+  Audit and safely synchronize this repository's GitHub Flow branches:
+  protected main plus short-lived feature/* branches. Use for branch drift,
+  safe fast-forward pulls, branch or worktree cleanup, or questions about what
+  is out of date. Never force-pushes, rewrites history, deletes unmerged work,
+  or removes unprotected local-only data.
 ---
 
-# Sync
+# Sync — GitHub Flow Branch Audit
 
-Read and follow `../../../.agents/skills/sync/SKILL.md` completely. It is the
-canonical GitHub Flow workflow and owns the cleanup guard used by both agent
-frontends. Do not substitute this older frontend's former `dev`-branch flow.
+Audit branch state first, then perform only explicitly authorized safe actions.
+The standard lifecycle is `main` → `feature/<topic>` → PR → `main` → cleanup.
+There is no long-lived `dev` branch.
+
+## Safety rules
+
+- Require a clean working tree before switching branches or updating refs.
+- Fetch with pruning before drawing conclusions.
+- Use fast-forward-only pulls and merges. Never rebase, reset, amend, or force-push.
+- Never commit or push directly to `main`; it moves through reviewed PRs or an
+  explicit user-owned GitHub action.
+- Never push an unpublished/local-ahead feature branch without user authorization.
+- Branch deletion requires explicit user confirmation after the audit identifies
+  the exact local/remote refs and proves where their unique commits remain.
+- Use `git branch -d`, never `-D`. If safe deletion refuses, stop and explain why.
+- Do not switch or delete a branch checked out by another worktree or active task.
+- Before removing a worktree or cleaning ignored files, run
+  `powershell -NoProfile -File .claude/skills/sync/scripts/check_worktree_cleanup.ps1 -Worktree <absolute-path>`
+  from the primary checkout. Treat an external junction/symlink as a hard stop,
+  and classify every ignored path as backed up, uniquely valuable, or
+  regenerable before proceeding.
+- Never run root-wide `git clean -fdX`. Ignored project contracts, skills,
+  research, INIs, and tool source are authoritative local data, not build litter.
+
+## 1. Preflight and fetch
+
+For a normal sync run, use:
+
+```text
+git status --porcelain
+git worktree list --porcelain
+git fetch --all --prune
+```
+
+If the user explicitly requests a read-only/no-ref-mutation audit, do not fetch or
+prune. Use `git ls-remote --heads origin` for live remote tips, label local
+remote-tracking refs as cached, and make no changes.
+
+If the tree is dirty, another task owns the checkout, or Cargo/worktree ownership is
+unclear, stop before mutation and report the conflict.
+
+### Local-only backup preflight
+
+Before an authorized action could remove a checkout or local-only data, refresh
+the adjacent private local backup using the machine-local command recorded in
+`LOCAL.md` (section "Local-only backup").
+
+Require a successful backup commit before continuing. If the backup script is
+missing, refuses because source files disappeared, or reports unapproved
+deletions, stop. Do not bypass it by copying a few visible files or by passing
+the deletion override without separately reviewing the exact stale paths.
+
+## 2. Audit
+
+Collect:
+
+```text
+git branch --format='%(refname:short)|%(upstream:short)|%(upstream:track)|%(objectname:short)'
+git rev-list --left-right --count <branch>...main
+git ls-remote --heads origin
+```
+
+For `main` and every relevant feature branch report:
+
+- local tip and upstream tip;
+- ahead/behind relative to upstream;
+- commits unique to the branch versus `main`;
+- whether it is checked out in any worktree;
+- whether it is unpublished, active, merged, or a cleanup candidate.
+
+Treat a legacy `dev` ref like any other obsolete branch. Never recreate or
+fast-forward it. It is deletable only when it has zero unique commits versus `main`
+and the user explicitly confirms local/remote deletion.
+
+Present the audit before changing refs. A compact example:
+
+```text
+main                    [origin/main] sync
+feature/current-task    (local only)  4 unique commits — keep
+feature/merged-task     [origin/...]  0 unique commits — delete candidate
+```
+
+## 3. Classify actions
+
+- **NO ACTION** — synchronized or legitimate unique work.
+- **PULL MAIN** — local `main` is behind `origin/main` and can fast-forward.
+- **PULL FEATURE** — a clean feature branch is behind its upstream and can fast-forward.
+- **PUBLISH CANDIDATE** — local branch has unpushed commits; report only unless the
+  user asked to push or open/update a PR.
+- **DELETE CANDIDATE** — branch has zero unique commits versus `main`, or the user
+  explicitly wants a remote-only deletion while retaining a proven local copy.
+- **ANOMALY** — divergence, missing commits, unclear ownership, dirty state, or a
+  protected-branch mismatch. Stop and request direction.
+
+## 4. Execute safe catch-up
+
+For an authorized pull:
+
+```text
+git switch main
+git pull --ff-only origin main
+```
+
+or:
+
+```text
+git switch feature/<topic>
+git pull --ff-only
+```
+
+If `--ff-only` refuses, stop. Do not substitute a merge commit or rebase.
+
+## 5. Clean up confirmed branches
+
+After rechecking unique commits and worktree ownership:
+
+```text
+git branch -d feature/<topic>
+git push origin --delete feature/<topic>
+git fetch origin --prune
+```
+
+For a confirmed remote-only deletion that keeps the local branch:
+
+```text
+git push origin --delete feature/<topic>
+git branch --unset-upstream feature/<topic>
+```
+
+If stale upstream metadata makes `git branch -d` refuse even though the branch is
+merged into the current protected history, remove only that upstream association and
+retry `-d`; never escalate to `-D`.
+
+For worktree removal, first run the local-only backup preflight and the bundled
+cleanup check. `git worktree remove --force` is forbidden while the check reports
+external reparse points, dirty files, or unclassified ignored content.
+
+## 6. Verify and report
+
+Verify exact local/remote tips, absence of deleted refs, a clean working tree, and no
+unexpected branch switch. Report kept, updated, deleted, skipped, and unpublished
+branches in one screen. Zero mutations is a valid result when nothing is safely
+actionable.
+
+## Never do
+
+- `git push --force` or `--force-with-lease`
+- `git rebase`, `git reset --hard`, or `git commit --amend`
+- `git branch -D`
+- direct commits or pushes to `main`
+- automatic publication of local feature work
+- deletion of an unmerged or worktree-owned branch
+- root-wide ignored-file cleanup
+- forced removal of a worktree containing external junctions or symlinks
+- recreation of a long-lived `dev` branch

--- a/.claude/skills/sync/scripts/check_worktree_cleanup.ps1
+++ b/.claude/skills/sync/scripts/check_worktree_cleanup.ps1
@@ -1,0 +1,85 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Worktree
+)
+
+$ErrorActionPreference = "Stop"
+
+function ConvertTo-NormalizedPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    return [System.IO.Path]::GetFullPath($Path).TrimEnd([char]92, [char]47)
+}
+
+$resolvedWorktree = (Resolve-Path -LiteralPath $Worktree).Path
+$worktreeRoot = ConvertTo-NormalizedPath $resolvedWorktree
+if (-not (Get-Item -LiteralPath $worktreeRoot).PSIsContainer) {
+    throw "Worktree path is not a directory: $worktreeRoot"
+}
+
+$gitRootOutput = & git -C $worktreeRoot rev-parse --show-toplevel 2>$null
+if ($LASTEXITCODE -ne 0) {
+    throw "Not a Git worktree: $worktreeRoot"
+}
+$gitRoot = ConvertTo-NormalizedPath ($gitRootOutput | Select-Object -First 1)
+if (-not $gitRoot.Equals($worktreeRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "Pass the worktree root, not a subdirectory: $gitRoot"
+}
+
+$externalLinks = @()
+$reparsePoints = @(Get-ChildItem -LiteralPath $worktreeRoot -Force -Recurse `
+    -Attributes ReparsePoint -ErrorAction Stop)
+foreach ($link in $reparsePoints) {
+    $targets = @($link.Target)
+    if ($targets.Count -eq 0 -or [string]::IsNullOrWhiteSpace([string]$targets[0])) {
+        $externalLinks += $link.FullName
+        Write-Output "reparse=$($link.FullName)|target=UNKNOWN|inside_worktree=False"
+        continue
+    }
+
+    foreach ($target in $targets) {
+        $targetPath = if ([System.IO.Path]::IsPathRooted($target)) {
+            ConvertTo-NormalizedPath $target
+        } else {
+            ConvertTo-NormalizedPath (Join-Path $link.DirectoryName $target)
+        }
+        $insideWorktree = $targetPath.Equals(
+            $worktreeRoot,
+            [System.StringComparison]::OrdinalIgnoreCase
+        ) -or $targetPath.StartsWith(
+            "$worktreeRoot\",
+            [System.StringComparison]::OrdinalIgnoreCase
+        )
+        Write-Output "reparse=$($link.FullName)|target=$targetPath|inside_worktree=$insideWorktree"
+        if (-not $insideWorktree) {
+            $externalLinks += $link.FullName
+        }
+    }
+}
+
+if ($externalLinks.Count -gt 0) {
+    throw "Unsafe external reparse point(s): $($externalLinks -join ', ')"
+}
+
+$dirty = @(& git -C $worktreeRoot status --porcelain=v1 --untracked-files=all)
+if ($LASTEXITCODE -ne 0) {
+    throw "Unable to inspect worktree status: $worktreeRoot"
+}
+if ($dirty.Count -gt 0) {
+    $preview = ($dirty | Select-Object -First 20) -join [Environment]::NewLine
+    throw "Worktree has tracked or untracked changes:`n$preview"
+}
+
+$ignored = @(& git -C $worktreeRoot clean -ndX)
+if ($LASTEXITCODE -ne 0) {
+    throw "Unable to preview ignored-file cleanup: $worktreeRoot"
+}
+
+Write-Output "worktree=$worktreeRoot"
+Write-Output "external_reparse_points=0"
+Write-Output "ignored_cleanup_candidates=$($ignored.Count)"
+$ignored | Select-Object -First 50
+if ($ignored.Count -gt 50) {
+    Write-Output "ignored_cleanup_candidates_omitted=$($ignored.Count - 50)"
+}


### PR DESCRIPTION
Replace the sync/rust-scan/architecture-scan pointer stubs with full adapted copies (slash invocation notation, own references/ and scripts/), so neither skill tree reaches into the other. The sync backup preflight now cites the machine-local command in gitignored LOCAL.md instead of embedding the private backup path.