### PR TITLE
Integrate Phase 3 FNPC bridge projection

### DIFF
--- a/docs/plans/2026-08-26-fnpc-forward-bridge-projection-design.md
+++ b/docs/plans/2026-08-26-fnpc-forward-bridge-projection-design.md
@@ -9,49 +9,60 @@ ring, gate, ordering, and selection behavior.
 ## Architecture Context
 
 `src/sim/find_nearby_cell.rs` owns deterministic FNPC search. Candidate validation feeds
-`collect_candidates`, which calls `is_direct_candidate` per accepted coordinate and retains the
-result for collection diagnostics and early-stop. At inspected base revision `eeb2515e`, Rust
-reuses that cached value for final pool partition, while native invokes `FUN_006D6410` again
-there. Bridge-aware-zone queries
-intentionally arm early-stop without the collection projection result while final selection still
-re-runs projection.
+`collect_candidates`. Ordinary collection invokes the projection per accepted coordinate for
+per-ring early-stop; bridge-aware-zone collection skips it entirely and lets any accepted
+candidate arm early-stop. Final selection independently invokes the projection for every stored
+candidate in order. At inspected base revision `eeb2515e`, Rust reused a cached classification;
+the first builder revision `2cef3ea2` restored the second call site but still ran an approximate
+six-cell projection and incorrectly performed projection during bridge-aware collection.
 
 `ResolvedTerrainCell.bridge_facts.raw_flags` already owns the modeled live
-`CellClass+0x140` bits. `ResolvedTerrainGrid::cellclass_bridge_flags_0x1180` is the existing
-real-cell/shared-dummy lookup seam; `src/map/bridge_facts.rs` names `0x1000` as
+`CellClass+0x140` bits. `ResolvedTerrainGrid` owns the real-cell/shared-dummy lookup seam;
+this design adds one narrow projection view that returns signed `CellClass+0x11B` and raw
+`CellClass+0x140 & 0x1180` from the same lookup. `src/map/bridge_facts.rs` names `0x1000` as
 `BRIDGE_FLAG_FORWARD_SIDE` and `0x100` as `BRIDGE_FLAG_STRUCTURAL`, and active
 `SetBridgeDirection` stamping preserves both. No new state or writer is needed.
 
