### PR TITLE
Integrate Phase 3 legacy theater tile translation

### DIFF
--- a/docs/plans/2026-08-27-phase3-last-tiles-in-set-design.md
+++ b/docs/plans/2026-08-27-phase3-last-tiles-in-set-design.md
@@ -1,0 +1,198 @@
+# Phase 3 `LastTilesInSet` compatibility translation design
+
+**Status: proposed for fresh read-only design review.**
+
+## Goal
+
+Implement the live YR theater compatibility table and exact IsoMap tile-index
+translation proven in
+`PHASE3_LAST_TILES_IN_SET_COMPATIBILITY_TRANSLATION_GHIDRA_REPORT.md`.
+Installed stock theaters produce an empty table, so the change must preserve
+all stock outputs while closing the active executable path for retail-format
+legacy/custom theater data.
+
+## Native contract
+
+`Read_Theater_TileSets_INI @ 0x00545150` builds declaration-ordered
+`{legacy_boundary:i32, delta:i32}` records. For each nonterminating tileset
+with `T=TilesInSet`, `L=LastTilesInSet`, and a wrapping signed legacy cursor:
+
+```text
+if L != -1 and L != T:
+    boundary = legacy_cursor wrapping+ L
+    delta = T wrapping- L
+    append(boundary, delta)
+    legacy_cursor = boundary
+else:
+    legacy_cursor = legacy_cursor wrapping+ T
+```
+
+Both keys use native `ReadInt`; exact `TilesInSet=-1` terminates, while other
+negative values do not. Missing section/key also produces `-1`, malformed
+present text produces zero, and native hexadecimal forms remain accepted.
+
+`CalculateLegacyMapTileIndex @ 0x00544E30` returns positive `65535` unchanged.
+Otherwise it walks records in declaration order, stops at the first signed
+`boundary > original_raw`, and wrapping-adds every preceding delta. Every
+comparison uses the original raw value, never the accumulated result.
+
+The helper is called only by the five IsoMap readers after destination-cell
+acceptance and before tile storage. Fill, runtime Mark/direct tile mutation,
+and save restoration do not translate. Save data already contains actual
+translated IDs and must never be translated again.
+
+## State ownership
+
+Add a private copyable `LegacyTileIndexException` and a private
+`legacy_tile_index_exceptions: Vec<_>` to `TilesetLookup`. This is immutable
+theater definition state, not simulation state: it is reconstructed from the
+active theater INI, is not serialized in snapshots, and does not enter the
+world hash. `load_theater` rebuilds a value-equivalent table on every map load
+from the active immutable theater bytes. The native vector's allocation
+address, capacity-growth identity, and ownership bytes are not gameplay state,
+and same-theater external file mutation while the process is running is outside
+the installed-retail domain. No process-global Rust table is introduced.
+
+Expose one pure `pub(crate)` method on `TilesetLookup`:
+
+```rust
+translate_legacy_map_tile_index(raw: i32) -> i32
+```
+
+It implements the exact sentinel, signed original-input comparisons,
+declaration-order early stop, and wrapping accumulation. It performs no range
+validation, sorting, clamping, or registry lookup.
+
+## Parser changes
+
+Replace the fixed `0..10000`/section-presence loop in `parse_tileset_ini` with
+an ordinal loop that treats an absent section as native `TilesInSet=-1` and
+stops only on exact `-1`. Use `IniSection::read_int` for both numeric keys.
+
+Maintain a separate signed wrapping `legacy_cursor`. Build the compatibility
+record before converting the current positive tile count into safe Rust
+registry slots. `TilesInSet=0` and values below zero other than `-1` create a
+zero-count bounds/metadata row but still update legacy arithmetic. A positive
+count creates exactly that many registry slots even when files are blank or
+missing.
+
+Correct `SetName`'s already-verified native missing-key default to `"No Name"`;
+`FileName` remains empty. This is the only adjacent parser correction admitted
+by the slice. Other tileset fields retain their current owners.
+
+Rust's tile identity is `u16`, so a positive registry total that cannot be
+represented must return a dedicated `MapError` rather than truncate, allocate
+unboundedly, or emulate native memory corruption/OOM. Likewise, ordinal
+overflow is a safe invalid-input rejection. These are explicit invalid-domain
+exclusions and cannot affect the six installed retail theaters.
+
+The safe representable limits are explicit. Positive tile ID `65535` is the
+IsoMap no-tile sentinel, so the registry may contain at most 65,535 usable
+slots, IDs `0..=65534`; the first total of 65,536 errors before allocation or
+`TilesetBounds` narrowing. Tileset ordinals `0..=65535` fit the existing
+`u16`-owned metadata and lookup APIs; attempting to continue at ordinal 65,536
+returns the ordinal-overflow error. Removing the arbitrary 10,000-section cap
+therefore makes `TileSet10000` load normally without weakening either real
+representation boundary. A missing `SetName` is stored as native default
+`"No Name"`.
+
+## Map-ingress integration
+
+`MapFile.cells` has two existing ingress meanings: decoded IsoMapPack cells are
+raw compatibility-space IDs, while RMG and manually constructed maps already
+contain actual registry IDs. Preserve that distinction using the existing
+load-only provenance: a nonempty `iso_map_pack_lookups` vector means the
+represented explicit cells came through an IsoMap decoder. A sentinel-only
+pack yields no explicit cells, so its empty vector has no tile to translate.
+
+In the production `materialize_map_load_cells` path, pass the active
+`TilesetLookup` separately from the variant selector. Only when that IsoMap
+provenance is present, clone each coordinate-accepted explicit record,
+translate only `tile_index`, and then replace the prefilled cell. RMG/manual
+actual-ID cells remain unchanged. Invalid/null Pack records remain dummy-only
+and never translate. Fill cells retain the cached actual Clear/Water IDs.
+
+The selector-free `ResolvedTerrainGrid` constructor is a synthetic/test path.
+When it is supplied `TheaterData`, it translates explicit cells only if the
+same IsoMap provenance vector is nonempty; RMG/manual actual-ID fixtures and
+theater-less fixtures remain raw. This path remains distinct from snapshot
+restore. `Simulation.resolved_terrain` is skipped by serde: the persistence
+owner clones the retained, already-translated terrain template into
+`rebuild_caches_after_load`, then
+`restore_map_authority_after_snapshot_load` reapplies serialized
+`dynamic_terrain_cells`, whose tile IDs are also actual IDs. Neither stage may
+call the legacy transform.
+
+Do not add translation to LAT, variant selection, `IsometricTileClass::Mark`,
+cliff/bridge mutations, snapshot load, or any lookup method. Those consumers
+must receive the already-translated actual ID.
+
+## Player-experience and subsystem ledger
+
+- Tile image, variant chain, TMP metadata, LAT/slope inputs, land type, bridge
+  classification, radar, and world rendering all consume the translated cell
+  ID through the existing materialized terrain pipeline.
+- Coordinate, subtile, level, ice-growth, stream order, and dummy-cell behavior
+  remain unchanged.
+- Empty compatibility vectors are identity and must preserve all installed
+  stock map output, RNG, source lineage, and state hashes.
+- Pack1-4 are compiled live callers but absent from all 386 installed map
+  payloads. The API is format-neutral, while this builder changes only the
+  represented Pack5 ingress.
+
+## Acceptance tests
+
+1. Parser builds `{5,+3}` and `{11,-2}` from the verified three-set example.
+2. Translation with a nonempty table asserts `4->4`, `5->8`, `10->13`,
+   `11->12`, positive `65535->65535`, and separately proves that signed `-1`
+   is translated rather than mistaken for that sentinel.
+3. An accumulated result crossing a later boundary proves comparisons still
+   use original raw; a negative boundary proves signed comparison; a
+   nonmonotonic table proves first-greater early stop and no sorting. Separate
+   `i32::MAX/MIN` cases prove wrapping transform accumulation.
+4. Empty-vector identity covers representative positive, negative,
+   `i32::MIN/MAX`, `-1`, and positive `65535` inputs.
+5. Missing/malformed/hex values, exact `TilesInSet=-1` termination with later
+   sections, direct `LastTilesInSet=-1` suppression, direct
+   `LastTilesInSet==TilesInSet` suppression, zero, nonterminating negative
+   counts, and parser-side wrapping cursor/delta arithmetic are pinned.
+6. Positive missing/blank files still consume actual registry slots. Exactly
+   65,535 slots succeeds and the 65,536th errors; ordinal 65,535 is accepted
+   and ordinal 65,536 errors through a focused checked-ordinal helper test.
+   `TileSet10000` succeeds after cap removal, and a missing `SetName` yields
+   `"No Name"`.
+7. Production-shaped Pack5 materialization proves a coordinate-accepted
+   explicit record reaches translated `source_tile_index`, variant/TMP lookup,
+   LAT input, and final tile state.
+8. Fill at an applicable numeric boundary remains unchanged; invalid Pack5
+   coordinates only update the dummy and do not materialize a translated cell.
+9. The same boundary-valued explicit ID translates in a Pack5-provenance map
+   through both production and selector-free constructors, but remains
+   unchanged in RMG/manual actual-ID maps and theater-less fixtures.
+10. Runtime actual-ID mutation plus the full persistence
+    prepare/serde/rebuild/restore route retains an ID that would change if the
+    transform ran again, proving both retained-template and dynamic-cell
+    authority avoid double translation.
+11. All six active retail theater INIs build empty vectors and retain existing
+    registry starts/counts and map expectations.
+
+Focused validation uses only `cargo test -p vera20k --lib <filter>` after
+confirming Cargo/rustc are idle. The phase-wide full suite remains deferred
+until every Phase 3 row closes.
+
+## Exclusions
+
+- Do not emulate native allocator failure, null-record dereference,
+  negative-index memory access, or unbounded allocation.
+- Do not add Pack1-4 decoders in this slice.
+- Do not implement Marble Madness, theater conversion, TMP extension fallback,
+  RMG generation, or editor behavior. Preserving existing RMG actual-ID cells
+  at shared materialization ingress is required, not an RMG expansion.
+- Do not update older stale research documents in the implementation commit;
+  their corrections are already recorded in the new verified report.
+
+## Decision
+
+Proceed only after a fresh read-only design critic returns PASS with zero
+findings. Any ambiguous parser, ingress, no-double-translation, or stock-
+preservation behavior keeps this mechanism open.

