### PR TITLE
Sweep residuals: preview projection delegation, tooling bucket derivation, sub-cell cross-links

### DIFF
--- a/src/bin/measure-atlas.rs
+++ b/src/bin/measure-atlas.rs
@@ -22,10 +22,10 @@
 const VXL_TYPES_PER_PLAYER: usize = 30;
 
 /// Body/composite facing buckets (matches `unit_atlas::UNIT_FACING_BUCKETS`).
-const BODY_FACING_BUCKETS: usize = 32;
+const BODY_FACING_BUCKETS: usize = vera20k::render::vxl_raster::VOXEL_FACING_STEPS as usize;
 
 /// Turret/barrel facing buckets (matches `unit_atlas::TURRET_FACING_BUCKETS`).
-const TURRET_FACING_BUCKETS: usize = 32;
+const TURRET_FACING_BUCKETS: usize = vera20k::render::vxl_raster::VOXEL_FACING_STEPS as usize;
 
 /// Slope variants pre-rendered for ground vehicles (slopes 0..=16, ramps
 /// + corner tilts). Aircraft never tilt and use slope_type=0 only.

--- a/src/map/rmg/preview.rs
+++ b/src/map/rmg/preview.rs
@@ -33,10 +33,6 @@ pub struct PreviewImage {
 /// Leptons per cell; a cell centre sits half a cell in on both axes.
 const LEPTONS_PER_CELL: i32 = crate::util::lepton::LEPTONS_PER_CELL_I32;
 const CELL_CENTRE_LEPTONS: i32 = crate::util::lepton::CELL_CENTER_LEPTON_I32;
-/// Projection scales — the isometric tile is 60x30, and the transform halves
-/// both before the fixed-point shift.
-const PROJECT_X_SCALE: i32 = 60;
-const PROJECT_Y_SCALE: i32 = 30;
 /// Constant added to the projected X after the shift, keeping the whole
 /// playfield in positive territory.
 const PROJECT_X_BIAS: i32 = 0x3C00;
@@ -54,28 +50,18 @@ const MARKER_ORIGIN_BIAS: i32 = -1;
 /// Only the first eight waypoints get a marker.
 pub const MARKER_WAYPOINT_COUNT: u8 = 8;
 
-/// Project a cell to the preview's pre-division coordinate space.
+/// Project a cell centre to the preview's coordinate space.
 ///
-/// The halving happens before the fixed-point shift, and the shift adds a
-/// sign-dependent bias so negatives truncate toward zero rather than flooring —
-/// dropping that bias shifts the whole west/north edge of the map by a pixel.
+/// Delegates to the canonical native projector (halved 60/30 terms, then a
+/// toward-zero /256 — `util::lepton::project_absolute_lepton_xy`); only the
+/// preview's X bias is local. Cell-centre inputs always divide exactly, so
+/// the i64 no-wrap canonical is bit-identical here.
 fn project_cell_centre(cell_x: i32, cell_y: i32) -> (i32, i32) {
     let lepton_x = cell_x * LEPTONS_PER_CELL + CELL_CENTRE_LEPTONS;
     let lepton_y = cell_y * LEPTONS_PER_CELL + CELL_CENTRE_LEPTONS;
-
-    let raw_x = (lepton_x * PROJECT_X_SCALE) / 2 + (lepton_y * -PROJECT_X_SCALE) / 2;
-    let raw_y = (lepton_x * PROJECT_Y_SCALE) / 2 + (lepton_y * PROJECT_Y_SCALE) / 2;
-
-    let projected_x = shift_with_sign_bias(raw_x) + PROJECT_X_BIAS;
-    let projected_y = shift_with_sign_bias(raw_y);
-    (projected_x, projected_y)
-}
-
-/// The fixed-point `>> 8` the projection uses, biased so negative values
-/// truncate toward zero — the same signed shift as lepton→cell, delegated so
-/// the bias formula exists once.
-const fn shift_with_sign_bias(value: i32) -> i32 {
-    crate::util::direction_tables::lepton_to_cell(value)
+    let (projected_x, projected_y) =
+        crate::util::lepton::project_absolute_lepton_xy(lepton_x, lepton_y);
+    (projected_x + PROJECT_X_BIAS, projected_y)
 }
 
 /// Preview-pixel column and row for a projected cell, before the surface origin
@@ -545,12 +531,12 @@ mod tests {
     }
 
     #[test]
-    fn the_shift_truncates_negatives_toward_zero() {
-        // Floor would give -2 for a value that truncation puts at -1.
-        assert_eq!(shift_with_sign_bias(-300), -1);
-        assert_eq!(shift_with_sign_bias(300), 1);
-        assert_eq!(shift_with_sign_bias(-256), -1);
-        assert_eq!(shift_with_sign_bias(0), 0);
+    fn projection_matches_the_canonical_with_preview_bias() {
+        // Cell (0, 1): leptons (128, 384) → canonical (-30, 30); only the X
+        // bias is preview-local. The toward-zero truncation of the shared
+        // canonical is pinned at util::direction_tables and mission::readiness.
+        assert_eq!(project_cell_centre(0, 1), (-30 + PROJECT_X_BIAS, 30));
+        assert_eq!(project_cell_centre(0, 0), (PROJECT_X_BIAS, 15));
     }
 
     #[test]

--- a/src/render/vxl_raster.rs
+++ b/src/render/vxl_raster.rs
@@ -33,7 +33,7 @@ const WORLD_YAW_OFFSET_DEG: f32 = 45.0;
 /// The original quantizes facing to 5 bits before building the rotation matrix and
 /// reuses those same 5 bits as its draw-cache key, so there is no finer sub-facing
 /// anywhere in the voxel pipeline: a rendered voxel is always exactly 1 of 32.
-pub(crate) const VOXEL_FACING_STEPS: u32 = 32;
+pub const VOXEL_FACING_STEPS: u32 = 32;
 
 /// Angular size of one voxel facing step: 360° / 32 = 11.25° = π/16.
 const VOXEL_FACING_STEP_RAD: f32 = std::f32::consts::PI / 16.0;

--- a/src/sim/cell_kernel.rs
+++ b/src/sim/cell_kernel.rs
@@ -13,6 +13,10 @@ pub const LEPTONS_PER_CELL: i32 = crate::util::lepton::LEPTONS_PER_CELL_I32;
 pub const CELL_CENTER_LEPTONS: i32 = crate::util::lepton::CELL_CENTER_LEPTON_I32;
 pub const INFANTRY_OCCUPATION_VEHICLE_BIT: u8 = 0x20;
 pub const INFANTRY_OCCUPATION_OBJECT_BIT: u8 = 0x40;
+/// Native-ordered (x, y, z) sub-cell lepton offsets, slots 0..4. Same values
+/// as `util::lepton::SUBCELL_*` (the SimFixed pairs); kept as a separate
+/// integer table because this is the native ordering + Z shape the kernel
+/// indexes by slot. Change both or neither.
 pub const INFANTRY_SUBCELL_OFFSETS: [(i32, i32, i32); 5] = [
     (128, 128, 0),
     (64, 64, 0),

--- a/src/util/lepton.rs
+++ b/src/util/lepton.rs
@@ -74,6 +74,8 @@ const SIM_FIXED_SCALE: i64 = 1 << 16;
 /// - Sub-cell 3: bottom-left  ( 64, 192) — used for infantry placement
 /// - Sub-cell 4: bottom-right (192, 192) — used for infantry placement
 
+/// Same values as `sim::cell_kernel::INFANTRY_SUBCELL_OFFSETS` (the
+/// native-ordered integer table); change both or neither.
 /// Sub-cell center position (sub-cell 0, and fallback for vehicles).
 pub const SUBCELL_CENTER_X: SimFixed = SimFixed::lit("128");
 pub const SUBCELL_CENTER_Y: SimFixed = SimFixed::lit("128");


### PR DESCRIPTION
The final commit of the duplicate-authority sweep (87879fd3). It was pushed to feature/engine-domain-boundaries moments before PR #127 was merged, but the merge captured head 22caf598 and the branch cleanup orphaned it - this PR re-lands it.

Content (all value-identical, suite 7009/0 at this commit on the old branch):
- RMG preview projection delegates to util::lepton::project_absolute_lepton_xy (map->util; map may not name render). Cell-centre inputs divide exactly - bit-identical; new test pins concrete canonical values.
- VOXEL_FACING_STEPS made pub so the measure-atlas tooling bin derives its bucket counts.
- Sub-cell 64/192 tables (util SimFixed pairs vs cell_kernel native-ordered integer table) cross-referenced change-both-or-neither.