### PR TITLE
Integrate Phase 3 Spark shared-dummy routing

### DIFF
--- a/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
+++ b/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
@@ -1,7 +1,7 @@
 # Phase 3 Spark shared-dummy routing design
 
-**Status:** implemented in `4c71b488`; validation repair `72bf8e15`; critic round
-active, not yet parity-pass certified
+**Status:** implemented in `4c71b488`; review repairs `72bf8e15`, `96779c16`,
+and `0054549e`; critic 4 P1 prose repair active, not yet parity-pass certified
 
 **Phase/GSI ownership hypothesis:** Phase 3 / GSI-04.03, behavior-3 Spark
 height/collision lookup routing. The general overlay writer lifecycle remains

--- a/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
+++ b/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
@@ -1,7 +1,13 @@
 # Phase 3 Spark shared-dummy routing design
 
-**Status:** implemented in `4c71b488`; review repairs `72bf8e15`, `96779c16`,
-and `0054549e`; critic 4 P1 prose repair active, not yet parity-pass certified
+**Status:** implemented in `4c71b488`; critic 6 ledger repair complete; awaiting
+fresh critic 7; not yet parity-pass certified
+
+**Completion ledger:** validation repairs `72bf8e15`, `96779c16`, and
+`0054549e`; critic 4 authoritative-prose repair `439059f1`; critic 5 source-
+provenance repair `c5cd916f`. Critic 5 also recorded the lower-priority stale
+status prose; critic 6 rechecked the prior fixes and found only that remaining
+ledger issue. This update closes the ledger finding but does not declare PASS.
 
 **Phase/GSI ownership hypothesis:** Phase 3 / GSI-04.03, behavior-3 Spark
 height/collision lookup routing. The general overlay writer lifecycle remains

--- a/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
+++ b/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
@@ -1,0 +1,346 @@
+# Phase 3 Spark shared-dummy routing design
+
+**Status:** proposed for fresh design review; no Rust implementation yet
+
+**Phase/GSI ownership hypothesis:** Phase 3 / GSI-04.03, behavior-3 Spark
+height/collision lookup routing. The general overlay writer lifecycle remains
+owned by GSI-04.07; this design closes only the exact projection Spark observes.
+
+**Native authority:**
+`docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md`
+
+## Verdict
+
+Replace Spark's eager, strict real-cell fact collection with the native staged
+lookup transcript over the existing process-global `SharedCellDummy` identity.
+A cell miss must select and stamp the dummy, then continue through ordinary
+collision, coordinate, deletion, color-RNG, and lifetime processing.
+
+The implementation must not turn the staged native transcript into another
+eager fact bundle. Candidate ground is read first, candidate structural state is
+read second, the old cell is selected only when candidate structural state is
+clear, building/wall reads occur only in the contact band after bridge crossing
+has failed, and the candidate slope is selected only after a collision has been
+chosen.
+
+This slice will not add a general dummy overlay field. The verified supported
+writers that can reach the dummy use bridge-family overlay IDs, none of which is
+one of Spark's three wall IDs (`2`, `26`, `243`); ordinary valid wall placement
+cannot write its wall ID to the dummy. For Spark, a dummy's sentinel wall query
+therefore returns false exactly. General persistence of dummy overlay identity
+is recorded for GSI-04.07 rather than approximated here.
+
+## Player-experience and lockstep ledger
+
+| Situation | Native result | Current Rust divergence | Required result |
+|---|---|---|---|
+| Constructor floor lookup enters a null fixed-array slot | Dummy-derived ground; creation continues | Miss becomes `None`, so Z may not clamp | Use dummy level/slope and repeat the lookup only when `input_z <= first_ground` |
+| Flying Spark crosses the allocated Size rim | Normal dummy-based collision/no-collision | Query errors after persistent-Z write | Commit coordinates/delete state, consume one color draw, then decrement lifetime |
+| Candidate structural dummy bit is clear | Old cell is selected and can become the final dummy stamp | Rust selects old first and always selects both | Candidate first; old only on the native short-circuit arm |
+| Candidate structural dummy bit is set without crossing | Old lookup is skipped; candidate remains last stamp | Rust selects old and can alter the stamp | Skip old exactly |
+| Any collision is selected | Candidate slope lookup occurs last and restamps candidate on a miss | Rust reads slope eagerly with the first candidate selection | Delay slope selection until collision is known |
+| No collision is selected | No slope lookup; last stamp remains candidate or old | Rust still resolves slope | Represent slope as absent and perform no lookup |
+| Noncanonical axes alias an allocated slot | Real-cell hit; dummy is untouched | Current strict helper already aliases some cases but is separate | Reuse the common fixed-stride fallback helper without component bounds |
+
+Severity is edge-bound but deterministic: when a Spark reaches an allocated map
+rim, the current error path changes coordinates, deletion, color RNG, lifetime,
+and therefore subsequent lockstep state.
+
+## Verified native contract
+
+### Constructor
+
+For behavior 3, construction takes the lifetime RNG draw, copies the input
+coordinate, calls `CellClass::GetGroundHeight(input)`, and calls the same helper
+a second time only if `input_z <= first_ground`. It then commits coordinates and
+only later takes the optional authored start-color draw. A miss is a normal
+dummy selection on both ground calls.
+
+### Per-tick transcript
+
+After the persistent-Z store and candidate arithmetic:
+
+1. candidate ground lookup;
+2. candidate Cell lookup and raw/live structural read;
+3. old Cell lookup only if candidate structural is clear;
+4. bridge-crossing classification;
+5. building lookup, then wall lookup only when there is no bridge collision and
+   raw candidate Z is in `[ground, ground + 150)`;
+6. complete collision classification, including below-ground paths;
+7. candidate slope lookup only when a collision was selected;
+8. normal commit/delete, one color draw, and lifetime decrement.
+
+The candidate Cell pointer is retained across the optional old lookup. If both
+select the dummy, they alias the same object after the old-coordinate restamp.
+The coordinate restamp does not clear level, slope, flags, overlay, or list
+state.
+
+### Spark-consumed fallback state
+
+| State | Rust source in this design |
+|---|---|
+| packed requested coordinate | existing `get_cellclass_fallback_leptons` stamp |
+| signed level and slope | real `ResolvedTerrainCell` or live dummy snapshot |
+| structural bit `0x100` | real static-plus-runtime projection; dummy raw flag directly |
+| ground object list | real occupancy list; dummy is the verified permanently empty list |
+| sentinel wall identity | real `OverlayGrid`; dummy false under the verified supported writer exclusion |
+
+## Current architecture and constraints
+
+- `src/sim/cell_rect.rs` already owns the non-null fixed-stride lookup and one
+  process-global dummy handle. Spark must reuse it rather than creating another
+  fallback API.
+- `src/map/resolved_terrain.rs` already stores dummy coordinate, level, slope,
+  and the modeled raw bridge-bit subset, reconstructs it at map Resize, and
+  includes its bridge bits in the state hash. Dummy coordinate, level, and
+  slope are currently hashed only while a projectile retains `DummyCell`.
+  Spark makes level/slope future-state authority without such a projectile, so
+  this slice must hash dummy level/slope unconditionally with the bridge subset.
+- `src/sim/particles/spark_world.rs` currently performs old/candidate strict
+  lookups, eagerly resolves all facts, and errors on fixed-array misses.
+- `src/sim/particles/spark.rs` owns the exact x87 predicates and collision
+  arithmetic. World lookup code must not duplicate or approximate those
+  comparisons.
+- `src/sim/particles/spark_spawn.rs` currently performs only one optional
+  ground lookup and treats any adapter failure as no floor.
+- Real structural state remains the existing static Cell flag plus live
+  `BridgeRuntimeState::deck_present` projection. Dummy structural state is its
+  raw bit and must not require a runtime bridge cell.
+
+## Chosen design
+
+### 1. Spark-local selected-cell view
+
+Add a small private selected-cell view in `spark_world.rs` around
+`get_cellclass_fallback_leptons`. It preserves `CellRef::Real` versus the live
+`SharedCellDummy` handle and exposes only the facts Spark reads:
+
+- signed level byte and slope byte;
+- structural state, with real and dummy routing separated;
+- canonical real-cell coordinate for occupancy/overlay adapters;
+- a dummy discriminator for the proven empty-building/non-wall projections.
+
+Selection itself is the side effect. The view must not reconstruct, clear, or
+copy the shared dummy into an independent identity. A retained dummy view must
+continue to refer to the same shared handle after an old-cell restamp.
+
+Factor selection behind a private closure- or trait-driven seam used by the
+production adapter and focused tests. The test implementation records the role
+and coordinate of every selection (`ground`, `cell`, or `slope`). This is
+required because two consecutive candidate stamps have the same final state;
+checking only the last dummy coordinate cannot prove that both native calls
+occurred.
+
+### 2. One ground evaluator over real or dummy selection
+
+Route both constructor and behavior-3 candidate ground through the common
+selected-cell view and `ground_height_leptons`. A miss supplies the live dummy's
+level/slope; unsupported slope values remain the existing safe-state error, not
+a zero-height substitution.
+
+The constructor floor operation should be factored behind a tiny closure- or
+adapter-driven helper so focused tests can prove one versus two lookup calls.
+Production behavior is:
+
+```text
+first = ground(input)
+if input_z <= first:
+    input_z = ground(input) // second native lookup/restamp
+```
+
+Constructor ground selection must be terrain-only. It may not construct a
+`SparkCollisionWorld` whose initializer requires `OverlayGrid`, because native
+does not inspect overlay state while flooring a particle. An entirely missing
+resolved terrain remains a clearly documented unsupported fixture policy and
+may retain the existing no-floor behavior. Missing overlay state is irrelevant
+to constructor flooring. A present map with a null/unallocated/invalid cell may
+not use either unsupported-world policy.
+
+### 3. Share collision gates with the arithmetic owner
+
+Extract package-private pure helpers in `spark.rs` for the exact bridge-crossing
+classification and raw-f32 contact-band gate already implemented there.
+`spark_world.rs` uses those helpers solely to decide which native queries occur;
+the final collision owner reuses the same helpers when producing the committed
+coordinate and kind. Do not copy the inequalities into `spark_world.rs`.
+
+The final complete kind classification must also be available as a pure helper
+so the world adapter can decide whether the collision-only slope lookup is
+required without reimplementing below-ground precedence.
+
+### 4. Make absent slope explicit
+
+Change `SparkCollisionFacts.slope_matrix` to an optional collision-only fact.
+No-collision queries return `None` and therefore prove that no slope lookup was
+performed. Collision queries perform the final candidate selection and return
+`Some(matrix)`.
+
+The collision owner must reject `None` only when its own exact classification
+selects a collision. It must not read or require a matrix for a no-collision
+result. This invariant prevents a future eager default matrix from hiding a
+missing native lookup.
+
+### 5. Native-ordered world query
+
+`SparkCollisionWorld::query` performs:
+
+```text
+ground = select(candidate); evaluate ground
+candidate = select(candidate); candidate_structural = structural(candidate)
+if candidate_structural:
+    old_structural = false // no lookup
+else:
+    old = select(old); old_structural = structural(old)
+
+bridge_kind = exact shared helper(...)
+if bridge_kind is none and exact contact-band helper(...):
+    building = accepted_building(candidate) // dummy => false
+    if not building:
+        wall = sentinel_wall(candidate)      // dummy => false
+
+kind = exact shared complete classifier(...)
+matrix = if kind is some:
+    slope = select(candidate).slope          // final native restamp
+    Some(slope_matrix(slope))
+else:
+    None
+```
+
+For a real candidate, building retains the verified ground-object insertion
+order and first-building exclusions. Wall reads the real canonical overlay
+cell. Those reads remain errors only for corrupt/missing real-world dependencies
+already outside the supported map contract. A fixed-array miss is never an
+error.
+
+`SparkCollisionWorld::new` must not eagerly require `OverlayGrid`. Construction
+requires only terrain and the stable simulation/rules borrows. The real-cell
+wall arm obtains `OverlayGrid` at the instant native calls the sentinel wall
+predicate; only reaching that arm may report a missing real overlay dependency.
+Dummy wall false never consults the rectangular overlay grid.
+
+### 6. Preserve commit and RNG ownership
+
+Keep `begin_particle_tick` before the world query and
+`finish_particle_tick` after it. Once a present-map miss becomes a normal fact
+selection, the existing owner supplies the native commit/delete, one color RNG
+draw, and lifetime decrement. Do not add RNG to the world adapter.
+
+Update stale comments that describe query failure after the persistent-Z write
+as ordinary missing-cell behavior. That partial-write error boundary remains
+only for genuine unsupported/corrupt dependencies or arithmetic errors.
+
+## Rejected alternatives
+
+### Keep eager facts and merely substitute dummy values
+
+Rejected because native lookup order and short-circuiting determine the final
+shared-dummy coordinate. It would still query old, building/wall, and slope on
+branches where native does not.
+
+### Add component-wise or playfield bounds
+
+Rejected because native bounds only the signed fixed-stride linear index.
+Noncanonical axes may alias a real slot and must leave the dummy untouched.
+
+### Extend the shared dummy with full overlay identity in this slice
+
+Rejected as unnecessary cross-row expansion. The active supported dummy writers
+proven in the Spark investigation cannot produce Spark wall IDs, while general
+overlay identity persistence belongs to GSI-04.07. Spark's dummy wall result is
+therefore an evidence-backed false projection, not an approximation.
+
+### Treat a null/unallocated slot as an unsupported world
+
+Rejected because valid retail-format Size diamonds necessarily have adjacent
+null canonical slots and stock Spark motion can reach them.
+
+## Files expected to change
+
+- `src/sim/particles/spark_world.rs`
+- `src/sim/particles/spark.rs`
+- `src/sim/particles/spark_spawn.rs`
+- focused tests colocated in those modules and, only if needed for the
+  production dispatch assertion, `src/sim/particles/system_ai.rs`
+- `src/sim/world/world_hash.rs`
+- `src/sim/snapshot.rs`
+- stale Spark report/comment wording only where the implementation makes it
+  factually wrong
+
+Advance `SNAPSHOT_VERSION` from 111 to 112 and reject v111 at the preamble.
+Although the wire shape is unchanged, a serialized active Spark resumes with
+different coordinate, deletion, color-RNG, and lifetime behavior after this
+fix. That is the same behavior-boundary rationale used for v110 to v111.
+
+Hash dummy level and slope unconditionally beside its already-unconditional
+bridge subset. Spark now consumes those persistent fields and can alter future
+state even when no projectile retains a dummy target. Add a regression proving
+that two otherwise equal Spark-reachable worlds with different dummy
+level/slope values produce different hashes. Dummy coordinate remains
+conditional on a retained pointer/consumer; this slice does not make the
+coordinate itself a future Spark input after the current query completes.
+
+## Acceptance tests
+
+1. Constructor lookup seam records one ground call when above the dummy floor
+   and two identical calls when equal/below; lifetime RNG remains before and
+   optional start-color RNG remains after coordinate flooring.
+2. The instrumented production-selection seam proves exact transcripts:
+   structural-clear/no collision is `ground(candidate), cell(candidate),
+   cell(old)`; structural-set/no crossing is `ground(candidate),
+   cell(candidate)`; each collision case appends `slope(candidate)` to its
+   applicable prefix.
+3. Transcript tests prove bridge-collision and out-of-contact-band paths do not
+   query building or wall, and an accepted building suppresses the wall query.
+4. Mixed candidate-real/old-dummy and candidate-dummy/old-real cases retain the
+   candidate view while preserving the exact selection transcript and final
+   dummy stamp.
+5. Candidate dummy structural clear plus old dummy, with no collision, finishes
+   with the old coordinate stamped and an absent slope matrix.
+6. Candidate dummy structural set plus no bridge crossing skips old lookup and
+   finishes with candidate stamped.
+7. A dummy-fact collision performs the final candidate slope lookup, commits
+   and marks deletion, consumes exactly one color draw, and decrements lifetime.
+8. A dummy no-collision commits candidate, consumes exactly one color draw,
+   decrements lifetime, and leaves slope absent.
+9. Collision classification with an absent matrix is rejected, while
+   no-collision classification with an absent matrix succeeds without reading
+   one.
+10. Dummy building is false and dummy sentinel wall is false under constructor
+    defaults and supported bridge-writer contamination. Terrain-present
+    constructor/no-contact cases do not require `OverlayGrid`.
+11. Fixed-stride alias to an allocated real slot is a real hit and leaves an
+    earlier dummy coordinate unchanged.
+12. Null allocated-mask slots plus negative and high linear indices continue
+    through the normal Spark path without `OutOfRangeCell` or `UnavailableCell`.
+13. Dummy level/slope changes alter the world hash even with no retained dummy
+    projectile; snapshot schema is 112 and v111 is rejected before body decode.
+14. Existing real-cell bridge collapse, building ordering, LaserFence exclusion,
+    wall, below-ground, slope-matrix, coordinate, deletion, RNG, and lifetime
+    tests continue to pass.
+15. The row gate `gsi_04_03_spark_shared_dummy_query_order_and_miss_continuation`
+    exercises production dispatch and the instrumented production-selection
+    seam rather than a Rust-vs-Rust duplicate oracle.
+
+Focused validation should include the narrow Spark world/spawn/system filters
+and the existing Spark arithmetic tests. Every command must use
+`cargo test -p vera20k --lib <filter>`. The Phase-wide full `--lib` suite remains
+deferred until every Phase 3 row is closed.
+
+## Critic packet and pass condition
+
+Each fresh read-only critic receives:
+
+- this design;
+- the native report and cited active-retail data;
+- the implementation diff;
+- literal focused test output.
+
+PASS requires zero findings, open questions, approximations, or residuals inside
+this bounded mechanism. Any error-on-miss path, eager lookup, duplicated native
+predicate, missing final restamp, constructor single-call clamp, untested RNG /
+lifetime continuation, missing exact transcript assertion, conditional-only
+dummy level/slope hash, stale snapshot schema, eager overlay precondition, or
+unsupported-slope substitution keeps the mechanism open. General dummy overlay
+persistence remains explicitly assigned to GSI-04.07 and is not a Spark
+behavioral residual because its three-ID predicate is exactly excluded for every
+supported dummy writer established by the native report.

--- a/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
+++ b/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
@@ -1,13 +1,16 @@
 # Phase 3 Spark shared-dummy routing design
 
-**Status:** implemented in `4c71b488`; critic 6 ledger repair complete; awaiting
-fresh critic 7; not yet parity-pass certified
+**Status:** PARITY PASS — implemented in `4c71b488`; fresh critic 7 found zero
+findings, open questions, approximations, or residuals
 
 **Completion ledger:** validation repairs `72bf8e15`, `96779c16`, and
 `0054549e`; critic 4 authoritative-prose repair `439059f1`; critic 5 source-
-provenance repair `c5cd916f`. Critic 5 also recorded the lower-priority stale
-status prose; critic 6 rechecked the prior fixes and found only that remaining
-ledger issue. This update closes the ledger finding but does not declare PASS.
+provenance repair `c5cd916f`; critic 6 ledger repair `548fc0cf`. Critic 5 also
+recorded the lower-priority stale status prose; critic 6 rechecked the prior
+fixes and found only that remaining ledger issue. Fresh critic 7 rechecked all
+prior findings and independently audited the complete mechanism, returning PASS
+with zero findings. Current-HEAD focused validation: `gsi_04_03` 69/0,
+`sim::particles::spark` 45/0, exact v111 rejection 1/0.
 
 **Phase/GSI ownership hypothesis:** Phase 3 / GSI-04.03, behavior-3 Spark
 height/collision lookup routing. The general overlay writer lifecycle remains

--- a/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
+++ b/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
@@ -1,6 +1,7 @@
 # Phase 3 Spark shared-dummy routing design
 
-**Status:** implemented in `4c71b488`; critic round active, not yet parity-pass certified
+**Status:** implemented in `4c71b488`; validation repair `72bf8e15`; critic round
+active, not yet parity-pass certified
 
 **Phase/GSI ownership hypothesis:** Phase 3 / GSI-04.03, behavior-3 Spark
 height/collision lookup routing. The general overlay writer lifecycle remains

--- a/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
+++ b/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
@@ -1,6 +1,6 @@
 # Phase 3 Spark shared-dummy routing design
 
-**Status:** proposed for fresh design review; no Rust implementation yet
+**Status:** implemented in `4c71b488`; critic round active, not yet parity-pass certified
 
 **Phase/GSI ownership hypothesis:** Phase 3 / GSI-04.03, behavior-3 Spark
 height/collision lookup routing. The general overlay writer lifecycle remains

