### PR TITLE
Integrate Phase 3 Cell ground-height 104 domain

### DIFF
--- a/docs/plans/2026-07-18-spark-live-collision-adapter-and-owner-design.md
+++ b/docs/plans/2026-07-18-spark-live-collision-adapter-and-owner-design.md
@@ -116,14 +116,16 @@ Before implementation, a bounded Ghidra pass must prove:
   candidate `f32` Z selects ground/contact/clamp predicates. [GHIDRA
   `0x0062C6E0`]
 - Candidate X/Y are converted to the native cell frame with the exact verified
-  signed semantics; invalid cells use the native dummy-cell result, not `None` or
-  a clamped edge. [doc: collision report section `Cell and ground semantics`]
+  signed semantics. Rust now has the shared mutable dummy substrate in
+  `cell_rect`, but Spark still returns typed unavailable/off-array errors rather
+  than routing through it; that caller-specific integration remains open. [doc:
+  `PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md`]
 - Candidate ground includes signed terrain level and exact slope contribution.
   [GHIDRA `0x00578080`, `0x0047B3A0`; exact formula pending prerequisite]
 - The slope matrix is selected by the candidate cell's slope byte, not particle
   facing. [GHIDRA `0x006D6AD0`, `0x007559B0`]
 - Structural collision checks the live old-cell or candidate-cell `0x100` bit;
-  plane and equality rules remain `G+360`, with ascending commit `G+340`.
+  plane and equality rules use `G+416`, with ascending commit `G+396`.
   [doc: collision report section `Collision decision table`]
 - Building lookup scans the candidate ground object list and stops at the first
   `WhatAmI==6`; an excluded first building does not authorize unordered searching
@@ -194,7 +196,9 @@ rejected. It must not opportunistically add burst spawning, lights, or rendering
 
 - World-query input is the exact `SparkMotionStep`, not only a rounded cell.
 - Facts are owned values; no world borrow crosses the RNG call.
-- Missing ordinary cell data follows verified dummy semantics.
+- Missing ordinary cell data still returns a typed unavailable/error result in
+  Spark even though the shared dummy substrate exists; closing that routing is
+  separate mechanism work.
 - A genuinely unsupported prerequisite returns a typed unavailable/error result.
   It never substitutes flat ground, identity slope, static bridge state, or an
   ordinary building.

--- a/docs/plans/2026-07-18-spark-native-float-and-point-compositor-design.md
+++ b/docs/plans/2026-07-18-spark-native-float-and-point-compositor-design.md
@@ -168,12 +168,13 @@ is not production simulation code.
 - World-lepton to cell conversion divides by 256 with signed truncation toward
   zero. Invalid cells use native dummy-cell semantics.
   [doc: same §Cell and ground semantics]
-- Candidate ground uses candidate-cell level times 90 plus its slope-table
+- Candidate ground uses the verified common 104-lepton Cell evaluator plus its slope-table
   contribution. Cell axes are not isometric screen axes.
   [doc: same §Coordinate and numeric-frame diagram]
 - Structural crossing checks the old or candidate cell live bit 0x100. The
-  plane is G+360; descending and ascending equality sides differ; ascending
-  commits G+340.
+  plane is G+416; descending and ascending equality sides differ; ascending
+  commits G+396. These corrected numeric values come from
+  `PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md`.
   [doc: same §Collision decision table]
 - Near-ground clamping is strict: G-100 is not clamped. Building/wall contact
   is exactly [G,G+150).

--- a/docs/plans/2026-08-27-phase3-cell-ground-height-104-design.md
+++ b/docs/plans/2026-08-27-phase3-cell-ground-height-104-design.md
@@ -1,0 +1,342 @@
+# Phase 3 Cell ground-height 104-domain correction design
+
+**Phase/GSI ownership hypothesis:** Phase 3 / GSI-04.03, with shared lookup
+substrate dependencies in GSI-04.01
+
+**Bounded mechanism:** the active-retail `CellClass` ground-height scalar,
+slope evaluator, and the Rust consumers currently routed through the false
+90-lepton duplicate evaluator
+
+**Evidence:**
+`docs/research/PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md`
+
+## Verdict first
+
+Active retail does not have a 90-lepton Cell ground domain. The executable
+independently initializes the Cell, Foot, Techno/InRange, area-damage, Anim,
+Bullet, Particle, Unit, and VXL level scalars, but every captured value is 104.
+`CellClass::ComputeGroundHeightAtCoord @ 0x0047B3A0` consumes the Cell-owned
+104 directly. The nearby `90.0` literal is an angle used to derive `pi/6`, not
+a height.
+
+Rust already has the correct 104 evaluator and most consumers use it. A later
+regression added a second 90 evaluator and routed five production callsites
+through it. This slice removes that false numeric split, routes those callers
+through the one verified evaluator, preserves Spark's already-correct 104/416
+composition, rebaselines exact fixtures, and corrects the load-bearing stale
+documentation that introduced the split.
+
+This slice deliberately does not claim all of GSI-04.03 closed. The shared
+dummy/unavailable-cell behavior of height callers, shipped-map slope 17..20
+reachability, and remaining cliff/height consumer questions stay explicit row
+work after this numeric mechanism passes.
+
+## 1. Native contract
+
+### 1.1 Scalar and slope formula
+
+The Cell-owned scalar at `0x0089E7C0` is 104. For a signed `i8` Level byte and
+unsigned slope byte:
+
+```text
+base = ftol_chop(sign_extend_i8(Level) * 104 + 0.5)
+raw  = (local_y * coeff_y + local_x * coeff_x) * (104 / 256)
+       + bias_a + bias_b
+slope_term = clamp(raw, 0, maximum)
+height = ftol_chop(base + slope_term)
+```
+
+Local X/Y are the unsigned low bytes of the world coordinates. Slope 0 is
+flat; records 1..20 use the verified table. Rust must safely reject slopes
+above 20 rather than imitate native's unsafe out-of-table read.
+
+Flat examples are `Level 0 -> 0`, `1 -> 104`, `2 -> 208`, and byte `0xFF`
+(`-1`) -> `-103`. At cell center, slope contributions 0..20 are:
+
+```text
+0, 52, 52, 52, 52,
+0, 0, 0, 0,
+104, 104, 104, 104, 104, 104, 104, 104,
+52, 52, 52, 52
+```
+
+### 1.2 Floor and deck remain separate
+
+`CellClass::GetCoords @ 0x00486840` and
+`CellClass::Get_Center_Coords @ 0x00480A30` return the 104-based ground only.
+`CellClass::GetTargetCoords @ 0x00486890` adds the separately initialized 416
+only when raw `CellClass+0x140 & 0x100` is set. The common ground evaluator
+must never include bridge height.
+
+Spark calls `CellClass::GetGroundHeight @ 0x00578080` and therefore already
+uses 104. Its structural plane is `ground + 416`, and its ascending commit is
+`ground + 396`. Current Rust's Spark numeric choices match and must not change.
+
+### 1.3 Authority and exclusions
+
+- No rules, art, theater, map, or scenario INI writes these scalars.
+- Independently owned native globals do not imply different numeric domains.
+- No active symbol `MapClass::GetZPos` was verified; implementation comments
+  cite the proven Cell methods instead.
+- `90.0`, `RadLevelDelay=90`, and other timing/angle values are unrelated.
+- Malformed slopes above 20 remain a safe Rust error boundary.
+
+## 2. Current architecture and exact mismatch
+
+### 2.1 Correct authority to preserve
+
+`src/util/lepton.rs` already owns:
+
+- `LEPTONS_PER_LEVEL = 104`;
+- `GROUND_LEVEL_HEIGHT_LEPTONS = 104`;
+- one 104-derived 21-entry slope table;
+- `ground_height_leptons`, whose signed base, low-byte local coordinates,
+  clamp order, and chop behavior match native.
+
+`src/sim/cell_kernel.rs::cell_floor_height` and current Spark, Anim, radar
+visibility, combat/AoE, range, miner, overlay, smudge, radiation, lifecycle,
+tube, and runtime paths already consume this authority.
+
+### 2.2 False duplicate to remove
+
+`src/util/lepton.rs` also owns the incorrect:
+
+- `CELLCLASS_GROUND_LEVEL_HEIGHT_LEPTONS = 90`;
+- `CELLCLASS_GROUND_SLOPE_RECORDS` derived from 90;
+- `cellclass_ground_height_leptons` wrapper;
+- tests and prose asserting a separate 90 surface.
+
+Five production consumers use that duplicate:
+
+1. `src/render/minimap_interaction.rs` radar-click Cell center Z;
+2. `src/sim/naval_base_placement.rs` first-yard 3D candidate Z;
+3. `src/sim/projectile.rs` allocated real Cell target Z;
+4. `src/sim/projectile.rs` retained shared-dummy Cell target Z;
+5. `src/sim/production/production_spawn.rs` produced-unit Cell center
+   evaluation. This helper presently discards the computed Z after forming a
+   center and returns only X/Y-derived Cell coordinates, so changing 90 to 104
+   does not itself move the spawned unit. The call still must migrate because
+   it executes the native height/unsupported-slope gate and the duplicate API
+   must disappear.
+
+The duplicate makes flat Level 2 produce 180 instead of 208. Structural
+Level-2 targets become 596 instead of 624, and Sonic's additional +50 becomes
+646 instead of 674.
+
+### 2.3 Lookup behavior is not silently folded into this numeric change
+
+The repository already has the exact fixed-512 real-or-shared-dummy substrate
+in `src/sim/cell_rect.rs::{get_cellclass_fallback,
+get_cellclass_fallback_leptons}`. Production spawn and retained projectile
+dummy targets already use live dummy state. Other consumers still have
+caller-specific absence behavior:
+
+- minimap camera resolution returns `None` for an unavailable clamped Cell;
+- naval placement rejects an unavailable candidate;
+- Spark returns `UnavailableCell`/`OutOfRangeCell` instead of evaluating the
+  shared dummy;
+- the stable projectile helper's headless `unwrap_or(0)` is not the same as a
+  live nonzero dummy, while the distinct retained-dummy target path is live.
+
+Those differences remain open and must not be described as exact after this
+slice. They require their own caller/lifecycle proof because changing lookup
+selection affects overlay, bridge, occupancy, target identity, and mutation
+order in addition to numeric height.
+
+## 3. Design options
+
+### Option A — change the duplicate constant from 90 to 104
+
+This is numerically sufficient for current callsites but retains two slope
+tables and two APIs with identical active behavior. It preserves the exact
+failure mode that allowed the stale claim to diverge again. Rejected.
+
+### Option B — retain a Cell-named alias routed through the common evaluator
+
+This documents independent native ownership and eliminates numeric drift, but
+the alias still encourages callers to infer a semantic domain split that the
+binary disproves. It also leaves duplicate production vocabulary and test
+surface without providing a Rust ownership boundary. Rejected unless a compile
+dependency discovered during implementation makes immediate removal unsafe.
+
+### Option C — one verified evaluator and explicit provenance at consumers
+
+Remove the false Cell constant, duplicate table, and wrapper. Route all five
+callers through `ground_height_leptons`, while their nearby comments retain the
+specific native Cell method and bridge-selection provenance. Preserve
+independent semantic composition at the caller: ground only for GetCoords,
+ground plus conditional 416 for GetTargetCoords. Selected.
+
+## 4. Required implementation
+
+### 4.1 Consolidate the evaluator
+
+In `src/util/lepton.rs`:
+
+1. Correct the 104 constants' documentation to state that active retail's
+   independently initialized ground/object/VXL scalars resolve to the same
+   value.
+2. Remove `CELLCLASS_GROUND_LEVEL_HEIGHT_LEPTONS`.
+3. Remove `CELLCLASS_GROUND_SLOPE_RECORDS`.
+4. Remove `cellclass_ground_height_leptons`.
+5. Make the `ground_height_leptons` documentation cite
+   `CellClass::ComputeGroundHeightAtCoord @ 0x0047B3A0` and describe the shared
+   verified 104 numeric formula without implying bridge inclusion.
+6. Replace the false 90-specific unit test with one discriminating 104 Cell
+   contract covering flat levels, signed `0xFF`, all 0..20 center records, and
+   unsupported 21.
+7. Correct `src/sim/cell_kernel.rs::cell_floor_height`'s invented
+   `CellClass::GetFloorHeight` label to the verified inner
+   `CellClass::ComputeGroundHeightAtCoord @ 0x0047B3A0` identity.
+
+No floating-point approximation, new table, or schema field is introduced.
+
+### 4.2 Route all false consumers
+
+Replace the removed helper at each of the five production callsites with
+`ground_height_leptons`. Keep existing safe unsupported-slope handling and
+existing caller-specific lookup selection unchanged in this numeric slice.
+
+Update nearby source comments so they say:
+
+- Cell ground is 104;
+- GetCoords remains ground-only;
+- GetTargetCoords adds 416 only for raw structural bit `0x100`;
+- Spark already uses the same ground evaluator;
+- independent native globals are ownership detail, not numeric domains.
+
+No consumer may multiply Level directly as a shortcut; every slope-aware path
+uses the common evaluator.
+
+### 4.3 Rebaseline dependent tests and snapshots
+
+Update assertions whose only difference is the corrected ground result,
+including the known projectile/dummy, bridge, combat, snapshot, lifecycle,
+world/Wave, naval, minimap, and production fixtures found by repository-wide
+search. Expected compositions include:
+
+```text
+Level 2 ground                       = 208
+Level 2 structural Cell target       = 624
+Level 2 structural Cell + Sonic 50   = 674
+Spark Level 2 structural plane       = 624
+Spark Level 2 ascending commit       = 604
+```
+
+This changes deterministic behavior without changing serialized shape. The
+repository's snapshot contract rejects old bytes whenever they would resume
+under different authoritative logic: versions 78 and 79 already establish
+behavior/hash-only precedents. A v110 save can retain a Cell target or pending
+world state that produces different raised-terrain results after this repair.
+Therefore `SNAPSHOT_VERSION` advances 110 -> 111, the version history records
+the behavior-only ground-domain boundary, the exact version test moves to 111,
+and v110 rejection remains covered. Stored expected hashes/coordinates are
+rebaselined only where the verified 104 result flows into them.
+
+### 4.4 Correct stale evidence and design prose
+
+Update the load-bearing wrong claims in:
+
+- `docs/research/PARTICLE_SPARK_LIVE_COLLISION_INPUTS_GHIDRA_REPORT.md`;
+- `docs/research/PARTICLE_SPARK_COLLISION_AND_PIXEL_COMPOSITOR_GHIDRA_REPORT.md`;
+- `docs/research/PHASE3_NAVAL_BASE_PLACEMENT_LIFECYCLE_GHIDRA_REPORT.md`;
+- `docs/plans/2026-07-18-spark-native-float-and-point-compositor-design.md`;
+- `docs/plans/2026-07-18-spark-live-collision-adapter-and-owner-design.md`;
+- `docs/plans/2026-08-26-naval-base-placement-design.md`.
+
+Each correction cites the new active-runtime census and changes 90 -> 104,
+`G+360` -> `G+416`, and `G+340` -> `G+396` where applicable. It must not
+rewrite unrelated historical design decisions. Older documents that clearly
+label 90 as approximate/unverified remain historical leads; they are not used
+as active evidence.
+
+The live-collision report's stale lookup conclusion is corrected as well:
+Rust now has a mutable process-global shared-dummy substrate, but Spark's
+adapter is not yet routed through it and still returns typed unavailable/off-
+array errors. The substrate is present; Spark integration remains an open
+caller-specific parity gap. A supersession banner alone is acceptable for a
+large historical report only if it names every invalid numeric conclusion and
+the dummy-routing correction prominently enough that its old handoff cannot be
+mistaken for current evidence.
+
+Do not mechanically replace unrelated 360 values. In particular, the
+Ship-locomotion under-bridge Z-offset owns a separate native global and remains
+outside this Cell/Spark numeric slice until independently verified.
+
+## 5. Acceptance ledger
+
+### Evaluator
+
+- Flat `0,1,2,0xFF` return `0,104,208,-103`.
+- Slope 0..20 at center yields the exact sequence in section 1.1.
+- Low-byte local XY, clamp-before-base, final chop, and signed negative behavior
+  remain covered at representative boundaries.
+- Slope 21 returns `UnsupportedGroundSlope(21)`.
+- No `CELLCLASS_GROUND_LEVEL_HEIGHT_LEPTONS`, duplicate Cell slope table, or
+  `cellclass_ground_height_leptons` identifier remains.
+
+### Production consumers
+
+- Radar click on a raised Cell reports the 104-based center Z and still excludes
+  bridge height.
+- Naval first-yard distance changes only by the corrected candidate Z and keeps
+  first-yard ordering, foundation center, signed cap, and no-yard bypass.
+- Real and retained-dummy projectile targets use 104 ground; raw structural bit
+  adds exactly 416.
+- Production spawn evaluates the selected real-or-dummy Cell through the 104
+  authority and retains the native unsupported-slope gate, while its current
+  X/Y-only returned spawn Cell remains unchanged because the intermediate Z is
+  discarded.
+- Sonic/Wave target composition on Level 2 structural terrain is 674.
+
+### Preservation
+
+- Spark Level-2 floor is 208, plane is 624, ascending commit is 604, and
+  Level-0 plane remains 416.
+- Particle construction clamps input `Z <= ground` to the 104-based floor.
+- Existing correct 104 consumers do not change APIs or add bridge height.
+- Bridge selection changes only the conditional +416 term.
+- No RNG, scheduling, ownership, object identity, or serialized layout changes;
+  snapshot compatibility advances to 111 for the deterministic behavior-only
+  boundary.
+
+### Documentation and residual honesty
+
+- Active source/research/design prose no longer calls Cell ground 90.
+- Stale `G+360`/`G+340` Spark claims are corrected.
+- Caller-specific unavailable-cell/shared-dummy divergences remain explicitly
+  open; no test or comment calls them exact merely because the scalar is fixed.
+
+## 6. Validation and review cadence
+
+The builder checks `Get-Process cargo,rustc` before every Cargo command and
+runs only focused library filters, for example:
+
+```text
+cargo test -p vera20k --lib ground_height
+cargo test -p vera20k --lib native_click
+cargo test -p vera20k --lib first_yard
+cargo test -p vera20k --lib dummy_target
+cargo test -p vera20k --lib sonic
+cargo test -p vera20k --lib production_spawn
+cargo test -p vera20k --lib spark
+cargo test -p vera20k --lib snapshot
+```
+
+The phase-wide full `cargo test -p vera20k --lib` remains reserved for final
+Phase 3 certification.
+
+After the builder commits, a fresh read-only critic receives this design, the
+native census, the full diff, and literal focused output. PASS requires zero
+open, approximate, missing, or regressed behavior inside this numeric domain
+mechanism. Any finding is repaired by the same builder and resubmitted to a new
+critic. GSI-04.03 remains open after PASS for the separately recorded lookup,
+slope-reachability, cliff, and remaining height-consumer work.
+
+## 7. Decision
+
+Option C is the smallest architecture-correct repair. It restores active
+retail's one numeric ground formula, preserves the correct Spark path and
+caller-owned bridge composition, deletes the duplicate drift surface, and
+leaves distinct lookup-lifecycle disparities visible for their own evidence
+and builder/critic loop.

--- a/docs/plans/2026-08-27-phase3-cell-ground-height-104-design.md
+++ b/docs/plans/2026-08-27-phase3-cell-ground-height-104-design.md
@@ -10,6 +10,15 @@ slope evaluator, and the Rust consumers currently routed through the false
 **Evidence:**
 `docs/research/PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md`
 
+**Integration rebase (2026-08-30):** This design was authored on the source
+branch, where a separate naval-placement slice existed and the accumulated
+snapshot version was 110. Current `origin/main` has no naval-placement module
+or its two documents, and this integration intentionally does not restore that
+later AI/naval scope. The current slice therefore migrates four active
+production callsites and advances the actual mainline snapshot contract
+`105 -> 106`. Source-branch naval facts below are retained only when explicitly
+labelled as historical/later-owner context.
+
 ## Verdict first
 
 Active retail does not have a 90-lepton Cell ground domain. The executable
@@ -20,11 +29,12 @@ Bullet, Particle, Unit, and VXL level scalars, but every captured value is 104.
 a height.
 
 Rust already has the correct 104 evaluator and most consumers use it. A later
-regression added a second 90 evaluator and routed five production callsites
-through it. This slice removes that false numeric split, routes those callers
-through the one verified evaluator, preserves Spark's already-correct 104/416
-composition, rebaselines exact fixtures, and corrects the load-bearing stale
-documentation that introduced the split.
+regression added a second 90 evaluator. The source branch routed five
+production callsites through it; current main retains four because the
+separate naval-placement slice is absent. This integration removes that false
+numeric split from all four active callers, preserves Spark's already-correct
+104/416 composition, rebaselines exact fixtures, and corrects the load-bearing
+stale documentation that introduced the split.
 
 This slice deliberately does not claim all of GSI-04.03 closed. The shared
 dummy/unavailable-cell behavior of height callers, shipped-map slope 17..20
@@ -106,18 +116,24 @@ tube, and runtime paths already consume this authority.
 - `cellclass_ground_height_leptons` wrapper;
 - tests and prose asserting a separate 90 surface.
 
-Five production consumers use that duplicate:
+Four production consumers present on the current integration base used that
+duplicate before this slice:
 
 1. `src/render/minimap_interaction.rs` radar-click Cell center Z;
-2. `src/sim/naval_base_placement.rs` first-yard 3D candidate Z;
-3. `src/sim/projectile.rs` allocated real Cell target Z;
-4. `src/sim/projectile.rs` retained shared-dummy Cell target Z;
-5. `src/sim/production/production_spawn.rs` produced-unit Cell center
+2. `src/sim/projectile.rs` allocated real Cell target Z;
+3. `src/sim/projectile.rs` retained shared-dummy Cell target Z;
+4. `src/sim/production/production_spawn.rs` produced-unit Cell center
    evaluation. This helper presently discards the computed Z after forming a
    center and returns only X/Y-derived Cell coordinates, so changing 90 to 104
    does not itself move the spawned unit. The call still must migrate because
    it executes the native height/unsupported-slope gate and the duplicate API
    must disappear.
+
+The source branch also had a fifth caller in
+`src/sim/naval_base_placement.rs`. That module and its design/research files
+are absent from current main and are intentionally not restored by this slice.
+Its verified 104 requirement belongs to the later owner if that naval
+mechanism is integrated separately.
 
 The duplicate makes flat Level 2 produce 180 instead of 208. Structural
 Level-2 targets become 596 instead of 624, and Sonic's additional +50 becomes
@@ -132,7 +148,6 @@ dummy targets already use live dummy state. Other consumers still have
 caller-specific absence behavior:
 
 - minimap camera resolution returns `None` for an unavailable clamped Cell;
-- naval placement rejects an unavailable candidate;
 - Spark returns `UnavailableCell`/`OutOfRangeCell` instead of evaluating the
   shared dummy;
 - the stable projectile helper's headless `unwrap_or(0)` is not the same as a
@@ -161,11 +176,11 @@ dependency discovered during implementation makes immediate removal unsafe.
 
 ### Option C — one verified evaluator and explicit provenance at consumers
 
-Remove the false Cell constant, duplicate table, and wrapper. Route all five
-callers through `ground_height_leptons`, while their nearby comments retain the
-specific native Cell method and bridge-selection provenance. Preserve
-independent semantic composition at the caller: ground only for GetCoords,
-ground plus conditional 416 for GetTargetCoords. Selected.
+Remove the false Cell constant, duplicate table, and wrapper. Route all four
+active current-main callers through `ground_height_leptons`, while their nearby
+comments retain the specific native Cell method and bridge-selection
+provenance. Preserve independent semantic composition at the caller: ground
+only for GetCoords, ground plus conditional 416 for GetTargetCoords. Selected.
 
 ## 4. Required implementation
 
@@ -193,9 +208,13 @@ No floating-point approximation, new table, or schema field is introduced.
 
 ### 4.2 Route all false consumers
 
