### PR TITLE
Add goal-prompt composer and shadow program-observer skills

### DIFF
--- a/.claude/skills/goal-prompt/SKILL.md
+++ b/.claude/skills/goal-prompt/SKILL.md
@@ -93,6 +93,29 @@ do not try to pre-decide everything.
    `cargo test -p vera20k --lib`; all completed tiers published for review —
    not parked on the branch.
 
+## Two continuation models — choose before writing
+
+A program outliving one session continues in one of two ways; pick
+deliberately, because they produce different prompts:
+
+- **Idempotent re-entry** (prefer when available). Write the prompt as a
+  convergent pass, not a linear program: "Preserve what already matches,
+  replace what is wrong, and implement what is missing" over an external
+  frozen ledger (a phase/plan document). Every invocation re-derives the
+  frontier by checking each item's disposition against the bar — no
+  memory, no handoff, no stale done-inventory to trust. When a run dies
+  (usage limit, crash), fire the same prompt again. This works exactly
+  when a fresh executor can determine what is done by inspecting the
+  artifact against the bar; it is the proven pattern of the Codex phase
+  prompts, which converged over repeated runs with zero handoff text.
+- **Continuation header** (below). Needed when the truth lives in session
+  state rather than in the work: mid-slice on a shared branch, unreviewed
+  inherited commits, a tool switch, an ownership question. The header
+  transfers exactly the facts the world cannot re-derive.
+
+The test: if re-running from scratch would waste nothing but a little
+re-checking, write idempotently and skip the header.
+
 ## Continuation header template
 
 Prepend this to the governing prompt, filled in concretely:

