### PR TITLE
movement: keep the in-flight Drive curve across a mid-curve re-order

### DIFF
--- a/src/sim/movement/movement_commands.rs
+++ b/src/sim/movement/movement_commands.rs
@@ -318,9 +318,6 @@ pub(crate) fn issue_move_command_with_layered(
     if !can_accept_destination(entity) {
         return false;
     }
-    let start_rx: u16 = entity.position.rx;
-    let start_ry: u16 = entity.position.ry;
-    let current_layer = entity.movement_layer_or_ground();
     // The original engine dispatches its cell-entry predicate by object class,
     // so terrain-object occupation is read at sub-cell granularity for infantry
     // and whole-cell for everything else. The search has to know which.
@@ -329,6 +326,42 @@ pub(crate) fn issue_move_command_with_layered(
     let uses_drive_locomotor = locomotor_kind == Some(LocomotorKind::Drive);
     let uses_ship_locomotor = locomotor_kind == Some(LocomotorKind::Ship);
     let uses_shared_tracks = uses_drive_locomotor || uses_ship_locomotor;
+    // A new destination never rewinds a curve already in flight.
+    // `TechnoClass::Set_Destination` @ `0x00741970` only records the target —
+    // NavCom in `FootClass::Set_Destination_Internal` @ `0x004D94B0`, the
+    // coordinate in Drive `Head_To_Coord` @ `0x004AFD40` — and never touches
+    // the Drive track cursor, so the new path takes effect at the curve's next
+    // node. Installing a fresh curve here re-read the body position from the
+    // new curve's lead-in point (the current cell centre) and visibly snapped
+    // the vehicle backward, up to half a cell, on every mid-drive re-order.
+    // Keep the curve and anchor the new path at its committed head cell.
+    let current_cell = (entity.position.rx, entity.position.ry);
+    let in_flight_curve_head: Option<(u16, u16)> = if uses_shared_tracks {
+        entity.drive_track.as_ref().and_then(|track| {
+            let (_, head) = drive_track::is_at_coord_track_cells(track, current_cell, false);
+            u16::try_from(head.0).ok().zip(u16::try_from(head.1).ok())
+        })
+    } else {
+        None
+    };
+    let keep_in_flight_curve = in_flight_curve_head.is_some();
+    let (start_rx, start_ry) = in_flight_curve_head.unwrap_or(current_cell);
+    let current_layer = match in_flight_curve_head {
+        // The layer the body will be on at the curve head — from the accepted
+        // path while it still lists that node, else the current layer.
+        Some(head) => entity
+            .movement_target
+            .as_ref()
+            .and_then(|target| {
+                target
+                    .path
+                    .iter()
+                    .position(|&cell| cell == head)
+                    .map(|index| target.layer_at(index))
+            })
+            .unwrap_or_else(|| entity.movement_layer_or_ground()),
+        None => entity.movement_layer_or_ground(),
+    };
     // Derive movement_zone from the entity's locomotor — no parameter needed.
     let movement_zone: Option<MovementZone> = entity.locomotor.as_ref().map(|l| l.movement_zone);
     let speed_type = entity.locomotor.as_ref().map(|l| l.speed_type);
@@ -564,10 +597,27 @@ pub(crate) fn issue_move_command_with_layered(
         new_facing = Some(facing_from_delta(dx, dy));
     }
 
+    // A kept curve's head cell is a future node the body has not crossed into
+    // yet: the queue cursor starts ON it so the coordinate crossing consumes
+    // it, exactly as it would have consumed that node under the replaced path.
+    let head_not_yet_reached = keep_in_flight_curve && (start_rx, start_ry) != current_cell;
+    let first_target_index = if head_not_yet_reached { 0 } else { 1 };
+
     // Compute initial direction vector toward the first path step.
     // No carry-forward needed — sub_x/sub_y already encode the entity's
     // exact lepton position, so it continues from wherever it is.
-    let (dir_x, dir_y, dir_len) = if path.len() >= 2 {
+    let (dir_x, dir_y, dir_len) = if head_not_yet_reached {
+        // The first vector target is the kept curve's head itself — up to two
+        // cells out for a two-node curve — so use the Euclidean form (as in
+        // `issue_direct_move`) in case the curve is torn down early and the
+        // vector step has to cover the multi-cell delta.
+        let dx = i32::from(start_rx) - i32::from(current_cell.0);
+        let dy = i32::from(start_ry) - i32::from(current_cell.1);
+        let dir_x = SimFixed::from_num(dx * 256);
+        let dir_y = SimFixed::from_num(dy * 256);
+        let dir_len = crate::util::fixed_math::fixed_distance(dir_x, dir_y);
+        (dir_x, dir_y, dir_len)
+    } else if path.len() >= 2 {
         crate::util::lepton::cell_delta_to_lepton_dir(
             path[1].0 as i32 - path[0].0 as i32,
             path[1].1 as i32 - path[0].1 as i32,
@@ -589,7 +639,10 @@ pub(crate) fn issue_move_command_with_layered(
     let movement: MovementTarget = MovementTarget {
         path,
         path_layers,
-        next_index: 1, // Index 0 is the current position, 1 is the first target.
+        // Index 0 is the path anchor: the current position normally (first
+        // target is 1), the kept curve's still-unreached head when re-ordered
+        // mid-curve (the head itself is the first queued node).
+        next_index: first_target_index,
         speed,
         current_speed: speed,
         move_dir_x: dir_x,
@@ -662,7 +715,9 @@ pub(crate) fn issue_move_command_with_layered(
         // Set when the body is not yet on the head path node's octant: gamemd
         // commands that turn and installs no curve until the body reaches it.
         let mut turn_first: Option<u8> = None;
-        if let Some(f) = new_facing {
+        // A kept in-flight curve owns facing and position until it completes;
+        // the fresh-curve selection below runs only from a standstill anchor.
+        if !keep_in_flight_curve && let Some(f) = new_facing {
             if entity_mut.category != EntityCategory::Infantry
                 && uses_shared_tracks
                 && let Some((dx, dy)) = initial_step_delta
@@ -732,7 +787,10 @@ pub(crate) fn issue_move_command_with_layered(
                 }
             }
         }
-        if uses_drive_locomotor {
+        // A kept curve's head-to and handoff occupation claims stay with it —
+        // the body is still physically driving into the claimed cells. The
+        // clear/replace arms below are for curves this order replaces.
+        if uses_drive_locomotor && !keep_in_flight_curve {
             let current_cell = (entity_mut.position.rx, entity_mut.position.ry);
             let current_layer = entity_mut
                 .occupancy_list_layer()
@@ -793,7 +851,7 @@ pub(crate) fn issue_move_command_with_layered(
                     }
                 }
             }
-        } else if uses_ship_locomotor {
+        } else if uses_ship_locomotor && !keep_in_flight_curve {
             let fallback_z = entity_mut.position.z;
             if let Some(ship) = entity_mut.ship_locomotion.as_mut() {
                 if let Some(reference) = accepted_path_reference {

--- a/src/sim/movement/movement_tests.rs
+++ b/src/sim/movement/movement_tests.rs
@@ -1230,6 +1230,172 @@ fn test_issue_move_command_starts_drive_track_for_initial_drive_turn() {
     assert_eq!(entity.facing_target, Some(0x60));
 }
 
+// `TechnoClass::Set_Destination` @ `0x00741970` records the new destination
+// (NavCom @ `0x004D94B0`, Drive coordinate @ `0x004AFD40`) without touching the
+// Drive track cursor: a curve already in flight keeps driving to its committed
+// head cell and the new path takes over there.
+#[test]
+fn test_reissue_mid_curve_keeps_track_and_anchors_path_at_head() {
+    let mut entities = EntityStore::new();
+    let grid: PathGrid = PathGrid::new(20, 20);
+
+    let mut e = GameEntity::test_default(1, "HTNK", "Americans", 2, 3);
+    e.locomotor = Some(LocomotorState::for_test_kind(LocomotorKind::Drive));
+    e.facing = 64;
+    entities.insert(e);
+
+    // First order east installs a straight curve committed to head (3,3).
+    assert!(issue_move_command(
+        &mut entities,
+        &grid,
+        1,
+        (7, 3),
+        SimFixed::from_num(768),
+        false,
+        None,
+        None,
+        None,
+        false,
+    ));
+    let entity = entities.get(1).expect("entity exists");
+    let track_before = entity.drive_track.as_ref().expect("curve installed");
+    let track_before = (track_before.raw_track_index, track_before.point_index);
+    let drive = entity.drive_locomotion.as_ref().expect("drive state");
+    assert_eq!(
+        drive.occupation_head_to.map(|head| (head.rx, head.ry)),
+        Some((3, 3)),
+    );
+
+    // Re-order behind the body while the curve is in flight. Pre-fix this
+    // cleared/replaced the curve; the curve must survive untouched and the new
+    // path must start on its head so no position rewrite can occur.
+    assert!(issue_move_command(
+        &mut entities,
+        &grid,
+        1,
+        (0, 3),
+        SimFixed::from_num(768),
+        false,
+        None,
+        None,
+        None,
+        false,
+    ));
+    let entity = entities.get(1).expect("entity exists");
+    let track_after = entity.drive_track.as_ref().expect("in-flight curve kept");
+    assert_eq!(
+        (track_after.raw_track_index, track_after.point_index),
+        track_before,
+        "the in-flight curve must survive the re-order untouched"
+    );
+    let movement = entity.movement_target.as_ref().expect("movement target");
+    assert_eq!(
+        movement.path.first().copied(),
+        Some((3, 3)),
+        "new path is anchored at the curve's committed head cell"
+    );
+    assert_eq!(
+        movement.next_index, 0,
+        "the still-unreached head is itself the first queued node"
+    );
+    assert_eq!(movement.final_goal, Some((0, 3)));
+    let drive = entity.drive_locomotion.as_ref().expect("drive state");
+    assert_eq!(
+        drive.occupation_head_to.map(|head| (head.rx, head.ry)),
+        Some((3, 3)),
+        "the kept curve keeps its head-to occupation claim"
+    );
+    assert_eq!(drive.path.reference_cell, Some((3, 3)));
+    assert_eq!(drive.path.cursor, 0);
+    assert_eq!(entity.navigation.nav_com, Some(NavTargetRef::cell(0, 3)));
+}
+
+// The player-visible symptom of replacing an in-flight curve: the fresh curve's
+// cursor restarted at the lead-in point on the current cell centre, so every
+// mid-drive re-order teleported the body backward by its mid-cell progress.
+#[test]
+fn test_reissue_mid_curve_does_not_snap_position_backward() {
+    let mut entities = EntityStore::new();
+    let grid: PathGrid = PathGrid::new(20, 20);
+
+    let mut e = GameEntity::test_default(1, "HTNK", "Americans", 2, 3);
+    e.locomotor = Some(LocomotorState::for_test_kind(LocomotorKind::Drive));
+    e.facing = 64;
+    // No rules are loaded, so `accel_factor` is 0 and the Accelerates= ramp
+    // would hold the speed fraction at 0 forever; drive at constant speed.
+    e.drive_accelerates = false;
+    entities.insert(e);
+
+    // Slow enough that each tick pays about one 7-cost track point.
+    let speed = SimFixed::from_num(120);
+    assert!(issue_move_command(
+        &mut entities,
+        &grid,
+        1,
+        (7, 3),
+        speed,
+        false,
+        None,
+        None,
+        None,
+        false,
+    ));
+
+    // Advance until the body sits visibly past its cell centre (sub_x 128)
+    // but has not crossed into (3,3) yet.
+    let mut lifecycle_requests = Vec::new();
+    let mut observed_mid_cell = false;
+    for _ in 0..50 {
+        tick_movement(&mut entities, &mut test_interner(), &mut lifecycle_requests);
+        let entity = entities.get(1).expect("entity exists");
+        if entity.position.rx > 2 {
+            break;
+        }
+        if entity.position.sub_x.to_num::<i32>() >= 168 {
+            observed_mid_cell = true;
+            break;
+        }
+    }
+    assert!(
+        observed_mid_cell,
+        "the curve never presented a mid-cell state past the centre"
+    );
+    let entity = entities.get(1).expect("entity exists");
+    assert!(entity.drive_track.is_some(), "curve still in flight");
+    let sub_x_before = entity.position.sub_x;
+    let east_before = i32::from(entity.position.rx) * 256 + sub_x_before.to_num::<i32>();
+
+    // Re-order further east mid-curve: the order itself must not move the
+    // body, and the next tick must continue forward — never snap back toward
+    // the cell centre.
+    assert!(issue_move_command(
+        &mut entities,
+        &grid,
+        1,
+        (9, 3),
+        speed,
+        false,
+        None,
+        None,
+        None,
+        false,
+    ));
+    let entity = entities.get(1).expect("entity exists");
+    assert_eq!(
+        entity.position.sub_x, sub_x_before,
+        "issuing the order must not move the body"
+    );
+    tick_movement(&mut entities, &mut test_interner(), &mut lifecycle_requests);
+    let entity = entities.get(1).expect("entity exists");
+    let east_after = i32::from(entity.position.rx) * 256 + entity.position.sub_x.to_num::<i32>();
+    assert!(
+        east_after > east_before,
+        "body must keep moving forward across a mid-curve re-order \
+         (east {east_before} -> {east_after}); a regression here is the \
+         backward-teleport-on-click symptom"
+    );
+}
+
 #[test]
 fn test_issue_move_command_no_path() {
     let mut entities = EntityStore::new();

--- a/src/sim/movement/movement_tick.rs
+++ b/src/sim/movement/movement_tick.rs
@@ -2390,7 +2390,14 @@ fn tick_movement_with_grids_scoped(
                         let head_cell = target.path[target.next_index];
                         let ndx = head_cell.0 as i32 - cur_cell.0 as i32;
                         let ndy = head_cell.1 as i32 - cur_cell.1 as i32;
-                        if ndx != 0 || ndy != 0 {
+                        // gamemd's queue head is octant-adjacent by
+                        // construction (the path queue stores direction
+                        // octants), so a chain is only planned against an
+                        // adjacent node. A two-cell head occurs in VERA only
+                        // while a curve kept across a mid-flight re-order still
+                        // has its own two-node head queued; chaining against it
+                        // would anchor the follow-on curve on the wrong cell.
+                        if (ndx != 0 || ndy != 0) && ndx.abs() <= 1 && ndy.abs() <= 1 {
                             let next_face = super::facing_from_delta(ndx, ndy);
                             // Use the active track's post-turn facing as the
                             // chain "from-dir." By the time the chain attempt

--- a/src/sim/world/slice6_retask_tests.rs
+++ b/src/sim/world/slice6_retask_tests.rs
@@ -170,8 +170,18 @@ fn unit(owner: &str, type_id: &str, cx: u16, cy: u16, cat: EntityCategory) -> Ma
 // the v28/v29 gates, so both named legacy probes intentionally move with the
 // live composition; filtering them out would create an undocumented hybrid
 // schema rather than reproduce either probe's stated contract.
-const SLICE6_PRE_LIFECYCLE_V28_HASH: u64 = 0xFA1F_9E65_F1BD_497D;
-const SLICE6_PRE_MISSION_V29_HASH: u64 = 0xAAC4_502B_90AF_E0A6;
+// Re-baselined 2026-08-18: a mid-curve re-order now keeps the in-flight Drive
+// curve and anchors the new path at its committed head cell (`TechnoClass::
+// Set_Destination` @ 0x00741970 never touches the track cursor; see
+// movement_commands.rs). This fixture retasks a moving MTNK at ticks 1/3/5/7,
+// so its trajectory legitimately changes — previously each retask restarted
+// the curve at the cell lead-in, teleporting the body backward. Behavior-
+// bearing, NOT composition-only: position/movement state is hashed in every
+// schema, so all three probes move together. Rust regression ratchet; the
+// kept-curve contract is exercised by
+// `movement_tests::test_reissue_mid_curve_keeps_track_and_anchors_path_at_head`.
+const SLICE6_PRE_LIFECYCLE_V28_HASH: u64 = 0xF2F0_9EA2_E633_977D;
+const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x18E3_B2D8_2E04_8245;
 // Snapshot/hash schema v29 adds lossless Mission dwords, readiness leaves,
 // suspended Target/falling state, and raw locomotor-ready inputs. The two
 // schema probes below must prove the shift is composition-only before updating
@@ -262,7 +272,9 @@ const SLICE6_PRE_MISSION_V29_HASH: u64 = 0xAAC4_502B_90AF_E0A6;
 // exact, isolating the change from the retask behavior under test. This is a
 // Rust regression ratchet; the native sequence-timing sources are documented
 // by that commit, while non-stock READY/GUARD precedence remains UNCHECKED.
-const SLICE6_BASELINE_HASH: u64 = 0xB3F2_F453_2BAE_3FE7;
+// Re-baselined 2026-08-18 for the kept in-flight Drive curve on mid-curve
+// re-orders; see the dated comment at the two legacy probes above.
+const SLICE6_BASELINE_HASH: u64 = 0xD997_73E0_DDC6_FBEE;
 
 #[test]
 fn replay_hash_stable_through_slice6() {


### PR DESCRIPTION
## Symptom

Clicking a new destination for a moving tank visibly teleported it backward (~100 leptons, up to half a cell) on nearly every re-order — constant during normal micro.

## Cause

`issue_move_command_with_layered` installed a fresh drive curve at order time. The fresh curve's cursor restarts at the lead-in point on the current cell centre, and the track advance writes position absolutely from the curve point, so the next tick discarded the body's mid-cell progress.

## gamemd contract

`TechnoClass::Set_Destination` @ `0x00741970` only records the target — NavCom in `FootClass::Set_Destination_Internal` @ `0x004D94B0`, the coordinate in Drive `Head_To_Coord` @ `0x004AFD40` — and never touches the track cursor (`UNITCLASS_SET_DESTINATION_NORMAL_DRIVE_CELL_GHIDRA_REPORT.md`). The new path takes effect at the curve's next node.

## Change

- A re-order while a Drive/Ship curve is in flight keeps the curve — state, facing, head-to/handoff occupation claims — and anchors the new path at the curve's committed head cell.
- The still-unreached head is queued at `next_index 0` so the coordinate crossing consumes it normally; NavCom and the Drive destination still update at order time as in gamemd.
- Chain planner gains an octant-adjacency guard: gamemd's path queue stores direction octants so a queued head is adjacent by construction; a kept two-node curve can briefly queue a two-cell head that must not be chained against.

## Verification

- `test_reissue_mid_curve_keeps_track_and_anchors_path_at_head` — pins the kept-curve contract (track state, path anchor, occupation claim, NavCom).
- `test_reissue_mid_curve_does_not_snap_position_backward` — ticks a curve mid-cell, re-orders, asserts forward motion. Both verified red with the fix disabled (east 688 → 668, the exact snap-back).
- Full `cargo test -p vera20k --lib`: green except the five known worktree-environment reds (missing `ini/` + retail assets).
- Slice6 retask hashes re-baselined in the same commit: the fixture retasks a moving MTNK at ticks 1/3/5/7, so its trajectory legitimately changes (behavior-bearing, not composition-only; slice6 and the global harness verified green on unmodified main first).

## Residual

A Drive vehicle mid-cell in the vector-movement fallback (no active curve) would still anchor a fresh curve at its cell centre — essentially unreachable for Drive in practice, since curves cover all octants and fallback states end at cell centres.
