### PR TITLE
docs(readme): process section wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Constructed from the ground up for large multiplayer — targeting support for u
 **3.**
 Offer known old and new rts feautures never seen before to enhance the cnc ra2 experience.
 
-## How we build it
+## Development process
 
-Every behavior starts in the decompiled `gamemd.exe`: we read the original function and its callers in Ghidra, record it as a research note, then write Rust that matches it. The engine is mapped as 336 systems in player-visible loops (move, attack, harvest, build, reveal…), ordered into dependency phases. AI agents close those phases one mechanism at a time: one agent builds and tests it, a fresh agent that didn't build it reviews the diff against the native evidence and names the largest gap, and that loop repeats until nothing is left. Playtesting in retail and in VERA decides what comes next.
+Every behavior starts in the decompiled `gamemd.exe`: we read the original function and its callers in Ghidra, and the Rust that matches it cites that function and address next to the code, backed by 1,100+ reverse-engineering notes in `docs/research/`. The engine is mapped as 336 systems in player-visible loops (move, attack, harvest, build, reveal…), ordered into dependency phases. AI agents close those phases one mechanism at a time: one agent builds and tests it, a fresh agent that didn't build it reviews the diff against the native evidence and names the largest gap, and that loop repeats until nothing is left. Playtesting in retail and in VERA decides what comes next.
 
 ## Current Status
 


### PR DESCRIPTION
Rename 'How we build it' to 'Development process'. Current goal sessions record evidence as provenance comments and commit citations, not new research notes (PR #151: 1 note in 45 commits; #145: 0 in 14) — wording now says so, and credits the existing docs/research corpus.