### PR TITLE
Integrate Phase 3 Drive/Ship slope lifecycle

### DIFF
--- a/docs/plans/2026-08-27-phase3-drive-ship-slope-transition-design.md
+++ b/docs/plans/2026-08-27-phase3-drive-ship-slope-transition-design.md
@@ -1,0 +1,624 @@
+# Phase 3 Drive/Ship slope-transition design
+
+**Status: proposed for fresh read-only design review.**
+
+## Goal
+
+Implement the verified active-retail Drive/Ship containing-cell slope cache and
+three-frame voxel interpolation without changing impact-driven body rocking,
+general locomotion, or any excluded locomotor class.
+
+The representative production path is an ordinary stock YR skirmish in which a
+voxel-bodied vehicle or ship using its currently active Drive or Ship locomotor
+spawns on, idles on, or crosses a ramp. The complete native evidence is
+`docs/research/PHASE3_DRIVE_SHIP_SLOPE_TRANSITION_LIFECYCLE_GHIDRA_REPORT.md`.
+That report proves stock activation for 52 Drive and 13 Ship types and leaves no
+load-bearing native question open.
+
+## Architecture Context
+
+### Native owner and lifecycle
+
+The state belongs to the complete active Drive or Ship locomotor object, not to
+the unit body and not to terrain presentation. Both classes persist the same
+defined fields: cached/current slope byte, previous slope byte, signed timer
+start frame, duration, and transition total. Construction starts at slope zero
+with an inactive timer; successful `FootClass::Unlimbo` immediately snaps both
+slopes to the final containing cell. At each eligible `Process` entry, before
+any movement or track work, a changed current-cell byte copies current to
+previous, installs the sample as current, and starts duration/total `3`.
+[doc: `PHASE3_DRIVE_SHIP_SLOPE_TRANSITION_LIFECYCLE_GHIDRA_REPORT.md`
+§§2–3; GHIDRA `0x004AF540`, `0x0069EC50`, `0x004D7170`, `0x004B0500`,
+`0x0069FC10`]
+
+`Draw_Matrix` derives, but never mutates, the phase from the signed global
+frame. A change detected at frame `F` renders old at `F`, `1/3` at `F+1`,
+`2/3` at `F+2`, and stable new at `F+3`. Expiry does not clear the stored total.
+A retarget during interpolation starts from the prior cached target byte, not
+from a baked intermediate matrix. No RNG participates.
+[doc: same report §3; GHIDRA `0x0046B640`, `0x004B4D70`, `0x004AFF60`,
+`0x0069F670`, `0x00755A40`]
+
+### Current Rust owners and flow
+
+- `GameEntity::new_at_frame` in `src/sim/game_entity.rs` initializes
+  `rocking: None`. `RockingState` in `src/sim/components.rs` currently combines
+  five impact/body-rocking fields with three slope fields. Production spawn does
+  not attach it, so production Drive/Ship slope transitions are absent.
+- `src/sim/rocking/rocking_system.rs` samples slope for every manually attached
+  `RockingState`, decrements a mutable counter on an equal sample, and runs in
+  the global Phase 2.5 pass after movement. The same pass also owns the existing
+  spring/damper, ship-rocking integration, and wide-amplitude self-destruct
+  check; those body-rocking operations must retain their current ordering and
+  eligibility.
+- `LocomotorState` distinguishes `active_kind()` from `effective_kind()`.
+  `LocomotorRuntimePayload` and `StashedLocomotor` in
+  `src/sim/movement/locomotion/piggyback.rs` are the existing Rust-native owner
+  for class-local state that must travel with an active or suspended complete
+  locomotor. Drive and Ship payloads are currently unit variants.
+- `World::advance_master_frame` visits each live object in authoritative order,
+  runs object AI, then calls `tick_movement_object_with_grids`. Inside
+  `tick_movement_with_grids_scoped`, active low-bridge `TubeMovement` can own the
+  whole object turn, forced Drive tracks run before ordinary movement, and
+  stationary entities still enter the scoped function. This is the smallest
+  production seam capable of representing a Drive/Ship `Process` prologue
+  without absorbing movement mechanics.
+- All successful entity placement converges on
+  `Simulation::try_reveal_entity` in `src/sim/world/lifecycle.rs`. Coordinates
+  are committed before `mark_entity_put`; a failed mark restores limbo and
+  returns before display/LogicVector registration. This is the single correct
+  Rust owner for the successful-unlimbo snap.
+- `build_unit_instances` in
+  `src/app/presentation/instances/units.rs` reads the live immutable simulation
+  after a committed frame. It currently derives phases from the mutable
+  `transition_ticks_remaining` and otherwise falls back to the terrain cell.
+  The transient atlas already keys a numerator with denominator `3`, so its
+  ownership remains usable, but the numerator type and rasterizer's lower clamp
+  must change to preserve signed native extrapolation.
+- `Simulation` is serialized positionally with bincode. Snapshot version `109`
+  is strict; `#[serde(default)]` cannot migrate a changed mid-record shape.
+  `world_hash.rs` already hashes both the active locomotor payload and a nested
+  stashed runtime, but Drive/Ship payloads contain no state. It separately hashes
+  every current `RockingState` field.
+
+The older slope reports named in the verified report's stale-doc section are
+discovery maps only. In particular, post-movement sampling, a mutable
+three-tick countdown, next/head-to-cell sampling, a Process-time immediate
+snap, and locomotor byte `+0x62` as slope state are superseded. The two Chrono
+Miner system-model syntheses also predate the current active/effective
+locomotor and complete-runtime piggyback implementation; current Rust plus the
+new exhaustive report are authoritative for this design.
+
+## Impact Analysis
+
+### Files and functions that change
+
+- `src/sim/movement/slope_transition.rs` (new): the deterministic state and
+  pure constructor, snap, Process-entry sample, signed remaining-time, and
+  render-phase derivation.
+- `src/sim/movement/mod.rs`: expose the bounded mechanism internally.
+- `src/sim/movement/locomotion/piggyback.rs`: change only
+  `LocomotorRuntimePayload::Drive` and `::Ship` to carry the dedicated state;
+  construct it with the current binary frame and transfer it unchanged through
+  capture/stash/restore. Remove `LocomotorRuntimePayload::Default`; a class-local
+  payload may no longer be invented without a kind and construction frame.
+- `src/sim/movement/locomotor.rs`: add active-payload accessors and thread the
+  construction frame through normal locomotor and piggyback construction.
+  Remove `#[serde(default)]` from `runtime_payload`; strict schema 110 requires
+  the payload. `active_kind()`, never `effective_kind()`, gates the class half
+  of the mechanism.
+- Production/test callers of `LocomotorState::from_object_type`,
+  `LocomotorRuntimePayload::for_kind`, and `begin_piggyback`, especially
+  `src/sim/world/world_spawn.rs`, `src/sim/movement/movement_commands.rs`,
+  `src/sim/miner/miner_system.rs`, `src/sim/movement/teleport_movement.rs`,
+  `src/sim/world/world_commands.rs`, and direct locomotor fixtures: supply the
+  exact current frame. A frame-zero test adapter may remain explicit, but no
+  production constructor may silently default the frame.
+- `src/sim/movement/movement_tick.rs`: run the active Drive/Ship sample once at
+  the eligible Process-entry seam, after entry-active Tube ownership is known
+  and before forced-track, pending-arrival, or ordinary movement can change the
+  position.
+- `src/sim/world/lifecycle.rs`: snap the active Drive/Ship payload immediately
+  after a successful `mark_entity_put` and before display/LogicVector exposure.
+  Failed and early-rejected reveals do not touch it.
+- `src/sim/components.rs`, `src/sim/game_entity.rs`, and
+  `src/sim/rocking/rocking_system.rs`: make `RockingState` body-rocking-only and
+  remove slope sampling/counter mutation from the Phase 2.5 pass. Keep
+  `GameEntity.rocking`, its `None` construction default, impact impulse math,
+  spring/damper order, ship-rocking behavior, and self-destruct behavior.
+- `src/sim/world/mod.rs`: rename the Phase 2.5 description to body rocking and
+  preserve its present place and gate. Do not make creation of slope state
+  activate the body-rocking pass.
+- `src/app/presentation/instances/units.rs`: read the active Drive/Ship payload,
+  snapshot one last-processed binary frame for the build pass, and derive
+  `0/3`, `1/3`, `2/3`, or stable without sim mutation. Preserve the existing
+  terrain fallback for locomotors outside this mechanism; an active Drive/Ship
+  cache is authoritative even when its cached slope is zero.
+- `src/render/unit_slope_transition_cache.rs` and `src/render/vxl_raster.rs`:
+  make the transient `phase_num` signed and preserve the exact numerator in the
+  cache key. Remove the current lower-bound clamp/early return so negative
+  native fractions extrapolate through quaternion SLERP; retain the `t >= 1`
+  stable destination branch and the equal-slope shortcut. These remain
+  read-only presentation caches, not persistence/hash authority.
+- `src/sim/world/world_hash.rs`: remove the retired slope bytes from the body
+  rocking fold and hash every dedicated field under both active Drive/Ship
+  payloads and any stashed Drive/Ship runtime.
+- `src/sim/snapshot.rs`: bump the strict internal schema from `109` to `110`
+  (or from the then-current value to its next coordinated value if another
+  authorized snapshot change lands first) and add the exact reason.
+- Existing rocking, locomotor/piggyback, movement, lifecycle, presentation,
+  snapshot, and hash tests require targeted updates; no broad subsystem rewrite
+  is part of this slice.
+
+### Blast radius and risks
+
+- Drive/Ship payload shape changes are serialized and hashed for most stock
+  vehicles, so committed state-hash goldens will move even when a unit remains
+  on flat ground. Rebaseline only verified affected goldens and coordinate the
+  one snapshot-version owner.
+- A top-level entity component would lose native ownership during a piggyback
+  swap. Keeping the state in the typed payload ensures active and stashed
+  locomotors serialize and hash independently through the existing mechanism.
+- Rust commits `session.binary_frame` at the end of the master frame, after the
+  Process-entry writer ran. Presentation reads after that commit. If rendering
+  used the post-commit value directly, a transition started during frame `F`
+  would first appear at `1/3` and skip native phase zero. The design therefore
+  snapshots `session.binary_frame.wrapping_sub(1)` as the last processed/display
+  frame for this derived render query. State still stores the exact pre-commit
+  writer frame `F`.
+- Low-bridge `TubeMovement` is not `TunnelLocomotionClass`. Entry-active Tube
+  owns the whole unit turn and must bypass the Drive/Ship Process sample;
+  a direction-8 Tube armed later in an ordinary Drive Process does not undo the
+  sample that already occurred at that Process entry.
+- Missing terrain/cell authority exists only in synthetic/headless Rust worlds.
+  It must retain the existing cache without inventing slope zero; production
+  map bootstrap supplies resolved terrain.
+
+## Chosen Approach
+
+Add a dedicated `SlopeTransitionState` and store it in the Drive and Ship
+variants of `LocomotorRuntimePayload`.
+
+This is slightly more source movement than reshaping `RockingState`, but it is
+the smallest coherent ownership model. Native state lives in the complete
+locomotor and follows save/load and piggyback ownership. Rust already represents
+that exact concept with typed payloads and a boxed stashed runtime. The design
+therefore follows an established mechanism rather than creating a parallel
+entity-level lifecycle. Impact body rocking remains an independent optional
+component and cannot accidentally become active merely because a Drive unit
+needs slope state.
+
+The recommended state is:
+
+```text
+SlopeTransitionState
+  previous_slope: u8
+  current_slope: u8
+  start_frame: i32
+  transition_total: u8  // exactly 0 or 3 in valid constructed state
+```
+
+`transition_total` is also the duration. The exhaustive writer census proves
+that the two native fields are always written together as `0/0` or `3/3`, so
+one stored value is formally equivalent. The native timer's unused middle
+dword is intentionally absent. All fields are private outside the mechanism;
+writers preserve the valid `0|3` invariant.
+
+## Player-Experience Detail Ledger
+
+- **MILESTONE-BLOCKING — recurrent ramp orientation.** Every ramp entry, exit,
+  or orientation change by one of 65 stock Drive/Ship types must show old,
+  `1/3`, `2/3`, then new tilt. Trigger frequency is recurrent on any ramped map
+  and immediately visible on voxel bodies. [doc: report §§1–3; GHIDRA
+  `0x004AFF60`, `0x0069F670`]
+- **MILESTONE-BLOCKING — Process-entry order.** Sampling uses only the owner's
+  current containing cell before movement/track work. A boundary crossed later
+  in frame `F` is first discovered at the next eligible Process entry, not by a
+  post-movement pass in `F`. Forced Drive tracks are still Drive Process work;
+  entry-active low-bridge Tube turns are not. [doc: report §3; GHIDRA
+  `0x004B050B..0x004B0576`, `0x0069FC1B..0x0069FC86`; Rust:
+  `movement_tick.rs`]
+- **MILESTONE-BLOCKING — successful-unlimbo snap.** A Drive/Ship placed on a
+  ramp renders the ramp immediately with no flat-to-ramp spawn blend. Failed
+  placement cannot mutate the cache. Trigger frequency includes all scenario,
+  production, held-production, and later reveal paths. [doc: report §3;
+  GHIDRA `0x004D71A9`, `0x004B04D0`, `0x0069FBE0`]
+- **MILESTONE-BLOCKING — Foot plus active-class authority.** Eligibility
+  requires a normally processed Foot-equivalent Rust category (`Unit`,
+  `Infantry`, or `Aircraft`) and `active_kind() == Drive|Ship`, even when
+  installed/effective identity is Teleport during a Chrono Miner Drive
+  piggyback. A `Structure` with a modded positive speed and Drive payload is not
+  a Foot and remains excluded. Conversely, a modded Infantry or Aircraft with
+  active Drive/Ship is eligible; stock members of those categories are absent
+  only because their active locomotor classes differ. Gating on installed
+  identity, voxel art, or `RockingState` would visibly miss ordinary stock
+  movement.
+  [doc: report §§2,10; Rust: `locomotor.rs::active_kind/effective_kind`]
+- **COMPOUNDING — locomotor-owned piggyback state.** Constructor, active, and
+  stashed Drive/Ship slope caches must move with their complete locomotor
+  runtime. A top-level cache can survive under the wrong active class and later
+  restore stale state, affecting subsequent ramp draws and save/load.
+  [doc: report §§2–3, persistence; Rust: `locomotion/piggyback.rs`]
+- **MILESTONE-BLOCKING — exact no-write/equal behavior.** An equal sample,
+  including while stationary, writes nothing: it does not decrement, reset, or
+  clear total on expiry. A changed sample during interpolation uses cached
+  current as the new previous slope. [doc: report §3; GHIDRA `0x004B0523`,
+  `0x0069FC33`]
+- **MILESTONE-BLOCKING — global-frame phase and repeated draws.** Timer reads
+  are signed/wrapping and render-only. At writer frame `F`, ordinary forward
+  phases are `0/3`, `1/3`, `2/3`, stable; two draws in one frame produce
+  identical output and no hash mutation. Native signed arithmetic also permits
+  negative elapsed/numerator after a persisted timer crosses the signed frame
+  domain (for example start `0`, current `u32::MAX` gives `-1/3`); presentation
+  must preserve that SLERP extrapolation rather than clamp to the source. The
+  `start_frame == -1` sentinel returns the stored duration and therefore yields
+  numerator zero, including the real frame collision at `u32::MAX`.
+  [doc: report §3; GHIDRA `0x0046B640`, `0x004B4D70`; Rust:
+  `World::run_late_region` late frame commit]
+- **COMPOUNDING — persistence and hash.** Previous, current, start, total, active
+  versus stashed ownership, and payload presence affect future output and must
+  round-trip and hash. Load does not resample or snap; the next eligible Process
+  performs the normal comparison. Trigger frequency is each player save/load;
+  a mismatch can also desynchronize replay/lockstep. [doc: report §3
+  persistence; GHIDRA `0x004AF780`, `0x004AF800`, `0x0069EE90`, `0x0069EF10`]
+- **COMPOUNDING — raw source byte.** Sim stores the exact current-cell `u8` and
+  performs no look-ahead, previous-cell lookup, `min(20)`, or renderer-driven
+  rewrite. Existing render handling for slope-table values outside populated
+  `0..=16` remains a presentation concern. [doc: report §§2–3]
+- **COMPOUNDING — body-rocking independence.** Damage impulse velocities,
+  spring/damper integration, ship-rocking mode, saturation/deadband, and
+  self-destruct checks remain on the existing optional `RockingState` and its
+  current Phase 2.5 schedule. Trigger frequency is each active body-rocking
+  update; coupling slope construction to that component would create unrelated
+  gameplay and hash changes. [Rust: `rocking/impulse.rs`,
+  `rocking/rocking_system.rs`, `rocking/self_destruct.rs`]
+- **EXACTIFICATION-RESIDUAL — non-voxel eligible bodies.** Drive/Ship slope
+  state still updates and persists, but a SHP/non-voxel body has no voxel
+  matrix on which to show the SLERP. No alternate asset or frame is selected.
+  Trigger frequency is every slope crossing by such a modded/stock art case;
+  player effect for this mechanism is none. [doc: report §§3,9]
+- **EXACTIFICATION-RESIDUAL — narrow Tunnel restoration.** Native snaps only
+  after the proved ground-layer Tunnel/piggyback restoration inside
+  `TechnoClass::Set_Destination`; it is not a generic move-start or piggyback-END
+  rule. Rust's subterranean `TunnelLocomotionClass` is intentionally dormant TS
+  and the active low-bridge Tube path is a different mechanism, so no ordinary
+  stock caller exists. The exact hook location is nevertheless specified below
+  so later activation cannot generalize it. [doc: report §§2–3; GHIDRA
+  `0x00742BE3`; ENGINE.md TS exclusion]
+- **EXACTIFICATION-RESIDUAL — unused native timer dword.** It is indeterminate,
+  never read by this lifecycle, and need not be serialized, hashed, or seeded.
+  Trigger frequency and player effect are zero. [doc: report §2]
+- **MILESTONE-BLOCKING — RNG absence.** Construction, snap, sample, timer, phase
+  extraction, and render-state selection consume no `SimRng`; sharing wake,
+  dust, or combat-rocking RNG would desynchronize ordinary play. [doc: report
+  §3 Native RNG audit]
+
+There are no `UNKNOWN-RISK` ledger items. The native slice is exhausted, and
+the current Rust call sites provide a discoverable integration seam for every
+active stock behavior.
+
+## Design
+
+### Components
+
+`src/sim/movement/slope_transition.rs` owns the state and named constant
+`SLOPE_TRANSITION_FRAMES: u8 = 3`. It provides only these operations:
+
+1. `constructed(binary_frame)`: `previous=current=0`, signed
+   `start_frame=binary_frame as i32`, total `0`.
+2. `snap(sample, binary_frame)`: `previous=current=sample`, capture the signed
+   frame, total `0`.
+3. `sample_process_entry(sample, binary_frame)`: on difference only, assign
+   `previous=current`, `current=sample`, capture the signed frame, total `3`;
+   on equality, return without a write.
+4. `remaining(binary_frame) -> i32`: if total is zero, the caller is stable; if
+   `start_frame == -1`, return signed total; otherwise compute signed
+   `elapsed = (binary_frame as i32).wrapping_sub(start_frame)`. If
+   `elapsed < i32::from(total)`, return
+   `i32::from(total).wrapping_sub(elapsed)`; otherwise return zero. This
+   intentionally permits a value greater than total for negative elapsed and
+   preserves 32-bit wrapping.
+5. `render_phase(binary_frame)`: return stable when total is zero or native
+   remaining is zero; otherwise return source, destination, signed numerator
+   `i32::from(total).wrapping_sub(remaining)` and denominator `3`. Ordinary produced
+   phases are `0`, `1`, and `2`, while persisted/wrapped valid state may yield
+   a negative numerator. Presentation carries that signed numerator unchanged
+   into unclamped quaternion SLERP.
+
+`LocomotorRuntimePayload` becomes `Drive(SlopeTransitionState)` and
+`Ship(SlopeTransitionState)`. Its existing capture/install/serde path carries
+the state without a new pointer, side table, or entity lookup. Its `Default`
+implementation and `LocomotorState.runtime_payload`'s serde default are
+removed: every constructor and replacement must supply kind plus binary frame,
+and current-version deserialization must contain the exact payload. Accessors
+on `LocomotorState` match both active kind and payload variant; mismatched
+manually constructed/corrupt state is not treated as eligible.
+
+`RockingState` retains only body angles, velocities, and
+`is_ship_rocking`. Its `is_neutral` predicate becomes body-only. No slope
+constructor creates `RockingState`, and no impact writer touches the new
+locomotor payload.
+
+### Interfaces / Contracts
+
+- **Construction contract:** every production creation of a Drive/Ship
+  locomotor supplies the current `ScenarioSession::binary_frame`, including a
+  fresh piggyback replacement. Constructor start is defined persisted state
+  even while total is zero. Test-only constructors state frame zero explicitly.
+- **Eligibility contract:** only a normally processed Foot-equivalent category
+  (`Unit | Infantry | Aircraft`) whose current active payload matches Drive or
+  Ship is readable/writable. Structures remain excluded even if mod data gives
+  them speed and a Drive payload. Installed/effective class, voxel art,
+  `IsTrain`, and body-rocking presence do not add or remove eligibility after
+  that Foot boundary; a modded Infantry/Aircraft with active Drive/Ship is
+  included.
+- **Terrain contract:** the sim helper receives the exact `ResolvedTerrainCell`
+  `slope_type` at the owner's current `(rx, ry)`. It never clamps or asks for a
+  destination/head-to cell. Missing terrain/cell retains the cache unchanged
+  and may emit a debug diagnostic; it does not synthesize native behavior for
+  an invalid Rust world.
+- **Body-rocking contract:** Phase 2.5 keeps its existing rules/terrain gate,
+  stable-ID iteration, per-axis order, and self-destruct call. Only the slope
+  read/write is removed.
+- **Presentation contract:** sim exposes immutable state plus pure phase
+  derivation; app presentation snapshots one display frame and selects the
+  existing stable or transition atlas path. Render and cache code never writes
+  sim state.
+- **Persistence contract:** all new defined fields serialize as part of active
+  or stashed locomotor payload. Restore trusts them, rebuilds only skipped
+  caches, and never routes through unlimbo or a terrain resample.
+- **RNG contract:** none of these APIs accepts `SimRng` or another random
+  source.
+
+The conditional native Tunnel restoration contract is deliberately narrow:
+only after an exact `Set_Destination` branch has proved an active
+`TunnelLocomotionClass`, ground layer, and a stashed Drive runtime may it restore
+that Drive and then call `snap(current_containing_cell_slope, binary_frame)` on
+the now-active Drive payload before destination handling continues. Generic
+`end_piggyback`, Teleport-to-Drive creation, Stop, ordinary move commands,
+low-bridge Tube entry/exit, and every successful Drive/Ship Process sample must
+not call this snap. Current Rust has no active-retail owner for the dormant
+Tunnel branch, so this slice records and tests the predicate contract without
+wiring a speculative caller.
+
+### Data Flow
+
+#### Construction and placement
+
+1. Spawn/type resolution constructs the installed locomotor payload at current
+   binary frame. Drive/Ship state is flat/inactive; other variants carry none.
+2. The object enters limbo storage. Failed reveal leaves constructor state.
+3. After coordinates commit and `mark_entity_put` succeeds,
+   `try_reveal_entity` samples the final containing cell and snaps an active
+   Drive/Ship payload.
+4. Display and LogicVector registration occur afterward. The first render on a
+   ramp is stable at that ramp slope.
+
+#### One live object turn
+
+```text
+object AI
+  -> capture entry-active low-bridge Tube ownership
+  -> if not Tube-owned: active Drive/Ship slope sample at Process entry
+  -> active Tube leaf OR forced Drive track OR ordinary/pending-arrival movement
+  -> air/special locomotor leaves and piggyback restore
+  -> post-movement object tail
+```
+
+The sample runs even when no movement target exists. A Drive/Ship that crosses
+the cell boundary later in this turn still holds the old containing-cell cache
+until its next eligible Process entry. If ordinary processing arms low-bridge
+Tube during the turn, that does not retroactively suppress the already-run
+prologue; an entry-active Tube turn runs no locomotor Process and therefore no
+sample.
+
+#### Render time
+
+`World::run_late_region` processes frame `F`, then commits session frame `F+1`.
+`build_unit_instances` snapshots
+`display_binary_frame = session.binary_frame.wrapping_sub(1)` once and passes it
+to every slope query in the build. The derived transition key stores a signed
+numerator, and `VxlSlopeBlend` converts `numerator / 3` without a lower clamp so
+native negative extrapolation survives. A state started at `F` therefore
+selects:
+
+| presentation snapshot | derived numerator | result |
+|---:|---:|---|
+| `F` | `0` | old/source slope |
+| `F+1` | `1` | one-third blend |
+| `F+2` | `2` | two-thirds blend |
+| `F+3` and later | stable | current/destination slope |
+
+Repeated redraws while paused reuse the same snapshot. A saved simulation
+restores the same session frame and payload, so it also reconstructs the same
+display frame without a mutable presentation countdown.
+
+For an active Drive/Ship, cached current slope remains authoritative after
+expiry, including cached zero. For another locomotor, retain the current
+adjacent terrain-derived stable behavior; this slice does not claim or change
+the stable-matrix rules of excluded classes.
+
+### Error Handling
+
+- Valid production state has a coherent active kind/payload pair and total
+  `0|3`. Keep fields private so normal Rust writers cannot create anything
+  else. Debug assertions may flag internal incoherence, but gameplay code does
+  not repair it by borrowing terrain or another component.
+- There is no payload default. Missing payload bytes in a version-110 record
+  are a decode error, and no fallback constructs Drive state at frame zero.
+- A missing terrain grid or out-of-grid current cell in synthetic fixtures is
+  a no-write result. It must not become a slope-zero transition and must not
+  make ordinary movement fail.
+- Do not clamp raw slope bytes in sim. Existing presentation handling for
+  unpopulated native matrix-table slots remains at the app/render boundary.
+- No cross-version bincode migration is attempted. Version `109` snapshots are
+  rejected cleanly after the bump. Mapping their `RockingState` counter into the
+  new payload would promote known-wrong post-movement/countdown data and still
+  could not reconstruct active versus stashed native ownership. Current-version
+  save/load is exact and performs no load-time snap.
+
+### Testing Strategy
+
+The implementation builder should use focused `--lib` filters only; the phase
+owner retains the single full-suite run for Phase 3 closure. Tests must be
+production-path discriminating rather than manually attaching `RockingState`.
+
+1. **Drive successful-unlimbo:** spawn a real Drive unit on nonzero slope via
+   normal placement. Assert the Drive payload exists without a manual component,
+   previous=current=cell byte, total zero, and the first render is stable ramp.
+   A failed mark leaves constructor state and produces no exposure.
+2. **Ship counterpart:** repeat through a real Ship type and prove identical
+   state and phase behavior.
+3. **Pre-movement boundary timing:** cross A→B during frame `F`; prove no
+   post-movement write in `F`, then prove the next eligible entry starts A→B.
+   Separate fixtures show forced Drive track samples before advancing and an
+   entry-active low-bridge Tube turn does not sample.
+4. **Stationary and stable no-write:** change the authoritative current-cell
+   slope without assigning a movement target; the next Drive/Ship Process
+   discovers it. Repeated equal samples before and after expiry leave the full
+   state byte-identical.
+5. **Exact render ledger:** through the production late-frame commit and unit
+   instance extraction, assert `0/3`, `1/3`, `2/3`, stable. Extract the same
+   frame twice and prove equal output plus unchanged sim hash.
+6. **Signed/wrapping timer and extrapolation:** cover a forward transition
+   across `i32::MAX` to `i32::MIN`; a transition started at
+   `u32::MAX`/signed `-1` proving the sentinel keeps remaining equal to duration;
+   and persisted `start=0, current=u32::MAX`, which must return remaining `4`,
+   numerator `-1`, key signed phase `-1`, and an unclamped `-1/3` SLERP result
+   distinct from the source matrix. No unsigned, saturating, source-clamped, or
+   monotonic `session.tick` implementation may pass.
+7. **Mid-transition retarget:** A→B followed before expiry by B→C starts B→C at
+   numerator zero; no interpolated A/B matrix becomes state.
+8. **Eligibility matrix:** Unit Drive and Ship pass; Foot-equivalent Infantry
+   and Aircraft with modded active Drive/Ship also pass; a Structure with a
+   Drive payload fails. Stock Walk, Hover, Fly, Jumpjet, Rocket, Teleport,
+   Tunnel, Mech, and DropPod active classes do not acquire or mutate this state.
+   A Drive fixture with `IsTrain=yes` remains eligible. SHP art does not remove
+   sim ownership.
+9. **Active versus effective piggyback:** a Teleport-installed unit with a fresh
+   active Drive payload samples as Drive. Capture/stash/restore round-trips the
+   payload with no leakage to the inactive class. Generic restore and move
+   issuance do not snap. A focused synthetic predicate test pins that only a
+   ground Tunnel→stashed-Drive restoration is eligible for the documented
+   immediate snap; low-bridge Tube and Teleport cases are rejected.
+10. **Save/load and hash:** save at `1/3`, restore at the same session frame,
+    and assert payload, derived render phase, and state-hash continuity before
+    any Process. Then run an equal sample and prove start/total are unchanged.
+    Independently mutate each field in active Drive, active Ship, and stashed
+    Drive payloads and require hash divergence.
+11. **No load resample:** save a cache whose current byte differs from live
+    terrain, restore it unchanged, then prove only the next eligible Process
+    restarts the transition.
+12. **No RNG:** compare scenario RNG state across construction, unlimbo snap,
+    equal sample, changed sample, phase extraction, and repeated render reads.
+13. **Impact body-rocking regression:** retain the existing impulse,
+    spring/damper, ship-rocking, self-destruct, serde, and hash discrimination
+    tests with body-only `RockingState`. Prove slope construction leaves
+    `entity.rocking` unchanged and body rocking never writes the locomotor
+    payload.
+14. **Schema boundary:** current snapshots report version `110`; a version
+    `109` preamble is rejected before body decode. The round trip includes both
+    an active and a stashed Drive/Ship slope payload. A nonzero-frame ordinary
+    constructor and fresh piggyback replacement must retain that frame before
+    reveal/sampling; no default/omitted payload path may create frame zero.
+
+## Architectural Decisions
+
+- **Follow typed locomotor payload ownership.** This is the existing Rust-native
+  equivalent of native class-local complete-object state. It preserves the
+  behavior contract without recreating COM objects, vtables, or raw persistence.
+- **Keep body rocking separate.** The current optional component and Phase 2.5
+  pass remain the owner of impact behavior. This corrects an existing hidden
+  coupling instead of widening it.
+- **Place sampling at the scoped movement entry, not in a new global pass.** The
+  seam is already called once for each live object after object AI and can see
+  Tube ownership before any position writer. It represents the required
+  Process prologue while leaving track/path systems in their current modules.
+- **Place snapping in lifecycle authority.** Central successful reveal covers
+  map, production, held, and later real unlimbo paths and naturally excludes
+  failed attempts. Spawn call-site duplication would eventually miss a path.
+- **Derive presentation phase from deterministic state.** No countdown or
+  render-owned cache becomes authority. The one-frame display snapshot adapts
+  Rust's late frame commit without falsifying the stored writer frame.
+- **Strict snapshot boundary, no migration.** The old schema stores a known-wrong
+  mechanism in the wrong owner; rejecting it is safer and more honest than an
+  approximate conversion.
+- **No new architectural blocker.** The only conditional native integration
+  without a stock Rust caller is the documented dormant Tunnel restoration.
+  It is an evidence-backed inactive exclusion, not an unknown mechanism and not
+  a reason to approximate generic piggyback behavior.
+
+Adversarial self-review supports this choice: a common stock ramp loop would
+still look wrong if sampling remained after movement, if phase zero were lost
+to Rust's late frame commit, or if unlimbo blended from flat. A future
+piggyback/save implementation would require expensive rework if the state lived
+on `GameEntity` or `RockingState`. Typed payload ownership closes all three
+risks now while leaving movement, impact rocking, and rendering boundaries
+intact.
+
+## Alternatives Considered
+
+### 1. Dedicated top-level `GameEntity::slope_transition`
+
+This cleanly separates slope state from body rocking and is a smaller enum
+change. It is rejected because the state would belong to the unit rather than
+the complete active locomotor. A Drive payload stashed under another locomotor
+would leave its cache live at entity scope, and restore could not recover two
+independent active/stashed caches. Extra swap callbacks could emulate that, but
+they would duplicate the ownership transfer already implemented by
+`LocomotorRuntimePayload` and make save/hash correctness depend on every caller.
+
+### 2. Reshape shared `RockingState`
+
+Replace its mutable remaining counter with start/total, attach it to all
+Drive/Ship entities, move its slope writer to Process entry, and leave body
+angles alongside it. This is the research report's smallest textual patch, but
+it is rejected architecturally. `RockingState` is optional body-impact state;
+attaching it to make production slopes work also activates the body-rocking
+pass and self-destruct owner. Conversely, an entity may need impact rocking
+without an eligible locomotor. The component still would not travel with a
+stashed complete locomotor. Independent gates can suppress immediate symptoms,
+but the state owner remains wrong and creates persistent hidden coupling.
+
+### 3. Presentation-only terrain interpolation
+
+Track prior/current terrain cells or visual slope in app/render state and blend
+there. This is rejected outright: native Process timing, stationary discovery,
+mid-transition retarget, piggyback ownership, save/load continuity, and hash
+state are deterministic simulation behavior. A presentation cache cannot
+reconstruct them and would violate the `sim/` authority boundary.
+
+## Explicit Exclusions
+
+- General Drive/Ship pathfinding, speed, track selection/geometry, wake, dust,
+  and movement-side effects.
+- Impact impulse formulas, body-angle rendering, EMP/naval continuous rocking,
+  and the existing body-rocking residuals. They are preserved, not exactified
+  in this slice.
+- Terrain/TMP slope production, LAT smoothing, passability, cliff, bridge, and
+  height mechanics. This slice consumes the resolved current-cell byte only.
+- Any slope-transition lifecycle for active Fly, Jumpjet, Rocket, Hover, Walk,
+  Teleport, Tunnel, Mech, or DropPod locomotors, and any non-Foot Structure.
+  Infantry and Aircraft are absent in stock because of their active classes,
+  not categorically excluded if a mod gives a Foot object active Drive/Ship.
+  Stable matrix behavior outside active Drive/Ship is not generalized.
+- Treating low-bridge `TubeMovement` as `TunnelLocomotionClass`, or wiring the
+  narrow `0x00742BE3` snap to generic `Set_Destination`, Stop, END, move start,
+  Tube exit, or Teleport restoration.
+- The dormant bulk helper `LocomotionClass::ForEach_SetSlopeIndex @ 0x004E1570`.
+- Native raw-object padding/unused timer middle dword, COM/vtable/pointer
+  persistence, or allocator behavior.
+- Alternate assets, palettes, anchors, z-order, or full voxel body/turret
+  composition. The existing slope transition cache consumes the derived matrix
+  phase.
+- Load-time terrain resampling, snapshot migration from the wrong countdown,
+  RNG consumption, or a new global scheduler pass.
+
+## Decision
+
+Recommend the dedicated Drive/Ship locomotor-payload state. Proceed only after
+a fresh read-only design critic confirms the ownership, Tube/forced-track
+ordering, last-processed render frame, strict snapshot boundary, body-rocking
+preservation, and dormant Tunnel exclusion. Any generic reset, post-movement
+writer, mutable render countdown, load-time resample, or un-hashed defined state
+keeps the mechanism open.