--- a/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
+++ b/docs/plans/2026-08-27-phase3-spark-shared-dummy-routing-design.md
@@ -10,7 +10,13 @@ recorded the lower-priority stale status prose; critic 6 rechecked the prior
 fixes and found only that remaining ledger issue. Fresh critic 7 rechecked all
 prior findings and independently audited the complete mechanism, returning PASS
 with zero findings. Current-HEAD focused validation: `gsi_04_03` 69/0,
-`sim::particles::spark` 45/0, exact v111 rejection 1/0.
+`sim::particles::spark` 45/0, exact v106 rejection 1/0.
+
+**Integration rebase (2026-08-30):** The source branch accumulated unrelated
+snapshot changes before this mechanism and therefore used `111 -> 112`.
+Current main enters this slice at version 106, so the identical Spark hash and
+resume boundary is integrated as `106 -> 107`; no excluded source-branch
+schema fields are imported.
 
 **Phase/GSI ownership hypothesis:** Phase 3 / GSI-04.03, behavior-3 Spark
 height/collision lookup routing. The general overlay writer lifecycle remains
@@ -276,10 +282,10 @@ null canonical slots and stock Spark motion can reach them.
 - stale Spark report/comment wording only where the implementation makes it
   factually wrong
 
-Advance `SNAPSHOT_VERSION` from 111 to 112 and reject v111 at the preamble.
+Advance `SNAPSHOT_VERSION` from 106 to 107 and reject v106 at the preamble.
 Although the wire shape is unchanged, a serialized active Spark resumes with
 different coordinate, deletion, color-RNG, and lifetime behavior after this
-fix. That is the same behavior-boundary rationale used for v110 to v111.
+fix. That is the same behavior-boundary rationale used for v105 to v106.
 
 Hash dummy level and slope unconditionally beside its already-unconditional
 bridge subset. Spark now consumes those persistent fields and can alter future
@@ -323,7 +329,7 @@ coordinate itself a future Spark input after the current query completes.
 12. Null allocated-mask slots plus negative and high linear indices continue
     through the normal Spark path without `OutOfRangeCell` or `UnavailableCell`.
 13. Dummy level/slope changes alter the world hash even with no retained dummy
-    projectile; snapshot schema is 112 and v111 is rejected before body decode.
+    projectile; snapshot schema is 107 and v106 is rejected before body decode.
 14. Existing real-cell bridge collapse, building ordering, LaserFence exclusion,
     wall, below-ground, slope-matrix, coordinate, deletion, RNG, and lifetime
     tests continue to pass.

--- a/docs/research/PARTICLE_SPARK_LIVE_COLLISION_INPUTS_GHIDRA_REPORT.md
+++ b/docs/research/PARTICLE_SPARK_LIVE_COLLISION_INPUTS_GHIDRA_REPORT.md
@@ -12,6 +12,15 @@
 
 **Implementation scope:** none; this report is a research handoff and intentionally changes no Rust code
 
+**Post-implementation status (2026-08-27):** Spark shared-dummy routing and
+invalid/unallocated-cell continuation are implemented. The current authority is
+the [Phase 3 Spark shared-dummy routing contract](PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md).
+Implementation and review repairs are `4c71b488`, `72bf8e15`, `96779c16`, and
+`0054549e`. Any statement below that says Spark still returns typed unavailable,
+has not integrated the dummy, or leaves invalid-cell parity open is a historical
+pre-`4c71b488` Rust baseline, not current behavior. The native evidence remains
+valid; only those dated Rust-state conclusions are superseded.
+
 **2026-08-27 numeric correction:** active runtime capture in
 `PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md`
 supersedes this report's original 90/360/340 interpretation. Cell ground is
@@ -31,7 +40,11 @@ The adapter must not approximate these inputs:
 - `Gravity` is an `i32` rule with constructor default 3 and stock override 6, while `ColorSpeed` is stored as the exact `f64` widening of an INI-parsed `f32`;
 - the stock LaserFence exception is compiled and reachable only when a type enables it; stock rules do not enable it.
 
-The current Rust owners already contain most source facts, but two precision changes are mandatory before activation: retain `Gravity` as the native integer-derived `f32` input, and retain `ColorSpeed` as native `f64` bits instead of `SimFixed`. The shared mutable dummy substrate now exists in `src/sim/cell_rect.rs`; Spark's adapter is not yet routed through it and still returns a typed unavailable/error result rather than substituting height zero, identity slope, or missing collision facts. That caller-specific routing remains open.
+At the 2026-07-18 Rust baseline, most source facts already had owners, while
+precision and activation work remained. In that baseline the shared mutable
+dummy substrate existed in `src/sim/cell_rect.rs`, but Spark had not yet routed
+through it and still returned typed unavailable. That specific historical gap
+is closed by `4c71b488` and the three review-repair commits listed above.
 
 ## 1. Scope, duplication check, and source order
 
@@ -106,7 +119,7 @@ This is signed truncation toward zero by 256. Concrete fixtures:
 
 The lookup then forms `linear = cell_y * 0x200 + cell_x`. It validates the flattened result and pointer, not X and Y independently. Consequently, an individually out-of-range axis can alias an in-range flattened slot. A Rust helper that bounds-checks X/Y separately is not equivalent at this boundary.
 
-On failure or null pointer, the wrapper uses the shared dummy cell at `0x00ABDC50`, writes the requested packed cell coordinate at dummy `+0x24` (`0x00ABDC74`), and calls the same inner ground function. `CellClass::Constructor @ 0x0047BBF0`, reached for the dummy at the end of the `MapClass::Resize` path around `0x005670E7`, initializes dummy level `+0x11B` and slope `+0x11C` to zero. Other off-map helpers can mutate shared dummy state later. Rust now models the shared mutable substrate in `cell_rect`, but Spark has not integrated it; its adapter must continue reporting typed unavailable state until that separate routing mechanism is verified and implemented.
+On failure or null pointer, the wrapper uses the shared dummy cell at `0x00ABDC50`, writes the requested packed cell coordinate at dummy `+0x24` (`0x00ABDC74`), and calls the same inner ground function. `CellClass::Constructor @ 0x0047BBF0`, reached for the dummy at the end of the `MapClass::Resize` path around `0x005670E7`, initializes dummy level `+0x11B` and slope `+0x11C` to zero. Other off-map helpers can mutate shared dummy state later. Rust models that shared mutable substrate in `cell_rect`, and Spark now consumes it through the native-ordered routing implemented in `4c71b488`.
 
 Evidence: fresh Ghidra `disassemble_function(address="0x00578080")`, `decompile_function(address="0x00565730")`, `decompile_function(address="0x0047BBF0")`, and disassembly around `0x005670E7`; the coordinate conversion and dummy writes are explicit instructions, not inferred names.
 
@@ -339,7 +352,7 @@ After resolving the opening ledger, a second pass revisited all direct callees a
 
 | Question | Answer |
 |---|---|
-| What if a candidate X/Y axis is negative or individually outside 0-511? | Native conversion truncates toward zero and only the flattened index is validated; Rust must reproduce a valid alias or return typed unavailable when the shared dummy would be used. |
+| What if a candidate X/Y axis is negative or individually outside 0-511? | Native conversion truncates toward zero and only the flattened index is validated; current Rust reproduces valid aliases and routes misses through the shared dummy. |
 | What if a collapsed high bridge is repaired by an engineer? | Its overlays/attributes are repaired, but structural `0x100` is not restored; Spark no longer applies the 416-lepton bridge plane there. |
 | What if the terrain slope is 0 or 17-20? | Slope 0 returns identity. Slopes 17-20 return zero matrices even though their ground contribution is 52. |
 | What if `.13` is stored through `SimFixed` because the visual result seems close? | That changes the native `f64` input and is DRIFT; retain `0x3FC0A3D700000000`. |
@@ -355,7 +368,7 @@ After resolving the opening ledger, a second pass revisited all direct callees a
 | G02 | RESOLVED | Signed level times 104, add 0.5, x87 chop. |
 | G03 | RESOLVED | Low-byte X/Y affine record, clamp to `[0,max]`, add base, chop. |
 | G04 | RESOLVED | All 20 records are listed in §3.3. |
-| G05 | RESOLVED | Native dummy routing is known and Rust has the shared substrate; Spark integration remains open because its adapter still returns typed unavailable. |
+| G05 | RESOLVED | Native dummy routing is known and current Rust routes Spark through the shared substrate; the former typed-unavailable gap was closed by `4c71b488`. |
 | M01 | RESOLVED | `VXL_MasterLighting_Init` writes identity 0 and rotations 1-16; 17-20 remain BSS zero. |
 | M02 | RESOLVED | Exact `f32` bits are listed in §4.3. |
 | M03 | RESOLVED | Direct `slope*0x30` copy; no clamp or fallback. |
@@ -410,11 +423,15 @@ No in-scope question remains deferred. The generic shared-dummy mutation taxonom
 | 30 | `0x005283D0` | native `ReadDouble` | Yes |
 | 31 | `0x00644BE0` | ParticleType constructor/default owner | Yes |
 
-## 12. Implementation handoff
+## 12. Historical implementation handoff
+
+This table records the 2026-07-18 implementation baseline. Its Spark
+shared-dummy row is completed by `4c71b488`; later review coverage is in
+`72bf8e15`, `96779c16`, and `0054549e`.
 
 | Verified requirement | Current Rust state | Required delta | Acceptance test |
 |---|---|---|---|
-| Exact valid-cell coordinate selection and ground formula | `cell_rect` owns the fixed-512 real-or-shared-dummy substrate, and the existing `spark_world` adapter reproduces signed conversion and valid flattened aliases while returning typed unavailable at the dummy boundary | Route Spark's adapter through the existing shared dummy without changing its already-exact valid-cell path | Retain fixtures `255/256/-1/-255/-256`, flattened alias, and slopes 0-20; add shared-dummy level/slope/coordinate routing fixtures |
+| Exact valid-cell coordinate selection and ground formula | Historical pre-`4c71b488`: `cell_rect` owned the substrate while Spark returned typed unavailable at the dummy boundary | Completed in `4c71b488` without changing valid flattened aliases | Retained boundary/alias fixtures plus shared-dummy level, slope, coordinate, transcript, and hash coverage |
 | Exact candidate slope matrix | No Spark world table; renderer table is not authoritative for collision and treats unsupported slopes differently | Add native-derived matrix source using §4.3 bits or exact table builder; 0 identity, 17-20 zero | Compare all 21×12 raw `f32` bits to §4.3 |
 | Live structural bit | Static bridge facts and runtime `deck_present` exist separately | Query static structural AND runtime state exactly as §5.3 | Intact true; collapsed false; repaired-after-collapse remains false; forward-3/extra false |
 | Candidate building/wall facts | Occupancy and overlay grids exist | Read in verified list order; preserve typed failure at unavailable terrain boundary | Multiple-object list ordering; accepted building; rejected non-building; wall overlay ID |
@@ -423,10 +440,10 @@ No in-scope question remains deferred. The generic shared-dummy mutation taxonom
 | Borrow/RNG ordering | Pure Spark kernel exists; production dispatch disabled | Gather all facts into owned input, release world borrows, then call kernel with authoritative RNG | Fact-query failure consumes no RNG; successful tick consumes the parent-report sequence only |
 | Activation safety | Spark/Railgun public dispatch/render remain disabled | Keep disabled until adapter integration and focused tests pass; no fallback path | Unsupported/unavailable input reports error and never silently activates approximation |
 
-Current implementation surface and remaining integration seam:
+Historical implementation surface and integration seam:
 
 - preserve the existing read-only `src/sim/particles/spark_world.rs` valid-cell ground/matrix/bridge/occupancy/overlay fact gathering;
-- preserve the existing shared real-or-dummy substrate in `src/sim/cell_rect.rs` and route only Spark's unavailable-cell branch through it;
+- the planned routing through the existing shared real-or-dummy substrate in `src/sim/cell_rect.rs` was completed by `4c71b488`;
 - retain the focused rule ownership in `src/rules/ruleset.rs` and `src/rules/particle_type.rs`;
 - owner wiring only after owned facts are complete and all borrows are released;
 - no change to public Spark spawn/render activation in the same patch.

--- a/docs/research/PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md
@@ -32,6 +32,15 @@ advanced the actual mainline snapshot contract `105 -> 106`. Naval entries
 below are historical source-branch evidence and a later-owner obligation, not
 current implementation scope.
 
+**Post-implementation Spark status (2026-08-27):** The Spark-specific
+shared-dummy and invalid/unallocated-cell gap identified in this census is
+closed. The current authority is the [Phase 3 Spark shared-dummy routing
+contract](PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md). Implementation
+and review repairs are `4c71b488`, `72bf8e15`, `96779c16`, and `0054549e`.
+Spark-gap statements below are retained only as a historical pre-`4c71b488`
+baseline; they do not describe current Rust. This addendum does not change the
+status of other 104-domain consumers owned by separate rows.
+
 ## Verdict
 
 The proposed split between a **90-lepton `CellClass::GetGroundHeight` domain** and a **104-lepton object/VXL/bridge domain is false in the active retail executable**.
@@ -368,17 +377,22 @@ ascending snap       = bridge plane - 20 = ground + 396
 
 The stale `ground + 360` / `ground + 340` interpretation is wrong.
 
-### 7.3 Current Rust Spark verdict
+### 7.3 Post-implementation Rust Spark verdict
 
 `src/sim/particles/spark_world.rs` calls `ground_height_leptons` at lines 96 and 119. That evaluator uses 104 and is the correct scalar choice. `src/sim/particles/spark.rs` obtains `STRUCTURAL_BRIDGE_HEIGHT` from the 416-lepton bridge topology constant. These numeric choices match active retail.
 
-The remaining boundary distinction is lookup failure:
+The historical pre-`4c71b488` boundary distinction was lookup failure:
 
-- Rust's Spark adapter reproduces signed truncation and fixed-stride flattened indexing.
-- For a canonical cell missing from resolved terrain, it returns `UnavailableCell`; constructor `ground_height_at` converts that to `None`.
+- Rust's Spark adapter reproduced signed truncation and fixed-stride flattened indexing.
+- For a canonical cell missing from resolved terrain, it returned `UnavailableCell`; constructor ground converted that to `None`.
 - Native uses the shared dummy and continues.
 
-This is an explicit safety/availability divergence, not evidence for a different height scalar. It cannot be called exact invalid-cell parity until Spark is routed through the existing shared dummy-cell substrate or invalid-cell reachability is separately excluded for every active Spark entry path.
+Current Rust now routes constructor ground and behavior-3 collision through the
+same terrain-bound shared dummy with native lookup order, restamping, lazy fact
+reads, collision continuation, and unconditional level/slope hash authority.
+For Spark, the former safety/availability divergence and invalid-cell residual
+are closed; other height consumers retain their own separately scoped routing
+status.
 
 ## 8. Native scalar xrefs and ownership
 
@@ -641,8 +655,8 @@ For flat level 2, current bad output is `180`; native is `208`. With a structura
 | Spark ground | same Cell wrapper, 104 | common 104 | PASS |
 | Spark plane | ground +416 | ground +416 | PASS numeric |
 | signed world-to-cell | trunc toward zero | Spark uses shared trunc helper | PASS |
-| flattened 512 lookup | flattened range/pointer; dummy fallback | Spark matches fixed stride but errors on missing cell | PARTIAL; invalid-cell residual |
-| shared dummy ground | live dummy level/slope | generic cell substrate models it; not all height callers use it | PARTIAL integration |
+| flattened 512 lookup | flattened range/pointer; dummy fallback | Spark uses the shared fixed-stride fallback and preserves valid aliases | PASS for Spark |
+| shared dummy ground | live dummy level/slope | Spark consumes the terrain-bound dummy; other height callers remain separately owned | PASS for Spark |
 | INI override | none | constants | PASS conceptually |
 
 ## 12. Final questions log
