### PR TITLE
docs(readme): add what-works / not-yet checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ Offer known old and new rts feautures never seen before to enhance the cnc ra2 e
 
 **Early development** — Work is focused on the core engine. Approximately 35% complete.
 
+**What works today**
+
+- [x] Skirmish on retail Yuri's Revenge maps with the original menus, loading screen and sidebar
+- [x] Base building, power, tech tree, placement, selling and repair
+- [x] Harvesting with War, Chrono and Slave miners
+- [x] Ground, naval, air and spawned-unit combat; garrisons, transports, engineer capture, mind control, cloak
+- [x] Lightning Storm, Iron Curtain, Force Shield, Genetic Mutator, Psychic Reveal, Paradrop
+- [x] Save/load mid-match, match recording and replay
+
+**Not yet**
+
+- [ ] Network play (lockstep and checksums exist, no transport)
+- [ ] A real AI opponent (the current one builds a base and sends waves)
+- [ ] Nuke, Chronosphere, Psychic Dominator, Spy Plane
+- [ ] Campaign missions and most map triggers
+
 
 ## Requirements
 


### PR DESCRIPTION
Adds a task-list style status section under Current Status: six player-visible things that work in a skirmish today and four things that don't yet (network transport, real AI, four superweapons, campaign/triggers). Derived from the current code tree, not the system map's baseline status fields.