--- a/docs/research/PHASE3_LAST_TILES_IN_SET_COMPATIBILITY_TRANSLATION_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_LAST_TILES_IN_SET_COMPATIBILITY_TRANSLATION_GHIDRA_REPORT.md
@@ -1,0 +1,353 @@
+# Phase 3 `LastTilesInSet` compatibility translation research
+
+**Verdict:** COMPLETE / HIGH confidence.
+
+**Active in YR:** conditional. The loader and translator are live active-retail
+code, but the installed stock theater data makes the exception table empty.
+
+**Player impact:** high whenever triggered: affected ground cells can resolve
+the wrong TMP and then feed wrong variant, LAT, terrain-property, bridge, and
+rendering behavior. Trigger frequency is zero in installed stock data because
+all six active YR theater INIs contain zero active `LastTilesInSet=` keys.
+
+**Scope:** exception-table construction, IsoMap ingress translation,
+persistence, immediate consumers, and evidence-backed exclusions only.
+
+## Native owners and lifecycle
+
+`Read_Theater_TileSets_INI @ 0x00545150` constructs the compatibility table
+while reading `%sMD.INI` and `[TileSet%04d]`.
+
+Verified direct callers:
+
+| Caller | Callsite | Behavior |
+|---|---:|---|
+| `Read_Map_Section_And_IsoMapPacks @ 0x004ACE70` | `0x004AD048` | ordinary scenario map load |
+| `RandomMapGenerator__InitMapFromSyntheticINI @ 0x00599650` | `0x0059A1E9` | RMG theater initialization |
+| `MouseClass__Load @ 0x005BDF70` | `0x005BE647` | save-game restoration |
+
+Each caller compares the requested theater with cached theater
+`DAT_00822CF8`. If equal, it calls `FUN_00547110` instead and does not rebuild
+or clear the compatibility table. The table therefore persists across
+same-theater reuse. All three loader calls pass `DL=1`.
+
+At a real rebuild, `0x0054526B..0x005452B1` deletes every prior exception
+record back-to-front and reduces the active count to zero while retaining the
+vector backing allocation/capacity.
+
+### Static vector layout
+
+Static initialization at `0x00543E70..0x00543EA1` proves that
+`DAT_00AA1078` is a `DynamicVectorClass` object:
+
+| Address / offset | Exact role |
+|---|---|
+| `DAT_00AA1078 + 0x00` | vtable `0x007ECBDC` |
+| `DAT_00AA107C + 0x04` | backing array of `LegacyException*` pointers |
+| `DAT_00AA1080 + 0x08` | pointer-array capacity |
+| `DAT_00AA1084 + 0x0C` | vector-valid byte, initialized `1` |
+| `DAT_00AA1085 + 0x0D` | owns-backing-storage byte |
+| `DAT_00AA1088 + 0x10` | signed active count |
+| `DAT_00AA108C + 0x14` | capacity growth step, exactly `10` |
+
+The backing array is not a flat array of eight-byte records. Each four-byte
+pointer targets one separately allocated record:
+
+```text
+LegacyException +0x00: signed i32 legacy_boundary
+LegacyException +0x04: signed i32 delta
+```
+
+The resize body begins at `0x0054A630`, although Ghidra has no function
+boundary there. It allocates `new_capacity * 4`, copies the old pointer slots,
+frees owned old storage, and returns `AL=1`; allocation failure returns `AL=0`.
+Ordinary capacity progresses `0 -> 10 -> 20 -> ...`; there is no semantic
+fixed entry cap.
+
+## Exact INI parser and exception formula
+
+Section ordinal starts at zero and advances by one. `TileSet%04d` uses a
+minimum width, not a 10,000-section limit.
+
+`TilesInSet`:
+
+- is read through `CCINIClass__ReadInt @ 0x005276D0`;
+- uses key string `0x0082929C`;
+- has signed default `-1`, proven before `0x00545FD4`;
+- terminates only on exact signed `-1`;
+- therefore terminates on a missing section, missing key, or absent value;
+- converts present malformed text through CRT `atoi` to zero;
+- accepts `$xx` and `xxh`/`xxH` hexadecimal forms;
+- does not terminate for other negative values;
+- has no native `0..10000` loop cap.
+
+`LastTilesInSet` uses key string `0x0082928C`, is read only after a
+non-terminating `TilesInSet`, has signed default `-1` at `0x00545FF7`, and uses
+the same malformed/hexadecimal parsing behavior.
+
+Native maintains separate wrapping signed 32-bit actual-registry and legacy
+cursors. For each non-terminating set with `T = TilesInSet` and
+`L = LastTilesInSet`:
+
+```text
+if L != -1 and L != T:
+    boundary = wrapping_i32(legacy_cursor + L)
+    delta    = wrapping_i32(T - L)
+    append { boundary, delta }
+    legacy_cursor = boundary
+else:
+    legacy_cursor = wrapping_i32(legacy_cursor + T)
+```
+
+Evidence is `0x00545FFE..0x0054602D` and
+`0x0054608C..0x0054609A`: `ADD ECX,EBX` creates the boundary,
+`SUB EDX,EBX` creates the delta, and the mismatch/non-mismatch paths publish
+the corresponding next legacy cursor.
+
+Entries append in declaration order. There is no validation, sorting,
+deduplication, clamping, or positivity gate. `LastTilesInSet=-1` and equality
+with `TilesInSet` suppress an entry. Positive `TilesInSet` runs the tile-object
+loop and advances the actual cursor by `T`. Zero or negative values other than
+`-1` create no tile objects, but legacy-cursor arithmetic still occurs. Missing
+TMP files do not remove registry slots. Every add/subtract wraps as x86 `i32`.
+
+The pointer vector grows by ten slots when full. A null eight-byte record
+allocation is immediately dereferenced and crashes. If pointer-array growth
+fails, the record leaks and is not appended, but the legacy cursor still
+advances. These OOM/invalid-input failures are excluded from deliberate Rust
+emulation.
+
+The loop publishes the candidate tileset start and increments
+`DAT_00ABC558` before reading `TilesInSet`; consequently the terminating
+ordinal leaves one candidate start entry. No exception/translation consumer
+uses this sentinel bookkeeping, so this slice need not manufacture a fake
+Rust tileset.
+
+## Exact transform
+
+`CalculateLegacyMapTileIndex @ 0x00544E30`, body
+`0x00544E30..0x00544E68`, is:
+
+```rust
+fn translate(raw: i32, entries: &[LegacyException]) -> i32 {
+    if raw == 0x0000_FFFF {
+        return 0x0000_FFFF;
+    }
+    let mut result = raw;
+    for entry in entries {
+        if entry.boundary > raw {
+            break;
+        }
+        result = result.wrapping_add(entry.delta);
+    }
+    result
+}
+```
+
+The sentinel is positive `65535`; `-1` is not special. Input/output are full
+signed 32-bit values. Count `<= 0` is identity. Comparisons are signed against
+the original raw input, equality applies the entry, adds wrap, and the first
+boundary strictly greater than raw stops the walk. Nonmonotonic malicious
+tables therefore retain declaration order and can hide later entries.
+
+Example:
+
+```text
+TileSet0000: TilesInSet=3, Last absent
+TileSet0001: TilesInSet=5, LastTilesInSet=2 -> { boundary=5, delta=+3 }
+TileSet0002: TilesInSet=4, LastTilesInSet=6 -> { boundary=11, delta=-2 }
+```
+
+| Raw | Result |
+|---:|---:|
+| 4 | 4 |
+| 5 | 8 |
+| 10 | 13 |
+| 11 | 12 |
+| 65535 | 65535 |
+
+## Every transform caller and ingress order
+
+The helper has exactly five callers:
+
+| Decoder | Callsite | Input behavior |
+|---|---:|---|
+| `[IsoMapPack]` `FUN_0056B5A0` | `0x0056B636` | prewrites dword `0xFFFF`, then reads a zero-extended two-byte raw index |
+| `[IsoMapPack2]` `FUN_0056B780` | `0x0056B828` | full four-byte raw index |
+| `[IsoMapPack3]` `FUN_0056B8A0` | `0x0056B92B` | full four-byte raw index |
+| `[IsoMapPack4]` `FUN_0056B9A0` | `0x0056BA48` | full four-byte raw index |
+| `ReadIsoMapPack5 @ 0x0056BAC0` | `0x0056BB68` | full four-byte raw index |
+
+`Read_Map_Section_And_IsoMapPacks` attempts those sections in order at
+`0x004AD422`, `0x004AD4D5`, `0x004AD588`, `0x004AD63B`, and `0x004AD6E6`.
+Multiple present sections are processed in that order.
+
+For each valid Pack5 record native reads signed `X:i16` and unsigned `Y:u16`,
+computes `Y*512+X`, validates `[0,0x3FFFF]` plus non-null destination, prewrites
+`Cell+0x38=0xFFFF`, reads the raw dword, translates it, overwrites `+0x38`, then
+reads subtile `+0x11A`, absolute level `+0x11B`, and ice growth `+0x119`.
+Pack2-5 invalid/null destinations consume remaining bytes without translating;
+Pack1's fixed traversal can use the shared dummy and still translate.
+
+There is no registry-length check before translation/storage. Later
+`ProcessTileVariantsAndCullUnusedTMPs @ 0x00546DA0` treats exact `0xFFFF` and
+signed `tile_count <= tile` as invalid, but hostile negative non-`-1` values
+can index before the registry.
+
+Variant processing runs at `0x004AD743` after every pack reader. Full Init
+returns from map load at `0x006879FF` and later calls
+`CellClass::RecalcAttributes @ 0x0047D2B0` from `0x00687A5A`. Translated IDs
+are therefore authoritative before variant selection, LAT/slope work, land
+derivation, and every later consumer.
+
+## Evidence-backed exclusions
+
+- **Fill:** pre-IsoMap Fill writes cached actual registry IDs from ClearTile or
+  WaterSet and never calls the translator. It occurs before current-theater
+  table publication. A numerically matching Fill ID must remain unchanged.
+- **Runtime Mark/mutation:** `IsometricTileClass::Mark @ 0x00543330` and direct
+  runtime tile mutations already receive actual registry IDs and never call
+  the translator. Translating them would double-translate live state.
+- **Pack1-4 installed data:** all 386 recognized installed map payloads contain
+  exactly `[IsoMapPack5]`; Pack1-4 counts are zero. Those callers remain live
+  compatibility code but are absent from the installed corpus.
+- **Unsafe failures:** native allocator crashes/leaks, negative-index memory
+  access, and other hostile-data corruption are invalid-domain behaviors, not
+  safe Rust parity requirements.
+
+The physical map census covered 17 `MAPS01.MIX`, 17 `MAPS02.MIX`, 14
+`mapsmd03.mix`, 97 `MULTI.MIX`, 173 `multimd.mix`, 13 `expandmd01.mix`, 53
+top-level `.mmx`/`.yro` packages, and two loose maps.
+
+## Save/load/replay implications
+
+`MouseClass__Save @ 0x005BE6D0` saves allocated cells through OLE.
+`CellClass__Save @ 0x00483C10` reaches `AbstractClass__Save @ 0x00410320`, whose
+raw receiver block includes translated `Cell+0x38`. Load restores that block
+through `CellClass__Load @ 0x004839F0` and `AbstractClass__Load @ 0x00410380`
+before pointer swizzles/map attachment and never calls the translator.
+
+Thus saves persist already-translated actual IDs, load restores them verbatim,
+and no second translation occurs. The exception vector itself is not
+serialized; its xrefs close to static lifecycle, theater loading, and the
+helper. Changed-theater load reconstructs it; same-theater load preserves it.
+If theater contents change between save/load, native does not migrate numeric
+cell IDs. No replay/network command directly calls the helper; initial replay
+scenario loading uses ordinary ingress and later commands use actual IDs.
+
+## Installed retail theater data
+
+All six active theater INIs resolve from `ra2md.mix -> localmd.mix`; repository
+extracts match the installed entries byte-for-byte.
+
+| Theater INI | Bytes | TileSet sections | Active `LastTilesInSet` | Commented | FNV-1a |
+|---|---:|---:|---:|---:|---|
+| `temperatmd.ini` | 25,269 | 82 | 0 | 20 | `d7dfe4e2e00155e5` |
+| `snowmd.ini` | 24,258 | 83 | 0 | 18 | `084cde6830ee27ce` |
+| `urbanmd.ini` | 30,237 | 111 | 0 | 20 | `b189cec0969fb87a` |
+| `urbannmd.ini` | 32,614 | 122 | 0 | 20 | `96f5634036b5de84` |
+| `desertmd.ini` | 25,514 | 82 | 0 | 20 | `ab2c2af32b0e9b8b` |
+| `lunarmd.ini` | 26,560 | 85 | 0 | 20 | `e2f225d71782d6f3` |
+
+The commented assignments are historical/editor documentation. Map-local
+`[TileSet...]` sections cannot activate the feature because native reads the
+separate theater MD.INI object.
+
+## Current Rust mismatch
+
+`TilesetLookup` has no compatibility state or transform API.
+`parse_tileset_ini` currently loops `0..10000`, stops only when the section is
+absent, parses `TilesInSet` as `get_i32(...).unwrap_or(0).max(0) as u32`, and
+discards the signed values needed for native exception construction. Its
+nearby default comment is also wrong. `IniSection::read_int` already provides
+the exact missing/malformed/hexadecimal semantics.
+
+`parse_iso_map_pack_records` correctly preserves Pack5's raw signed tile dword
+and coordinate validation and should remain theater-independent.
+`materialize_map_load_cells` applies Fill and then accepted explicit records,
+but does not translate those explicit indexes before source lineage, LAT, or
+variant lookup. `MapFile.cells` should remain raw; translation belongs in the
+theater-aware materialization step.
+
+## Builder-ready handoff
+
+Add a compact declaration-ordered exception vector to `TilesetLookup` and a
+pure `translate_legacy_map_tile_index(raw: i32) -> i32` method with the exact
+sentinel, original-input signed comparison, wrapping prefix accumulation, and
+no clamp.
+
+Parser requirements:
+
+1. Maintain separate signed actual and legacy cursors.
+2. Resolve ordinal `TileSet%04d` without a fixed 10,000 cap.
+3. Read `TilesInSet` via `read_int(...,-1)`; stop only on exact `-1`.
+4. Read `LastTilesInSet` via `read_int(...,-1)`.
+5. Build exception state with wrapping arithmetic before safe allocation
+   normalization.
+6. Other negative `TilesInSet` values may create zero Rust registry slots
+   while retaining exact legacy arithmetic; do not emulate memory corruption.
+
+Apply translation only to coordinate-accepted explicit map records, after
+Pack5 parsing and before they replace Fill/source lineage. Never translate
+Fill, runtime Mark/direct mutation, or snapshot restoration. Keep the API
+format-neutral for future Pack1-4 support.
+
+Required tests cover parser construction; equality and multi-entry boundaries;
+comparison against original raw; empty-table identity; missing/malformed/hex
+ReadInt behavior; exact `-1` termination; nonterminating negatives; wrapping
+and `-1` versus `65535`; end-to-end explicit source/LAT/variant/final state;
+Fill, OOB, runtime-mutation, and persistence exclusions; all six retail
+fixtures empty; and a nonmonotonic declaration-order early-stop case.
+
+## Stale-document corrections
+
+- `ISOMAPPACK5_DECODER_GHIDRA_REPORT.md` incorrectly describes a flat sorted
+  pair array and calls the helper validation. It is a declaration-ordered
+  pointer vector of compatibility records and does not validate registry
+  range.
+- `ISOMETRIC_TILE_TYPE_CLASS_GHIDRA_REPORT.md` places the TilesInSet read before
+  start publication; live order publishes the candidate start first.
+- `ASSET_PARSING_BRIDGES_GHIDRA_REPORT.md` uses `{first_tile,count_diff}` and
+  implies a derived Last default. Exact default is `-1`; field zero is the
+  cumulative legacy boundary.
+- “Global tile-array gaps/unloaded tilesets” is not the proven formula. The
+  exact mechanism reconciles historical per-set counts declared by
+  `LastTilesInSet`.
+
+## Certainty ledger
+
+| Area | Status | Confidence |
+|---|---|---:|
+| Loader lifecycle and same-theater reuse | verified | HIGH |
+| Parser defaults/sentinel | verified | HIGH |
+| Exception vector/record layout | verified | HIGH |
+| Capacity/order/failure behavior | verified/excluded where unsafe | HIGH |
+| Boundary/delta formula | verified | HIGH |
+| Transform signedness/sentinel/wrapping | verified | HIGH |
+| Five-caller closure and ingress ordering | verified | HIGH |
+| Variant/LAT ordering | verified | HIGH |
+| Fill/Mark/save/replay exclusions | verified | HIGH |
+| Installed theater/map reachability | verified | HIGH |
+| Current Rust divergence and handoff | verified | HIGH |
+
+No load-bearing questions remain for this mechanism.
+
+## Ghidra annotation candidates
+
+No metadata was changed. Candidates are `DAT_00AA1078` as
+`g_LegacyTileIndexExceptions`, `DAT_00AA107C` as
+`LegacyTileIndexException**`, the subsequent capacity/valid/owns/count/growth
+fields, and a function boundary at `0x0054A630` for the pointer-vector resize.
+`Read_Theater_TileSets_INI` and `CalculateLegacyMapTileIndex` are already
+correctly named.
+
+## Sources
+
+- Active retail `gamemd.exe`, image base `0x00400000`, live Ghidra
+  decompilation/assembly/xrefs at the addresses cited above.
+- `docs/research/ISOMETRIC_TILE_TYPE_CLASS_GHIDRA_REPORT.md`
+- `docs/research/ISOMAPPACK5_DECODER_GHIDRA_REPORT.md`
+- `docs/research/bridges/01-assets-map-load-overlay/ASSET_PARSING_BRIDGES_GHIDRA_REPORT.md`
+- `src/map/theater.rs`, `src/map/map_file.rs`,
+  `src/map/resolved_terrain.rs`, and `src/rules/ini_value.rs`.
+- Installed active theater entries and the physical installed map corpus.