-Replace the removed helper at each of the five production callsites with
+Replace the removed helper at each of the four active production callsites with
 `ground_height_leptons`. Keep existing safe unsupported-slope handling and
 existing caller-specific lookup selection unchanged in this numeric slice.
+
+Do not restore the source branch's deleted naval-placement caller. If a later
+owner integrates that mechanism, it must use the same evaluator under its own
+scope and review.
 
 Update nearby source comments so they say:
 
@@ -212,7 +231,7 @@ uses the common evaluator.
 
 Update assertions whose only difference is the corrected ground result,
 including the known projectile/dummy, bridge, combat, snapshot, lifecycle,
-world/Wave, naval, minimap, and production fixtures found by repository-wide
+world/Wave, minimap, and production fixtures found by repository-wide
 search. Expected compositions include:
 
 ```text
@@ -226,11 +245,11 @@ Spark Level 2 ascending commit       = 604
 This changes deterministic behavior without changing serialized shape. The
 repository's snapshot contract rejects old bytes whenever they would resume
 under different authoritative logic: versions 78 and 79 already establish
-behavior/hash-only precedents. A v110 save can retain a Cell target or pending
+behavior/hash-only precedents. A v105 save can retain a Cell target or pending
 world state that produces different raised-terrain results after this repair.
-Therefore `SNAPSHOT_VERSION` advances 110 -> 111, the version history records
-the behavior-only ground-domain boundary, the exact version test moves to 111,
-and v110 rejection remains covered. Stored expected hashes/coordinates are
+Therefore `SNAPSHOT_VERSION` advances 105 -> 106, the version history records
+the behavior-only ground-domain boundary, the exact version test moves to 106,
+and v105 rejection remains covered. Stored expected hashes/coordinates are
 rebaselined only where the verified 104 result flows into them.
 
 ### 4.4 Correct stale evidence and design prose
@@ -239,10 +258,12 @@ Update the load-bearing wrong claims in:
 
 - `docs/research/PARTICLE_SPARK_LIVE_COLLISION_INPUTS_GHIDRA_REPORT.md`;
 - `docs/research/PARTICLE_SPARK_COLLISION_AND_PIXEL_COMPOSITOR_GHIDRA_REPORT.md`;
-- `docs/research/PHASE3_NAVAL_BASE_PLACEMENT_LIFECYCLE_GHIDRA_REPORT.md`;
 - `docs/plans/2026-07-18-spark-native-float-and-point-compositor-design.md`;
-- `docs/plans/2026-07-18-spark-live-collision-adapter-and-owner-design.md`;
-- `docs/plans/2026-08-26-naval-base-placement-design.md`.
+- `docs/plans/2026-07-18-spark-live-collision-adapter-and-owner-design.md`.
+
+The two naval-placement documents named by the source-branch design are absent
+from current main and remain excluded with their implementation. This
+integration does not recreate them merely to patch historical prose.
 
 Each correction cites the new active-runtime census and changes 90 -> 104,
 `G+360` -> `G+416`, and `G+340` -> `G+396` where applicable. It must not
@@ -279,8 +300,6 @@ outside this Cell/Spark numeric slice until independently verified.
 
 - Radar click on a raised Cell reports the 104-based center Z and still excludes
   bridge height.
-- Naval first-yard distance changes only by the corrected candidate Z and keeps
-  first-yard ordering, foundation center, signed cap, and no-yard bypass.
 - Real and retained-dummy projectile targets use 104 ground; raw structural bit
   adds exactly 416.
 - Production spawn evaluates the selected real-or-dummy Cell through the 104
@@ -297,8 +316,10 @@ outside this Cell/Spark numeric slice until independently verified.
 - Existing correct 104 consumers do not change APIs or add bridge height.
 - Bridge selection changes only the conditional +416 term.
 - No RNG, scheduling, ownership, object identity, or serialized layout changes;
-  snapshot compatibility advances to 111 for the deterministic behavior-only
+  snapshot compatibility advances to 106 for the deterministic behavior-only
   boundary.
+- No deleted naval-placement module or document is restored. Its 104-based
+  candidate requirement remains a later-owner obligation.
 
 ### Documentation and residual honesty
 
@@ -315,7 +336,6 @@ runs only focused library filters, for example:
 ```text
 cargo test -p vera20k --lib ground_height
 cargo test -p vera20k --lib native_click
-cargo test -p vera20k --lib first_yard
 cargo test -p vera20k --lib dummy_target
 cargo test -p vera20k --lib sonic
 cargo test -p vera20k --lib production_spawn
@@ -323,8 +343,8 @@ cargo test -p vera20k --lib spark
 cargo test -p vera20k --lib snapshot
 ```
 
-The phase-wide full `cargo test -p vera20k --lib` remains reserved for final
-Phase 3 certification.
+The integration owner runs the full `cargo test -p vera20k --lib` exactly once
+after the final critic pass and before declaring the small PR ready for main.
 
 After the builder commits, a fresh read-only critic receives this design, the
 native census, the full diff, and literal focused output. PASS requires zero

--- a/docs/plans/2026-08-27-phase3-drive-ship-slope-transition-design.md
+++ b/docs/plans/2026-08-27-phase3-drive-ship-slope-transition-design.md
@@ -444,8 +444,11 @@ the stable-matrix rules of excluded classes.
   `0|3`. Keep fields private so normal Rust writers cannot create anything
   else. Debug assertions may flag internal incoherence, but gameplay code does
   not repair it by borrowing terrain or another component.
-- There is no payload default. Missing payload bytes in a version-105 record
-  are a decode error, and no fallback constructs Drive state at frame zero.
+- There is no payload default. Historically, the slope-payload change advanced
+  schema 104 -> 105 so missing payload bytes could not default to Drive state at
+  frame zero. The later Cell ground-height correction advanced 105 -> 106; the
+  current loader rejects a v105 preamble before body decode, so missing v105
+  payload bytes no longer reach deserialization.
 - A missing terrain grid or out-of-grid current cell in synthetic fixtures is
   a no-write result. It must not become a slope-zero transition and must not
   make ordinary movement fail.
@@ -516,9 +519,11 @@ production-path discriminating rather than manually attaching `RockingState`.
     tests with body-only `RockingState`. Prove slope construction leaves
     `entity.rocking` unchanged and body rocking never writes the locomotor
     payload.
-14. **Schema boundary:** current snapshots report version `105`; a version
-    `104` preamble is rejected before body decode. The round trip includes both
-    an active and a stashed Drive/Ship slope payload. A nonzero-frame ordinary
+14. **Schema boundary:** the slope change historically advanced snapshots
+    `104 -> 105`; the later Cell ground-height correction advanced `105 -> 106`.
+    Current snapshots report version `106`, and the loader rejects v105 (as well
+    as older) preambles before body decode. The round trip includes both an
+    active and a stashed Drive/Ship slope payload. A nonzero-frame ordinary
     constructor and fresh piggyback replacement must retain that frame before
     reveal/sampling; no default/omitted payload path may create frame zero.
 

--- a/docs/research/PARTICLE_SPARK_COLLISION_AND_PIXEL_COMPOSITOR_GHIDRA_REPORT.md
+++ b/docs/research/PARTICLE_SPARK_COLLISION_AND_PIXEL_COMPOSITOR_GHIDRA_REPORT.md
@@ -7,6 +7,14 @@
 **Confidence:** HIGH for the static movement, collision, draw-gate, A-buffer, Z-buffer, color, and surface-write mechanisms; PARTIAL for a retail-mode final packed pixel because no running `gamemd.exe` process was available to capture the active DirectDraw masks or a native pixel  
 **Implementation scope:** none; this document contains research and a handoff only
 
+**2026-08-27 numeric correction:** active runtime capture in
+`PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md`
+supersedes the original HIGH-confidence 90/360/340 conclusions in this static
+report. Cell ground is 104, Particle's independently owned structural offset is
+416, and Spark's ascending commit is ground +396. The collision inequalities,
+float integration, RNG, and compositor findings remain independently verified;
+the affected numeric text below has been corrected.
+
 ## Verdict
 
 The two load-bearing roots are live, Ghidra-backed active-YR mechanisms, and both are now sufficiently recovered for a separate implementation-contract step.
@@ -58,10 +66,10 @@ Merged YR authority is base `ini/rules.ini` patched by `ini/rulesmd.ini`.
 | `WeldingSpark` start colors | `(80,255,255)` and `(255,255,100)` |
 | `WeldingSpark` ColorList | `(0,128,255)`, `(255,255,255)`, `(200,200,150)`, `(80,80,80)`, `(0,0,0)` |
 | Spark-family ground fixture height | `0` leptons on a flat level-zero cell |
-| Terrain level step | `90` leptons |
-| Structural bridge plane offset | `360` leptons (`4 * 90`) |
+| Terrain level step | `104` leptons |
+| Structural bridge plane offset | `416` leptons (`4 * 104`) |
 
-Evidence: direct reads of the stock INIs; Ghidra initializers `0x0047B220`, `0x0062B4A0`, and `0x0062B540` derive the 90-lepton level and 360-lepton bridge offset.
+Evidence: direct reads of the stock INIs plus the active-runtime capture and initializer correction in `PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md`; Ghidra initializers `0x0047B220`, `0x0062B4A0`, and `0x0062B540` resolve the 104-lepton level and independently owned 416-lepton bridge offset.
 
 ## Field ledger
 
@@ -117,7 +125,7 @@ Evidence: root disassembly/decompilation, `ParticleClass` constructor `0x0062B5E
 | Candidate coordinate | old world coordinate plus probe, `f32` | `0x0043A100` adds the vector; `Math__ftol` truncates to signed integer components | candidate `CoordStruct`, signed `i32` world leptons |
 | Cell selection | candidate X/Y, signed world leptons | `(v + ((v >> 31) & 255)) >> 8` | signed cell coordinate, truncation toward zero by 256 |
 | Terrain query | candidate cell | cell terrain level/slope lookup | ground height, signed world-Z leptons; slope byte |
-| Bridge query | old and candidate cells plus Z | cell flag `0x100`, compare with `ground + 360` | collision kind and snapped world-Z |
+| Bridge query | old and candidate cells plus Z | cell flag `0x100`, compare with `ground + 416` | collision kind and snapped world-Z |
 | Slope-local impact probe | `(vx, -vy, old_vz - 2g)`, `f32` | inverse slope matrix, negate local Z, forward slope matrix, negate final Y | stack-local reflected vector, `f32`; not persistent |
 | Commit | selected candidate/snap/clamp coordinate | three signed dword stores to particle coordinate | `ParticleClass+0x9C..+0xA4` |
 | Draw projection | signed world leptons | isometric integer projection plus Z adjustment and tactical offsets | signed client/surface pixel coordinate |
@@ -222,11 +230,11 @@ The original and inverse transforms are `f32`. The operation defines the axis-si
 
 Both `0x00578080` and `0x00565730` reduce signed world X/Y to cell axes by truncation toward zero at 256 leptons per cell. Negative coordinates therefore do not arithmetic-floor. Invalid coordinates return the dummy cell at `0x00ABDC50` and record the packed requested cell.
 
-Ground height is based on signed cell terrain level (`CellClass+0x11B`) times the 90-lepton level height plus slope-table contribution from `CellClass+0x11C`. The candidate coordinate, not the old coordinate, supplies the primary cell and ground query. Old and new cells are both consulted for the structural-bridge crossing test.
+Ground height is based on signed cell terrain level (`CellClass+0x11B`) times the 104-lepton level height plus slope-table contribution from `CellClass+0x11C`. The candidate coordinate, not the old coordinate, supplies the primary cell and ground query. Old and new cells are both consulted for the structural-bridge crossing test.
 
 ### Collision decision table
 
-Let `G` be candidate-cell ground height and `P = G + 360` be the structural bridge plane.
+Let `G` be candidate-cell ground height and `P = G + 416` be the structural bridge plane.
 
 | Condition | Exact predicate | Resulting Z | Delete byte |
 |---|---|---:|---|
@@ -283,13 +291,13 @@ Inputs: flat cell, `G=0`, slope index `0`, no bridge/building/wall; world coordi
 
 ### Trace 2 — structural bridge crossings
 
-Inputs: flat ground `G=0`, old or new cell has structural bit `0x100`, so `P=360`.
+Inputs: flat ground `G=0`, old or new cell has structural bit `0x100`, so `P=416`.
 
 | Variant | Old state and velocity | Stored/probe Z | Candidate | Predicate/result |
 |---|---|---|---:|---|
-| Descending | `oldZ=370`, `old_vz=0` | stored `-6`, probe `-12` | `358` | `358 < 360` and `370 >= 360`; snap to `360`, delete |
-| Ascending | `oldZ=350`, `old_vz=30` | stored `24`, probe `18` | `368` | `368 >= 360` and `350 < 360`; force to `340`, delete |
-| Equality boundary | choose probe yielding `newZ=360` from above | data-dependent | `360` | descending predicate false because it requires `newZ < 360` |
+| Descending | `oldZ=426`, `old_vz=0` | stored `-6`, probe `-12` | `414` | `414 < 416` and `426 >= 416`; snap to `416`, delete |
+| Ascending | `oldZ=406`, `old_vz=30` | stored `24`, probe `18` | `424` | `424 >= 416` and `406 < 416`; force to `396`, delete |
+| Equality boundary | choose probe yielding `newZ=416` from above | data-dependent | `416` | descending predicate false because it requires `newZ < 416` |
 
 Both collision variants then commit, consume the color RNG step, decrement lifetime, and enter same-tick cleanup eligibility.
 
@@ -546,7 +554,7 @@ There are no `OPEN` items. Deferred items require runtime evidence unavailable i
 | F04 | Which coordinate selects cell/ground? | RESOLVED | candidate coordinate; old cell additionally participates in bridge-flag test |
 | F05 | How do signed world coordinates become cells? | RESOLVED | truncation toward zero by 256 |
 | F06 | What does cell bit `0x100` mean here? | RESOLVED | active structural/high-bridge body/deck flag |
-| F07 | What is bridge plane? | RESOLVED | candidate ground plus 360 leptons |
+| F07 | What is bridge plane? | RESOLVED | candidate ground plus 416 leptons |
 | F08 | What are crossing inequalities? | RESOLVED | descending `< / >=`; ascending `>= / <` as tabulated |
 | F09 | What is ground clamp boundary? | RESOLVED | clamp only when `G-100 < newZ` |
 | F10 | What is building/wall band? | RESOLVED | `[G,G+150)` |
@@ -562,8 +570,8 @@ There are no `OPEN` items. Deferred items require runtime evidence unavailable i
 | F20 | Does collision consume color RNG? | RESOLVED | yes, after coordinate/delete work |
 | F21 | When is deletion observed? | RESOLVED | reverse cleanup in same owning Spark-system tick |
 | F22 | What if lifetime starts at zero? | RESOLVED | decrements to `-1`; no lifetime equality deletion |
-| M01 | What is terrain level height? | RESOLVED | 90 leptons from active initializer |
-| M02 | What is structural bridge offset? | RESOLVED | 360 leptons from active initializer |
+| M01 | What is terrain level height? | RESOLVED | 104 leptons from active runtime and initializer |
+| M02 | What is structural bridge offset? | RESOLVED | 416 leptons from the Particle-owned initializer |
 | M03 | Is this subterranean/Tube logic? | RESOLVED | no |
 | P01 | What is exact point caller chain? | RESOLVED | tactical `+0x104` → `ObjectClass::DrawIt` → Particle `+0x114` |
 | P02 | Is Particle `+0x110` the draw call? | RESOLVED | no; it targets a `RET 8` stub |
@@ -602,8 +610,8 @@ This is not an implementation contract and authorizes no code change. It states 
 | Spawn/state | Spark particles must carry signed world-lepton coordinates, three `f32` velocity components, per-particle RGB, signed index, `f64` accumulator, signed `i16` lifetime, and delete byte semantics | `spawn.rs` rejects Spark/Railgun; Rust uses `IVec3`, fixed-point direction/scalar velocity, drift fields, RGB/index/accumulator abstractions | MISSING/DRIFT; prove a Rust-native state mapping that preserves every native conversion and byte-visible result |
 | AI dispatch/order | forward particle AI, collision commit, color RNG, signed lifetime decrement, reverse cleanup | system AI currently no-ops Spark/Railgun | MISSING; preserve exact owner iteration and RNG consumption |
 | Gravity/motion | persistent `old_vz-g`, candidate probe `old_vz-2g`, `f32` addition, `Math__ftol` component conversion | simulation math uses fixed point by architecture rule | DRIFT until exact equivalence is positively proved; a contract must reconcile the project fixed-point rule with native `f32`/x87-visible outputs |
-| Terrain/cell | truncation-toward-zero `/256`, candidate-ground query, 90-lepton levels, slope byte | resolved terrain/map surfaces exist | UNCHECKED; add the smallest read-only sim query with exact frames and signed conversion |
-| Bridges | old/new structural bit, plane `ground+360`, asymmetric crossing snaps | bridge state/topology surfaces exist | UNCHECKED; query active structural/deck state without render dependency or Tube/subterranean conflation |
+| Terrain/cell | truncation-toward-zero `/256`, candidate-ground query, 104-lepton levels, slope byte | resolved terrain/map surfaces exist | UNCHECKED; add the smallest read-only sim query with exact frames and signed conversion |
+| Bridges | old/new structural bit, plane `ground+416`, asymmetric crossing snaps | bridge state/topology surfaces exist | UNCHECKED; query active structural/deck state without render dependency or Tube/subterranean conflation |
 | Occupancy | first linked building order, laser-fence and 1x1 exceptions, sentinel wall overlays | occupancy/entity store exist but ordering equivalence is unproved | DRIFT/UNCHECKED; do not replace first-match semantics with unordered presence |
 | Collision result | coordinate commit plus delete byte; no bounce/impact velocity write | no Spark implementation | MISSING; avoid inventing persistent reflected velocity |
 | Point projection | exact native integer isometric conversion, data-driven Z multiplier, offsets, clip | app particle builder uses sprite presentation | MISSING/DRIFT; a distinct point compositor is required |

--- a/docs/research/PARTICLE_SPARK_LIVE_COLLISION_INPUTS_GHIDRA_REPORT.md
+++ b/docs/research/PARTICLE_SPARK_LIVE_COLLISION_INPUTS_GHIDRA_REPORT.md
@@ -12,20 +12,26 @@
 
 **Implementation scope:** none; this report is a research handoff and intentionally changes no Rust code
 
+**2026-08-27 numeric correction:** active runtime capture in
+`PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md`
+supersedes this report's original 90/360/340 interpretation. Cell ground is
+104; Particle's independently owned structural offset is 416; Spark's
+ascending commit is ground +396. The text below incorporates that correction.
+
 ## Verdict
 
 The live-input prerequisites for the approved Spark collision adapter are closed for valid stock map cells.
 
 The adapter must not approximate these inputs:
 
-- ground height uses a signed cell conversion, a flattened 512-stride lookup, a 90-lepton level step, and one of 20 slope records;
+- ground height uses a signed cell conversion, a flattened 512-stride lookup, the active-retail 104-lepton Cell scalar, and one of 20 slope records;
 - Spark queries a 3x4 `f32` matrix by the candidate cell's slope byte, including identity for slope 0 and an all-zero matrix for slopes 17-20;
 - the structural bridge test is the live `CellClass+0x140 & 0x100` bit, not the presence of a bridge overlay or a generic deck height;
 - high-bridge collapse clears `0x100`, and engineer repair does **not** restore it—an active native quirk;
 - `Gravity` is an `i32` rule with constructor default 3 and stock override 6, while `ColorSpeed` is stored as the exact `f64` widening of an INI-parsed `f32`;
 - the stock LaserFence exception is compiled and reachable only when a type enables it; stock rules do not enable it.
 
-The current Rust owners already contain most source facts, but two precision changes are mandatory before activation: retain `Gravity` as the native integer-derived `f32` input, and retain `ColorSpeed` as native `f64` bits instead of `SimFixed`. Invalid/dummy-cell parity is deliberately outside this slice; the adapter must return a typed unavailable/error result there and must not substitute height zero, identity slope, or missing collision facts.
+The current Rust owners already contain most source facts, but two precision changes are mandatory before activation: retain `Gravity` as the native integer-derived `f32` input, and retain `ColorSpeed` as native `f64` bits instead of `SimFixed`. The shared mutable dummy substrate now exists in `src/sim/cell_rect.rs`; Spark's adapter is not yet routed through it and still returns a typed unavailable/error result rather than substituting height zero, identity slope, or missing collision facts. That caller-specific routing remains open.
 
 ## 1. Scope, duplication check, and source order
 
@@ -100,7 +106,7 @@ This is signed truncation toward zero by 256. Concrete fixtures:
 
 The lookup then forms `linear = cell_y * 0x200 + cell_x`. It validates the flattened result and pointer, not X and Y independently. Consequently, an individually out-of-range axis can alias an in-range flattened slot. A Rust helper that bounds-checks X/Y separately is not equivalent at this boundary.
 
-On failure or null pointer, the wrapper uses the shared dummy cell at `0x00ABDC50`, writes the requested packed cell coordinate at dummy `+0x24` (`0x00ABDC74`), and calls the same inner ground function. `CellClass::Constructor @ 0x0047BBF0`, reached for the dummy at the end of the `MapClass::Resize` path around `0x005670E7`, initializes dummy level `+0x11B` and slope `+0x11C` to zero. Other off-map helpers can mutate shared dummy state later. Because Rust does not model that shared mutable dummy contract, an invalid/dummy lookup must be reported as unavailable rather than silently treated as a flat level-zero cell.
+On failure or null pointer, the wrapper uses the shared dummy cell at `0x00ABDC50`, writes the requested packed cell coordinate at dummy `+0x24` (`0x00ABDC74`), and calls the same inner ground function. `CellClass::Constructor @ 0x0047BBF0`, reached for the dummy at the end of the `MapClass::Resize` path around `0x005670E7`, initializes dummy level `+0x11B` and slope `+0x11C` to zero. Other off-map helpers can mutate shared dummy state later. Rust now models the shared mutable substrate in `cell_rect`, but Spark has not integrated it; its adapter must continue reporting typed unavailable state until that separate routing mechanism is verified and implemented.
 
 Evidence: fresh Ghidra `disassemble_function(address="0x00578080")`, `decompile_function(address="0x00565730")`, `decompile_function(address="0x0047BBF0")`, and disassembly around `0x005670E7`; the coordinate conversion and dummy writes are explicit instructions, not inferred names.
 
@@ -108,18 +114,18 @@ Evidence: fresh Ghidra `disassemble_function(address="0x00578080")`, `decompile_
 
 The inner ground function `0x0047B3A0` receives `ECX = CellClass*` and a pointer to the original world/lepton coordinate. It lazily initializes:
 
-- ground `LevelHeight = 90`;
-- `LevelHeight / 256 = 0.3515625`;
+- ground `LevelHeight = 104`;
+- `LevelHeight / 256 = 0.40625`;
 - the 20 ground-slope records in §3.3;
-- the structural bridge plane constant `ftol(4 * 90 + 0.5) = 360`.
+- the structural bridge plane constant `ftol(4 * 104 + 0.5) = 416`.
 
 Base height is:
 
 ```text
-base = ftol_chop(sign_extend_i8(cell.level) * 90 + 0.5)
+base = ftol_chop(sign_extend_i8(cell.level) * 104 + 0.5)
 ```
 
-For ordinary nonnegative map levels this is exactly `level * 90`. The signed load matters for corrupted or synthetic negative levels: level `-1` produces `ftol(-89.5) = -89`, not `-90`.
+For ordinary nonnegative map levels this is exactly `level * 104`. The signed load matters for corrupted or synthetic negative levels: level `-1` produces `ftol(-103.5) = -103`, not `-104`.
 
 Evidence: fresh Ghidra `decompile_function(address="0x0047B3A0")` plus full `disassemble_function(address="0x0047B3A0")`; the body uses `MOVSX`, `FILD`, adds the `0.5` constant at `0x007E1738`, and calls `Math__ftol @ 0x007C5F00`.
 
@@ -130,15 +136,15 @@ Slope zero returns `base`. For nonzero `s`, the function reads record `(s - 1) *
 ```text
 x = world_x & 0xFF
 y = world_y & 0xFF
-raw = y * coeff_y * (90 / 256)
-    + x * coeff_x * (90 / 256)
+raw = y * coeff_y * (104 / 256)
+    + x * coeff_x * (104 / 256)
     + bias_a
     + bias_b
 clamped = min(max(raw, 0.0), max_value)
 height = ftol_chop(base + clamped)
 ```
 
