### PR TITLE
scenario: gate start placement with the playfield diamond, not a LocalSize box

### DIFF
--- a/src/app/frontend/skirmish.rs
+++ b/src/app/frontend/skirmish.rs
@@ -12,12 +12,12 @@ use crate::map::overlay::OverlayEntry;
 use crate::map::overlay_types::{
     OverlayTypeRegistry, is_bridge_overlay_index, is_high_bridge_index,
 };
-use crate::render::overlay_assets::resolve_overlay_name_for_render;
 use crate::map::waypoints;
 use crate::render::batch::BatchRenderer;
 use crate::render::bridge_atlas::{self, BridgeAtlas};
 use crate::render::bridge_railing_atlas::{self, BridgeRailingAtlas, BridgeRailingTileBases};
 use crate::render::gpu::GpuContext;
+use crate::render::overlay_assets::resolve_overlay_name_for_render;
 use crate::render::overlay_atlas::{self, OverlayAtlas};
 use crate::rules::art_data::ArtRegistry;
 use crate::rules::color_scheme::scheme_entry_for_priority;
@@ -145,7 +145,6 @@ pub(crate) fn house_color_map_for_launch_session(
     }
     colors
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -745,7 +744,12 @@ mod tests {
         let mut sim = Simulation::new();
         let rules = test_standard_launch_rules();
 
-        initialize_skirmish_launch_houses(&mut sim, &HouseRoster::default(), &rules, &launch_descriptor(&session));
+        initialize_skirmish_launch_houses(
+            &mut sim,
+            &HouseRoster::default(),
+            &rules,
+            &launch_descriptor(&session),
+        );
 
         let order: Vec<_> = sim
             .session
@@ -786,7 +790,12 @@ mod tests {
 
         let session = test_session();
         let mut sim = Simulation::new();
-        initialize_skirmish_launch_houses(&mut sim, &HouseRoster::default(), &rules, &launch_descriptor(&session));
+        initialize_skirmish_launch_houses(
+            &mut sim,
+            &HouseRoster::default(),
+            &rules,
+            &launch_descriptor(&session),
+        );
         assert!(sim.entities().is_empty());
 
         let spawned = sim.spawn_from_map(
@@ -857,12 +866,8 @@ mod tests {
         apply_skirmish_ai_opening_credits(&mut sim);
 
         let credits = |owner: &str| {
-            crate::sim::house_state::house_state_for_owner(
-                &sim.houses,
-                owner,
-                &sim.interner,
-            )
-            .map(|house| house.credits)
+            crate::sim::house_state::house_state_for_owner(&sim.houses, owner, &sim.interner)
+                .map(|house| house.credits)
         };
         assert_eq!(credits("Player"), Some(10_000));
         assert_eq!(credits("Computer1"), Some(20_000));
@@ -1133,8 +1138,9 @@ mod tests {
         let map = test_map_with_starts(&starts);
         let terrain = test_terrain(64, 64);
         let rules = test_standard_launch_rules();
-        let plan = preload_standard_battle_start_plan(&launch_descriptor(&session), &map, launch_seed)
-            .expect("complete standard Battle starts preload");
+        let plan =
+            preload_standard_battle_start_plan(&launch_descriptor(&session), &map, launch_seed)
+                .expect("complete standard Battle starts preload");
 
         let loading_assignments =
             crate::app::loading::pump::selected_map_start_assignments(&session, Some(&plan));
@@ -1425,7 +1431,11 @@ mod tests {
         };
 
         assert_eq!(
-            crate::app::presentation::sidebar_render::sidebar_theme_for_owner_sources(None, &roster, "MapPlayer",),
+            crate::app::presentation::sidebar_render::sidebar_theme_for_owner_sources(
+                None,
+                &roster,
+                "MapPlayer",
+            ),
             Some(SidebarTheme::Soviet),
             "an absent live owner must preserve the existing roster resolver"
         );
@@ -1865,6 +1875,85 @@ mod tests {
             .count();
         assert_eq!(player_units, 5);
         assert_eq!(ai_units, 4);
+    }
+
+    /// NearOreF.MAP geometry: `Size=0,0,80,58`, `LocalSize=2,4,76,48`, with
+    /// authored starts far outside any axis-aligned reading of LocalSize but
+    /// inside the retail playfield diamond. gamemd unlimbos every starting MCV
+    /// exactly on its authored waypoint (mode `+0xC8` @ `0x005D7030`; diamond
+    /// gate in the scan-place helper @ `0x00688ED0`). The old LocalSize-shaped
+    /// `NativeStartBounds` gate rejected these cells and clamped the fallback
+    /// spiral onto the false edge, piling several MCVs into the same corner.
+    #[test]
+    fn starting_mcvs_spawn_on_authored_waypoints_outside_the_localsize_box() {
+        let mut sim = Simulation::new();
+        // Raw Size width feeds the diamond's `base`; LocalSize feeds its band
+        // constants. Stored verbatim, exactly as the map loader does.
+        sim.playfield_bounds = Some(crate::sim::cell_rect::PlayfieldBounds {
+            base: 80,
+            off_fc: 2,
+            off_100: 4,
+            off_104: 76,
+            off_108: 48,
+        });
+        sim.session.local_left = 2;
+        sim.session.local_top = 4;
+        sim.session.local_width = 76;
+        sim.session.local_height = 48;
+        // Canonical cell-array extent for an 80x58 map (~SizeW+SizeH).
+        sim.session.map_width = 138;
+        sim.session.map_height = 138;
+
+        // NearOreF waypoints 0 and 7: (38,63) fails the false box on ry,
+        // (100,75) fails it on both axes; both are inside the retail diamond.
+        let starts = [
+            Waypoint {
+                index: 0,
+                rx: 38,
+                ry: 63,
+            },
+            Waypoint {
+                index: 1,
+                rx: 100,
+                ry: 75,
+            },
+        ];
+        let map = test_map_with_starts(&starts);
+        let terrain = test_terrain(139, 139);
+        let mut session = test_session();
+        session.local.start_position = LaunchStartPosition::Position(0);
+        session.opponents[0].start_position = LaunchStartPosition::Position(1);
+
+        let result = apply_explicit_skirmish_launch_session(
+            &mut sim,
+            &map,
+            &roster_with_neutral_and_playable(),
+            &test_standard_launch_rules(),
+            &test_height_map(),
+            &terrain,
+            &launch_descriptor(&session),
+        );
+
+        assert_eq!(result.spawned_mcvs, 2);
+        let mut cells: Vec<((u16, u16), String)> = sim
+            .entities()
+            .values()
+            .map(|entity| {
+                (
+                    (entity.position.rx, entity.position.ry),
+                    sim.interner.resolve(entity.owner).to_string(),
+                )
+            })
+            .collect();
+        cells.sort();
+        assert_eq!(
+            cells,
+            vec![
+                ((38, 63), "Player".to_string()),
+                ((100, 75), "Computer1".to_string()),
+            ],
+            "starting MCVs must unlimbo exactly on their authored waypoints"
+        );
     }
 
     #[test]

--- a/src/app/frontend/skirmish.rs
+++ b/src/app/frontend/skirmish.rs
@@ -155,6 +155,7 @@ mod tests {
     use crate::map::waypoints::Waypoint;
     use crate::rules::ini_parser::IniFile;
     use crate::rules::terrain_rules::{SpeedCostProfile, TerrainClass};
+    use crate::sim::cell_rect::{PlayfieldBounds, cell_is_in_playfield};
     use crate::sim::house_state::{HouseDifficulty, HouseState};
     use crate::sim::mission::MissionType;
     use crate::sim::rng::SimRng;
@@ -609,8 +610,9 @@ mod tests {
         let _ = expected.next_range_u32_inclusive(10, 54);
         let occupancy = crate::sim::occupancy::OccupancyGrid::new();
 
-        let starts =
-            native_gather_start_positions(&waypoints, 2, &terrain, &occupancy, bounds, &mut rng);
+        let starts = native_gather_start_positions(
+            &waypoints, 2, &terrain, &occupancy, bounds, None, &mut rng,
+        );
 
         assert_eq!(starts.len(), 2);
         assert_eq!(starts[0], authored);
@@ -663,6 +665,75 @@ mod tests {
     }
 
     #[test]
+    fn deficient_start_skips_passable_anchor_outside_diamond() {
+        let terrain = test_terrain(32, 32);
+        let occupancy = crate::sim::occupancy::OccupancyGrid::new();
+        let bounds = NativeStartBounds {
+            min_rx: 0,
+            min_ry: 0,
+            width: 32,
+            height: 32,
+        };
+        let diamond = PlayfieldBounds {
+            base: 10,
+            off_fc: 2,
+            off_100: 1,
+            off_104: 10,
+            off_108: 6,
+        };
+        assert!(deficient_start_rect_track_passable(
+            &terrain, &occupancy, 6, 6
+        ));
+        assert!(!cell_is_in_playfield(
+            (6, 6),
+            Some(diamond),
+            Some(&terrain),
+            Some((terrain.width(), terrain.height())),
+        ));
+
+        assert_eq!(
+            find_nearby_start_rect(&terrain, &occupancy, bounds, Some(diamond), 6, 6),
+            Some((6, 7))
+        );
+    }
+
+    #[test]
+    fn deficient_start_gates_anchor_not_full_8x8_footprint() {
+        let terrain = test_terrain(32, 32);
+        let occupancy = crate::sim::occupancy::OccupancyGrid::new();
+        let bounds = NativeStartBounds {
+            min_rx: 0,
+            min_ry: 0,
+            width: 32,
+            height: 32,
+        };
+        let diamond = PlayfieldBounds {
+            base: 10,
+            off_fc: 2,
+            off_100: 1,
+            off_104: 10,
+            off_108: 6,
+        };
+        assert!(cell_is_in_playfield(
+            (6, 7),
+            Some(diamond),
+            Some(&terrain),
+            Some((terrain.width(), terrain.height())),
+        ));
+        assert!(!cell_is_in_playfield(
+            (13, 14),
+            Some(diamond),
+            Some(&terrain),
+            Some((terrain.width(), terrain.height())),
+        ));
+
+        assert_eq!(
+            find_nearby_start_rect(&terrain, &occupancy, bounds, Some(diamond), 6, 7),
+            Some((6, 7))
+        );
+    }
+
+    #[test]
     fn gsi_04_16_standard_battle_gathers_deficient_starts_twice() {
         let authored = Waypoint {
             index: 0,
@@ -695,6 +766,7 @@ mod tests {
             &terrain,
             &empty_occupancy,
             bounds,
+            None,
             &mut expected_rng,
         );
         let final_starts = native_gather_start_positions(
@@ -703,6 +775,7 @@ mod tests {
             &terrain,
             &empty_occupancy,
             bounds,
+            None,
             &mut expected_rng,
         );
         assert_ne!(provisional[1], final_starts[1]);

--- a/src/app/frontend/skirmish.rs
+++ b/src/app/frontend/skirmish.rs
@@ -427,6 +427,67 @@ mod tests {
         }
     }
 
+    fn nearoref_starts() -> [Waypoint; 8] {
+        [
+            Waypoint {
+                index: 0,
+                rx: 38,
+                ry: 63,
+            },
+            Waypoint {
+                index: 1,
+                rx: 53,
+                ry: 48,
+            },
+            Waypoint {
+                index: 2,
+                rx: 71,
+                ry: 32,
+            },
+            Waypoint {
+                index: 3,
+                rx: 99,
+                ry: 32,
+            },
+            Waypoint {
+                index: 4,
+                rx: 39,
+                ry: 106,
+            },
+            Waypoint {
+                index: 5,
+                rx: 68,
+                ry: 107,
+            },
+            Waypoint {
+                index: 6,
+                rx: 85,
+                ry: 90,
+            },
+            Waypoint {
+                index: 7,
+                rx: 100,
+                ry: 75,
+            },
+        ]
+    }
+
+    fn configure_nearoref_geometry(sim: &mut Simulation, map: &mut MapFile) {
+        map.header.width = 80;
+        map.header.height = 58;
+        map.header.local_left = 2;
+        map.header.local_top = 4;
+        map.header.local_width = 76;
+        map.header.local_height = 48;
+        sim.playfield_bounds = Some(PlayfieldBounds::from_map_header(&map.header));
+        sim.session.map_width = 138;
+        sim.session.map_height = 138;
+        sim.session.local_left = 2;
+        sim.session.local_top = 4;
+        sim.session.local_width = 76;
+        sim.session.local_height = 48;
+    }
+
     fn test_launch_starts() -> [Waypoint; 4] {
         [
             Waypoint {
@@ -617,6 +678,11 @@ mod tests {
         assert_eq!(starts.len(), 2);
         assert_eq!(starts[0], authored);
         assert_eq!(starts[1].index, 1);
+        assert_eq!(
+            (starts[1].rx, starts[1].ry),
+            (54, 21),
+            "first native ranged draw is Y, second is X"
+        );
         assert!(deficient_start_rect_track_passable(
             &terrain,
             &occupancy,
@@ -1794,6 +1860,79 @@ mod tests {
     }
 
     #[test]
+    fn nearoref_blocked_start_fallback_uses_full_cell_array_clamp() {
+        let mut sim = Simulation::with_seed(0);
+        let mut session = test_session();
+        session.local.start_position = LaunchStartPosition::Position(0);
+        session.opponents.clear();
+        session.options.bases = true;
+        session.options.unit_count = 0;
+        let starts = [Waypoint {
+            index: 0,
+            rx: 100,
+            ry: 75,
+        }];
+        let mut map = test_map_with_starts(&starts);
+        configure_nearoref_geometry(&mut sim, &mut map);
+        let terrain = test_terrain(138, 138);
+        let rules = test_standard_launch_rules();
+        let descriptor = launch_descriptor(&session);
+        initialize_skirmish_launch_houses(
+            &mut sim,
+            &roster_with_neutral_and_playable(),
+            &rules,
+            &descriptor,
+        );
+        sim.spawn_object(
+            "AMCV",
+            "Neutral",
+            100,
+            75,
+            STARTING_MCV_FACING,
+            &rules,
+            &test_height_map(),
+        )
+        .expect("authored start blocker");
+        let mut expected_rng = sim.scenario_rng.clone();
+        assert_eq!(
+            expected_rng.next_range_u32_inclusive(0, 7),
+            3,
+            "seed zero chooses the southeast radius-one spoke"
+        );
+        let _ = expected_rng.next_range_u32_inclusive(0, 0xffff);
+
+        let result = apply_explicit_skirmish_launch_session(
+            &mut sim,
+            &map,
+            &roster_with_neutral_and_playable(),
+            &rules,
+            &test_height_map(),
+            &terrain,
+            &descriptor,
+        );
+
+        assert_eq!(result.active_slots, 1);
+        assert_eq!(result.spawned_mcvs, 1);
+        assert_eq!(sim.entities().len(), 2);
+        assert_eq!(entity_position_for_owner(&sim, "Neutral"), Some((100, 75)));
+        assert_eq!(
+            entity_position_for_owner(&sim, "Player"),
+            Some((101, 76)),
+            "the valid spoke stays outside the old LocalSize box instead of clamping to (77,51)"
+        );
+        assert_eq!(
+            crate::sim::house_state::house_state_for_owner(&sim.houses, "Player", &sim.interner)
+                .and_then(|house| house.base_center),
+            Some((100, 75)),
+            "fallback placement must not rewrite the assigned base center"
+        );
+        assert_eq!(
+            sim.scenario_rng.logical_state(),
+            expected_rng.logical_state()
+        );
+    }
+
+    #[test]
     fn skirmish_start_unit_budget_is_global_but_house_pools_filter_tech_and_mask() {
         let rules = test_starting_unit_rules();
         let slots = normalized_launch_slots(&test_session());
@@ -1950,52 +2089,31 @@ mod tests {
         assert_eq!(ai_units, 4);
     }
 
-    /// NearOreF.MAP geometry: `Size=0,0,80,58`, `LocalSize=2,4,76,48`, with
-    /// authored starts far outside any axis-aligned reading of LocalSize but
-    /// inside the retail playfield diamond. gamemd unlimbos every starting MCV
-    /// exactly on its authored waypoint (mode `+0xC8` @ `0x005D7030`; diamond
-    /// gate in the scan-place helper @ `0x00688ED0`). The old LocalSize-shaped
-    /// `NativeStartBounds` gate rejected these cells and clamped the fallback
-    /// spiral onto the false edge, piling several MCVs into the same corner.
+    /// NearOreF.MAP geometry: `Size=0,0,80,58`, `LocalSize=2,4,76,48`.
+    /// GameMD unlimbos all eight starting MCVs exactly on their authored
+    /// waypoints. The former Cartesian LocalSize test accepted only indices 1
+    /// and 2, displaced the other six, and consumed fallback RNG.
     #[test]
-    fn starting_mcvs_spawn_on_authored_waypoints_outside_the_localsize_box() {
-        let mut sim = Simulation::new();
-        // Raw Size width feeds the diamond's `base`; LocalSize feeds its band
-        // constants. Stored verbatim, exactly as the map loader does.
-        sim.playfield_bounds = Some(crate::sim::cell_rect::PlayfieldBounds {
-            base: 80,
-            off_fc: 2,
-            off_100: 4,
-            off_104: 76,
-            off_108: 48,
-        });
-        sim.session.local_left = 2;
-        sim.session.local_top = 4;
-        sim.session.local_width = 76;
-        sim.session.local_height = 48;
-        // Canonical cell-array extent for an 80x58 map (~SizeW+SizeH).
-        sim.session.map_width = 138;
-        sim.session.map_height = 138;
-
-        // NearOreF waypoints 0 and 7: (38,63) fails the false box on ry,
-        // (100,75) fails it on both axes; both are inside the retail diamond.
-        let starts = [
-            Waypoint {
-                index: 0,
-                rx: 38,
-                ry: 63,
-            },
-            Waypoint {
-                index: 1,
-                rx: 100,
-                ry: 75,
-            },
-        ];
-        let map = test_map_with_starts(&starts);
-        let terrain = test_terrain(139, 139);
+    fn all_eight_nearoref_mcvs_spawn_on_authored_waypoints_without_fallback_rng() {
+        let mut sim = Simulation::with_seed(0);
+        let starts = nearoref_starts();
+        let mut map = test_map_with_starts(&starts);
+        configure_nearoref_geometry(&mut sim, &mut map);
+        let terrain = test_terrain(138, 138);
         let mut session = test_session();
         session.local.start_position = LaunchStartPosition::Position(0);
-        session.opponents[0].start_position = LaunchStartPosition::Position(1);
+        session.options.bases = true;
+        session.options.unit_count = 0;
+        let ai_template = session.opponents[0].clone();
+        session.opponents = (1..8)
+            .map(|index| SkirmishAiSlot {
+                color_index: (index + 1) as u8,
+                start_position: LaunchStartPosition::Position(index as u8),
+                ..ai_template.clone()
+            })
+            .collect();
+        let mut expected_rng = sim.scenario_rng.clone();
+        let _ = expected_rng.next_range_u32_inclusive(0, 0xffff);
 
         let result = apply_explicit_skirmish_launch_session(
             &mut sim,
@@ -2007,25 +2125,47 @@ mod tests {
             &launch_descriptor(&session),
         );
 
-        assert_eq!(result.spawned_mcvs, 2);
-        let mut cells: Vec<((u16, u16), String)> = sim
+        assert_eq!(result.active_slots, 8);
+        assert_eq!(result.spawned_mcvs, 8);
+        assert_eq!(sim.entities().len(), 8);
+        let cells: BTreeMap<String, (u16, u16)> = sim
             .entities()
             .values()
             .map(|entity| {
                 (
-                    (entity.position.rx, entity.position.ry),
                     sim.interner.resolve(entity.owner).to_string(),
+                    (entity.position.rx, entity.position.ry),
                 )
             })
             .collect();
-        cells.sort();
+        let expected_cells: BTreeMap<String, (u16, u16)> = starts
+            .iter()
+            .enumerate()
+            .map(|(index, start)| {
+                let owner = if index == 0 {
+                    "Player".to_string()
+                } else {
+                    format!("Computer{index}")
+                };
+                (owner, (start.rx, start.ry))
+            })
+            .collect();
         assert_eq!(
-            cells,
-            vec![
-                ((38, 63), "Player".to_string()),
-                ((100, 75), "Computer1".to_string()),
-            ],
+            cells, expected_cells,
             "starting MCVs must unlimbo exactly on their authored waypoints"
+        );
+        for (owner, expected_cell) in &expected_cells {
+            assert_eq!(
+                crate::sim::house_state::house_state_for_owner(&sim.houses, owner, &sim.interner,)
+                    .and_then(|house| house.base_center),
+                Some(*expected_cell),
+                "{owner} must retain its authored base center"
+            );
+        }
+        assert_eq!(
+            sim.scenario_rng.logical_state(),
+            expected_rng.logical_state(),
+            "exact placement consumes only the final scenario synchronization draw"
         );
     }
 

--- a/src/app/frontend/skirmish.rs
+++ b/src/app/frontend/skirmish.rs
@@ -650,6 +650,10 @@ mod tests {
         assert!(slots[0].is_human);
     }
 
+    /// gamemd-derived: active YR `ScenarioClass__Gather_Start_Positions
+    /// @ 0x00688380`, seed block `0x00688528..0x0068857C`, draws Y before X
+    /// from the full cell-array bounds. Research:
+    /// `docs/research/skirmish-ui/SKIRMISH_GATHER_START_POSITIONS_DEFICIENT_WAYPOINT_FALLBACK_00688380_GHIDRA_REPORT.md`.
     #[test]
     fn native_gather_generates_deficient_start_with_two_ranged_draws() {
         let authored = Waypoint {
@@ -730,6 +734,11 @@ mod tests {
         ));
     }
 
+    /// gamemd-derived: active YR `FootClass__Find_Nearby_Passable_Cell
+    /// @ 0x0056DC20` gates the candidate anchor through
+    /// `MapClass__Is_Cell_In_Playfield_CellClass @ 0x00578540` before the 8x8
+    /// scan. Research:
+    /// `docs/research/skirmish-ui/FOOTCLASS_FIND_NEARBY_PASSABLE_CELL_0056DC20_START_FALLBACK_GHIDRA_REPORT.md`.
     #[test]
     fn deficient_start_skips_passable_anchor_outside_diamond() {
         let terrain = test_terrain(32, 32);
@@ -763,6 +772,10 @@ mod tests {
         );
     }
 
+    /// gamemd-derived: `CellRect__CheckPassability @ 0x0056E7C0` scans the 8x8
+    /// footprint after `0x00578540` gates only its anchor; retail does not
+    /// diamond-test the other 63 cells. Research:
+    /// `docs/research/skirmish-ui/FOOTCLASS_FIND_NEARBY_PASSABLE_CELL_0056DC20_START_FALLBACK_GHIDRA_REPORT.md`.
     #[test]
     fn deficient_start_gates_anchor_not_full_8x8_footprint() {
         let terrain = test_terrain(32, 32);
@@ -799,6 +812,9 @@ mod tests {
         );
     }
 
+    /// gamemd-derived: standard Battle dispatches start gathering through its
+    /// `+0x80 @ 0x005D6BE0` and `+0x84 @ 0x005D6C70` phases, both reaching
+    /// `ScenarioClass__Gather_Start_Positions @ 0x00688380`.
     #[test]
     fn gsi_04_16_standard_battle_gathers_deficient_starts_twice() {
         let authored = Waypoint {
@@ -1859,6 +1875,12 @@ mod tests {
         );
     }
 
+    /// gamemd-derived: active YR
+    /// `MultiplayerGameMode__Create_Starting_Base_Unit @ 0x005D7030` falls
+    /// through to `Try_Unlimbo_Object_At_Or_Near_Cell @ 0x00688ED0`; probes
+    /// clamp through the `0x00565C10` full cell-array rect and then use the
+    /// `0x00578460` diamond. Research:
+    /// `docs/research/skirmish-ui/SKIRMISH_MCV_NEARBY_PLACEMENT_FALLBACK_00688ED0_GHIDRA_REPORT.md`.
     #[test]
     fn nearoref_blocked_start_fallback_uses_full_cell_array_clamp() {
         let mut sim = Simulation::with_seed(0);
@@ -2089,10 +2111,16 @@ mod tests {
         assert_eq!(ai_units, 4);
     }
 
-    /// NearOreF.MAP geometry: `Size=0,0,80,58`, `LocalSize=2,4,76,48`.
+    /// gamemd-derived: active YR
+    /// `MultiplayerGameMode__Create_Starting_Base_Unit @ 0x005D7030` and
+    /// `Try_Unlimbo_Object_At_Or_Near_Cell @ 0x00688ED0` use the independent
+    /// full-array clamp (`0x00565C10`) and playfield diamond (`0x00578460`).
+    /// NearOreF.MAP geometry is `Size=0,0,80,58`, `LocalSize=2,4,76,48`.
     /// GameMD unlimbos all eight starting MCVs exactly on their authored
     /// waypoints. The former Cartesian LocalSize test accepted only indices 1
     /// and 2, displaced the other six, and consumed fallback RNG.
+    /// Research:
+    /// `docs/research/skirmish-ui/SKIRMISH_MCV_NEARBY_PLACEMENT_FALLBACK_00688ED0_GHIDRA_REPORT.md`.
     #[test]
     fn all_eight_nearoref_mcvs_spawn_on_authored_waypoints_without_fallback_rng() {
         let mut sim = Simulation::with_seed(0);

--- a/src/sim/cell_rect.rs
+++ b/src/sim/cell_rect.rs
@@ -8,6 +8,7 @@
 use std::collections::BTreeMap;
 
 use crate::map::entities::EntityCategory;
+use crate::map::map_file::MapHeader;
 use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid, zone_class};
 use crate::rules::locomotor_type::{MovementZone, SpeedType};
 use crate::sim::entity_store::EntityStore;
@@ -581,25 +582,106 @@ pub struct CellRectOccupancyContext<'a> {
 /// The five map bound values that define the engine's isometric playfield diamond,
 /// read by `cell_in_playfield_diamond`.
 ///
-/// Field meanings verified 2026-06-04 (see
-/// `docs/research/CELLCLASS_PLAYFIELD_BOUNDS_FROM_LOCALSIZE_GHIDRA_REPORT.md`): `base` is the map's
-/// `[Map] Size=` width; the other four are the raw `[Map] LocalSize=` values (left, top, width, height)
-/// stored verbatim — there is no transform here. The `*2` doubling and the `+2`/`+4` constants live
-/// entirely in `cell_in_playfield_diamond`. All five are signed map-coord values. The `off_*` field
-/// names are legacy (named after their source struct offsets) and kept to avoid a rename churn across
-/// the tests and the diamond fn.
+/// Field meanings verified against active YR `MapClass::Set_Clipped_LocalSize
+/// @ 0x00567230`: `base` is the map's signed `[Map] Size=` width; the other
+/// four are `[Map] LocalSize=` after signed intersection with normalized
+/// `Size=(0,0,width,height)`, the native left/top floor, and right/bottom
+/// margin caps. The `*2` doubling and the `+2`/`+4` diamond constants live in
+/// `cell_in_playfield_diamond`. The `off_*` names are legacy source-struct
+/// offsets retained to avoid rename churn across consumers and tests.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PlayfieldBounds {
     /// `[Map] Size=` width (3rd value).
     pub base: i32,
-    /// `[Map] LocalSize=` left (1st value).
+    /// Clipped/normalized `[Map] LocalSize=` left (1st value).
     pub off_fc: i32,
-    /// `[Map] LocalSize=` top (2nd value).
+    /// Clipped/normalized `[Map] LocalSize=` top (2nd value).
     pub off_100: i32,
-    /// `[Map] LocalSize=` width (3rd value).
+    /// Clipped/normalized `[Map] LocalSize=` width (3rd value).
     pub off_104: i32,
-    /// `[Map] LocalSize=` height (4th value).
+    /// Clipped/normalized `[Map] LocalSize=` height (4th value).
     pub off_108: i32,
+}
+
+impl PlayfieldBounds {
+    /// Construct the live MapClass playfield fields from the raw map header.
+    ///
+    /// `MapHeader` preserves signed INI values in `u32` bit patterns; recover
+    /// them before reproducing `ClipRect @ 0x00421B60` and
+    /// `MapClass::Set_Clipped_LocalSize @ 0x00567230`. Wrapping arithmetic is
+    /// intentional x86 parity for malformed headers, and final spans are not
+    /// saturated back to zero after the native margin caps.
+    pub(crate) fn from_map_header(header: &MapHeader) -> Self {
+        let size_width = header.width as i32;
+        let size_height = header.height as i32;
+        let [clipped_left, clipped_top, clipped_width, clipped_height] = clip_local_size_to_map(
+            size_width,
+            size_height,
+            [
+                header.local_left as i32,
+                header.local_top as i32,
+                header.local_width as i32,
+                header.local_height as i32,
+            ],
+        );
+
+        let left = clipped_left.max(2);
+        let top = clipped_top.max(2);
+        let width_cap = size_width.wrapping_sub(left).wrapping_sub(2);
+        let height_cap = size_height.wrapping_sub(top).wrapping_sub(6);
+
+        Self {
+            base: size_width,
+            off_fc: left,
+            off_100: top,
+            off_104: clipped_width.min(width_cap),
+            off_108: clipped_height.min(height_cap),
+        }
+    }
+}
+
+/// Signed intersection of raw LocalSize with normalized Size, matching the
+/// active `ClipRect @ 0x00421B60` call inside `0x00567230`.
+fn clip_local_size_to_map(
+    size_width: i32,
+    size_height: i32,
+    [mut left, mut top, mut width, mut height]: [i32; 4],
+) -> [i32; 4] {
+    if size_width <= 0 || size_height <= 0 || width <= 0 || height <= 0 {
+        return [0; 4];
+    }
+
+    if left < 0 {
+        width = width.wrapping_add(left);
+        left = 0;
+    }
+    if width <= 0 {
+        return [0; 4];
+    }
+
+    if top < 0 {
+        height = height.wrapping_add(top);
+        top = 0;
+    }
+    if height <= 0 {
+        return [0; 4];
+    }
+
+    if size_width < left.wrapping_add(width) {
+        width = size_width.wrapping_sub(left);
+    }
+    if width <= 0 {
+        return [0; 4];
+    }
+
+    if size_height < top.wrapping_add(height) {
+        height = size_height.wrapping_sub(top);
+    }
+    if height <= 0 {
+        return [0; 4];
+    }
+
+    [left, top, width, height]
 }
 
 pub fn check_passability_rect(ctx: CellRectPassabilityContext<'_>) -> bool {
@@ -971,6 +1053,95 @@ mod tests {
     use crate::rules::terrain_rules::{SpeedCostProfile, TerrainClass};
     use crate::sim::occupancy::CellListInsertion;
     use crate::sim::pathfinding::zone_map::ZoneGrid;
+
+    fn map_header_with_rects(size: (i32, i32), local: [i32; 4]) -> MapHeader {
+        MapHeader {
+            theater: "TEMPERATE".to_string(),
+            fill: "Clear".to_string(),
+            level: 0,
+            width: size.0 as u32,
+            height: size.1 as u32,
+            local_left: local[0] as u32,
+            local_top: local[1] as u32,
+            local_width: local[2] as u32,
+            local_height: local[3] as u32,
+        }
+    }
+
+    #[test]
+    fn playfield_bounds_from_map_header_keeps_nearoref_native_values() {
+        let bounds =
+            PlayfieldBounds::from_map_header(&map_header_with_rects((80, 58), [2, 4, 76, 48]));
+
+        assert_eq!(
+            bounds,
+            PlayfieldBounds {
+                base: 80,
+                off_fc: 2,
+                off_100: 4,
+                off_104: 76,
+                off_108: 48,
+            }
+        );
+    }
+
+    #[test]
+    fn playfield_bounds_from_map_header_clips_signed_local_before_margins() {
+        let bounds =
+            PlayfieldBounds::from_map_header(&map_header_with_rects((80, 80), [-5, -6, 100, 100]));
+
+        assert_eq!(
+            bounds,
+            PlayfieldBounds {
+                base: 80,
+                off_fc: 2,
+                off_100: 2,
+                off_104: 76,
+                off_108: 72,
+            }
+        );
+    }
+
+    #[test]
+    fn playfield_bounds_from_map_header_preserves_native_empty_and_small_results() {
+        assert_eq!(
+            PlayfieldBounds::from_map_header(&map_header_with_rects((40, 50), [0; 4])),
+            PlayfieldBounds {
+                base: 40,
+                off_fc: 2,
+                off_100: 2,
+                off_104: 0,
+                off_108: 0,
+            }
+        );
+        assert_eq!(
+            PlayfieldBounds::from_map_header(&map_header_with_rects((0, 0), [0; 4])),
+            PlayfieldBounds {
+                base: 0,
+                off_fc: 2,
+                off_100: 2,
+                off_104: -4,
+                off_108: -8,
+            }
+        );
+    }
+
+    #[test]
+    fn playfield_bounds_from_map_header_caps_present_rect_at_native_margins() {
+        let bounds =
+            PlayfieldBounds::from_map_header(&map_header_with_rects((40, 50), [5, 6, 40, 50]));
+
+        assert_eq!(
+            bounds,
+            PlayfieldBounds {
+                base: 40,
+                off_fc: 5,
+                off_100: 6,
+                off_104: 33,
+                off_108: 38,
+            }
+        );
+    }
 
     fn clear_to_move_request() -> IsClearToMoveRequest {
         IsClearToMoveRequest {

--- a/src/sim/cell_rect.rs
+++ b/src/sim/cell_rect.rs
@@ -589,6 +589,8 @@ pub struct CellRectOccupancyContext<'a> {
 /// margin caps. The `*2` doubling and the `+2`/`+4` diamond constants live in
 /// `cell_in_playfield_diamond`. The `off_*` names are legacy source-struct
 /// offsets retained to avoid rename churn across consumers and tests.
+/// Research:
+/// `docs/research/skirmish-ui/SKIRMISH_MCV_NEARBY_PLACEMENT_FALLBACK_00688ED0_GHIDRA_REPORT.md`, section 3.4.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct PlayfieldBounds {
     /// `[Map] Size=` width (3rd value).

--- a/src/sim/runtime.rs
+++ b/src/sim/runtime.rs
@@ -362,15 +362,12 @@ where
         sim.radar_events =
             crate::sim::radar::RadarEventQueue::from_config(&rules.radar_event_config);
     }
-    // The playfield diamond: [Map] Size width + the raw LocalSize rect, stored
-    // verbatim — the isometric transform lives in the validator's diamond test.
-    sim.playfield_bounds = Some(crate::sim::cell_rect::PlayfieldBounds {
-        base: map_data.header.width as i32,
-        off_fc: map_data.header.local_left as i32,
-        off_100: map_data.header.local_top as i32,
-        off_104: map_data.header.local_width as i32,
-        off_108: map_data.header.local_height as i32,
-    });
+    // Normal loading first clips/normalizes LocalSize through
+    // `MapClass::Set_Clipped_LocalSize @ 0x00567230`; every playfield consumer
+    // then shares those stored fields and the same isometric-diamond test.
+    sim.playfield_bounds = Some(crate::sim::cell_rect::PlayfieldBounds::from_map_header(
+        &map_data.header,
+    ));
     let bridge_destroyable = map_data
         .special_flags
         .effective_destroyable_bridges(bridge_destroyability_mode);

--- a/src/sim/scenario_bootstrap.rs
+++ b/src/sim/scenario_bootstrap.rs
@@ -1849,6 +1849,38 @@ mod tests {
     }
 
     #[test]
+    fn nearoref_native_start_bounds_use_inclusive_full_cell_array_endpoints() {
+        let mut sim = Simulation::new();
+        sim.session.map_width = 138;
+        sim.session.map_height = 138;
+        sim.session.local_left = 2;
+        sim.session.local_top = 4;
+        sim.session.local_width = 76;
+        sim.session.local_height = 48;
+        let terrain = ResolvedTerrainGrid::from_cells(138, 138, Vec::new());
+
+        let bounds = NativeStartBounds::from_session(&sim, &terrain);
+
+        assert_eq!(
+            (
+                bounds.min_rx,
+                bounds.min_ry,
+                bounds.width,
+                bounds.height,
+                bounds.max_rx(),
+                bounds.max_ry(),
+            ),
+            (1, 1, 137, 137, 137, 137)
+        );
+        assert_eq!(bounds.clamp(0, 0), (1, 1));
+        assert_eq!(bounds.clamp(1, 1), (1, 1));
+        assert_eq!(bounds.clamp(100, 75), (100, 75));
+        assert_eq!(bounds.clamp(137, 137), (137, 137));
+        assert_eq!(bounds.clamp(138, 138), (137, 137));
+        assert_eq!(bounds.clamp(i32::MIN, i32::MAX), (1, 137));
+    }
+
+    #[test]
     fn untouched_bootstrap_cursors_match_fresh_descriptor_construction() {
         let seed = 0x51C0_1001;
         let expected = Simulation::from_descriptor(&descriptor(seed)).rng_state();

--- a/src/sim/scenario_bootstrap.rs
+++ b/src/sim/scenario_bootstrap.rs
@@ -36,12 +36,13 @@ pub(crate) struct NativeStartBounds {
 }
 
 impl NativeStartBounds {
-    /// The native start machinery is bounded by the MapClass CELL-ARRAY rect,
-    /// never by `LocalSize=`: `MapClass::Resize` @ `0x00565C10` writes
+    /// gamemd-derived: active YR start placement is bounded by the MapClass
+    /// CELL-ARRAY rect, never by `LocalSize=`. `MapClass::Resize @ 0x00565C10` writes
     /// `MapClass+0x124..0x130` as `(1, 1, SizeW+SizeH-1, SizeW+SizeH-1)`, and
-    /// both `ScenarioClass::Gather_Start_Positions` @ `0x00688564` (deficient
-    /// seed draws) and the starting-unit scan-place helper @ `0x00688ED0`
-    /// (fallback probe clamp) read exactly those four fields. Playable-area
+    /// both `ScenarioClass__Gather_Start_Positions @ 0x00688380` (deficient
+    /// seed block `0x00688528..0x0068857C`) and
+    /// `Try_Unlimbo_Object_At_Or_Near_Cell @ 0x00688ED0` (fallback probe clamp)
+    /// read exactly those four fields. Playable-area
     /// acceptance is the separate isometric-diamond predicate
     /// (`cell_rect::cell_is_in_playfield`); `LocalSize=` feeds that test's
     /// band constants only, never an axis-aligned bound. Treating LocalSize
@@ -109,8 +110,9 @@ pub(crate) fn native_gather_start_positions(
     }
 
     while starts.len() < target_count {
-        // `ScenarioClass::Gather_Start_Positions` @ `0x00688564`: the first
-        // draw `RandomRanged(0, rect.h - 10)` lands on the Y axis
+        // gamemd-derived: active YR `ScenarioClass__Gather_Start_Positions
+        // @ 0x00688380`, seed block `0x00688528..0x0068857C`: the first draw
+        // `RandomRanged(0, rect.h - 10)` lands on the Y axis
         // (`+ 10 + rect.y`), the second `RandomRanged(10, rect.w - 10)` on the
         // X axis (`+ rect.x`). The rect is the MapClass cell-array rect (see
         // `NativeStartBounds::from_session`), which is square, so a transposed
@@ -183,9 +185,10 @@ pub(crate) fn find_nearby_start_rect(
             {
                 continue;
             }
-            // Active YR `FootClass::Find_Nearby_Passable_Cell @ 0x0056DC20`
-            // applies `MapClass::Is_Cell_In_Playfield(cell, 1) @ 0x00578540`
-            // to the candidate anchor before scanning its 8x8 passability rect.
+            // gamemd-derived: active YR `FootClass__Find_Nearby_Passable_Cell
+            // @ 0x0056DC20` applies `MapClass__Is_Cell_In_Playfield_CellClass
+            // @ 0x00578540` to the candidate anchor before
+            // `CellRect__CheckPassability @ 0x0056E7C0` scans its 8x8 rect.
             // Only the anchor is diamond-gated; requiring all 64 cells to lie in
             // the diamond would be stricter than retail.
             if !cell_is_in_playfield(

--- a/src/sim/scenario_bootstrap.rs
+++ b/src/sim/scenario_bootstrap.rs
@@ -16,6 +16,7 @@ use crate::map::waypoints::Waypoint;
 use crate::rng_continuation::MapGenRngContinuation;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::ai::AiPlayerState;
+use crate::sim::cell_rect::{PlayfieldBounds, cell_is_in_playfield};
 use crate::sim::house_state::{HouseDifficulty, HouseState, determine_waypoint_edge};
 use crate::sim::mission::{MissionId, MissionType};
 use crate::sim::rng::{SimRng, SimRngLogicalState};
@@ -92,6 +93,7 @@ pub(crate) fn native_gather_start_positions(
     terrain: &ResolvedTerrainGrid,
     occupancy: &crate::sim::occupancy::OccupancyGrid,
     bounds: NativeStartBounds,
+    playfield_bounds: Option<PlayfieldBounds>,
     rng: &mut SimRng,
 ) -> Vec<Waypoint> {
     let authored_prefix = (0..8u32)
@@ -124,8 +126,14 @@ pub(crate) fn native_gather_start_positions(
             .next_range_u32_inclusive(10, x_high)
             .wrapping_add(u32::from(bounds.min_rx)) as u16;
 
-        let Some((rx, ry)) = find_nearby_start_rect(terrain, occupancy, bounds, seed_rx, seed_ry)
-        else {
+        let Some((rx, ry)) = find_nearby_start_rect(
+            terrain,
+            occupancy,
+            bounds,
+            playfield_bounds,
+            seed_rx,
+            seed_ry,
+        ) else {
             continue;
         };
         starts.push(Waypoint {
@@ -142,10 +150,11 @@ pub(crate) fn native_gather_start_positions(
 /// start gathering: scan square rings from the seed, finish the first ring
 /// containing an 8x8 passable candidate, and select its first candidate at
 /// frame zero.
-fn find_nearby_start_rect(
+pub(crate) fn find_nearby_start_rect(
     terrain: &ResolvedTerrainGrid,
     occupancy: &crate::sim::occupancy::OccupancyGrid,
     bounds: NativeStartBounds,
+    playfield_bounds: Option<PlayfieldBounds>,
     seed_rx: u16,
     seed_ry: u16,
 ) -> Option<(u16, u16)> {
@@ -172,6 +181,19 @@ fn find_nearby_start_rect(
                 || rx + i32::from(DEFICIENT_START_RECT_W) - 1 > i32::from(bounds.max_rx())
                 || ry + i32::from(DEFICIENT_START_RECT_H) - 1 > i32::from(bounds.max_ry())
             {
+                continue;
+            }
+            // Active YR `FootClass::Find_Nearby_Passable_Cell @ 0x0056DC20`
+            // applies `MapClass::Is_Cell_In_Playfield(cell, 1) @ 0x00578540`
+            // to the candidate anchor before scanning its 8x8 passability rect.
+            // Only the anchor is diamond-gated; requiring all 64 cells to lie in
+            // the diamond would be stricter than retail.
+            if !cell_is_in_playfield(
+                (rx, ry),
+                playfield_bounds,
+                Some(terrain),
+                Some((terrain.width(), terrain.height())),
+            ) {
                 continue;
             }
             let (rx, ry) = (rx as u16, ry as u16);
@@ -1693,6 +1715,7 @@ impl Simulation {
             terrain,
             &self.substrate.occupancy,
             bounds,
+            self.playfield_bounds,
             &mut self.scenario_rng,
         )
     }

--- a/src/sim/scenario_bootstrap.rs
+++ b/src/sim/scenario_bootstrap.rs
@@ -35,21 +35,32 @@ pub(crate) struct NativeStartBounds {
 }
 
 impl NativeStartBounds {
+    /// The native start machinery is bounded by the MapClass CELL-ARRAY rect,
+    /// never by `LocalSize=`: `MapClass::Resize` @ `0x00565C10` writes
+    /// `MapClass+0x124..0x130` as `(1, 1, SizeW+SizeH-1, SizeW+SizeH-1)`, and
+    /// both `ScenarioClass::Gather_Start_Positions` @ `0x00688564` (deficient
+    /// seed draws) and the starting-unit scan-place helper @ `0x00688ED0`
+    /// (fallback probe clamp) read exactly those four fields. Playable-area
+    /// acceptance is the separate isometric-diamond predicate
+    /// (`cell_rect::cell_is_in_playfield`); `LocalSize=` feeds that test's
+    /// band constants only, never an axis-aligned bound. Treating LocalSize
+    /// as a cell rectangle here previously rejected most authored starts and
+    /// clamped every displaced MCV onto the false edge.
     pub(crate) fn from_session(sim: &Simulation, terrain: &ResolvedTerrainGrid) -> Self {
-        if sim.session.local_width != 0 && sim.session.local_height != 0 {
-            Self {
-                min_rx: sim.session.local_left,
-                min_ry: sim.session.local_top,
-                width: sim.session.local_width,
-                height: sim.session.local_height,
-            }
+        // `session.map_width/height` hold the canonical cell-array extent
+        // (~SizeW+SizeH), so the native rect side is that extent minus one.
+        // Sessions without header data (headless fixtures) fall back to the
+        // terrain grid extent — VERA-internal, same shape.
+        let (extent_x, extent_y) = if sim.session.map_width != 0 && sim.session.map_height != 0 {
+            (sim.session.map_width, sim.session.map_height)
         } else {
-            Self {
-                min_rx: 0,
-                min_ry: 0,
-                width: terrain.width(),
-                height: terrain.height(),
-            }
+            (terrain.width(), terrain.height())
+        };
+        Self {
+            min_rx: 1,
+            min_ry: 1,
+            width: extent_x.saturating_sub(1),
+            height: extent_y.saturating_sub(1),
         }
     }
 
@@ -66,10 +77,6 @@ impl NativeStartBounds {
             rx.clamp(i32::from(self.min_rx), i32::from(self.max_rx())) as u16,
             ry.clamp(i32::from(self.min_ry), i32::from(self.max_ry())) as u16,
         )
-    }
-
-    pub(crate) fn contains(self, rx: u16, ry: u16) -> bool {
-        rx >= self.min_rx && rx <= self.max_rx() && ry >= self.min_ry && ry <= self.max_ry()
     }
 }
 
@@ -100,15 +107,22 @@ pub(crate) fn native_gather_start_positions(
     }
 
     while starts.len() < target_count {
-        let x_span = u32::from(bounds.width.saturating_sub(10));
-        let y_high = u32::from(bounds.height.saturating_sub(10));
-        let seed_rx = rng
-            .next_range_u32_inclusive(0, x_span)
-            .wrapping_add(u32::from(bounds.min_rx))
-            .wrapping_add(10) as u16;
+        // `ScenarioClass::Gather_Start_Positions` @ `0x00688564`: the first
+        // draw `RandomRanged(0, rect.h - 10)` lands on the Y axis
+        // (`+ 10 + rect.y`), the second `RandomRanged(10, rect.w - 10)` on the
+        // X axis (`+ rect.x`). The rect is the MapClass cell-array rect (see
+        // `NativeStartBounds::from_session`), which is square, so a transposed
+        // mapping is RNG-neutral — but the seeded POINT mirrors across the
+        // diagonal, so the axes are kept exactly as native writes them.
+        let y_span = u32::from(bounds.height.saturating_sub(10));
+        let x_high = u32::from(bounds.width.saturating_sub(10));
         let seed_ry = rng
-            .next_range_u32_inclusive(10, y_high)
+            .next_range_u32_inclusive(0, y_span)
+            .wrapping_add(10)
             .wrapping_add(u32::from(bounds.min_ry)) as u16;
+        let seed_rx = rng
+            .next_range_u32_inclusive(10, x_high)
+            .wrapping_add(u32::from(bounds.min_rx)) as u16;
 
         let Some((rx, ry)) = find_nearby_start_rect(terrain, occupancy, bounds, seed_rx, seed_ry)
         else {
@@ -1198,7 +1212,7 @@ fn place_starting_object_near_base(
     resolved_terrain: &ResolvedTerrainGrid,
 ) -> Option<u64> {
     let category = rules.object(type_id)?.category;
-    if starting_object_cell_placeable(sim, resolved_terrain, bounds, base_rx, base_ry, category) {
+    if starting_object_cell_placeable(sim, resolved_terrain, base_rx, base_ry, category) {
         return sim.spawn_object(type_id, owner, base_rx, base_ry, facing, rules, height_map);
     }
 
@@ -1227,14 +1241,7 @@ fn place_starting_object_near_base(
                 }
 
                 if (rx, ry) == (base_rx, base_ry)
-                    || !starting_object_cell_placeable(
-                        sim,
-                        resolved_terrain,
-                        bounds,
-                        rx,
-                        ry,
-                        category,
-                    )
+                    || !starting_object_cell_placeable(sim, resolved_terrain, rx, ry, category)
                 {
                     continue;
                 }
@@ -1491,12 +1498,22 @@ fn starting_unit_infantry_allowed(
 fn starting_object_cell_placeable(
     sim: &Simulation,
     resolved_terrain: &ResolvedTerrainGrid,
-    bounds: NativeStartBounds,
     rx: u16,
     ry: u16,
     category: crate::rules::object_type::ObjectCategory,
 ) -> bool {
-    if !bounds.contains(rx, ry) {
+    // Acceptance is the retail isometric-diamond predicate: the mode's
+    // starting-unit creator (vtable `+0xC8` @ `0x005D7030`) unlimbos at the
+    // start coord, and its scan-place fallback @ `0x00688ED0` gates the seed
+    // cell and every ring candidate with `MapClass::Is_Cell_In_Playfield(cell,
+    // 1)`. The cell-array rect only clamps probe coordinates — it is never an
+    // acceptance test.
+    if !crate::sim::cell_rect::cell_is_in_playfield(
+        (i32::from(rx), i32::from(ry)),
+        sim.playfield_bounds,
+        Some(resolved_terrain),
+        Some((resolved_terrain.width(), resolved_terrain.height())),
+    ) {
         return false;
     }
     if let Some(occupancy) = sim.occupancy().get(rx, ry) {
@@ -1872,9 +1889,7 @@ mod tests {
             usize::try_from(generated.index_a).expect("test MapGen cursor A is non-negative"),
             usize::try_from(generated.index_b).expect("test MapGen cursor B is non-negative"),
         ));
-        let actual = owner
-            .into_simulation(&descriptor(match_seed))
-            .rng_state();
+        let actual = owner.into_simulation(&descriptor(match_seed)).rng_state();
 
         assert_eq!(
             actual.scenario,


### PR DESCRIPTION
## Symptom

With 8 players on an 8-start map, nearly all MCVs spawn bunched along one line or corner instead of at the numbered start positions; picking a start number often lands you somewhere else. Fires in most skirmishes on most retail maps (NearOreF: 6 of 8 starts displaced, two onto the same cell; Death: 5 of 8 displaced, three to one corner).

## Cause

`NativeStartBounds` treated the raw `LocalSize=` header values as an axis-aligned cell rectangle. Start assignment was already correct; the placement gate rejected most authored waypoints as "outside" and the fallback spiral clamped every probe back into the false box, piling the displaced MCVs onto its edge.

## gamemd contract (live decompile)

- The mode's starting-unit creator (vtable `+0xC8` @ `0x005D7030`) unlimbos the MCV at the assigned start coord; no rectangle gate exists.
- The scan-place fallback @ `0x00688ED0` gates the seed cell and every ring candidate with `MapClass::Is_Cell_In_Playfield(cell, 1)` — the isometric diamond — and clamps probes to the MapClass **cell-array rect**, written by `MapClass::Resize` @ `0x00565C10` as `(1, 1, SizeW+SizeH−1, SizeW+SizeH−1)`.
- `ScenarioClass::Gather_Start_Positions` @ `0x00688564` reads that same rect for its deficient-map seed draws.
- `LocalSize=` feeds only the diamond predicate's band constants (already ported and verified at `cell_rect.rs::cell_in_playfield_diamond`); no native start path uses it as a rectangle.

## Changes

- `NativeStartBounds::from_session` now carries the native cell-array rect `(1,1)..(extent−1)`; `LocalSize` no longer contributes anywhere in this path.
- `starting_object_cell_placeable` accepts via the existing verified diamond predicate (`cell_is_in_playfield`) instead of `bounds.contains` (removed).
- Deficient-gather seed draws take the native axis mapping (first draw → Y, second → X); the prior port had them transposed — RNG-neutral on the square native rect, but the seeded point mirrored across the diagonal.

## Verification

- New test `starting_mcvs_spawn_on_authored_waypoints_outside_the_localsize_box` reproduces NearOreF geometry end-to-end and asserts both MCVs unlimbo exactly on their authored waypoints — confirmed red against the previous code, green with the fix.
- Both maps' waypoint sets hand-walked through the diamond arithmetic (all authored starts accepted, matching retail).
- Full `cargo test -p vera20k --lib`: 7040 passed; only the two known worktree-environment reds (missing gitignored `ini/`).