--- a/src/app/persistence/mod.rs
+++ b/src/app/persistence/mod.rs
@@ -459,7 +459,9 @@ mod tests {
     use crate::app::match_runtime::frame_pacer::LocalFramePacer;
     use crate::map::lighting::CellLightGrid;
     use crate::map::overlay::OverlayEntry;
+    use crate::map::resolved_terrain::{DynamicTerrainCellState, ResolvedTerrainCell};
     use crate::rules::ini_parser::IniFile;
+    use crate::rules::terrain_rules::{SpeedCostProfile, TerrainClass};
     use crate::sim::overlay_grid::OverlayGrid;
     use crate::sim::replay::{ReplayHeader, ReplayLog};
     use crate::sim::world::{Simulation, SimulationRngState};
@@ -697,6 +699,64 @@ mod tests {
 
     fn load_fixture_terrain() -> ResolvedTerrainGrid {
         ResolvedTerrainGrid::from_cells(0, 0, Vec::new())
+    }
+
+    fn compatibility_snapshot_cell(tile_index: i32) -> ResolvedTerrainCell {
+        ResolvedTerrainCell {
+            rx: 0,
+            ry: 0,
+            source_tile_index: tile_index,
+            source_sub_tile: 0,
+            final_tile_index: tile_index,
+            final_sub_tile: 0,
+            is_wood_bridge_repair_tile: false,
+            level: 0,
+            filled_clear: false,
+            tileset_index: Some(0),
+            land_type: 0,
+            yr_cell_land_type: 0,
+            slope_type: 0,
+            template_height: 0,
+            height_in_pixels: 0,
+            render_offset_x: 0,
+            render_offset_y: 0,
+            terrain_class: TerrainClass::Clear,
+            speed_costs: SpeedCostProfile::default(),
+            is_water: false,
+            is_cliff_like: false,
+            is_rough: false,
+            is_road: false,
+            accepts_smudge: false,
+            allows_tiberium: false,
+            variant: 0,
+            has_ramp: false,
+            canonical_ramp: None,
+            ground_walk_blocked: false,
+            terrain_object_blocks: false,
+            terrain_object_occupation: None,
+            overlay_blocks: false,
+            overlay_zone_type: None,
+            outside_playfield: false,
+            zone_type: crate::map::resolved_terrain::zone_class::GROUND,
+            base_ground_walk_blocked: false,
+            base_build_blocked: false,
+            base_land_type: 0,
+            base_yr_cell_land_type: 0,
+            base_terrain_class: TerrainClass::Clear,
+            base_speed_costs: SpeedCostProfile::default(),
+            build_blocked: false,
+            has_bridge_deck: false,
+            bridge_walkable: false,
+            bridge_transition: false,
+            bridge_deck_level: 0,
+            bridge_layer: None,
+            bridge_facts: crate::map::bridge_facts::BridgeCellFacts::default(),
+            tube_index: None,
+            radar_left: [0, 0, 0],
+            radar_right: [0, 0, 0],
+            has_damaged_data: false,
+            bridgehead_anchor_class_at_load: None,
+        }
     }
 
     fn snapshot_bytes(simulation: &Simulation, rules: &RuleSet) -> Vec<u8> {
@@ -1018,6 +1078,64 @@ mod tests {
         );
 
         std::fs::remove_dir_all(directory).expect("remove startup fixture directory");
+    }
+
+    #[test]
+    fn gsi_04_02_last_tiles_full_load_route_does_not_retranslate_actual_runtime_ids() {
+        let compatibility = crate::map::theater::parse_tileset_ini(
+            b"[TileSet0000]\nTilesInSet=3\n\
+              [TileSet0001]\nTilesInSet=5\nLastTilesInSet=2\n\
+              [TileSet0002]\nTilesInSet=1\n",
+            "tem",
+        )
+        .expect("compatibility table");
+        assert_eq!(compatibility.translate_legacy_map_tile_index(5), 8);
+
+        let rules = load_fixture_rules();
+        let registry = OverlayTypeRegistry::empty();
+        let translated_template =
+            ResolvedTerrainGrid::from_cells(1, 1, vec![compatibility_snapshot_cell(8)]);
+        let mut runtime_actual = compatibility_snapshot_cell(5);
+        runtime_actual.radar_left = [31, 32, 33];
+
+        let mut saved = load_fixture_simulation(false);
+        saved.overlay_grid = Some(OverlayGrid::new(1, 1));
+        saved.install_resolved_terrain_for_new_map(translated_template.clone());
+        saved
+            .dynamic_terrain_cells
+            .insert((0, 0), DynamicTerrainCellState::capture(&runtime_actual));
+        let bytes = snapshot_bytes(&saved, &rules);
+
+        let mut current = load_fixture_simulation(false);
+        current.overlay_grid = Some(OverlayGrid::new(1, 1));
+        let (restored, _) = PreparedLoad::prepare_candidate(
+            &bytes,
+            Some(&current),
+            Some(LOAD_FIXTURE_MAP_HASH),
+            Some(&rules),
+            Some(&translated_template),
+            Some(&registry),
+        )
+        .expect("full persistence prepare/serde/rebuild/restore route");
+
+        let restored_cell = restored
+            .resolved_terrain
+            .as_ref()
+            .and_then(|terrain| terrain.cell(0, 0))
+            .expect("restored dynamic terrain cell");
+        assert_eq!(
+            restored_cell.source_tile_index, 8,
+            "the retained already-translated map template is cloned verbatim"
+        );
+        assert_eq!(
+            restored_cell.final_tile_index, 5,
+            "serialized runtime actual ID must not cross legacy translation again"
+        );
+        assert_eq!(restored_cell.radar_left, [31, 32, 33]);
+        assert_eq!(
+            restored.dynamic_terrain_cells.get(&(0, 0)),
+            Some(&DynamicTerrainCellState::capture(&runtime_actual))
+        );
     }
 
     #[test]

--- a/src/map/map_file.rs
+++ b/src/map/map_file.rs
@@ -57,6 +57,8 @@ pub enum MapError {
     Lzo(LzoError),
     Asset(AssetError),
     CellDataTruncated { expected: usize, actual: usize },
+    TilesetRegistryTooLarge { attempted: usize, maximum: usize },
+    TilesetOrdinalOverflow { ordinal: u32, maximum: u32 },
     Io(std::io::Error),
 }
 
@@ -79,6 +81,14 @@ impl std::fmt::Display for MapError {
                     expected, actual
                 )
             }
+            MapError::TilesetRegistryTooLarge { attempted, maximum } => write!(
+                f,
+                "Theater tileset registry requires {attempted} slots, but Rust can represent at most {maximum} usable tile IDs"
+            ),
+            MapError::TilesetOrdinalOverflow { ordinal, maximum } => write!(
+                f,
+                "Theater tileset ordinal {ordinal} exceeds the supported maximum {maximum}"
+            ),
             MapError::Io(e) => write!(f, "IO error: {}", e),
         }
     }