@@ -719,7 +733,9 @@ Both reproduced 104 and 416. The current Ghidra plate comments on `CellClass::Ge
    builder should avoid retaining duplicate tables that can drift again.
 3. Preserve Spark's current 104 `ground_height_leptons` call and 416 structural plane.
 4. Rebaseline all 90-derived tests, snapshot hashes, wave target expectations, and recent design prose.
-5. Route height callers through the shared fixed-stride/dummy-cell substrate where native can observe unavailable cells. If the builder does not close this in the same slice, GSI-04.03 remains open; returning zero/`None` is not exact native behavior.
+5. Spark-specific shared fixed-stride/dummy-cell routing is completed by
+   `4c71b488` and its review repairs. Other height callers remain separately
+   owned and must not infer parity from Spark's closure.
 6. Keep floor and deck composition separate. Do not add 416 inside `ground_height_leptons`.
 
 ### Acceptance fixtures
@@ -776,7 +792,7 @@ Flat level-0 maps hide the scalar regression because both domains return zero th
 - replace slope-table `L=90` and slopes 17..20 contribution 45 with `L=104` and contribution 52;
 - replace Spark plane `G+360` and ascending `G+340` with `G+416` and `G+396`;
 - delete the claim that VXL 104 and Cell ground 90 are different numeric domains; retain only that their globals/initializers are independently owned.
-- replace its stale claim that Rust has no mutable shared dummy: the substrate now exists in `cell_rect`, while Spark's adapter still returns typed unavailable/off-array errors instead of routing through it.
+- replace its stale pre-implementation claim that Spark returns typed unavailable/off-array errors: the substrate exists in `cell_rect`, and Spark routing is implemented in `4c71b488` with review repairs through `0054549e`.
 
 `docs/research/PARTICLE_SPARK_COLLISION_AND_PIXEL_COMPOSITOR_GHIDRA_REPORT.md`:
 
@@ -797,7 +813,7 @@ Flat level-0 maps hide the scalar regression because both domains return zero th
 `docs/plans/2026-07-18-spark-live-collision-adapter-and-owner-design.md`:
 
 - replace its retained `G+360` / ascending `G+340` adapter contract with the verified `G+416` / `G+396` composition;
-- state explicitly that the existing Spark ground evaluator already uses the correct 104 scalar while shared-dummy routing remains open.
+- state explicitly that the Spark ground evaluator uses the correct 104 scalar and shared-dummy routing is implemented; use the current Spark routing contract for status.
 
 `docs/plans/2026-08-26-naval-base-placement-design.md` (historical
 source-branch file, absent from current main) and any later plans/tests copied

--- a/docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md
@@ -4,17 +4,20 @@ Date: 2026-08-27
 Scope: GSI-04.03, behavior-3 `Spark` only
 Binary: active retail Yuri's Revenge `gamemd.exe` in live Ghidra (`/gamemd.exe`)
 Method: exhaustive-slice re-investigation; live decompile plus assembly, active retail INI, current Rust read
-Status: **VERIFIED native contract; Rust implemented; critic 6 ledger repair complete; awaiting fresh critic 7; not yet parity-pass certified**
+Status: **PARITY PASS — verified native contract implemented; fresh critic 7 found zero findings, open questions, approximations, or residuals**
 
 ## Post-implementation addendum
 
 Production shared-dummy routing landed in `4c71b488`. Critic-driven validation
 repairs landed in `72bf8e15`, `96779c16`, and `0054549e`; the critic 4 stale
 authoritative-prose repair landed in `439059f1`; and the critic 5 nearby source-
-provenance repair landed in `c5cd916f`. Critic 5 had identified that provenance
-gap plus lower-priority stale status prose. After the provenance repair, critic
-6 found only that remaining status-ledger issue; this update closes it. The
-mechanism now awaits a fresh critic 7 and is **not** declared parity PASS here.
+provenance repair landed in `c5cd916f`, and the critic 6 ledger repair landed in
+`548fc0cf`. Critic 5 had identified that provenance gap plus lower-priority stale
+status prose. After the provenance repair, critic 6 found only that remaining
+status-ledger issue. Fresh critic 7 then independently rechecked every prior
+finding and the complete bounded mechanism and returned **PASS with zero
+findings**. Current-HEAD focused validation was `gsi_04_03` 69/0,
+`sim::particles::spark` 45/0, and the exact v111 rejection gate 1/0.
 
 The pre-fix Rust summary in the verdict, the disparity inventory in section 9,
 and the prescriptive handoff in section 10 are retained as historical
@@ -442,7 +445,7 @@ gsi_04_03_spark_shared_dummy_query_order_and_miss_continuation
 | Dummy object-list contamination | Excluded for supported active lifecycle |
 | Overlay/flags persistence | Closed: constructor defaults, active fallback writers, no per-lookup reset |
 | Save/load lifecycle | Closed: not an allocated serialized cell; reconstructed at Resize |
-| Rust mismatch and handoff | Implemented in `4c71b488`; validation repairs `72bf8e15`, `96779c16`, `0054549e`; authoritative-prose repair `439059f1`; source-provenance repair `c5cd916f`; critic 6 ledger repair complete; awaiting fresh critic 7 before PASS |
+| Rust mismatch and handoff | CLOSED: implemented in `4c71b488`; validation repairs `72bf8e15`, `96779c16`, `0054549e`; authoritative-prose repair `439059f1`; source-provenance repair `c5cd916f`; ledger repair `548fc0cf`; fresh critic 7 PASS with zero findings |
 
 No load-bearing Spark/dummy mechanism remains approximate in this report.
 

--- a/docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md
@@ -17,7 +17,11 @@ status prose. After the provenance repair, critic 6 found only that remaining
 status-ledger issue. Fresh critic 7 then independently rechecked every prior
 finding and the complete bounded mechanism and returned **PASS with zero
 findings**. Current-HEAD focused validation was `gsi_04_03` 69/0,
-`sim::particles::spark` 45/0, and the exact v111 rejection gate 1/0.
+`sim::particles::spark` 45/0, and the exact v106 rejection gate 1/0.
+
+For the 2026-08-30 current-main integration, the source branch's accumulated
+snapshot `111 -> 112` numbering is rebased to `106 -> 107`. The behavior/hash
+boundary is unchanged; no unrelated source-branch schema fields are imported.
 
 The pre-fix Rust summary in the verdict, the disparity inventory in section 9,
 and the prescriptive handoff in section 10 are retained as historical

--- a/docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md
@@ -4,17 +4,23 @@ Date: 2026-08-27
 Scope: GSI-04.03, behavior-3 `Spark` only
 Binary: active retail Yuri's Revenge `gamemd.exe` in live Ghidra (`/gamemd.exe`)
 Method: exhaustive-slice re-investigation; live decompile plus assembly, active retail INI, current Rust read
-Status: **VERIFIED native contract; Rust implemented; critic 4 P1 prose repair active; not yet parity-pass certified**
+Status: **VERIFIED native contract; Rust implemented; critic 6 ledger repair complete; awaiting fresh critic 7; not yet parity-pass certified**
 
 ## Post-implementation addendum
 
-Production shared-dummy routing landed in `4c71b488`; critic-driven validation
-and provenance repairs landed in `72bf8e15`, `96779c16`, and `0054549e`. The
-pre-fix Rust summary in the verdict, the disparity inventory in section 9, and
-the prescriptive handoff in section 10 are retained as historical implementation
-provenance. They describe the baseline before `4c71b488`, not active behavior.
-The native evidence and acceptance contract remain authoritative while the
-fresh-critic loop is active; this addendum does not declare parity pass.
+Production shared-dummy routing landed in `4c71b488`. Critic-driven validation
+repairs landed in `72bf8e15`, `96779c16`, and `0054549e`; the critic 4 stale
+authoritative-prose repair landed in `439059f1`; and the critic 5 nearby source-
+provenance repair landed in `c5cd916f`. Critic 5 had identified that provenance
+gap plus lower-priority stale status prose. After the provenance repair, critic
+6 found only that remaining status-ledger issue; this update closes it. The
+mechanism now awaits a fresh critic 7 and is **not** declared parity PASS here.
+
+The pre-fix Rust summary in the verdict, the disparity inventory in section 9,
+and the prescriptive handoff in section 10 are retained as historical
+implementation provenance. They describe the baseline before `4c71b488`, not
+active behavior. The native evidence and acceptance contract remain
+authoritative throughout the fresh-critic loop.
 
 ## Question and stop condition
 
@@ -436,7 +442,7 @@ gsi_04_03_spark_shared_dummy_query_order_and_miss_continuation
 | Dummy object-list contamination | Excluded for supported active lifecycle |
 | Overlay/flags persistence | Closed: constructor defaults, active fallback writers, no per-lookup reset |
 | Save/load lifecycle | Closed: not an allocated serialized cell; reconstructed at Resize |
-| Rust mismatch and handoff | Implemented in `4c71b488`, with review repairs `72bf8e15`, `96779c16`, and `0054549e`; row remains open pending critic pass |
+| Rust mismatch and handoff | Implemented in `4c71b488`; validation repairs `72bf8e15`, `96779c16`, `0054549e`; authoritative-prose repair `439059f1`; source-provenance repair `c5cd916f`; critic 6 ledger repair complete; awaiting fresh critic 7 before PASS |
 
 No load-bearing Spark/dummy mechanism remains approximate in this report.
 

--- a/docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md
@@ -1,0 +1,454 @@
+# Phase 3 Spark shared-dummy routing contract
+
+Date: 2026-08-27
+Scope: GSI-04.03, behavior-3 `Spark` only
+Binary: active retail Yuri's Revenge `gamemd.exe` in live Ghidra (`/gamemd.exe`)
+Method: exhaustive-slice re-investigation; live decompile plus assembly, active retail INI, current Rust read
+Status: **VERIFIED implementation handoff; Rust row remains OPEN**
+
+## Question and stop condition
+
+What exactly happens when `ParticleClass` construction or behavior-3 Spark AI
+queries a world coordinate whose fixed-512 linear cell is invalid, whose slot is
+null/unallocated, or whose noncanonical axes alias a materialized slot? Establish
+the ordered lookup transcript, every `CellClass` field Spark consumes, shared
+dummy mutation/restamping, delete and RNG consequences, reachability, lifecycle,
+and the smallest architecture-correct Rust delta.
+
+Stop after the complete Spark-facing contract and evidence-backed exclusions are
+closed. Do not expand into unrelated CellClass consumers or implement Rust here.
+
+## Verdict first
+
+The active binary **never treats a Spark cell miss as absence or error**. Both
+`CellClass::GetGroundHeight @ 0x00578080` and
+`MapClass::Get_CellClass_At_Coord @ 0x00565730` select the same process-global
+dummy `CellClass @ 0x00ABDC50`, stamp only its packed coordinate at `+0x24`
+(`0x00ABDC74`), and continue. Spark then consumes the dummy's persistent level,
+slope, raw structural-bridge flag, overlay identity, and empty object-list
+behavior in a branch-dependent order. Later lookups can restamp the same object
+before retained-pointer reads.
+
+Current Rust's shared substrate is sufficient in shape but Spark bypasses it.
+`SparkCollisionWorld` performs strict real-cell lookups, errors on invalid or
+unallocated cells, queries old before candidate, evaluates both bridge cells
+without native short-circuiting, gathers building/overlay/slope eagerly, and
+turns a constructor miss into `None`. That changes dummy state, collisions,
+coordinates, deletion, lifetime, and the synchronized particle RNG stream.
+
+This is not safely excludable. A valid allocated Size-diamond edge cell has an
+adjacent unallocated canonical slot; behavior-3 motion has no interior-margin or
+playfield clipping gate and stock types author signed horizontal velocity. An
+edge Spark can therefore cross into the null slot. Truly out-of-capacity linear
+indices need a coordinate near a fixed-array boundary and are not established as
+an ordinary shipped-map occurrence, but they use the identical native branch and
+do not change the implementation requirement.
+
+## 1. Evidence sources and supersession
+
+Primary live evidence:
+
+- `ParticleClass__Constructor @ 0x0062B5E0`
+- behavior-3 particle AI `0x0062C6E0`
+- `CellClass::GetGroundHeight @ 0x00578080`
+- `MapClass::Get_CellClass_At_Coord @ 0x00565730`
+- `CellClass::ComputeGroundHeightAtCoord @ 0x0047B3A0`
+- slope projection helper `FUN_006D6AD0`
+- `Look_up_building_in_cell @ 0x0047C520`
+- `CellClass::IsWallConnectableInDirection @ 0x00480510`
+- `CellClass__Constructor @ 0x0047BBF0`
+- `CellClass::AddContent @ 0x0047E8A0`
+- `TechnoClass__EnterCell_AddToMultiCells @ 0x005683C0`
+- `OverlayClass__Mark @ 0x005FC570`
+- `MapClass__Resize @ 0x00565C10`
+
+Retail data:
+
+- `ini/rulesmd.ini`: `[General] Gravity=6`.
+- Active systems include `SparkSys`, `WeldingSys`, `FirestormSparkSys`, and
+  `LGSparkSys`; `DamageParticleSystems` and `DefaultSparkSystem` actively route
+  stock combat to Spark.
+- Stock horizontal moduli are `10`, `16`, `16`, and `13`; `MinZVelocity=40`,
+  `ZVelocityRange=15`; `MaxEC=500` for all four Spark particle types.
+
+Earlier corrected Spark collision and height reports were used only as leads.
+Any older claim that the ground scalar is 90, the structural offset is 360, or
+Spark is inactive is superseded here: active YR uses 104 leptons per level,
+416 leptons for the structural bridge plane, and production Rust now dispatches
+Spark.
+
+## 2. World-to-cell and dummy contract
+
+### 2.1 Both helpers use signed truncation and a fixed 512 stride
+
+For each world/lepton component, both helpers compute signed division by 256
+with truncation toward zero:
+
+```text
+cell_x = (x + ((x >> 31) & 255)) >> 8
+cell_y = (y + ((y >> 31) & 255)) >> 8
+linear = cell_y * 512 + cell_x
+```
+
+Neither helper independently bounds `cell_x` or `cell_y`. A noncanonical pair
+whose signed linear result is admitted aliases that canonical table slot.
+
+At `0x005780B9..0x005780CE`, `GetGroundHeight` rejects a negative linear index,
+an index at least global map capacity `DAT_0087F928`, or a null slot under
+`g_CellArray_Base`. At `0x0056575C..0x00565771`, the world-coordinate Map helper
+performs the same tests against `Map+0x140` and `Map+0x13C`.
+
+On either miss:
+
+1. the converted `cell_x/cell_y` are narrowed to signed 16-bit words;
+2. their exact packed dword is written to dummy `+0x24` at `0x00ABDC74`;
+3. the helper selects/returns `0x00ABDC50`;
+4. no other dummy field is cleared.
+
+A real hit leaves the dummy untouched. Invalid linear and null-slot misses are
+observationally identical after selection.
+
+### 2.2 Ground evaluation continues on the dummy
+
+`GetGroundHeight` calls `ComputeGroundHeightAtCoord @ 0x0047B3A0` after either
+selection. That evaluator reads:
+
+- signed byte `Cell+0x11B` as base level and multiplies it by 104;
+- byte `Cell+0x11C` as the slope-table selector;
+- the original low lepton bytes of X/Y for slope interpolation.
+
+Thus a miss is **not** zero/no-ground unless the dummy currently has constructor
+defaults. Persistent dummy level or slope changes the returned height. Valid
+retail slopes are 0..20; malformed larger dummy slope values inherit native's
+unsafe table behavior and are outside the safe authored-state boundary.
+
+## 3. Particle constructor ordering
+
+For behavior 3, `ParticleClass__Constructor @ 0x0062B5E0` executes:
+
+1. one lifetime RNG draw at `0x0062B870`, then the native 16-bit lifetime add;
+2. copy the input coordinate to its local coordinate;
+3. first `GetGroundHeight(input)` at `0x0062B8B1`;
+4. if `input_z <= first_ground`, call the same helper again at `0x0062B8C2`
+   and assign that second result to local Z;
+5. `Set_Raw_Coords @ 0x0062B8D2`;
+6. only later, take the conditional start-color draw at `0x0062BAC0` when the
+   authored color endpoints require interpolation.
+
+The behavior-1-only draw at `0x0062B7F2` is excluded because Spark behavior is
+3. A constructor miss therefore stamps its cell once, or twice with the same
+coordinate when the clamp branch is taken. There is no RNG or other lookup
+between those two stamps. The miss itself does not delete or reject creation.
+
+## 4. Exact behavior-3 AI lookup transcript
+
+The live assembly at `0x0062C6E0` establishes this order after the persistent-Z
+write and candidate-coordinate arithmetic:
+
+1. **Candidate ground** — call `GetGroundHeight(candidate)` at `0x0062C7D4`.
+2. **Candidate CellClass** — call `MapClass::Get_CellClass_At_Coord(candidate)`
+   at `0x0062C7F4`; retain its pointer in `ESI`.
+3. Read candidate raw `Cell+0x140 & 0x100` at `0x0062C80A`.
+4. **Short-circuit old CellClass** — only when the candidate structural bit is
+   clear, call the Map helper for the old coordinate at `0x0062C81C` and read
+   old `Cell+0x140 & 0x100`. Candidate structural true skips the old lookup.
+5. Resolve bridge-plane crossing from the short-circuit OR.
+6. Only when there was no bridge collision and candidate Z is in the contact
+   band `[ground, ground+150)`, call `Look_up_building_in_cell(ESI)` at
+   `0x0062C883`; if it returns no accepted building, call
+   `ESI->IsWallConnectableInDirection(-1,-1)` at `0x0062C894`.
+7. Only when any collision kind is selected, call `FUN_006D6AD0(candidate)` at
+   `0x0062C95A`. That helper performs another world-coordinate Map lookup and
+   then reads `Cell+0x11C` for the reflection matrix.
+8. Set the collision delete byte at `0x0062CA34`, commit coordinates, then take
+   exactly one color RNG draw at `0x0062CA86`; lifetime processing follows.
+
+There is no lookup failure branch anywhere in this transcript.
+
+### 4.1 Observable shared-dummy restamping
+
+If candidate ground misses, it first stamps candidate. Candidate Cell lookup
+then stamps candidate again. After that:
+
+- candidate structural true: old lookup is skipped; the dummy remains stamped
+  candidate until some later collision-slope lookup (which stamps candidate
+  again);
+- candidate structural false: old lookup runs; if old misses, the one dummy is
+  restamped old even though `ESI` still points to the candidate lookup's result;
+- building and wall checks use retained `ESI` without another lookup; if both
+  lookups missed, they inspect the same dummy object after the old-coordinate
+  restamp;
+- a selected collision performs the slope helper and restamps candidate;
+- no collision performs no slope lookup, so the last stamp remains candidate or
+  old according to the short-circuit branch above.
+
+The coordinate stamp does not alter level, slope, overlay, flags, or list state.
+
+## 5. Every dummy field Spark consumes
+
+| Field / state | Spark use | Native miss behavior | Rust implication |
+|---|---|---|---|
+| `+0x24` packed coord | side effect; retained helpers can observe last writer | stamped on every miss, never on real hit | preserve exact call/short-circuit order through the shared handle |
+| signed `+0x11B` level | candidate ground evaluator | persistent; constructor default 0 | use live dummy snapshot, not `None` |
+| `+0x11C` slope | candidate ground and collision-only matrix lookup | persistent; constructor default 0; collision lookup restamps candidate first | compute ground from the selected live cell; delay matrix lookup until collision |
+| raw `+0x140 & 0x100` | candidate then conditional old structural bridge | persistent; constructor clears low 23 bits | read from the same fallback result; do not require live bridge runtime state for a dummy |
+| `+0xE4` ground object-list head | first-building scan | proven permanently null for supported active lifecycle | return no building for dummy; no dummy list model needed for Spark |
+| `+0x44` overlay identity | `IsWallConnectable(-1,-1)` | constructor `-1`; persistent and writable in the global object | wall iff live value is exactly 2, 26, or 243; do not route miss to rectangular OverlayGrid |
+
+No other CellClass field is read by this Spark path. In particular, passing
+`targetOverlay=-1` and `direction=-1` makes `IsWallConnectableInDirection`
+read only `+0x44`; it does not inspect overlay data, owner, or object lists.
+
+### 5.1 Object-list exclusion is closed
+
+`Look_up_building_in_cell @ 0x0047C520` scans the ground list at `Cell+0xE4`,
+following `Object+0x30`, and returns the first object whose `WhatAmI()==6`.
+`CellClass__Constructor` initializes dummy `+0xE4=0`.
+
+The only direct call to `CellClass::AddContent @ 0x0047E8A0` is
+`TechnoClass__EnterCell_AddToMultiCells @ 0x005683C0`. Before that call, the
+caller checks `linear >= 0`, `linear < Map capacity`, and the slot pointer is
+non-null. Failed admission skips `AddContent`; its later fallback-shaped block
+does not bypass the identical admission. Therefore ordinary active object-list
+maintenance cannot add an object to the dummy. Remove paths cannot populate an
+empty list. Dummy building lookup is consequently false, not unknown.
+
+### 5.2 Overlay and flags are persistent, not immutable
+
+`CellClass__Constructor @ 0x0047BBF0` sets `+0x44=-1`, level/slope zero, and
+clears the low 23 raw flag bits. Primary lookups never restore those defaults.
+
+Active overlay/bridge code can write through never-null fallbacks. In
+`OverlayClass__Mark @ 0x005FC570`, the bridge-family paths perform fixed
+three-cell writes through `MapClass__Get_CellClass` and call
+`CellClass__RecalcAttributes`; edge-adjacent misses therefore can persistently
+change dummy overlay/derived flags. The live bridge table values read at
+`0x008333D0`, `0x008333F0`, `0x00833418`, and `0x00833438` are bridge IDs
+(`74,83,92,94,96,98,205,214,223,225,227,229` and nearby `+0..3` variants), not
+Spark's wall IDs 2/26/243. Ordinary valid wall placement writes its primary
+allocated cell; cardinal wall cleanup may read an edge dummy but does not copy a
+wall ID into it. Thus constructor-fresh or valid edge-bridge contamination is
+non-wall for Spark, while the architecture must still preserve shared persistent
+overlay/flag state rather than synthesize an OverlayGrid cell.
+
+Corrupt/off-map object injection could write other overlay IDs to the dummy, but
+that is outside supported valid retail-format lifecycle; it is not needed to
+justify the active null-slot route.
+
+## 6. Miss collision, deletion, and RNG consequences
+
+A miss selects facts; it is not itself collision, deletion, or RNG consumption.
+The normal collision formula then runs against those facts:
+
+- dummy ground may cause bridge, below-ground, building, wall, or no collision;
+- dummy raw structural `0x100` participates in candidate-first short-circuit;
+- dummy building result is false;
+- dummy overlay supplies the exact three-ID wall predicate;
+- when collision is selected, dummy slope selects the reflection matrix after
+  the final candidate restamp.
+
+Collision sets the deletion flag and commits the collision coordinate before
+the one per-tick color draw. No collision commits the candidate. In both cases
+the color draw and lifetime decrement still occur. Therefore converting a miss
+to a Rust error is synchronization-visible: current Rust preserves only the
+already-written persistent Z velocity, then returns before coordinate commit,
+delete, color RNG, and lifetime.
+
+## 7. Reachability and exclusions
+
+### 7.1 Unallocated canonical slot: reachable
+
+Map Resize materializes the Size diamond inside the fixed table, not every
+canonical slot. Each valid Size-diamond rim cell has a neighboring canonical
+slot whose table entry is null. Spark AI contains no allocation-mask check,
+playfield clamp, or interior safety margin before applying horizontal velocity.
+
+Stock behavior-3 types author signed X/Y remainder domains:
+
+- Spark: `[-9,9]` on each horizontal axis;
+- WeldingSpark and FirestormSpark: `[-15,15]`;
+- LargeSpark: `[-12,12]`.
+
+With stock `MinZVelocity=40`, range 15, and gravity 6, valid draws provide many
+ticks of flight; an outward-moving Spark originating on or sufficiently near an
+allocated rim crosses the 256-lepton cell boundary. Active stock damage and
+default Spark producers have no rule requiring an interior map margin. This is
+an ordinary supported-state mechanism, even though its frequency is edge-bound.
+
+### 7.2 Fixed-array invalid linear index: conditional, same contract
+
+Spark can move only a bounded number of cells during its flight. Reaching
+`linear < 0` or `linear >= Map capacity` therefore additionally requires a
+valid source near a fixed-array boundary (possible for a valid maximum-edge
+retail-format map, not shown as an occurrence in the shipped-map set). Smaller
+shipped maps are separated from the fixed-array boundary by far more than one
+Spark flight. This incidence distinction is non-load-bearing: the native branch
+and Rust implementation are exactly the same as a null-slot miss.
+
+The attempted shipped-map size diagnostic was stopped before completion to
+avoid turning a mechanism proof into a corpus audit. No claim is made that a
+specific shipped scenario produces an out-of-capacity Spark. There is no such
+uncertainty for the adjacent null-slot route.
+
+### 7.3 Fixed-stride alias: must remain real
+
+Because only signed `linear` is bounded, a noncanonical `(cell_x,cell_y)` can
+alias an allocated canonical slot. That is a real hit: it neither stamps nor
+uses the dummy. Spark must inherit `get_cellclass_fallback_leptons` semantics,
+not add component bounds before selection.
+
+## 8. Dummy lifecycle and persistence
+
+The dummy is one fixed identity at `0x00ABDC50`. `MapClass__Resize @ 0x00565C10`
+calls the constructor on it at `0x005670F2`. Scenario full initialization,
+load-driven resize, and RMG initialization establish this reset boundary before
+their gameplay state.
+
+Between Resize calls, all modeled writes persist globally across callers and
+ticks; a lookup writes only coordinate. Save iterates allocated slots through
+the non-stamping allocation probe and the dummy is not an allocated table slot,
+so its transient state is not serialized as a map cell. Load/resize reconstructs
+it, after which misses during load or gameplay can establish new persistent
+state. Rust's existing `SharedCellDummy` identity and
+`reconstruct_for_map_resize` boundary match this lifecycle for its represented
+fields.
+
+## 9. Exact current Rust disparities
+
+Current files were read in the active Phase 3 worktree.
+
+1. `src/sim/particles/spark_spawn.rs:327-336` calls
+   `SparkCollisionWorld::ground_height_at`; `src/sim/particles/spark_world.rs:117-119`
+   converts any miss/error to `None`. Native returns dummy-derived ground and
+   may make a second identical call/stamp on the clamp branch.
+2. `spark_world.rs:73-81` looks up old before candidate and evaluates old before
+   candidate. Native is candidate ground, candidate cell/flag, then conditional
+   old cell/flag.
+3. `spark_world.rs:122-146` rejects invalid or unallocated cells instead of
+   using `cell_rect::get_cellclass_fallback_leptons` and the shared dummy.
+4. `spark_world.rs:79-81` converts a structural real cell through live bridge
+   runtime state; a native dummy raw `0x100` is consumed directly and cannot
+   require a `BridgeRuntimeState` cell.
+5. `spark_world.rs:82-107` eagerly gathers building, rectangular overlay, ground,
+   and slope. Native gates building/wall by bridge result and contact band, and
+   performs the slope lookup only after a collision.
+6. `spark_world.rs:88-92` errors when candidate is outside OverlayGrid. Native
+   reads retained `CellClass+0x44`, including the dummy.
+7. `system_ai.rs:216-225` propagates the query error after
+   `begin_particle_tick`; as documented in `spark.rs:484-488`, Rust then retains
+   persistent Z but consumes no RNG and leaves coordinate/lifetime untouched.
+   Native continues through normal commit/delete/color/lifetime.
+8. `SharedCellDummy` currently represents coordinate, level, slope, and
+   `+0x140 & 0x1180`. It does not represent overlay identity. That omission is
+   harmless only if Spark deliberately uses the proven valid-lifecycle non-wall
+   projection; it must not consult a rectangular OverlayGrid on fallback.
+
+## 10. Smallest architecture-correct handoff
+
+Keep arithmetic and world ownership where they are. Replace only Spark's eager
+strict fact adapter with a native-ordered query transcript over the existing
+shared substrate:
+
+1. Add a Spark-local selected-cell view around
+   `cell_rect::get_cellclass_fallback_leptons`, preserving `CellRef::Real` versus
+   the one `SharedCellDummy` handle. It must expose signed level, slope, raw
+   structural bit, and whether the result is dummy.
+2. Make constructor ground lookup return a value for both real and dummy. Call
+   it once for the comparison and again only on `z <= ground`; do not swallow a
+   cell miss. Missing entire map fixtures may keep a clearly separate
+   test-only/unsupported-world policy.
+3. In per-tick Spark, execute candidate ground first; select candidate cell and
+   read candidate raw structural; select old only when candidate structural is
+   false. Do not prefetch both.
+4. Gate building/wall exactly behind no bridge collision plus the 150-lepton
+   contact band. Dummy returns no building. Real cells retain the verified
+   object-list ordering/filter adapter.
+5. For wall, real cells may map `CellClass+0x44` from OverlayGrid; dummy must use
+   shared dummy overlay state or the proven valid-lifecycle non-wall projection.
+   The more reusable parity direction is to extend `SharedCellDummy` with signed
+   overlay identity initialized to `-1` and let active overlay writers update it;
+   do not create per-query dummy overlay snapshots.
+6. Only after collision selection, reselect candidate through
+   `get_cellclass_fallback_leptons` and read its live slope for the matrix. This
+   is the required final candidate restamp.
+7. Return normal `SparkCollisionFacts` and let the existing kernel preserve its
+   verified commit/delete/color/lifetime ordering. Misses must not return a
+   `SparkWorldError`.
+
+Do not globally replace strict terrain access, add playfield clipping, component
+bounds, or reconstruct the dummy on a miss. Those would alter other contracts.
+
+## 11. Acceptance tests
+
+Required focused tests should prove the transcript, not only final collision:
+
+1. Constructor null-slot miss above ground: one candidate stamp, no clamp;
+   below/equal: two same-coordinate stamps and clamp from persistent dummy
+   level/slope; lifetime draw remains before and color draw after.
+2. Candidate dummy structural clear, old dummy: final no-collision stamp is old;
+   candidate retained pointer still observes shared non-coordinate state.
+3. Candidate dummy structural set: old lookup is skipped and final stamp remains
+   candidate when no later slope query occurs.
+4. Collision from dummy facts: final slope lookup restamps candidate, collision
+   deletes/commits, exactly one color draw occurs, and lifetime decrements.
+5. No collision on a dummy: candidate commits, exactly one color draw occurs,
+   lifetime decrements, and no slope restamp occurs.
+6. Dummy object list behaves empty; dummy wall checks `-1`, 2, 26, and 243 if
+   overlay state is modeled, with only the three IDs true.
+7. Noncanonical fixed-stride alias to an allocated real cell is a real hit and
+   leaves the prior dummy coordinate unchanged.
+8. Null allocated-mask slot and negative/high linear misses follow the same
+   normal Spark path rather than returning `SparkWorldError`.
+9. Existing real-cell bridge/building/wall/collision tests continue to pass and
+   additionally assert native query short-circuit order.
+
+Suggested row gate:
+
+```text
+gsi_04_03_spark_shared_dummy_query_order_and_miss_continuation
+```
+
+## 12. Opening-question ledger
+
+| Question | Result |
+|---|---|
+| Constructor ground calls and RNG order | Closed: one call, conditional identical second; lifetime before, optional color after |
+| Fixed-512 miss selection/stamp | Closed for both helpers |
+| Every Spark-consumed dummy field | Closed: coord, level, slope, structural bit, object-list empty, overlay identity |
+| Subsequent restamps/order | Closed, including candidate structural short-circuit and collision-only slope restamp |
+| Collision/delete/RNG on miss | Closed: no error branch; normal resolution and one color draw |
+| Null-slot reachability | Closed: valid rim plus stock signed motion, no interior guard |
+| True out-of-capacity shipped incidence | Non-load-bearing incidence not claimed; same verified implementation branch |
+| Dummy object-list contamination | Excluded for supported active lifecycle |
+| Overlay/flags persistence | Closed: constructor defaults, active fallback writers, no per-lookup reset |
+| Save/load lifecycle | Closed: not an allocated serialized cell; reconstructed at Resize |
+| Rust mismatch and handoff | Closed; row remains open pending implementation/tests/critic loop |
+
+No load-bearing Spark/dummy mechanism remains approximate in this report.
+
+## 13. Ghidra annotation candidates (not applied)
+
+No Ghidra mutation was performed. Candidate comments for a later certainty-gated
+metadata pass:
+
+- behavior-3 `0x0062C6E0`: document candidate-ground -> candidate-cell/structural
+  -> conditional old-cell/structural -> gated building/wall -> collision-only
+  candidate slope lookup.
+- `FUN_006D6AD0`: candidate name
+  `MapClass__GetSlopeTypeAtWorldCoord`, noting that it reuses/stamps the shared
+  dummy and reads `Cell+0x11C`.
+- `Look_up_building_in_cell @ 0x0047C520`: note ground list `+0xE4`, first
+  `WhatAmI()==6`, no fallback special case.
+
+## 14. Validation performed
+
+- Live Ghidra decompile and assembly re-read of every primary function named in
+  sections 2-5.
+- Program-wide instruction census of `MOV ... [reg+0x44]` writers, followed by
+  focused live inspection of relevant Cell/Overlay/bridge paths.
+- Raw retail bridge overlay table reads for the active IDs cited above.
+- Current Rust direct read of `spark_world.rs`, `spark_spawn.rs`, `spark.rs`,
+  `system_ai.rs`, `cell_rect.rs`, and `resolved_terrain.rs`.
+- Retail `rulesmd.ini` read for active systems, producer routing, velocity,
+  gravity, and lifetime domains.
+- No Rust source edit, commit, push, or Ghidra mutation.

--- a/docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md
@@ -4,15 +4,15 @@ Date: 2026-08-27
 Scope: GSI-04.03, behavior-3 `Spark` only
 Binary: active retail Yuri's Revenge `gamemd.exe` in live Ghidra (`/gamemd.exe`)
 Method: exhaustive-slice re-investigation; live decompile plus assembly, active retail INI, current Rust read
-Status: **VERIFIED native contract; Rust implemented; critic round remains OPEN**
+Status: **VERIFIED native contract; Rust implemented; critic 4 P1 prose repair active; not yet parity-pass certified**
 
 ## Post-implementation addendum
 
-Production shared-dummy routing landed in `4c71b488`; the first critic-driven
-validation and stale-prose repair landed in `72bf8e15`. The pre-fix Rust summary
-in the verdict, the disparity inventory in section 9, and the prescriptive
-handoff in section 10 are retained as historical implementation provenance.
-They describe the baseline before `4c71b488`, not the active Rust behavior.
+Production shared-dummy routing landed in `4c71b488`; critic-driven validation
+and provenance repairs landed in `72bf8e15`, `96779c16`, and `0054549e`. The
+pre-fix Rust summary in the verdict, the disparity inventory in section 9, and
+the prescriptive handoff in section 10 are retained as historical implementation
+provenance. They describe the baseline before `4c71b488`, not active behavior.
 The native evidence and acceptance contract remain authoritative while the
 fresh-critic loop is active; this addendum does not declare parity pass.
 
@@ -261,8 +261,8 @@ The normal collision formula then runs against those facts:
 Collision sets the deletion flag and commits the collision coordinate before
 the one per-tick color draw. No collision commits the candidate. In both cases
 the color draw and lifetime decrement still occur. Therefore converting a miss
-to a Rust error is synchronization-visible: current Rust preserves only the
-already-written persistent Z velocity, then returns before coordinate commit,
+to a Rust error is synchronization-visible. Pre-fix Rust preserved only the
+already-written persistent Z velocity, then returned before coordinate commit,
 delete, color RNG, and lifetime.
 
 ## 7. Reachability and exclusions
@@ -436,7 +436,7 @@ gsi_04_03_spark_shared_dummy_query_order_and_miss_continuation
 | Dummy object-list contamination | Excluded for supported active lifecycle |
 | Overlay/flags persistence | Closed: constructor defaults, active fallback writers, no per-lookup reset |
 | Save/load lifecycle | Closed: not an allocated serialized cell; reconstructed at Resize |
-| Rust mismatch and handoff | Implemented in `4c71b488`, with validation repair `72bf8e15`; row remains open pending critic pass |
+| Rust mismatch and handoff | Implemented in `4c71b488`, with review repairs `72bf8e15`, `96779c16`, and `0054549e`; row remains open pending critic pass |
 
 No load-bearing Spark/dummy mechanism remains approximate in this report.
 

--- a/docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_SPARK_SHARED_DUMMY_ROUTING_GHIDRA_REPORT.md
@@ -4,7 +4,17 @@ Date: 2026-08-27
 Scope: GSI-04.03, behavior-3 `Spark` only
 Binary: active retail Yuri's Revenge `gamemd.exe` in live Ghidra (`/gamemd.exe`)
 Method: exhaustive-slice re-investigation; live decompile plus assembly, active retail INI, current Rust read
-Status: **VERIFIED implementation handoff; Rust row remains OPEN**
+Status: **VERIFIED native contract; Rust implemented; critic round remains OPEN**
+
+## Post-implementation addendum
+
+Production shared-dummy routing landed in `4c71b488`; the first critic-driven
+validation and stale-prose repair landed in `72bf8e15`. The pre-fix Rust summary
+in the verdict, the disparity inventory in section 9, and the prescriptive
+handoff in section 10 are retained as historical implementation provenance.
+They describe the baseline before `4c71b488`, not the active Rust behavior.
+The native evidence and acceptance contract remain authoritative while the
+fresh-critic loop is active; this addendum does not declare parity pass.
 
 ## Question and stop condition
 
@@ -29,12 +39,13 @@ slope, raw structural-bridge flag, overlay identity, and empty object-list
 behavior in a branch-dependent order. Later lookups can restamp the same object
 before retained-pointer reads.
 
-Current Rust's shared substrate is sufficient in shape but Spark bypasses it.
-`SparkCollisionWorld` performs strict real-cell lookups, errors on invalid or
-unallocated cells, queries old before candidate, evaluates both bridge cells
-without native short-circuiting, gathers building/overlay/slope eagerly, and
-turns a constructor miss into `None`. That changes dummy state, collisions,
-coordinates, deletion, lifetime, and the synchronized particle RNG stream.
+Historically, Rust's shared substrate was sufficient in shape but Spark bypassed
+it. Pre-fix `SparkCollisionWorld` performed strict real-cell lookups, errored on
+invalid or unallocated cells, queried old before candidate, evaluated both
+bridge cells without native short-circuiting, gathered building/overlay/slope
+eagerly, and turned a constructor miss into `None`. That changed dummy state,
+collisions, coordinates, deletion, lifetime, and the synchronized particle RNG
+stream.
 
 This is not safely excludable. A valid allocated Size-diamond edge cell has an
 adjacent unallocated canonical slot; behavior-3 motion has no interior-margin or
@@ -313,9 +324,10 @@ state. Rust's existing `SharedCellDummy` identity and
 `reconstruct_for_map_resize` boundary match this lifecycle for its represented
 fields.
 
-## 9. Exact current Rust disparities
+## 9. Historical pre-implementation Rust disparities (superseded)
 
-Current files were read in the active Phase 3 worktree.
+These files were read in the active Phase 3 worktree before `4c71b488`; the
+following disparities are retained only as the implementation baseline.
 
 1. `src/sim/particles/spark_spawn.rs:327-336` calls
    `SparkCollisionWorld::ground_height_at`; `src/sim/particles/spark_world.rs:117-119`
@@ -343,7 +355,9 @@ Current files were read in the active Phase 3 worktree.
    harmless only if Spark deliberately uses the proven valid-lifecycle non-wall
    projection; it must not consult a rectangular OverlayGrid on fallback.
 
-## 10. Smallest architecture-correct handoff
+## 10. Historical architecture-correct handoff (implemented)
+
+The following handoff is satisfied by `4c71b488` and is retained for provenance.
 
 Keep arithmetic and world ownership where they are. Replace only Spark's eager
 strict fact adapter with a native-ordered query transcript over the existing
@@ -422,7 +436,7 @@ gsi_04_03_spark_shared_dummy_query_order_and_miss_continuation
 | Dummy object-list contamination | Excluded for supported active lifecycle |
 | Overlay/flags persistence | Closed: constructor defaults, active fallback writers, no per-lookup reset |
 | Save/load lifecycle | Closed: not an allocated serialized cell; reconstructed at Resize |
-| Rust mismatch and handoff | Closed; row remains open pending implementation/tests/critic loop |
+| Rust mismatch and handoff | Implemented in `4c71b488`, with validation repair `72bf8e15`; row remains open pending critic pass |
 
 No load-bearing Spark/dummy mechanism remains approximate in this report.
 

--- a/src/sim/particles/spark.rs
+++ b/src/sim/particles/spark.rs
@@ -1,7 +1,7 @@
 //! Behavior-3 Spark arithmetic, collision, and native-ordered tick kernel.
 //!
-//! Production dispatch remains disabled. Callers must supply already-resolved
-//! native-frame collision facts and the authoritative particle RNG.
+//! Production callers gather native-ordered live-world collision facts before
+//! advancing the authoritative particle RNG.
 
 use glam::IVec3;
 use thiserror::Error;
@@ -26,7 +26,7 @@ const COLOR_JITTER_SCALE: NativeF64Bits = NativeF64Bits::from_bits(0x3fa9_9999_9
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SparkCollisionFacts {
     pub ground_z: i32,
-    pub slope_matrix: [NativeF32Bits; 12],
+    pub slope_matrix: Option<[NativeF32Bits; 12]>,
     pub old_has_structural_bridge: bool,
     pub candidate_has_structural_bridge: bool,
     pub accepted_building: bool,
@@ -89,6 +89,8 @@ pub enum SparkKernelError {
     InvalidColorCount(usize),
     #[error("Spark color RNG sample {0:#x} is outside 0..=0x7ffffffe")]
     InvalidColorRngSample(u32),
+    #[error("Spark {0:?} collision requires a slope matrix")]
+    MissingSlopeMatrixForCollision(SparkCollisionKind),
     #[error(transparent)]
     NativeX87(#[from] NativeX87Error),
 }
@@ -182,81 +184,28 @@ fn resolve_collision_decision(
     motion: SparkMotionStep,
     facts: SparkCollisionFacts,
 ) -> Result<SparkCollisionDecision, SparkKernelError> {
-    let old_z = motion.old_coords.z;
-    let candidate_z_integer = motion.candidate_coords.z;
-    let candidate_z = X87Chop53::load_f32(motion.candidate_f32[2])?;
     let ground_z = facts.ground_z;
     let ground_exact = X87Chop53::load_i32(ground_z);
     let bridge_plane = ground_z.wrapping_add(STRUCTURAL_BRIDGE_HEIGHT);
-    let structural = facts.old_has_structural_bridge || facts.candidate_has_structural_bridge;
-
-    let bridge_kind = if structural && candidate_z_integer < bridge_plane && old_z >= bridge_plane {
-        Some(SparkCollisionKind::DescendingBridge)
-    } else if structural && candidate_z_integer >= bridge_plane && old_z < bridge_plane {
-        Some(SparkCollisionKind::AscendingBridge)
-    } else {
-        None
-    };
-
-    // Native performs the contact-band gate against the retained raw candidate
-    // and an exact FILD ground value before its final collision-selection block.
-    let contact_kind = if bridge_kind.is_none()
-        && X87Chop53::compare(candidate_z, ground_exact) != X87Ordering::Less
-    {
-        let contact_floor = X87Chop53::sub(
-            candidate_z,
-            X87Chop53::load_f32(BUILDING_CONTACT_HEIGHT_F32)?,
-        );
-        if X87Chop53::compare(contact_floor, ground_exact) == X87Ordering::Less {
-            if facts.accepted_building {
-                Some(SparkCollisionKind::Building)
-            } else if matches!(facts.wall_overlay_id, Some(0x02) | Some(0x1a) | Some(0xf3)) {
-                Some(SparkCollisionKind::Wall)
-            } else {
-                None
-            }
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-
+    let kind = classify_collision_kind(motion, facts)?;
     let ground_stored_bits = X87Chop53::store_f32(ground_exact)?;
-    let ground_stored = X87Chop53::load_f32(ground_stored_bits)?;
 
-    let (committed_z_bits, kind) = match bridge_kind {
-        Some(SparkCollisionKind::DescendingBridge) => (
-            integer_as_stored_f32(bridge_plane)?,
-            Some(SparkCollisionKind::DescendingBridge),
-        ),
-        Some(SparkCollisionKind::AscendingBridge) => (
-            integer_as_stored_f32(bridge_plane.wrapping_sub(ASCENDING_BRIDGE_DELETE_OFFSET))?,
-            Some(SparkCollisionKind::AscendingBridge),
-        ),
-        _ if X87Chop53::compare(candidate_z, ground_stored) == X87Ordering::Less => {
-            let clamp_boundary = X87Chop53::load_i32(ground_z.wrapping_sub(GROUND_CLAMP_DEPTH));
-            if X87Chop53::compare(clamp_boundary, candidate_z) == X87Ordering::Less {
-                (
-                    ground_stored_bits,
-                    Some(SparkCollisionKind::BelowGroundNear),
-                )
-            } else {
-                (
-                    motion.candidate_f32[2],
-                    Some(SparkCollisionKind::BelowGroundDeep),
-                )
-            }
+    let committed_z_bits = match kind {
+        Some(SparkCollisionKind::DescendingBridge) => integer_as_stored_f32(bridge_plane)?,
+        Some(SparkCollisionKind::AscendingBridge) => {
+            integer_as_stored_f32(bridge_plane.wrapping_sub(ASCENDING_BRIDGE_DELETE_OFFSET))?
         }
-        _ if contact_kind.is_some() => (ground_stored_bits, contact_kind),
-        _ => (motion.candidate_f32[2], None),
+        Some(SparkCollisionKind::BelowGroundNear)
+        | Some(SparkCollisionKind::Building)
+        | Some(SparkCollisionKind::Wall) => ground_stored_bits,
+        Some(SparkCollisionKind::BelowGroundDeep) | None => motion.candidate_f32[2],
     };
 
-    let transient_reflection = if kind.is_some() {
-        Some(reflect_slope_vector(
-            motion.probe_velocity,
-            facts.slope_matrix,
-        )?)
+    let transient_reflection = if let Some(kind) = kind {
+        let slope_matrix = facts
+            .slope_matrix
+            .ok_or(SparkKernelError::MissingSlopeMatrixForCollision(kind))?;
+        Some(reflect_slope_vector(motion.probe_velocity, slope_matrix)?)
     } else {
         None
     };
@@ -270,6 +219,87 @@ fn resolve_collision_decision(
         kind,
         transient_reflection,
     })
+}
+
+pub(super) fn bridge_collision_kind(
+    motion: SparkMotionStep,
+    ground_z: i32,
+    old_has_structural_bridge: bool,
+    candidate_has_structural_bridge: bool,
+) -> Option<SparkCollisionKind> {
+    let bridge_plane = ground_z.wrapping_add(STRUCTURAL_BRIDGE_HEIGHT);
+    let structural = old_has_structural_bridge || candidate_has_structural_bridge;
+    if structural && motion.candidate_coords.z < bridge_plane && motion.old_coords.z >= bridge_plane
+    {
+        Some(SparkCollisionKind::DescendingBridge)
+    } else if structural
+        && motion.candidate_coords.z >= bridge_plane
+        && motion.old_coords.z < bridge_plane
+    {
+        Some(SparkCollisionKind::AscendingBridge)
+    } else {
+        None
+    }
+}
+
+/// Native's raw-candidate contact-band gate, shared with the live-world query
+/// owner so building and overlay state stay lazy without duplicating thresholds.
+pub(super) fn in_contact_band(
+    motion: SparkMotionStep,
+    ground_z: i32,
+) -> Result<bool, SparkKernelError> {
+    let candidate_z = X87Chop53::load_f32(motion.candidate_f32[2])?;
+    let ground_exact = X87Chop53::load_i32(ground_z);
+    if X87Chop53::compare(candidate_z, ground_exact) == X87Ordering::Less {
+        return Ok(false);
+    }
+    let contact_floor = X87Chop53::sub(
+        candidate_z,
+        X87Chop53::load_f32(BUILDING_CONTACT_HEIGHT_F32)?,
+    );
+    Ok(X87Chop53::compare(contact_floor, ground_exact) == X87Ordering::Less)
+}
+
+/// Collision selection without the slope transform. This is the single owner
+/// used both to decide whether the world must select a slope cell and to commit
+/// the final collision.
+pub(super) fn classify_collision_kind(
+    motion: SparkMotionStep,
+    facts: SparkCollisionFacts,
+) -> Result<Option<SparkCollisionKind>, SparkKernelError> {
+    if let Some(kind) = bridge_collision_kind(
+        motion,
+        facts.ground_z,
+        facts.old_has_structural_bridge,
+        facts.candidate_has_structural_bridge,
+    ) {
+        return Ok(Some(kind));
+    }
+
+    let candidate_z = X87Chop53::load_f32(motion.candidate_f32[2])?;
+    let ground_exact = X87Chop53::load_i32(facts.ground_z);
+    let ground_stored = X87Chop53::load_f32(X87Chop53::store_f32(ground_exact)?)?;
+    if X87Chop53::compare(candidate_z, ground_stored) == X87Ordering::Less {
+        let clamp_boundary = X87Chop53::load_i32(facts.ground_z.wrapping_sub(GROUND_CLAMP_DEPTH));
+        return Ok(Some(
+            if X87Chop53::compare(clamp_boundary, candidate_z) == X87Ordering::Less {
+                SparkCollisionKind::BelowGroundNear
+            } else {
+                SparkCollisionKind::BelowGroundDeep
+            },
+        ));
+    }
+
+    if !in_contact_band(motion, facts.ground_z)? {
+        return Ok(None);
+    }
+    if facts.accepted_building {
+        Ok(Some(SparkCollisionKind::Building))
+    } else if matches!(facts.wall_overlay_id, Some(0x02) | Some(0x1a) | Some(0xf3)) {
+        Ok(Some(SparkCollisionKind::Wall))
+    } else {
+        Ok(None)
+    }
 }
 
 fn finalize_collision(
@@ -484,8 +514,8 @@ pub fn tick_particle_with_facts(
 /// Apply the native persistent-Z write and compute the candidate probe.
 ///
 /// The persistent velocity write intentionally happens before any live-world
-/// query. A caller that cannot resolve collision facts must retain that write
-/// while consuming no RNG and leaving coordinates/lifetime untouched.
+/// query. A genuinely corrupt or unsupported world dependency must retain that
+/// write while consuming no RNG and leaving coordinates/lifetime untouched.
 pub fn begin_particle_tick(
     particle: &mut Particle,
     gravity: NativeF32Bits,
@@ -564,7 +594,7 @@ mod tests {
     fn facts(ground_z: i32) -> SparkCollisionFacts {
         SparkCollisionFacts {
             ground_z,
-            slope_matrix: identity_matrix(),
+            slope_matrix: Some(identity_matrix()),
             old_has_structural_bridge: false,
             candidate_has_structural_bridge: false,
             accepted_building: false,
@@ -832,6 +862,25 @@ mod tests {
         assert_eq!(
             resolve_collision(motion(0, 150), building).unwrap().kind,
             None
+        );
+    }
+
+    #[test]
+    fn gsi_04_03_slope_matrix_is_required_only_after_collision_selection() {
+        let mut clear = facts(0);
+        clear.slope_matrix = None;
+        assert_eq!(
+            resolve_collision(motion(200, 200), clear).unwrap().kind,
+            None
+        );
+
+        let mut collision = facts(0);
+        collision.slope_matrix = None;
+        assert_eq!(
+            resolve_collision(motion(0, -1), collision),
+            Err(SparkKernelError::MissingSlopeMatrixForCollision(
+                SparkCollisionKind::BelowGroundNear
+            ))
         );
     }
 

--- a/src/sim/particles/spark.rs
+++ b/src/sim/particles/spark.rs
@@ -184,6 +184,8 @@ fn resolve_collision_decision(
     motion: SparkMotionStep,
     facts: SparkCollisionFacts,
 ) -> Result<SparkCollisionDecision, SparkKernelError> {
+    // gamemd-derived: behavior-3 ParticleClass AI @ 0x0062C6E0 owns these
+    // bridge, ground, building, wall, commit-Z, and slope-reflection decisions.
     let ground_z = facts.ground_z;
     let ground_exact = X87Chop53::load_i32(ground_z);
     let bridge_plane = ground_z.wrapping_add(STRUCTURAL_BRIDGE_HEIGHT);
@@ -516,6 +518,9 @@ pub fn tick_particle_with_facts(
 /// The persistent velocity write intentionally happens before any live-world
 /// query. A genuinely corrupt or unsupported world dependency must retain that
 /// write while consuming no RNG and leaving coordinates/lifetime untouched.
+///
+/// gamemd-derived: behavior-3 ParticleClass AI @ 0x0062C6E0 stores persistent
+/// Z velocity and computes the candidate before querying live CellClass facts.
 pub fn begin_particle_tick(
     particle: &mut Particle,
     gravity: NativeF32Bits,
@@ -535,6 +540,9 @@ pub fn begin_particle_tick(
 
 /// Resolve and commit owned collision facts, then consume color RNG and lifetime
 /// in the verified order.
+///
+/// gamemd-derived: behavior-3 ParticleClass AI @ 0x0062C6E0 commits collision
+/// state before the color draw and final lifetime decrement.
 pub fn finish_particle_tick(
     particle: &mut Particle,
     motion: SparkMotionStep,

--- a/src/sim/particles/spark_spawn.rs
+++ b/src/sim/particles/spark_spawn.rs
@@ -54,6 +54,8 @@ pub(crate) enum SparkSpawnError {
     NonSparkParticle(String),
     #[error("spark spawn x87 evaluation failed: {0}")]
     X87(#[from] NativeX87Error),
+    #[error(transparent)]
+    World(#[from] super::spark_world::SparkWorldError),
 }
 
 /// Run one tick of `AI_Spark`'s spawn half against `sys`.
@@ -158,13 +160,8 @@ pub(super) fn spark_spawn_pass(
                 // `DynamicVector` growth (`0x00630250`), so a Spark system can
                 // exceed `ParticleCap`. `WeldingSys` (cap 15, 20 spawn frames)
                 // relies on that.
-                let particle = construct_spark_particle(
-                    sim,
-                    rules,
-                    &particle_type,
-                    particle_type_id,
-                    system_coords,
-                )?;
+                let particle =
+                    construct_spark_particle(sim, &particle_type, particle_type_id, system_coords)?;
                 sys.particles.push(particle);
                 let particle = sys
                     .particles
@@ -306,7 +303,6 @@ pub(super) fn spark_spawn_pass(
 /// fault on, and `saturating_add` replaces native's 16-bit `ADD AX` wrap.
 fn construct_spark_particle(
     sim: &mut Simulation,
-    rules: &RuleSet,
     particle_type: &ParticleType,
     particle_type_id: crate::rules::particle_type::ParticleTypeId,
     system_coords: IVec3,
@@ -317,24 +313,16 @@ fn construct_spark_particle(
     let lifetime_extra = sim.particle_rng().next_raw_abs_modulo(base) as i16;
     let lifetime_remaining = (particle_type.max_ec as i16).saturating_add(lifetime_extra);
 
-    // `CellClass::GetGroundHeight` floor: `if (nZ <= ground) nZ = ground`.
+    // `CellClass::GetGroundHeight` floor: native queries once for the compare,
+    // then repeats the same lookup only when `nZ <= ground` and assigns that
+    // second result. Both calls route misses through the shared dummy.
     //
     // VERA-internal, gamemd equivalent UNCHECKED: a world that cannot be built
-    // — no resolved terrain or overlay grid — is treated as "no floor" rather
-    // than faulting. Native always has a map, so `GetGroundHeight` cannot fail
-    // there; the swallow is unreachable in production and exists so a fixture
-    // without terrain still exercises the spawn arithmetic.
-    let ground_z = super::spark_world::SparkCollisionWorld::new(sim, rules)
-        .ok()
-        .and_then(|world| world.ground_height_at(system_coords.x, system_coords.y));
-    let coords = IVec3::new(
-        system_coords.x,
-        system_coords.y,
-        match ground_z {
-            Some(ground) if system_coords.z <= ground => ground,
-            _ => system_coords.z,
-        },
-    );
+    // — no resolved terrain — is treated as "no floor". Native always has a
+    // map, so that branch remains a fixture-only compatibility policy.
+    let coords = floor_constructor_coords_with(system_coords, |x, y| {
+        super::spark_world::constructor_ground_height(sim, x, y)
+    })?;
 
     // The colour seed. Native reads the list only when it has entries, and
     // takes the interpolated arm only when at least one of the six
@@ -390,6 +378,22 @@ fn construct_spark_particle(
         prev_delta: [SIM_ZERO; 3],
         state_advance_counter: 0,
     })
+}
+
+fn floor_constructor_coords_with<E, F>(
+    system_coords: IVec3,
+    mut ground_height: F,
+) -> Result<IVec3, E>
+where
+    F: FnMut(i32, i32) -> Result<Option<i32>, E>,
+{
+    let first_ground = ground_height(system_coords.x, system_coords.y)?;
+    let z = if first_ground.is_some_and(|ground| system_coords.z <= ground) {
+        ground_height(system_coords.x, system_coords.y)?.unwrap_or(system_coords.z)
+    } else {
+        system_coords.z
+    };
+    Ok(IVec3::new(system_coords.x, system_coords.y, z))
 }
 
 /// `FUN_00661020(start1, start2, t)` — per-channel linear blend on the scaled
@@ -534,7 +538,6 @@ mod tests {
         for (input_z, expected_z) in [(207, 208), (208, 208), (209, 209)] {
             let particle = construct_spark_particle(
                 &mut sim,
-                &rules,
                 &particle_type,
                 particle_type_id,
                 IVec3::new(128, 128, input_z),
@@ -542,6 +545,63 @@ mod tests {
             .expect("finite stock-shaped Spark construction");
             assert_eq!(particle.coords.z, expected_z, "input Z {input_z}");
         }
+    }
+
+    #[test]
+    fn gsi_04_03_constructor_ground_query_is_conditional_and_repeated() {
+        let mut calls = Vec::new();
+        let mut samples = [Some(104), Some(208)].into_iter();
+        let floored = floor_constructor_coords_with(IVec3::new(7, 9, 100), |x, y| {
+            calls.push((x, y));
+            Ok::<_, ()>(samples.next().unwrap())
+        })
+        .unwrap();
+        assert_eq!(calls, vec![(7, 9), (7, 9)]);
+        assert_eq!(
+            floored.z, 208,
+            "the conditional second lookup owns the assigned floor"
+        );
+
+        calls.clear();
+        let untouched = floor_constructor_coords_with(IVec3::new(7, 9, 105), |x, y| {
+            calls.push((x, y));
+            Ok::<_, ()>(Some(104))
+        })
+        .unwrap();
+        assert_eq!(calls, vec![(7, 9)]);
+        assert_eq!(untouched.z, 105);
+    }
+
+    #[test]
+    fn gsi_04_03_constructor_miss_uses_live_dummy_without_overlay_grid() {
+        let rules = spark_rules(1, 2, "1");
+        let particle_type_id = crate::rules::particle_type::ParticleTypeId(0);
+        let particle_type = rules.particle_type(particle_type_id).clone();
+        let mut sim = super::super::spark_world::tests::one_cell_sim(
+            super::super::spark_world::tests::terrain_cell(0, 0),
+        );
+        sim.overlay_grid = None;
+        let terrain = sim.resolved_terrain.as_ref().unwrap();
+        terrain.test_set_dummy_cell_level_slope(2, 0);
+
+        let particle = construct_spark_particle(
+            &mut sim,
+            &particle_type,
+            particle_type_id,
+            IVec3::new(256, 0, 0),
+        )
+        .unwrap();
+
+        assert_eq!(particle.coords.z, 208);
+        assert_eq!(
+            sim.resolved_terrain
+                .as_ref()
+                .unwrap()
+                .shared_cell_dummy()
+                .snapshot()
+                .coord,
+            (1, 0)
+        );
     }
 
     #[test]

--- a/src/sim/particles/spark_spawn.rs
+++ b/src/sim/particles/spark_spawn.rs
@@ -668,6 +668,41 @@ mod tests {
     }
 
     #[test]
+    fn gsi_04_03_constructor_miss_uses_dummy_nonzero_slope_off_center() {
+        let rules = spark_rules(1, 2, "1");
+        let particle_type_id = crate::rules::particle_type::ParticleTypeId(0);
+        let particle_type = rules.particle_type(particle_type_id).clone();
+        let mut sim = super::super::spark_world::tests::one_cell_sim(
+            super::super::spark_world::tests::terrain_cell(0, 0),
+        );
+        let terrain = sim.resolved_terrain.as_ref().unwrap();
+        terrain.test_set_dummy_cell_level_slope(2, 1);
+
+        let particle = construct_spark_particle(
+            &mut sim,
+            &particle_type,
+            particle_type_id,
+            IVec3::new(320, 192, 0),
+        )
+        .unwrap();
+
+        assert_eq!(
+            particle.coords.z, 234,
+            "level 2 plus slope 1 at local (64,192) uses the exact 104-lepton Cell domain"
+        );
+        assert_ne!(particle.coords.z, 208, "the nonzero slope must be observed");
+        assert_eq!(
+            sim.resolved_terrain
+                .as_ref()
+                .unwrap()
+                .shared_cell_dummy()
+                .snapshot()
+                .coord,
+            (1, 0)
+        );
+    }
+
+    #[test]
     fn gsi_05_13_spawn_frames_one_bursts_and_takes_no_gate_draw() {
         // `CMP EAX,0x1 / JZ 0x0062E89E` skips the probability roll entirely.
         // Stock `[SparkSys]` and `[FirestormSparkSys]` both set

--- a/src/sim/particles/spark_spawn.rs
+++ b/src/sim/particles/spark_spawn.rs
@@ -307,6 +307,25 @@ fn construct_spark_particle(
     particle_type_id: crate::rules::particle_type::ParticleTypeId,
     system_coords: IVec3,
 ) -> Result<Particle, SparkSpawnError> {
+    construct_spark_particle_with_ground(
+        sim,
+        particle_type,
+        particle_type_id,
+        system_coords,
+        |sim, x, y| Ok(super::spark_world::constructor_ground_height(sim, x, y)?),
+    )
+}
+
+fn construct_spark_particle_with_ground<F>(
+    sim: &mut Simulation,
+    particle_type: &ParticleType,
+    particle_type_id: crate::rules::particle_type::ParticleTypeId,
+    system_coords: IVec3,
+    mut ground_height: F,
+) -> Result<Particle, SparkSpawnError>
+where
+    F: FnMut(&Simulation, i32, i32) -> Result<Option<i32>, SparkSpawnError>,
+{
     // `if (ptype+0x314 == 4) |Next() % 10| else |Next() % MaxEC|`, then
     // `+ MaxEC`. Spark is not behaviour 4, so it always takes the MaxEC arm.
     let base = (particle_type.max_ec as u32).max(1);
@@ -321,7 +340,7 @@ fn construct_spark_particle(
     // — no resolved terrain — is treated as "no floor". Native always has a
     // map, so that branch remains a fixture-only compatibility policy.
     let coords = floor_constructor_coords_with(system_coords, |x, y| {
-        super::spark_world::constructor_ground_height(sim, x, y)
+        ground_height(sim, x, y)
     })?;
 
     // The colour seed. Native reads the list only when it has entries, and
@@ -570,6 +589,50 @@ mod tests {
         .unwrap();
         assert_eq!(calls, vec![(7, 9)]);
         assert_eq!(untouched.z, 105);
+    }
+
+    #[test]
+    fn gsi_04_03_constructor_rng_brackets_ground_with_active_start_color_draw() {
+        let rules = RuleSet::from_ini(&IniFile::from_str(
+            "[General]\nFixtureOnly=1\n\
+             [Particles]\n1=Spark\n\
+             [Spark]\nBehavesLike=Spark\nMaxEC=500\n\
+             ColorList=255,255,255,0,0,0\n\
+             StartColor1=255,128,0\nStartColor2=128,64,32\n",
+        ))
+        .unwrap();
+        let particle_type_id = crate::rules::particle_type::ParticleTypeId(0);
+        let particle_type = rules.particle_type(particle_type_id).clone();
+        assert_eq!(particle_type.color_list.len(), 2);
+        assert_ne!(particle_type.start_color_1, [0, 0, 0]);
+        let mut sim = Simulation::with_seed(900);
+        let mut expected = SimRng::new(900);
+        expected.next_raw_abs_modulo(particle_type.max_ec as u32);
+        let after_lifetime = expected.logical_view();
+        let mut ground_calls = 0;
+
+        let particle = construct_spark_particle_with_ground(
+            &mut sim,
+            &particle_type,
+            particle_type_id,
+            IVec3::new(7, 9, 100),
+            |sim, x, y| {
+                ground_calls += 1;
+                assert_eq!((x, y), (7, 9));
+                assert_eq!(
+                    sim.rng_views().scenario,
+                    after_lifetime,
+                    "lifetime is consumed before either ground lookup and color is not"
+                );
+                Ok(Some(if ground_calls == 1 { 104 } else { 208 }))
+            },
+        )
+        .unwrap();
+
+        expected.next_range_u32_inclusive(0, MAX_RANDOM_RANGED_SAMPLE);
+        assert_eq!(ground_calls, 2);
+        assert_eq!(particle.coords.z, 208);
+        assert_eq!(sim.rng_views().scenario, expected.logical_view());
     }
 
     #[test]

--- a/src/sim/particles/spark_world.rs
+++ b/src/sim/particles/spark_world.rs
@@ -6,18 +6,20 @@
 
 use thiserror::Error;
 
-use super::spark::{SparkCollisionFacts, SparkMotionStep, lepton_to_cell_trunc};
+use super::spark::{
+    SparkCollisionFacts, SparkKernelError, SparkMotionStep, bridge_collision_kind,
+    classify_collision_kind, in_contact_band,
+};
+use crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL;
 use crate::map::entities::EntityCategory;
-use crate::map::resolved_terrain::ResolvedTerrainCell;
+use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use crate::rules::foundation::foundation_dimensions;
 use crate::rules::ruleset::RuleSet;
-use crate::sim::cell_rect::{CELL_ROW_STRIDE, cell_linear_index};
+use crate::sim::cell_rect::{CellRef, get_cellclass_fallback_leptons};
 use crate::sim::movement::locomotor::MovementLayer;
 use crate::sim::world::Simulation;
 use crate::util::lepton::{UnsupportedGroundSlope, ground_height_leptons};
 use crate::util::native_x87::NativeF32Bits;
-
-const CELL_AXIS_MASK: i64 = CELL_ROW_STRIDE - 1;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum SparkWorldError {
@@ -25,17 +27,6 @@ pub enum SparkWorldError {
     MissingTerrain,
     #[error("Spark collision requires the mutable overlay grid")]
     MissingOverlayGrid,
-    #[error("native cell lookup ({x}, {y}) falls outside the fixed cell array")]
-    OutOfRangeCell { x: i32, y: i32 },
-    #[error(
-        "native cell lookup ({x}, {y}) resolves to unavailable canonical cell ({canonical_x}, {canonical_y})"
-    )]
-    UnavailableCell {
-        x: i32,
-        y: i32,
-        canonical_x: u16,
-        canonical_y: u16,
-    },
     #[error("overlay state is unavailable at canonical cell ({rx}, {ry})")]
     UnavailableOverlayCell { rx: u16, ry: u16 },
     #[error("slope type {0} is outside the verified 0..=20 table")]
@@ -50,6 +41,65 @@ pub enum SparkWorldError {
     MissingObjectType(u64),
     #[error("building entity {0} needs unmodelled LaserFence connectivity state")]
     UnsupportedLaserFence(u64),
+    #[error(transparent)]
+    Kernel(#[from] SparkKernelError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SparkCellSelectionRole {
+    Ground,
+    Cell,
+    Slope,
+}
+
+#[derive(Debug, Clone)]
+struct SelectedSparkCell<'a> {
+    role: SparkCellSelectionRole,
+    cell: CellRef<'a>,
+}
+
+fn select_cell<'a>(
+    terrain: &'a ResolvedTerrainGrid,
+    role: SparkCellSelectionRole,
+    world_x: i32,
+    world_y: i32,
+) -> SelectedSparkCell<'a> {
+    SelectedSparkCell {
+        role,
+        cell: get_cellclass_fallback_leptons(Some(terrain), world_x, world_y),
+    }
+}
+
+fn ground_height_for_selection(
+    selection: &SelectedSparkCell<'_>,
+    world_x: i32,
+    world_y: i32,
+) -> Result<i32, SparkWorldError> {
+    debug_assert_eq!(selection.role, SparkCellSelectionRole::Ground);
+    let (level, slope_type) = match &selection.cell {
+        CellRef::Real(cell) => (cell.level, cell.slope_type),
+        CellRef::Dummy { cell } => {
+            let snapshot = cell.snapshot();
+            (snapshot.level as u8, snapshot.slope_type)
+        }
+    };
+    ground_height_leptons(level, slope_type, world_x, world_y)
+        .map_err(|UnsupportedGroundSlope(slope)| SparkWorldError::UnsupportedSlope(slope))
+}
+
+/// Constructor-only terrain query. Missing terrain retains the pre-existing
+/// no-floor policy; with terrain present, a native miss returns the live dummy
+/// and therefore still produces a ground height.
+pub(super) fn constructor_ground_height(
+    sim: &Simulation,
+    world_x: i32,
+    world_y: i32,
+) -> Result<Option<i32>, SparkWorldError> {
+    let Some(terrain) = sim.resolved_terrain.as_ref() else {
+        return Ok(None);
+    };
+    let selected = select_cell(terrain, SparkCellSelectionRole::Ground, world_x, world_y);
+    ground_height_for_selection(&selected, world_x, world_y).map(Some)
 }
 
 /// Concrete read-only view over the live simulation state Spark collision reads.
@@ -63,107 +113,176 @@ impl<'a> SparkCollisionWorld<'a> {
         if sim.resolved_terrain.is_none() {
             return Err(SparkWorldError::MissingTerrain);
         }
-        if sim.overlay_grid.is_none() {
-            return Err(SparkWorldError::MissingOverlayGrid);
-        }
         Ok(Self { sim, rules })
     }
 
     /// Gather every native collision input before the owner borrows mutable RNG.
     pub fn query(&self, motion: SparkMotionStep) -> Result<SparkCollisionFacts, SparkWorldError> {
-        let (old_rx, old_ry, old_cell) =
-            self.cell_for_world_coords(motion.old_coords.x, motion.old_coords.y)?;
-        let (candidate_rx, candidate_ry, candidate_cell) =
-            self.cell_for_world_coords(motion.candidate_coords.x, motion.candidate_coords.y)?;
-
-        let old_has_structural_bridge = self.live_structural_bridge(old_rx, old_ry, old_cell)?;
-        let candidate_has_structural_bridge =
-            self.live_structural_bridge(candidate_rx, candidate_ry, candidate_cell)?;
-        let accepted_building = self.accepted_building(candidate_rx, candidate_ry)?;
-        let overlay = self
-            .sim
-            .overlay_grid
-            .as_ref()
-            .ok_or(SparkWorldError::MissingOverlayGrid)?;
-        if candidate_rx >= overlay.width() || candidate_ry >= overlay.height() {
-            return Err(SparkWorldError::UnavailableOverlayCell {
-                rx: candidate_rx,
-                ry: candidate_ry,
-            });
-        }
-
-        Ok(SparkCollisionFacts {
-            ground_z: ground_height_leptons(
-                candidate_cell.level,
-                candidate_cell.slope_type,
-                motion.candidate_coords.x,
-                motion.candidate_coords.y,
-            )
-            .map_err(|UnsupportedGroundSlope(slope)| SparkWorldError::UnsupportedSlope(slope))?,
-            slope_matrix: slope_matrix(candidate_cell.slope_type)?,
-            old_has_structural_bridge,
-            candidate_has_structural_bridge,
-            accepted_building,
-            wall_overlay_id: overlay.cell(candidate_rx, candidate_ry).overlay_id,
-        })
-    }
-
-    /// `CellClass::GetGroundHeight` at one world coordinate.
-    ///
-    /// `ParticleClass::Constructor @ 0x0062B5E0` floors a new particle's Z on
-    /// this before `Set_Raw_Coords`, so the spawn path needs it without
-    /// building a whole motion step. `None` when the coordinate has no
-    /// resolved cell, which the caller treats as "no floor".
-    pub(super) fn ground_height_at(&self, world_x: i32, world_y: i32) -> Option<i32> {
-        let (_, _, cell) = self.cell_for_world_coords(world_x, world_y).ok()?;
-        ground_height_leptons(cell.level, cell.slope_type, world_x, world_y).ok()
-    }
-
-    fn cell_for_world_coords(
-        &self,
-        world_x: i32,
-        world_y: i32,
-    ) -> Result<(u16, u16, &ResolvedTerrainCell), SparkWorldError> {
-        let x = lepton_to_cell_trunc(world_x);
-        let y = lepton_to_cell_trunc(world_y);
-        let Some((canonical_x, canonical_y)) = canonical_cell(x, y) else {
-            return Err(SparkWorldError::OutOfRangeCell { x, y });
-        };
         let terrain = self
             .sim
             .resolved_terrain
             .as_ref()
             .ok_or(SparkWorldError::MissingTerrain)?;
-        let cell =
-            terrain
-                .cell(canonical_x, canonical_y)
-                .ok_or(SparkWorldError::UnavailableCell {
-                    x,
-                    y,
-                    canonical_x,
-                    canonical_y,
-                })?;
-        Ok((canonical_x, canonical_y, cell))
+        self.query_with_selector(motion, |role, x, y| select_cell(terrain, role, x, y))
+    }
+
+    #[cfg(test)]
+    pub(super) fn query_with_transcript(
+        &self,
+        motion: SparkMotionStep,
+    ) -> Result<(SparkCollisionFacts, Vec<(SparkCellSelectionRole, i32, i32)>), SparkWorldError>
+    {
+        let terrain = self
+            .sim
+            .resolved_terrain
+            .as_ref()
+            .ok_or(SparkWorldError::MissingTerrain)?;
+        let mut transcript = Vec::new();
+        let facts = self.query_with_selector(motion, |role, x, y| {
+            transcript.push((role, x, y));
+            select_cell(terrain, role, x, y)
+        })?;
+        Ok((facts, transcript))
+    }
+
+    fn query_with_selector<F>(
+        &self,
+        motion: SparkMotionStep,
+        mut select: F,
+    ) -> Result<SparkCollisionFacts, SparkWorldError>
+    where
+        F: FnMut(SparkCellSelectionRole, i32, i32) -> SelectedSparkCell<'a>,
+    {
+        let candidate_ground = select(
+            SparkCellSelectionRole::Ground,
+            motion.candidate_coords.x,
+            motion.candidate_coords.y,
+        );
+        let ground_z = ground_height_for_selection(
+            &candidate_ground,
+            motion.candidate_coords.x,
+            motion.candidate_coords.y,
+        )?;
+
+        let candidate_cell = select(
+            SparkCellSelectionRole::Cell,
+            motion.candidate_coords.x,
+            motion.candidate_coords.y,
+        );
+        let candidate_has_structural_bridge = self.live_structural_bridge(&candidate_cell)?;
+        let old_has_structural_bridge = if candidate_has_structural_bridge {
+            false
+        } else {
+            let old_cell = select(
+                SparkCellSelectionRole::Cell,
+                motion.old_coords.x,
+                motion.old_coords.y,
+            );
+            self.live_structural_bridge(&old_cell)?
+        };
+
+        let bridge_kind = bridge_collision_kind(
+            motion,
+            ground_z,
+            old_has_structural_bridge,
+            candidate_has_structural_bridge,
+        );
+        let mut accepted_building = false;
+        let mut wall_overlay_id = None;
+        if bridge_kind.is_none() && in_contact_band(motion, ground_z)? {
+            accepted_building = self.accepted_building_for_selection(&candidate_cell)?;
+            if !accepted_building {
+                wall_overlay_id = self.wall_overlay_for_selection(&candidate_cell)?;
+            }
+        }
+
+        let mut facts = SparkCollisionFacts {
+            ground_z,
+            slope_matrix: None,
+            old_has_structural_bridge,
+            candidate_has_structural_bridge,
+            accepted_building,
+            wall_overlay_id,
+        };
+        if classify_collision_kind(motion, facts)?.is_some() {
+            let candidate_slope = select(
+                SparkCellSelectionRole::Slope,
+                motion.candidate_coords.x,
+                motion.candidate_coords.y,
+            );
+            facts.slope_matrix = Some(self.slope_matrix_for_selection(&candidate_slope)?);
+        }
+        Ok(facts)
     }
 
     fn live_structural_bridge(
         &self,
-        rx: u16,
-        ry: u16,
-        cell: &ResolvedTerrainCell,
+        selection: &SelectedSparkCell<'_>,
     ) -> Result<bool, SparkWorldError> {
-        if !cell.bridge_facts.has_structural_bridge() {
-            return Ok(false);
+        debug_assert_eq!(selection.role, SparkCellSelectionRole::Cell);
+        match &selection.cell {
+            CellRef::Dummy { cell } => {
+                Ok(cell.snapshot().bridge_flags_0x1180 & BRIDGE_FLAG_STRUCTURAL != 0)
+            }
+            CellRef::Real(cell) => {
+                if !cell.bridge_facts.has_structural_bridge() {
+                    return Ok(false);
+                }
+                let (rx, ry) = (cell.rx, cell.ry);
+                let state = self
+                    .sim
+                    .bridge_state
+                    .as_ref()
+                    .ok_or(SparkWorldError::MissingBridgeRuntimeState { rx, ry })?;
+                let runtime = state
+                    .cell(rx, ry)
+                    .ok_or(SparkWorldError::MissingBridgeRuntimeCell { rx, ry })?;
+                Ok(runtime.deck_present)
+            }
         }
-        let state = self
-            .sim
-            .bridge_state
-            .as_ref()
-            .ok_or(SparkWorldError::MissingBridgeRuntimeState { rx, ry })?;
-        let runtime = state
-            .cell(rx, ry)
-            .ok_or(SparkWorldError::MissingBridgeRuntimeCell { rx, ry })?;
-        Ok(runtime.deck_present)
+    }
+
+    fn accepted_building_for_selection(
+        &self,
+        selection: &SelectedSparkCell<'_>,
+    ) -> Result<bool, SparkWorldError> {
+        match &selection.cell {
+            CellRef::Dummy { .. } => Ok(false),
+            CellRef::Real(cell) => self.accepted_building(cell.rx, cell.ry),
+        }
+    }
+
+    fn wall_overlay_for_selection(
+        &self,
+        selection: &SelectedSparkCell<'_>,
+    ) -> Result<Option<u8>, SparkWorldError> {
+        match &selection.cell {
+            CellRef::Dummy { .. } => Ok(None),
+            CellRef::Real(cell) => {
+                let (rx, ry) = (cell.rx, cell.ry);
+                let overlay = self
+                    .sim
+                    .overlay_grid
+                    .as_ref()
+                    .ok_or(SparkWorldError::MissingOverlayGrid)?;
+                if rx >= overlay.width() || ry >= overlay.height() {
+                    return Err(SparkWorldError::UnavailableOverlayCell { rx, ry });
+                }
+                Ok(overlay.cell(rx, ry).overlay_id)
+            }
+        }
+    }
+
+    fn slope_matrix_for_selection(
+        &self,
+        selection: &SelectedSparkCell<'_>,
+    ) -> Result<[NativeF32Bits; 12], SparkWorldError> {
+        debug_assert_eq!(selection.role, SparkCellSelectionRole::Slope);
+        let slope_type = match &selection.cell {
+            CellRef::Real(cell) => cell.slope_type,
+            CellRef::Dummy { cell } => cell.snapshot().slope_type,
+        };
+        slope_matrix(slope_type)
     }
 
     fn accepted_building(&self, rx: u16, ry: u16) -> Result<bool, SparkWorldError> {
@@ -198,14 +317,6 @@ impl<'a> SparkCollisionWorld<'a> {
         }
         Ok(false)
     }
-}
-
-fn canonical_cell(x: i32, y: i32) -> Option<(u16, u16)> {
-    let index = cell_linear_index(x, y)?;
-    Some((
-        (index & CELL_AXIS_MASK) as u16,
-        (index / CELL_ROW_STRIDE) as u16,
-    ))
 }
 
 macro_rules! matrix {
@@ -374,10 +485,18 @@ pub(super) mod tests {
     }
 
     fn motion_at(x: i32, y: i32) -> SparkMotionStep {
+        motion_between(IVec3::new(x, y, 100), IVec3::new(x, y, 100))
+    }
+
+    fn motion_between(old_coords: IVec3, candidate_coords: IVec3) -> SparkMotionStep {
         SparkMotionStep {
-            old_coords: IVec3::new(x, y, 100),
-            candidate_coords: IVec3::new(x, y, 100),
-            candidate_f32: [NativeF32Bits::POSITIVE_ZERO; 3],
+            old_coords,
+            candidate_coords,
+            candidate_f32: [
+                NativeF32Bits::from_bits((candidate_coords.x as f32).to_bits()),
+                NativeF32Bits::from_bits((candidate_coords.y as f32).to_bits()),
+                NativeF32Bits::from_bits((candidate_coords.z as f32).to_bits()),
+            ],
             persistent_velocity: [NativeF32Bits::POSITIVE_ZERO; 3],
             probe_velocity: [NativeF32Bits::POSITIVE_ZERO; 3],
         }
@@ -427,10 +546,15 @@ pub(super) mod tests {
 
     #[test]
     fn fixed_stride_lookup_preserves_native_aliasing() {
-        assert_eq!(canonical_cell(0, 0), Some((0, 0)));
-        assert_eq!(canonical_cell(512, -1), Some((0, 0)));
-        assert_eq!(canonical_cell(-1, 1), Some((511, 0)));
-        assert_eq!(canonical_cell(-1, 0), None);
+        let terrain = ResolvedTerrainGrid::from_cells(1, 1, vec![terrain_cell(0, 0)]);
+        assert!(matches!(
+            select_cell(&terrain, SparkCellSelectionRole::Cell, 512 * 256, -256).cell,
+            CellRef::Real(_)
+        ));
+        assert!(matches!(
+            select_cell(&terrain, SparkCellSelectionRole::Cell, -256, 0).cell,
+            CellRef::Dummy { .. }
+        ));
     }
 
     #[test]
@@ -477,7 +601,7 @@ pub(super) mod tests {
             .unwrap()
             .query(motion_at(0, 0))
             .unwrap();
-        assert!(intact.old_has_structural_bridge);
+        assert!(!intact.old_has_structural_bridge);
         assert!(intact.candidate_has_structural_bridge);
 
         sim.bridge_state
@@ -499,12 +623,254 @@ pub(super) mod tests {
         let mut cell = terrain_cell(0, 0);
         cell.level = 2;
         let sim = one_cell_sim(cell);
+        sim.resolved_terrain
+            .as_ref()
+            .unwrap()
+            .shared_cell_dummy()
+            .stamp_coord(77, -9);
         let rules = empty_rules();
         let aliased = SparkCollisionWorld::new(&sim, &rules)
             .unwrap()
             .query(motion_at(512 * 256, -256))
             .unwrap();
         assert_eq!(aliased.ground_z, 208);
+        assert_eq!(
+            sim.resolved_terrain
+                .as_ref()
+                .unwrap()
+                .shared_cell_dummy()
+                .snapshot()
+                .coord,
+            (77, -9),
+            "a fixed-stride real alias leaves the dummy untouched"
+        );
+    }
+
+    #[test]
+    fn gsi_04_03_production_selection_seam_records_native_query_transcript() {
+        let sim = one_cell_sim(terrain_cell(0, 0));
+        let rules = empty_rules();
+        let world = SparkCollisionWorld::new(&sim, &rules).unwrap();
+        let terrain = sim.resolved_terrain.as_ref().unwrap();
+        let motion = motion_between(IVec3::new(0, 0, 200), IVec3::new(256, 0, 200));
+        let mut transcript = Vec::new();
+
+        let facts = world
+            .query_with_selector(motion, |role, x, y| {
+                transcript.push((role, x, y));
+                select_cell(terrain, role, x, y)
+            })
+            .unwrap();
+
+        assert_eq!(
+            transcript,
+            vec![
+                (SparkCellSelectionRole::Ground, 256, 0),
+                (SparkCellSelectionRole::Cell, 256, 0),
+                (SparkCellSelectionRole::Cell, 0, 0),
+            ]
+        );
+        assert!(
+            facts.slope_matrix.is_none(),
+            "no collision performs no slope lookup"
+        );
+        assert_eq!(terrain.shared_cell_dummy().snapshot().coord, (1, 0));
+    }
+
+    #[test]
+    fn gsi_04_03_collision_reselects_candidate_slope_after_old_cell_lookup() {
+        let sim = one_cell_sim(terrain_cell(0, 0));
+        let rules = empty_rules();
+        let world = SparkCollisionWorld::new(&sim, &rules).unwrap();
+        let terrain = sim.resolved_terrain.as_ref().unwrap();
+        let motion = motion_between(IVec3::new(0, 0, 20), IVec3::new(256, 0, -100));
+        let mut transcript = Vec::new();
+
+        let facts = world
+            .query_with_selector(motion, |role, x, y| {
+                transcript.push((role, x, y));
+                select_cell(terrain, role, x, y)
+            })
+            .unwrap();
+
+        assert_eq!(
+            transcript,
+            vec![
+                (SparkCellSelectionRole::Ground, 256, 0),
+                (SparkCellSelectionRole::Cell, 256, 0),
+                (SparkCellSelectionRole::Cell, 0, 0),
+                (SparkCellSelectionRole::Slope, 256, 0),
+            ]
+        );
+        assert!(facts.slope_matrix.is_some());
+        assert_eq!(terrain.shared_cell_dummy().snapshot().coord, (1, 0));
+    }
+
+    #[test]
+    fn gsi_04_03_candidate_and_old_dummy_no_collision_finishes_with_old_stamp() {
+        let sim = one_cell_sim(terrain_cell(0, 0));
+        let rules = empty_rules();
+        let world = SparkCollisionWorld::new(&sim, &rules).unwrap();
+        let terrain = sim.resolved_terrain.as_ref().unwrap();
+        let motion = motion_between(IVec3::new(512, 0, 200), IVec3::new(256, 0, 200));
+        let mut transcript = Vec::new();
+
+        let facts = world
+            .query_with_selector(motion, |role, x, y| {
+                transcript.push((role, x, y));
+                select_cell(terrain, role, x, y)
+            })
+            .unwrap();
+
+        assert_eq!(
+            transcript,
+            vec![
+                (SparkCellSelectionRole::Ground, 256, 0),
+                (SparkCellSelectionRole::Cell, 256, 0),
+                (SparkCellSelectionRole::Cell, 512, 0),
+            ]
+        );
+        assert!(facts.slope_matrix.is_none());
+        assert_eq!(terrain.shared_cell_dummy().snapshot().coord, (2, 0));
+    }
+
+    #[test]
+    fn gsi_04_03_candidate_real_old_dummy_retains_real_candidate_view() {
+        let sim = one_cell_sim(terrain_cell(0, 0));
+        let rules = empty_rules();
+        let world = SparkCollisionWorld::new(&sim, &rules).unwrap();
+        let terrain = sim.resolved_terrain.as_ref().unwrap();
+        let motion = motion_between(IVec3::new(256, 0, 200), IVec3::new(0, 0, 200));
+        let mut transcript = Vec::new();
+
+        let facts = world
+            .query_with_selector(motion, |role, x, y| {
+                transcript.push((role, x, y));
+                select_cell(terrain, role, x, y)
+            })
+            .unwrap();
+
+        assert_eq!(
+            transcript,
+            vec![
+                (SparkCellSelectionRole::Ground, 0, 0),
+                (SparkCellSelectionRole::Cell, 0, 0),
+                (SparkCellSelectionRole::Cell, 256, 0),
+            ]
+        );
+        assert!(!facts.candidate_has_structural_bridge);
+        assert_eq!(terrain.shared_cell_dummy().snapshot().coord, (1, 0));
+    }
+
+    #[test]
+    fn gsi_04_03_dummy_structural_no_crossing_skips_old_and_slope_selection() {
+        let mut sim = one_cell_sim(terrain_cell(0, 0));
+        sim.overlay_grid = None;
+        let terrain = sim.resolved_terrain.as_ref().unwrap();
+        terrain
+            .shared_cell_dummy()
+            .set_bridge_flags_0x1180(BRIDGE_FLAG_STRUCTURAL);
+        let rules = empty_rules();
+        let world = SparkCollisionWorld::new(&sim, &rules).unwrap();
+        let motion = motion_between(IVec3::new(0, 0, 0), IVec3::new(256, 0, 300));
+        let mut transcript = Vec::new();
+
+        let facts = world
+            .query_with_selector(motion, |role, x, y| {
+                transcript.push((role, x, y));
+                select_cell(terrain, role, x, y)
+            })
+            .unwrap();
+
+        assert!(facts.candidate_has_structural_bridge);
+        assert!(!facts.old_has_structural_bridge);
+        assert_eq!(
+            transcript,
+            vec![
+                (SparkCellSelectionRole::Ground, 256, 0),
+                (SparkCellSelectionRole::Cell, 256, 0),
+            ]
+        );
+        assert!(facts.slope_matrix.is_none());
+    }
+
+    #[test]
+    fn gsi_04_03_overlay_and_slope_dependencies_are_lazy() {
+        let mut sim = one_cell_sim(terrain_cell(0, 0));
+        sim.overlay_grid = None;
+        let rules = empty_rules();
+        let world = SparkCollisionWorld::new(&sim, &rules).unwrap();
+
+        let clear = world
+            .query(motion_between(IVec3::new(0, 0, 200), IVec3::new(0, 0, 200)))
+            .unwrap();
+        assert!(clear.slope_matrix.is_none());
+
+        assert_eq!(
+            world.query(motion_between(IVec3::new(0, 0, 100), IVec3::new(0, 0, 100),)),
+            Err(SparkWorldError::MissingOverlayGrid)
+        );
+    }
+
+    #[test]
+    fn gsi_04_03_building_and_wall_queries_obey_native_lazy_gates() {
+        let rules = RuleSet::from_ini(&IniFile::from_str(
+            "[BuildingTypes]\n1=Solid\n[Solid]\nFoundation=2x2\n",
+        ))
+        .unwrap();
+
+        let mut corrupt = one_cell_sim(terrain_cell(0, 0));
+        corrupt.occupancy_mut().add(
+            0,
+            0,
+            999,
+            MovementLayer::Ground,
+            None,
+            CellListInsertion::AppendBuilding,
+        );
+        corrupt.overlay_grid = None;
+        let world = SparkCollisionWorld::new(&corrupt, &rules).unwrap();
+        assert!(
+            world
+                .query(motion_between(IVec3::new(0, 0, 200), IVec3::new(0, 0, 200),))
+                .is_ok()
+        );
+        assert_eq!(
+            world.query(motion_between(IVec3::new(0, 0, 100), IVec3::new(0, 0, 100),)),
+            Err(SparkWorldError::MissingOccupantEntity(999))
+        );
+
+        let mut accepted = one_cell_sim(terrain_cell(0, 0));
+        add_building(&mut accepted, 1, "Solid");
+        accepted.overlay_grid = None;
+        let facts = SparkCollisionWorld::new(&accepted, &rules)
+            .unwrap()
+            .query(motion_between(IVec3::new(0, 0, 100), IVec3::new(0, 0, 100)))
+            .unwrap();
+        assert!(facts.accepted_building);
+        assert_eq!(
+            facts.wall_overlay_id, None,
+            "accepted building suppresses wall read"
+        );
+        assert!(facts.slope_matrix.is_some());
+    }
+
+    #[test]
+    fn gsi_04_03_null_mask_and_invalid_linear_cells_are_normal_dummy_results() {
+        let mut terrain =
+            ResolvedTerrainGrid::from_cells(2, 1, vec![terrain_cell(0, 0), terrain_cell(1, 0)]);
+        terrain.test_set_native_allocated_cells(&[(0, 0)]);
+        let mut sim = Simulation::new();
+        sim.resolved_terrain = Some(terrain);
+        let rules = empty_rules();
+        let world = SparkCollisionWorld::new(&sim, &rules).unwrap();
+
+        for x in [256, -256, i32::MAX] {
+            let facts = world
+                .query(motion_between(IVec3::new(x, 0, 200), IVec3::new(x, 0, 200)))
+                .unwrap();
+            assert!(facts.slope_matrix.is_none(), "x={x}");
+        }
     }
 
     #[test]

--- a/src/sim/particles/spark_world.rs
+++ b/src/sim/particles/spark_world.rs
@@ -763,6 +763,87 @@ pub(super) mod tests {
     }
 
     #[test]
+    fn gsi_04_03_candidate_dummy_ignores_old_real_contact_contents() {
+        let rules = RuleSet::from_ini(&IniFile::from_str(
+            "[BuildingTypes]\n1=Solid\n[Solid]\nFoundation=2x2\n",
+        ))
+        .unwrap();
+        let mut sim = one_cell_sim(terrain_cell(0, 0));
+        add_building(&mut sim, 1, "Solid");
+        sim.overlay_grid.as_mut().unwrap().cell_mut(0, 0).overlay_id = Some(0x02);
+        let world = SparkCollisionWorld::new(&sim, &rules).unwrap();
+        let terrain = sim.resolved_terrain.as_ref().unwrap();
+        let motion = motion_between(IVec3::new(0, 0, 100), IVec3::new(256, 0, 100));
+        let (facts, transcript) = world.query_with_transcript(motion).unwrap();
+
+        assert_eq!(
+            transcript,
+            vec![
+                (SparkCellSelectionRole::Ground, 256, 0),
+                (SparkCellSelectionRole::Cell, 256, 0),
+                (SparkCellSelectionRole::Cell, 0, 0),
+            ]
+        );
+        assert!(!facts.accepted_building);
+        assert_eq!(facts.wall_overlay_id, None);
+        assert!(facts.slope_matrix.is_none());
+        assert_eq!(terrain.shared_cell_dummy().snapshot().coord, (1, 0));
+    }
+
+    #[test]
+    fn gsi_04_03_candidate_real_keeps_wall_after_old_dummy_restamp() {
+        let mut sim = one_cell_sim(terrain_cell(0, 0));
+        sim.overlay_grid.as_mut().unwrap().cell_mut(0, 0).overlay_id = Some(0x02);
+        let rules = empty_rules();
+        let world = SparkCollisionWorld::new(&sim, &rules).unwrap();
+        let terrain = sim.resolved_terrain.as_ref().unwrap();
+        let motion = motion_between(IVec3::new(256, 0, 100), IVec3::new(0, 0, 100));
+        let (facts, transcript) = world.query_with_transcript(motion).unwrap();
+
+        assert_eq!(
+            transcript,
+            vec![
+                (SparkCellSelectionRole::Ground, 0, 0),
+                (SparkCellSelectionRole::Cell, 0, 0),
+                (SparkCellSelectionRole::Cell, 256, 0),
+                (SparkCellSelectionRole::Slope, 0, 0),
+            ]
+        );
+        assert!(!facts.accepted_building);
+        assert_eq!(facts.wall_overlay_id, Some(0x02));
+        assert!(facts.slope_matrix.is_some());
+        assert_eq!(terrain.shared_cell_dummy().snapshot().coord, (1, 0));
+    }
+
+    #[test]
+    fn gsi_04_03_candidate_real_keeps_building_after_old_dummy_restamp() {
+        let rules = RuleSet::from_ini(&IniFile::from_str(
+            "[BuildingTypes]\n1=Solid\n[Solid]\nFoundation=2x2\n",
+        ))
+        .unwrap();
+        let mut sim = one_cell_sim(terrain_cell(0, 0));
+        add_building(&mut sim, 1, "Solid");
+        let world = SparkCollisionWorld::new(&sim, &rules).unwrap();
+        let terrain = sim.resolved_terrain.as_ref().unwrap();
+        let motion = motion_between(IVec3::new(256, 0, 100), IVec3::new(0, 0, 100));
+        let (facts, transcript) = world.query_with_transcript(motion).unwrap();
+
+        assert_eq!(
+            transcript,
+            vec![
+                (SparkCellSelectionRole::Ground, 0, 0),
+                (SparkCellSelectionRole::Cell, 0, 0),
+                (SparkCellSelectionRole::Cell, 256, 0),
+                (SparkCellSelectionRole::Slope, 0, 0),
+            ]
+        );
+        assert!(facts.accepted_building);
+        assert_eq!(facts.wall_overlay_id, None);
+        assert!(facts.slope_matrix.is_some());
+        assert_eq!(terrain.shared_cell_dummy().snapshot().coord, (1, 0));
+    }
+
+    #[test]
     fn gsi_04_03_dummy_structural_no_crossing_skips_old_and_slope_selection() {
         let mut sim = one_cell_sim(terrain_cell(0, 0));
         sim.overlay_grid = None;
@@ -852,6 +933,58 @@ pub(super) mod tests {
             facts.wall_overlay_id, None,
             "accepted building suppresses wall read"
         );
+        assert!(facts.slope_matrix.is_some());
+    }
+
+    #[test]
+    fn gsi_04_03_bridge_crossing_skips_contact_dependencies_and_selects_slope() {
+        let mut cell = terrain_cell(0, 0);
+        cell.bridge_facts.raw_flags = BRIDGE_FLAG_STRUCTURAL;
+        let mut sim = one_cell_sim(cell);
+        sim.occupancy_mut().add(
+            0,
+            0,
+            999,
+            MovementLayer::Ground,
+            None,
+            CellListInsertion::AppendBuilding,
+        );
+        sim.overlay_grid = None;
+        let mut bridge = BridgeRuntimeState::default();
+        bridge.test_seed_cell(
+            0,
+            0,
+            BridgeRuntimeCell {
+                deck_present: true,
+                destroyable: true,
+                deck_level: 4,
+                bridge_group_id: Some(1),
+                damage_state: DamageState::Healthy { variant: 0 },
+                axis: Some(Axis::NS),
+                role: BridgeCellRole::Body,
+                anchor_span_id: Some(1),
+                overlay_byte: 0x18,
+                damaged_variant: false,
+                bridgehead_anchor_class: BridgeheadAnchorClass::Variant0,
+            },
+        );
+        sim.bridge_state = Some(bridge);
+        let rules = empty_rules();
+        let world = SparkCollisionWorld::new(&sim, &rules).unwrap();
+        let motion = motion_between(IVec3::new(0, 0, 500), IVec3::new(0, 0, 100));
+        let (facts, transcript) = world.query_with_transcript(motion).unwrap();
+
+        assert_eq!(
+            transcript,
+            vec![
+                (SparkCellSelectionRole::Ground, 0, 0),
+                (SparkCellSelectionRole::Cell, 0, 0),
+                (SparkCellSelectionRole::Slope, 0, 0),
+            ]
+        );
+        assert!(facts.candidate_has_structural_bridge);
+        assert!(!facts.accepted_building);
+        assert_eq!(facts.wall_overlay_id, None);
         assert!(facts.slope_matrix.is_some());
     }
 

--- a/src/sim/particles/spark_world.rs
+++ b/src/sim/particles/spark_world.rs
@@ -58,6 +58,8 @@ struct SelectedSparkCell<'a> {
     cell: CellRef<'a>,
 }
 
+// gamemd-derived: MapClass::Get_CellClass_At_Coord @ 0x00565730 uses the
+// fixed-512 real-or-shared-dummy selection and stamps a miss before continuing.
 fn select_cell<'a>(
     terrain: &'a ResolvedTerrainGrid,
     role: SparkCellSelectionRole,
@@ -70,6 +72,8 @@ fn select_cell<'a>(
     }
 }
 
+// gamemd-derived: CellClass::GetGroundHeight @ 0x00578080 evaluates the real
+// or shared-dummy CellClass selected for the original world coordinate.
 fn ground_height_for_selection(
     selection: &SelectedSparkCell<'_>,
     world_x: i32,
@@ -90,6 +94,10 @@ fn ground_height_for_selection(
 /// Constructor-only terrain query. Missing terrain retains the pre-existing
 /// no-floor policy; with terrain present, a native miss returns the live dummy
 /// and therefore still produces a ground height.
+///
+/// gamemd-derived: ParticleClass::Constructor @ 0x0062B5E0 calls
+/// CellClass::GetGroundHeight @ 0x00578080 once for the comparison and again
+/// only when the input Z is at or below the first result.
 pub(super) fn constructor_ground_height(
     sim: &Simulation,
     world_x: i32,
@@ -153,6 +161,9 @@ impl<'a> SparkCollisionWorld<'a> {
     where
         F: FnMut(SparkCellSelectionRole, i32, i32) -> SelectedSparkCell<'a>,
     {
+        // gamemd-derived: behavior-3 ParticleClass AI @ 0x0062C6E0 orders
+        // candidate ground, candidate cell, conditional old cell, gated
+        // building/wall, then a collision-only candidate slope selection.
         let candidate_ground = select(
             SparkCellSelectionRole::Ground,
             motion.candidate_coords.x,

--- a/src/sim/particles/spark_world.rs
+++ b/src/sim/particles/spark_world.rs
@@ -707,6 +707,33 @@ pub(super) mod tests {
     }
 
     #[test]
+    fn gsi_04_03_dummy_collision_uses_exact_nonzero_slope_and_candidate_restamp() {
+        let sim = one_cell_sim(terrain_cell(0, 0));
+        let terrain = sim.resolved_terrain.as_ref().unwrap();
+        terrain.test_set_dummy_cell_level_slope(0, 5);
+        let rules = empty_rules();
+        let world = SparkCollisionWorld::new(&sim, &rules).unwrap();
+        let motion = motion_between(IVec3::new(512, 0, 20), IVec3::new(320, 192, -100));
+        let (facts, transcript) = world.query_with_transcript(motion).unwrap();
+
+        assert_eq!(
+            transcript,
+            vec![
+                (SparkCellSelectionRole::Ground, 320, 192),
+                (SparkCellSelectionRole::Cell, 320, 192),
+                (SparkCellSelectionRole::Cell, 512, 0),
+                (SparkCellSelectionRole::Slope, 320, 192),
+            ]
+        );
+        assert_eq!(facts.slope_matrix, Some(slope_matrix(5).unwrap()));
+        assert_eq!(
+            terrain.shared_cell_dummy().snapshot().coord,
+            (1, 0),
+            "the collision-only slope selection must restamp the candidate after old"
+        );
+    }
+
+    #[test]
     fn gsi_04_03_candidate_and_old_dummy_no_collision_finishes_with_old_stamp() {
         let sim = one_cell_sim(terrain_cell(0, 0));
         let rules = empty_rules();

--- a/src/sim/particles/system_ai.rs
+++ b/src/sim/particles/system_ai.rs
@@ -4,7 +4,7 @@
 //! takes it from storage, runs per-`BehavesLike` AI, decrements lifetime, then
 //! reinserts it. Completed systems enter the common deferred-delete path.
 //! Smoke (C2), Gas (C3), and Fire (C4) have
-//! full bodies; the Tier-3 variants (Spark, Railgun) are still no-ops.
+//! full bodies; Spark dispatch is active while Railgun remains a no-op.
 //!
 //! Pulling each system out before ticking lets the inner AI take `&mut Simulation`
 //! freely — needed for spawning child systems and applying damage to entities —
@@ -24,8 +24,8 @@ use super::spark::{
 };
 use super::spark_world::{SparkCollisionWorld, SparkWorldError};
 
-// Retained with the verified Spark activation seam while live dispatch keeps
-// Spark and Railgun systems dormant.
+// Errors retained at the production Spark begin/query/finish boundary. Railgun
+// alone remains dormant in the behavior dispatch below.
 #[allow(dead_code)]
 #[derive(Debug, Error)]
 pub(crate) enum SparkSystemTickError {
@@ -550,6 +550,7 @@ SpawnSparkPercentage=1
     #[test]
     fn gsi_04_03_spark_shared_dummy_query_order_and_miss_continuation() {
         use super::super::spark_world::{SparkCellSelectionRole, SparkCollisionWorld};
+        use crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL;
         use crate::map::resolved_terrain::ResolvedTerrainGrid;
 
         let rules = spark_rules(0);
@@ -560,18 +561,23 @@ SpawnSparkPercentage=1
             vec![super::super::spark_world::tests::terrain_cell(0, 0)],
         ));
         sim.overlay_grid = None;
+        sim.resolved_terrain
+            .as_ref()
+            .unwrap()
+            .shared_cell_dummy()
+            .set_bridge_flags_0x1180(BRIDGE_FLAG_STRUCTURAL);
         let mut sys = fake_system(ParticleSystemTypeId(0), 100);
         let mut particle = spark_particle(256, 2);
-        particle.coords.z = 200;
+        particle.coords.z = 100;
         sys.particles.push(particle);
 
         let motion = SparkMotionStep {
-            old_coords: IVec3::new(256, 0, 200),
-            candidate_coords: IVec3::new(256, 0, 200),
+            old_coords: IVec3::new(256, 0, 100),
+            candidate_coords: IVec3::new(256, 0, 100),
             candidate_f32: [
                 NativeF32Bits::from_bits(256.0f32.to_bits()),
                 NativeF32Bits::POSITIVE_ZERO,
-                NativeF32Bits::from_bits(200.0f32.to_bits()),
+                NativeF32Bits::from_bits(100.0f32.to_bits()),
             ],
             persistent_velocity: [NativeF32Bits::POSITIVE_ZERO; 3],
             probe_velocity: [NativeF32Bits::POSITIVE_ZERO; 3],
@@ -585,15 +591,18 @@ SpawnSparkPercentage=1
             vec![
                 (SparkCellSelectionRole::Ground, 256, 0),
                 (SparkCellSelectionRole::Cell, 256, 0),
-                (SparkCellSelectionRole::Cell, 256, 0),
             ]
         );
+        assert!(facts.candidate_has_structural_bridge);
+        assert!(!facts.old_has_structural_bridge);
+        assert!(!facts.accepted_building);
+        assert_eq!(facts.wall_overlay_id, None);
         assert!(facts.slope_matrix.is_none());
 
         tick_spark_system_compat(&mut sys, &mut sim, &rules).unwrap();
 
         assert_eq!(sys.particles.len(), 1);
-        assert_eq!(sys.particles[0].coords, IVec3::new(256, 0, 200));
+        assert_eq!(sys.particles[0].coords, IVec3::new(256, 0, 100));
         assert_eq!(sys.particles[0].lifetime_remaining, 1);
         assert!(!sys.particles[0].marked_for_deletion);
         let mut expected_rng = SimRng::new(789);

--- a/src/sim/particles/system_ai.rs
+++ b/src/sim/particles/system_ai.rs
@@ -337,7 +337,7 @@ mod tests {
     fn flat_facts() -> SparkCollisionFacts {
         SparkCollisionFacts {
             ground_z: 0,
-            slope_matrix: super::super::spark_world::slope_matrix(0).unwrap(),
+            slope_matrix: Some(super::super::spark_world::slope_matrix(0).unwrap()),
             old_has_structural_bridge: false,
             candidate_has_structural_bridge: false,
             accepted_building: false,
@@ -545,6 +545,105 @@ SpawnSparkPercentage=1
             0xc0c0_0000
         );
         assert_eq!(sim.rng_state().scenario, rng_before);
+    }
+
+    #[test]
+    fn gsi_04_03_spark_shared_dummy_query_order_and_miss_continuation() {
+        use super::super::spark_world::{SparkCellSelectionRole, SparkCollisionWorld};
+        use crate::map::resolved_terrain::ResolvedTerrainGrid;
+
+        let rules = spark_rules(0);
+        let mut sim = Simulation::with_seed(789);
+        sim.resolved_terrain = Some(ResolvedTerrainGrid::from_cells(
+            1,
+            1,
+            vec![super::super::spark_world::tests::terrain_cell(0, 0)],
+        ));
+        sim.overlay_grid = None;
+        let mut sys = fake_system(ParticleSystemTypeId(0), 100);
+        let mut particle = spark_particle(256, 2);
+        particle.coords.z = 200;
+        sys.particles.push(particle);
+
+        let motion = SparkMotionStep {
+            old_coords: IVec3::new(256, 0, 200),
+            candidate_coords: IVec3::new(256, 0, 200),
+            candidate_f32: [
+                NativeF32Bits::from_bits(256.0f32.to_bits()),
+                NativeF32Bits::POSITIVE_ZERO,
+                NativeF32Bits::from_bits(200.0f32.to_bits()),
+            ],
+            persistent_velocity: [NativeF32Bits::POSITIVE_ZERO; 3],
+            probe_velocity: [NativeF32Bits::POSITIVE_ZERO; 3],
+        };
+        let (facts, transcript) = SparkCollisionWorld::new(&sim, &rules)
+            .unwrap()
+            .query_with_transcript(motion)
+            .unwrap();
+        assert_eq!(
+            transcript,
+            vec![
+                (SparkCellSelectionRole::Ground, 256, 0),
+                (SparkCellSelectionRole::Cell, 256, 0),
+                (SparkCellSelectionRole::Cell, 256, 0),
+            ]
+        );
+        assert!(facts.slope_matrix.is_none());
+
+        tick_spark_system_compat(&mut sys, &mut sim, &rules).unwrap();
+
+        assert_eq!(sys.particles.len(), 1);
+        assert_eq!(sys.particles[0].coords, IVec3::new(256, 0, 200));
+        assert_eq!(sys.particles[0].lifetime_remaining, 1);
+        assert!(!sys.particles[0].marked_for_deletion);
+        let mut expected_rng = SimRng::new(789);
+        expected_rng.next_range_u32_inclusive(0, 0x7fff_fffe);
+        assert_eq!(sim.rng_views().scenario, expected_rng.logical_view());
+        assert_eq!(
+            sim.resolved_terrain
+                .as_ref()
+                .unwrap()
+                .shared_cell_dummy()
+                .snapshot()
+                .coord,
+            (1, 0)
+        );
+
+        let mut collision_sim = Simulation::with_seed(790);
+        collision_sim.resolved_terrain = Some(ResolvedTerrainGrid::from_cells(
+            1,
+            1,
+            vec![super::super::spark_world::tests::terrain_cell(0, 0)],
+        ));
+        collision_sim.overlay_grid = None;
+        let mut collision_particle = spark_particle(256, 2);
+        collision_particle.coords.z = -1;
+        let motion = begin_particle_tick(
+            &mut collision_particle,
+            gravity_as_stored_f32(rules.general.gravity).unwrap(),
+        )
+        .unwrap();
+        let facts = SparkCollisionWorld::new(&collision_sim, &rules)
+            .unwrap()
+            .query(motion)
+            .unwrap();
+        assert!(facts.slope_matrix.is_some(), "a selected collision performs the final slope lookup");
+        let particle_type = rules.particle_type(collision_particle.type_id);
+        finish_particle_tick(
+            &mut collision_particle,
+            motion,
+            facts,
+            particle_type.color_speed,
+            particle_type.color_list.len(),
+            collision_sim.particle_rng(),
+        )
+        .unwrap();
+        assert!(collision_particle.marked_for_deletion);
+        assert_eq!(collision_particle.coords, IVec3::new(256, 0, 0));
+        assert_eq!(collision_particle.lifetime_remaining, 1);
+        let mut expected_rng = SimRng::new(790);
+        expected_rng.next_range_u32_inclusive(0, 0x7fff_fffe);
+        assert_eq!(collision_sim.rng_views().scenario, expected_rng.logical_view());
     }
 
     mod advance_state_tests {

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -311,7 +311,9 @@ use crate::sim::world::Simulation;
 // Bumped 105 -> 106: active-retail Cell ground is one 104-lepton numeric
 // authority rather than the false 90-lepton duplicate. Shape is unchanged,
 // but retained Cell targets/world state would resume with different Z results.
-const SNAPSHOT_VERSION: u32 = 106;
+// Bumped 106 -> 107: add unconditional shared-dummy level/slope hash authority
+// now that active Spark ground and collision queries consume those bytes.
+const SNAPSHOT_VERSION: u32 = 107;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -2716,10 +2718,11 @@ mod tests {
     /// structure-upgrade parent/slot identity; 104 -> 105 adds active/stashed
     /// Drive/Ship slope-transition state; 105 -> 106 rejects saves that would
     /// resume under the corrected one-authority 104-lepton Cell ground formula
-    /// despite unchanged wire shape.
+    /// despite unchanged wire shape; 106 -> 107 adds unconditional shared-
+    /// dummy level/slope hash authority for active Spark queries.
     #[test]
-    fn phase3_cell_ground_104_snapshot_version_is_106() {
-        assert_eq!(super::SNAPSHOT_VERSION, 106);
+    fn phase3_spark_dummy_snapshot_version_is_107() {
+        assert_eq!(super::SNAPSHOT_VERSION, 107);
     }
 
     #[test]
@@ -2764,7 +2767,7 @@ mod tests {
 
         let bytes = GameSnapshot::save(&sim, 1, 2, "Drive Ship slope", 3);
         let mut restored = GameSnapshot::load(&bytes)
-            .expect("current v106 slope snapshot")
+            .expect("current v107 slope snapshot")
             .sim;
         let loaded = restored
             .substrate

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -311,8 +311,10 @@ use crate::sim::world::Simulation;
 // Bumped 105 -> 106: active-retail Cell ground is one 104-lepton numeric
 // authority rather than the false 90-lepton duplicate. Shape is unchanged,
 // but retained Cell targets/world state would resume with different Z results.
-// Bumped 106 -> 107: add unconditional shared-dummy level/slope hash authority
-// now that active Spark ground and collision queries consume those bytes.
+// Bumped 106 -> 107: behavior-3 Spark now consumes the shared CellClass dummy's
+// persistent Level and Slope without requiring a retained dummy projectile.
+// The wire shape remains unchanged, but older saves do not certify the same
+// future-affecting lockstep hash authority for those live process-global bytes.
 const SNAPSHOT_VERSION: u32 = 107;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";

--- a/src/sim/world/bridge_parity_harness_tests.rs
+++ b/src/sim/world/bridge_parity_harness_tests.rs
@@ -103,7 +103,9 @@ const MIN_DISTINCT_DECK_CELLS: usize = 6;
 /// The ordered path, all 12 visited cells, bridge height/occupation tripwires,
 /// all three RNG streams, and tick-for-tick replay remain exact; only the
 /// hash composition moved from retired body-rocking bytes to the locomotor.
-const BRIDGE_HARNESS_FINAL_HASH: u64 = 0x584D_9C4F_23BD_388F;
+/// Re-baselined 2026-08-30 for v107's Spark shared-dummy tag plus level/slope
+/// folds. The path, bridge tripwires, and RNG streams remain byte-identical.
+const BRIDGE_HARNESS_FINAL_HASH: u64 = 0x5B44_6C68_9BC2_F0AF;
 
 fn bridge_ini() -> IniFile {
     // One armed ground vehicle and one distant infantryman on a second house, so

--- a/src/sim/world/global_parity_harness_tests.rs
+++ b/src/sim/world/global_parity_harness_tests.rs
@@ -512,7 +512,10 @@ const GLOBAL_HARNESS_PRE_MISSION_V29_HASH: u64 = 0xE2B3_9FAA_432F_4A75;
 // Re-baselined 2026-08-30 for the same GSI-04.03 slope payload ownership.
 // The historical probes move consistently, the absolute RNG tuple is unchanged,
 // and record/replay equality remains exact: this is hash composition, not route drift.
-const GLOBAL_HARNESS_FINAL_HASH: u64 = 0xDA92_C04D_B53F_B58D;
+// Re-baselined 2026-08-30 for v107's Spark shared-dummy tag plus level/slope
+// folds. Both historical probes and all three RNG streams remain byte-identical,
+// isolating the shift to current-schema composition.
+const GLOBAL_HARNESS_FINAL_HASH: u64 = 0x254E_775C_65A2_B50A;
 
 fn harness_ini() -> IniFile {
     // Multi-faction vehicles + infantry + buildings (war factory, refinery) plus a

--- a/src/sim/world/slice6_retask_tests.rs
+++ b/src/sim/world/slice6_retask_tests.rs
@@ -317,7 +317,10 @@ const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x9856_E7DA_D9F1_676A;
 // the two legacy probes above isolate the shared behavior-bearing portion.
 // Re-baselined 2026-08-30 for the same slope payload move; both historical
 // probes shift consistently and the replay remains deterministic.
-const SLICE6_BASELINE_HASH: u64 = 0x9F9B_BB9B_3B35_0410;
+// Re-baselined 2026-08-30 for v107's Spark shared-dummy tag plus level/slope
+// folds. Both historical probes remain byte-identical, so only current-schema
+// composition moved.
+const SLICE6_BASELINE_HASH: u64 = 0x214E_DE3E_7939_F143;
 
 #[test]
 fn replay_hash_stable_through_slice6() {

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -157,6 +157,23 @@ mod shared_dummy_bridge_hash_tests {
             "without a retained Bullet only persistent 0x1180 joins the hash"
         );
     }
+
+    #[test]
+    fn gsi_04_03_hashes_dummy_level_slope_without_retained_projectile() {
+        let sim = Simulation::new();
+        let dummy = sim.effective_shared_cell_dummy();
+        let clear_hash = sim.state_hash();
+        let v106_clear_hash = sim.state_hash_without_spark_dummy_level_slope_v107();
+
+        dummy.set_level_slope(-3, 9);
+
+        assert_ne!(clear_hash, sim.state_hash());
+        assert_eq!(
+            v106_clear_hash,
+            sim.state_hash_without_spark_dummy_level_slope_v107(),
+            "the v106 provenance schema excludes unretained dummy level/slope"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -307,7 +324,7 @@ impl Simulation {
     /// components in stable-entity-ID order (EntityStore keys_sorted) for determinism.
     pub fn state_hash(&self) -> u64 {
         self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, true, true, true, true, true, true,
         )
     }
 
@@ -319,6 +336,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             true, false, false, false, false, false, false, false, false, false, false, false,
+            false,
         )
     }
 
@@ -330,6 +348,16 @@ impl Simulation {
     pub(crate) fn state_hash_before_lifecycle_v28_and_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             false, false, false, false, false, false, false, false, false, false, false, false,
+            false,
+        )
+    }
+
+    /// Test-only provenance probe for the v107 unconditional Spark dummy
+    /// level/slope fold. It reconstructs the committed v106 hash layout.
+    #[cfg(test)]
+    pub(crate) fn state_hash_without_spark_dummy_level_slope_v107(&self) -> u64 {
+        self.state_hash_with_schema(
+            true, true, true, true, true, true, true, true, true, true, true, true, false,
         )
     }
 
@@ -347,6 +375,7 @@ impl Simulation {
         include_real_cell_bridge_flags_v90: bool,
         include_base_defense_response_v97: bool,
         include_techno_constructor_v104: bool,
+        include_spark_dummy_level_slope_v107: bool,
     ) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
 
@@ -417,18 +446,30 @@ impl Simulation {
             // Unlike the requested coordinate, native `+0x140 & 0x1180`
             // survives ordinary lookups and changes later bridge/FNPC/target
             // behavior even when no Bullet currently retains the dummy.
-            b"shared-cell-dummy-bridge-v3".hash(&mut hasher);
-            shared_dummy.bridge_flags_0x1180.hash(&mut hasher);
+            if include_spark_dummy_level_slope_v107 {
+                b"shared-cell-dummy-spark-v4".hash(&mut hasher);
+                shared_dummy.bridge_flags_0x1180.hash(&mut hasher);
+                shared_dummy.level.hash(&mut hasher);
+                shared_dummy.slope_type.hash(&mut hasher);
+            } else {
+                b"shared-cell-dummy-bridge-v3".hash(&mut hasher);
+                shared_dummy.bridge_flags_0x1180.hash(&mut hasher);
+            }
             if self.projectiles.iter().any(|(_, projectile)| {
                 projectile.target == crate::sim::projectile::ProjectileTarget::DummyCell
             }) {
-                // A retained Bullet pointer additionally makes coordinate,
-                // level, and slope deterministic future behavior. The bridge
-                // subset was folded unconditionally above.
-                b"shared-cell-dummy-target-v2".hash(&mut hasher);
-                shared_dummy.coord.hash(&mut hasher);
-                shared_dummy.level.hash(&mut hasher);
-                shared_dummy.slope_type.hash(&mut hasher);
+                // A retained Bullet pointer additionally makes coordinate
+                // deterministic future behavior. Preserve the complete v106
+                // field/tag order for historical provenance probes.
+                if include_spark_dummy_level_slope_v107 {
+                    b"shared-cell-dummy-target-v3".hash(&mut hasher);
+                    shared_dummy.coord.hash(&mut hasher);
+                } else {
+                    b"shared-cell-dummy-target-v2".hash(&mut hasher);
+                    shared_dummy.coord.hash(&mut hasher);
+                    shared_dummy.level.hash(&mut hasher);
+                    shared_dummy.slope_type.hash(&mut hasher);
+                }
             }
             self.hash_waves(&mut hasher);
         }

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -154,7 +154,7 @@ mod shared_dummy_bridge_hash_tests {
         assert_eq!(
             bridge_hash,
             sim.state_hash(),
-            "without a retained Bullet only persistent 0x1180 joins the hash"
+            "without a retained Bullet the requested coordinate stays excluded; 0x1180, level, and slope are unconditional"
         );
     }
 
@@ -165,13 +165,31 @@ mod shared_dummy_bridge_hash_tests {
         let clear_hash = sim.state_hash();
         let v106_clear_hash = sim.state_hash_without_spark_dummy_level_slope_v107();
 
-        dummy.set_level_slope(-3, 9);
-
-        assert_ne!(clear_hash, sim.state_hash());
+        dummy.set_level_slope(-3, 0);
+        let level_only_hash = sim.state_hash();
+        assert_ne!(
+            clear_hash, level_only_hash,
+            "dummy level alone is unconditional v107 hash authority"
+        );
         assert_eq!(
             v106_clear_hash,
             sim.state_hash_without_spark_dummy_level_slope_v107(),
-            "the v106 provenance schema excludes unretained dummy level/slope"
+            "the v106 provenance schema excludes an unretained dummy level change"
+        );
+
+        dummy.set_level_slope(0, 0);
+        assert_eq!(clear_hash, sim.state_hash());
+
+        dummy.set_level_slope(0, 9);
+        let slope_only_hash = sim.state_hash();
+        assert_ne!(
+            clear_hash, slope_only_hash,
+            "dummy slope alone is unconditional v107 hash authority"
+        );
+        assert_eq!(
+            v106_clear_hash,
+            sim.state_hash_without_spark_dummy_level_slope_v107(),
+            "the v106 provenance schema excludes an unretained dummy slope change"
         );
     }
 }

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -135,7 +135,29 @@ mod playfield_authority_hash_tests {
 #[cfg(test)]
 mod shared_dummy_bridge_hash_tests {
     use super::Simulation;
+    use glam::IVec3;
+
     use crate::map::bridge_facts::BRIDGE_FLAG_ANCHOR_SELF;
+    use crate::map::resolved_terrain::ResolvedTerrainGrid;
+    use crate::rules::ini_parser::IniFile;
+    use crate::rules::ruleset::RuleSet;
+    use crate::sim::particles::spark::SparkMotionStep;
+    use crate::sim::particles::spark_world::{SparkCollisionWorld, slope_matrix};
+    use crate::util::native_x87::NativeF32Bits;
+
+    fn spark_motion_at(x: i32, y: i32, z: i32) -> SparkMotionStep {
+        SparkMotionStep {
+            old_coords: IVec3::new(x, y, z),
+            candidate_coords: IVec3::new(x, y, z),
+            candidate_f32: [
+                NativeF32Bits::from_bits((x as f32).to_bits()),
+                NativeF32Bits::from_bits((y as f32).to_bits()),
+                NativeF32Bits::from_bits((z as f32).to_bits()),
+            ],
+            persistent_velocity: [NativeF32Bits::POSITIVE_ZERO; 3],
+            probe_velocity: [NativeF32Bits::POSITIVE_ZERO; 3],
+        }
+    }
 
     #[test]
     fn gsi_04_01_hashes_dummy_bridge_bits_without_retained_projectile() {
@@ -160,12 +182,33 @@ mod shared_dummy_bridge_hash_tests {
 
     #[test]
     fn gsi_04_03_hashes_dummy_level_slope_without_retained_projectile() {
-        let sim = Simulation::new();
+        let mut sim = Simulation::new();
+        sim.install_resolved_terrain_for_new_map(ResolvedTerrainGrid::from_cells(
+            0,
+            0,
+            Vec::new(),
+        ));
         let dummy = sim.effective_shared_cell_dummy();
+        let terrain_dummy = sim
+            .resolved_terrain
+            .as_ref()
+            .unwrap()
+            .shared_cell_dummy();
+        assert!(
+            dummy.same_identity(&terrain_dummy),
+            "the hash authority must be the dummy bound into production terrain"
+        );
+        let rules = RuleSet::from_ini(&IniFile::from_str("")).unwrap();
         let clear_hash = sim.state_hash();
         let v106_clear_hash = sim.state_hash_without_spark_dummy_level_slope_v107();
 
         dummy.set_level_slope(-3, 0);
+        let level_facts = SparkCollisionWorld::new(&sim, &rules)
+            .unwrap()
+            .query(spark_motion_at(320, 192, 300))
+            .unwrap();
+        assert_eq!(level_facts.ground_z, -311);
+        assert!(level_facts.slope_matrix.is_none());
         let level_only_hash = sim.state_hash();
         assert_ne!(
             clear_hash, level_only_hash,
@@ -181,6 +224,12 @@ mod shared_dummy_bridge_hash_tests {
         assert_eq!(clear_hash, sim.state_hash());
 
         dummy.set_level_slope(0, 9);
+        let slope_facts = SparkCollisionWorld::new(&sim, &rules)
+            .unwrap()
+            .query(spark_motion_at(320, 192, -100))
+            .unwrap();
+        assert_eq!(slope_facts.ground_z, 104);
+        assert_eq!(slope_facts.slope_matrix, Some(slope_matrix(9).unwrap()));
         let slope_only_hash = sim.state_hash();
         assert_ne!(
             clear_hash, slope_only_hash,


### PR DESCRIPTION
## What this integrates

- routes Spark collision queries through the shared CellClass dummy with the verified candidate-ground, candidate-cell, old-cell fallback, building/wall, and collision-slope ordering
- preserves constructor and update RNG ordering, deletion/lifetime behavior, lazy map reads, and invalid-cell continuation
- persists and hashes shared-dummy level/slope authority and advances the snapshot contract from 106 to 107
- rebases the three current-schema replay ratchets measured by the final integration tree

## Scope

This is the isolated critic-passed Spark shared-dummy slice. It does not import RawTrack, Temporal, Gattling, Explodes, naval, BasePlan, or unrelated AI work from the larger Phase 3 branch.

## Validation

- critic R1: PASS, no findings
- critic R2 after rebaseline: PASS, no findings
- focused GSI-04.03: 69 passed, 0 failed
- focused Spark: 45 passed, 0 failed
- snapshot gate: 1 passed, 0 failed
- three replay ratchets: 1 passed, 0 failed each
- full cargo test -p vera20k --lib: 7626 passed, 0 failed, 76 ignored