### PR TITLE
render: draw terrain under shroud; the flat curtain hides it

### DIFF
--- a/src/app/presentation/render/build_instances.rs
+++ b/src/app/presentation/render/build_instances.rs
@@ -170,21 +170,9 @@ pub(super) fn build_world_instances(state: &mut AppState, sw: f32, sh: f32) -> W
         None
     };
     let terrain = if let Some(grid) = &state.match_state.match_presentation.terrain_grid {
-        // Skip terrain for fully shrouded cells — matches gamemd which doesn't
-        // render terrain under shroud. The multiply pass still darkens edges.
-        let local_owner_name = crate::app::input::commands::preferred_local_owner_name(state);
-        let fog_vis: Option<(
-            crate::sim::intern::InternedId,
-            &crate::sim::vision::FogState,
-        )> = if state.match_state.sandbox_full_visibility {
-            None
-        } else if let (Some(rt), Some(owner)) = (state.match_state.sim_runtime.as_ref(), &local_owner_name) {
-            // F10 cone: render-feed reads go through SimView getters.
-            let view = rt.view();
-            view.interner().get(owner).map(|id| (id, view.fog()))
-        } else {
-            None
-        };
+        // Terrain draws regardless of shroud — the native tile walk has no
+        // explored gate (`CellOverlay_TileDraw @ 0x00480350`); the flat shroud
+        // curtain blacks out unexplored ground in the multiply pass.
         let bridge_state = state
             .match_state.sim_runtime
             .as_ref()
@@ -197,7 +185,6 @@ pub(super) fn build_world_instances(state: &mut AppState, sw: f32, sh: f32) -> W
             sw,
             sh,
             uv_fn,
-            fog_vis,
             bridge_state,
         )
     } else {

--- a/src/app/presentation/render/mod.rs
+++ b/src/app/presentation/render/mod.rs
@@ -86,6 +86,7 @@ pub(crate) fn render_game(
     // Phase 2: Build debug overlay instances (pathgrid, cell grid, heightmap).
     let debug = build_instances::build_debug_instances(state, vsw, vsh);
 
+
     // Phase 3: Rebuild shroud ABuffer (CPU blit + GPU upload). The final
     // building-bracket front redraw samples this CPU buffer during UI build.
     let rw = state.render_width();

--- a/src/map/terrain.rs
+++ b/src/map/terrain.rs
@@ -1088,7 +1088,7 @@ mod tests {
 
         // Camera at origin, 1024x768 viewport — only first cell should be visible.
         let result: crate::render::terrain_instances::TerrainInstances =
-            crate::render::terrain_instances::build_visible_instances(&grid, None, 0.0, 0.0, 1024.0, 768.0, None, None, None);
+            crate::render::terrain_instances::build_visible_instances(&grid, None, 0.0, 0.0, 1024.0, 768.0, None, None);
         assert_eq!(result.normal.len(), 1);
     }
 
@@ -1146,7 +1146,6 @@ mod tests {
             0.0,
             1024.0,
             768.0,
-            None,
             None,
             None,
         );
@@ -1237,7 +1236,7 @@ mod tests {
         let uv_fn: UvLookupFn = Some(&lookup);
 
         let _ =
-            crate::render::terrain_instances::build_visible_instances(&grid, None, 0.0, 0.0, 1024.0, 768.0, uv_fn, None, Some(&bs));
+            crate::render::terrain_instances::build_visible_instances(&grid, None, 0.0, 0.0, 1024.0, 768.0, uv_fn, Some(&bs));
         let (tid, sub, var) = captured.borrow().expect("uv_fn was called");
         // Override fired: tile_id = NS AboutToFall slot = 203.
         assert_eq!(tid, 203);
@@ -1272,7 +1271,7 @@ mod tests {
         let uv_fn: UvLookupFn = Some(&lookup);
 
         let _ =
-            crate::render::terrain_instances::build_visible_instances(&grid, None, 0.0, 0.0, 1024.0, 768.0, uv_fn, None, Some(&bs));
+            crate::render::terrain_instances::build_visible_instances(&grid, None, 0.0, 0.0, 1024.0, 768.0, uv_fn, Some(&bs));
         let (tid, _sub, _var) = captured.borrow().expect("uv_fn was called");
         // Override bypassed: native tile_id retained.
         assert_eq!(tid, 100);
@@ -1298,7 +1297,7 @@ mod tests {
         let uv_fn: UvLookupFn = Some(&lookup);
 
         let _ =
-            crate::render::terrain_instances::build_visible_instances(&grid, None, 0.0, 0.0, 1024.0, 768.0, uv_fn, None, Some(&bs));
+            crate::render::terrain_instances::build_visible_instances(&grid, None, 0.0, 0.0, 1024.0, 768.0, uv_fn, Some(&bs));
         let (tid, _sub, _var) = captured.borrow().expect("uv_fn was called");
         // Override bypassed (no table): native tile_id retained.
         assert_eq!(tid, 100);

--- a/src/render/shroud_buffer.rs
+++ b/src/render/shroud_buffer.rs
@@ -410,6 +410,22 @@ impl ShroudBuffer {
             }
         }
 
+        // Debug: dump the CPU brightness buffer as a grayscale PNG when
+        // RA2_DUMP_SHROUD names a path. Diagnostic only — no gamemd counterpart.
+        if let Ok(path) = std::env::var("RA2_DUMP_SHROUD") {
+            let w = self.width as usize;
+            let mut img = vec![0u8; w * self.height as usize];
+            for y in 0..self.height as usize {
+                let src = y * self.row_stride as usize;
+                img[y * w..(y + 1) * w].copy_from_slice(&self.pixels[src..src + w]);
+            }
+            if let Err(e) =
+                image::save_buffer(&path, &img, self.width, self.height, image::ColorType::L8)
+            {
+                log::warn!("shroud dump failed: {e}");
+            }
+        }
+
         // Upload to GPU.
         gpu.queue.write_texture(
             wgpu::TexelCopyTextureInfo {

--- a/src/render/terrain_instances.rs
+++ b/src/render/terrain_instances.rs
@@ -44,10 +44,6 @@ pub fn build_visible_instances(
     screen_width: f32,
     screen_height: f32,
     uv_fn: UvLookupFn<'_>,
-    fog: Option<(
-        crate::sim::intern::InternedId,
-        &crate::sim::vision::FogState,
-    )>,
     bridge_state: Option<&crate::sim::bridge_state::BridgeRuntimeState>,
 ) -> TerrainInstances {
     let view_left: f32 = camera_x - CULL_MARGIN;
@@ -71,13 +67,12 @@ pub fn build_visible_instances(
             continue;
         }
 
-        // Skip fully shrouded cells — matches gamemd which doesn't render terrain
-        // for unexplored cells at all (ZBuffer cleared to 0xFFFF prevents drawing).
-        if let Some((owner, fog_state)) = fog {
-            if !fog_state.is_cell_revealed(owner, cell.rx, cell.ry) {
-                continue;
-            }
-        }
+        // No shroud gate: the native tile walk draws every in-bounds cell
+        // regardless of explored state (`CellOverlay_TileDraw @ 0x00480350`
+        // has no shroud test), and the flat ABuffer curtain blacks out
+        // unexplored ground. Culling here left undrawn holes the curtain's
+        // feather could not darken — hard south-facing shroud edges wherever
+        // the feather extended past the last drawn tile.
 
         // Depth: reconstruct elevation-free iso row, then normalize.
         // Lower screen_y → larger depth (drawn behind). Elevation bias ensures


### PR DESCRIPTION
Third and root fix in the shroud series (#146, #149 were necessary but not sufficient).

## Symptom
Screen-south shroud edges render as hard diamond staircases with zero feathering; north edges feather fine. Reproduced on the minerloop fixture (reveal disc: top soft, bottom scalloped).

## Root cause
The terrain pass culled unexplored cells, with a comment claiming gamemd does the same. Live decompile disproves it: the native tile walk projects every in-bounds cell flat (Z=0) and `CellOverlay_TileDraw @ 0x00480350` draws unconditionally — no explored gate — applying the height shift at draw time (`y -= Level*15`). Unexplored ground is hidden purely by the flat ABuffer shroud curtain. Our cull created undrawn holes exactly where each boundary cell''s feather gradient extends toward the shroud side (screen-south), so the gradient had nothing to darken. Elevation widens the effect because the flat curtain sits `Level*15` below the art — also native behavior.

## Change
- Remove the shroud cull from `build_visible_instances` (terrain draws under shroud; multiply pass hides it) and its now-dead fog plumbing.
- Keep the `RA2_DUMP_SHROUD` env-gated debug dump (grayscale PNG of the CPU brightness buffer) that isolated the fault to the terrain pass.

## Validation
- Minerloop fixture before/after captures: reveal-disc edges now feather symmetrically on all sides.
- `cargo test -p vera20k --lib`: 7086 passed, 0 failed, 29 ignored.