-The clamp occurs before adding base; final conversion chops toward zero. Let `L = 90`:
+The clamp occurs before adding base; final conversion chops toward zero. Let `L = 104`:
 
 | Slope | `coeff_x` | `coeff_y` | `bias_a` | `max` | `bias_b` |
 |---:|---:|---:|---:|---:|---:|
@@ -163,7 +169,7 @@ The clamp occurs before adding base; final conversion chops toward zero. Let `L 
 | 19 | `0` | `0` | `0` | `L/2` | `L/2` |
 | 20 | `0` | `0` | `L` | `L/2` | `-L/2` |
 
-Ground slopes 17-20 therefore all add exactly 45 leptons, independent of local X/Y. This does **not** imply that their VXL/Spark reflection matrices are identity; §4 shows they are zero.
+Ground slopes 17-20 therefore all add exactly 52 leptons, independent of local X/Y. This does **not** imply that their VXL/Spark reflection matrices are identity; §4 shows they are zero.
 
 Evidence: Ghidra disassembly `0x0047B3ED..0x0047BA8E` for record initialization and `0x0047BA94..0x0047BB58` for the evaluation/clamp/return path. `FUN_006D6AD0` independently confirms that slope is read as the unsigned byte at `CellClass+0x11C` with no clamp.
 
@@ -183,7 +189,7 @@ Evidence: fresh Ghidra `decompile_function` and `disassemble_function` on `0x007
 
 ### 4.2 VXL height and tilt derivation
 
-Ground `LevelHeight=90` and VXL `LevelHeight=104` are different globals and different mechanisms.
+Cell ground and VXL use independently owned and initialized globals, but active runtime capture proves that both `LevelHeight` values are 104. Independent ownership does not create different numeric domains.
 
 `VXL_Init_CellHeightRatio @ 0x007549E0` uses the tangent lookup `0x004CAD50`, not an analytic sine. Its `pi/6` sample selects table index 341, whose retail `f32` is `0.5766686797142029`; multiplying by half the 256-cell diagonal and chopping yields VXL level height 104.
 
@@ -328,10 +334,10 @@ After resolving the opening ledger, a second pass revisited all direct callees a
 | Question | Answer |
 |---|---|
 | What if a candidate X/Y axis is negative or individually outside 0-511? | Native conversion truncates toward zero and only the flattened index is validated; Rust must reproduce a valid alias or return typed unavailable when the shared dummy would be used. |
-| What if a collapsed high bridge is repaired by an engineer? | Its overlays/attributes are repaired, but structural `0x100` is not restored; Spark no longer applies the 360-lepton bridge plane there. |
-| What if the terrain slope is 0 or 17-20? | Slope 0 returns identity. Slopes 17-20 return zero matrices even though their ground contribution is 45. |
+| What if a collapsed high bridge is repaired by an engineer? | Its overlays/attributes are repaired, but structural `0x100` is not restored; Spark no longer applies the 416-lepton bridge plane there. |
+| What if the terrain slope is 0 or 17-20? | Slope 0 returns identity. Slopes 17-20 return zero matrices even though their ground contribution is 52. |
 | What if `.13` is stored through `SimFixed` because the visual result seems close? | That changes the native `f64` input and is DRIFT; retain `0x3FC0A3D700000000`. |
-| What if VXL level height 104 is reused for ground or bridge height? | Wrong reference frame/mechanism: ground levels are 90 and Spark structural plane is 360; 104 exists only in VXL tilt initialization. |
+| What if independently owned Cell/VXL globals are assumed numerically different? | Wrong: active runtime capture proves both level scalars are 104; Spark composes its independently owned 416 structural offset over Cell ground. |
 | What if stock maps never use a discovered edge? | Trigger frequency affects priority, not parity. Every valid stock slope 0-20 and bridge lifecycle state must retain the listed mechanism. |
 
 ## 10. Final questions disposition
@@ -340,10 +346,10 @@ After resolving the opening ledger, a second pass revisited all direct callees a
 |---|---|---|
 | S01 | RESOLVED | Spark AI consumes one owned bundle per forward particle tick; reverse cleanup follows. |
 | G01 | RESOLVED | Signed truncation toward zero by 256, then flattened 512-stride index. |
-| G02 | RESOLVED | Signed level times 90, add 0.5, x87 chop. |
+| G02 | RESOLVED | Signed level times 104, add 0.5, x87 chop. |
 | G03 | RESOLVED | Low-byte X/Y affine record, clamp to `[0,max]`, add base, chop. |
 | G04 | RESOLVED | All 20 records are listed in §3.3. |
-| G05 | RESOLVED | Native dummy routing is known; adapter returns typed unavailable because full mutable dummy state is outside scope. |
+| G05 | RESOLVED | Native dummy routing is known and Rust has the shared substrate; Spark integration remains open because its adapter still returns typed unavailable. |
 | M01 | RESOLVED | `VXL_MasterLighting_Init` writes identity 0 and rotations 1-16; 17-20 remain BSS zero. |
 | M02 | RESOLVED | Exact `f32` bits are listed in §4.3. |
 | M03 | RESOLVED | Direct `slope*0x30` copy; no clamp or fallback. |

--- a/docs/research/PARTICLE_SPARK_LIVE_COLLISION_INPUTS_GHIDRA_REPORT.md
+++ b/docs/research/PARTICLE_SPARK_LIVE_COLLISION_INPUTS_GHIDRA_REPORT.md
@@ -116,8 +116,14 @@ The inner ground function `0x0047B3A0` receives `ECX = CellClass*` and a pointer
 
 - ground `LevelHeight = 104`;
 - `LevelHeight / 256 = 0.40625`;
-- the 20 ground-slope records in §3.3;
-- the structural bridge plane constant `ftol(4 * 104 + 0.5) = 416`.
+- the 20 ground-slope records in §3.3.
+
+The ground evaluator owns only the 104-based floor and slope result. Cell's
+416 structural-deck offset is initialized separately. Spark does not consume
+that Cell-owned offset: it reads Particle's independently initialized 416 and
+composes `ground + 416` in its collision path. See the active-runtime ownership
+census in
+`PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md`.
 
 Base height is:
 
@@ -408,7 +414,7 @@ No in-scope question remains deferred. The generic shared-dummy mutation taxonom
 
 | Verified requirement | Current Rust state | Required delta | Acceptance test |
 |---|---|---|---|
-| Exact valid-cell coordinate selection and ground formula | Terrain stores level/slope, but existing rectangular helpers do not reproduce all flattened aliases/dummy semantics | Add a read-only Spark world adapter that performs the native signed conversion/flattened lookup; return typed unavailable at dummy boundary | Fixtures `255/256/-1/-255/-256`; one flattened alias; invalid lookup errors; slopes 0-20 match §3 |
+| Exact valid-cell coordinate selection and ground formula | `cell_rect` owns the fixed-512 real-or-shared-dummy substrate, and the existing `spark_world` adapter reproduces signed conversion and valid flattened aliases while returning typed unavailable at the dummy boundary | Route Spark's adapter through the existing shared dummy without changing its already-exact valid-cell path | Retain fixtures `255/256/-1/-255/-256`, flattened alias, and slopes 0-20; add shared-dummy level/slope/coordinate routing fixtures |
 | Exact candidate slope matrix | No Spark world table; renderer table is not authoritative for collision and treats unsupported slopes differently | Add native-derived matrix source using §4.3 bits or exact table builder; 0 identity, 17-20 zero | Compare all 21×12 raw `f32` bits to §4.3 |
 | Live structural bit | Static bridge facts and runtime `deck_present` exist separately | Query static structural AND runtime state exactly as §5.3 | Intact true; collapsed false; repaired-after-collapse remains false; forward-3/extra false |
 | Candidate building/wall facts | Occupancy and overlay grids exist | Read in verified list order; preserve typed failure at unavailable terrain boundary | Multiple-object list ordering; accepted building; rejected non-building; wall overlay ID |
@@ -417,10 +423,11 @@ No in-scope question remains deferred. The generic shared-dummy mutation taxonom
 | Borrow/RNG ordering | Pure Spark kernel exists; production dispatch disabled | Gather all facts into owned input, release world borrows, then call kernel with authoritative RNG | Fact-query failure consumes no RNG; successful tick consumes the parent-report sequence only |
 | Activation safety | Spark/Railgun public dispatch/render remain disabled | Keep disabled until adapter integration and focused tests pass; no fallback path | Unsupported/unavailable input reports error and never silently activates approximation |
 
-Recommended implementation surface from the approved design:
+Current implementation surface and remaining integration seam:
 
-- new read-only `src/sim/particles/spark_world.rs` for native cell/ground/matrix/bridge/occupancy/overlay fact gathering;
-- focused rule changes in `src/rules/ruleset.rs` and `src/rules/particle_type.rs`;
+- preserve the existing read-only `src/sim/particles/spark_world.rs` valid-cell ground/matrix/bridge/occupancy/overlay fact gathering;
+- preserve the existing shared real-or-dummy substrate in `src/sim/cell_rect.rs` and route only Spark's unavailable-cell branch through it;
+- retain the focused rule ownership in `src/rules/ruleset.rs` and `src/rules/particle_type.rs`;
 - owner wiring only after owned facts are complete and all borrows are released;
 - no change to public Spark spawn/render activation in the same patch.
 

--- a/docs/research/PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md
@@ -596,7 +596,7 @@ Every current production use of the wrong helper is:
 | `src/sim/naval_base_placement.rs:174` | candidate Cell center distance point | candidate Z uses 90 instead of 104 |
 | `src/sim/projectile.rs:241` | allocated real `CellClass::GetTargetCoords` | ground uses 90; conditional +416 is correct |
 | `src/sim/projectile.rs:284` | shared dummy `CellClass::GetTargetCoords` | dummy ground uses 90; conditional +416 is correct |
-| `src/sim/production/production_spawn.rs:637` | spawn Cell center ground | ground uses 90 instead of 104 |
+| `src/sim/production/production_spawn.rs:637` | spawn Cell center evaluation | evaluator uses 90 instead of 104, but the current helper discards center Z and returns only the X/Y-derived Cell; the correction preserves output coordinates while removing the false domain and retaining the unsupported-slope gate |
 
 Tests and prose that encode the same false values occur in:
 
@@ -700,7 +700,8 @@ At minimum:
 - dummy level `0xFF`, flat returns -103 and retains requested packed coordinate;
 - Spark level-2 flat ground is 208, bridge plane 624, ascending snap 604; level-0 plane remains 416;
 - Particle constructor clamps input `Z <= ground` to the 104-based ground;
-- radar click, naval-base distance, production spawn, projectile real target, and projectile dummy target all share the 104 evaluator;
+- radar click, naval-base distance, production's intermediate Cell-center evaluation, projectile real target, and projectile dummy target all share the 104 evaluator;
+- production's current X/Y-only returned spawn Cell remains unchanged because its intermediate center Z is discarded;
 - Sonic target composed over level-2 structural cell is `208 + 416 + 50 = 674`;
 - changing structural bridge state changes only the +416 selection, never the ground scalar;
 - focused tests prove no production identifier or assertion still describes Cell terrain as 90 leptons.
@@ -721,7 +722,7 @@ Severity is high whenever nonzero elevation participates:
 
 - radar clicks and action targets on raised terrain;
 - projectile/cell target coordinates and Sonic/wave endpoints on raised or bridged cells;
-- production/unlimbo spawn coordinates on raised cells;
+- production's intermediate Cell-center evaluation on raised cells (the current Rust helper discards that Z before returning its X/Y-only spawn Cell, so this scalar correction alone does not move the unit);
 - naval-base first-yard 3D distance checks near elevation changes;
 - any test/snapshot derived from those values.
 
@@ -737,11 +738,27 @@ Flat level-0 maps hide the scalar regression because both domains return zero th
 - replace slope-table `L=90` and slopes 17..20 contribution 45 with `L=104` and contribution 52;
 - replace Spark plane `G+360` and ascending `G+340` with `G+416` and `G+396`;
 - delete the claim that VXL 104 and Cell ground 90 are different numeric domains; retain only that their globals/initializers are independently owned.
+- replace its stale claim that Rust has no mutable shared dummy: the substrate now exists in `cell_rect`, while Spark's adapter still returns typed unavailable/off-array errors instead of routing through it.
+
+`docs/research/PARTICLE_SPARK_COLLISION_AND_PIXEL_COMPOSITOR_GHIDRA_REPORT.md`:
+
+- mark its HIGH-confidence 90/360/340 conclusions superseded by this live runtime capture, or correct every affected table, trace, questions-log entry, and Rust handoff to 104/416/396;
+- retain its independently verified float integration, collision inequalities, RNG, and compositor findings.
+
+`docs/research/PHASE3_NAVAL_BASE_PLACEMENT_LIFECYCLE_GHIDRA_REPORT.md`:
+
+- replace the claim that 104-lepton Cell ground is wrong with the verified 104 evaluator;
+- replace its `cellclass_ground_height_leptons` Rust handoff with the common `ground_height_leptons` authority.
 
 `docs/plans/2026-07-18-spark-native-float-and-point-compositor-design.md`:
 
 - replace candidate ground `level*90` with the verified 104-lepton Cell evaluator;
 - replace structural plane `G+360` / ascending commit `G+340` with `G+416` / `G+396`.
+
+`docs/plans/2026-07-18-spark-live-collision-adapter-and-owner-design.md`:
+
+- replace its retained `G+360` / ascending `G+340` adapter contract with the verified `G+416` / `G+396` composition;
+- state explicitly that the existing Spark ground evaluator already uses the correct 104 scalar while shared-dummy routing remains open.
 
 `docs/plans/2026-08-26-naval-base-placement-design.md` and any plans/tests copied from it:
 