--- a/.claude/skills/goal-prompt/SKILL.md
+++ b/.claude/skills/goal-prompt/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: goal-prompt
+description: >
+  Compose or revise a goal prompt for a long-running autonomous VERA20k
+  program (Claude Code or Codex), or write the continuation header that lets a
+  fresh session take over a goal mid-flight. Use when the user asks to write,
+  redesign, tighten, or review a goal prompt, wants to launch a multi-slice
+  autonomous program, or wants an in-progress goal handed to another session.
+  Produces paste-ready prompt text; never launches the program itself.
+---
+
+# Goal Prompt — Autonomous Program Launcher
+
+A goal prompt is the one document a long-running session re-reads when its
+context compacts, its plans drift, or a fresh session takes over. Every
+sentence either constrains the program or wastes the executor's attention —
+write it like a contract, not a briefing.
+
+Two modes. Decide first, because they produce different documents:
+
+- **New goal** — the program does not exist yet. Produce the full prompt.
+- **Continuation** — a program is mid-flight (often started in another tool,
+  e.g. Codex). Produce a continuation header + the governing prompt. Skipping
+  the header makes the new session re-trace, re-derive, or fork the branch.
+
+## The reference is yours to supply
+
+An autonomous loop is good at closing the gap between what exists and the
+reference you gave it. It cannot decide what the reference should be. Name
+the reference explicitly in every goal prompt: for sim behavior it is gamemd
+and the delivery bar (ENGINE.md); for refactors it is behavior-preservation
+proven by hashes and bytes; for tooling it is the named user workflow. A
+prompt whose bar is a vibe ("clean", "idiomatic", "coherent") authorizes
+unbounded work — the program will happily consume weeks matching a reference
+nobody chose.
+
+## New-goal template
+
+Six parts, in this order. Keep the whole prompt near one page; the executor's
+fresh-critic loop is the catch-all for cases the prompt doesn't anticipate —
+do not try to pre-decide everything.
+
+1. **Outcome and ranked scope.** What exists when this is done, and the
+   ranking that lets the program stop early with the valuable part finished:
+   player-visibility × frequency first, determinism risk second, maintenance
+   cost last. Say which tiers may end as recorded residuals. A goal that
+   cannot stop early will not stop early.
+2. **Ground rules.** Read AGENTS.md and ENGINE.md completely. Reconcile git,
+   worktrees, running processes, and in-progress work before editing — and
+   again before any slice that moves files or splits state containers; defer
+   those slices while other branches are in flight.
+3. **Trace → frozen ledger → ratchet.** Trace the real production
+   architecture first; convert findings into a finite ledger; freeze its
+   scope (later discoveries are residuals unless required for correctness).
+   Immediately after the trace, install the cheap enforcement that stops
+   drift while work proceeds (dependency guards with current violations
+   allowlisted, a golden, a schema check — whatever ratchets this domain).
+4. **Execution protocol.** One coherent slice at a time. Builder implements;
+   smallest relevant `--lib` filter; a fresh read-only critic gets the
+   requirement, evidence, diff, and literal validation output — builders
+   never grade themselves; close the largest meaningful gap and repeat with
+   a fresh critic until pass; commit. **Publish per tier**: open or update
+   the PR when a tier completes — correctness fixes never wait on refactor
+   slices. Evidence rules: sim behavior changes name their gamemd source or
+   carry UNCHECKED; verification is production-observable ("it compiled" and
+   "it plays" are different checkpoints — pin the one that matters).
+5. **Structure rules.** A trait only where two real implementations already
+   exist in production. Fix dependency direction by moving code to the lower
+   layer, never by inverting through an interface. Headless, replay, and
+   tests run the real simulation through the same concrete types. No
+   speculative abstractions, giant relocations, mass formatting, or
+   unrelated cleanup. (Each clause exists because its generic form has been
+   exploited: "test seam", "dependency inversion", and "repeated behavior"
+   all re-admit one-implementation traits.)
+6. **Done-clause.** Every ledger item fixed, proven intentional, or recorded
+   as a bounded residual; the ratchet green; one final full
+   `cargo test -p vera20k --lib`; all completed tiers published for review —
+   not parked on the branch.
+
+## Continuation header template
+
+Prepend this to the governing prompt, filled in concretely:
+
+> **Continuation.** This goal is mid-flight. The approved design/ledger is at
+> `<main-checkout>/<doc path>` (docs/ is gitignored — resolve the main
+> checkout via `git worktree list`; the doc is absent from worktrees). Do not
+> re-trace or re-derive — adopt it. Completed on `<branch>`: <item → SHA
+> list>. Verify no other session or tool owns the checkout/branch before
+> touching it (<how to check>; if owned, stop and report). First actions:
+> <e.g. critic-review the unreviewed commits, publish the completed tier,
+> install the ratchet, resume at item N>.
+
+The header exists because three things go wrong without it: the new session
+re-runs the expensive trace; it cannot find the design doc (main-checkout
+gitignore); it forks a second branch and orphans the finished work. Each
+line of the header closes one of those.
+
+## Failure modes this template encodes against
+
+Observed, not hypothetical — check a draft against each:
+
+- **Unbounded endpoint**: "until coherent/idiomatic" has no stop; ranked
+  tiers with residuals do.
+- **No merge cadence**: "ready for review" only in the done-clause parks
+  weeks of unmerged commits while every parallel branch drifts against them.
+- **Reconcile-once**: worktree checks only at start miss branches created
+  after launch; high-churn slices need a re-check and a deferral clause.
+- **Escape-hatch clauses**: every justification list ("...or a test
+  boundary, or dependency inversion") will be read as authorization by a
+  compliant executor. Gate on facts ("two implementations exist"), not
+  purposes.
+- **Prompt bloat**: a clause added "just in case" competes with the load-
+  bearing ones. The critic loop handles the unanticipated; the prompt only
+  needs the rules the critic can't infer.
+- **Self-graded verification**: any bar the builder can attest to itself
+  ("tests added", "looks correct") will be attested. Bars are literal test
+  output, hashes, bytes, or a fresh critic's verdict.
+
+## Worked example
+
+Read [references/engine-boundaries-example.md](references/engine-boundaries-example.md)
+for the real prompt pair that ran the 2026-08 engine-domain-boundaries
+program: the revised new-goal prompt, the continuation header that moved it
+from Codex to Claude Code without re-tracing, and one paragraph on what each
+revision fixed. Use it as the calibration for length and specificity.

--- a/.claude/skills/goal-prompt/SKILL.md
+++ b/.claude/skills/goal-prompt/SKILL.md
@@ -34,6 +34,16 @@ prompt whose bar is a vibe ("clean", "idiomatic", "coherent") authorizes
 unbounded work — the program will happily consume weeks matching a reference
 nobody chose.
 
+A valid bar passes three tests: **named** (a specific thing, not a
+category), **fetchable** (the critic can read it, run it, decompile it, or
+diff against it), and **comparable** (the work and the bar can sit side by
+side under one judgment). Everything else in the prompt is scaffolding —
+the loop only produces quality if the thing it compares against is real.
+If the user hasn't named a bar, propose two or three concrete candidates
+and stop for their pick before writing the prompt; never invent the
+reference silently, because the executor's critics will then invent their
+own.
+
 ## New-goal template
 
 Six parts, in this order. Keep the whole prompt near one page; the executor's
@@ -57,13 +67,19 @@ do not try to pre-decide everything.
    allowlisted, a golden, a schema check — whatever ratchets this domain).
 4. **Execution protocol.** One coherent slice at a time. Builder implements;
    smallest relevant `--lib` filter; a fresh read-only critic gets the
