### PR TITLE
render: draw border filler cells, hide them by camera and radar only

### DIFF
--- a/src/app/presentation/instances/overlays.rs
+++ b/src/app/presentation/instances/overlays.rs
@@ -575,14 +575,6 @@ pub(crate) fn build_overlay_instances(
         .map(|g| (g.origin_y, g.world_height))
         .unwrap_or((0.0, 1.0));
 
-    // Playable area bounds — skip overlays outside LocalSize (border filler).
-    let local_bounds = state
-        .match_state
-        .match_presentation
-        .terrain_grid
-        .as_ref()
-        .and_then(|g| g.local_bounds);
-
     // Cell visibility for the local owner — used to cull overlays and terrain
     // objects in unrevealed cells. The shroud multiply pass darkens per-pixel,
     // but tall sprites (bridges, trees) extend their canopy into screen-space
@@ -704,12 +696,8 @@ pub(crate) fn build_overlay_instances(
         let (screen_x, screen_y) = terrain::iso_to_screen(entry.rx, entry.ry, z);
         let screen_y: f32 = screen_y + track_y_offset;
 
-        // Playable area bounds — skip overlays outside LocalSize (border filler).
-        if let Some(ref bounds) = local_bounds {
-            if !bounds.contains(screen_x, screen_y) {
-                continue;
-            }
-        }
+        // No LocalSize gate: gamemd draws overlays on border filler cells like
+        // any other; fog visibility and the camera clamp are the only hiders.
         if !in_view(
             screen_x, screen_y, 120.0, 120.0, cam_x, cam_y, sw, sh, 120.0,
         ) {
@@ -800,11 +788,6 @@ pub(crate) fn build_overlay_instances(
             .copied()
             .unwrap_or(0);
         let (screen_x, screen_y) = terrain::iso_to_screen(obj.rx, obj.ry, z);
-        if let Some(ref bounds) = local_bounds {
-            if !bounds.contains(screen_x, screen_y) {
-                continue;
-            }
-        }
         if !in_view(
             screen_x, screen_y, 120.0, 120.0, cam_x, cam_y, sw, sh, 120.0,
         ) {

--- a/src/map/terrain.rs
+++ b/src/map/terrain.rs
@@ -546,7 +546,6 @@ pub fn build_terrain_grid(map: &MapFile, local_bounds: Option<LocalBounds>) -> T
     let mut min_y: f32 = f32::MAX;
     let mut max_x: f32 = f32::MIN;
     let mut max_y: f32 = f32::MIN;
-    let mut clipped: u32 = 0;
 
     for cell in &map.cells {
         // This legacy direct path has no theater context, so retain its tile-0
@@ -564,15 +563,11 @@ pub fn build_terrain_grid(map: &MapFile, local_bounds: Option<LocalBounds>) -> T
 
         let (sx, sy): (f32, f32) = iso_to_screen(cell.rx, cell.ry, cell.z);
 
-        // Clip cells outside the playable area (LocalSize bounds).
-        // In RA2, these border cells are hidden under permanent shroud.
-        if let Some(ref bounds) = local_bounds {
-            if !bounds.contains(sx, sy) {
-                clipped += 1;
-                continue;
-            }
-        }
-
+        // Border filler cells (outside LocalSize) are kept: gamemd draws every
+        // allocated cell and hides the border purely by clamping the tactical
+        // camera to LocalSize. Dropping them while the fog still reveals them
+        // left revealed-but-undrawn holes — hard black cutouts with no shroud
+        // feathering — wherever a zoomed-out view reached the map border.
         cells.push(TerrainCell {
             screen_x: sx,
             screen_y: sy,
@@ -593,14 +588,6 @@ pub fn build_terrain_grid(map: &MapFile, local_bounds: Option<LocalBounds>) -> T
         min_y = min_y.min(sy);
         max_x = max_x.max(sx + TILE_WIDTH);
         max_y = max_y.max(sy + TILE_HEIGHT);
-    }
-
-    if clipped > 0 {
-        log::info!(
-            "LocalSize clip: {} cells kept, {} clipped (outside playable area)",
-            cells.len(),
-            clipped,
-        );
     }
 
     // Sort by screen_y for back-to-front draw order.
@@ -635,17 +622,12 @@ pub fn build_terrain_grid_from_resolved(
     let mut min_y: f32 = f32::MAX;
     let mut max_x: f32 = f32::MIN;
     let mut max_y: f32 = f32::MIN;
-    let mut clipped: u32 = 0;
 
     for cell in resolved.iter() {
         let (tile_id, sub_tile) = resolved.presentation_tile(cell);
         let (sx, sy) = iso_to_screen(cell.rx, cell.ry, cell.level);
-        if let Some(ref bounds) = local_bounds {
-            if !bounds.contains(sx, sy) {
-                clipped += 1;
-                continue;
-            }
-        }
+        // Filler cells kept — see build_terrain_grid: gamemd draws every
+        // allocated cell; only the camera clamp hides the border.
         cells.push(TerrainCell {
             screen_x: sx,
             screen_y: sy,
@@ -665,14 +647,6 @@ pub fn build_terrain_grid_from_resolved(
         min_y = min_y.min(sy);
         max_x = max_x.max(sx + TILE_WIDTH);
         max_y = max_y.max(sy + TILE_HEIGHT);
-    }
-
-    if clipped > 0 {
-        log::info!(
-            "LocalSize clip: {} resolved cells kept, {} clipped (outside playable area)",
-            cells.len(),
-            clipped,
-        );
     }
 
     cells.sort_by(|a, b| {

--- a/src/render/minimap.rs
+++ b/src/render/minimap.rs
@@ -114,6 +114,14 @@ impl MinimapRenderer {
         let (map_offset_x, map_offset_y, map_pixel_w, map_pixel_h) = compute_aspect_fit(w, h);
 
         for cell in &grid.cells {
+            // Radar shows only the playable rect: gamemd's radar is sized to
+            // LocalSize, so border filler cells never appear on it even though
+            // they render in the tactical view.
+            if let Some(ref bounds) = grid.local_bounds {
+                if !bounds.contains(cell.screen_x, cell.screen_y) {
+                    continue;
+                }
+            }
             let (px, py): (u32, u32) = world_to_minimap_pixel(
                 cell.screen_x,
                 cell.screen_y,
@@ -141,6 +149,13 @@ impl MinimapRenderer {
         // Build overlay pixels from classified overlay entries.
         let mut overlay_pixels: Vec<OverlayPixel> = Vec::new();
         for &(rx, ry, classification, density, precomputed) in overlay_data {
+            // Same playable-rect filter as terrain pixels above.
+            if let Some(ref bounds) = grid.local_bounds {
+                let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
+                if !bounds.contains(sx, sy) {
+                    continue;
+                }
+            }
             let color: [u8; 4] = if let Some(c) = precomputed {
                 c
             } else if let Some(c) = classification.color(density) {


### PR DESCRIPTION
Follow-up to #146, which was merged before this commit was pushed to its branch.

Border filler cells (between LocalSize and the Size diamond) were deleted at terrain-grid build while native reveal (`MapClass::RevealShroud @ 0x005673A0`) still explores them — revealed-but-undrawn cells rendered as hard black cutouts with no shroud feathering, widest on the south where the native bottom margin is 6 rows vs 2 (`MapClass::Set_Clipped_LocalSize @ 0x00567230`). gamemd draws every allocated cell and hides the border only via the camera clamp.

Change: keep filler cells, their overlays, and terrain objects in the tactical view (fog remains the only cull); filter the minimap to the playable rect, which is all the native radar shows.

Validation: full `cargo test -p vera20k --lib` on this exact tree: 7086 passed, 0 failed, 29 ignored.