--- a/src/map/map_file.rs
+++ b/src/map/map_file.rs
@@ -157,16 +157,19 @@ pub struct MapSmudgeEntry {
 /// A single isometric terrain cell from IsoMapPack5.
 ///
 /// Layout per ModEnc + FinalAlert2 source: 11 bytes total.
-/// tile_index is a flat cumulative index into the theater's tileset list.
-/// -1 (0xFFFFFFFF) means "no tile" (clear ground at level 0).
+/// `tile_index` is the signed raw value from the pack. Map materialization
+/// translates it through the active theater's `LastTilesInSet` table before
+/// treating it as an actual cumulative tileset index. Consequently, raw `-1`
+/// is not intrinsically the runtime no-tile sentinel on a legacy/custom
+/// theater with a reached compatibility record.
 #[derive(Debug, Clone)]
 pub struct MapCell {
     /// Canonical isometric X coordinate after the 512-wide native lookup.
     pub rx: u16,
     /// Canonical isometric Y coordinate after the 512-wide native lookup.
     pub ry: u16,
-    /// Flat index into the theater's tile list (i32, NOT u16).
-    /// -1 = no tile / clear ground. Cumulative across all TileSet sections.
+    /// Signed raw Pack5 tile value (i32, NOT u16). After the map-load
+    /// compatibility seam, this field holds the translated actual tile index.
     pub tile_index: i32,
     /// Sub-tile index within a multi-cell TMP template (0 for single-cell tiles).
     pub sub_tile: u8,

--- a/src/map/map_file.rs
+++ b/src/map/map_file.rs
@@ -485,29 +485,29 @@ fn parse_iso_map_pack(ini: &IniFile) -> Result<ParsedIsoMapPack, MapError> {
 
     // Diagnostic: tile_index distribution. Lets a reader of the load logs see
     // how high a map's IsoMapPack5 reaches vs. what the theater INI defines.
-    let mut min_pos: i32 = i32::MAX;
-    let mut max_idx: i32 = -1;
-    let mut no_tile: usize = 0;
+    let mut min_idx: i32 = i32::MAX;
+    let mut max_idx: i32 = i32::MIN;
+    let mut raw_negative: usize = 0;
+    let mut no_tile_sentinel: usize = 0;
     let mut distinct: std::collections::HashSet<i32> = std::collections::HashSet::new();
     for c in &parsed.cells {
         if c.tile_index < 0 {
-            no_tile += 1;
-        } else {
-            if c.tile_index < min_pos {
-                min_pos = c.tile_index;
-            }
-            if c.tile_index > max_idx {
-                max_idx = c.tile_index;
-            }
+            raw_negative += 1;
         }
+        if c.tile_index == i32::from(u16::MAX) {
+            no_tile_sentinel += 1;
+        }
+        min_idx = min_idx.min(c.tile_index);
+        max_idx = max_idx.max(c.tile_index);
         distinct.insert(c.tile_index);
     }
     log::info!(
-        "IsoMapPack5: {} cells, {} no-tile, tile_index min={}, max={}, distinct={}",
+        "IsoMapPack5: {} cells, {} raw-negative, {} positive-0xFFFF no-tile, tile_index min={}, max={}, distinct={}",
         parsed.cells.len(),
-        no_tile,
-        if min_pos == i32::MAX { -1 } else { min_pos },
-        max_idx,
+        raw_negative,
+        no_tile_sentinel,
+        if min_idx == i32::MAX { -1 } else { min_idx },
+        if max_idx == i32::MIN { -1 } else { max_idx },
         distinct.len()
     );
 

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -1,9 +1,10 @@
 //! Resolved terrain/topology stage built from raw map cells plus theater/TMP metadata.
 //!
 //! This module sits between `MapFile` parsing and downstream consumers such as
-//! rendering, pathfinding, and building placement. It preserves raw IsoMapPack5
-//! data while attaching resolved per-cell metadata such as final LAT-adjusted
-//! tile choice, land/slope bytes from TMP, and coarse blocking/buildability flags.
+//! rendering, pathfinding, and building placement. It materializes raw
+//! IsoMapPack5 tile values into theater-compatible actual IDs, then attaches
+//! resolved per-cell metadata such as final LAT-adjusted tile choice,
+//! land/slope bytes from TMP, and coarse blocking/buildability flags.
 
 /// Zone classification constants matching gamemd.exe RecalcZoneType output.
 /// These index columns of `MOVEMENT_ZONE_PASSABILITY` in pathfinding/passability.rs.

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -4409,9 +4409,9 @@ mod tests {
         map.header.width = 3;
         map.header.height = 2;
         map.iso_map_pack_lookups = vec![crate::map::map_file::IsoMapPackLookup {
-            raw_x: -510,
+            raw_x: -509,
             raw_y: 3,
-            canonical: Some((2, 2)),
+            canonical: Some((3, 2)),
         }];
 
         let mut cache = crate::map::tile_variant_selector::TileVariantSelectorCache::default();
@@ -4502,7 +4502,9 @@ mod tests {
             8
         );
 
-        let manual = make_map(pack.cells.clone(), Vec::new(), Vec::new());
+        let mut manual = make_map(pack.cells.clone(), Vec::new(), Vec::new());
+        manual.header.width = 3;
+        manual.header.height = 2;
         let selector_free_manual =
             ResolvedTerrainGrid::build(&manual, Some(&theater), None, None, None, false, 0);
         assert_eq!(
@@ -4526,6 +4528,28 @@ mod tests {
         cache.complete_theater_registry_load(Some(5), None);
         let mut forbidden_main = || panic!("compatibility fixture has no variants");
         let mut fill = |_low, _high| 0;
+        let production_manual = {
+            let mut selector = cache.begin_load(&mut forbidden_main);
+            ResolvedTerrainGrid::build_with_variant_selector(
+                &manual,
+                Some(&theater),
+                None,
+                None,
+                None,
+                None,
+                false,
+                0,
+                &mut fill,
+                &mut selector,
+            )
+        };
+        assert_eq!(
+            production_manual
+                .cell(2, 2)
+                .expect("production manual actual-ID cell")
+                .source_tile_index,
+            5
+        );
         let production_pack = {
             let mut selector = cache.begin_load(&mut forbidden_main);
             ResolvedTerrainGrid::build_with_variant_selector(

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -33,7 +33,7 @@ use crate::map::overlay_types::{
     uses_early_recalc_land_branch,
 };
 use crate::map::rmg::preview::Playfield;
-use crate::map::theater::{self, TheaterData, TileKey};
+use crate::map::theater::{self, TheaterData, TileKey, TilesetLookup};
 use crate::map::tile_variant_selector::TileVariantSelectionContext;
 use crate::map::tube_facts::{TubeFact, TubeId};
 use crate::rules::terrain_object_type::TerrainObjectType;
@@ -1918,11 +1918,18 @@ impl ResolvedTerrainGrid {
             variant_selector.as_deref_mut(),
             scenario_fill_ranged.as_deref_mut(),
         ) {
-            materialize_map_load_cells(map, selector, fill_ranged, &shared_cell_dummy)
+            materialize_map_load_cells(
+                map,
+                theater_data.map(|theater| &theater.lookup),
+                selector,
+                fill_ranged,
+                &shared_cell_dummy,
+            )
         } else {
             // The selector-free constructor is retained for focused tests and
-            // synthetic grids. Production always takes the native load path.
-            map.cells.clone()
+            // synthetic grids. Pack-derived fixtures still cross the native
+            // compatibility seam, while manual/RMG actual IDs stay untouched.
+            selector_free_map_cells(map, theater_data.map(|theater| &theater.lookup))
         };
         let (width, height) = grid_dimensions(&raw_cells);
         if width == 0 || height == 0 {
@@ -3660,8 +3667,23 @@ fn wheel_speed_at_or_below_one_percent(wheel: Option<u8>) -> bool {
 
 /// Reproduce the active map-load order: initialize every allocated Size-diamond
 /// CellClass, then let IsoMapPack records overwrite those cells in stream order.
+fn selector_free_map_cells(map: &MapFile, lookup: Option<&TilesetLookup>) -> Vec<MapCell> {
+    let translate_raw_pack_cells = !map.iso_map_pack_lookups.is_empty();
+    map.cells
+        .iter()
+        .cloned()
+        .map(|mut cell| {
+            if translate_raw_pack_cells && let Some(lookup) = lookup {
+                cell.tile_index = lookup.translate_legacy_map_tile_index(cell.tile_index);
+            }
+            cell
+        })
+        .collect()
+}
+
 fn materialize_map_load_cells(
     map: &MapFile,
+    lookup: Option<&TilesetLookup>,
     selector: &mut TileVariantSelectionContext<'_, '_>,
     scenario_fill_ranged: &mut dyn FnMut(u32, u32) -> u32,
     shared_cell_dummy: &SharedCellDummy,
@@ -3739,11 +3761,22 @@ fn materialize_map_load_cells(
         }
     }
 
+    let translate_raw_pack_cells = !map.iso_map_pack_lookups.is_empty();
     for explicit in &map.cells {
         let Some(&index) = index_by_coord.get(&(explicit.rx, explicit.ry)) else {
             continue;
         };
-        cells[index] = explicit.clone();
+        let mut materialized = explicit.clone();
+        if translate_raw_pack_cells && let Some(lookup) = lookup {
+            // Retail provenance: Pack5 callsite 0x0056BB68 reaches
+            // `CalculateLegacyMapTileIndex @ 0x00544E30` only after the
+            // destination CellClass was accepted, and before Cell+0x38 becomes
+            // authoritative for variant/LAT/Recalc consumers. Fill, RMG, and
+            // manual/runtime actual IDs never cross this seam.
+            materialized.tile_index =
+                lookup.translate_legacy_map_tile_index(materialized.tile_index);
+        }
+        cells[index] = materialized;
     }
     cells
 }
@@ -3852,6 +3885,71 @@ mod tests {
         data.extend_from_slice(&0u32.to_le_bytes());
         data.extend_from_slice(&0u32.to_le_bytes());
         data
+    }
+
+    fn gsi_04_02_last_tiles_tmp_bytes(
+        terrain_type: u8,
+        radar_left: [u8; 3],
+        radar_right: [u8; 3],
+    ) -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(&1u32.to_le_bytes());
+        data.extend_from_slice(&1u32.to_le_bytes());
+        data.extend_from_slice(&8u32.to_le_bytes());
+        data.extend_from_slice(&4u32.to_le_bytes());
+        data.extend_from_slice(&20u32.to_le_bytes());
+        data.extend_from_slice(&[0u8; 40]);
+        data.push(3);
+        data.push(terrain_type);
+        data.push(0);
+        data.extend_from_slice(&radar_left);
+        data.extend_from_slice(&radar_right);
+        data.extend_from_slice(&[0u8; 3]);
+        data.extend(1u8..=16);
+        data
+    }
+
+    fn gsi_04_02_last_tiles_theater() -> TheaterData {
+        synthetic_theater_from_ini(
+            b"[General]\nRoughTile=2\nClearToRoughLat=3\n\
+              [TileSet0000]\nTilesInSet=3\nFileName=base\nSetName=Clear\n\
+              [TileSet0001]\nTilesInSet=5\nLastTilesInSet=2\nFileName=old\nSetName=Clear\n\
+              [TileSet0002]\nTilesInSet=1\nFileName=rough\nSetName=Rough\n\
+              [TileSet0003]\nTilesInSet=16\nFileName=lat\nSetName=Rough LAT\n",
+        )
+    }
+
+    fn gsi_04_02_asset_manager_with_loose_tmps(
+        files: &[(&str, &[u8])],
+    ) -> (Gsi0404AssetDirectory, AssetManager) {
+        let directory = Gsi0404AssetDirectory::new();
+        let empty_mix = gsi_04_04_mix_bytes("gsi0402.bin", b"fixture");
+        for name in [
+            "ra2md.mix",
+            "ra2.mix",
+            "cachemd.mix",
+            "cache.mix",
+            "localmd.mix",
+            "local.mix",
+            "conqmd.mix",
+            "conquer.mix",
+            "cameomd.mix",
+            "cameo.mix",
+            "mapsmd03.mix",
+            "multimd.mix",
+            "movmd03.mix",
+        ] {
+            directory.write(name, &empty_mix);
+        }
+        for &(name, bytes) in files {
+            directory.write(name, bytes);
+        }
+        let manager = AssetManager::new_with_media_mode(
+            directory.path(),
+            MediaArchiveMode::Numbered { media_index: 2 },
+        )
+        .expect("construct compatibility-translation asset stack");
+        (directory, manager)
     }
 
     fn make_map(
@@ -4278,6 +4376,212 @@ mod tests {
     }
 
     #[test]
+    fn gsi_04_02_last_tiles_pack_materialization_precedes_tmp_lat_and_final_state() {
+        let theater = gsi_04_02_last_tiles_theater();
+        assert_eq!(theater.lookup.translate_legacy_map_tile_index(5), 8);
+        let rough = gsi_04_02_last_tiles_tmp_bytes(3, [1, 2, 3], [4, 5, 6]);
+        let lat = gsi_04_02_last_tiles_tmp_bytes(7, [21, 22, 23], [24, 25, 26]);
+        let (_directory, assets) = gsi_04_02_asset_manager_with_loose_tmps(&[
+            ("rough01.tem", &rough),
+            ("lat16.tem", &lat),
+        ]);
+        let mut map = make_map(
+            vec![MapCell {
+                rx: 2,
+                ry: 2,
+                tile_index: 5,
+                sub_tile: 0,
+                z: 4,
+            }],
+            Vec::new(),
+            Vec::new(),
+        );
+        map.header.width = 3;
+        map.header.height = 2;
+        map.iso_map_pack_lookups = vec![crate::map::map_file::IsoMapPackLookup {
+            raw_x: -510,
+            raw_y: 3,
+            canonical: Some((2, 2)),
+        }];
+
+        let mut cache = crate::map::tile_variant_selector::TileVariantSelectorCache::default();
+        cache.complete_theater_registry_load(Some(5), None);
+        let mut forbidden_main = || panic!("single-file TMPs must not draw Main");
+        let mut fill = |_low, _high| 0;
+        let without_lat = {
+            let mut selector = cache.begin_load(&mut forbidden_main);
+            ResolvedTerrainGrid::build_with_variant_selector(
+                &map,
+                Some(&theater),
+                Some(&assets),
+                None,
+                None,
+                None,
+                false,
+                0,
+                &mut fill,
+                &mut selector,
+            )
+        };
+        let translated = without_lat.cell(2, 2).expect("accepted Pack5 cell");
+        assert_eq!(translated.source_tile_index, 8);
+        assert_eq!(translated.final_tile_index, 8);
+        assert_eq!(translated.tileset_index, Some(2));
+        assert_eq!(translated.radar_left, [1, 2, 3]);
+        assert_eq!(translated.radar_right, [4, 5, 6]);
+        assert_eq!(translated.variant, 0);
+        assert_eq!(translated.level, 4);
+
+        let fill_cell = without_lat.cell(1, 3).expect("prefilled real CellClass");
+        assert_eq!(fill_cell.source_tile_index, 5);
+        assert_ne!(fill_cell.source_tile_index, 8);
+
+        let with_lat = {
+            let mut selector = cache.begin_load(&mut forbidden_main);
+            ResolvedTerrainGrid::build_with_variant_selector(
+                &map,
+                Some(&theater),
+                Some(&assets),
+                None,
+                None,
+                None,
+                true,
+                0,
+                &mut fill,
+                &mut selector,
+            )
+        };
+        let lat_fixed = with_lat.cell(2, 2).expect("LAT-fixed Pack5 cell");
+        assert_eq!(lat_fixed.source_tile_index, 8);
+        assert_eq!(lat_fixed.final_tile_index, 24);
+        assert_eq!(lat_fixed.tileset_index, Some(3));
+        assert_eq!(lat_fixed.radar_left, [21, 22, 23]);
+        assert_eq!(lat_fixed.radar_right, [24, 25, 26]);
+    }
+
+    #[test]
+    fn gsi_04_02_last_tiles_provenance_gates_both_materialization_paths() {
+        let theater = gsi_04_02_last_tiles_theater();
+        let mut pack = make_map(
+            vec![MapCell {
+                rx: 2,
+                ry: 2,
+                tile_index: 5,
+                sub_tile: 0,
+                z: 0,
+            }],
+            Vec::new(),
+            Vec::new(),
+        );
+        pack.iso_map_pack_lookups = vec![crate::map::map_file::IsoMapPackLookup {
+            raw_x: -510,
+            raw_y: 3,
+            canonical: Some((2, 2)),
+        }];
+        pack.header.width = 3;
+        pack.header.height = 2;
+
+        let selector_free_pack =
+            ResolvedTerrainGrid::build(&pack, Some(&theater), None, None, None, false, 0);
+        assert_eq!(
+            selector_free_pack
+                .cell(2, 2)
+                .expect("selector-free Pack5 cell")
+                .source_tile_index,
+            8
+        );
+
+        let manual = make_map(pack.cells.clone(), Vec::new(), Vec::new());
+        let selector_free_manual =
+            ResolvedTerrainGrid::build(&manual, Some(&theater), None, None, None, false, 0);
+        assert_eq!(
+            selector_free_manual
+                .cell(2, 2)
+                .expect("manual actual-ID cell")
+                .source_tile_index,
+            5
+        );
+
+        let theaterless_pack = ResolvedTerrainGrid::build(&pack, None, None, None, None, false, 0);
+        assert_eq!(
+            theaterless_pack
+                .cell(2, 2)
+                .expect("theater-less synthetic Pack cell")
+                .source_tile_index,
+            5
+        );
+
+        let mut cache = crate::map::tile_variant_selector::TileVariantSelectorCache::default();
+        cache.complete_theater_registry_load(Some(5), None);
+        let mut forbidden_main = || panic!("compatibility fixture has no variants");
+        let mut fill = |_low, _high| 0;
+        let production_pack = {
+            let mut selector = cache.begin_load(&mut forbidden_main);
+            ResolvedTerrainGrid::build_with_variant_selector(
+                &pack,
+                Some(&theater),
+                None,
+                None,
+                None,
+                None,
+                false,
+                0,
+                &mut fill,
+                &mut selector,
+            )
+        };
+        assert_eq!(
+            production_pack
+                .cell(2, 2)
+                .expect("production Pack5 cell")
+                .source_tile_index,
+            8
+        );
+    }
+
+    #[test]
+    fn gsi_04_02_last_tiles_does_not_translate_fill_or_dummy_only_pack_misses() {
+        let theater = gsi_04_02_last_tiles_theater();
+        let mut map = make_map(
+            vec![MapCell {
+                rx: 99,
+                ry: 99,
+                tile_index: 5,
+                sub_tile: 7,
+                z: 9,
+            }],
+            Vec::new(),
+            Vec::new(),
+        );
+        map.header.width = 3;
+        map.header.height = 2;
+        map.iso_map_pack_lookups = vec![crate::map::map_file::IsoMapPackLookup {
+            raw_x: 99,
+            raw_y: 99,
+            canonical: None,
+        }];
+        let dummy = SharedCellDummy::fresh();
+        let mut cache = crate::map::tile_variant_selector::TileVariantSelectorCache::default();
+        cache.complete_theater_registry_load(Some(5), None);
+        let mut forbidden_main = || panic!("Fill and misses do not draw Main");
+        let mut selector = cache.begin_load(&mut forbidden_main);
+        let mut fill = |_low, _high| 0;
+
+        let cells = materialize_map_load_cells(
+            &map,
+            Some(&theater.lookup),
+            &mut selector,
+            &mut fill,
+            &dummy,
+        );
+
+        assert!(!cells.is_empty());
+        assert!(cells.iter().all(|cell| cell.tile_index == 5));
+        assert!(cells.iter().all(|cell| cell.tile_index != 8));
+        assert_eq!(dummy.snapshot().coord, (99, 99));
+    }
+
+    #[test]
     fn gsi_04_01_resize_clears_bridge_bits_without_replacing_dummy_identity() {
         let dummy = SharedCellDummy::fresh();
         let retained = dummy.clone();
@@ -4354,7 +4658,7 @@ mod tests {
         let mut selector = cache.begin_load(&mut forbidden_main);
         let mut fill = |_low, _high| 0;
 
-        let cells = materialize_map_load_cells(&map, &mut selector, &mut fill, &dummy);
+        let cells = materialize_map_load_cells(&map, None, &mut selector, &mut fill, &dummy);
 
         let real = cells
             .iter()
@@ -4408,7 +4712,7 @@ mod tests {
         let mut selector = cache.begin_load(&mut forbidden_main);
         let mut fill = |_low, _high| 0;
 
-        let cells = materialize_map_load_cells(&map, &mut selector, &mut fill, &dummy);
+        let cells = materialize_map_load_cells(&map, None, &mut selector, &mut fill, &dummy);
 
         assert_eq!(dummy.snapshot(), expected_dummy);
         assert_eq!(
@@ -4671,6 +4975,7 @@ mod tests {
             let mut selector = cache.begin_load(&mut main_draw);
             let cells = materialize_map_load_cells(
                 &map,
+                None,
                 &mut selector,
                 &mut scenario_fill_ranged,
                 &SharedCellDummy::fresh(),
@@ -4747,6 +5052,7 @@ mod tests {
             };
             let cells = materialize_map_load_cells(
                 &map,
+                None,
                 &mut selector,
                 &mut scenario_fill_ranged,
                 &SharedCellDummy::fresh(),

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -4377,17 +4377,27 @@ mod tests {
 
     #[test]
     fn gsi_04_02_last_tiles_pack_materialization_precedes_tmp_lat_and_final_state() {
-        let theater = gsi_04_02_last_tiles_theater();
-        assert_eq!(theater.lookup.translate_legacy_map_tile_index(5), 8);
+        let mut theater = gsi_04_02_last_tiles_theater();
+        let raw_legacy = gsi_04_02_last_tiles_tmp_bytes(6, [11, 12, 13], [14, 15, 16]);
         let rough = gsi_04_02_last_tiles_tmp_bytes(3, [1, 2, 3], [4, 5, 6]);
+        let rough_suffix =
+            gsi_04_02_last_tiles_tmp_bytes(9, [31, 32, 33], [34, 35, 36]);
         let lat = gsi_04_02_last_tiles_tmp_bytes(7, [21, 22, 23], [24, 25, 26]);
         let (_directory, assets) = gsi_04_02_asset_manager_with_loose_tmps(&[
+            ("old03.tem", &raw_legacy),
             ("rough01.tem", &rough),
+            ("rough01a.tem", &rough_suffix),
             ("lat16.tem", &lat),
         ]);
+        crate::map::theater::resolve_contiguous_variant_chains_for_test(
+            &mut theater.lookup,
+            &assets,
+        );
+        assert_eq!(theater.lookup.translate_legacy_map_tile_index(5), 8);
+        assert_eq!(theater.lookup.total_file_count(8), 2);
         let mut map = make_map(
             vec![MapCell {
-                rx: 2,
+                rx: 3,
                 ry: 2,
                 tile_index: 5,
                 sub_tile: 0,
@@ -4406,10 +4416,10 @@ mod tests {
 
         let mut cache = crate::map::tile_variant_selector::TileVariantSelectorCache::default();
         cache.complete_theater_registry_load(Some(5), None);
-        let mut forbidden_main = || panic!("single-file TMPs must not draw Main");
+        let mut deterministic_main = || 0;
         let mut fill = |_low, _high| 0;
         let without_lat = {
-            let mut selector = cache.begin_load(&mut forbidden_main);
+            let mut selector = cache.begin_load(&mut deterministic_main);
             ResolvedTerrainGrid::build_with_variant_selector(
                 &map,
                 Some(&theater),
@@ -4423,13 +4433,14 @@ mod tests {
                 &mut selector,
             )
         };
-        let translated = without_lat.cell(2, 2).expect("accepted Pack5 cell");
+        let translated = without_lat.cell(3, 2).expect("accepted Pack5 cell");
         assert_eq!(translated.source_tile_index, 8);
         assert_eq!(translated.final_tile_index, 8);
         assert_eq!(translated.tileset_index, Some(2));
-        assert_eq!(translated.radar_left, [1, 2, 3]);
-        assert_eq!(translated.radar_right, [4, 5, 6]);
-        assert_eq!(translated.variant, 0);
+        assert!(translated.variant > 0);
+        assert_eq!(translated.variant, 1);
+        assert_eq!(translated.radar_left, [31, 32, 33]);
+        assert_eq!(translated.radar_right, [34, 35, 36]);
         assert_eq!(translated.level, 4);
 
         let fill_cell = without_lat.cell(1, 3).expect("prefilled real CellClass");
@@ -4437,7 +4448,7 @@ mod tests {
         assert_ne!(fill_cell.source_tile_index, 8);
 
         let with_lat = {
-            let mut selector = cache.begin_load(&mut forbidden_main);
+            let mut selector = cache.begin_load(&mut deterministic_main);
             ResolvedTerrainGrid::build_with_variant_selector(
                 &map,
                 Some(&theater),
@@ -4451,7 +4462,7 @@ mod tests {
                 &mut selector,
             )
         };
-        let lat_fixed = with_lat.cell(2, 2).expect("LAT-fixed Pack5 cell");
+        let lat_fixed = with_lat.cell(3, 2).expect("LAT-fixed Pack5 cell");
         assert_eq!(lat_fixed.source_tile_index, 8);
         assert_eq!(lat_fixed.final_tile_index, 24);
         assert_eq!(lat_fixed.tileset_index, Some(3));

--- a/src/map/theater.rs
+++ b/src/map/theater.rs
@@ -19,9 +19,11 @@ use crate::map::map_file::MapError;
 use crate::rules::ini_parser::{IniFile, IniSection};
 use crate::map::bridge_facts::{Axis, BridgeheadAnchorClass};
 
-/// Marker for "no tile" in IsoMapPack5 data.
-/// The raw field is i32; -1 (0xFFFFFFFF) means clear ground.
-/// We also treat the legacy u16 0xFFFF as no-tile for compatibility.
+/// Marker for "no tile" after raw Pack5 compatibility translation.
+///
+/// A raw signed `-1` can be shifted by a reached `LastTilesInSet` record, so
+/// callers must not classify it before the map-load translation seam. Positive
+/// legacy u16 `0xFFFF` is translation-exempt and is also treated as no-tile.
 pub const NO_TILE: i32 = -1;
 
 /// Identifies a specific sub-tile within a TMP template, including variant.

--- a/src/map/theater.rs
+++ b/src/map/theater.rs
@@ -495,6 +495,23 @@ fn checked_tileset_ordinal(ordinal: u32) -> Result<u16, MapError> {
     })
 }
 
+fn read_tileset_row<'a>(
+    ini: &'a IniFile,
+    ordinal: u32,
+) -> Result<Option<(&'a IniSection, i32)>, MapError> {
+    let section_name = format!("TileSet{ordinal:04}");
+    let section = ini.section(&section_name);
+    let tiles_in_set = section.map_or(-1, |section| section.read_int("TilesInSet", -1));
+    if tiles_in_set == -1 {
+        return Ok(None);
+    }
+    checked_tileset_ordinal(ordinal)?;
+    Ok(Some((
+        section.expect("nonterminating TilesInSet requires a section"),
+        tiles_in_set,
+    )))
+}
+
 /// Parse a theater INI file into a TilesetLookup.
 ///
 /// Iterates [TileSet0000], [TileSet0001], ... sections in order.
@@ -520,14 +537,9 @@ pub fn parse_tileset_ini(ini_data: &[u8], extension: &str) -> Result<TilesetLook
     // exact signed -1 sentinel. `%04d` is a minimum width, not a 10,000-row cap.
     let mut idx = 0u32;
     loop {
-        let _ordinal = checked_tileset_ordinal(idx)?;
-        let section_name: String = format!("TileSet{:04}", idx);
-        let section = ini.section(&section_name);
-        let tiles_in_set = section.map_or(-1, |section| section.read_int("TilesInSet", -1));
-        if tiles_in_set == -1 {
+        let Some((section, tiles_in_set)) = read_tileset_row(&ini, idx)? else {
             break;
-        }
-        let section: &IniSection = section.expect("nonterminating TilesInSet requires a section");
+        };
 
         let filename: &str = section.get("FileName").unwrap_or("");
         let set_name: &str = section.get("SetName").unwrap_or("No Name");

--- a/src/map/theater.rs
+++ b/src/map/theater.rs
@@ -145,7 +145,7 @@ const THEATER_DEFS: &[(&str, TheaterDef)] = &[
 ];
 
 /// Start tile_id and count for one tileset section (e.g., [TileSet0013]).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TilesetBounds {
     /// First tile_id belonging to this tileset.
     pub start: u16,
@@ -311,7 +311,22 @@ pub struct TilesetLookup {
     /// `None` means the tile declared no `Tile%02dAnim`, matching the tile
     /// type's -1 animation index.
     tile_anims: Vec<Option<TileAnimAttachment>>,
+    /// Declaration-ordered compatibility records built from each unequal
+    /// `LastTilesInSet`. Values replace native's pointer-vector storage while
+    /// retaining its exact signed walk semantics.
+    legacy_tile_index_exceptions: Vec<LegacyTileIndexException>,
 }
+
+/// Immutable value projection of one native separately allocated eight-byte
+/// `LegacyException` record.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LegacyTileIndexException {
+    legacy_boundary: i32,
+    delta: i32,
+}
+
+const MAX_USABLE_TILE_SLOTS: usize = u16::MAX as usize;
+const MAX_TILESET_ORDINAL: u32 = u16::MAX as u32;
 
 impl TilesetLookup {
     /// Get the TMP filename for a given tile index.
@@ -450,12 +465,40 @@ impl TilesetLookup {
             .copied()
             .unwrap_or(false)
     }
+
+    /// Translate one raw IsoMap tile index through the active theater's
+    /// declaration-ordered `LastTilesInSet` compatibility records.
+    ///
+    /// Retail provenance: `CalculateLegacyMapTileIndex @ 0x00544E30` keeps
+    /// positive 0xFFFF unchanged, compares every signed boundary with the
+    /// original raw input, stops on the first greater boundary, and wrapping-
+    /// adds every delta already reached.
+    pub(crate) fn translate_legacy_map_tile_index(&self, raw: i32) -> i32 {
+        if raw == i32::from(u16::MAX) {
+            return raw;
+        }
+        let mut result = raw;
+        for entry in &self.legacy_tile_index_exceptions {
+            if entry.legacy_boundary > raw {
+                break;
+            }
+            result = result.wrapping_add(entry.delta);
+        }
+        result
+    }
+}
+
+fn checked_tileset_ordinal(ordinal: u32) -> Result<u16, MapError> {
+    u16::try_from(ordinal).map_err(|_| MapError::TilesetOrdinalOverflow {
+        ordinal,
+        maximum: MAX_TILESET_ORDINAL,
+    })
 }
 
 /// Parse a theater INI file into a TilesetLookup.
 ///
 /// Iterates [TileSet0000], [TileSet0001], ... sections in order.
-/// Each section's `TilesInSet` (default 1) advances the global tile_id counter.
+/// Each section's positive `TilesInSet` advances the global tile_id counter.
 /// The filename is `{FileName}{NN:02}.{extension}` where NN is 1-indexed.
 /// Blank FileName entries consume tile_id slots but map to None.
 pub fn parse_tileset_ini(ini_data: &[u8], extension: &str) -> Result<TilesetLookup, MapError> {
@@ -468,26 +511,62 @@ pub fn parse_tileset_ini(ini_data: &[u8], extension: &str) -> Result<TilesetLook
     let mut morphable_flags: Vec<bool> = Vec::new();
     let mut allow_tiberium_flags: Vec<bool> = Vec::new();
     let mut tile_anims: Vec<Option<TileAnimAttachment>> = Vec::new();
+    let mut legacy_tile_index_exceptions = Vec::new();
+    let mut actual_cursor = 0i32;
+    let mut legacy_cursor = 0i32;
 
-    // Iterate tileset sections in numerical order: TileSet0000, TileSet0001, ...
-    for idx in 0..10000u32 {
+    // Retail provenance: `Read_Theater_TileSets_INI @ 0x00545150` publishes
+    // candidates in ordinal order and terminates only when ReadInt returns the
+    // exact signed -1 sentinel. `%04d` is a minimum width, not a 10,000-row cap.
+    let mut idx = 0u32;
+    loop {
+        let _ordinal = checked_tileset_ordinal(idx)?;
         let section_name: String = format!("TileSet{:04}", idx);
-        let section: &IniSection = match ini.section(&section_name) {
-            Some(s) => s,
-            None => break, // No more tilesets.
-        };
+        let section = ini.section(&section_name);
+        let tiles_in_set = section.map_or(-1, |section| section.read_int("TilesInSet", -1));
+        if tiles_in_set == -1 {
+            break;
+        }
+        let section: &IniSection = section.expect("nonterminating TilesInSet requires a section");
 
         let filename: &str = section.get("FileName").unwrap_or("");
-        let set_name: &str = section.get("SetName").unwrap_or("");
+        let set_name: &str = section.get("SetName").unwrap_or("No Name");
         let raw_tiles: Option<&str> = section.get("TilesInSet");
-        // TilesInSet=0 means empty tileset — consume 0 tile_id slots.
-        // Do NOT clamp to 1; that shifts all subsequent tile indices.
-        let tiles_in_set: u32 = section.get_i32("TilesInSet").unwrap_or(0).max(0) as u32;
+        let last_tiles_in_set = section.read_int("LastTilesInSet", -1);
+        if last_tiles_in_set != -1 && last_tiles_in_set != tiles_in_set {
+            let boundary = legacy_cursor.wrapping_add(last_tiles_in_set);
+            legacy_tile_index_exceptions.push(LegacyTileIndexException {
+                legacy_boundary: boundary,
+                delta: tiles_in_set.wrapping_sub(last_tiles_in_set),
+            });
+            legacy_cursor = boundary;
+        } else {
+            legacy_cursor = legacy_cursor.wrapping_add(tiles_in_set);
+        }
 
-        let start: u16 = entries.len() as u16;
+        // Native creates no tile objects for zero or negative counts other
+        // than the terminating -1, but its compatibility cursor above still
+        // advances. Positive counts retain missing/blank registry slots.
+        let represented_count = usize::try_from(tiles_in_set).unwrap_or(0);
+        let attempted_slots = entries
+            .len()
+            .checked_add(represented_count)
+            .unwrap_or(usize::MAX);
+        if attempted_slots > MAX_USABLE_TILE_SLOTS {
+            return Err(MapError::TilesetRegistryTooLarge {
+                attempted: attempted_slots,
+                maximum: MAX_USABLE_TILE_SLOTS,
+            });
+        }
+        let tiles_in_set = u16::try_from(represented_count)
+            .expect("registry limit proves each represented count fits u16");
+
+        let start = u16::try_from(actual_cursor)
+            .expect("safe registry domain proves the native actual cursor fits u16");
+        debug_assert_eq!(usize::from(start), entries.len());
         tileset_bounds.push(TilesetBounds {
             start,
-            count: tiles_in_set as u16,
+            count: tiles_in_set,
         });
         set_names.push(set_name.to_string());
         let morphable: bool = section.get_bool("Morphable").unwrap_or(false);
@@ -518,7 +597,7 @@ pub fn parse_tileset_ini(ini_data: &[u8], extension: &str) -> Result<TilesetLook
 
         if filename.is_empty() {
             // Blank tileset — consume slots but produce None entries.
-            for _ in 0..tiles_in_set {
+            for _ in 0..usize::from(tiles_in_set) {
                 entries.push(None);
                 variant_filenames.push(Vec::new());
                 tile_anims.push(None);
@@ -527,13 +606,18 @@ pub fn parse_tileset_ini(ini_data: &[u8], extension: &str) -> Result<TilesetLook
             // Each tile is named {prefix}{NN:02}.{ext}, 1-indexed. Sibling
             // discovery waits until load_theater has activated the theater
             // archives, keeping this parser asset-independent.
-            for i in 1..=tiles_in_set {
+            for i in 1..=u32::from(tiles_in_set) {
                 let main_name = format!("{}{:02}.{}", filename, i, extension);
                 entries.push(Some(main_name));
                 variant_filenames.push(Vec::new());
                 tile_anims.push(anim_section.and_then(|section| parse_tile_anim(section, i)));
             }
         }
+        actual_cursor = actual_cursor.wrapping_add(i32::from(tiles_in_set));
+        idx = idx.checked_add(1).ok_or(MapError::TilesetOrdinalOverflow {
+            ordinal: u32::MAX,
+            maximum: MAX_TILESET_ORDINAL,
+        })?;
     }
 
     // Diagnostic: log first 15 tilesets for debugging tile mapping.
@@ -570,6 +654,7 @@ pub fn parse_tileset_ini(ini_data: &[u8], extension: &str) -> Result<TilesetLook
         morphable_flags,
         allow_tiberium_flags,
         tile_anims,
+        legacy_tile_index_exceptions,
     })
 }
 

--- a/src/map/theater.rs
+++ b/src/map/theater.rs
@@ -599,10 +599,11 @@ pub fn parse_tileset_ini(ini_data: &[u8], extension: &str) -> Result<TilesetLook
             set_name
         );
 
-        // Animation keys live in the section named by SetName, so a tileset
-        // with no SetName (or one naming an absent section) can never carry
-        // them. The loader resolves that section once per tileset, before the
-        // per-tile walk.
+        // Animation keys live in the section named by the effective SetName.
+        // A missing key uses the native "No Name" default and can therefore
+        // resolve a `[No Name]` section; only an empty name or an absent named
+        // section has no animation block. Resolve it once before the per-tile
+        // walk.
         let anim_section: Option<&IniSection> = if set_name.is_empty() {
             None
         } else {

--- a/src/map/theater.rs
+++ b/src/map/theater.rs
@@ -1181,6 +1181,14 @@ fn resolve_contiguous_variant_chains(lookup: &mut TilesetLookup, asset_manager: 
     );
 }
 
+#[cfg(test)]
+pub(crate) fn resolve_contiguous_variant_chains_for_test(
+    lookup: &mut TilesetLookup,
+    asset_manager: &AssetManager,
+) {
+    resolve_contiguous_variant_chains(lookup, asset_manager);
+}
+
 fn resolve_tileset_start(lookup: &TilesetLookup, ordinal: Option<i32>) -> Option<u16> {
     let ordinal = ordinal?;
     if ordinal < 0 {

--- a/src/map/theater_tests.rs
+++ b/src/map/theater_tests.rs
@@ -335,6 +335,21 @@ fn gsi_04_02_last_tiles_safe_domains_and_native_string_defaults() {
             maximum: 65_535,
         })
     ));
+
+    let absent = IniFile::from_str("[TileSet65535]\nTilesInSet=0\n");
+    assert!(
+        read_tileset_row(&absent, 65_536)
+            .expect("absent row retains the native -1 terminator")
+            .is_none()
+    );
+    let nonterminating = IniFile::from_str("[TileSet65536]\nTilesInSet=0\n");
+    assert!(matches!(
+        read_tileset_row(&nonterminating, 65_536),
+        Err(crate::map::map_file::MapError::TilesetOrdinalOverflow {
+            ordinal: 65_536,
+            maximum: 65_535,
+        })
+    ));
 }
 
 #[test]

--- a/src/map/theater_tests.rs
+++ b/src/map/theater_tests.rs
@@ -102,6 +102,287 @@ fn test_parse_tileset_ini_basic() {
 }
 
 #[test]
+fn gsi_04_02_last_tiles_parser_builds_native_ordered_exceptions_and_boundaries() {
+    let lookup = parse_tileset_ini(
+        b"[TileSet0000]\nTilesInSet=3\nFileName=a\n\n\
+          [TileSet0001]\nTilesInSet=5\nLastTilesInSet=2\nFileName=b\n\n\
+          [TileSet0002]\nTilesInSet=4\nLastTilesInSet=6\nFileName=c\n",
+        "tem",
+    )
+    .expect("verified compatibility example parses");
+
+    assert_eq!(
+        lookup.legacy_tile_index_exceptions,
+        vec![
+            LegacyTileIndexException {
+                legacy_boundary: 5,
+                delta: 3,
+            },
+            LegacyTileIndexException {
+                legacy_boundary: 11,
+                delta: -2,
+            },
+        ]
+    );
+    assert_eq!(lookup.len(), 12);
+    assert_eq!(lookup.translate_legacy_map_tile_index(4), 4);
+    assert_eq!(lookup.translate_legacy_map_tile_index(5), 8);
+    assert_eq!(lookup.translate_legacy_map_tile_index(10), 13);
+    assert_eq!(lookup.translate_legacy_map_tile_index(11), 12);
+    assert_eq!(
+        lookup.translate_legacy_map_tile_index(i32::from(u16::MAX)),
+        i32::from(u16::MAX),
+        "only positive 0xFFFF is the native no-tile sentinel"
+    );
+}
+
+#[test]
+fn gsi_04_02_last_tiles_transform_is_signed_original_ordered_and_wrapping() {
+    let signed = parse_tileset_ini(b"[TileSet0000]\nTilesInSet=2\nLastTilesInSet=-2\n", "tem")
+        .expect("negative-boundary theater");
+    assert_eq!(signed.translate_legacy_map_tile_index(-1), 3);
+    assert_eq!(signed.translate_legacy_map_tile_index(0), 4);
+    assert_eq!(
+        signed.translate_legacy_map_tile_index(i32::from(u16::MAX)),
+        i32::from(u16::MAX),
+    );
+
+    let original_raw = parse_tileset_ini(
+        b"[TileSet0000]\nTilesInSet=105\nLastTilesInSet=5\n\n\
+          [TileSet0001]\nTilesInSet=1\nLastTilesInSet=45\n",
+        "tem",
+    )
+    .expect("original-input comparison theater");
+    assert_eq!(original_raw.translate_legacy_map_tile_index(5), 105);
+
+    let nonmonotonic = parse_tileset_ini(
+        b"[TileSet0000]\nTilesInSet=11\nLastTilesInSet=10\n\n\
+          [TileSet0001]\nTilesInSet=-4\nLastTilesInSet=-5\n",
+        "tem",
+    )
+    .expect("nonmonotonic declaration-order theater");
+    assert_eq!(
+        nonmonotonic.legacy_tile_index_exceptions[1].legacy_boundary,
+        5
+    );
+    assert_eq!(nonmonotonic.translate_legacy_map_tile_index(6), 6);
+
+    let wraps_max = parse_tileset_ini(
+        format!(
+            "[TileSet0000]\nTilesInSet={}\nLastTilesInSet={}\n",
+            i32::MIN,
+            i32::MAX
+        )
+        .as_bytes(),
+        "tem",
+    )
+    .expect("wrapping delta theater");
+    assert_eq!(
+        wraps_max.legacy_tile_index_exceptions,
+        vec![LegacyTileIndexException {
+            legacy_boundary: i32::MAX,
+            delta: 1,
+        }]
+    );
+    assert_eq!(
+        wraps_max.translate_legacy_map_tile_index(i32::MAX),
+        i32::MIN
+    );
+
+    let mut wraps_min = parse_tileset_ini(b"", "tem").expect("empty theater");
+    wraps_min.legacy_tile_index_exceptions = vec![LegacyTileIndexException {
+        legacy_boundary: i32::MIN,
+        delta: -1,
+    }];
+    assert_eq!(
+        wraps_min.translate_legacy_map_tile_index(i32::MIN),
+        i32::MAX
+    );
+}
+
+#[test]
+fn gsi_04_02_empty_last_tiles_table_is_full_signed_identity() {
+    let lookup = parse_tileset_ini(b"[TileSet0000]\nTilesInSet=1\n", "tem")
+        .expect("empty compatibility table");
+    assert!(lookup.legacy_tile_index_exceptions.is_empty());
+    for raw in [i32::MIN, -123, -1, 0, 123, i32::from(u16::MAX), i32::MAX] {
+        assert_eq!(lookup.translate_legacy_map_tile_index(raw), raw);
+    }
+}
+
+#[test]
+fn gsi_04_02_last_tiles_parser_preserves_readint_termination_and_wrapping() {
+    let parsed = parse_tileset_ini(
+        b"[TileSet0000]\nTilesInSet=junk\nLastTilesInSet=-1\n\n\
+          [TileSet0001]\nTilesInSet=$3\nLastTilesInSet=1H\n\n\
+          [TileSet0002]\nTilesInSet=-1\n\n\
+          [TileSet0003]\nTilesInSet=9\nLastTilesInSet=0\n",
+        "tem",
+    )
+    .expect("ReadInt edge theater");
+    assert_eq!(parsed.bounds().len(), 2);
+    assert_eq!(parsed.bounds()[0].count, 0, "present junk is atoi zero");
+    assert_eq!(
+        parsed.bounds()[1].count,
+        3,
+        "native hexadecimal is accepted"
+    );
+    assert_eq!(
+        parsed.legacy_tile_index_exceptions,
+        vec![LegacyTileIndexException {
+            legacy_boundary: 1,
+            delta: 2,
+        }]
+    );
+
+    for terminator in [
+        "[TileSet0000]\nTilesInSet=0\n\n\
+         [TileSet0001]\nFileName=missing-key\n\n\
+         [TileSet0002]\nTilesInSet=9\n",
+        "[TileSet0000]\nTilesInSet=0\n\n\
+         [TileSet0001]\nTilesInSet=\n\n\
+         [TileSet0002]\nTilesInSet=9\n",
+    ] {
+        let terminated = parse_tileset_ini(terminator.as_bytes(), "tem")
+            .expect("missing or empty TilesInSet terminates");
+        assert_eq!(terminated.bounds().len(), 1);
+        assert_eq!(terminated.len(), 0);
+    }
+
+    let malformed_last = parse_tileset_ini(
+        b"[TileSet0000]\nTilesInSet=2\nLastTilesInSet=not-a-number\n",
+        "tem",
+    )
+    .expect("present malformed LastTilesInSet is native atoi zero");
+    assert_eq!(
+        malformed_last.legacy_tile_index_exceptions,
+        vec![LegacyTileIndexException {
+            legacy_boundary: 0,
+            delta: 2,
+        }]
+    );
+
+    let suppressed = parse_tileset_ini(
+        b"[TileSet0000]\nTilesInSet=2\nLastTilesInSet=-1\n\n\
+          [TileSet0001]\nTilesInSet=3\nLastTilesInSet=3\n",
+        "tem",
+    )
+    .expect("suppressed records");
+    assert!(suppressed.legacy_tile_index_exceptions.is_empty());
+
+    let negative = parse_tileset_ini(
+        b"[TileSet0000]\nTilesInSet=-2\n\n\
+          [TileSet0001]\nTilesInSet=2\nLastTilesInSet=0\n",
+        "tem",
+    )
+    .expect("nonterminating negative count");
+    assert_eq!(negative.bounds()[0], TilesetBounds { start: 0, count: 0 });
+    assert_eq!(negative.bounds()[1], TilesetBounds { start: 0, count: 2 });
+    assert_eq!(
+        negative.legacy_tile_index_exceptions,
+        vec![LegacyTileIndexException {
+            legacy_boundary: -2,
+            delta: 2,
+        }]
+    );
+
+    let cursor_wrap = parse_tileset_ini(
+        format!(
+            "[TileSet0000]\nTilesInSet=0\nLastTilesInSet={}\n\n\
+             [TileSet0001]\nTilesInSet=0\nLastTilesInSet=1\n",
+            i32::MAX
+        )
+        .as_bytes(),
+        "tem",
+    )
+    .expect("wrapping legacy cursor");
+    assert_eq!(
+        cursor_wrap.legacy_tile_index_exceptions,
+        vec![
+            LegacyTileIndexException {
+                legacy_boundary: i32::MAX,
+                delta: -i32::MAX,
+            },
+            LegacyTileIndexException {
+                legacy_boundary: i32::MIN,
+                delta: -1,
+            },
+        ]
+    );
+}
+
+#[test]
+fn gsi_04_02_last_tiles_safe_domains_and_native_string_defaults() {
+    let maximum = parse_tileset_ini(b"[TileSet0000]\nTilesInSet=65535\n", "tem")
+        .expect("all usable u16 tile IDs fit");
+    assert_eq!(maximum.len(), 65_535);
+    assert_eq!(maximum.bounds()[0].count, u16::MAX);
+    assert_eq!(maximum.set_name(0), Some("No Name"));
+    assert_eq!(maximum.filename(0), None);
+
+    assert!(matches!(
+        parse_tileset_ini(b"[TileSet0000]\nTilesInSet=65536\n", "tem"),
+        Err(crate::map::map_file::MapError::TilesetRegistryTooLarge {
+            attempted: 65_536,
+            maximum: 65_535,
+        })
+    ));
+    assert!(matches!(checked_tileset_ordinal(65_535), Ok(65_535)));
+    assert!(matches!(
+        checked_tileset_ordinal(65_536),
+        Err(crate::map::map_file::MapError::TilesetOrdinalOverflow {
+            ordinal: 65_536,
+            maximum: 65_535,
+        })
+    ));
+}
+
+#[test]
+fn gsi_04_02_tileset_10000_is_not_an_artificial_terminator() {
+    let mut ini = String::new();
+    for ordinal in 0..10_000u32 {
+        ini.push_str(&format!("[TileSet{ordinal:04}]\nTilesInSet=0\n\n"));
+    }
+    ini.push_str("[TileSet10000]\nTilesInSet=1\nFileName=late\n");
+    let lookup = parse_tileset_ini(ini.as_bytes(), "tem").expect("ordinal 10000 parses");
+    assert_eq!(lookup.bounds().len(), 10_001);
+    assert_eq!(
+        lookup.bounds()[10_000],
+        TilesetBounds { start: 0, count: 1 }
+    );
+    assert_eq!(lookup.filename(0), Some("late01.tem"));
+}
+
+#[test]
+#[ignore = "requires VERA20K_RETAIL_THEATER_INI_DIR"]
+fn gsi_04_02_all_retail_theaters_have_empty_compatibility_tables() {
+    let root = std::path::PathBuf::from(
+        std::env::var_os("VERA20K_RETAIL_THEATER_INI_DIR")
+            .expect("set VERA20K_RETAIL_THEATER_INI_DIR to extracted retail ini directory"),
+    );
+    let expected = [
+        ("temperatmd.ini", 82, 838, 837),
+        ("snowmd.ini", 83, 964, 960),
+        ("urbanmd.ini", 111, 1_081, 1_077),
+        ("urbannmd.ini", 122, 1_175, 1_174),
+        ("desertmd.ini", 82, 726, 726),
+        ("lunarmd.ini", 85, 198, 192),
+    ];
+    for (name, section_count, slot_count, last_start) in expected {
+        let bytes = std::fs::read(root.join(name)).expect("read extracted retail theater INI");
+        let lookup = parse_tileset_ini(&bytes, "tmp").expect("parse retail theater INI");
+        assert!(lookup.legacy_tile_index_exceptions.is_empty(), "{name}");
+        assert_eq!(lookup.bounds().len(), section_count, "{name}");
+        assert_eq!(lookup.len(), slot_count, "{name}");
+        assert_eq!(
+            lookup.bounds().last().map(|bounds| bounds.start),
+            Some(last_start),
+            "{name}"
+        );
+    }
+}
+
+#[test]
 fn gsi_02_11_actual_chain_count_stops_at_first_missing_sibling() {
     let present = [
         "clear01.urb",


### PR DESCRIPTION
## Summary
- transplant the completed Phase 3 GSI-04.02 LastTilesInSet compatibility slice onto current main
- reproduce signed, wrapping, declaration-ordered legacy tile translation at raw IsoMapPack5 ingress
- preserve actual/manual/runtime/snapshot tile IDs and stock-theater behavior
- correct raw-versus-actual diagnostics and documentation found by independent critics

## Native evidence
- Read_Theater_TileSets_INI at 0x00545150
- CalculateLegacyMapTileIndex at 0x00544E30
- docs/research/PHASE3_LAST_TILES_IN_SET_COMPATIBILITY_TRANSLATION_GHIDRA_REPORT.md

## Validation
- focused mechanism tests: 8 passed
- theater module: 46 passed, 2 ignored; stock-theater exclusion separately executed against all six retail INIs and passed
- independent critic ratchet: PASS after three findings rounds and a fresh final critic
- cargo test -p vera20k --lib: 7587 passed, 0 failed, 76 ignored

This PR intentionally excludes naval BasePlan/AI, triggers, crates, mind control, Building destruction, Explodes, Temporal, and other later-phase work from the source branch.