--- a/docs/plans/2026-08-27-phase3-drive-ship-slope-transition-design.md
+++ b/docs/plans/2026-08-27-phase3-drive-ship-slope-transition-design.md
@@ -75,7 +75,7 @@ from a baked intermediate matrix. No RNG participates.
   The transient atlas already keys a numerator with denominator `3`, so its
   ownership remains usable, but the numerator type and rasterizer's lower clamp
   must change to preserve signed native extrapolation.
-- `Simulation` is serialized positionally with bincode. Snapshot version `109`
+- `Simulation` is serialized positionally with bincode. Snapshot version `104`
   is strict; `#[serde(default)]` cannot migrate a changed mid-record shape.
   `world_hash.rs` already hashes both the active locomotor payload and a nested
   stashed runtime, but Drive/Ship payloads contain no state. It separately hashes
@@ -104,7 +104,7 @@ new exhaustive report are authoritative for this design.
   payload may no longer be invented without a kind and construction frame.
 - `src/sim/movement/locomotor.rs`: add active-payload accessors and thread the
   construction frame through normal locomotor and piggyback construction.
-  Remove `#[serde(default)]` from `runtime_payload`; strict schema 110 requires
+  Remove `#[serde(default)]` from `runtime_payload`; strict schema 105 requires
   the payload. `active_kind()`, never `effective_kind()`, gates the class half
   of the mechanism.
 - Production/test callers of `LocomotorState::from_object_type`,
@@ -143,7 +143,7 @@ new exhaustive report are authoritative for this design.
 - `src/sim/world/world_hash.rs`: remove the retired slope bytes from the body
   rocking fold and hash every dedicated field under both active Drive/Ship
   payloads and any stashed Drive/Ship runtime.
-- `src/sim/snapshot.rs`: bump the strict internal schema from `109` to `110`
+- `src/sim/snapshot.rs`: bump the strict internal schema from `104` to `105`
   (or from the then-current value to its next coordinated value if another
   authorized snapshot change lands first) and add the exact reason.
 - Existing rocking, locomotor/piggyback, movement, lifecycle, presentation,
@@ -444,14 +444,14 @@ the stable-matrix rules of excluded classes.
   `0|3`. Keep fields private so normal Rust writers cannot create anything
   else. Debug assertions may flag internal incoherence, but gameplay code does
   not repair it by borrowing terrain or another component.
-- There is no payload default. Missing payload bytes in a version-110 record
+- There is no payload default. Missing payload bytes in a version-105 record
   are a decode error, and no fallback constructs Drive state at frame zero.
 - A missing terrain grid or out-of-grid current cell in synthetic fixtures is
   a no-write result. It must not become a slope-zero transition and must not
   make ordinary movement fail.
 - Do not clamp raw slope bytes in sim. Existing presentation handling for
   unpopulated native matrix-table slots remains at the app/render boundary.
-- No cross-version bincode migration is attempted. Version `109` snapshots are
+- No cross-version bincode migration is attempted. Version `104` snapshots are
   rejected cleanly after the bump. Mapping their `RockingState` counter into the
   new payload would promote known-wrong post-movement/countdown data and still
   could not reconstruct active versus stashed native ownership. Current-version
@@ -516,8 +516,8 @@ production-path discriminating rather than manually attaching `RockingState`.
     tests with body-only `RockingState`. Prove slope construction leaves
     `entity.rocking` unchanged and body rocking never writes the locomotor
     payload.
-14. **Schema boundary:** current snapshots report version `110`; a version
-    `109` preamble is rejected before body decode. The round trip includes both
+14. **Schema boundary:** current snapshots report version `105`; a version
+    `104` preamble is rejected before body decode. The round trip includes both
     an active and a stashed Drive/Ship slope payload. A nonzero-frame ordinary
     constructor and fresh piggyback replacement must retain that frame before
     reveal/sampling; no default/omitted payload path may create frame zero.

--- a/docs/research/PHASE3_DRIVE_SHIP_SLOPE_TRANSITION_LIFECYCLE_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_DRIVE_SHIP_SLOPE_TRANSITION_LIFECYCLE_GHIDRA_REPORT.md
@@ -1,0 +1,480 @@
+# Phase 3 Drive/Ship slope-transition lifecycle — active retail Ghidra report
+
+**Address(es):** `0x004B0500` (Drive Process), `0x0069FC10` (Ship Process), `0x004AFF60` / `0x0069F670` (Draw_Matrix consumers)
+
+**Investigation Mode:** exhaustive-slice
+
+**Claimed Scope:** active-retail Drive/Ship containing-cell slope cache, transition timer, scheduling, rendering, persistence, and Rust handoff
+
+**Non-Scope:** general locomotion/pathfinding/track geometry, impact-driven body rocking, wake/dust, and unrelated voxel composition
+
+**Confidence:** High
+
+**Active in YR:** Yes — conditional on the active locomotor being Drive or Ship; stock activation is proven from retail `rulesmd.ini`
+
+**Verdict:** **VERIFIED / CLOSED for implementation.** Active retail `gamemd.exe` has one shared slope-transition mechanism, implemented independently but instruction-for-instruction equivalently by `DriveLocomotionClass` and `ShipLocomotionClass`. It samples the owner's **current containing cell at the beginning of each eligible locomotor `Process` call**, before movement or track processing. A changed byte-valued `CellClass+0x11C` slope starts a three-frame, global-frame-based render interpolation from the previously cached slope to the newly sampled slope. Successful unlimbo and a narrow tunnel/piggyback restoration path snap the cache immediately and disable interpolation. No native RNG participates.
+
+Current Rust does not run this lifecycle for production entities because `GameEntity::new` initializes `rocking: None`; its manually enabled implementation also samples after movement and decrements a mutable counter, which differs from the native pre-movement/global-frame contract. The smallest exact implementation contract and discriminating tests are specified below. No load-bearing question remains open.
+
+## Investigation contract
+
+- **Mode:** `exhaustive-slice`
+- **Scope:** the active-retail Drive/Ship voxel slope-transition state, its live callers, sampling and render scheduling, eligibility/exclusions, persistence, RNG involvement, and the smallest Rust-facing closure.
+- **Non-scope:** general Drive/Ship pathfinding, speed, track geometry, body rocking from impacts, wake/dust effects, and general voxel matrix composition except where needed to order or consume the slope transition.
+- **Binary:** the active Ghidra program `gamemd.exe` in project `testProsjekt`.
+- **Data authority:** retail `ini/rulesmd.ini` for stock locomotor selection.
+- **Candidate-only inputs:** existing slope/Drive/Ship reports and current Rust. Conflicting candidate claims were rechecked against the active binary rather than inherited.
+- **Confidence:** high for every implementation-bearing claim. The only indeterminate native value is an unused/preserved timer middle dword; it has no effect on this lifecycle.
+
+## 1. Overview
+
+Whenever a stock Drive- or Ship-locomotor voxel unit crosses between cells whose `CellClass+0x11C` slope bytes differ, its body tilt renders at old slope, one-third blend, two-thirds blend, then new slope. Because sampling occurs before movement, a cell boundary crossed later in the same `Process` call is noticed at the next eligible `Process` entry. This is checked every eligible update even while the unit is stationary, but state is rewritten only on a slope change.
+
+The trigger is ordinary and recurrent: every ramp entry, exit, or change of ramp orientation by an eligible unit. The current Rust omission is therefore player-visible on every such crossing, not a rare save/load or expert-only edge case. It affects presentation orientation, not native passability or movement speed.
+
+## 2. Class Layout / Key Offsets
+
+### Exact active classes
+
+| Class | ILocomotion vtable | RTTI complete-object locator | RTTI type descriptor | RTTI name | CLSID |
+|---|---:|---:|---:|---|---|
+| Drive | `0x007E7EB0` | `0x007FFDE8` | `0x00820248` | `.?AVDriveLocomotionClass@@` | `{4A582741-9839-11D1-B709-00A024DDAFD1}` |
+| Ship | `0x007F2D8C` | `0x008093A0` | `0x0083F880` | `.?AVShipLocomotionClass@@` | `{2BEA74E1-7CCA-11D3-BE14-00104B62A16C}` |
+
+The class identity is therefore exact rather than inferred from method similarity. Ship has a full counterpart: constructor, force-slope wrapper/helper, `Process`, `Draw_Matrix`, timer fields, and persistence are all present and equivalent to Drive.
+
+### Live owner/caller chain
+
+`FootClass::AI @ 0x004DA530` is the active per-object caller. At `0x004DA877` it dispatches ILocomotion slot `+0x40` (`Process`) through the active locomotor held at `FootClass+0x674`. The call is behind the ordinary active-Foot gates visible in this function: a non-null locomotor plus object-state tests at `FootClass+0x3CD`, `+0x8D`, `+0x81`, and the `+0x2A8` / type `+0x692` pair. This report does not assign speculative semantic names to those bytes.
+
+The behavioral eligibility rule is exact and small:
+
+> Run the slope lifecycle when a normally processed `FootClass` object's **currently active** ILocomotion object has the Drive or Ship vtable.
+
+In stock retail data those owners are `UnitClass` objects. The retail `rulesmd.ini` census selects Drive for 52 vehicle types and Ship for 13:
+
+- **Drive (52):** `MTNK`, `FV`, `MGTK`, `SREF`, `BFRT`, `AMCV`, `TNKD`, `HOWI`, `DRON`, `HTK`, `HTNK`, `V3`, `APOC`, `SMCV`, `HORV`, `HARV`, `UTNK`, `TTNK`, `DTRUCK`, `LTNK`, `YTNK`, `TELE`, `MIND`, `CAOS`, `PCV`, `SMIN`, `TRUCKA`, `TRUCKB`, `BUS`, `CIVP`, `DDBX`, `PICK`, `CAR`, `WINI`, `XCOMET`, `PROPA`, `CONA`, `COP`, `EUROC`, `LIMO`, `STANG`, `SUVB`, `SUVW`, `TAXI`, `YCAB`, `JEEP`, `BCAB`, `PTRUCK`, `DOLY`, `CBLC`, `FTRK`, `AMBU`.
+- **Ship (13):** `DEST`, `DLPH`, `AEGIS`, `CARRIER`, `HYD`, `SUB`, `SQD`, `DRED`, `BSUB`, `VLAD`, `CRUISE`, `TUG`, `CDEST`.
+
+Commented alternate `Locomotor=` lines do not change this census. A modded `UnitClass` with either exact CLSID is eligible by the same runtime rule.
+
+### Explicit exclusions
+
+The relevant ILocomotion slots show that only Drive and Ship override both force-slope slots and own the interpolating `Draw_Matrix`:
+
+| Class | vtable | Draw `+0x24` | Process `+0x40` | Force_New_Slope `+0x50` | Set_Slope `+0x7C` |
+|---|---:|---:|---:|---:|---:|
+| base Locomotion | `0x007EADF4` | `0x0055A730` | `0x0055AC60` | `0x0055AC20` | `0x0055ACE0` |
+| Drive | `0x007E7EB0` | `0x004AFF60` | `0x004B0500` | `0x004B04D0` | `0x004AFB40` |
+| DropPod | `0x007E8278` | `0x0055A730` | `0x004B5B70` | `0x0055AC20` | `0x0055ACE0` |
+| Fly | `0x007E89F4` | `0x004CF610` | `0x004CCB40` | `0x0055AC20` | `0x0055ACE0` |
+| Hover | `0x007EACFC` | `0x00513F40` | `0x00514310` | `0x0055AC20` | `0x0055ACE0` |
+| Jumpjet | `0x007ECD68` | `0x0054DCC0` | `0x0054AEC0` | `0x0055AC20` | `0x0055ACE0` |
+| Mech | `0x007EDB6C` | `0x0055A730` | `0x005B0060` | `0x0055AC20` | `0x0055ACE0` |
+| Rocket | `0x007F0B1C` | `0x00663470` | `0x006622C0` | `0x0055AC20` | `0x0055ACE0` |
+| Ship | `0x007F2D8C` | `0x0069F670` | `0x0069FC10` | `0x0069FBE0` | `0x0069F250` |
+| Teleport | `0x007F5000` | `0x0055A730` | `0x007192F0` | `0x0055AC20` | `0x0055ACE0` |
+| Tunnel | `0x007F5A24` | `0x00729B40` | `0x00728E30` | `0x0055AC20` | `0x0055ACE0` |
+| Walk | `0x007F69F8` | `0x0055A730` | `0x0075AC80` | `0x0055AC20` | `0x0055ACE0` |
+
+Every class name in this exclusion table was independently bound by the required RTTI walk (`vtable-4` → COL → `COL+0x0C` TypeDescriptor → mangled name), not by a display label:
+
+| Class | COL | TypeDescriptor / mangled-name identity |
+|---|---:|---|
+| base Locomotion | `0x008032A0` | `0x00820228`, `.?AVLocomotionClass@@` |
+| DropPod | `0x00800040` | `0x008202F8`, `.?AVDropPodLocomotionClass@@` |
+| Fly | `0x00800658` | `0x008223E8`, `.?AVFlyLocomotionClass@@` |
+| Hover | `0x00803228` | `0x008254B8`, `.?AVHoverLocomotionClass@@` |
+| Jumpjet | `0x00804C88` | `0x00829648`, `.?AVJumpjetLocomotionClass@@` |
+| Mech | `0x00805C28` | `0x0082C228`, `.?AVMechLocomotionClass@@` |
+| Rocket | `0x00808908` | `0x008399C8`, `.?AVRocketLocomotionClass@@` |
+| Teleport | `0x0080C178` | `0x00844538`, `.?AVTeleportLocomotionClass@@` |
+| Tunnel | `0x0080CAE8` | `0x00844AA0`, `.?AVTunnelLocomotionClass@@` |
+| Walk | `0x0080D240` | `0x00847BF0`, `.?AVWalkLocomotionClass@@` |
+
+`0x0055AC20` is a no-op and `0x0055ACE0` is a no-op `RET 8`. Consequently aircraft (`Fly`, `Jumpjet`, `Rocket`), Hover, Walk, Tunnel, and the dormant/non-stock-selected Mech and DropPod classes do not participate in this mechanism.
+
+“Train” is not a separate locomotor class. `IsTrain=` is a type flag consumed by Drive behavior, and retail has no active `IsTrain=yes` assignment. A modded train that uses Drive remains eligible; excluding it merely because `IsTrain` is set would be incorrect.
+
+`LocomotionClass::ForEach_SetSlopeIndex @ 0x004E1570` is not part of the proved active chain: it has no direct code caller and is not reached by the verified `FootClass::AI`, unlimbo, or render routes. It is a dormant bulk helper, not an alternate active scheduler.
+
+### State layout and constructor defaults
+
+The Drive constructor is `0x004AF540`; Ship is `0x0069EC50`. Their slope-related writes are structurally identical. The complete locomotor object uses a persistence size of `0x70`; ILocomotion method `this` points four bytes into that object. Both coordinate systems are shown to avoid the common four-byte offset error.
+
+| Role | object-base offset | ILocomotion-`this` offset | constructor state | behavior |
+|---|---:|---:|---|---|
+| cached/current slope | `+0x1C` | `+0x18` | `0` | latest sampled `Cell+0x11C` byte |
+| previous slope | `+0x20` | `+0x1C` | `0` | cached slope immediately before last change |
+| timer start frame | `+0x24` | `+0x20` | `g_CurrentFrameCounter` | absolute binary frame of transition start |
+| timer middle dword | `+0x28` | `+0x24` | **not initialized here** | never read by `Start`, `Remaining`, change detection, or draw interpolation |
+| timer duration | `+0x2C` | `+0x28` | `0` | set to `3` on a sampled change |
+| transition total/gate | `+0x30` | `+0x2C` | `0` | set to `3` on a sampled change; zero means snap/stable |
+
+`LocomotionClass::Constructor @ 0x0055A6C0` initializes only the common base through object `+0x14`; it does not define the slope timer's middle dword. The immediate helpers at `0x004AFB40` and `0x0069F250` copy an indeterminate stack-local dword into object `+0x28` while setting all behavior-bearing fields deterministically. This is an opaque/padding-like preserved value, not native entropy or RNG and not a Rust compatibility requirement.
+
+Constructor slope zero is not the live placed-object initial visual state. Successful unlimbo immediately replaces it with the containing cell slope as described next.
+
+## 3. Core Logic
+
+### Initialization and immediate synchronization
+
+`FootClass::Unlimbo @ 0x004D7170` calls the active locomotor's slot `+0x50` at `0x004D71A9` after `TechnoClass::Unlimbo` succeeds. Drive wrapper `0x004B04D0` and Ship wrapper `0x0069FBE0` both:
+
+1. query the linked owner's current containing cell through owner vtable slot `+0x1BC`;
+2. load the byte at `CellClass+0x11C`;
+3. dispatch ILocomotion slot `+0x7C` with that byte.
+
+Drive helper `0x004AFB40` and Ship helper `0x0069F250` then set `previous = current = sampled_slope`, set timer start to the current global frame, set duration and total to zero, and therefore produce an immediate stable render. There is no flat-to-ramp spawn blend.
+
+An exact indirect-call census found only three ILocomotion `+0x7C` dispatches:
+
+- `0x004B04ED`, inside the Drive force-slope wrapper;
+- `0x0069FBFD`, inside the Ship force-slope wrapper;
+- `0x00742BE3`, inside `TechnoClass::Set_Destination @ 0x00741970`.
+
+The third call is not a general “movement started” reset. Its enclosing branch identifies an active Tunnel locomotor under piggyback, requires the ground-layer case, performs the Tunnel/Drive piggyback conversion/restoration, and then snaps the restored active locomotor to the owner's current containing-cell slope. This narrow restoration path must not be generalized into every move command.
+
+### Exact per-tick sampling and scheduling
+
+### Drive
+
+`DriveLocomotionClass::Process @ 0x004B0500` executes the slope prologue before any movement/track branch:
+
+- `0x004B050B..0x004B0510`: obtain the owner's current containing cell;
+- `0x004B051B`: load `CellClass+0x11C`;
+- `0x004B0523..0x004B0528`: compare with cached/current slope;
+- on change, `0x004B052A`: copy current to previous;
+- `0x004B0533`: store sampled slope as current;
+- `0x004B052D..0x004B0554`: start/copy a duration-3 timer;
+- `0x004B0557`: store transition total `3`.
+
+Only after this prologue does the routine inspect/process track state (`0x004B0576` onward), invoke the no-track movement path (`0x004B0647`), the active movement path (`0x004B0A79`), and final track processing (`0x004B0AAA`).
+
+### Ship
+
+`ShipLocomotionClass::Process @ 0x0069FC10` has the same slope prologue at `0x0069FC1B..0x0069FC67`, before its first track decision/call at `0x0069FC86`, no-track movement call at `0x0069FCEE`, and subsequent active movement/track work.
+
+### Consequences
+
+- Sampling is **pre-movement and pre-track**.
+- Sampling is unconditional on movement intent within an eligible `Process` entry, so a stationary unit is checked too.
+- Only the owner's **current containing cell** is sampled. There is no previous-cell query and no next/head-to/destination-cell look-ahead.
+- “Previous slope” is a cached byte, not a previous cell reference. “Next slope” means the newly sampled current-cell byte after it differs, not a path preview.
+- If movement later in the same call crosses a cell boundary, the new cell's slope is observed on the next eligible `Process` entry.
+- Equal slope leaves all transition fields unchanged. There is no stable-cell decrement or expiry callback in `Process`.
+- A change during an in-progress transition uses the prior **target/current slope byte** as the new `previous`; it does not sample or bake the visually interpolated matrix.
+
+The byte at locomotor object `+0x62` (ILocomotion `this+0x5E`) is not a slope countdown. Its `Process` use follows `FacingClass::Is_Rotating @ 0x004C9480` and records owner-facing/turn completion state. Treating it as slope lifecycle state is a candidate-report error.
+
+### Timer and render consumption
+
+`CDTimerClass::Start @ 0x0046B640` writes the current global frame to timer `+0` and the requested duration to timer `+8`; it deliberately does not touch the middle dword at `+4`.
+
+`CDTimerClass::Remaining @ 0x004B4D70` behaves as follows:
+
+- if start frame is `-1`, return the stored duration;
+- otherwise compute signed `elapsed = g_CurrentFrameCounter - start_frame`;
+- return `duration - elapsed` while signed `elapsed < duration`, else return `0`.
+
+No RNG and no mutable per-tick decrement are involved.
+
+Drive `Draw_Matrix @ 0x004AFF60` and Ship `Draw_Matrix @ 0x0069F670` read the same state. If total is zero they use `t = 1`. Otherwise they call `Remaining` and compute:
+
+```text
+t = (total - remaining) / total
+```
+
+When `t < 1`, both call `VXL_InterpolatedFacing @ 0x00755A40` with `previous` as the source slope, `current` as the destination slope, and `t`; that routine uses the voxel slope quaternion/matrix table and SLERP. Unit voxel rendering reaches active-locomotor `Draw_Matrix` at `UnitClass::DrawVoxelBody` call `0x0073B5CB` and `UnitClass::Draw_Body_And_Turret` call `0x0073C87A`.
+
+For a transition detected in binary frame `F`, the exact visible phases are:
+
+| global frame | Remaining | interpolation `t` | result |
+|---:|---:|---:|---|
+| `F` | `3` | `0/3` | previous/old slope |
+| `F+1` | `2` | `1/3` | one-third blend |
+| `F+2` | `1` | `2/3` | two-thirds blend |
+| `F+3` and later | `0` | `1` | current/new slope |
+
+Multiple draws in one global frame are read-only and see the same phase. Expiry does not zero the stored total; total can remain `3` indefinitely while `Remaining` returns zero and draw uses the stable current slope. A later change overwrites start/duration/total. The immediate helper instead sets total zero, which also draws stable current slope.
+
+This draw path is player-visible for voxel-rendered bodies. The locomotor state exists independently of whether a particular modded unit supplies a voxel body, but a non-voxel body has no voxel matrix on which to display the SLERP.
+
+### Persistence and load behavior
+
+| Class | persistence vtable | Load | Save | persisted object size |
+|---|---:|---:|---:|---:|
+| Drive | `0x007E7F7C` | `0x004AF780` | `0x004AF800` | `0x70` (`0x004B4CF0`) |
+| Ship | `0x007F2E58` | `0x0069EE90` | `0x0069EF10` | `0x70` (`0x006A42A0`) |
+
+The shared save helper `0x0055AA60` writes the class-reported `0x70` raw bytes before class-specific piggyback data; shared load helper `0x0055AAC0` restores the raw block and participates in pointer swizzling. Class Load restores the correct vtables and class-specific piggyback state. Therefore current slope, previous slope, timer start, duration, total, and the opaque middle dword all survive native save/load. Load does not resample terrain or snap the slope cache. The next eligible `Process` restarts only if the restored cached current slope differs from the then-current containing cell.
+
+Rust need not serialize the unused indeterminate middle dword, but it must serialize/hash enough defined state to resume the same global-frame phase: previous slope, current slope, transition start frame, and total/duration (or a formally equivalent representation proven against load timing).
+
+### Native RNG audit
+
+No RNG call occurs in either constructor slope initialization, force-slope wrapper/helper, `Process` slope prologue, `CDTimerClass::Start`, `CDTimerClass::Remaining`, either `Draw_Matrix` slope branch, or `VXL_InterpolatedFacing`. The indeterminate timer middle dword is never consumed and is not a random source. Dust, wake, combat rocking, and other calls elsewhere in Drive/Ship behavior are outside this mechanism.
+
+## 4. INI Keys
+
+There is no slope-transition duration, enable, or interpolation INI key. The duration `3`, containing-cell byte source, and class restriction are hard-coded. Activation follows the installed `Locomotor=` CLSID.
+
+| Key | Type | Retail value/default in target set | Effect on this slice | Active in YR? | Evidence / confidence |
+|---|---|---|---|---|---|
+| `Locomotor` | CLSID string | every one of the 65 stock sections listed in §2 explicitly selects Drive or Ship | installs the only two classes that override the slope lifecycle slots | Yes | retail `ini/rulesmd.ini` census + RTTI/vtable walk; HIGH |
+| `IsTrain` | boolean type flag | no active `IsTrain=yes` assignment in retail `rulesmd.ini` | consumed inside Drive behavior but does not exclude or replace the Drive slope lifecycle | No stock activation; conditional for mods | retail INI search + Drive class identity; HIGH for this slice |
+
+The absent/invalid `Locomotor=` fallback is not exercised by any stock section in this target set and is not used to generalize eligibility: runtime active-vtable identity is authoritative.
+
+## 5. Integration Points
+
+| Stage | Entry/callsite | Exact order and condition | Output/consumer | Confidence / Active in YR |
+|---|---|---|---|---|
+| construction | Drive `0x004AF540`, Ship `0x0069EC50` | before placement; defined behavior fields start flat/inactive | later successful unlimbo replaces the live cache | HIGH / Yes |
+| placement | `FootClass::Unlimbo @ 0x004D7170`, call `0x004D71A9` | after successful `TechnoClass::Unlimbo` | Drive/Ship force wrapper snaps to containing cell | HIGH / Yes |
+| active tick | `FootClass::AI @ 0x004DA530`, dispatch `0x004DA877` | after normal Foot gates; before locomotor-owned movement | Drive/Ship `Process` slope prologue | HIGH / Yes |
+| movement/track | Drive `0x004B0576+`; Ship `0x0069FC86+` | strictly after the slope prologue | may change position; change is observed at next eligible Process | HIGH / Yes |
+| narrow restore | `TechnoClass::Set_Destination @ 0x00741970`, call `0x00742BE3` | only in proved Tunnel/piggyback ground restoration branch | immediate active-locomotor slope snap | HIGH / Conditional |
+| voxel render | Unit callsites `0x0073B5CB`, `0x0073C87A` | reads active locomotor matrix after sim state exists | Drive/Ship Draw_Matrix and SLERP | HIGH / Yes for voxel bodies |
+| save/load | Drive/Ship class Load/Save plus `0x0055AA60` / `0x0055AAC0` | raw class state persists; no load-time resample | next Process compares restored cache | HIGH / Yes |
+
+No direct or indirect active scheduler found in the bounded census supersedes these integration points. The bulk helper `0x004E1570` is dormant relative to this proved chain.
+
+## 6. Current Rust Implementation Status
+
+The audited Rust state is commit `0755e46e` in `feature/phase3-map-spatial-close`.
+
+| Rust surface | Current behavior | Native mismatch |
+|---|---|---|
+| `src/sim/game_entity.rs:797,1170` (`GameEntity::new`) | initializes `rocking: None` | production Drive/Ship objects have no slope-transition state; tests manually attach it |
+| `src/sim/components.rs:1082` (`RockingState`) | stores `prev_slope`, `curr_slope`, mutable `transition_ticks_remaining` together with body rocking | defined native slope lifecycle is a global-frame timer, not a decrementing counter |
+| `src/sim/rocking/rocking_system.rs:165,187` | processes every entity with `rocking: Some`; samples terrain, then decrements remaining on equal slope | class eligibility is not Drive/Ship-specific; native stable `Process` does not mutate transition state |
+| `src/sim/world/mod.rs:6768` phase 2.5 | calls `rocking::tick` after all movement | native samples at each Drive/Ship `Process` entry before movement/track work |
+| `src/app/presentation/instances/units.rs:146,174` | maps remaining `3,2,1` to phases `0,1,2`; falls back to terrain when component absent | phase fractions happen to match manually seeded tests, but production omission and scheduling do not |
+| `src/sim/world/world_hash.rs:1496,1505` | hashes optional `RockingState` and remaining counter | hashing exists, but the wrong/absent lifecycle state is hashed |
+| serde/snapshot | `GameEntity`/`RockingState` derive serialization | shape is persistable, but a schema bump is required if fields change and a production component must actually exist |
+
+The existing rocking tests prove the local countdown and renderer phase mapping, but their production helper explicitly sets `rocking = Some(RockingState::default())` because spawn does not. They therefore do not prove the live production path or native scheduling.
+
+## 7. Coverage Ledger
+
+| Area / function / branch | Status | Evidence | What remains |
+|---|---|---|---|
+| Drive class identity/vtable | verified | COL `0x007FFDE8`, TD `0x00820248`, vtable `0x007E7EB0` | none |
+| Ship class identity/vtable | verified | COL `0x008093A0`, TD `0x0083F880`, vtable `0x007F2D8C` | none |
+| Drive constructor/defaults | verified | `0x004AF540`, base `0x0055A6C0` | none |
+| Ship constructor/defaults | verified | `0x0069EC50`, base `0x0055A6C0` | none |
+| Drive Process slope prologue | verified | `0x004B0500`, writes `0x004B052A..0x004B0557` | none |
+| Ship Process slope prologue | verified | `0x0069FC10`, writes `0x0069FC1B..0x0069FC67` | none |
+| movement/track relative order | verified | Drive `0x004B0576+`; Ship `0x0069FC86+` | none |
+| active tick owner/caller | verified | `FootClass::AI @ 0x004DA530`, call `0x004DA877` | none |
+| successful-unlimbo initialization | verified | `0x004D7170`, call `0x004D71A9`, wrappers/helpers | none |
+| Drive immediate helper | verified | wrapper `0x004B04D0`, helper `0x004AFB40` | none |
+| Ship immediate helper | verified | wrapper `0x0069FBE0`, helper `0x0069F250` | none |
+| Set_Destination restoration branch | verified | `0x00741970`, indirect call `0x00742BE3` | none |
+| timer Start/Remaining semantics | verified | `0x0046B640`, `0x004B4D70` | none |
+| Drive/Ship Draw_Matrix | verified | `0x004AFF60`, `0x0069F670` | none |
+| slope matrix interpolation | verified | `VXL_InterpolatedFacing @ 0x00755A40` | none |
+| Unit voxel draw integration | verified | calls `0x0073B5CB`, `0x0073C87A` | none within scoped matrix consumption |
+| locomotor exclusion matrix | verified | complete relevant vtable slot reads and target bodies in §2 | none |
+| dormant bulk helper | verified | `0x004E1570`, no direct code caller; absent from active chains | none |
+| retail Drive/Ship activation set | verified | `ini/rulesmd.ini` explicit CLSIDs | none |
+| Drive persistence | verified | `0x004AF780`, `0x004AF800`, size `0x004B4CF0` | none |
+| Ship persistence | verified | `0x0069EE90`, `0x0069EF10`, size `0x006A42A0` | none |
+| shared raw persistence helpers | verified | `0x0055AA60`, `0x0055AAC0` | none |
+| RNG absence in bounded chain | verified | full bounded callee/body audit | none |
+| Rust production reachability | verified | `GameEntity::new`, `rocking: None`; production tests inject state | implementation mismatch remains |
+| Rust scheduling/phase/hash | verified | `rocking_system.rs`, `world/mod.rs`, `units.rs`, `world_hash.rs` | implementation mismatch remains |
+
+All planned and discovered in-scope areas are `verified`; there are no `touched-not-exhausted`, `not-touched`, `deferred`, or `conflict-needs-resolution` rows for the claimed slice.
+
+## 8. Open Questions — Final State of the Investigation Log
+
+- `[RESOLVED] Q01 — What live method schedules slope sampling? → Drive/Ship Process.` (evidence: `0x004B0500`, `0x0069FC10`)
+- `[RESOLVED] Q02 — What owner calls those methods? → FootClass::AI dispatches the active locomotor Process.` (evidence: `0x004DA877` in `0x004DA530`)
+- `[RESOLVED] Q03 — Which active classes are eligible? → only active Drive and Ship vtables.` (evidence: `0x007E7EB0`, `0x007F2D8C`, vtable matrix §2)
+- `[RESOLVED] Q04 — Does Ship have a real counterpart? → yes, with independent equivalent constructor, Process, Draw, helpers, and persistence.` (evidence: `0x0069EC50`, `0x0069FC10`, `0x0069F670`, `0x0069F250`)
+- `[RESOLVED] Q05 — What are constructor defaults? → current/previous zero, start current frame, duration/total zero.` (evidence: `0x004AF540`, `0x0069EC50`)
+- `[RESOLVED] Q06 — Is every timer dword initialized and meaningful? → no; middle dword is indeterminate and unread by this lifecycle.` (evidence: constructors, `0x004AFB40`, `0x0046B640`, `0x004B4D70`)
+- `[RESOLVED] Q07 — What establishes the initial live cache? → successful Foot unlimbo snaps both slopes to the containing-cell byte.` (evidence: `0x004D71A9`, `0x004B04D0`, `0x0069FBE0`)
+- `[RESOLVED] Q08 — Does spawn blend from flat? → no; force helpers set total zero.` (evidence: `0x004AFB40`, `0x0069F250`)
+- `[RESOLVED] Q09 — Which cell is sampled? → the owner's current containing cell only.` (evidence: both Process prologues and force wrappers)
+- `[RESOLVED] Q10 — Is a previous or next/head-to cell queried? → no; previous is a cached byte and no look-ahead slope load exists.` (evidence: `0x004B0500`, `0x0069FC10`)
+- `[RESOLVED] Q11 — Is sampling before movement/track work? → yes, at Process entry.` (evidence: Drive `0x004B050B` before `0x004B0576`; Ship `0x0069FC1B` before `0x0069FC86`)
+- `[RESOLVED] Q12 — What does an equal sample do? → no transition field write and no decrement.` (evidence: compare branches in both Process methods)
+- `[RESOLVED] Q13 — What does a changed sample do? → current→previous, sample→current, timer duration/total=3.` (evidence: Drive `0x004B052A..0x004B0557`; Ship `0x0069FC1B..0x0069FC67`)
+- `[RESOLVED] Q14 — How is phase advanced? → signed global-frame Remaining arithmetic, not mutable ticking.` (evidence: `0x0046B640`, `0x004B4D70`)
+- `[RESOLVED] Q15 — What are exact draw phases? → 0, 1/3, 2/3, then stable current.` (evidence: `0x004AFF60`, `0x0069F670`)
+- `[RESOLVED] Q16 — Does render mutate phase? → no; all timer and slope reads are read-only.` (evidence: both Draw_Matrix bodies)
+- `[RESOLVED] Q17 — Is locomotor object +0x62 slope state? → no, its writer follows FacingClass::Is_Rotating.` (evidence: Process use of `0x004C9480`)
+- `[RESOLVED] Q18 — Are Fly/Jumpjet/Rocket/Hover/Walk/Tunnel/Teleport/Mech/DropPod included? → no; none override both slope slots and the interpolating draw path.` (evidence: vtable matrix §2)
+- `[RESOLVED] Q19 — Is a train automatically excluded? → no; it is a Drive type flag, not another locomotor class.` (evidence: retail `IsTrain` census and Drive vtable)
+- `[RESOLVED] Q20 — Is the bulk ForEach helper active here? → no direct code caller and no connection to the proved AI/unlimbo/draw chain.` (evidence: `0x004E1570` caller/xref check)
+- `[RESOLVED] Q21 — Does every move start snap slope? → no; the extra call is confined to a Tunnel/piggyback ground restoration branch.` (evidence: `0x00742BE3` within `0x00741970`)
+- `[RESOLVED] Q22 — Is transition state saved/loaded? → yes, inside the raw 0x70-byte locomotor block.` (evidence: class Load/Save/size methods and `0x0055AA60` / `0x0055AAC0`)
+- `[RESOLVED] Q23 — Does load resample terrain? → no; the next eligible Process performs the ordinary compare.` (evidence: Load bodies plus Process prologues)
+- `[RESOLVED] Q24 — Does native RNG participate? → no.` (evidence: bounded constructor/writer/timer/draw/SLERP callee audit)
+- `[RESOLVED] Q25 — Is current Rust production-reachable? → no; constructor leaves rocking absent and tests inject it.` (evidence: `src/sim/game_entity.rs`, `src/sim/rocking/rocking_tests.rs`)
+- `[RESOLVED] Q26 — Does current Rust schedule sampling natively? → no; it samples in a global post-movement pass.` (evidence: `src/sim/world/mod.rs`, `src/sim/rocking/rocking_system.rs`)
+
+No entry is deferred and no load-bearing question remains.
+
+## 9. Visual/UI Composition Ledger
+
+The visual scope is deliberately the slope matrix layer, not full Unit art composition. The transition changes the body transform applied to the already selected voxel/HVA body; it does not select an alternate image/frame or palette.
+
+| Order | Function / address | Condition / flag proof | Asset / frame | Rect / anchor | Palette / convert | Active for target? | Role |
+|---:|---|---|---|---|---|---|---|
+| 1 | Unit voxel body calls at `0x0073B5CB` / `0x0073C87A` | Unit voxel rendering dispatches active locomotor slot `+0x24` | already selected data-driven VXL/HVA body | existing Unit world anchor; unchanged by this slice | existing voxel palette/conversion; unchanged | yes for voxel-bodied eligible Unit | body matrix request |
+| 2 | Drive `Draw_Matrix @ 0x004AFF60` or Ship `0x0069F670` | active locomotor vtable identity; total zero or timer-derived phase | no alternate asset/frame selected | same anchor | no palette change | yes | compose slope transform |
+| 3 | `VXL_InterpolatedFacing @ 0x00755A40` | only while computed `t < 1`; source=previous, destination=current | native slope quaternion/matrix table | matrix-space, not screen rect | not applicable | conditional during frames F..F+2 | quaternion SLERP |
+| 4 | caller continues normal voxel body draw | returned matrix | same body VXL/HVA | normal projected body bounds | normal voxel conversion | yes | rasterized visible result |
+
+| Asset / data | Loaded | Drawn | Visible in target | Content/preview | Chrome/container | Overlay | Transition-only | Inactive | Evidence |
+|---|---|---|---|---|---|---|---|---|---|
+| unit-selected VXL/HVA body | data-driven | yes | yes for voxel-bodied eligible units | content | no | no | no | no | Unit callsites `0x0073B5CB`, `0x0073C87A` |
+| native slope quaternion/matrix table | in-process data | used as transform | yes through body orientation | content transform | no | no | yes for interpolated frames | no | `VXL_InterpolatedFacing @ 0x00755A40` |
+| alternate slope sprite/frame | no | no | no | no | no | no | no | yes | Draw_Matrix bodies select a transform, not an image |
+
+## 10. Implementation Handoff
+
+| Verified behavior | Evidence | Current Rust delta | Affected Rust surface | Required implementation effect | Acceptance scenario | Risk / do-not-do |
+|---|---|---|---|---|---|---|
+| only active Drive/Ship own sampling | vtable/COL matrix; `0x004DA877` | mismatch: generic `rocking: Some` gate and production absence | `game_entity.rs`, `movement/locomotor.rs`, movement Process-entry seam | attach/drive slope state from `active_kind()` Drive/Ship | production Drive and Ship work without manual state; excluded classes do not | do not gate on effective/installed kind or generic voxel/body-rocking presence |
+| successful unlimbo snaps cache | `0x004D71A9`, wrappers/helpers | missing | `world_spawn.rs` successful reveal/unlimbo path | previous=current=final cell slope, total=0 | spawn directly on ramp renders stable ramp | do not blend constructor zero to placement slope |
+| Process samples before movement/track | `0x004B050B` / `0x0069FC1B` before movement addresses | mismatch: `rocking::tick` is after movement | `movement_tick.rs` Drive/Ship Process-entry path; remove slope work from global post-move stage | detect boundary one eligible Process after crossing | cross A→B during F, detect at next entry only | do not retain an after-movement global slope pass |
+| timer is frame-derived, stable Process is no-write | `0x0046B640`, `0x004B4D70`, Draw bodies | mismatch: mutable remaining decrement | `components.rs`, `rocking_system.rs`, presentation snapshot/renderer | retain start/total and derive 0,1/3,2/3,stable from binary frame | exact four-frame phase ledger plus duplicate-render immutability | do not decrement on equal slope or clear total on expiry |
+| restoration snap is narrow | `0x00742BE3` branch context | unchecked/missing exact slope side effect | piggyback/Tunnel restoration path | snap only when equivalent branch restores active Drive | Teleport/Tunnel restoration fixture | do not reset slope for every Set_Destination/move command |
+| state persists and is deterministic | class Load/Save and raw `0x70` block | partial: serde/hash exist for current wrong fields | `snapshot.rs`, `world_hash.rs`, component serde | persist/hash defined previous/current/start/total fields and bump schema | mid-transition save/load resumes same phase/hash | do not serialize native unused middle dword or recompute cache on load |
+| slope lifecycle consumes no RNG | bounded callee audit | current slope update itself consumes none | Process-entry slope helper/tests | keep RNG state unchanged | RNG before/after initialize/change/render equal | do not share wake/dust RNG calls with slope update |
+
+### Smallest exact implementation contract
+
+This is a behavior contract, not a prescribed refactor. Reusing `RockingState` is the smallest source change if slope eligibility is gated separately from body-rocking eligibility.
+
+1. **Defined slope state:** represent `previous_slope`, `current_slope`, signed/native-frame `start_frame`, and `total = 0 or 3`. The duration is `3` whenever total is `3`. Do not reproduce the native unused middle dword.
+2. **Eligibility:** run slope sampling only when the entity is a `Foot`-equivalent with `locomotor.active_kind()` equal to `Drive` or `Ship`. Do not gate on `effective_kind()`: a temporarily active Drive piggyback is natively a Drive object and is eligible. Voxel-body presentation determines visibility, not sim ownership.
+3. **Successful unlimbo:** after placement succeeds and before ordinary active ticking, sample the final containing-cell slope and set `previous = current = slope`, `start_frame = binary_frame`, `total = 0`.
+4. **Process entry:** at the start of each eligible Drive/Ship object update, before tube/forced-track/ordinary movement can change position, sample the current containing-cell slope. On difference, assign `previous = current`, `current = sample`, `start_frame = binary_frame`, `total = 3`. On equality, do nothing.
+5. **Movement ordering:** a boundary crossed by movement in frame `F` must not be detected by an after-movement global pass in `F`; it is detected at the next eligible Drive/Ship process entry.
+6. **Immediate restoration:** if Rust exercises the Tunnel/piggyback-to-Drive restoration equivalent of `0x00742BE3`, snap to the current cell with total zero after restoration. Do not perform this reset for every move command.
+7. **Render:** derive remaining/phase from the saved transition start and the current binary frame, yielding exactly phases `0`, `1/3`, `2/3`, then stable. Drawing must not mutate state. A stable elapsed transition need not be cleared.
+8. **Persistence/determinism:** serialize the defined state, bump the snapshot schema for any layout change, and hash every defined field/presence bit. A mid-transition save/load at a restored frame must resume the same phase.
+9. **Exclusions:** do not give this lifecycle to Fly/aircraft, Jumpjet, Rocket, Hover, Walk, Tunnel, Teleport, Mech, DropPod, buildings, or infantry merely because they can render or carry a body-rocking component. A modded `IsTrain` Drive unit remains included.
+10. **RNG:** consume no `SimRng` values and introduce no RNG-dependent initialization or phase choice.
+
+The current post-movement all-`RockingState` pass can remain for body rocking only, but slope sampling must move to the active Drive/Ship `Process` entry seam. If one component continues to hold both concerns, its body-rocking update and slope-transition update must use independent eligibility and scheduling.
+
+### Discriminating acceptance tests
+
+1. **Production Drive unlimbo on ramp:** spawn a real Drive `Unit` onto nonzero slope without manual component injection. Assert previous=current=cell slope and total zero; first render is stable, not a flat-to-ramp transition.
+2. **Production Ship counterpart:** perform the same test with a real Ship type and prove identical state/phase behavior.
+3. **Pre-movement boundary timing:** begin an eligible Drive unit on slope A and make its movement cross into slope B during frame `F`. Assert no A→B transition is started by an after-movement pass in `F`; assert the next eligible process entry starts it at phase 0.
+4. **Exact four-frame render ledger:** after detection at `F`, assert old at `F`, `1/3` at `F+1`, `2/3` at `F+2`, and stable new at `F+3`.
+5. **Stationary discovery and stable no-write:** externally place/reconcile an eligible unit so its containing slope differs, with no movement target; its next process starts a transition. Repeated equal-slope process calls do not mutate start/total.
+6. **Mid-transition retarget:** change A→B at `F`, then B→C before expiry. Assert the new transition is B→C, not interpolated(A,B)→C, and restarts at phase 0.
+7. **Class exclusion matrix:** identical terrain changes for Walk, Hover, Fly, Jumpjet, Rocket, Teleport, and Tunnel do not create slope state or consume slope RNG. Include a Drive unit with `IsTrain=yes` and assert it remains eligible.
+8. **Active-vs-effective piggyback:** an installed Teleport unit temporarily driven by active Drive samples as Drive; ordinary restoration follows its specific snap contract rather than a generic move-start reset.
+9. **Save/load:** save at phase `1/3`, load with the same restored binary frame, and assert render phase/state hash continuity. Also assert subsequent equal-slope process does not reset start.
+10. **No RNG consumption:** compare `SimRng` state before/after initialization, stable processing, changed-slope processing, and render-state extraction.
+11. **Production-path discrimination:** remove every manual `rocking = Some(...)` assignment from the fixture setup for the slope test; reach the mechanism exclusively through normal spawn/unlimbo and active locomotor resolution.
+12. **Multiple render reads:** extract/render the same frame twice and prove identical phase with no sim/hash mutation.
+
+### Stale Docs / Follow-up Docs
+
+Live evidence corrects these candidate interpretations:
+
+- `Process` does **not** invoke `Set_Slope`/slot `+0x7C` after starting the timer and therefore does not immediately cancel every transition.
+- locomotor object `+0x62` is facing/turn bookkeeping, not a three-tick slope countdown.
+- slope is sampled before movement, not after movement.
+- there is no next-cell/head-to slope lookup.
+- constructor zero is not the placed-unit initial cache; successful `FootClass::Unlimbo` snaps to the occupied cell.
+- the `TechnoClass::Set_Destination` `+0x7C` call is a narrow Tunnel/piggyback restoration branch, not every movement start.
+- Ship is not absent or materially different; it owns an exact active counterpart.
+
+Existing research documents remain useful as discovery candidates, but these corrected facts should be authoritative for implementation of this bounded lifecycle. Exact replacement wording for the known stale claims is: **“Drive and Ship sample their current containing-cell slope at Process entry, start a global-frame duration-3 render timer on change, and do not call the immediate slope helper from Process; successful unlimbo and the narrow Tunnel/piggyback restoration branch snap instead.”**
+
+### Exhaustion gate: adversarial checks
+
+1. **Could a hidden call at the end of `Process` snap/cancel the timer?** No. The complete ILocomotion `+0x7C` indirect-call census has only the two wrappers and the narrow Set_Destination restoration call; neither `Process` body dispatches it.
+2. **Could Ship merely inherit Drive behavior without persistent state?** No. Ship has its own constructor, state writes, Process prologue, Draw_Matrix consumer, Load/Save, and exact vtable overrides.
+3. **Could the slope byte come from the destination or track head-to cell?** No. Both prologues obtain the linked owner's current containing cell before any track branch and perform no destination-cell slope load.
+4. **Could the three-frame phase be decremented elsewhere between Process and Draw?** No. Draw calls `CDTimerClass::Remaining`, which derives from the global frame; stable Process makes no timer write and no writer to a countdown field exists.
+5. **Could generic voxel or body-rocking eligibility imply all locomotors receive slope interpolation?** No. The class vtable matrix isolates the override to Drive and Ship, while all named exclusions inherit no-op force-slope slots.
+
+### Exhaustion gate: cold spot checks
+
+1. **Initialization cold spot:** following `FootClass::Unlimbo` changed the initial-state conclusion. Constructor zero does not cause a first-tick flat-to-ramp blend because successful unlimbo calls the class override and snaps both cached slopes to the containing cell.
+2. **Persistence cold spot:** following the secondary persistence vtables and shared raw-block helpers proved that slope/timer phase is serialized rather than recomputed on load. This makes snapshot state and hash coverage part of the Rust acceptance contract.
+
+### Exhaustion gate: zero-add pass
+
+After resolving the lifecycle, a final bounded search rechecked:
+
+- all indirect calls at ILocomotion slots `+0x50` and `+0x7C`;
+- the full Drive and Ship `Process` entry ordering around every `Cell+0x11C` load;
+- all locomotor vtable implementations of Draw, Process, force-slope, and set-slope slots;
+- the `FootClass::AI`, successful-unlimbo, Tunnel/piggyback restoration, and Unit voxel draw chains;
+- the Drive/Ship persistence vtables, class sizes, and shared raw save/load helpers;
+- constructor and helper assembly for every defined and indeterminate slope timer dword;
+- RNG callees in the bounded writer/timer/render chain; and
+- current Rust spawn, movement ordering, component update, render phase, serialization, and hash surfaces.
+
+The pass added no new active writer, eligible class, random input, alternate sampled cell, decrement path, or load-time resample. The slice remains closed.
+
+## 11. Ghidra Annotation Candidates
+
+No Ghidra metadata was changed during this investigation. Suggested future annotations, after independent review:
+
+| Address/source | Current metadata | Proposed metadata | Kind | Live proof | Status |
+|---|---|---|---|---|---|
+| `0x004B050B`, `0x0069FC1B` | class method context only | pre-movement containing-cell slope sample prologues | comment | instruction order in both Process bodies | worker-report-only |
+| `0x004D71A9` | Foot unlimbo indirect dispatch | successful-unlimbo immediate Drive/Ship slope synchronization | comment | receiver/slot/body trace | worker-report-only |
+| `0x00742BE3` | indirect slot call | narrow Tunnel/piggyback restoration slope snap; not generic move start | comment | enclosing branch receiver/condition trace | worker-report-only |
+| object `+0x1C/+0x20/+0x24/+0x2C/+0x30` | incomplete/ambiguous field metadata | current slope / previous slope / timer start / duration / transition total | struct comments | constructor, Process, timer, Draw, persistence bodies | worker-report-only |
+| object `+0x28` | ambiguous timer member | opaque unused timer-middle dword | struct comment | constructor/helper assembly plus Start/Remaining reads | worker-report-only |
+| object `+0x62` | potentially stale slope interpretation | facing/turn bookkeeping; not slope countdown | correction comment | Process call to `0x004C9480` and branch writes | worker-report-only |
+
+## Sources
+
+### Active binary evidence
+
+- `DriveLocomotionClass` constructor `0x004AF540`, force helper `0x004AFB40`, Draw `0x004AFF60`, force wrapper `0x004B04D0`, Process `0x004B0500`, Load `0x004AF780`, Save `0x004AF800`.
+- `ShipLocomotionClass` constructor `0x0069EC50`, force helper `0x0069F250`, Draw `0x0069F670`, force wrapper `0x0069FBE0`, Process `0x0069FC10`, Load `0x0069EE90`, Save `0x0069EF10`.
+- `LocomotionClass::Constructor @ 0x0055A6C0`.
+- `FootClass::Unlimbo @ 0x004D7170`; `FootClass::AI @ 0x004DA530`.
+- `TechnoClass::Set_Destination @ 0x00741970`, call at `0x00742BE3`.
+- `CDTimerClass::Start @ 0x0046B640`; `CDTimerClass::Remaining @ 0x004B4D70`.
+- `VXL_InterpolatedFacing @ 0x00755A40`.
+- Unit voxel matrix call sites `0x0073B5CB` and `0x0073C87A`.
+- shared persistence helpers `0x0055AA60` and `0x0055AAC0`; size methods `0x004B4CF0` and `0x006A42A0`.
+- dormant bulk helper `LocomotionClass::ForEach_SetSlopeIndex @ 0x004E1570`.
+
+### Retail data
+
+- `ini/rulesmd.ini`: uncommented `Locomotor=` selections for stock `VehicleTypes`/unit sections.
+
+### Current Rust inspected
+
+- `src/sim/components.rs`
+- `src/sim/game_entity.rs`
+- `src/sim/rocking/rocking_system.rs`
+- `src/sim/rocking/rocking_tests.rs`
+- `src/sim/world/mod.rs`
+- `src/sim/world/world_spawn.rs`
+- `src/sim/movement/locomotor.rs`
+- `src/sim/movement/movement_tick.rs`
+- `src/app/presentation/instances/units.rs`
+- `src/sim/world/world_hash.rs`
+- `src/sim/snapshot.rs`
+
+### Candidate research consulted and live-reconciled
+
+- `docs/research/VXL_SLOPE_CELL_SAMPLING_GHIDRA_REPORT.md`
+- `docs/research/VXL_INTERPOLATED_FACING_AND_SLOPE_TRANSITION_GHIDRA_REPORT.md`
+- `docs/research/DRIVE_PROCESS_MOVEMENT_TICK_ORDER_GHIDRA_REPORT.md`
+- `docs/research/SHIP_VS_DRIVE_LOCOMOTION_COMPARISON.md`
+- `docs/research/FORCE_NEW_SLOPE_CALLERS_GHIDRA_REPORT.md`
+- `docs/research/SHIP_LOCOMOTION_CLASS_GHIDRA_REPORT.md`
+- `docs/research/VXL_DRAW_MATRIX_GHIDRA_REPORT.md`
+- `docs/research/ILOCOMOTION_COM_PROTOCOL_SPEC.md`

