### PR TITLE
build: ungate drive_locomotor_is_moving re-export used by release builds

### DIFF
--- a/src/sim/movement/mod.rs
+++ b/src/sim/movement/mod.rs
@@ -90,11 +90,11 @@ pub use facing_class::FacingClass;
 // The drive-locomotor "Process" presence marker, consumed read-only by the
 // per-object AI shell (sim/world/techno_ai.rs, Slice S1) to observe that the
 // locomotor would process AFTER mission dispatch. Behavior-neutral re-export.
-// Gated to match its only consumer (the debug/test S1 shadow) so release builds
-// carry no unused re-export.
 #[cfg(test)]
 pub(crate) use drive_locomotion::owner_current_speed_from_fraction;
-#[cfg(any(test, debug_assertions))]
+// NOT test-gated: `techno_common_pre`'s DisguiseWhenStill check
+// (sim/world/techno_ai.rs) consumes this in every build; a 2026-08-14
+// warning-cleanup gate on it broke release-only compilation.
 pub(crate) use drive_locomotion::drive_locomotor_is_moving;
 #[cfg(test)]
 pub(crate) use drive_locomotion::{DriveProcessOutcome, process_drive_locomotion_shell};


### PR DESCRIPTION
Release builds of main have failed to compile since 2026-08-14: commit a2b72b89 (warning cleanup) gated the `drive_locomotor_is_moving` re-export to `cfg(any(test, debug_assertions))`, but `techno_common_pre`'s DisguiseWhenStill check (sim/world/techno_ai.rs, live since 7e181246) consumes it in every build, so `cargo build --release` fails with E0425. Nobody noticed because dev/test builds keep `debug_assertions` on. One-line ungate, no behavior change; verified by building `--release` locally.