--- a/docs/research/PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md
@@ -1,0 +1,807 @@
+# Phase 3 Cell Ground Height 104 Domain and Consumer Census — Ghidra Report
+
+**Date:** 2026-08-27
+
+**Target:** active-retail Yuri's Revenge `gamemd.exe`, image base `0x00400000`, x86 32-bit
+
+**Ghidra session:** project `testProsjekt`, program `/gamemd.exe`, connected read-only at `http://127.0.0.1:8089/`
+
+**Primary functions:**
+
+- `CellClass::GetGroundHeight @ 0x00578080` (world-coordinate wrapper)
+- `CellClass::ComputeGroundHeightAtCoord @ 0x0047B3A0` (cell-owned slope evaluator)
+- `CellClass::GetCoords @ 0x00486840` (ground-only cell-center coordinate)
+- `CellClass::GetTargetCoords @ 0x00486890` (structural-bridge-aware target coordinate)
+- Spark particle AI `FUN_0062C6E0`, ground call at `0x0062C7D4`
+
+**Investigation mode:** exhaustive mechanism slice plus complete direct-xref census
+
+**Active in YR:** yes. The functions have 185 direct wrapper calls and 32 direct inner-evaluator calls spanning map/cell, movement, placement, targeting, projectile, particle, damage, radar, and draw paths. Spark behavior 3 calls the same wrapper directly.
+
+**Confidence:** HIGH for the scalar values, initializer formula, coordinate and slope domains, bridge offsets, named/global xrefs, the 185/32 direct-call census, and current-Rust consumer inventory. The malformed-slope and unavailable-cell boundaries remain intentionally classified rather than approximated.
+
+**Implementation scope:** none. This report is a research handoff. It changes no Rust code and makes no Ghidra changes.
+
+## Verdict
+
+The proposed split between a **90-lepton `CellClass::GetGroundHeight` domain** and a **104-lepton object/VXL/bridge domain is false in the active retail executable**.
+
+Active runtime capture and static initializer disassembly agree:
+
+- `g_nCellGroundLevelHeightLeptons @ 0x0089E7C0` is **104**, not 90.
+- `CellClass::ComputeGroundHeightAtCoord @ 0x0047B3A0` multiplies the signed cell level and every slope record by that 104-lepton scalar.
+- the literal `90.0 @ 0x007E1730` is an **angle in degrees** used with `60.0` to form `pi/6`; it is not a height result;
+- `CellClass::GetTargetCoords` adds `g_nCellGroundStructuralDeckOffsetLeptons @ 0x0089E7B4 = 416` only when `CellClass+0x140 & 0x100` is set;
+- Spark obtains ground by calling the same `CellClass::GetGroundHeight`, then adds its module-local `DAT_00AC4A0C = 416` bridge plane;
+- independent Foot, Techno/InRange, area-damage, Anim, Bullet, Particle, Unit, and VXL initializer families also resolve to 104, and all examined four-level deck offsets resolve to 416.
+
+Current Rust therefore has one high-impact regression and one important preservation rule:
+
+1. `src/util/lepton.rs::CELLCLASS_GROUND_LEVEL_HEIGHT_LEPTONS = 90` and `cellclass_ground_height_leptons` are wrong. Their production callers produce incorrect terrain Z, target Z, placement Z, and test fixtures on every nonzero level and many slopes.
+2. Spark's current use of `ground_height_leptons` (104) is correct and must be preserved. Changing Spark to 90 would introduce the exact bug this investigation disproves.
+
+There is no validated active symbol named `MapClass::GetZPos` in this program. The load-bearing native distinction is not `MapClass 104` versus `CellClass 90`; it is:
+
+```text
+ground-only surface = CellClass::GetGroundHeight / GetCoords
+bridge-aware target = ground-only surface + a caller-owned 416 offset when its bridge predicate selects deck
+```
+
+## 1. Scope and evidence order
+
+### Included
+
+1. Static derivation and live runtime value of the Cell ground-level scalar.
+2. Exact Cell ground formula, coordinate units, signedness, slope-table domain, clamp order, and rounding.
+3. World-coordinate lookup, flattened 512-wide indexing, and shared dummy behavior.
+4. Ground-only versus bridge-aware coordinate APIs.
+5. Spark constructor and behavior-3 height consumers.
+6. Every direct xref to the ground wrapper and inner evaluator.
+7. Direct readers of the named module-local 104/416 scalar pairs plus the Bullet, Particle, Unit, and VXL peers needed to close the domain hypothesis.
+8. Every current Rust use of the 90-specific helper and the current 104 ground evaluator.
+9. Evidence-backed exclusions: INI authority, nonexistent `MapClass::GetZPos` label, bridge non-inclusion in ground sampling, invalid slopes, and unavailable-cell policy.
+
+### Not re-investigated here
+
+- Spark's already-researched float integration, reflection matrices, RNG, color, or compositor arithmetic, except where their collision plane consumes ground/bridge Z.
+- The complete behavior of every one of the 217 direct callers. This report exhaustively enumerates them and classifies their height role; caller-specific state machines remain owned by their system reports.
+- Every writer to the shared dummy cell. The lookup and restamp behavior needed by this height mechanism is verified; complete global dummy lifecycle belongs to the map/cell substrate.
+- Malformed executable state with slope bytes above 20. Native performs an unbounded table read; Rust must not emulate memory-unsafety.
+
+### Evidence order
+
+1. Fresh Ghidra disassembly/decompile and direct-xref queries against active `gamemd.exe`.
+2. Read-only `ReadProcessMemory` capture of the running active-retail `gamemd.exe` process.
+3. Current Rust source and git history.
+4. Existing research/plans only as leads. Stale prose was not used to prove the scalar.
+
+## 2. Opening questions log
+
+| ID | Opening question |
+|---|---|
+| Q01 | What value is actually stored in the active Cell ground scalar? |
+| Q02 | Does the static Cell initializer calculate 90 or 104? |
+| Q03 | What does the literal 90.0 mean in that initializer? |
+| Q04 | Is Cell ground numerically distinct from the VXL/object domain? |
+| Q05 | What are the exact level, slope, XY, and return coordinate domains? |
+| Q06 | What are the base-height rounding and negative-level semantics? |
+| Q07 | What is the slope record layout, clamp order, and valid index range? |
+| Q08 | How does the wrapper convert signed world coordinates to a cell? |
+| Q09 | What happens when the flattened lookup misses? |
+| Q10 | Does the ground sampler include bridge height? |
+| Q11 | Which native method returns bridge-aware cell target coordinates? |
+| Q12 | What bridge offset does that method add? |
+| Q13 | What ground and bridge constants does Spark consume? |
+| Q14 | Does Particle construction use the same ground wrapper? |
+| Q15 | Which independent modules carry peer level/deck scalars? |
+| Q16 | Are any of these values controlled by retail INI/map data? |
+| Q17 | Is `MapClass::GetZPos` a verified active symbol? |
+| Q18 | Which direct native consumers can observe the Cell ground result? |
+| Q19 | Which current Rust production callers use the false 90 domain? |
+| Q20 | Which current Rust callers already use the correct 104 domain? |
+| Q21 | What exact correction and regression tests does the builder need? |
+
+All questions are resolved in §12. No numeric claim in this slice remains approximate.
+
+## 3. CellClass layout and coordinate domains
+
+| Source | Native field/input | Width and interpretation | Height role |
+|---|---|---|---|
+| `CellClass+0x24` | packed cell X | signed `i16` | `GetCoords` forms `X * 256 + 128` |
+| `CellClass+0x26` | packed cell Y | signed `i16` | `GetCoords` forms `Y * 256 + 128` |
+| `CellClass+0x11B` | Level | signed `i8` at evaluation | base terrain height |
+| `CellClass+0x11C` | slope index | unsigned `u8` | record 0 means flat; verified table indices 1..20 |
+| `CellClass+0x140` | flags | `u32`; bit `0x100` | structural bridge predicate used by bridge-aware callers |
+| ground wrapper input | world X/Y | signed `i32` leptons | divided by 256 with truncation toward zero |
+| ground local X/Y | low coordinate bytes | unsigned `0..255` | slope interpolation within one cell |
+| returned Z | world Z | signed `i32` leptons | terrain floor only |
+| bridge offset | module-local integer | signed `i32` leptons | 416, added only by a caller that selected deck |
+
+The coordinate frames are therefore compatible, not competing:
+
+```text
+1 cell axis step             = 256 world leptons
+1 terrain Level step         = 104 world-Z leptons
+1 structural deck offset     = 4 Levels = 416 world-Z leptons
+cell-center local coordinate = (128, 128) leptons
+```
+
+## 4. The Cell scalar is 104, not 90
+
+### 4.1 Static initializer
+
+The Cell initializer region is a sequence of CRT init thunks. The load-bearing chain is:
+
+```text
+0x0047B1E0: radians60 = (pi / 180) * 60.0
+0x0047B200: radians90 = (pi / 180) * 90.0
+0x0047B220: angle = radians90 - radians60
+0x0047B232: tan = Math__TanFromTable4096(angle)
+0x0047B237: tan *= cell_diagonal
+0x0047B240: tan *= 0.5
+0x0047B246: Math__ftol
+0x0047B24B: g_nCellGroundLevelHeightLeptons = EAX
+```
+
+The earlier thunks derive `cell_diagonal = sqrt(2 * 256^2)`. The live double at `0x0089E750` is `362.0386657714844`. The angle intermediates captured live are:
+
+| Address | Runtime double | Meaning |
+|---|---:|---|
+| `0x0089E728` | `1.5707963267948966` | 90 degrees in radians |
+| `0x0089E758` | `1.0471975511965976` | 60 degrees in radians |
+| `0x0089E750` | `362.0386657714844` | cell diagonal |
+
+Thus the static expression is:
+
+```text
+CellLevelHeight = ftol_chop(
+    tan_table((90.0 - 60.0) * pi/180)
+    * sqrt(2 * 256^2)
+    * 0.5
+) = 104
+```
+
+The old 90 claim stopped at the degree literal `0x007E1730` and misidentified an initializer input as its integer output.
+
+### 4.2 Live runtime capture
+
+The active process was `C:\Users\enok\Documents\Command and Conquer Red Alert II\gamemd.exe` (PID 9452 at capture time). Read-only `OpenProcess(PROCESS_VM_READ)` and `ReadProcessMemory` returned:
+
+| Address | Runtime bytes | Signed integer | Role |
+|---|---|---:|---|
+| `0x0089E7C0` | `68 00 00 00` | 104 | Cell ground LevelHeight |
+| `0x0089E7B4` | `A0 01 00 00` | 416 | Cell structural-deck target offset |
+| `0x00AC13C8` | `68 00 00 00` | 104 | Foot/object LevelHeight |
+| `0x00AC13BC` | `A0 01 00 00` | 416 | Foot OnBridge deck offset |
+| `0x00B0EB34` | `68 00 00 00` | 104 | Techno/InRange LevelHeight |
+| `0x00B0EB24` | `A0 01 00 00` | 416 | Techno/InRange structural-deck offset |
+| `0x0089E870` | `68 00 00 00` | 104 | area-damage LevelHeight |
+| `0x0089E864` | `A0 01 00 00` | 416 | area-damage structural-deck offset |
+| `0x0089A1C0` | `68 00 00 00` | 104 | Anim LevelHeight |
+| `0x0089A1B4` | `A0 01 00 00` | 416 | Anim structural-deck offset |
+| `0x0089DE70` | `68 00 00 00` | 104 | Bullet module LevelHeight |
+| `0x0089DE64` | `A0 01 00 00` | 416 | Bullet collision/deck plane offset |
+| `0x00AC4A18` | `68 00 00 00` | 104 | Particle module LevelHeight |
+| `0x00AC4A0C` | `A0 01 00 00` | 416 | Particle/Spark bridge plane offset |
+| `0x00B1D0B8` | `68 00 00 00` | 104 | Unit module LevelHeight |
+| `0x00B1D0AC` | `A0 01 00 00` | 416 | Unit bridge offset |
+| `0x00B45578` | `68 00 00 00` | 104 | VXL LevelHeight |
+
+These are separate globals and separately emitted initializer thunks, which matters for ownership and xrefs. They are not separate numeric height systems in the retail executable.
+
+### 4.3 Derived deck value
+
+The Cell deck thunk `0x0047B2C0..0x0047B2E5` reads `0x0089E7C0`, forms `4 * scalar`, adds `0.5`, chops with `Math__ftol`, and writes `0x0089E7B4`:
+
+```text
+CellDeckOffset = ftol_chop(4 * 104 + 0.5) = 416
+```
+
+Particle's peer thunk `0x0062B540..0x0062B566` reads `0x00AC4A18` and writes `0x00AC4A0C` with the same `4*x + 0.5` sequence. Foot does the same at `0x005F3860..0x005F3886`. The other module pairs have the same resolved values and their own xref sets.
+
+## 5. Exact ground-height evaluator
+
+### 5.1 Base height
+
+`CellClass::ComputeGroundHeightAtCoord @ 0x0047B3A0` lazily converts the integer scalar to a double and caches `scalar / 256`. Assembly at `0x0047BA94..0x0047BAB5` then:
+
+1. sign-extends `Cell+0x11B`;
+2. multiplies by `g_nCellGroundLevelHeightLeptons`;
+3. adds `0.5`;
+4. calls `Math__ftol @ 0x007C5F00`, with the active control word chopping toward zero;
+5. reads slope as the unsigned byte at `Cell+0x11C`.
+
+For flat slope 0:
+
+```text
+base = ftol_chop(sign_extend_i8(Level) * 104 + 0.5)
+```
+
+Examples:
+
+| Level byte | Signed level | Flat ground Z |
+|---:|---:|---:|
+| `0x00` | 0 | 0 |
+| `0x01` | 1 | 104 |
+| `0x02` | 2 | 208 |
+| `0xFF` | -1 | -103 |
+
+The negative result is intentionally asymmetric because `-104 + 0.5 = -103.5`, then chop toward zero yields `-103`.
+
+### 5.2 Slope contribution
+
+For nonzero slope `s`, native indexes record `s-1` in the 20-record table rooted at `0x0081C900`. Only `world_x & 0xFF` and `world_y & 0xFF` participate. With `G = 104`:
+
+```text
+raw = (local_y * coeff_y + local_x * coeff_x) * (G / 256)
+    + bias_a
+    + bias_b
+slope_term = clamp(raw, 0, maximum)
+height = ftol_chop(base + slope_term)
+```
+
+The clamp is applied to the slope term before base is added. The final conversion also chops toward zero.
+
+| Slope | `coeff_x` | `coeff_y` | `bias_a` | `maximum` | `bias_b` |
+|---:|---:|---:|---:|---:|---:|
+| 0 | 0 | 0 | 0 | 0 | 0 |
+| 1 | 1 | 0 | 0 | G | 0 |
+| 2 | 0 | 1 | 0 | G | 0 |
+| 3 | -1 | 0 | G | G | 0 |
+| 4 | 0 | -1 | G | G | 0 |
+| 5 | 1 | 1 | -G | G | 0 |
+| 6 | -1 | 1 | 0 | G | 0 |
+| 7 | -1 | -1 | G | G | 0 |
+| 8 | 1 | -1 | 0 | G | 0 |
+| 9 | 1 | 1 | 0 | G | 0 |
+| 10 | -1 | 1 | G | G | 0 |
+| 11 | -1 | -1 | 2G | G | 0 |
+| 12 | 1 | -1 | G | G | 0 |
+| 13 | 1 | 1 | 0 | 2G | 0 |
+| 14 | -1 | 1 | G | 2G | 0 |
+| 15 | -1 | -1 | 2G | 2G | 0 |
+| 16 | 1 | -1 | G | 2G | 0 |
+| 17 | 0 | 0 | 0 | G/2 | G/2 |
+| 18 | 0 | 0 | G | G/2 | -G/2 |
+| 19 | 0 | 0 | 0 | G/2 | G/2 |
+| 20 | 0 | 0 | G | G/2 | -G/2 |
+
+At cell center `(128,128)`, the contributions for slopes 0..20 are:
+
+```text
+0, 52, 52, 52, 52,
+0, 0, 0, 0,
+104, 104, 104, 104, 104, 104, 104, 104,
+52, 52, 52, 52
+```
+
+Native has no safe bounds check for a malformed slope above 20. The Rust `UnsupportedGroundSlope` result is the correct safe boundary, but it is not bit-for-bit behavior for corrupt executable state.
+
+## 6. Lookup, dummy cell, and coordinate methods
+
+### 6.1 Wrapper conversion and flattened lookup
+
+`CellClass::GetGroundHeight @ 0x00578080` converts each signed world axis as:
+
+```text
+cell_axis = (world_axis + ((world_axis >> 31) & 0xFF)) >> 8
+```
+
+This equals signed division by 256 truncating toward zero. It then forms:
+
+```text
+linear = cell_y * 512 + cell_x
+```
+
+The validation is on the flattened index and pointer, not on X and Y independently. An individually out-of-range X can alias a valid linear slot when the flattened result is valid.
+
+On invalid flattened index or null pointer, the wrapper uses the shared dummy `CellClass @ 0x00ABDC50`, stamps the requested packed coordinate at dummy `+0x24/+0x26` (`0x00ABDC74`), and calls the same inner evaluator. Dummy level/slope are live shared state, not an implicit immutable `(0,0)`.
+
+Current Rust already has the correct generic substrate in `src/sim/cell_rect.rs::get_cellclass_fallback`: fixed 512-wide indexing, packed-coordinate truncation, real-or-dummy return, and shared dummy coordinate stamping. Callers that use `checked_cell_from_world` or return `None`/typed unavailable instead are not exact at this boundary.
+
+### 6.2 Ground-only cell center
+
+`CellClass::GetCoords @ 0x00486840`, vtable slot `+0x48`, forms:
+
+```text
+X = sign_extend_i16(Cell.X) * 256 + 128
+Y = sign_extend_i16(Cell.Y) * 256 + 128
+Z = CellClass::ComputeGroundHeightAtCoord(this, X, Y)
+```
+
+It does not add a bridge term. `CellClass::Get_Center_Coords @ 0x00480A30` is a direct-call sibling that passes the same local `(128,128)` point into the inner evaluator.
+
+### 6.3 Bridge-aware target coordinate
+
+`CellClass::GetTargetCoords @ 0x00486890`, vtable slot `+0x58`, is the bridge-aware cell target method:
+
+```text
+coord = this->GetCoords()
+if (this->flags_0x140 & 0x100) != 0:
+    coord.z += g_nCellGroundStructuralDeckOffsetLeptons  // 416
+return coord
+```
+
+This is a caller composition over the same 104-lepton ground. It is not a second terrain evaluator.
+
+### 6.4 `MapClass::GetZPos` exclusion
+
+Fresh Ghidra symbol search for `GetZ` found `AnimClass::GetZAdjust @ 0x00425630` and `MapClass::GetZoneID @ 0x0056D230`; it found no `MapClass::GetZPos`. A repository-wide source/doc search also found no such verified symbol. Treat `MapClass::GetZPos` as an unverified shorthand, not an evidence label. The active functions proven above are the names and addresses implementation should cite.
+
+## 7. Spark uses 104 ground plus 416 deck plane
+
+### 7.1 Constructor floor
+
+`ParticleClass::Constructor @ 0x0062B5E0` calls `CellClass::GetGroundHeight` at `0x0062B8B1`. If the input Z is at or below ground, it calls again at `0x0062B8C2` and replaces Z with that ground result before `Set_Raw_Coords`. There is no Spark-specific 90 scalar in this path.
+
+### 7.2 Behavior-3 collision
+
+Spark AI `FUN_0062C6E0` does:
+
+```text
+0x0062C7D4  ground = CellClass::GetGroundHeight(candidate_coord)
+0x0062C7D9  deck_offset = DAT_00AC4A0C
+0x0062C7E8  bridge_plane = ground + deck_offset
+0x0062C7F4  candidate_cell = MapClass::Get_CellClass_At_Coord(candidate)
+0x0062C81C  old_cell       = MapClass::Get_CellClass_At_Coord(old)
+```
+
+It tests `Cell+0x140 & 0x100` on candidate or old cell, then performs its asymmetric ascending/descending crossing checks around `bridge_plane`. Live runtime values are:
+
+```text
+Particle LevelHeight = 104
+Spark bridge offset  = 416
+Spark bridge plane   = candidate CellClass ground + 416
+ascending snap       = bridge plane - 20 = ground + 396
+```
+
+The stale `ground + 360` / `ground + 340` interpretation is wrong.
+
+### 7.3 Current Rust Spark verdict
+
+`src/sim/particles/spark_world.rs` calls `ground_height_leptons` at lines 96 and 119. That evaluator uses 104 and is the correct scalar choice. `src/sim/particles/spark.rs` obtains `STRUCTURAL_BRIDGE_HEIGHT` from the 416-lepton bridge topology constant. These numeric choices match active retail.
+
+The remaining boundary distinction is lookup failure:
+
+- Rust's Spark adapter reproduces signed truncation and fixed-stride flattened indexing.
+- For a canonical cell missing from resolved terrain, it returns `UnavailableCell`; constructor `ground_height_at` converts that to `None`.
+- Native uses the shared dummy and continues.
+
+This is an explicit safety/availability divergence, not evidence for a different height scalar. It cannot be called exact invalid-cell parity until Spark is routed through the existing shared dummy-cell substrate or invalid-cell reachability is separately excluded for every active Spark entry path.
+
+## 8. Native scalar xrefs and ownership
+
+### 8.1 Named Cell pair
+
+`g_nCellGroundLevelHeightLeptons @ 0x0089E7C0`:
+
+- reads: `CellClass::RecalcAttributes @ 0x0047D9C9`; `ComputeGroundHeightAtCoord @ 0x0047B3B5, 0x0047BA9B`; `CellClass::BlowUpBridge @ 0x0047DE83`; `CellOverlay_TileDraw @ 0x004804DC`; derivative thunks `0x0047B260, 0x0047B291, 0x0047B2C1`;
+- write: `0x0047B24B`.
+
+`g_nCellGroundStructuralDeckOffsetLeptons @ 0x0089E7B4`:
+
+- reads: `FUN_00487720 @ 0x00487771`; `CellClass::BlowUpBridge @ 0x0047DEA0`; `CellClass::PlaceInfantryInCell @ 0x0048147B`; `CellClass::GetTargetCoords @ 0x004868A1`;
+- write: `0x0047B2E0`.
+
+### 8.2 Other named 104/416 pairs
+
+| Owner | 104 scalar direct readers | 416 scalar direct readers |
+|---|---|---|
+| Foot/object `0x00AC13C8` / `0x00AC13BC` | `ObjectClass::IsHighFlying 0x005F6B9F`; `IsLowFlying 0x005F6B6F`; `ShouldBeOnBridge 0x005F6AEA, 0x005F6B20` | `FootClass::Set_Height_On_Bridge 0x005F5FB5`; `ObjectClass::GetHeight 0x005F5F86`; `Mark_Put 0x005F60B0`; `Mark_Remove 0x005F6130` |
+| Techno/InRange `0x00B0EB34` / `0x00B0EB24` | railgun helper `0x0070C833`; `TechnoClass::InRange 0x006F74F8`; `FUN_006F6F60 0x006F7087`; `TechnoClass::GetFireError 0x006FCC9C` | `TechnoClass::InRange 0x006F7367, 0x006F761C`; `TechnoClass::CanFireAt 0x006F7887` |
+| area damage `0x0089E870` / `0x0089E864` | `Apply_area_damage 0x0048979E, 0x0048982B, 0x00489F90, 0x00489FB1, 0x0048A114`; `Warhead::SelectExplosionAnim 0x0048A541` | area-damage bridge selectors; writer `0x00489120` derives `4*104` |
+| Anim `0x0089A1C0` / `0x0089A1B4` | `AnimClass::BounceAI 0x004257A3, 0x00425830, 0x004259B8`; helper `0x0042610C` | `AnimClass::AI 0x00423CB6`; `BounceAI 0x0042585D, 0x004259E5, 0x00425A7B`; occupancy `0x0042629B, 0x00426328` |
+
+### 8.3 Additional peer globals used by direct ground consumers
+
+| Owner | 104 scalar | 416 scalar | Representative readers |
+|---|---:|---:|---|
+| Bullet | `0x0089DE70` | `0x0089DE64` | `BulletClass::AI`, detonation, rotating-SHP draw |
+| Particle/Spark | `0x00AC4A18` | `0x00AC4A0C` | particle move behaviors, Spark AI |
+| Unit | `0x00B1D0B8` | `0x00B1D0AC` | unit scatter, scenario unit read, action/occupation/draw |
+| VXL | `0x00B45578` | not the Cell target offset | VXL slope tilt initialization |
+
+Independent ownership explains why the binary has multiple globals. It does not justify numerically splitting Rust ground evaluators.
+
+## 9. Complete native direct-call census
+
+Fresh `get_xrefs_to` returned exactly **185** direct calls to wrapper `0x00578080`, grouped into **107** named/unnamed function owners below. Every returned callsite is included. This proves the ground wrapper is shared broadly; it does not claim every caller's entire state machine was re-audited here.
+
+### 9.1 Damage, projectiles, particles, and effects
+
+- `Apply_area_damage`: `0x004893B5`, `0x00489573`
+- `Warhead__SelectExplosionAnim`: `0x0048A53C`
+- `AnimClass__AI`: `0x00423CB1`
+- `AnimClass__BounceAI`: `0x0042582B`, `0x00425847`, `0x00425858`, `0x004259B3`, `0x004259CF`, `0x004259E0`, `0x00425A76`
+- `AnimClass__MarkCellOccupancy`: `0x00426296`
+- `AnimClass__ClearCellOccupancy`: `0x00426323`
+- `BounceClass__Update`: `0x00439BF3`
+- `FUN_00439A10`: `0x00439A45`
+- `BulletClass__AI`: `0x00467074`, `0x0046737B`, `0x0046749E`
+- `BulletClass__HomingTrack`: `0x005B26DC`
+- `BulletClassDrawItRotatingShpFrameDispatch`: `0x004682AB`
+- `BulletClassFireRevealArmAndSubmit`: `0x0046891F`
+- `ParticleClass__Constructor`: `0x0062B8B1`, `0x0062B8C2`
+- `ParticleClass__Move_Dispatch`: `0x0062D68F`, `0x0062D6A0`
+- particle behaviors `FUN_0062BD50`: `0x0062BF22`; Spark `FUN_0062C6E0`: `0x0062C7D4`; `FUN_0062D2A0`: `0x0062D356`, `0x0062D3AF`, `0x0062D3C9`; `FUN_0062D3F0`: `0x0062D4AF`
+- `VoxelAnimClass__AI`: `0x0074A00B`
+- `BuildingClass__ReceiveDamage`: `0x0044277C`
+- effect/damage helpers `FUN_0043E940`: `0x0043EB6D`; `FUN_00487720`: `0x0048776C`; `FUN_004A9070`: `0x004A914E`
+
+### 9.2 Targeting, range, actions, and superweapons
+
+- `TechnoClass__InRange`: `0x006F7340`, `0x006F7617`
+- railgun helper `FUN_0070C690`: `0x0070CA6E`
+- `FootClass__Greatest_Threat_Scan`: `0x004D5F80`, `0x004D6172`
+- `FootClass__What_Action_OnCell`: `0x004DDE32`
+- `FootClass__What_Action_OnObject`: `0x004DDF13`
+- `FootClass__ClickedAction_Cell`: `0x004D7EF5`
+- `FootClass__ClickedAction_Object`: `0x004D7837`, `0x004D784C`, `0x004D79C7`
+- `UnitClass__What_Action_OnCell`: `0x0074059E`
+- `DisplayClass__SetCursorFromAction`: `0x004AAF87`
+- `DisplayClass__DetermineAction`: `0x00692A5D`
+- `SuperClass__Launch`: `0x006CDAC6`, `0x006CDD88`
+- `House__LaunchNukeDown`: `0x006E3466`
+- `BuildingClass__Mission_Missile`: `0x0044D001`
+- `TriggerAction__Execute`: `0x006DD975`, `0x006DDA4E`, `0x006DEE46`, `0x006DF44D`, `0x006DF7DC`
+- trigger/superweapon helpers `FUN_006E1CC0`: `0x006E1D0E`; `FUN_006E2290`: `0x006E22E1`; `FUN_006E2390`: `0x006E23E4`; `FUN_006E2520`: `0x006E2571`; `FUN_006E2C40`: `0x006E2C93`, `0x006E2D89`; `FUN_006E38F0`: `0x006E3946`; `FUN_00692300`: `0x0069244C`
+
+### 9.3 Placement, cell occupancy, harvestability, and object lifecycle
+
+- `CellClass__PlaceInfantryInCell`: `0x00481428`, `0x0048146E`
+- `Try_Unlimbo_Object_At_Or_Near_Cell`: `0x00688F6A`, `0x0068924C`
+- `AircraftClass__Unlimbo`: `0x00414361`, `0x00414378`
+- `AircraftClass__Carryall_Pickup`: `0x00416B3C`
+- `InfantryClass__Unlimbo`: `0x0051E002`
+- `FootClass__Set_Height_On_Bridge`: `0x005F5FF6`, `0x005F603F`
+- `ObjectClass__GetHeight`: `0x005F5F6E`
+- `ObjectClass__ShouldBeOnBridge`: `0x005F6AAE`, `0x005F6AD9`
+- `ObjectClass__Mark_Put`: `0x005F60AB`
+- `ObjectClass__Mark_Remove`: `0x005F612B`
+- `InfantryClass__MarkCellOccupancy`: `0x005217E6`
+- `InfantryClass__UnmarkCellOccupancy`: `0x00521873`
+- `UnitClass__MarkCellOccupationBit20`: `0x007441C9`
+- `UnitClass__ClearCellOccupationBit20`: `0x00744229`
+- `OverlayClass__Mark`: `0x005FD159`
+- `FootClass__Is_Cell_Harvestable`: `0x004DCEE5`
+- `FootClass__Is_Cell_Weedable`: `0x004DDA82`
+- `VeinholeMonsterClass__Constructor`: `0x0074C8D3`
+- `ScenarioClass__Read_Units_Section`: `0x00743505`
+- `EventClass__Execute`: `0x004C6FFE`
+- `TeamClass__Recruit_Or_Add`: `0x006E9AFA`
+- `TechnoClass__Set_Destination`: `0x007428D1`
+- lifecycle helpers `FUN_0049F550`: `0x0049F587`, `0x0049F59C`; `FUN_00513D20`: `0x00513D75`, `0x00513DC3`; `FUN_0051B350`: `0x0051B45E`, `0x0051B46F`, `0x0051B98A`; `FUN_0051FB00`: `0x0051FDC4`, `0x0051FDDB`; `FUN_0054D6D0`: `0x0054D746`, `0x0054D7CD`; `FUN_007298F0`: `0x0072991D`
+
+### 9.4 Locomotion and spatial movement
+
+- `DriveLocomotionClass__Process_Drive_Track`: `0x004B1003`, `0x004B1422`, `0x004B1469`, `0x004B18C7`
+- `DriveLocomotionClass__Process_Movement`: `0x004B2BB2`, `0x004B3097`, `0x004B3CEC`, `0x004B3D1A`
+- `ShipLocomotionClass__Process_Drive_Track`: `0x006A06D3`, `0x006A0AEA`, `0x006A0B31`, `0x006A0F53`
+- `ShipLocomotionClass__Process_Movement`: `0x006A2202`, `0x006A26E7`, `0x006A333B`, `0x006A3369`
+- `FlyLocomotionClass__Process`: `0x004CD6F8`
+- `FlyLocomotionClass__Descent_Step`: `0x004CEAAC`, `0x004CEB41`, `0x004CECE7`
+- `FlyLocomotionClass__Horizontal_Step`: `0x004CF3EC`
+- `FlyLocomotionClass__Move_To_Coord`: `0x004CCE5B`, `0x004CCEE2`
+- `FlyLocomotionClass__Emergency_Relocate`: `0x004CD1C4`
+- `HoverLocomotionClass__Move`: `0x00514BF8`
+- hover helpers `FUN_00514F70`: `0x0051525C`, `0x005152AC`, `0x00515395`; `FUN_005164D0`: `0x00516A23`
+- `JumpjetLocomotionClass__Update_Coordinates_And_Altitude`: `0x0054D29A`, `0x0054D3EF`
+- `JumpjetLocomotionClass__State4_Descend`: `0x0054C874`
+- `JumpjetLocomotionClass__State5_Touchdown`: `0x0054CB48`
+- `TeleportLocomotionClass__Process`: `0x00718C56`, `0x00719221`
+- `TeleportLocomotionClass__Update_Position`: `0x007186D9`
+- `WalkLocomotionClass__ProcessMovement`: `0x0075B4E6`, `0x0075B532`
+- `WalkLocomotionClass__FindSubCellDest`: `0x0075C4FB`
+- `UnitClass__TubeMovement`: `0x00735B05`, `0x00735B16`
+- movement helpers `FUN_005B01C0`: `0x005B07D7`, `0x005B0823`, `0x005B0916`; `FUN_005B17B0`: `0x005B17F6`; `FUN_004DE1D0`: `0x004DE22F`, `0x004DE379`
+
+### 9.5 Radar, tactical placement, and drawing
+
+- `RadarClass__RenderCellPixel`: `0x00655D33`
+- `TechnoClass__DrawRadarActionLines`: `0x004DC48D`
+- `TechnoClass__DrawActionLines`: `0x004DC268`
+- `BuildingPlacement_OverlayRenderer`: `0x006D535E`
+- `BuildingPlacement_per_cell_draw`: `0x0047ED66`
+- `AircraftClass__Draw_It`: `0x004146AD`
+- `UnitClass__DrawVoxelBody`: `0x0073C310`
+- `InfantryClass__DrawExtras`: `0x005193B0`
+- draw/tactical helpers `FUN_00684C30`: `0x00684D2F`; `FUN_006DA9D0`: `0x006DAB52`; `FUN_006539D0`: `0x00653B0B`
+
+### 9.6 Unnamed Ghidra owners retained verbatim
+
+The following direct callsites currently have no owning function name in the active database and are retained so the census is lossless:
+
+```text
+0x00464A96 0x0046C515 0x0046C52C 0x004B609A
+0x00514DF9 0x00516F26 0x005247F5 0x0052480C
+0x00537392 0x00537482 0x00537572 0x00537662
+0x0054B634 0x005FD9AF 0x0071E0F5 0x0071E10C
+0x00729E95 0x00747ED5 0x00747EEC 0x00749BF6
+0x0074D0A4
+```
+
+### 9.7 Direct inner-evaluator census
+
+Fresh `get_xrefs_to 0x0047B3A0` returned exactly **32** direct calls:
+
+- `CellClass__Get_Center_Coords`: `0x00480A60`
+- `CellClass__GetGroundHeight`: `0x005780ED`
+- `CellClass__GetCoords`: `0x0048686C`
+- `CellClass__AddContent`: `0x0047E953`, `0x0047E9A4`
+- `CellClass__IsShrouded_AtMapCoord`: `0x00487980`
+- `CrateClass__PickupCloak`: `0x004828D0`
+- `FUN_00484180`: `0x004842DD`
+- `FUN_00487A10`: `0x00487AE4`
+- `FUN_00486920`: `0x00486A0A`
+- `FUN_00482900`: `0x00483334`
+- `FUN_00485080`: `0x0048509E`
+- `FUN_00580BC0`: `0x00580CE5`, `0x00580D91`, `0x00580E79`, `0x00580F75`
+- unnamed owners: `0x00482002`, `0x00482258`, `0x004822E8`, `0x00482416`, `0x00482529`, `0x00482608`, `0x00482762`, `0x00482A02`, `0x00482B5C`, `0x00482BE5`, `0x00482DD8`, `0x00482F03`, `0x00482FBB`, `0x004830F2`, `0x004831A7`, `0x004832CE`
+
+## 10. Retail data and INI authority
+
+No `Rules`, `Art`, map, theater, or scenario INI read writes any scalar in this report. The values are initialized by executable geometry/trigonometry thunks before consumers run. Direct xref sets show one static writer per scalar family plus derived thunks; none is an INI parser.
+
+The active install exposes only runtime/user INIs at the filesystem root; stock rules/art live in MIX archives. That packaging does not affect the conclusion because the executable writers do not consult INI storage. Existing reports that call these values `BridgeHeight` as a semantic label must not be read as evidence for a `[Rules] BridgeHeight=` key.
+
+Evidence-backed exclusions:
+
+- lighting `[Lighting] Level=` is unrelated visual/scenario state;
+- `RadLevelDelay=90` and timing values of 90 are unrelated units;
+- the `90.0` geometry literal is degrees;
+- no retail INI can make Cell ground use 90 while VXL uses 104;
+- TS-only branches in some consumers do not change the shared active evaluator or its scalar.
+
+## 11. Current Rust comparison
+
+### 11.1 Correct common evaluator and correct consumers
+
+`src/util/lepton.rs::GROUND_LEVEL_HEIGHT_LEPTONS = 104` and `ground_height_leptons` reproduce the verified base, low-byte local XY, record coefficients, clamp, and signed chop for slopes 0..20. `src/sim/cell_kernel.rs::cell_floor_height` already routes through it.
+
+Production/read-path users currently on the correct 104 evaluator include:
+
+- `src/sim/particles/spark_world.rs:96,119` — Spark candidate and constructor ground;
+- `src/sim/anim_class.rs:484` — Anim ground;
+- `src/render/radar_visibility.rs:127` — radar height sample;
+- `src/sim/combat/combat_aoe.rs:180,808,953,1049` — area-damage/impact geometry;
+- `src/sim/combat/base_defense_response/admission.rs:105`;
+- `src/sim/combat/mod.rs:1398`;
+- `src/sim/combat/in_range.rs:41` — InRange terrain ground;
+- `src/sim/miner/miner_system.rs:59`;
+- `src/sim/overlay_grid.rs:395`;
+- `src/sim/combat/smudge_dispatch.rs:404,750`;
+- `src/sim/radiation.rs:100`;
+- `src/sim/runtime.rs:559`;
+- `src/sim/world/lifecycle.rs:392,1374`;
+- `src/sim/movement/tube_movement.rs:659`;
+- `src/sim/cell_kernel.rs:100`.
+
+Direct multiplication users of `GROUND_LEVEL_HEIGHT_LEPTONS`/`LEPTONS_PER_LEVEL` also use 104. Their caller-specific omission status is outside this scalar correction, but their numeric domain must not be changed to 90.
+
+### 11.2 False 90 helper and all production consumers
+
+`src/util/lepton.rs` currently declares:
+
+```rust
+pub const CELLCLASS_GROUND_LEVEL_HEIGHT_LEPTONS: i32 = 90;
+```
+
+and constructs a second slope table plus `cellclass_ground_height_leptons`. This was introduced by commit `26a4da9e` (`Match gamemd slope-aware radar click target...`). The parent revision correctly stated that the Cell initializer independently resolved to 104. The change hardened the stale Spark report's false premise into code.
+
+Every current production use of the wrong helper is:
+
+| Rust consumer | Native role | Current mismatch |
+|---|---|---|
+| `src/render/minimap_interaction.rs:130` | `CellClass::Get_Center_Coords` for radar click | level/slope Z uses 90 instead of 104 |
+| `src/sim/naval_base_placement.rs:174` | candidate Cell center distance point | candidate Z uses 90 instead of 104 |
+| `src/sim/projectile.rs:241` | allocated real `CellClass::GetTargetCoords` | ground uses 90; conditional +416 is correct |
+| `src/sim/projectile.rs:284` | shared dummy `CellClass::GetTargetCoords` | dummy ground uses 90; conditional +416 is correct |
+| `src/sim/production/production_spawn.rs:637` | spawn Cell center ground | ground uses 90 instead of 104 |
+
+Tests and prose that encode the same false values occur in:
+
+- `src/util/lepton.rs:480..500`;
+- `src/sim/projectile.rs:1298..1331`;
+- `src/sim/bridge_specs.rs:1779`;
+- `src/sim/combat/combat_tests.rs:7409`;
+- `src/sim/snapshot.rs:5508,5564` and the expected-ground helper at `5376`;
+- `src/sim/world/lifecycle_tests.rs:4349`;
+- `src/sim/world/world_tests.rs:2777,2988`;
+- `src/sim/world/bridge_orchestrator.rs:3128`;
+- the recent naval-base design/fixtures that cite a 90-lepton candidate.
+
+For flat level 2, current bad output is `180`; native is `208`. With a structural deck, current bad target is `596`; native is `624`. With Sonic's `+50`, bad tests expect `646`; native composition is `674`.
+
+### 11.3 Mechanism matrix
+
+| Mechanism | Native | Current Rust | Verdict |
+|---|---|---|---|
+| Cell Level scalar | independent global, value 104 | common 104 plus false duplicate 90 | FAIL where duplicate is used |
+| Cell slope records | `G=104`, indices 0..20 | common table with 104 is exact; duplicate table uses 90 | preserve common, remove/fix duplicate |
+| signed negative base | `ftol(level*104+0.5)` | common returns `-103` for -1 | PASS common; FAIL duplicate (`-89`) |
+| local slope XY | unsigned low bytes | common and duplicate both use low bytes | PASS operation shape |
+| ground bridge inclusion | none | common floor excludes bridge | PASS |
+| bridge-aware Cell target | ground +416 iff raw structural bit | projectile composes helper +416 | predicate/offset PASS; ground FAIL |
+| Spark ground | same Cell wrapper, 104 | common 104 | PASS |
+| Spark plane | ground +416 | ground +416 | PASS numeric |
+| signed world-to-cell | trunc toward zero | Spark uses shared trunc helper | PASS |
+| flattened 512 lookup | flattened range/pointer; dummy fallback | Spark matches fixed stride but errors on missing cell | PARTIAL; invalid-cell residual |
+| shared dummy ground | live dummy level/slope | generic cell substrate models it; not all height callers use it | PARTIAL integration |
+| INI override | none | constants | PASS conceptually |
+
+## 12. Final questions log
+
+| ID | Disposition |
+|---|---|
+| Q01 | **RESOLVED:** live `0x0089E7C0 = 104`. |
+| Q02 | **RESOLVED:** `0x0047B220..0x0047B24B` calculates and writes 104. |
+| Q03 | **RESOLVED:** `90.0 @ 0x007E1730` is degrees; it becomes radians and is subtracted from the 60-degree angle. |
+| Q04 | **RESOLVED:** Cell and VXL use separate globals/initializers but both resolve to 104. There is no 90 numeric domain. |
+| Q05 | **RESOLVED:** signed i8 Level, unsigned u8 slope, signed i32 world XY/Z leptons, unsigned low-byte local XY. |
+| Q06 | **RESOLVED:** add 0.5 then chop; level -1 flat gives -103. |
+| Q07 | **RESOLVED:** 20 records plus flat 0, clamp slope before base, then final chop; >20 is unsafe native malformed state. |
+| Q08 | **RESOLVED:** biased arithmetic shift equals signed `/256` truncation toward zero. |
+| Q09 | **RESOLVED:** flattened 512-wide validation; failure restamps and evaluates shared dummy. |
+| Q10 | **RESOLVED:** ground sampler returns floor only. |
+| Q11 | **RESOLVED:** `CellClass::GetTargetCoords @ 0x00486890`, not a proven `MapClass::GetZPos`. |
+| Q12 | **RESOLVED:** Cell target offset `0x0089E7B4 = 416`, gated by raw flag `0x100`. |
+| Q13 | **RESOLVED:** Spark calls Cell ground (104) and adds `0x00AC4A0C = 416`. |
+| Q14 | **RESOLVED:** constructor calls wrapper twice around the `input_z <= ground` clamp. |
+| Q15 | **RESOLVED:** named Cell/Foot/Techno/AoE/Anim peers and Bullet/Particle/Unit/VXL peers were captured; all level scalars are 104 and all examined four-level offsets are 416. |
+| Q16 | **RESOLVED:** executable initializer constants, no INI writer. |
+| Q17 | **RESOLVED:** no verified active `MapClass::GetZPos` symbol; use the proven Cell methods. |
+| Q18 | **RESOLVED:** complete 185 wrapper and 32 inner direct-xref census is in §9. |
+| Q19 | **RESOLVED:** five production callsites use the false helper, plus named test/prose fixtures. |
+| Q20 | **RESOLVED:** Spark and the common sim consumers use the correct 104 evaluator; list in §11.1. |
+| Q21 | **RESOLVED:** implementation handoff and acceptance tests are in §14. |
+
+## 13. Adversarial review and zero-add pass
+
+### Adversarial questions
+
+1. **Could live memory be modified by a mod or trainer while static retail really says 90?** No. The active executable's own static initializer writes `0x0089E7C0`, and its FPU expression resolves to 104. Live memory independently agrees.
+2. **Could Cell use 90 while the captured 104 belongs only to a later bridge helper?** No. `0x0047BA9B` inside the active inner evaluator directly multiplies Level by `0x0089E7C0`; slope setup derives from the same global.
+3. **Could Spark use a hidden 90 table despite calling the wrapper?** No. `0x0062C7D4` calls `0x00578080`; that wrapper calls `0x0047B3A0`. Spark's only nearby height constant is its 416 bridge offset derived from Particle's 104.
+4. **Could 90 be a map/theater override that the captured session happened not to use?** No. the writer is a fixed executable geometry initializer with no INI/map input, and its direct xref set contains no parser.
+5. **Could independently named globals justify keeping separate Rust constants?** Separate names may document ownership, but giving one the value 90 is false. If separate aliases remain, every active-retail value and evaluator output must still be 104-identical.
+
+### Zero-add cold reread
+
+After drafting the findings, two load-bearing paths were reread without adding new hypotheses:
+
+- static Cell chain `0x0047B1E0..0x0047B24B` plus live `0x0089E7C0/0x0089E7B4`;
+- Spark `0x0062C7D4..0x0062C81C` plus live `0x00AC4A18/0x00AC4A0C`.
+
+Both reproduced 104 and 416. The current Ghidra plate comments on `CellClass::GetCoords @ 0x00486840`, `GetTargetCoords @ 0x00486890`, and inner `0x0047B3A0` also state 104 and agree with the bytes. No new mechanism appeared in the cold reread.
+
+## 14. Implementation handoff
+
+### Required code delta
+
+1. Remove the false 90-lepton semantic split in `src/util/lepton.rs`.
+   - Prefer one 104 ground evaluator/table for all Cell ground users.
+   - If ownership-specific aliases remain for documentation, assert they equal 104 and route both APIs through the same records/evaluator.
+   - Correct comments that say Cell uses 90.
+2. Correct all five production users in §11.2. A constant-only change may be sufficient numerically, but the builder should avoid retaining duplicate tables that can drift again.
+3. Preserve Spark's current 104 `ground_height_leptons` call and 416 structural plane.
+4. Rebaseline all 90-derived tests, snapshot hashes, wave target expectations, and recent design prose.
+5. Route height callers through the shared fixed-stride/dummy-cell substrate where native can observe unavailable cells. If the builder does not close this in the same slice, GSI-04.03 remains open; returning zero/`None` is not exact native behavior.
+6. Keep floor and deck composition separate. Do not add 416 inside `ground_height_leptons`.
+
+### Acceptance fixtures
+
+At minimum:
+
+- flat levels: 0 -> 0, 1 -> 104, 2 -> 208, `0xFF` -> -103;
+- all slope 0..20 center contributions exactly match §5.2 with `G=104`;
+- representative boundary coordinates use low unsigned bytes and preserve clamp-before-base/final chop;
+- `GetCoords` equivalent at flat level 2 returns Z 208;
+- `GetTargetCoords` equivalent at the same cell returns 208 without structural bit and 624 with bit `0x100`;
+- dummy level `0xFF`, flat returns -103 and retains requested packed coordinate;
+- Spark level-2 flat ground is 208, bridge plane 624, ascending snap 604; level-0 plane remains 416;
+- Particle constructor clamps input `Z <= ground` to the 104-based ground;
+- radar click, naval-base distance, production spawn, projectile real target, and projectile dummy target all share the 104 evaluator;
+- Sonic target composed over level-2 structural cell is `208 + 416 + 50 = 674`;
+- changing structural bridge state changes only the +416 selection, never the ground scalar;
+- focused tests prove no production identifier or assertion still describes Cell terrain as 90 leptons.
+
+### Do not implement
+
+- Do not change Spark ground from 104 to 90.
+- Do not use the degree literal as a height.
+- Do not fold bridge height into the ground evaluator.
+- Do not replace signed Level with unsigned arithmetic.
+- Do not mathematically floor negative world axes; native truncates toward zero.
+- Do not independently reject X/Y before the flattened 512-wide lookup where exact Cell lookup is required.
+- Do not emulate native out-of-bounds slope memory reads.
+
+### Expected player-visible triggers
+
+Severity is high whenever nonzero elevation participates:
+
+- radar clicks and action targets on raised terrain;
+- projectile/cell target coordinates and Sonic/wave endpoints on raised or bridged cells;
+- production/unlimbo spawn coordinates on raised cells;
+- naval-base first-yard 3D distance checks near elevation changes;
+- any test/snapshot derived from those values.
+
+Flat level-0 maps hide the scalar regression because both domains return zero there. Slopes can expose it even at level 0.
+
+## 15. Documentation corrections and annotation candidates
+
+### Documents that contain load-bearing stale claims
+
+`docs/research/PARTICLE_SPARK_LIVE_COLLISION_INPUTS_GHIDRA_REPORT.md`:
+
+- replace every `Cell LevelHeight = 90` statement with `Cell LevelHeight = 104`;
+- replace slope-table `L=90` and slopes 17..20 contribution 45 with `L=104` and contribution 52;
+- replace Spark plane `G+360` and ascending `G+340` with `G+416` and `G+396`;
+- delete the claim that VXL 104 and Cell ground 90 are different numeric domains; retain only that their globals/initializers are independently owned.
+
+`docs/plans/2026-07-18-spark-native-float-and-point-compositor-design.md`:
+
+- replace candidate ground `level*90` with the verified 104-lepton Cell evaluator;
+- replace structural plane `G+360` / ascending commit `G+340` with `G+416` / `G+396`.
+
+`docs/plans/2026-08-26-naval-base-placement-design.md` and any plans/tests copied from it:
+
+- replace the 90-lepton candidate Cell center with 104.
+
+Older bridge plans that explicitly label 90 as approximate or unverified should be marked superseded by this live capture rather than used as implementation evidence.
+
+### Ghidra annotation candidates
+
+No Ghidra mutation was made. Current comments on `0x0047B3A0`, `0x00486840`, and `0x00486890` are already correct. Remaining stale particle-function comments, if any, should state:
+
+```text
+Spark calls CellClass::GetGroundHeight, whose active Cell scalar is 104.
+DAT_00AC4A0C is the Particle module's independently derived four-level
+structural bridge offset, 416. Bridge plane = ground + 416.
+```
+
+Candidate names for currently unnamed peer globals, subject to the project's annotation sync policy:
+
+- `0x00AC4A18`: `g_nParticleLevelHeightLeptons`
+- `0x00AC4A0C`: `g_nParticleStructuralDeckOffsetLeptons`
+- `0x0089DE70`: `g_nBulletLevelHeightLeptons`
+- `0x0089DE64`: `g_nBulletStructuralDeckOffsetLeptons`
+- `0x00B1D0B8`: `g_nUnitLevelHeightLeptons`
+- `0x00B1D0AC`: `g_nUnitStructuralDeckOffsetLeptons`
+
+## 16. Sources
+
+### Fresh active-binary operations
+
+- `disassemble_bytes 0x0047B170..0x0047B310`
+- `decompile_function 0x0047B3A0`
+- `get_xrefs_to 0x0047B3A0` (32 results)
+- `get_xrefs_to 0x00578080` (185 results)
+- `decompile_function 0x00486840`
+- `decompile_function 0x00486890`
+- `decompile_function 0x0062B5E0`
+- `decompile_function 0x0062C6E0`
+- `disassemble_bytes 0x0062B520..0x0062B580`
+- `disassemble_bytes 0x005F3830..0x005F38A0`
+- `decompile_function 0x007549E0`
+- direct-xref queries for every scalar address listed in §§4 and 8
+- Ghidra symbol searches for `GetZ`, `LevelHeight`, and `Deck`
+
+### Fresh active-runtime reads
+
+Read-only process-memory capture of every address in §4.2 plus Cell initializer intermediates `0x0089E728`, `0x0089E758`, and `0x0089E750`.
+
+### Current Rust sources
+
+- `src/util/lepton.rs`
+- `src/sim/cell_kernel.rs`
+- `src/sim/cell_rect.rs`
+- `src/sim/particles/spark_world.rs`
+- `src/sim/particles/spark.rs`
+- all `ground_height_leptons` and `cellclass_ground_height_leptons` callsites found by repository-wide `rg`
+- git history for commit `26a4da9e`
+
+### Existing leads inspected but not trusted without fresh verification
+
+- `docs/research/PARTICLE_SPARK_LIVE_COLLISION_INPUTS_GHIDRA_REPORT.md`
+- `docs/plans/2026-07-18-spark-native-float-and-point-compositor-design.md`
+- bridge height and Cell target-coordinate reports referenced by the research index