--- a/src/app/presentation/instances/units.rs
+++ b/src/app/presentation/instances/units.rs
@@ -28,6 +28,7 @@ use crate::render::unit_slope_transition_cache::{
 };
 use crate::rules::house_colors::{self, HouseColorIndex};
 use crate::sim::components::HarvestOverlay;
+use crate::sim::movement::slope_transition::SLOPE_TRANSITION_FRAMES;
 use std::borrow::Cow;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -94,6 +95,7 @@ enum UnitRenderSlopeState {
         from_slope: u8,
         to_slope: u8,
         phase_num: i32,
+        phase_den: u8,
     },
 }
 
@@ -186,7 +188,7 @@ fn locomotor_render_slope_state(
                 from_slope,
                 to_slope,
                 phase_num,
-                ..
+                phase_den,
             } => {
                 let from_slope = clamp_slope_for_render(from_slope);
                 let to_slope = clamp_slope_for_render(to_slope);
@@ -197,6 +199,7 @@ fn locomotor_render_slope_state(
                         from_slope,
                         to_slope,
                         phase_num,
+                        phase_den,
                     }
                 }
             }
@@ -538,11 +541,16 @@ pub(crate) fn build_unit_instances(
 /// camera/slope/body-facing chain the hull was drawn with. That matters on ramps:
 /// the pivot is a point on the tilted hull, so it has to rise and fall with it
 /// rather than being nudged by a fixed screen-space vector.
-fn turret_screen_offset(turret_offset: i32, body_facing: u8, slope_type: u8) -> (f32, f32) {
-    crate::render::vxl_raster::turret_pivot_screen_offset(
+fn turret_screen_offset(
+    turret_offset: i32,
+    body_facing: u8,
+    slope_state: UnitRenderSlopeState,
+) -> (f32, f32) {
+    crate::render::vxl_raster::turret_pivot_screen_offset_for_slope_state(
         turret_offset,
         body_facing,
-        slope_type,
+        stable_slope_for_key(slope_state),
+        slope_blend_for_render_state(slope_state),
         crate::render::vxl_raster::VxlRenderParams::default().scale,
     )
 }
@@ -598,6 +606,25 @@ fn stable_slope_for_key(slope_state: UnitRenderSlopeState) -> u8 {
     }
 }
 
+fn slope_blend_for_render_state(
+    slope_state: UnitRenderSlopeState,
+) -> Option<crate::render::vxl_raster::VxlSlopeBlend> {
+    match slope_state {
+        UnitRenderSlopeState::Stable(_) => None,
+        UnitRenderSlopeState::Transition {
+            from_slope,
+            to_slope,
+            phase_num,
+            phase_den,
+        } => Some(crate::render::vxl_raster::VxlSlopeBlend {
+            from_slope,
+            to_slope,
+            phase_num,
+            phase_den,
+        }),
+    }
+}
+
 fn transition_key_for_unit(
     key: &UnitSpriteKey,
     slope_state: UnitRenderSlopeState,
@@ -608,6 +635,7 @@ fn transition_key_for_unit(
             from_slope,
             to_slope,
             phase_num,
+            phase_den,
         } => Some(TransitionUnitSpriteKey {
             type_id: key.type_id.clone(),
             facing: key.facing,
@@ -616,6 +644,7 @@ fn transition_key_for_unit(
             from_slope,
             to_slope,
             phase_num,
+            phase_den,
         }),
     }
 }
@@ -755,9 +784,9 @@ fn emit_turret_unit_sprites(
         .and_then(|a| a.get(type_id))
         .map(|e| e.turret_offset)
         .unwrap_or(0);
-    // Same slope the body sprite was keyed with, so the pivot cannot disagree with
-    // the hull it sits on.
-    let (tur_ox, tur_oy) = turret_screen_offset(art_offset, body_facing, slope_type);
+    // Use the same stable or quaternion-SLERP slope matrix as every hull,
+    // turret, and barrel raster layer in this presentation phase.
+    let (tur_ox, tur_oy) = turret_screen_offset(art_offset, body_facing, slope_state);
 
     // All layers of a turreted unit share one depth so insertion order
     // (body, then turret/barrel) controls visual stacking via stable sort.
@@ -980,6 +1009,7 @@ mod tests {
                     from_slope: 3,
                     to_slope: 8,
                     phase_num: 0,
+                    phase_den: SLOPE_TRANSITION_FRAMES,
                 },
             ),
             (
@@ -988,6 +1018,7 @@ mod tests {
                     from_slope: 3,
                     to_slope: 8,
                     phase_num: 1,
+                    phase_den: SLOPE_TRANSITION_FRAMES,
                 },
             ),
             (
@@ -996,6 +1027,7 @@ mod tests {
                     from_slope: 3,
                     to_slope: 8,
                     phase_num: 2,
+                    phase_den: SLOPE_TRANSITION_FRAMES,
                 },
             ),
             (44, UnitRenderSlopeState::Stable(8)),
@@ -1059,9 +1091,51 @@ mod tests {
                 from_slope: 4,
                 to_slope: 9,
                 phase_num: 1,
+                phase_den: SLOPE_TRANSITION_FRAMES,
             }),
             "session frame 51 presents processed frame 50, one third through a timer started at 49"
         );
+    }
+
+    #[test]
+    fn turret_offset_pivot_uses_the_same_slope_blend_as_raster_layers() {
+        const OFFSET: i32 = 80;
+        const FACING: u8 = 0;
+        fn close(a: (f32, f32), b: (f32, f32)) -> bool {
+            (a.0 - b.0).abs() < 0.000_01 && (a.1 - b.1).abs() < 0.000_01
+        }
+
+        let stable_from = turret_screen_offset(OFFSET, FACING, UnitRenderSlopeState::Stable(0));
+        let stable_to = turret_screen_offset(OFFSET, FACING, UnitRenderSlopeState::Stable(4));
+        assert_eq!(
+            stable_to,
+            crate::render::vxl_raster::turret_pivot_screen_offset(OFFSET, FACING, 4, 1.0),
+            "the stable path remains the existing exact slope transform"
+        );
+
+        let blended = |phase_num| {
+            turret_screen_offset(
+                OFFSET,
+                FACING,
+                UnitRenderSlopeState::Transition {
+                    from_slope: 0,
+                    to_slope: 4,
+                    phase_num,
+                    phase_den: SLOPE_TRANSITION_FRAMES,
+                },
+            )
+        };
+        let phase_zero = blended(0);
+        let phase_one_third = blended(1);
+        let phase_two_thirds = blended(2);
+
+        assert!(close(phase_zero, stable_from));
+        assert!(!close(phase_zero, stable_to));
+        assert!(!close(phase_one_third, stable_from));
+        assert!(!close(phase_one_third, stable_to));
+        assert!(!close(phase_two_thirds, stable_from));
+        assert!(!close(phase_two_thirds, stable_to));
+        assert!(!close(phase_one_third, phase_two_thirds));
     }
 
     fn spawn_manager(states: &[SpawnSlotState]) -> SpawnManagerState {

--- a/src/app/presentation/instances/units.rs
+++ b/src/app/presentation/instances/units.rs
@@ -204,6 +204,13 @@ fn locomotor_render_slope_state(
     })
 }
 
+/// Presentation follows the just-committed simulation frame. Drive/Ship
+/// `Draw_Matrix` therefore observes the last frame whose Process entry has
+/// completed, including the unsigned wrap at the initial committed frame.
+const fn display_binary_frame_for_committed_session(committed_binary_frame: u32) -> u32 {
+    committed_binary_frame.wrapping_sub(1)
+}
+
 /// Depth key for one voxel body, from the screen row it was drawn at.
 ///
 /// Two corrections sit between the drawn row and the key: the entity's own
