### PR TITLE
Implement native Sonic Wave lifecycle and geometry

### DIFF
--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -1062,6 +1062,12 @@ pub(crate) fn load_map_initial_with_assets(
     // `[Tubes]` are valid in ordinary .map/.mpr/.mmx content, not just .SED
     // random maps.  OnceLock keeps repeated map loads read-only and cheap.
     crate::map::rmg::trig::install_from_dir(&ra2_dir);
+    if !crate::map::retail_trig::wave_tables_available() {
+        anyhow::bail!(
+            "{} does not provide the verified gamemd sine/Acos tables required by stock Sonic Wave simulation",
+            ra2_dir.join("gamemd.exe").display()
+        );
+    }
 
     // Check RA2_QUICKPLAY env var: if it names a .map/.mpr file, load that directly.
     // UI-selected map name/path (requested_map) takes precedence.

--- a/src/headless_scenario.rs
+++ b/src/headless_scenario.rs
@@ -146,6 +146,13 @@ pub const SIM_TICK_MS: u32 = 1000 / crate::util::fixed_math::RA2_LOGIC_FRAMES_PE
 ///
 /// `map_file_name` is resolved relative to the retail root (e.g. `"Dustbowl.mmx"`).
 pub fn load(retail_dir: &Path, map_file_name: &str, seed: u32) -> Result<HeadlessScenario, String> {
+    crate::map::retail_trig::install_from_dir(retail_dir);
+    if !crate::map::retail_trig::wave_tables_available() {
+        return Err(format!(
+            "{} does not provide the verified gamemd sine/Acos tables required by stock Sonic Wave simulation",
+            retail_dir.join("gamemd.exe").display()
+        ));
+    }
     let map_path = retail_dir.join(map_file_name);
     let map = map_file::load_from_path(&map_path)
         .map_err(|error| format!("parse {}: {error}", map_path.display()))?;

--- a/src/map/bridge_facts.rs
+++ b/src/map/bridge_facts.rs
@@ -46,7 +46,9 @@ impl BridgeFlags {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Default,
+)]
 pub enum BridgeStampFamily {
     #[default]
     None,
@@ -54,7 +56,7 @@ pub enum BridgeStampFamily {
     Nwse,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum BridgeStampSlot {
     Anchor,
     Forward1,
@@ -166,7 +168,7 @@ const fn packed_i32(cell: (i16, i16)) -> (i32, i32) {
     (cell.0 as i32, cell.1 as i32)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct BridgeAnchorRelation {
     pub anchor: (u16, u16),
     pub slot: BridgeStampSlot,
@@ -174,7 +176,7 @@ pub struct BridgeAnchorRelation {
     pub direction: u8,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum BridgeRampKind {
     TopRight,
     TopLeft,
@@ -182,14 +184,16 @@ pub enum BridgeRampKind {
     Middle2,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct BridgeRampTile {
     pub kind: BridgeRampKind,
     pub relative_tile_index: u16,
     pub height_byte: u8,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Default,
+)]
 pub struct BridgeCellFacts {
     pub raw_flags: u32,
     pub state_byte: u8,
@@ -667,4 +671,3 @@ pub enum BridgeheadAnchorClass {
     Damaged,
     AboutToFall,
 }
-

--- a/src/map/lat.rs
+++ b/src/map/lat.rs
@@ -242,32 +242,37 @@ fn apply_lat_cell(
 ) -> u32 {
     let x = i32::from(cells[cell_index].rx);
     let y = i32::from(cells[cell_index].ry);
-    let mut changes = 0;
+    let cardinal = CARDINAL_OFFSETS.map(|(dx, dy)| neighbor_tile(cells, by_coord, x + dx, y + dy));
+    let old_tile = cells[cell_index].tile_index;
+    let new_tile = lat_fixed_tile(old_tile, cardinal, lat_config);
+    cells[cell_index].tile_index = new_tile;
+    u32::from(old_tile != new_tile)
+}
+
+/// Runtime form of the LAT half for one CellClass. Native changes only the tile
+/// identity here; the owning caller decides whether/when RecalcAttributes runs.
+pub(crate) fn lat_fixed_tile(
+    mut tile: i32,
+    cardinal_tiles: [i32; 4],
+    lat_config: &LatConfig,
+) -> i32 {
     for ground in &lat_config.grounds {
-        if !ground.is_enabled() || !ground.contains(cells[cell_index].tile_index) {
+        if !ground.is_enabled() || !ground.contains(tile) {
             continue;
         }
-
         let mut mask = 0u8;
-        for (bit, (dx, dy)) in CARDINAL_OFFSETS.iter().copied().enumerate() {
-            let neighbor = neighbor_tile(cells, by_coord, x + dx, y + dy);
+        for (bit, neighbor) in cardinal_tiles.into_iter().enumerate() {
             if !ground.contains(neighbor) && !ground.exempts(neighbor) {
                 mask |= 1u8 << bit;
             }
         }
-
-        let new_tile = if mask == 0 {
+        tile = if mask == 0 {
             ground.base_tile
         } else {
             ground.lat_base + i32::from(mask)
         };
-        if cells[cell_index].tile_index != new_tile {
-            changes += 1;
-        }
-        cells[cell_index].tile_index = new_tile;
-        // Native changes tile identity only; preserve sub_tile.
     }
-    changes
+    tile
 }
 
 fn ramp_range_contains(tile: i32, base: i32, last_offset: i32) -> bool {

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -131,7 +131,7 @@ pub struct BridgeOracleAnchor {
     pub direction: u8,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 /// Canonical ramp direction from TS++ TIBSUN_DEFINES.H (slope types 1-4).
 /// These are the four basic full-edge ramps where two adjacent corners are raised.
 ///
@@ -150,7 +150,7 @@ pub enum RampDirection {
 /// bridge SHP body frames directly from these labels; rendering follows the
 /// runtime bridge state-byte family (`Axis::NS => 0..=8`, `Axis::EW => 9..=17`).
 /// Low bridges have no height offset.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum BridgeDirection {
     /// BRIDGE1, BRIDGEB1 — EW direction. Height offset = CellHeight + 1 = 16px.
     EastWest,
@@ -160,7 +160,7 @@ pub enum BridgeDirection {
     Low,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct BridgeLayer {
     pub overlay_id: u8,
     pub overlay_name: String,
@@ -556,6 +556,199 @@ impl CellClassBridgeFlagState {
     }
 }
 
+/// Serialized behavior authority for a CellClass whose isometric tile was
+/// replaced after map construction. The live ResolvedTerrainGrid is derived
+/// and skipped by Simulation snapshots, so collapse projects these exact
+/// fields into Simulation and reapplies them after map reconstruction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub(crate) struct DynamicTerrainCellState {
+    pub final_tile_index: i32,
+    pub final_sub_tile: u8,
+    pub is_wood_bridge_repair_tile: bool,
+    pub level: u8,
+    pub filled_clear: bool,
+    pub tileset_index: Option<u16>,
+    pub land_type: u8,
+    pub yr_cell_land_type: u8,
+    pub slope_type: u8,
+    pub template_height: u8,
+    pub height_in_pixels: i8,
+    pub render_offset_x: i32,
+    pub render_offset_y: i32,
+    pub terrain_class: TerrainClass,
+    pub speed_costs: SpeedCostProfile,
+    pub is_water: bool,
+    pub is_cliff_like: bool,
+    pub is_rough: bool,
+    pub is_road: bool,
+    pub accepts_smudge: bool,
+    pub allows_tiberium: bool,
+    pub variant: u8,
+    pub has_ramp: bool,
+    pub canonical_ramp: Option<RampDirection>,
+    pub ground_walk_blocked: bool,
+    pub overlay_blocks: bool,
+    pub overlay_zone_type: Option<u8>,
+    pub zone_type: u8,
+    pub base_ground_walk_blocked: bool,
+    pub base_build_blocked: bool,
+    pub base_land_type: u8,
+    pub base_yr_cell_land_type: u8,
+    pub base_terrain_class: TerrainClass,
+    pub base_speed_costs: SpeedCostProfile,
+    pub build_blocked: bool,
+    pub has_bridge_deck: bool,
+    pub bridge_walkable: bool,
+    pub bridge_transition: bool,
+    pub bridge_deck_level: u8,
+    pub bridge_layer: Option<BridgeLayer>,
+    pub bridge_facts: BridgeCellFacts,
+    pub radar_left: [u8; 3],
+    pub radar_right: [u8; 3],
+    pub has_damaged_data: bool,
+    pub bridgehead_anchor_class_at_load:
+        Option<crate::map::bridge_facts::BridgeheadAnchorClass>,
+}
+
+impl DynamicTerrainCellState {
+    pub(crate) fn capture(cell: &ResolvedTerrainCell) -> Self {
+        Self {
+            final_tile_index: cell.final_tile_index,
+            final_sub_tile: cell.final_sub_tile,
+            is_wood_bridge_repair_tile: cell.is_wood_bridge_repair_tile,
+            level: cell.level,
+            filled_clear: cell.filled_clear,
+            tileset_index: cell.tileset_index,
+            land_type: cell.land_type,
+            yr_cell_land_type: cell.yr_cell_land_type,
+            slope_type: cell.slope_type,
+            template_height: cell.template_height,
+            height_in_pixels: cell.height_in_pixels,
+            render_offset_x: cell.render_offset_x,
+            render_offset_y: cell.render_offset_y,
+            terrain_class: cell.terrain_class,
+            speed_costs: cell.speed_costs,
+            is_water: cell.is_water,
+            is_cliff_like: cell.is_cliff_like,
+            is_rough: cell.is_rough,
+            is_road: cell.is_road,
+            accepts_smudge: cell.accepts_smudge,
+            allows_tiberium: cell.allows_tiberium,
+            variant: cell.variant,
+            has_ramp: cell.has_ramp,
+            canonical_ramp: cell.canonical_ramp,
+            ground_walk_blocked: cell.ground_walk_blocked,
+            overlay_blocks: cell.overlay_blocks,
+            overlay_zone_type: cell.overlay_zone_type,
+            zone_type: cell.zone_type,
+            base_ground_walk_blocked: cell.base_ground_walk_blocked,
+            base_build_blocked: cell.base_build_blocked,
+            base_land_type: cell.base_land_type,
+            base_yr_cell_land_type: cell.base_yr_cell_land_type,
+            base_terrain_class: cell.base_terrain_class,
+            base_speed_costs: cell.base_speed_costs,
+            build_blocked: cell.build_blocked,
+            has_bridge_deck: cell.has_bridge_deck,
+            bridge_walkable: cell.bridge_walkable,
+            bridge_transition: cell.bridge_transition,
+            bridge_deck_level: cell.bridge_deck_level,
+            bridge_layer: cell.bridge_layer.clone(),
+            bridge_facts: cell.bridge_facts,
+            radar_left: cell.radar_left,
+            radar_right: cell.radar_right,
+            has_damaged_data: cell.has_damaged_data,
+            bridgehead_anchor_class_at_load: cell.bridgehead_anchor_class_at_load,
+        }
+    }
+
+    pub(crate) fn apply(&self, cell: &mut ResolvedTerrainCell) {
+        cell.final_tile_index = self.final_tile_index;
+        cell.final_sub_tile = self.final_sub_tile;
+        cell.is_wood_bridge_repair_tile = self.is_wood_bridge_repair_tile;
+        cell.level = self.level;
+        cell.filled_clear = self.filled_clear;
+        cell.tileset_index = self.tileset_index;
+        cell.land_type = self.land_type;
+        cell.yr_cell_land_type = self.yr_cell_land_type;
+        cell.slope_type = self.slope_type;
+        cell.template_height = self.template_height;
+        cell.height_in_pixels = self.height_in_pixels;
+        cell.render_offset_x = self.render_offset_x;
+        cell.render_offset_y = self.render_offset_y;
+        cell.terrain_class = self.terrain_class;
+        cell.speed_costs = self.speed_costs;
+        cell.is_water = self.is_water;
+        cell.is_cliff_like = self.is_cliff_like;
+        cell.is_rough = self.is_rough;
+        cell.is_road = self.is_road;
+        cell.accepts_smudge = self.accepts_smudge;
+        cell.allows_tiberium = self.allows_tiberium;
+        cell.variant = self.variant;
+        cell.has_ramp = self.has_ramp;
+        cell.canonical_ramp = self.canonical_ramp;
+        cell.ground_walk_blocked = self.ground_walk_blocked;
+        cell.overlay_blocks = self.overlay_blocks;
+        cell.overlay_zone_type = self.overlay_zone_type;
+        cell.zone_type = self.zone_type;
+        cell.base_ground_walk_blocked = self.base_ground_walk_blocked;
+        cell.base_build_blocked = self.base_build_blocked;
+        cell.base_land_type = self.base_land_type;
+        cell.base_yr_cell_land_type = self.base_yr_cell_land_type;
+        cell.base_terrain_class = self.base_terrain_class;
+        cell.base_speed_costs = self.base_speed_costs;
+        cell.build_blocked = self.build_blocked;
+        cell.has_bridge_deck = self.has_bridge_deck;
+        cell.bridge_walkable = self.bridge_walkable;
+        cell.bridge_transition = self.bridge_transition;
+        cell.bridge_deck_level = self.bridge_deck_level;
+        cell.bridge_layer = self.bridge_layer.clone();
+        cell.bridge_facts = self.bridge_facts;
+        cell.radar_left = self.radar_left;
+        cell.radar_right = self.radar_right;
+        cell.has_damaged_data = self.has_damaged_data;
+        cell.bridgehead_anchor_class_at_load = self.bridgehead_anchor_class_at_load;
+    }
+}
+
+#[derive(Debug, Clone)]
+struct DynamicTilePrototype {
+    metadata: TileMetadata,
+    accepts_smudge: bool,
+    allows_tiberium: bool,
+}
+
+#[derive(Debug, Clone)]
+struct SparseTileTemplate {
+    tile_id: u16,
+    width: u8,
+    height: u8,
+    entries: Vec<Option<DynamicTilePrototype>>,
+}
+
+#[derive(Debug, Clone)]
+struct DestroyableCliffCatalog {
+    destroyable_start: u16,
+    old: [SparseTileTemplate; 2],
+    replacements: [SparseTileTemplate; 4],
+    lat_config: lat::LatConfig,
+    slope_config: lat::SlopeFixupConfig,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DestroyableCliffFamily {
+    A,
+    B,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DestroyableCliffMutation {
+    pub family: DestroyableCliffFamily,
+    pub origin: (i16, i16),
+    pub original_footprint: Vec<(u16, u16)>,
+    pub animation_cells: Vec<(i16, i16)>,
+    pub changed_cells: Vec<(u16, u16)>,
+}
+
 /// Send-safe identity handle for MapClass's process-global fallback `CellClass`.
 ///
 /// Active YR owns one object at `0x00ABDC50`. `MapClass::Get_CellClass` at
@@ -827,6 +1020,9 @@ pub struct ResolvedTerrainGrid {
     /// Terrain animations the load resolved, in the native anti-diagonal cell
     /// order so a spawner reproduces the engine's animation creation order.
     tile_animations: Vec<TerrainTileAnimation>,
+    /// Immutable active-theater sparse TMP authority used only by the two
+    /// verified destroyable-cliff callers.
+    destroyable_cliff_catalog: Option<DestroyableCliffCatalog>,
 }
 
 impl ResolvedTerrainGrid {
@@ -859,6 +1055,7 @@ impl ResolvedTerrainGrid {
             bridge_set_start: None,
             wood_bridge_set_start: None,
             tile_animations: Vec::new(),
+            destroyable_cliff_catalog: None,
         }
     }
 
@@ -1137,6 +1334,318 @@ impl ResolvedTerrainGrid {
         self.cells.get_mut(idx)
     }
 
+    pub(crate) fn apply_dynamic_cell_state(
+        &mut self,
+        rx: u16,
+        ry: u16,
+        state: &DynamicTerrainCellState,
+    ) -> bool {
+        let Some(index) = self.index(rx, ry) else {
+            return false;
+        };
+        state.apply(&mut self.cells[index]);
+        self.radar_color_valid[index] = true;
+        self.damaged_radar_metadata[index] = None;
+        true
+    }
+
+    pub(crate) fn is_destroyable_cliff(&self, rx: u16, ry: u16) -> bool {
+        let Some(catalog) = self.destroyable_cliff_catalog.as_ref() else {
+            return false;
+        };
+        self.cell(rx, ry).is_some_and(|cell| {
+            cell.final_tile_index == i32::from(catalog.destroyable_start)
+                || cell.final_tile_index == i32::from(catalog.destroyable_start) + 1
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_install_destroyable_cliff_catalog(&mut self, destroyable_start: u16) {
+        fn prototype(template_height: u8, slope_type: u8) -> DynamicTilePrototype {
+            DynamicTilePrototype {
+                metadata: TileMetadata {
+                    tileset_index: Some(1),
+                    land_type: LandType::Clear.as_index(),
+                    yr_cell_land_type: LandType::Clear.as_index(),
+                    slope_type,
+                    template_height,
+                    terrain_class: TerrainClass::Clear,
+                    radar_left: [slope_type, 1, 2],
+                    radar_right: [slope_type, 3, 4],
+                    ..TileMetadata::default()
+                },
+                accepts_smudge: true,
+                allows_tiberium: false,
+            }
+        }
+        fn template(
+            tile_id: u16,
+            width: u8,
+            height: u8,
+            template_height: u8,
+            slope_type: u8,
+            holes: &[usize],
+        ) -> SparseTileTemplate {
+            let mut entries = vec![
+                Some(prototype(template_height, slope_type));
+                usize::from(width) * usize::from(height)
+            ];
+            for &index in holes {
+                entries[index] = None;
+            }
+            SparseTileTemplate {
+                tile_id,
+                width,
+                height,
+                entries,
+            }
+        }
+        self.destroyable_cliff_catalog = Some(DestroyableCliffCatalog {
+            destroyable_start,
+            old: [
+                template(destroyable_start, 6, 4, 1, 0, &[0, 5, 18, 23]),
+                template(destroyable_start + 1, 4, 6, 1, 0, &[0, 3, 20, 23]),
+            ],
+            replacements: [
+                template(destroyable_start + 100, 3, 4, 1, 1, &[0, 9]),
+                template(destroyable_start + 101, 3, 4, 1, 2, &[2, 11]),
+                template(destroyable_start + 102, 4, 3, 1, 3, &[8, 11]),
+                template(destroyable_start + 103, 4, 3, 1, 4, &[0, 3]),
+            ],
+            lat_config: lat::LatConfig {
+                grounds: Vec::new(),
+            },
+            slope_config: lat::SlopeFixupConfig {
+                ramp_base: -1,
+                ramp_smooth: -1,
+            },
+        });
+    }
+
+    /// gamemd-derived: `MapClass::CollapseDestroyableCliff @ 0x00581140`
+    /// terrain half. The world owner surrounds this with zones, detach/dirty,
+    /// and AnimClass construction so all non-grid authorities remain ordered.
+    pub(crate) fn collapse_destroyable_cliff_terrain(
+        &mut self,
+        rx: u16,
+        ry: u16,
+        mut clear_replacement_cell: impl FnMut(u16, u16),
+    ) -> Option<DestroyableCliffMutation> {
+        let catalog = self.destroyable_cliff_catalog.clone()?;
+        let selected = self.cell(rx, ry)?;
+        let family = match selected.final_tile_index {
+            tile if tile == i32::from(catalog.destroyable_start) => DestroyableCliffFamily::A,
+            tile if tile == i32::from(catalog.destroyable_start) + 1 => {
+                DestroyableCliffFamily::B
+            }
+            _ => return None,
+        };
+        let old = &catalog.old[match family {
+            DestroyableCliffFamily::A => 0,
+            DestroyableCliffFamily::B => 1,
+        }];
+        let sub_tile = selected.final_sub_tile;
+        let (sub_x, sub_y) = match family {
+            DestroyableCliffFamily::A => (sub_tile % 6, sub_tile / 6),
+            DestroyableCliffFamily::B => (sub_tile & 3, sub_tile >> 2),
+        };
+        let origin = (
+            (rx as i16).wrapping_sub(i16::from(sub_x)),
+            (ry as i16).wrapping_sub(i16::from(sub_y)),
+        );
+
+        let coord_for = |x: u8, y: u8| -> Option<(u16, u16)> {
+            let x = origin.0.wrapping_add(i16::from(x));
+            let y = origin.1.wrapping_add(i16::from(y));
+            let (Ok(x), Ok(y)) = (u16::try_from(x), u16::try_from(y)) else {
+                return None;
+            };
+            Some((x, y))
+        };
+        let mut original_footprint = Vec::new();
+        for y in 0..old.height {
+            for x in 0..old.width {
+                let index = usize::from(y) * usize::from(old.width) + usize::from(x);
+                let Some(prototype) = old.entries.get(index).and_then(Option::as_ref) else {
+                    continue;
+                };
+                let Some(coord) = coord_for(x, y) else {
+                    continue;
+                };
+                if !self
+                    .cell(coord.0, coord.1)
+                    .is_some_and(|cell| !cell.outside_playfield)
+                {
+                    continue;
+                }
+                original_footprint.push(coord);
+                if let Some(cell) = self.cell_mut(coord.0, coord.1)
+                    && cell.final_tile_index == i32::from(old.tile_id)
+                    && usize::from(cell.final_sub_tile) == index
+                {
+                    cell.final_tile_index = 0xFFFF;
+                    cell.final_sub_tile = 0;
+                    cell.level = (cell.level as i8)
+                        .wrapping_sub(prototype.metadata.template_height as i8)
+                        as u8;
+                }
+            }
+        }
+
+        let stamps: [(usize, (i16, i16)); 2] = match family {
+            DestroyableCliffFamily::A => [(0, origin), (1, (origin.0.wrapping_add(3), origin.1))],
+            DestroyableCliffFamily::B => [(3, origin), (2, (origin.0, origin.1.wrapping_add(3)))],
+        };
+        let mut changed_cells = Vec::new();
+        for (template_index, anchor) in stamps {
+            let template = &catalog.replacements[template_index];
+            for y in 0..template.height {
+                for x in 0..template.width {
+                    let index = usize::from(y) * usize::from(template.width) + usize::from(x);
+                    let Some(prototype) = template.entries.get(index).and_then(Option::as_ref)
+                    else {
+                        continue;
+                    };
+                    let x = anchor.0.wrapping_add(i16::from(x));
+                    let y = anchor.1.wrapping_add(i16::from(y));
+                    let (Ok(x), Ok(y)) = (u16::try_from(x), u16::try_from(y)) else {
+                        continue;
+                    };
+                    if !self
+                        .cell(x, y)
+                        .is_some_and(|cell| !cell.outside_playfield)
+                    {
+                        continue;
+                    }
+                    let cell_index = self.index(x, y).expect("validated real cell");
+                    clear_replacement_cell(x, y);
+                    stamp_dynamic_tile_identity(
+                        &mut self.cells[cell_index],
+                        template.tile_id,
+                        index as u8,
+                        prototype,
+                    );
+                    self.apply_runtime_lat_slope(x as i16, y as i16, &catalog, &mut changed_cells);
+                    for (dx, dy) in [(0i16, -1i16), (1, 0), (0, 1), (-1, 0)] {
+                        self.apply_runtime_lat_slope(
+                            (x as i16).wrapping_add(dx),
+                            (y as i16).wrapping_add(dy),
+                            &catalog,
+                            &mut changed_cells,
+                        );
+                    }
+                    recalc_dynamic_tile_attributes(&mut self.cells[cell_index], prototype);
+                    self.radar_color_valid[cell_index] = true;
+                    self.damaged_radar_metadata[cell_index] = None;
+                    if !changed_cells.contains(&(x, y)) {
+                        changed_cells.push((x, y));
+                    }
+                }
+            }
+        }
+
+        let (anim_width, anim_height) = match family {
+            DestroyableCliffFamily::A => (5u8, 3u8),
+            DestroyableCliffFamily::B => (3u8, 5u8),
+        };
+        let mut animation_cells = Vec::with_capacity(15);
+        for y in 0..anim_height {
+            for x in 0..anim_width {
+                let x = origin.0.wrapping_add(i16::from(x));
+                let y = origin.1.wrapping_add(i16::from(y));
+                animation_cells.push((x, y));
+            }
+        }
+        Some(DestroyableCliffMutation {
+            family,
+            origin,
+            original_footprint,
+            animation_cells,
+            changed_cells,
+        })
+    }
+
+    fn apply_runtime_lat_slope(
+        &mut self,
+        x: i16,
+        y: i16,
+        catalog: &DestroyableCliffCatalog,
+        changed_cells: &mut Vec<(u16, u16)>,
+    ) {
+        let (Ok(rx), Ok(ry)) = (u16::try_from(x), u16::try_from(y)) else {
+            self.shared_cell_dummy
+                .stamp_coord(i32::from(x), i32::from(y));
+            return;
+        };
+        let Some(index) = self.index(rx, ry) else {
+            self.shared_cell_dummy
+                .stamp_coord(i32::from(x), i32::from(y));
+            return;
+        };
+        if self.native_allocated.as_ref().is_some_and(|allocated| {
+            !allocated.get(index).copied().unwrap_or(false)
+        }) || self.cells[index].outside_playfield
+        {
+            self.shared_cell_dummy
+                .stamp_coord(i32::from(x), i32::from(y));
+            return;
+        }
+        let cardinal_coords = [
+            (x, y.wrapping_sub(1)),
+            (x.wrapping_add(1), y),
+            (x, y.wrapping_add(1)),
+            (x.wrapping_sub(1), y),
+        ];
+        let cardinal_tiles = cardinal_coords.map(|(nx, ny)| {
+            u16::try_from(nx)
+                .ok()
+                .zip(u16::try_from(ny).ok())
+                .and_then(|(nx, ny)| self.cell(nx, ny))
+                .map_or(0, |cell| match cell.final_tile_index {
+                    tile if tile < 0 || tile == 0xFFFF => 0,
+                    tile => tile,
+                })
+        });
+        let cardinal_slopes = cardinal_coords.map(|(nx, ny)| {
+            u16::try_from(nx)
+                .ok()
+                .zip(u16::try_from(ny).ok())
+                .and_then(|(nx, ny)| self.cell(nx, ny))
+                .map_or(0, |cell| cell.slope_type)
+        });
+        let old_tile = self.cells[index].final_tile_index;
+        let lat_tile = lat::lat_fixed_tile(old_tile, cardinal_tiles, &catalog.lat_config);
+        let new_tile = lat::slope_fixed_tile(
+            lat_tile,
+            self.cells[index].slope_type,
+            cardinal_slopes,
+            catalog.slope_config,
+        );
+        if new_tile != old_tile {
+            self.cells[index].final_tile_index = new_tile;
+            if !changed_cells.contains(&(rx, ry)) {
+                changed_cells.push((rx, ry));
+            }
+        }
+    }
+
+    /// CellClass lookup used by the collapse animation producer. Invalid
+    /// signed coordinates resolve through the one shared dummy; the caller
+    /// still retains the signed coordinate for the world X/Y calculation.
+    pub(crate) fn collapse_animation_level(&self, x: i16, y: i16) -> i8 {
+        let cell = u16::try_from(x)
+            .ok()
+            .zip(u16::try_from(y).ok())
+            .and_then(|(x, y)| self.cell(x, y));
+        if let Some(cell) = cell {
+            cell.level as i8
+        } else {
+            self.shared_cell_dummy
+                .stamp_coord(i32::from(x), i32::from(y));
+            self.dummy_cell_level_slope().0
+        }
+    }
+
     pub fn iter(&self) -> impl Iterator<Item = &ResolvedTerrainCell> {
         self.cells.iter().enumerate().filter_map(|(index, cell)| {
             self.native_allocated
@@ -1404,6 +1913,7 @@ impl ResolvedTerrainGrid {
                         .map(|bounds| bounds.start)
                 }),
                 tile_animations: Vec::new(),
+                destroyable_cliff_catalog: None,
             };
         }
 
@@ -2171,6 +2681,11 @@ impl ResolvedTerrainGrid {
                     .map(|bounds| bounds.start)
             }),
             tile_animations,
+            destroyable_cliff_catalog: build_destroyable_cliff_catalog(
+                theater_data,
+                asset_manager,
+                terrain_rules,
+            ),
         }
     }
 
@@ -2602,6 +3117,143 @@ fn retained_damaged_radar_metadata(
         right: damaged.radar_right,
         valid: damaged.subtile_entry_valid == Some(true),
     })
+}
+
+fn build_destroyable_cliff_catalog(
+    theater_data: Option<&TheaterData>,
+    asset_manager: Option<&crate::assets::asset_manager::AssetManager>,
+    terrain_rules: Option<&TerrainRules>,
+) -> Option<DestroyableCliffCatalog> {
+    let td = theater_data?;
+    let assets = asset_manager?;
+    let destroyable_start = td.cliff_ranges.destroyable_cliffs?;
+    let slope_start = td
+        .slope_set_pieces
+        .and_then(|set| td.lookup.bounds().get(usize::from(set)))?
+        .start;
+    let mut warned_unknown_land_types = HashSet::new();
+    let mut load_template = |tile_id: u16| -> Option<SparseTileTemplate> {
+        let filename = td.lookup.filename(i32::from(tile_id))?;
+        let bytes = assets.get(filename)?;
+        let tmp = TmpFile::from_bytes(&bytes).ok()?;
+        let width = u8::try_from(tmp.template_width).ok()?;
+        let height = u8::try_from(tmp.template_height).ok()?;
+        let entries = tmp
+            .tiles
+            .iter()
+            .enumerate()
+            .map(|(sub_tile, entry)| {
+                entry.as_ref()?;
+                let sub_tile = u8::try_from(sub_tile).ok()?;
+                Some(DynamicTilePrototype {
+                    metadata: load_tile_metadata(
+                        Some(td),
+                        Some(assets),
+                        terrain_rules,
+                        TileKey {
+                            tile_id,
+                            sub_tile,
+                            variant: 0,
+                        },
+                        &mut warned_unknown_land_types,
+                    ),
+                    accepts_smudge: td.lookup.is_morphable(tile_id),
+                    allows_tiberium: td.lookup.allows_tiberium(tile_id),
+                })
+            })
+            .collect();
+        Some(SparseTileTemplate {
+            tile_id,
+            width,
+            height,
+            entries,
+        })
+    };
+    Some(DestroyableCliffCatalog {
+        destroyable_start,
+        old: [
+            load_template(destroyable_start)?,
+            load_template(destroyable_start.checked_add(1)?)?,
+        ],
+        replacements: [
+            load_template(slope_start)?,
+            load_template(slope_start.checked_add(1)?)?,
+            load_template(slope_start.checked_add(2)?)?,
+            load_template(slope_start.checked_add(3)?)?,
+        ],
+        lat_config: lat::parse_lat_config(&td.ini_data, &td.lookup),
+        slope_config: lat::SlopeFixupConfig {
+            ramp_base: td.rmg_tiles.ramp_base.map_or(-1, i32::from),
+            ramp_smooth: td.rmg_tiles.ramp_smooth.map_or(-1, i32::from),
+        },
+    })
+}
+
+fn stamp_dynamic_tile_identity(
+    cell: &mut ResolvedTerrainCell,
+    tile_id: u16,
+    sub_tile: u8,
+    prototype: &DynamicTilePrototype,
+) {
+    cell.final_tile_index = i32::from(tile_id);
+    cell.final_sub_tile = sub_tile;
+    cell.is_wood_bridge_repair_tile = false;
+    cell.slope_type = prototype.metadata.slope_type;
+    cell.level = (cell.level as i8)
+        .wrapping_add(prototype.metadata.template_height as i8) as u8;
+    cell.overlay_blocks = false;
+    cell.overlay_zone_type = None;
+}
+
+fn recalc_dynamic_tile_attributes(
+    cell: &mut ResolvedTerrainCell,
+    prototype: &DynamicTilePrototype,
+) {
+    let metadata = &prototype.metadata;
+    cell.filled_clear = false;
+    cell.tileset_index = metadata.tileset_index;
+    cell.land_type = metadata.land_type;
+    cell.yr_cell_land_type = metadata.yr_cell_land_type;
+    cell.template_height = metadata.template_height;
+    cell.height_in_pixels = metadata.height_in_pixels;
+    cell.render_offset_x = metadata.render_offset_x;
+    cell.render_offset_y = metadata.render_offset_y;
+    cell.terrain_class = metadata.terrain_class;
+    cell.speed_costs = metadata.speed_costs;
+    cell.is_water = metadata.is_water;
+    cell.is_cliff_like = metadata.is_cliff_like;
+    cell.is_rough = metadata.is_rough;
+    cell.is_road = metadata.is_road;
+    cell.accepts_smudge = prototype.accepts_smudge;
+    cell.allows_tiberium = prototype.allows_tiberium;
+    cell.variant = 0;
+    cell.has_ramp = metadata.has_ramp;
+    cell.canonical_ramp = canonical_ramp_from_slope_type(metadata.slope_type);
+    cell.base_ground_walk_blocked = metadata.ground_blocked;
+    cell.base_build_blocked = metadata.build_blocked;
+    cell.base_land_type = metadata.land_type;
+    cell.base_yr_cell_land_type = metadata.yr_cell_land_type;
+    cell.base_terrain_class = metadata.terrain_class;
+    cell.base_speed_costs = metadata.speed_costs;
+    cell.ground_walk_blocked = metadata.ground_blocked || cell.terrain_object_blocks;
+    cell.build_blocked = metadata.build_blocked || cell.terrain_object_blocks;
+    cell.zone_type = recalc_zone_type(
+        cell.outside_playfield,
+        None,
+        cell.land_type,
+        cell.speed_costs.wheel,
+        cell.terrain_object_occupation,
+    );
+    cell.has_bridge_deck = false;
+    cell.bridge_walkable = false;
+    cell.bridge_transition = false;
+    cell.bridge_deck_level = cell.level;
+    cell.bridge_layer = None;
+    cell.bridge_facts = BridgeCellFacts::default();
+    cell.radar_left = metadata.radar_left;
+    cell.radar_right = metadata.radar_right;
+    cell.has_damaged_data = metadata.has_damaged_data;
+    cell.bridgehead_anchor_class_at_load = None;
 }
 
 fn load_tile_metadata(
@@ -6263,6 +6915,130 @@ Tile03ZAdjust=-10
                 !cliff_back_normal_reclass_applies(land.as_index()),
                 "{land:?} must keep its own land type behind a cliff"
             );
+        }
+    }
+
+    #[test]
+    fn destroyable_cliff_a_collapses_old_sparse_footprint_then_stamps_two_halves() {
+        let mut cells = Vec::new();
+        for ry in 0..4 {
+            for rx in 0..6 {
+                let mut cell = make_test_cell(rx, ry);
+                let sub_tile = (ry * 6 + rx) as u8;
+                if ![0, 5, 18, 23].contains(&usize::from(sub_tile)) {
+                    cell.final_tile_index = 100;
+                    cell.final_sub_tile = sub_tile;
+                }
+                cell.level = 1;
+                cells.push(cell);
+            }
+        }
+        let mut grid = ResolvedTerrainGrid::from_cells(6, 4, cells);
+        grid.test_install_destroyable_cliff_catalog(100);
+
+        let mutation = grid
+            .collapse_destroyable_cliff_terrain(4, 1, |_, _| {})
+            .expect("family-A destroyable cliff");
+
+        assert_eq!(mutation.family, DestroyableCliffFamily::A);
+        assert_eq!(mutation.origin, (0, 0));
+        assert_eq!(mutation.original_footprint.len(), 20);
+        assert_eq!(
+            mutation.animation_cells,
+            (0..3)
+                .flat_map(|ry| (0..5).map(move |rx| (rx, ry)))
+                .collect::<Vec<_>>(),
+        );
+        assert_eq!(mutation.changed_cells.len(), 20);
+        for ry in 0..4 {
+            for rx in 0..6 {
+                let cell = grid.cell(rx, ry).unwrap();
+                if [(0, 0), (5, 0), (0, 3), (5, 3)].contains(&(rx, ry)) {
+                    assert_eq!(cell.final_tile_index, 0, "sparse holes stay untouched");
+                    continue;
+                }
+                let (tile, sub_tile, slope) = if rx < 3 {
+                    (200, ry * 3 + rx, 1)
+                } else {
+                    (201, ry * 3 + (rx - 3), 2)
+                };
+                assert_eq!(cell.final_tile_index, tile);
+                assert_eq!(u16::from(cell.final_sub_tile), sub_tile);
+                assert_eq!(cell.slope_type, slope);
+                assert_eq!(cell.level, 1, "old height subtracts before replacement add");
+                assert!(!cell.has_bridge_deck);
+                assert_eq!(cell.bridge_facts, BridgeCellFacts::default());
+            }
+        }
+    }
+
+    #[test]
+    fn destroyable_cliff_origin_recovery_accepts_every_present_a_and_b_subtile() {
+        for (family, tile, width, height, holes) in [
+            (DestroyableCliffFamily::A, 100, 6u16, 4u16, &[0usize, 5, 18, 23][..]),
+            (DestroyableCliffFamily::B, 101, 4u16, 6u16, &[0usize, 3, 20, 23][..]),
+        ] {
+            for selected_subtile in 0..usize::from(width * height) {
+                if holes.contains(&selected_subtile) {
+                    continue;
+                }
+                let mut cells = Vec::new();
+                for ry in 0..height {
+                    for rx in 0..width {
+                        let mut cell = make_test_cell(rx, ry);
+                        let sub_tile = usize::from(ry * width + rx);
+                        if !holes.contains(&sub_tile) {
+                            cell.final_tile_index = tile;
+                            cell.final_sub_tile = sub_tile as u8;
+                        }
+                        cell.level = 1;
+                        cells.push(cell);
+                    }
+                }
+                let mut grid = ResolvedTerrainGrid::from_cells(width, height, cells);
+                grid.test_install_destroyable_cliff_catalog(100);
+                let selected = (
+                    (selected_subtile % usize::from(width)) as u16,
+                    (selected_subtile / usize::from(width)) as u16,
+                );
+
+                let mutation = grid
+                    .collapse_destroyable_cliff_terrain(selected.0, selected.1, |_, _| {})
+                    .expect("present sparse subtile selects its family");
+
+                assert_eq!(mutation.family, family);
+                assert_eq!(mutation.origin, (0, 0));
+                assert_eq!(mutation.original_footprint.len(), 20);
+                assert_eq!(mutation.changed_cells.len(), 20);
+                for ry in 0..height {
+                    for rx in 0..width {
+                        let index = usize::from(ry * width + rx);
+                        let cell = grid.cell(rx, ry).unwrap();
+                        if holes.contains(&index) {
+                            assert_eq!(cell.final_tile_index, 0, "sparse hole {index}");
+                            continue;
+                        }
+                        let (expected_tile, expected_subtile, expected_slope) = match family {
+                            DestroyableCliffFamily::A if rx < 3 => {
+                                (200, usize::from(ry * 3 + rx), 1)
+                            }
+                            DestroyableCliffFamily::A => {
+                                (201, usize::from(ry * 3 + (rx - 3)), 2)
+                            }
+                            DestroyableCliffFamily::B if ry < 3 => {
+                                (203, usize::from(ry * 4 + rx), 4)
+                            }
+                            DestroyableCliffFamily::B => {
+                                (202, usize::from((ry - 3) * 4 + rx), 3)
+                            }
+                        };
+                        assert_eq!(cell.final_tile_index, expected_tile);
+                        assert_eq!(usize::from(cell.final_sub_tile), expected_subtile);
+                        assert_eq!(cell.slope_type, expected_slope);
+                        assert_eq!(cell.level, 1);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/map/retail_trig.rs
+++ b/src/map/retail_trig.rs
@@ -3,8 +3,9 @@
 //! The river carver steers by a floating-point heading and resolves it through
 //! two table lookups every step. The table is **not reproducible from a
 //! formula**: computing `sin` in double precision and rounding disagrees with it
-//! on 4997 of its 10240 entries, and so does the correctly-rounded true sine, by
-//! up to one unit in the last place. It is an artifact of whatever generated it
+//! on 4997 of its first 10240 indexed entries, and so does the correctly-rounded
+//! true sine, by up to one unit in the last place. It is an artifact of whatever
+//! generated it
 //! in the original build. It is not even exactly periodic — one of the 2048
 //! wrap-around pairs disagrees, which is what an accumulating recurrence looks
 //! like and what a per-index evaluation does not.
@@ -24,8 +25,10 @@ use std::sync::OnceLock;
 /// Virtual address of the table in the retail image.
 const TABLE_VA: u32 = 0x0084_F084;
 /// Entries. The extra quarter period past a full turn is what lets the cosine
-/// offset run past the end of the sine range without wrapping.
-pub const TABLE_LEN: usize = 0x2800;
+/// offset run past the end of the sine range without wrapping; the final exact
+/// `1.0` is part of the retail data extent even though the lookup ceilings stop
+/// one entry before it.
+pub const TABLE_LEN: usize = 0x2801;
 /// Entries in one full turn.
 const PERIOD: i32 = 0x2000;
 /// Quarter period: the offset that turns the sine table into a cosine table.
@@ -42,9 +45,16 @@ const COS_CEILING: i32 = PERIOD + QUARTER - 1;
 pub const UNITS_PER_TURN: f64 = (2 * PERIOD) as f64;
 
 /// FNV-1a (64-bit) over the table's raw little-endian bytes in the retail
-/// image, machine-derived by reading all 40960 bytes out of the binary. This is
+/// image, machine-derived by reading all 40964 bytes out of the binary. This is
 /// the whole-table check: it is a genuine exhaustive comparison, not a sample.
-pub const RETAIL_FNV1A64: u64 = 0x4642_825e_c40e_ce86;
+pub const RETAIL_FNV1A64: u64 = 0x74ac_b749_b33d_5aa7;
+
+/// Virtual address and exact size of `Acos_lookup @ 0x004CADB0`'s signed
+/// arcsine table. `WaveClass` indexes the inclusive endpoints, hence 4097
+/// entries rather than 4096.
+const ACOS_TABLE_VA: u32 = 0x0085_9094;
+pub const ACOS_TABLE_LEN: usize = 0x1001;
+pub const ACOS_RETAIL_FNV1A64: u64 = 0x9251_751b_f328_3bc1;
 
 /// Something went wrong reading the table out of the executable.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -73,6 +83,12 @@ impl std::error::Error for TrigTableError {}
 /// The retail sine table.
 #[derive(Debug, Clone)]
 pub struct TrigTable {
+    entries: Vec<f32>,
+}
+
+/// Retail binary32 table consumed by `Acos_lookup @ 0x004CADB0`.
+#[derive(Debug, Clone)]
+pub struct AcosTable {
     entries: Vec<f32>,
 }
 
@@ -166,12 +182,22 @@ impl TrigTable {
 
     /// Sine of an angle given in caller units.
     pub fn sin(&self, angle_units: i32) -> f32 {
-        self.entries[sin_index(angle_units) as usize]
+        self.entries[self.sin_index(angle_units)]
     }
 
     /// Cosine of an angle given in caller units.
     pub fn cos(&self, angle_units: i32) -> f32 {
-        self.entries[cos_index(angle_units) as usize]
+        self.entries[self.cos_index(angle_units)]
+    }
+
+    /// Exact raw table index used by `Math::SinFromTable`.
+    pub fn sin_index(&self, angle_units: i32) -> usize {
+        sin_index(angle_units) as usize
+    }
+
+    /// Exact raw table index used by `Math::CosFromTable`.
+    pub fn cos_index(&self, angle_units: i32) -> usize {
+        cos_index(angle_units) as usize
     }
 
     /// Sine of an angle in radians. The scaling and the truncation to an integer
@@ -192,6 +218,53 @@ impl TrigTable {
         Self {
             entries: (0..TABLE_LEN)
                 .map(|i| (i as f64 * std::f64::consts::TAU / PERIOD as f64).sin() as f32)
+                .collect(),
+        }
+    }
+}
+
+impl AcosTable {
+    /// Read the signed arcsine table out of a retail `gamemd.exe` image.
+    pub fn from_executable(image: &[u8]) -> Result<Self, TrigTableError> {
+        let start = file_offset_of(image, ACOS_TABLE_VA)?;
+        let need = ACOS_TABLE_LEN * 4;
+        let bytes = image
+            .get(start..start + need)
+            .ok_or(TrigTableError::Truncated {
+                need,
+                have: image.len().saturating_sub(start),
+            })?;
+        let entries = bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+        Ok(Self { entries })
+    }
+
+    pub fn fnv1a64(&self) -> u64 {
+        let mut hash = crate::util::fnv::FNV1A64_OFFSET_BASIS;
+        for entry in &self.entries {
+            hash = crate::util::fnv::fnv1a64_fold_bytes(hash, &entry.to_le_bytes());
+        }
+        hash
+    }
+
+    pub fn matches_retail(&self) -> bool {
+        self.entries.len() == ACOS_TABLE_LEN && self.fnv1a64() == ACOS_RETAIL_FNV1A64
+    }
+
+    pub fn entry(&self, index: usize) -> f32 {
+        self.entries[index]
+    }
+
+    /// A shape-compatible table used only by unit tests that exercise Wave
+    /// lifetime/cell mechanics without a retail installation. Exact geometry
+    /// fixtures always load the executable-backed table.
+    #[cfg(test)]
+    pub fn synthetic() -> Self {
+        Self {
+            entries: (0..ACOS_TABLE_LEN)
+                .map(|i| ((i as f64 - 2048.0) / 2048.0).asin() as f32)
                 .collect(),
         }
     }
@@ -320,7 +393,7 @@ mod tests {
         assert_eq!(sin_index(-7997) - sin_index(-7997 + turn), 1);
     }
 
-    /// The exhaustive check. Not a sample: every one of the 40960 bytes feeds
+    /// The exhaustive check. Not a sample: every one of the 40964 bytes feeds
     /// the hash, and the expected value was derived by reading them out of the
     /// binary rather than computed by hand.
     #[test]
@@ -338,6 +411,10 @@ mod tests {
              written against"
         );
         assert!(table.matches_retail());
+        let acos = AcosTable::from_executable(&image).expect("read the Acos table");
+        assert_eq!(acos.entries.len(), ACOS_TABLE_LEN);
+        assert_eq!(acos.fnv1a64(), ACOS_RETAIL_FNV1A64);
+        assert!(acos.matches_retail());
     }
 
     /// Anchors that would catch a table read at the wrong offset even if a hash
@@ -375,32 +452,43 @@ mod tests {
     }
 }
 
-/// Process-wide table, installed once from the retail install.
+/// Process-wide table bundle, installed once from the retail install.
 ///
 /// A global because consumers sit at different engine layers and only startup
 /// knows where the retail install is. It is written once and read-only
 /// thereafter, so it cannot make a run non-deterministic.
-static TABLE: OnceLock<Option<TrigTable>> = OnceLock::new();
+#[derive(Debug)]
+struct RetailMathTables {
+    trig: TrigTable,
+    acos: AcosTable,
+}
+
+static TABLES: OnceLock<Option<RetailMathTables>> = OnceLock::new();
 
 /// Read the table out of `<ra2_dir>/gamemd.exe` and install it. Later calls are
 /// ignored; the first one wins.
 pub fn install_from_dir(ra2_dir: &Path) {
-    TABLE.get_or_init(|| {
+    TABLES.get_or_init(|| {
         let path = ra2_dir.join("gamemd.exe");
         match std::fs::read(&path) {
-            Ok(image) => match TrigTable::from_executable(&image) {
-                Ok(table) if table.matches_retail() => Some(table),
-                Ok(_) => {
+            Ok(image) => match (
+                TrigTable::from_executable(&image),
+                AcosTable::from_executable(&image),
+            ) {
+                (Ok(trig), Ok(acos)) if trig.matches_retail() && acos.matches_retail() => {
+                    Some(RetailMathTables { trig, acos })
+                }
+                (Ok(_), Ok(_)) => {
                     log::warn!(
-                        "{} holds a sine table this build does not recognise; \
+                        "{} holds retail math tables this build does not recognise; \
                          retail-table consumers will be disabled",
                         path.display()
                     );
                     None
                 }
-                Err(err) => {
+                (Err(err), _) | (_, Err(err)) => {
                     log::warn!(
-                        "retail sine table {}: {err}; retail-table consumers will be disabled",
+                        "retail math tables {}: {err}; retail-table consumers will be disabled",
                         path.display()
                     );
                     None
@@ -408,7 +496,7 @@ pub fn install_from_dir(ra2_dir: &Path) {
             },
             Err(err) => {
                 log::warn!(
-                    "cannot read retail sine table from {}: {err}; \
+                    "cannot read retail math tables from {}: {err}; \
                      retail-table consumers will be disabled",
                     path.display()
                 );
@@ -420,5 +508,22 @@ pub fn install_from_dir(ra2_dir: &Path) {
 
 /// The installed table, if there is one.
 pub fn global() -> Option<&'static TrigTable> {
-    TABLE.get().and_then(|slot| slot.as_ref())
+    TABLES
+        .get()
+        .and_then(|slot| slot.as_ref())
+        .map(|tables| &tables.trig)
+}
+
+/// The installed table consumed by `Acos_lookup`, if there is one.
+pub fn global_acos() -> Option<&'static AcosTable> {
+    TABLES
+        .get()
+        .and_then(|slot| slot.as_ref())
+        .map(|tables| &tables.acos)
+}
+
+/// Stock Sonic Wave geometry is active, so a match may start only when both
+/// exact executable-backed math tables are available.
+pub fn wave_tables_available() -> bool {
+    global().is_some() && global_acos().is_some()
 }

--- a/src/rules/combat_damage.rs
+++ b/src/rules/combat_damage.rs
@@ -27,6 +27,9 @@ pub struct CombatDamageDefaults {
     /// Signed post-Verses cap used by ApplyWarheadDamage. The executable's
     /// constructor default is 1000; stock rulesmd.ini overrides it to 10000.
     pub max_damage: i32,
+    /// Signed, unclamped destroyable-cliff chance compared against one
+    /// Scenario RandomRanged(0,99) draw. Native constructor default is 100.
+    pub collapse_chance: i32,
     /// Global `DeathWeapon=` used only when a dying type has neither an
     /// explicit death weapon nor a live current-weapon fallback.
     pub death_weapon: Option<String>,
@@ -55,6 +58,7 @@ impl CombatDamageDefaults {
     pub fn from_ini_section(section: &IniSection) -> Self {
         Self {
             max_damage: section.get_i32("MaxDamage").unwrap_or(1000),
+            collapse_chance: section.get_i32("CollapseChance").unwrap_or(100),
             death_weapon: read_name(section, "DeathWeapon"),
             default_large_grey_smoke_system: read_name(section, "DefaultLargeGreySmokeSystem"),
             default_small_grey_smoke_system: read_name(section, "DefaultSmallGreySmokeSystem"),
@@ -73,6 +77,7 @@ impl Default for CombatDamageDefaults {
     fn default() -> Self {
         Self {
             max_damage: 1000,
+            collapse_chance: 100,
             death_weapon: None,
             default_large_grey_smoke_system: None,
             default_small_grey_smoke_system: None,

--- a/src/rules/terrain_rules.rs
+++ b/src/rules/terrain_rules.rs
@@ -127,7 +127,7 @@ pub fn tmp_terrain_to_land_type(tmp_terrain_type: u8) -> LandType {
         .unwrap_or(LandType::Clear)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum TerrainClass {
     Clear,
     Rough,
@@ -186,7 +186,9 @@ impl LandType {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
 pub struct SpeedCostProfile {
     pub foot: Option<u8>,
     pub track: Option<u8>,

--- a/src/sim/combat/combat_cloak_fire_tests.rs
+++ b/src/sim/combat/combat_cloak_fire_tests.rs
@@ -77,6 +77,7 @@ fn resolve_once(
         false,
         77,
         67,
+        false,
         &mut rng,
         Some(sounds),
         &mut hooks,

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -43,6 +43,74 @@ fn test_rules() -> RuleSet {
 }
 
 #[test]
+fn sonic_active_wave_gate_precedes_target_resolution_and_all_shot_work() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[VehicleTypes]\n0=DLPH\n1=TARGET\n\n\
+         [DLPH]\nStrength=200\nArmor=light\nSpeed=8\nPrimary=SonicZap\n\n\
+         [TARGET]\nStrength=100\nArmor=wood\n\n\
+         [SonicZap]\nDamage=4\nAmbientDamage=10\nROF=20\nRange=6\nWarhead=SonicWH\nIsSonic=yes\n\n\
+         [SonicWH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,0%,0%\n",
+    ))
+    .expect("Sonic whole-shot gate fixture");
+    let mut entities = EntityStore::new();
+    let mut firer = GameEntity::test_default(1, "DLPH", "Americans", 4, 5);
+    firer.attack_target = Some(AttackTarget::new(999));
+    firer.current_weapon_index = 1;
+    entities.insert(firer);
+    let mut interner = test_interner();
+    let snap = build_attacker_snapshot(
+        entities.get(1).expect("Dolphin"),
+        TargetKind::Entity(999),
+        0,
+        0,
+        0,
+        None,
+        None,
+        None,
+    );
+    let mut resources = BTreeMap::new();
+    let mut rng = SimRng::new(0x50_4e_49_43);
+    let rng_before = rng.logical_state();
+    let mut hooks: Option<&mut dyn CombatInlineHooks> = None;
+    let mut emit = CombatEmit::default();
+
+    resolve_attacker_fire(
+        &snap,
+        &mut entities,
+        &rules,
+        &mut interner,
+        None,
+        &mut resources,
+        None,
+        &OccupancyGrid::new(),
+        None,
+        None,
+        None,
+        None,
+        None,
+        false,
+        false,
+        17,
+        67,
+        true,
+        &mut rng,
+        None,
+        &mut hooks,
+        &mut emit,
+    );
+
+    assert!(emit.fire_events.is_empty());
+    assert!(emit.damage_events.is_empty());
+    assert!(emit.projectile_spawns.is_empty());
+    assert!(emit.current_weapon_updates.is_empty());
+    assert!(emit.burst_updates.is_empty());
+    assert!(emit.retarget_events.is_empty());
+    assert!(emit.remove_attack.is_empty());
+    assert_eq!(rng.logical_state(), rng_before);
+    assert_eq!(entities.get(1).unwrap().current_weapon_index, 1);
+}
+
+#[test]
 fn gsi_08_05_rof_is_a_native_frame_count_plus_a_zero_to_two_jitter() {
     // `TechnoClass::GetROF @ 0x006FCFA0` returns
     // `ftol(ROF * difficulty + RandomRanged(0, 2))`. The jitter is ADDED, so a
@@ -4822,6 +4890,7 @@ fn run_playfield_retarget_branch(
             100,
             0,
             &[],
+            &BTreeSet::new(),
             &BTreeSet::new(),
             &[],
             &[],

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -1717,6 +1717,56 @@ pub(crate) enum BaseDefenseResponseCallSite {
 /// methods so `Simulation` is borrowed only once while combat temporarily owns
 /// entities, map grids, and the scenario RNG.
 pub(crate) trait CombatInlineHooks {
+    #[cfg(test)]
+    fn trace_wave_receiver(&mut self, _wave_id: u64, _target_id: u64) {}
+
+    #[allow(clippy::too_many_arguments)]
+    fn commit_wave_fire_event(
+        &mut self,
+        _rules: &RuleSet,
+        _overlay_registry: Option<&OverlayTypeRegistry>,
+        _event: &crate::sim::world::SimFireEvent,
+        _entities: &mut EntityStore,
+        _occupancy: &mut OccupancyGrid,
+        _interner: &mut StringInterner,
+        _main_rng: &mut SimRng,
+        _scenario_rng: &mut SimRng,
+        _resource_nodes: &mut BTreeMap<(u16, u16), ResourceNode>,
+        _houses: &mut BTreeMap<InternedId, HouseState>,
+        _overlay_grid: Option<&mut OverlayGrid>,
+        _terrain: Option<&mut crate::map::resolved_terrain::ResolvedTerrainGrid>,
+        _bridge_state: Option<&BridgeRuntimeState>,
+        _terrain_area_state: Option<&mut TerrainAreaState>,
+        _sound_events: Option<&mut Vec<SimSoundEvent>>,
+    ) {
+    }
+
+    fn rebuild_cliff_navigation(
+        &mut self,
+        _rules: &RuleSet,
+        _terrain: &mut Option<crate::map::resolved_terrain::ResolvedTerrainGrid>,
+        _entities: &mut EntityStore,
+        _interner: &mut StringInterner,
+    ) {
+    }
+
+    fn mark_cliff_radar_dirty(&mut self, _cell: (u16, u16)) {}
+
+    fn mark_cliff_tactical_dirty(&mut self, _cells: &[(u16, u16)]) {}
+
+    fn spawn_cliff_anims(
+        &mut self,
+        _rules: &RuleSet,
+        _interner: &mut StringInterner,
+        _scenario_rng: &mut SimRng,
+        _sound_events: &mut Vec<SimSoundEvent>,
+        _spawns: Vec<(
+            crate::sim::components::AnimClassSpawnDescriptor,
+            crate::sim::anim_class::AnimWorldCoord,
+        )>,
+    ) {
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn respond_to_base_attack(
         &mut self,
@@ -1912,7 +1962,7 @@ fn commit_smudge_batch_or_defer(
 }
 
 impl DeathEffects {
-    fn append(&mut self, mut other: Self) {
+    pub(crate) fn append(&mut self, mut other: Self) {
         self.despawned_ids.append(&mut other.despawned_ids);
         self.immediate_uninit_ids
             .append(&mut other.immediate_uninit_ids);
@@ -2795,6 +2845,37 @@ fn resolve_receive_damage(
         outcome,
         invulnerability_impact,
     })
+}
+
+/// Inspect the value left in WaveClass::DamageArea's shared per-cell damage
+/// local by one concrete Techno receiver. The receiver commit immediately
+/// following this call runs the same pure ABI resolver against the same live
+/// state; exposing the pointer result here avoids fabricating immutable damage
+/// inputs for later occupants.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn wave_post_object_damage(
+    event: &EntityDamageEvent,
+    entities: &EntityStore,
+    rules: &RuleSet,
+    interner: &StringInterner,
+    houses: &BTreeMap<InternedId, HouseState>,
+    alliances: &HouseAllianceMap,
+    scenario_no_damage: bool,
+    current_tick: u64,
+    terrain: Option<&crate::map::resolved_terrain::ResolvedTerrainGrid>,
+) -> Option<i32> {
+    resolve_receive_damage(
+        event,
+        entities,
+        rules,
+        interner,
+        houses,
+        alliances,
+        scenario_no_damage,
+        current_tick,
+        terrain,
+    )
+    .and_then(|resolved| resolved.outcome.post_object_damage)
 }
 
 /// TechnoClass::ReceiveDamage builds the anger-node increment from the final
@@ -4736,6 +4817,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng(
         binary_frame,
         live_order,
         &BTreeSet::new(),
+        &BTreeSet::new(),
         projectile_detonations,
         wave_damage_events,
         radiation,
@@ -4990,6 +5072,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
     binary_frame: u32,
     live_order: &[u64],
     fire_suppressed: &BTreeSet<u64>,
+    active_wave_owners: &BTreeSet<u64>,
     projectile_detonations: &[ProjectileDetonation],
     wave_damage_events: &[WaveDamageEvent],
     mut radiation: Option<&mut crate::sim::radiation::RadiationState>,
@@ -5556,6 +5639,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
         let explosion_start = emit.explosion_effects.len();
         let smudge_start = emit.smudge_spawn_requests.len();
         let current_weapon_start = emit.current_weapon_updates.len();
+        let fire_event_start = emit.fire_events.len();
         let terrain_objects =
             terrain_area_state
                 .as_deref()
@@ -5581,6 +5665,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             require_playfield_membership,
             binary_frame,
             tick_ms,
+            active_wave_owners.contains(&live_snap.stable_id),
             scenario_rng,
             sound_sink.as_deref_mut(),
             &mut inline_hooks,
@@ -5636,6 +5721,28 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             terrain_area_state.as_deref(),
         );
         under_attack_events.append(&mut pings);
+        let wave_fire_events = emit.fire_events[fire_event_start..].to_vec();
+        for event in &wave_fire_events {
+            if let Some(hooks) = inline_hooks.as_deref_mut() {
+                hooks.commit_wave_fire_event(
+                    rules,
+                    overlay_registry,
+                    event,
+                    entities,
+                    occupancy,
+                    interner,
+                    main_rng,
+                    scenario_rng,
+                    resource_nodes,
+                    houses,
+                    overlay_grid.as_deref_mut(),
+                    terrain.as_deref_mut(),
+                    bridge_state,
+                    terrain_area_state.as_deref_mut(),
+                    sound_sink.as_deref_mut(),
+                );
+            }
+        }
         // S3: only this Unit's explicit retarget/remove may replace its seeded
         // destination. Synchronous target expiry from VERA's immediate-delivery
         // approximation is deliberately not visible to native Facing_Update.
@@ -6204,6 +6311,7 @@ pub(crate) fn resolve_attacker_fire(
     require_playfield_membership: bool,
     binary_frame: u32,
     _tick_ms: u32,
+    has_active_wave: bool,
     scenario_rng: &mut SimRng,
     mut sound_sink: Option<&mut Vec<SimSoundEvent>>,
     inline_hooks: &mut Option<&mut dyn CombatInlineHooks>,
@@ -6233,6 +6341,19 @@ pub(crate) fn resolve_attacker_fire(
             return;
         }
     };
+
+    // Stock Sonic weapons occupy index 0, and native FireAt tests that
+    // WeaponType before resolving the target. Preserve that whole-call gate
+    // so a stale/missing target cannot retarget or clear the order while the
+    // owner's exact Wave link remains live. The selected-weapon check below
+    // retains the same protection for non-stock overrides/secondary layouts.
+    if has_active_wave
+        && combat_weapon::primary_for_tier(obj, snap.veterancy)
+            .and_then(|weapon_id| rules.weapon(weapon_id))
+            .is_some_and(|weapon| weapon.is_sonic)
+    {
+        return;
+    }
 
     // Check if target is alive and get its data.
     // For structures, target_coords returns the foundation center instead
@@ -6391,6 +6512,13 @@ pub(crate) fn resolve_attacker_fire(
         }
     };
     let weapon = selected.weapon;
+    // gamemd-derived: `TechnoClass::FireAt @ 0x006FDE4A..0x006FDE5C`.
+    // Only an IsSonic selected weapon observes the firer's active-Wave link,
+    // and that return precedes every shot/cooldown/report/current-weapon side
+    // effect owned below. Type-3's local effect check is not this gate.
+    if weapon.is_sonic && has_active_wave {
+        return;
+    }
     if delayed_building_slot.is_none() {
         out.current_weapon_updates.push((
             snap.stable_id,

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -1718,7 +1718,7 @@ pub(crate) enum BaseDefenseResponseCallSite {
 /// entities, map grids, and the scenario RNG.
 pub(crate) trait CombatInlineHooks {
     #[cfg(test)]
-    fn trace_wave_receiver(&mut self, _wave_id: u64, _target_id: u64) {}
+    fn trace_wave_receiver(&mut self, _wave_id: u64, _target_id: u64, _scenario_rng_state: u64) {}
 
     #[allow(clippy::too_many_arguments)]
     fn commit_wave_fire_event(

--- a/src/sim/smudge_grid.rs
+++ b/src/sim/smudge_grid.rs
@@ -117,6 +117,20 @@ impl SmudgeGrid {
         cleared
     }
 
+    /// Raw CellClass Mark(1) writer: clear only this cell's native smudge slot
+    /// and data byte, without expanding to the owning Rust footprint.
+    pub(crate) fn clear_cell_slot(&mut self, rx: u16, ry: u16) -> bool {
+        let Some(index) = self.index_of(rx, ry) else {
+            return false;
+        };
+        if self.cells[index] == SmudgeCell::default() {
+            return false;
+        }
+        self.cells[index] = SmudgeCell::default();
+        self.dirty_cells.push((rx, ry));
+        true
+    }
+
     pub fn iter_occupied(&self) -> impl Iterator<Item = (u16, u16, &SmudgeCell)> {
         self.cells.iter().enumerate().filter_map(move |(idx, c)| {
             if c.type_id.is_some() {

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -3008,6 +3008,21 @@ mod tests {
             },
             None,
         ));
+        let constructor_direction = active.direction_octant;
+        let moved_endpoint = ProjectileCoord::new(0, 512, 0);
+        let _ = active.advance(
+            WaveUpdateContext {
+                owner_position: Some(active_source),
+                owner_current_target: Some(active_target),
+                target_position: Some(moved_endpoint),
+            },
+            None,
+        );
+        assert_eq!(
+            active.direction_octant, constructor_direction,
+            "live geometry refresh retains constructor-only +0x1CC"
+        );
+        let moved_edges = active.edge_geometry;
         sim.admit_wave(active_id, active);
         sim.active_wave_links.insert(owner_ids[0], active_id);
 
@@ -3053,6 +3068,14 @@ mod tests {
         assert_eq!(restored.state_hash(), expected_hash);
         assert_eq!(restored.active_wave_links, sim.active_wave_links);
         assert_eq!(restored.waves.get(active_id), sim.waves.get(active_id));
+        assert_eq!(
+            restored.waves.get(active_id).unwrap().direction_octant,
+            constructor_direction
+        );
+        assert_eq!(
+            restored.waves.get(active_id).unwrap().edge_geometry,
+            moved_edges
+        );
         assert_eq!(restored.waves.get(inactive_id), sim.waves.get(inactive_id));
         assert_eq!(restored.waves.get(dummy_id), sim.waves.get(dummy_id));
         assert_eq!(

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -302,7 +302,9 @@ use crate::sim::world::Simulation;
 // resolved TechnoType identity rather than an ambiguous interned name alone.
 // Bumped 101 -> 102: retain AITrigger token 6's category-distinct resolved
 // TechnoType identity rather than an ambiguous interned name alone.
-const SNAPSHOT_VERSION: u32 = 102;
+// Bumped 102 -> 103: WaveClass persists live ownership/fade/CellClass identity,
+// and destroyable-cliff replacement persists exact changed CellClass values.
+const SNAPSHOT_VERSION: u32 = 103;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -490,6 +492,8 @@ pub enum SnapshotRestoreError {
     MapAuthorityCellStorageMismatch { expected: usize, found: usize },
     #[error("snapshot real-cell bridge flags do not match restored CellClass allocation")]
     RealCellBridgeFlagAuthorityMismatch,
+    #[error("snapshot dynamic terrain cell ({rx},{ry}) is absent from restored CellClass allocation")]
+    DynamicTerrainCellMissing { rx: u16, ry: u16 },
 }
 
 /// Derived facts produced by the transactional map-authority restore seam.
@@ -1258,6 +1262,49 @@ fn restore_object_references(
         }
     }
 
+    let wave_ids = sim.waves.iter().map(|(&id, _)| id).collect::<BTreeSet<_>>();
+    for (&wave_id, wave) in sim.waves.iter() {
+        if let Some(owner_id) = wave.owner_id {
+            require_resolved_reference(
+                entity_ids.contains(&owner_id),
+                "WaveStore",
+                wave_id,
+                "owner_id",
+                "EntityStore",
+                owner_id,
+            )?;
+        }
+        if let Some(TargetKind::Entity(target_id)) = wave.target_ref {
+            require_resolved_reference(
+                entity_ids.contains(&target_id),
+                "WaveStore",
+                wave_id,
+                "target_ref",
+                "EntityStore",
+                target_id,
+            )?;
+        }
+    }
+    for (&owner_id, &wave_id) in &sim.active_wave_links {
+        require_resolved_reference(
+            entity_ids.contains(&owner_id),
+            "ActiveWaveLinks",
+            owner_id,
+            "owner",
+            "EntityStore",
+            owner_id,
+        )?;
+        require_resolved_reference(
+            wave_ids.contains(&wave_id)
+                && sim.waves.get(wave_id).and_then(|wave| wave.owner_id) == Some(owner_id),
+            "ActiveWaveLinks",
+            owner_id,
+            "wave",
+            "WaveStore",
+            wave_id,
+        )?;
+    }
+
     for &object_id in &sim.substrate.pending_delete {
         require_resolved_reference(
             identities.contains_key(&object_id),
@@ -1547,6 +1594,20 @@ impl Simulation {
                 terrain_width,
                 terrain_height,
             });
+        }
+
+        // Reproject runtime isometric replacements onto the pristine
+        // app-supplied map before overlay, bridge, and zone reconstruction.
+        {
+            let terrain = self
+                .resolved_terrain
+                .as_mut()
+                .expect("validated terrain cache");
+            for (&(rx, ry), state) in &self.dynamic_terrain_cells {
+                if !terrain.apply_dynamic_cell_state(rx, ry, state) {
+                    return Err(SnapshotRestoreError::DynamicTerrainCellMissing { rx, ry });
+                }
+            }
         }
 
         // Native CellClass::Load restores allocated real-cell flag words as
@@ -2642,10 +2703,11 @@ mod tests {
     /// verification proved that token is required but discarded; 99 -> 100
     /// adds the three post-load TeamType zone-derivation fields; 100 -> 101
     /// adds category-distinct resolved TaskForce member identities; 101 -> 102
-    /// adds category-distinct resolved AITrigger token-6 identities.
+    /// adds category-distinct resolved AITrigger token-6 identities; 102 -> 103
+    /// adds WaveClass state and destroyable-cliff replacement CellClass values.
     #[test]
-    fn phase3_team_ai_registry_snapshot_version_is_102() {
-        assert_eq!(super::SNAPSHOT_VERSION, 102);
+    fn phase3_team_ai_and_wave_snapshot_version_is_103() {
+        assert_eq!(super::SNAPSHOT_VERSION, 103);
     }
 
     #[test]
@@ -2883,6 +2945,120 @@ mod tests {
             (true, true, true, -12, 1800)
         );
         assert_eq!(restored.state_hash(), expected_hash);
+    }
+
+    #[test]
+    fn wave_active_inactive_dummy_links_roundtrip_with_identical_hash() {
+        use crate::map::entities::EntityCategory;
+        use crate::sim::components::Health;
+        use crate::sim::game_entity::GameEntity;
+        use crate::sim::projectile::ProjectileCoord;
+        use crate::sim::wave::{Wave, WaveRecordedCell, WaveUpdateContext};
+        use crate::util::native_x87::NativeF64Bits;
+
+        let mut sim = Simulation::new();
+        sim.scenario_rng = crate::sim::rng::SimRng::new(0);
+        let owner = sim.interner.intern("Americans");
+        let type_ref = sim.interner.intern("DLPH");
+        let mut owner_ids = Vec::new();
+        for ordinal in 1..=3 {
+            let stable_id = sim.allocate_stable_id();
+            owner_ids.push(stable_id);
+            let mut entity = GameEntity::new_at_frame_zero_for_test(
+                stable_id,
+                ordinal,
+                2,
+                0,
+                0,
+                owner,
+                Health {
+                    current: 200,
+                    max: 200,
+                },
+                type_ref,
+                EntityCategory::Unit,
+                0,
+                5,
+                false,
+            );
+            entity.in_logic_vector = true;
+            sim.substrate.entities.insert(entity);
+            sim.substrate
+                .logic
+                .try_push(stable_id)
+                .expect("owner Logic registration");
+        }
+
+        let active_id = sim.allocate_stable_id();
+        let active_target = crate::sim::combat::TargetKind::Cell(8, 2);
+        let active_source = ProjectileCoord::new(256, 512, 0);
+        let active_endpoint = ProjectileCoord::new(2048, 512, 0);
+        let mut active = Wave::new_owned(
+            0,
+            owner_ids[0],
+            active_target,
+            active_source,
+            active_endpoint,
+        );
+        assert!(!active.initialize(
+            WaveUpdateContext {
+                owner_position: Some(active_source),
+                owner_current_target: Some(active_target),
+                target_position: Some(active_endpoint),
+            },
+            None,
+        ));
+        sim.admit_wave(active_id, active);
+        sim.active_wave_links.insert(owner_ids[0], active_id);
+
+        let inactive_id = sim.allocate_stable_id();
+        let mut inactive = Wave::new_owned(
+            0,
+            owner_ids[1],
+            crate::sim::combat::TargetKind::Cell(9, 2),
+            ProjectileCoord::new(512, 512, 0),
+            ProjectileCoord::new(2304, 512, 50),
+        );
+        inactive.active_geometry = false;
+        inactive.decaying = true;
+        inactive.fade_in = NativeF64Bits::from_bits(0x3fe0_0000_0000_0000);
+        inactive.fade_out = NativeF64Bits::from_bits(0x3fc9_9999_a000_0000);
+        inactive.direction_octant = 6;
+        inactive.replace_recorded_cells(vec![WaveRecordedCell::real(7, 2)]);
+        sim.admit_wave(inactive_id, inactive);
+        sim.active_wave_links.insert(owner_ids[1], inactive_id);
+
+        let dummy_id = sim.allocate_stable_id();
+        let mut dummy = Wave::new_owned(
+            0,
+            owner_ids[2],
+            crate::sim::combat::TargetKind::Cell(10, 2),
+            ProjectileCoord::new(768, 512, 0),
+            ProjectileCoord::new(2560, 512, 50),
+        );
+        dummy.active_geometry = false;
+        dummy.decaying = true;
+        dummy.direction_octant = 2;
+        dummy.replace_recorded_cells(vec![WaveRecordedCell::shared_dummy()]);
+        sim.admit_wave(dummy_id, dummy);
+        sim.active_wave_links.insert(owner_ids[2], dummy_id);
+
+        let expected_hash = sim.state_hash();
+        let bytes = GameSnapshot::save(&sim, 0, 0, "wave-state.map", 0);
+        let mut restored = GameSnapshot::load(&bytes).expect("Wave snapshot").sim;
+        restored
+            .restore_after_snapshot_load()
+            .expect("Wave identities restore structurally");
+
+        assert_eq!(restored.state_hash(), expected_hash);
+        assert_eq!(restored.active_wave_links, sim.active_wave_links);
+        assert_eq!(restored.waves.get(active_id), sim.waves.get(active_id));
+        assert_eq!(restored.waves.get(inactive_id), sim.waves.get(inactive_id));
+        assert_eq!(restored.waves.get(dummy_id), sim.waves.get(dummy_id));
+        assert_eq!(
+            restored.waves.get(dummy_id).unwrap().recorded_cells,
+            vec![WaveRecordedCell::shared_dummy()],
+        );
     }
 
     #[test]

--- a/src/sim/wave.rs
+++ b/src/sim/wave.rs
@@ -9,12 +9,13 @@ use std::hash::Hash;
 
 use crate::map::cell_index::CELL_ROW_STRIDE;
 use crate::map::resolved_terrain::ResolvedTerrainGrid;
+use crate::map::retail_trig::{AcosTable, TrigTable};
 use crate::sim::cell_rect::{CellRef, get_cellclass_fallback};
 use crate::sim::combat::TargetKind;
 use crate::sim::projectile::ProjectileCoord;
-use crate::util::fixed_math::SimFixed;
 use crate::util::native_x87::{
-    NativeF32Bits, NativeF64Bits, X87Chop53, X87Ordering, distance_3d_leptons,
+    NativeF32Bits, NativeF64Bits, X87Chop53, X87Ordering, X87Value, adjust_for_z_standard,
+    distance_3d_leptons, sqrt_approx_f32,
 };
 
 const STEP_F32: NativeF32Bits = NativeF32Bits::from_bits(0x3d4c_cccd);
@@ -250,6 +251,14 @@ impl Wave {
         context: WaveUpdateContext,
         terrain: Option<&ResolvedTerrainGrid>,
     ) -> bool {
+        // `WaveClass::Constructor @ 0x0075E950` builds the initial quad and
+        // stores +0x1CC before Logic registration invokes the lifecycle once.
+        // Later lifecycle refreshes must never overwrite this selector.
+        if self.wave_type == 0 {
+            let geometry = type0_nonmagnetic_geometry(self.source, self.target);
+            self.apply_type0_geometry(geometry);
+            self.direction_octant = geometry.direction_octant;
+        }
         self.update_geometry_and_cells(context, terrain)
     }
 
@@ -331,20 +340,22 @@ impl Wave {
         }
 
         if self.active_geometry
-            && let (Some(owner), Some(mut target)) =
-                (context.owner_position, context.target_position)
+            && let (Some(owner), Some(target)) = (context.owner_position, context.target_position)
         {
             if self.wave_type == 0 {
-                target.z = target.z.wrapping_add(SONIC_TARGET_Z_ADJUST);
+                self.apply_type0_geometry(type0_nonmagnetic_geometry(owner, target));
+            } else {
+                // Type 3 is outside the exactified 0x00761640 slice and keeps
+                // its established projection until 0x00762070 is researched.
+                self.source = owner;
+                self.target = target;
+                self.edge_geometry = legacy_nonmagnetic_edges(owner, target);
+                let yaw = crate::sim::movement::homing_movement::atan2_bam(
+                    crate::util::fixed_math::SimFixed::from_num(target.y.wrapping_sub(owner.y)),
+                    crate::util::fixed_math::SimFixed::from_num(target.x.wrapping_sub(owner.x)),
+                );
+                self.direction_octant = i32::from((yaw >> 13) & 7);
             }
-            self.source = owner;
-            self.target = target;
-            self.edge_geometry = nonmagnetic_edges(owner, target);
-            let yaw = crate::sim::movement::homing_movement::atan2_bam(
-                SimFixed::from_num(target.y.wrapping_sub(owner.y)),
-                SimFixed::from_num(target.x.wrapping_sub(owner.x)),
-            );
-            self.direction_octant = i32::from((yaw >> 13) & 7);
         }
 
         self.fade_in = add_f32_step_to_f64(self.fade_in);
@@ -438,6 +449,12 @@ impl Wave {
         if self.recorded_cells.try_reserve(1).is_ok() {
             self.recorded_cells.push(WaveRecordedCell { identity });
         }
+    }
+
+    fn apply_type0_geometry(&mut self, geometry: Type0NonmagneticGeometry) {
+        self.source = geometry.source;
+        self.target = geometry.target;
+        self.edge_geometry = geometry.edges;
     }
 
     pub const fn visible_through_fog(
@@ -607,10 +624,320 @@ fn lepton_cell(coord: ProjectileCoord) -> (i32, i32) {
     (coord.x / 256, coord.y / 256)
 }
 
-fn nonmagnetic_edges(source: ProjectileCoord, target: ProjectileCoord) -> WaveEdgeGeometry {
-    // `WaveClass::Draw_NonMagnetic @ 0x00761640` writes the four cached
-    // vertices in field order. Type 0 uses local offsets (-30,+/-100) and
-    // (+30,+/-100); UpdateCells later pairs vertex 2 -> 0 or 3 -> 1.
+const NEGATIVE_2048_F32: NativeF32Bits = NativeF32Bits::from_bits(0xc500_0000);
+const TRIG_SCALE_F32: NativeF32Bits = NativeF32Bits::from_bits(0x4522_f983);
+const PI_OVER_TWO_F64: NativeF64Bits = NativeF64Bits::from_bits(0x3ff9_21fb_5444_2d18);
+const TAN_PI_OVER_EIGHT_F64: NativeF64Bits = NativeF64Bits::from_bits(0x3fda_8279_a061_eb64);
+const INV_TAN_PI_OVER_EIGHT_F64: NativeF64Bits = NativeF64Bits::from_bits(0x4003_504f_2e96_fc59);
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)] // machine-fixture diagnostics retained beside the behavior fields
+struct Type0NonmagneticGeometry {
+    source: ProjectileCoord,
+    target: ProjectileCoord,
+    edges: WaveEdgeGeometry,
+    direction_octant: i32,
+    horizontal: i32,
+    sqrt_bits: NativeF32Bits,
+    acos_index: usize,
+    angle_bits: NativeF32Bits,
+    trig_units: i32,
+    sin_index: usize,
+    cos_index: usize,
+    target_screen: (i32, i32),
+    firer_b_screen: (i32, i32),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TransformedVertex {
+    x: NativeF32Bits,
+    y: NativeF32Bits,
+    z: NativeF32Bits,
+}
+
+fn x87_store_f32(value: X87Value) -> NativeF32Bits {
+    X87Chop53::store_f32(value).expect("verified Wave geometry stays in finite binary32 range")
+}
+
+fn x87_ftol_i32(value: X87Value) -> i32 {
+    X87Chop53::ftol_i64(value).expect("verified Wave geometry stays in signed integer range") as i32
+}
+
+fn project_wave_point(coord: ProjectileCoord) -> (i32, i32) {
+    let (x, planar_y) = crate::util::lepton::project_absolute_lepton_xy(coord.x, coord.y);
+    (x, planar_y.wrapping_sub(adjust_for_z_standard(coord.z)))
+}
+
+fn direction_from_projected(from: (i32, i32), to: (i32, i32)) -> i32 {
+    // `0x0075F230`: dx=to.x-from.x and n=from.y-to.y. The four equality
+    // boundaries are intentionally asymmetric.
+    let dx = to.0.wrapping_sub(from.0);
+    let n = from.1.wrapping_sub(to.1);
+    if dx == 0 {
+        return if n > 0 { 0 } else { 4 };
+    }
+
+    let slope = X87Chop53::div(X87Chop53::load_i32(n), X87Chop53::load_i32(dx))
+        .expect("nonzero projected dx divides exactly in the verified finite domain");
+    let tan = load_f64(TAN_PI_OVER_EIGHT_F64);
+    let inv_tan = load_f64(INV_TAN_PI_OVER_EIGHT_F64);
+    let neg_tan = X87Chop53::neg(tan);
+    let neg_inv_tan = X87Chop53::neg(inv_tan);
+
+    let band = if X87Chop53::compare(slope, tan) != X87Ordering::Less
+        && X87Chop53::compare(slope, inv_tan) == X87Ordering::Less
+    {
+        Some(5)
+    } else if X87Chop53::compare(slope, neg_tan) != X87Ordering::Less
+        && X87Chop53::compare(slope, tan) == X87Ordering::Less
+    {
+        Some(6)
+    } else if X87Chop53::compare(slope, neg_inv_tan) != X87Ordering::Less
+        && X87Chop53::compare(slope, neg_tan) == X87Ordering::Less
+    {
+        Some(7)
+    } else {
+        None
+    };
+    match band {
+        Some(base) if dx > 0 => base - 4,
+        Some(base) => base,
+        None if n > 0 => 0,
+        None => 4,
+    }
+}
+
+fn transform_type0_vertex(
+    local_x: i32,
+    local_y: i32,
+    local_z: NativeF32Bits,
+    sin: NativeF32Bits,
+    cos: NativeF32Bits,
+) -> TransformedVertex {
+    // `Matrix3x4::TransformPoint @ 0x005AFB80`, including the native
+    // non-fused operation order and explicit binary32 stores.
+    let zero = X87Chop53::load_i32(0);
+    let one = load_f32(NativeF32Bits::ONE);
+    let x = X87Chop53::load_i32(local_x);
+    let y = X87Chop53::load_i32(local_y);
+    let z = load_f32(local_z);
+    let sin = load_f32(sin);
+    let cos = load_f32(cos);
+
+    let transformed_x = X87Chop53::add(
+        X87Chop53::add(
+            X87Chop53::mul(z, zero),
+            X87Chop53::mul(y, X87Chop53::neg(sin)),
+        ),
+        X87Chop53::mul(x, cos),
+    );
+    let transformed_y = X87Chop53::add(
+        X87Chop53::add(X87Chop53::mul(x, sin), X87Chop53::mul(z, zero)),
+        X87Chop53::mul(y, cos),
+    );
+    let transformed_z = X87Chop53::add(
+        X87Chop53::add(X87Chop53::mul(x, zero), X87Chop53::mul(z, one)),
+        X87Chop53::mul(y, zero),
+    );
+    TransformedVertex {
+        x: x87_store_f32(transformed_x),
+        y: x87_store_f32(transformed_y),
+        z: x87_store_f32(transformed_z),
+    }
+}
+
+fn type0_nonmagnetic_geometry_with_tables(
+    source: ProjectileCoord,
+    raw_target: ProjectileCoord,
+    trig: &TrigTable,
+    acos: &AcosTable,
+) -> Type0NonmagneticGeometry {
+    // Type 0's endpoint factor is exactly 1.0: +C0 is the owner, +B4 is the
+    // target with its post-ftol Sonic Z adjustment.
+    let target = ProjectileCoord::new(
+        raw_target.x,
+        raw_target.y,
+        raw_target.z.wrapping_add(SONIC_TARGET_Z_ADJUST),
+    );
+    let first_dx = X87Chop53::load_i32(target.x.wrapping_sub(source.x));
+    let first_dy = X87Chop53::load_i32(target.y.wrapping_sub(source.y));
+    let first_squared = X87Chop53::add(
+        X87Chop53::mul(first_dx, first_dx),
+        X87Chop53::mul(first_dy, first_dy),
+    );
+    let sqrt_bits =
+        sqrt_approx_f32(first_squared).expect("type-0 Wave horizontal squared length is finite");
+    let horizontal = x87_ftol_i32(load_f32(sqrt_bits));
+    let local_x = [
+        horizontal.wrapping_sub(30),
+        horizontal.wrapping_sub(30),
+        30,
+        30,
+    ];
+    let local_y = [-100, 100, -100, 100];
+
+    let local_z = if horizontal == 0 {
+        // The native masked divide/convert path produces NaN/Inf, then the low
+        // dword of integer-indefinite zeroes each cached Z. native_x87 rejects
+        // nonfinite values by design, so preserve the verified observable here.
+        [NativeF32Bits::POSITIVE_ZERO; 4]
+    } else {
+        let dz = X87Chop53::load_i32(source.z.wrapping_sub(target.z));
+        let divisor = X87Chop53::load_i32(horizontal);
+        local_x.map(|x| {
+            let slope = X87Chop53::div(X87Chop53::mul(X87Chop53::load_i32(x), dz), divisor)
+                .expect("nonzero Wave horizontal length divides in finite x87 domain");
+            x87_store_f32(X87Chop53::add(X87Chop53::load_i32(target.z), slope))
+        })
+    };
+
+    let angle_dx_i32 = source.x.wrapping_sub(target.x);
+    let angle_dy_i32 = source.y.wrapping_sub(target.y);
+    let angle_dx_f32 = x87_store_f32(X87Chop53::load_i32(angle_dx_i32));
+    let angle_squared = X87Chop53::add(
+        X87Chop53::mul(load_f32(angle_dx_f32), load_f32(angle_dx_f32)),
+        X87Chop53::mul(
+            X87Chop53::load_i32(angle_dy_i32),
+            X87Chop53::load_i32(angle_dy_i32),
+        ),
+    );
+    let angle_length_bits =
+        sqrt_approx_f32(angle_squared).expect("type-0 Wave angle squared length is finite");
+    let angle_length = load_f32(angle_length_bits);
+
+    let (acos_index, mut angle) = if horizontal == 0 {
+        let entry = NativeF32Bits::from_bits(acos.entry(0).to_bits());
+        (
+            0,
+            X87Chop53::sub(load_f64(PI_OVER_TWO_F64), load_f32(entry)),
+        )
+    } else {
+        let mut numerator = X87Chop53::load_i32(angle_dx_i32);
+        if X87Chop53::compare(numerator, angle_length) == X87Ordering::Greater {
+            numerator = angle_length;
+        }
+        let negative_length = X87Chop53::neg(angle_length);
+        if X87Chop53::compare(numerator, negative_length) == X87Ordering::Less {
+            numerator = negative_length;
+        }
+        let ratio = X87Chop53::div(numerator, angle_length)
+            .expect("nonzero Wave angle length divides in finite x87 domain");
+        let scaled = X87Chop53::mul(
+            X87Chop53::add(ratio, load_f32(NativeF32Bits::ONE)),
+            load_f32(NEGATIVE_2048_F32),
+        );
+        let raw_index = x87_ftol_i32(scaled).wrapping_neg() as usize;
+        let entry = NativeF32Bits::from_bits(acos.entry(raw_index).to_bits());
+        (
+            raw_index,
+            X87Chop53::sub(load_f64(PI_OVER_TWO_F64), load_f32(entry)),
+        )
+    };
+    if target.y > source.y {
+        angle = X87Chop53::neg(angle);
+    }
+    let angle_bits = x87_store_f32(angle);
+    let trig_units = x87_ftol_i32(X87Chop53::mul(
+        load_f32(angle_bits),
+        load_f32(TRIG_SCALE_F32),
+    ));
+    let sin_index = trig.sin_index(trig_units);
+    let cos_index = trig.cos_index(trig_units);
+    let sin = NativeF32Bits::from_bits(trig.entry(sin_index).to_bits());
+    let cos = NativeF32Bits::from_bits(trig.entry(cos_index).to_bits());
+
+    // Native transforms all four local points before translating/storing any
+    // world field. Keep that boundary visible.
+    let transformed = [
+        transform_type0_vertex(local_x[0], local_y[0], local_z[0], sin, cos),
+        transform_type0_vertex(local_x[1], local_y[1], local_z[1], sin, cos),
+        transform_type0_vertex(local_x[2], local_y[2], local_z[2], sin, cos),
+        transform_type0_vertex(local_x[3], local_y[3], local_z[3], sin, cos),
+    ];
+    let target_y_f32 = x87_store_f32(X87Chop53::load_i32(target.y));
+    let mut world = [ProjectileCoord::new(0, 0, 0); 4];
+    for (index, vertex) in transformed.into_iter().enumerate() {
+        let world_x = x87_ftol_i32(X87Chop53::add(
+            X87Chop53::load_i32(target.x),
+            load_f32(vertex.x),
+        ));
+        let target_y = if index == 0 {
+            X87Chop53::load_i32(target.y)
+        } else {
+            load_f32(target_y_f32)
+        };
+        let world_y = x87_ftol_i32(X87Chop53::add(target_y, load_f32(vertex.y)));
+        let world_z = x87_ftol_i32(load_f32(vertex.z));
+        world[index] = ProjectileCoord::new(world_x, world_y, world_z);
+    }
+
+    let edges = WaveEdgeGeometry {
+        firer_a: world[0],
+        firer_b: world[1],
+        target_a: world[2],
+        target_b: world[3],
+    };
+    let target_screen = project_wave_point(target);
+    let firer_b_screen = project_wave_point(edges.firer_b);
+    Type0NonmagneticGeometry {
+        source,
+        target,
+        edges,
+        direction_octant: direction_from_projected(target_screen, firer_b_screen),
+        horizontal,
+        sqrt_bits,
+        acos_index,
+        angle_bits,
+        trig_units,
+        sin_index,
+        cos_index,
+        target_screen,
+        firer_b_screen,
+    }
+}
+
+fn installed_wave_math_tables() -> (&'static TrigTable, &'static AcosTable) {
+    if let (Some(trig), Some(acos)) = (
+        crate::map::retail_trig::global(),
+        crate::map::retail_trig::global_acos(),
+    ) {
+        return (trig, acos);
+    }
+
+    #[cfg(test)]
+    {
+        use std::sync::OnceLock;
+        static TEST_TABLES: OnceLock<(TrigTable, AcosTable)> = OnceLock::new();
+        let tables = TEST_TABLES.get_or_init(|| {
+            let exact = std::env::var_os("RA2_DIR")
+                .and_then(|dir| {
+                    std::fs::read(std::path::PathBuf::from(dir).join("gamemd.exe")).ok()
+                })
+                .and_then(|image| {
+                    let trig = TrigTable::from_executable(&image).ok()?;
+                    let acos = AcosTable::from_executable(&image).ok()?;
+                    (trig.matches_retail() && acos.matches_retail()).then_some((trig, acos))
+                });
+            exact.unwrap_or_else(|| (TrigTable::synthetic(), AcosTable::synthetic()))
+        });
+        return (&tables.0, &tables.1);
+    }
+
+    #[cfg(not(test))]
+    panic!("verified gamemd sine/Acos tables were not installed before type-0 Wave geometry");
+}
+
+fn type0_nonmagnetic_geometry(
+    source: ProjectileCoord,
+    raw_target: ProjectileCoord,
+) -> Type0NonmagneticGeometry {
+    let (trig, acos) = installed_wave_math_tables();
+    type0_nonmagnetic_geometry_with_tables(source, raw_target, trig, acos)
+}
+
+fn legacy_nonmagnetic_edges(source: ProjectileCoord, target: ProjectileCoord) -> WaveEdgeGeometry {
+    // Preserve the pre-existing type-3 projection until its separate helper at
+    // 0x00762070 is exactified. Type 0 never reaches this host-float path.
     let dx = f64::from(target.x.wrapping_sub(source.x));
     let dy = f64::from(target.y.wrapping_sub(source.y));
     let dz = f64::from(target.z.wrapping_sub(source.z));
@@ -723,10 +1050,378 @@ mod tests {
         }
     }
 
+    fn exact_retail_wave_tables() -> Option<(TrigTable, AcosTable)> {
+        let dir = std::env::var_os("RA2_DIR")?;
+        let image = std::fs::read(std::path::PathBuf::from(dir).join("gamemd.exe")).ok()?;
+        let trig = TrigTable::from_executable(&image).ok()?;
+        let acos = AcosTable::from_executable(&image).ok()?;
+        (trig.matches_retail() && acos.matches_retail()).then_some((trig, acos))
+    }
+
     #[test]
     fn constructor_uses_strict_239_240_xy_edge() {
         assert!(!Wave::new(0, point(0, 0, 0), point(239, 0, 999)).constructor_distance_is_live());
         assert!(Wave::new(0, point(0, 0, 0), point(240, 0, -999)).constructor_distance_is_live());
+    }
+
+    #[test]
+    fn type0_nonmagnetic_geometry_matches_all_eight_machine_octants() {
+        let Some((trig, acos)) = exact_retail_wave_tables() else {
+            eprintln!("skipped: set RA2_DIR to the retail install to run exact Wave fixtures");
+            return;
+        };
+        struct Fixture {
+            target: (i32, i32),
+            horizontal: i32,
+            sqrt_bits: u32,
+            acos_index: usize,
+            angle_bits: u32,
+            edges: [(i32, i32, i32); 4],
+            screens: ((i32, i32), (i32, i32)),
+        }
+        let fixtures = [
+            Fixture {
+                target: (4352, 4224),
+                horizontal: 286,
+                sqrt_bits: 0x438f_1bbc,
+                acos_index: 216,
+                angle_bits: 0xc02b_6743,
+                edges: [
+                    (4078, 4198, 5),
+                    (4167, 4019, 5),
+                    (4280, 4299, 44),
+                    (4370, 4121, 44),
+                ],
+                screens: ((15, 495), (17, 478)),
+            },
+            Fixture {
+                target: (4352, 4352),
+                horizontal: 362,
+                sqrt_bits: 0x43b5_04f3,
+                acos_index: 599,
+                angle_bits: 0xc016_d574,
+                edges: [
+                    (4046, 4187, 4),
+                    (4188, 4046, 4),
+                    (4260, 4401, 45),
+                    (4401, 4260, 45),
+                ],
+                screens: ((0, 503), (16, 481)),
+            },
+            Fixture {
+                target: (4096, 4352),
+                horizontal: 256,
+                sqrt_bits: 0x4380_0000,
+                acos_index: 2048,
+                angle_bits: 0xbfc9_0fda,
+                edges: [
+                    (3996, 4125, 5),
+                    (4196, 4126, 5),
+                    (3996, 4321, 44),
+                    (4196, 4322, 44),
+                ],
+                screens: ((-30, 488), (8, 486)),
+            },
+            Fixture {
+                target: (3840, 4096),
+                horizontal: 256,
+                sqrt_bits: 0x4380_0000,
+                acos_index: 4096,
+                angle_bits: 0x33a2_2168,
+                edges: [
+                    (4066, 3996, 5),
+                    (4066, 4196, 5),
+                    (3870, 3996, 44),
+                    (3870, 4196, 44),
+                ],
+                screens: ((-30, 458), (-15, 483)),
+            },
+            Fixture {
+                target: (3840, 3968),
+                horizontal: 286,
+                sqrt_bits: 0x438f_1bbc,
+                acos_index: 3879,
+                angle_bits: 0x3eed_d3be,
+                edges: [
+                    (4113, 3993, 5),
+                    (4024, 4172, 5),
+                    (3911, 3892, 44),
+                    (3821, 4070, 44),
+                ],
+                screens: ((-15, 450), (-17, 479)),
+            },
+            Fixture {
+                target: (3968, 3840),
+                horizontal: 286,
+                sqrt_bits: 0x438f_1bbc,
+                acos_index: 2963,
+                angle_bits: 0x3f8d_c707,
+                edges: [
+                    (4171, 4024, 5),
+                    (3992, 4113, 5),
+                    (4070, 3822, 44),
+                    (3891, 3911, 44),
+                ],
+                screens: ((15, 450), (-14, 473)),
+            },
+            Fixture {
+                target: (4096, 3840),
+                horizontal: 256,
+                sqrt_bits: 0x4380_0000,
+                acos_index: 2048,
+                angle_bits: 0x3fc9_0fda,
+                edges: [
+                    (4196, 4065, 5),
+                    (3996, 4066, 5),
+                    (4196, 3869, 44),
+                    (3996, 3870, 44),
+                ],
+                screens: ((30, 458), (-8, 471)),
+            },
+            Fixture {
+                target: (4352, 4096),
+                horizontal: 256,
+                sqrt_bits: 0x4380_0000,
+                acos_index: 0,
+                angle_bits: 0x4049_0fda,
+                edges: [
+                    (4126, 4196, 5),
+                    (4126, 3996, 5),
+                    (4322, 4196, 44),
+                    (4322, 3996, 44),
+                ],
+                screens: ((30, 488), (15, 474)),
+            },
+        ];
+
+        for (direction, fixture) in fixtures.into_iter().enumerate() {
+            let geometry = type0_nonmagnetic_geometry_with_tables(
+                point(4096, 4096, 0),
+                point(fixture.target.0, fixture.target.1, 0),
+                &trig,
+                &acos,
+            );
+            assert_eq!(
+                geometry.horizontal, fixture.horizontal,
+                "direction {direction}"
+            );
+            assert_eq!(
+                geometry.sqrt_bits.bits(),
+                fixture.sqrt_bits,
+                "direction {direction}"
+            );
+            assert_eq!(
+                geometry.acos_index, fixture.acos_index,
+                "direction {direction}"
+            );
+            assert_eq!(
+                geometry.angle_bits.bits(),
+                fixture.angle_bits,
+                "direction {direction}"
+            );
+            assert_eq!(
+                [
+                    geometry.edges.firer_a,
+                    geometry.edges.firer_b,
+                    geometry.edges.target_a,
+                    geometry.edges.target_b
+                ]
+                .map(|coord| (coord.x, coord.y, coord.z)),
+                fixture.edges,
+                "direction {direction}"
+            );
+            assert_eq!(
+                (geometry.target_screen, geometry.firer_b_screen),
+                fixture.screens
+            );
+            assert_eq!(geometry.direction_octant, direction as i32);
+        }
+    }
+
+    #[test]
+    fn type0_nonmagnetic_geometry_matches_signed_edges_and_nonflat_z() {
+        let Some((trig, acos)) = exact_retail_wave_tables() else {
+            eprintln!("skipped: set RA2_DIR to the retail install to run exact Wave fixtures");
+            return;
+        };
+        let fixtures = [
+            (
+                point(1024, 1024, 0),
+                point(255, 255, 0),
+                1087,
+                0x4487_f0f0,
+                [
+                    (1073, 931, 1),
+                    (931, 1073, 1),
+                    (346, 205, 48),
+                    (205, 346, 48),
+                ],
+                [(4, 3), (3, 4), (1, 0), (0, 1)],
+                4,
+            ),
+            (
+                point(1024, 1024, 0),
+                point(256, 256, 0),
+                1086,
+                0x4487_c3b6,
+                [
+                    (1073, 931, 1),
+                    (931, 1073, 1),
+                    (347, 206, 48),
+                    (206, 347, 48),
+                ],
+                [(4, 3), (3, 4), (1, 0), (0, 1)],
+                4,
+            ),
+            (
+                point(512, 512, 0),
+                point(-255, -255, 0),
+                1084,
+                0x4487_966d,
+                [
+                    (561, 419, 1),
+                    (419, 561, 1),
+                    (-163, -304, 48),
+                    (-304, -163, 48),
+                ],
+                [(2, 1), (1, 2), (0, -1), (-1, 0)],
+                4,
+            ),
+            (
+                point(512, 512, 0),
+                point(-256, -256, 0),
+                1086,
+                0x4487_c3b6,
+                [
+                    (561, 419, 1),
+                    (419, 561, 1),
+                    (-164, -305, 48),
+                    (-305, -164, 48),
+                ],
+                [(2, 1), (1, 2), (0, -1), (-1, 0)],
+                4,
+            ),
+            (
+                point(513, -257, 180),
+                point(-260, 769, 646),
+                1284,
+                0x44a0_92ef,
+                [
+                    (414, -292, 192),
+                    (574, -172, 192),
+                    (-321, 684, 683),
+                    (-162, 805, 683),
+                ],
+                [(1, -1), (2, 0), (-1, 2), (0, 3)],
+                2,
+            ),
+        ];
+        for (source, target, horizontal, sqrt_bits, expected, cells, direction) in fixtures {
+            let geometry = type0_nonmagnetic_geometry_with_tables(source, target, &trig, &acos);
+            let edges = [
+                geometry.edges.firer_a,
+                geometry.edges.firer_b,
+                geometry.edges.target_a,
+                geometry.edges.target_b,
+            ];
+            assert_eq!(geometry.horizontal, horizontal);
+            assert_eq!(geometry.sqrt_bits.bits(), sqrt_bits);
+            assert_eq!(edges.map(|coord| (coord.x, coord.y, coord.z)), expected);
+            assert_eq!(edges.map(lepton_cell), cells);
+            assert_eq!(geometry.direction_octant, direction);
+        }
+    }
+
+    #[test]
+    fn converged_live_type0_geometry_keeps_native_exceptional_quad() {
+        let Some((trig, acos)) = exact_retail_wave_tables() else {
+            eprintln!("skipped: set RA2_DIR to the retail install to run exact Wave fixtures");
+            return;
+        };
+        let geometry = type0_nonmagnetic_geometry_with_tables(
+            point(4096, 4096, 0),
+            point(4096, 4096, 0),
+            &trig,
+            &acos,
+        );
+        let edges = [
+            geometry.edges.firer_a,
+            geometry.edges.firer_b,
+            geometry.edges.target_a,
+            geometry.edges.target_b,
+        ];
+        assert_eq!(geometry.horizontal, 0);
+        assert_eq!(geometry.acos_index, 0);
+        assert_eq!(geometry.angle_bits.bits(), 0x4049_0fda);
+        assert_eq!(geometry.trig_units, 8191);
+        assert_eq!((geometry.sin_index, geometry.cos_index), (4096, 6144));
+        assert_eq!(edges.map(|coord| coord.z), [0; 4]);
+        assert_eq!(
+            edges
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            4
+        );
+    }
+
+    #[test]
+    fn type0_live_refresh_preserves_constructor_projected_direction() {
+        let target_ref = TargetKind::Cell(17, 16);
+        let source = point(4096, 4096, 0);
+        let initial_target = point(4352, 4096, 0);
+        let mut wave = Wave::new_owned(0, 7, target_ref, source, initial_target);
+        assert!(!wave.initialize(
+            WaveUpdateContext {
+                owner_position: Some(source),
+                owner_current_target: Some(target_ref),
+                target_position: Some(initial_target),
+            },
+            None,
+        ));
+        assert_eq!(wave.direction_octant, 7);
+
+        let moved_target = point(3840, 4096, 0);
+        let _ = wave.advance(
+            WaveUpdateContext {
+                owner_position: Some(source),
+                owner_current_target: Some(target_ref),
+                target_position: Some(moved_target),
+            },
+            None,
+        );
+        assert_eq!(wave.direction_octant, 7);
+        assert_eq!(
+            wave.edge_geometry,
+            type0_nonmagnetic_geometry(source, moved_target).edges
+        );
+    }
+
+    #[test]
+    fn inactive_update_cells_uses_exact_fc_108_114_120_identities() {
+        let terrain = flat_terrain(8, 8);
+        let geometry = type0_nonmagnetic_geometry(point(1024, 1024, 0), point(255, 255, 0));
+        let mut wave = Wave::new(0, geometry.source, geometry.target);
+        wave.apply_type0_geometry(geometry);
+        wave.active_geometry = false;
+        wave.fade_in = f32_to_f64(STEP_F32);
+        wave.fade_out = f32_to_f64(STEP_F32);
+
+        // direction<4 traces +0x114 -> +0xFC before the centerline.
+        wave.direction_octant = 3;
+        wave.update_cells(Some(&terrain));
+        assert_eq!(
+            wave.recorded_cells,
+            vec![WaveRecordedCell::real(1, 0), WaveRecordedCell::real(1, 1)]
+        );
+
+        // direction>=4 traces the centerline before +0x120 -> +0x108.
+        wave.direction_octant = 4;
+        wave.update_cells(Some(&terrain));
+        assert_eq!(
+            wave.recorded_cells,
+            vec![WaveRecordedCell::real(1, 1), WaveRecordedCell::real(0, 1)]
+        );
     }
 
     #[test]

--- a/src/sim/wave.rs
+++ b/src/sim/wave.rs
@@ -1,34 +1,117 @@
-//! Persistent YR `WaveClass` runtime state.
+//! Persistent YR `WaveClass` runtime state and type-0 CellClass sampling.
 //!
-//! This is deliberately a simulation-owned display registration, rather than a
-//! one-frame weapon-fire effect.  Native `WaveClass::Ctor` registers the wave
-//! with LogicClass and the display array bucket returned by `InWhichLayer`.
+//! Wave lifecycle is simulation authority: Sonic Waves own a live firer/target
+//! relationship, mixed binary32/double fade state, and a pointer-identity cell
+//! vector consumed synchronously from the mixed LogicClass order.
 
 use std::collections::BTreeMap;
 use std::hash::Hash;
 
-use crate::sim::intern::InternedId;
+use crate::map::cell_index::CELL_ROW_STRIDE;
+use crate::map::resolved_terrain::ResolvedTerrainGrid;
+use crate::sim::cell_rect::{CellRef, get_cellclass_fallback};
+use crate::sim::combat::TargetKind;
 use crate::sim::projectile::ProjectileCoord;
+use crate::util::fixed_math::SimFixed;
+use crate::util::native_x87::{
+    NativeF32Bits, NativeF64Bits, X87Chop53, X87Ordering, distance_3d_leptons,
+};
 
+const STEP_F32: NativeF32Bits = NativeF32Bits::from_bits(0x3d4c_cccd);
+const HALF_STEP_F32: NativeF32Bits = NativeF32Bits::from_bits(0x3ccc_cccd);
+const SNAP_FADE_F32: NativeF32Bits = NativeF32Bits::from_bits(0x3f7a_e148);
+const AUTO_DECAY_F64: NativeF64Bits = NativeF64Bits::from_bits(0x3fb9_9999_9999_999a);
+const SONIC_TARGET_Z_ADJUST: i32 = 50;
+const CONSTRUCTOR_MIN_XY_DISTANCE: i64 = 240;
+const MAX_TRACKING_DISTANCE_LEPTONS: i32 = 2172;
+
+/// Stable serialization of a native CellClass pointer retained by WaveClass.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct WaveRecordedCell {
-    pub rx: u16,
-    pub ry: u16,
+pub enum WaveCellIdentity {
+    Real { fixed_stride_index: u32 },
+    SharedDummy,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct WaveDamagePayload {
-    pub firer_id: u64,
-    pub base_damage: i32,
-    pub warhead: InternedId,
+pub struct WaveRecordedCell {
+    pub identity: WaveCellIdentity,
+}
+
+impl WaveRecordedCell {
+    pub const fn real(rx: u16, ry: u16) -> Self {
+        Self {
+            identity: WaveCellIdentity::Real {
+                fixed_stride_index: ry as u32 * CELL_ROW_STRIDE as u32 + rx as u32,
+            },
+        }
+    }
+
+    pub const fn shared_dummy() -> Self {
+        Self {
+            identity: WaveCellIdentity::SharedDummy,
+        }
+    }
+
+    pub fn current_cell(self, terrain: Option<&ResolvedTerrainGrid>) -> WaveCellView {
+        match self.identity {
+            WaveCellIdentity::Real { fixed_stride_index } => {
+                let rx = (fixed_stride_index % CELL_ROW_STRIDE as u32) as u16;
+                let ry = (fixed_stride_index / CELL_ROW_STRIDE as u32) as u16;
+                let cell = terrain.and_then(|grid| grid.cell(rx, ry));
+                WaveCellView {
+                    rx: i32::from(rx),
+                    ry: i32::from(ry),
+                    level: cell.map_or(0, |cell| cell.level as i8),
+                    structural_bridge: cell
+                        .is_some_and(|cell| cell.bridge_facts.has_structural_bridge()),
+                    real: true,
+                }
+            }
+            WaveCellIdentity::SharedDummy => {
+                let snapshot = terrain
+                    .map(|grid| grid.shared_cell_dummy().snapshot())
+                    .unwrap_or(crate::map::resolved_terrain::SharedCellDummySnapshot {
+                        coord: (0, 0),
+                        level: 0,
+                        slope_type: 0,
+                        bridge_flags_0x1180: 0,
+                    });
+                WaveCellView {
+                    rx: snapshot.coord.0,
+                    ry: snapshot.coord.1,
+                    level: snapshot.level,
+                    structural_bridge: snapshot.bridge_flags_0x1180 & 0x100 != 0,
+                    real: false,
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WaveCellView {
+    pub rx: i32,
+    pub ry: i32,
+    pub level: i8,
+    pub structural_bridge: bool,
+    pub real: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WaveDamageRequest {
     pub wave_id: u64,
-    pub payload: WaveDamagePayload,
+    pub firer_id: u64,
     pub recorded_cells: Vec<WaveRecordedCell>,
     pub wave_z: i32,
+}
+
+/// Compatibility record used by direct receiver helpers. WaveClass itself no
+/// longer stores one: DamageArea resolves GetWeapon(0) once per cell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WaveDamagePayload {
+    pub firer_id: u64,
+    pub base_damage: i32,
+    pub warhead: crate::sim::intern::InternedId,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -38,10 +121,6 @@ pub struct WaveDamageEvent {
     pub payload: WaveDamagePayload,
 }
 
-/// `WaveClass::InWhichLayer` returns this display registration bucket.
-///
-/// It is not a global tactical pass position: YR has no generic five-layer
-/// traversal that gives bucket 3 an across-family ordering.
 pub const WAVE_DISPLAY_REGISTRATION_BUCKET: u8 = 3;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -52,52 +131,104 @@ pub enum WaveColorMode {
     None,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct WaveEdgeGeometry {
+    pub firer_a: ProjectileCoord,
+    pub firer_b: ProjectileCoord,
+    pub target_a: ProjectileCoord,
+    pub target_b: ProjectileCoord,
+}
+
+impl WaveEdgeGeometry {
+    const fn collapsed(source: ProjectileCoord, target: ProjectileCoord) -> Self {
+        Self {
+            firer_a: source,
+            firer_b: source,
+            target_a: target,
+            target_b: target,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct WaveUpdateContext {
+    pub owner_position: Option<ProjectileCoord>,
+    pub owner_current_target: Option<TargetKind>,
+    pub target_position: Option<ProjectileCoord>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Wave {
     pub id: u64,
-    /// LogicClass membership is reconstructed from the serialized mixed order.
     #[serde(skip)]
     pub in_logic_vector: bool,
     pub wave_type: u8,
+    pub owner_id: Option<u64>,
+    pub target_ref: Option<TargetKind>,
+    /// Live firer-side endpoint (+0xC0).
     pub source: ProjectileCoord,
+    /// Live target-side endpoint (+0xB4), including Sonic's Z adjustment.
     pub target: ProjectileCoord,
-    /// Native `WaveClass+0x130`; types 0 and 3 decrement this every tick.
+    pub edge_geometry: WaveEdgeGeometry,
+    pub active_geometry: bool,
+    pub decaying: bool,
     pub lifetime: i32,
-    /// Native `WaveClass+0x1d0`; types 1 and 2 subtract six every tick.
+    pub type3_cycle_count: i32,
+    pub fade_in: NativeF64Bits,
+    pub fade_out: NativeF64Bits,
+    pub direction_octant: i32,
     pub intensity: i32,
-    /// `WaveClass+0x1f4/+0x200`: insertion order is damage order and duplicates
-    /// remain observable. The exact native UpdateCells producer is still an
-    /// explicit residual; callers may only provide evidence-backed records.
     pub recorded_cells: Vec<WaveRecordedCell>,
-    pub damage_payload: Option<WaveDamagePayload>,
 }
 
 impl Wave {
     pub const DEFAULT_LIFETIME: i32 = 100;
     pub const DEFAULT_LASER_INTENSITY: i32 = 160;
 
-    /// Named location: `WaveClass::Ctor @ 0x0075e950`.
+    /// gamemd-derived: `WaveClass::Constructor @ 0x0075E950`.
     pub const fn new(wave_type: u8, source: ProjectileCoord, target: ProjectileCoord) -> Self {
         Self {
             id: 0,
             in_logic_vector: false,
             wave_type,
+            owner_id: None,
+            target_ref: None,
             source,
             target,
+            edge_geometry: WaveEdgeGeometry::collapsed(source, target),
+            active_geometry: true,
+            decaying: false,
             lifetime: Self::DEFAULT_LIFETIME,
+            type3_cycle_count: 0,
+            fade_in: NativeF64Bits::POSITIVE_ZERO,
+            fade_out: NativeF64Bits::POSITIVE_ZERO,
+            direction_octant: 0,
             intensity: Self::DEFAULT_LASER_INTENSITY,
             recorded_cells: Vec::new(),
-            damage_payload: None,
         }
     }
 
-    pub fn with_damage_payload(mut self, payload: WaveDamagePayload) -> Self {
-        self.damage_payload = Some(payload);
-        self
+    pub const fn new_owned(
+        wave_type: u8,
+        owner_id: u64,
+        target_ref: TargetKind,
+        source: ProjectileCoord,
+        target: ProjectileCoord,
+    ) -> Self {
+        let mut wave = Self::new(wave_type, source, target);
+        wave.owner_id = Some(owner_id);
+        wave.target_ref = Some(target_ref);
+        wave
     }
 
     pub fn replace_recorded_cells(&mut self, cells: Vec<WaveRecordedCell>) {
         self.recorded_cells = cells;
+    }
+
+    pub fn constructor_distance_is_live(&self) -> bool {
+        let dx = i64::from(self.target.x) - i64::from(self.source.x);
+        let dy = i64::from(self.target.y) - i64::from(self.source.y);
+        dx * dx + dy * dy >= CONSTRUCTOR_MIN_XY_DISTANCE * CONSTRUCTOR_MIN_XY_DISTANCE
     }
 
     pub const fn color_mode(&self) -> WaveColorMode {
@@ -113,38 +244,202 @@ impl Wave {
         WAVE_DISPLAY_REGISTRATION_BUCKET
     }
 
-    /// Named location: `WaveClass::Update @ 0x00760f50`.
-    pub fn advance(&mut self) -> WaveTickResult {
+    /// Constructor tail: lifecycle/geometry runs once, but DamageArea does not.
+    pub fn initialize(
+        &mut self,
+        context: WaveUpdateContext,
+        terrain: Option<&ResolvedTerrainGrid>,
+    ) -> bool {
+        self.update_geometry_and_cells(context, terrain)
+    }
+
+    /// gamemd-derived: `WaveClass::AI @ 0x00760F50` and lifecycle owner
+    /// `0x00762AF0`.
+    pub fn advance(
+        &mut self,
+        context: WaveUpdateContext,
+        terrain: Option<&ResolvedTerrainGrid>,
+    ) -> WaveTickResult {
         match self.wave_type {
             0 | 3 => {
-                self.lifetime -= 1;
-                let alive = self.lifetime >= 0;
+                let terminal_from_fade = self.update_geometry_and_cells(context, terrain);
+                let damage_recorded_cells = self.wave_type == 0;
+                self.lifetime = self.lifetime.wrapping_sub(1);
+                let terminal_from_lifetime = self.lifetime < 0;
                 WaveTickResult {
-                    alive,
-                    update_geometry: true,
-                    damage_recorded_cells: self.wave_type == 0,
-                    call_object_ai: alive,
+                    alive: !terminal_from_fade && !terminal_from_lifetime,
+                    damage_recorded_cells,
+                    call_object_ai: !terminal_from_lifetime,
+                    uninitialized: terminal_from_fade || terminal_from_lifetime,
                 }
             }
             1 | 2 => {
-                self.intensity -= 6;
+                self.intensity = self.intensity.wrapping_sub(6);
+                let alive = self.intensity > 31;
                 WaveTickResult {
-                    alive: self.intensity >= 32,
-                    update_geometry: false,
+                    alive,
                     damage_recorded_cells: false,
                     call_object_ai: false,
+                    uninitialized: !alive,
                 }
             }
             _ => WaveTickResult {
                 alive: true,
-                update_geometry: false,
                 damage_recorded_cells: false,
                 call_object_ai: false,
+                uninitialized: false,
             },
         }
     }
 
-    /// Named location: `WaveClass::DrawIt @ 0x0075f9f0`.
+    fn update_geometry_and_cells(
+        &mut self,
+        context: WaveUpdateContext,
+        terrain: Option<&ResolvedTerrainGrid>,
+    ) -> bool {
+        let fade_delta = X87Chop53::sub(load_f64(self.fade_in), load_f64(self.fade_out));
+        if self.wave_type == 0
+            && X87Chop53::compare(load_f64(AUTO_DECAY_F64), fade_delta) == X87Ordering::Less
+        {
+            self.decaying = true;
+        }
+
+        if self.wave_type == 3 && self.lifetime == 20 {
+            self.lifetime = 64;
+            self.type3_cycle_count = self.type3_cycle_count.wrapping_add(1);
+        }
+
+        if context.target_position.is_none()
+            || context.owner_position.is_none()
+            || self.lifetime == 20
+            || self.target_ref != context.owner_current_target
+        {
+            self.active_geometry = false;
+            self.decaying = true;
+        }
+
+        if self.wave_type != 3
+            && let (Some(owner), Some(target)) =
+                (context.owner_position, context.target_position)
+            && distance_3d_leptons(
+                [owner.x, owner.y, owner.z],
+                [target.x, target.y, target.z],
+            ) > MAX_TRACKING_DISTANCE_LEPTONS
+        {
+            self.active_geometry = false;
+            self.decaying = true;
+        }
+
+        if self.active_geometry
+            && let (Some(owner), Some(mut target)) =
+                (context.owner_position, context.target_position)
+        {
+            if self.wave_type == 0 {
+                target.z = target.z.wrapping_add(SONIC_TARGET_Z_ADJUST);
+            }
+            self.source = owner;
+            self.target = target;
+            self.edge_geometry = nonmagnetic_edges(owner, target);
+            let yaw = crate::sim::movement::homing_movement::atan2_bam(
+                SimFixed::from_num(target.y.wrapping_sub(owner.y)),
+                SimFixed::from_num(target.x.wrapping_sub(owner.x)),
+            );
+            self.direction_octant = i32::from((yaw >> 13) & 7);
+        }
+
+        self.fade_in = add_f32_step_to_f64(self.fade_in);
+        if X87Chop53::compare(
+            load_f32(f64_to_f32(self.fade_in)),
+            load_f32(SNAP_FADE_F32),
+        ) == X87Ordering::Greater
+        {
+            self.fade_in = NativeF64Bits::ONE;
+        }
+
+        if self.decaying && f32_le_sum(self.fade_out, self.fade_in, HALF_STEP_F32) {
+            self.fade_out = add_f32_step_to_f64(self.fade_out);
+            if X87Chop53::compare(
+                load_f32(f64_to_f32(self.fade_out)),
+                load_f32(f64_to_f32(self.fade_in)),
+            ) != X87Ordering::Less
+            {
+                // Native returns before UpdateCells, leaving the previous vector.
+                return true;
+            }
+        }
+
+        self.update_cells(terrain);
+        false
+    }
+
+    /// gamemd-derived: `WaveClass::UpdateCells @ 0x007610F0`.
+    fn update_cells(&mut self, terrain: Option<&ResolvedTerrainGrid>) {
+        self.recorded_cells.clear();
+        if self.active_geometry {
+            let mut previous = lepton_cell(self.target);
+            let mut t = f32_to_f64(STEP_F32);
+            while f32_le_sum(t, self.fade_in, HALF_STEP_F32) {
+                let cell = lepton_cell(interpolate(self.target, self.source, t));
+                if cell != previous {
+                    previous = cell;
+                    self.lookup_and_append(terrain, cell);
+                }
+                t = add_f32_step_to_f64(t);
+            }
+            return;
+        }
+
+        let edges = self.edge_geometry;
+        let mut previous_a = lepton_cell(edges.firer_a);
+        let mut previous_center = lepton_cell(self.source);
+        let mut previous_b = lepton_cell(edges.firer_b);
+        let mut t = self.fade_out;
+        while f32_le_sum(t, self.fade_in, HALF_STEP_F32) {
+            if self.direction_octant < 4 {
+                let cell = lepton_cell(interpolate(edges.target_a, edges.firer_a, t));
+                if cell != previous_a {
+                    previous_a = cell;
+                    self.lookup_and_append(terrain, cell);
+                }
+            }
+            let cell = lepton_cell(interpolate(self.target, self.source, t));
+            if cell != previous_center {
+                previous_center = cell;
+                self.lookup_and_append(terrain, cell);
+            }
+            if self.direction_octant >= 4 {
+                let cell = lepton_cell(interpolate(edges.target_b, edges.firer_b, t));
+                if cell != previous_b {
+                    previous_b = cell;
+                    self.lookup_and_append(terrain, cell);
+                }
+            }
+            t = add_f32_step_to_f64(t);
+        }
+    }
+
+    fn lookup_and_append(&mut self, terrain: Option<&ResolvedTerrainGrid>, cell: (i32, i32)) {
+        // GetCellClass runs before pointer lookup, so repeated misses restamp
+        // the dummy even when its pointer is already present in the vector.
+        let identity = match get_cellclass_fallback(terrain, cell.0, cell.1) {
+            CellRef::Real(real) => WaveCellIdentity::Real {
+                fixed_stride_index: u32::from(real.ry) * CELL_ROW_STRIDE as u32
+                    + u32::from(real.rx),
+            },
+            CellRef::Dummy { .. } => WaveCellIdentity::SharedDummy,
+        };
+        if self
+            .recorded_cells
+            .iter()
+            .any(|recorded| recorded.identity == identity)
+        {
+            return;
+        }
+        if self.recorded_cells.try_reserve(1).is_ok() {
+            self.recorded_cells.push(WaveRecordedCell { identity });
+        }
+    }
+
     pub const fn visible_through_fog(
         &self,
         scenario_fog_gate: bool,
@@ -158,16 +453,11 @@ impl Wave {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WaveTickResult {
     pub alive: bool,
-    pub update_geometry: bool,
-    /// Type 0 has this native side effect. The CellClass damage kernel remains
-    /// its own authority; this result keeps the handoff explicit.
     pub damage_recorded_cells: bool,
     pub call_object_ai: bool,
+    pub uninitialized: bool,
 }
 
-/// Stable-ID collection matching the WaveClass array/Logic registration's
-/// persistence boundary. The `BTreeMap` gives a deterministic update order
-/// without inventing a cross-display-bucket render order.
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct WaveStore {
     waves: BTreeMap<u64, Wave>,
@@ -177,12 +467,20 @@ impl std::hash::Hash for Wave {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state);
         self.wave_type.hash(state);
+        self.owner_id.hash(state);
+        self.target_ref.hash(state);
         self.source.hash(state);
         self.target.hash(state);
+        self.edge_geometry.hash(state);
+        self.active_geometry.hash(state);
+        self.decaying.hash(state);
         self.lifetime.hash(state);
+        self.type3_cycle_count.hash(state);
+        self.fade_in.hash(state);
+        self.fade_out.hash(state);
+        self.direction_octant.hash(state);
         self.intensity.hash(state);
         self.recorded_cells.hash(state);
-        self.damage_payload.hash(state);
     }
 }
 
@@ -215,9 +513,6 @@ impl WaveStore {
         self.waves.remove(&id)
     }
 
-    // AbstractClass::AssignUniqueID @ 0x00410230 obtains this identity from
-    // ScenarioClass::NextUniqueID @ 0x0068BCB0; the store never owns a second
-    // allocator.
     pub fn spawn(&mut self, id: u64, mut wave: Wave) -> u64 {
         wave.id = id;
         wave.in_logic_vector = false;
@@ -225,41 +520,106 @@ impl WaveStore {
         id
     }
 
-    /// Advance registered waves. Type-0 recorded-cell damage is deliberately
-    /// exposed to the caller instead of approximating CellClass effects here.
-    pub fn advance(&mut self) -> Vec<WaveDamageRequest> {
-        let mut sonic_damage = Vec::new();
-        let ids: Vec<u64> = self.waves.keys().copied().collect();
-        for id in ids {
-            let Some((request, alive)) = self.advance_one(id) else {
-                continue;
-            };
-            if let Some(request) = request {
-                sonic_damage.push(request);
-            }
-            if !alive {
-                self.waves.remove(&id);
-            }
-        }
-        sonic_damage
-    }
-
-    pub(crate) fn advance_one(&mut self, id: u64) -> Option<(Option<WaveDamageRequest>, bool)> {
+    pub(crate) fn advance_one(
+        &mut self,
+        id: u64,
+        context: WaveUpdateContext,
+        terrain: Option<&ResolvedTerrainGrid>,
+    ) -> Option<(Option<WaveDamageRequest>, WaveTickResult)> {
         let wave = self.waves.get_mut(&id)?;
-        let result = wave.advance();
-        // Native type 0 damages its vector before the lifetime decrement,
-        // including the tick that changes lifetime 0 to -1 and uninitializes.
+        let result = wave.advance(context, terrain);
         let request = if result.damage_recorded_cells {
-            wave.damage_payload.map(|payload| WaveDamageRequest {
+            wave.owner_id.map(|firer_id| WaveDamageRequest {
                 wave_id: id,
-                payload,
+                firer_id,
                 recorded_cells: wave.recorded_cells.clone(),
                 wave_z: wave.target.z,
             })
         } else {
             None
         };
-        Some((request, result.alive))
+        Some((request, result))
+    }
+}
+
+fn load_f32(bits: NativeF32Bits) -> crate::util::native_x87::X87Value {
+    X87Chop53::load_f32(bits).expect("Wave finite binary32 state")
+}
+
+fn load_f64(bits: NativeF64Bits) -> crate::util::native_x87::X87Value {
+    X87Chop53::load_f64(bits).expect("Wave finite double state")
+}
+
+fn f64_to_f32(bits: NativeF64Bits) -> NativeF32Bits {
+    // The active x87 path keeps 53-bit arithmetic precision but uses the
+    // ordinary nearest-even store rule for the explicit binary32 narrowing.
+    // Integer coordinate conversion is the separate toward-zero operation.
+    NativeF32Bits::from_bits((f64::from_bits(bits.bits()) as f32).to_bits())
+}
+
+fn f32_to_f64(bits: NativeF32Bits) -> NativeF64Bits {
+    X87Chop53::store_f64(load_f32(bits)).expect("finite binary32 widens to double")
+}
+
+fn add_f32_step_to_f64(value: NativeF64Bits) -> NativeF64Bits {
+    let sum = X87Chop53::add(load_f32(f64_to_f32(value)), load_f32(STEP_F32));
+    X87Chop53::store_f64(sum).expect("Wave fade step remains finite double")
+}
+
+fn f32_le_sum(lhs: NativeF64Bits, rhs: NativeF64Bits, addend: NativeF32Bits) -> bool {
+    let rhs_sum = X87Chop53::add(load_f32(f64_to_f32(rhs)), load_f32(addend));
+    X87Chop53::compare(load_f32(f64_to_f32(lhs)), rhs_sum) != X87Ordering::Greater
+}
+
+fn interpolate(a: ProjectileCoord, b: ProjectileCoord, t: NativeF64Bits) -> ProjectileCoord {
+    let t = load_f64(t);
+    let one_minus_t = X87Chop53::sub(load_f64(NativeF64Bits::ONE), t);
+    let axis = |a: i32, b: i32| {
+        X87Chop53::ftol_i64(X87Chop53::add(
+            X87Chop53::mul(one_minus_t, X87Chop53::load_i32(a)),
+            X87Chop53::mul(t, X87Chop53::load_i32(b)),
+        ))
+        .expect("Wave interpolation remains in map coordinate range") as i32
+    };
+    ProjectileCoord::new(axis(a.x, b.x), axis(a.y, b.y), axis(a.z, b.z))
+}
+
+fn lepton_cell(coord: ProjectileCoord) -> (i32, i32) {
+    (coord.x / 256, coord.y / 256)
+}
+
+fn nonmagnetic_edges(source: ProjectileCoord, target: ProjectileCoord) -> WaveEdgeGeometry {
+    // `WaveClass::Draw_NonMagnetic @ 0x00761640` writes the four cached
+    // vertices in field order. Type 0 uses local offsets (-30,+/-100) and
+    // (+30,+/-100); UpdateCells later pairs vertex 2 -> 0 or 3 -> 1.
+    let dx = f64::from(target.x.wrapping_sub(source.x));
+    let dy = f64::from(target.y.wrapping_sub(source.y));
+    let dz = f64::from(target.z.wrapping_sub(source.z));
+    let horizontal = dx.hypot(dy);
+    if horizontal == 0.0 {
+        return WaveEdgeGeometry::collapsed(source, target);
+    }
+    let angle_magnitude = (dx / horizontal).clamp(-1.0, 1.0).asin();
+    let angle = if source.y > target.y {
+        -angle_magnitude
+    } else {
+        angle_magnitude
+    };
+    let (sin, cos) = angle.sin_cos();
+    let vertex = |offset_x: i32, offset_y: i32| {
+        let local_x = horizontal + f64::from(offset_x);
+        let local_y = f64::from(offset_y);
+        ProjectileCoord::new(
+            (f64::from(source.x) + local_x * cos - local_y * sin).trunc() as i32,
+            (f64::from(source.y) + local_x * sin + local_y * cos).trunc() as i32,
+            (local_x * dz / horizontal + f64::from(source.z)).trunc() as i32,
+        )
+    };
+    WaveEdgeGeometry {
+        firer_a: vertex(-30, -100),
+        firer_b: vertex(-30, 100),
+        target_a: vertex(30, -100),
+        target_b: vertex(30, 100),
     }
 }
 
@@ -267,101 +627,219 @@ impl WaveStore {
 mod tests {
     use super::*;
 
-    fn point() -> ProjectileCoord {
-        ProjectileCoord::new(0, 0, 0)
+    fn flat_cell(rx: u16, ry: u16) -> crate::map::resolved_terrain::ResolvedTerrainCell {
+        crate::map::resolved_terrain::ResolvedTerrainCell {
+            rx,
+            ry,
+            source_tile_index: 0,
+            source_sub_tile: 0,
+            final_tile_index: 0,
+            final_sub_tile: 0,
+            is_wood_bridge_repair_tile: false,
+            level: 0,
+            filled_clear: false,
+            tileset_index: Some(0),
+            land_type: 0,
+            yr_cell_land_type: 0,
+            slope_type: 0,
+            template_height: 0,
+            render_offset_x: 0,
+            render_offset_y: 0,
+            terrain_class: crate::rules::terrain_rules::TerrainClass::Clear,
+            speed_costs: crate::rules::terrain_rules::SpeedCostProfile::default(),
+            is_water: false,
+            is_cliff_like: false,
+            height_in_pixels: 0,
+            variant: 0,
+            is_rough: false,
+            is_road: false,
+            accepts_smudge: false,
+            allows_tiberium: false,
+            has_ramp: false,
+            canonical_ramp: None,
+            ground_walk_blocked: false,
+            terrain_object_blocks: false,
+            terrain_object_occupation: None,
+            overlay_blocks: false,
+            overlay_zone_type: None,
+            outside_playfield: false,
+            zone_type: 0,
+            base_ground_walk_blocked: false,
+            base_build_blocked: false,
+            base_land_type: 0,
+            base_yr_cell_land_type: 0,
+            base_terrain_class: crate::rules::terrain_rules::TerrainClass::Clear,
+            base_speed_costs: crate::rules::terrain_rules::SpeedCostProfile::default(),
+            build_blocked: false,
+            has_bridge_deck: false,
+            bridge_walkable: false,
+            bridge_transition: false,
+            bridge_deck_level: 0,
+            bridge_layer: None,
+            bridge_facts: crate::map::bridge_facts::BridgeCellFacts::default(),
+            tube_index: None,
+            radar_left: [0, 0, 0],
+            radar_right: [0, 0, 0],
+            has_damaged_data: false,
+            bridgehead_anchor_class_at_load: None,
+        }
+    }
+
+    fn flat_terrain(width: u16, height: u16) -> ResolvedTerrainGrid {
+        let cells = (0..height)
+            .flat_map(|ry| (0..width).map(move |rx| flat_cell(rx, ry)))
+            .collect();
+        ResolvedTerrainGrid::from_cells(width, height, cells)
+    }
+
+    fn point(x: i32, y: i32, z: i32) -> ProjectileCoord {
+        ProjectileCoord::new(x, y, z)
+    }
+
+    fn valid_context(target_ref: TargetKind) -> WaveUpdateContext {
+        WaveUpdateContext {
+            owner_position: Some(point(0, 0, 0)),
+            owner_current_target: Some(target_ref),
+            target_position: Some(point(1024, 0, 0)),
+        }
     }
 
     #[test]
-    fn type_zero_lifetime_boundary_matches_yr() {
-        let mut wave = Wave {
-            lifetime: 1,
-            ..Wave::new(0, point(), point())
-        };
-        let survive = wave.advance();
-        assert!(survive.alive);
-        assert_eq!(wave.lifetime, 0);
-        assert!(survive.damage_recorded_cells);
-        assert!(survive.call_object_ai);
-
-        let expired = wave.advance();
-        assert!(!expired.alive);
-        assert_eq!(wave.lifetime, -1);
-        assert!(!expired.call_object_ai);
+    fn constructor_uses_strict_239_240_xy_edge() {
+        assert!(!Wave::new(0, point(0, 0, 0), point(239, 0, 999)).constructor_distance_is_live());
+        assert!(Wave::new(0, point(0, 0, 0), point(240, 0, -999)).constructor_distance_is_live());
     }
 
     #[test]
-    fn laser_intensity_boundary_matches_yr() {
-        let mut survive = Wave {
-            intensity: 38,
-            ..Wave::new(1, point(), point())
-        };
-        assert!(survive.advance().alive);
-        assert_eq!(survive.intensity, 32);
-
-        let mut expired = Wave {
-            intensity: 37,
-            ..Wave::new(2, point(), point())
-        };
-        assert!(!expired.advance().alive);
-        assert_eq!(expired.intensity, 31);
+    fn type_zero_mixed_precision_fade_yields_21_passes_and_stale_terminal_cells() {
+        let target_ref = TargetKind::Cell(4, 0);
+        let ctx = valid_context(target_ref);
+        let mut wave = Wave::new_owned(0, 7, target_ref, point(0, 0, 0), point(1024, 0, 0));
+        assert!(!wave.initialize(ctx, None));
+        assert_eq!(wave.fade_in.bits(), 0x3fa9_9999_a000_0000);
+        let mut passes = 0;
+        let mut ai20_cells = Vec::new();
+        loop {
+            let result = wave.advance(ctx, None);
+            if result.damage_recorded_cells {
+                passes += 1;
+            }
+            if passes == 20 {
+                ai20_cells = wave.recorded_cells.clone();
+            }
+            if !result.alive {
+                assert_eq!(passes, 21);
+                assert_eq!(wave.lifetime, 79);
+                assert_eq!(wave.recorded_cells, ai20_cells);
+                break;
+            }
+        }
     }
 
     #[test]
-    fn fog_gate_and_registration_bucket_are_exact() {
-        let wave = Wave::new(3, point(), point());
-        assert_eq!(wave.registration_bucket(), 3);
-        assert!(!wave.visible_through_fog(true, true, true));
-        assert!(wave.visible_through_fog(false, true, true));
-        assert!(wave.visible_through_fog(true, false, true));
+    fn negative_sampling_deduplicates_shared_dummy_and_keeps_final_restamp() {
+        let terrain = ResolvedTerrainGrid::from_cells(0, 0, Vec::new());
+        let mut wave = Wave::new(0, point(-1024, -1024, 0), point(-256, -256, 50));
+        wave.fade_in = NativeF64Bits::ONE;
+        wave.update_cells(Some(&terrain));
+        assert_eq!(wave.recorded_cells, vec![WaveRecordedCell::shared_dummy()]);
+        assert_eq!(terrain.shared_cell_dummy().snapshot().coord, (-4, -4));
+    }
+
+    #[test]
+    fn active_sampling_excludes_the_target_seed_cell() {
+        let terrain = flat_terrain(8, 1);
+        let mut wave = Wave::new(0, point(0, 0, 0), point(4 * 256, 0, 50));
+        wave.fade_in = f32_to_f64(STEP_F32);
+        wave.update_cells(Some(&terrain));
+        assert_eq!(wave.recorded_cells, vec![WaveRecordedCell::real(3, 0)]);
+        assert!(!wave.recorded_cells.contains(&WaveRecordedCell::real(4, 0)));
+    }
+
+    #[test]
+    fn inactive_sampling_selects_only_the_direction_owned_edge() {
+        let terrain = flat_terrain(12, 1);
+        let mut wave = Wave::new(0, point(0, 0, 0), point(0, 0, 50));
+        wave.active_geometry = false;
+        wave.fade_in = f32_to_f64(STEP_F32);
+        wave.fade_out = f32_to_f64(STEP_F32);
+        wave.edge_geometry = WaveEdgeGeometry {
+            firer_a: point(0, 0, 0),
+            firer_b: point(0, 0, 0),
+            target_a: point(4 * 256, 0, 0),
+            target_b: point(8 * 256, 0, 0),
+        };
+
+        wave.direction_octant = 3;
+        wave.update_cells(Some(&terrain));
+        assert_eq!(wave.recorded_cells, vec![WaveRecordedCell::real(3, 0)]);
+
+        wave.direction_octant = 4;
+        wave.update_cells(Some(&terrain));
+        assert_eq!(wave.recorded_cells, vec![WaveRecordedCell::real(7, 0)]);
+    }
+
+    #[test]
+    fn fixed_stride_alias_and_dummy_reentry_dedupe_by_cellclass_identity() {
+        let terrain = flat_terrain(512, 1);
+        let mut wave = Wave::new(0, point(0, 0, 0), point(1024, 0, 0));
+        wave.lookup_and_append(Some(&terrain), (511, 0));
+        wave.lookup_and_append(Some(&terrain), (-1, 1));
+        wave.lookup_and_append(Some(&terrain), (-20, -30));
+        wave.lookup_and_append(Some(&terrain), (510, 0));
+        wave.lookup_and_append(Some(&terrain), (-40, -50));
+
         assert_eq!(
-            wave.color_mode(),
-            WaveColorMode::FramebufferMagnetronDistortion
-        );
-    }
-
-    #[test]
-    fn store_keeps_waves_until_their_post_decrement_expiry() {
-        let mut store = WaveStore::new();
-        store.spawn(1, Wave {
-            lifetime: 1,
-            ..Wave::new(3, point(), point())
-        });
-        store.advance();
-        assert_eq!(store.len(), 1);
-        store.advance();
-        assert_eq!(store.len(), 0);
-    }
-
-    #[test]
-    fn type_zero_reports_recorded_cells_before_final_uninit_in_native_order() {
-        let payload = WaveDamagePayload {
-            firer_id: 7,
-            base_damage: 20,
-            warhead: InternedId::from_index(3),
-        };
-        let mut wave = Wave {
-            lifetime: 0,
-            ..Wave::new(0, point(), point()).with_damage_payload(payload)
-        };
-        wave.replace_recorded_cells(vec![
-            WaveRecordedCell { rx: 4, ry: 5 },
-            WaveRecordedCell { rx: 4, ry: 5 },
-            WaveRecordedCell { rx: 6, ry: 7 },
-        ]);
-        let mut store = WaveStore::new();
-        let id = store.spawn(1, wave);
-
-        let requests = store.advance();
-        assert_eq!(store.len(), 0);
-        assert_eq!(requests.len(), 1);
-        assert_eq!(requests[0].wave_id, id);
-        assert_eq!(
-            requests[0].recorded_cells,
+            wave.recorded_cells,
             vec![
-                WaveRecordedCell { rx: 4, ry: 5 },
-                WaveRecordedCell { rx: 4, ry: 5 },
-                WaveRecordedCell { rx: 6, ry: 7 },
-            ]
+                WaveRecordedCell::real(511, 0),
+                WaveRecordedCell::shared_dummy(),
+                WaveRecordedCell::real(510, 0),
+            ],
         );
+        assert_eq!(terrain.shared_cell_dummy().snapshot().coord, (-40, -50));
+    }
+
+    #[test]
+    fn type_three_cycles_20_to_64_and_never_requests_damage() {
+        let target_ref = TargetKind::Cell(4, 0);
+        let ctx = valid_context(target_ref);
+        let mut wave = Wave::new_owned(3, 1, target_ref, point(0, 0, 0), point(1024, 0, 0));
+        wave.lifetime = 20;
+        let result = wave.advance(ctx, None);
+        assert_eq!(wave.lifetime, 63);
+        assert_eq!(wave.type3_cycle_count, 1);
+        assert!(!result.damage_recorded_cells);
+    }
+
+    #[test]
+    fn non_type_three_tracking_invalidates_only_when_native_distance_exceeds_2172() {
+        let target_ref = TargetKind::Cell(8, 0);
+        assert_eq!(distance_3d_leptons([0, 0, 0], [2173, 0, 0]), 2172);
+        assert_eq!(distance_3d_leptons([0, 0, 0], [2174, 0, 0]), 2173);
+        let context_at_limit = WaveUpdateContext {
+            owner_position: Some(point(0, 0, 0)),
+            owner_current_target: Some(target_ref),
+            target_position: Some(point(2173, 0, 0)),
+        };
+        let mut at_limit =
+            Wave::new_owned(0, 1, target_ref, point(0, 0, 0), point(2173, 0, 0));
+        let _ = at_limit.advance(context_at_limit, None);
+        assert!(at_limit.active_geometry);
+
+        let context_beyond = WaveUpdateContext {
+            target_position: Some(point(2174, 0, 0)),
+            ..context_at_limit
+        };
+        let mut beyond =
+            Wave::new_owned(0, 1, target_ref, point(0, 0, 0), point(2174, 0, 0));
+        let _ = beyond.advance(context_beyond, None);
+        assert!(!beyond.active_geometry);
+        assert!(beyond.decaying);
+
+        let mut magnetic =
+            Wave::new_owned(3, 1, target_ref, point(0, 0, 0), point(2174, 0, 0));
+        let _ = magnetic.advance(context_beyond, None);
+        assert!(magnetic.active_geometry);
     }
 }

--- a/src/sim/wave.rs
+++ b/src/sim/wave.rs
@@ -513,6 +513,25 @@ impl WaveStore {
         self.waves.remove(&id)
     }
 
+    /// gamemd-derived: `WaveClass::PointerExpired @ 0x0075F610` clears only
+    /// exact object-pointer matches. Cell targets are CellClass pointers and
+    /// therefore cannot match an expiring ObjectClass identity.
+    pub(crate) fn pointer_expired(&mut self, id: u64, expired_id: u64) -> Option<(bool, bool)> {
+        let wave = self.waves.get_mut(&id)?;
+        let owner_cleared = wave.owner_id == Some(expired_id);
+        let target_cleared = matches!(
+            wave.target_ref,
+            Some(TargetKind::Entity(target_id)) if target_id == expired_id
+        );
+        if owner_cleared {
+            wave.owner_id = None;
+        }
+        if target_cleared {
+            wave.target_ref = None;
+        }
+        Some((owner_cleared, target_cleared))
+    }
+
     pub fn spawn(&mut self, id: u64, mut wave: Wave) -> u64 {
         wave.id = id;
         wave.in_logic_vector = false;

--- a/src/sim/world/global_parity_harness_tests.rs
+++ b/src/sim/world/global_parity_harness_tests.rs
@@ -491,7 +491,12 @@ const GLOBAL_HARNESS_PRE_MISSION_V29_HASH: u64 = 0xC5B2_3DFA_C256_6948;
 // AIMD/TeamType/TaskForce, and typed AITrigger authority to the current hash.
 // Both historical probes and all three final RNG fingerprints remain exact,
 // and tick-for-tick record/replay equality passes, proving composition-only.
-const GLOBAL_HARNESS_FINAL_HASH: u64 = 0x0407_5297_2B7A_F360;
+// Re-baselined 2026-08-26 for snapshot/hash schema v103: the empty
+// `active_wave_links` map and empty persisted destroyable-cliff mutation map
+// now join the current hash. Both historical probes, all three final RNG
+// fingerprints, and tick-for-tick record/replay equality remain exact, proving
+// this measured shift is composition-only.
+const GLOBAL_HARNESS_FINAL_HASH: u64 = 0xB90E_9180_E783_1032;
 
 fn harness_ini() -> IniFile {
     // Multi-faction vehicles + infantry + buildings (war factory, refinery) plus a

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -2588,6 +2588,12 @@ impl Simulation {
         }
         let projectile = self.projectiles.remove(stable_id);
         let wave = self.waves.remove(stable_id);
+        if let Some(wave) = wave.as_ref()
+            && let Some(owner_id) = wave.owner_id
+            && self.active_wave_links.get(&owner_id) == Some(&stable_id)
+        {
+            self.active_wave_links.remove(&owner_id);
+        }
         if let Some(system) = particle_system.as_ref()
             && let Some(owner_id) = system.owner_entity
             && let Some(owner) = self.substrate.entities.get_mut(owner_id)

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -2009,6 +2009,7 @@ impl Simulation {
                 .map(|(&stable_id, _)| stable_id),
         );
         listeners.extend(self.projectiles.iter().map(|(&stable_id, _)| stable_id));
+        listeners.extend(self.waves.iter().map(|(&stable_id, _)| stable_id));
         listeners.sort_unstable();
         debug_assert!(
             listeners.windows(2).all(|pair| pair[0] != pair[1]),
@@ -2346,7 +2347,8 @@ impl Simulation {
             let is_anim = self.substrate.anims.contains_key(listener_id);
             let is_particle = self.substrate.particle_systems.contains_key(listener_id);
             let is_projectile = self.projectiles.get(listener_id).is_some();
-            if !is_entity && !is_anim && !is_particle && !is_projectile {
+            let is_wave = self.waves.get(listener_id).is_some();
+            if !is_entity && !is_anim && !is_particle && !is_projectile && !is_wave {
                 continue;
             }
 
@@ -2461,6 +2463,20 @@ impl Simulation {
                             target,
                         },
                     );
+                }
+            } else if is_wave {
+                let (owner_cleared, _) = self
+                    .waves
+                    .pointer_expired(listener_id, expired_id)
+                    .expect("Wave listener disappeared during expiry callback");
+                if owner_cleared
+                    && self.active_wave_links.get(&expired_id) == Some(&listener_id)
+                {
+                    // TechnoClass keeps the Wave link through the dying/deferred
+                    // interval. Once the exact owner pointer expires, retaining
+                    // this Rust projection would serialize a link whose Wave
+                    // owner is now null.
+                    self.active_wave_links.remove(&expired_id);
                 }
             }
         }

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -302,6 +302,14 @@ pub(crate) enum LifecycleTestEvent {
     WaveDamageReceiverSelected {
         wave_id: u64,
         target_id: u64,
+        scenario_rng_state: u64,
+    },
+    /// The FireAt transaction has committed every receiver/effect owned by
+    /// this shot. Wave registration happens at this boundary, but the new
+    /// Logic tail must not dispatch until all later pre-existing callbacks.
+    CombatFireEffectsCommitted {
+        attacker_id: u64,
+        scenario_rng_state: u64,
     },
     UninitAliveCleared {
         stable_id: u64,

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -5142,6 +5142,7 @@ fn wave_elite_ambient_damage_carries_within_cell_and_resets_on_next_cell() {
             LifecycleTestEvent::WaveDamageReceiverSelected {
                 wave_id: selected_wave,
                 target_id,
+                ..
             } if *selected_wave == wave_id => Some(*target_id),
             _ => None,
         })
@@ -5248,6 +5249,7 @@ fn wave_walks_nonbuilding_terrain_building_order_and_terrain_owns_wood_gate() {
                 LifecycleTestEvent::WaveDamageReceiverSelected {
                     wave_id: selected_wave,
                     target_id,
+                    ..
                 } if *selected_wave == wave_id => Some(*target_id),
                 _ => None,
             })
@@ -5648,6 +5650,7 @@ fn gsi_01_05_wave_reselects_live_cell_list_after_fatal_receiver_unmark() {
             LifecycleTestEvent::WaveDamageReceiverSelected {
                 wave_id: selected_wave,
                 target_id,
+                ..
             } if *selected_wave == wave_id => Some(*target_id),
             _ => None,
         })

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -3526,6 +3526,8 @@ fn gsi_05_02_mixed_fixture() -> (Simulation, [u64; 6]) {
 
     let entity_id = sim.allocate_stable_id();
     insert_entity(&mut sim, entity_id, EntityCategory::Unit);
+    sim.substrate.entities.get_mut(entity_id).unwrap().attack_target =
+        Some(AttackTarget::for_cell(1, 0));
     sim.register_live_object(entity_id);
 
     let anim_id = sim.allocate_stable_id();
@@ -3559,8 +3561,10 @@ fn gsi_05_02_mixed_fixture() -> (Simulation, [u64; 6]) {
     let wave_id = sim.allocate_stable_id();
     sim.admit_wave(
         wave_id,
-        Wave::new(
+        Wave::new_owned(
             3,
+            entity_id,
+            TargetKind::Cell(1, 0),
             ProjectileCoord::new(0, 0, 0),
             ProjectileCoord::new(256, 0, 0),
         ),

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -4790,6 +4790,175 @@ fn gsi_01_05_damage_rules() -> crate::rules::ruleset::RuleSet {
 }
 
 #[test]
+fn wave_pointer_expiry_target_survives_dying_then_uninit_starts_decay_tail() {
+    let mut sim = Simulation::new();
+    let owner_id = sim.allocate_stable_id();
+    let target_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, owner_id, EntityCategory::Unit);
+    insert_entity(&mut sim, target_id, EntityCategory::Unit);
+    {
+        let owner = sim.substrate.entities.get_mut(owner_id).unwrap();
+        owner.position.rx = 0;
+        owner.position.ry = 0;
+        owner.attack_target = Some(AttackTarget::new(target_id));
+    }
+    {
+        let target = sim.substrate.entities.get_mut(target_id).unwrap();
+        target.position.rx = 4;
+        target.position.ry = 0;
+        target.health.current = 0;
+        target.dying = true;
+    }
+
+    let wave_id = sim.allocate_stable_id();
+    let wave = Wave::new_owned(
+        0,
+        owner_id,
+        TargetKind::Entity(target_id),
+        ProjectileCoord::new(128, 128, 0),
+        ProjectileCoord::new(4 * 256 + 128, 128, 50),
+    );
+    sim.admit_wave(wave_id, wave);
+    sim.active_wave_links.insert(owner_id, wave_id);
+
+    let represented = sim.wave_update_context(wave_id);
+    assert_eq!(
+        represented.target_position,
+        Some(ProjectileCoord::new(4 * 256 + 128, 128, 0)),
+        "health zero and the death animation do not expire a Wave pointer",
+    );
+    let _ = sim
+        .waves
+        .advance_one(wave_id, represented, sim.resolved_terrain.as_ref())
+        .expect("represented Wave AI");
+    assert!(sim.waves.get(wave_id).unwrap().active_geometry);
+    assert!(!sim.waves.get(wave_id).unwrap().decaying);
+
+    sim.uninit(target_id);
+
+    let wave = sim.waves.get(wave_id).expect("Wave remains represented");
+    assert_eq!(wave.owner_id, Some(owner_id));
+    assert_eq!(wave.target_ref, None, "UnInit synchronously expires +0xAC");
+    assert_eq!(sim.active_wave_links.get(&owner_id), Some(&wave_id));
+    let expired = sim.wave_update_context(wave_id);
+    assert_eq!(expired.target_position, None);
+    let _ = sim
+        .waves
+        .advance_one(wave_id, expired, sim.resolved_terrain.as_ref())
+        .expect("post-expiry Wave AI");
+    let wave = sim.waves.get(wave_id).unwrap();
+    assert!(!wave.active_geometry);
+    assert!(wave.decaying, "null target activates the decay/fade tail");
+}
+
+#[test]
+fn wave_pointer_expiry_owner_allows_dying_damage_then_uninit_nulls_later_calls() {
+    let rules = gsi_01_05_damage_rules();
+    let mut sim = Simulation::new();
+    let owner_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, owner_id, EntityCategory::Unit);
+    {
+        let owner = sim.substrate.entities.get_mut(owner_id).unwrap();
+        owner.type_ref = sim.interner.intern("FIRER");
+        owner.health.current = 0;
+        owner.dying = true;
+        owner.attack_target = Some(AttackTarget::for_cell(4, 5));
+    }
+    let receiver_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, receiver_id, EntityCategory::Unit);
+    {
+        let receiver = sim.substrate.entities.get_mut(receiver_id).unwrap();
+        receiver.type_ref = sim.interner.intern("VICTIM");
+        receiver.health = Health {
+            current: 30,
+            max: 30,
+        };
+    }
+    assert!(matches!(
+        sim.try_reveal_entity(receiver_id, common_raw_request(4, 5, 0, 128, 128)),
+        RevealOutcome::Revealed { .. }
+    ));
+
+    let wave_id = sim.allocate_stable_id();
+    let mut wave = Wave::new_owned(
+        0,
+        owner_id,
+        TargetKind::Cell(4, 5),
+        ProjectileCoord::new(0, 0, 0),
+        ProjectileCoord::new(4 * 256, 5 * 256, 50),
+    );
+    wave.replace_recorded_cells(vec![WaveRecordedCell::real(4, 5)]);
+    sim.admit_wave(wave_id, wave);
+    sim.active_wave_links.insert(owner_id, wave_id);
+    let request = crate::sim::wave::WaveDamageRequest {
+        wave_id,
+        firer_id: owner_id,
+        recorded_cells: vec![WaveRecordedCell::real(4, 5)],
+        wave_z: 0,
+    };
+    assert!(
+        sim.wave_update_context(wave_id).owner_position.is_some(),
+        "the dying-but-represented owner still supplies live Wave coordinates",
+    );
+    assert_eq!(sim.active_wave_links.get(&owner_id), Some(&wave_id));
+
+    sim.commit_logic_wave_damage_request(&rules, None, &request);
+    assert_eq!(
+        sim.substrate.entities.get(receiver_id).unwrap().health.current,
+        20,
+        "DamageArea consults the represented owner pointer, not health/dying state",
+    );
+
+    sim.uninit(owner_id);
+    assert_eq!(sim.waves.get(wave_id).unwrap().owner_id, None);
+    assert_eq!(
+        sim.waves.get(wave_id).unwrap().target_ref,
+        Some(TargetKind::Cell(4, 5)),
+        "owner expiry does not clear an unrelated CellClass target",
+    );
+    assert!(!sim.active_wave_links.contains_key(&owner_id));
+
+    sim.commit_logic_wave_damage_request(&rules, None, &request);
+    assert_eq!(
+        sim.substrate.entities.get(receiver_id).unwrap().health.current,
+        20,
+        "the now-null live owner makes every later DamageArea call a no-op",
+    );
+}
+
+#[test]
+fn wave_pointer_expiry_ignores_unrelated_object_and_preserves_owner_link() {
+    let mut sim = Simulation::new();
+    let owner_id = sim.allocate_stable_id();
+    let target_id = sim.allocate_stable_id();
+    let unrelated_id = sim.allocate_stable_id();
+    for id in [owner_id, target_id, unrelated_id] {
+        insert_entity(&mut sim, id, EntityCategory::Unit);
+    }
+    sim.substrate.entities.get_mut(owner_id).unwrap().attack_target =
+        Some(AttackTarget::new(target_id));
+    let wave_id = sim.allocate_stable_id();
+    sim.admit_wave(
+        wave_id,
+        Wave::new_owned(
+            0,
+            owner_id,
+            TargetKind::Entity(target_id),
+            ProjectileCoord::new(0, 0, 0),
+            ProjectileCoord::new(1_024, 0, 50),
+        ),
+    );
+    sim.active_wave_links.insert(owner_id, wave_id);
+
+    sim.uninit(unrelated_id);
+
+    let wave = sim.waves.get(wave_id).expect("unrelated expiry keeps Wave");
+    assert_eq!(wave.owner_id, Some(owner_id));
+    assert_eq!(wave.target_ref, Some(TargetKind::Entity(target_id)));
+    assert_eq!(sim.active_wave_links.get(&owner_id), Some(&wave_id));
+}
+
+#[test]
 fn gsi_01_05_lethal_bullet_commits_receiver_before_retirement_and_double_compaction() {
     let rules = gsi_01_05_damage_rules();
     let mut sim = Simulation::new();

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -32,7 +32,8 @@ use crate::sim::projectile::{
 };
 use crate::sim::snapshot::{GameSnapshot, SnapshotRestoreError};
 use crate::sim::terrain_object::{TerrainObjectLifecycle, TerrainObjectState};
-use crate::sim::wave::{Wave, WaveDamagePayload, WaveRecordedCell};
+use crate::sim::wave::{Wave, WaveRecordedCell};
+use crate::util::native_x87::NativeF64Bits;
 use crate::util::fixed_math::SimFixed;
 use glam::IVec3;
 
@@ -4772,13 +4773,16 @@ fn gsi_05_04_projectile_listener_keeps_mixed_object_construction_order() {
 fn gsi_01_05_damage_rules() -> crate::rules::ruleset::RuleSet {
     crate::rules::ruleset::RuleSet::from_ini(&crate::rules::ini_parser::IniFile::from_str(
         "[InfantryTypes]\n\
-             [VehicleTypes]\n0=VICTIM\n1=SUCCESSOR\n\
+             [VehicleTypes]\n0=VICTIM\n1=SUCCESSOR\n2=FIRER\n\
              [AircraftTypes]\n\
              [BuildingTypes]\n0=DUPBLDG\n\
              [Warheads]\n0=KILLWH\n\
              [VICTIM]\nStrength=30\nArmor=light\n\
              [SUCCESSOR]\nStrength=30\nArmor=light\n\
+             [FIRER]\nStrength=30\nArmor=light\nPrimary=SONIC\nElitePrimary=SONICE\n\
              [DUPBLDG]\nStrength=10\nArmor=concrete\nFoundation=2x1\n\
+             [SONIC]\nDamage=1\nAmbientDamage=10\nWarhead=KILLWH\nIsSonic=yes\n\
+             [SONICE]\nDamage=2\nAmbientDamage=15\nWarhead=KILLWH\nIsSonic=yes\n\
              [KILLWH]\nCellSpread=0\nPercentAtMax=1\n\
              Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
     ))
@@ -4909,18 +4913,28 @@ fn gsi_01_05_terminal_wave_damages_once_before_single_current_removal() {
     ));
 
     let wave_id = sim.allocate_stable_id();
-    let mut wave = Wave::new(
+    let firer_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, firer_id, EntityCategory::Unit);
+    sim.substrate.entities.get_mut(firer_id).unwrap().type_ref = sim.interner.intern("FIRER");
+    sim.substrate.entities.get_mut(firer_id).unwrap().attack_target = Some(AttackTarget {
+        target: TargetKind::Entity(victim_id),
+        cooldown_ticks: 0,
+        burst_remaining: 0,
+        burst_delay_ticks: 0,
+        pending_infantry_fire: None,
+    });
+    let mut wave = Wave::new_owned(
         0,
+        firer_id,
+        TargetKind::Entity(victim_id),
         ProjectileCoord::new(4 * 256, 5 * 256, 0),
         ProjectileCoord::new(5 * 256, 5 * 256, 0),
-    )
-    .with_damage_payload(WaveDamagePayload {
-        firer_id: crate::sim::combat::RAD_NO_ATTACKER,
-        base_damage: 10,
-        warhead: sim.interner.intern("KILLWH"),
-    });
-    wave.lifetime = 0;
-    wave.replace_recorded_cells(vec![WaveRecordedCell { rx: 4, ry: 5 }]);
+    );
+    wave.active_geometry = false;
+    wave.decaying = true;
+    wave.fade_in = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+    wave.fade_out = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+    wave.replace_recorded_cells(vec![WaveRecordedCell::real(4, 5)]);
     sim.admit_wave(wave_id, wave);
     sim.set_logic_order_for_test(vec![wave_id, victim_id, successor_id]);
     sim.lifecycle_test_events.clear();
@@ -4981,6 +4995,597 @@ fn gsi_01_05_terminal_wave_damages_once_before_single_current_removal() {
 }
 
 #[test]
+fn terminal_type_zero_wave_with_empty_recorded_vector_has_no_damage_area_tail() {
+    let rules = gsi_01_05_damage_rules();
+    let mut sim = Simulation::new();
+    let firer_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, firer_id, EntityCategory::Unit);
+    {
+        let firer = sim.substrate.entities.get_mut(firer_id).unwrap();
+        firer.type_ref = sim.interner.intern("FIRER");
+        firer.attack_target = Some(AttackTarget {
+            target: TargetKind::Cell(4, 5),
+            cooldown_ticks: 0,
+            burst_remaining: 0,
+            burst_delay_ticks: 0,
+            pending_infantry_fire: None,
+        });
+    }
+    let wave_id = sim.allocate_stable_id();
+    let mut wave = Wave::new_owned(
+        0,
+        firer_id,
+        TargetKind::Cell(4, 5),
+        ProjectileCoord::new(4 * 256, 5 * 256, 0),
+        ProjectileCoord::new(5 * 256, 5 * 256, 0),
+    );
+    wave.active_geometry = false;
+    wave.decaying = true;
+    wave.fade_in = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+    wave.fade_out = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+    sim.admit_wave(wave_id, wave);
+    sim.active_wave_links.insert(firer_id, wave_id);
+    sim.scenario_rng = crate::sim::rng::SimRng::new(0x45_4d_50_54_59);
+    let expected_rng = sim.scenario_rng.logical_state();
+
+    assert!(sim.object_ai_visit_one(
+        wave_id,
+        Some(&rules),
+        ObjectAiCtx::default()
+    ));
+
+    assert_eq!(sim.scenario_rng.logical_state(), expected_rng);
+    assert!(sim.active_wave_links.get(&firer_id).is_none());
+    assert!(sim.pending_wave_damage_requests.is_empty());
+    assert!(sim.dynamic_terrain_cells.is_empty());
+    assert!(sim.radar_terrain_dirty_cells.is_empty());
+    assert!(sim.tactical_dirty_cells.is_empty());
+    assert_eq!(sim.substrate.pending_delete, vec![wave_id]);
+}
+
+#[test]
+fn wave_elite_ambient_damage_carries_within_cell_and_resets_on_next_cell() {
+    let rules = crate::rules::ruleset::RuleSet::from_ini(
+        &crate::rules::ini_parser::IniFile::from_str(
+            "[InfantryTypes]\n\
+             [VehicleTypes]\n0=FIRST\n1=SECOND\n2=NEXT\n3=FIRER\n\
+             [AircraftTypes]\n[BuildingTypes]\n\
+             [FIRST]\nStrength=100\nArmor=flak\n\
+             [SECOND]\nStrength=100\nArmor=none\n\
+             [NEXT]\nStrength=100\nArmor=none\n\
+             [FIRER]\nStrength=100\nArmor=light\nPrimary=SONIC\nElitePrimary=SONICE\n\
+             [SONIC]\nDamage=4\nAmbientDamage=10\nWarhead=WH\nIsSonic=yes\n\
+             [SONICE]\nDamage=8\nAmbientDamage=15\nWarhead=WH\nIsSonic=yes\n\
+             [WH]\nCellSpread=0\nPercentAtMax=1\n\
+             Verses=100%,50%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+        ),
+    )
+    .expect("Wave shared-damage fixture");
+    let mut sim = Simulation::new();
+    let second_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, second_id, EntityCategory::Unit);
+    sim.substrate.entities.get_mut(second_id).unwrap().type_ref = sim.interner.intern("SECOND");
+    assert!(matches!(
+        sim.try_reveal_entity(second_id, common_raw_request(4, 5, 0, 128, 128)),
+        RevealOutcome::Revealed { .. }
+    ));
+
+    let first_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, first_id, EntityCategory::Unit);
+    sim.substrate.entities.get_mut(first_id).unwrap().type_ref = sim.interner.intern("FIRST");
+    assert!(matches!(
+        sim.try_reveal_entity(first_id, common_raw_request(4, 5, 0, 128, 128)),
+        RevealOutcome::Revealed { .. }
+    ));
+
+    let next_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, next_id, EntityCategory::Unit);
+    sim.substrate.entities.get_mut(next_id).unwrap().type_ref = sim.interner.intern("NEXT");
+    assert!(matches!(
+        sim.try_reveal_entity(next_id, common_raw_request(5, 5, 0, 128, 128)),
+        RevealOutcome::Revealed { .. }
+    ));
+
+    let firer_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, firer_id, EntityCategory::Unit);
+    {
+        let firer = sim.substrate.entities.get_mut(firer_id).unwrap();
+        firer.type_ref = sim.interner.intern("FIRER");
+        firer.veterancy = 200;
+        firer.attack_target = Some(AttackTarget {
+            target: TargetKind::Entity(next_id),
+            cooldown_ticks: 0,
+            burst_remaining: 0,
+            burst_delay_ticks: 0,
+            pending_infantry_fire: None,
+        });
+    }
+
+    let wave_id = sim.allocate_stable_id();
+    let mut wave = Wave::new_owned(
+        0,
+        firer_id,
+        TargetKind::Entity(next_id),
+        ProjectileCoord::new(4 * 256, 5 * 256, 0),
+        ProjectileCoord::new(6 * 256, 5 * 256, 0),
+    );
+    wave.active_geometry = false;
+    wave.decaying = true;
+    wave.fade_in = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+    wave.fade_out = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+    wave.replace_recorded_cells(vec![
+        WaveRecordedCell::real(4, 5),
+        WaveRecordedCell::real(5, 5),
+    ]);
+    sim.admit_wave(wave_id, wave);
+    sim.active_wave_links.insert(firer_id, wave_id);
+    sim.lifecycle_test_events.clear();
+
+    assert!(sim.object_ai_visit_one(wave_id, Some(&rules), ObjectAiCtx::default()));
+
+    assert_eq!(sim.substrate.entities.get(first_id).unwrap().health.current, 93);
+    assert_eq!(
+        sim.substrate.entities.get(second_id).unwrap().health.current,
+        93,
+        "second occupant receives the first callback's 7-point mutable value",
+    );
+    assert_eq!(
+        sim.substrate.entities.get(next_id).unwrap().health.current,
+        85,
+        "the next recorded cell reloads elite AmbientDamage=15, never Damage=8",
+    );
+    assert!(!sim.active_wave_links.contains_key(&firer_id));
+    let selected = sim
+        .lifecycle_test_events
+        .iter()
+        .filter_map(|event| match event {
+            LifecycleTestEvent::WaveDamageReceiverSelected {
+                wave_id: selected_wave,
+                target_id,
+            } if *selected_wave == wave_id => Some(*target_id),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(selected, vec![first_id, second_id, next_id]);
+}
+
+#[test]
+fn wave_walks_nonbuilding_terrain_building_order_and_terrain_owns_wood_gate() {
+    fn run(wood: bool) -> (Vec<u64>, i32, i32, i32) {
+        let rules = crate::rules::ruleset::RuleSet::from_ini(
+            &crate::rules::ini_parser::IniFile::from_str(&format!(
+                "[InfantryTypes]\n\
+                 [VehicleTypes]\n0=UNIT\n1=FIRER\n\
+                 [AircraftTypes]\n\
+                 [BuildingTypes]\n0=BLDG\n\
+                 [TerrainTypes]\n0=TREE01\n\
+                 [UNIT]\nStrength=100\nArmor=none\n\
+                 [BLDG]\nStrength=100\nArmor=wood\nFoundation=1x1\n\
+                 [FIRER]\nStrength=100\nArmor=light\nPrimary=SONIC\n\
+                 [TREE01]\nStrength=100\nArmor=wood\nImmune=no\n\
+                 [SONIC]\nDamage=4\nAmbientDamage=10\nWarhead=WH\nIsSonic=yes\n\
+                 [WH]\nWood={}\nCellSpread=0\nPercentAtMax=1\n\
+                 Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+                if wood { "yes" } else { "no" },
+            )),
+        )
+        .expect("Wave Terrain fixture");
+        let mut sim = Simulation::new();
+
+        let unit_id = sim.allocate_stable_id();
+        insert_entity(&mut sim, unit_id, EntityCategory::Unit);
+        sim.substrate.entities.get_mut(unit_id).unwrap().type_ref = sim.interner.intern("UNIT");
+        assert!(matches!(
+            sim.try_reveal_entity(unit_id, common_raw_request(4, 5, 0, 128, 128)),
+            RevealOutcome::Revealed { .. }
+        ));
+
+        let building_id = sim.allocate_stable_id();
+        insert_entity(&mut sim, building_id, EntityCategory::Structure);
+        {
+            let building = sim.substrate.entities.get_mut(building_id).unwrap();
+            building.type_ref = sim.interner.intern("BLDG");
+            building.foundation = "1x1".to_string();
+        }
+        assert!(matches!(
+            sim.try_reveal_entity(building_id, common_raw_request(4, 5, 0, 128, 128)),
+            RevealOutcome::Revealed { .. }
+        ));
+
+        let terrain_id = sim.allocate_stable_id();
+        sim.production.terrain_objects.insert(
+            terrain_id,
+            TerrainObjectState {
+                stable_id: terrain_id,
+                in_logic_vector: false,
+                type_ref: sim.interner.intern("TREE01"),
+                rx: 4,
+                ry: 5,
+                health: 100,
+                max_health: 100,
+                occupation_bits: 0,
+                lifecycle: TerrainObjectLifecycle::Live,
+            },
+        );
+        sim.production
+            .terrain_object_cells
+            .insert((4, 5), terrain_id);
+
+        let firer_id = sim.allocate_stable_id();
+        insert_entity(&mut sim, firer_id, EntityCategory::Unit);
+        {
+            let firer = sim.substrate.entities.get_mut(firer_id).unwrap();
+            firer.type_ref = sim.interner.intern("FIRER");
+            firer.attack_target = Some(AttackTarget {
+                target: TargetKind::Entity(building_id),
+                cooldown_ticks: 0,
+                burst_remaining: 0,
+                burst_delay_ticks: 0,
+                pending_infantry_fire: None,
+            });
+        }
+        let wave_id = sim.allocate_stable_id();
+        let mut wave = Wave::new_owned(
+            0,
+            firer_id,
+            TargetKind::Entity(building_id),
+            ProjectileCoord::new(4 * 256, 5 * 256, 0),
+            ProjectileCoord::new(6 * 256, 5 * 256, 0),
+        );
+        wave.active_geometry = false;
+        wave.decaying = true;
+        wave.fade_in = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+        wave.fade_out = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+        wave.replace_recorded_cells(vec![WaveRecordedCell::real(4, 5)]);
+        sim.admit_wave(wave_id, wave);
+        sim.lifecycle_test_events.clear();
+
+        assert!(sim.object_ai_visit_one(wave_id, Some(&rules), ObjectAiCtx::default()));
+        let selected = sim
+            .lifecycle_test_events
+            .iter()
+            .filter_map(|event| match event {
+                LifecycleTestEvent::WaveDamageReceiverSelected {
+                    wave_id: selected_wave,
+                    target_id,
+                } if *selected_wave == wave_id => Some(*target_id),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        (
+            selected,
+            i32::from(sim.substrate.entities.get(unit_id).unwrap().health.current),
+            sim.production.terrain_objects[&terrain_id].health,
+            i32::from(sim.substrate
+                .entities
+                .get(building_id)
+                .unwrap()
+                .health
+                .current),
+        )
+    }
+
+    let (selected, unit_health, tree_health, building_health) = run(true);
+    assert_eq!(
+        selected,
+        vec![1, 3, 2],
+        "one-cell order is nonbuilding, Terrain, then Building",
+    );
+    assert_eq!(unit_health, 90);
+    assert_eq!(tree_health, 90);
+    assert_eq!(building_health, 90);
+
+    let (_, unit_health, tree_health, building_health) = run(false);
+    assert_eq!(unit_health, 90);
+    assert_eq!(tree_health, 100, "TerrainClass owns the Warhead Wood gate");
+    assert_eq!(building_health, 90);
+}
+
+#[test]
+fn wave_tail_consumes_wall_roll_before_mandatory_cliff_chance_roll() {
+    let ini = crate::rules::ini_parser::IniFile::from_str(
+        "[CombatDamage]\nCollapseChance=0\n\
+         [InfantryTypes]\n\
+         [VehicleTypes]\n0=FIRER\n\
+         [AircraftTypes]\n[BuildingTypes]\n\
+         [OverlayTypes]\n0=WALLX\n\
+         [FIRER]\nStrength=100\nArmor=light\nPrimary=SONIC\n\
+         [SONIC]\nDamage=4\nAmbientDamage=10\nWarhead=WH\nIsSonic=yes\n\
+         [WH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+         [WALLX]\nWall=yes\nChainReaction=yes\nStrength=100\nDamageLevels=4\n",
+    );
+    let rules = crate::rules::ruleset::RuleSet::from_ini(&ini).expect("wall+cliff rules");
+    let registry = crate::map::overlay_types::OverlayTypeRegistry::from_ini(&ini, None);
+    let mut sim = Simulation::new();
+    let firer_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, firer_id, EntityCategory::Unit);
+    {
+        let firer = sim.substrate.entities.get_mut(firer_id).unwrap();
+        firer.type_ref = sim.interner.intern("FIRER");
+        firer.attack_target = Some(AttackTarget {
+            target: TargetKind::Cell(4, 1),
+            cooldown_ticks: 0,
+            burst_remaining: 0,
+            burst_delay_ticks: 0,
+            pending_infantry_fire: None,
+        });
+    }
+
+    let mut cells = Vec::new();
+    for ry in 0..4 {
+        for rx in 0..6 {
+            let mut cell = common_raw_terrain_cell(rx, ry, 1, false);
+            let sub_tile = (ry * 6 + rx) as u8;
+            if ![0, 5, 18, 23].contains(&usize::from(sub_tile)) {
+                cell.final_tile_index = 100;
+                cell.final_sub_tile = sub_tile;
+            }
+            cells.push(cell);
+        }
+    }
+    let mut terrain = ResolvedTerrainGrid::from_cells(6, 4, cells);
+    terrain.test_install_destroyable_cliff_catalog(100);
+    sim.resolved_terrain = Some(terrain);
+    let mut overlay = crate::sim::overlay_grid::OverlayGrid::new(6, 4);
+    overlay.place_overlay(
+        4,
+        1,
+        registry.id_for_name("WALLX").expect("wall overlay"),
+        0,
+    );
+    sim.overlay_grid = Some(overlay);
+
+    let wave_id = sim.allocate_stable_id();
+    let mut wave = Wave::new_owned(
+        0,
+        firer_id,
+        TargetKind::Cell(4, 1),
+        ProjectileCoord::new(0, 0, 0),
+        ProjectileCoord::new(4 * 256, 256, 50),
+    );
+    wave.active_geometry = false;
+    wave.decaying = true;
+    wave.fade_in = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+    wave.fade_out = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+    wave.replace_recorded_cells(vec![WaveRecordedCell::real(4, 1)]);
+    sim.admit_wave(wave_id, wave);
+
+    sim.scenario_rng = crate::sim::rng::SimRng::new(0x57_41_4c_4c);
+    let mut expected = sim.scenario_rng.clone();
+    let _wall_roll = expected.next_range_u32_inclusive(0, 100);
+    let _cliff_chance_roll = expected.next_range_u32_inclusive(0, 99);
+
+    assert!(sim.object_ai_visit_one(
+        wave_id,
+        Some(&rules),
+        ObjectAiCtx {
+            overlay_registry: Some(&registry),
+            ..ObjectAiCtx::default()
+        },
+    ));
+
+    assert_eq!(sim.scenario_rng.logical_state(), expected.logical_state());
+    assert!(sim
+        .resolved_terrain
+        .as_ref()
+        .unwrap()
+        .is_destroyable_cliff(4, 1));
+    assert!(sim.dynamic_terrain_cells.is_empty());
+}
+
+#[test]
+fn wave_cliff_collapse_consumes_exact_body_rng_and_spawns_row_major_anims() {
+    let ini = crate::rules::ini_parser::IniFile::from_str(
+        "[CombatDamage]\nCollapseChance=100\n\
+         [InfantryTypes]\n\
+         [VehicleTypes]\n0=FIRER\n\
+         [AircraftTypes]\n[BuildingTypes]\n[OverlayTypes]\n0=DECAL\n\
+         [FIRER]\nStrength=100\nArmor=light\nPrimary=SONIC\n\
+         [SONIC]\nDamage=4\nAmbientDamage=10\nWarhead=WH\nIsSonic=yes\n\
+         [WH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+         [DECAL]\n",
+    );
+    let mut rules = crate::rules::ruleset::RuleSet::from_ini(&ini).expect("cliff body rules");
+    let overlay_registry = crate::map::overlay_types::OverlayTypeRegistry::from_ini(&ini, None);
+    let mut art = crate::rules::art_data::ArtRegistry::from_ini(
+        &crate::rules::ini_parser::IniFile::from_str(
+            "[XGRYMED1]\nEnd=1\nRate=1\nRandomRate=900,300\n\
+             [XGRYMED2]\nEnd=1\nRate=1\nRandomRate=900,300\n\
+             [XGRYSML1]\nEnd=1\nRate=1\nRandomRate=900,300\n",
+        ),
+    );
+    for name in ["XGRYMED1", "XGRYMED2", "XGRYSML1"] {
+        art.bind_anim_frame_count_for_test(name, 1);
+    }
+    rules.merge_art_data(&art);
+    let mut sim = Simulation::new();
+    let firer_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, firer_id, EntityCategory::Unit);
+    {
+        let firer = sim.substrate.entities.get_mut(firer_id).unwrap();
+        firer.type_ref = sim.interner.intern("FIRER");
+        firer.attack_target = Some(AttackTarget {
+            target: TargetKind::Cell(4, 1),
+            cooldown_ticks: 0,
+            burst_remaining: 0,
+            burst_delay_ticks: 0,
+            pending_infantry_fire: None,
+        });
+    }
+    let mut cells = Vec::new();
+    for ry in 0..4 {
+        for rx in 0..6 {
+            let mut cell = common_raw_terrain_cell(rx, ry, 1, false);
+            let sub_tile = (ry * 6 + rx) as u8;
+            if ![0, 5, 18, 23].contains(&usize::from(sub_tile)) {
+                cell.final_tile_index = 100;
+                cell.final_sub_tile = sub_tile;
+            }
+            cells.push(cell);
+        }
+    }
+    let mut terrain = ResolvedTerrainGrid::from_cells(6, 4, cells);
+    terrain.test_install_destroyable_cliff_catalog(100);
+    let pristine_terrain = terrain.clone();
+    sim.resolved_terrain = Some(terrain);
+    let mut overlay = crate::sim::overlay_grid::OverlayGrid::new(6, 4);
+    let decal = overlay_registry.id_for_name("DECAL").expect("test decal");
+    overlay.place_overlay(0, 0, decal, 11);
+    overlay.place_overlay(1, 0, decal, 12);
+    sim.overlay_grid = Some(overlay);
+    let mut smudge = crate::sim::smudge_grid::SmudgeGrid::new(6, 4);
+    for (rx, frame_offset) in [(0, 0), (1, 1)] {
+        smudge.test_force_set(
+            rx,
+            0,
+            crate::sim::smudge_grid::SmudgeCell {
+                type_id: Some(9),
+                footprint_origin: Some((0, 0)),
+                frame_offset,
+            },
+        );
+    }
+    sim.smudge_grid = Some(smudge);
+
+    let wave_id = sim.allocate_stable_id();
+    let mut wave = Wave::new_owned(
+        0,
+        firer_id,
+        TargetKind::Cell(4, 1),
+        ProjectileCoord::new(0, 0, 0),
+        ProjectileCoord::new(4 * 256, 256, 50),
+    );
+    wave.active_geometry = false;
+    wave.decaying = true;
+    wave.fade_in = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+    wave.fade_out = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+    wave.replace_recorded_cells(vec![WaveRecordedCell::real(4, 1)]);
+    sim.admit_wave(wave_id, wave);
+
+    sim.scenario_rng = crate::sim::rng::SimRng::new(0x43_4c_49_46_46);
+    let mut expected_rng = sim.scenario_rng.clone();
+    let chance = expected_rng.next_range_u32_inclusive(0, 99);
+    assert!(chance < 100);
+    let mut expected_spawns = Vec::new();
+    for ry in 0..3i32 {
+        for rx in 0..5i32 {
+            for _ in 0..2 {
+                let type_index = expected_rng.next_range_u32_inclusive(0, 2) as usize;
+                let jitter_x = expected_rng.next_range_u32_inclusive(0, 16) as i32 - 8;
+                let jitter_y = expected_rng.next_range_u32_inclusive(0, 24) as i32 - 12;
+                let delay = expected_rng.next_range_u32_inclusive(0, 2) as u16;
+                let rate = expected_rng.next_range_u32_inclusive(1, 3) as u16;
+                expected_spawns.push((
+                    type_index,
+                    AnimWorldCoord {
+                        x: rx * 256 + 128 + jitter_x,
+                        y: ry * 256 + 128 + jitter_y,
+                        z: 104,
+                    },
+                    delay,
+                    rate,
+                ));
+            }
+        }
+    }
+
+    assert!(sim.object_ai_visit_one(
+        wave_id,
+        Some(&rules),
+        ObjectAiCtx {
+            overlay_registry: Some(&overlay_registry),
+            ..ObjectAiCtx::default()
+        },
+    ));
+
+    assert_eq!(sim.scenario_rng.logical_state(), expected_rng.logical_state());
+    assert_eq!(sim.dynamic_terrain_cells.len(), 20);
+    assert_eq!(sim.radar_terrain_dirty_cells.len(), 20);
+    assert_eq!(sim.tactical_dirty_cells.len(), 20);
+    let overlay = sim.overlay_grid.as_ref().unwrap();
+    assert_eq!(overlay.cell(1, 0).overlay_id, None);
+    assert_eq!(overlay.cell(0, 0).overlay_id, Some(decal), "sparse hole untouched");
+    let smudge = sim.smudge_grid.as_ref().unwrap();
+    assert_eq!(smudge.cell(1, 0), &crate::sim::smudge_grid::SmudgeCell::default());
+    assert_eq!(smudge.cell(0, 0).type_id, Some(9), "raw clear must not expand footprint");
+    assert_eq!(sim.substrate.anims.len(), 30);
+    let names = ["XGRYMED1", "XGRYMED2", "XGRYSML1"];
+    let actual_spawns = sim
+        .substrate
+        .anims
+        .iter()
+        .map(|(_, anim)| {
+            (
+                names
+                    .iter()
+                    .position(|name| *name == sim.interner.resolve(anim.type_id))
+                    .expect("one of the three cliff anim types"),
+                anim.world_coord,
+                anim.runtime.delay_remaining,
+                anim.runtime.rate_reload,
+                anim.draw_flags,
+                anim.runtime.loop_remaining,
+                anim.runtime.constructor_reverse,
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        actual_spawns,
+        expected_spawns
+            .into_iter()
+            .map(|(kind, coord, delay, rate)| {
+                (kind, coord, delay, rate, 0x600, 1, false)
+            })
+            .collect::<Vec<_>>(),
+    );
+    assert!(sim
+        .substrate
+        .entities
+        .get(firer_id)
+        .unwrap()
+        .attack_target
+        .is_none());
+
+    // GameSnapshot's established full-deserialize seam canonicalizes Scenario
+    // RNG to seed zero; the collapse draw-order assertion above already pins
+    // the live cursor before normalizing this independent snapshot fixture.
+    sim.scenario_rng = crate::sim::rng::SimRng::new(0);
+    let expected_dynamic_terrain = sim.dynamic_terrain_cells.clone();
+    let expected_hash = sim.state_hash();
+    let bytes = GameSnapshot::save(&sim, 0, 0, "collapsed-dcliff", 0);
+    let mut restored = GameSnapshot::load(&bytes).expect("collapsed cliff snapshot").sim;
+    restored
+        .restore_after_snapshot_load()
+        .expect("collapsed cliff stable identities");
+    assert_eq!(
+        restored.state_hash(),
+        expected_hash,
+        "serialized collapse state must hash equally before derived map caches rebuild",
+    );
+    restored.rebuild_caches_after_load(
+        pristine_terrain,
+        Default::default(),
+        Vec::new(),
+        Vec::new(),
+        BTreeMap::new(),
+    );
+    restored
+        .restore_map_authority_after_snapshot_load(&rules, &overlay_registry)
+        .expect("dynamic cliff terrain reprojects over the pristine map");
+    assert_eq!(restored.dynamic_terrain_cells, expected_dynamic_terrain);
+    assert_eq!(restored.state_hash(), expected_hash);
+    let restored_terrain = restored.resolved_terrain.as_ref().unwrap();
+    for (&(rx, ry), expected) in &expected_dynamic_terrain {
+        assert_eq!(
+            crate::map::resolved_terrain::DynamicTerrainCellState::capture(
+                restored_terrain.cell(rx, ry).unwrap(),
+            ),
+            *expected,
+        );
+    }
+}
+
+#[test]
 fn gsi_01_05_wave_reselects_live_cell_list_after_fatal_receiver_unmark() {
     let rules = gsi_01_05_damage_rules();
     let mut sim = Simulation::new();
@@ -5005,20 +5610,30 @@ fn gsi_01_05_wave_reselects_live_cell_list_after_fatal_receiver_unmark() {
     assert!(sim.substrate.occupancy.contains_entity(5, 5, building_id));
 
     let wave_id = sim.allocate_stable_id();
-    let mut wave = Wave::new(
+    let firer_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, firer_id, EntityCategory::Unit);
+    sim.substrate.entities.get_mut(firer_id).unwrap().type_ref = sim.interner.intern("FIRER");
+    sim.substrate.entities.get_mut(firer_id).unwrap().attack_target = Some(AttackTarget {
+        target: TargetKind::Entity(building_id),
+        cooldown_ticks: 0,
+        burst_remaining: 0,
+        burst_delay_ticks: 0,
+        pending_infantry_fire: None,
+    });
+    let mut wave = Wave::new_owned(
         0,
+        firer_id,
+        TargetKind::Entity(building_id),
         ProjectileCoord::new(4 * 256, 5 * 256, 0),
         ProjectileCoord::new(6 * 256, 5 * 256, 0),
-    )
-    .with_damage_payload(WaveDamagePayload {
-        firer_id: crate::sim::combat::RAD_NO_ATTACKER,
-        base_damage: 10,
-        warhead: sim.interner.intern("KILLWH"),
-    });
-    wave.lifetime = 0;
+    );
+    wave.active_geometry = false;
+    wave.decaying = true;
+    wave.fade_in = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+    wave.fade_out = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
     wave.replace_recorded_cells(vec![
-        WaveRecordedCell { rx: 4, ry: 5 },
-        WaveRecordedCell { rx: 5, ry: 5 },
+        WaveRecordedCell::real(4, 5),
+        WaveRecordedCell::real(5, 5),
     ]);
     sim.admit_wave(wave_id, wave);
     sim.set_logic_order_for_test(vec![wave_id, building_id]);

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -2406,7 +2406,7 @@ impl Simulation {
             self.real_cell_bridge_flags_0x1180 = terrain.capture_real_cell_bridge_flags_0x1180();
         }
         self.sound_events = sound_events;
-        self.merge_receiver_anger_state(&houses);
+        self.merge_receiver_house_state(&houses);
         self.absorb_noncombat_damage_effects(
             rules,
             overlay_registry,

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -1932,6 +1932,19 @@ impl Simulation {
         overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
         request: &crate::sim::wave::WaveDamageRequest,
     ) {
+        // DamageArea reads WaveClass+0x1D4 at the call boundary. Health and
+        // Rust death-animation state do not null that pointer; only the exact
+        // PointerExpired callback does. Revalidate the buffered fixture path
+        // against the live Wave so an intervening owner UnInit still aborts.
+        if self
+            .waves
+            .get(request.wave_id)
+            .and_then(|wave| wave.owner_id)
+            != Some(request.firer_id)
+        {
+            return;
+        }
+
         #[derive(Clone, Copy, PartialEq, Eq)]
         enum CellObject {
             Entity(u64),
@@ -2001,10 +2014,7 @@ impl Simulation {
                 // GetWeapon(0) is re-entered exactly once per cell, with the
                 // owner's current rank. A null owner aborts DamageArea before
                 // any receiver, wall, cliff, or RNG work.
-                let Some(firer) = entities
-                    .get(request.firer_id)
-                    .filter(|firer| firer.is_alive() && !firer.dying)
-                else {
+                let Some(firer) = entities.get(request.firer_id) else {
                     break;
                 };
                 let Some(object_type) = rules.object(interner.resolve(firer.type_ref)) else {

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -1453,6 +1453,41 @@ impl crate::sim::combat::CombatInlineHooks for SimulationCombatInlineHooks<'_> {
 }
 
 impl Simulation {
+    /// Resolve the CellClass identity returned by MapClass::Get_CellClass and
+    /// then dispatch its live GetTargetCoords virtual. Fixed-stride aliases
+    /// therefore use the returned real CellClass's canonical coordinate, while
+    /// misses retain and restamp the one process-global dummy identity.
+    fn wave_cell_target_position(&self, rx: u16, ry: u16) -> ProjectileCoord {
+        use crate::sim::cell_rect::{CellRef, get_cellclass_fallback};
+
+        match get_cellclass_fallback(
+            self.resolved_terrain.as_ref(),
+            i32::from(rx),
+            i32::from(ry),
+        ) {
+            CellRef::Real(cell) => crate::sim::projectile::cell_target_coord(
+                self.resolved_terrain.as_ref(),
+                cell.rx,
+                cell.ry,
+            ),
+            CellRef::Dummy { cell } => {
+                let live_dummy = if self.resolved_terrain.is_some() {
+                    cell
+                } else {
+                    // A mapless lookup still addresses Simulation's retained
+                    // process dummy. The fallback supplies native i16 packing;
+                    // restamp only its coordinate so live level/slope/bridge
+                    // bytes remain authoritative.
+                    let coord = cell.snapshot().coord;
+                    let live_dummy = self.effective_shared_cell_dummy();
+                    live_dummy.stamp_coord(coord.0, coord.1);
+                    live_dummy
+                };
+                crate::sim::projectile::dummy_cell_target_coord(&live_dummy)
+            }
+        }
+    }
+
     /// Combat borrows a staged house map while fatal lifecycle hooks temporarily
     /// re-enter `Simulation`. Merge only receiver-owned fields back so live
     /// lifecycle mutations to strategy mode, counts, economy, or defeat state
@@ -1804,23 +1839,7 @@ impl Simulation {
                 )
             }
             crate::sim::combat::TargetKind::Cell(rx, ry) => {
-                let x = i32::from(rx) * 256 + 128;
-                let y = i32::from(ry) * 256 + 128;
-                let z = self
-                    .resolved_terrain
-                    .as_ref()
-                    .and_then(|terrain| terrain.cell(rx, ry))
-                    .and_then(|cell| {
-                        crate::util::lepton::ground_height_leptons(
-                            cell.level,
-                            cell.slope_type,
-                            x,
-                            y,
-                        )
-                        .ok()
-                    })
-                    .unwrap_or(0);
-                ProjectileCoord::new(x, y, z)
+                self.wave_cell_target_position(rx, ry)
             }
         };
         let source = self

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -1102,10 +1102,13 @@ struct SimulationCombatInlineHooks<'a> {
 
 impl crate::sim::combat::CombatInlineHooks for SimulationCombatInlineHooks<'_> {
     #[cfg(test)]
-    fn trace_wave_receiver(&mut self, wave_id: u64, target_id: u64) {
-        self.sim.trace_lifecycle_for_test(
-            LifecycleTestEvent::WaveDamageReceiverSelected { wave_id, target_id },
-        );
+    fn trace_wave_receiver(&mut self, wave_id: u64, target_id: u64, scenario_rng_state: u64) {
+        self.sim
+            .trace_lifecycle_for_test(LifecycleTestEvent::WaveDamageReceiverSelected {
+                wave_id,
+                target_id,
+                scenario_rng_state,
+            });
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1129,6 +1132,13 @@ impl crate::sim::combat::CombatInlineHooks for SimulationCombatInlineHooks<'_> {
         >,
         borrowed_sound_events: Option<&mut Vec<SimSoundEvent>>,
     ) {
+        #[cfg(test)]
+        self.sim
+            .trace_lifecycle_for_test(LifecycleTestEvent::CombatFireEffectsCommitted {
+                attacker_id: event.attacker_id,
+                scenario_rng_state: borrowed_scenario_rng.state(),
+            });
+
         std::mem::swap(&mut self.sim.substrate.entities, borrowed_entities);
         std::mem::swap(&mut self.sim.substrate.occupancy, borrowed_occupancy);
         std::mem::swap(&mut self.sim.interner, borrowed_interner);
@@ -1764,7 +1774,7 @@ impl Simulation {
     fn create_wave_from_fire_event(
         &mut self,
         rules: &RuleSet,
-        overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+        _overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
         event: &SimFireEvent,
     ) {
         let Some(weapon) = rules.weapon(self.interner.resolve(event.weapon_id)) else {
@@ -1865,19 +1875,33 @@ impl Simulation {
         let _terminal = wave.initialize(context, self.resolved_terrain.as_ref());
         self.admit_wave(stable_id, wave);
         self.active_wave_links.insert(event.attacker_id, stable_id);
+    }
 
-        // LogicClass reloads its live count after the firing Techno callback;
-        // the tail-appended Wave therefore owns its first AI before the next
-        // pre-existing live object callback. The per-FireAt hook invokes this
-        // method at that exact combat boundary.
-        let _ = self.object_ai_visit_one(
-            stable_id,
-            Some(rules),
-            techno_ai::ObjectAiCtx {
-                overlay_registry,
-                ..techno_ai::ObjectAiCtx::default()
-            },
-        );
+    /// Finish the live Logic pass after combat has modeled the pre-existing
+    /// Techno callbacks. FireAt registers each Wave immediately, preserving
+    /// its actual tail position; the live-length walk reaches those new slots
+    /// only after every object that was already ahead of them has fired.
+    fn visit_combat_appended_wave_tail(
+        &mut self,
+        preexisting_wave_ids: &BTreeSet<u64>,
+        rules: &RuleSet,
+        overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+    ) {
+        let mut index = 0;
+        while index < self.substrate.logic.len() {
+            let stable_id = self.substrate.logic.as_slice()[index];
+            if !preexisting_wave_ids.contains(&stable_id) && self.waves.get(stable_id).is_some() {
+                let _ = self.object_ai_visit_one(
+                    stable_id,
+                    Some(rules),
+                    techno_ai::ObjectAiCtx {
+                        overlay_registry,
+                        ..techno_ai::ObjectAiCtx::default()
+                    },
+                );
+            }
+            index += 1;
+        }
     }
 
     /// Walk one Wave damage request in recorded-cell and current Cell-list
@@ -2066,7 +2090,11 @@ impl Simulation {
                             inline_hooks
                                 .as_deref_mut()
                                 .expect("world Wave hook")
-                                .trace_wave_receiver(request.wave_id, target_id);
+                                .trace_wave_receiver(
+                                    request.wave_id,
+                                    target_id,
+                                    scenario_rng.state(),
+                                );
                             crate::sim::combat::combat_aoe::AreaDamageReceiver::Entity(event)
                         }
                         CellObject::Terrain(stable_id) => {
@@ -2074,7 +2102,11 @@ impl Simulation {
                             inline_hooks
                                 .as_deref_mut()
                                 .expect("world Wave hook")
-                                .trace_wave_receiver(request.wave_id, stable_id);
+                                .trace_wave_receiver(
+                                    request.wave_id,
+                                    stable_id,
+                                    scenario_rng.state(),
+                                );
                             crate::sim::combat::combat_aoe::AreaDamageReceiver::Terrain(
                                 crate::sim::combat::TerrainDamageEvent {
                                     stable_id,
@@ -6719,6 +6751,11 @@ impl Simulation {
             for request in sonic_damage_requests {
                 self.commit_logic_wave_damage_request(rules, overlay_registry, &request);
             }
+            let preexisting_wave_ids = self
+                .waves
+                .iter()
+                .map(|(&stable_id, _)| stable_id)
+                .collect::<BTreeSet<_>>();
             let fire_suppressed = tube_turn_owned_ids.clone();
             let combat_result = self.tick_combat_with_fatal_lifecycle(
                 rules,
@@ -6733,6 +6770,7 @@ impl Simulation {
                 let stable_id = self.allocate_stable_id();
                 self.admit_projectile(stable_id, projectile);
             }
+            self.visit_combat_appended_wave_tail(&preexisting_wave_ids, rules, overlay_registry);
             turret::tick_turret_rotation(
                 &mut self.substrate.entities,
                 rules,

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -735,6 +735,11 @@ pub struct Simulation {
     /// Persistent WaveClass registrations. They have their own logic lifetime;
     /// this is not a one-frame weapon-fire presentation list.
     pub waves: crate::sim::wave::WaveStore,
+    /// Stable form of TechnoClass +0x324: owner stable id -> exact Wave stable
+    /// id. The native link is installed even for a constructor-short Wave and
+    /// is cleared only by exact pointer-expiry cleanup.
+    #[serde(default)]
+    pub(crate) active_wave_links: BTreeMap<u64, u64>,
     /// Hookless-test adapter retained for old fixture callsites. Production
     /// combat and superweapons commit smudges inline, so this remains empty and
     /// never persists across ticks.
@@ -781,6 +786,12 @@ pub struct Simulation {
     /// cells. This is value state, never a setter/replay log.
     #[serde(default)]
     pub(crate) real_cell_bridge_flags_0x1180: RealCellBridgeFlags0x1180,
+    /// Exact value projection of runtime isometric-tile replacement. The
+    /// parsed terrain grid is derived/skipped and receives these values before
+    /// overlay/bridge/navigation reconstruction on restore.
+    #[serde(default)]
+    pub(crate) dynamic_terrain_cells:
+        BTreeMap<(u16, u16), crate::map::resolved_terrain::DynamicTerrainCellState>,
     pub bridge_state: Option<BridgeRuntimeState>,
     /// Per-cell mutable overlay state (ore density, wall damage, bridge frames).
     /// Seeded from map [OverlayPack] at init, mutated during gameplay.
@@ -1090,6 +1101,169 @@ struct SimulationCombatInlineHooks<'a> {
 }
 
 impl crate::sim::combat::CombatInlineHooks for SimulationCombatInlineHooks<'_> {
+    #[cfg(test)]
+    fn trace_wave_receiver(&mut self, wave_id: u64, target_id: u64) {
+        self.sim.trace_lifecycle_for_test(
+            LifecycleTestEvent::WaveDamageReceiverSelected { wave_id, target_id },
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn commit_wave_fire_event(
+        &mut self,
+        rules: &RuleSet,
+        overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+        event: &SimFireEvent,
+        borrowed_entities: &mut EntityStore,
+        borrowed_occupancy: &mut OccupancyGrid,
+        borrowed_interner: &mut StringInterner,
+        borrowed_main_rng: &mut SimRng,
+        borrowed_scenario_rng: &mut SimRng,
+        borrowed_resource_nodes: &mut BTreeMap<(u16, u16), crate::sim::miner::ResourceNode>,
+        borrowed_houses: &mut BTreeMap<InternedId, HouseState>,
+        borrowed_overlay_grid: Option<&mut crate::sim::overlay_grid::OverlayGrid>,
+        borrowed_terrain: Option<&mut ResolvedTerrainGrid>,
+        borrowed_bridge_state: Option<&BridgeRuntimeState>,
+        borrowed_terrain_area_state: Option<
+            &mut crate::sim::terrain_object::TerrainAreaState,
+        >,
+        borrowed_sound_events: Option<&mut Vec<SimSoundEvent>>,
+    ) {
+        std::mem::swap(&mut self.sim.substrate.entities, borrowed_entities);
+        std::mem::swap(&mut self.sim.substrate.occupancy, borrowed_occupancy);
+        std::mem::swap(&mut self.sim.interner, borrowed_interner);
+        std::mem::swap(&mut self.sim.main_rng, borrowed_main_rng);
+        std::mem::swap(&mut self.sim.scenario_rng, borrowed_scenario_rng);
+        std::mem::swap(
+            &mut self.sim.production.resource_nodes,
+            borrowed_resource_nodes,
+        );
+        std::mem::swap(&mut self.sim.houses, borrowed_houses);
+
+        let mut borrowed_terrain_area_state = borrowed_terrain_area_state;
+        if let Some(area_state) = borrowed_terrain_area_state.as_deref_mut() {
+            area_state.swap_authority(
+                &mut self.sim.production,
+                &mut self.sim.substrate.raw_cell_occupation,
+            );
+        }
+
+        let had_overlay = borrowed_overlay_grid.is_some();
+        let mut borrowed_overlay_grid = borrowed_overlay_grid;
+        if let Some(grid) = borrowed_overlay_grid.as_deref_mut() {
+            debug_assert!(self.sim.overlay_grid.is_none());
+            self.sim.overlay_grid = Some(grid.clone());
+            std::mem::swap(self.sim.overlay_grid.as_mut().expect("installed"), grid);
+        }
+        let had_terrain = borrowed_terrain.is_some();
+        let mut borrowed_terrain = borrowed_terrain;
+        if let Some(terrain) = borrowed_terrain.as_deref_mut() {
+            debug_assert!(self.sim.resolved_terrain.is_none());
+            self.sim.resolved_terrain = Some(terrain.clone());
+            std::mem::swap(
+                self.sim.resolved_terrain.as_mut().expect("installed"),
+                terrain,
+            );
+        }
+        debug_assert!(self.sim.bridge_state.is_none());
+        self.sim.bridge_state = borrowed_bridge_state.cloned();
+
+        let mut borrowed_sound_events = borrowed_sound_events;
+        if let Some(sound_events) = borrowed_sound_events.as_deref_mut() {
+            std::mem::swap(&mut self.sim.sound_events, sound_events);
+        }
+
+        self.sim
+            .create_wave_from_fire_event(rules, overlay_registry, event);
+
+        if let Some(sound_events) = borrowed_sound_events.as_deref_mut() {
+            std::mem::swap(&mut self.sim.sound_events, sound_events);
+        }
+        self.sim.bridge_state = None;
+        if let Some(terrain) = borrowed_terrain.as_deref_mut() {
+            std::mem::swap(
+                self.sim.resolved_terrain.as_mut().expect("installed"),
+                terrain,
+            );
+        }
+        if had_terrain {
+            self.sim.resolved_terrain = None;
+        }
+        if let Some(grid) = borrowed_overlay_grid.as_deref_mut() {
+            std::mem::swap(self.sim.overlay_grid.as_mut().expect("installed"), grid);
+        }
+        if had_overlay {
+            self.sim.overlay_grid = None;
+        }
+        if let Some(area_state) = borrowed_terrain_area_state.as_deref_mut() {
+            area_state.swap_authority(
+                &mut self.sim.production,
+                &mut self.sim.substrate.raw_cell_occupation,
+            );
+        }
+
+        std::mem::swap(&mut self.sim.houses, borrowed_houses);
+        std::mem::swap(
+            &mut self.sim.production.resource_nodes,
+            borrowed_resource_nodes,
+        );
+        std::mem::swap(&mut self.sim.scenario_rng, borrowed_scenario_rng);
+        std::mem::swap(&mut self.sim.main_rng, borrowed_main_rng);
+        std::mem::swap(&mut self.sim.interner, borrowed_interner);
+        std::mem::swap(&mut self.sim.substrate.occupancy, borrowed_occupancy);
+        std::mem::swap(&mut self.sim.substrate.entities, borrowed_entities);
+    }
+
+    fn rebuild_cliff_navigation(
+        &mut self,
+        rules: &RuleSet,
+        borrowed_terrain: &mut Option<crate::map::resolved_terrain::ResolvedTerrainGrid>,
+        borrowed_entities: &mut EntityStore,
+        borrowed_interner: &mut StringInterner,
+    ) {
+        std::mem::swap(&mut self.sim.resolved_terrain, borrowed_terrain);
+        std::mem::swap(&mut self.sim.substrate.entities, borrowed_entities);
+        std::mem::swap(&mut self.sim.interner, borrowed_interner);
+        let _ = self.sim.rebuild_dynamic_navigation(rules);
+        std::mem::swap(&mut self.sim.interner, borrowed_interner);
+        std::mem::swap(&mut self.sim.substrate.entities, borrowed_entities);
+        std::mem::swap(&mut self.sim.resolved_terrain, borrowed_terrain);
+    }
+
+    fn mark_cliff_radar_dirty(&mut self, cell: (u16, u16)) {
+        self.sim.mark_radar_terrain_dirty_cells([cell]);
+    }
+
+    fn mark_cliff_tactical_dirty(&mut self, cells: &[(u16, u16)]) {
+        for &cell in cells {
+            if !self.sim.tactical_dirty_cells.contains(&cell) {
+                self.sim.tactical_dirty_cells.push(cell);
+            }
+        }
+    }
+
+    fn spawn_cliff_anims(
+        &mut self,
+        rules: &RuleSet,
+        borrowed_interner: &mut crate::sim::intern::StringInterner,
+        borrowed_scenario_rng: &mut SimRng,
+        borrowed_sound_events: &mut Vec<SimSoundEvent>,
+        spawns: Vec<(
+            crate::sim::components::AnimClassSpawnDescriptor,
+            crate::sim::anim_class::AnimWorldCoord,
+        )>,
+    ) {
+        std::mem::swap(&mut self.sim.interner, borrowed_interner);
+        std::mem::swap(&mut self.sim.scenario_rng, borrowed_scenario_rng);
+        std::mem::swap(&mut self.sim.sound_events, borrowed_sound_events);
+        for (descriptor, coord) in spawns {
+            let _ = self.sim.spawn_anim_at_world(rules, descriptor, coord);
+        }
+        std::mem::swap(&mut self.sim.sound_events, borrowed_sound_events);
+        std::mem::swap(&mut self.sim.scenario_rng, borrowed_scenario_rng);
+        std::mem::swap(&mut self.sim.interner, borrowed_interner);
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn respond_to_base_attack(
         &mut self,
@@ -1415,6 +1589,7 @@ impl Simulation {
         let current_tick = u64::from(self.session.binary_frame);
         let binary_frame = self.session.binary_frame;
         let scenario_no_damage = self.session.no_damage;
+        let active_wave_owners = self.active_wave_links.keys().copied().collect();
         // Active YR TechnoClass::Evaluate_Candidate @ 0x006F7DB0 reads the
         // candidate's stored Techno+0x3D5 flag at 0x006F7DF1. Only a live
         // MapClass authority makes that native admission rule applicable.
@@ -1446,6 +1621,7 @@ impl Simulation {
                 binary_frame,
                 logic_order,
                 fire_suppressed,
+                &active_wave_owners,
                 projectile_detonations,
                 wave_damage_events,
                 Some(&mut radiation),
@@ -1583,6 +1759,127 @@ impl Simulation {
         );
     }
 
+    /// Complete the Wave-producing tail of `TechnoClass::FireAt` while the
+    /// firing object's combat transaction still owns all mutable authorities.
+    fn create_wave_from_fire_event(
+        &mut self,
+        rules: &RuleSet,
+        overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+        event: &SimFireEvent,
+    ) {
+        let Some(weapon) = rules.weapon(self.interner.resolve(event.weapon_id)) else {
+            return;
+        };
+        let wave_type = if weapon.is_sonic {
+            0
+        } else if weapon.is_mag_beam {
+            3
+        } else {
+            return;
+        };
+        let target = match event.target {
+            crate::sim::combat::TargetKind::Entity(id) => {
+                let Some(entity) = self.substrate.entities.get(id) else {
+                    return;
+                };
+                ProjectileCoord::new(
+                    i32::from(entity.position.rx) * 256
+                        + entity.position.sub_x.to_num::<i32>(),
+                    i32::from(entity.position.ry) * 256
+                        + entity.position.sub_y.to_num::<i32>(),
+                    crate::sim::combat::object_world_z_leptons(
+                        entity,
+                        self.resolved_terrain.as_ref(),
+                    ),
+                )
+            }
+            crate::sim::combat::TargetKind::Cell(rx, ry) => {
+                let x = i32::from(rx) * 256 + 128;
+                let y = i32::from(ry) * 256 + 128;
+                let z = self
+                    .resolved_terrain
+                    .as_ref()
+                    .and_then(|terrain| terrain.cell(rx, ry))
+                    .and_then(|cell| {
+                        crate::util::lepton::ground_height_leptons(
+                            cell.level,
+                            cell.slope_type,
+                            x,
+                            y,
+                        )
+                        .ok()
+                    })
+                    .unwrap_or(0);
+                ProjectileCoord::new(x, y, z)
+            }
+        };
+        let source = self
+            .substrate
+            .entities
+            .get(event.attacker_id)
+            .map(|entity| {
+                ProjectileCoord::new(
+                    i32::from(entity.position.rx) * 256
+                        + entity.position.sub_x.to_num::<i32>(),
+                    i32::from(entity.position.ry) * 256
+                        + entity.position.sub_y.to_num::<i32>(),
+                    crate::sim::combat::object_world_z_leptons(
+                        entity,
+                        self.resolved_terrain.as_ref(),
+                    ),
+                )
+            })
+            .unwrap_or_else(|| {
+                ProjectileCoord::new(
+                    i32::from(event.origin_snapshot.rx) * 256
+                        + event.origin_snapshot.sub_x.to_num::<i32>(),
+                    i32::from(event.origin_snapshot.ry) * 256
+                        + event.origin_snapshot.sub_y.to_num::<i32>(),
+                    i32::from(event.origin_snapshot.z)
+                        * crate::util::lepton::GROUND_LEVEL_HEIGHT_LEPTONS,
+                )
+            });
+        let mut wave = crate::sim::wave::Wave::new_owned(
+            wave_type,
+            event.attacker_id,
+            event.target,
+            source,
+            target,
+        );
+        let stable_id = self.allocate_stable_id();
+        if !wave.constructor_distance_is_live() {
+            // Constructor UnInit precedes registration and unique identity,
+            // but FireAt stores the returned dead pointer. The stable id only
+            // represents that same-frame deferred cleanup window.
+            self.waves.spawn(stable_id, wave);
+            self.active_wave_links.insert(event.attacker_id, stable_id);
+            let retired = self.retire_non_entity_object(stable_id);
+            debug_assert!(retired);
+            return;
+        }
+        let context = crate::sim::wave::WaveUpdateContext {
+            owner_position: Some(source),
+            owner_current_target: Some(event.target),
+            target_position: Some(target),
+        };
+        let _terminal = wave.initialize(context, self.resolved_terrain.as_ref());
+        self.admit_wave(stable_id, wave);
+        self.active_wave_links.insert(event.attacker_id, stable_id);
+
+        // LogicClass reloads its live count after the firing Techno callback;
+        // the tail-appended Wave therefore owns its first AI before the next
+        // pre-existing live object callback. The per-FireAt hook invokes this
+        // method at that exact combat boundary.
+        let _ = self.object_ai_visit_one(
+            stable_id,
+            Some(rules),
+            techno_ai::ObjectAiCtx {
+                overlay_registry,
+                ..techno_ai::ObjectAiCtx::default()
+            },
+        );
+    }
+
     /// Walk one Wave damage request in recorded-cell and current Cell-list
     /// order. Each receiver commits before the next occupant is selected, so
     /// fatal UnInit and nested effects are visible to the remaining walk.
@@ -1592,73 +1889,470 @@ impl Simulation {
         overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
         request: &crate::sim::wave::WaveDamageRequest,
     ) {
-        for cell in &request.recorded_cells {
-            let layer = self
-                .resolved_terrain
-                .as_ref()
-                .and_then(|terrain| terrain.cell(cell.rx, cell.ry))
-                .map(|terrain_cell| {
-                    if crate::sim::cell_kernel::selects_infantry_bridge_layer(
-                        terrain_cell.bridge_facts.has_structural_bridge(),
-                        terrain_cell.level,
-                        request.wave_z,
-                    ) {
-                        MovementLayer::Bridge
-                    } else {
-                        MovementLayer::Ground
-                    }
-                })
-                .unwrap_or(MovementLayer::Ground);
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        enum CellObject {
+            Entity(u64),
+            Terrain(u64),
+        }
 
-            // Re-read the native list after every concrete receiver. `visited`
-            // prevents a surviving current object from being selected again;
-            // it does not preserve objects removed by an earlier callback.
-            let mut visited = Vec::new();
-            loop {
-                let next_id = self
-                    .substrate
-                    .occupancy
-                    .get(cell.rx, cell.ry)
-                    .and_then(|occupancy| {
-                        occupancy
-                            .iter_layer(layer)
-                            .find(|occupant| !visited.contains(&occupant.entity_id))
-                    })
-                    .map(|occupant| occupant.entity_id);
-                let Some(target_id) = next_id else { break };
-                visited.push(target_id);
-                if target_id == request.payload.firer_id {
+        fn current_order(
+            occupancy: &crate::sim::occupancy::OccupancyGrid,
+            terrain_cells: &BTreeMap<(u16, u16), u64>,
+            rx: u16,
+            ry: u16,
+            layer: MovementLayer,
+        ) -> Vec<CellObject> {
+            let terrain_id = (layer == MovementLayer::Ground)
+                .then(|| terrain_cells.get(&(rx, ry)).copied())
+                .flatten();
+            let mut order = Vec::new();
+            let mut terrain_inserted = terrain_id.is_none();
+            if let Some(occupancy) = occupancy.get(rx, ry) {
+                for occupant in occupancy.iter_layer(layer) {
+                    if !terrain_inserted && occupant.is_building {
+                        order.push(CellObject::Terrain(terrain_id.expect("present")));
+                        terrain_inserted = true;
+                    }
+                    order.push(CellObject::Entity(occupant.entity_id));
+                }
+            }
+            if !terrain_inserted {
+                order.push(CellObject::Terrain(terrain_id.expect("present")));
+            }
+            order
+        }
+
+        let rule_handles = self.rule_handles;
+        let mut entities = std::mem::take(&mut self.substrate.entities);
+        let mut occupancy = std::mem::take(&mut self.substrate.occupancy);
+        let mut interner = std::mem::take(&mut self.interner);
+        let mut main_rng = std::mem::replace(&mut self.main_rng, SimRng::new(0));
+        let mut scenario_rng = std::mem::replace(&mut self.scenario_rng, SimRng::new(0));
+        let mut resource_nodes = std::mem::take(&mut self.production.resource_nodes);
+        let mut overlay_grid = self.overlay_grid.take();
+        let mut smudge_grid = self.smudge_grid.take();
+        let mut resolved_terrain = self.resolved_terrain.take();
+        let mut sound_events = std::mem::take(&mut self.sound_events);
+        let mut terrain_area_state = crate::sim::terrain_object::TerrainAreaState::take_from(
+            &mut self.production,
+            &mut self.substrate.raw_cell_occupation,
+        );
+        let mut houses = self.houses.clone();
+        let house_order = self.session.house_order.clone();
+        let house_alliances = self.house_alliances.clone();
+        let current_tick = u64::from(self.session.binary_frame);
+        let scenario_no_damage = self.session.no_damage;
+        let mut handled_deaths = Vec::new();
+        let mut effects = crate::sim::combat::DeathEffects::default();
+        let mut under_attack_events = Vec::new();
+        let mut collapsed_terrain_cells = BTreeMap::new();
+
+        {
+            let mut inline_hooks = SimulationCombatInlineHooks { sim: self };
+            let mut inline_hooks: Option<&mut dyn crate::sim::combat::CombatInlineHooks> =
+                Some(&mut inline_hooks);
+            let mut sound_sink = Some(&mut sound_events);
+
+            for recorded in &request.recorded_cells {
+                let cell = recorded.current_cell(resolved_terrain.as_ref());
+                // GetWeapon(0) is re-entered exactly once per cell, with the
+                // owner's current rank. A null owner aborts DamageArea before
+                // any receiver, wall, cliff, or RNG work.
+                let Some(firer) = entities
+                    .get(request.firer_id)
+                    .filter(|firer| firer.is_alive() && !firer.dying)
+                else {
+                    break;
+                };
+                let Some(object_type) = rules.object(interner.resolve(firer.type_ref)) else {
+                    break;
+                };
+                let Some(weapon_name) = crate::sim::combat::combat_weapon::primary_for_tier(
+                    object_type,
+                    firer.veterancy,
+                ) else {
+                    break;
+                };
+                let Some(weapon) = rules.weapon(weapon_name) else {
+                    break;
+                };
+                let raw_ambient_damage = weapon.ambient_damage;
+                let Some(warhead_name) = weapon.warhead.as_deref() else {
+                    break;
+                };
+                let warhead_ref = interner.intern(warhead_name);
+                let source_house = Some(firer.owner);
+                let mut shared_damage = raw_ambient_damage;
+
+                // The shared dummy is still a native CellClass entry, so the
+                // GetWeapon(0) call above belongs to it too. Its final stamped
+                // coordinate cannot own a real cell list, wall, or cliff.
+                if !cell.real {
                     continue;
                 }
-                let Some(entity) = self.substrate.entities.get(target_id) else {
+                let (Ok(rx), Ok(ry)) = (u16::try_from(cell.rx), u16::try_from(cell.ry)) else {
                     continue;
                 };
-                if !entity.is_alive() || entity.dying || entity.lifecycle.in_limbo {
-                    continue;
+                let layer = if crate::sim::cell_kernel::selects_infantry_bridge_layer(
+                    cell.structural_bridge,
+                    cell.level as u8,
+                    request.wave_z,
+                ) {
+                    MovementLayer::Bridge
+                } else {
+                    MovementLayer::Ground
+                };
+
+                let mut current = current_order(
+                    &occupancy,
+                    terrain_area_state.terrain_object_cells(),
+                    rx,
+                    ry,
+                    layer,
+                )
+                .first()
+                .copied();
+                while let Some(receiver_object) = current {
+                    let receiver = match receiver_object {
+                        CellObject::Entity(target_id) => {
+                            let eligible = target_id != request.firer_id
+                                && entities.get(target_id).is_some_and(|entity| {
+                                    entity.is_alive()
+                                        && !entity.dying
+                                        && !entity.lifecycle.in_limbo
+                                        && entity.lifecycle.object_alive
+                                });
+                            if !eligible {
+                                let order = current_order(
+                                    &occupancy,
+                                    terrain_area_state.terrain_object_cells(),
+                                    rx,
+                                    ry,
+                                    layer,
+                                );
+                                current = order
+                                    .iter()
+                                    .position(|&item| item == receiver_object)
+                                    .and_then(|index| order.get(index + 1).copied());
+                                continue;
+                            }
+                            let event = crate::sim::combat::EntityDamageEvent::direct_receiver(
+                                target_id,
+                                shared_damage,
+                                0,
+                                request.firer_id,
+                                source_house,
+                                warhead_ref,
+                                crate::sim::combat::ReceiverCallFlags {
+                                    ignore_defenses: false,
+                                    arg6: false,
+                                },
+                            );
+                            let post_object_damage = crate::sim::combat::wave_post_object_damage(
+                                &event,
+                                &entities,
+                                rules,
+                                &interner,
+                                &houses,
+                                &house_alliances,
+                                scenario_no_damage,
+                                current_tick,
+                                resolved_terrain.as_ref(),
+                            );
+                            if let Some(value) = post_object_damage {
+                                shared_damage = value;
+                            }
+                            #[cfg(test)]
+                            inline_hooks
+                                .as_deref_mut()
+                                .expect("world Wave hook")
+                                .trace_wave_receiver(request.wave_id, target_id);
+                            crate::sim::combat::combat_aoe::AreaDamageReceiver::Entity(event)
+                        }
+                        CellObject::Terrain(stable_id) => {
+                            #[cfg(test)]
+                            inline_hooks
+                                .as_deref_mut()
+                                .expect("world Wave hook")
+                                .trace_wave_receiver(request.wave_id, stable_id);
+                            crate::sim::combat::combat_aoe::AreaDamageReceiver::Terrain(
+                                crate::sim::combat::TerrainDamageEvent {
+                                    stable_id,
+                                    rx,
+                                    ry,
+                                    damage: shared_damage,
+                                    distance_leptons: 0,
+                                    warhead_ref,
+                                    near_center_ic_isolation_eligible: false,
+                                },
+                            )
+                        }
+                    };
+                    let (nested, mut pings) =
+                        crate::sim::combat::commit_area_damage_receivers_with_scenario(
+                            std::slice::from_ref(&receiver),
+                            &mut entities,
+                            &mut occupancy,
+                            rules,
+                            &mut interner,
+                            rule_handles,
+                            &mut houses,
+                            &house_order,
+                            &house_alliances,
+                            &mut main_rng,
+                            &mut scenario_rng,
+                            &mut handled_deaths,
+                            &mut resource_nodes,
+                            overlay_grid.as_mut(),
+                            overlay_registry,
+                            resolved_terrain.as_mut(),
+                            Some(&mut terrain_area_state),
+                            scenario_no_damage,
+                            current_tick,
+                            &mut inline_hooks,
+                            &mut sound_sink,
+                        );
+                    effects.append(nested);
+                    under_attack_events.append(&mut pings);
+
+                    // Native loads current->NextObject only after its callback.
+                    // If UnInit removed the current object, its represented
+                    // list link is gone and this walk terminates.
+                    let order = current_order(
+                        &occupancy,
+                        terrain_area_state.terrain_object_cells(),
+                        rx,
+                        ry,
+                        layer,
+                    );
+                    current = order
+                        .iter()
+                        .position(|&item| item == receiver_object)
+                        .and_then(|index| order.get(index + 1).copied());
                 }
-                let event = crate::sim::wave::WaveDamageEvent {
-                    wave_id: request.wave_id,
-                    target_id,
-                    payload: request.payload,
-                };
-                let receiver = crate::sim::combat::combat_aoe::AreaDamageReceiver::Entity(
-                    crate::sim::combat::EntityDamageEvent::from_wave(
-                        event,
-                        &self.substrate.entities,
-                    ),
-                );
-                #[cfg(test)]
-                self.trace_lifecycle_for_test(LifecycleTestEvent::WaveDamageReceiverSelected {
-                    wave_id: request.wave_id,
-                    target_id,
-                });
-                self.commit_noncombat_aoe_receivers(
-                    rules,
-                    overlay_registry,
-                    std::slice::from_ref(&receiver),
-                );
+
+                // ChainReaction's Wave-tail callee is a bare RET. Wall damage
+                // follows receivers and reloads raw AmbientDamage, ignoring
+                // the shared mutable occupant value.
+                if let (Some(grid), Some(registry)) =
+                    (overlay_grid.as_mut(), overlay_registry)
+                    && let Some(overlay_id) = grid.cell(rx, ry).overlay_id
+                    && let Some(flags) = registry.flags(overlay_id)
+                {
+                    let _chain_reaction_no_op = flags.chain_reaction;
+                    if flags.wall {
+                        let wall = crate::sim::overlay_grid::damage_wall_overlay(
+                            grid,
+                            registry,
+                            rx,
+                            ry,
+                            raw_ambient_damage,
+                            &mut scenario_rng,
+                        );
+                        if let Some(terrain) = resolved_terrain.as_mut() {
+                            for mutation in &wall.mutations {
+                                let changed = crate::sim::overlay_grid::recalc_overlay_passability(
+                                    grid,
+                                    terrain,
+                                    registry,
+                                    mutation.rx,
+                                    mutation.ry,
+                                );
+                                grid.record_synchronous_passability_change_at(
+                                    mutation.rx,
+                                    mutation.ry,
+                                    changed,
+                                );
+                            }
+                        }
+                        if grid.cell(rx, ry).overlay_id.is_none() {
+                            crate::sim::combat::combat_aoe::detach_cell_target_references(
+                                &mut entities,
+                                rx,
+                                ry,
+                                &mut effects.cell_target_detaches,
+                            );
+                        }
+                        effects.wall_mutations.extend(wall.mutations);
+                    }
+                }
+
+                // The cliff tail is independent of damage magnitude and
+                // Warhead. Eligibility alone consumes one Scenario draw,
+                // including signed chances outside 0..=100.
+                let destroyable_cliff = resolved_terrain
+                    .as_ref()
+                    .is_some_and(|terrain| terrain.is_destroyable_cliff(rx, ry));
+                if destroyable_cliff {
+                    let chance_draw = scenario_rng.next_range_u32_inclusive(0, 99) as i32;
+                    if chance_draw < rules.combat_damage.collapse_chance
+                        && let Some(mutation) = resolved_terrain.as_mut().and_then(|terrain| {
+                            terrain.collapse_destroyable_cliff_terrain(
+                                rx,
+                                ry,
+                                |cell_x, cell_y| {
+                                    if let Some(grid) = overlay_grid.as_mut() {
+                                        let _ = grid.clear_overlay(cell_x, cell_y);
+                                    }
+                                    if let Some(grid) = smudge_grid.as_mut() {
+                                        let _ = grid.clear_cell_slot(cell_x, cell_y);
+                                    }
+                                },
+                            )
+                        })
+                    {
+                        // Native performs one complete zone rebuild after the
+                        // two sparse stamps and before its three footprint
+                        // passes. The Rust navigation owner rebuilds all
+                        // movement zones as the corresponding single unit.
+                        inline_hooks
+                            .as_deref_mut()
+                            .expect("world cliff hook")
+                            .rebuild_cliff_navigation(
+                                rules,
+                                &mut resolved_terrain,
+                                &mut entities,
+                                &mut interner,
+                            );
+
+                        // Pass three's externally represented effects remain
+                        // strictly interleaved: detach this CellClass target,
+                        // then dirty this radar cell, in old-TMP row order.
+                        for &coord in &mutation.original_footprint {
+                            crate::sim::combat::combat_aoe::detach_cell_target_references(
+                                &mut entities,
+                                coord.0,
+                                coord.1,
+                                &mut effects.cell_target_detaches,
+                            );
+                            inline_hooks
+                                .as_deref_mut()
+                                .expect("world cliff hook")
+                                .mark_cliff_radar_dirty(coord);
+                        }
+                        inline_hooks
+                            .as_deref_mut()
+                            .expect("world cliff hook")
+                            .mark_cliff_tactical_dirty(&mutation.original_footprint);
+
+                        // Resolve the three types in native order, then make
+                        // two row-major attempts at each of the 15 grid cells.
+                        // Every representable allocation is successful, so
+                        // each attempt consumes type, X, Y, and delay draws.
+                        let anim_types = [
+                            interner.intern("XGRYMED1"),
+                            interner.intern("XGRYMED2"),
+                            interner.intern("XGRYSML1"),
+                        ];
+                        for &(cell_x, cell_y) in &mutation.animation_cells {
+                            for _ in 0..2 {
+                                let type_index =
+                                    scenario_rng.next_range_u32_inclusive(0, 2) as usize;
+                                let jitter_x =
+                                    scenario_rng.next_range_u32_inclusive(0, 16) as i32 - 8;
+                                let jitter_y =
+                                    scenario_rng.next_range_u32_inclusive(0, 24) as i32 - 12;
+                                let level = resolved_terrain
+                                    .as_ref()
+                                    .expect("collapse terrain retained")
+                                    .collapse_animation_level(cell_x, cell_y);
+                                let delay =
+                                    scenario_rng.next_range_u32_inclusive(0, 2) as u16;
+                                let world_coord = crate::sim::anim_class::AnimWorldCoord {
+                                    x: i32::from(cell_x)
+                                        .wrapping_mul(256)
+                                        .wrapping_add(128)
+                                        .wrapping_add(jitter_x),
+                                    y: i32::from(cell_y)
+                                        .wrapping_mul(256)
+                                        .wrapping_add(128)
+                                        .wrapping_add(jitter_y),
+                                    z: i32::from(level).wrapping_mul(104),
+                                };
+                                let mut descriptor =
+                                    crate::sim::components::AnimClassSpawnDescriptor::new(
+                                        anim_types[type_index],
+                                        cell_x as u16,
+                                        cell_y as u16,
+                                        SimFixed::from_num(128 + jitter_x),
+                                        SimFixed::from_num(128 + jitter_y),
+                                        level as u8,
+                                    );
+                                descriptor.delay = delay;
+                                descriptor.loop_count = 1;
+                                descriptor.draw_flags = 0x600;
+                                descriptor.z_adjust = 0;
+                                descriptor.reverse = false;
+                                // AnimClass construction completes before the
+                                // next attempt selects its type. This matters
+                                // when the selected AnimType consumes Scenario
+                                // RNG for RandomRate during construction.
+                                let cliff_sound_events = sound_sink
+                                    .take()
+                                    .expect("Wave receiver sound sink retained");
+                                inline_hooks
+                                    .as_deref_mut()
+                                    .expect("world cliff hook")
+                                    .spawn_cliff_anims(
+                                        rules,
+                                        &mut interner,
+                                        &mut scenario_rng,
+                                        &mut *cliff_sound_events,
+                                        vec![(descriptor, world_coord)],
+                                    );
+                                sound_sink = Some(cliff_sound_events);
+                            }
+                        }
+
+                        let terrain = resolved_terrain
+                            .as_ref()
+                            .expect("collapse terrain retained");
+                        for &(cell_x, cell_y) in &mutation.changed_cells {
+                            if let Some(cell) = terrain.cell(cell_x, cell_y) {
+                                collapsed_terrain_cells.insert(
+                                    (cell_x, cell_y),
+                                    crate::map::resolved_terrain::DynamicTerrainCellState::capture(
+                                        cell,
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
             }
         }
+
+        let inactive_terrain_logic_ids = terrain_area_state.inactive_logic_ids();
+        let terrain_navigation_changed_cells = terrain_area_state.restore_into(
+            &mut self.production,
+            &mut self.substrate.raw_cell_occupation,
+        );
+        for stable_id in inactive_terrain_logic_ids {
+            let retired = self.retire_non_entity_object(stable_id);
+            debug_assert!(retired);
+        }
+        self.substrate.entities = entities;
+        self.substrate.occupancy = occupancy;
+        self.interner = interner;
+        self.main_rng = main_rng;
+        self.scenario_rng = scenario_rng;
+        self.production.resource_nodes = resource_nodes;
+        self.overlay_grid = overlay_grid;
+        self.smudge_grid = smudge_grid;
+        self.resolved_terrain = resolved_terrain;
+        self.dynamic_terrain_cells.extend(collapsed_terrain_cells);
+        if let Some(terrain) = self.resolved_terrain.as_ref() {
+            self.real_cell_bridge_flags_0x1180 = terrain.capture_real_cell_bridge_flags_0x1180();
+        }
+        self.sound_events = sound_events;
+        self.merge_receiver_anger_state(&houses);
+        self.absorb_noncombat_damage_effects(
+            rules,
+            overlay_registry,
+            effects,
+            under_attack_events,
+            terrain_navigation_changed_cells,
+        );
     }
 
     /// Commit one non-combat Apply_area_damage hit list through the ordinary
@@ -2011,6 +2705,7 @@ impl Simulation {
         self.bind_shared_cell_dummy(resolved_terrain.shared_cell_dummy());
         self.real_cell_bridge_flags_0x1180 =
             resolved_terrain.capture_real_cell_bridge_flags_0x1180();
+        self.dynamic_terrain_cells.clear();
         self.resolved_terrain = Some(resolved_terrain);
     }
 
@@ -2212,6 +2907,7 @@ impl Simulation {
             invulnerability_impact_effects: Vec::new(),
             projectiles: crate::sim::projectile::ProjectileStore::new(),
             waves: crate::sim::wave::WaveStore::new(),
+            active_wave_links: BTreeMap::new(),
             pending_smudge_requests: Vec::new(),
             bale_events: Vec::new(),
             bunker_wall_events: Vec::new(),
@@ -2224,6 +2920,7 @@ impl Simulation {
             resolved_terrain: None,
             shared_cell_dummy: SharedCellDummy::fresh(),
             real_cell_bridge_flags_0x1180: RealCellBridgeFlags0x1180::default(),
+            dynamic_terrain_cells: BTreeMap::new(),
             bridge_state: None,
             overlay_grid: None,
             smudge_grid: None,
@@ -6021,16 +6718,14 @@ impl Simulation {
             // same frame, retain the live one-receiver-at-a-time contract.
             for request in sonic_damage_requests {
                 self.commit_logic_wave_damage_request(rules, overlay_registry, &request);
-                // Wall-overlay and cliff mutation are proven DamageArea tails,
-                // but remain explicit residuals until their per-wave producer
-                // inputs are represented; do not approximate them here.
             }
+            let fire_suppressed = tube_turn_owned_ids.clone();
             let combat_result = self.tick_combat_with_fatal_lifecycle(
                 rules,
                 overlay_registry,
                 tick_ms,
                 &logic_order,
-                &tube_turn_owned_ids,
+                &fire_suppressed,
                 &projectile_detonations,
                 &[],
             );
@@ -6196,62 +6891,6 @@ impl Simulation {
                     start_sound_id: None,
                     start_sound_emitted: false,
                 });
-            }
-            // `WaveClass::Ctor @ 0x75e950` registers Sonic (0) and Magnetron
-            // (3) effects persistently. The CellClass damage vector for type 0
-            // remains a separate, explicit handoff in `WaveStore::advance`.
-            for event in &combat_result.fire_events {
-                let Some(weapon) = rules.weapon(self.interner.resolve(event.weapon_id)) else {
-                    continue;
-                };
-                let wave_type = if weapon.is_sonic {
-                    0
-                } else if weapon.is_mag_beam {
-                    3
-                } else {
-                    continue;
-                };
-                let target = match event.target {
-                    crate::sim::combat::TargetKind::Entity(id) => {
-                        let Some(entity) = self.substrate.entities.get(id) else {
-                            continue;
-                        };
-                        ProjectileCoord::new(
-                            i32::from(entity.position.rx) * 256
-                                + entity.position.sub_x.to_num::<i32>(),
-                            i32::from(entity.position.ry) * 256
-                                + entity.position.sub_y.to_num::<i32>(),
-                            i32::from(entity.position.z)
-                                * crate::util::lepton::GROUND_LEVEL_HEIGHT_LEPTONS,
-                        )
-                    }
-                    crate::sim::combat::TargetKind::Cell(rx, ry) => ProjectileCoord::new(
-                        i32::from(rx) * 256 + 128,
-                        i32::from(ry) * 256 + 128,
-                        0,
-                    ),
-                };
-                let source = ProjectileCoord::new(
-                    i32::from(event.origin_snapshot.rx) * 256
-                        + event.origin_snapshot.sub_x.to_num::<i32>(),
-                    i32::from(event.origin_snapshot.ry) * 256
-                        + event.origin_snapshot.sub_y.to_num::<i32>(),
-                    i32::from(event.origin_snapshot.z)
-                        * crate::util::lepton::GROUND_LEVEL_HEIGHT_LEPTONS,
-                );
-                let mut wave = crate::sim::wave::Wave::new(wave_type, source, target);
-                if let Some(warhead) = weapon.warhead.as_deref() {
-                    wave = wave.with_damage_payload(crate::sim::wave::WaveDamagePayload {
-                        firer_id: event.attacker_id,
-                        base_damage: weapon.damage,
-                        warhead: self.interner.intern(warhead),
-                    });
-                }
-                // `WaveClass::UpdateCells @ 0x007610f0` is the remaining exact
-                // producer seam. Do not synthesize a Bresenham/supercover list;
-                // an empty vector makes that residual explicit and deterministic.
-                let stable_id = self.allocate_stable_id();
-                self.admit_wave(stable_id, wave);
             }
             // gamemd-derived: `EBolt::Init @ 0x004C2A60` creates one spark
             // system per electric bolt at `0x004C2B30`, passing

--- a/src/sim/world/slice6_retask_tests.rs
+++ b/src/sim/world/slice6_retask_tests.rs
@@ -300,7 +300,12 @@ const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x8B8B_8734_0788_3530;
 // AIMD/TeamType/TaskForce, and typed AITrigger authority to the current hash.
 // Both historical probes remain byte-identical; this 16-tick fixture creates
 // no Teams or AI registries, so the shift is current-schema composition only.
-const SLICE6_BASELINE_HASH: u64 = 0xDD7D_7757_3ACD_3A22;
+// Re-baselined 2026-08-26 for snapshot/hash schema v103: the empty
+// `active_wave_links` map and empty persisted destroyable-cliff mutation map
+// now join the current hash. Both historical probes remain byte-identical;
+// this fixture creates no Wave or cliff mutation, so the measured shift is
+// current-schema composition only.
+const SLICE6_BASELINE_HASH: u64 = 0xA623_FD5A_9571_E3AD;
 
 #[test]
 fn replay_hash_stable_through_slice6() {

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -63,12 +63,11 @@ impl Simulation {
                 target_position: None,
             };
         };
-        let owner = wave.owner_id.and_then(|owner_id| {
-            self.substrate
-                .entities
-                .get(owner_id)
-                .filter(|entity| entity.is_alive() && !entity.dying)
-        });
+        // WaveClass keeps raw owner/target pointers through the represented
+        // dying interval. Only PointerExpired makes either identity null.
+        let owner = wave
+            .owner_id
+            .and_then(|owner_id| self.substrate.entities.get(owner_id));
         let owner_position = owner.map(|entity| {
             ProjectileCoord::new(
                 i32::from(entity.position.rx) * 256 + entity.position.sub_x.to_num::<i32>(),
@@ -87,7 +86,6 @@ impl Simulation {
                 .substrate
                 .entities
                 .get(target_id)
-                .filter(|entity| entity.is_alive() && !entity.dying)
                 .map(|entity| {
                     ProjectileCoord::new(
                         i32::from(entity.position.rx) * 256

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -100,25 +100,7 @@ impl Simulation {
                         ),
                     )
                 }),
-            Some(TargetKind::Cell(rx, ry)) => {
-                let x = i32::from(rx) * 256 + 128;
-                let y = i32::from(ry) * 256 + 128;
-                let z = self
-                    .resolved_terrain
-                    .as_ref()
-                    .and_then(|terrain| terrain.cell(rx, ry))
-                    .and_then(|cell| {
-                        crate::util::lepton::ground_height_leptons(
-                            cell.level,
-                            cell.slope_type,
-                            x,
-                            y,
-                        )
-                        .ok()
-                    })
-                    .unwrap_or(0);
-                Some(ProjectileCoord::new(x, y, z))
-            }
+            Some(TargetKind::Cell(rx, ry)) => Some(self.wave_cell_target_position(rx, ry)),
             None => None,
         };
         crate::sim::wave::WaveUpdateContext {

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -44,6 +44,92 @@ pub(crate) struct ObjectAiCtx<'a> {
 use crate::sim::production::StepOutcome;
 
 impl Simulation {
+    pub(crate) fn clear_active_wave_link(&mut self, wave_id: u64) {
+        self.active_wave_links
+            .retain(|_, linked_wave_id| *linked_wave_id != wave_id);
+    }
+
+    pub(crate) fn wave_update_context(
+        &self,
+        wave_id: u64,
+    ) -> crate::sim::wave::WaveUpdateContext {
+        use crate::sim::combat::TargetKind;
+        use crate::sim::projectile::ProjectileCoord;
+
+        let Some(wave) = self.waves.get(wave_id) else {
+            return crate::sim::wave::WaveUpdateContext {
+                owner_position: None,
+                owner_current_target: None,
+                target_position: None,
+            };
+        };
+        let owner = wave.owner_id.and_then(|owner_id| {
+            self.substrate
+                .entities
+                .get(owner_id)
+                .filter(|entity| entity.is_alive() && !entity.dying)
+        });
+        let owner_position = owner.map(|entity| {
+            ProjectileCoord::new(
+                i32::from(entity.position.rx) * 256 + entity.position.sub_x.to_num::<i32>(),
+                i32::from(entity.position.ry) * 256 + entity.position.sub_y.to_num::<i32>(),
+                crate::sim::combat::object_world_z_leptons(
+                    entity,
+                    self.resolved_terrain.as_ref(),
+                ),
+            )
+        });
+        let owner_current_target = owner
+            .and_then(|entity| entity.attack_target.as_ref())
+            .map(|attack| attack.target);
+        let target_position = match wave.target_ref {
+            Some(TargetKind::Entity(target_id)) => self
+                .substrate
+                .entities
+                .get(target_id)
+                .filter(|entity| entity.is_alive() && !entity.dying)
+                .map(|entity| {
+                    ProjectileCoord::new(
+                        i32::from(entity.position.rx) * 256
+                            + entity.position.sub_x.to_num::<i32>(),
+                        i32::from(entity.position.ry) * 256
+                            + entity.position.sub_y.to_num::<i32>(),
+                        crate::sim::combat::object_world_z_leptons(
+                            entity,
+                            self.resolved_terrain.as_ref(),
+                        ),
+                    )
+                }),
+            Some(TargetKind::Cell(rx, ry)) => {
+                let x = i32::from(rx) * 256 + 128;
+                let y = i32::from(ry) * 256 + 128;
+                let z = self
+                    .resolved_terrain
+                    .as_ref()
+                    .and_then(|terrain| terrain.cell(rx, ry))
+                    .and_then(|cell| {
+                        crate::util::lepton::ground_height_leptons(
+                            cell.level,
+                            cell.slope_type,
+                            x,
+                            y,
+                        )
+                        .ok()
+                    })
+                    .unwrap_or(0);
+                Some(ProjectileCoord::new(x, y, z))
+            }
+            None => None,
+        };
+        crate::sim::wave::WaveUpdateContext {
+            owner_position,
+            owner_current_target,
+            target_position,
+        }
+    }
+}
+
+impl Simulation {
     /// Object-AI stage: the authoritative per-object Mission host.
     ///
     /// Walks the live LogicVector order via `for_each_live_object` — the same
@@ -221,10 +307,17 @@ impl Simulation {
             return true;
         }
         if self.waves.get(id).is_some() {
-            let (request, alive) = self
+            let context = self.wave_update_context(id);
+            let terrain = self.resolved_terrain.as_ref();
+            let (request, result) = self
                 .waves
-                .advance_one(id)
+                .advance_one(id, context, terrain)
                 .expect("wave remained present for its Logic slot");
+            // Fade-terminal UnInit dispatches exact pointer expiry before the
+            // stale AI-20 cell vector is damaged on AI-21.
+            if result.uninitialized {
+                self.clear_active_wave_link(id);
+            }
             if let Some(request) = request {
                 if let Some(rules) = rules {
                     self.commit_logic_wave_damage_request(rules, ctx.overlay_registry, &request);
@@ -234,7 +327,7 @@ impl Simulation {
                     self.pending_wave_damage_requests.push(request);
                 }
             }
-            if !alive {
+            if !result.alive {
                 let retired = self.retire_non_entity_object(id);
                 debug_assert!(retired);
             }

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -348,6 +348,8 @@ impl Simulation {
             // schema tag and the value authority introduced at snapshot v90.
             b"real-cell-bridge-flags-v2".hash(&mut hasher);
             self.real_cell_bridge_flags_0x1180.hash(&mut hasher);
+            b"dynamic-terrain-cells-v1".hash(&mut hasher);
+            self.dynamic_terrain_cells.hash(&mut hasher);
         }
         self.hash_overlay_grid(&mut hasher);
         self.hash_smudge_grid(&mut hasher);
@@ -474,17 +476,15 @@ impl Simulation {
     }
 
     fn hash_waves(&self, hasher: &mut impl Hasher) {
+        self.active_wave_links.len().hash(hasher);
+        for (&owner_id, &wave_id) in &self.active_wave_links {
+            owner_id.hash(hasher);
+            wave_id.hash(hasher);
+        }
         self.waves.len().hash(hasher);
         for (&id, wave) in self.waves.iter() {
             id.hash(hasher);
-            wave.id.hash(hasher);
-            wave.wave_type.hash(hasher);
-            wave.source.hash(hasher);
-            wave.target.hash(hasher);
-            wave.lifetime.hash(hasher);
-            wave.intensity.hash(hasher);
-            wave.recorded_cells.hash(hasher);
-            wave.damage_payload.hash(hasher);
+            wave.hash(hasher);
         }
     }
 

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -2614,6 +2614,20 @@ fn sonic_wave_test_rules() -> RuleSet {
     .expect("Sonic Wave fixture")
 }
 
+fn sonic_tail_order_test_rules() -> RuleSet {
+    RuleSet::from_ini(&IniFile::from_str(
+        "[VehicleTypes]\n0=DLPH\n1=LATER\n2=TARGET\n\n\
+         [DLPH]\nStrength=200\nArmor=light\nSpeed=8\nSight=8\nPrimary=SonicZap\n\n\
+         [LATER]\nStrength=200\nArmor=light\nSpeed=8\nSight=8\nPrimary=LaterGun\n\n\
+         [TARGET]\nStrength=100\nArmor=none\nSpeed=1\n\n\
+         [SonicZap]\nDamage=4\nAmbientDamage=10\nROF=20\nRange=6\nWarhead=SonicWH\nIsSonic=yes\n\n\
+         [LaterGun]\nDamage=7\nROF=20\nRange=6\nWarhead=LaterWH\n\n\
+         [SonicWH]\nWood=yes\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,0%,0%\n\n\
+         [LaterWH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,0%,0%\n",
+    ))
+    .expect("Sonic Logic-tail ordering fixture")
+}
+
 fn sonic_fire_event(
     sim: &mut Simulation,
     attacker_id: u64,
@@ -2681,7 +2695,7 @@ fn sonic_constructor_dead_pointer_link_lives_until_deferred_delete_at_239() {
 }
 
 #[test]
-fn sonic_constructor_at_240_admits_and_runs_first_wave_ai_immediately() {
+fn sonic_constructor_at_240_registers_then_runs_at_same_pass_tail() {
     let rules = sonic_wave_test_rules();
     let mut sim = Simulation::new();
     let firer_id = sim.allocate_stable_id();
@@ -2710,9 +2724,147 @@ fn sonic_constructor_at_240_admits_and_runs_first_wave_ai_immediately() {
         .expect("live owner link");
     let wave = sim.waves.get(wave_id).expect("registered Wave");
     assert!(wave.in_logic_vector);
+    assert_eq!(wave.lifetime, 100, "FireAt only registers the Logic tail");
+
+    sim.visit_combat_appended_wave_tail(&BTreeSet::new(), &rules, None);
+
+    let wave = sim.waves.get(wave_id).expect("Wave survives first tail AI");
     assert_eq!(wave.lifetime, 99, "first AI belongs to the firing pass");
-    assert_eq!(wave.target.z, 50, "type-0 uses the live target-side Sonic Z adjustment");
+    assert_eq!(
+        wave.target.z, 50,
+        "type-0 uses the live target-side Sonic Z adjustment"
+    );
     assert!(sim.substrate.pending_delete.is_empty());
+}
+
+#[test]
+fn sonic_fire_registers_immediately_but_later_techno_fires_before_wave_tail_ai() {
+    let rules = sonic_tail_order_test_rules();
+    let mut sim = Simulation::with_seed(0x5EED_760F);
+    sim.input_delay_ticks = 0;
+    let terrain = ResolvedTerrainGrid::from_cells(
+        8,
+        3,
+        (0..3)
+            .flat_map(|ry| (0..8).map(move |rx| bridgehead_base_cell(rx, ry)))
+            .collect(),
+    );
+    sim.install_resolved_terrain_for_new_map(terrain);
+    let heights = empty_heights();
+    let dolphin_id = sim
+        .spawn_object("DLPH", "Americans", 0, 0, 64, &rules, &heights)
+        .expect("Dolphin placed first in Logic order");
+    let later_id = sim
+        .spawn_object("LATER", "Americans", 0, 2, 64, &rules, &heights)
+        .expect("later shooter placed after Dolphin");
+    let sonic_endpoint_id = sim
+        .spawn_object("TARGET", "Russians", 6, 0, 0, &rules, &heights)
+        .expect("Sonic endpoint");
+    let wave_receiver_id = sim
+        .spawn_object("TARGET", "Russians", 5, 0, 0, &rules, &heights)
+        .expect("cell-list Wave receiver");
+    let later_target_id = sim
+        .spawn_object("TARGET", "Russians", 2, 2, 0, &rules, &heights)
+        .expect("later shooter's target");
+    assert!(crate::sim::combat::issue_attack_command(
+        &mut sim.substrate.entities,
+        dolphin_id,
+        sonic_endpoint_id,
+        Some(&rules),
+        &sim.interner,
+    ));
+    assert!(crate::sim::combat::issue_attack_command(
+        &mut sim.substrate.entities,
+        later_id,
+        later_target_id,
+        Some(&rules),
+        &sim.interner,
+    ));
+    sim.clear_lifecycle_test_events_for_test();
+
+    let path = PathGrid::test_all_passable(8, 3);
+    let _ = sim.advance_tick(&[], Some(&rules), &heights, Some(&path), None, 67);
+
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(later_target_id)
+            .expect("later target survives")
+            .health
+            .current,
+        93,
+        "the later pre-existing Techno completed its FireAt effects",
+    );
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(wave_receiver_id)
+            .expect("Wave receiver survives")
+            .health
+            .current,
+        90,
+        "the appended Wave still damages its first recorded cell this frame",
+    );
+    let wave_id = *sim
+        .active_wave_links
+        .get(&dolphin_id)
+        .expect("Dolphin retains the live Wave link");
+    assert_eq!(
+        sim.waves.get(wave_id).expect("Wave remains live").lifetime,
+        99,
+        "the new Logic tail owns its first AI in the firing pass",
+    );
+
+    let events = sim.lifecycle_test_events_for_test();
+    let dolphin_boundary = events
+        .iter()
+        .enumerate()
+        .find_map(|(index, event)| match event {
+            LifecycleTestEvent::CombatFireEffectsCommitted {
+                attacker_id,
+                scenario_rng_state,
+            } if *attacker_id == dolphin_id => Some((index, *scenario_rng_state)),
+            _ => None,
+        })
+        .expect("Dolphin FireAt boundary traced");
+    let later_boundary = events
+        .iter()
+        .enumerate()
+        .find_map(|(index, event)| match event {
+            LifecycleTestEvent::CombatFireEffectsCommitted {
+                attacker_id,
+                scenario_rng_state,
+            } if *attacker_id == later_id => Some((index, *scenario_rng_state)),
+            _ => None,
+        })
+        .expect("later FireAt boundary traced");
+    let wave_receiver = events
+        .iter()
+        .enumerate()
+        .find_map(|(index, event)| match event {
+            LifecycleTestEvent::WaveDamageReceiverSelected {
+                wave_id: selected_wave,
+                target_id,
+                scenario_rng_state,
+            } if *selected_wave == wave_id && *target_id == wave_receiver_id => {
+                Some((index, *scenario_rng_state))
+            }
+            _ => None,
+        })
+        .expect("Wave receiver boundary traced");
+    assert!(dolphin_boundary.0 < later_boundary.0);
+    assert!(
+        later_boundary.0 < wave_receiver.0,
+        "later FireAt/effects must finish before the appended Wave receiver walk",
+    );
+    assert_ne!(
+        dolphin_boundary.1, later_boundary.1,
+        "the later FireAt consumed its own ROF RNG before the Wave",
+    );
+    assert_eq!(
+        later_boundary.1, wave_receiver.1,
+        "the Wave receiver begins from the RNG state left by the later Techno",
+    );
 }
 
 fn short_game_defeat_test_rules() -> RuleSet {

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -2738,6 +2738,75 @@ fn sonic_constructor_at_240_registers_then_runs_at_same_pass_tail() {
 }
 
 #[test]
+fn sonic_cell_target_uses_persistent_dummy_gettargetcoords_on_create_and_refresh() {
+    let rules = sonic_wave_test_rules();
+    let mut sim = Simulation::new();
+    let terrain = ResolvedTerrainGrid::from_cells(0, 0, Vec::new());
+    terrain.test_set_dummy_cell_level_slope(2, 0);
+    let process_dummy = terrain.shared_cell_dummy();
+    process_dummy.set_bridge_flags_0x1180(crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL);
+    sim.install_resolved_terrain_for_new_map(terrain);
+    assert!(
+        process_dummy.same_identity(&sim.effective_shared_cell_dummy()),
+        "the Wave lookup must retain the map's process-global dummy identity",
+    );
+
+    let firer_id = sim.allocate_stable_id();
+    let owner = sim.interner.intern("Americans");
+    let firer_type = sim.interner.intern("DLPH");
+    let mut firer = GameEntity::test_default(firer_id, "DLPH", "Americans", 0, 0);
+    firer.owner = owner;
+    firer.type_ref = firer_type;
+    firer.position.sub_x = SimFixed::from_num(0);
+    firer.position.sub_y = SimFixed::from_num(0);
+    firer.attack_target = Some(AttackTarget::for_cell(u16::MAX, 7));
+    sim.substrate.entities.insert(firer);
+
+    let mut event = sonic_fire_event(&mut sim, firer_id, u64::MAX);
+    event.target = crate::sim::combat::TargetKind::Cell(u16::MAX, 7);
+    sim.create_wave_from_fire_event(&rules, None, &event);
+
+    let wave_id = *sim
+        .active_wave_links
+        .get(&firer_id)
+        .expect("off-map Cell target produces a live Wave");
+    let wave = sim.waves.get(wave_id).expect("registered Wave");
+    assert_eq!(
+        wave.target,
+        crate::sim::projectile::ProjectileCoord::new(-128, 1_920, 646),
+        "CellClass ground 2*90 plus structural +416 and Sonic +50",
+    );
+    assert_eq!(process_dummy.snapshot().coord, (-1, 7));
+
+    process_dummy.stamp_coord(-9, -9);
+    let context = sim.wave_update_context(wave_id);
+    assert_eq!(process_dummy.snapshot().coord, (-1, 7));
+    assert_eq!(
+        context.target_position,
+        Some(crate::sim::projectile::ProjectileCoord::new(
+            -128, 1_920, 596,
+        )),
+        "every live refresh re-enters GetCellClass then GetTargetCoords",
+    );
+    assert_eq!(process_dummy.snapshot().level, 2);
+    assert_eq!(
+        process_dummy.snapshot().bridge_flags_0x1180,
+        crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL,
+        "coordinate restamps preserve the dummy's live non-coordinate fields",
+    );
+
+    sim.visit_combat_appended_wave_tail(&BTreeSet::new(), &rules, None);
+    let wave = sim.waves.get(wave_id).expect("Wave survives first live AI");
+    assert_eq!(wave.lifetime, 99);
+    assert_eq!(wave.target.z, 646);
+    assert_eq!(
+        process_dummy.snapshot().coord,
+        (0, 6),
+        "UpdateCells keeps the shared identity but leaves the final miss restamp live",
+    );
+}
+
+#[test]
 fn sonic_fire_registers_immediately_but_later_techno_fires_before_wave_tail_ai() {
     let rules = sonic_tail_order_test_rules();
     let mut sim = Simulation::with_seed(0x5EED_760F);
@@ -2864,6 +2933,69 @@ fn sonic_fire_registers_immediately_but_later_techno_fires_before_wave_tail_ai()
     assert_eq!(
         later_boundary.1, wave_receiver.1,
         "the Wave receiver begins from the RNG state left by the later Techno",
+    );
+}
+
+#[test]
+fn sonic_cell_fire_same_frame_wave_damage_selects_level_two_bridge_plane() {
+    let rules = sonic_wave_test_rules();
+    let mut sim = Simulation::with_seed(0x5EED_6240);
+    sim.input_delay_ticks = 0;
+    let mut cells = (0..8)
+        .map(|rx| bridgehead_base_cell(rx, 0))
+        .collect::<Vec<_>>();
+    for cell in &mut cells {
+        cell.level = 2;
+        cell.template_height = 2;
+        cell.has_bridge_deck = true;
+        cell.bridge_walkable = true;
+        cell.bridge_deck_level = 6;
+        cell.bridge_facts.raw_flags |= crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL;
+    }
+    sim.install_resolved_terrain_for_new_map(ResolvedTerrainGrid::from_cells(8, 1, cells));
+    let heights = empty_heights();
+    let dolphin_id = sim
+        .spawn_object("DLPH", "Americans", 0, 0, 64, &rules, &heights)
+        .expect("bridge Dolphin");
+    let receiver_id = sim
+        .spawn_object("TARGET", "Russians", 5, 0, 0, &rules, &heights)
+        .expect("bridge receiver");
+    for id in [dolphin_id, receiver_id] {
+        sim.remove_entity_occupancy(id);
+        sim.substrate.entities.get_mut(id).expect("live entity").on_bridge = true;
+        sim.add_entity_occupancy(id);
+    }
+    assert!(crate::sim::combat::issue_attack_cell_command(
+        &mut sim.substrate.entities,
+        dolphin_id,
+        6,
+        0,
+        Some(&rules),
+        &sim.interner,
+    ));
+
+    let path = PathGrid::test_all_passable(8, 1);
+    let _ = sim.advance_tick(&[], Some(&rules), &heights, Some(&path), None, 67);
+
+    let wave_id = *sim
+        .active_wave_links
+        .get(&dolphin_id)
+        .expect("cell FireAt registered its Wave");
+    let wave = sim.waves.get(wave_id).expect("same-frame Wave survives");
+    assert_eq!(wave.lifetime, 99, "the appended tail ran in the firing pass");
+    assert_eq!(
+        wave.target.z, 646,
+        "level 2 CellClass target is 2*90 + structural 416 + Sonic 50",
+    );
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(receiver_id)
+            .expect("bridge receiver survives")
+            .health
+            .current,
+        90,
+        "Wave Z 646 meets the level-2 equality threshold 624 and walks AltObject",
     );
 }
 

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -2602,6 +2602,119 @@ fn combat_test_rules() -> RuleSet {
     RuleSet::from_ini(&ini).expect("combat test rules should parse")
 }
 
+fn sonic_wave_test_rules() -> RuleSet {
+    RuleSet::from_ini(&IniFile::from_str(
+        "[VehicleTypes]\n0=DLPH\n1=TARGET\n\n\
+         [DLPH]\nStrength=200\nArmor=light\nSpeed=8\nPrimary=SonicZap\nElitePrimary=SonicZapE\n\n\
+         [TARGET]\nStrength=100\nArmor=wood\n\n\
+         [SonicZap]\nDamage=4\nAmbientDamage=10\nROF=20\nRange=6\nWarhead=SonicWH\nIsSonic=yes\n\n\
+         [SonicZapE]\nDamage=8\nAmbientDamage=15\nROF=20\nRange=6\nWarhead=SonicWH\nIsSonic=yes\n\n\
+         [SonicWH]\nWood=yes\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,0%,0%\n",
+    ))
+    .expect("Sonic Wave fixture")
+}
+
+fn sonic_fire_event(
+    sim: &mut Simulation,
+    attacker_id: u64,
+    target_id: u64,
+) -> SimFireEvent {
+    SimFireEvent {
+        attacker_id,
+        attacker_type_ref: sim.interner.intern("DLPH"),
+        weapon_slot: crate::sim::combat::combat_weapon::WeaponSlot::Primary,
+        weapon_id: sim.interner.intern("SonicZap"),
+        facing: 0,
+        veterancy: 0,
+        origin_snapshot: FireOriginSnapshot {
+            rx: 0,
+            ry: 0,
+            sub_x: SimFixed::from_num(0),
+            sub_y: SimFixed::from_num(0),
+            z: 0,
+            facing: 0,
+            category: EntityCategory::Unit,
+            burst_index: 0,
+        },
+        target: crate::sim::combat::TargetKind::Entity(target_id),
+        report_sound_id: None,
+        garrison_muzzle_index: None,
+        occupant_anim: None,
+    }
+}
+
+#[test]
+fn sonic_constructor_dead_pointer_link_lives_until_deferred_delete_at_239() {
+    let rules = sonic_wave_test_rules();
+    let mut sim = Simulation::new();
+    let firer_id = sim.allocate_stable_id();
+    let target_id = sim.allocate_stable_id();
+    let owner = sim.interner.intern("Americans");
+    let firer_type = sim.interner.intern("DLPH");
+    let target_type = sim.interner.intern("TARGET");
+    let mut firer = GameEntity::test_default(firer_id, "DLPH", "Americans", 0, 0);
+    firer.owner = owner;
+    firer.type_ref = firer_type;
+    firer.position.sub_x = SimFixed::from_num(0);
+    firer.position.sub_y = SimFixed::from_num(0);
+    let mut target = GameEntity::test_default(target_id, "TARGET", "Russians", 0, 0);
+    target.type_ref = target_type;
+    target.position.sub_x = SimFixed::from_num(239);
+    target.position.sub_y = SimFixed::from_num(0);
+    sim.substrate.entities.insert(firer);
+    sim.substrate.entities.insert(target);
+    let event = sonic_fire_event(&mut sim, firer_id, target_id);
+
+    sim.create_wave_from_fire_event(&rules, None, &event);
+
+    let wave_id = *sim
+        .active_wave_links
+        .get(&firer_id)
+        .expect("dead pointer stored");
+    assert!(sim.waves.get(wave_id).is_some());
+    assert!(!sim.waves.get(wave_id).unwrap().in_logic_vector);
+    assert_eq!(sim.substrate.pending_delete, vec![wave_id]);
+
+    sim.process_pending_delete();
+    assert!(!sim.active_wave_links.contains_key(&firer_id));
+    assert!(sim.waves.get(wave_id).is_none());
+}
+
+#[test]
+fn sonic_constructor_at_240_admits_and_runs_first_wave_ai_immediately() {
+    let rules = sonic_wave_test_rules();
+    let mut sim = Simulation::new();
+    let firer_id = sim.allocate_stable_id();
+    let target_id = sim.allocate_stable_id();
+    let owner = sim.interner.intern("Americans");
+    let firer_type = sim.interner.intern("DLPH");
+    let target_type = sim.interner.intern("TARGET");
+    let mut firer = GameEntity::test_default(firer_id, "DLPH", "Americans", 0, 0);
+    firer.owner = owner;
+    firer.type_ref = firer_type;
+    firer.position.sub_x = SimFixed::from_num(0);
+    firer.position.sub_y = SimFixed::from_num(0);
+    let mut target = GameEntity::test_default(target_id, "TARGET", "Russians", 0, 0);
+    target.type_ref = target_type;
+    target.position.sub_x = SimFixed::from_num(240);
+    target.position.sub_y = SimFixed::from_num(0);
+    sim.substrate.entities.insert(firer);
+    sim.substrate.entities.insert(target);
+    let event = sonic_fire_event(&mut sim, firer_id, target_id);
+
+    sim.create_wave_from_fire_event(&rules, None, &event);
+
+    let wave_id = *sim
+        .active_wave_links
+        .get(&firer_id)
+        .expect("live owner link");
+    let wave = sim.waves.get(wave_id).expect("registered Wave");
+    assert!(wave.in_logic_vector);
+    assert_eq!(wave.lifetime, 99, "first AI belongs to the firing pass");
+    assert_eq!(wave.target.z, 50, "type-0 uses the live target-side Sonic Z adjustment");
+    assert!(sim.substrate.pending_delete.is_empty());
+}
+
 fn short_game_defeat_test_rules() -> RuleSet {
     let ini = IniFile::from_str(
         "[General]\nBaseUnit=AMCV,SMCV,PCV\n\n\


### PR DESCRIPTION
## Summary
- implement the verified type-0 Sonic Wave damage-area lifecycle and live Logic-tail scheduling
- resolve Wave targets through CellClass and expire owner/target pointers at Object UnInit
- reproduce the verified nonmagnetic type-0 geometry and persist/hash Wave plus cliff-mutation state
- reconcile snapshot schema 103 and the merged House receiver-state API

## Evidence
Active-retail gamemd.exe: TechnoClass::FireAt 0x006FDD50; WaveClass constructor/AI/lifecycle/UpdateCells at 0x0075E950, 0x00760F50, 0x00762AF0, and 0x007610F0; Wave pointer expiry 0x0075F610; LogicClass tail 0x0055B5FF..0x0055B619; nonmagnetic geometry 0x00761640.

## Validation
- cargo check -p vera20k: passed
- cargo test -p vera20k --lib wave -- --nocapture: 39 passed, 0 failed
- final-state full library run: 7503 passed, 1 failed only because the fresh worktree lacked ignored config.toml, 43 ignored
- after linking the existing ignored config.toml, the exact remaining retail-asset test passed: 1 passed, 0 failed
- mixed Logic fixture, Slice 6 hash, and global parity hash focused checks: each passed

Railgun simulation and presentation commits are intentionally excluded.