--- a/docs/research/PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md
@@ -18,9 +18,19 @@
 
 **Active in YR:** yes. The functions have 185 direct wrapper calls and 32 direct inner-evaluator calls spanning map/cell, movement, placement, targeting, projectile, particle, damage, radar, and draw paths. Spark behavior 3 calls the same wrapper directly.
 
-**Confidence:** HIGH for the scalar values, initializer formula, coordinate and slope domains, bridge offsets, named/global xrefs, the 185/32 direct-call census, and current-Rust consumer inventory. The malformed-slope and unavailable-cell boundaries remain intentionally classified rather than approximated.
+**Confidence:** HIGH for the scalar values, initializer formula, coordinate and slope domains, bridge offsets, named/global xrefs, the 185/32 direct-call census, and the investigation-time source-branch Rust consumer inventory. The malformed-slope and unavailable-cell boundaries remain intentionally classified rather than approximated.
 
 **Implementation scope:** none. This report is a research handoff. It changes no Rust code and makes no Ghidra changes.
+
+**Integration rebase (2026-08-30):** The native evidence is unchanged, but
+the Rust inventory in sections 11 and 14 was captured on the source branch,
+where `src/sim/naval_base_placement.rs` and its two documents existed and the
+accumulated snapshot version was 110. Current `origin/main` has none of that
+separate AI/naval slice. The completed integration therefore corrected the
+four active current-main callsites, did not restore the naval files, and
+advanced the actual mainline snapshot contract `105 -> 106`. Naval entries
+below are historical source-branch evidence and a later-owner obligation, not
+current implementation scope.
 
 ## Verdict
 
@@ -35,7 +45,8 @@ Active runtime capture and static initializer disassembly agree:
 - Spark obtains ground by calling the same `CellClass::GetGroundHeight`, then adds its module-local `DAT_00AC4A0C = 416` bridge plane;
 - independent Foot, Techno/InRange, area-damage, Anim, Bullet, Particle, Unit, and VXL initializer families also resolve to 104, and all examined four-level deck offsets resolve to 416.
 
-Current Rust therefore has one high-impact regression and one important preservation rule:
+At investigation time, the source-branch Rust tree had one high-impact
+regression and one important preservation rule:
 
 1. `src/util/lepton.rs::CELLCLASS_GROUND_LEVEL_HEIGHT_LEPTONS = 90` and `cellclass_ground_height_leptons` are wrong. Their production callers produce incorrect terrain Z, target Z, placement Z, and test fixtures on every nonzero level and many slopes.
 2. Spark's current use of `ground_height_leptons` (104) is correct and must be preserved. Changing Spark to 90 would introduce the exact bug this investigation disproves.
@@ -58,7 +69,7 @@ bridge-aware target = ground-only surface + a caller-owned 416 offset when its b
 5. Spark constructor and behavior-3 height consumers.
 6. Every direct xref to the ground wrapper and inner evaluator.
 7. Direct readers of the named module-local 104/416 scalar pairs plus the Bullet, Particle, Unit, and VXL peers needed to close the domain hypothesis.
-8. Every current Rust use of the 90-specific helper and the current 104 ground evaluator.
+8. Every investigation-time source-branch Rust use of the 90-specific helper and the 104 ground evaluator.
 9. Evidence-backed exclusions: INI authority, nonexistent `MapClass::GetZPos` label, bridge non-inclusion in ground sampling, invalid slopes, and unavailable-cell policy.
 
 ### Not re-investigated here
@@ -554,11 +565,12 @@ Evidence-backed exclusions:
 
 ## 11. Current Rust comparison
 
-### 11.1 Correct common evaluator and correct consumers
+### 11.1 Correct common evaluator and already-correct consumers at investigation time
 
 `src/util/lepton.rs::GROUND_LEVEL_HEIGHT_LEPTONS = 104` and `ground_height_leptons` reproduce the verified base, low-byte local XY, record coefficients, clamp, and signed chop for slopes 0..20. `src/sim/cell_kernel.rs::cell_floor_height` already routes through it.
 
-Production/read-path users currently on the correct 104 evaluator include:
+Production/read-path users already on the correct 104 evaluator when the
+source-branch inventory was captured included:
 
 - `src/sim/particles/spark_world.rs:96,119` — Spark candidate and constructor ground;
 - `src/sim/anim_class.rs:484` — Anim ground;
@@ -578,9 +590,9 @@ Production/read-path users currently on the correct 104 evaluator include:
 
 Direct multiplication users of `GROUND_LEVEL_HEIGHT_LEPTONS`/`LEPTONS_PER_LEVEL` also use 104. Their caller-specific omission status is outside this scalar correction, but their numeric domain must not be changed to 90.
 
-### 11.2 False 90 helper and all production consumers
+### 11.2 False 90 helper and production consumers at investigation time
 