@@ -255,7 +262,8 @@ pub(crate) fn build_unit_instances(
     let z = state.match_state.input.zoom_level;
     // Presentation runs after the just-completed simulation frame; snapshot
     // the one binary frame used by every Drive/Ship Draw_Matrix in this pass.
-    let display_binary_frame = sim.session.binary_frame.wrapping_sub(1);
+    let display_binary_frame =
+        display_binary_frame_for_committed_session(sim.session.binary_frame);
     let (cam_x, cam_y, sw, sh) = (
         state.match_state.input.camera_x,
         state.match_state.input.camera_y,
@@ -937,6 +945,7 @@ mod tests {
     use crate::sim::game_entity::GameEntity;
     use crate::sim::intern::InternedId;
     use crate::sim::movement::locomotor::LocomotorState;
+    use crate::sim::snapshot::GameSnapshot;
     use crate::sim::spawn_manager::{
         SpawnManagerMode, SpawnManagerState, SpawnSlot, SpawnSlotState, SpawnTimer,
     };
@@ -961,6 +970,8 @@ mod tests {
         slope.snap(3, 39);
         slope.sample_process_entry(8, 40);
         sim.substrate.entities.insert(entity);
+
+        assert_eq!(display_binary_frame_for_committed_session(0), u32::MAX);
 
         for (committed_binary_frame, expected) in [
             (
@@ -991,7 +1002,9 @@ mod tests {
         ] {
             sim.session.binary_frame = committed_binary_frame;
             let before_hash = sim.state_hash();
-            let display_binary_frame = sim.session.binary_frame.wrapping_sub(1);
+            let display_binary_frame =
+                display_binary_frame_for_committed_session(sim.session.binary_frame);
+            assert_eq!(display_binary_frame, committed_binary_frame.wrapping_sub(1));
             let entity = sim.substrate.entities.get(1).unwrap();
             assert_eq!(
                 locomotor_render_slope_state(entity, display_binary_frame),
@@ -1002,8 +1015,53 @@ mod tests {
                 Some(expected),
                 "repeated presentation extraction for one committed frame is stable"
             );
+            assert_eq!(
+                display_binary_frame_for_committed_session(sim.session.binary_frame),
+                display_binary_frame,
+                "a paused presentation pass retains the same committed-frame selector"
+            );
             assert_eq!(sim.state_hash(), before_hash, "presentation is read-only");
         }
+    }
+
+    #[test]
+    fn drive_ship_slope_snapshot_uses_production_display_frame_selector() {
+        let mut sim = Simulation::with_seed(0);
+        sim.session.binary_frame = 51;
+        let mut entity = GameEntity::test_default(1, "SHIP", "Americans", 0, 0);
+        entity.owner = sim.intern("Americans");
+        entity.type_ref = sim.intern("SHIP");
+        entity.locomotor = Some(LocomotorState::for_test_kind_at_frame(
+            LocomotorKind::Ship,
+            40,
+        ));
+        let slope = entity
+            .locomotor
+            .as_mut()
+            .unwrap()
+            .active_slope_transition_mut()
+            .unwrap();
+        slope.snap(4, 40);
+        slope.sample_process_entry(9, 49);
+        sim.substrate.entities.insert(entity);
+
+        let bytes = GameSnapshot::save(&sim, 1, 2, "slope display selector", 3);
+        let restored = GameSnapshot::load(&bytes).expect("current slope snapshot").sim;
+        let display_binary_frame =
+            display_binary_frame_for_committed_session(restored.session.binary_frame);
+        assert_eq!(display_binary_frame, 50);
+        assert_eq!(
+            locomotor_render_slope_state(
+                restored.substrate.entities.get(1).unwrap(),
+                display_binary_frame,
+            ),
+            Some(UnitRenderSlopeState::Transition {
+                from_slope: 4,
+                to_slope: 9,
+                phase_num: 1,
+            }),
+            "session frame 51 presents processed frame 50, one third through a timer started at 49"
+        );
     }
 
     fn spawn_manager(states: &[SpawnSlotState]) -> SpawnManagerState {

--- a/src/app/presentation/instances/units.rs
+++ b/src/app/presentation/instances/units.rs
@@ -93,7 +93,7 @@ enum UnitRenderSlopeState {
     Transition {
         from_slope: u8,
         to_slope: u8,
-        phase_num: u8,
+        phase_num: i32,
     },
 }
 
@@ -143,17 +143,17 @@ fn terrain_slope_for_render(state: &AppState, rx: u16, ry: u16) -> u8 {
         .unwrap_or(0)
 }
 
-pub(crate) fn slope_transition_phase_num(remaining: u8) -> Option<u8> {
-    match remaining {
-        1..=3 => Some(3 - remaining),
-        _ => None,
-    }
-}
-
 fn unit_render_slope_state(
     state: &AppState,
     entity: &crate::sim::game_entity::GameEntity,
+    display_binary_frame: u32,
 ) -> UnitRenderSlopeState {
+    // Drive/Ship Draw_Matrix reads the locomotor-owned cache even when the
+    // cached slope is zero. Terrain is only a compatibility fallback for
+    // locomotor classes excluded from the native override pair.
+    if let Some(slope_state) = locomotor_render_slope_state(entity, display_binary_frame) {
+        return slope_state;
+    }
     if entity.category == EntityCategory::Aircraft {
         return UnitRenderSlopeState::Stable(0);
     }
@@ -166,29 +166,42 @@ fn unit_render_slope_state(
         return UnitRenderSlopeState::Stable(0);
     }
 
-    let terrain_slope = terrain_slope_for_render(state, entity.position.rx, entity.position.ry);
-    let Some(rocking) = entity.rocking.as_ref() else {
-        return UnitRenderSlopeState::Stable(terrain_slope);
-    };
+    UnitRenderSlopeState::Stable(terrain_slope_for_render(
+        state,
+        entity.position.rx,
+        entity.position.ry,
+    ))
+}
 
-    if let Some(phase_num) = slope_transition_phase_num(rocking.transition_ticks_remaining) {
-        let from_slope = clamp_slope_for_render(rocking.prev_slope);
-        let to_slope = clamp_slope_for_render(rocking.curr_slope);
-        if from_slope != to_slope {
-            return UnitRenderSlopeState::Transition {
+fn locomotor_render_slope_state(
+    entity: &crate::sim::game_entity::GameEntity,
+    display_binary_frame: u32,
+) -> Option<UnitRenderSlopeState> {
+    crate::sim::movement::slope_transition::state_for_entity(entity).map(|slope_state| {
+        match slope_state.render_phase(display_binary_frame) {
+            crate::sim::movement::slope_transition::SlopeRenderPhase::Stable(slope) => {
+                UnitRenderSlopeState::Stable(clamp_slope_for_render(slope))
+            }
+            crate::sim::movement::slope_transition::SlopeRenderPhase::Transition {
                 from_slope,
                 to_slope,
                 phase_num,
-            };
+                ..
+            } => {
+                let from_slope = clamp_slope_for_render(from_slope);
+                let to_slope = clamp_slope_for_render(to_slope);
+                if from_slope == to_slope {
+                    UnitRenderSlopeState::Stable(to_slope)
+                } else {
+                    UnitRenderSlopeState::Transition {
+                        from_slope,
+                        to_slope,
+                        phase_num,
+                    }
+                }
+            }
         }
-    }
-
-    let stable_slope = clamp_slope_for_render(rocking.curr_slope);
-    if stable_slope == 0 && terrain_slope != 0 {
-        UnitRenderSlopeState::Stable(terrain_slope)
-    } else {
-        UnitRenderSlopeState::Stable(stable_slope)
-    }
+    })
 }
 
 /// Depth key for one voxel body, from the screen row it was drawn at.
@@ -240,6 +253,9 @@ pub(crate) fn build_unit_instances(
         _ => return,
     };
     let z = state.match_state.input.zoom_level;
+    // Presentation runs after the just-completed simulation frame; snapshot
+    // the one binary frame used by every Drive/Ship Draw_Matrix in this pass.
+    let display_binary_frame = sim.session.binary_frame.wrapping_sub(1);
     let (cam_x, cam_y, sw, sh) = (
         state.match_state.input.camera_x,
         state.match_state.input.camera_y,
@@ -322,7 +338,7 @@ pub(crate) fn build_unit_instances(
         // Render slope comes from the locomotor's cached previous/current
         // slope during gamemd's 3-frame transition, then falls back to the
         // stable terrain slope path.
-        let slope_state = unit_render_slope_state(state, entity);
+        let slope_state = unit_render_slope_state(state, entity, display_binary_frame);
         let (sx, sy) = crate::render::locomotor_visual::screen_position(entity);
         let interp_z = pos.z;
         if !in_view(sx, sy, TILE_WIDTH, TILE_HEIGHT, cam_x, cam_y, sw, sh, 120.0) {
@@ -917,10 +933,78 @@ pub(super) fn house_color_to_remap_row(hc: HouseColorIndex) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rules::locomotor_type::LocomotorKind;
+    use crate::sim::game_entity::GameEntity;
     use crate::sim::intern::InternedId;
+    use crate::sim::movement::locomotor::LocomotorState;
     use crate::sim::spawn_manager::{
         SpawnManagerMode, SpawnManagerState, SpawnSlot, SpawnSlotState, SpawnTimer,
     };
+    use crate::sim::world::Simulation;
+
+    #[test]
+    fn drive_ship_slope_unit_extraction_uses_last_processed_frame_without_mutation() {
+        let mut sim = Simulation::new();
+        let mut entity = GameEntity::test_default(1, "DRIVE", "Americans", 0, 0);
+        entity.owner = sim.intern("Americans");
+        entity.type_ref = sim.intern("DRIVE");
+        entity.locomotor = Some(LocomotorState::for_test_kind_at_frame(
+            LocomotorKind::Drive,
+            39,
+        ));
+        let slope = entity
+            .locomotor
+            .as_mut()
+            .unwrap()
+            .active_slope_transition_mut()
+            .unwrap();
+        slope.snap(3, 39);
+        slope.sample_process_entry(8, 40);
+        sim.substrate.entities.insert(entity);
+
+        for (committed_binary_frame, expected) in [
+            (
+                41,
+                UnitRenderSlopeState::Transition {
+                    from_slope: 3,
+                    to_slope: 8,
+                    phase_num: 0,
+                },
+            ),
+            (
+                42,
+                UnitRenderSlopeState::Transition {
+                    from_slope: 3,
+                    to_slope: 8,
+                    phase_num: 1,
+                },
+            ),
+            (
+                43,
+                UnitRenderSlopeState::Transition {
+                    from_slope: 3,
+                    to_slope: 8,
+                    phase_num: 2,
+                },
+            ),
+            (44, UnitRenderSlopeState::Stable(8)),
+        ] {
+            sim.session.binary_frame = committed_binary_frame;
+            let before_hash = sim.state_hash();
+            let display_binary_frame = sim.session.binary_frame.wrapping_sub(1);
+            let entity = sim.substrate.entities.get(1).unwrap();
+            assert_eq!(
+                locomotor_render_slope_state(entity, display_binary_frame),
+                Some(expected)
+            );
+            assert_eq!(
+                locomotor_render_slope_state(entity, display_binary_frame),
+                Some(expected),
+                "repeated presentation extraction for one committed frame is stable"
+            );
+            assert_eq!(sim.state_hash(), before_hash, "presentation is read-only");
+        }
+    }
 
     fn spawn_manager(states: &[SpawnSlotState]) -> SpawnManagerState {
         SpawnManagerState {
@@ -1035,20 +1119,6 @@ mod tests {
             assert!((actual - expected).abs() < 0.0001);
         }
         assert_ne!(unit, aircraft);
-    }
-
-    #[test]
-    fn drive_vxl_slope_transition_phase_counts_three_visible_frames() {
-        assert_eq!(slope_transition_phase_num(3), Some(0));
-        assert_eq!(slope_transition_phase_num(2), Some(1));
-        assert_eq!(slope_transition_phase_num(1), Some(2));
-        assert_eq!(slope_transition_phase_num(0), None);
-    }
-
-    #[test]
-    fn drive_vxl_slope_transition_rejects_out_of_range_remaining() {
-        assert_eq!(slope_transition_phase_num(4), None);
-        assert_eq!(slope_transition_phase_num(u8::MAX), None);
     }
 
     #[test]

--- a/src/render/unit_slope_transition_cache.rs
+++ b/src/render/unit_slope_transition_cache.rs
@@ -28,6 +28,7 @@ pub struct TransitionUnitSpriteKey {
     pub from_slope: u8,
     pub to_slope: u8,
     pub phase_num: i32,
+    pub phase_den: u8,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -141,7 +142,7 @@ impl VxlSlopeTransitionCache {
             from_slope: key.from_slope,
             to_slope: key.to_slope,
             phase_num: key.phase_num,
-            phase_den: 3,
+            phase_den: key.phase_den,
         };
         let (sprite, _) = render_unit_sprite_with_slope_blend(
             asset_manager,
@@ -216,6 +217,7 @@ mod tests {
             from_slope,
             to_slope,
             phase_num,
+            phase_den: crate::sim::movement::slope_transition::SLOPE_TRANSITION_FRAMES,
         }
     }
 

--- a/src/render/unit_slope_transition_cache.rs
+++ b/src/render/unit_slope_transition_cache.rs
@@ -27,7 +27,7 @@ pub struct TransitionUnitSpriteKey {
     pub frame: u32,
     pub from_slope: u8,
     pub to_slope: u8,
-    pub phase_num: u8,
+    pub phase_num: i32,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -207,7 +207,7 @@ impl VxlSlopeTransitionCache {
 mod tests {
     use super::*;
 
-    fn key(from_slope: u8, to_slope: u8, phase_num: u8) -> TransitionUnitSpriteKey {
+    fn key(from_slope: u8, to_slope: u8, phase_num: i32) -> TransitionUnitSpriteKey {
         TransitionUnitSpriteKey {
             type_id: "CMIN".to_string(),
             facing: 64,

--- a/src/render/vxl_raster.rs
+++ b/src/render/vxl_raster.rs
@@ -105,13 +105,36 @@ pub fn turret_pivot_screen_offset(
     slope_type: u8,
     scale: f32,
 ) -> (f32, f32) {
+    turret_pivot_screen_offset_for_slope_state(
+        turret_offset_leptons,
+        body_facing,
+        slope_type,
+        None,
+        scale,
+    )
+}
+
+/// Blend-aware form of [`turret_pivot_screen_offset`]. The optional blend is
+/// consumed by the same quaternion-SLERP matrix helper as VXL limb rastering,
+/// so a separated turret/barrel pivot cannot lead the hull to its destination
+/// slope during an in-progress transition.
+pub fn turret_pivot_screen_offset_for_slope_state(
+    turret_offset_leptons: i32,
+    body_facing: u8,
+    slope_type: u8,
+    slope_blend: Option<VxlSlopeBlend>,
+    scale: f32,
+) -> (f32, f32) {
     if turret_offset_leptons == 0 {
         return (0.0, 0.0);
     }
     let offset_units: f32 = (turret_offset_leptons / TURRET_OFFSET_DIVISOR) as f32;
     let body_facing_mat: Mat4 =
         Mat4::from_rotation_z(voxel_facing_angle(voxel_facing_step(body_facing)));
-    let chain: Mat4 = voxel_camera_view() * compute_slope_rotation(slope_type) * body_facing_mat;
+    let slope_mat = slope_blend
+        .map(compute_slope_blend_rotation)
+        .unwrap_or_else(|| compute_slope_rotation(slope_type));
+    let chain: Mat4 = voxel_camera_view() * slope_mat * body_facing_mat;
     let disp: Vec3 = chain.transform_vector3(Vec3::new(offset_units, 0.0, 0.0));
     (disp.x * scale, -disp.y * scale)
 }
@@ -776,6 +799,7 @@ pub fn hva_to_mat4(raw: &[f32; 12], limb_scale: f32) -> Mat4 {
 mod tests {
     use super::*;
     use crate::assets::vxl_file::{VxlLimb, VxlVoxel};
+    use crate::sim::movement::slope_transition::SLOPE_TRANSITION_FRAMES;
 
     fn make_test_vxl() -> VxlFile {
         let identity: [f32; 12] = [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0];
@@ -1288,7 +1312,7 @@ mod tests {
             from_slope: 4,
             to_slope: 8,
             phase_num: 0,
-            phase_den: 3,
+            phase_den: SLOPE_TRANSITION_FRAMES,
         };
         assert_mat4_close(
             compute_slope_blend_rotation(blend),
@@ -1302,8 +1326,8 @@ mod tests {
         let blend = VxlSlopeBlend {
             from_slope: 4,
             to_slope: 8,
-            phase_num: 3,
-            phase_den: 3,
+            phase_num: i32::from(SLOPE_TRANSITION_FRAMES),
+            phase_den: SLOPE_TRANSITION_FRAMES,
         };
         assert_mat4_close(
             compute_slope_blend_rotation(blend),
@@ -1318,7 +1342,7 @@ mod tests {
             from_slope: 4,
             to_slope: 8,
             phase_num: 1,
-            phase_den: 3,
+            phase_den: SLOPE_TRANSITION_FRAMES,
         };
         let mid = compute_slope_blend_rotation(blend);
         let from = compute_slope_rotation(4);
@@ -1334,7 +1358,7 @@ mod tests {
             from_slope: 4,
             to_slope: 8,
             phase_num: -1,
-            phase_den: 3,
+            phase_den: SLOPE_TRANSITION_FRAMES,
         });
         let from = compute_slope_rotation(4);
         let sample = Vec3::new(0.25, 0.75, 1.0);
@@ -1354,7 +1378,7 @@ mod tests {
                 from_slope: 4,
                 to_slope: 8,
                 phase_num: 1,
-                phase_den: 3,
+                phase_den: SLOPE_TRANSITION_FRAMES,
             }),
             ..Default::default()
         };

--- a/src/render/vxl_raster.rs
+++ b/src/render/vxl_raster.rs
@@ -151,7 +151,7 @@ const CORNER_TILT_RAD: f32 = 0.385_882_7;
 pub struct VxlSlopeBlend {
     pub from_slope: u8,
     pub to_slope: u8,
-    pub phase_num: u8,
+    pub phase_num: i32,
     pub phase_den: u8,
 }
 
@@ -406,8 +406,8 @@ fn compute_slope_rotation(slope_type: u8) -> Mat4 {
 
 fn compute_slope_blend_rotation(blend: VxlSlopeBlend) -> Mat4 {
     let den = blend.phase_den.max(1) as f32;
-    let t = (blend.phase_num as f32 / den).clamp(0.0, 1.0);
-    if t <= 0.0 || blend.from_slope == blend.to_slope {
+    let t = blend.phase_num as f32 / den;
+    if blend.from_slope == blend.to_slope {
         return compute_slope_rotation(blend.from_slope);
     }
     if t >= 1.0 {
@@ -1326,6 +1326,22 @@ mod tests {
         let sample = Vec3::new(0.25, 0.75, 1.0);
         assert!((mid.transform_point3(sample) - from.transform_point3(sample)).length() > 0.001);
         assert!((mid.transform_point3(sample) - to.transform_point3(sample)).length() > 0.001);
+    }
+
+    #[test]
+    fn drive_ship_slope_negative_one_third_extrapolates_without_lower_clamp() {
+        let negative = compute_slope_blend_rotation(VxlSlopeBlend {
+            from_slope: 4,
+            to_slope: 8,
+            phase_num: -1,
+            phase_den: 3,
+        });
+        let from = compute_slope_rotation(4);
+        let sample = Vec3::new(0.25, 0.75, 1.0);
+        assert!(
+            (negative.transform_point3(sample) - from.transform_point3(sample)).length() > 0.001,
+            "native signed -1/3 phase must reach SLERP instead of clamping to the source"
+        );
     }
 
     #[test]

--- a/src/sim/aircraft/mod.rs
+++ b/src/sim/aircraft/mod.rs
@@ -349,6 +349,7 @@ pub fn tick_aircraft_missions(
                                 crate::sim::movement::locomotor::LocomotorState::from_object_type(
                                     obj,
                                     rules.general.flight_level,
+                                    sim.session.binary_frame,
                                 )
                                 .target_altitude;
                             m.set_target_altitude = Some(cruise);

--- a/src/sim/animation_tests.rs
+++ b/src/sim/animation_tests.rs
@@ -361,7 +361,7 @@ fn gsi_13_06_counter_suppressions_hold_the_persistent_value() {
             .locomotor
             .as_mut()
             .expect("locomotor")
-            .begin_piggyback(LocomotorKind::Teleport, MovementLayer::Ground)
+            .begin_piggyback(LocomotorKind::Teleport, MovementLayer::Ground, 0)
     );
     variants.push(("piggyback", piggyback));
 

--- a/src/sim/combat/combat_aoe.rs
+++ b/src/sim/combat/combat_aoe.rs
@@ -1434,6 +1434,7 @@ mod tests {
             let mut locomotor = crate::sim::movement::locomotor::LocomotorState::from_object_type(
                 rules.object(type_id).unwrap(),
                 rules.general.flight_level,
+                0,
             );
             locomotor.layer = MovementLayer::Air;
             locomotor.altitude = SimFixed::from_num(altitude);
@@ -1914,6 +1915,7 @@ mod tests {
                     crate::sim::movement::locomotor::LocomotorState::from_object_type(
                         rules.object("AIRBOMB").unwrap(),
                         rules.general.flight_level,
+                        0,
                     );
                 air_locomotor.layer = MovementLayer::Air;
                 air_locomotor.altitude = SimFixed::from_num(1);
@@ -3374,6 +3376,7 @@ mod tests {
                 crate::sim::movement::locomotor::LocomotorState::from_object_type(
                     rules.object("E1").expect("E1 type"),
                     rules.general.flight_level,
+                    0,
                 ),
             );
             victim.mission.apply_test_fixture(MissionTestFixture {
@@ -3653,6 +3656,7 @@ mod tests {
         let mut air_locomotor = crate::sim::movement::locomotor::LocomotorState::from_object_type(
             rules.object("AIR").expect("air type"),
             rules.general.flight_level,
+            0,
         );
         air_locomotor.layer = MovementLayer::Air;
         air_locomotor.altitude = SimFixed::from_num(1);

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -5447,7 +5447,9 @@ fn crusher_driveover_destroys_wall_but_noncrusher_does_not() {
         veh.regular_crusher = obj.crusher;
         veh.omni_crusher = obj.omni_crusher;
         veh.locomotor =
-            Some(crate::sim::movement::locomotor::LocomotorState::from_object_type(obj, 0));
+            Some(crate::sim::movement::locomotor::LocomotorState::from_object_type(
+                obj, 0, 0,
+            ));
         veh.health = Health {
             current: 300,
             max: 300,

--- a/src/sim/combat/in_range.rs
+++ b/src/sim/combat/in_range.rs
@@ -557,6 +557,7 @@ mod tests {
             piggyback: None,
             runtime_payload: crate::sim::movement::locomotion::LocomotorRuntimePayload::for_kind(
                 LocomotorKind::Fly,
+                0,
             ),
             layer: MovementLayer::Air,
             phase: GroundMovePhase::Idle,

--- a/src/sim/components.rs
+++ b/src/sim/components.rs
@@ -1069,11 +1069,11 @@ pub struct C4PlantState {
     pub target_building_id: u64,
 }
 
-/// Body rocking and slope-transition state for voxel-bodied units.
+/// Body rocking state for voxel-bodied units.
 ///
-/// Tracks both the spring-damped roll/pitch angles (driven by weapon impacts
-/// and EMP wobble) and the 3-tick quaternion-SLERP slope transition when the
-/// unit moves to a cell with a different slope_type.
+/// Tracks spring-damped roll/pitch angles driven by weapon impacts and EMP
+/// wobble. Drive/Ship slope interpolation is locomotor-owned state and is
+/// intentionally independent from this optional component.
 ///
 /// Optional component on `GameEntity` — present on vehicles, ships, and
 /// voxel-bodied buildings; `None` for infantry, aircraft, SHP-bodied
@@ -1090,12 +1090,6 @@ pub struct RockingState {
     pub vel_forwards: SimFixed,
     /// If true, integrate without damping (EMP wobble, naval continuous rocking).
     pub is_ship_rocking: bool,
-    /// Slope_type before the current transition (== curr_slope when no transition).
-    pub prev_slope: u8,
-    /// Current cell's slope_type.
-    pub curr_slope: u8,
-    /// Counts down from 3 to 0. Nonzero ⇒ render-time SLERP between prev and curr.
-    pub transition_ticks_remaining: u8,
 }
 
 impl RockingState {
@@ -1103,11 +1097,9 @@ impl RockingState {
     /// renders via the static atlas path.
     pub const DEADBAND: SimFixed = SimFixed::lit("0.00002");
 
-    /// Returns true when the unit can render via the static atlas path
-    /// (no active rocking, no in-progress slope transition).
+    /// Returns true when the body-rocking transform is neutral.
     pub fn is_neutral(&self) -> bool {
         !self.is_ship_rocking
-            && self.transition_ticks_remaining == 0
             && self.angle_sideways.abs() <= Self::DEADBAND
             && self.angle_forwards.abs() <= Self::DEADBAND
     }
@@ -1317,13 +1309,6 @@ mod tests {
         // DEADBAND is 2e-5; SIM_EPSILON is ~1.5e-5 — exactly one delta below.
         r.angle_sideways = SimFixed::DELTA;
         assert!(r.is_neutral());
-    }
-
-    #[test]
-    fn rocking_transition_is_not_neutral() {
-        let mut r = RockingState::default();
-        r.transition_ticks_remaining = 1;
-        assert!(!r.is_neutral());
     }
 
     #[test]

--- a/src/sim/game_entity.rs
+++ b/src/sim/game_entity.rs
@@ -499,7 +499,8 @@ pub struct GameEntity {
     pub air_spatial_enter_order: u64,
 
     // --- Optional subsystem components ---
-    /// Locomotor state — present on movable entities (speed > 0 in rules.ini).
+    /// Locomotor state — present on moving types and on zero-speed Foot
+    /// Drive/Ship types whose native class-local payload still exists.
     pub locomotor: Option<LocomotorState>,
     /// Active movement path — present when unit is moving along an A* path.
     pub movement_target: Option<MovementTarget>,

--- a/src/sim/game_entity.rs
+++ b/src/sim/game_entity.rs
@@ -809,9 +809,9 @@ pub struct GameEntity {
     /// Infantry fear/prone runtime. `None` for non-infantry entities.
     #[serde(default)]
     pub infantry: Option<InfantryRuntime>,
-    /// Body rocking + slope-transition state. `None` for entities that don't
-    /// rock (infantry, aircraft, SHP-bodied buildings). `Some(default)` for
-    /// vehicles and voxel-bodied buildings.
+    /// Optional body-rocking state only. Drive/Ship slope transitions belong
+    /// to their typed locomotor payloads. This defaults to `None` and becomes
+    /// present only when an explicit body-rocking producer activates it.
     #[serde(default)]
     pub rocking: Option<RockingState>,
     /// Exact native-width Mission state. All writes pass through a named legacy

--- a/src/sim/miner/miner_system.rs
+++ b/src/sim/miner/miner_system.rs
@@ -1629,6 +1629,7 @@ fn try_issue_chrono_far_return_teleport(
         true,
         false,
         sim.playfield_bounds,
+        sim.session.binary_frame,
     );
     if issued {
         emit_chrono_warp_sounds(sim, rules, snap.type_id, (snap.rx, snap.ry), staging);
@@ -2197,7 +2198,8 @@ fn issue_stock_miner_drive_move_with_overlay_registry(
                     locomotor.layer,
                     locomotor.phase,
                 );
-                let _ = locomotor.begin_drive_piggyback_for_teleporter();
+                let _ = locomotor
+                    .begin_drive_piggyback_for_teleporter(sim.session.binary_frame);
                 snapshot
             })
     } else {

--- a/src/sim/movement/air_movement.rs
+++ b/src/sim/movement/air_movement.rs
@@ -709,6 +709,7 @@ mod tests {
             piggyback: None,
             runtime_payload: crate::sim::movement::locomotion::LocomotorRuntimePayload::for_kind(
                 LocomotorKind::Fly,
+                0,
             ),
             layer: MovementLayer::Air,
             phase: crate::sim::movement::locomotor::GroundMovePhase::Idle,
@@ -747,6 +748,7 @@ mod tests {
             piggyback: None,
             runtime_payload: crate::sim::movement::locomotion::LocomotorRuntimePayload::for_kind(
                 LocomotorKind::Jumpjet,
+                0,
             ),
             layer: MovementLayer::Air,
             phase: crate::sim::movement::locomotor::GroundMovePhase::Idle,

--- a/src/sim/movement/jumpjet_movement.rs
+++ b/src/sim/movement/jumpjet_movement.rs
@@ -290,6 +290,7 @@ mod tests {
             piggyback: None,
             runtime_payload: crate::sim::movement::locomotion::LocomotorRuntimePayload::for_kind(
                 LocomotorKind::Jumpjet,
+                0,
             ),
             layer: MovementLayer::Air,
             phase: GroundMovePhase::Idle,

--- a/src/sim/movement/locomotion/piggyback.rs
+++ b/src/sim/movement/locomotion/piggyback.rs
@@ -33,6 +33,7 @@ use crate::util::fixed_math::SimFixed;
 use super::super::drop_pod_movement::DropPodState;
 use super::super::locomotor::{AirMovePhase, GroundMovePhase, LocomotorState, MovementLayer};
 use super::super::rocket_movement::RocketState;
+use super::super::slope_transition::SlopeTransitionState;
 use super::super::teleport_movement::TeleportState;
 use super::super::tunnel_movement::TunnelState;
 
@@ -74,7 +75,7 @@ pub struct LocomotorCommonRuntime {
 /// byte when a complete locomotor is suspended or loaded.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum LocomotorRuntimePayload {
-    Drive,
+    Drive(SlopeTransitionState),
     Walk,
     Teleport(Option<TeleportState>),
     Tunnel(Option<TunnelState>),
@@ -82,16 +83,18 @@ pub enum LocomotorRuntimePayload {
     DropPod(Option<DropPodState>),
     Hover,
     Mech,
-    Ship,
+    Ship(SlopeTransitionState),
     Fly,
     Jumpjet,
     Parachute,
 }
 
 impl LocomotorRuntimePayload {
-    pub(crate) fn for_kind(kind: LocomotorKind) -> Self {
+    pub(crate) fn for_kind(kind: LocomotorKind, binary_frame: u32) -> Self {
         match kind {
-            LocomotorKind::Drive => Self::Drive,
+            LocomotorKind::Drive => {
+                Self::Drive(SlopeTransitionState::at_binary_frame(binary_frame))
+            }
             LocomotorKind::Walk => Self::Walk,
             LocomotorKind::Teleport => Self::Teleport(None),
             LocomotorKind::Tunnel => Self::Tunnel(None),
@@ -99,17 +102,13 @@ impl LocomotorRuntimePayload {
             LocomotorKind::DropPod => Self::DropPod(None),
             LocomotorKind::Hover => Self::Hover,
             LocomotorKind::Mech => Self::Mech,
-            LocomotorKind::Ship => Self::Ship,
+            LocomotorKind::Ship => {
+                Self::Ship(SlopeTransitionState::at_binary_frame(binary_frame))
+            }
             LocomotorKind::Fly => Self::Fly,
             LocomotorKind::Jumpjet => Self::Jumpjet,
             LocomotorKind::Parachute => Self::Parachute,
         }
-    }
-}
-
-impl Default for LocomotorRuntimePayload {
-    fn default() -> Self {
-        Self::Drive
     }
 }
 
@@ -187,13 +186,14 @@ impl LocomotorRuntime {
         state: &LocomotorState,
         kind: LocomotorKind,
         layer: MovementLayer,
+        binary_frame: u32,
     ) -> Self {
         let mut runtime = Self::capture(state);
         runtime.kind = kind;
         runtime.layer = layer;
         runtime.common.phase = GroundMovePhase::Idle;
         runtime.common.air_phase = AirMovePhase::Landed;
-        runtime.payload = LocomotorRuntimePayload::for_kind(kind);
+        runtime.payload = LocomotorRuntimePayload::for_kind(kind, binary_frame);
         runtime
     }
 
@@ -299,8 +299,9 @@ pub fn begin(
     state: &mut LocomotorState,
     kind: LocomotorKind,
     layer: MovementLayer,
+    binary_frame: u32,
 ) -> BeginOutcome {
-    let incoming = LocomotorRuntime::replacement_from(state, kind, layer);
+    let incoming = LocomotorRuntime::replacement_from(state, kind, layer, binary_frame);
     begin_with_runtime(state, Some(incoming))
 }
 
@@ -424,12 +425,22 @@ mod tests {
         let before = state.clone();
 
         assert_eq!(
-            begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground),
+            begin(
+                &mut state,
+                LocomotorKind::Drive,
+                MovementLayer::Ground,
+                0,
+            ),
             BeginOutcome::Installed
         );
         let nested_before = state.clone();
         assert_eq!(
-            begin(&mut state, LocomotorKind::Ship, MovementLayer::Ground),
+            begin(
+                &mut state,
+                LocomotorKind::Ship,
+                MovementLayer::Ground,
+                0,
+            ),
             BeginOutcome::RefusedNested
         );
         assert_eq!(state.piggyback, nested_before.piggyback);
@@ -444,7 +455,12 @@ mod tests {
         let installed = state.slot;
 
         assert_eq!(
-            begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground),
+            begin(
+                &mut state,
+                LocomotorKind::Drive,
+                MovementLayer::Ground,
+                0,
+            ),
             BeginOutcome::Installed
         );
         assert_eq!(state.kind, LocomotorKind::Drive);
@@ -470,10 +486,18 @@ mod tests {
         }));
 
         assert_eq!(
-            begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground),
+            begin(
+                &mut state,
+                LocomotorKind::Drive,
+                MovementLayer::Ground,
+                0,
+            ),
             BeginOutcome::Installed
         );
-        assert_eq!(state.runtime_payload, LocomotorRuntimePayload::Drive);
+        assert_eq!(
+            state.runtime_payload,
+            LocomotorRuntimePayload::for_kind(LocomotorKind::Drive, 0)
+        );
         assert_eq!(
             state.piggyback.as_deref().map(|runtime| &runtime.payload),
             Some(&LocomotorRuntimePayload::Tunnel(Some(TunnelState {
@@ -497,7 +521,12 @@ mod tests {
             phase: TunnelPhase::Digging,
         }));
         assert_eq!(
-            begin(&mut state, LocomotorKind::DropPod, MovementLayer::Air),
+            begin(
+                &mut state,
+                LocomotorKind::DropPod,
+                MovementLayer::Air,
+                0,
+            ),
             BeginOutcome::Installed
         );
         state.runtime_payload = LocomotorRuntimePayload::DropPod(None);
@@ -524,7 +553,12 @@ mod tests {
         let mut output = None;
         assert_eq!(end_into(&mut state, Some(&mut output)), EndOutcome::Empty);
 
-        begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground);
+        begin(
+            &mut state,
+            LocomotorKind::Drive,
+            MovementLayer::Ground,
+            0,
+        );
         assert_eq!(
             end_into(&mut state, Some(&mut output)),
             EndOutcome::Restored
@@ -540,7 +574,12 @@ mod tests {
     #[test]
     fn ordinary_and_special_end_gates_are_distinct() {
         let mut state = teleporter();
-        begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground);
+        begin(
+            &mut state,
+            LocomotorKind::Drive,
+            MovementLayer::Ground,
+            0,
+        );
         let ready = EndGateContext {
             owner_moving: false,
             owner_teleporting: false,
@@ -580,7 +619,12 @@ mod tests {
     fn serialized_presence_matches_the_single_suspended_runtime() {
         let mut state = teleporter();
         assert_eq!(serialized_presence(&state), 0);
-        begin(&mut state, LocomotorKind::Drive, MovementLayer::Ground);
+        begin(
+            &mut state,
+            LocomotorKind::Drive,
+            MovementLayer::Ground,
+            0,
+        );
         assert_eq!(serialized_presence(&state), 1);
     }
 }

--- a/src/sim/movement/locomotor.rs
+++ b/src/sim/movement/locomotor.rs
@@ -29,6 +29,7 @@ use crate::sim::movement::locomotion::LocomotorSlot;
 use crate::sim::movement::locomotion::piggyback::{
     self, EndGateContext, LocomotorRuntimePayload, StashedLocomotor,
 };
+use crate::sim::movement::slope_transition::SlopeTransitionState;
 use crate::util::fixed_math::{SIM_ZERO, SimFixed, sim_from_f32};
 
 /// Which spatial layer the unit currently occupies.
@@ -153,7 +154,6 @@ pub struct LocomotorState {
     pub piggyback: Option<StashedLocomotor>,
     /// Class-local state of the locomotor currently driving this entity.
     /// Piggyback BEGIN/END transfers this value with the complete runtime.
-    #[serde(default)]
     pub runtime_payload: LocomotorRuntimePayload,
     /// Which spatial layer the unit currently occupies.
     pub layer: MovementLayer,
@@ -259,7 +259,7 @@ impl LocomotorState {
     /// `flight_level` is the cruise altitude in leptons from `[General] FlightLevel=`
     /// (typically `rules.general.flight_level`). Fly/Rocket locomotors use this
     /// as their target altitude.
-    pub fn from_object_type(obj: &ObjectType, flight_level: i32) -> Self {
+    pub fn from_object_type(obj: &ObjectType, flight_level: i32, binary_frame: u32) -> Self {
         let kind: LocomotorKind = obj.locomotor;
         let sim_one: SimFixed = SimFixed::from_num(1);
 
@@ -305,7 +305,7 @@ impl LocomotorState {
             slot: LocomotorSlot::from_kind(kind),
             powered: true,
             piggyback: None,
-            runtime_payload: LocomotorRuntimePayload::for_kind(kind),
+            runtime_payload: LocomotorRuntimePayload::for_kind(kind, binary_frame),
             layer,
             phase: GroundMovePhase::Idle,
             air_phase: AirMovePhase::Landed,
@@ -362,6 +362,11 @@ impl LocomotorState {
 
     #[cfg(test)]
     pub(crate) fn for_test_kind(kind: LocomotorKind) -> Self {
+        Self::for_test_kind_at_frame(kind, 0)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test_kind_at_frame(kind: LocomotorKind, binary_frame: u32) -> Self {
         let (layer, speed_multiplier) = match kind {
             LocomotorKind::Fly
             | LocomotorKind::Jumpjet
@@ -376,7 +381,7 @@ impl LocomotorState {
             slot: LocomotorSlot::from_kind(kind),
             powered: true,
             piggyback: None,
-            runtime_payload: LocomotorRuntimePayload::for_kind(kind),
+            runtime_payload: LocomotorRuntimePayload::for_kind(kind, binary_frame),
             layer,
             phase: GroundMovePhase::Idle,
             air_phase: AirMovePhase::Landed,
@@ -441,6 +446,24 @@ impl LocomotorState {
         self.kind
     }
 
+    pub(crate) fn active_slope_transition(&self) -> Option<&SlopeTransitionState> {
+        match (self.active_kind(), &self.runtime_payload) {
+            (LocomotorKind::Drive, LocomotorRuntimePayload::Drive(state))
+            | (LocomotorKind::Ship, LocomotorRuntimePayload::Ship(state)) => Some(state),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn active_slope_transition_mut(
+        &mut self,
+    ) -> Option<&mut SlopeTransitionState> {
+        match (self.kind, &mut self.runtime_payload) {
+            (LocomotorKind::Drive, LocomotorRuntimePayload::Drive(state))
+            | (LocomotorKind::Ship, LocomotorRuntimePayload::Ship(state)) => Some(state),
+            _ => None,
+        }
+    }
+
     /// The unit's identity for mission-level decisions: the installed class,
     /// seen through any piggyback that is currently driving it.
     ///
@@ -459,7 +482,7 @@ impl LocomotorState {
     /// Activate Drive over a stashed Teleport locomotor — the Chrono Miner
     /// bridge model: the unit stays a Teleport unit, Drive temporarily drives it
     /// for destinations that need ground movement.
-    pub fn begin_drive_piggyback_for_teleporter(&mut self) -> bool {
+    pub fn begin_drive_piggyback_for_teleporter(&mut self, binary_frame: u32) -> bool {
         if self.effective_kind() != LocomotorKind::Teleport {
             return false;
         }
@@ -468,7 +491,11 @@ impl LocomotorState {
             // ownership; it never reconstructs a missing Teleport COM object.
             return self.piggyback.is_some();
         }
-        self.begin_piggyback(LocomotorKind::Drive, MovementLayer::Ground)
+        self.begin_piggyback(
+            LocomotorKind::Drive,
+            MovementLayer::Ground,
+            binary_frame,
+        )
     }
 
     /// Return from an active piggyback to the stashed locomotor.
@@ -499,8 +526,13 @@ impl LocomotorState {
     ///
     /// Refuses, changing nothing, if a stash is already present — the native
     /// BEGIN returns `E_FAIL` in exactly that case.
-    pub fn begin_piggyback(&mut self, kind: LocomotorKind, layer: MovementLayer) -> bool {
-        piggyback::begin(self, kind, layer) == piggyback::BeginOutcome::Installed
+    pub fn begin_piggyback(
+        &mut self,
+        kind: LocomotorKind,
+        layer: MovementLayer,
+        binary_frame: u32,
+    ) -> bool {
+        piggyback::begin(self, kind, layer, binary_frame) == piggyback::BeginOutcome::Installed
     }
 
     /// End the active piggyback, restoring the stashed locomotor.

--- a/src/sim/movement/locomotor_tests.rs
+++ b/src/sim/movement/locomotor_tests.rs
@@ -286,7 +286,7 @@ fn make_obj(locomotor: LocomotorKind, category: ObjectCategory) -> ObjectType {
 #[test]
 fn test_drive_locomotor() {
     let obj = make_obj(LocomotorKind::Drive, ObjectCategory::Vehicle);
-    let state = LocomotorState::from_object_type(&obj, 1500);
+    let state = LocomotorState::from_object_type(&obj, 1500, 0);
     assert_eq!(state.kind, LocomotorKind::Drive);
     assert_eq!(state.layer, MovementLayer::Ground);
     assert_eq!(state.phase, GroundMovePhase::Idle);
@@ -301,7 +301,7 @@ fn test_hover_cruises_at_full_base_speed() {
     // Hover now cruises at its full base Speed (throttle 1.0), not the old
     // made-up 0.65x. The accel/brake throttle ramp lives in sim/movement/hover.rs.
     let obj = make_obj(LocomotorKind::Hover, ObjectCategory::Vehicle);
-    let state = LocomotorState::from_object_type(&obj, 1500);
+    let state = LocomotorState::from_object_type(&obj, 1500, 0);
     assert_eq!(state.kind, LocomotorKind::Hover);
     assert_eq!(state.speed_multiplier, SIM_ONE);
     assert!(state.is_ground_mover());
@@ -310,7 +310,7 @@ fn test_hover_cruises_at_full_base_speed() {
 #[test]
 fn test_walk_locomotor() {
     let obj = make_obj(LocomotorKind::Walk, ObjectCategory::Infantry);
-    let state = LocomotorState::from_object_type(&obj, 1500);
+    let state = LocomotorState::from_object_type(&obj, 1500, 0);
     assert_eq!(state.kind, LocomotorKind::Walk);
     assert_eq!(state.layer, MovementLayer::Ground);
     assert!(state.is_ground_mover());
@@ -319,7 +319,7 @@ fn test_walk_locomotor() {
 #[test]
 fn test_fly_locomotor_air_layer() {
     let obj = make_obj(LocomotorKind::Fly, ObjectCategory::Aircraft);
-    let state = LocomotorState::from_object_type(&obj, 1500);
+    let state = LocomotorState::from_object_type(&obj, 1500, 0);
     assert_eq!(state.kind, LocomotorKind::Fly);
     assert_eq!(state.layer, MovementLayer::Air);
     assert_eq!(state.air_phase, AirMovePhase::Landed);
@@ -332,7 +332,7 @@ fn test_fly_locomotor_air_layer() {
 #[test]
 fn test_jumpjet_air_layer() {
     let obj = make_obj(LocomotorKind::Jumpjet, ObjectCategory::Infantry);
-    let state = LocomotorState::from_object_type(&obj, 1500);
+    let state = LocomotorState::from_object_type(&obj, 1500, 0);
     assert_eq!(state.kind, LocomotorKind::Jumpjet);
     assert_eq!(state.layer, MovementLayer::Air);
     assert!(!state.is_ground_mover());
@@ -355,7 +355,7 @@ fn test_jumpjet_with_custom_params() {
         deviation: 40,
         no_wobbles: false,
     });
-    let state = LocomotorState::from_object_type(&obj, 1500);
+    let state = LocomotorState::from_object_type(&obj, 1500, 0);
     assert_eq!(state.target_altitude, SimFixed::from_num(750));
     assert_eq!(state.jumpjet_speed, sim_from_f32(20.0));
     assert_eq!(state.climb_rate, sim_from_f32(8.0) * SimFixed::from_num(15));
@@ -364,7 +364,7 @@ fn test_jumpjet_with_custom_params() {
 #[test]
 fn test_ship_is_ground_mover() {
     let obj = make_obj(LocomotorKind::Ship, ObjectCategory::Vehicle);
-    let state = LocomotorState::from_object_type(&obj, 1500);
+    let state = LocomotorState::from_object_type(&obj, 1500, 0);
     assert_eq!(state.kind, LocomotorKind::Ship);
     assert!(state.is_ground_mover());
     assert!(!state.is_air_mover());
@@ -377,7 +377,7 @@ fn cmin_locomotor_initializes_primary_and_active_teleport() {
     obj.teleporter = true;
     obj.turret_rot = 5;
 
-    let state = LocomotorState::from_object_type(&obj, 1500);
+    let state = LocomotorState::from_object_type(&obj, 1500, 0);
 
     assert_eq!(state.active_kind(), LocomotorKind::Teleport);
     assert_eq!(state.effective_kind(), LocomotorKind::Teleport);
@@ -388,7 +388,7 @@ fn cmin_locomotor_initializes_primary_and_active_teleport() {
 #[test]
 fn test_is_airborne() {
     let obj = make_obj(LocomotorKind::Fly, ObjectCategory::Aircraft);
-    let mut state = LocomotorState::from_object_type(&obj, 1500);
+    let mut state = LocomotorState::from_object_type(&obj, 1500, 0);
     assert!(!state.is_airborne());
     state.altitude = SimFixed::from_num(100);
     assert!(state.is_airborne());
@@ -399,13 +399,13 @@ fn test_is_airborne() {
 #[test]
 fn test_override_teleport_round_trip() {
     let obj = make_obj(LocomotorKind::Drive, ObjectCategory::Vehicle);
-    let mut state = LocomotorState::from_object_type(&obj, 1500);
+    let mut state = LocomotorState::from_object_type(&obj, 1500, 0);
     assert!(!state.is_overridden());
     assert_eq!(state.kind, LocomotorKind::Drive);
     assert_eq!(state.layer, MovementLayer::Ground);
 
     // Begin teleport override.
-    state.begin_piggyback(LocomotorKind::Teleport, MovementLayer::Ground);
+    state.begin_piggyback(LocomotorKind::Teleport, MovementLayer::Ground, 0);
     assert!(state.is_overridden());
     assert_eq!(state.kind, LocomotorKind::Teleport);
     assert_eq!(state.layer, MovementLayer::Ground);
@@ -421,7 +421,7 @@ fn test_override_teleport_round_trip() {
 #[test]
 fn end_piggyback_without_a_stash_reports_nothing_to_pop() {
     let obj = make_obj(LocomotorKind::Drive, ObjectCategory::Vehicle);
-    let mut state = LocomotorState::from_object_type(&obj, 1500);
+    let mut state = LocomotorState::from_object_type(&obj, 1500, 0);
     let result = state.end_piggyback();
     assert!(
         !result,
@@ -434,10 +434,10 @@ fn end_piggyback_without_a_stash_reports_nothing_to_pop() {
 fn test_override_preserves_speed_type() {
     let mut obj = make_obj(LocomotorKind::Drive, ObjectCategory::Vehicle);
     obj.speed_type = SpeedType::Wheel;
-    let mut state = LocomotorState::from_object_type(&obj, 1500);
+    let mut state = LocomotorState::from_object_type(&obj, 1500, 0);
     assert_eq!(state.speed_type, SpeedType::Wheel);
 
-    state.begin_piggyback(LocomotorKind::Teleport, MovementLayer::Ground);
+    state.begin_piggyback(LocomotorKind::Teleport, MovementLayer::Ground, 0);
     // SpeedType should still reflect the original during override.
     state.end_piggyback();
     assert_eq!(state.speed_type, SpeedType::Wheel);
@@ -446,9 +446,9 @@ fn test_override_preserves_speed_type() {
 #[test]
 fn drive_piggyback_restores_primary_teleport_only_after_not_moving() {
     let obj = make_obj(LocomotorKind::Teleport, ObjectCategory::Vehicle);
-    let mut state = LocomotorState::from_object_type(&obj, 1500);
+    let mut state = LocomotorState::from_object_type(&obj, 1500, 0);
 
-    assert!(state.begin_drive_piggyback_for_teleporter());
+    assert!(state.begin_drive_piggyback_for_teleporter(0));
     assert_eq!(state.active_kind(), LocomotorKind::Drive);
     assert_eq!(state.effective_kind(), LocomotorKind::Teleport);
     assert!(!state.can_restore_primary_from_piggyback(true, false, false));
@@ -465,10 +465,10 @@ fn drive_piggyback_restores_primary_teleport_only_after_not_moving() {
 #[test]
 fn drive_piggyback_refuses_an_unstashed_active_drive() {
     let obj = make_obj(LocomotorKind::Teleport, ObjectCategory::Vehicle);
-    let mut state = LocomotorState::from_object_type(&obj, 1500);
+    let mut state = LocomotorState::from_object_type(&obj, 1500, 0);
     state.kind = LocomotorKind::Drive;
 
-    assert!(!state.begin_drive_piggyback_for_teleporter());
+    assert!(!state.begin_drive_piggyback_for_teleporter(0));
     assert_eq!(state.kind, LocomotorKind::Drive);
     assert!(state.piggyback.is_none());
 }

--- a/src/sim/movement/mod.rs
+++ b/src/sim/movement/mod.rs
@@ -65,6 +65,7 @@ mod movement_tick;
 mod navcom;
 mod path_markers;
 pub(crate) mod ready_producer;
+pub(crate) mod slope_transition;
 
 // --- Movement-related modules (public API) ---
 pub mod air_movement;

--- a/src/sim/movement/movement_bridge.rs
+++ b/src/sim/movement/movement_bridge.rs
@@ -884,6 +884,7 @@ mod tests {
             piggyback: None,
             runtime_payload: crate::sim::movement::locomotion::LocomotorRuntimePayload::for_kind(
                 LocomotorKind::Drive,
+                0,
             ),
             layer,
             phase: GroundMovePhase::Idle,

--- a/src/sim/movement/movement_commands.rs
+++ b/src/sim/movement/movement_commands.rs
@@ -143,6 +143,7 @@ pub fn set_destination_for_teleporter_entity(
     is_teleporter: bool,
     destination_has_building: bool,
     playfield_bounds: Option<crate::sim::cell_rect::PlayfieldBounds>,
+    binary_frame: u32,
 ) -> bool {
     let Some(entity) = entities.get(entity_id) else {
         return false;
@@ -184,7 +185,7 @@ pub fn set_destination_for_teleporter_entity(
         if let Some(entity) = entities.get_mut(entity_id)
             && let Some(ref mut loco) = entity.locomotor
         {
-            loco.begin_drive_piggyback_for_teleporter();
+            loco.begin_drive_piggyback_for_teleporter(binary_frame);
         }
         return issue_move_command_with_layered(
             entities,

--- a/src/sim/movement/movement_tests.rs
+++ b/src/sim/movement/movement_tests.rs
@@ -256,6 +256,327 @@ fn gsi_04_05_tick_production_movement(
     );
 }
 
+fn drive_ship_slope_process_tick(
+    sim: &mut Simulation,
+    terrain: &crate::map::resolved_terrain::ResolvedTerrainGrid,
+    native_frame: u32,
+) {
+    let live_order = [1];
+    let mut sound_events = Vec::new();
+    let mut lifecycle_requests = Vec::new();
+    tick_movement_with_grids(
+        &mut sim.substrate.entities,
+        Some(&live_order),
+        None,
+        &Default::default(),
+        &Default::default(),
+        &mut sim.substrate.occupancy,
+        &mut sim.substrate.cell_occupation,
+        &mut sim.substrate.raw_cell_occupation,
+        &mut sim.substrate.next_occupancy_enter_order,
+        &mut sim.scenario_rng,
+        u64::from(native_frame),
+        native_frame,
+        None,
+        Some(terrain),
+        None,
+        &crate::sim::pathfinding::terrain_speed::TerrainSpeedConfig::default(),
+        SIM_ZERO,
+        9,
+        60,
+        &mut sim.interner,
+        None,
+        &mut sound_events,
+        &mut lifecycle_requests,
+    );
+}
+
+fn slope_cell(rx: u16, slope_type: u8) -> crate::map::resolved_terrain::ResolvedTerrainCell {
+    slope_cell_at(rx, 0, slope_type)
+}
+
+fn slope_cell_at(
+    rx: u16,
+    ry: u16,
+    slope_type: u8,
+) -> crate::map::resolved_terrain::ResolvedTerrainCell {
+    crate::map::resolved_terrain::ResolvedTerrainCell {
+        slope_type,
+        ..drive_speed_test_cell(rx, ry, Default::default())
+    }
+}
+
+#[test]
+fn drive_ship_slope_process_samples_stationary_retargets_and_keeps_rng() {
+    let terrain = crate::map::resolved_terrain::ResolvedTerrainGrid::from_cells(
+        2,
+        1,
+        vec![slope_cell(0, 5), slope_cell(1, 11)],
+    );
+    for kind in [LocomotorKind::Drive, LocomotorKind::Ship] {
+        let mut sim = Simulation::with_seed(0x51_0f_e);
+        let mut entity = GameEntity::test_default(1, "SLOPE", "Americans", 0, 0);
+        entity.owner = sim.intern("Americans");
+        entity.type_ref = sim.intern("SLOPE");
+        entity.locomotor = Some(LocomotorState::for_test_kind_at_frame(kind, 2));
+        entity
+            .locomotor
+            .as_mut()
+            .unwrap()
+            .active_slope_transition_mut()
+            .unwrap()
+            .snap(2, 2);
+        sim.substrate.entities.insert(entity);
+        let rng_before = sim.scenario_rng.logical_state();
+
+        drive_ship_slope_process_tick(&mut sim, &terrain, 10);
+        let first = crate::sim::movement::slope_transition::state_for_entity(
+            sim.substrate.entities.get(1).unwrap(),
+        )
+        .unwrap()
+        .hash_fields();
+        assert_eq!(first, (2, 5, 10, 3));
+        drive_ship_slope_process_tick(&mut sim, &terrain, 11);
+        assert_eq!(
+            crate::sim::movement::slope_transition::state_for_entity(
+                sim.substrate.entities.get(1).unwrap()
+            )
+            .unwrap()
+            .hash_fields(),
+            first,
+            "equal stationary Process is a complete no-write"
+        );
+
+        sim.substrate.entities.get_mut(1).unwrap().position.rx = 1;
+        drive_ship_slope_process_tick(&mut sim, &terrain, 12);
+        assert_eq!(
+            crate::sim::movement::slope_transition::state_for_entity(
+                sim.substrate.entities.get(1).unwrap()
+            )
+            .unwrap()
+            .hash_fields(),
+            (5, 11, 12, 3),
+            "mid-transition retarget starts from the prior target slope"
+        );
+        assert_eq!(sim.scenario_rng.logical_state(), rng_before);
+    }
+}
+
+#[test]
+fn drive_slope_boundary_is_detected_on_process_after_ordinary_crossing() {
+    let terrain = crate::map::resolved_terrain::ResolvedTerrainGrid::from_cells(
+        2,
+        1,
+        vec![slope_cell(0, 3), slope_cell(1, 8)],
+    );
+    let mut sim = Simulation::with_seed(3);
+    let mut entity = GameEntity::test_default(1, "DRIVE", "Americans", 0, 0);
+    entity.owner = sim.intern("Americans");
+    entity.type_ref = sim.intern("DRIVE");
+    entity.facing = 64;
+    entity.locomotor = Some(LocomotorState::for_test_kind_at_frame(
+        LocomotorKind::Drive,
+        0,
+    ));
+    entity
+        .locomotor
+        .as_mut()
+        .unwrap()
+        .active_slope_transition_mut()
+        .unwrap()
+        .snap(3, 0);
+    entity.drive_locomotion = Some(crate::sim::components::DriveLocomotionRuntime {
+        target_speed_fraction: SIM_ONE,
+        current_speed_fraction: SIM_ONE,
+        ..Default::default()
+    });
+    entity.movement_target = Some(MovementTarget {
+        path: vec![(0, 0), (1, 0)],
+        path_layers: vec![MovementLayer::Ground; 2],
+        next_index: 1,
+        speed: SimFixed::from_num(15_360),
+        current_speed: SimFixed::from_num(15_360),
+        move_dir_x: SimFixed::from_num(256),
+        move_dir_y: SIM_ZERO,
+        move_dir_len: SimFixed::from_num(256),
+        final_goal: Some((1, 0)),
+        ..Default::default()
+    });
+    sim.substrate.entities.insert(entity);
+
+    let crossing_frame = (20..80)
+        .find(|frame| {
+            drive_ship_slope_process_tick(&mut sim, &terrain, *frame);
+            sim.substrate.entities.get(1).unwrap().position.rx == 1
+        })
+        .expect("ordinary movement crosses into the adjacent cell");
+    assert_eq!(sim.substrate.entities.get(1).unwrap().position.rx, 1);
+    assert_eq!(
+        crate::sim::movement::slope_transition::state_for_entity(
+            sim.substrate.entities.get(1).unwrap()
+        )
+        .unwrap()
+        .hash_fields(),
+        (3, 3, 0, 0),
+        "the crossing frame has already sampled the old containing cell"
+    );
+    drive_ship_slope_process_tick(&mut sim, &terrain, crossing_frame + 1);
+    assert_eq!(
+        crate::sim::movement::slope_transition::state_for_entity(
+            sim.substrate.entities.get(1).unwrap()
+        )
+        .unwrap()
+        .hash_fields(),
+        (3, 8, (crossing_frame + 1) as i32, 3)
+    );
+}
+
+#[test]
+fn drive_slope_boundary_is_detected_on_process_after_forced_track_crossing() {
+    let terrain = crate::map::resolved_terrain::ResolvedTerrainGrid::from_cells(
+        1,
+        2,
+        vec![slope_cell_at(0, 0, 4), slope_cell_at(0, 1, 10)],
+    );
+    let mut sim = Simulation::with_seed(4);
+    let mut entity = GameEntity::test_default(1, "DRIVE", "Americans", 0, 0);
+    entity.owner = sim.intern("Americans");
+    entity.type_ref = sim.intern("DRIVE");
+    entity.locomotor = Some(LocomotorState::for_test_kind_at_frame(
+        LocomotorKind::Drive,
+        0,
+    ));
+    entity.drive_locomotion = Some(Default::default());
+    sim.substrate.entities.insert(entity);
+    assert!(matches!(
+        sim.reveal(1),
+        crate::sim::world::RevealOutcome::Revealed { .. }
+    ));
+    sim.substrate
+        .entities
+        .get_mut(1)
+        .unwrap()
+        .locomotor
+        .as_mut()
+        .unwrap()
+        .active_slope_transition_mut()
+        .unwrap()
+        .snap(4, 0);
+    let forced = drive_track::begin_forced_turn_track(
+        0x47,
+        0,
+        256,
+        SimFixed::from_num(128),
+        false,
+    )
+    .expect("retail southbound force track");
+    {
+        let (entities, cell_occupation) = (
+            &mut sim.substrate.entities,
+            &mut sim.substrate.cell_occupation,
+        );
+        assert!(install_forced_drive_track(
+            entities.get_mut(1).unwrap(),
+            cell_occupation,
+            forced,
+        ));
+    }
+
+    let crossing_frame = (40..120)
+        .find(|frame| {
+            drive_ship_slope_process_tick(&mut sim, &terrain, *frame);
+            sim.substrate.entities.get(1).unwrap().position.ry == 1
+        })
+        .expect("forced track crosses into the adjacent cell");
+    assert_eq!(
+        crate::sim::movement::slope_transition::state_for_entity(
+            sim.substrate.entities.get(1).unwrap()
+        )
+        .unwrap()
+        .hash_fields(),
+        (4, 4, 0, 0),
+        "the crossing frame samples before the forced track advances"
+    );
+    drive_ship_slope_process_tick(&mut sim, &terrain, crossing_frame + 1);
+    assert_eq!(
+        crate::sim::movement::slope_transition::state_for_entity(
+            sim.substrate.entities.get(1).unwrap()
+        )
+        .unwrap()
+        .hash_fields(),
+        (4, 10, (crossing_frame + 1) as i32, 3)
+    );
+}
+
+#[test]
+fn drive_ship_slope_process_uses_foot_class_boundary_not_object_speed_or_art() {
+    let terrain = crate::map::resolved_terrain::ResolvedTerrainGrid::from_cells(
+        1,
+        1,
+        vec![slope_cell(0, 12)],
+    );
+    for (category, kind, expected) in [
+        (EntityCategory::Unit, LocomotorKind::Drive, 12),
+        (EntityCategory::Unit, LocomotorKind::Ship, 12),
+        (EntityCategory::Infantry, LocomotorKind::Drive, 12),
+        (EntityCategory::Aircraft, LocomotorKind::Ship, 12),
+        (EntityCategory::Structure, LocomotorKind::Drive, 0),
+    ] {
+        let mut sim = Simulation::new();
+        let mut entity = GameEntity::test_default(1, "MODDED", "Americans", 0, 0);
+        entity.owner = sim.intern("Americans");
+        entity.type_ref = sim.intern("MODDED");
+        entity.category = category;
+        entity.locomotor = Some(LocomotorState::for_test_kind(kind));
+        sim.substrate.entities.insert(entity);
+
+        drive_ship_slope_process_tick(&mut sim, &terrain, 7);
+        let state = sim
+            .substrate
+            .entities
+            .get(1)
+            .unwrap()
+            .locomotor
+            .as_ref()
+            .unwrap()
+            .active_slope_transition()
+            .unwrap();
+        assert_eq!(state.hash_fields().1, expected, "{category:?} {kind:?}");
+    }
+}
+
+#[test]
+fn entry_active_tube_excludes_drive_slope_process_for_the_whole_turn() {
+    let terrain = crate::map::resolved_terrain::ResolvedTerrainGrid::from_cells(
+        1,
+        1,
+        vec![slope_cell(0, 9)],
+    );
+    let mut sim = Simulation::new();
+    let mut entity = GameEntity::test_default(1, "DRIVE", "Americans", 0, 0);
+    entity.owner = sim.intern("Americans");
+    entity.type_ref = sim.intern("DRIVE");
+    entity.locomotor = Some(LocomotorState::for_test_kind(LocomotorKind::Drive));
+    entity.low_bridge_tube_state = Some(
+        crate::sim::movement::tube_movement::LowBridgeTubeMovementState {
+            tube_id: crate::map::tube_facts::TubeId(0),
+            cursor: 0,
+            target: DriveCoord::cell(0, 0, 0),
+        },
+    );
+    sim.substrate.entities.insert(entity);
+
+    drive_ship_slope_process_tick(&mut sim, &terrain, 30);
+    assert_eq!(
+        crate::sim::movement::slope_transition::state_for_entity(
+            sim.substrate.entities.get(1).unwrap()
+        )
+        .unwrap()
+        .hash_fields(),
+        (0, 0, 0, 0)
+    );
+}
+
 #[test]
 fn gsi_04_05_production_drive_observes_premark_clear_cross_and_finish() {
     let mut sim = Simulation::new();
@@ -3294,6 +3615,7 @@ fn make_drive_loco_for_test() -> crate::sim::movement::locomotor::LocomotorState
         piggyback: None,
         runtime_payload: crate::sim::movement::locomotion::LocomotorRuntimePayload::for_kind(
             LocomotorKind::Drive,
+            0,
         ),
         layer: MovementLayer::Ground,
         phase: GroundMovePhase::Idle,
@@ -4013,6 +4335,7 @@ fn make_drive_loco(layer: MovementLayer) -> LocomotorState {
         piggyback: None,
         runtime_payload: crate::sim::movement::locomotion::LocomotorRuntimePayload::for_kind(
             LocomotorKind::Drive,
+            0,
         ),
         layer,
         phase: GroundMovePhase::Idle,

--- a/src/sim/movement/movement_tick.rs
+++ b/src/sim/movement/movement_tick.rs
@@ -1584,6 +1584,33 @@ fn tick_movement_with_grids_scoped(
         })
         .collect();
 
+    // DriveLocomotionClass::Process @ 0x004B0500 samples CellClass+0x11C at
+    // 0x004B050B..0x004B0557 before its first track/movement branch;
+    // ShipLocomotionClass::Process @ 0x0069FC10 does the same at
+    // 0x0069FC1B..0x0069FC67. Entry-active Tube owns the whole object turn and
+    // is the only exclusion here. Stationary eligible objects still Process.
+    if let Some(terrain) = resolved_terrain {
+        for &entity_id in entity_order {
+            if tube_active_at_start.contains(&entity_id) {
+                continue;
+            }
+            let sampled_slope = entities.get(entity_id).and_then(|entity| {
+                terrain
+                    .cell(entity.position.rx, entity.position.ry)
+                    .map(|cell| cell.slope_type)
+            });
+            if let Some(sampled_slope) = sampled_slope
+                && let Some(entity) = entities.get_mut(entity_id)
+            {
+                super::slope_transition::sample_process_entry(
+                    entity,
+                    sampled_slope,
+                    native_frame,
+                );
+            }
+        }
+    }
+
     let drive_reaims: Vec<(u64, crate::sim::components::DriveCoord)> =
         drive_locomotion::drive_entity_nav_targets(entities)
             .into_iter()

--- a/src/sim/movement/parachute_descent.rs
+++ b/src/sim/movement/parachute_descent.rs
@@ -151,6 +151,7 @@ mod tests {
             piggyback: None,
             runtime_payload: crate::sim::movement::locomotion::LocomotorRuntimePayload::for_kind(
                 LocomotorKind::Walk,
+                0,
             ),
             layer: MovementLayer::Ground,
             phase: GroundMovePhase::Idle,

--- a/src/sim/movement/slope_transition.rs
+++ b/src/sim/movement/slope_transition.rs
@@ -10,8 +10,8 @@
 use crate::map::entities::EntityCategory;
 use crate::rules::locomotor_type::LocomotorKind;
 use crate::sim::game_entity::GameEntity;
-use crate::sim::movement::locomotion::{LocomotorRuntime, LocomotorRuntimePayload};
-use crate::sim::movement::locomotor::{LocomotorState, MovementLayer};
+use crate::sim::movement::locomotion::LocomotorRuntimePayload;
+use crate::sim::movement::locomotor::MovementLayer;
 
 /// Literal Drive/Ship slope interpolation duration installed by both native
 /// `Process` implementations.
@@ -170,19 +170,23 @@ pub(crate) fn sample_process_entry(
     }
 }
 
-/// Proof captured from the complete pre-restore locomotor objects. Its private
-/// runtime cannot be caller-asserted: it exists only while an active ground
-/// Tunnel owns a suspended Drive with its class-local slope payload.
+/// `TechnoClass::Set_Destination @ 0x00741970` has one extra force-slope call
+/// at `0x00742BE3`, confined to ground-layer Tunnel/piggyback restoration.
+/// Rust has no active stock Tunnel caller. This dormant transaction keeps the
+/// typed pre-restore check, real piggyback END, restored-Drive check, and snap
+/// inseparable on one entity so no generic restoration path can reuse a proof.
 #[allow(dead_code)]
-#[derive(Debug, PartialEq)]
-pub(crate) struct TunnelDriveRestoreToken {
-    restored_runtime: LocomotorRuntime,
-}
-
-#[allow(dead_code)]
-pub(crate) fn tunnel_drive_restore_token(
-    locomotor: &LocomotorState,
-) -> Option<TunnelDriveRestoreToken> {
+fn restore_ground_tunnel_stashed_drive_and_snap(
+    entity: &mut GameEntity,
+    sampled_slope: u8,
+    binary_frame: u32,
+) -> bool {
+    if !foot_equivalent(entity.category) {
+        return false;
+    }
+    let Some(locomotor) = entity.locomotor.as_mut() else {
+        return false;
+    };
     if locomotor.active_kind() != LocomotorKind::Tunnel
         || locomotor.layer != MovementLayer::Ground
         || !matches!(
@@ -190,44 +194,24 @@ pub(crate) fn tunnel_drive_restore_token(
             LocomotorRuntimePayload::Tunnel(_)
         )
     {
-        return None;
+        return false;
     }
-    let stashed = locomotor.piggyback.as_deref()?;
+    let Some(stashed) = locomotor.piggyback.as_deref() else {
+        return false;
+    };
     if stashed.kind != LocomotorKind::Drive
         || !matches!(&stashed.payload, LocomotorRuntimePayload::Drive(_))
     {
-        return None;
+        return false;
     }
-    Some(TunnelDriveRestoreToken {
-        restored_runtime: stashed.clone(),
-    })
-}
-
-/// `TechnoClass::Set_Destination @ 0x00741970` has one extra force-slope call
-/// at `0x00742BE3`, confined to ground-layer Tunnel/piggyback restoration.
-/// Rust has no active stock Tunnel caller; keeping this predicate explicit
-/// prevents a future restoration bridge from becoming a generic move snap.
-#[allow(dead_code)]
-pub(crate) fn snap_after_tunnel_piggyback_restore(
-    entity: &mut GameEntity,
-    token: TunnelDriveRestoreToken,
-    sampled_slope: u8,
-    binary_frame: u32,
-) {
-    if !foot_equivalent(entity.category) {
-        return;
+    if !locomotor.end_piggyback() || locomotor.active_kind() != LocomotorKind::Drive {
+        return false;
     }
-    let Some(locomotor) = entity.locomotor.as_mut() else {
-        return;
+    let LocomotorRuntimePayload::Drive(state) = &mut locomotor.runtime_payload else {
+        return false;
     };
-    if LocomotorRuntime::capture(locomotor) != token.restored_runtime
-        || locomotor.active_kind() != LocomotorKind::Drive
-    {
-        return;
-    }
-    if let LocomotorRuntimePayload::Drive(state) = &mut locomotor.runtime_payload {
-        state.snap(sampled_slope, binary_frame);
-    }
+    state.snap(sampled_slope, binary_frame);
+    true
 }
 
 #[cfg(test)]
@@ -424,27 +408,34 @@ mod tests {
         use crate::sim::movement::locomotor::MovementLayer;
 
         let mut exact = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
+        let identical_other_entity = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
         assert!(exact.locomotor.as_mut().unwrap().begin_piggyback(
             LocomotorKind::Tunnel,
             MovementLayer::Ground,
             22,
         ));
-        let token = super::tunnel_drive_restore_token(exact.locomotor.as_ref().unwrap())
-            .expect("active ground Tunnel with a typed Drive stash");
         assert_eq!(
             exact.locomotor.as_ref().unwrap().active_kind(),
             LocomotorKind::Tunnel
         );
-        assert!(exact.locomotor.as_mut().unwrap().end_piggyback());
+        assert!(super::restore_ground_tunnel_stashed_drive_and_snap(
+            &mut exact, 9, 30
+        ));
         assert_eq!(
             exact.locomotor.as_ref().unwrap().active_kind(),
             LocomotorKind::Drive,
-            "the test performs the real complete-runtime restore before snapping"
+            "the integrated operation performs the real complete-runtime restore"
         );
-        super::snap_after_tunnel_piggyback_restore(&mut exact, token, 9, 30);
         assert_eq!(
             super::state_for_entity(&exact).unwrap().hash_fields(),
             (9, 9, 30, 0)
+        );
+        assert_eq!(
+            super::state_for_entity(&identical_other_entity)
+                .unwrap()
+                .hash_fields(),
+            (0, 0, 0, 0),
+            "no transferable proof API can affect an identical runtime on entity B"
         );
 
         let mut wrong_layer = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
@@ -454,14 +445,19 @@ mod tests {
             22,
         ));
         assert!(
-            super::tunnel_drive_restore_token(wrong_layer.locomotor.as_ref().unwrap()).is_none(),
-            "an air-layer Tunnel cannot mint the proof"
+            !super::restore_ground_tunnel_stashed_drive_and_snap(&mut wrong_layer, 9, 30),
+            "an air-layer Tunnel is not restored"
         );
+        assert_eq!(
+            wrong_layer.locomotor.as_ref().unwrap().active_kind(),
+            LocomotorKind::Tunnel
+        );
+        assert!(wrong_layer.locomotor.as_ref().unwrap().piggyback.is_some());
 
-        let missing_stash = entity_with(EntityCategory::Unit, LocomotorKind::Tunnel);
+        let mut missing_stash = entity_with(EntityCategory::Unit, LocomotorKind::Tunnel);
         assert!(
-            super::tunnel_drive_restore_token(missing_stash.locomotor.as_ref().unwrap()).is_none(),
-            "an active Tunnel without a suspended runtime cannot mint the proof"
+            !super::restore_ground_tunnel_stashed_drive_and_snap(&mut missing_stash, 9, 30),
+            "an active Tunnel without a suspended runtime is not restored"
         );
 
         let mut wrong_stash = entity_with(EntityCategory::Unit, LocomotorKind::Ship);
@@ -471,48 +467,90 @@ mod tests {
             22,
         ));
         assert!(
-            super::tunnel_drive_restore_token(wrong_stash.locomotor.as_ref().unwrap()).is_none(),
-            "a suspended Ship is not a typed Drive slope runtime"
+            !super::restore_ground_tunnel_stashed_drive_and_snap(&mut wrong_stash, 9, 30),
+            "a suspended Ship is not restored through the Drive-only transaction"
         );
-
-        let mut not_restored = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
-        assert!(not_restored.locomotor.as_mut().unwrap().begin_piggyback(
-            LocomotorKind::Tunnel,
-            MovementLayer::Ground,
-            22,
-        ));
-        let token = super::tunnel_drive_restore_token(not_restored.locomotor.as_ref().unwrap())
-            .expect("exact pre-restore proof");
-        super::snap_after_tunnel_piggyback_restore(&mut not_restored, token, 9, 30);
         assert_eq!(
-            not_restored.locomotor.as_ref().unwrap().active_kind(),
+            wrong_stash.locomotor.as_ref().unwrap().active_kind(),
             LocomotorKind::Tunnel
         );
-        assert!(not_restored.locomotor.as_ref().unwrap().piggyback.is_some());
-        assert!(not_restored.locomotor.as_mut().unwrap().end_piggyback());
+        assert!(wrong_stash.locomotor.as_ref().unwrap().piggyback.is_some());
+
+        let mut wrong_active_payload = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
+        assert!(wrong_active_payload
+            .locomotor
+            .as_mut()
+            .unwrap()
+            .begin_piggyback(
+                LocomotorKind::Tunnel,
+                MovementLayer::Ground,
+                22,
+            ));
+        wrong_active_payload
+            .locomotor
+            .as_mut()
+            .unwrap()
+            .runtime_payload = LocomotorRuntimePayload::Teleport(None);
+        assert!(
+            !super::restore_ground_tunnel_stashed_drive_and_snap(
+                &mut wrong_active_payload,
+                9,
+                30,
+            ),
+            "a Tunnel discriminant with a non-Tunnel active payload is rejected"
+        );
         assert_eq!(
-            super::state_for_entity(&not_restored)
+            wrong_active_payload
+                .locomotor
+                .as_ref()
                 .unwrap()
-                .hash_fields(),
-            (0, 0, 0, 0),
-            "the proof cannot snap the suspended Drive before it is restored"
+                .active_kind(),
+            LocomotorKind::Tunnel,
+        );
+        assert_eq!(
+            wrong_active_payload
+                .locomotor
+                .as_ref()
+                .unwrap()
+                .piggyback
+                .as_deref()
+                .unwrap()
+                .kind,
+            LocomotorKind::Drive
         );
 
-        let mut wrong_restore = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
-        assert!(wrong_restore.locomotor.as_mut().unwrap().begin_piggyback(
-            LocomotorKind::Tunnel,
+        let mut teleport = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
+        assert!(teleport.locomotor.as_mut().unwrap().begin_piggyback(
+            LocomotorKind::Teleport,
             MovementLayer::Ground,
             22,
         ));
-        let token = super::tunnel_drive_restore_token(wrong_restore.locomotor.as_ref().unwrap())
-            .expect("exact pre-restore proof");
-        assert!(wrong_restore.locomotor.as_mut().unwrap().end_piggyback());
-        wrong_restore.locomotor = Some(LocomotorState::for_test_kind(LocomotorKind::Ship));
-        super::snap_after_tunnel_piggyback_restore(&mut wrong_restore, token, 9, 30);
+        assert!(
+            !super::restore_ground_tunnel_stashed_drive_and_snap(&mut teleport, 9, 30),
+            "generic Teleport piggyback restoration is not this Tunnel branch"
+        );
         assert_eq!(
-            super::state_for_entity(&wrong_restore).unwrap().hash_fields(),
+            teleport.locomotor.as_ref().unwrap().active_kind(),
+            LocomotorKind::Teleport
+        );
+        assert!(teleport.locomotor.as_ref().unwrap().piggyback.is_some());
+
+        let mut tube = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
+        tube.low_bridge_tube_state = Some(
+            crate::sim::movement::tube_movement::LowBridgeTubeMovementState {
+                tube_id: crate::map::tube_facts::TubeId(0),
+                cursor: 0,
+                target: crate::sim::components::DriveCoord::cell(0, 0, 0),
+            },
+        );
+        assert!(
+            !super::restore_ground_tunnel_stashed_drive_and_snap(&mut tube, 9, 30),
+            "ordinary low-bridge Tube state is not a Tunnel locomotor restore"
+        );
+        assert_eq!(
+            super::state_for_entity(&tube).unwrap().hash_fields(),
             (0, 0, 0, 0),
-            "the token cannot snap a different now-active restored kind/runtime"
+            "Tube movement cannot acquire the restoration snap"
         );
     }
 }

--- a/src/sim/movement/slope_transition.rs
+++ b/src/sim/movement/slope_transition.rs
@@ -1,0 +1,391 @@
+//! Drive/Ship locomotor slope cache and global-frame transition timer.
+//!
+//! Active `gamemd.exe` stores this state on each Drive/Ship locomotor object:
+//! Drive constructor `0x004AF540`, Process `0x004B0500`, force helper
+//! `0x004AFB40`, and Draw_Matrix `0x004AFF60`; Ship uses the instruction-for-
+//! instruction equivalent constructor `0x0069EC50`, Process `0x0069FC10`,
+//! force helper `0x0069F250`, and Draw_Matrix `0x0069F670`. The native timer
+//! helpers are `CDTimerClass::Start @ 0x0046B640` and `Remaining @ 0x004B4D70`.
+
+use crate::map::entities::EntityCategory;
+use crate::sim::game_entity::GameEntity;
+use crate::sim::movement::locomotor::MovementLayer;
+
+/// Defined, persistent state owned by one active or stashed Drive/Ship
+/// locomotor. The native unused timer dword is deliberately not represented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SlopeTransitionState {
+    previous_slope: u8,
+    current_slope: u8,
+    start_frame: i32,
+    transition_total: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SlopeRenderPhase {
+    Stable(u8),
+    Transition {
+        from_slope: u8,
+        to_slope: u8,
+        phase_num: i32,
+        phase_den: u8,
+    },
+}
+
+impl SlopeTransitionState {
+    /// Drive/Ship constructor defaults use the current signed global frame.
+    pub(crate) fn at_binary_frame(binary_frame: u32) -> Self {
+        Self {
+            previous_slope: 0,
+            current_slope: 0,
+            start_frame: binary_frame as i32,
+            transition_total: 0,
+        }
+    }
+
+    /// `Force_Slope`/successful Foot unlimbo synchronizes immediately.
+    pub(crate) fn snap(&mut self, sampled_slope: u8, binary_frame: u32) {
+        self.previous_slope = sampled_slope;
+        self.current_slope = sampled_slope;
+        self.start_frame = binary_frame as i32;
+        self.transition_total = 0;
+    }
+
+    /// Drive/Ship `Process` entry starts a literal three-frame timer only when
+    /// the current containing-cell slope differs from the cached target.
+    pub(crate) fn sample_process_entry(&mut self, sampled_slope: u8, binary_frame: u32) {
+        if sampled_slope == self.current_slope {
+            return;
+        }
+        self.previous_slope = self.current_slope;
+        self.current_slope = sampled_slope;
+        self.start_frame = binary_frame as i32;
+        self.transition_total = 3;
+    }
+
+    pub(crate) fn remaining(&self, binary_frame: u32) -> u8 {
+        if self.transition_total == 0 {
+            return 0;
+        }
+        if self.start_frame == -1 {
+            return self.transition_total;
+        }
+        let elapsed = (binary_frame as i32).wrapping_sub(self.start_frame);
+        if elapsed < i32::from(self.transition_total) {
+            self.transition_total.wrapping_sub(elapsed as u8)
+        } else {
+            0
+        }
+    }
+
+    pub(crate) fn render_phase(&self, binary_frame: u32) -> SlopeRenderPhase {
+        let remaining = self.remaining(binary_frame);
+        if self.transition_total == 0 || remaining == 0 {
+            return SlopeRenderPhase::Stable(self.current_slope);
+        }
+        let phase_num = i32::from(self.transition_total) - i32::from(remaining);
+        if phase_num >= i32::from(self.transition_total) {
+            SlopeRenderPhase::Stable(self.current_slope)
+        } else {
+            SlopeRenderPhase::Transition {
+                from_slope: self.previous_slope,
+                to_slope: self.current_slope,
+                phase_num,
+                phase_den: self.transition_total,
+            }
+        }
+    }
+
+    pub(crate) fn hash_fields(&self) -> (u8, u8, i32, u8) {
+        (
+            self.previous_slope,
+            self.current_slope,
+            self.start_frame,
+            self.transition_total,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_fields_for_test(
+        previous_slope: u8,
+        current_slope: u8,
+        start_frame: i32,
+        transition_total: u8,
+    ) -> Self {
+        Self {
+            previous_slope,
+            current_slope,
+            start_frame,
+            transition_total,
+        }
+    }
+}
+
+fn foot_equivalent(category: EntityCategory) -> bool {
+    matches!(
+        category,
+        EntityCategory::Unit | EntityCategory::Infantry | EntityCategory::Aircraft
+    )
+}
+
+pub(crate) fn state_for_entity(entity: &GameEntity) -> Option<&SlopeTransitionState> {
+    foot_equivalent(entity.category)
+        .then_some(())
+        .and_then(|()| entity.locomotor.as_ref()?.active_slope_transition())
+}
+
+fn state_for_entity_mut(entity: &mut GameEntity) -> Option<&mut SlopeTransitionState> {
+    foot_equivalent(entity.category)
+        .then_some(())
+        .and_then(|()| entity.locomotor.as_mut()?.active_slope_transition_mut())
+}
+
+/// FootClass::Unlimbo @ `0x004D7170` dispatches the active locomotor force-
+/// slope slot at `0x004D71A9` only after TechnoClass::Unlimbo succeeds.
+pub(crate) fn snap_after_successful_unlimbo(
+    entity: &mut GameEntity,
+    sampled_slope: u8,
+    binary_frame: u32,
+) {
+    if let Some(state) = state_for_entity_mut(entity) {
+        state.snap(sampled_slope, binary_frame);
+    }
+}
+
+/// Drive Process `0x004B050B..0x004B0557` and Ship Process
+/// `0x0069FC1B..0x0069FC67` sample before any track/movement branch.
+pub(crate) fn sample_process_entry(
+    entity: &mut GameEntity,
+    sampled_slope: u8,
+    binary_frame: u32,
+) {
+    if let Some(state) = state_for_entity_mut(entity) {
+        state.sample_process_entry(sampled_slope, binary_frame);
+    }
+}
+
+/// `TechnoClass::Set_Destination @ 0x00741970` has one extra force-slope call
+/// at `0x00742BE3`, confined to ground-layer Tunnel/piggyback restoration.
+/// Rust has no active stock Tunnel caller; keeping this predicate explicit
+/// prevents a future restoration bridge from becoming a generic move snap.
+#[allow(dead_code)]
+pub(crate) fn snap_after_tunnel_piggyback_restore(
+    entity: &mut GameEntity,
+    restored_from_active_tunnel: bool,
+    sampled_slope: u8,
+    binary_frame: u32,
+) {
+    if !restored_from_active_tunnel
+        || entity.locomotor.as_ref().map(|l| l.layer) != Some(MovementLayer::Ground)
+    {
+        return;
+    }
+    snap_after_successful_unlimbo(entity, sampled_slope, binary_frame);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SlopeRenderPhase, SlopeTransitionState};
+    use crate::map::entities::EntityCategory;
+    use crate::rules::locomotor_type::LocomotorKind;
+    use crate::sim::game_entity::GameEntity;
+    use crate::sim::movement::locomotion::LocomotorRuntimePayload;
+    use crate::sim::movement::locomotor::LocomotorState;
+
+    #[test]
+    fn slope_timer_preserves_signed_minus_one_and_negative_phase() {
+        let mut state = SlopeTransitionState::at_binary_frame(0);
+        state.previous_slope = 4;
+        state.current_slope = 9;
+        state.start_frame = 0;
+        state.transition_total = 3;
+
+        assert_eq!(
+            state.render_phase(u32::MAX),
+            SlopeRenderPhase::Transition {
+                from_slope: 4,
+                to_slope: 9,
+                phase_num: -1,
+                phase_den: 3,
+            }
+        );
+
+        state.start_frame = -1;
+        assert_eq!(state.remaining(0), 3);
+        assert_eq!(state.remaining(u32::MAX), 3);
+    }
+
+    #[test]
+    fn slope_timer_uses_signed_wrapping_frame_subtraction() {
+        let mut state = SlopeTransitionState::at_binary_frame(0x7fff_fffe);
+        state.sample_process_entry(7, 0x7fff_ffff);
+        assert_eq!(state.remaining(0x8000_0000), 2);
+        assert_eq!(state.remaining(0x8000_0001), 1);
+        assert_eq!(state.remaining(0x8000_0002), 0);
+    }
+
+    #[test]
+    fn equal_process_sample_is_a_complete_no_write() {
+        let mut state = SlopeTransitionState::at_binary_frame(10);
+        state.sample_process_entry(6, 10);
+        let before = state;
+        state.sample_process_entry(6, 99);
+        assert_eq!(state, before);
+    }
+
+    #[test]
+    fn drive_ship_slope_three_frame_ledger_and_mid_transition_retarget_are_exact() {
+        let mut state = SlopeTransitionState::at_binary_frame(8);
+        state.snap(2, 8);
+        state.sample_process_entry(7, 10);
+        assert_eq!(
+            state.render_phase(10),
+            SlopeRenderPhase::Transition {
+                from_slope: 2,
+                to_slope: 7,
+                phase_num: 0,
+                phase_den: 3,
+            }
+        );
+        assert_eq!(state.remaining(11), 2);
+        assert_eq!(state.remaining(12), 1);
+        assert_eq!(state.render_phase(13), SlopeRenderPhase::Stable(7));
+
+        state.sample_process_entry(12, 11);
+        assert_eq!(state.hash_fields(), (7, 12, 11, 3));
+        assert_eq!(
+            state.render_phase(11),
+            SlopeRenderPhase::Transition {
+                from_slope: 7,
+                to_slope: 12,
+                phase_num: 0,
+                phase_den: 3,
+            }
+        );
+    }
+
+    fn entity_with(category: EntityCategory, kind: LocomotorKind) -> GameEntity {
+        let mut entity = GameEntity::test_default(1, "SLOPE", "Americans", 2, 2);
+        entity.category = category;
+        entity.locomotor = Some(LocomotorState::for_test_kind(kind));
+        entity
+    }
+
+    #[test]
+    fn slope_ownership_is_foot_plus_matching_active_drive_ship_only() {
+        for category in [
+            EntityCategory::Unit,
+            EntityCategory::Infantry,
+            EntityCategory::Aircraft,
+        ] {
+            assert!(super::state_for_entity(&entity_with(category, LocomotorKind::Drive)).is_some());
+            assert!(super::state_for_entity(&entity_with(category, LocomotorKind::Ship)).is_some());
+        }
+        assert!(
+            super::state_for_entity(&entity_with(
+                EntityCategory::Structure,
+                LocomotorKind::Drive
+            ))
+            .is_none()
+        );
+        for kind in [
+            LocomotorKind::Walk,
+            LocomotorKind::Hover,
+            LocomotorKind::Fly,
+            LocomotorKind::Jumpjet,
+            LocomotorKind::Rocket,
+            LocomotorKind::Teleport,
+            LocomotorKind::Tunnel,
+        ] {
+            assert!(super::state_for_entity(&entity_with(EntityCategory::Unit, kind)).is_none());
+        }
+
+        let mut mismatched = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
+        mismatched.locomotor.as_mut().unwrap().runtime_payload = LocomotorRuntimePayload::Walk;
+        assert!(super::state_for_entity(&mismatched).is_none());
+    }
+
+    #[test]
+    fn active_drive_piggyback_is_eligible_while_stashed_drive_is_not_active() {
+        let constructor = LocomotorState::for_test_kind_at_frame(LocomotorKind::Drive, 17);
+        assert_eq!(
+            constructor
+                .active_slope_transition()
+                .unwrap()
+                .hash_fields(),
+            (0, 0, 17, 0),
+            "ordinary construction retains the live nonzero frame"
+        );
+
+        let mut active_drive = entity_with(EntityCategory::Unit, LocomotorKind::Teleport);
+        assert!(
+            active_drive
+                .locomotor
+                .as_mut()
+                .unwrap()
+                .begin_drive_piggyback_for_teleporter(22)
+        );
+        assert!(super::state_for_entity(&active_drive).is_some());
+        assert_eq!(
+            super::state_for_entity(&active_drive).unwrap().hash_fields(),
+            (0, 0, 22, 0),
+            "fresh Drive replacement retains the live nonzero frame"
+        );
+        assert_eq!(
+            active_drive.locomotor.as_ref().unwrap().effective_kind(),
+            LocomotorKind::Teleport
+        );
+
+        let mut stashed_drive = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
+        assert!(stashed_drive.locomotor.as_mut().unwrap().begin_piggyback(
+            LocomotorKind::Teleport,
+            crate::sim::movement::locomotor::MovementLayer::Ground,
+            23,
+        ));
+        assert!(super::state_for_entity(&stashed_drive).is_none());
+        assert!(matches!(
+            stashed_drive
+                .locomotor
+                .as_ref()
+                .unwrap()
+                .piggyback
+                .as_deref()
+                .map(|runtime| &runtime.payload),
+            Some(LocomotorRuntimePayload::Drive(_))
+        ));
+        assert!(stashed_drive.locomotor.as_mut().unwrap().end_piggyback());
+        assert_eq!(
+            super::state_for_entity(&stashed_drive).unwrap().hash_fields(),
+            (0, 0, 0, 0),
+            "generic piggyback restore does not invent a terrain snap"
+        );
+    }
+
+    #[test]
+    fn only_ground_tunnel_piggyback_restore_uses_the_extra_force_slope_gate() {
+        let mut entity = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
+        super::snap_after_tunnel_piggyback_restore(&mut entity, false, 9, 30);
+        assert_eq!(
+            super::state_for_entity(&entity).unwrap().hash_fields(),
+            (0, 0, 0, 0),
+            "ordinary, Tube, and Teleport restore callers do not satisfy the Tunnel gate"
+        );
+
+        entity.locomotor.as_mut().unwrap().layer =
+            crate::sim::movement::locomotor::MovementLayer::Air;
+        super::snap_after_tunnel_piggyback_restore(&mut entity, true, 9, 30);
+        assert_eq!(
+            super::state_for_entity(&entity).unwrap().hash_fields(),
+            (0, 0, 0, 0),
+            "the native extra call is ground-layer-only"
+        );
+
+        entity.locomotor.as_mut().unwrap().layer =
+            crate::sim::movement::locomotor::MovementLayer::Ground;
+        super::snap_after_tunnel_piggyback_restore(&mut entity, true, 9, 30);
+        assert_eq!(
+            super::state_for_entity(&entity).unwrap().hash_fields(),
+            (9, 9, 30, 0)
+        );
+    }
+}

--- a/src/sim/movement/slope_transition.rs
+++ b/src/sim/movement/slope_transition.rs
@@ -10,8 +10,8 @@
 use crate::map::entities::EntityCategory;
 use crate::rules::locomotor_type::LocomotorKind;
 use crate::sim::game_entity::GameEntity;
-use crate::sim::movement::locomotion::LocomotorRuntimePayload;
-use crate::sim::movement::locomotor::MovementLayer;
+use crate::sim::movement::locomotion::{LocomotorRuntime, LocomotorRuntimePayload};
+use crate::sim::movement::locomotor::{LocomotorState, MovementLayer};
 
 /// Literal Drive/Ship slope interpolation duration installed by both native
 /// `Process` implementations.
@@ -170,32 +170,37 @@ pub(crate) fn sample_process_entry(
     }
 }
 
-/// Exact provenance carried by a future caller of the dormant Tunnel
-/// piggyback restoration seam. A boolean cannot distinguish the active-
-/// Tunnel path from Teleport, Tube, or generic piggyback restoration.
+/// Proof captured from the complete pre-restore locomotor objects. Its private
+/// runtime cannot be caller-asserted: it exists only while an active ground
+/// Tunnel owns a suspended Drive with its class-local slope payload.
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SlopeRestoreSource {
-    ActiveTunnel,
-    Teleport,
-    LowBridgeTube,
-    GenericPiggyback,
+#[derive(Debug, PartialEq)]
+pub(crate) struct TunnelDriveRestoreToken {
+    restored_runtime: LocomotorRuntime,
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct TunnelDriveRestoreFacts {
-    pub(crate) source: SlopeRestoreSource,
-    pub(crate) prior_active_kind: LocomotorKind,
-    pub(crate) prior_layer: MovementLayer,
-    pub(crate) restored_stashed_kind: LocomotorKind,
-}
-
-fn is_exact_tunnel_drive_restore(facts: TunnelDriveRestoreFacts) -> bool {
-    facts.source == SlopeRestoreSource::ActiveTunnel
-        && facts.prior_active_kind == LocomotorKind::Tunnel
-        && facts.prior_layer == MovementLayer::Ground
-        && facts.restored_stashed_kind == LocomotorKind::Drive
+pub(crate) fn tunnel_drive_restore_token(
+    locomotor: &LocomotorState,
+) -> Option<TunnelDriveRestoreToken> {
+    if locomotor.active_kind() != LocomotorKind::Tunnel
+        || locomotor.layer != MovementLayer::Ground
+        || !matches!(
+            &locomotor.runtime_payload,
+            LocomotorRuntimePayload::Tunnel(_)
+        )
+    {
+        return None;
+    }
+    let stashed = locomotor.piggyback.as_deref()?;
+    if stashed.kind != LocomotorKind::Drive
+        || !matches!(&stashed.payload, LocomotorRuntimePayload::Drive(_))
+    {
+        return None;
+    }
+    Some(TunnelDriveRestoreToken {
+        restored_runtime: stashed.clone(),
+    })
 }
 
 /// `TechnoClass::Set_Destination @ 0x00741970` has one extra force-slope call
@@ -205,17 +210,19 @@ fn is_exact_tunnel_drive_restore(facts: TunnelDriveRestoreFacts) -> bool {
 #[allow(dead_code)]
 pub(crate) fn snap_after_tunnel_piggyback_restore(
     entity: &mut GameEntity,
-    facts: TunnelDriveRestoreFacts,
+    token: TunnelDriveRestoreToken,
     sampled_slope: u8,
     binary_frame: u32,
 ) {
-    if !is_exact_tunnel_drive_restore(facts) || !foot_equivalent(entity.category) {
+    if !foot_equivalent(entity.category) {
         return;
     }
     let Some(locomotor) = entity.locomotor.as_mut() else {
         return;
     };
-    if locomotor.active_kind() != LocomotorKind::Drive {
+    if LocomotorRuntime::capture(locomotor) != token.restored_runtime
+        || locomotor.active_kind() != LocomotorKind::Drive
+    {
         return;
     }
     if let LocomotorRuntimePayload::Drive(state) = &mut locomotor.runtime_payload {
@@ -414,87 +421,98 @@ mod tests {
 
     #[test]
     fn only_ground_tunnel_piggyback_restore_uses_the_extra_force_slope_gate() {
-        use super::{SlopeRestoreSource, TunnelDriveRestoreFacts};
         use crate::sim::movement::locomotor::MovementLayer;
 
-        let exact = TunnelDriveRestoreFacts {
-            source: SlopeRestoreSource::ActiveTunnel,
-            prior_active_kind: LocomotorKind::Tunnel,
-            prior_layer: MovementLayer::Ground,
-            restored_stashed_kind: LocomotorKind::Drive,
-        };
-        let cases = [
-            (exact, LocomotorKind::Drive, true, "exact Tunnel restore"),
-            (
-                TunnelDriveRestoreFacts {
-                    source: SlopeRestoreSource::Teleport,
-                    ..exact
-                },
-                LocomotorKind::Drive,
-                false,
-                "Teleport restore",
-            ),
-            (
-                TunnelDriveRestoreFacts {
-                    source: SlopeRestoreSource::LowBridgeTube,
-                    ..exact
-                },
-                LocomotorKind::Drive,
-                false,
-                "Tube restore",
-            ),
-            (
-                TunnelDriveRestoreFacts {
-                    source: SlopeRestoreSource::GenericPiggyback,
-                    ..exact
-                },
-                LocomotorKind::Drive,
-                false,
-                "generic restore",
-            ),
-            (
-                TunnelDriveRestoreFacts {
-                    prior_active_kind: LocomotorKind::Teleport,
-                    ..exact
-                },
-                LocomotorKind::Drive,
-                false,
-                "non-Tunnel prior locomotor",
-            ),
-            (
-                TunnelDriveRestoreFacts {
-                    prior_layer: MovementLayer::Air,
-                    ..exact
-                },
-                LocomotorKind::Drive,
-                false,
-                "non-ground prior Tunnel",
-            ),
-            (
-                TunnelDriveRestoreFacts {
-                    restored_stashed_kind: LocomotorKind::Ship,
-                    ..exact
-                },
-                LocomotorKind::Ship,
-                false,
-                "restored Ship",
-            ),
-            (
-                exact,
-                LocomotorKind::Ship,
-                false,
-                "facts claim Drive but now-active payload is Ship",
-            ),
-        ];
+        let mut exact = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
+        assert!(exact.locomotor.as_mut().unwrap().begin_piggyback(
+            LocomotorKind::Tunnel,
+            MovementLayer::Ground,
+            22,
+        ));
+        let token = super::tunnel_drive_restore_token(exact.locomotor.as_ref().unwrap())
+            .expect("active ground Tunnel with a typed Drive stash");
+        assert_eq!(
+            exact.locomotor.as_ref().unwrap().active_kind(),
+            LocomotorKind::Tunnel
+        );
+        assert!(exact.locomotor.as_mut().unwrap().end_piggyback());
+        assert_eq!(
+            exact.locomotor.as_ref().unwrap().active_kind(),
+            LocomotorKind::Drive,
+            "the test performs the real complete-runtime restore before snapping"
+        );
+        super::snap_after_tunnel_piggyback_restore(&mut exact, token, 9, 30);
+        assert_eq!(
+            super::state_for_entity(&exact).unwrap().hash_fields(),
+            (9, 9, 30, 0)
+        );
 
-        for (facts, now_active_kind, should_snap, label) in cases {
-            let mut entity = entity_with(EntityCategory::Unit, now_active_kind);
-            super::snap_after_tunnel_piggyback_restore(&mut entity, facts, 9, 30);
-            assert_eq!(
-                super::state_for_entity(&entity).unwrap().hash_fields(),
-                if should_snap { (9, 9, 30, 0) } else { (0, 0, 0, 0) },
-                "{label}"
-            );
-        }
+        let mut wrong_layer = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
+        assert!(wrong_layer.locomotor.as_mut().unwrap().begin_piggyback(
+            LocomotorKind::Tunnel,
+            MovementLayer::Air,
+            22,
+        ));
+        assert!(
+            super::tunnel_drive_restore_token(wrong_layer.locomotor.as_ref().unwrap()).is_none(),
+            "an air-layer Tunnel cannot mint the proof"
+        );
+
+        let missing_stash = entity_with(EntityCategory::Unit, LocomotorKind::Tunnel);
+        assert!(
+            super::tunnel_drive_restore_token(missing_stash.locomotor.as_ref().unwrap()).is_none(),
+            "an active Tunnel without a suspended runtime cannot mint the proof"
+        );
+
+        let mut wrong_stash = entity_with(EntityCategory::Unit, LocomotorKind::Ship);
+        assert!(wrong_stash.locomotor.as_mut().unwrap().begin_piggyback(
+            LocomotorKind::Tunnel,
+            MovementLayer::Ground,
+            22,
+        ));
+        assert!(
+            super::tunnel_drive_restore_token(wrong_stash.locomotor.as_ref().unwrap()).is_none(),
+            "a suspended Ship is not a typed Drive slope runtime"
+        );
+
+        let mut not_restored = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
+        assert!(not_restored.locomotor.as_mut().unwrap().begin_piggyback(
+            LocomotorKind::Tunnel,
+            MovementLayer::Ground,
+            22,
+        ));
+        let token = super::tunnel_drive_restore_token(not_restored.locomotor.as_ref().unwrap())
+            .expect("exact pre-restore proof");
+        super::snap_after_tunnel_piggyback_restore(&mut not_restored, token, 9, 30);
+        assert_eq!(
+            not_restored.locomotor.as_ref().unwrap().active_kind(),
+            LocomotorKind::Tunnel
+        );
+        assert!(not_restored.locomotor.as_ref().unwrap().piggyback.is_some());
+        assert!(not_restored.locomotor.as_mut().unwrap().end_piggyback());
+        assert_eq!(
+            super::state_for_entity(&not_restored)
+                .unwrap()
+                .hash_fields(),
+            (0, 0, 0, 0),
+            "the proof cannot snap the suspended Drive before it is restored"
+        );
+
+        let mut wrong_restore = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
+        assert!(wrong_restore.locomotor.as_mut().unwrap().begin_piggyback(
+            LocomotorKind::Tunnel,
+            MovementLayer::Ground,
+            22,
+        ));
+        let token = super::tunnel_drive_restore_token(wrong_restore.locomotor.as_ref().unwrap())
+            .expect("exact pre-restore proof");
+        assert!(wrong_restore.locomotor.as_mut().unwrap().end_piggyback());
+        wrong_restore.locomotor = Some(LocomotorState::for_test_kind(LocomotorKind::Ship));
+        super::snap_after_tunnel_piggyback_restore(&mut wrong_restore, token, 9, 30);
+        assert_eq!(
+            super::state_for_entity(&wrong_restore).unwrap().hash_fields(),
+            (0, 0, 0, 0),
+            "the token cannot snap a different now-active restored kind/runtime"
+        );
     }
 }

--- a/src/sim/movement/slope_transition.rs
+++ b/src/sim/movement/slope_transition.rs
@@ -13,6 +13,10 @@ use crate::sim::game_entity::GameEntity;
 use crate::sim::movement::locomotion::LocomotorRuntimePayload;
 use crate::sim::movement::locomotor::MovementLayer;
 
+/// Literal Drive/Ship slope interpolation duration installed by both native
+/// `Process` implementations.
+pub(crate) const SLOPE_TRANSITION_FRAMES: u8 = 3;
+
 /// Defined, persistent state owned by one active or stashed Drive/Ship
 /// locomotor. The native unused timer dword is deliberately not represented.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -62,7 +66,7 @@ impl SlopeTransitionState {
         self.previous_slope = self.current_slope;
         self.current_slope = sampled_slope;
         self.start_frame = binary_frame as i32;
-        self.transition_total = 3;
+        self.transition_total = SLOPE_TRANSITION_FRAMES;
     }
 
     pub(crate) fn remaining(&self, binary_frame: u32) -> i32 {
@@ -230,11 +234,12 @@ mod tests {
 
     #[test]
     fn slope_timer_preserves_signed_minus_one_and_negative_phase() {
+        assert_eq!(super::SLOPE_TRANSITION_FRAMES, 3);
         let mut state = SlopeTransitionState::at_binary_frame(0);
         state.previous_slope = 4;
         state.current_slope = 9;
         state.start_frame = 0;
-        state.transition_total = 3;
+        state.transition_total = super::SLOPE_TRANSITION_FRAMES;
 
         assert_eq!(
             state.render_phase(u32::MAX),
@@ -242,7 +247,7 @@ mod tests {
                 from_slope: 4,
                 to_slope: 9,
                 phase_num: -1,
-                phase_den: 3,
+                phase_den: super::SLOPE_TRANSITION_FRAMES,
             }
         );
         assert_eq!(state.remaining(0xffff_feff), 260);
@@ -252,7 +257,7 @@ mod tests {
                 from_slope: 4,
                 to_slope: 9,
                 phase_num: -257,
-                phase_den: 3,
+                phase_den: super::SLOPE_TRANSITION_FRAMES,
             }
         );
 
@@ -290,7 +295,7 @@ mod tests {
                 from_slope: 2,
                 to_slope: 7,
                 phase_num: 0,
-                phase_den: 3,
+                phase_den: super::SLOPE_TRANSITION_FRAMES,
             }
         );
         assert_eq!(state.remaining(11), 2);
@@ -305,7 +310,7 @@ mod tests {
                 from_slope: 7,
                 to_slope: 12,
                 phase_num: 0,
-                phase_den: 3,
+                phase_den: super::SLOPE_TRANSITION_FRAMES,
             }
         );
     }

--- a/src/sim/movement/slope_transition.rs
+++ b/src/sim/movement/slope_transition.rs
@@ -8,7 +8,9 @@
 //! helpers are `CDTimerClass::Start @ 0x0046B640` and `Remaining @ 0x004B4D70`.
 
 use crate::map::entities::EntityCategory;
+use crate::rules::locomotor_type::LocomotorKind;
 use crate::sim::game_entity::GameEntity;
+use crate::sim::movement::locomotion::LocomotorRuntimePayload;
 use crate::sim::movement::locomotor::MovementLayer;
 
 /// Defined, persistent state owned by one active or stashed Drive/Ship
@@ -63,16 +65,16 @@ impl SlopeTransitionState {
         self.transition_total = 3;
     }
 
-    pub(crate) fn remaining(&self, binary_frame: u32) -> u8 {
+    pub(crate) fn remaining(&self, binary_frame: u32) -> i32 {
         if self.transition_total == 0 {
             return 0;
         }
         if self.start_frame == -1 {
-            return self.transition_total;
+            return i32::from(self.transition_total);
         }
         let elapsed = (binary_frame as i32).wrapping_sub(self.start_frame);
         if elapsed < i32::from(self.transition_total) {
-            self.transition_total.wrapping_sub(elapsed as u8)
+            i32::from(self.transition_total).wrapping_sub(elapsed)
         } else {
             0
         }
@@ -83,7 +85,7 @@ impl SlopeTransitionState {
         if self.transition_total == 0 || remaining == 0 {
             return SlopeRenderPhase::Stable(self.current_slope);
         }
-        let phase_num = i32::from(self.transition_total) - i32::from(remaining);
+        let phase_num = i32::from(self.transition_total).wrapping_sub(remaining);
         if phase_num >= i32::from(self.transition_total) {
             SlopeRenderPhase::Stable(self.current_slope)
         } else {
@@ -164,6 +166,34 @@ pub(crate) fn sample_process_entry(
     }
 }
 
+/// Exact provenance carried by a future caller of the dormant Tunnel
+/// piggyback restoration seam. A boolean cannot distinguish the active-
+/// Tunnel path from Teleport, Tube, or generic piggyback restoration.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SlopeRestoreSource {
+    ActiveTunnel,
+    Teleport,
+    LowBridgeTube,
+    GenericPiggyback,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TunnelDriveRestoreFacts {
+    pub(crate) source: SlopeRestoreSource,
+    pub(crate) prior_active_kind: LocomotorKind,
+    pub(crate) prior_layer: MovementLayer,
+    pub(crate) restored_stashed_kind: LocomotorKind,
+}
+
+fn is_exact_tunnel_drive_restore(facts: TunnelDriveRestoreFacts) -> bool {
+    facts.source == SlopeRestoreSource::ActiveTunnel
+        && facts.prior_active_kind == LocomotorKind::Tunnel
+        && facts.prior_layer == MovementLayer::Ground
+        && facts.restored_stashed_kind == LocomotorKind::Drive
+}
+
 /// `TechnoClass::Set_Destination @ 0x00741970` has one extra force-slope call
 /// at `0x00742BE3`, confined to ground-layer Tunnel/piggyback restoration.
 /// Rust has no active stock Tunnel caller; keeping this predicate explicit
@@ -171,16 +201,22 @@ pub(crate) fn sample_process_entry(
 #[allow(dead_code)]
 pub(crate) fn snap_after_tunnel_piggyback_restore(
     entity: &mut GameEntity,
-    restored_from_active_tunnel: bool,
+    facts: TunnelDriveRestoreFacts,
     sampled_slope: u8,
     binary_frame: u32,
 ) {
-    if !restored_from_active_tunnel
-        || entity.locomotor.as_ref().map(|l| l.layer) != Some(MovementLayer::Ground)
-    {
+    if !is_exact_tunnel_drive_restore(facts) || !foot_equivalent(entity.category) {
         return;
     }
-    snap_after_successful_unlimbo(entity, sampled_slope, binary_frame);
+    let Some(locomotor) = entity.locomotor.as_mut() else {
+        return;
+    };
+    if locomotor.active_kind() != LocomotorKind::Drive {
+        return;
+    }
+    if let LocomotorRuntimePayload::Drive(state) = &mut locomotor.runtime_payload {
+        state.snap(sampled_slope, binary_frame);
+    }
 }
 
 #[cfg(test)]
@@ -206,6 +242,16 @@ mod tests {
                 from_slope: 4,
                 to_slope: 9,
                 phase_num: -1,
+                phase_den: 3,
+            }
+        );
+        assert_eq!(state.remaining(0xffff_feff), 260);
+        assert_eq!(
+            state.render_phase(0xffff_feff),
+            SlopeRenderPhase::Transition {
+                from_slope: 4,
+                to_slope: 9,
+                phase_num: -257,
                 phase_den: 3,
             }
         );
@@ -363,29 +409,87 @@ mod tests {
 
     #[test]
     fn only_ground_tunnel_piggyback_restore_uses_the_extra_force_slope_gate() {
-        let mut entity = entity_with(EntityCategory::Unit, LocomotorKind::Drive);
-        super::snap_after_tunnel_piggyback_restore(&mut entity, false, 9, 30);
-        assert_eq!(
-            super::state_for_entity(&entity).unwrap().hash_fields(),
-            (0, 0, 0, 0),
-            "ordinary, Tube, and Teleport restore callers do not satisfy the Tunnel gate"
-        );
+        use super::{SlopeRestoreSource, TunnelDriveRestoreFacts};
+        use crate::sim::movement::locomotor::MovementLayer;
 
-        entity.locomotor.as_mut().unwrap().layer =
-            crate::sim::movement::locomotor::MovementLayer::Air;
-        super::snap_after_tunnel_piggyback_restore(&mut entity, true, 9, 30);
-        assert_eq!(
-            super::state_for_entity(&entity).unwrap().hash_fields(),
-            (0, 0, 0, 0),
-            "the native extra call is ground-layer-only"
-        );
+        let exact = TunnelDriveRestoreFacts {
+            source: SlopeRestoreSource::ActiveTunnel,
+            prior_active_kind: LocomotorKind::Tunnel,
+            prior_layer: MovementLayer::Ground,
+            restored_stashed_kind: LocomotorKind::Drive,
+        };
+        let cases = [
+            (exact, LocomotorKind::Drive, true, "exact Tunnel restore"),
+            (
+                TunnelDriveRestoreFacts {
+                    source: SlopeRestoreSource::Teleport,
+                    ..exact
+                },
+                LocomotorKind::Drive,
+                false,
+                "Teleport restore",
+            ),
+            (
+                TunnelDriveRestoreFacts {
+                    source: SlopeRestoreSource::LowBridgeTube,
+                    ..exact
+                },
+                LocomotorKind::Drive,
+                false,
+                "Tube restore",
+            ),
+            (
+                TunnelDriveRestoreFacts {
+                    source: SlopeRestoreSource::GenericPiggyback,
+                    ..exact
+                },
+                LocomotorKind::Drive,
+                false,
+                "generic restore",
+            ),
+            (
+                TunnelDriveRestoreFacts {
+                    prior_active_kind: LocomotorKind::Teleport,
+                    ..exact
+                },
+                LocomotorKind::Drive,
+                false,
+                "non-Tunnel prior locomotor",
+            ),
+            (
+                TunnelDriveRestoreFacts {
+                    prior_layer: MovementLayer::Air,
+                    ..exact
+                },
+                LocomotorKind::Drive,
+                false,
+                "non-ground prior Tunnel",
+            ),
+            (
+                TunnelDriveRestoreFacts {
+                    restored_stashed_kind: LocomotorKind::Ship,
+                    ..exact
+                },
+                LocomotorKind::Ship,
+                false,
+                "restored Ship",
+            ),
+            (
+                exact,
+                LocomotorKind::Ship,
+                false,
+                "facts claim Drive but now-active payload is Ship",
+            ),
+        ];
 
-        entity.locomotor.as_mut().unwrap().layer =
-            crate::sim::movement::locomotor::MovementLayer::Ground;
-        super::snap_after_tunnel_piggyback_restore(&mut entity, true, 9, 30);
-        assert_eq!(
-            super::state_for_entity(&entity).unwrap().hash_fields(),
-            (9, 9, 30, 0)
-        );
+        for (facts, now_active_kind, should_snap, label) in cases {
+            let mut entity = entity_with(EntityCategory::Unit, now_active_kind);
+            super::snap_after_tunnel_piggyback_restore(&mut entity, facts, 9, 30);
+            assert_eq!(
+                super::state_for_entity(&entity).unwrap().hash_fields(),
+                if should_snap { (9, 9, 30, 0) } else { (0, 0, 0, 0) },
+                "{label}"
+            );
+        }
     }
 }

--- a/src/sim/movement/teleport_movement.rs
+++ b/src/sim/movement/teleport_movement.rs
@@ -180,6 +180,7 @@ pub fn issue_teleport_command(
     target: (u16, u16),
     rules: &GeneralRules,
     is_harvester: bool,
+    binary_frame: u32,
 ) -> bool {
     {
         let Some(entity) = entities.get_mut(entity_id) else {
@@ -196,6 +197,7 @@ pub fn issue_teleport_command(
                 loco.begin_piggyback(
                     crate::rules::locomotor_type::LocomotorKind::Teleport,
                     crate::sim::movement::locomotor::MovementLayer::Ground,
+                    binary_frame,
                 );
             }
         }
@@ -770,7 +772,8 @@ mod tests {
             1,
             (20, 20),
             &rules,
-            false
+            false,
+            0
         ));
         let entity = entities.get(1).expect("should exist");
         let ts = entity
@@ -823,7 +826,8 @@ mod tests {
             1,
             (8, 9),
             &rules,
-            true
+            true,
+            0
         ));
 
         let warp_out_type = crate::sim::intern::test_intern("WARPOUT");
@@ -873,7 +877,8 @@ mod tests {
             1,
             (20, 20),
             &rules,
-            false
+            false,
+            0
         ));
 
         let warp_out_type = crate::sim::intern::test_intern("WARPOUT");
@@ -972,7 +977,7 @@ mod tests {
     fn test_teleport_with_piggyback_restores_drive() {
         let mut entities = EntityStore::new();
         let obj = make_drive_obj();
-        let loco = LocomotorState::from_object_type(&obj, 1500);
+        let loco = LocomotorState::from_object_type(&obj, 1500, 0);
         let mut e = GameEntity::test_default(1, "CMIN", "Americans", 5, 5);
         e.locomotor = Some(loco);
         entities.insert(e);
@@ -986,7 +991,8 @@ mod tests {
             1,
             (20, 20),
             &rules,
-            false
+            false,
+            0
         ));
         // Should have overridden to Teleport.
         let entity = entities.get(1).expect("should exist");
@@ -1011,7 +1017,7 @@ mod tests {
     fn teleporter_empty_destination_starts_teleport_without_drive_override() {
         let mut entities = EntityStore::new();
         let obj = make_teleport_harvester_obj();
-        let loco = LocomotorState::from_object_type(&obj, 1500);
+        let loco = LocomotorState::from_object_type(&obj, 1500, 0);
         let mut e = GameEntity::test_default(1, "CMIN", "Americans", 5, 5);
         e.locomotor = Some(loco);
         entities.insert(e);
@@ -1035,6 +1041,7 @@ mod tests {
             true,
             false,
             None,
+            0,
         ));
 
         let entity = entities.get(1).expect("entity");
@@ -1050,7 +1057,7 @@ mod tests {
     fn teleporter_building_destination_activates_drive_piggyback() {
         let mut entities = EntityStore::new();
         let obj = make_teleport_harvester_obj();
-        let loco = LocomotorState::from_object_type(&obj, 1500);
+        let loco = LocomotorState::from_object_type(&obj, 1500, 0);
         let mut e = GameEntity::test_default(1, "CMIN", "Americans", 5, 5);
         e.locomotor = Some(loco);
         entities.insert(e);
@@ -1075,6 +1082,7 @@ mod tests {
             true,
             true,
             None,
+            0,
         ));
 
         let entity = entities.get(1).expect("entity");
@@ -1152,7 +1160,8 @@ mod tests {
             1,
             (90, 90),
             &rules,
-            true
+            true,
+            0
         ));
         let ts = entities
             .get(1)
@@ -1170,7 +1179,7 @@ mod tests {
     fn test_harvester_relocate_cleans_up_in_one_tick() {
         let mut entities = EntityStore::new();
         let obj = make_drive_obj();
-        let loco = LocomotorState::from_object_type(&obj, 1500);
+        let loco = LocomotorState::from_object_type(&obj, 1500, 0);
         let mut e = GameEntity::test_default(1, "CMIN", "Americans", 5, 5);
         e.locomotor = Some(loco);
         entities.insert(e);
@@ -1181,7 +1190,8 @@ mod tests {
             1,
             (20, 20),
             &rules,
-            true
+            true,
+            0
         ));
         // Override applied at issue time.
         let entity = entities.get(1).expect("should exist");
@@ -1216,7 +1226,8 @@ mod tests {
             1,
             (20, 20),
             &rules,
-            false
+            false,
+            0
         ));
         let initial_ticks = entities
             .get(1)
@@ -1253,6 +1264,7 @@ mod tests {
             (20, 20),
             &default_rules(),
             false,
+            0,
         ));
         let outcomes =
             tick_teleport_movement(&mut entities, &mut OccupancyGrid::new(), &[], 0, None);

--- a/src/sim/rocking/mod.rs
+++ b/src/sim/rocking/mod.rs
@@ -1,8 +1,8 @@
-//! Body rocking and slope-transition simulation.
+//! Body-rocking simulation.
 //!
 //! Implements the spring-damper that drives `RockingState::angle_*` toward zero
-//! each tick, plus the 3-tick slope-transition tracker. The renderer reads the
-//! resulting angles + slope-blend matrix to compose the body matrix per frame.
+//! each tick. Drive/Ship slope interpolation is owned separately by locomotor
+//! runtime payload state.
 //!
 //! ## Dependency rules
 //! - Part of sim/ — depends only on sim/components, sim/entity_store, map,

--- a/src/sim/rocking/rocking_system.rs
+++ b/src/sim/rocking/rocking_system.rs
@@ -1,11 +1,10 @@
-//! Per-tick spring-damper + slope-transition advance.
+//! Per-tick body-rocking spring-damper advance.
 //!
 //! All angles and angular velocities are in radians, stored as `SimFixed`
 //! (I16F16, ~1.5e-5 precision). Constants here are extracted from the
 //! reference engine; do not change without binary verification.
 
 use crate::map::entities::EntityCategory;
-use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::components::RockingState;
 use crate::sim::entity_store::EntityStore;
@@ -40,9 +39,6 @@ pub const SNAP_BACK_RATE: SimFixed = SimFixed::lit("0.005");
 
 /// Per-axis velocity cap applied at impulse-receive time (rad/tick).
 pub const IMPULSE_VEL_CAP: SimFixed = SimFixed::lit("0.05");
-
-/// Slope-transition duration in sim ticks (hard-coded constant).
-pub const SLOPE_TRANSITION_TICKS: u8 = 3;
 
 /// Saturation cap on rocker impulse force from area-damage (clamped to 4.0
 /// before the per-axis velocity gate). Bounds defended both at the source
@@ -153,40 +149,18 @@ pub(crate) fn advance_ship_rocking(rocking: &mut RockingState, type_supports_shi
     }
 }
 
-/// Update the slope-transition state for one entity.
-///
-/// If `cell_slope` differs from the tracked `curr_slope`, start (or
-/// restart) a fresh 3-tick transition: the old `curr_slope` becomes the
-/// new `prev_slope`, and the counter resets to `SLOPE_TRANSITION_TICKS`.
-/// Otherwise, decrement the counter (saturating at 0).
-///
-/// The render side reads `prev_slope`/`curr_slope`/`transition_ticks_remaining`
-/// to SLERP between the two slope matrices.
-pub(crate) fn update_slope_transition(rocking: &mut RockingState, cell_slope: u8) {
-    if cell_slope != rocking.curr_slope {
-        rocking.prev_slope = rocking.curr_slope;
-        rocking.curr_slope = cell_slope;
-        rocking.transition_ticks_remaining = SLOPE_TRANSITION_TICKS;
-    } else if rocking.transition_ticks_remaining > 0 {
-        rocking.transition_ticks_remaining -= 1;
-    }
-}
-
 /// Advance every entity's `RockingState` by one sim tick.
 ///
 /// Order per entity:
-///   1. Read `cell.slope_type` at the entity's current position; aircraft are
-///      forced to slope_type=0 [L23]. Update slope-transition tracking.
-///   2. If `is_ship_rocking`: integrate without damping (`advance_ship_rocking`).
-///   3. Else: spring-damper on each axis (`advance_axis`). The forwards-axis
+///   1. If `is_ship_rocking`: integrate without damping (`advance_ship_rocking`).
+///   2. Else: spring-damper on each axis (`advance_axis`). The forwards-axis
 ///      ±π/10 override during vehicle-vs-building crush [L8] is DEFERRED until
 ///      building-crushing lands; both axes use ±π/4 uniformly.
-///   4. Wide-amplitude self-destruct check [L30]: if either body angle now
+///   3. Wide-amplitude self-destruct check [L30]: if either body angle now
 ///      exceeds ±π, fire `hook`. Mirrors the end-of-RockingUpdate damage call
 ///      in the reference engine.
 pub fn tick(
     entities: &mut EntityStore,
-    terrain: &ResolvedTerrainGrid,
     rules: &RuleSet,
     self_destruct_hook: &mut dyn SelfDestructHook,
 ) {
@@ -200,28 +174,14 @@ pub fn tick(
         }
 
         // Read whole-entity properties before borrowing rocking mutably.
-        let raw_slope = terrain
-            .cell(entity.position.rx, entity.position.ry)
-            .map(|c| c.slope_type)
-            .unwrap_or(0);
-        // Aircraft skip slope tilting [L23]. Clamp to the 0..=20 range the
-        // slope-transition tracker expects (slope_type values 17..=20 are
-        // unpopulated but still legal).
-        let cell_slope = if entity.category == EntityCategory::Aircraft {
-            0
-        } else {
-            raw_slope.min(20)
-        };
         let is_moving = entity_is_moving(entity);
         let supports_ship_rock = entity_type_supports_ship_rocking(entity);
         let fallback = rules.general.fallback_coefficient;
 
-        // 1–3: mutate the rocking state. The &mut borrow is scoped to this
-        // block so step 4 can take a fresh &mut GameEntity for the hook.
+        // 1–2: mutate the rocking state. The &mut borrow is scoped to this
+        // block so step 3 can take a fresh &mut GameEntity for the hook.
         {
             let rocking = entity.rocking.as_mut().unwrap();
-            update_slope_transition(rocking, cell_slope);
-
             if rocking.is_ship_rocking {
                 advance_ship_rocking(rocking, supports_ship_rock);
             } else {
@@ -245,7 +205,7 @@ pub fn tick(
             }
         }
 
-        // 4: wide-amplitude self-destruct check [L30].
+        // 3: wide-amplitude self-destruct check [L30].
         crate::sim::rocking::self_destruct::check_and_fire(entity, self_destruct_hook);
     }
 }

--- a/src/sim/rocking/rocking_tests.rs
+++ b/src/sim/rocking/rocking_tests.rs
@@ -5,8 +5,8 @@
 use crate::sim::components::RockingState;
 use crate::sim::rocking::impulse::apply_rocker_impulse;
 use crate::sim::rocking::rocking_system::{
-    IMPULSE_VEL_CAP, NORMAL_RANGE_PI2, SATURATION_PI4, SATURATION_PI10, SLOPE_TRANSITION_TICKS,
-    TILT_DEADBAND, advance_axis, advance_ship_rocking, update_slope_transition,
+    IMPULSE_VEL_CAP, NORMAL_RANGE_PI2, SATURATION_PI4, SATURATION_PI10, TILT_DEADBAND,
+    advance_axis, advance_ship_rocking,
 };
 use crate::util::fixed_math::SimFixed;
 
@@ -175,49 +175,6 @@ fn ship_rocking_no_clamp_when_type_doesnt_support() {
     r.vel_sideways = SimFixed::lit("0.01");
     advance_ship_rocking(&mut r, false);
     assert!(r.angle_sideways > SATURATION_PI4);
-}
-
-#[test]
-fn slope_change_starts_three_tick_transition() {
-    let mut r = RockingState::default();
-    r.curr_slope = 0;
-    update_slope_transition(&mut r, 5);
-    assert_eq!(r.prev_slope, 0);
-    assert_eq!(r.curr_slope, 5);
-    assert_eq!(r.transition_ticks_remaining, SLOPE_TRANSITION_TICKS);
-}
-
-#[test]
-fn slope_unchanged_decrements_counter() {
-    let mut r = RockingState::default();
-    r.curr_slope = 5;
-    r.transition_ticks_remaining = 3;
-    update_slope_transition(&mut r, 5);
-    assert_eq!(r.transition_ticks_remaining, 2);
-    update_slope_transition(&mut r, 5);
-    assert_eq!(r.transition_ticks_remaining, 1);
-    update_slope_transition(&mut r, 5);
-    assert_eq!(r.transition_ticks_remaining, 0);
-}
-
-#[test]
-fn slope_counter_saturates_at_zero() {
-    let mut r = RockingState::default();
-    r.curr_slope = 5;
-    r.transition_ticks_remaining = 0;
-    update_slope_transition(&mut r, 5);
-    assert_eq!(r.transition_ticks_remaining, 0);
-}
-
-#[test]
-fn slope_change_mid_transition_resets_to_three() {
-    let mut r = RockingState::default();
-    r.curr_slope = 5;
-    r.transition_ticks_remaining = 1;
-    update_slope_transition(&mut r, 7);
-    assert_eq!(r.prev_slope, 5);
-    assert_eq!(r.curr_slope, 7);
-    assert_eq!(r.transition_ticks_remaining, SLOPE_TRANSITION_TICKS);
 }
 
 #[test]
@@ -598,12 +555,11 @@ fn integration_impulse_decays_to_neutral_over_60_ticks() {
     assert!(
         r.is_neutral(),
         "rocking should have decayed to neutral after 60 ticks; \
-         angles=({:?},{:?}) vels=({:?},{:?}) transition_remaining={}",
+         angles=({:?},{:?}) vels=({:?},{:?})",
         r.angle_sideways,
         r.angle_forwards,
         r.vel_sideways,
         r.vel_forwards,
-        r.transition_ticks_remaining,
     );
 }
 

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -306,7 +306,9 @@ use crate::sim::world::Simulation;
 // and destroyable-cliff replacement persists exact changed CellClass values.
 // Bumped 103 -> 104: every Techno persists its constructor Scenario-RNG low
 // word, and authored structure-upgrade Technos persist their parent/slot link.
-const SNAPSHOT_VERSION: u32 = 104;
+// Bumped 104 -> 105: persist active and stashed Drive/Ship locomotor slope
+// cache/global-frame timer state; the positional payload enum changed shape.
+const SNAPSHOT_VERSION: u32 = 105;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -2708,10 +2710,154 @@ mod tests {
     /// adds category-distinct resolved AITrigger token-6 identities; 102 -> 103
     /// adds WaveClass state and destroyable-cliff replacement CellClass values;
     /// 103 -> 104 adds the persistent Techno constructor word and authored
-    /// structure-upgrade parent/slot identity.
+    /// structure-upgrade parent/slot identity; 104 -> 105 adds active/stashed
+    /// Drive/Ship slope-transition state.
     #[test]
-    fn techno_constructor_snapshot_version_is_104() {
-        assert_eq!(super::SNAPSHOT_VERSION, 104);
+    fn phase3_drive_ship_slope_snapshot_version_is_105() {
+        assert_eq!(super::SNAPSHOT_VERSION, 105);
+    }
+
+    #[test]
+    fn drive_ship_active_and_stashed_slope_phase_roundtrip_without_resample_or_rng() {
+        use crate::map::entities::EntityCategory;
+        use crate::rules::locomotor_type::LocomotorKind;
+        use crate::sim::game_entity::GameEntity;
+        use crate::sim::movement::locomotion::LocomotorRuntimePayload;
+        use crate::sim::movement::locomotor::LocomotorState;
+
+        // Full snapshot load restarts Scenario RNG from Seed0. Start on that
+        // canonical cursor so the slope-only round trip can prove no draw.
+        let mut sim = Simulation::with_seed(0);
+        sim.session.binary_frame = 51;
+        let mut entity = GameEntity::test_default(1, "SLOPE", "Americans", 0, 0);
+        entity.owner = sim.intern("Americans");
+        entity.type_ref = sim.intern("SLOPE");
+        entity.category = EntityCategory::Unit;
+        let mut locomotor = LocomotorState::for_test_kind_at_frame(LocomotorKind::Drive, 40);
+        let drive = locomotor.active_slope_transition_mut().unwrap();
+        drive.snap(2, 40);
+        drive.sample_process_entry(7, 50);
+        assert!(locomotor.begin_piggyback(LocomotorKind::Ship, MovementLayer::Ground, 50));
+        let ship = locomotor.active_slope_transition_mut().unwrap();
+        ship.snap(4, 40);
+        ship.sample_process_entry(9, 50);
+        entity.locomotor = Some(locomotor);
+        sim.substrate.entities.insert(entity);
+
+        let before_hash = sim.state_hash();
+        let before_rng = sim.scenario_rng.logical_state();
+        let before = sim
+            .substrate
+            .entities
+            .get(1)
+            .unwrap()
+            .locomotor
+            .as_ref()
+            .unwrap();
+        let active_before = before.runtime_payload.clone();
+        let stashed_before = before.piggyback.clone();
+
+        let bytes = GameSnapshot::save(&sim, 1, 2, "Drive Ship slope", 3);
+        let mut restored = GameSnapshot::load(&bytes)
+            .expect("current v105 slope snapshot")
+            .sim;
+        let loaded = restored
+            .substrate
+            .entities
+            .get(1)
+            .unwrap()
+            .locomotor
+            .as_ref()
+            .unwrap();
+        assert_eq!(loaded.runtime_payload, active_before);
+        assert_eq!(loaded.piggyback, stashed_before);
+        assert_eq!(restored.session.binary_frame, 51);
+        assert_eq!(restored.state_hash(), before_hash);
+        assert_eq!(restored.scenario_rng.logical_state(), before_rng);
+        assert_eq!(
+            loaded.active_slope_transition().unwrap().render_phase(51),
+            crate::sim::movement::slope_transition::SlopeRenderPhase::Transition {
+                from_slope: 4,
+                to_slope: 9,
+                phase_num: 1,
+                phase_den: 3,
+            }
+        );
+        assert!(matches!(
+            loaded.piggyback.as_deref().map(|runtime| &runtime.payload),
+            Some(LocomotorRuntimePayload::Drive(state))
+                if matches!(state.render_phase(51),
+                    crate::sim::movement::slope_transition::SlopeRenderPhase::Transition {
+                        from_slope: 2,
+                        to_slope: 7,
+                        phase_num: 1,
+                        phase_den: 3,
+                    })
+        ));
+
+        let mut live_cell = clear_terrain_cell(0, 0);
+        live_cell.slope_type = 12;
+        let live_terrain = ResolvedTerrainGrid::from_cells(1, 1, vec![live_cell]);
+        restored.resolved_terrain = Some(live_terrain.clone());
+        assert_eq!(
+            restored
+                .substrate
+                .entities
+                .get(1)
+                .unwrap()
+                .locomotor
+                .as_ref()
+                .unwrap()
+                .active_slope_transition()
+                .unwrap()
+                .hash_fields(),
+            (4, 9, 50, 3),
+            "load/rebuild trusts the saved cache instead of resampling live terrain"
+        );
+
+        let mut sound_events = Vec::new();
+        let mut lifecycle_requests = Vec::new();
+        crate::sim::movement::tick_movement_with_grids(
+            &mut restored.substrate.entities,
+            Some(&[1]),
+            None,
+            &Default::default(),
+            &Default::default(),
+            &mut restored.substrate.occupancy,
+            &mut restored.substrate.cell_occupation,
+            &mut restored.substrate.raw_cell_occupation,
+            &mut restored.substrate.next_occupancy_enter_order,
+            &mut restored.scenario_rng,
+            52,
+            52,
+            None,
+            Some(&live_terrain),
+            None,
+            &crate::sim::pathfinding::terrain_speed::TerrainSpeedConfig::default(),
+            crate::util::fixed_math::SIM_ZERO,
+            9,
+            60,
+            &mut restored.interner,
+            None,
+            &mut sound_events,
+            &mut lifecycle_requests,
+        );
+        assert_eq!(
+            restored
+                .substrate
+                .entities
+                .get(1)
+                .unwrap()
+                .locomotor
+                .as_ref()
+                .unwrap()
+                .active_slope_transition()
+                .unwrap()
+                .hash_fields(),
+            (9, 12, 52, 3),
+            "only the next eligible Process restarts against live terrain"
+        );
+        assert_eq!(restored.scenario_rng.logical_state(), before_rng);
     }
 
     #[test]

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -2736,11 +2736,11 @@ mod tests {
         let mut locomotor = LocomotorState::for_test_kind_at_frame(LocomotorKind::Drive, 40);
         let drive = locomotor.active_slope_transition_mut().unwrap();
         drive.snap(2, 40);
-        drive.sample_process_entry(7, 50);
+        drive.sample_process_entry(7, 49);
         assert!(locomotor.begin_piggyback(LocomotorKind::Ship, MovementLayer::Ground, 50));
         let ship = locomotor.active_slope_transition_mut().unwrap();
         ship.snap(4, 40);
-        ship.sample_process_entry(9, 50);
+        ship.sample_process_entry(9, 49);
         entity.locomotor = Some(locomotor);
         sim.substrate.entities.insert(entity);
 
@@ -2775,24 +2775,14 @@ mod tests {
         assert_eq!(restored.state_hash(), before_hash);
         assert_eq!(restored.scenario_rng.logical_state(), before_rng);
         assert_eq!(
-            loaded.active_slope_transition().unwrap().render_phase(51),
-            crate::sim::movement::slope_transition::SlopeRenderPhase::Transition {
-                from_slope: 4,
-                to_slope: 9,
-                phase_num: 1,
-                phase_den: 3,
-            }
+            loaded.active_slope_transition().unwrap().hash_fields(),
+            (4, 9, 49, 3),
+            "the saved active timer starts two committed frames before session frame 51"
         );
         assert!(matches!(
             loaded.piggyback.as_deref().map(|runtime| &runtime.payload),
             Some(LocomotorRuntimePayload::Drive(state))
-                if matches!(state.render_phase(51),
-                    crate::sim::movement::slope_transition::SlopeRenderPhase::Transition {
-                        from_slope: 2,
-                        to_slope: 7,
-                        phase_num: 1,
-                        phase_den: 3,
-                    })
+                if state.hash_fields() == (2, 7, 49, 3)
         ));
 
         let mut live_cell = clear_terrain_cell(0, 0);
@@ -2811,7 +2801,7 @@ mod tests {
                 .active_slope_transition()
                 .unwrap()
                 .hash_fields(),
-            (4, 9, 50, 3),
+            (4, 9, 49, 3),
             "load/rebuild trusts the saved cache instead of resampling live terrain"
         );
 

--- a/src/sim/world/bridge_orchestrator.rs
+++ b/src/sim/world/bridge_orchestrator.rs
@@ -2351,6 +2351,7 @@ mod tests {
             piggyback: None,
             runtime_payload: crate::sim::movement::locomotion::LocomotorRuntimePayload::for_kind(
                 LocomotorKind::Drive,
+                0,
             ),
             layer: MovementLayer::Bridge,
             phase: GroundMovePhase::Cruising,

--- a/src/sim/world/bridge_parity_harness_tests.rs
+++ b/src/sim/world/bridge_parity_harness_tests.rs
@@ -99,7 +99,11 @@ const MIN_DISTINCT_DECK_CELLS: usize = 6;
 /// Technos now consume and persist the raw Scenario words written at
 /// 0x006F3254. Path nodes, visited cells, bridge tripwires, and record/replay
 /// equality remain exact; this is a Rust regression ratchet, not parity evidence.
-const BRIDGE_HARNESS_FINAL_HASH: u64 = 0x49EF_3591_2127_4502;
+/// Re-baselined 2026-08-30 for GSI-04.03 Drive/Ship slope payload ownership.
+/// The ordered path, all 12 visited cells, bridge height/occupation tripwires,
+/// all three RNG streams, and tick-for-tick replay remain exact; only the
+/// hash composition moved from retired body-rocking bytes to the locomotor.
+const BRIDGE_HARNESS_FINAL_HASH: u64 = 0x584D_9C4F_23BD_388F;
 
 fn bridge_ini() -> IniFile {
     // One armed ground vehicle and one distant infantryman on a second house, so

--- a/src/sim/world/global_parity_harness_tests.rs
+++ b/src/sim/world/global_parity_harness_tests.rs
@@ -345,8 +345,12 @@ const FINAL_STREAM_STATES: (u64, u64, u64) = (
 // Technos consume the raw Scenario words stored at 0x006F3254. That
 // behavior-bearing Scenario shift reaches both historical schema probes;
 // record/replay remains exact and Main plus MapGen remain unchanged.
-const GLOBAL_HARNESS_PRE_LIFECYCLE_V28_HASH: u64 = 0x4185_6CCF_FF66_1666;
-const GLOBAL_HARNESS_PRE_MISSION_V29_HASH: u64 = 0x6E21_7425_AAC6_F794;
+// Re-baselined 2026-08-30 for GSI-04.03 Drive/Ship slope payload ownership.
+// The payload is part of the common locomotor fold, so both historical probes
+// move. All three RNG fingerprints and tick-for-tick record/replay remain exact,
+// isolating this to the intentional hash-owner composition change.
+const GLOBAL_HARNESS_PRE_LIFECYCLE_V28_HASH: u64 = 0x0F6E_2B0B_5FF4_B23D;
+const GLOBAL_HARNESS_PRE_MISSION_V29_HASH: u64 = 0xE2B3_9FAA_432F_4A75;
 // Snapshot/hash schema v29 originally added the exact Mission/readiness state.
 // Its schema shift was composition-only; the later behavior-bearing Drive,
 // authority-flip, and Harvest-absorption re-baselines are documented above.
@@ -505,7 +509,10 @@ const GLOBAL_HARNESS_PRE_MISSION_V29_HASH: u64 = 0x6E21_7425_AAC6_F794;
 // this measured shift is composition-only.
 // The current schema additionally folds the persistent Techno constructor
 // fields; the historical probes above isolate the shared RNG-behavior shift.
-const GLOBAL_HARNESS_FINAL_HASH: u64 = 0x848C_B752_96E9_9804;
+// Re-baselined 2026-08-30 for the same GSI-04.03 slope payload ownership.
+// The historical probes move consistently, the absolute RNG tuple is unchanged,
+// and record/replay equality remains exact: this is hash composition, not route drift.
+const GLOBAL_HARNESS_FINAL_HASH: u64 = 0xDA92_C04D_B53F_B58D;
 
 fn harness_ini() -> IniFile {
     // Multi-faction vehicles + infantry + buildings (war factory, refinery) plus a

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -734,6 +734,25 @@ impl Simulation {
                 });
             }
         }
+        // FootClass::Unlimbo @ 0x004D7170 dispatches active Drive/Ship
+        // Force_Slope at 0x004D71A9 only after TechnoClass placement succeeds.
+        // This precedes display/Logic exposure and must not run on either
+        // failed placement path above.
+        let reveal_slope = self.substrate.entities.get(stable_id).and_then(|entity| {
+            self.resolved_terrain
+                .as_ref()?
+                .cell(entity.position.rx, entity.position.ry)
+                .map(|cell| cell.slope_type)
+        });
+        if let Some(sampled_slope) = reveal_slope
+            && let Some(entity) = self.substrate.entities.get_mut(stable_id)
+        {
+            crate::sim::movement::slope_transition::snap_after_successful_unlimbo(
+                entity,
+                sampled_slope,
+                self.session.binary_frame,
+            );
+        }
         if !self
             .substrate
             .entities

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -349,14 +349,33 @@ fn drive_ship_slope_production_spawn_unlimbo_snaps_without_manual_rocking_state(
     ] {
         let mut sim = Simulation::with_seed(0x51_0f_e);
         sim.session.binary_frame = 37;
+        sim.playfield_bounds = Some(crate::sim::cell_rect::PlayfieldBounds {
+            base: 0,
+            off_fc: -100,
+            off_100: -100,
+            off_104: 200,
+            off_108: 200,
+        });
         install_common_raw_terrain(&mut sim, 10, 5, 0, None);
-        sim.resolved_terrain
+        let terrain_cell = sim
+            .resolved_terrain
             .as_mut()
             .unwrap()
             .cell_mut(cell.0, cell.1)
-            .unwrap()
-            .slope_type = slope;
-        let rng_before = sim.scenario_rng.logical_state();
+            .unwrap();
+        terrain_cell.slope_type = slope;
+        terrain_cell.speed_costs = SpeedCostProfile {
+            foot: Some(100),
+            track: Some(100),
+            wheel: Some(100),
+            float: Some(100),
+            amphibious: Some(100),
+            float_beach: Some(100),
+            hover: Some(100),
+        };
+        terrain_cell.base_speed_costs = terrain_cell.speed_costs;
+        let mut expected_rng = sim.scenario_rng.clone();
+        let _constructor_word = expected_rng.next_u32();
 
         let stable_id = sim
             .spawn_object(type_id, "Americans", cell.0, cell.1, 0, &rules, &BTreeMap::new())
@@ -370,7 +389,11 @@ fn drive_ship_slope_production_spawn_unlimbo_snaps_without_manual_rocking_state(
             (slope, slope, 37, 0),
             "successful Foot unlimbo snaps both slope bytes at the current frame"
         );
-        assert_eq!(sim.scenario_rng.logical_state(), rng_before);
+        assert_eq!(
+            sim.scenario_rng.logical_state(),
+            expected_rng.logical_state(),
+            "the Techno constructor consumes its one proven word and slope Unlimbo adds no draw"
+        );
     }
 }
 
@@ -379,14 +402,32 @@ fn zero_speed_foot_drive_ship_payloads_survive_all_world_spawn_paths() {
     let rules = zero_speed_drive_ship_slope_rules();
     let mut sim = Simulation::with_seed(0x51_0f_e);
     sim.session.binary_frame = 71;
+    sim.playfield_bounds = Some(crate::sim::cell_rect::PlayfieldBounds {
+        base: 0,
+        off_fc: -100,
+        off_100: -100,
+        off_104: 200,
+        off_108: 200,
+    });
     install_common_raw_terrain(&mut sim, 12, 8, 0, None);
     for (cell, slope) in [((2, 2), 5), ((4, 2), 8), ((6, 2), 11), ((8, 2), 14)] {
-        sim.resolved_terrain
+        let terrain_cell = sim
+            .resolved_terrain
             .as_mut()
             .unwrap()
             .cell_mut(cell.0, cell.1)
-            .unwrap()
-            .slope_type = slope;
+            .unwrap();
+        terrain_cell.slope_type = slope;
+        terrain_cell.speed_costs = SpeedCostProfile {
+            foot: Some(100),
+            track: Some(100),
+            wheel: Some(100),
+            float: Some(100),
+            amphibious: Some(100),
+            float_beach: Some(100),
+            hover: Some(100),
+        };
+        terrain_cell.base_speed_costs = terrain_cell.speed_costs;
     }
 
     for (type_id, cell, expected_kind, slope) in [
@@ -422,6 +463,7 @@ fn zero_speed_foot_drive_ship_payloads_survive_all_world_spawn_paths() {
         mission: None,
         recruitable_a: true,
         recruitable_b: true,
+        structure_upgrades: [None, None, None],
     };
     assert_eq!(sim.spawn_from_map(&[placement], Some(&rules), &BTreeMap::new()), 1);
     let map_entity = sim

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -118,6 +118,16 @@ fn request(rx: u16, ry: u16, placement: PlacementEvidence) -> RevealRequest {
     }
 }
 
+fn drive_ship_slope_rules() -> crate::rules::ruleset::RuleSet {
+    let ini = crate::rules::ini_parser::IniFile::from_str(
+        "[VehicleTypes]\n0=DRIVE\n1=SHIP\n2=TTRAIN\n\
+         [DRIVE]\nStrength=100\nSpeed=6\nLocomotor={4A582741-9839-11D1-B709-00A024DDAFD1}\n\
+         [SHIP]\nStrength=100\nSpeed=6\nLocomotor={2BEA74E1-7CCA-11D3-BE14-00104B62A16C}\n\
+         [TTRAIN]\nStrength=100\nSpeed=6\nIsTrain=yes\nLocomotor={4A582741-9839-11D1-B709-00A024DDAFD1}\n",
+    );
+    crate::rules::ruleset::RuleSet::from_ini(&ini).expect("Drive/Ship slope rules")
+}
+
 fn packed_reservation_test_coord(x: i32, y: i32) -> u32 {
     u32::from(x as i16 as u16) | (u32::from(y as i16 as u16) << 16)
 }
@@ -310,6 +320,73 @@ fn install_common_raw_terrain(
         crate::sim::bridge_state::BridgeRuntimeState::from_resolved_terrain(&terrain, true, 1500),
     );
     sim.resolved_terrain = Some(terrain);
+}
+
+#[test]
+fn drive_ship_slope_production_spawn_unlimbo_snaps_without_manual_rocking_state() {
+    let rules = drive_ship_slope_rules();
+    for (type_id, cell, slope) in [
+        ("DRIVE", (2, 2), 5),
+        ("SHIP", (4, 2), 9),
+        ("TTRAIN", (6, 2), 12),
+    ] {
+        let mut sim = Simulation::with_seed(0x51_0f_e);
+        sim.session.binary_frame = 37;
+        install_common_raw_terrain(&mut sim, 10, 5, 0, None);
+        sim.resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .unwrap()
+            .slope_type = slope;
+        let rng_before = sim.scenario_rng.logical_state();
+
+        let stable_id = sim
+            .spawn_object(type_id, "Americans", cell.0, cell.1, 0, &rules, &BTreeMap::new())
+            .expect("production spawn/unlimbo");
+        let entity = sim.substrate.entities.get(stable_id).unwrap();
+        assert!(entity.rocking.is_none(), "slope state is not manually injected");
+        assert_eq!(
+            crate::sim::movement::slope_transition::state_for_entity(entity)
+                .expect("active Drive/Ship state")
+                .hash_fields(),
+            (slope, slope, 37, 0),
+            "successful Foot unlimbo snaps both slope bytes at the current frame"
+        );
+        assert_eq!(sim.scenario_rng.logical_state(), rng_before);
+    }
+}
+
+#[test]
+fn drive_ship_slope_failed_reveal_does_not_snap_or_consume_rng() {
+    let mut sim = Simulation::with_seed(0x51_0f_e);
+    sim.session.binary_frame = 40;
+    install_common_raw_terrain(&mut sim, 8, 8, 0, None);
+    sim.resolved_terrain
+        .as_mut()
+        .unwrap()
+        .cell_mut(3, 4)
+        .unwrap()
+        .slope_type = 8;
+    insert_entity(&mut sim, 1, EntityCategory::Unit);
+    sim.substrate.entities.get_mut(1).unwrap().locomotor = Some(
+        LocomotorState::for_test_kind_at_frame(LocomotorKind::Drive, 11),
+    );
+    let rng_before = sim.scenario_rng.logical_state();
+
+    assert_eq!(
+        sim.try_reveal_entity(1, request(3, 4, PlacementEvidence::MarkFailed)),
+        RevealOutcome::Failed(RevealFailure::MarkFailed)
+    );
+    assert_eq!(
+        crate::sim::movement::slope_transition::state_for_entity(
+            sim.substrate.entities.get(1).unwrap()
+        )
+        .unwrap()
+        .hash_fields(),
+        (0, 0, 11, 0)
+    );
+    assert_eq!(sim.scenario_rng.logical_state(), rng_before);
 }
 
 #[test]

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use crate::map::bridge_facts::{
     BRIDGE_FLAG_ANCHOR_SELF, BRIDGE_FLAG_STRUCTURAL, BridgeCellFacts, BridgeStampFamily,
 };
-use crate::map::entities::EntityCategory;
+use crate::map::entities::{EntityCategory, MapEntity};
 use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid};
 use crate::rules::locomotor_type::LocomotorKind;
 use crate::rules::terrain_rules::{SpeedCostProfile, TerrainClass};
@@ -126,6 +126,23 @@ fn drive_ship_slope_rules() -> crate::rules::ruleset::RuleSet {
          [TTRAIN]\nStrength=100\nSpeed=6\nIsTrain=yes\nLocomotor={4A582741-9839-11D1-B709-00A024DDAFD1}\n",
     );
     crate::rules::ruleset::RuleSet::from_ini(&ini).expect("Drive/Ship slope rules")
+}
+
+fn zero_speed_drive_ship_slope_rules() -> crate::rules::ruleset::RuleSet {
+    let ini = crate::rules::ini_parser::IniFile::from_str(
+        "[VehicleTypes]\n0=ZUNITD\n1=ZMAPD\n2=ZLIMBOS\n3=ZWALK\n\
+         [InfantryTypes]\n0=ZINFD\n\
+         [AircraftTypes]\n0=ZAIRS\n\
+         [BuildingTypes]\n0=ZBUILDD\n\
+         [ZUNITD]\nStrength=100\nSpeed=0\nLocomotor={4A582741-9839-11D1-B709-00A024DDAFD1}\n\
+         [ZMAPD]\nStrength=100\nSpeed=0\nLocomotor={4A582741-9839-11D1-B709-00A024DDAFD1}\n\
+         [ZLIMBOS]\nStrength=100\nSpeed=0\nLocomotor={2BEA74E1-7CCA-11D3-BE14-00104B62A16C}\n\
+         [ZWALK]\nStrength=100\nSpeed=0\nLocomotor={4A582744-9839-11D1-B709-00A024DDAFD1}\n\
+         [ZINFD]\nStrength=100\nSpeed=0\nLocomotor={4A582741-9839-11D1-B709-00A024DDAFD1}\n\
+         [ZAIRS]\nStrength=100\nSpeed=0\nLocomotor={2BEA74E1-7CCA-11D3-BE14-00104B62A16C}\n\
+         [ZBUILDD]\nStrength=100\nSpeed=0\nLocomotor={4A582741-9839-11D1-B709-00A024DDAFD1}\n",
+    );
+    crate::rules::ruleset::RuleSet::from_ini(&ini).expect("zero-speed Drive/Ship rules")
 }
 
 fn packed_reservation_test_coord(x: i32, y: i32) -> u32 {
@@ -354,6 +371,94 @@ fn drive_ship_slope_production_spawn_unlimbo_snaps_without_manual_rocking_state(
             "successful Foot unlimbo snaps both slope bytes at the current frame"
         );
         assert_eq!(sim.scenario_rng.logical_state(), rng_before);
+    }
+}
+
+#[test]
+fn zero_speed_foot_drive_ship_payloads_survive_all_world_spawn_paths() {
+    let rules = zero_speed_drive_ship_slope_rules();
+    let mut sim = Simulation::with_seed(0x51_0f_e);
+    sim.session.binary_frame = 71;
+    install_common_raw_terrain(&mut sim, 12, 8, 0, None);
+    for (cell, slope) in [((2, 2), 5), ((4, 2), 8), ((6, 2), 11), ((8, 2), 14)] {
+        sim.resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .unwrap()
+            .slope_type = slope;
+    }
+
+    for (type_id, cell, expected_kind, slope) in [
+        ("ZUNITD", (2, 2), LocomotorKind::Drive, 5),
+        ("ZINFD", (4, 2), LocomotorKind::Drive, 8),
+        ("ZAIRS", (6, 2), LocomotorKind::Ship, 11),
+    ] {
+        let stable_id = sim
+            .spawn_object(type_id, "Americans", cell.0, cell.1, 0, &rules, &BTreeMap::new())
+            .expect("zero-speed Foot production spawn/reveal");
+        let entity = sim.substrate.entities.get(stable_id).unwrap();
+        assert_eq!(entity.locomotor.as_ref().unwrap().active_kind(), expected_kind);
+        assert_eq!(
+            crate::sim::movement::slope_transition::state_for_entity(entity)
+                .expect("constructor-owned Drive/Ship payload")
+                .hash_fields(),
+            (slope, slope, 71, 0),
+            "successful reveal snaps the payload without test injection"
+        );
+    }
+
+    let placement = MapEntity {
+        owner: "Americans".to_string(),
+        type_id: "ZMAPD".to_string(),
+        health: 256,
+        cell_x: 8,
+        cell_y: 2,
+        facing: 0,
+        category: EntityCategory::Unit,
+        sub_cell: 0,
+        veterancy: 0,
+        high: false,
+        mission: None,
+        recruitable_a: true,
+        recruitable_b: true,
+    };
+    assert_eq!(sim.spawn_from_map(&[placement], Some(&rules), &BTreeMap::new()), 1);
+    let map_entity = sim
+        .substrate
+        .entities
+        .values()
+        .find(|entity| sim.interner.resolve(entity.type_ref) == "ZMAPD")
+        .unwrap();
+    assert_eq!(
+        crate::sim::movement::slope_transition::state_for_entity(map_entity)
+            .unwrap()
+            .hash_fields(),
+        (14, 14, 71, 0),
+        "scenario world spawn also constructs and reveals the zero-speed Drive payload"
+    );
+
+    let limbo_ship = sim
+        .spawn_object_limbo_at_height("ZLIMBOS", "Americans", 10, 2, 0, 0, &rules)
+        .expect("zero-speed limbo Ship");
+    assert_eq!(
+        crate::sim::movement::slope_transition::state_for_entity(
+            sim.substrate.entities.get(limbo_ship).unwrap()
+        )
+        .unwrap()
+        .hash_fields(),
+        (0, 0, 71, 0),
+        "limbo construction owns fresh class state without an Unlimbo snap"
+    );
+
+    for type_id in ["ZBUILDD", "ZWALK"] {
+        let stable_id = sim
+            .spawn_object_limbo_at_height(type_id, "Americans", 10, 3, 0, 0, &rules)
+            .unwrap();
+        assert!(
+            sim.substrate.entities.get(stable_id).unwrap().locomotor.is_none(),
+            "{type_id}: structures and non-Drive/Ship zero-speed types stay excluded"
+        );
     }
 }
 

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -6607,18 +6607,14 @@ impl Simulation {
         // separate from the weapon-damage wall path. No-op when no crusher sits
         // on a wall, so it is hash-neutral for every non-crush scenario.
         self.apply_wall_crush_on_driveover(rules, overlay_registry);
-        // --- Phase 2.5: Body rocking + slope-transition advance ---
-        // DEPENDS ON: all movement above (slope_type lookups must see the
-        //   latest entity positions); rules.general.fallback_coefficient for
-        //   the moving-vehicle decay scale.
-        // PRODUCES: per-entity RockingState (angles, velocities, slope blend
-        //   state) consumed by the renderer to compose the body matrix.
-        // Aircraft skip slope tilting; infantry skip ship rocking. Wide-amplitude
-        // self-destruct uses NoopSelfDestruct until combat-side damage lands
-        // (Task 19); swap in a real hook then.
-        if let (Some(rules), Some(terrain)) = (rules, self.resolved_terrain.as_ref()) {
+        // --- Phase 2.5: body rocking ---
+        // Drive/Ship slope sampling now belongs to locomotor Process entry,
+        // before movement. Body rocking keeps its established post-movement
+        // order, rules/terrain gate, and fallback-coefficient input
+        // independently.
+        if let (Some(rules), Some(_terrain)) = (rules, self.resolved_terrain.as_ref()) {
             let mut hook = crate::sim::rocking::self_destruct::NoopSelfDestruct;
-            crate::sim::rocking::tick(&mut self.substrate.entities, terrain, rules, &mut hook);
+            crate::sim::rocking::tick(&mut self.substrate.entities, rules, &mut hook);
         }
 
         // Aircraft mission state machines — between movement and combat.

--- a/src/sim/world/slice6_retask_tests.rs
+++ b/src/sim/world/slice6_retask_tests.rs
@@ -191,8 +191,11 @@ fn unit(owner: &str, type_id: &str, cx: u16, cy: u16, cat: EntityCategory) -> Ma
 // Technos now consume the raw Scenario word stored at 0x006F3254. That
 // behavior-bearing Scenario shift reaches every schema probe, and record/replay
 // equality remains exact.
-const SLICE6_PRE_LIFECYCLE_V28_HASH: u64 = 0xEC57_2CB0_656C_A6DF;
-const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x667E_E413_E196_0D48;
+// Re-baselined 2026-08-30 for GSI-04.03 Drive slope payload ownership. The
+// common locomotor fold reaches both historical probes; the scripted retasks
+// and record/replay equality remain exact, so this is composition-only.
+const SLICE6_PRE_LIFECYCLE_V28_HASH: u64 = 0x368E_E20F_77C7_0725;
+const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x9856_E7DA_D9F1_676A;
 // Snapshot/hash schema v29 adds lossless Mission dwords, readiness leaves,
 // suspended Target/falling state, and raw locomotor-ready inputs. The two
 // schema probes below must prove the shift is composition-only before updating
@@ -312,7 +315,9 @@ const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x667E_E413_E196_0D48;
 // current-schema composition only.
 // Techno constructor RNG also persists in the current-schema Techno fields;
 // the two legacy probes above isolate the shared behavior-bearing portion.
-const SLICE6_BASELINE_HASH: u64 = 0xD919_789E_36B6_D056;
+// Re-baselined 2026-08-30 for the same slope payload move; both historical
+// probes shift consistently and the replay remains deterministic.
+const SLICE6_BASELINE_HASH: u64 = 0x9F9B_BB9B_3B35_0410;
 
 #[test]
 fn replay_hash_stable_through_slice6() {

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -4917,7 +4917,7 @@ mod tests {
             .locomotor
             .as_mut()
             .unwrap()
-            .begin_piggyback(LocomotorKind::Teleport, MovementLayer::Ground);
+            .begin_piggyback(LocomotorKind::Teleport, MovementLayer::Ground, 0);
         assert_ordinary_drive_host_error(
             &piggyback,
             &control,

--- a/src/sim/world/world_commands.rs
+++ b/src/sim/world/world_commands.rs
@@ -618,6 +618,7 @@ impl Simulation {
                         (*target_rx, *target_ry),
                         general_rules.unwrap_or(&default_general),
                         false,
+                        self.session.binary_frame,
                     )
                 } else if info.loco_layer == MovementLayer::Air {
                     // Jumpjet infantry walk fallback: ≤3 cells + !HoverAttack → ground walk.
@@ -1045,6 +1046,7 @@ impl Simulation {
                         (*target_rx, *target_ry),
                         general_rules_ref,
                         false,
+                        self.session.binary_frame,
                     )
                 } else if info.loco_layer == MovementLayer::Air {
                     // Air units fly in straight lines.
@@ -2744,6 +2746,7 @@ mod tests {
         entity.locomotor = Some(LocomotorState::from_object_type(
             obj,
             rules.general.flight_level,
+            sim.session.binary_frame,
         ));
         entity.regular_crusher = obj.crusher;
         entity.drive_accelerates = obj.accelerates;

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -34,6 +34,62 @@ fn hash_projectile_target(
 }
 
 #[cfg(test)]
+mod drive_ship_slope_hash_tests {
+    use super::Simulation;
+    use crate::map::entities::EntityCategory;
+    use crate::rules::locomotor_type::LocomotorKind;
+    use crate::sim::game_entity::GameEntity;
+    use crate::sim::movement::locomotion::LocomotorRuntimePayload;
+    use crate::sim::movement::locomotor::{LocomotorState, MovementLayer};
+    use crate::sim::movement::slope_transition::SlopeTransitionState;
+
+    fn hash_with_state(kind: LocomotorKind, stashed: bool, state: SlopeTransitionState) -> u64 {
+        let mut sim = Simulation::new();
+        let mut entity = GameEntity::test_default(1, "SLOPE", "Americans", 2, 2);
+        entity.category = EntityCategory::Unit;
+        let mut locomotor = LocomotorState::for_test_kind(kind);
+        locomotor.runtime_payload = match kind {
+            LocomotorKind::Drive => LocomotorRuntimePayload::Drive(state),
+            LocomotorKind::Ship => LocomotorRuntimePayload::Ship(state),
+            _ => unreachable!(),
+        };
+        if stashed {
+            assert!(locomotor.begin_piggyback(
+                LocomotorKind::Teleport,
+                MovementLayer::Ground,
+                90,
+            ));
+        }
+        entity.locomotor = Some(locomotor);
+        sim.substrate.entities.insert(entity);
+        sim.state_hash()
+    }
+
+    #[test]
+    fn every_active_and_stashed_drive_ship_slope_field_changes_current_hash() {
+        let base = SlopeTransitionState::from_fields_for_test(1, 2, 30, 3);
+        let variants = [
+            SlopeTransitionState::from_fields_for_test(9, 2, 30, 3),
+            SlopeTransitionState::from_fields_for_test(1, 9, 30, 3),
+            SlopeTransitionState::from_fields_for_test(1, 2, -1, 3),
+            SlopeTransitionState::from_fields_for_test(1, 2, 30, 0),
+        ];
+        for kind in [LocomotorKind::Drive, LocomotorKind::Ship] {
+            for stashed in [false, true] {
+                let baseline = hash_with_state(kind, stashed, base);
+                for variant in variants {
+                    assert_ne!(
+                        baseline,
+                        hash_with_state(kind, stashed, variant),
+                        "kind={kind:?} stashed={stashed} must hash every slope field"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
 mod playfield_authority_hash_tests {
     use super::Simulation;
     use crate::map::playfield::PlayfieldBounds;
@@ -1405,8 +1461,9 @@ impl Simulation {
                 0u8.hash(hasher);
             }
 
-            // Body rocking + slope-transition state. I16F16 doesn't implement
-            // Hash directly; .to_bits() gives the underlying i32.
+            // Body rocking state. I16F16 doesn't implement Hash directly;
+            // .to_bits() gives the underlying i32. Drive/Ship slope state is
+            // hashed with its active/stashed locomotor payload below.
             if let Some(ref r) = entity.rocking {
                 1u8.hash(hasher);
                 r.angle_sideways.to_bits().hash(hasher);
@@ -1414,9 +1471,6 @@ impl Simulation {
                 r.vel_sideways.to_bits().hash(hasher);
                 r.vel_forwards.to_bits().hash(hasher);
                 r.is_ship_rocking.hash(hasher);
-                r.prev_slope.hash(hasher);
-                r.curr_slope.hash(hasher);
-                r.transition_ticks_remaining.hash(hasher);
             } else {
                 0u8.hash(hasher);
             }
@@ -1520,7 +1574,10 @@ fn hash_locomotor_payload(
 ) {
     use crate::sim::movement::locomotion::piggyback::LocomotorRuntimePayload;
     match payload {
-        LocomotorRuntimePayload::Drive => 0u8.hash(hasher),
+        LocomotorRuntimePayload::Drive(state) => {
+            0u8.hash(hasher);
+            hash_slope_transition_state(state, hasher);
+        }
         LocomotorRuntimePayload::Walk => 1u8.hash(hasher),
         LocomotorRuntimePayload::Teleport(state) => {
             2u8.hash(hasher);
@@ -1540,11 +1597,28 @@ fn hash_locomotor_payload(
         }
         LocomotorRuntimePayload::Hover => 6u8.hash(hasher),
         LocomotorRuntimePayload::Mech => 7u8.hash(hasher),
-        LocomotorRuntimePayload::Ship => 8u8.hash(hasher),
+        LocomotorRuntimePayload::Ship(state) => {
+            8u8.hash(hasher);
+            hash_slope_transition_state(state, hasher);
+        }
         LocomotorRuntimePayload::Fly => 9u8.hash(hasher),
         LocomotorRuntimePayload::Jumpjet => 10u8.hash(hasher),
         LocomotorRuntimePayload::Parachute => 11u8.hash(hasher),
     }
+}
+
+fn hash_slope_transition_state(
+    state: &crate::sim::movement::slope_transition::SlopeTransitionState,
+    hasher: &mut impl Hasher,
+) {
+    // Native Drive/Ship raw-block persistence includes these defined fields;
+    // Load does not resample (`Save` 0x004AF800/0x0069EF10, shared raw writer
+    // 0x0055AA60). Hash every defined field for active and stash.
+    let (previous_slope, current_slope, start_frame, transition_total) = state.hash_fields();
+    previous_slope.hash(hasher);
+    current_slope.hash(hasher);
+    start_frame.hash(hasher);
+    transition_total.hash(hasher);
 }
 
 /// TeleportLocomotionClass::Process @ 0x007192f0 owns this complete, named

--- a/src/sim/world/world_spawn.rs
+++ b/src/sim/world/world_spawn.rs
@@ -175,8 +175,10 @@ fn object_uses_voxel(type_id: &str, object: &ObjectType, rules: &RuleSet) -> boo
 }
 
 /// A Foot object owns its configured locomotor independently of the parsed
-/// `Speed=` scalar. Drive/Ship constructor state is therefore load-bearing at
-/// Speed=0, while Structures remain outside Foot and other zero-speed custom
+/// `Speed=` scalar. `DriveLocomotionClass::Process @ 0x004B0500` and
+/// `ShipLocomotionClass::Process @ 0x0069FC10` consume their class-local state
+/// without a Speed gate. That state is therefore load-bearing at Speed=0,
+/// while Structures remain outside Foot and other zero-speed custom
 /// locomotors retain the existing inactive compatibility behavior.
 fn should_construct_locomotor(category: EntityCategory, object: &ObjectType) -> bool {
     object.speed > 0

--- a/src/sim/world/world_spawn.rs
+++ b/src/sim/world/world_spawn.rs
@@ -522,7 +522,11 @@ impl Simulation {
             if let Some(obj) = rules.and_then(|r| r.object(&map_ent.type_id)) {
                 if obj.speed > 0 {
                     let flight_level = rules.map_or(1500, |r| r.general.flight_level);
-                    let mut loco = LocomotorState::from_object_type(obj, flight_level);
+                    let mut loco = LocomotorState::from_object_type(
+                        obj,
+                        flight_level,
+                        self.session.binary_frame,
+                    );
                     if bridge_spawn.is_some() {
                         loco.layer = MovementLayer::Bridge;
                     }
@@ -971,6 +975,7 @@ impl Simulation {
             ge.locomotor = Some(LocomotorState::from_object_type(
                 obj,
                 rules.general.flight_level,
+                self.session.binary_frame,
             ));
             if ge.locomotor.as_ref().is_some_and(|locomotor| {
                 locomotor.kind == crate::rules::locomotor_type::LocomotorKind::Ship
@@ -1160,6 +1165,7 @@ impl Simulation {
             ge.locomotor = Some(LocomotorState::from_object_type(
                 obj,
                 rules.general.flight_level,
+                self.session.binary_frame,
             ));
             if ge.locomotor.as_ref().is_some_and(|locomotor| {
                 locomotor.kind == crate::rules::locomotor_type::LocomotorKind::Ship

--- a/src/sim/world/world_spawn.rs
+++ b/src/sim/world/world_spawn.rs
@@ -14,6 +14,7 @@ use super::{
 };
 use crate::map::entities::{EntityCategory, MapEntity};
 use crate::map::resolved_terrain::ResolvedTerrainGrid;
+use crate::rules::locomotor_type::LocomotorKind;
 use crate::rules::object_type::{FactoryType, ObjectCategory, ObjectType};
 use crate::rules::ruleset::RuleSet;
 use crate::sim::animation::{Animation, SequenceKind};
@@ -171,6 +172,18 @@ fn object_uses_voxel(type_id: &str, object: &ObjectType, rules: &RuleSet) -> boo
             object.category,
             ObjectCategory::Vehicle | ObjectCategory::Aircraft
         ))
+}
+
+/// A Foot object owns its configured locomotor independently of the parsed
+/// `Speed=` scalar. Drive/Ship constructor state is therefore load-bearing at
+/// Speed=0, while Structures remain outside Foot and other zero-speed custom
+/// locomotors retain the existing inactive compatibility behavior.
+fn should_construct_locomotor(category: EntityCategory, object: &ObjectType) -> bool {
+    object.speed > 0
+        || (matches!(
+            category,
+            EntityCategory::Unit | EntityCategory::Infantry | EntityCategory::Aircraft
+        ) && matches!(object.locomotor, LocomotorKind::Drive | LocomotorKind::Ship))
 }
 
 impl Simulation {
@@ -520,7 +533,7 @@ impl Simulation {
             }
             // Locomotor for movable entities.
             if let Some(obj) = rules.and_then(|r| r.object(&map_ent.type_id)) {
-                if obj.speed > 0 {
+                if should_construct_locomotor(map_ent.category, obj) {
                     let flight_level = rules.map_or(1500, |r| r.general.flight_level);
                     let mut loco = LocomotorState::from_object_type(
                         obj,
@@ -971,7 +984,7 @@ impl Simulation {
         }
         ge.zfudge_bridge = obj.zfudge_bridge;
         ge.too_big_to_fit_under_bridge = obj.too_big_to_fit_under_bridge;
-        if obj.speed > 0 {
+        if should_construct_locomotor(category, obj) {
             ge.locomotor = Some(LocomotorState::from_object_type(
                 obj,
                 rules.general.flight_level,
@@ -1161,7 +1174,7 @@ impl Simulation {
         }
         ge.zfudge_bridge = obj.zfudge_bridge;
         ge.too_big_to_fit_under_bridge = obj.too_big_to_fit_under_bridge;
-        if obj.speed > 0 {
+        if should_construct_locomotor(category, obj) {
             ge.locomotor = Some(LocomotorState::from_object_type(
                 obj,
                 rules.general.flight_level,


### PR DESCRIPTION
## Scope

Integrates only the completed Phase 3 Drive/Ship slope lifecycle slice onto current main.

- matches native Drive/Ship slope payload ownership and the signed three-frame timer
- preserves Foot/unlimbo/process ordering, tunnel restore, presentation pivot, and interpolation
- persists and hashes the typed runtime with snapshot version 104 to 105
- reconciles current-main fixtures without importing RawTrack or later-phase mechanisms
- updates only the deterministic hash ratchets measured from this exact composition

## Review

The builder/critic loop completed with a fresh final critic PASS. The critic rechecked the prior snapshot-contract correction and confirmed no later-scope work was imported.

## Validation

- slope_transition: 9 passed, 0 failed
- drive_ship: 13 passed, 0 failed
- rocking: 42 passed, 0 failed
- full cargo test -p vera20k --lib: 7603 passed, 0 failed, 76 ignored