-   requirement, evidence, diff, and literal validation output — builders
-   never grade themselves; close the largest meaningful gap and repeat with
-   a fresh critic until pass; commit. **Publish per tier**: open or update
-   the PR when a tier completes — correctness fixes never wait on refactor
-   slices. Evidence rules: sim behavior changes name their gamemd source or
-   carry UNCHECKED; verification is production-observable ("it compiled" and
-   "it plays" are different checkpoints — pin the one that matters).
+   requirement, evidence, diff, and actual validation output — **not the
+   builder's reasoning** (the builder remembers why every decision felt
+   right; the critic must judge the artifact, not the narrative). Builders
+   never grade themselves. The critic passes a slice only when its diff and
+   non-interactive validation **reproduce the contract** without unsupported
+   approximations — a defined pass condition, not a review ritual. On
+   BLOCK: close the largest meaningful gap and resubmit to a fresh critic
+   until pass; re-verify the previous round's fixes before judging anything
+   new; commit. **Publish per tier**: open or update the PR when a tier
+   completes — correctness fixes never wait on refactor slices. Evidence
+   rules: sim behavior changes name their gamemd source or carry UNCHECKED;
+   verification is production-observable ("it compiled" and "it plays" are
+   different checkpoints — pin the one that matters).
 5. **Structure rules.** A trait only where two real implementations already
    exist in production. Fix dependency direction by moving code to the lower
    layer, never by inverting through an interface. Headless, replay, and