-`src/util/lepton.rs` currently declares:
+At the time of the source-branch investigation, `src/util/lepton.rs` declared:
 
 ```rust
 pub const CELLCLASS_GROUND_LEVEL_HEIGHT_LEPTONS: i32 = 90;
@@ -588,12 +600,16 @@ pub const CELLCLASS_GROUND_LEVEL_HEIGHT_LEPTONS: i32 = 90;
 
 and constructs a second slope table plus `cellclass_ground_height_leptons`. This was introduced by commit `26a4da9e` (`Match gamemd slope-aware radar click target...`). The parent revision correctly stated that the Cell initializer independently resolved to 104. The change hardened the stale Spark report's false premise into code.
 
-Every current production use of the wrong helper is:
+That source branch had five production uses of the wrong helper. Current main
+had only the four non-naval rows when this slice was integrated; all four now
+use `ground_height_leptons`, and the false helper/table are gone. The naval row
+is retained to preserve the source-branch evidence, but its module was
+intentionally not restored.
 
-| Rust consumer | Native role | Current mismatch |
+| Rust consumer | Native role | Investigation-time mismatch / integration status |
 |---|---|---|
 | `src/render/minimap_interaction.rs:130` | `CellClass::Get_Center_Coords` for radar click | level/slope Z uses 90 instead of 104 |
-| `src/sim/naval_base_placement.rs:174` | candidate Cell center distance point | candidate Z uses 90 instead of 104 |
+| `src/sim/naval_base_placement.rs:174` | candidate Cell center distance point | Historical source-branch mismatch; module absent from current main and excluded from this integration |
 | `src/sim/projectile.rs:241` | allocated real `CellClass::GetTargetCoords` | ground uses 90; conditional +416 is correct |
 | `src/sim/projectile.rs:284` | shared dummy `CellClass::GetTargetCoords` | dummy ground uses 90; conditional +416 is correct |
 | `src/sim/production/production_spawn.rs:637` | spawn Cell center evaluation | evaluator uses 90 instead of 104, but the current helper discards center Z and returns only the X/Y-derived Cell; the correction preserves output coordinates while removing the false domain and retaining the unsupported-slope gate |
@@ -614,9 +630,9 @@ For flat level 2, current bad output is `180`; native is `208`. With a structura
 
 ### 11.3 Mechanism matrix
 
-| Mechanism | Native | Current Rust | Verdict |
+| Mechanism | Native | Source-branch Rust at investigation time | Verdict |
 |---|---|---|---|
-| Cell Level scalar | independent global, value 104 | common 104 plus false duplicate 90 | FAIL where duplicate is used |
+| Cell Level scalar | independent global, value 104 | integration has one common 104 authority; source branch formerly had false duplicate 90 | PASS integrated scalar; historical FAIL where duplicate was used |
 | Cell slope records | `G=104`, indices 0..20 | common table with 104 is exact; duplicate table uses 90 | preserve common, remove/fix duplicate |
 | signed negative base | `ftol(level*104+0.5)` | common returns `-103` for -1 | PASS common; FAIL duplicate (`-89`) |
 | local slope XY | unsigned low bytes | common and duplicate both use low bytes | PASS operation shape |
@@ -651,7 +667,7 @@ For flat level 2, current bad output is `180`; native is `208`. With a structura
 | Q16 | **RESOLVED:** executable initializer constants, no INI writer. |
 | Q17 | **RESOLVED:** no verified active `MapClass::GetZPos` symbol; use the proven Cell methods. |
 | Q18 | **RESOLVED:** complete 185 wrapper and 32 inner direct-xref census is in §9. |
-| Q19 | **RESOLVED:** five production callsites use the false helper, plus named test/prose fixtures. |
+| Q19 | **RESOLVED:** the source branch had five production callsites using the false helper; current main had four because naval placement is absent, and all four were migrated by this integration. |
 | Q20 | **RESOLVED:** Spark and the common sim consumers use the correct 104 evaluator; list in §11.1. |
 | Q21 | **RESOLVED:** implementation handoff and acceptance tests are in §14. |
 
@@ -676,13 +692,31 @@ Both reproduced 104 and 416. The current Ghidra plate comments on `CellClass::Ge
 
 ## 14. Implementation handoff
 
+### Current integration disposition (2026-08-30)
+
+- Completed: removed the false 90-lepton helper/table and routed all four
+  active current-main consumers through `ground_height_leptons`.
+- Completed: preserved ground-only versus conditional +416 deck composition,
+  typed unsupported-slope failure, Spark's existing 104/416 numeric path, and
+  the dependent current-main fixtures.
+- Completed: advanced the current mainline snapshot contract `105 -> 106`.
+- Excluded: the source branch's naval-placement module and two documents were
+  already absent on current main and were not restored. Their verified
+  104-lepton candidate requirement belongs to a later owner if that separate
+  mechanism is integrated.
+- Still separate: caller-specific shared-dummy/unavailable-cell closure,
+  including Spark routing, remains outside this numeric slice.
+
 ### Required code delta
 
 1. Remove the false 90-lepton semantic split in `src/util/lepton.rs`.
    - Prefer one 104 ground evaluator/table for all Cell ground users.
    - If ownership-specific aliases remain for documentation, assert they equal 104 and route both APIs through the same records/evaluator.
    - Correct comments that say Cell uses 90.
-2. Correct all five production users in §11.2. A constant-only change may be sufficient numerically, but the builder should avoid retaining duplicate tables that can drift again.
+2. Correct the four active current-main production users in §11.2. The fifth,
+   naval-placement row is source-branch context only and must not be restored
+   by this slice. A constant-only change may be sufficient numerically, but the
+   builder should avoid retaining duplicate tables that can drift again.
 3. Preserve Spark's current 104 `ground_height_leptons` call and 416 structural plane.
 4. Rebaseline all 90-derived tests, snapshot hashes, wave target expectations, and recent design prose.
 5. Route height callers through the shared fixed-stride/dummy-cell substrate where native can observe unavailable cells. If the builder does not close this in the same slice, GSI-04.03 remains open; returning zero/`None` is not exact native behavior.
@@ -700,7 +734,10 @@ At minimum:
 - dummy level `0xFF`, flat returns -103 and retains requested packed coordinate;
 - Spark level-2 flat ground is 208, bridge plane 624, ascending snap 604; level-0 plane remains 416;
 - Particle constructor clamps input `Z <= ground` to the 104-based ground;
-- radar click, naval-base distance, production's intermediate Cell-center evaluation, projectile real target, and projectile dummy target all share the 104 evaluator;
+- radar click, production's intermediate Cell-center evaluation, projectile
+  real target, and projectile dummy target all share the 104 evaluator;
+- if a later owner restores naval-base placement, its candidate distance path
+  must also use the 104 evaluator under that mechanism's own review;
 - production's current X/Y-only returned spawn Cell remains unchanged because its intermediate center Z is discarded;
 - Sonic target composed over level-2 structural cell is `208 + 416 + 50 = 674`;
 - changing structural bridge state changes only the +416 selection, never the ground scalar;
@@ -723,7 +760,8 @@ Severity is high whenever nonzero elevation participates:
 - radar clicks and action targets on raised terrain;
 - projectile/cell target coordinates and Sonic/wave endpoints on raised or bridged cells;
 - production's intermediate Cell-center evaluation on raised cells (the current Rust helper discards that Z before returning its X/Y-only spawn Cell, so this scalar correction alone does not move the unit);
-- naval-base first-yard 3D distance checks near elevation changes;
+- naval-base first-yard 3D distance checks near elevation changes apply only
+  to the excluded source-branch mechanism, not current main;
 - any test/snapshot derived from those values.
 
 Flat level-0 maps hide the scalar regression because both domains return zero there. Slopes can expose it even at level 0.
@@ -745,7 +783,8 @@ Flat level-0 maps hide the scalar regression because both domains return zero th
 - mark its HIGH-confidence 90/360/340 conclusions superseded by this live runtime capture, or correct every affected table, trace, questions-log entry, and Rust handoff to 104/416/396;
 - retain its independently verified float integration, collision inequalities, RNG, and compositor findings.
 
-`docs/research/PHASE3_NAVAL_BASE_PLACEMENT_LIFECYCLE_GHIDRA_REPORT.md`:
+`docs/research/PHASE3_NAVAL_BASE_PLACEMENT_LIFECYCLE_GHIDRA_REPORT.md`
+(historical source-branch file, absent from current main):
 
 - replace the claim that 104-lepton Cell ground is wrong with the verified 104 evaluator;
 - replace its `cellclass_ground_height_leptons` Rust handoff with the common `ground_height_leptons` authority.
@@ -760,7 +799,9 @@ Flat level-0 maps hide the scalar regression because both domains return zero th
 - replace its retained `G+360` / ascending `G+340` adapter contract with the verified `G+416` / `G+396` composition;
 - state explicitly that the existing Spark ground evaluator already uses the correct 104 scalar while shared-dummy routing remains open.
 
-`docs/plans/2026-08-26-naval-base-placement-design.md` and any plans/tests copied from it:
+`docs/plans/2026-08-26-naval-base-placement-design.md` (historical
+source-branch file, absent from current main) and any later plans/tests copied
+from it:
 
 - replace the 90-lepton candidate Cell center with 104.
 

