### PR TITLE
sim: let a low bridge's Land= carry its own passability

### DIFF
--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -1020,6 +1020,7 @@ impl ResolvedTerrainGrid {
                             &mut metadata,
                             land,
                             overlay_effects.effective_land_speed_costs,
+                            overlay_effects.effective_land_ground_blocked,
                         );
                     }
                 }
@@ -1050,7 +1051,12 @@ impl ResolvedTerrainGrid {
                     metadata.speed_costs.wheel,
                     terrain_object_occupation,
                 );
-                let ground_walk_blocked = base_ground_walk_blocked
+                // Same shape as `base_ground_walk_blocked`, but on the metadata
+                // *after* any overlay land override. `base_*` stays pristine on
+                // purpose — it is the restoration value for overlay removal —
+                // so reading it here would pin a low bridge's deck to the
+                // water underneath it.
+                let ground_walk_blocked = (canonical_ramp.is_none() && metadata.ground_blocked)
                     || terrain_object_blocks
                     || overlay_effects.overlay_blocks;
                 let bridge_walkable = overlay_effects.has_bridge_deck
@@ -1628,6 +1634,10 @@ struct OverlayEffects {
     is_low_bridge: bool,
     effective_land: Option<LandType>,
     effective_land_speed_costs: Option<SpeedCostProfile>,
+    /// Ground-blocking of `effective_land`'s rules row. Travels with
+    /// `effective_land` so the replacement LandType brings its own passability
+    /// instead of leaving the tile's behind. See `OverlayTypeFlags::land_ground_blocked`.
+    effective_land_ground_blocked: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -1945,8 +1955,7 @@ fn mark_invalid_subtile_metadata(
     metadata.slope_type = 0;
     metadata.template_height = 0;
     metadata.has_ramp = false;
-    apply_canonical_land_to_metadata(metadata, LandType::Clear, None);
-    metadata.ground_blocked = false;
+    apply_canonical_land_to_metadata(metadata, LandType::Clear, None, false);
     metadata.build_blocked = false;
     if let Some(clear) =
         terrain_rules.and_then(|rules| rules.semantics_for_land_type(LandType::Clear.as_index()))
@@ -2022,8 +2031,7 @@ fn merge_tmp_metadata(metadata: &mut TileMetadata, tile: &TmpTile) {
     metadata.raw_land_type = tile.terrain_type;
     metadata.yr_cell_land_type = yr_cell_land_type_from_tmp(tile.terrain_type);
     metadata.land_type =
-        crate::rules::terrain_rules::tmp_terrain_to_land_type(tile.terrain_type)
-            .as_index();
+        crate::rules::terrain_rules::tmp_terrain_to_land_type(tile.terrain_type).as_index();
     metadata.slope_type = tile.ramp_type;
     metadata.template_height = tile.height;
     metadata.render_offset_x = tile.offset_x;
@@ -2094,10 +2102,22 @@ fn apply_land_type_semantics(
     metadata.build_blocked = !semantics.buildable;
 }
 
+/// Replace every land-derived attribute of a cell with the overlay's `Land=` row.
+///
+/// Overlay land override: `CellClass__RecalcAttributes` @ `0x0047D2B0`. Its
+/// entry branch loads `OverlayTypeClass+0x298` into `Cell->LandType` and, when
+/// that land is Wall(4)/Railroad(9) or `+0x2AC` (`NoUseTileLandType`) is set,
+/// runs the LAT fixup and zone recompute and **returns** — the tile's own
+/// subtile land type is never consulted. LandType is the only land attribute
+/// gamemd stores, so nothing can survive the swap; passability is re-derived
+/// from it. `ground_blocked` is VERA's cache of that derivation and must be
+/// replaced here too, or a low bridge (`Land=Road`, `NoUseTileLandType=yes`)
+/// over water keeps the water tile's block and rejects every ground unit.
 fn apply_canonical_land_to_metadata(
     metadata: &mut TileMetadata,
     land: LandType,
     speed_costs: Option<SpeedCostProfile>,
+    ground_blocked: bool,
 ) {
     metadata.land_type = land.as_index();
     metadata.yr_cell_land_type = land.as_index();
@@ -2107,6 +2127,7 @@ fn apply_canonical_land_to_metadata(
     metadata.is_cliff_like = land.is_cliff_like();
     metadata.is_rough = land.is_rough();
     metadata.is_road = land.is_road();
+    metadata.ground_blocked = ground_blocked;
 }
 
 fn classify_overlay_effects(
@@ -2139,6 +2160,7 @@ fn classify_overlay_effects(
             if let Some(land) = retained_overlay_land(flags, slope_type) {
                 result.effective_land = Some(land);
                 result.effective_land_speed_costs = flags.land_speed_costs;
+                result.effective_land_ground_blocked = flags.land_ground_blocked;
             }
             if clears_tiberium_on_slope(flags, slope_type) {
                 continue;
@@ -3995,6 +4017,83 @@ NoUseTileLandType=yes
     }
 
     #[test]
+    fn low_bridge_overlay_land_replaces_the_tiles_ground_block_at_load() {
+        // Low bridges (LOBRDG01..28 wood, LOBRDB01..28 concrete) are overlays
+        // laid straight onto the water tiles they span, with `Land=Road` and
+        // `NoUseTileLandType=yes`. `CellClass__RecalcAttributes` @ 0x0047D2B0
+        // takes its early branch for exactly that pair and returns before the
+        // tile's own subtile land type is read, so nothing of the water
+        // survives — LandType is the only land attribute gamemd stores.
+        let ini = IniFile::from_str(
+            "[OverlayTypes]
+0=LOBRDB10
+1=WATERKEEP
+[Road]
+Foot=100%
+Track=100%
+Wheel=100%
+[Water]
+Float=100%
+[LOBRDB10]
+Land=Road
+NoUseTileLandType=yes
+[WATERKEEP]
+Land=Water
+NoUseTileLandType=yes
+",
+        );
+        let registry = OverlayTypeRegistry::from_ini(&ini, None);
+
+        // The blocked-ness of the replacement row travels with the land.
+        assert!(!registry.flags(0).expect("bridge flags").land_ground_blocked);
+        assert!(registry.flags(1).expect("water flags").land_ground_blocked);
+
+        // Start from a water tile: blocked to ground, water-classed.
+        let mut metadata = TileMetadata {
+            has_tmp_metadata: true,
+            land_type: LandType::Water.as_index(),
+            yr_cell_land_type: LandType::Water.as_index(),
+            terrain_class: TerrainClass::Water,
+            is_water: true,
+            ground_blocked: true,
+            ..TileMetadata::default()
+        };
+        let canonical_ramp = canonical_ramp_from_slope_type(metadata.slope_type);
+        let base_ground_walk_blocked = canonical_ramp.is_none() && metadata.ground_blocked;
+        assert!(base_ground_walk_blocked);
+
+        let overlay = OverlayEntry {
+            rx: 0,
+            ry: 0,
+            overlay_id: 0,
+            frame: 1,
+        };
+        let effects = classify_overlay_effects(Some(&vec![&overlay]), Some(&registry), 0, 0);
+        let land = effects.effective_land.expect("bridge retains Land=Road");
+        assert_eq!(land, LandType::Road);
+        assert!(!effects.effective_land_ground_blocked);
+
+        apply_canonical_land_to_metadata(
+            &mut metadata,
+            land,
+            effects.effective_land_speed_costs,
+            effects.effective_land_ground_blocked,
+        );
+
+        assert_eq!(metadata.land_type, LandType::Road.as_index());
+        assert!(!metadata.is_water);
+        // The regression: `ground_blocked` was the one land-derived field the
+        // override skipped, so the deck stayed impassable while every other
+        // attribute said Road.
+        assert!(!metadata.ground_blocked);
+        let ground_walk_blocked =
+            (canonical_ramp.is_none() && metadata.ground_blocked) || effects.overlay_blocks;
+        assert!(!ground_walk_blocked);
+        // The pristine snapshot is untouched, so overlay removal still restores water.
+        assert!(base_ground_walk_blocked);
+    }
+
+    #[test]
     fn gsi_04_04_load_tiberium_slope_branches_retain_only_early_copied_land() {
         let ini = IniFile::from_str(
             "\
@@ -4055,6 +4154,7 @@ NoUseTileLandType=no
                         &mut current,
                         effective_land,
                         effects.effective_land_speed_costs,
+                        effects.effective_land_ground_blocked,
                     );
                 }
                 let expected_land = if retains_current_land {
@@ -4185,8 +4285,7 @@ NoUseTileLandType=no
         let mut metadata = TileMetadata {
             has_tmp_metadata: true,
             raw_land_type: 15,
-            land_type: crate::rules::terrain_rules::tmp_terrain_to_land_type(15)
-                .as_index(),
+            land_type: crate::rules::terrain_rules::tmp_terrain_to_land_type(15).as_index(),
             slope_type: 2,
             terrain_class: TerrainClass::Cliff,
             ground_blocked: true,

--- a/src/rules/overlay_types.rs
+++ b/src/rules/overlay_types.rs
@@ -147,6 +147,19 @@ pub struct OverlayTypeFlags {
     pub no_use_tile_land_type: bool,
     /// Final Land row's speed profile, when that canonical rules section exists.
     pub land_speed_costs: Option<SpeedCostProfile>,
+    /// Whether the final Land row blocks ground movement on its own.
+    ///
+    /// Taken from the same `terrain_rules` row as `land_speed_costs`, because a
+    /// cell whose LandType the overlay replaces must derive *every* land
+    /// attribute from the replacement. `CellClass__RecalcAttributes` @
+    /// `0x0047D2B0` stores exactly one land attribute — `Cell->LandType` — and
+    /// its early overlay branch writes `OverlayTypeClass+0x298` (`Land=`) and
+    /// returns before the tile's own subtile land type is ever read, whenever
+    /// `Land` is Wall/Railroad or `+0x2AC` (`NoUseTileLandType`) is set. gamemd
+    /// has no cached per-cell "blocked" bit to go stale; ground passability is
+    /// re-derived from that stored LandType. VERA caches the derivation, so the
+    /// cache has to move with the LandType that produced it.
+    pub land_ground_blocked: bool,
     /// Strength= from rules.ini — hit points for destructible overlays.
     /// Only meaningful when wall=true. Default 1.
     pub strength: u16,
@@ -177,6 +190,7 @@ impl Default for OverlayTypeFlags {
             land: LandType::Clear,
             no_use_tile_land_type: true,
             land_speed_costs: None,
+            land_ground_blocked: false,
             radar_color: None,
             strength: 1,
             damage_levels: 1,
@@ -259,9 +273,10 @@ impl OverlayTypeRegistry {
         // Native registry allocation follows declaration order; numeric key
         // text is not a sorting authority.
         let terrain_rules = TerrainRules::from_ini(ini);
-        let clear_speed_costs = terrain_rules
-            .semantics_for_land_type(LandType::Clear.as_index())
-            .map(|semantics| semantics.speed_costs);
+        let clear_semantics = terrain_rules.semantics_for_land_type(LandType::Clear.as_index());
+        let clear_speed_costs = clear_semantics.map(|semantics| semantics.speed_costs);
+        let clear_ground_blocked =
+            clear_semantics.is_some_and(|semantics| semantics.ground_blocked);
         let mut flags: Vec<OverlayTypeFlags> = Vec::with_capacity(names.len());
         for (idx, name) in names.iter().enumerate() {
             let upper_name = name.to_ascii_uppercase();
@@ -278,9 +293,10 @@ impl OverlayTypeRegistry {
                 if tiberium && land == LandType::Clear {
                     land = LandType::Tiberium;
                 }
-                let land_speed_costs = terrain_rules
-                    .semantics_for_land_type(land.as_index())
-                    .map(|semantics| semantics.speed_costs);
+                let land_semantics = terrain_rules.semantics_for_land_type(land.as_index());
+                let land_speed_costs = land_semantics.map(|semantics| semantics.speed_costs);
+                let land_ground_blocked =
+                    land_semantics.is_some_and(|semantics| semantics.ground_blocked);
                 let land_wheel_speed_zero =
                     land_speed_costs.is_some_and(|speed_costs| speed_costs.wheel == Some(0));
                 // Strength from rules section (e.g., [GAWALL] Strength=300).
@@ -323,6 +339,7 @@ impl OverlayTypeRegistry {
                         .get_bool("NoUseTileLandType")
                         .unwrap_or(true),
                     land_speed_costs,
+                    land_ground_blocked,
                     radar_color,
                     strength,
                     damage_levels,
@@ -332,6 +349,7 @@ impl OverlayTypeRegistry {
                     bridge_deck,
                     track,
                     land_speed_costs: clear_speed_costs,
+                    land_ground_blocked: clear_ground_blocked,
                     land_wheel_speed_zero: clear_speed_costs
                         .is_some_and(|speed_costs| speed_costs.wheel == Some(0)),
                     ..OverlayTypeFlags::default()

--- a/src/sim/overlay_grid.rs
+++ b/src/sim/overlay_grid.rs
@@ -615,16 +615,28 @@ pub fn recalc_overlay_passability(
     } else {
         flags
     };
+    // Ground blocking follows whichever land the cell ends up with. With no
+    // overlay land that is the pristine terrain value already cached in
+    // `base_ground_walk_blocked`; with one it is the overlay's `Land=` row.
+    // `CellClass__RecalcAttributes` @ `0x0047D2B0` recomputes LandType from
+    // scratch on every overlay change and keeps no separate blocked bit, so
+    // neither value may outlive the land that produced it.
+    let mut land_ground_blocked = terrain_cell.base_ground_walk_blocked;
     if let Some(flags) = current_land_flags {
         if let Some(land) = retained_overlay_land(flags, slope_type) {
             apply_overlay_land(terrain_cell, land, flags.land_speed_costs);
+            // The ramp exemption is a property of the tile, not the land row,
+            // so it survives the override exactly as it does in the pristine
+            // value baked into `base_ground_walk_blocked`.
+            land_ground_blocked =
+                terrain_cell.canonical_ramp.is_none() && flags.land_ground_blocked;
         }
     }
 
     terrain_cell.overlay_blocks = new_blocks;
     terrain_cell.overlay_zone_type = overlay_zone;
     terrain_cell.ground_walk_blocked =
-        terrain_cell.base_ground_walk_blocked || terrain_cell.terrain_object_blocks || new_blocks;
+        land_ground_blocked || terrain_cell.terrain_object_blocks || new_blocks;
     terrain_cell.build_blocked = terrain_cell.base_build_blocked
         || terrain_cell.terrain_object_blocks
         || new_blocks
@@ -2119,6 +2131,62 @@ IsRubble=yes
                 "overlay id {overlay_id}"
             );
         }
+    }
+
+    #[test]
+    fn low_bridge_land_override_clears_the_water_tiles_ground_block() {
+        use crate::rules::ini_parser::IniFile;
+        use crate::rules::terrain_rules::{LandType, SpeedCostProfile};
+
+        // A low bridge is an overlay, not a raised deck: LOBRDG01..28 /
+        // LOBRDB01..28 carry `Land=Road` and `NoUseTileLandType=yes`, and their
+        // span cells sit directly on the water tiles they cross.
+        let ini = IniFile::from_str(
+            "[OverlayTypes]
+0=LOBRDG10
+[Road]
+Foot=100%
+Track=100%
+Wheel=100%
+[Water]
+Foot=0%
+Track=0%
+Wheel=0%
+Float=100%
+[LOBRDG10]
+Land=Road
+NoUseTileLandType=yes
+",
+        );
+        let registry = OverlayTypeRegistry::from_ini(&ini, None);
+        let mut water_costs = SpeedCostProfile::default();
+        water_costs.wheel = Some(0);
+
+        let mut terrain = single_cell_terrain(LandType::Water.as_index(), water_costs, true, true);
+        let mut overlay_grid = OverlayGrid::new(1, 1);
+        overlay_grid.place_overlay(0, 0, 0, 1);
+        recalc_overlay_passability(&mut overlay_grid, &mut terrain, &registry, 0, 0);
+
+        let deck = terrain.cell(0, 0).expect("bridge deck cell");
+        assert_eq!(deck.land_type, LandType::Road.as_index());
+        assert!(!deck.is_water);
+        // The regression: `ground_walk_blocked` used to be rebuilt from
+        // `base_ground_walk_blocked`, so the water underneath kept the deck
+        // closed to every ground unit even though its LandType was Road.
+        assert!(
+            !deck.ground_walk_blocked,
+            "Land=Road + NoUseTileLandType must carry its own passability onto the cell"
+        );
+        // The pristine snapshot stays water — it is the restoration value.
+        assert!(deck.base_ground_walk_blocked);
+        assert_eq!(deck.base_land_type, LandType::Water.as_index());
+
+        // Removing the bridge hands the cell back to the water tile.
+        *overlay_grid.cell_mut(0, 0) = OverlayCell::default();
+        recalc_overlay_passability(&mut overlay_grid, &mut terrain, &registry, 0, 0);
+        let bare = terrain.cell(0, 0).expect("cleared cell");
+        assert_eq!(bare.land_type, LandType::Water.as_index());
+        assert!(bare.ground_walk_blocked);
     }
 
     #[test]


### PR DESCRIPTION
## Symptom

Ground units could reach a low bridge's ends but not cross it. The span cells stayed
impassable, so no path over the water existed and units refused to step onto the middle of
the deck. Reported in-game on a temperate map with low bridges.

## Why

Low bridges (`LOBRDG01..28` wood, `LOBRDB01..28` concrete) are overlays laid directly on the
water tiles they cross. Unlike high bridges they have no raised deck layer, so crossing one
is ordinary ground movement over a cell whose LandType the overlay has replaced with Road.

**gamemd source.** `CellClass__RecalcAttributes @ 0x0047D2B0` loads `OverlayTypeClass+0x298`
(`Land=`) into `Cell->LandType` and, when that land is Wall(4)/Railroad(9) or `+0x2AC`
(`NoUseTileLandType`) is set, runs the LAT and slope fixup, recomputes the zone, and
**returns** — the tile's own subtile land type is never read. LandType is the only land
attribute the cell stores. `CellClass__CheckCellPassability @ 0x004834A0` then gates terrain
entry on `Ground[LandType].Cost[SpeedType] == 0`; there is no cached blocked bit that could
survive the swap.

Two further checks confirm low bridges never join the elevated-deck path: `Flags` bit
`0x100` is written only by `CellClass__SetBridgeDirection_NESW @ 0x0047E040` / `_NWSE @
0x0047E470` via `(param_3 & 1) << 8`, whose callers are all `_High` variants; and
`ObjectClass__ShouldBeOnBridge @ 0x005F6A70` requires a ground-height delta above
`3 x FootLevelHeightLeptons`, which a low bridge does not have.

## The defect

VERA caches that derivation as `ground_blocked`. The overlay override replaced `land_type`,
`terrain_class`, `speed_costs`, `is_water`, `is_cliff_like`, `is_rough` and `is_road` while
leaving `ground_blocked` alone — and `ground_walk_blocked` was rebuilt from the pristine
pre-overlay snapshot on both the load and runtime paths. A Road deck over water therefore
kept the water's block, and `PathCell::ground_walkable` fell through to
`!ground_walk_blocked || is_water` with both halves false.

Cells near the shore sit on non-water tiles and were never blocked, which is exactly why the
ends worked and the middle did not.

## The fix

The blocked-ness of the replacement `Land=` row now travels with it, from the same
`terrain_rules` lookup that already supplies `land_speed_costs`, and the current value is
derived from the post-override land on both paths. The `base_*` snapshots stay pristine, so
removing an overlay still restores the terrain underneath.

## Tests

- `map::resolved_terrain::tests::low_bridge_overlay_land_replaces_the_tiles_ground_block_at_load`
- `sim::overlay_grid::tests::low_bridge_land_override_clears_the_water_tiles_ground_block`
  (runtime path, including the overlay-removal round trip)

Full suite: `test result: ok. 7086 passed; 0 failed; 29 ignored; 0 measured; 0 filtered out`

## Residual

Not yet verified in-game — the fix is derived from the binary and pinned by the two tests
above, but no live crossing has been observed on this branch.

VERA keeps a `ground_blocked` boolean at all, where gamemd asks the speed table per
SpeedType. That summary is pre-existing (the cost grid does read per-SpeedType rows) and is
not introduced here, but it cannot express "closed to Track, open to Hover". Recorded as
drift.