--- a/.claude/skills/goal-prompt/references/engine-boundaries-example.md
+++ b/.claude/skills/goal-prompt/references/engine-boundaries-example.md
@@ -1,0 +1,132 @@
+# Worked example — the engine-domain-boundaries program (2026-08)
+
+The prompt pair below ran a real 14-item architecture program: started by a
+Codex session (F01–F04 partial), continued by a Claude Code session that
+completed F04–F09 in a weekend, with every slice critic-gated and the tier
+published as a PR. Use it to calibrate length and specificity — the whole
+governing prompt is under a page.
+
+## What each revision fixed (against the original draft)
+
+The original draft's endpoint was "refactor domain-by-domain until ownership,
+dependencies, state boundaries, module layout, and APIs are coherent and
+idiomatic" — an unbounded bar that made all fourteen items mandatory. Four
+edits fixed what execution later proved mattered:
+
+1. Ranked scope + residual tiers → the program could stop after the
+   valuable tiers (it did: F10+ deferred as maintenance).
+2. Guard-first ratchet → the dependency guards landed before cleanup, so
+   the architecture could only improve while work proceeded. The guards also
+   caught a scanner blind spot via independent review — the ratchet itself
+   needs adversarial checking once.
+3. Publish-per-tier → PR opened at tier 1 instead of parking ~40 commits;
+   (residual lesson: the PR still grew as later tiers stacked on the same
+   branch — a stricter variant would branch per tier).
+4. Tightened trait clause → the draft's justification list ("real
+   test/headless boundary, dependency inversion, repeated behavior") was
+   replaced by the two-implementations fact-gate, because the headless path
+   was deliberately served by concrete shared construction, not a trait.
+
+## The governing prompt (as run)
+
+> Establish a source-backed overview of the VERA20k engine, then close
+> ownership, dependency, and API defects in ranked order. Coherence is the
+> direction, not the finish line: rank the ledger by player-visibility ×
+> frequency first, determinism risk second, maintenance cost last; pure
+> relocations and cosmetic regrouping are the lowest tier and may end as
+> recorded residuals.
+>
+> Read AGENTS.md and ENGINE.md completely. Reconcile Git, worktrees, running
+> processes, and in-progress work before editing, and again before any slice
+> that moves files or splits state containers; defer those slices while
+> other branches are in flight.
+>
+> First trace the real production architecture: app orchestration,
+> simulation, rules/assets, map loading, rendering, input, audio,
+> persistence, replay, and tests. Identify authoritative state owners,
+> mutation paths, forbidden dependencies, duplicate authority, oversized
+> orchestrators, misplaced modules, dead compatibility paths, and unclear
+> APIs. Convert these findings into a finite cleanup ledger; freeze its
+> scope; later discoveries become residuals unless required for correctness.
+> Immediately after the trace, install source-level dependency guards with
+> current violations allowlisted, before any cleanup slice.
+>
+> Complete the ledger one item at a time. Preserve correct behavior. For
+> simulation behavior changes, establish the smallest retail contract from
+> verified gamemd.exe callsites and retail data, or label it UNCHECKED.
+>
+> For each batch: define the boundary, have a builder implement it, run
+> minimum focused `--lib` tests, then give a fresh read-only critic the
+> requirement, evidence, diff, and validation output. Builders cannot grade
+> themselves. Close the critic's largest meaningful gap and repeat with a
+> fresh critic until passed. Commit each coherent slice, and open or update
+> the feature PR after each completed tier — correctness fixes never wait on
+> refactor slices to publish.
+>
+> Use a trait only where two real implementations already exist in
+> production code; otherwise concrete types, enums, and functions. Fix
+> dependency direction by moving code to the lower layer, never by inverting
+> through an interface. Headless, replay, and tests run the real simulation
+> through the same concrete types. No speculative one-implementation traits,
+> giant relocations, mass formatting, or unrelated cleanup.
+>
+> Keep simulation authoritative and independent of app/render/UI/audio.
+> Narrow visibility, remove duplicate state ownership, and decompose large
+> state containers incrementally; a decomposition slice must prove per-tick
+> hashes, RNG cursors, and snapshot bytes identical.
+>
+> Done means every ledger item is fixed, proven intentional, or recorded as
+> a bounded residual; the guards are green; focused checks pass; one final
+> `cargo test -p vera20k --lib` passes; and all completed tiers are
+> published for review, not parked on the branch.
+
+## The continuation header (as run)
+
+> **Continuation.** This goal is mid-flight. The approved design and frozen
+> ledger (F01–F14) are in
+> `docs/plans/2026-08-15-engine-domain-boundaries-design.md` in the main
+> checkout (resolve via `git worktree list`; the doc is gitignored and
+> absent from worktrees). Do not re-trace or re-derive the ledger — adopt
+> it. Completed on `feature/rust-scan-v2`: F01 (`8a413592`, `2321ee13`), F02
+> (`c5c9c41a`), F03 (`7a9e9c01`), and the first bullet of F04 (`4bc0cf90`).
+> Verify a Codex session no longer owns the main checkout before touching
+> that branch; if it does, stop and report. First actions: run the
+> fresh-critic review of the unreviewed commits above, publish the completed
+> tier as a PR, install the dependency guards, then resume at the remaining
+> F04 bullets in frozen order.
+
+## External corroboration — the Gauntlet Loop postmortem (2026-07)
+
+The viral "Gauntlet Loop" (Matt Shumer's Claude-of-Duty run) is the same
+builder/fresh-critic/biggest-gap shape, and its published postmortem
+independently confirms two rules worth carrying into goal prompts:
+
+- **Sequential single-owner beats parallel fan-out for coupled concerns.**
+  The repo's own numbers: three rounds of six parallel agents gained +0.46
+  on its quality score while frame-ruining defects rose; one sequential
+  pass with a single owner per coupled system gained +1.00 and cut defects
+  66 → 26. This is the ledger's "one compiling owner per commit" rule,
+  proven at someone else's expense — parallelize only independently
+  checkable pieces.
+- **Regressions go first.** The strongest variant re-verifies last round's
+  fixes before judging anything new ("the hunter's verdicts go first in the
+  next round"). Worth a clause in any goal prompt whose critics iterate:
+  a fix that quietly regressed must not survive because attention moved on.
+
+Its cautionary findings also transfer: a vibes bar ("utterly wowed") was
+never met — scores plateaued at 5/10 and the run was stopped by hand; and
+with no existing reference the critic "invents its own arbitrary standard
+and approves work against criteria you never chose." Measurable bars and a
+named reference are not optional decoration; they are what makes the loop
+terminate and point somewhere.
+
+## What the continuation achieved (why the header earns its lines)
+
+The taking-over session, on its first turn: resolved the main checkout,
+adopted the ledger without re-tracing, ran the documented Codex-ownership
+check (found the goal thread paused), then launched four parallel fresh
+critics on the inherited commits before writing any code. One critic
+BLOCKed F03 with a real finding (tautological freeze-gate tests) that the
+original builder's own tests had certified green — the strongest argument
+recorded so far for both the fresh-critic rule and for critic-reviewing
+inherited work instead of trusting it.

--- a/.claude/skills/shadow/SKILL.md
+++ b/.claude/skills/shadow/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: shadow
+description: >
+  Project-scoped, read-only observer loop for VERA20k multi-session programs.
+  Use when explicitly invoked as /shadow, or when the user asks for a standing
+  observer, watchdog, or "shadow" over an active goal program running across
+  Claude Code / Codex sessions. Watches the trajectory (commits, PRs, session
+  transcripts) rather than individual slices, and posts short delta-only risk
+  notes to the user. Never edits, never builds, never messages working
+  sessions, and declines to loop when no program is active.
+---
+
+# Shadow — Program Observer
+
+You are the advisor, not a participant. Builders hold the pen; critics gate
+slices; you watch the **program** — the thing no scoped agent sees. Your value
+comes from reading the trajectory across sessions and surfacing what tunnel
+vision hides: drift, contradiction, duplication, and risk accumulating between
+slices. You never produce work product and you never block anyone.
+
+## Preconditions — decline when there is nothing to shadow
+
+A shadow over an idle repo is pure overhead. Before starting the loop:
+
+1. List active sessions (`mcp__ccd_session_mgmt__list_sessions`) and active
+   feature branches (`git worktree list`, `git branch -vv` in the main
+   checkout).
+2. If no session is actively driving a goal program (no running session with
+   recent commits on a feature branch), say so and do not start the loop.
+3. Identify the program's contract: the goal prompt, design doc, or ledger the
+   driving session follows, and its done-clause. You judge drift against that
+   contract, so read it once, completely, at startup.
+
+## Hard boundaries
+
+These are what make an unaccountable third voice safe:
+
+- **Read-only, absolutely.** No Edit/Write inside any checkout, no cargo or
+  rustc (another session owns Cargo — you must never contend), no Ghidra
+  mutations, no gh commands that change state (no comments, labels, merges).
+- **Never message a working session.** Your notes go to the user, who forwards
+  what they agree with. A shadow that whispers to the builder mid-slice adds
+  an influence no critic reviews. Draft forwardable text when useful; sending
+  it is the user's call.
+- **Advisory, never authoritative.** Git, tests, and guards are the record.
+  Every factual claim you post cites what you read: a commit SHA, file:line,
+  PR number, or session-transcript excerpt. No claim without a citation.
+- **No ledgers.** Do not maintain a status file, dashboard, or completion
+  tracker in the repository. Your own pass-state lives only in the session
+  scratchpad. Hand-maintained status artifacts rot; ENGINE.md forbids them.
+
+## Pass state
+
+The shadow is one persistent session running its own loop — passes are turns
+of that session, not fresh subagents. Keep a small JSON file in this
+session's scratchpad (never the repo) recording, per branch, the last SHA you
+inspected, and per session, the last transcript position. Each pass reads
+only what is new since then — deltas keep passes cheap and the notes
+non-repetitive. If the state file is missing (first pass, or scratchpad
+lost), re-derive a baseline from the program contract: the commit where the
+program started, or the merge-base with `main`, and say the pass is a
+re-baseline.
+
+## Each pass — read the deltas
+
+1. `git fetch origin --quiet`, then new commits since last pass on the
+   branches the program drives (`git log <last-sha>..<branch>`), in the main
+   checkout via `git -C`. "Active" means branches named by the program
+   contract or visibly driven by its sessions — not every stale worktree
+   branch in the repo.
+2. Open PR state: `gh pr list` / `gh pr view` — size, mergeability, reviews.
+3. Recent transcript of each session **participating in the program**
+   (`mcp__ccd_session_mgmt__list_events`) — enough to know what each is doing
+   and what instructions are queued but unacted. Unrelated running sessions
+   are out of scope unless they touch the program's files or branch.
+4. Spot-diffs where risk concentrates in this project: the frozen exception
+   inventory in `src/architecture_guards.rs`, `SNAPSHOT_VERSION`,
+   `docs/scans/PENDING_REBASELINES.md`, and any commit touching `src/sim/`
+   hashing, RNG, or snapshot code. `docs/` is gitignored and exists only in
+   the main checkout — resolve those paths there (`git worktree list` finds
+   it), never in a worktree.
+
+## Lenses — what a shadow looks for
+
+Scoped agents verify slices; you ask program-level questions:
+
+- **Contract drift.** Is the work still inside the goal's frozen scope and
+  done-clause? Are deferred items quietly being executed, or committed scope
+  quietly dropped?
+- **Cross-slice contradiction.** Does a later slice assume what an earlier
+  slice's residual notes disclaimed? Do two sessions' changes collide (same
+  files, same golden baselines, same branch)?
+- **Review surface.** Is the PR still reviewable, or has it grown past the
+  point where the human gate becomes a rubber stamp? Is unmerged work aging
+  while other branches drift against it?
+- **Process integrity.** Did a slice land without its critic pass? Is a
+  session waiting on Cargo another session holds? Are queued user
+  instructions being skipped? Is a paused external driver (e.g. a Codex goal
+  thread) still able to wake and double-own a branch?
+- **Delivery-bar relevance.** Periodically ask the uncomfortable question: is
+  this program still the most player-valuable thing running? Flag it at most
+  once — the decision is the user's, not yours to relitigate.
+- **Determinism and parity exposure.** Any delta touching sim ordering, RNG,
+  hashing, or snapshots that is not visibly paired with hash/RNG proof.
+
+## Reporting rules
+
+- **Deltas only, at most ~10 lines.** New risks since the last pass. No
+  status recaps, no progress narration — git already records progress, and a
+  note that repeats it trains the reader to skim.
+- **Nothing new → post nothing.** Silence is a valid, informative result;
+  end the pass as a no-op. (If a pass runs as a subagent that must return a
+  final message, return the single line "no new risks since <last SHA>"
+  rather than literal silence — the rule bans narration, not the return
+  value.)
+- **Severity needs a frequency clause** (project rule): say what triggers the
+  risk and how often that occurs, not "low priority".
+- **Escalate rarely.** Stop-the-line items only: a red nightly equivalent,
+  two writers on one branch, unreviewed determinism-relevant changes about
+  to merge, or an imminent destructive operation. Escalate with
+  `PushNotification` if that tool is available in the environment; if not,
+  lead the note with a first line beginning `STOP-THE-LINE:` so it cannot be
+  skimmed past. Everything else waits in the note.
+
+## Loop mechanics
+
+Run under `/loop` with self-pacing: 30–60 minutes while sessions are actively
+committing, stretching to the maximum interval when the program goes quiet.
+Mark quiet passes as no-ops so the user's terminal collapses them.
+
+Propose stopping — do not just stop — when the program's PR merges and the
+driving sessions go idle, or the user ends the goal. One line: what you
+observed over the program's life is not needed; just say the program looks
+finished and ask whether to stand down.


### PR DESCRIPTION
## What

- `.claude/skills/goal-prompt/` — composes goal prompts for long-running autonomous programs (Claude Code or Codex): new-goal template (ranked scope, ratchet-first, fresh-critic execution protocol, done-clause), two continuation models (idempotent re-entry vs continuation header), observed failure-mode checklist, and a worked example from the 2026-08 engine-domain-boundaries program.
- `.claude/skills/shadow/` — read-only observer loop for multi-session programs: watches commits/PRs/session transcripts for contract drift, cross-slice contradiction, and determinism exposure; posts delta-only notes to the user; never edits, builds, or messages working sessions.

## Why

Both skills encode process lessons proven during the engine-domain-boundaries program (fresh-critic gating catching tautological tests, fact-gates over purpose-gates, publish-per-tier). Publishing them makes the workflow reusable from main instead of stranded on this branch.

## Validation

Prose-only skill additions; no engine code. Reviewed for public-repo safety (no local paths or private info) and for guardrails (shadow is strictly read-only, no repo ledgers per ENGINE.md).