-Native `FUN_006D6410 @ 0x006D6410` reads the candidate flag at
-`0x006D6473..0x006D6486`; only when `0x1000` is set does it read each projected probe's
-`0x100` bit and add four to that probe's signed height delta at
-`0x006D64F8..0x006D6513`. The naval FNPC query reaches both the collection and final-pool
-uses of this helper. [docs/research/PHASE3_AI_BASE_PLACEMENT_VECTOR_SELECTOR_005060B0_GHIDRA_REPORT.md
+Native `FUN_006D6410 @ 0x006D6410` performs two separate candidate lookups (first flags,
+then signed level), starts at candidate centre plus `0x600` leptons on both axes, subtracts
+eight leptons before every probe lookup, and therefore reads repeated cells far-to-near. Each
+probe is looked up once, and its signed level and raw flags come from that same returned
+CellClass. Only when candidate `0x1000` is set does probe `0x100` add four to the signed height
+delta. The helper returns either the current probe cell after the projected-axis comparison or
+the candidate after the later equality check. [Ghidra `0x006D641B..0x006D6588`;
+docs/research/PHASE3_AI_BASE_PLACEMENT_VECTOR_SELECTOR_005060B0_GHIDRA_REPORT.md
 §2.2, §9 Handoff B; docs/research/PHASE3_HOUSECLASS_ORDINARY_BASE_PLACEMENT_005060B0_GHIDRA_REPORT.md
 §8.2, §11.1 item 13]
 
 ## Impact Analysis
 
-- Change only `src/sim/find_nearby_cell.rs`: read candidate/probe flags inside
-  `is_direct_candidate`, call that corrected classifier again during final pool partition,
-  replace its stale UNCHECKED residual comment, and add focused tests.
-- Reuse `ResolvedTerrainGrid::cellclass_bridge_flags_0x1180`; do not change bridge facts,
-  `PathGrid`, snapshots, hashing, callers, or function signatures.
+- Change `src/sim/find_nearby_cell.rs` plus the narrow CellClass lookup seam in
+  `src/map/resolved_terrain.rs`; do not change bridge facts, `PathGrid`, snapshots, hashing,
+  public callers, or persistent state.
+- Replace the threshold shortcut with a pure instruction-faithful projection kernel. Feed it
+  one lookup closure so transcript/order tests and the runtime real-or-dummy view exercise the
+  same arithmetic.
 - Blast radius is every FNPC caller because the helper is shared, but observable change is
   gated by the exact candidate-`0x1000` plus projected-probe-`0x100` combination. Nonbridge
   terrain and structural probes without candidate forward-side remain bit-for-bit unchanged.
-- The search consumes no RNG and changes no caller-owned state. Its CellClass flag lookups retain
-  native shared-dummy coordinate side effects through the existing accessor. Candidate order,
-  ring termination, frame-modulo indexing, and same-tick determinism remain owned by existing code.
+- The search consumes no RNG. Its CellClass lookups intentionally retain native shared-dummy
+  coordinate side effects: every missed lookup stamps the packed requested coordinate once and
+  returns the dummy's live signed level and flags. Candidate order, frame-modulo indexing, and
+  same-tick determinism remain owned by existing code.
 
 ## Chosen Approach
 
-Read the candidate's modeled raw bridge flags once before the six-step projection loop. For
-each probe, add `BRIDGE_LEVEL_RISE` (`4`) to its signed level only when the cached candidate
-has `BRIDGE_FLAG_FORWARD_SIDE` and that probe has `BRIDGE_FLAG_STRUCTURAL`; then feed the
-adjusted probe level into the existing relative-rise threshold unchanged. Invoke the same
-classifier during collection and again, in stored candidate order, when partitioning the final
-direct and indirect pools.
+Implement native lepton-to-cell truncation, wrapped 32-bit arithmetic, two candidate lookups,
+and the subtract-eight projection loop exactly. Cache only the candidate's forward-side bit.
+For each probe, consume one CellClass view; compute the signed level delta, conditionally add
+`BRIDGE_LEVEL_RISE` (`4`) from that same view, perform the two projected-axis comparisons, then
+the current-cell equality check in native order. The candidate is direct exactly when the
+returned packed cell equals the candidate.
+
+Ordinary collection invokes this classifier per accepted candidate. Bridge-aware collection
+does not invoke it at all; accepted candidates retain only a diagnostic `direct = false` value
+and arm early-stop. Final partition invokes the classifier independently for every stored
+candidate in order and never reads cached `Candidate.direct`.
 
 This is the smallest Rust-native translation: it changes the classifier at the exact point
 native changes its height delta, uses the existing CellClass flag authority, and restores the
@@ -68,9 +79,9 @@ native two-site projection call pattern without changing candidate or selection 
 - **COMPOUNDING — both semantic uses:** the classifier runs during ordinary collection
   early-stop and again during final direct/indirect pool partition, which can change pool length
   and `frame % pool_len` output. [selector report §2.2; exhaustive report §8.2]
-- **COMPOUNDING — preserve bridge-aware asymmetry:** `bridge_aware_zone` still arms early-stop
-  on any accepted candidate, while final selection uses projected classification. This slice
-  changes only the projection result. [current `collect_candidates`; FNPC caller evidence]
+- **COMPOUNDING — preserve bridge-aware asymmetry:** `bridge_aware_zone` collection performs
+  zero projection/dummy lookups and any accepted candidate arms early-stop, while final selection
+  still projects every stored candidate. [Ghidra FNPC collection branch and final partition]
 - **COMPOUNDING — flag authority:** use modeled live CellClass flags through the existing
   resolved-terrain/shared-dummy seam; do not infer forward-side from path passability or add a
   writer. [current `bridge_facts.rs`, `resolved_terrain.rs`; exhaustive report §8.2]
@@ -85,40 +96,47 @@ native two-site projection call pattern without changing candidate or selection 
 
 ### Components
 
-- `is_direct_candidate`: add the exact flag-gated probe-level correction and canonical
-  `gamemd-derived` provenance for `FUN_006D6410 @ 0x006D6410`.
-- Final pool construction: invoke `is_direct_candidate` once per stored candidate in order,
-  matching native's final partition use rather than reusing collection-time classification.
+- `ResolvedTerrainGrid::cellclass_projection_view`: one stamping MapClass lookup returning
+  signed level and modeled raw flags together. A miss stamps exactly once and snapshots the live
+  shared dummy after that stamp.
+- `project_candidate_with_lookup`: exact pure `FUN_006D6410` kernel, including packed shorts,
+  wrapped lepton arithmetic, duplicate candidate reads, repeated far-to-near probes, two-bit
+  bridge correction, comparison order, and returned cell.
+- Collection/final orchestration: inject one classifier internally so tests can prove invocation
+  count/order. Bridge-aware collection skips it; final partition always invokes it once per stored
+  candidate and ignores `Candidate.direct`.
 - Test fixtures in the same leaf module: stamp raw flags directly on resolved terrain so each
   load-bearing branch is executable without adding production-only scaffolding.
 
 ### Interfaces / Contracts
 
-No public API changes. Missing resolved terrain continues to expose no modeled bridge flags,
-matching existing compatibility behavior. The exact active runtime supplies resolved terrain.
+No public API changes. The active runtime supplies resolved terrain and therefore uses the exact
+real-or-dummy projection view. The existing no-terrain compatibility path retains its level
+facade and zero flags; it has no CellClass authority to mutate.
 
 ### Data Flow
 
-`ResolvedTerrainGrid bridge flags -> collection is_direct_candidate -> per-ring early-stop;
-stored candidate order -> final is_direct_candidate -> preferred pool -> existing target/frame
+`MapClass-like real/dummy view -> exact projection kernel -> ordinary collection early-stop;
+stored candidate order -> fresh exact projection -> preferred pool -> existing target/frame
 choice`.
 
 ### Error Handling
 
-No new failure state. Off-grid/unallocated flag reads use the existing CellClass dummy accessor;
-existing level lookup and candidate conversion behavior are unchanged.
+No new failure state. Off-grid/unallocated projection reads stamp and expose the one live shared
+dummy. Candidate/probe packed-short conversion and signed levels follow native instructions.
 
 ### Testing Strategy
 
 Focused executable tests will prove:
 
-1. a forward-side candidate plus structural probe contributes exactly four levels at a known
-   projection threshold;
-2. the same structural probe is ignored without candidate forward-side;
-3. the correction turns the duplicated radius-zero seed indirect, extends collection through
-   ring one, and changes the final frame-modulo direct pool in exact ring order;
-4. nonbridge candidate classifications, collection, and frame-selected outputs remain unchanged;
-5. the complete existing `sim::find_nearby_cell::tests::` module still passes.
+1. the pure kernel performs two candidate reads followed by the exact far-to-near repeated probe
+   transcript/count (179 lookups for flat candidate `(5,5)`);
+2. a sparse allocated edge consumes live shared-dummy signed level/flags and leaves the dummy at
+   the final requested coordinate;
+3. ordinary collection and final partition invoke projection separately and in order;
+4. bridge-aware collection performs no projection, while final partition still projects;
+5. candidate-forward plus probe-structural adds exactly four, the probe bit is ignored without
+   candidate-forward, and existing nonbridge results are unchanged.
 
 ## Architectural Decisions
 
@@ -131,25 +149,29 @@ Focused executable tests will prove:
 
 ## Alternatives Considered
 
-1. **Recommended: adjust probe level inside `is_direct_candidate` and invoke it at both native
-   sites.** Exact native location and call pattern, one implementation, and existing architecture
-   stays intact.
+1. **Chosen: exact lepton kernel plus one real-or-dummy CellClass view, invoked at both native
+   sites.** Preserves native arithmetic, lookup order, dummy side effects, and one implementation.
 2. **Fold the correction into generic `cell_level`.** Rejected because it would affect FNPC's
    separate seed-height gate and every caller, while native gates it only inside projection.
 3. **Keep the current cached final classification.** Rejected: native re-runs the helper, and the
    authoritative CellClass flag accessor retains shared-dummy lookup side effects, so equivalence
    is no longer proven even though ordinary in-grid classification values are identical.
+4. **Keep the six-cell threshold shortcut.** Rejected after critic review: it cannot reproduce
+   repeated far-to-near misses, live dummy level/flags, or the exact return point.
 
 ## Autonomous Approval Record
 
-**Review verdict: APPROVE.** Initial review found one P1 issue: the first draft treated cached
-collection classification as sufficient for final partition, but the live body/callsites prove a
-second native invocation and the raw-flag accessor carries CellClass dummy lookup semantics. The
-design now calls one corrected classifier at both sites.
+**Review verdict after first critic: APPROVE REVISION.** The first builder revision fixed cached
+final classification but the fresh critic found one P1: its six unique near-to-far probes skipped
+native's repeated far-to-near lookups, forced misses to zero, skipped probe lookups when candidate
+`0x1000` was clear, and still projected during bridge-aware collection. Cold assembly at
+`0x006D6410..0x006D6588` confirms the finding. This revision resolves it with the exact kernel,
+one real-or-dummy view, explicit collection skip, and mutation-resistant lookup transcripts.
 
-Why approve: every behavior claim is grounded in the two cited exhaustive reports, current Rust,
-and a cold decompile/assembly read of `0x006D6410`; all blocking details have executable tests; no
-new state, RNG, scheduler, or cross-layer dependency is introduced.
+Why approve: every behavior claim is grounded in the two cited exhaustive reports, the critic's
+exact finding, current Rust at `2cef3ea2`, and a cold decompile/assembly read of `0x006D6410`; all
+blocking details now have executable order/count/side-effect tests, with no new state, RNG,
+scheduler, or cross-layer dependency.
 
 What could still make ordinary skirmish wrong: changing ring order, the bridge-aware early-stop
 asymmetry, direct-pool preference, or frame-modulo ordering. The design explicitly leaves those

--- a/docs/plans/2026-08-26-fnpc-forward-bridge-projection-design.md
+++ b/docs/plans/2026-08-26-fnpc-forward-bridge-projection-design.md
@@ -1,0 +1,161 @@
+# FNPC Forward-Side Bridge Projection Design
+
+## Goal
+
+Make `Find_Nearby_Passable_Cell` classify bridge-adjacent candidates with the exact active
+`gamemd.exe` forward-side/structural-probe height correction while preserving every other
+ring, gate, ordering, and selection behavior.
+
+## Architecture Context
+
+`src/sim/find_nearby_cell.rs` owns deterministic FNPC search. Candidate validation feeds
+`collect_candidates`, which calls `is_direct_candidate` per accepted coordinate and retains the
+result for collection diagnostics and early-stop. At inspected base revision `eeb2515e`, Rust
+reuses that cached value for final pool partition, while native invokes `FUN_006D6410` again
+there. Bridge-aware-zone queries
+intentionally arm early-stop without the collection projection result while final selection still
+re-runs projection.
+
+`ResolvedTerrainCell.bridge_facts.raw_flags` already owns the modeled live
+`CellClass+0x140` bits. `ResolvedTerrainGrid::cellclass_bridge_flags_0x1180` is the existing
+real-cell/shared-dummy lookup seam; `src/map/bridge_facts.rs` names `0x1000` as
+`BRIDGE_FLAG_FORWARD_SIDE` and `0x100` as `BRIDGE_FLAG_STRUCTURAL`, and active
+`SetBridgeDirection` stamping preserves both. No new state or writer is needed.
+
+Native `FUN_006D6410 @ 0x006D6410` reads the candidate flag at
+`0x006D6473..0x006D6486`; only when `0x1000` is set does it read each projected probe's
+`0x100` bit and add four to that probe's signed height delta at
+`0x006D64F8..0x006D6513`. The naval FNPC query reaches both the collection and final-pool
+uses of this helper. [docs/research/PHASE3_AI_BASE_PLACEMENT_VECTOR_SELECTOR_005060B0_GHIDRA_REPORT.md
+§2.2, §9 Handoff B; docs/research/PHASE3_HOUSECLASS_ORDINARY_BASE_PLACEMENT_005060B0_GHIDRA_REPORT.md
+§8.2, §11.1 item 13]
+
+## Impact Analysis
+
+- Change only `src/sim/find_nearby_cell.rs`: read candidate/probe flags inside
+  `is_direct_candidate`, call that corrected classifier again during final pool partition,
+  replace its stale UNCHECKED residual comment, and add focused tests.
+- Reuse `ResolvedTerrainGrid::cellclass_bridge_flags_0x1180`; do not change bridge facts,
+  `PathGrid`, snapshots, hashing, callers, or function signatures.
+- Blast radius is every FNPC caller because the helper is shared, but observable change is
+  gated by the exact candidate-`0x1000` plus projected-probe-`0x100` combination. Nonbridge
+  terrain and structural probes without candidate forward-side remain bit-for-bit unchanged.
+- The search consumes no RNG and changes no caller-owned state. Its CellClass flag lookups retain
+  native shared-dummy coordinate side effects through the existing accessor. Candidate order,
+  ring termination, frame-modulo indexing, and same-tick determinism remain owned by existing code.
+
+## Chosen Approach
+
+Read the candidate's modeled raw bridge flags once before the six-step projection loop. For
+each probe, add `BRIDGE_LEVEL_RISE` (`4`) to its signed level only when the cached candidate
+has `BRIDGE_FLAG_FORWARD_SIDE` and that probe has `BRIDGE_FLAG_STRUCTURAL`; then feed the
+adjusted probe level into the existing relative-rise threshold unchanged. Invoke the same
+classifier during collection and again, in stored candidate order, when partitioning the final
+direct and indirect pools.
+
+This is the smallest Rust-native translation: it changes the classifier at the exact point
+native changes its height delta, uses the existing CellClass flag authority, and restores the
+native two-site projection call pattern without changing candidate or selection ordering.
+
+## Player-Experience Detail Ledger
+
+- **MILESTONE-BLOCKING — exact two-bit gate:** probe `0x100` is ignored unless candidate
+  `0x1000` is set; otherwise intact bridges can change direct rings and selected cells.
+  [Ghidra `0x006D6473..0x006D6516`]
+- **MILESTONE-BLOCKING — exact magnitude/order:** add four signed height levels to the probe
+  delta before the existing isometric projection comparison, not to the candidate/base height
+  and not after classification. [Ghidra `0x006D64F8..0x006D651D`]
+- **COMPOUNDING — both semantic uses:** the classifier runs during ordinary collection
+  early-stop and again during final direct/indirect pool partition, which can change pool length
+  and `frame % pool_len` output. [selector report §2.2; exhaustive report §8.2]
+- **COMPOUNDING — preserve bridge-aware asymmetry:** `bridge_aware_zone` still arms early-stop
+  on any accepted candidate, while final selection uses projected classification. This slice
+  changes only the projection result. [current `collect_candidates`; FNPC caller evidence]
+- **COMPOUNDING — flag authority:** use modeled live CellClass flags through the existing
+  resolved-terrain/shared-dummy seam; do not infer forward-side from path passability or add a
+  writer. [current `bridge_facts.rs`, `resolved_terrain.rs`; exhaustive report §8.2]
+- **MILESTONE-BLOCKING — determinism:** retain ring order, duplicate radius-zero seed,
+  24-candidate cap, frame-modulo selection, and zero Scenario RNG. [current FNPC tests;
+  selector report §2.2]
+- **No exactification residual:** all behavior in this narrow correction is verified and its
+  required Rust inputs already exist. Naval selection and ordinary base placement remain
+  separate mechanisms, not approximations inside this slice.
+
+## Design
+
+### Components
+
+- `is_direct_candidate`: add the exact flag-gated probe-level correction and canonical
+  `gamemd-derived` provenance for `FUN_006D6410 @ 0x006D6410`.
+- Final pool construction: invoke `is_direct_candidate` once per stored candidate in order,
+  matching native's final partition use rather than reusing collection-time classification.
+- Test fixtures in the same leaf module: stamp raw flags directly on resolved terrain so each
+  load-bearing branch is executable without adding production-only scaffolding.
+
+### Interfaces / Contracts
+
+No public API changes. Missing resolved terrain continues to expose no modeled bridge flags,
+matching existing compatibility behavior. The exact active runtime supplies resolved terrain.
+
+### Data Flow
+
+`ResolvedTerrainGrid bridge flags -> collection is_direct_candidate -> per-ring early-stop;
+stored candidate order -> final is_direct_candidate -> preferred pool -> existing target/frame
+choice`.
+
+### Error Handling
+
+No new failure state. Off-grid/unallocated flag reads use the existing CellClass dummy accessor;
+existing level lookup and candidate conversion behavior are unchanged.
+
+### Testing Strategy
+
+Focused executable tests will prove:
+
+1. a forward-side candidate plus structural probe contributes exactly four levels at a known
+   projection threshold;
+2. the same structural probe is ignored without candidate forward-side;
+3. the correction turns the duplicated radius-zero seed indirect, extends collection through
+   ring one, and changes the final frame-modulo direct pool in exact ring order;
+4. nonbridge candidate classifications, collection, and frame-selected outputs remain unchanged;
+5. the complete existing `sim::find_nearby_cell::tests::` module still passes.
+
+## Architectural Decisions
+
+- Keep one classifier implementation, but call it at native's collection and final-partition
+  sites; do not duplicate its logic or reuse stale classification across those sites.
+- Read CellClass flags from resolved terrain, not `PathGrid`: forward-side is a raw CellClass
+  flag, while path passability exposes no equivalent authority.
+- Add no persistent state, scheduling, RNG, or cross-layer dependency.
+- Tech debt introduced: none.
+
+## Alternatives Considered
+
+1. **Recommended: adjust probe level inside `is_direct_candidate` and invoke it at both native
+   sites.** Exact native location and call pattern, one implementation, and existing architecture
+   stays intact.
+2. **Fold the correction into generic `cell_level`.** Rejected because it would affect FNPC's
+   separate seed-height gate and every caller, while native gates it only inside projection.
+3. **Keep the current cached final classification.** Rejected: native re-runs the helper, and the
+   authoritative CellClass flag accessor retains shared-dummy lookup side effects, so equivalence
+   is no longer proven even though ordinary in-grid classification values are identical.
+
+## Autonomous Approval Record
+
+**Review verdict: APPROVE.** Initial review found one P1 issue: the first draft treated cached
+collection classification as sufficient for final partition, but the live body/callsites prove a
+second native invocation and the raw-flag accessor carries CellClass dummy lookup semantics. The
+design now calls one corrected classifier at both sites.
+
+Why approve: every behavior claim is grounded in the two cited exhaustive reports, current Rust,
+and a cold decompile/assembly read of `0x006D6410`; all blocking details have executable tests; no
+new state, RNG, scheduler, or cross-layer dependency is introduced.
+
+What could still make ordinary skirmish wrong: changing ring order, the bridge-aware early-stop
+asymmetry, direct-pool preference, or frame-modulo ordering. The design explicitly leaves those
+owners unchanged and reruns the full existing FNPC module tests.
+
+What could create expensive later rework: inventing a second bridge-flag authority or folding
+the correction into generic height lookup. Both are rejected; the design consumes the existing
+CellClass raw-flag seam at the native projection boundary. No open question or residual remains
+for this narrow mechanism. Autonomous approval is recorded under the user's explicit authority.

--- a/docs/research/PHASE3_AI_BASE_PLACEMENT_VECTOR_SELECTOR_005060B0_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_AI_BASE_PLACEMENT_VECTOR_SELECTOR_005060B0_GHIDRA_REPORT.md
@@ -1,0 +1,744 @@
+# Phase 3 AI Base-Placement Vector Selector (`0x005060B0`) — Ghidra Report
+
+**Date:** 2026-08-26
+**Binary:** active Yuri's Revenge `gamemd.exe`, image base `0x00400000`
+**Primary function:** `FUN_005060B0 @ 0x005060B0..0x00506B65`
+**Mode:** `/re-investigate`, exhaustive single-mechanism slice
+**Status:** **COMPLETE** for the selector core and its ownership boundary; **not** a
+closure claim for the separate BasePlan, defense-influence, or production-scheduler mechanisms
+**Rust revision inspected:** `origin/main` at `eeb2515e361669e08c7570baeb57a90fe56cb68b`
+**Confidence:** high for every implementation-handoff claim; load-bearing bounds,
+signedness, ordering, activity, return, and RNG claims have decompile plus assembly or
+decompile plus caller evidence.
+
+## Scope
+
+This report closes the active selector that consumes the ordered House/Base reservation
+perimeter vector maintained by `BuildingClass::MarkBaseReservation` and its clearer. It
+establishes:
+
+- every direct caller and ordinary YR reachability;
+- naval, uninitialized-base, and null-type branches;
+- perimeter-vector iteration, both score callbacks, the cloak-generator override,
+  signed sort semantics, and tie behavior;
+- adjacent `CellClass+0xDC` probes, their signed-short vector sum, and symmetric
+  cancellation;
+- coordinate derivation, two local passes, three attempts per pass, two whole retries,
+  all rejection gates in order, success, and failure;
+- RNG/non-RNG behavior; and
+- the exact current-Rust ownership and missing delta.
+
+`HouseClass__AI_ScanBasePerimeter @ 0x005082C0` and AITrigger/Team AI remain outside this
+slice. The caller-side BasePlan, defense-influence, and production scheduler/Strategy
+mechanisms are bounded below because they own inputs and call timing, but their internal
+policies remain separate named implementation mechanisms. The naval branch is included
+because it is an active branch of this function and must bypass the vector path exactly.
+
+No Tiberian Sun source, address, or behavior was used as authority. All reachability and
+mechanism claims below come from the open active `gamemd.exe`; direct active YR callers
+prove this is not an inherited-but-dead TS helper.
+
+## Verdict
+
+`FUN_005060B0` is the active deterministic House AI building-site selector. For ordinary
+non-naval buildings it scores the writer-maintained ordered perimeter vector, sorts by a
+signed 32-bit key, derives an outward site from the signed-short **sum of every** same-House
+reservation direction among eight clockwise probes, skips a final zero vector (including
+symmetric cancellation), and tests up to 12 sites per retained vector entry (two local
+passes times three sites, repeated as a whole twice). It does not perform a radius spiral
+and does not consume scenario RNG. This correction is cold-verified by
+`disassemble_function(address="0x005060B0", program="/gamemd.exe")` at
+`0x0050655B..0x005065E0` and `disassemble_function(address="0x0042D510",
+program="/gamemd.exe")` at `0x0042D510..0x0042D536`.
+
+Current Rust has the exact prerequisite perimeter vector but does not consume it.
+`src/sim/ai.rs::find_placement_cell` still uses a clamped radius-12 square-ring scan around
+an average of live structure anchors. Its partial reservation predicate also orders the
+native gates differently, omits the selector's base-height gate, and sends Naval types
+through the non-naval spiral. This is a material, frequent stock-skirmish divergence whenever
+an AI places a completed building. However, replacing that ready-time spiral with this helper
+alone would still not close native behavior: current Rust lacks the distinct base-plan center,
+the BasePlan node/site lifecycle, and the production-planning influence grid that owns the
+standard callback.
+
+## 1. Function contract and direct callers
+
+The effective ABI is:
+
+```text
+CellStruct* __thiscall HouseClass::SelectBasePlacementCell(
+    HouseClass* this,                 // ECX
+    CellStruct* out,                  // stack +0x08
+    BuildingTypeClass* type,          // stack +0x0C
+    int (__fastcall *score)(...),     // stack +0x10; House in ECX, cell* in EDX
+    int score_arg                     // stack +0x14
+);                                   // RET 0x10
+```
+
+`get_function_xrefs(0x005060B0)` returns exactly three call instructions in two functions:
+
+| Callsite | Caller | Arguments and role |
+|---|---|---|
+| `0x00444FE1` | `BuildingClass__ExitObject_Main @ 0x00443C60` | House=`Building+0x21C`, type, scorer `0x00505F80`, arg `-1`; non-human AI construction/factory exit-placement path |
+| `0x004450BD` | same | same selector arguments on the caller's alternate placement branch |
+| `0x00507A20` | `HouseClass__AI_ChooseNextProduction @ 0x00506EF0` | chosen type, scorer `FUN_00505FD0`, arg `selected_quadrant*2` (`0,2,4,6`); preselects a building site when its optional candidate-list parameter is null |
+
+At both `ExitObject_Main` sites, raw assembly pushes `-1`, `0x00505F80`, the type,
+and the output pointer, then sets ECX from `[building+0x21C]`. The enclosing switch case
+has already rejected a human-controlled House. This is the normal computer building
+placement path, not an editor-only or legacy-only path.
+
+`HouseClass__AI_ChooseNextProduction` has one direct caller,
+`HouseClass__AI_Choose_Building @ 0x004FE3E0` at `0x004FE633`.
+`AI_Choose_Building` is called from `HouseClass__AI_Manage_Build_Queue` at `0x004FE3B5`
+and from normal `HouseClass__Update` at `0x004F90AE`, `0x004F9242`, and `0x004F924B`.
+This independently proves ordinary active YR tick reachability.
+
+The non-null optional-candidate-list branch of `AI_ChooseNextProduction` scores and sorts
+that supplied list itself; it does **not** call `0x005060B0`. It is not another selector
+caller.
+
+## 2. Entry branches and evidence-backed exclusions
+
+### 2.1 Null type
+
+Assembly `0x005060C6..0x005060DF` stores the packed `_g_InvalidCell` from
+`0x00A8EF98` in `out` and returns immediately. No vector, map, or RNG access occurs.
+
+### 2.2 Naval type (`BuildingType+0x0CCE != 0`)
+
+Assembly `0x005060E2..0x0050623A` bypasses the perimeter vector completely.
+
+1. It calls `HouseClass__FirstBuildableFromArray @ 0x005051E0` twice on the Rules
+   `Shipyard=` vector rooted at `Rules+0x880`; the first result supplies foundation width
+   and the independently repeated result supplies foundation height. This is a source-order
+   shipyard selector, not generic `BuildOption.enabled`: it applies Owner,
+   RequiredHouses, ForbiddenHouses, and exact `AIBasePlanningSide`, followed only by the
+   primary-superweapon shell-disable/`BuildTech` exemption tail. It applies no TechLevel,
+   prerequisites, factory, BuildLimit, cost, credit, stolen-tech, or category gate.
+2. Its seed is `House+0x5494` unless that packed cell is the invalid sentinel, in which
+   case it uses `House+0x5490`.
+3. It calls `FootClass__Find_Nearby_Passable_Cell @ 0x0056DC20` with native arguments:
+   `out, origin, 5, -1, 0, 0, width+2, height+2, 0, 0, 0, 1,
+   &packed_zero, 0, 0`. Here `-1` disables required-zone equality, MovementZone is
+   `0` (Normal), bridge-aware height/zone input is `0`, and structural bridges are
+   allowed. Packed-zero reference selects by current-frame modulo rather than RNG.
+4. If the owned BuildConst vector at `House+0x54` has a first object, the result must be
+   within `Rules+0xE0C * 256` leptons of it; otherwise the function returns invalid.
+
+`Rules+0xE0C` is `[General] AINavalYardAdjacency`, **not** `MaxBaseDistance`.
+Retail `rulesmd.ini` sets `AINavalYardAdjacency=20`, `Shipyard=GAYARD,NAYARD,YAYARD`,
+and has many active `Naval=yes` types. Therefore this is an active stock branch, but it is
+an evidence-backed exclusion from perimeter-vector selection.
+
+The selector itself calls no RNG in this branch. FNPC's packed-zero reference selects by
+simulation frame modulo the chosen pool length; it is deterministic and is not
+`Random__RandomRanged`.
+
+This naval call makes one previously omitted shared-helper rule reachable. Because its
+bridge-aware input is zero while structural bridge cells are allowed, FNPC runs
+`FUN_006D6410` at four collection-side sites and again during final pool partition. The
+helper reads candidate `CellClass+0x140 & 0x1000`; only when that bit is set, each projected
+probe with `CellClass+0x140 & 0x100` receives **four additional signed height levels** before
+the isometric direct/indirect comparison. That can change first-direct-ring termination,
+pool membership and length, and the frame-modulo-selected cell. Fresh
+`decompile_function(address="0x006D6410", program="/gamemd.exe")` and
+`disassemble_function(address="0x006D6410", program="/gamemd.exe")` verify the flag gates
+and `+4` at `0x006D6473..0x006D6513`; `get_function_xrefs(address="0x006D6410",
+program="/gamemd.exe")` verifies FNPC callsites `0x0056DF0B`, `0x0056E122`,
+`0x0056E364`, `0x0056E559`, and `0x0056E62E`.
+
+Current Rust already retains and stamps those bits as
+`BRIDGE_FLAG_FORWARD_SIDE=0x1000` and `BRIDGE_FLAG_STRUCTURAL=0x100` in
+`src/map/bridge_facts.rs`, but `src/sim/find_nearby_cell.rs::is_direct_candidate`
+explicitly omits the correction under stale `UNCHECKED` wording. The smallest prerequisite
+is local to that shared pure classifier: include candidate-forward-side/probe-structural
+height adjustment and test both collection early-stop and final direct/fallback pool
+selection. No bridge destruction, cliff, or new flag-writer work is required.
+
+### 2.3 Non-naval type with `(House+0x5750,+0x5752) == (0,0)`
+
+Assembly/decompile `0x00506248..0x005062C1` bypasses vector scoring and validation. It
+returns `House+0x5494`, or `House+0x5490` if `+0x5494` is the packed-zero
+empty/invalid sentinel. `House+0x5750..+0x5753` is the distinct **base-plan center**, not
+the primary/launch cell and not a reservation-writer bound. Fresh
+`disassemble_function(address="0x005060B0", program="/gamemd.exe")` verifies the three
+field reads at `0x00506248..0x005062A3`.
+
+### 2.4 Three House cell authorities must remain distinct
+
+The complete direct-instruction inventories are separate:
+
+- `House+0x5490` is the primary/starting cell. The House constructor initializes it from
+  packed-zero `0x00A8EF98` at `0x004F5A3C..0x004F5A41`; active writers include
+  `HouseClass__Set_Starting_Cell @ 0x0050E000`, Recenter, ComputerTakeover, and the
+  separate base-center recalculation routine. The selector reads it only as the naval
+  origin or zero-base-plan-center fallback.
+- `House+0x5494` is the alternate/override primary cell. The constructor initializes it
+  to the same packed zero at `0x004F5A47..0x004F5A4D`. Trigger action `137` reaches
+  `FUN_006E44E0 -> FUN_0050DFE0` and writes a valid waypoint cell; action `138` reaches
+  `FUN_006E4540 -> FUN_0050DFF0` and restores packed zero. The selector prefers it over
+  `+0x5490` only in the two fallback/origin branches above. Fresh
+  `get_function_xrefs(address="0x0050DFE0"/"0x0050DFF0", program="/gamemd.exe")`,
+  `decompile_function(address="0x006E44E0"/"0x006E4540", program="/gamemd.exe")`, and
+  `disassemble_function(address="0x0050DFE0"/"0x0050DFF0", program="/gamemd.exe")`
+  verify both writers and TriggerAction cases `0x89/0x8A`. The tracked exhaustive report's
+  physical retail census finds action 137 in exactly three shipped YR campaign maps; a
+  separate resolved-name scan of 310 archive maps plus two loose maps reproduced those
+  three and found no action 138 occurrence.
+- `House+0x5750` is the base-plan center used by both score callbacks, selector zero/nonzero
+  dispatch, orientation reference, and anchor-height reference. The complete direct
+  `search_instructions(operand_pattern="0x5750", limit=200, program="/gamemd.exe")`
+  inventory is untruncated and contains four stores: ordinary reverse-owned-order
+  `HouseClass__RecenterBase @ 0x0050C325`, successful non-player ConstructionYard deploy
+  `0x007398F3`, the conditional ComputerTakeover writer `0x0050A7E9`, and TriggerAction
+  case `0x1E` at `0x006DE270`. The last has no occurrence in the resolved retail map
+  census; it remains a supported binary writer, not an ordinary stock-skirmish input.
+  Recenter and deploy also write `+0x5490`, but that synchronization does not merge the
+  fields: other writers and selector uses remain distinct.
+
+`HouseState::base_center` at the inspected Rust revision is assigned from the launch/start
+waypoint and corresponds to the primary `+0x5490` authority. There is no alternate cell or
+distinct base-plan-center state. Reusing or recentering that field as `+0x5750` would break
+its existing launch/primary consumers.
+
+### 2.5 Cloak-generator scoring override
+
+When `BuildingType+0x16C7` (`CloakGenerator=`) is nonzero, the function ignores the
+supplied callback. For each perimeter cell it gets the House base/starting cell's 3-D
+world coordinate, compares it to the candidate cell center `(x*256+128,y*256+128,0)`,
+and forms:
+
+```text
+key = wrapping_i32(vector_index + ftol(Sqrt_Approx(dx*dx + dy*dy + dz*dz)) * 1000)
+```
+
+This branch is implemented and reachable for custom data, but no active
+`CloakGenerator=yes` occurs in stock `rulesmd.ini` or `rules.ini`. It is therefore an
+evidence-backed stock-retail exclusion, not permission to omit custom-data behavior.
+
+## 3. Perimeter-vector traversal and scoring
+
+### 3.1 Source order
+
+The non-naval main path reads:
+
+- coordinate storage pointer: `House+0x5724`;
+- signed count: `House+0x5730`;
+- element: packed signed-short `(x,y)` at `data + 4*index`.
+
+It traverses `index=0,1,...,count-1`. This is the exact stable append/remove order
+maintained by the reservation writer; it is not an `ExitList`, foundation list, map scan,
+or recomputed geometric perimeter. A signed count `<=0` yields no scored entries.
+
+Each scored record is exactly `{ i32 key, packed CellStruct coordinate }`. Native vector
+allocation failure can omit an append; that OOM behavior is not a normal parity target.
+
+### 3.2 Exit-placement score callback at `0x00505F80`
+
+This coherent callback body is not currently defined as a Ghidra function, but both
+`ExitObject_Main` callsites push its aligned entry and it ends in `RET 0x8` at
+`0x00505FBF`. Assembly uses `MOVSX`, signed `SUB`, signed absolute-value idioms, and
+signed `JG`:
+
+```text
+dx = signed_short(candidate.x) - signed_short(House+0x5750)
+dy = signed_short(candidate.y) - signed_short(House+0x5752)
+coarse = max(abs_i32(dx), abs_i32(dy))        // Chebyshev cell distance
+key = wrapping_i32(vector_index + coarse * 1000)
+```
+
+The second callback argument is ignored. This is **not** square root/Euclidean distance.
+
+### 3.3 Threat-and-angle score callback `FUN_00505FD0`
+
+The callback indexes the current House threat grid:
+
+```text
+linear = (candidate.y - House+0x5758) * (House+0x575C)
+       + (candidate.x - House+0x5754)
+threat = *(i32*)(House+0x16060 + 4*linear)
+```
+
+If `score_arg == -1`, angular penalty is zero. Otherwise:
+
+```text
+raw16 = ftol((atan2(-(candidate.y-base_y), candidate.x-base_x) - pi/2)
+             * (-32768/pi))
+angle_byte = ((((uint16)raw16 >> 7) + 1) >> 1) & 0xff
+delta = abs_i32(score_arg * 32 - angle_byte)
+if delta >= 128: delta = 255 - delta       // literal 255, not 256
+key = wrapping_i32(vector_index + (threat * 128 + delta) * 1000)
+```
+
+`AI_ChooseNextProduction` passes quadrant indices doubled, so its ideal angle bytes are
+`0`, `64`, `128`, and `192`. Constants are the live `pi/2 @ 0x007E2820` and
+`-32768/pi @ 0x007E2818`; the x87 `ftol`, unsigned 16-bit truncation, shifts, and all
+integer math feeding the later comparator are load-bearing.
+
+### 3.4 Sort signedness and ties
+
+The function calls `FUN_007C8B48` (the shipped CRT-style `qsort`) with record size `8`
+and comparator `0x005108F0`. Comparator assembly `CMP EAX,ECX`, `SETGE`, and the
+`DEC/AND/INC` sequence returns:
+
+- `-1` when left key is signed-less-than right;
+- `0` for equality;
+- `+1` when left key is signed-greater-than right.
+
+The result is ascending **signed `i32`** order. Coordinates are then copied in that sort
+order to a second vector and traversed from index zero upward.
+
+Equal keys are not given an insertion-order tie-break. `FUN_007C8B48` is deterministic
+but unstable, and its complete linked-retail behavior is required rather than delegated
+to a host-library sort:
+
+1. ranges of at most eight records use `FUN_007C8C9C`, repeatedly retaining the first
+   strictly greatest record, swapping it with the current high record through byte-swap
+   helper `FUN_007C8CEA`, and decrementing high;
+2. longer ranges swap `low + floor(count/2)` with low and use it as the pivot;
+3. the forward scan advances while `candidate <= pivot`, the reverse scan retreats while
+   `candidate >= pivot`, crossed scans swap the pivot with the reverse record, and native
+   continues with the smaller partition while pushing the larger partition on its fixed
+   30-entry local stacks. The strict range tests are `low+1 < reverse`, `forward < high`,
+   and `(reverse-low-1) < (high-forward)` for the smaller-partition choice.
+
+Assembly-derived fixtures are exact:
+
+```text
+input ids, all keys equal              native output ids
+[0,1]                                  [1,0]
+[0,1,2,3,4,5,6,7]                      [1,2,3,4,5,6,7,0]
+[0,1,2,3,4,5,6,7,8]                    [4,1,2,3,0,5,6,7,8]
+```
+
+Collisions are possible: in a 1,001-record fixture, `id=0` has index `0`, score `1`, key
+`1000`; records `id=1..1000` have score `0`, key equal to index. Native places the equal
+keys at sorted positions `999:id=1000`, `1000:id=0`. Rust must locally port this sorter;
+neither stable sort nor the standard-library unstable sort is an exact substitute.
+
+## 4. Reservation-neighbor probe and direction choice
+
+Before candidate traversal the selector resolves the CellClass at `House+0x5750`, reads
+its **signed byte** height at `CellClass+0x11B`, and caches the same-House reservation bit
+`1 << (House+0x30 & 31)`.
+
+For every sorted perimeter coordinate it probes all eight entries of
+`g_DirectionOffsets @ 0x0089F688` in this exact order:
+
+| index | delta | direction |
+|---:|---:|---|
+| 0 | `(0,-1)` | N |
+| 1 | `(1,-1)` | NE |
+| 2 | `(1,0)` | E |
+| 3 | `(1,1)` | SE |
+| 4 | `(0,1)` | S |
+| 5 | `(-1,1)` | SW |
+| 6 | `(-1,0)` | W |
+| 7 | `(-1,-1)` | NW |
+
+Each probe uses `MapCoord_Add @ 0x0042D510`, whose two word `ADD`s wrap X and Y
+independently at 16 bits, resolves the adjacent CellClass, and tests its `+0xDC` mask.
+Every hit is added through the same helper to a signed-short accumulator initialized to
+`(0,0)`. Native does **not** retain the last hit. After all eight probes, a final `(0,0)`
+sum skips the perimeter coordinate. Thus no hits skip, and symmetric arrangements such as
+N+S or all eight directions also cancel and skip. (The eight unique unit offsets bound
+the mathematical sum to `[-3,3]` per component, but the mechanism still uses word-wrap
+addition and candidate-neighbor coordinates can wrap.)
+
+A nonzero `(sum_x,sum_y)` becomes direction index:
+
+```text
+raw16 = ftol((atan2(sum_y, -sum_x) - pi/2) * (-32768/pi))
+q = ((((uint16)raw16 >> 12) + 1) >> 1) & 7
+```
+
+There is no priority for the last scanned direction and no random wobble.
+
+Map-edge probes use the native shared dummy CellClass behavior. A faithful Rust port must
+use the existing reservation grid's off-map/dummy semantics and 16-bit packed-coordinate
+arithmetic, not clamp candidates to `0..511`.
+
+## 5. Candidate-coordinate derivation
+
+Let:
+
+```text
+W = BuildingType foundation width
+H = BuildingType foundation height
+b = signed Rules.AIBaseSpacing (Rules+0x1460)
+extra = 1 if (BuildingType+0x1765 ProtectWithWall)
+             OR (BuildingType+0x1578 WantsExtraSpace), else 0
+s = wrapping_i32(b + extra)
+```
+
+Assembly `0x00506673` and `0x00506684` proves the second flag's byte offset is direct
+`BuildingType+0x1578`. The decompiler spelling `param_3[0x55e]` scales through `int*`
+and must not be read as byte offset `+0x55E`.
+
+The selector stores the following initial signed-short offset; conversion/truncation and
+later coordinate adds have native 16-bit wrapping semantics:
+
+```text
+ox = s           when q in {1,2,3}
+   = 1-W-s       when q in {5,6,7}
+   = 0           when q in {0,4}
+
+oy = s+1         when q in {3,4,5}
+   = 1-H-s       when q in {7,0,1}
+   = 0           when q in {2,6}
+```
+
+Two selector-local direction tables are initialized once and are **rotations**, not copies
+of the static N-first table:
+
+| q | local T1 at `0x00A8EF78` | local T2 at `0x00A8EFA8` |
+|---:|---|---|
+| 0 | W `(-1,0)` | E `(1,0)` |
+| 1 | NW `(-1,-1)` | SE `(1,1)` |
+| 2 | N `(0,-1)` | S `(0,1)` |
+| 3 | NE `(1,-1)` | SW `(-1,1)` |
+| 4 | E `(1,0)` | W `(-1,0)` |
+| 5 | SE `(1,1)` | NW `(-1,-1)` |
+| 6 | S `(0,1)` | N `(0,-1)` |
+| 7 | SW `(-1,1)` | NE `(1,-1)` |
+
+For each candidate, each of two local passes starts from:
+
+```text
+p0 = perimeter_candidate + (ox,oy) + T1[q]
+```
+
+- local pass 0 uses clearance `s` and tests `p0`, `p0+T2[q]`,
+  `p0+2*T2[q]`;
+- local pass 1 first adds static `g_DirectionOffsets[(q-4)&7]` to `p0`, uses
+  clearance `s-b`, and tests the analogous three T2 steps.
+
+`(ox,oy)` is **not recomputed** for the reduced second-pass clearance. With stock
+`AIBaseSpacing=1`, the second clearance is `0` normally and `1` for either extra-space
+flag. The third failed attempt computes one further unused step.
+
+Retail `rulesmd.ini` has `AIBaseSpacing=1` and many active `ProtectWithWall=yes` types.
+Its `WantsExtraSpace=yes` examples are commented out, so that flag is inactive in stock
+data but active for custom INI. Current Rust already parses both booleans and signed
+`AIBaseSpacing`; those fields should be preserved.
+
+## 6. Per-attempt rejection gates, exact order
+
+Every attempted packed cell is tested in this order. The first failure advances to the
+next T2 site or local pass.
+
+1. **Expanded-rectangle occupancy.** Construct
+   `(x-clearance, y-clearance, W+2*clearance, H+2*clearance)` with native wrapping
+   signed arithmetic and call `CellRect__CheckOccupancy @ 0x00586780` with
+   `House+0x30`. It must return true.
+2. **Building-type placeability.** Call type virtual slot `+0xA8` with the exact
+   unexpanded anchor and House. The Building override
+   `BuildingTypeClass__CanPlaceAt @ 0x00464AC0` accepts immediately when `PlaceAnywhere`
+   is set; otherwise it delegates to `TechnoTypeClass__CanPlaceAt @ 0x00716150`, which
+   walks the foundation/occupy list and calls
+   `Cell_passability_building_placement @ 0x0047C620` per Building cell. It must return
+   true.
+3. **Anchor height.** Resolve the attempted anchor's CellClass, read signed byte `+0x11B`,
+   and require `abs_i32(base_reference_height - candidate_height) < 3`. Assembly compares
+   to `3` and rejects on signed `JGE`; a difference of exactly three fails.
+4. **Reservation-network proximity.** Call
+   `HouseClass__HasBaseReservationNearBuilding @ 0x0050B760`; it must return true.
+
+`HasBaseReservationNearBuilding` returns true immediately only when `g_GameMode==0`.
+Otherwise, for signed spacing `b`, it scans X outer and Y inner from
+`(x-b-1,y-b-1)` through inclusive `(x+W+2b,y+H+2b)` and returns true on the first
+`CellClass+0xDC` hit for the House bit. These intentionally asymmetric literal limits are
+also what current Rust's `has_reservation_inclusive` call expresses. The selector therefore
+requires connection to the House reservation network in ordinary active games.
+
+The selector does not clamp anchors to map dimensions and does not replace these four
+gates with one generic preview call. Shared-dummy lookups remain part of off-map behavior.
+
+## 7. Retry, success, failure, and RNG
+
+- Success stores and returns the exact current attempted packed cell immediately at
+  `0x00506B0E`.
+- After all sorted candidates are exhausted, the selector repeats the **entire sorted
+  traversal once**, unchanged. Therefore the maximum is `vector_count * 2 * 2 * 3`
+  validation attempts, excluding vector entries with no reserved neighbor.
+- No bridge flag changes between the two local passes or the two full traversals. Calling
+  either a "bridge retry" is unsupported.
+- After both whole traversals fail, assembly `0x00506AAD..0x00506AC3` stores packed cell
+  `0`, i.e. `(0,0)`, not `_g_InvalidCell`.
+- `AI_ChooseNextProduction` explicitly treats `(0,0)` as failure at
+  `0x00507A34..0x00507A47`.
+- An empty/nonpositive vector still performs the base-height lookup and both empty
+  traversals, then returns `(0,0)`.
+- The non-naval main path contains no `Random__` call, scenario-RNG access, frame-counter
+  read, or random direction offset. For fixed House/map/type inputs and native qsort it is
+  deterministic. RNG used elsewhere in upstream AI policy does not belong to this selector.
+
+## 8. Current Rust mapping at `eeb2515e...`
+
+### Reusable state that already matches
+
+- `src/sim/house_state.rs:148-215` owns `BaseReservationState`, including ordered
+  `perimeter_cells: Vec<u32>`, append-if-absent, stable first removal, bounds, and an
+  accessor. This is the exact selector-vector input.
+- `src/sim/world/lifecycle.rs:946-1009` updates that vector from the authoritative
+  reservation grid after mark/clear; `src/sim/world/substrate.rs` owns per-House masks and
+  shared-dummy state. The selector must consume, not rebuild or reorder, this state.
+- `src/rules/object_type.rs` parses `naval`, `protect_with_wall`, and
+  `wants_extra_space`; `src/rules/ruleset.rs` preserves signed `ai_base_spacing`.
+- `HouseState::base_center` is the launch/primary `House+0x5490` equivalent. Preserving it
+  is correct, but it is not the missing `House+0x5750` base-plan center.
+- `src/map/bridge_facts.rs` already retains/stamps the two FNPC projection flags. The
+  missing `+4` rule is local to `src/sim/find_nearby_cell.rs::is_direct_candidate`.
+
+### Wrong or missing ownership
+
+- `src/sim/ai.rs::find_placement_cell` ignores the ordered perimeter vector, clamps to
+  `0..511`, walks radius-`0..12` square rings around an average of live structure anchors,
+  and uses one generic preview. It lacks the exact sort, vector-sum orientation, site
+  derivation, height gate, gate order, duplicate traversal, packed-zero failure, and Naval
+  branch.
+- `ai_base_reservation_candidate_ok` combines partial occupancy/proximity concepts before
+  generic preview. Native order is occupancy, type placeability, signed height, proximity.
+- `production_placement.rs` leaves its `_height_map` unused, so generic preview cannot
+  satisfy `abs(base-plan-center height - anchor height) < 3`.
+- Rust has no alternate `+0x5494` cell, distinct `+0x5750` base-plan center, ordered
+  BasePlan nodes/cached sites, authentic defense-influence grids/category selector, parsed
+  source-ordered `Shipyard=`, or `AINavalYardAdjacency` owner.
+- No production code consumes `BaseReservationState::perimeter_cells()` outside tests,
+  snapshot, and hashing.
+
+The earlier proposal to route an isolated selector directly through
+`place_ready_buildings` is **not parity preserving**. Native ordinary production calls the
+standard scorer during planning, stores the cell in the caller-selected House BasePlan node,
+then Building exit looks up/reuses or reselects that node's cell with the Chebyshev scorer.
+Current Rust chooses only when a building is ready and has no equivalent plan node. The pure
+selector core can be implemented and tested in isolation, but it must not be presented as a
+player-path closure until the caller-owned lifecycle is connected.
+
+## 9. Corrected implementation handoff and mechanism boundary
+
+### Handoff A — independently implement the pure selector core
+
+Create deterministic, caller-parameterized selector services over the existing ordered
+perimeter vector. This coherent slice includes:
+
+- exact callback-key construction with wrapping `i32` arithmetic;
+- a local port of linked `0x007C8B48/0x007C8C9C/0x007C8CEA` signed-key sort;
+- all-hit signed-short reservation-direction summation, zero/symmetric-cancellation skip,
+  exact x87-derived direction quantization, initial offsets, T1/T2 tables, two clearance
+  phases, three tangential attempts, four short-circuit gates, two complete traversals,
+  immediate success, and packed `(0,0)` exhaustion;
+- the non-naval zero-base-plan-center fallback, given explicit primary, alternate, and
+  base-plan-center inputs.
+
+Acceptance must include the three equal-key permutations and 1,001-record collision above;
+negative/wrapping keys; vector insertion-order indices; no-hit, one-hit, multiple-hit sum,
+N+S cancellation, and all-eight cancellation; all eight seeds; 1x1/non-square foundations;
+stock, extra, negative, and short-wrapping spacing; four-gate trace order; height deltas
+`-3,-2,+2,+3`; off-map dummy behavior; exact attempt count; first success; zero failure;
+and proof of zero selector RNG.
+
+This helper must accept a supplied exact score policy/grid and distinct base-plan center.
+It must not read `HouseState::base_center` as `+0x5750`, fabricate a neutral influence
+grid, mutate the writer vector, or be wired into ready-time placement as a closure claim.
+
+### Handoff B — close the narrow shared FNPC prerequisite, then the Naval branch
+
+First change only the shared FNPC direct-classification rule: when the candidate has
+`BRIDGE_FLAG_FORWARD_SIDE`, add four signed height levels for every projected probe with
+`BRIDGE_FLAG_STRUCTURAL`. Prove the correction affects both collection-side early-stop and
+final direct/fallback partition; recheck existing FNPC callers. No new bridge writer,
+bridge-destruction, cliff, or terrain-state mechanism is required.
+
+Then implement the Naval selector branch with explicit primary/alternate cells, the exact
+15-argument query, frame-modulo pool selection, first owned BuildConst distance cap, source-
+ordered `Shipyard=` selection, and signed `AINavalYardAdjacency`. Its buildability helper
+must use only the exact Owner/Required/Forbidden/AIBasePlanningSide and primary-superweapon
+tail, not generic `BuildOption.enabled`. Tests must prove vector bypass; the three retail
+yard side outcomes and `6x6` footprint; alternate-to-primary fallback; absent BuildConst cap
+bypass; cap/cap+1; both bridge-projection semantic sites; and zero Scenario RNG.
+
+### Handoff C — keep caller-owned prerequisites as separate named mechanisms
+
+The following are not selector-core implementation details and remain independently open:
+
+1. **House base-cell authority lifecycle:** preserve primary `+0x5490`; add snapshot/hash-
+   covered alternate `+0x5494` with exact action 137 writer, action 138 clearer, alphabetic
+   waypoint decoder, and packed-zero initialization; add distinct base-plan center `+0x5750`
+   with its verified Recenter/deploy/ComputerTakeover/action-30 writers.
+2. **Ordered BasePlan node/site lifecycle:** scenario/generated population, production-time
+   selected-node site capture, cached-site lookup/reuse/reselection, successful-Unlimbo fill
+   and retry reset, failure clearing/retry/eviction, and wall/power node mutations.
+3. **Defense influence/category chooser:** lifecycle-owned grids, exact ratios/category/type
+   choice and RNG, so the standard scorer receives an authentic grid and direction.
+4. **Production scheduler/Strategy:** exact call cadence/mode and RNG ordering that decides
+   when planning occurs; it must remain separate from ready-building placement.
+
+Building-exit Chebyshev scoring can be unit-tested with an explicit base-plan center, and
+the standard scorer can be unit-tested with a supplied exact grid. Neither is end-to-end
+active until its separate caller-side owner above is present. Any missing owner keeps the
+ordinary player-path row open rather than authorizing a guessed input or ready-time bypass.
+
+## 10. Negative facts / do not do
+
+- Do not retain, extend, or widen the radius-12 spiral for ordinary AI building placement.
+- Do not call the writer vector an `ExitList`, sort by Euclidean distance for the normal
+  ExitObject callback, or assume the static and two local direction tables are identical.
+- Do not stop at the first reserved neighbor or let the last hit win; add every matching
+  direction and skip a final zero sum, including symmetric cancellation.
+- Do not use stable sort, add a coordinate tie-break, or assume `+index` prevents equal keys.
+- Do not substitute the host's unstable sort; port the linked retail algorithm and fixtures.
+- Do not read decompiler `param_3[0x55e]` as byte offset `+0x55E`; it is
+  `BuildingType+0x1578 WantsExtraSpace`.
+- Do not label either repeated pass a bridge retry; no bridge state changes here.
+- Do not return invalid sentinel on main-vector exhaustion; the native value is packed zero.
+- Do not consume scenario RNG or add random direction wobble.
+- Do not fold the wall/base-bounds scanner into this selector; that is a separate active owner.
+- Do not use `MaxBaseDistance` for the Naval cap; the field is `AINavalYardAdjacency`.
+- Do not treat `HouseState::base_center` as the base-plan center; it owns primary `+0x5490`.
+- Do not connect the isolated selector to ready-time placement and call the native path
+  closed; BasePlan owns planned/cached sites and the influence grid exists only at planning.
+- Do not supply a neutral/guessed influence grid, use generic build eligibility for the
+  Shipyard scan, or bypass the FNPC forward-side/structural-probe `+4` projection.
+
+## 11. Exhaustiveness ledger
+
+| Obligation | Status | Evidence |
+|---|---|---|
+| Function boundary/ABI | resolved | decompile plus prologue/`RET 0x10` assembly |
+| Complete direct caller census | resolved | three active xrefs in two functions |
+| Ordinary YR reachability | resolved | `HouseClass__Update`/AI queue caller chain plus non-human ExitObject branch |
+| Null, naval, zero-base fallbacks | resolved | entry/branch assembly `0x5060C6..0x5062C1` |
+| Primary/alternate/base-plan-center distinction | resolved | complete direct instruction inventories plus constructor/setter/clearer/Recenter/deploy/caller evidence |
+| Retail alternate-cell activation | resolved | tracked exhaustive 461-candidate/386-map physical census; separate resolved-name scan corroborates three action-137 and zero action-138 entries |
+| Vector pointer/count/order | resolved | decompile plus indexed-load assembly |
+| Both supplied score callbacks | resolved | full raw assembly `0x505F80..0x5060A3` plus caller arguments |
+| CloakGenerator override | resolved | target decompile/assembly plus retail INI negative search |
+| Sort key signedness and complete tie behavior | resolved | comparator plus full qsort/selection-sort/byte-swap assembly and four permutation fixtures |
+| Adjacent `+0xDC` probe order/vector sum | resolved | target and `MapCoord_Add` assembly; zero initialization, all-hit add, final zero skip |
+| Direction quantization and tables | resolved | target decompile plus literal table initialization stores |
+| Coordinate derivation/all attempts | resolved | target decompile plus `0x506673..0x506B0E` assembly |
+| Rejection gates and order | resolved | target assembly plus decompile of `0x716150` and `0x50B760` |
+| Success/failure/retry | resolved | target tail assembly and AIChoose consumer check |
+| RNG | resolved | complete target/callee census; no selector RNG reference |
+| Naval FNPC bridge projection | resolved/native, open/Rust prerequisite | `0x6D6410` decompile+assembly, five FNPC callsites, Rust bridge flag writers and omitted classifier rule |
+| Retail INI activation/exclusion | resolved | `rulesmd.ini` and `rules.ini` literal searches |
+| Current Rust owner/delta | resolved | direct inspection of exact `origin/main` revision |
+| Save/load/replay | partially reusable, caller state open | perimeter vector and primary cell are covered; alternate cell, base-plan center, BasePlan nodes, and caller grids/lifecycle are absent |
+| Pause/frame behavior | resolved | non-naval selector has no frame input; naval FNPC uses the authoritative frame-counter argument |
+| Selector/caller mechanism boundary | resolved | selector callers plus BasePlan plan-time write and Building-exit lookup/reselection evidence |
+
+No material native selector-core question remains. The named caller-side mechanisms remain
+implementation prerequisites, not uncertainties that may be approximated inside this slice.
+
+## 12. Adversarial zero-add pass
+
+Seven adversarial questions were asked after the first complete model:
+
+1. **Can a tie actually occur despite the index term?** Yes: score bands can differ by one
+   while indices differ by 1000; the full linked sort and exact permutations are required.
+2. **Does the reservation-neighbor loop choose a first or last matching side?** Neither:
+   it sums every matching direction with `MapCoord_Add`; opposite/symmetric hits can cancel
+   to zero and skip the candidate.
+3. **Does the extra-space retry recompute its footprint offset?** No: it preserves `(ox,oy)`
+   from `s` and only changes the clearance to `s-b` plus the opposite static delta.
+4. **Are the two retries bridge-dependent or randomized?** No: neither bridge state nor RNG
+   changes; the sorted traversal is repeated literally.
+5. **Can current primary `base_center` or generic preview supply selector inputs?** No:
+   `base_center` is `+0x5490`, while scoring/height use distinct `+0x5750`; preview's
+   `height_map` parameter is unused.
+6. **Can the active selector be attached only at completed-building ready time?** No:
+   the standard scorer runs during production planning and writes a BasePlan-node site;
+   Building exit later performs cached-site lookup/reuse/reselection.
+7. **Is shared FNPC exact enough for Naval today?** No: its current classifier omits the
+   candidate-`0x1000`/probe-`0x100` `+4` projection at both semantic uses.
+
+Zero-add result: no further native selector branch or input remains unbounded. The pass did
+correct three earlier false closures: last-hit became vector sum, `base_center` became three
+distinct authorities, and Naval gained its narrow shared-FNPC prerequisite. It also moved
+BasePlan/influence/scheduler work out of the core instead of hiding those dependencies.
+
+Cold spot-checks:
+
+- A fresh decompile of `0x005060B0` and raw re-read of `0x005069DB..0x00506B30`
+  reconfirmed four-gate order, strict height `<3`, three T2 attempts, success, and two whole
+  traversals.
+- A fresh raw re-read of `0x00505F80..0x005060A3`, comparator `0x005108F0`, and selection
+  sort `0x007C8C9C`, plus full `0x007C8B48` and byte-swap `0x007C8CEA`, reconfirmed exact
+  scoring conversion, signed comparison, and complete unstable equal-key behavior.
+- Fresh direct-instruction inventories for `0x5490`, `0x5494`, and `0x5750`, plus cold
+  reads of `RecenterBase`, ConstructionYard deploy, the action-137/138 setter/clearer, and
+  `FUN_006D6410`, reconfirmed the three cell authorities and FNPC bridge projection.
+
+## 13. Required stale-doc replacement wording
+
+In `FIND_NEAREST_VARIANTS_SPIRAL_COMPARISON_GHIDRA_REPORT.md`, replace Variant F wording
+that says `ExitList`, Euclidean/square-root normal scoring, identical direction tables,
+first probe/bridge retry, impossible ties, or `MaxBaseDistance` with:
+
+> `FUN_005060B0` consumes the House/Base writer-maintained ordered reservation-perimeter
+> vector. The ExitObject scorer uses `index + 1000*ChebyshevDistance`; AI preplanning uses
+> `index + 1000*(128*threat + anglePenalty)`. Signed i32 keys are sorted by the shipped
+> unstable qsort, whose exact linked algorithm and equality permutations must be ported.
+> Each vector coordinate probes static N,NE,E,SE,S,SW,W,NW, sums every same-House
+> `Cell+0xDC` direction with wrapping word arithmetic, and skips a zero result including
+> symmetric cancellation. Two rotated local tables derive three sites in each of two local
+> passes, and the entire sorted traversal is repeated twice. Neither repeat is a bridge
+> retry. Scoring/orientation/height use the distinct `House+0x5750` BasePlan center; zero
+> fallback and Naval origin prefer alternate `+0x5494` then primary `+0x5490`. The Naval
+> branch bypasses the vector, requires FNPC's candidate-forward/probe-structural `+4`
+> projection, and caps output with `AINavalYardAdjacency`.
+
+In `WALL_PLACEMENT_AND_PROTECTWITHWALL_GHIDRA_REPORT.md`, replace `BuildingType+0x55E`
+with:
+
+> The raw address is `BuildingTypeClass+0x1578` (`WantsExtraSpace`). The decompiler rendered
+> it as `param_3[0x55e]` because `param_3` was typed `int*`; `0x55e * 4 == 0x1578`.
+
+## 14. Ghidra annotation candidates (not applied)
+
+| Address | Candidate | Confidence/status |
+|---|---|---|
+| `0x005060B0` | rename `FUN_005060B0` to `HouseClass__SelectBasePlacementCell` and type the ABI above | high; receiver and both active roles proven; worker-report-only |
+| `0x00505F80` | create/function-label `HouseClass__ScoreBasePerimeterChebyshev` | high boundary/role; function creation requires separate authorized metadata pass |
+| `0x00505FD0` | rename `FUN_00505FD0` to `HouseClass__ScoreBasePerimeterThreatAngle` | high; formula and caller proven |
+| `0x005108F0` | create/function-label `BasePlacementScoreComparator` | high boundary/role; callback body ends at `0x00510911` |
+| `0x00A8EF78` / `0x00A8EFA8` | label `g_BasePlacementStartOffsets` / `g_BasePlacementStepOffsets` | high literal initialization; no mutation authorized |
+
+No Ghidra metadata was changed.
+
+## Sources inspected
+
+Primary live binary evidence:
+
+- `FUN_005060B0 @ 0x005060B0`
+- callback body `0x00505F80..0x00505FBF`
+- `FUN_00505FD0 @ 0x00505FD0`
+- comparator `0x005108F0..0x00510911`
+- qsort `FUN_007C8B48`, small-partition sort `FUN_007C8C9C`, byte swap `FUN_007C8CEA`
+- `BuildingClass__ExitObject_Main @ 0x00443C60`
+- `HouseClass__AI_ChooseNextProduction @ 0x00506EF0`
+- `HouseClass__AI_Choose_Building @ 0x004FE3E0`
+- `HouseClass__FirstBuildableFromArray @ 0x005051E0`
+- `HouseClass__RecenterBase @ 0x0050C210`
+- `HouseClass__Set_Starting_Cell @ 0x0050E000`
+- alternate-cell setter/clearer `FUN_0050DFE0` / `FUN_0050DFF0`
+- trigger action bodies `FUN_006E44E0` / `FUN_006E4540`
+- `HouseClass__HasBaseReservationNearBuilding @ 0x0050B760`
+- `BuildingTypeClass__CanPlaceAt @ 0x00464AC0`
+- `TechnoTypeClass__CanPlaceAt @ 0x00716150`
+- `MapCoord_Add @ 0x0042D510`
+- `FootClass__Find_Nearby_Passable_Cell @ 0x0056DC20`
+- FNPC projection helper `FUN_006D6410 @ 0x006D6410`
+
+Repository/data evidence:
+
+- `docs/research/PHASE3_CELLCLASS_0XDC_ACTIVE_WRITER_CLEARER_LIFECYCLE_GHIDRA_REPORT.md`
+- `docs/research/PHASE3_HOUSECLASS_ORDINARY_BASE_PLACEMENT_005060B0_GHIDRA_REPORT.md`
+- `docs/research/CELLCLASS_0XDC_RESERVATION_LIFECYCLE_GHIDRA_REPORT.md`
+- `docs/research/pathfinding/FIND_NEARBY_PASSABLE_CELL_CALLER_PARAMETER_MATRIX_GHIDRA_REPORT.md`
+- `docs/research/FIND_NEAREST_VARIANTS_SPIRAL_COMPARISON_GHIDRA_REPORT.md`
+- `docs/research/WALL_PLACEMENT_AND_PROTECTWITHWALL_GHIDRA_REPORT.md`
+- `ini/rulesmd.ini`, `ini/rules.ini`
+- exact `origin/main` sources at `eeb2515e361669e08c7570baeb57a90fe56cb68b`

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -428,6 +428,17 @@ pub struct SharedCellDummySnapshot {
     pub bridge_flags_0x1180: u32,
 }
 
+/// One `MapClass::Get_CellClass` result as consumed by FNPC's isometric
+/// projection helper.
+///
+/// Keeping the signed level and raw bridge subset in one value prevents callers
+/// from accidentally performing two dummy-stamping lookups for one native probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CellClassProjectionView {
+    pub signed_level: i32,
+    pub raw_flags_0x1180: u32,
+}
+
 const UNALLOCATED_REAL_CELL_BRIDGE_FLAGS: u16 = u16::MAX;
 
 /// Serialized value authority for the exact `CellClass+0x140 & 0x1180`
@@ -1209,9 +1220,13 @@ impl ResolvedTerrainGrid {
         true
     }
 
-    /// Stamping lookup view for later CellClass flag consumers such as FNPC.
-    /// A miss updates the dummy coordinate before exposing its live `0x1180`.
-    pub(crate) fn cellclass_bridge_flags_0x1180(&self, x: i32, y: i32) -> u32 {
+    /// One stamping lookup for FNPC's level-plus-flags projection probe.
+    ///
+    /// Native `MapClass::Get_CellClass @ 0x005657A0` returns one real CellClass
+    /// or stamps `+0x24` on the process-global dummy before returning that same
+    /// live object (`0x005657C8..0x005657D5`). `FUN_006D6410` then reads signed
+    /// level `+0x11B` and, conditionally, flags `+0x140` from that one result.
+    pub(crate) fn cellclass_projection_view(&self, x: i32, y: i32) -> CellClassProjectionView {
         let (x, y) = crate::map::cell_index::packed_cell_coord(x, y);
         if let Some(index) = native_resolved_cell_index(
             self.width,
@@ -1221,10 +1236,24 @@ impl ResolvedTerrainGrid {
             x,
             y,
         ) {
-            return self.cells[index].bridge_facts.raw_flags & MODELED_CELLCLASS_BRIDGE_FLAG_MASK;
+            let cell = &self.cells[index];
+            return CellClassProjectionView {
+                signed_level: i32::from(cell.level as i8),
+                raw_flags_0x1180: cell.bridge_facts.raw_flags & MODELED_CELLCLASS_BRIDGE_FLAG_MASK,
+            };
         }
         self.shared_cell_dummy.stamp_coord(x, y);
-        self.shared_cell_dummy.bridge_flags_0x1180()
+        let dummy = self.shared_cell_dummy.snapshot();
+        CellClassProjectionView {
+            signed_level: i32::from(dummy.level),
+            raw_flags_0x1180: dummy.bridge_flags_0x1180,
+        }
+    }
+
+    /// Stamping lookup view for later CellClass flag-only consumers.
+    /// A miss updates the dummy coordinate before exposing its live `0x1180`.
+    pub(crate) fn cellclass_bridge_flags_0x1180(&self, x: i32, y: i32) -> u32 {
+        self.cellclass_projection_view(x, y).raw_flags_0x1180
     }
 
     pub(crate) fn dummy_cell_level_slope(&self) -> (i8, u8) {

--- a/src/sim/find_nearby_cell.rs
+++ b/src/sim/find_nearby_cell.rs
@@ -4,10 +4,10 @@
 //! NOT a Manhattan diamond (see `ring_cells`); per-candidate passability (plus an
 //! optional occupancy check that always SKIPS reservations); frame-counter
 //! selection when no target cell is given, nearest-distance selection when a
-//! target is given. This is a read-only projection over the cell grids — it
-//! mutates nothing and consumes no RNG stream, so threading it changes no hashed
-//! state by itself. Depends only on `sim/` grids + `rules/` data; never on
-//! render/ui/sidebar/audio/net.
+//! target is given. It consumes no RNG stream. Exact CellClass projection misses
+//! do stamp the process-shared dummy coordinate, so lookup order is deterministic,
+//! future-affecting state; no other grid state is changed. Depends only on `map/`,
+//! `sim/`, and `rules/`; never on render/ui/sidebar/audio/net.
 //!
 //! Determinism contract:
 //! - The square-ring candidate ORDER is fully deterministic; it feeds both the
@@ -18,7 +18,7 @@
 //!   construction: two no-target calls on the same frame with the same candidate
 //!   count return the same index. Do NOT add any per-call perturbation.
 
-use crate::map::resolved_terrain::ResolvedTerrainGrid;
+use crate::map::resolved_terrain::{CellClassProjectionView, ResolvedTerrainGrid};
 use crate::rules::locomotor_type::{MovementZone, SpeedType};
 use crate::sim::cell_rect::{
     CellRect, CellRectOccupancyContext, CellRectPassabilityContext,
@@ -72,19 +72,15 @@ const MAX_SEED_LEVEL_DELTA_EXCLUSIVE: i16 = 2;
 /// arithmetic and what it actually admits are spelled out in [`candidate_height_ok`].
 const BRIDGE_LEVEL_RISE: i16 = 4;
 
-/// Diagonal steps south-east of a candidate that the direct/indirect occlusion test
-/// probes. The engine's projection ray starts a fixed `0x600` leptons — six cells at
-/// 256 leptons per cell — south-east of the candidate's own centre on BOTH axes, then
-/// walks back up-screen to it, so a cell seven or more diagonal steps away can never
-/// draw over the candidate. See [`is_direct_candidate`].
-const OCCLUSION_PROBE_CELLS: i32 = 6;
-/// Terrain levels of rise per diagonal step in the occlusion threshold `2q - 1`. One
-/// terrain level lifts a cell's rendered diamond up-screen by half a cell diagonal, so
-/// covering one more diagonal step of separation costs two levels of height.
-const OCCLUSION_RISE_PER_STEP: i16 = 2;
-/// Constant term of the occlusion threshold `2q - 1`: the immediate south-east
-/// neighbour (`q == 1`) needs only a single level of rise to occlude.
-const OCCLUSION_RISE_BIAS: i16 = -1;
+/// Candidate-cell origin plus centre (`0x80`) plus native's `0x600`-lepton
+/// south-east projection reach.
+const PROJECTION_START_LEPTONS: i32 = 0x680;
+/// Native walks the projection ray back toward the candidate by eight leptons
+/// before every CellClass lookup.
+const PROJECTION_STEP_LEPTONS: i32 = 8;
+/// One signed CellClass terrain level shifts both projected map axes by half a
+/// cell (`0x80` leptons).
+const PROJECTION_LEVEL_LEPTONS: i32 = 0x80;
 
 /// The subset of the passability config the search always supplies the same way for
 /// each candidate rectangle: `required_height_or_level = -1` (None) is fixed by the search.
@@ -179,14 +175,20 @@ pub struct NearbyQuery<'a> {
     pub playfield_bounds: Option<crate::sim::cell_rect::PlayfieldBounds>,
 }
 
-/// A surviving FNPC candidate, classified `direct` vs indirect by the engine's
-/// screen-occlusion test on the candidate's own south-east diagonal (see
-/// [`is_direct_candidate`]) — NOT a cardinal-axis test, and NOT an absolute-height
-/// test. Direct candidates are preferred at selection time.
+/// A surviving FNPC candidate. `direct` records only the ordinary collection-time
+/// projection used for per-ring early-stop; bridge-aware collection deliberately
+/// leaves it false, and final partition always projects again rather than reading it.
 #[derive(Debug, Clone, Copy)]
 struct Candidate {
     cell: (i32, i32),
     direct: bool,
+}
+
+/// The two native semantic call sites for `FUN_006D6410`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProjectionUse {
+    Collection,
+    FinalPartition,
 }
 
 /// Engine `Find_Nearby_Passable_Cell`.
@@ -211,7 +213,23 @@ pub fn find_nearby_passable_cell_with_options(
     options: NearbySearchOptions,
     frame_counter: u32,
 ) -> Option<(u16, u16)> {
-    let candidates = collect_candidates(seed, q, options);
+    let mut project = |_site: ProjectionUse, cx: i32, cy: i32| is_direct_candidate(q, cx, cy);
+    find_nearby_passable_cell_with_projection(seed, q, options, frame_counter, &mut project)
+}
+
+/// Internal seam that keeps projection ownership observable in focused tests.
+/// Production always supplies [`is_direct_candidate`].
+fn find_nearby_passable_cell_with_projection<F>(
+    seed: (i32, i32),
+    q: &NearbyQuery<'_>,
+    options: NearbySearchOptions,
+    frame_counter: u32,
+    project: &mut F,
+) -> Option<(u16, u16)>
+where
+    F: FnMut(ProjectionUse, i32, i32) -> bool,
+{
+    let candidates = collect_candidates_with_projection(seed, q, options, project);
     if candidates.is_empty() {
         return None;
     }
@@ -221,7 +239,11 @@ pub fn find_nearby_passable_cell_with_options(
     let mut direct_pool: Vec<&Candidate> = Vec::new();
     let mut indirect_pool: Vec<&Candidate> = Vec::new();
     for candidate in &candidates {
-        if is_direct_candidate(q, candidate.cell.0, candidate.cell.1) {
+        if project(
+            ProjectionUse::FinalPartition,
+            candidate.cell.0,
+            candidate.cell.1,
+        ) {
             direct_pool.push(candidate);
         } else {
             indirect_pool.push(candidate);
@@ -277,13 +299,26 @@ pub fn find_nearby_passable_cell_with_options(
 /// Arming the early-out is ASYMMETRIC with the pool split: in the bridge-aware zone the
 /// engine skips the occlusion projection entirely, so *any* accepted candidate arms the
 /// early-out there, while selection still re-runs the projection on every stored
-/// candidate to split the pools. That is why the flag and the stored classification are
-/// computed separately below.
+/// candidate to split the pools. That is why bridge-aware collection stores no
+/// projection result below.
 fn collect_candidates(
     seed: (i32, i32),
     q: &NearbyQuery<'_>,
     options: NearbySearchOptions,
 ) -> Vec<Candidate> {
+    let mut project = |_site: ProjectionUse, cx: i32, cy: i32| is_direct_candidate(q, cx, cy);
+    collect_candidates_with_projection(seed, q, options, &mut project)
+}
+
+fn collect_candidates_with_projection<F>(
+    seed: (i32, i32),
+    q: &NearbyQuery<'_>,
+    options: NearbySearchOptions,
+    project: &mut F,
+) -> Vec<Candidate>
+where
+    F: FnMut(ProjectionUse, i32, i32) -> bool,
+{
     let mut out: Vec<Candidate> = Vec::new();
     let cap = q.radius_cap.min(RADIUS_HARD_CAP) as i32;
     let mut direct_found = false;
@@ -296,9 +331,14 @@ fn collect_candidates(
             if !candidate_passes(q, options, seed_level, cx, cy) {
                 continue;
             }
-            let direct = is_direct_candidate(q, cx, cy);
-            // Bridge-aware searches skip the projection, so any accept arms the
-            // early-out; `direct` still carries the projection for the pool split.
+            // gamemd-derived: FNPC's bridge-aware collection branch skips
+            // `FUN_006D6410` entirely; final partition below is a separate call
+            // site and still projects every stored candidate.
+            let direct = if q.passability.bridge_aware_zone {
+                false
+            } else {
+                project(ProjectionUse::Collection, cx, cy)
+            };
             direct_found |= q.passability.bridge_aware_zone || direct;
             out.push(Candidate {
                 cell: (cx, cy),
@@ -349,73 +389,95 @@ fn ring_cells(seed: (i32, i32), r: i32) -> Vec<(i32, i32)> {
     cells
 }
 
-/// Engine "direct" classification — a screen-occlusion test on the candidate's own
-/// south-east diagonal, measured RELATIVE to the candidate's own terrain level.
+/// Engine "direct" classification — exact `FUN_006D6410` returned-cell test.
 ///
-/// The engine projects the candidate's lepton centre down the isometric height ray: it
-/// starts [`OCCLUSION_PROBE_CELLS`] cells south-east of that centre and walks back
-/// up-screen toward it in small steps, asking at each cell whether that cell's
-/// *rendered* diamond — its own diamond lifted up-screen by half a cell diagonal per
-/// terrain level — already covers the candidate's centre. The candidate is DIRECT when
-/// the walk resolves back to the candidate's own cell, i.e. when nothing south-east of
-/// it draws over it.
+/// The native helper performs two independent candidate CellClass lookups, then
+/// starts at candidate centre plus `0x600` leptons south-east and subtracts eight
+/// leptons before every probe. This produces repeated far-to-near CellClass reads;
+/// their lookup order and shared-dummy stamps are future-affecting behavior, not a
+/// threshold-table optimization opportunity.
 ///
-/// Why the south-east diagonal specifically: cell `+X` renders down-right and `+Y`
-/// down-left, so `+X +Y` is straight DOWN the screen. A cell south-east of the
-/// candidate is drawn in FRONT of it, and its height lifts it up-screen across the
-/// candidate. A cliff due east or due south is a different screen direction and does
-/// not occlude, so only the exact diagonal is probed.
-///
-/// The two axes carry identical offsets, so the ray arithmetic collapses to one scalar
-/// and yields a fixed threshold table — the minimum rise at diagonal step `q` that
-/// makes the candidate INDIRECT:
-///
-/// | step `q`      | 1  | 2  | 3  | 4  | 5  | 6   | 7+          |
-/// |---------------|----|----|----|----|----|-----|-------------|
-/// | rise to occlude | +1 | +3 | +5 | +7 | +9 | +11 | never probed |
-///
-/// which is `OCCLUSION_RISE_PER_STEP * q + OCCLUSION_RISE_BIAS`.
-///
-/// Being relative rather than absolute is the whole point: on a uniformly raised
-/// plateau every difference is 0, so every cell is direct exactly as at level 0, and a
-/// candidate at level 7 under a level-7 neighbour is direct while the same candidate
-/// under a level-8 neighbour is not. Off-grid probes read level 0, matching the engine's
-/// out-of-range cell lookup, which returns a shared zeroed cell rather than failing.
-///
-/// A candidate's structural `0x100` bridge bit alone plays no part here. Its distinct
-/// forward-side `0x1000` bit gates a four-level addition for each projected probe that
-/// carries structural `0x100`; without candidate `0x1000`, probe bridge bits are ignored.
-// gamemd-derived: `FUN_006D6410 @ 0x006D6410`; candidate `CellClass+0x140 & 0x1000`
-// gates probe `CellClass+0x140 & 0x100` times four at `0x006D6473..0x006D6513`.
+/// Candidate `CellClass+0x140 & 0x1000` gates a four-level addition when the same
+/// probe view carries `CellClass+0x140 & 0x100`. The probe level is signed. Native
+/// tests the projected axes before testing whether the current probe cell reached
+/// the candidate; the returned cell is direct exactly when it equals the candidate.
+// gamemd-derived: `FUN_006D6410 @ 0x006D6410`; candidate conversions/lookups
+// `0x006D641B..0x006D648E`, far-to-near 8-lepton probe loop and signed level/flag
+// correction `0x006D64B1..0x006D6513`, return decisions `0x006D6516..0x006D6588`.
 fn is_direct_candidate(q: &NearbyQuery<'_>, cx: i32, cy: i32) -> bool {
-    let base_level = cell_level(q, cx, cy);
-    let candidate_is_forward_side =
-        cell_bridge_flags(q, cx, cy) & crate::map::bridge_facts::BRIDGE_FLAG_FORWARD_SIDE != 0;
-    for step in 1..=OCCLUSION_PROBE_CELLS {
-        let probe_x = cx + step;
-        let probe_y = cy + step;
-        let probe_is_structural = candidate_is_forward_side
-            && cell_bridge_flags(q, probe_x, probe_y)
-                & crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL
-                != 0;
-        let probe_level = cell_level(q, probe_x, probe_y)
-            + if probe_is_structural {
-                BRIDGE_LEVEL_RISE
-            } else {
-                0
-            };
-        let rise = probe_level.saturating_sub(base_level);
-        let rise_that_occludes = OCCLUSION_RISE_PER_STEP * step as i16 + OCCLUSION_RISE_BIAS;
-        if rise >= rise_that_occludes {
-            return false;
-        }
-    }
-    true
+    let candidate = crate::map::cell_index::packed_cell_coord(cx, cy);
+    project_candidate(q, candidate.0, candidate.1) == candidate
 }
 
-fn cell_bridge_flags(q: &NearbyQuery<'_>, cx: i32, cy: i32) -> u32 {
-    q.resolved_terrain
-        .map_or(0, |terrain| terrain.cellclass_bridge_flags_0x1180(cx, cy))
+fn project_candidate(q: &NearbyQuery<'_>, cx: i32, cy: i32) -> (i32, i32) {
+    project_candidate_with_lookup(cx, cy, |x, y| projection_cell_view(q, x, y))
+}
+
+fn projection_cell_view(q: &NearbyQuery<'_>, cx: i32, cy: i32) -> CellClassProjectionView {
+    q.resolved_terrain.map_or_else(
+        || CellClassProjectionView {
+            // Compatibility-only callers without MapClass authority retain the
+            // existing path-grid level facade and have no dummy/flag state to read.
+            signed_level: i32::from(cell_level(q, cx, cy)),
+            raw_flags_0x1180: 0,
+        },
+        |terrain| terrain.cellclass_projection_view(cx, cy),
+    )
+}
+
+/// Instruction-faithful projection kernel. The lookup closure represents one
+/// native `MapClass::Get_CellClass` call and must return level and flags together.
+fn project_candidate_with_lookup<F>(cx: i32, cy: i32, mut lookup: F) -> (i32, i32)
+where
+    F: FnMut(i32, i32) -> CellClassProjectionView,
+{
+    let (cx, cy) = crate::map::cell_index::packed_cell_coord(cx, cy);
+
+    // Native looks up the candidate twice: first for +0x140, then for signed
+    // +0x11B. Do not merge these calls; misses stamp the shared dummy twice.
+    let candidate_is_forward_side =
+        lookup(cx, cy).raw_flags_0x1180 & crate::map::bridge_facts::BRIDGE_FLAG_FORWARD_SIDE != 0;
+    let candidate_level = lookup(cx, cy).signed_level;
+
+    let mut probe_world_x = cx
+        .wrapping_mul(crate::util::lepton::LEPTONS_PER_CELL_I32)
+        .wrapping_add(PROJECTION_START_LEPTONS);
+    let mut probe_world_y = cy
+        .wrapping_mul(crate::util::lepton::LEPTONS_PER_CELL_I32)
+        .wrapping_add(PROJECTION_START_LEPTONS);
+
+    loop {
+        probe_world_x = probe_world_x.wrapping_sub(PROJECTION_STEP_LEPTONS);
+        probe_world_y = probe_world_y.wrapping_sub(PROJECTION_STEP_LEPTONS);
+        let probe = (
+            native_lepton_to_cell(probe_world_x),
+            native_lepton_to_cell(probe_world_y),
+        );
+        let probe_view = lookup(probe.0, probe.1);
+        let mut level_delta = probe_view.signed_level.wrapping_sub(candidate_level);
+        if candidate_is_forward_side
+            && probe_view.raw_flags_0x1180 & crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL != 0
+        {
+            level_delta = level_delta.wrapping_add(i32::from(BRIDGE_LEVEL_RISE));
+        }
+
+        let projection_shift = level_delta.wrapping_mul(PROJECTION_LEVEL_LEPTONS);
+        let projected_x = native_lepton_to_cell(probe_world_x.wrapping_sub(projection_shift));
+        let projected_y = native_lepton_to_cell(probe_world_y.wrapping_sub(projection_shift));
+
+        if projected_x <= cx && projected_y <= cy {
+            return probe;
+        }
+        if probe == (cx, cy) {
+            return (cx, cy);
+        }
+    }
+}
+
+/// Native signed divide-by-256 conversion followed by packed-short truncation.
+fn native_lepton_to_cell(leptons: i32) -> i32 {
+    let adjusted = leptons.wrapping_add((leptons >> 31) & 0xff);
+    (adjusted >> 8) as i16 as i32
 }
 
 /// Run the per-candidate predicates in engine order: the independent height-aware
@@ -811,6 +873,134 @@ mod tests {
     }
 
     #[test]
+    fn find_nearby_projection_kernel_reads_candidate_then_repeated_far_to_near_cells() {
+        let mut transcript = Vec::new();
+        let returned = project_candidate_with_lookup(5, 5, |x, y| {
+            transcript.push((x, y));
+            CellClassProjectionView {
+                signed_level: 0,
+                raw_flags_0x1180: 0,
+            }
+        });
+
+        let mut expected = vec![(5, 5), (5, 5)];
+        expected.extend(std::iter::repeat_n((11, 11), 16));
+        for cell in [(10, 10), (9, 9), (8, 8), (7, 7), (6, 6)] {
+            expected.extend(std::iter::repeat_n(cell, 32));
+        }
+        expected.push((5, 5));
+
+        assert_eq!(returned, (5, 5));
+        assert_eq!(transcript, expected);
+        assert_eq!(transcript.len(), 179, "two candidate reads plus 177 probes");
+    }
+
+    #[test]
+    fn find_nearby_sparse_edge_uses_one_live_dummy_view_for_level_and_flags() {
+        let mut terrain = flat_terrain(3, 3);
+        terrain.cells[1 * 3 + 1].bridge_facts.raw_flags = BRIDGE_FLAG_FORWARD_SIDE;
+        terrain.test_set_native_allocated_cells(&[(1, 1)]);
+        let dummy = terrain.shared_cell_dummy();
+        dummy.set_level_slope(-3, 0);
+        dummy.set_bridge_flags_0x1180(0);
+        let path_grid = PathGrid::from_resolved_terrain(&terrain);
+        let q = base_query(&terrain, &path_grid);
+
+        assert_eq!(
+            project_candidate(&q, 1, 1),
+            (1, 1),
+            "negative dummy level alone leaves the candidate direct"
+        );
+
+        dummy.set_bridge_flags_0x1180(BRIDGE_FLAG_STRUCTURAL);
+        assert_eq!(
+            project_candidate(&q, 1, 1),
+            (2, 2),
+            "the same dummy lookup contributes -3 + 4 and returns the probe"
+        );
+        assert!(!is_direct_candidate(&q, 1, 1));
+        let snapshot = dummy.snapshot();
+        assert_eq!(snapshot.coord, (2, 2));
+        assert_eq!(snapshot.level, -3);
+        assert_eq!(snapshot.bridge_flags_0x1180, BRIDGE_FLAG_STRUCTURAL);
+    }
+
+    #[test]
+    fn find_nearby_collection_and_final_partition_project_separately_in_order() {
+        let terrain = flat_terrain(3, 3);
+        let path_grid = PathGrid::from_resolved_terrain(&terrain);
+        let mut q = base_query(&terrain, &path_grid);
+        q.radius_cap = 1;
+        let mut events = Vec::new();
+        let mut project = |site, x, y| {
+            events.push((site, (x, y)));
+            matches!(site, ProjectionUse::FinalPartition)
+        };
+
+        assert_eq!(
+            find_nearby_passable_cell_with_projection(
+                (1, 1),
+                &q,
+                NearbySearchOptions::default(),
+                0,
+                &mut project,
+            ),
+            Some((1, 1))
+        );
+        assert_eq!(
+            events,
+            vec![
+                (ProjectionUse::Collection, (1, 1)),
+                (ProjectionUse::Collection, (1, 1)),
+                (ProjectionUse::FinalPartition, (1, 1)),
+                (ProjectionUse::FinalPartition, (1, 1)),
+            ]
+        );
+    }
+
+    #[test]
+    fn find_nearby_bridge_aware_collection_skips_projection_but_final_still_runs() {
+        let terrain = flat_terrain(3, 3);
+        let dummy = terrain.shared_cell_dummy();
+        dummy.stamp_coord(99, 99);
+        let path_grid = PathGrid::from_resolved_terrain(&terrain);
+        let mut q = base_query(&terrain, &path_grid);
+        q.radius_cap = 1;
+        q.passability.bridge_aware_zone = true;
+
+        let candidates = collect_candidates((1, 1), &q, NearbySearchOptions::default());
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(
+            dummy.snapshot().coord,
+            (99, 99),
+            "bridge-aware collection must perform no hidden dummy lookup"
+        );
+
+        let mut events = Vec::new();
+        let mut project = |site, x, y| {
+            events.push((site, (x, y)));
+            true
+        };
+        assert_eq!(
+            find_nearby_passable_cell_with_projection(
+                (1, 1),
+                &q,
+                NearbySearchOptions::default(),
+                0,
+                &mut project,
+            ),
+            Some((1, 1))
+        );
+        assert_eq!(
+            events,
+            vec![
+                (ProjectionUse::FinalPartition, (1, 1)),
+                (ProjectionUse::FinalPartition, (1, 1)),
+            ]
+        );
+    }
+
+    #[test]
     fn find_nearby_direct_threshold_is_two_levels_per_diagonal_step_minus_one() {
         // A cell `q` diagonal steps SOUTH-EAST of the candidate occludes it — making the
         // candidate INDIRECT — once it rises `2q - 1` levels above it. One level below
@@ -867,9 +1057,9 @@ mod tests {
         }
         assert!(direct_at(&downhill, (5, 5)));
 
-        // At the map's south-east corner every probe leaves the grid and reads level 0,
-        // matching the engine's out-of-range cell lookup (a shared zeroed cell, never
-        // null), so a raised corner cell is still direct.
+        // At the map's south-east corner every probe leaves the grid and reads the
+        // fixture's fresh shared dummy (level 0, never null), so a raised corner cell
+        // is still direct.
         let mut corner = flat_terrain(GRID as u16, GRID as u16);
         corner.cells[(GRID - 1) * GRID + (GRID - 1)].level = 3;
         assert!(direct_at(&corner, (GRID as i32 - 1, GRID as i32 - 1)));
@@ -1053,7 +1243,7 @@ mod tests {
         assert_eq!(armed.len(), 2, "ring 0 alone arms the early-out");
         assert!(
             armed.iter().all(|c| !c.direct),
-            "the stored classification still comes from the projection"
+            "bridge-aware collection stores no projection classification"
         );
     }
 
@@ -1247,11 +1437,10 @@ mod tests {
 
     #[test]
     fn find_nearby_selection_is_bit_identical_across_runs() {
-        // Determinism guard (the hash-neutral, pre-authority-flip portion of the
-        // parity harness): replaying the same FNPC query over the same grid yields a
-        // bit-identical sequence of chosen cells across a frame sweep. When T7 flips
-        // FNPC authority, this is the determinism property the replay/baseline harness
-        // builds on; landing it now keeps the search itself replay-safe.
+        // Determinism guard: replaying the same FNPC query over the same grid yields a
+        // bit-identical sequence of chosen cells across a frame sweep. Projection may
+        // deterministically stamp the shared dummy, so repeatability includes that
+        // ordered side effect rather than claiming the helper is hash-neutral.
         let terrain = flat_terrain(11, 11);
         let path_grid = PathGrid::from_resolved_terrain(&terrain);
         let q = base_query(&terrain, &path_grid);

--- a/src/sim/find_nearby_cell.rs
+++ b/src/sim/find_nearby_cell.rs
@@ -216,13 +216,24 @@ pub fn find_nearby_passable_cell_with_options(
         return None;
     }
 
+    // Native re-runs the projection while partitioning the stored candidates;
+    // collection-time classification only owns the per-ring early-out.
+    let mut direct_pool: Vec<&Candidate> = Vec::new();
+    let mut indirect_pool: Vec<&Candidate> = Vec::new();
+    for candidate in &candidates {
+        if is_direct_candidate(q, candidate.cell.0, candidate.cell.1) {
+            direct_pool.push(candidate);
+        } else {
+            indirect_pool.push(candidate);
+        }
+    }
     // Direct candidates are preferred; only fall back to indirects when there are
     // no directs at all.
-    let has_direct = candidates.iter().any(|c| c.direct);
-    let pool: Vec<&Candidate> = candidates
-        .iter()
-        .filter(|c| c.direct == has_direct)
-        .collect();
+    let pool = if direct_pool.is_empty() {
+        indirect_pool
+    } else {
+        direct_pool
+    };
     if pool.is_empty() {
         return None;
     }
@@ -371,27 +382,40 @@ fn ring_cells(seed: (i32, i32), r: i32) -> Vec<(i32, i32)> {
 /// under a level-8 neighbour is not. Off-grid probes read level 0, matching the engine's
 /// out-of-range cell lookup, which returns a shared zeroed cell rather than failing.
 ///
-/// The candidate's own bridge bit deliberately plays NO part here — it belongs to the
-/// caller's height gate ([`candidate_height_ok`]) and to the bridge filter, and folding
-/// it in was what made this port call every bridge cell indirect.
-///
-/// VERA-internal, gamemd equivalent UNCHECKED: the engine adds four levels to a *probe*
-/// cell that carries a bridge, but only when the candidate cell carries a second,
-/// unidentified cell flag. That flag's writer was not found, so the correction is
-/// omitted rather than invented. Direction of the residual: gamemd classifies slightly
-/// MORE cells indirect than we do near a bridge deck. Trigger: a candidate within six
-/// diagonal steps north-west of a bridge deck that also carries the unidentified flag;
-/// free-unit placement rejects bridge cells outright, so it is unreachable there.
+/// A candidate's structural `0x100` bridge bit alone plays no part here. Its distinct
+/// forward-side `0x1000` bit gates a four-level addition for each projected probe that
+/// carries structural `0x100`; without candidate `0x1000`, probe bridge bits are ignored.
+// gamemd-derived: `FUN_006D6410 @ 0x006D6410`; candidate `CellClass+0x140 & 0x1000`
+// gates probe `CellClass+0x140 & 0x100` times four at `0x006D6473..0x006D6513`.
 fn is_direct_candidate(q: &NearbyQuery<'_>, cx: i32, cy: i32) -> bool {
     let base_level = cell_level(q, cx, cy);
+    let candidate_is_forward_side =
+        cell_bridge_flags(q, cx, cy) & crate::map::bridge_facts::BRIDGE_FLAG_FORWARD_SIDE != 0;
     for step in 1..=OCCLUSION_PROBE_CELLS {
-        let rise = cell_level(q, cx + step, cy + step).saturating_sub(base_level);
+        let probe_x = cx + step;
+        let probe_y = cy + step;
+        let probe_is_structural = candidate_is_forward_side
+            && cell_bridge_flags(q, probe_x, probe_y)
+                & crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL
+                != 0;
+        let probe_level = cell_level(q, probe_x, probe_y)
+            + if probe_is_structural {
+                BRIDGE_LEVEL_RISE
+            } else {
+                0
+            };
+        let rise = probe_level.saturating_sub(base_level);
         let rise_that_occludes = OCCLUSION_RISE_PER_STEP * step as i16 + OCCLUSION_RISE_BIAS;
         if rise >= rise_that_occludes {
             return false;
         }
     }
     true
+}
+
+fn cell_bridge_flags(q: &NearbyQuery<'_>, cx: i32, cy: i32) -> u32 {
+    q.resolved_terrain
+        .map_or(0, |terrain| terrain.cellclass_bridge_flags_0x1180(cx, cy))
 }
 
 /// Run the per-candidate predicates in engine order: the independent height-aware
@@ -553,7 +577,9 @@ fn cell_to_u16(cell: (i32, i32)) -> Option<(u16, u16)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::map::bridge_facts::{BRIDGE_FLAG_STRUCTURAL, BridgeCellFacts};
+    use crate::map::bridge_facts::{
+        BRIDGE_FLAG_FORWARD_SIDE, BRIDGE_FLAG_STRUCTURAL, BridgeCellFacts,
+    };
     use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid, zone_class};
     use crate::rules::terrain_rules::{SpeedCostProfile, TerrainClass};
 
@@ -857,6 +883,114 @@ mod tests {
         let mut terrain = flat_terrain(20, 20);
         terrain.cells[5 * 20 + 5].bridge_facts.raw_flags = BRIDGE_FLAG_STRUCTURAL;
         assert!(direct_at(&terrain, (5, 5)));
+    }
+
+    #[test]
+    fn find_nearby_bridge_projection_adds_exactly_four_probe_levels() {
+        const GRID: usize = 20;
+        let mut terrain = flat_terrain(GRID as u16, GRID as u16);
+        terrain.cells[5 * GRID + 5].bridge_facts.raw_flags = BRIDGE_FLAG_FORWARD_SIDE;
+        terrain.cells[8 * GRID + 8].bridge_facts.raw_flags = BRIDGE_FLAG_STRUCTURAL;
+
+        assert!(
+            direct_at(&terrain, (5, 5)),
+            "step-three threshold is five, so a structural probe's +4 remains direct"
+        );
+        terrain.cells[8 * GRID + 8].level = 1;
+        assert!(
+            !direct_at(&terrain, (5, 5)),
+            "the same +1 probe becomes +5 only after the exact four-level correction"
+        );
+    }
+
+    #[test]
+    fn find_nearby_bridge_projection_ignores_structural_probe_without_forward_candidate() {
+        const GRID: usize = 20;
+        let mut terrain = flat_terrain(GRID as u16, GRID as u16);
+        terrain.cells[8 * GRID + 8].level = 1;
+        terrain.cells[8 * GRID + 8].bridge_facts.raw_flags = BRIDGE_FLAG_STRUCTURAL;
+
+        assert!(
+            direct_at(&terrain, (5, 5)),
+            "probe structural bit is ignored while candidate 0x1000 is clear"
+        );
+        terrain.cells[5 * GRID + 5].bridge_facts.raw_flags = BRIDGE_FLAG_FORWARD_SIDE;
+        assert!(
+            !direct_at(&terrain, (5, 5)),
+            "the same probe contributes four only after candidate 0x1000 is set"
+        );
+    }
+
+    #[test]
+    fn find_nearby_bridge_projection_changes_collection_stop_and_frame_pool_exactly() {
+        const GRID: usize = 20;
+        let seed = (5, 5);
+
+        let baseline = flat_terrain(GRID as u16, GRID as u16);
+        let baseline_path = PathGrid::from_resolved_terrain(&baseline);
+        let mut baseline_query = base_query(&baseline, &baseline_path);
+        baseline_query.radius_cap = 2;
+        let baseline_candidates =
+            collect_candidates(seed, &baseline_query, NearbySearchOptions::default());
+        assert_eq!(baseline_candidates.len(), 2);
+        assert!(baseline_candidates.iter().all(|candidate| candidate.direct));
+        assert_eq!(
+            find_nearby_passable_cell(seed, &baseline_query, 0),
+            Some((5, 5))
+        );
+        assert_eq!(
+            find_nearby_passable_cell(seed, &baseline_query, 1),
+            Some((5, 5))
+        );
+
+        let mut projected = flat_terrain(GRID as u16, GRID as u16);
+        let projected_path = PathGrid::from_resolved_terrain(&projected);
+        projected.cells[5 * GRID + 5].bridge_facts.raw_flags = BRIDGE_FLAG_FORWARD_SIDE;
+        projected.cells[6 * GRID + 6].bridge_facts.raw_flags = BRIDGE_FLAG_STRUCTURAL;
+        let mut projected_query = base_query(&projected, &projected_path);
+        projected_query.radius_cap = 2;
+
+        let projected_candidates =
+            collect_candidates(seed, &projected_query, NearbySearchOptions::default());
+        assert_eq!(
+            projected_candidates.len(),
+            10,
+            "two indirect radius-zero entries defer early-stop through ring one"
+        );
+        assert!(
+            projected_candidates[..2]
+                .iter()
+                .all(|candidate| !candidate.direct)
+        );
+        assert!(
+            projected_candidates[2..]
+                .iter()
+                .all(|candidate| candidate.direct)
+        );
+
+        let ring_one = ring_cells(seed, 1);
+        for (frame, expected) in ring_one.into_iter().enumerate() {
+            assert_eq!(
+                find_nearby_passable_cell(seed, &projected_query, frame as u32),
+                cell_to_u16(expected),
+                "frame modulo must walk the final direct pool in ring order"
+            );
+        }
+    }
+
+    #[test]
+    fn find_nearby_bridge_projection_leaves_nonbridge_callers_unchanged() {
+        let terrain = plateau_terrain(20, 20, 7);
+        let path_grid = PathGrid::from_resolved_terrain(&terrain);
+        let mut q = base_query(&terrain, &path_grid);
+        q.radius_cap = 2;
+
+        let candidates = collect_candidates((5, 5), &q, NearbySearchOptions::default());
+        assert_eq!(candidates.len(), 2);
+        assert!(candidates.iter().all(|candidate| candidate.direct));
+        for frame in 0..4 {
+            assert_eq!(find_nearby_passable_cell((5, 5), &q, frame), Some((5, 5)));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What this integrates

- replaces FNPC's approximate six-cell threshold with the verified FUN_006D6410 projection kernel
- preserves the exact two candidate reads and repeated far-to-near eight-lepton probe transcript
- applies the candidate-forward/probe-structural four-level correction with signed CellClass levels
- preserves ordinary collection, bridge-aware collection, fresh final partitioning, frame-modulo selection, and zero RNG
- routes misses through the existing process-shared CellClass dummy without adding snapshot or hash schema

## Scope

This is the isolated Phase 3 FNPC bridge-projection slice. It does not import naval placement, BasePlan, AI, crates, Temporal, Gattling, Explodes, or other later work.

## Validation

- fresh read-only critic: PASS, zero findings
- cargo test -p vera20k --lib find_nearby: 31 passed, 0 failed
- cargo test -p vera20k --lib gsi_04_03: 69 passed, 0 failed
- full cargo test -p vera20k --lib: 7634 passed, 0 failed, 76 ignored
- git range-diff: both source patches preserved exactly
- git diff --check: clean