--- a/src/render/minimap_interaction.rs
+++ b/src/render/minimap_interaction.rs
@@ -30,14 +30,9 @@ fn clamp_native_radar_click_cell(
 ) -> (i16, i16) {
     let horizontal_cells = tactical_size.0 / 60;
     let horizontal_half = horizontal_cells.wrapping_add(2) / 2;
-    let difference_limit = map_size
-        .0
-        .wrapping_sub(horizontal_half)
-        .wrapping_sub(1);
+    let difference_limit = map_size.0.wrapping_sub(horizontal_half).wrapping_sub(1);
     let vertical_cells = tactical_size.1 / 60;
-    let minimum_sum = vertical_cells
-        .wrapping_add(map_size.0)
-        .wrapping_add(1);
+    let minimum_sum = vertical_cells.wrapping_add(map_size.0).wrapping_add(1);
     let maximum_sum = map_size
         .1
         .wrapping_mul(2)
@@ -55,9 +50,7 @@ fn clamp_native_radar_click_cell(
 
     let x_minus_y = i32::from(x).wrapping_sub(i32::from(y));
     if x_minus_y > difference_limit.wrapping_sub(1) {
-        let delta = x_minus_y
-            .wrapping_sub(difference_limit)
-            .wrapping_add(1) as i16;
+        let delta = x_minus_y.wrapping_sub(difference_limit).wrapping_add(1) as i16;
         y = y.wrapping_add(delta);
         x = x.wrapping_sub(delta);
     }
@@ -125,15 +118,13 @@ fn native_camera_target_from_signed(
     // `CellClass::Get_Center_Coords @ 0x00480A30` reads the cell object's
     // signed packed coordinate, forms X/Y at subcell (128,128), and asks
     // `0x0047B3A0` for ground Z. It does not add bridge-deck height.
-    let x = i32::from(cell.rx as i16).wrapping_mul(256).wrapping_add(128);
-    let y = i32::from(cell.ry as i16).wrapping_mul(256).wrapping_add(128);
-    let z = crate::util::lepton::cellclass_ground_height_leptons(
-        cell.level,
-        cell.slope_type,
-        x,
-        y,
-    )
-    .ok()?;
+    let x = i32::from(cell.rx as i16)
+        .wrapping_mul(256)
+        .wrapping_add(128);
+    let y = i32::from(cell.ry as i16)
+        .wrapping_mul(256)
+        .wrapping_add(128);
+    let z = crate::util::lepton::ground_height_leptons(cell.level, cell.slope_type, x, y).ok()?;
     Some(NativeRadarCameraTarget {
         cell: (cell.rx, cell.ry),
         world_leptons: (x, y, z),
@@ -181,7 +172,11 @@ impl MinimapRenderer {
                 NativeRadarScreenGeometry::new(surface, [rect_x, rect_y, rect_w, rect_h])
                     .content_rect()
             })
-            .or_else(|| self.playfield_bounds.is_none().then_some([rect_x, rect_y, rect_w, rect_h]))
+            .or_else(|| {
+                self.playfield_bounds
+                    .is_none()
+                    .then_some([rect_x, rect_y, rect_w, rect_h])
+            })
     }
 
     /// `RadarClass::GetObjectAtRadarPixel @ 0x00656750`: screen to generated
@@ -326,22 +321,20 @@ mod tests {
             foundation,
             radar_scale: 1.0,
             discovery_observed: true,
-            visibility: RadarRegistrationVisibilityFacts::Mobile(
-                RadarMobileVisibilityFacts {
-                    type_invisible: false,
-                    sinking: false,
-                    object_alive: true,
-                    in_limbo: false,
-                    owner_is_human_player: false,
-                    fresh_in_playfield: true,
-                    shrouded: false,
-                    cloak_state: 0,
-                    has_sensor: false,
-                    allied_with_current_player: false,
-                    height_leptons: 0,
-                    veteran_radar_invisible: false,
-                },
-            ),
+            visibility: RadarRegistrationVisibilityFacts::Mobile(RadarMobileVisibilityFacts {
+                type_invisible: false,
+                sinking: false,
+                object_alive: true,
+                in_limbo: false,
+                owner_is_human_player: false,
+                fresh_in_playfield: true,
+                shrouded: false,
+                cloak_state: 0,
+                has_sensor: false,
+                allied_with_current_player: false,
+                height_leptons: 0,
+                veteran_radar_invisible: false,
+            }),
             local_front: false,
         }
     }
@@ -418,14 +411,38 @@ mod tests {
     fn native_click_clamp_preserves_signed_words_and_strict_branch_equality() {
         let map = (100, 100);
         let tactical = (632, 570);
-        assert_eq!(clamp_native_radar_click_cell((50, 143), map, tactical), (50, 143));
-        assert_eq!(clamp_native_radar_click_cell((50, 144), map, tactical), (51, 143));
-        assert_eq!(clamp_native_radar_click_cell((142, 50), map, tactical), (142, 50));
-        assert_eq!(clamp_native_radar_click_cell((143, 50), map, tactical), (142, 51));
-        assert_eq!(clamp_native_radar_click_cell((55, 55), map, tactical), (55, 55));
-        assert_eq!(clamp_native_radar_click_cell((54, 55), map, tactical), (55, 56));
-        assert_eq!(clamp_native_radar_click_cell((145, 145), map, tactical), (145, 145));
-        assert_eq!(clamp_native_radar_click_cell((145, 146), map, tactical), (144, 145));
+        assert_eq!(
+            clamp_native_radar_click_cell((50, 143), map, tactical),
+            (50, 143)
+        );
+        assert_eq!(
+            clamp_native_radar_click_cell((50, 144), map, tactical),
+            (51, 143)
+        );
+        assert_eq!(
+            clamp_native_radar_click_cell((142, 50), map, tactical),
+            (142, 50)
+        );
+        assert_eq!(
+            clamp_native_radar_click_cell((143, 50), map, tactical),
+            (142, 51)
+        );
+        assert_eq!(
+            clamp_native_radar_click_cell((55, 55), map, tactical),
+            (55, 55)
+        );
+        assert_eq!(
+            clamp_native_radar_click_cell((54, 55), map, tactical),
+            (55, 56)
+        );
+        assert_eq!(
+            clamp_native_radar_click_cell((145, 145), map, tactical),
+            (145, 145)
+        );
+        assert_eq!(
+            clamp_native_radar_click_cell((145, 146), map, tactical),
+            (144, 145)
+        );
     }
 
     #[test]
@@ -433,29 +450,27 @@ mod tests {
         let surface = NativeRadarSurfaceGeometry::from_raw_rect(30, 20, 300, 180).unwrap();
         let signed = signed_tracker_or_inverse_cell(surface, (0, 0), None);
         assert_eq!(signed, (-4, 25));
-        assert_eq!(clamp_native_radar_click_cell(signed, (100, 100), (632, 570)), (85, 114));
+        assert_eq!(
+            clamp_native_radar_click_cell(signed, (100, 100), (632, 570)),
+            (85, 114)
+        );
     }
 
     #[test]
     fn native_click_target_samples_all_active_slopes_at_cell_center() {
         let mut terrain = click_terrain(64, 64);
         let expected_contributions = [
-            0, 45, 45, 45, 45, 0, 0, 0, 0, 90, 90, 90, 90, 90, 90, 90, 90, 45, 45,
-            45, 45,
+            0, 52, 52, 52, 52, 0, 0, 0, 0, 104, 104, 104, 104, 104, 104, 104, 104, 52, 52, 52, 52,
         ];
         for (slope, contribution) in expected_contributions.into_iter().enumerate() {
             let cell = terrain.cell_mut(55, 55).unwrap();
             cell.level = 2;
             cell.slope_type = slope as u8;
-            let target = native_camera_target_from_signed(
-                (55, 55),
-                (100, 100),
-                (632, 570),
-                &terrain,
-            )
-            .unwrap();
+            let target =
+                native_camera_target_from_signed((55, 55), (100, 100), (632, 570), &terrain)
+                    .unwrap();
             assert_eq!(target.cell, (55, 55));
-            assert_eq!(target.world_leptons, (14_208, 14_208, 180 + contribution));
+            assert_eq!(target.world_leptons, (14_208, 14_208, 208 + contribution));
         }
     }
 
@@ -468,34 +483,23 @@ mod tests {
         cell.has_bridge_deck = true;
         cell.bridge_walkable = true;
         cell.bridge_deck_level = 7;
-        let target = native_camera_target_from_signed(
+        let target =
+            native_camera_target_from_signed((63, 63), (100, 100), (632, 570), &terrain).unwrap();
+        assert_eq!(
+            target.cell,
             (63, 63),
-            (100, 100),
-            (632, 570),
-            &terrain,
-        )
-        .unwrap();
-        assert_eq!(target.cell, (63, 63), "last real grid cell remains available");
-        assert_eq!(target.world_leptons, (16_256, 16_256, 315));
+            "last real grid cell remains available"
+        );
+        assert_eq!(target.world_leptons, (16_256, 16_256, 364));
 
         assert_eq!(
-            native_camera_target_from_signed(
-                (64, 64),
-                (100, 100),
-                (632, 570),
-                &terrain,
-            ),
+            native_camera_target_from_signed((64, 64), (100, 100), (632, 570), &terrain,),
             None,
-            "Rust has no exact shared-dummy substrate, so invalid lookup cannot flatten to Z=0",
+            "this caller still fails closed instead of routing through the existing shared dummy",
         );
         terrain.test_set_native_allocated_cells(&[]);
         assert_eq!(
-            native_camera_target_from_signed(
-                (63, 63),
-                (100, 100),
-                (632, 570),
-                &terrain,
-            ),
+            native_camera_target_from_signed((63, 63), (100, 100), (632, 570), &terrain,),
             None,
             "a Size-diamond hole is not a rectangular/level-zero fallback",
         );
@@ -512,44 +516,31 @@ mod tests {
         ));
         let tracker_signed = tracker_object_signed_cell(&tracker, &entities, (40, 60)).unwrap();
         assert_eq!(tracker_signed, (55, 55));
-        let tracker_target = native_camera_target_from_signed(
-            tracker_signed,
-            (100, 100),
-            (632, 570),
-            &terrain,
-        );
-        let empty_target = native_camera_target_from_signed(
-            (55, 55),
-            (100, 100),
-            (632, 570),
-            &terrain,
-        );
+        let tracker_target =
+            native_camera_target_from_signed(tracker_signed, (100, 100), (632, 570), &terrain);
+        let empty_target =
+            native_camera_target_from_signed((55, 55), (100, 100), (632, 570), &terrain);
         assert_eq!(tracker_target, empty_target);
     }
 
     #[test]
     fn native_click_cellclass_xyz_uses_the_full_6d6070_camera_projection() {
-        // Cell (55,55), Level=2, slope 1 at center: 180 base + 45 slope.
+        // Cell (55,55), Level=2, slope 1 at center: 208 base + 52 slope.
         // Get_Center_Coords 0x00480A30 passes this complete XYZ to 0x006D6070;
         // the latter projects/AdjustForZ before writing current and desired to
         // one identical immediate top-left (represented by Rust's one point).
-        let world = crate::util::lepton::absolute_leptons_to_screen(14_208, 14_208, 225);
-        assert_eq!(world, (0.0, 1_648.0));
-        let camera = crate::app::input::camera::tactical_camera_top_left(
-            world,
-            856.0,
-            736.0,
-            1.0,
-        );
-        assert_eq!(camera, (-428.0, 1_280.0));
-        assert_eq!(
-            ((world.0 - camera.0), (world.1 - camera.1)),
-            (428.0, 368.0),
-        );
+        let world = crate::util::lepton::absolute_leptons_to_screen(14_208, 14_208, 260);
+        assert_eq!(world, (0.0, 1_643.0));
+        let camera = crate::app::input::camera::tactical_camera_top_left(world, 856.0, 736.0, 1.0);
+        assert_eq!(camera, (-428.0, 1_275.0));
+        assert_eq!(((world.0 - camera.0), (world.1 - camera.1)), (428.0, 368.0),);
 
-        let level_only = crate::util::lepton::absolute_leptons_to_screen(14_208, 14_208, 180);
-        assert_eq!(level_only, (0.0, 1_654.0));
-        assert_ne!(world, level_only, "the slope contribution cannot be reconstructed from Level");
+        let level_only = crate::util::lepton::absolute_leptons_to_screen(14_208, 14_208, 208);
+        assert_eq!(level_only, (0.0, 1_650.0));
+        assert_ne!(
+            world, level_only,
+            "the slope contribution cannot be reconstructed from Level"
+        );
     }
 
     #[test]
@@ -560,7 +551,10 @@ mod tests {
         assert_eq!(pixel, (0, 0));
         let signed = signed_tracker_or_inverse_cell(surface, pixel, None);
         assert_eq!(signed, (-4, 25));
-        assert_eq!(clamp_native_radar_click_cell(signed, (100, 100), (632, 570)), (85, 114));
+        assert_eq!(
+            clamp_native_radar_click_cell(signed, (100, 100), (632, 570)),
+            (85, 114)
+        );
     }
 
     #[test]
@@ -630,16 +624,17 @@ mod tests {
         let mut tracker = RetainedRadarTracker::default();
         tracker.update_object(tracker_update(1, None), false);
         tracker.update_object(tracker_update(2, Some((4, 3))), false);
-        assert_eq!(tracker.object_at_pixel(40, 60), Some(2), "native reverse bucket scan");
+        assert_eq!(
+            tracker.object_at_pixel(40, 60),
+            Some(2),
+            "native reverse bucket scan"
+        );
 
         let mut entities = crate::sim::entity_store::EntityStore::new();
-        let mobile = crate::sim::game_entity::GameEntity::test_default(
-            1, "MTNK", "Enemy", 60, 60,
-        );
+        let mobile = crate::sim::game_entity::GameEntity::test_default(1, "MTNK", "Enemy", 60, 60);
         entities.insert(mobile);
-        let mut building = crate::sim::game_entity::GameEntity::test_default(
-            2, "BLDG", "Enemy", 60, 60,
-        );
+        let mut building =
+            crate::sim::game_entity::GameEntity::test_default(2, "BLDG", "Enemy", 60, 60);
         building.category = crate::map::entities::EntityCategory::Structure;
         building.foundation = "4x3".to_string();
         building.position.sub_x = crate::util::fixed_math::SimFixed::from_num(200);
@@ -647,7 +642,11 @@ mod tests {
         entities.insert(building);
 
         let signed = tracker_object_signed_cell(&tracker, &entities, (40, 60));
-        assert_eq!(signed, Some((62, 61)), "4x3 foundation centre truncates after subcell");
+        assert_eq!(
+            signed,
+            Some((62, 61)),
+            "4x3 foundation centre truncates after subcell"
+        );
         assert_eq!(
             native_camera_cell_from_signed(signed.unwrap(), (100, 100), (632, 570)),
             (62, 61),

--- a/src/sim/bridge_specs.rs
+++ b/src/sim/bridge_specs.rs
@@ -649,26 +649,23 @@ fn update_ramp_perpendicular_recursive(
     let (dx, dy) = dir.offset();
     let target_x = anchor_pos.0 as i32 + dx;
     let target_y = anchor_pos.1 as i32 + dy;
-    let target_pos = match crate::sim::cell_rect::get_cellclass_fallback(
-        Some(terrain),
-        target_x,
-        target_y,
-    ) {
-        // MapClass applies signed packed/fixed-stride indexing before this
-        // helper reads CellClass state. Retain the resolved cell's canonical
-        // coordinate rather than re-casting the requested components.
-        crate::sim::cell_rect::CellRef::Real(cell) => (cell.rx, cell.ry),
-        // Native GetCell has already stamped the one shared dummy identity at
-        // this exact call point. Its +0x11E/tile selectors remain unmodeled,
-        // so no represented transition or setter follows from this frame.
-        crate::sim::cell_rect::CellRef::Dummy { .. } => {
-            return RampOutcome {
-                state_changed: false,
-                damaged_variant_cells: Vec::new(),
-                setter_transcript: Vec::new(),
-            };
-        }
-    };
+    let target_pos =
+        match crate::sim::cell_rect::get_cellclass_fallback(Some(terrain), target_x, target_y) {
+            // MapClass applies signed packed/fixed-stride indexing before this
+            // helper reads CellClass state. Retain the resolved cell's canonical
+            // coordinate rather than re-casting the requested components.
+            crate::sim::cell_rect::CellRef::Real(cell) => (cell.rx, cell.ry),
+            // Native GetCell has already stamped the one shared dummy identity at
+            // this exact call point. Its +0x11E/tile selectors remain unmodeled,
+            // so no represented transition or setter follows from this frame.
+            crate::sim::cell_rect::CellRef::Dummy { .. } => {
+                return RampOutcome {
+                    state_changed: false,
+                    damaged_variant_cells: Vec::new(),
+                    setter_transcript: Vec::new(),
+                };
+            }
+        };
 
     // Snapshot target read (avoids borrow conflict with subsequent mut access).
     let Some(target_cell) = state.cell(target_pos.0, target_pos.1).copied() else {
@@ -1691,14 +1688,8 @@ mod tests {
     fn update_ramp_perpendicular_ns_damage_a_anchor_target_transitions_to_4() {
         let mut state = make_perpendicular_test_state();
         let terrain = ramp_test_terrain_with_anchor_bits(&[(6, 5)]);
-        let outcome = update_ramp_perpendicular(
-            &mut state,
-            (5, 5),
-            Axis::NS,
-            Phase::DamageA,
-            true,
-            &terrain,
-        );
+        let outcome =
+            update_ramp_perpendicular(&mut state, (5, 5), Axis::NS, Phase::DamageA, true, &terrain);
         assert!(outcome.state_changed);
         let target = state.cell(6, 5).expect("E target");
         assert_eq!(target.damage_state, DamageState::Healthy { variant: 4 });
@@ -1708,14 +1699,8 @@ mod tests {
     fn update_ramp_perpendicular_ns_damage_b_anchor_target_walks_west() {
         let mut state = make_perpendicular_test_state();
         let terrain = ramp_test_terrain_with_anchor_bits(&[(4, 5)]);
-        let outcome = update_ramp_perpendicular(
-            &mut state,
-            (5, 5),
-            Axis::NS,
-            Phase::DamageB,
-            true,
-            &terrain,
-        );
+        let outcome =
+            update_ramp_perpendicular(&mut state, (5, 5), Axis::NS, Phase::DamageB, true, &terrain);
         assert!(outcome.state_changed);
         let target = state.cell(4, 5).expect("W target");
         assert_eq!(target.damage_state, DamageState::Healthy { variant: 5 });
@@ -1751,14 +1736,8 @@ mod tests {
         let dummy = terrain.shared_cell_dummy();
         dummy.apply_bridge_flag_slot(BridgeStampSlot::Anchor, true);
         // Anchor at (0, 0) calling NS DamageB → walks W → target x = -1 → out of bounds.
-        let outcome = update_ramp_perpendicular(
-            &mut state,
-            (0, 0),
-            Axis::NS,
-            Phase::DamageB,
-            true,
-            &terrain,
-        );
+        let outcome =
+            update_ramp_perpendicular(&mut state, (0, 0), Axis::NS, Phase::DamageB, true, &terrain);
         assert!(!outcome.state_changed);
         assert!(outcome.setter_transcript.is_empty());
         assert_eq!(dummy.snapshot().coord, (-1, 0));
@@ -1776,7 +1755,7 @@ mod tests {
         };
         assert_eq!(
             observed_target,
-            crate::sim::projectile::ProjectileCoord::new(-128, 128, 2 * 90 + 416),
+            crate::sim::projectile::ProjectileCoord::new(-128, 128, 2 * 104 + 416),
             "a retained DummyCell target observes the ramp helper's live restamp and structural height"
         );
     }
@@ -1795,14 +1774,8 @@ mod tests {
         let dummy = terrain.shared_cell_dummy();
         dummy.stamp_coord(8, 9);
 
-        let outcome = update_ramp_perpendicular(
-            &mut state,
-            (2, 2),
-            Axis::NS,
-            Phase::DamageA,
-            true,
-            &terrain,
-        );
+        let outcome =
+            update_ramp_perpendicular(&mut state, (2, 2), Axis::NS, Phase::DamageA, true, &terrain);
 
         assert!(!outcome.state_changed);
         assert!(outcome.setter_transcript.is_empty());
@@ -1833,11 +1806,7 @@ mod tests {
             .collect();
         let mut terrain = ResolvedTerrainGrid::from_cells(512, 1, cells);
         terrain.test_set_native_allocated_cells(&[(511, 0)]);
-        terrain
-            .cell_mut(511, 0)
-            .unwrap()
-            .bridge_facts
-            .raw_flags |= BRIDGE_FLAG_ANCHOR_SELF;
+        terrain.cell_mut(511, 0).unwrap().bridge_facts.raw_flags |= BRIDGE_FLAG_ANCHOR_SELF;
         let dummy = terrain.shared_cell_dummy();
         dummy.stamp_coord(7, 8);
         terrain.test_set_dummy_cell_level_slope(2, 0);
@@ -1851,14 +1820,8 @@ mod tests {
         // Requested (-1,1) aliases fixed slot 511, whose canonical coordinate
         // is (511,0). Native returns that real CellClass without stamping the
         // shared dummy.
-        let outcome = update_ramp_perpendicular(
-            &mut state,
-            (0, 1),
-            Axis::NS,
-            Phase::DamageB,
-            true,
-            &terrain,
-        );
+        let outcome =
+            update_ramp_perpendicular(&mut state, (0, 1), Axis::NS, Phase::DamageB, true, &terrain);
 
         assert!(outcome.state_changed);
         assert!(outcome.setter_transcript.is_empty());
@@ -2328,14 +2291,8 @@ mod tests {
             BridgeheadAnchorClass::Variant0,
         );
         let terrain = ramp_test_terrain_with_anchor_bits(&[(3, 2)]);
-        let outcome = update_ramp_perpendicular(
-            &mut state,
-            (2, 2),
-            Axis::NS,
-            Phase::DamageA,
-            true,
-            &terrain,
-        );
+        let outcome =
+            update_ramp_perpendicular(&mut state, (2, 2), Axis::NS, Phase::DamageA, true, &terrain);
         assert!(outcome.state_changed);
         // State byte advanced.
         assert_eq!(

--- a/src/sim/cell_kernel.rs
+++ b/src/sim/cell_kernel.rs
@@ -90,7 +90,8 @@ pub fn checked_cell_from_world(
     Some((x as u16, y as u16))
 }
 
-/// YR `CellClass::GetFloorHeight`; bridge height is deliberately not included.
+/// YR `CellClass::ComputeGroundHeightAtCoord @ 0x0047B3A0`; bridge height is
+/// deliberately not included.
 pub fn cell_floor_height(
     level: u8,
     slope_index: u8,

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -5447,9 +5447,7 @@ fn crusher_driveover_destroys_wall_but_noncrusher_does_not() {
         veh.regular_crusher = obj.crusher;
         veh.omni_crusher = obj.omni_crusher;
         veh.locomotor =
-            Some(crate::sim::movement::locomotor::LocomotorState::from_object_type(
-                obj, 0, 0,
-            ));
+            Some(crate::sim::movement::locomotor::LocomotorState::from_object_type(obj, 0, 0));
         veh.health = Health {
             current: 300,
             max: 300,
@@ -7270,7 +7268,7 @@ fn gsi_04_01_projectile_shrapnel_captures_each_shared_dummy_lookup() {
     use crate::sim::projectile::{
         ProjectileCoord, ProjectileTarget, dummy_cell_target_coord, projectile_random_shrapnel_cell,
     };
-    use crate::util::lepton::{BRIDGE_HEIGHT_DELTA_LEPTONS, cellclass_ground_height_leptons};
+    use crate::util::lepton::{BRIDGE_HEIGHT_DELTA_LEPTONS, ground_height_leptons};
 
     let rules = RuleSet::from_ini(&IniFile::from_str(
         "[VehicleTypes]\n0=MTNK\n\n[MTNK]\nStrength=100\nArmor=heavy\nPrimary=PARENT\n\n[PARENT]\nDamage=20\nROF=10\nRange=6\nSpeed=30\nProjectile=PARENTPROJ\nWarhead=WH\n\n[PARENTPROJ]\nAirburst=yes\nShrapnelWeapon=CHILD\nShrapnelCount=3\n\n[CHILD]\nDamage=5\nROF=10\nRange=3\nSpeed=40\nProjectile=CHILDPROJ\nWarhead=WH\n\n[CHILDPROJ]\nSubjectToWalls=yes\n\n[WH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
@@ -7321,8 +7319,7 @@ fn gsi_04_01_projectile_shrapnel_captures_each_shared_dummy_lookup() {
     let expected_target = |(rx, ry): (i32, i32), structural: bool| {
         let x = rx * 256 + 128;
         let y = ry * 256 + 128;
-        let z = cellclass_ground_height_leptons(2, 0, x, y)
-            .expect("flat CellClass surface is supported")
+        let z = ground_height_leptons(2, 0, x, y).expect("flat CellClass surface is supported")
             + if structural {
                 BRIDGE_HEIGHT_DELTA_LEPTONS as i32
             } else {
@@ -7390,7 +7387,7 @@ fn gsi_04_01_projectile_shrapnel_captures_each_shared_dummy_lookup() {
     let later_target = dummy_cell_target_coord(&later_dummy);
     assert_eq!(later_target.x, 9 * 256 + 128);
     assert_eq!(later_target.y, 10 * 256 + 128);
-    assert_eq!(later_target.z, 2 * 90 + BRIDGE_HEIGHT_DELTA_LEPTONS as i32);
+    assert_eq!(later_target.z, 2 * 104 + BRIDGE_HEIGHT_DELTA_LEPTONS as i32);
     assert_ne!(
         later_target,
         out.projectile_spawns[2].initial_target_position

--- a/src/sim/particles/spark.rs
+++ b/src/sim/particles/spark.rs
@@ -800,6 +800,20 @@ mod tests {
     }
 
     #[test]
+    fn gsi_04_03_cell_ground_104_preserves_level_two_spark_bridge_composition() {
+        let mut structural = facts(208);
+        structural.old_has_structural_bridge = true;
+
+        let descending = resolve_collision(motion(634, 622), structural).unwrap();
+        assert_eq!(descending.committed_coords.z, 624);
+        assert_eq!(descending.kind, Some(SparkCollisionKind::DescendingBridge));
+
+        let ascending = resolve_collision(motion(614, 632), structural).unwrap();
+        assert_eq!(ascending.committed_coords.z, 604);
+        assert_eq!(ascending.kind, Some(SparkCollisionKind::AscendingBridge));
+    }
+
+    #[test]
     fn ground_and_contact_height_boundaries_are_strict() {
         let near = resolve_collision(motion(0, -99), facts(0)).unwrap();
         assert_eq!(near.committed_coords.z, 0);

--- a/src/sim/particles/spark_spawn.rs
+++ b/src/sim/particles/spark_spawn.rs
@@ -523,6 +523,28 @@ mod tests {
     }
 
     #[test]
+    fn gsi_04_03_particle_constructor_clamps_at_or_below_level_two_104_floor() {
+        let rules = spark_rules(1, 2, "1");
+        let particle_type_id = crate::rules::particle_type::ParticleTypeId(0);
+        let particle_type = rules.particle_type(particle_type_id).clone();
+        let mut cell = super::super::spark_world::tests::terrain_cell(0, 0);
+        cell.level = 2;
+        let mut sim = super::super::spark_world::tests::one_cell_sim(cell);
+
+        for (input_z, expected_z) in [(207, 208), (208, 208), (209, 209)] {
+            let particle = construct_spark_particle(
+                &mut sim,
+                &rules,
+                &particle_type,
+                particle_type_id,
+                IVec3::new(128, 128, input_z),
+            )
+            .expect("finite stock-shaped Spark construction");
+            assert_eq!(particle.coords.z, expected_z, "input Z {input_z}");
+        }
+    }
+
+    #[test]
     fn gsi_05_13_spawn_frames_one_bursts_and_takes_no_gate_draw() {
         // `CMP EAX,0x1 / JZ 0x0062E89E` skips the probability roll entirely.
         // Stock `[SparkSys]` and `[FirestormSparkSys]` both set

--- a/src/sim/particles/spark_world.rs
+++ b/src/sim/particles/spark_world.rs
@@ -298,7 +298,7 @@ pub fn slope_matrix(slope: u8) -> Result<[NativeF32Bits; 12], SparkWorldError> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(super) mod tests {
     use super::*;
     use glam::IVec3;
 
@@ -315,7 +315,7 @@ mod tests {
     use crate::sim::occupancy::CellListInsertion;
     use crate::sim::overlay_grid::OverlayGrid;
 
-    fn terrain_cell(rx: u16, ry: u16) -> ResolvedTerrainCell {
+    pub(in crate::sim::particles) fn terrain_cell(rx: u16, ry: u16) -> ResolvedTerrainCell {
         ResolvedTerrainCell {
             rx,
             ry,
@@ -383,7 +383,7 @@ mod tests {
         }
     }
 
-    fn one_cell_sim(cell: ResolvedTerrainCell) -> Simulation {
+    pub(in crate::sim::particles) fn one_cell_sim(cell: ResolvedTerrainCell) -> Simulation {
         let mut sim = Simulation::new();
         sim.resolved_terrain = Some(ResolvedTerrainGrid::from_cells(1, 1, vec![cell]));
         sim.overlay_grid = Some(OverlayGrid::new(1, 1));

--- a/src/sim/production/production_spawn.rs
+++ b/src/sim/production/production_spawn.rs
@@ -634,8 +634,7 @@ fn resolve_produced_unit_cell_coords(
         .wrapping_mul(crate::sim::cell_kernel::LEPTONS_PER_CELL)
         .wrapping_add(crate::sim::cell_kernel::CELL_CENTER_LEPTONS);
     let ground_z =
-        crate::util::lepton::cellclass_ground_height_leptons(level, slope, center_x, center_y)
-            .ok()?;
+        crate::util::lepton::ground_height_leptons(level, slope, center_x, center_y).ok()?;
     let coords = crate::sim::cell_kernel::cell_center(
         crate::sim::cell_kernel::CellCoordinate {
             x: coord.0,
@@ -1968,6 +1967,71 @@ mod tests {
             )
             .exact_zero(),
             "an otherwise-identical in-diamond control remains admissible"
+        );
+    }
+
+    #[test]
+    fn production_cell_center_uses_104_for_real_and_dummy_without_changing_xy() {
+        let mut sim = production_admission_sim();
+        let requested = (8, 8);
+        let flat = resolve_produced_unit_cell_coords(&sim, requested);
+        assert_eq!(flat, Some(requested));
+
+        let cell = sim
+            .resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(requested.0, requested.1)
+            .unwrap();
+        cell.level = 2;
+        cell.slope_type = 0;
+        assert_eq!(
+            crate::util::lepton::ground_height_leptons(
+                cell.level,
+                cell.slope_type,
+                i32::from(requested.0) * 256 + 128,
+                i32::from(requested.1) * 256 + 128,
+            ),
+            Ok(208),
+        );
+        assert_eq!(
+            resolve_produced_unit_cell_coords(&sim, requested),
+            flat,
+            "GetCoords evaluates raised Z but the current production helper returns only X/Y",
+        );
+
+        sim.resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(requested.0, requested.1)
+            .unwrap()
+            .slope_type = 21;
+        assert_eq!(resolve_produced_unit_cell_coords(&sim, requested), None);
+
+        let dummy_grid = ResolvedTerrainGrid::from_cells(0, 0, Vec::new());
+        let mut dummy_sim = Simulation::default();
+        dummy_sim.resolved_terrain = Some(dummy_grid);
+        let dummy_request = (u16::MAX, 7);
+        let flat_dummy = resolve_produced_unit_cell_coords(&dummy_sim, dummy_request);
+        dummy_sim
+            .resolved_terrain
+            .as_ref()
+            .unwrap()
+            .test_set_dummy_cell_level_slope(2, 0);
+        assert_eq!(
+            resolve_produced_unit_cell_coords(&dummy_sim, dummy_request),
+            flat_dummy,
+            "shared-dummy GetCoords evaluates Level 2 as 208 but retains the same signed-center X/Y output",
+        );
+        dummy_sim
+            .resolved_terrain
+            .as_ref()
+            .unwrap()
+            .test_set_dummy_cell_level_slope(2, 21);
+        assert_eq!(
+            resolve_produced_unit_cell_coords(&dummy_sim, dummy_request),
+            None,
+            "the native-unsafe slope remains a Rust admission failure on the retained dummy too",
         );
     }
 

--- a/src/sim/projectile.rs
+++ b/src/sim/projectile.rs
@@ -235,10 +235,10 @@ pub(crate) fn cell_target_coord(
         .map(|cell| {
             // gamemd-derived: `CellClass::GetTargetCoords +0x58 @ 0x00486890`
             // delegates `+0x48 @ 0x00486840` to
-            // `CellClass::GetGroundHeight @ 0x0047B3A0`, then adds 416 iff
+            // `CellClass::ComputeGroundHeightAtCoord @ 0x0047B3A0`, then adds 416 iff
             // this CellClass's own `+0x140 & 0x100` is set. Bridge runtime
             // walkability is not consulted.
-            crate::util::lepton::cellclass_ground_height_leptons(cell.level, cell.slope_type, x, y)
+            crate::util::lepton::ground_height_leptons(cell.level, cell.slope_type, x, y)
                 .expect("resolved CellClass target must have a supported slope")
                 .wrapping_add(
                     if cell.bridge_facts.raw_flags
@@ -278,26 +278,25 @@ pub(crate) fn dummy_cell_target_coord(dummy: &SharedCellDummy) -> ProjectileCoor
         .wrapping_mul(crate::sim::cell_kernel::LEPTONS_PER_CELL)
         .wrapping_add(crate::sim::cell_kernel::CELL_CENTER_LEPTONS);
     // `CellClass` target virtual +0x58 at `0x00486890` delegates +0x48 at
-    // `0x00486840`, which calls `CellClass::GetGroundHeight @ 0x0047B3A0`.
-    // This is the 90-lepton CellClass surface domain, not the 104-lepton
-    // object/world floor kernel used by stable allocated-cell targeting.
-    let z = crate::util::lepton::cellclass_ground_height_leptons(
-        snapshot.level as u8,
-        snapshot.slope_type,
-        x,
-        y,
-    )
-    .expect("shared CellClass target must have a supported slope")
-    // `CellClass::GetTargetCoords @ 0x00486890` adds the process-global
-    // high-bridge delta when `CellClass+0x140 & 0x100` is live. The floor
-    // beneath it remains the verified 90-lepton CellClass kernel above.
-    .wrapping_add(
-        if snapshot.bridge_flags_0x1180 & crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL != 0 {
-            crate::util::lepton::BRIDGE_HEIGHT_DELTA_LEPTONS as i32
-        } else {
-            0
-        },
-    );
+    // `0x00486840`, which calls
+    // `CellClass::ComputeGroundHeightAtCoord @ 0x0047B3A0`.
+    // Active retail initializes the Cell-owned scalar independently, but its
+    // captured value is the same 104 used by the shared ground evaluator.
+    let z =
+        crate::util::lepton::ground_height_leptons(snapshot.level as u8, snapshot.slope_type, x, y)
+            .expect("shared CellClass target must have a supported slope")
+            // `CellClass::GetTargetCoords @ 0x00486890` adds the process-global
+            // high-bridge delta when `CellClass+0x140 & 0x100` is live. The floor
+            // beneath it remains the verified 104-lepton CellClass kernel above.
+            .wrapping_add(
+                if snapshot.bridge_flags_0x1180 & crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL
+                    != 0
+                {
+                    crate::util::lepton::BRIDGE_HEIGHT_DELTA_LEPTONS as i32
+                } else {
+                    0
+                },
+            );
     ProjectileCoord::new(x, y, z)
 }
 
@@ -307,7 +306,10 @@ pub enum ProjectileTarget {
     Entity(u64),
     /// Stable MapClass CellClass identity. Its target coordinate is resolved
     /// from live terrain state instead of freezing the cleanup-time Vec3.
-    Cell { rx: u16, ry: u16 },
+    Cell {
+        rx: u16,
+        ry: u16,
+    },
     /// Native null AbstractClass target. This is distinct from an expired
     /// entity lookup: BulletClass pointer cleanup has already handled the
     /// reference synchronously, so `TargetExpiryPolicy` must not run.
@@ -1276,12 +1278,9 @@ mod tests {
         });
         let id = store.spawn(1, guided);
 
-        store.advance(
-            &BTreeMap::new(),
-            None,
-            &SharedCellDummy::fresh(),
-            |_, _| None,
-        );
+        store.advance(&BTreeMap::new(), None, &SharedCellDummy::fresh(), |_, _| {
+            None
+        });
 
         let guided = store
             .get(id)
@@ -1298,8 +1297,8 @@ mod tests {
         let flat = dummy_cell_target_coord(&dummy);
         assert_eq!(
             flat,
-            ProjectileCoord::new(128, 128, -89),
-            "CellClass::GetGroundHeight uses the verified 90-lepton domain"
+            ProjectileCoord::new(128, 128, -103),
+            "CellClass::GetGroundHeight uses the verified 104-lepton domain"
         );
 
         dummy.set_level_slope(-1, 1);
@@ -1308,14 +1307,10 @@ mod tests {
         assert_eq!((target.x, target.y), (4 * 256 + 128, 5 * 256 + 128));
         assert_eq!(
             target.z,
-            crate::util::lepton::cellclass_ground_height_leptons(
-                0xff, 1, target.x, target.y
-            )
-            .unwrap()
+            crate::util::lepton::ground_height_leptons(0xff, 1, target.x, target.y).unwrap()
         );
         assert_ne!(
-            target.z,
-            flat.z,
+            target.z, flat.z,
             "the live slope byte participates in dummy floor resolution"
         );
 
@@ -1324,10 +1319,7 @@ mod tests {
         assert_eq!((moved.x, moved.y), (-2 * 256 + 128, 7 * 256 + 128));
         assert_eq!(
             moved.z,
-            crate::util::lepton::cellclass_ground_height_leptons(
-                0xff, 1, moved.x, moved.y
-            )
-            .unwrap(),
+            crate::util::lepton::ground_height_leptons(0xff, 1, moved.x, moved.y).unwrap(),
             "coord stamps preserve and reuse the level/slope bytes"
         );
     }
@@ -1358,12 +1350,9 @@ mod tests {
         let first = store.spawn(1, first_spawn);
         let second = store.spawn(2, spawn(ProjectileTarget::Cell { rx: 1, ry: 0 }));
 
-        let result = store.advance(
-            &BTreeMap::new(),
-            None,
-            &SharedCellDummy::fresh(),
-            |_, _| None,
-        );
+        let result = store.advance(&BTreeMap::new(), None, &SharedCellDummy::fresh(), |_, _| {
+            None
+        });
 
         assert_eq!(
             result
@@ -1386,12 +1375,7 @@ mod tests {
         let id = store.spawn(1, spawn(ProjectileTarget::Entity(42)));
         let targets = BTreeMap::from([(42, ProjectileCoord::new(128, 128, 0))]);
 
-        store.advance(
-            &targets,
-            None,
-            &SharedCellDummy::fresh(),
-            |_, _| None,
-        );
+        store.advance(&targets, None, &SharedCellDummy::fresh(), |_, _| None);
 
         assert_eq!(
             store.get(id).unwrap().position,
@@ -1404,19 +1388,11 @@ mod tests {
         let mut store = ProjectileStore::new();
         let id = store.spawn(1, spawn(ProjectileTarget::Entity(42)));
         let targets = BTreeMap::from([(42, ProjectileCoord::new(128, 0, 0))]);
-        store.advance(
-            &targets,
-            None,
-            &SharedCellDummy::fresh(),
-            |_, _| None,
-        );
+        store.advance(&targets, None, &SharedCellDummy::fresh(), |_, _| None);
 
-        let result = store.advance(
-            &BTreeMap::new(),
-            None,
-            &SharedCellDummy::fresh(),
-            |_, _| None,
-        );
+        let result = store.advance(&BTreeMap::new(), None, &SharedCellDummy::fresh(), |_, _| {
+            None
+        });
 
         assert_eq!(result.detonations.len(), 1);
         assert_eq!(result.detonations[0].projectile_id, id);
@@ -1477,10 +1453,7 @@ mod tests {
         let mut empty = crate::sim::world::Simulation::new();
         let mut sim = crate::sim::world::Simulation::new();
         let stable_id = sim.allocate_stable_id();
-        sim.admit_projectile(
-            stable_id,
-            spawn(ProjectileTarget::Cell { rx: 1, ry: 0 }),
-        );
+        sim.admit_projectile(stable_id, spawn(ProjectileTarget::Cell { rx: 1, ry: 0 }));
         // Native in-scenario load restarts Scenario RNG from Seed0. Normalize
         // both controls so this fixture isolates projectile persistence/hash.
         empty.scenario_rng = crate::sim::rng::SimRng::new(0);

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -308,7 +308,10 @@ use crate::sim::world::Simulation;
 // word, and authored structure-upgrade Technos persist their parent/slot link.
 // Bumped 104 -> 105: persist active and stashed Drive/Ship locomotor slope
 // cache/global-frame timer state; the positional payload enum changed shape.
-const SNAPSHOT_VERSION: u32 = 105;
+// Bumped 105 -> 106: active-retail Cell ground is one 104-lepton numeric
+// authority rather than the false 90-lepton duplicate. Shape is unchanged,
+// but retained Cell targets/world state would resume with different Z results.
+const SNAPSHOT_VERSION: u32 = 106;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -2711,10 +2714,12 @@ mod tests {
     /// adds WaveClass state and destroyable-cliff replacement CellClass values;
     /// 103 -> 104 adds the persistent Techno constructor word and authored
     /// structure-upgrade parent/slot identity; 104 -> 105 adds active/stashed
-    /// Drive/Ship slope-transition state.
+    /// Drive/Ship slope-transition state; 105 -> 106 rejects saves that would
+    /// resume under the corrected one-authority 104-lepton Cell ground formula
+    /// despite unchanged wire shape.
     #[test]
-    fn phase3_drive_ship_slope_snapshot_version_is_105() {
-        assert_eq!(super::SNAPSHOT_VERSION, 105);
+    fn phase3_cell_ground_104_snapshot_version_is_106() {
+        assert_eq!(super::SNAPSHOT_VERSION, 106);
     }
 
     #[test]
@@ -2759,7 +2764,7 @@ mod tests {
 
         let bytes = GameSnapshot::save(&sim, 1, 2, "Drive Ship slope", 3);
         let mut restored = GameSnapshot::load(&bytes)
-            .expect("current v105 slope snapshot")
+            .expect("current v106 slope snapshot")
             .sim;
         let loaded = restored
             .substrate
@@ -5290,7 +5295,7 @@ mod tests {
                 1,
             );
             let cell = pristine_load_template.cell(1, 1).unwrap();
-            crate::util::lepton::cellclass_ground_height_leptons(
+            crate::util::lepton::ground_height_leptons(
                 cell.level,
                 cell.slope_type,
                 target.x,
@@ -5425,7 +5430,7 @@ mod tests {
         assert_eq!(
             crate::sim::projectile::cell_target_coord(Some(restored_terrain), 1, 1).z,
             expected_ground_z,
-            "restored raw 0x100 clear removes +416 while retaining the 90-lepton ground kernel"
+            "restored raw 0x100 clear removes +416 while retaining the 104-lepton ground kernel"
         );
         assert_eq!(
             restored.state_hash(),
@@ -5481,7 +5486,7 @@ mod tests {
         assert_eq!(
             crate::sim::projectile::cell_target_coord(restored.resolved_terrain.as_ref(), 1, 1,).z,
             expected_ground_z,
-            "accepted Resize keeps the restored real CellClass on the 90-lepton ground surface"
+            "accepted Resize keeps the restored real CellClass on the 104-lepton ground surface"
         );
         assert_eq!(
             restored.real_cell_bridge_flags_0x1180,

--- a/src/sim/world/bridge_orchestrator.rs
+++ b/src/sim/world/bridge_orchestrator.rs
@@ -88,11 +88,10 @@ pub(crate) fn apply_bridge_damage_events_with_overlay_registry(
     // direction-0..7 recursion. Outcomes retain that pre-order per event.
     // Keep this sequence until the collapse dirty set is known so the Rust
     // presentation generation advances once for the native damage batch.
-    let damaged_variant_dirty: Vec<(u16, u16)> =
-        outcomes
-            .iter()
-            .flat_map(|outcome| outcome.damaged_variant_cells().iter().copied())
-            .collect();
+    let damaged_variant_dirty: Vec<(u16, u16)> = outcomes
+        .iter()
+        .flat_map(|outcome| outcome.damaged_variant_cells().iter().copied())
+        .collect();
     project_pending_low_bridge_overlay_writes(sim, overlay_registry);
 
     // Aggregate destroyed cells + the subset receiving BlowUpBridge from
@@ -508,11 +507,10 @@ fn apply_hut_bridge_execution(
         apply_runtime_bridge_flag_transcript_from_outcome(sim, outcome);
     }
 
-    let damaged_variant_dirty: Vec<(u16, u16)> =
-        outcomes
-            .iter()
-            .flat_map(|outcome| outcome.damaged_variant_cells().iter().copied())
-            .collect();
+    let damaged_variant_dirty: Vec<(u16, u16)> = outcomes
+        .iter()
+        .flat_map(|outcome| outcome.damaged_variant_cells().iter().copied())
+        .collect();
 
     let mut destroyed_set: BTreeSet<(u16, u16)> = BTreeSet::new();
     let mut blow_up_cells: Vec<(u16, u16)> = Vec::new();
@@ -3070,8 +3068,7 @@ mod tests {
         let mut sim = Simulation::new();
         let mut terrain = water_below_bridge_terrain(4);
         terrain.test_set_native_allocated_cells(&[(3, 2)]);
-        terrain.cell_mut(3, 2).unwrap().bridge_facts.raw_flags =
-            MODELED_CELLCLASS_BRIDGE_FLAG_MASK;
+        terrain.cell_mut(3, 2).unwrap().bridge_facts.raw_flags = MODELED_CELLCLASS_BRIDGE_FLAG_MASK;
         terrain.test_set_dummy_cell_level_slope(2, 0);
         let dummy = terrain.shared_cell_dummy();
         dummy.set_bridge_flags_0x1180(MODELED_CELLCLASS_BRIDGE_FLAG_MASK);
@@ -3099,11 +3096,7 @@ mod tests {
         };
         assert_eq!(
             outcome.setter_transcript,
-            vec![BridgeFlagStamp::new(
-                (3, 2),
-                Direction::N as u8,
-                false
-            )]
+            vec![BridgeFlagStamp::new((3, 2), Direction::N as u8, false)]
         );
         let dummy_after_planning = dummy.snapshot();
         assert_eq!(
@@ -3112,8 +3105,7 @@ mod tests {
             "the independent AboutToFall recursion's later GetCell miss wins after the setter's final slot"
         );
         assert_eq!(
-            dummy_after_planning.bridge_flags_0x1180,
-            BRIDGE_FLAG_ANCHOR_SELF,
+            dummy_after_planning.bridge_flags_0x1180, BRIDGE_FLAG_ANCHOR_SELF,
             "the synchronous setter clears missing-slot 0x1100 while preserving non-anchor 0x80"
         );
         let retained_target = crate::sim::projectile::ProjectileTarget::DummyCell;
@@ -3125,7 +3117,7 @@ mod tests {
         };
         assert_eq!(
             observed_target,
-            crate::sim::projectile::ProjectileCoord::new(4 * 256 + 128, 2 * 256 + 128, 2 * 90)
+            crate::sim::projectile::ProjectileCoord::new(4 * 256 + 128, 2 * 256 + 128, 2 * 104,)
         );
 
         for &stamp in &outcome.setter_transcript {
@@ -3138,8 +3130,7 @@ mod tests {
         );
         let terrain = sim.resolved_terrain.as_ref().unwrap();
         assert_eq!(
-            terrain.cell(3, 2).unwrap().bridge_facts.raw_flags
-                & MODELED_CELLCLASS_BRIDGE_FLAG_MASK,
+            terrain.cell(3, 2).unwrap().bridge_facts.raw_flags & MODELED_CELLCLASS_BRIDGE_FLAG_MASK,
             0
         );
         assert_eq!(
@@ -3330,8 +3321,7 @@ mod tests {
         );
         let dummy_after_planning = dummy.snapshot();
         assert_eq!(
-            dummy_after_planning.bridge_flags_0x1180,
-            BRIDGE_FLAG_ANCHOR_SELF,
+            dummy_after_planning.bridge_flags_0x1180, BRIDGE_FLAG_ANCHOR_SELF,
             "the first setter's missing non-anchor slots are live during later CABHUT retries"
         );
 

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -378,10 +378,21 @@ fn drive_ship_slope_production_spawn_unlimbo_snaps_without_manual_rocking_state(
         let _constructor_word = expected_rng.next_u32();
 
         let stable_id = sim
-            .spawn_object(type_id, "Americans", cell.0, cell.1, 0, &rules, &BTreeMap::new())
+            .spawn_object(
+                type_id,
+                "Americans",
+                cell.0,
+                cell.1,
+                0,
+                &rules,
+                &BTreeMap::new(),
+            )
             .expect("production spawn/unlimbo");
         let entity = sim.substrate.entities.get(stable_id).unwrap();
-        assert!(entity.rocking.is_none(), "slope state is not manually injected");
+        assert!(
+            entity.rocking.is_none(),
+            "slope state is not manually injected"
+        );
         assert_eq!(
             crate::sim::movement::slope_transition::state_for_entity(entity)
                 .expect("active Drive/Ship state")
@@ -436,10 +447,21 @@ fn zero_speed_foot_drive_ship_payloads_survive_all_world_spawn_paths() {
         ("ZAIRS", (6, 2), LocomotorKind::Ship, 11),
     ] {
         let stable_id = sim
-            .spawn_object(type_id, "Americans", cell.0, cell.1, 0, &rules, &BTreeMap::new())
+            .spawn_object(
+                type_id,
+                "Americans",
+                cell.0,
+                cell.1,
+                0,
+                &rules,
+                &BTreeMap::new(),
+            )
             .expect("zero-speed Foot production spawn/reveal");
         let entity = sim.substrate.entities.get(stable_id).unwrap();
-        assert_eq!(entity.locomotor.as_ref().unwrap().active_kind(), expected_kind);
+        assert_eq!(
+            entity.locomotor.as_ref().unwrap().active_kind(),
+            expected_kind
+        );
         assert_eq!(
             crate::sim::movement::slope_transition::state_for_entity(entity)
                 .expect("constructor-owned Drive/Ship payload")
@@ -465,7 +487,10 @@ fn zero_speed_foot_drive_ship_payloads_survive_all_world_spawn_paths() {
         recruitable_b: true,
         structure_upgrades: [None, None, None],
     };
-    assert_eq!(sim.spawn_from_map(&[placement], Some(&rules), &BTreeMap::new()), 1);
+    assert_eq!(
+        sim.spawn_from_map(&[placement], Some(&rules), &BTreeMap::new()),
+        1
+    );
     let map_entity = sim
         .substrate
         .entities
@@ -498,7 +523,12 @@ fn zero_speed_foot_drive_ship_payloads_survive_all_world_spawn_paths() {
             .spawn_object_limbo_at_height(type_id, "Americans", 10, 3, 0, 0, &rules)
             .unwrap();
         assert!(
-            sim.substrate.entities.get(stable_id).unwrap().locomotor.is_none(),
+            sim.substrate
+                .entities
+                .get(stable_id)
+                .unwrap()
+                .locomotor
+                .is_none(),
             "{type_id}: structures and non-Drive/Ship zero-speed types stay excluded"
         );
     }
@@ -4369,7 +4399,7 @@ fn gsi_04_01_cell_target_uses_live_structural_bit_when_runtime_unwalkable() {
     let projectile_id = sim.allocate_stable_id();
     let center_x = 6 * 256 + 128;
     let center_y = 7 * 256 + 128;
-    let bridge_z = crate::util::lepton::cellclass_ground_height_leptons(2, 1, center_x, center_y)
+    let bridge_z = crate::util::lepton::ground_height_leptons(2, 1, center_x, center_y)
         .unwrap()
         .wrapping_add(crate::util::lepton::BRIDGE_HEIGHT_DELTA_LEPTONS as i32);
     let center = ProjectileCoord::new(center_x, center_y, bridge_z);

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -2822,8 +2822,8 @@ fn sonic_cell_target_uses_persistent_dummy_gettargetcoords_on_create_and_refresh
     let wave = sim.waves.get(wave_id).expect("registered Wave");
     assert_eq!(
         wave.target,
-        crate::sim::projectile::ProjectileCoord::new(-128, 1_920, 646),
-        "CellClass ground 2*90 plus structural +416 and Sonic +50",
+        crate::sim::projectile::ProjectileCoord::new(-128, 1_920, 674),
+        "CellClass ground 2*104 plus structural +416 and Sonic +50",
     );
     assert_eq!(process_dummy.snapshot().coord, (-1, 7));
 
@@ -2833,7 +2833,7 @@ fn sonic_cell_target_uses_persistent_dummy_gettargetcoords_on_create_and_refresh
     assert_eq!(
         context.target_position,
         Some(crate::sim::projectile::ProjectileCoord::new(
-            -128, 1_920, 596,
+            -128, 1_920, 624,
         )),
         "every live refresh re-enters GetCellClass then GetTargetCoords",
     );
@@ -2847,7 +2847,7 @@ fn sonic_cell_target_uses_persistent_dummy_gettargetcoords_on_create_and_refresh
     sim.visit_combat_appended_wave_tail(&BTreeSet::new(), &rules, None);
     let wave = sim.waves.get(wave_id).expect("Wave survives first live AI");
     assert_eq!(wave.lifetime, 99);
-    assert_eq!(wave.target.z, 646);
+    assert_eq!(wave.target.z, 674);
     assert_eq!(
         process_dummy.snapshot().coord,
         (0, 6),
@@ -3048,8 +3048,8 @@ fn sonic_cell_fire_same_frame_wave_damage_selects_level_two_bridge_plane() {
         "the appended tail ran in the firing pass"
     );
     assert_eq!(
-        wave.target.z, 646,
-        "level 2 CellClass target is 2*90 + structural 416 + Sonic 50",
+        wave.target.z, 674,
+        "level 2 CellClass target is 2*104 + structural 416 + Sonic 50",
     );
     assert_eq!(
         sim.substrate
@@ -3059,7 +3059,7 @@ fn sonic_cell_fire_same_frame_wave_damage_selects_level_two_bridge_plane() {
             .health
             .current,
         90,
-        "Wave Z 646 meets the level-2 equality threshold 624 and walks AltObject",
+        "Wave Z 674 meets the level-2 equality threshold 624 and walks AltObject",
     );
 }
 

--- a/src/util/lepton.rs
+++ b/src/util/lepton.rs
@@ -100,20 +100,14 @@ pub const SUBCELL_4_Y: SimFixed = SimFixed::lit("192");
 // InRange (3D distance) constants
 // ---------------------------------------------------------------------------
 
-/// Native 104-lepton level step used by object, bridge, and VXL coordinate
-/// domains. CellClass terrain sampling has a distinct 90-lepton scalar; keep
-/// the domains named rather than aliasing them.
+/// Active-retail 104-lepton level step. Cell, Foot, Techno/InRange, area-
+/// damage, Anim, Bullet, Particle, Unit, and VXL own independently initialized
+/// native globals, but every captured value is 104.
 pub const LEPTONS_PER_LEVEL: i64 = 104;
 
-/// Existing object/gameplay ground-Z domain. This remains 104 because those
-/// consumers model the object/VXL LevelHeight rather than CellClass's terrain
-/// surface sampler.
+/// Verified active-retail ground-height scalar. Bridge/deck height is a
+/// caller-owned conditional addition and is never included here.
 pub const GROUND_LEVEL_HEIGHT_LEPTONS: i32 = 104;
-
-/// Active CellClass ground-surface scalar initialized inside `0x0047B3A0`.
-/// `CellClass::Get_Center_Coords @ 0x00480A30` samples this domain at subcell
-/// `(128,128)`; it must not be replaced by the 104-lepton object/VXL scalar.
-pub const CELLCLASS_GROUND_LEVEL_HEIGHT_LEPTONS: i32 = 90;
 
 /// Sentinel weapon range meaning "always in range". When the configured
 /// weapon range equals -512 leptons, InRange short-circuits to true regardless
@@ -164,16 +158,18 @@ const fn ground_slope_records(g: i32) -> [(i32, i32, i32, i32, i32); 21] {
 
 const GROUND_SLOPE_RECORDS: [(i32, i32, i32, i32, i32); 21] =
     ground_slope_records(GROUND_LEVEL_HEIGHT_LEPTONS);
-const CELLCLASS_GROUND_SLOPE_RECORDS: [(i32, i32, i32, i32, i32); 21] =
-    ground_slope_records(CELLCLASS_GROUND_LEVEL_HEIGHT_LEPTONS);
 
 // ---------------------------------------------------------------------------
 // Conversion helpers
 // ---------------------------------------------------------------------------
 
-/// Object/gameplay ground-Z calculation in the 104-lepton coordinate domain.
-/// CellClass terrain-surface consumers must call
-/// [`cellclass_ground_height_leptons`] instead.
+/// Active-retail ground-only Cell surface calculation in world leptons.
+///
+/// gamemd-derived: `CellClass::ComputeGroundHeightAtCoord @ 0x0047B3A0`
+/// sign-extends Level, applies the independently initialized 104-lepton Cell
+/// scalar, evaluates low-byte X/Y against the 21-record slope table, clamps the
+/// slope term before adding the base, and chops toward zero. Bridge height is
+/// deliberately composed by callers such as `CellClass::GetTargetCoords`.
 ///
 /// Residual kept outside this pure evaluator: the conditional placed-TMP
 /// lifecycle that applies per-subtile `+0x28` to CellClass Level.
@@ -193,26 +189,6 @@ pub fn ground_height_leptons(
     )
 }
 
-/// Exact terrain-surface Z used by `CellClass::GetGroundHeight @ 0x0047B3A0`.
-/// The binary sign-extends Level, biases the fixed-point base by `0.5`, chops
-/// toward zero, then evaluates the low-byte X/Y slope contribution against its
-/// separately initialized 90-lepton coefficient table.
-pub fn cellclass_ground_height_leptons(
-    level_byte: u8,
-    slope: u8,
-    world_x: i32,
-    world_y: i32,
-) -> Result<i32, UnsupportedGroundSlope> {
-    ground_height_with_level_height(
-        level_byte,
-        slope,
-        world_x,
-        world_y,
-        CELLCLASS_GROUND_LEVEL_HEIGHT_LEPTONS,
-        &CELLCLASS_GROUND_SLOPE_RECORDS,
-    )
-}
-
 fn ground_height_with_level_height(
     level_byte: u8,
     slope: u8,
@@ -222,9 +198,7 @@ fn ground_height_with_level_height(
     records: &[(i32, i32, i32, i32, i32); 21],
 ) -> Result<i32, UnsupportedGroundSlope> {
     let signed_level = i32::from(level_byte as i8);
-    let level_numerator = signed_level
-        .wrapping_mul(level_height)
-        .wrapping_mul(256);
+    let level_numerator = signed_level.wrapping_mul(level_height).wrapping_mul(256);
     let base = level_numerator.wrapping_add(128) / 256;
     if slope == 0 {
         return Ok(base);
@@ -394,7 +368,10 @@ mod tests {
     #[test]
     fn integer_and_fixed_leptons_per_cell_agree() {
         assert_eq!(LEPTONS_PER_CELL, SimFixed::from_num(LEPTONS_PER_CELL_I32));
-        assert_eq!(CELL_CENTER_LEPTON, SimFixed::from_num(CELL_CENTER_LEPTON_I32));
+        assert_eq!(
+            CELL_CENTER_LEPTON,
+            SimFixed::from_num(CELL_CENTER_LEPTON_I32)
+        );
     }
     use crate::map::terrain;
 
@@ -477,25 +454,27 @@ mod tests {
     }
 
     #[test]
-    fn gsi_04_01_cellclass_ground_height_uses_the_90_lepton_surface_domain() {
+    fn gsi_04_03_cellclass_ground_height_uses_the_104_lepton_surface_domain() {
         let center_contributions = [
-            0, 45, 45, 45, 45, 0, 0, 0, 0, 90, 90, 90, 90, 90, 90, 90, 90, 45, 45,
-            45, 45,
+            0, 52, 52, 52, 52, 0, 0, 0, 0, 104, 104, 104, 104, 104, 104, 104, 104, 52, 52, 52, 52,
         ];
         for (slope, contribution) in center_contributions.into_iter().enumerate() {
             assert_eq!(
-                cellclass_ground_height_leptons(2, slope as u8, 128, 128),
-                Ok(180 + contribution),
+                ground_height_leptons(2, slope as u8, 128, 128),
+                Ok(208 + contribution),
                 "active retail slope {slope}",
             );
         }
+        assert_eq!(ground_height_leptons(0, 0, 128, 128), Ok(0));
+        assert_eq!(ground_height_leptons(1, 0, 128, 128), Ok(104));
+        assert_eq!(ground_height_leptons(2, 0, 128, 128), Ok(208));
         assert_eq!(
-            cellclass_ground_height_leptons(0xff, 0, 128, 128),
-            Ok(-89),
+            ground_height_leptons(0xff, 0, 128, 128),
+            Ok(-103),
             "0x0047B3A0 adds 0.5 then chops the signed base toward zero",
         );
         assert_eq!(
-            cellclass_ground_height_leptons(0, 21, 128, 128),
+            ground_height_leptons(0, 21, 128, 128),
             Err(UnsupportedGroundSlope(21)),
         );
     }


### PR DESCRIPTION
## Scope

Integrates only the completed Phase 3 CellClass ground-height numeric-domain slice onto current main.

- removes the false 90-lepton Cell-specific evaluator and keeps one verified 104-lepton authority
- migrates all four active current-main consumers: radar click, real and shared-dummy Cell targets, and production Cell-center evaluation
- preserves ground-only versus conditional 416-lepton deck ownership and typed invalid-slope failure
- rebaselines the dependent minimap, projectile, Wave/Sonic, Spark-height, production, and persistence fixtures
- advances the current-main snapshot compatibility boundary from 105 to 106
- explicitly excludes the deleted naval/BasePlan/AI slice and does not import Spark shared-dummy routing or later mechanisms

## Review

The first fresh critic found only stale source-branch naval/version wording in the new handoff documents. Commit 4fab8a7b rebased both documents to current main. A second fresh critic rechecked that fix and the entire runtime diff and returned PASS with no findings.

## Validation

- ground_height: 5 passed, 0 failed, 6 ignored
- gsi_04_03: 49 passed, 0 failed
- native_click_: 7 passed, 0 failed
- focused production, snapshot, dummy target, Sonic, and shrapnel tests: all passed
- full cargo test -p vera20k --lib: 7606 passed, 0 failed, 76 ignored