### PR TITLE
Phase 6 rows 116-117: projectile and animation instance ownership

### DIFF
--- a/src/app/presentation/instances/overlays.rs
+++ b/src/app/presentation/instances/overlays.rs
@@ -145,7 +145,14 @@ fn overlay_display_identity(
 /// Appends to the SHP instance list so they draw in the same depth-sorted pass.
 /// Each effect's current frame is looked up in the SHP atlas.
 pub(crate) fn build_world_effect_instances(state: &AppState, paged: &mut [Vec<SpriteInstance>]) {
-    let (sim, atlas) = match (state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation), &state.match_state.match_presentation.sprite_atlas) {
+    let (sim, atlas) = match (
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation),
+        &state.match_state.match_presentation.sprite_atlas,
+    ) {
         (Some(s), Some(a)) => (s, a),
         _ => return,
     };
@@ -187,13 +194,16 @@ pub(crate) fn build_world_effect_instances(state: &AppState, paged: &mut [Vec<Sp
         };
         let depth_y: f32 = center_y + entry.offset_y + entry.pixel_size[1];
         let base_depth: f32 = compute_sprite_depth(state, depth_y, fx.z);
-        let cfg: Option<&AnimTypeRuntimeConfig> = state.rules()
+        let cfg: Option<&AnimTypeRuntimeConfig> = state
+            .rules()
             .and_then(|rules| rules.art_registry.anim_runtime_config(shp_name));
         // Anim SHP draws carry the type's ZAdjust= sort bias plus the
         // constant -2px anim bias (negative = toward camera).
         let type_z_adjust: i32 = cfg.map(|c| c.z_adjust).unwrap_or(0);
         let world_height: f32 = state
-            .match_state.match_presentation.terrain_grid
+            .match_state
+            .match_presentation
+            .terrain_grid
             .as_ref()
             .map(|g| g.world_height)
             .unwrap_or(1.0);
@@ -202,7 +212,11 @@ pub(crate) fn build_world_effect_instances(state: &AppState, paged: &mut [Vec<Sp
             type_z_adjust + ANIM_DRAW_DEPTH_BIAS_PX,
             world_height,
         );
-        let tint: [f32; 3] = state.match_state.match_presentation.lighting_grid.anim_tint_at((fx.rx, fx.ry), cfg);
+        let tint: [f32; 3] = state
+            .match_state
+            .match_presentation
+            .lighting_grid
+            .anim_tint_at((fx.rx, fx.ry), cfg);
         // Source-pixel weight the native blitter family gives this frame:
         // a fixed 25/50/75 stage from `Translucency=`, or the progressive
         // `Translucent=yes` fade keyed on the frame against the type's End.
@@ -234,11 +248,34 @@ fn anim_render_destination(
     config: Option<&AnimTypeRuntimeConfig>,
     ground_order: &crate::app::presentation::render::draw_plan_lowering::NativeGroundOrder,
 ) -> Option<AnimRenderDestination> {
-    // Owner-attached damage fire retains its established parent-adjacent path.
-    // gamemd-derived: no-owner `AnimClass::GetLayer @ 0x00424CB0` returns the
-    // AnimType layer; `GetYSort @ 0x00422BC0` adds AnimType YSortAdjust.
+    // gamemd-derived: `AnimClass::GetLayer @ 0x00424CB0` forces layer 2
+    // (Ground) for ANY anim carrying an owner at `Anim+0xCC`, ahead of both the
+    // AnimType `Layer=` read and the Top default — so an attached anim joins the
+    // sorted ground layer whatever its type asked for. Layer 2 is the only
+    // sorted `DisplayClass` layer: `Submit_Object @ 0x004A9720` sets the sorted
+    // flag with `CMP EDI,0x2` at `0x004A9747` / `SETZ CL` at `0x004A974D`, and every other layer
+    // plain-appends, so a layer-2 member is inserted in ascending y-sort against
+    // the non-anim ground objects by `ObjectClass::YSortComparator @ 0x005F6220`
+    // keyed on vtable `+0xB8`. For an anim that key is
+    // `AnimClass::GetYSort @ 0x00422BC0` = `ObjectClass::GetYSort @ 0x005F6BD0`
+    // + AnimType `YSortAdjust`, and `ObjectClass::GetYSort` reads slot `+0xAC`
+    // (`ObjectClass::GetRenderCoords @ 0x0041BE00`, which AnimClass does not
+    // override) — that re-enters the anim's own virtual `+0x48`, so an attached
+    // anim sorts at its OWNER-RESOLVED absolute position, not at the stored
+    // relative delta. `coord` is already that resolved value.
+    let config_y_sort_adjust = config.map_or(0, |config| config.y_sort_adjust);
     if owner_entity.is_some() {
-        return Some(AnimRenderDestination::Existing);
+        return ground_order
+            .anim_object_draw(
+                stable_id,
+                TacticalCoord {
+                    x: world_coord.x,
+                    y: world_coord.y,
+                    z: world_coord.z,
+                },
+                config_y_sort_adjust,
+            )
+            .map(AnimRenderDestination::Ground);
     }
     let config = config?;
     match config.layer {
@@ -265,10 +302,19 @@ pub(crate) fn build_anim_class_instances(
     top_instances: &mut Vec<SpriteInstance>,
     top_pages: &mut Vec<usize>,
     top_ids: &mut Vec<u64>,
-    ground_objects: &mut Vec<crate::app::presentation::render::draw_plan_lowering::PlannedGroundObjectInstance>,
+    ground_objects: &mut Vec<
+        crate::app::presentation::render::draw_plan_lowering::PlannedGroundObjectInstance,
+    >,
     ground_order: &crate::app::presentation::render::draw_plan_lowering::NativeGroundOrder,
 ) {
-    let (sim, atlas) = match (state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation), &state.match_state.match_presentation.sprite_atlas) {
+    let (sim, atlas) = match (
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation),
+        &state.match_state.match_presentation.sprite_atlas,
+    ) {
         (Some(s), Some(a)) => (s, a),
         _ => return,
     };
@@ -287,14 +333,19 @@ pub(crate) fn build_anim_class_instances(
             continue;
         }
         let type_name: &str = sim.interner.resolve(anim.type_id);
-        let config = state.rules()
+        let config = state
+            .rules()
             .and_then(|rules| rules.art_registry.anim_runtime_config(type_name));
         if !crate::sim::anim_class::anim_draw_detail_visible(
             crate::sim::anim_class::AnimDrawDetailInput {
                 // No authoritative draw-rate degradation producer exists yet.
                 frame_rate_below_minimum: false,
                 type_detail_level: config.map_or(0, |value| value.detail_level),
-                game_detail_level: state.match_state.match_presentation.in_game_options.detail_level as i32,
+                game_detail_level: state
+                    .match_state
+                    .match_presentation
+                    .in_game_options
+                    .detail_level as i32,
                 hidden: anim.draw_runtime.hidden,
                 special_hidden: anim.draw_runtime.special_hidden,
                 // The native special-hide type bit remains an explicit residual.
@@ -306,13 +357,23 @@ pub(crate) fn build_anim_class_instances(
         let Ok(frame) = u16::try_from(anim.runtime.current_frame) else {
             continue;
         };
-        let (center_x, center_y, rx, ry, z) = anim_world_render_coords(anim.world_coord);
+        // `AnimClass::GetCoords @ 0x00422BE0`: an owner-attached anim stores an
+        // owner-relative delta, so the draw position must be resolved through
+        // the owner rather than read off the field.
+        let Some(anim_coord) = sim.anim_absolute_coord(anim.stable_id) else {
+            continue;
+        };
+        let (center_x, center_y, rx, ry, z) = anim_world_render_coords(anim_coord);
         if !in_view(
             center_x, center_y, 200.0, 200.0, cam_x, cam_y, sw, sh, 200.0,
         ) {
             continue;
         }
-        let tint = state.match_state.match_presentation.lighting_grid.anim_tint_at((rx, ry), config);
+        let tint = state
+            .match_state
+            .match_presentation
+            .lighting_grid
+            .anim_tint_at((rx, ry), config);
         let key = ShpSpriteKey {
             type_id: type_name.to_string(),
             facing: 0,
@@ -330,13 +391,19 @@ pub(crate) fn build_anim_class_instances(
                 presentation_anim_frame_count(&atlas.active_anim_frame_counts, type_name)
                     .unwrap_or(0),
             ),
-            state.match_state.match_presentation.in_game_options.detail_level as i32,
+            state
+                .match_state
+                .match_presentation
+                .in_game_options
+                .detail_level as i32,
             anim.draw_runtime,
         ) else {
             continue;
         };
         let (origin_y, world_height) = state
-            .match_state.match_presentation.terrain_grid
+            .match_state
+            .match_presentation
+            .terrain_grid
             .as_ref()
             .map(|grid| (grid.origin_y, grid.world_height))
             .unwrap_or((0.0, 1.0));
@@ -359,7 +426,7 @@ pub(crate) fn build_anim_class_instances(
         match anim_render_destination(
             anim.stable_id,
             anim.owner_entity,
-            anim.world_coord,
+            anim_coord,
             config,
             ground_order,
         ) {
@@ -450,7 +517,9 @@ fn anim_instance_alpha_with_flags(
 /// the atlas has no matching shape.
 fn anim_shp_frame_count(state: &AppState, type_name: &str) -> i32 {
     state
-        .match_state.match_presentation.sprite_atlas
+        .match_state
+        .match_presentation
+        .sprite_atlas
         .as_ref()
         .and_then(|atlas| presentation_anim_frame_count(&atlas.active_anim_frame_counts, type_name))
         .map(i32::from)
@@ -485,22 +554,34 @@ pub(crate) fn build_overlay_instances(
     sw: f32,
     sh: f32,
     instances: &mut Vec<SpriteInstance>,
-    ground_objects: &mut Vec<crate::app::presentation::render::draw_plan_lowering::PlannedGroundObjectInstance>,
+    ground_objects: &mut Vec<
+        crate::app::presentation::render::draw_plan_lowering::PlannedGroundObjectInstance,
+    >,
     ground_order: &crate::app::presentation::render::draw_plan_lowering::NativeGroundOrder,
 ) {
     let atlas = match &state.match_state.match_presentation.overlay_atlas {
         Some(a) => a,
         None => return,
     };
-    let (cam_x, cam_y) = (state.match_state.input.camera_x, state.match_state.input.camera_y);
+    let (cam_x, cam_y) = (
+        state.match_state.input.camera_x,
+        state.match_state.input.camera_y,
+    );
     let (origin_y, world_height) = state
-        .match_state.match_presentation.terrain_grid
+        .match_state
+        .match_presentation
+        .terrain_grid
         .as_ref()
         .map(|g| (g.origin_y, g.world_height))
         .unwrap_or((0.0, 1.0));
 
     // Playable area bounds — skip overlays outside LocalSize (border filler).
-    let local_bounds = state.match_state.match_presentation.terrain_grid.as_ref().and_then(|g| g.local_bounds);
+    let local_bounds = state
+        .match_state
+        .match_presentation
+        .terrain_grid
+        .as_ref()
+        .and_then(|g| g.local_bounds);
 
     // Cell visibility for the local owner — used to cull overlays and terrain
     // objects in unrevealed cells. The shroud multiply pass darkens per-pixel,
@@ -515,7 +596,14 @@ pub(crate) fn build_overlay_instances(
         None
     } else {
         let local_owner_name = crate::app::input::commands::preferred_local_owner_name(state);
-        match (state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation), &local_owner_name) {
+        match (
+            state
+                .match_state
+                .sim_runtime
+                .as_ref()
+                .map(|rt| &rt.simulation),
+            &local_owner_name,
+        ) {
             (Some(sim), Some(owner)) => sim.interner.get(owner).map(|id| (id, &sim.fog)),
             _ => None,
         }
@@ -532,7 +620,12 @@ pub(crate) fn build_overlay_instances(
             }
         }
 
-        let Some(static_name) = state.match_state.match_presentation.overlay_names.get(&entry.overlay_id) else {
+        let Some(static_name) = state
+            .match_state
+            .match_presentation
+            .overlay_names
+            .get(&entry.overlay_id)
+        else {
             continue;
         };
 
@@ -546,7 +639,8 @@ pub(crate) fn build_overlay_instances(
         // Low bridges remain in the ordinary overlay pass, but CellClass's
         // live identity—not the map-pack seed—selects damaged/collapsed art.
         let live_overlay_cell = state
-            .match_state.sim_runtime
+            .match_state
+            .sim_runtime
             .as_ref()
             .map(|rt| &rt.simulation)
             .and_then(|sim| sim.overlay_grid.as_ref())
@@ -572,7 +666,12 @@ pub(crate) fn build_overlay_instances(
             state.rules().map(|rules| &rules.tiberium_types),
         );
         let name = if display_overlay_id == live_overlay_id {
-            state.match_state.match_presentation.overlay_names.get(&live_overlay_id).cloned()
+            state
+                .match_state
+                .match_presentation
+                .overlay_names
+                .get(&live_overlay_id)
+                .cloned()
         } else {
             overlay_registry
                 .and_then(|registry| registry.name(display_overlay_id).map(str::to_owned))
@@ -629,33 +728,41 @@ pub(crate) fn build_overlay_instances(
         let Some(spr) = spr else { continue };
         let depth_z: u8 = z;
         let depth: f32 = compute_sprite_depth_params(origin_y, world_height, screen_y, depth_z);
-        let tint: [f32; 3] = state.match_state.match_presentation.lighting_grid.overlay_tint_at((entry.rx, entry.ry));
-        planned_cells.push(crate::app::presentation::render::draw_plan_lowering::PlannedCellInstance {
-            draw: crate::render::tactical_draw_plan::CellDraw {
-                id: next_draw_id,
-                kind: crate::app::presentation::render::draw_plan_lowering::cell_draw_kind(is_wall),
-                policy: BlitPolicy::translucent(SpriteEncoding::Terrain, RenderZPolicy::None),
+        let tint: [f32; 3] = state
+            .match_state
+            .match_presentation
+            .lighting_grid
+            .overlay_tint_at((entry.rx, entry.ry));
+        planned_cells.push(
+            crate::app::presentation::render::draw_plan_lowering::PlannedCellInstance {
+                draw: crate::render::tactical_draw_plan::CellDraw {
+                    id: next_draw_id,
+                    kind: crate::app::presentation::render::draw_plan_lowering::cell_draw_kind(
+                        is_wall,
+                    ),
+                    policy: BlitPolicy::translucent(SpriteEncoding::Terrain, RenderZPolicy::None),
+                },
+                instance: SpriteInstance {
+                    position: [
+                        screen_x + TILE_WIDTH / 2.0 + spr.offset_x,
+                        screen_y + TILE_HEIGHT / 2.0 + spr.offset_y,
+                    ],
+                    size: spr.pixel_size,
+                    uv_origin: spr.uv_origin,
+                    uv_size: spr.uv_size,
+                    depth,
+                    tint,
+                    alpha: 1.0,
+                    ..Default::default()
+                },
             },
-            instance: SpriteInstance {
-                position: [
-                    screen_x + TILE_WIDTH / 2.0 + spr.offset_x,
-                    screen_y + TILE_HEIGHT / 2.0 + spr.offset_y,
-                ],
-                size: spr.pixel_size,
-                uv_origin: spr.uv_origin,
-                uv_size: spr.uv_size,
-                depth,
-                tint,
-                alpha: 1.0,
-                ..Default::default()
-            },
-        });
+        );
         next_draw_id += 1;
     }
 
-    instances.extend(crate::app::presentation::render::draw_plan_lowering::lower_cell_instances(
-        planned_cells,
-    ));
+    instances.extend(
+        crate::app::presentation::render::draw_plan_lowering::lower_cell_instances(planned_cells),
+    );
 
     if std::env::var("RA2_DEBUG_BRIDGE_RENDER_BUCKETS").is_ok() {
         log::debug!("Cell overlay instances: {}", instances.len());
@@ -666,7 +773,12 @@ pub(crate) fn build_overlay_instances(
     //   drawy = ... + f_y/2 - 3 - pic.wMaxHeight/2
     const TERRAIN_OBJECT_Y_FUDGE: f32 = -3.0;
 
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
         return;
     };
     for obj in sim.production.terrain_objects.values() {
@@ -702,7 +814,8 @@ pub(crate) fn build_overlay_instances(
         let frame: u8 = if let Some(count) = atlas.terrain_anim_frame_count(name) {
             // RA2 terrain animation rate: ~83ms per frame (12 fps).
             const TERRAIN_ANIM_RATE_MS: u32 = 83;
-            let tick = state.match_state.match_presentation.idle_anim_elapsed_ms / TERRAIN_ANIM_RATE_MS;
+            let tick =
+                state.match_state.match_presentation.idle_anim_elapsed_ms / TERRAIN_ANIM_RATE_MS;
             (tick % count as u32) as u8
         } else {
             0
@@ -714,12 +827,15 @@ pub(crate) fn build_overlay_instances(
         let Some(spr) = atlas.get(&key) else { continue };
 
         let depth: f32 = compute_sprite_depth_params(origin_y, world_height, screen_y, z);
-        let spawns_tiberium = state.rules()
+        let spawns_tiberium = state
+            .rules()
             .and_then(|rules| rules.terrain_object_type_case_insensitive(name))
             .map(|terrain_type| terrain_type.spawns_tiberium)
             .unwrap_or(false);
         let tint: [f32; 3] = state
-            .match_state.match_presentation.lighting_grid
+            .match_state
+            .match_presentation
+            .lighting_grid
             .terrain_object_tint_for_type((obj.rx, obj.ry), spawns_tiberium);
 
         let Some(parent) = ground_order.terrain_object_draw(obj.stable_id, obj.rx, obj.ry) else {
@@ -758,7 +874,10 @@ pub(crate) fn build_garrison_muzzle_flash_instances(
     state: &AppState,
     paged: &mut [Vec<SpriteInstance>],
 ) {
-    let (atlas, art_reg) = match (&state.match_state.match_presentation.sprite_atlas, state.rules().map(|rules| &rules.art_registry)) {
+    let (atlas, art_reg) = match (
+        &state.match_state.match_presentation.sprite_atlas,
+        state.rules().map(|rules| &rules.art_registry),
+    ) {
         (Some(a), Some(r)) => (a, r),
         _ => return,
     };
@@ -770,7 +889,9 @@ pub(crate) fn build_garrison_muzzle_flash_instances(
         state.render_height() as f32 / z,
     );
     let (origin_y, world_height) = state
-        .match_state.match_presentation.terrain_grid
+        .match_state
+        .match_presentation
+        .terrain_grid
         .as_ref()
         .map(|g| (g.origin_y, g.world_height))
         .unwrap_or((0.0, 1.0));
@@ -804,7 +925,11 @@ pub(crate) fn build_garrison_muzzle_flash_instances(
         };
         let fx: f32 = flash.screen_x + entry.offset_x;
         let fy: f32 = flash.screen_y + entry.offset_y;
-        let tint: [f32; 3] = state.match_state.match_presentation.lighting_grid.anim_tint_at((flash.rx, flash.ry), cfg);
+        let tint: [f32; 3] = state
+            .match_state
+            .match_presentation
+            .lighting_grid
+            .anim_tint_at((flash.rx, flash.ry), cfg);
         let depth: f32 = garrison_flash_depth(
             origin_y,
             world_height,
@@ -877,7 +1002,9 @@ pub(crate) fn build_weapon_muzzle_flash_instances(
         state.render_height() as f32 / z,
     );
     let (origin_y, world_height) = state
-        .match_state.match_presentation.terrain_grid
+        .match_state
+        .match_presentation
+        .terrain_grid
         .as_ref()
         .map(|g| (g.origin_y, g.world_height))
         .unwrap_or((0.0, 1.0));
@@ -900,9 +1027,14 @@ pub(crate) fn build_weapon_muzzle_flash_instances(
         let Some(entry) = atlas.get(&key) else {
             continue;
         };
-        let cfg: Option<&AnimTypeRuntimeConfig> = state.rules()
+        let cfg: Option<&AnimTypeRuntimeConfig> = state
+            .rules()
             .and_then(|rules| rules.art_registry.anim_runtime_config(&flash.shp_name));
-        let tint = state.match_state.match_presentation.lighting_grid.anim_tint_at((flash.rx, flash.ry), cfg);
+        let tint = state
+            .match_state
+            .match_presentation
+            .lighting_grid
+            .anim_tint_at((flash.rx, flash.ry), cfg);
         // Muzzle anims (e.g. GCMUZZLE, VTMUZZLE) carry their art section's
         // ZAdjust= as a sort bias plus the constant -2px anim bias.
         let type_z_adjust: i32 = cfg.map(|c| c.z_adjust).unwrap_or(0);
@@ -957,7 +1089,15 @@ fn projectile_authoritative_screen_position(
 /// YR `BulletClass::AI` linkage: rendering reads the same committed CoordStruct
 /// that the next authoritative flight pass will advance.
 fn build_authoritative_projectile_instances(state: &AppState, paged: &mut [Vec<SpriteInstance>]) {
-    let (sim, rules, atlas) = match (state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation), state.rules().map(|r| r), &state.match_state.match_presentation.sprite_atlas) {
+    let (sim, rules, atlas) = match (
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation),
+        state.rules().map(|r| r),
+        &state.match_state.match_presentation.sprite_atlas,
+    ) {
         (Some(sim), Some(rules), Some(atlas)) => (sim, rules, atlas),
         _ => return,
     };
@@ -969,7 +1109,9 @@ fn build_authoritative_projectile_instances(state: &AppState, paged: &mut [Vec<S
         state.render_height() as f32 / z,
     );
     let (origin_y, world_height) = state
-        .match_state.match_presentation.terrain_grid
+        .match_state
+        .match_presentation
+        .terrain_grid
         .as_ref()
         .map(|grid| (grid.origin_y, grid.world_height))
         .unwrap_or((0.0, 1.0));
@@ -1048,7 +1190,9 @@ pub(crate) fn build_projectile_visual_instances(
         state.render_height() as f32 / z,
     );
     let (origin_y, world_height) = state
-        .match_state.match_presentation.terrain_grid
+        .match_state
+        .match_presentation
+        .terrain_grid
         .as_ref()
         .map(|g| (g.origin_y, g.world_height))
         .unwrap_or((0.0, 1.0));
@@ -1089,7 +1233,12 @@ pub(crate) fn build_projectile_visual_instances(
 /// Build persistent WaveClass polygon edges from simulation registration state.
 pub(crate) fn build_weapon_wave_instances(state: &AppState) -> Vec<SpriteInstance> {
     let mut instances = Vec::new();
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
         return instances;
     };
     let observer = crate::app::input::commands::preferred_local_owner(state)
@@ -1151,7 +1300,14 @@ pub(crate) fn build_parachute_instances(
     /// frame-internal positioning, which our atlas doesn't replicate exactly.
     const CHUTE_Y_LIFT: f32 = 8.0;
 
-    let (sim, atlas) = match (state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation), &state.match_state.match_presentation.sprite_atlas) {
+    let (sim, atlas) = match (
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation),
+        &state.match_state.match_presentation.sprite_atlas,
+    ) {
         (Some(s), Some(a)) => (s, a),
         _ => return,
     };
@@ -1162,7 +1318,8 @@ pub(crate) fn build_parachute_instances(
         state.render_width() as f32 / z,
         state.render_height() as f32 / z,
     );
-    let config = match state.rules()
+    let config = match state
+        .rules()
         .and_then(|r| r.general.parachute_render.as_ref())
     {
         Some(c) => c,
@@ -1219,12 +1376,12 @@ pub(crate) fn build_parachute_instances(
         else {
             continue;
         };
-        parent
-            .pieces
-            .push(crate::app::presentation::render::draw_plan_lowering::GroundPieceInstance {
-                target: crate::app::presentation::render::draw_plan_lowering::GroundTexture::ShpPage(
-                    entry.page as usize,
-                ),
+        parent.pieces.push(
+            crate::app::presentation::render::draw_plan_lowering::GroundPieceInstance {
+                target:
+                    crate::app::presentation::render::draw_plan_lowering::GroundTexture::ShpPage(
+                        entry.page as usize,
+                    ),
                 instance: SpriteInstance {
                     position: [cx, cy],
                     size: entry.pixel_size,
@@ -1235,7 +1392,8 @@ pub(crate) fn build_parachute_instances(
                     alpha: 1.0,
                     ..Default::default()
                 },
-            });
+            },
+        );
     }
 }
 
@@ -1261,12 +1419,81 @@ mod tests {
     use crate::util::fixed_math::SimFixed;
 
     #[test]
+    fn gsi_05_12_owner_attached_anim_is_forced_onto_the_sorted_ground_layer() {
+        // `AnimClass::GetLayer @ 0x00424CB0` tests the owner at `Anim+0xCC`
+        // FIRST and returns 2 (Ground); only an ownerless anim reaches the
+        // AnimType `Layer=` read or the Top default. Layer 2 is the one sorted
+        // `DisplayClass` layer (`Submit_Object @ 0x004A9720`,
+        // `CMP EDI,0x2` at `0x004A9747` / `SETZ CL` at `0x004A974D`), so an attached anim is
+        // y-sorted against ordinary ground objects rather than appended.
+        let art = ArtRegistry::from_ini(&IniFile::from_str(
+            "[FIRE_TOP]\nLayer=top\nYSortAdjust=7\n\
+             [FIRE_AIR]\nLayer=air\n",
+        ));
+        let order =
+            crate::app::presentation::render::draw_plan_lowering::NativeGroundOrder::new(&[
+                5, 10, 20, 30,
+            ]);
+        // The owner-resolved absolute, which is what
+        // `ObjectClass::GetRenderCoords @ 0x0041BE00` hands the y-sort: it
+        // re-enters the anim's own `GetCoords`, so the sort key is built from
+        // the absolute, never from the stored owner-relative delta.
+        let resolved = crate::sim::anim_class::AnimWorldCoord {
+            x: 2450,
+            y: 2653,
+            z: 0,
+        };
+
+        let top_config = art.anim_runtime_config("FIRE_TOP");
+        assert_eq!(
+            anim_render_destination(10, None, resolved, top_config, &order),
+            Some(AnimRenderDestination::Top),
+            "without an owner the type's Layer=top still wins"
+        );
+
+        let Some(AnimRenderDestination::Ground(draw)) =
+            anim_render_destination(10, Some(77), resolved, top_config, &order)
+        else {
+            panic!("an owner-attached anim must enter the sorted ground layer");
+        };
+        assert_eq!((draw.coord.x, draw.coord.y, draw.coord.z), (2450, 2653, 0));
+        assert_eq!(draw.y_sort_adjust, 7);
+        assert_eq!(
+            draw.y_sort_key(),
+            2450 + 2653 + 7,
+            "ObjectClass::GetYSort @ 0x005F6BD0 returns coord.X + coord.Y, and \
+             AnimClass::GetYSort @ 0x00422BC0 adds the AnimType YSortAdjust"
+        );
+
+        // The override is unconditional on the type: air is pulled down too.
+        assert!(matches!(
+            anim_render_destination(
+                20,
+                Some(77),
+                resolved,
+                art.anim_runtime_config("FIRE_AIR"),
+                &order
+            ),
+            Some(AnimRenderDestination::Ground(_)),
+        ));
+        // And it does not need a known AnimType at all, because GetLayer
+        // returns before it reads `Anim+0xC8`.
+        assert!(matches!(
+            anim_render_destination(30, Some(77), resolved, None, &order),
+            Some(AnimRenderDestination::Ground(_)),
+        ));
+    }
+
+    #[test]
     fn gsi_13_04_wa_top_and_tuntop_ground_use_native_layer_and_ysort_lowering() {
         let art = ArtRegistry::from_ini(&IniFile::from_str(
             "[WA_CUSTOM]\nYSortAdjust=7\n\
              [TUNTOP_CUSTOM]\nLayer=ground\nYSortAdjust=1000\n",
         ));
-        let order = crate::app::presentation::render::draw_plan_lowering::NativeGroundOrder::new(&[5, 10, 20]);
+        let order =
+            crate::app::presentation::render::draw_plan_lowering::NativeGroundOrder::new(&[
+                5, 10, 20,
+            ]);
         let wa = art.anim_runtime_config("WA_CUSTOM");
         let tuntop = art.anim_runtime_config("TUNTOP_CUSTOM");
         let world = crate::sim::anim_class::AnimWorldCoord {
@@ -1310,10 +1537,10 @@ mod tests {
                 }],
             )
         };
-        let lowered = crate::app::presentation::render::draw_plan_lowering::lower_ground_object_instances(vec![
-            pieces(tunnel_draw),
-            pieces(ordinary),
-        ]);
+        let lowered =
+            crate::app::presentation::render::draw_plan_lowering::lower_ground_object_instances(
+                vec![pieces(tunnel_draw), pieces(ordinary)],
+            );
         assert_eq!(lowered.owners, [5, 20]);
     }
 

--- a/src/render/tactical_draw_plan.rs
+++ b/src/render/tactical_draw_plan.rs
@@ -203,14 +203,20 @@ impl TacticalDrawPlan {
     /// `lower_cell_instances`, which the SHP, unit and overlay instance
     /// builders consume. What is unchecked is whether every family reaches the
     /// frame through it: `render/tactical_compat.rs` and parts of the instance
-    /// builders assemble buffers on their own, and the anim layer-2 override
-    /// recorded in `sim/anim_class.rs` short-circuits before this planner sees
-    /// the anim at all.
-    /// - Trigger: drawing an owner-attached anim, or any family that bypasses
-    ///   the planner.
+    /// builders still assemble buffers on their own.
+    ///
+    /// The owner-attached anim half of this is CLOSED — GSI-05.12 removed the
+    /// short-circuit that used to keep burning-building fires out of this
+    /// planner. `AnimClass::GetLayer @ 0x00424CB0` forces layer 2 for any anim
+    /// carrying an owner, so `anim_render_destination` now routes them through
+    /// `anim_object_draw` into the same `ground_objects` vector as buildings
+    /// and units, and they sort here on the same key.
+    /// - Trigger: any family that still assembles its own buffer instead of
+    ///   entering this planner.
     /// - Player effect: where a bypassing path and this ordering disagree, a
     ///   sprite draws in front of or behind something it should not.
-    /// - Frequency: continuous for the anim override — every burning building.
+    /// - Frequency: per-family, and unmeasured — that is the open part. No
+    ///   bypassing family has been shown to disagree with this ordering.
     /// - Downstream risk: settling it needs a comparison against a real frame,
     ///   which `--lib` cannot reach, so it wants a capture harness rather than
     ///   another unit test.

--- a/src/sim/anim_class.rs
+++ b/src/sim/anim_class.rs
@@ -309,8 +309,14 @@ pub struct AnimObject {
     pub stable_id: AnimId,
     pub native_unique_id: i32,
     pub type_id: InternedId,
-    /// Absolute world leptons. Z uses the animation constructor's 128-lepton
-    /// height level, not combat's terrain-height conversion.
+    /// World leptons — but **owner-relative whenever `owner_entity` is set**,
+    /// exactly as `AnimClass::SetOwnerObject @ 0x00424B50` stores it. Read it
+    /// through [`Simulation::anim_absolute_coord`] for a world position; read
+    /// the field directly only where native reads the stored `ObjectClass`
+    /// coordinate directly, which is the multiplayer sync checksum
+    /// (`Compute_Game_Sync_Checksum @ 0x0064DAB0` folds `+0x9c`/`+0xa0`) and
+    /// the state hash. Z uses the animation constructor's 128-lepton height
+    /// level, not combat's terrain-height conversion.
     pub world_coord: AnimWorldCoord,
     pub draw_flags: u32,
     pub z_adjust: i32,
@@ -680,10 +686,14 @@ impl Simulation {
     }
 
     pub(crate) fn visit_anim(&mut self, id: AnimId, rules: &RuleSet) {
-        let Some((type_id, world_coord, first_guard, inactive)) = self.anim(id).map(|anim| {
+        // `AnimClass::GetCoords @ 0x00422BE0`, not the stored field: an
+        // owner-attached anim stores an owner-relative delta.
+        let Some(world_coord) = self.anim_absolute_coord(id) else {
+            return;
+        };
+        let Some((type_id, first_guard, inactive)) = self.anim(id).map(|anim| {
             (
                 anim.type_id,
-                anim.world_coord,
                 anim.runtime.first_ai_guard,
                 anim.runtime.inactive,
             )
@@ -832,10 +842,12 @@ impl Simulation {
         if already_queued {
             return;
         }
-        let Some((world, stop_sound)) = self
-            .anim(id)
-            .map(|anim| (anim.world_coord, anim.stop_sound_id))
-        else {
+        // `AnimClass::GetCoords @ 0x00422BE0` — the sound plays at the anim's
+        // resolved world position, not its owner-relative stored delta.
+        let Some(world) = self.anim_absolute_coord(id) else {
+            return;
+        };
+        let Some(stop_sound) = self.anim(id).map(|anim| anim.stop_sound_id) else {
             return;
         };
         self.detach_anim_from_owner(id);
@@ -861,44 +873,167 @@ impl Simulation {
     /// Techno/Object implementation is `FUN_00710410`; here the
     /// `damage_fire_anim_ids` slot clear) before the owner pointer itself.
     ///
-    /// RESIDUAL (GSI-05.12) — owner-relative attachment is not modelled.
-    /// `AnimClass::SetOwnerObject @ 0x00424B50` rewrites the anim coordinate to
-    /// `anim_abs - owner_abs` on attach and `AnimClass::GetCoords @ 0x00422BE0`
-    /// then returns `stored_offset + owner.GetCoords()`; `GetLayer @
-    /// 0x00424CB0` forces layer 2 for any attached anim; and native scans the
-    /// global anim array so the owner's "has attached anim" byte
-    /// (`Object+0x84`) clears only after the *last* attached anim leaves. The
-    /// three pieces have different exposure here:
-    /// - Moving owner. Trigger: an attached anim whose owner changes position.
-    ///   Player effect would be a stale draw position. Frequency: zero
-    ///   occurrences in this build — the only production attach site is the
-    ///   building damage-fire slot below and buildings do not move; every other
-    ///   anim producer emits an unattached `WorldEffect` row.
-    /// - Multi-attached owner. Trigger: a building past a damage-fire
-    ///   threshold, which fills two or more slots. Frequency: every such
-    ///   building, so continuously in ordinary play. Player effect: none —
-    ///   `detach_anim_from_owner` below already clears only the slot equal to
-    ///   the departing anim, and no consumer of `Object+0x84` exists on the
-    ///   building side, so the shared-owner scan has nothing to guard yet.
-    /// - Layer override. Approximated rather than absent:
-    ///   `anim_render_destination` in `app/presentation/instances/overlays.rs`
-    ///   short-circuits any owned anim to `AnimRenderDestination::Existing`,
-    ///   which is what keeps `FIRE01`..`FIRE03` (no `Layer=` key in artmd) off
-    ///   the `Top` default. Trigger: drawing any owner-attached anim, i.e. every
-    ///   burning building. Player effect: if the parent-adjacent path and native
-    ///   layer-2 ground sorting disagree, a damage fire draws in front of or
-    ///   behind a ground object it should be behind or in front of. Frequency:
-    ///   every frame of every burning building. Whether they do disagree is the
-    ///   open question — nothing checks the two orders against each other, and
-    ///   native reaches its ordering through `ground_order.anim_object_draw` by
-    ///   a different route.
-    /// - Downstream risk: the mechanism blocks every native producer that does
-    ///   attach — paradrop `PARACH`, the `BEHIND` marker, non-building muzzle
-    ///   anims, EMPulse sparks, Psychic Dominator per-victim anims,
-    ///   CaptureManager, transport/enter `+0x1D4`, deploy/undeploy `+0x130`,
-    ///   terrain catch-fire, and building damage side-effect debris. Temporal
-    ///   `SQDG` needs more than `SetOwnerObject`: it also registers in
-    ///   `g_AnimClass_RemoveListeners`, which has no analogue here.
+    /// gamemd-derived: `AnimClass::SetOwnerObject @ 0x00424B50` — the attach
+    /// half. Native stores an attached anim's coordinate RELATIVE to its owner
+    /// and resolves it back on read, so the anim follows a moving owner for
+    /// free. The disassembly is explicit about the sign and the axes: at
+    /// `0x00424C16` it takes the anim's own `GetCoords` (vtable `+0x48`, with
+    /// the owner pointer still null so this is the stored absolute), at
+    /// `0x00424C37` it writes the owner into `Anim+0xCC`, at `0x00424C46` it
+    /// takes the owner's `GetCoords`, then `SUB EBX,ECX` / `SUB EBP,EDI` /
+    /// `SUB ECX,EDX` (`0x00424C51`, `0x00424C5F`, `0x00424C5B`) form
+    /// `anim_abs - owner_abs` on X, Y and Z and hand that to `SetCoords`
+    /// (vtable `+0x1B4`) at `0x00424C70`. The detach half at `0x00424BBD`
+    /// mirrors it: read `GetCoords` while the owner is still set — so it comes
+    /// back absolute — null `Anim+0xCC`, and store the absolute.
+    ///
+    /// Three native steps are deliberately not modelled, and it matters what
+    /// each one actually is:
+    /// - The owner's "has an anim attached" byte. Attach sets
+    ///   `[owner+0x84] = 1` at `0x00424C30`; detach clears it at `0x00424BB6`,
+    ///   but only when the `g_AnimClass_Array` scan at `0x00424B85` finds no
+    ///   OTHER anim sharing that owner. Nothing in this engine reads
+    ///   `Object+0x84`, so neither write has an observable consequence here.
+    ///   The multi-slot case the scan exists for is already correct for a
+    ///   different reason: [`Self::detach_anim_from_owner`] clears only the
+    ///   slot equal to the departing anim.
+    /// - The same guard also gates a virtual call on the OWNER,
+    ///   `CALL [owner_vtable+0x17C]` at `0x00424BB0` — read directly, not
+    ///   inferred: BuildingClass's primary vtable base is `0x007E3EBC` and
+    ///   `+0x17C` there is `0x005F43C0`, whose body is a bare `RET`. So for the
+    ///   only producer this engine has, the skipped call does nothing. A
+    ///   non-building owner may override it; whoever adds the first such
+    ///   producer must read `+0x17C` on that class before reusing this.
+    /// - The `DisplayClass::RemoveFromLayer` / `Submit_Object` re-registration
+    ///   pair either side of the pointer write (`0x004A9770` / `0x004A9720`).
+    ///   Layer membership is rebuilt from `tactical_registration_order` every
+    ///   frame in this engine rather than held as a persistent container, so
+    ///   there is no registration to move.
+    ///
+    /// Returns `false` when the anim does not exist, or when the requested
+    /// owner does not.
+    pub(crate) fn set_anim_owner_object(&mut self, id: AnimId, new_owner: Option<u64>) -> bool {
+        if self.anim(id).is_none() {
+            return false;
+        }
+
+        // Detach half: resolve back to absolute *before* dropping the owner.
+        if self.anim(id).and_then(|anim| anim.owner_entity).is_some() {
+            let absolute = self
+                .anim_absolute_coord(id)
+                .expect("anim exists: checked at the head of this function");
+            if let Some(anim) = self.anim_mut_by_id(id) {
+                anim.owner_entity = None;
+                anim.world_coord = absolute;
+            }
+        }
+
+        // Attach half: the stored coordinate becomes the owner-relative delta.
+        if let Some(owner_id) = new_owner {
+            let Some(owner_coord) = self.anim_owner_coords(owner_id) else {
+                return false;
+            };
+            if let Some(anim) = self.anim_mut_by_id(id) {
+                anim.world_coord = AnimWorldCoord {
+                    x: anim.world_coord.x.wrapping_sub(owner_coord.x),
+                    y: anim.world_coord.y.wrapping_sub(owner_coord.y),
+                    z: anim.world_coord.z.wrapping_sub(owner_coord.z),
+                };
+                anim.owner_entity = Some(owner_id);
+            }
+        }
+        true
+    }
+
+    /// gamemd-derived: `AnimClass::GetCoords @ 0x00422BE0` — with an owner at
+    /// `Anim+0xCC` it returns `stored + owner->GetCoords()`, otherwise the
+    /// stored coordinate unchanged. This is the only correct way to read an
+    /// anim's world position: [`AnimObject::world_coord`] is owner-relative
+    /// whenever `owner_entity` is set, exactly as native stores it.
+    ///
+    /// Returns `None` only when the anim does not exist.
+    ///
+    /// VERA-internal, gamemd equivalent UNREACHABLE: an anim naming an owner
+    /// the store no longer holds is treated as unattached, so the stored
+    /// coordinate is returned as-is. Native cannot produce that state —
+    /// `AnimClass::Detach @ 0x00425150` runs from the owner's own uninit, via
+    /// `ObjectClass::Detach_From_All_Lists`, before the pointer can dangle, and
+    /// this engine mirrors it in `expire_anim_owner_reference`. The fallback
+    /// exists so every caller agrees on one behaviour instead of one panicking
+    /// and another silently dropping the anim; treating a dangling owner as no
+    /// owner is also the only reading under which the stored coordinate means
+    /// anything.
+    pub fn anim_absolute_coord(&self, id: AnimId) -> Option<AnimWorldCoord> {
+        let anim = self.anim(id)?;
+        let Some(owner_coord) = anim
+            .owner_entity
+            .and_then(|owner| self.anim_owner_coords(owner))
+        else {
+            return Some(anim.world_coord);
+        };
+        Some(AnimWorldCoord {
+            x: anim.world_coord.x.wrapping_add(owner_coord.x),
+            y: anim.world_coord.y.wrapping_add(owner_coord.y),
+            z: anim.world_coord.z.wrapping_add(owner_coord.z),
+        })
+    }
+
+    /// The owner side of `AnimClass::GetCoords`: `ObjectClass::GetCoords` on
+    /// the attached-to object, in the anim coordinate frame.
+    ///
+    /// X and Y are leptons, with `BuildingClass::GetCoords @ 0x00447AC0`'s
+    /// `(W-1) * 128` / `(H-1) * 128` shift off the stored NW anchor onto the
+    /// geometric foundation centre — the same derivation
+    /// `world/lifecycle.rs`'s `object_get_coords_cell` and `combat`'s
+    /// `target_coords` use.
+    ///
+    /// Z deliberately uses the anim height-level scale
+    /// (`ANIM_HEIGHT_LEVEL_LEPTONS`, 128), NOT `Position::exact_z_leptons` and
+    /// NOT the 104-lepton `LevelHeight` the locomotor and combat use. Native
+    /// has one Z frame and this engine has two: an anim's own Z is stored in
+    /// 128-per-level units (see [`AnimWorldCoord::to_cell_sub_z`] and the anim
+    /// constructor), so the owner's Z must be converted into that same frame or
+    /// the subtraction native performs would compare two different scales.
+    /// Feeding `exact_z_leptons` in here would look more faithful and be wrong.
+    ///
+    /// The consequence, recorded rather than hidden: this reads the owner's
+    /// coarse height level only. An owner with a non-zero locomotor altitude —
+    /// a flying or falling attach target — would contribute no altitude to the
+    /// delta. No attach producer in this engine targets a moving or airborne
+    /// owner (the sole producer is building damage fire), so the term has zero
+    /// occurrences today; the first airborne-owner producer must reconcile the
+    /// two Z frames before relying on it. The attach/detach round trip is exact
+    /// regardless, because the same value is subtracted and added back.
+    fn anim_owner_coords(&self, owner_id: u64) -> Option<AnimWorldCoord> {
+        let owner = self.substrate.entities.get(owner_id)?;
+        let mut x = i32::from(owner.position.rx)
+            .wrapping_mul(LEPTONS_PER_CELL)
+            .wrapping_add(owner.position.sub_x.to_num::<i32>());
+        let mut y = i32::from(owner.position.ry)
+            .wrapping_mul(LEPTONS_PER_CELL)
+            .wrapping_add(owner.position.sub_y.to_num::<i32>());
+        if owner.category == crate::map::entities::EntityCategory::Structure {
+            let (width, height) =
+                crate::rules::foundation::foundation_dimensions(&owner.foundation);
+            x = x.wrapping_add(
+                i32::from(width.saturating_sub(1)).wrapping_mul(BUILDING_RENDER_ORIGIN_LEPTONS),
+            );
+            y = y.wrapping_add(
+                i32::from(height.saturating_sub(1)).wrapping_mul(BUILDING_RENDER_ORIGIN_LEPTONS),
+            );
+        }
+        Some(AnimWorldCoord {
+            x,
+            y,
+            z: i32::from(owner.position.z).wrapping_mul(ANIM_HEIGHT_LEVEL_LEPTONS),
+        })
+    }
+
+    /// gamemd-derived: `AnimClass::SetOwnerObject @ 0x00424B50` detach half,
+    /// plus this engine's damage-fire slot bookkeeping. See
+    /// [`Self::set_anim_owner_object`] for the coordinate contract; the slot
+    /// clear below is why the native `g_AnimClass_Array` shared-owner scan has
+    /// nothing to guard here.
     pub(crate) fn detach_anim_from_owner(&mut self, id: AnimId) -> Option<u64> {
         let owner_id = self.anim(id).and_then(|anim| anim.owner_entity)?;
         if let Some(owner) = self.substrate.entities.get_mut(owner_id) {
@@ -908,9 +1043,7 @@ impl Simulation {
                 }
             }
         }
-        if let Some(anim) = self.anim_mut_by_id(id) {
-            anim.owner_entity = None;
-        }
+        self.set_anim_owner_object(id, None);
         Some(owner_id)
     }
 
@@ -937,46 +1070,58 @@ impl Simulation {
     /// block on `+0x19B == 0` at `0x004242B0`; and the `Next=` transition
     /// clears it, matching native's `+0x19B = 0` write there.
     ///
-    /// RESIDUAL (GSI-05.12) — the marker is checked much earlier in the visit
-    /// than native checks it. The gate sits 0x89F bytes into `AnimClass::AI`
-    /// (`0x00423AC0`..`0x0042435F`). Two `+0x19B` sites do sit inside that span —
-    /// the trailer guard at `0x004242B0` noted above and the `0x147C` writer at
-    /// `0x00424358` noted below — but none of the items enumerated here carries
-    /// a guard of its own, so native runs every one of them on a detached anim:
-    /// `AnimClass::UpdateLoopingSound @ 0x00750D40` (entered on
-    /// `Anim+0x198 == 0` and `AnimType+0x2F8 != -1`); `BounceAI` plus the
-    /// `AnimType+0x354` `ObjectClass::AI` call; the bouncer-impact block on
-    /// instance byte `+0x194`, which itself contains `AnimClass::Constructor`
-    /// calls and an `Apply_area_damage` call; the `+0x19D` draw-suppression
-    /// writers at `0x00423B5C`, `0x00423B7F`/`0x00423B88` and
-    /// `0x00423BB8`/`0x00423BC1`; and the `+0x11B` frame-equality cleanup at
-    /// `0x00423C03`..`0x00423C1D`. `visit_anim`
-    /// runs only the make-infantry occupation mark before its own gate, so a
-    /// detached anim skips every one of them.
+    /// DRIFT (GSI-05.12) — the marker is checked earlier in the visit than
+    /// native checks it, and the difference has no observable surface here yet.
+    /// The gate sits 0x89F bytes into `AnimClass::AI`
+    /// (`0x00423AC0`..`0x0042435F`), so native runs a prefix on a detached anim
+    /// that `visit_anim` skips: `AnimClass::UpdateLoopingSound @ 0x00750D40`
+    /// (entered on `Anim+0x198 == 0` and `AnimType+0x2F8 != -1`); `BounceAI`
+    /// plus the `AnimType+0x354` `ObjectClass::AI` call; the bouncer-impact
+    /// block on instance byte `+0x194`, which itself contains
+    /// `AnimClass::Constructor` calls and an `Apply_area_damage` call; the
+    /// `+0x19D` draw-suppression writers at `0x00423B5C`,
+    /// `0x00423B7F`/`0x00423B88` and `0x00423BB8`/`0x00423BC1`; and the `+0x11B`
+    /// frame-equality cleanup at `0x00423C03`..`0x00423C1D`. `visit_anim` runs
+    /// only the make-infantry occupation mark before its own gate.
+    ///
+    /// Three of those five items are inert in this engine today, which is why
+    /// moving the gate now would be a no-op rather than a fix:
+    /// - `UpdateLoopingSound` is pure maintenance of a loop handle — it
+    ///   revalidates the handle, recomputes volume and pan through
+    ///   `VocClass::CalcVolumeAndPan`, and stops the loop when the volume comes
+    ///   back non-positive. There is no loop-handle mechanism in this engine to
+    ///   maintain (recorded on `audio/sfx.rs`), so there is nothing for the
+    ///   extra pass to act on. `[FIRE01]`/`[FIRE02]` carry
+    ///   `StartSound=BuildingFireBig` and `[FIRE03]` `StartSound=BuildingFireMed`,
+    ///   so `AnimType+0x2F8 != -1` does hold for exactly this trigger — the pass
+    ///   really does run in native.
+    /// - The bouncer-impact block needs a bounce simulation, and there is none:
+    ///   `Bouncer=` is parsed into `art_data.rs`'s `bouncer` flag with no sim
+    ///   consumer, and damage-fire anims are not bouncers in any case.
+    /// - The `+0x19D` writes cannot reach a `DrawIt` even in native — the same
+    ///   call destroys the anim a few instructions later.
+    ///
+    /// The other two are NOT argued inert, and are why this stays recorded
+    /// rather than dismissed: `BounceAI` plus the `AnimType+0x354`
+    /// `ObjectClass::AI` call, and the `+0x11B` frame-equality cleanup at
+    /// `0x00423C03`..`0x00423C1D` (`if [+0x11B] && [+0x11C] == [+0xAC] then
+    /// [+0x11B] = 0`, a draw-family-adjacent byte). Neither has a mapped
+    /// analogue in this store, so whether they carry a consequence is
+    /// UNCHECKED, not clean.
+    ///
     /// - Trigger: a building destroyed while its damage-fire anims are live.
-    /// - Player effect: audible only, because the `+0x19D` writes cannot reach
-    ///   a `DrawIt` — the same call destroys the anim a few instructions later.
-    ///   `[FIRE01]`/`[FIRE02]` carry
-    ///   `StartSound=BuildingFireBig` and `[FIRE03]`
-    ///   `StartSound=BuildingFireMed`, so `AnimType+0x2F8 != -1` holds for
-    ///   exactly this trigger and native's looping-sound maintenance does run
-    ///   one more time before the destroy. What that last pass emits is the
-    ///   corpus's own open item — OQ-09 in
-    ///   `ANIMCLASS_DETACHEDOWNER_MARKER_0X19B_CONSUMERS_GHIDRA_REPORT.md`,
-    ///   deferred — so this is UNCHECKED, not clean. The spawn/damage half of
-    ///   the prefix is unreachable today: the bouncer-impact block needs a
-    ///   bounce simulation, and there is none — `Bouncer=` is parsed into
-    ///   `art_data.rs`'s `bouncer` flag but has no sim consumer, and damage-fire
-    ///   anims are not bouncers in any case.
+    /// - Player effect: none today; audible once loop handles exist, and what
+    ///   that final pass emits is the corpus's own open item, OQ-09 in
+    ///   `ANIMCLASS_DETACHEDOWNER_MARKER_0X19B_CONSUMERS_GHIDRA_REPORT.md`.
     /// - Frequency: every destroyed building that had reached a damage-fire
     ///   threshold, so several times in an ordinary skirmish.
-    /// - Downstream risk: grows with every anim producer added; the bouncer
-    ///   half becomes live the moment `Bouncer=` debris exists. The named
-    ///   acceptance check is
-    ///   `inactive_anim_runs_pre_destroy_ai_prefix_before_destroy`, and the
-    ///   corpus's negative fact applies verbatim: do not place the inactive
-    ///   check at the top of AI unless every pre-check side effect is proven
-    ///   irrelevant.
+    /// - Downstream risk: this is sequenced, not open-ended. It becomes
+    ///   observable exactly when `GSI-15.03`'s loop-handle mechanism lands, and
+    ///   the gate must move in the same slice that lands it. The corpus's
+    ///   negative fact applies verbatim and is the reason the gate has not been
+    ///   moved speculatively: do not place the inactive check at the top of AI
+    ///   unless every pre-check side effect is proven irrelevant — which is a
+    ///   claim about the prefix's contents, and the prefix grows.
     ///
     /// Separately unmodelled, and not a consequence of the ordering above: the
     /// `Rules+0x147C` occupied-cell path at `0x00424322`..`0x0042435E` is a
@@ -984,16 +1129,21 @@ impl Simulation {
     /// through `MapClass::Get_CellClass_At_Coord @ 0x00565730`, tests it via
     /// `0x0047C520`, and sets `+0x19B = 1` at `0x00424358`. A third writer, the
     /// `AnimType+0x360` overlay-bound path entered at `0x004243C2` and writing at
-    /// `0x00424427`, sits after the gate
-    /// and is out of scope here. Neither has an analogue in this store.
+    /// `0x00424427`, sits after the gate and is out of scope here. Neither has
+    /// an analogue in this store.
     ///
-    /// RESIDUAL (GSI-05.12, structural) — `runtime.inactive` doubles as this
+    /// DRIFT (GSI-05.12, structural) — `runtime.inactive` doubles as this
     /// store's "ready for pending delete" predicate
     /// (`world/lifecycle.rs pending_object_is_ready`), so the marker and object
     /// liveness are one field where native keeps display-layer membership
-    /// separate from both. No behavioral divergence is known from this; it is
-    /// recorded because a future attached-anim producer that must survive its
-    /// owner would have to split them first.
+    /// separate from both.
+    /// - Trigger: an attached anim that must outlive its owner.
+    /// - Player effect: none. No such producer exists — every native attach
+    ///   producer either dies with its owner or is not built here.
+    /// - Frequency: zero occurrences in this build.
+    /// - Downstream risk: recorded because splitting the two fields is a
+    ///   prerequisite for any future producer whose anim survives its owner;
+    ///   nothing else depends on it.
     pub(crate) fn expire_anim_owner_reference(&mut self, id: AnimId, expired_id: u64) -> bool {
         if self.anim(id).and_then(|anim| anim.owner_entity) != Some(expired_id) {
             return false;
@@ -1139,9 +1289,7 @@ impl Simulation {
             let anim_id = self
                 .spawn_anim_at_world(rules, descriptor, world)
                 .expect("validated stock damage-fire animation must spawn");
-            if let Some(anim) = self.anim_mut_by_id(anim_id) {
-                anim.owner_entity = Some(building_id);
-            }
+            self.set_anim_owner_object(anim_id, Some(building_id));
             if let Some(entity) = self.substrate.entities.get_mut(building_id) {
                 entity.damage_fire_anim_ids[slot] = Some(anim_id);
             }
@@ -1212,7 +1360,7 @@ impl Simulation {
             return;
         };
         let sound_id = self.interner.intern(&sound_name);
-        let Some(world) = self.anim(id).map(|anim| anim.world_coord) else {
+        let Some(world) = self.anim_absolute_coord(id) else {
             return;
         };
         if let Some(anim) = self.anim_mut_by_id(id) {
@@ -1953,6 +2101,64 @@ mod tests {
     }
 
     #[test]
+    fn gsi_05_12_attached_anim_follows_a_moving_owner_and_detaches_absolute() {
+        // The point of owner-relative storage: `AnimClass::GetCoords @
+        // 0x00422BE0` adds the owner's live coordinate, so the anim tracks the
+        // owner without anyone rewriting the anim. `SetOwnerObject @
+        // 0x00424B50` then writes the resolved absolute back on detach, so the
+        // anim stays where it was standing.
+        let (mut sim, rules, building_id) = damage_fire_fixture(false);
+        sim.substrate
+            .entities
+            .get_mut(building_id)
+            .unwrap()
+            .health
+            .current = 50;
+        sim.update_building_damage_fire(building_id, &rules);
+        let anim_id = sim
+            .substrate
+            .entities
+            .get(building_id)
+            .unwrap()
+            .damage_fire_anim_ids[0]
+            .expect("slot zero");
+        let before = sim.anim_absolute_coord(anim_id).expect("attached anim");
+        let stored_before = sim.anim(anim_id).unwrap().world_coord;
+
+        // Move the owner one cell east and one cell south.
+        {
+            let owner = sim.substrate.entities.get_mut(building_id).unwrap();
+            owner.position.rx += 1;
+            owner.position.ry += 1;
+        }
+
+        assert_eq!(
+            sim.anim(anim_id).unwrap().world_coord,
+            stored_before,
+            "the stored delta is untouched by owner movement"
+        );
+        assert_eq!(
+            sim.anim_absolute_coord(anim_id).unwrap(),
+            AnimWorldCoord {
+                x: before.x + LEPTONS_PER_CELL,
+                y: before.y + LEPTONS_PER_CELL,
+                z: before.z
+            },
+            "the resolved coordinate follows the owner one cell on each axis"
+        );
+
+        let moved = sim.anim_absolute_coord(anim_id).unwrap();
+        assert_eq!(sim.detach_anim_from_owner(anim_id), Some(building_id));
+        assert!(sim.anim(anim_id).unwrap().owner_entity.is_none());
+        assert_eq!(
+            sim.anim(anim_id).unwrap().world_coord,
+            moved,
+            "detach writes the resolved absolute back into the stored field"
+        );
+        assert_eq!(sim.anim_absolute_coord(anim_id).unwrap(), moved);
+    }
+
+    #[test]
     fn building_damage_fire_uses_exact_threshold_slots_coords_and_depth() {
         let (mut sim, rules, building_id) = damage_fire_fixture(false);
         sim.substrate
@@ -1986,13 +2192,25 @@ mod tests {
             type_names[expected_types[0]]
         );
         assert_eq!(first_anim.runtime.current_frame, expected_frames[0]);
+        // `AnimClass::SetOwnerObject @ 0x00424B50` stores the coordinate
+        // owner-relative; `GetCoords @ 0x00422BE0` resolves it back. The
+        // absolute is what the draw and the sound see, and it is unchanged.
         assert_eq!(
-            first_anim.world_coord,
+            sim.anim_absolute_coord(first).unwrap(),
             AnimWorldCoord {
                 x: 2450,
                 y: 2653,
                 z: 0
             }
+        );
+        assert_eq!(
+            first_anim.world_coord,
+            AnimWorldCoord {
+                x: 2450 - 3072,
+                y: 2653 - 3072,
+                z: 0
+            },
+            "stored coordinate is the owner-relative delta native writes"
         );
         assert_eq!(first_anim.z_adjust, -192);
         let second_anim = sim.anim(second).unwrap();
@@ -2003,12 +2221,21 @@ mod tests {
         );
         assert_eq!(second_anim.runtime.current_frame, expected_frames[1]);
         assert_eq!(
-            second_anim.world_coord,
+            sim.anim_absolute_coord(second).unwrap(),
             AnimWorldCoord {
                 x: 3140,
                 y: 2594,
                 z: 0
             }
+        );
+        assert_eq!(
+            second_anim.world_coord,
+            AnimWorldCoord {
+                x: 3140 - 3072,
+                y: 2594 - 3072,
+                z: 0
+            },
+            "stored coordinate is the owner-relative delta native writes"
         );
         assert_eq!(second_anim.z_adjust, -136);
         assert_eq!(

--- a/src/sim/movement/homing_movement.rs
+++ b/src/sim/movement/homing_movement.rs
@@ -321,42 +321,47 @@ impl HomingState {
     /// program's only writer zeroes them again, so a `u16` entity cell does
     /// reach it and the gate applies here exactly as it does to a stored Bullet.
     ///
-    /// RESIDUAL (GSI-05.11) — this arm and the stored-Bullet arm derive the
-    /// replacement cell differently. `notify_pointer_expired` feeds a stored
-    /// Bullet the `ObjectClass::GetCoords` truncation, which shifts a
-    /// BuildingClass from its stored NW anchor to the geometric foundation
-    /// centre; this arm is fed the raw `(position.rx, position.ry)`.
-    /// - Trigger: a homing missile losing a multi-cell building target.
-    /// - Player effect: the missile continues to the building's NW cell instead
-    ///   of its centre, so the impact lands up to half a foundation off.
-    /// - Frequency: every homing shot whose building target dies in flight.
-    ///   One attacker is enough — a V3, a Dreadnought or any burst weapon kills
-    ///   the structure with its own later missiles still travelling — so this
-    ///   is ordinary siege play, not a two-attacker coincidence.
-    /// - Downstream risk: aligning it means routing this arm through the same
-    ///   derivation, which moves the impact cell of an existing tested path, so
-    ///   it wants its own slice rather than a drive-by change here.
+    /// gamemd-derived: `BulletClass::PointerExpired @ 0x004684E0` has exactly
+    /// one target-repair arm, and it derives its replacement cell from the
+    /// expiring object's own `ObjectClass::GetCoords` (primary vtable `+0x48`),
+    /// truncated by the `(v + (v >> 31 & 0xFF)) >> 8` pair feeding
+    /// `MapCoord_Set`. A missile modelled as an entity with `HomingState` and a
+    /// missile stored in the projectile store are the same native Bullet, so
+    /// both are fed that one derivation — `target_cell` here is the caller's
+    /// `object_get_coords_cell`, which is what shifts a BuildingClass off its
+    /// stored NW anchor onto the geometric foundation centre.
+    ///
+    /// `None` stands for a coordinate that does not resolve to a map cell at
+    /// all. Native cannot reach it — `MapCoord_Set` always packs — so it is a
+    /// VERA-internal arm, shared with the store side, which takes the same
+    /// null-target outcome. It leaves the cached `last_known_*` steering coord
+    /// alone: there is no cell to cache, and the missile is target-null from
+    /// that point on.
     pub(crate) fn expire_object_target(
         &mut self,
         expired_id: u64,
-        target_cell: (u16, u16),
+        target_cell: Option<(u16, u16)>,
         target_is_high_flying: bool,
     ) -> bool {
         if self.target != Some(HomingTarget::Object(expired_id)) {
             return false;
         }
 
-        self.last_known_rx = target_cell.0;
-        self.last_known_ry = target_cell.1;
-        self.target = if target_is_high_flying
-            || target_cell == crate::sim::world::NULL_TARGET_CELL_SENTINEL
-        {
-            None
-        } else {
-            Some(HomingTarget::Cell {
-                rx: target_cell.0,
-                ry: target_cell.1,
-            })
+        if let Some((rx, ry)) = target_cell {
+            self.last_known_rx = rx;
+            self.last_known_ry = ry;
+        }
+        self.target = match target_cell {
+            Some(cell)
+                if !target_is_high_flying
+                    && cell != crate::sim::world::NULL_TARGET_CELL_SENTINEL =>
+            {
+                Some(HomingTarget::Cell {
+                    rx: cell.0,
+                    ry: cell.1,
+                })
+            }
+            _ => None,
         };
         true
     }

--- a/src/sim/score.rs
+++ b/src/sim/score.rs
@@ -409,7 +409,7 @@ mod tests {
     }
 
     #[test]
-    fn terminal_score_snapshot_roundtrips_in_v81() {
+    fn terminal_score_snapshot_roundtrips_in_v82() {
         let mut sim = natural_terminal_sim(0x51C0_DEF0);
         let tick = sim.advance_tick(
             &[],
@@ -427,10 +427,10 @@ mod tests {
 
         let bytes = crate::sim::snapshot::GameSnapshot::save(&sim, 1, 2, "score.map", 0);
         let header = crate::sim::snapshot::GameSnapshot::read_header(&bytes)
-            .expect("v81 score snapshot header");
-        assert_eq!(header.version, 81);
+            .expect("v82 score snapshot header");
+        assert_eq!(header.version, 82);
         let restored = crate::sim::snapshot::GameSnapshot::load(&bytes)
-            .expect("v81 score snapshot")
+            .expect("v82 score snapshot")
             .sim;
         assert_eq!(restored.terminal_score_snapshot(), Some(&expected));
     }

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -258,7 +258,7 @@ use crate::sim::world::Simulation;
 // and prevents score-bonus Scenario RNG draws from repeating after load.
 // Bumped 80 -> 81: pending CommandEnvelope payloads can now carry an offline
 // SetGameSpeed transition. Appending the enum variant changes the bincode schema.
-const SNAPSHOT_VERSION: u32 = 81;
+const SNAPSHOT_VERSION: u32 = 82;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -1538,12 +1538,13 @@ impl Simulation {
             .expect("validated overlay cache")
             .iter_occupied()
             .filter_map(|(rx, ry, cell)| {
-                cell.overlay_id.map(|overlay_id| crate::map::overlay::OverlayEntry {
-                    rx,
-                    ry,
-                    overlay_id,
-                    frame: cell.overlay_data,
-                })
+                cell.overlay_id
+                    .map(|overlay_id| crate::map::overlay::OverlayEntry {
+                        rx,
+                        ry,
+                        overlay_id,
+                        frame: cell.overlay_data,
+                    })
             })
             .collect();
         let native_tiberium_stats =
@@ -2161,9 +2162,17 @@ mod tests {
         let restore_output = restored
             .restore_map_authority_after_snapshot_load(&rules, &registry)
             .expect("restored overlay and navigation authority");
-        let terrain = restored.resolved_terrain.as_ref().expect("restored terrain");
+        let terrain = restored
+            .resolved_terrain
+            .as_ref()
+            .expect("restored terrain");
         assert!(!terrain.cell(0, 0).expect("cleared cell").overlay_blocks);
-        assert!(terrain.cell(2, 0).expect("runtime wall cell").overlay_blocks);
+        assert!(
+            terrain
+                .cell(2, 0)
+                .expect("runtime wall cell")
+                .overlay_blocks
+        );
         let path = restored.path_grid().expect("canonical restored path grid");
         assert!(path.is_walkable(0, 0));
         assert!(!path.is_walkable(2, 0));
@@ -2527,10 +2536,16 @@ mod tests {
     /// 78 -> 79 moved building-overlay finalization before the returned hash
     /// and made the already-serialized overlay component hash-authoritative;
     /// 79 -> 80 added the serialized/hash-authoritative terminal score snapshot;
-    /// 80 -> 81 added the pending-command offline GameSpeed transition payload.
+    /// 80 -> 81 added the pending-command offline GameSpeed transition payload;
+    /// 81 -> 82 made a serialized `AnimClass` coordinate owner-RELATIVE while
+    /// its `owner_entity` is set, matching
+    /// `AnimClass::SetOwnerObject @ 0x00424B50`. The layout is unchanged, so
+    /// old bytes still decode — and would then be re-resolved through the owner
+    /// a whole owner-coordinate away, moving every attached anim and the
+    /// returned hash with it. Cross-version load is refused for that reason.
     #[test]
-    fn gsi_13_06_snapshot_version_is_81() {
-        assert_eq!(super::SNAPSHOT_VERSION, 81);
+    fn gsi_13_06_snapshot_version_is_82() {
+        assert_eq!(super::SNAPSHOT_VERSION, 82);
     }
 
     #[test]
@@ -2577,14 +2592,14 @@ mod tests {
         let expected_hash = sim.state_hash();
 
         let bytes = GameSnapshot::save(&sim, 1, 2, "building-anim.map", 0);
-        let header = GameSnapshot::read_header(&bytes).expect("v81 building-overlay header");
-        assert_eq!(header.version, 81);
+        let header = GameSnapshot::read_header(&bytes).expect("v82 building-overlay header");
+        assert_eq!(header.version, 82);
         let mut restored = GameSnapshot::load(&bytes)
-            .expect("v81 building-overlay snapshot")
+            .expect("v82 building-overlay snapshot")
             .sim;
         restored
             .restore_after_snapshot_load()
-            .expect("v81 building-overlay snapshot restores structurally");
+            .expect("v82 building-overlay snapshot restores structurally");
         let overlays = restored
             .substrate
             .entities
@@ -2662,7 +2677,7 @@ mod tests {
 
         let bytes = GameSnapshot::save(&sim, 1, 2, "counter.map", 0);
         let restored = GameSnapshot::load(&bytes)
-            .expect("v81 body-counter snapshot")
+            .expect("v82 body-counter snapshot")
             .sim;
         assert_eq!(
             restored
@@ -2784,7 +2799,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_game_speed_transition_roundtrips_in_v81_and_executes_once() {
+    fn pending_game_speed_transition_roundtrips_in_v82_and_executes_once() {
         use crate::sim::command::{Command, CommandEnvelope};
         use crate::sim::house_state::HouseState;
 
@@ -2802,10 +2817,10 @@ mod tests {
         assert_eq!(sim.state_hash(), hash_without_pending_input);
 
         let bytes = GameSnapshot::save(&sim, 1, 2, "speed.map", 0);
-        let header = GameSnapshot::read_header(&bytes).expect("v81 GameSpeed header");
-        assert_eq!(header.version, 81);
+        let header = GameSnapshot::read_header(&bytes).expect("v82 GameSpeed header");
+        assert_eq!(header.version, 82);
         let mut restored = GameSnapshot::load(&bytes)
-            .expect("v81 GameSpeed snapshot")
+            .expect("v82 GameSpeed snapshot")
             .sim;
         assert_eq!(
             restored.pending_commands_for_tests(),

--- a/src/sim/tiberium/mod.rs
+++ b/src/sim/tiberium/mod.rs
@@ -1080,9 +1080,9 @@ SpreadPercentage=.06
         sim.scenario_rng = crate::sim::rng::SimRng::new(0);
         let expected_hash = sim.state_hash();
         let bytes = GameSnapshot::save(&sim, 0, 0, "gsi_04_09_packed.map", 0);
-        assert_eq!(GameSnapshot::read_header(&bytes).unwrap().version, 81);
+        assert_eq!(GameSnapshot::read_header(&bytes).unwrap().version, 82);
         let restored = GameSnapshot::load(&bytes)
-            .expect("v81 packed-map snapshot")
+            .expect("v82 packed-map snapshot")
             .sim;
         assert_eq!(restored.state_hash(), expected_hash);
         let restored_grid = restored

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -1937,7 +1937,10 @@ impl Simulation {
         &mut self,
         listener_id: u64,
         expired_id: u64,
-        expired_cell: (u16, u16),
+        // The expiring object's `ObjectClass::GetCoords` cell — the single
+        // derivation `BulletClass::PointerExpired @ 0x004684E0` uses for both
+        // the entity-hosted and store-hosted missile arms.
+        expired_get_coords_cell: Option<(u16, u16)>,
         expired_is_high_flying: bool,
         expired_object_alive: bool,
         expired_health: u16,
@@ -2082,7 +2085,11 @@ impl Simulation {
         }
 
         if let Some(homing) = listener.homing_state.as_mut() {
-            homing.expire_object_target(expired_id, expired_cell, expired_is_high_flying);
+            homing.expire_object_target(
+                expired_id,
+                expired_get_coords_cell,
+                expired_is_high_flying,
+            );
         }
 
         if let Some(pending) = listener.pending_c4_detonation.as_mut()
@@ -2113,7 +2120,6 @@ impl Simulation {
     /// the same destructure.
     fn notify_pointer_expired(&mut self, expired_id: u64, _context: UninitContext<'_>) {
         let Some((
-            expired_cell,
             expired_target_cell,
             expired_is_high_flying,
             expired_object_alive,
@@ -2126,7 +2132,6 @@ impl Simulation {
                 locomotor.is_airborne() && locomotor.altitude >= SimFixed::from_num(2 * 104)
             });
             (
-                (expired.position.rx, expired.position.ry),
                 object_get_coords_cell(expired),
                 high_flying,
                 expired.lifecycle.object_alive,
@@ -2161,18 +2166,32 @@ impl Simulation {
         // (0, 0). The third gate, `g_MapEditorMode`, is deliberately omitted:
         // it is zero for the whole of ordinary gameplay.
         //
-        // RESIDUAL (GSI-05.11) — the dummy cell is one process-global object
-        // and `Get_CellClass` restamps its coord on every miss anywhere in the
-        // program, so a native Bullet holding it reads whichever coordinate was
-        // requested most recently, not the one stamped for it. `Cell { rx, ry }`
-        // pins a stable coordinate instead. Trigger: two misses in the same
-        // frame while a Bullet holds a dummy target. Player effect: a homing
-        // shot that lost an unallocated-cell target would drift toward an
-        // unrelated cell in native and fly straight here. Frequency: needs a
-        // target to die on an unallocated cell first, which ordinary skirmish
-        // play does not produce. Downstream risk: none while no other system
-        // models the dummy; modelling it would mean sharing one mutable cell
-        // identity across the store, which the deterministic id model rejects.
+        // DRIFT (GSI-05.11) — recorded, not pending. `MapClass::Get_CellClass @
+        // 0x005657A0` stamps the requested packed coord into the shared dummy
+        // CellClass (`0x00ABDC50`, coord at `+0x24`) on both miss paths — an
+        // index outside `[0, 0x40000)` and an in-range NULL sparse slot — and
+        // returns that one process-global object. A native Bullet holding it
+        // therefore reads whichever coordinate was requested most recently
+        // anywhere in the program, not the one stamped when it took the target.
+        // `Cell { rx, ry }` pins a stable coordinate instead.
+        // - Trigger: any cell-lookup miss anywhere in the frame while a Bullet
+        //   holds a dummy target. The stamp is not confined to
+        //   `Get_CellClass`: the same fallback is inlined into
+        //   `Is_Cell_In_Playfield @ 0x00578498`, `Find_Nearby_Passable_Cell`,
+        //   `GetZoneID` and the bridge walkers among others.
+        // - Player effect: a homing shot that lost an unallocated-cell target
+        //   drifts toward an unrelated cell in native and flies straight here.
+        // - Frequency: needs a target to die on an unallocated cell — outside
+        //   the map diamond — first, which ordinary skirmish play does not
+        //   produce.
+        // - Downstream risk: none today. Reproducing it is not blocked by the
+        //   id model — a single hashed scalar on `Simulation` would carry the
+        //   coord — but it is not *correct* without also reproducing every
+        //   cell-lookup miss engine-wide in native call order, since that walk
+        //   is what decides which coord is current. That is the unbounded part,
+        //   and it is why this stays recorded rather than approximated: a
+        //   scalar fed by VERA's own miss order would be a different wrong
+        //   answer wearing native's shape.
         let projectile_replacement_target = (!expired_is_high_flying)
             .then_some(())
             .and(expired_target_cell)
@@ -2209,7 +2228,7 @@ impl Simulation {
                 self.notify_entity_pointer_expired(
                     listener_id,
                     expired_id,
-                    expired_cell,
+                    expired_target_cell,
                     expired_is_high_flying,
                     expired_object_alive,
                     expired_health,

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -2466,6 +2466,69 @@ fn homing_target_expiry_uses_ground_cell_but_nulls_high_flying_target() {
 }
 
 #[test]
+fn gsi_05_11_homing_building_target_expiry_uses_foundation_center_cell() {
+    // `BulletClass::PointerExpired @ 0x004684E0` derives its replacement cell
+    // from the expiring object's `ObjectClass::GetCoords` (vtable +0x48), so an
+    // entity-hosted missile must land on the same foundation-centre cell the
+    // store-hosted arm already uses (see
+    // `gsi_05_04_building_get_coords_uses_foundation_center_cell`).
+    let mut sim = Simulation::new();
+    sim.session.map_width = 20;
+    sim.session.map_height = 20;
+    install_common_raw_terrain(&mut sim, 20, 20, 0, None);
+
+    let target_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, target_id, EntityCategory::Structure);
+    let gapowr = sim.interner.intern("GAPOWR");
+    {
+        let target = sim.substrate.entities.get_mut(target_id).unwrap();
+        target.type_ref = gapowr;
+        target.foundation = "2x2".to_string();
+    }
+    assert!(matches!(
+        sim.try_reveal_entity(target_id, common_raw_request(9, 11, 0, 128, 128)),
+        RevealOutcome::Revealed { .. }
+    ));
+
+    let missile_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, missile_id, EntityCategory::Unit);
+    assert!(attach_homing_state(
+        &mut sim.substrate.entities,
+        missile_id,
+        (2, 3),
+        target_id,
+        (9, 11),
+        SimFixed::from_num(10),
+        5,
+        0,
+        false,
+        false,
+        SimFixed::from_num(1),
+    ));
+
+    sim.uninit(target_id);
+
+    let homing = sim
+        .substrate
+        .entities
+        .get(missile_id)
+        .unwrap()
+        .homing_state
+        .clone()
+        .unwrap();
+    assert_eq!(
+        homing.target,
+        Some(HomingTarget::Cell { rx: 10, ry: 12 }),
+        "the entity-hosted arm takes the GetCoords foundation centre, not the stored NW anchor"
+    );
+    assert_eq!(
+        (homing.last_known_rx, homing.last_known_ry),
+        (10, 12),
+        "the cached last-known cell follows the same derivation"
+    );
+}
+
+#[test]
 fn expiring_mixed_size_passenger_updates_transport_total_exactly() {
     let mut sim = Simulation::new();
     insert_entity(&mut sim, 1, EntityCategory::Unit);
@@ -3368,7 +3431,14 @@ fn gsi_05_02_mixed_six_family_order_roundtrips_and_dispatches_every_slot() {
 #[test]
 fn substrate_registration_and_removal_dispatch_is_order_identical() {
     let (mut sim, mixed) = gsi_05_02_mixed_fixture();
-    let [terrain_id, entity_id, wave_id, anim_id, projectile_id, particle_id] = mixed;
+    let [
+        terrain_id,
+        entity_id,
+        wave_id,
+        anim_id,
+        projectile_id,
+        particle_id,
+    ] = mixed;
 
     // Re-registering an existing member of every family reports success and
     // appends nothing (the membership gate short-circuits before the push).
@@ -3399,7 +3469,13 @@ fn substrate_registration_and_removal_dispatch_is_order_identical() {
             .unwrap()
             .in_logic_vector
     );
-    assert!(sim.substrate.entities.get(entity_id).unwrap().in_logic_vector);
+    assert!(
+        sim.substrate
+            .entities
+            .get(entity_id)
+            .unwrap()
+            .in_logic_vector
+    );
     assert!(sim.substrate.anims.get(anim_id).unwrap().in_logic_vector);
     assert!(sim.projectiles.get(projectile_id).unwrap().in_logic_vector);
     assert!(
@@ -3416,7 +3492,14 @@ fn substrate_registration_and_removal_dispatch_is_order_identical() {
     assert!(sim.register_live_object(wave_id));
     assert_eq!(
         sim.live_object_order_snapshot(),
-        vec![terrain_id, entity_id, anim_id, projectile_id, particle_id, wave_id]
+        vec![
+            terrain_id,
+            entity_id,
+            anim_id,
+            projectile_id,
+            particle_id,
+            wave_id
+        ]
     );
     assert!(sim.waves.get(wave_id).unwrap().in_logic_vector);
 


### PR DESCRIPTION
Rows 116 and 117 of `docs/plans/2026-07-30-clean-slate-system-implementation-order.md`, implemented rather than surveyed. Both rows' `RESIDUAL` work orders from PR #132 are closed or converted to recorded DRIFT with a stated reason.

## Row 116 — GSI-05.11, projectile instances and target references

A homing missile whose multi-cell building target died in flight steered to the building's NW anchor instead of its centre, up to half a foundation off. Ordinary siege play: a V3, a Dreadnought or any burst weapon kills a structure with its own later missiles still travelling.

`BulletClass::PointerExpired @ 0x004684E0` has exactly one target-repair arm, deriving the replacement cell from `ObjectClass::GetCoords` (vtable `+0x48`) on the expiring object. VERA hosts a missile two ways — as an entity carrying `HomingState`, or in the projectile store — but native has one Bullet and one derivation. Both arms now take it.

The row's other residual, the shared dummy `CellClass`, stays a recorded DRIFT: tracking which coordinate is current means reproducing every cell-lookup miss engine-wide in native call order, not one scalar.

## Row 117 — GSI-05.12, animation instances and attached ownership

Native stores an attached animation's coordinate relative to its owner and resolves it on read, so the anim tracks a moving owner for free and its draw order comes from the owner-resolved position. VERA stored an absolute and merely tagged the owner, then short-circuited every owned anim past the draw planner into an append-ordered buffer.

`AnimClass::SetOwnerObject @ 0x00424B50` and `GetCoords @ 0x00422BE0` are now modelled as a mechanism, and `GetLayer @ 0x00424CB0`'s owner-first layer-2 forcing puts burning-building fires into the sorted ground layer where native puts them. This unblocks the twelve other native attach producers — paradrop `PARACH`, the `BEHIND` marker, muzzle anims, EMP sparks, Chrono Legionnaire erase, `CaptureManager`, deploy/undeploy, terrain catch-fire — none of which could be built without it.

`SNAPSHOT_VERSION` 81 -> 82: layout unchanged, but a v81 save would decode and then re-resolve every attached anim an owner-coordinate away.

## Evidence

Every behavioural claim is cited to a live decompile or disassembly taken this session, with the address in the code. Two independent read-only critics verified each slice against the binary before it was committed; both blocked once and the blocks were closed before landing. Notably the magnitude and layer chains were read from disassembly, not decompiled C, because operand order and vtable slot identity were load-bearing.

## Validation

```
cargo test -p vera20k --lib sim::
test result: ok. 3497 passed; 0 failed; 13 ignored; 0 measured

cargo test -p vera20k --lib app::
test result: ok. 783 passed; 0 failed; 5 ignored; 0 measured

cargo test -p vera20k --lib render::
test result: ok. 450 passed; 0 failed; 6 ignored; 0 measured
```

The pinned global replay harness is unchanged — neither row moved it.

## Known validation limit

Moving burning-building fires into the sorted ground layer is a render-composition change no unit test can settle. It is derived from the binary by two independent readings and replaces an explicitly-labelled approximation, but it has not been checked against a live frame.