### PR TITLE
Integrate Phase 3 alternate-base waypoint actions

### DIFF
--- a/docs/plans/2026-08-26-alternate-base-cell-waypoint-actions-design.md
+++ b/docs/plans/2026-08-26-alternate-base-cell-waypoint-actions-design.md
@@ -1,0 +1,103 @@
+# Alternate Base Cell And Waypoint Action Design
+
+**Scope:** Close the stock-retail waypoint-code and `HouseClass+0x5494` alternate-base-cell
+mechanism needed by Phase 3 base placement. This is a prerequisite, not closure of the naval or
+ordinary placement selector.
+
+## Evidence and required behavior
+
+- `TActionClass::Read @ 0x006DD5B0` sends action token 8 to `FUN_00763690` except for the
+  explicitly numeric parameter types 5, 9, and 11. The decoder examines at most two bytes,
+  accepts ASCII letter case through CRT `isalpha`/`toupper`, maps `A..Z` to `0..25`, and maps a
+  second letter as `26 * first + second + 26`. Thus `P=15`, `AA=26`, `NZ=389`, and `ZZ=701`.
+  A non-letter first byte yields `-1`; trailing bytes after the first two do not participate.
+  The `TActionClass` constructor first initializes the destination dword at `+0x44` to zero, and
+  `Read` calls the decoder only when `strtok` returns token 8. Therefore an absent or empty-at-end
+  token 8 retains waypoint index 0, while a present whitespace/non-letter token decodes to `-1`.
+- The existing Rust action-48/action-112 camera path reads token 8 as a decimal integer. That is
+  wrong for the native reader and must consume the same alphabetic decoder.
+- `TriggerTypeClass::Read` resolves trigger token 1 case-insensitively through
+  `HouseTypeClass__FindIndexOfName @ 0x005117D0`. In source registration order it checks each
+  HouseType's `Name=` alias (`+0x64`) before its registry ID (`+0x24`); `<none>` resolves to the
+  first registered HouseType. `TriggerClass::Spring @ 0x007265C0` then passes that canonical
+  HouseType self-index (`+0xB4`) to `HouseClass__Find_By_Country_Index @ 0x00502D30`. The latter
+  scans the global House array in registration order and returns the first House whose Type
+  index (`House->Type+0xB8`) matches. Rust must therefore canonicalize the trigger owner through
+  the source-ordered `RuleSet` country registry, then scan `ScenarioSession.house_order` and
+  compare canonical indices through `HouseState.country`; trigger text is not an arbitrary
+  entity-owner name, and the event owner is irrelevant.
+- `TriggerAction__Execute @ 0x006DD8B0` cases 137/138 call `FUN_006E44E0`/`FUN_006E4540` with that
+  House pointer. Action 137 returns without mutation for a null House or a waypoint whose packed
+  cell is the zero invalid sentinel; otherwise it writes only `House+0x5494`. Action 138 returns
+  without mutation for a null House; otherwise it restores packed zero through `FUN_0050DFF0`.
+- `ScenarioClass__Read_Waypoints @ 0x0068BDC0` owns exactly 702 entries, indices `0..=701`.
+  Missing/zero entries contain the same packed-zero invalid cell; nonzero entries use signed
+  `/1000` and `%1000`. The Rust map parser already retains all valid entries in this range.
+- `HouseClass` construction initializes `+0x5494` to packed `(0,0)`. The exhaustive retail census
+  found action 137 in `all01umd.map` (`P -> (93,106)`), `all03umd.map`
+  (`NZ -> (122,135)`), and `all07smd.map` (`AA -> (105,194)`), and no action 138 in the scanned
+  shipped corpus. Action 138 is nevertheless exact, trivial, and shares the same live dispatch,
+  so implementing its clearer avoids a custom-map residual.
+
+The primary/launch cell `HouseState::base_center` remains the distinct `House+0x5490` authority.
+The `House+0x5750` base-plan center and all of its writers remain a separately reviewed mechanism.
+
+## Ownership and data flow
+
+1. Add a single ASCII waypoint-token decoder beside map action parsing. Return `Option<u32>` as
+   the deterministic Rust translation of native `-1`; accept no numeric substitute. Preserve the
+   constructor/read distinction: absent or empty-at-end token 8 retains index 0, but a present
+   whitespace/non-letter token is invalid.
+2. Keep the complete parsed waypoint table in `SimResources`. It is immutable map input, just like
+   trigger definitions, and survives an in-scenario load through `SimRuntime::rebind_restored`.
+   It must not be duplicated into mutable `Simulation` state merely to serve one trigger action.
+3. Borrow that table through `TriggerInputs` into `TriggerRuntime::advance_at_frame` and action
+   dispatch. Camera actions emit the decoded index. Action 137 resolves the decoded index to a
+   valid map waypoint before it mutates a House.
+4. Add `HouseState::alternate_base_center: (u16,u16)`, default/constructor `(0,0)`. It is mutable,
+   future-affecting selector state and therefore participates in both snapshots and `state_hash`.
+   Bump the bincode snapshot version because adding a field changes every encoded `HouseState`.
+5. Resolve `MapTrigger.owner` through the bound `RuleSet` in country source order, testing each
+   `CountryRules.name` alias before that entry's registry ID and mapping `<none>` to index 0. Then
+   scan only `session.house_order` and select the first state whose `HouseState.country` maps to
+   that same canonical index. Missing rules, owner/type resolution, country, registered House,
+   decoded waypoint, or waypoint entry performs no write.
+
+## Explicit exclusions
+
+- Malformed action records and non-alphabetic token-8 values do not occur in the exhaustive retail
+  action census. Native can index before its waypoint array after a decoded `-1`; Rust must not
+  emulate adjacent host-memory reads. Treat the decoded sentinel as invalid/no mutation.
+- The fresh shipped-content census covered 310 maps and 21,374 action chunks: exactly three action
+  137 records and zero action 138 records. No shipped record depends on malformed interior-empty
+  `strtok` collapsing. Deterministic ASCII-only decoding is evidence-backed; do not add numeric
+  fallback, clamping, RNG use, event-owner resolution, or writes to `+0x5490`/`+0x5750`.
+- This slice does not make the incomplete trigger runtime globally exact, add unimplemented trigger
+  actions, change trigger scheduling, or reinterpret action return values. All three stock action-137
+  records have a valid resolved House and waypoint, so those unrelated trigger-runtime differences
+  are not prerequisites for this state writer.
+- Static waypoint data is not state-hashed here. The map identity/hash and bound-resource restore
+  contract already own immutable match inputs; only the mutable alternate cell joins lockstep state.
+
+## Acceptance tests
+
+- Decoder vectors: `A`, `Z`, `a`, `P`, `AA`, `aa`, `NZ`, `ZZ`, present first-byte nonletter,
+  present whitespace, a letter followed by a nonletter, and ignored third/trailing bytes. Action
+  reading separately proves absent and empty-at-end token 8 retain constructor index 0.
+- Existing camera actions 48/112 use alphabetic token 8 and produce the decoded index; numeric
+  token 8 no longer masquerades as a native waypoint.
+- Action 137 writes only the first registration-order House with matching canonical HouseType and
+  only for a present waypoint whose packed cell is exactly nonzero. Prove `Name=` alias and
+  `<none>` resolution (including duplicate-alias order), missing rules/owner/country/House, invalid
+  token, absent/exact-`(0,0)` waypoint, and a same-name/wrong-country House. `(0,y)` and `(x,0)`
+  remain valid. No exclusion may mutate either base cell.
+- Replay the three retail fixtures `P`, `NZ`, and `AA` to their exact cells.
+- Action 138 clears only the matching House's alternate cell and is a no-op for a null resolution.
+- Primary `base_center` remains unchanged across 137/138.
+- A snapshot round trip preserves a nonzero alternate cell; changing only the alternate cell changes
+  `state_hash`; the current snapshot version assertion reflects the layout bump.
+- `SimRuntime::rebind_restored` retains the full waypoint table.
+
+Focused validation is `cargo test -p vera20k --lib` with filters for map action parsing, trigger
+runtime, runtime resource rebinding, house hash, and snapshot tests. The phase-wide full `--lib`
+suite remains reserved for final Phase 3 certification.

--- a/docs/plans/2026-08-26-alternate-base-cell-waypoint-actions-design.md
+++ b/docs/plans/2026-08-26-alternate-base-cell-waypoint-actions-design.md
@@ -45,15 +45,20 @@ The `House+0x5750` base-plan center and all of its writers remain a separately r
 ## Ownership and data flow
 
 1. Add a single ASCII waypoint-token decoder beside map action parsing. Return `Option<u32>` as
-   the deterministic Rust translation of native `-1`; accept no numeric substitute. Preserve the
-   constructor/read distinction: absent or empty-at-end token 8 retains index 0, but a present
-   whitespace/non-letter token is invalid.
+   the deterministic Rust translation of native `-1`; accept no numeric substitute. Materialize
+   the resolved `TActionClass+0x44` value in each `ActionEntry` at this reader boundary rather than
+   retaining token 8 for runtime reinterpretation. Preserve the constructor/read distinction:
+   absent or empty-at-end token 8 retains index 0, parameter types 5/9/11 retain index 0 while
+   parsing token 8 into their other native fields, and a present whitespace/non-letter token is
+   invalid. A counted final action with token 8 absent remains that action with constructor zero;
+   it must not fall through as an uncounted action whose kind is the count field.
 2. Keep the complete parsed waypoint table in `SimResources`. It is immutable map input, just like
    trigger definitions, and survives an in-scenario load through `SimRuntime::rebind_restored`.
    It must not be duplicated into mutable `Simulation` state merely to serve one trigger action.
 3. Borrow that table through `TriggerInputs` into `TriggerRuntime::advance_at_frame` and action
-   dispatch. Camera actions emit the decoded index. Action 137 resolves the decoded index to a
-   valid map waypoint before it mutates a House.
+   dispatch. Camera actions emit the already materialized `ActionEntry` index. Action 137 resolves
+   that same reader-owned index to a valid map waypoint before it mutates a House; runtime dispatch
+   never re-decodes token text or guesses parameter-type semantics.
 4. Add `HouseState::alternate_base_center: (u16,u16)`, default/constructor `(0,0)`. It is mutable,
    future-affecting selector state and therefore participates in both snapshots and `state_hash`.
    Bump the bincode snapshot version because adding a field changes every encoded `HouseState`.
@@ -82,8 +87,9 @@ The `House+0x5750` base-plan center and all of its writers remain a separately r
 ## Acceptance tests
 
 - Decoder vectors: `A`, `Z`, `a`, `P`, `AA`, `aa`, `NZ`, `ZZ`, present first-byte nonletter,
-  present whitespace, a letter followed by a nonletter, and ignored third/trailing bytes. Action
-  reading separately proves absent and empty-at-end token 8 retain constructor index 0.
+  present whitespace, a letter followed by a nonletter, and ignored third/trailing bytes. End-to-end
+  action reading separately proves absent and empty-at-end token 8 and parameter types 5/9/11
+  retain constructor index 0, including a counted action whose final token is truly absent.
 - Existing camera actions 48/112 use alphabetic token 8 and produce the decoded index; numeric
   token 8 no longer masquerades as a native waypoint.
 - Action 137 writes only the first registration-order House with matching canonical HouseType and

--- a/docs/plans/2026-08-26-alternate-base-cell-waypoint-actions-design.md
+++ b/docs/plans/2026-08-26-alternate-base-cell-waypoint-actions-design.md
@@ -31,11 +31,13 @@ ordinary placement selector.
   cell is the zero invalid sentinel; otherwise it writes only `House+0x5494`. Action 138 returns
   without mutation for a null House; otherwise it restores packed zero through `FUN_0050DFF0`.
 - `ScenarioClass__Read_Waypoints @ 0x0068BDC0` owns exactly 702 entries, indices `0..=701`.
-  Each key is read through `CCINIClass__ReadInt(..., default 0)`, including native `$FF`/`FFh`,
-  leading-decimal `atoi`, junk-to-zero, and `i32` wrapping behavior. Missing/zero entries contain
-  the same packed-zero invalid cell; nonzero entries use signed `i32 / 1000` and `i32 % 1000`, then
-  store the quotient and remainder as raw wrapped 16-bit halves. Negative nonzero values are
-  therefore retained cells, not parse failures or zero.
+  The loop generates each canonical decimal key string (`"0"` through `"701"`) and reads that exact
+  key through `CCINIClass__ReadInt(..., default 0)`; authored aliases such as `001=` or `+1=` are
+  never queried. Values retain native `$FF`/`FFh`, leading-decimal `atoi`, junk-to-zero, and `i32`
+  wrapping behavior. Missing/zero entries contain the same packed-zero invalid cell; nonzero
+  entries use signed `i32 / 1000` and `i32 % 1000`, then store the quotient and remainder as raw
+  wrapped 16-bit halves. Negative nonzero values are therefore retained cells, not parse failures
+  or zero.
 - `HouseClass` construction initializes `+0x5494` to packed `(0,0)`. The exhaustive retail census
   found action 137 in `all01umd.map` (`P -> (93,106)`), `all03umd.map`
   (`NZ -> (122,135)`), and `all07smd.map` (`AA -> (105,194)`), and no action 138 in the scanned
@@ -57,9 +59,11 @@ The `House+0x5750` base-plan center and all of its writers remain a separately r
    it must not fall through as an uncounted action whose kind is the count field.
 2. Keep the complete parsed waypoint table in `SimResources`. It is immutable map input, just like
    trigger definitions, and survives an in-scenario load through `SimRuntime::rebind_restored`.
-   Read each source value through the existing `IniSection::get_i32` native integer authority with
-   zero default, skip exact zero, and cast the signed quotient/remainder to `u16` without clamping.
-   It must not be duplicated into mutable `Simulation` state merely to serve one trigger action.
+   Generate the canonical decimal key for every index, read it through the existing
+   `IniSection::get_i32` native integer authority with zero default, skip exact zero, and cast the
+   signed quotient/remainder to `u16` without clamping. Never enumerate and reinterpret authored
+   key spellings. The table must not be duplicated into mutable `Simulation` state merely to serve
+   one trigger action.
 3. Borrow that table through `TriggerInputs` into `TriggerRuntime::advance_at_frame` and action
    dispatch. Camera actions emit the already materialized `ActionEntry` index. Action 137 resolves
    that same reader-owned index to a valid map waypoint before it mutates a House; runtime dispatch
@@ -102,8 +106,9 @@ The `House+0x5750` base-plan center and all of its writers remain a separately r
   `<none>` resolution (including duplicate-alias order), missing rules/owner/country/House, invalid
   token, absent/exact-`(0,0)` waypoint, and a same-name/wrong-country House. `(0,y)` and `(x,0)`
   remain valid. Parser vectors cover negative quotient/remainder wrapping plus native hex,
-  leading-decimal, junk-default, and `i32` wrapping forms; an end-to-end negative nonzero waypoint
-  must write its raw wrapped halves through 137.
+  leading-decimal, junk-default, and `i32` wrapping forms, and reject padded/plus-sign key aliases
+  even when they collide with a canonical key; an end-to-end negative nonzero waypoint must write
+  its raw wrapped halves through 137.
   No exclusion may mutate either base cell.
 - Replay the three retail fixtures `P`, `NZ`, and `AA` to their exact cells.
 - Action 138 clears only the matching House's alternate cell and is a no-op for a null resolution.

--- a/docs/plans/2026-08-26-alternate-base-cell-waypoint-actions-design.md
+++ b/docs/plans/2026-08-26-alternate-base-cell-waypoint-actions-design.md
@@ -31,8 +31,11 @@ ordinary placement selector.
   cell is the zero invalid sentinel; otherwise it writes only `House+0x5494`. Action 138 returns
   without mutation for a null House; otherwise it restores packed zero through `FUN_0050DFF0`.
 - `ScenarioClass__Read_Waypoints @ 0x0068BDC0` owns exactly 702 entries, indices `0..=701`.
-  Missing/zero entries contain the same packed-zero invalid cell; nonzero entries use signed
-  `/1000` and `%1000`. The Rust map parser already retains all valid entries in this range.
+  Each key is read through `CCINIClass__ReadInt(..., default 0)`, including native `$FF`/`FFh`,
+  leading-decimal `atoi`, junk-to-zero, and `i32` wrapping behavior. Missing/zero entries contain
+  the same packed-zero invalid cell; nonzero entries use signed `i32 / 1000` and `i32 % 1000`, then
+  store the quotient and remainder as raw wrapped 16-bit halves. Negative nonzero values are
+  therefore retained cells, not parse failures or zero.
 - `HouseClass` construction initializes `+0x5494` to packed `(0,0)`. The exhaustive retail census
   found action 137 in `all01umd.map` (`P -> (93,106)`), `all03umd.map`
   (`NZ -> (122,135)`), and `all07smd.map` (`AA -> (105,194)`), and no action 138 in the scanned
@@ -54,6 +57,8 @@ The `House+0x5750` base-plan center and all of its writers remain a separately r
    it must not fall through as an uncounted action whose kind is the count field.
 2. Keep the complete parsed waypoint table in `SimResources`. It is immutable map input, just like
    trigger definitions, and survives an in-scenario load through `SimRuntime::rebind_restored`.
+   Read each source value through the existing `IniSection::get_i32` native integer authority with
+   zero default, skip exact zero, and cast the signed quotient/remainder to `u16` without clamping.
    It must not be duplicated into mutable `Simulation` state merely to serve one trigger action.
 3. Borrow that table through `TriggerInputs` into `TriggerRuntime::advance_at_frame` and action
    dispatch. Camera actions emit the already materialized `ActionEntry` index. Action 137 resolves
@@ -96,7 +101,10 @@ The `House+0x5750` base-plan center and all of its writers remain a separately r
   only for a present waypoint whose packed cell is exactly nonzero. Prove `Name=` alias and
   `<none>` resolution (including duplicate-alias order), missing rules/owner/country/House, invalid
   token, absent/exact-`(0,0)` waypoint, and a same-name/wrong-country House. `(0,y)` and `(x,0)`
-  remain valid. No exclusion may mutate either base cell.
+  remain valid. Parser vectors cover negative quotient/remainder wrapping plus native hex,
+  leading-decimal, junk-default, and `i32` wrapping forms; an end-to-end negative nonzero waypoint
+  must write its raw wrapped halves through 137.
+  No exclusion may mutate either base cell.
 - Replay the three retail fixtures `P`, `NZ`, and `AA` to their exact cells.
 - Action 138 clears only the matching House's alternate cell and is a no-op for a null resolution.
 - Primary `base_center` remains unchanged across 137/138.

--- a/docs/plans/2026-08-26-alternate-base-cell-waypoint-actions-design.md
+++ b/docs/plans/2026-08-26-alternate-base-cell-waypoint-actions-design.md
@@ -47,6 +47,27 @@ ordinary placement selector.
 The primary/launch cell `HouseState::base_center` remains the distinct `House+0x5490` authority.
 The `House+0x5750` base-plan center and all of its writers remain a separately reviewed mechanism.
 
+## Integration commit provenance
+
+The source commits were transplanted without rewriting their history. Their exact evidence binding is:
+
+- `f9970fa5` (`1d8cb7cb` in the source branch): `TActionClass::Read @ 0x006DD5B0`,
+  `FUN_00763690`, `HouseTypeClass__FindIndexOfName @ 0x005117D0`,
+  `HouseClass__Find_By_Country_Index @ 0x00502D30`, `TriggerClass::Spring @ 0x007265C0`,
+  `TriggerAction__Execute @ 0x006DD8B0` cases 137/138, `FUN_006E44E0`, `FUN_006E4540`, and
+  `ScenarioClass__Read_Waypoints @ 0x0068BDC0`.
+- `04f56ab1` (`033920e4` in the source branch): `TActionClass::Read @ 0x006DD5B0` and
+  `FUN_00763690` for the materialized `TActionClass+0x44` waypoint state.
+- `8250ff7e` (`c3189204` in the source branch):
+  `ScenarioClass__Read_Waypoints @ 0x0068BDC0` for signed division/remainder and raw
+  16-bit CellStruct halves.
+- `e081dc21` (`f8391bd0` in the source branch):
+  `ScenarioClass__Read_Waypoints @ 0x0068BDC0` for generated canonical decimal keys and
+  native integer reads.
+- `e1d52329`: `TriggerAction__Execute @ 0x006DD8B0` cases 137/138; this corrective commit
+  makes the complete scenario waypoint table an explicit dependency of the sole authoritative
+  action evaluator.
+
 ## Ownership and data flow
 
 1. Add a single ASCII waypoint-token decoder beside map action parsing. Return `Option<u32>` as

--- a/src/app/loading/transitions.rs
+++ b/src/app/loading/transitions.rs
@@ -138,6 +138,7 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
             triggers: result.scenario.triggers,
             events: result.scenario.events,
             actions: result.scenario.actions,
+            waypoints: result.scenario.waypoints.clone(),
         },
     });
     state.match_state.match_presentation.combat_lights.clear();

--- a/src/headless_scenario.rs
+++ b/src/headless_scenario.rs
@@ -353,6 +353,7 @@ pub fn load(retail_dir: &Path, map_file_name: &str, seed: u32) -> Result<Headles
                 triggers: Default::default(),
                 events: Default::default(),
                 actions: Default::default(),
+                waypoints: map.waypoints.clone(),
             },
         },
         map,

--- a/src/map/actions.rs
+++ b/src/map/actions.rs
@@ -12,6 +12,12 @@ use crate::rules::ini_parser::IniFile;
 pub struct ActionEntry {
     pub kind: i32,
     pub params: Vec<String>,
+    /// Materialized native `TActionClass+0x44` waypoint destination.
+    ///
+    /// `Some(0)` includes the constructor default retained by a missing token
+    /// and parameter types 5/9/11. `None` safely represents native `-1` from
+    /// a present non-alphabetic token.
+    pub waypoint_index: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -109,19 +115,28 @@ fn parse_action_entries(fields: &[String], raw_fields: &[&str]) -> Vec<ActionEnt
     if let Some(count) = declared_count {
         let payload = &fields[1..];
         let chunk_len = 8;
-        let max_chunks = payload.len() / chunk_len;
-        let chunk_count = count.min(max_chunks);
-        if chunk_count > 0 {
+        if count > 0
+            && payload
+                .first()
+                .is_some_and(|kind| kind.parse::<i32>().is_ok())
+        {
             let raw_payload = &raw_fields[1..];
             return payload
-                .chunks_exact(chunk_len)
-                .zip(raw_payload.chunks_exact(chunk_len))
-                .take(chunk_count)
+                .chunks(chunk_len)
+                .zip(raw_payload.chunks(chunk_len))
+                .take(count)
                 .filter_map(|(chunk, raw_chunk)| {
                     let kind = chunk[0].trim().parse::<i32>().ok()?;
-                    let mut params = chunk[1..].to_vec();
-                    params[6] = raw_chunk[7].to_string();
-                    Some(ActionEntry { kind, params })
+                    let params = chunk[1..].to_vec();
+                    let waypoint_index = materialize_waypoint_index(
+                        chunk.get(1).map(String::as_str),
+                        raw_chunk.get(7).copied(),
+                    );
+                    Some(ActionEntry {
+                        kind,
+                        params,
+                        waypoint_index,
+                    })
                 })
                 .collect();
         }
@@ -129,13 +144,30 @@ fn parse_action_entries(fields: &[String], raw_fields: &[&str]) -> Vec<ActionEnt
 
     let kind = fields[0].trim().parse::<i32>().ok();
     kind.map(|kind| {
-        let mut params = fields[1..].to_vec();
-        if let (Some(token), Some(slot)) = (raw_fields.get(7), params.get_mut(6)) {
-            *slot = (*token).to_string();
-        }
-        vec![ActionEntry { kind, params }]
+        let params = fields[1..].to_vec();
+        let waypoint_index = materialize_waypoint_index(
+            fields.get(1).map(String::as_str),
+            raw_fields.get(7).copied(),
+        );
+        vec![ActionEntry {
+            kind,
+            params,
+            waypoint_index,
+        }]
     })
     .unwrap_or_default()
+}
+
+fn materialize_waypoint_index(param_type: Option<&str>, token_8: Option<&str>) -> Option<u32> {
+    if matches!(
+        param_type.and_then(|value| value.trim().parse::<i32>().ok()),
+        Some(5 | 9 | 11)
+    ) {
+        // These parameter types parse token 8 numerically into other TAction
+        // fields and leave the constructor-initialized +0x44 untouched.
+        return Some(0);
+    }
+    read_waypoint_token(token_8)
 }
 
 #[cfg(test)]
@@ -184,6 +216,7 @@ mod tests {
                             "0".to_string(),
                             "0".to_string(),
                         ],
+                        waypoint_index: None,
                     },
                     ActionEntry {
                         kind: 112,
@@ -196,6 +229,7 @@ mod tests {
                             "0".to_string(),
                             "9".to_string(),
                         ],
+                        waypoint_index: None,
                     },
                 ],
             })
@@ -210,6 +244,7 @@ mod tests {
                 &[ActionEntry {
                     kind: 11,
                     params: vec!["Americans".to_string(), "5".to_string()],
+                    waypoint_index: Some(0),
                 }][..]
             )
         );
@@ -248,8 +283,27 @@ mod tests {
         assert_eq!(read_waypoint_token(Some("")), Some(0));
         assert_eq!(read_waypoint_token(Some("   ")), None);
 
-        let ini = IniFile::from_str("[Actions]\nEMPTY=1,137,0,0,0,0,0,0,\n");
+        let ini = IniFile::from_str(
+            "[Actions]\n\
+             EMPTY=1,137,0,0,0,0,0,0,\n\
+             MISSING=1,112,0,0,0,0,0,0\n\
+             ALPHA=2,48,0,0,0,0,0,0,NZ,112,0,0,0,0,0,0,7\n\
+             NUMERIC=3,48,5,0,0,0,0,0,P,112,9,0,0,0,0,0,NZ,137,11,0,0,0,0,0,AA\n",
+        );
         let actions = parse_actions(&ini);
-        assert_eq!(actions["EMPTY"].entries[0].params[6], "");
+        assert_eq!(actions["EMPTY"].entries[0].waypoint_index, Some(0));
+        assert_eq!(actions["MISSING"].entries[0].kind, 112);
+        assert_eq!(actions["MISSING"].entries[0].params.len(), 6);
+        assert_eq!(actions["MISSING"].entries[0].waypoint_index, Some(0));
+        assert_eq!(actions["ALPHA"].entries[0].waypoint_index, Some(389));
+        assert_eq!(actions["ALPHA"].entries[1].waypoint_index, None);
+        assert_eq!(
+            actions["NUMERIC"]
+                .entries
+                .iter()
+                .map(|entry| (entry.kind, entry.waypoint_index))
+                .collect::<Vec<_>>(),
+            vec![(48, Some(0)), (112, Some(0)), (137, Some(0))]
+        );
     }
 }

--- a/src/map/actions.rs
+++ b/src/map/actions.rs
@@ -23,6 +23,45 @@ pub struct MapAction {
 
 pub type ActionMap = HashMap<String, MapAction>;
 
+/// Decode the alphabetic waypoint token stored in action field 8.
+///
+/// gamemd-derived: `TActionClass::Read @ 0x006DD5B0` routes non-numeric
+/// parameter types through `FUN_00763690`. That helper examines at most two
+/// ASCII letters, case-insensitively: `A..Z` are `0..25`, and a second letter
+/// extends the index as `26 * first + second + 26`. A non-letter first byte is
+/// the native `-1` sentinel, represented safely as `None` here.
+pub fn decode_waypoint_token(token: &str) -> Option<u32> {
+    let bytes = token.as_bytes();
+    let first = ascii_waypoint_letter(*bytes.first()?)?;
+    let Some(&second_byte) = bytes.get(1) else {
+        return Some(first);
+    };
+    let Some(second) = ascii_waypoint_letter(second_byte) else {
+        return Some(first);
+    };
+    Some(26 * first + second + 26)
+}
+
+/// Apply the `TActionClass` constructor/read contract around the decoder.
+///
+/// The constructor initializes the destination to waypoint 0. `Read` replaces
+/// it only when `strtok` returns token 8, so an absent or empty-at-end token
+/// retains zero. A present whitespace/non-letter token does reach the decoder
+/// and is invalid.
+pub fn read_waypoint_token(token: Option<&str>) -> Option<u32> {
+    match token {
+        None | Some("") => Some(0),
+        Some(token) => decode_waypoint_token(token),
+    }
+}
+
+fn ascii_waypoint_letter(byte: u8) -> Option<u32> {
+    byte.to_ascii_uppercase()
+        .checked_sub(b'A')
+        .filter(|value| *value < 26)
+        .map(u32::from)
+}
+
 /// Parse `[Actions]` into an id -> action record map.
 pub fn parse_actions(ini: &IniFile) -> ActionMap {
     let Some(section) = ini.section("Actions") else {
@@ -39,11 +78,12 @@ pub fn parse_actions(ini: &IniFile) -> ActionMap {
             continue;
         }
         let id = id.to_ascii_uppercase();
-        let fields: Vec<String> = raw_value
-            .split(',')
+        let raw_fields: Vec<&str> = raw_value.split(',').collect();
+        let fields: Vec<String> = raw_fields
+            .iter()
             .map(|part| part.trim().to_string())
             .collect();
-        let entries = parse_action_entries(&fields);
+        let entries = parse_action_entries(&fields, &raw_fields);
         actions.insert(
             id.clone(),
             MapAction {
@@ -60,7 +100,7 @@ pub fn parse_actions(ini: &IniFile) -> ActionMap {
     actions
 }
 
-fn parse_action_entries(fields: &[String]) -> Vec<ActionEntry> {
+fn parse_action_entries(fields: &[String], raw_fields: &[&str]) -> Vec<ActionEntry> {
     if fields.is_empty() {
         return Vec::new();
     }
@@ -72,15 +112,16 @@ fn parse_action_entries(fields: &[String]) -> Vec<ActionEntry> {
         let max_chunks = payload.len() / chunk_len;
         let chunk_count = count.min(max_chunks);
         if chunk_count > 0 {
+            let raw_payload = &raw_fields[1..];
             return payload
                 .chunks_exact(chunk_len)
+                .zip(raw_payload.chunks_exact(chunk_len))
                 .take(chunk_count)
-                .filter_map(|chunk| {
+                .filter_map(|(chunk, raw_chunk)| {
                     let kind = chunk[0].trim().parse::<i32>().ok()?;
-                    Some(ActionEntry {
-                        kind,
-                        params: chunk[1..].to_vec(),
-                    })
+                    let mut params = chunk[1..].to_vec();
+                    params[6] = raw_chunk[7].to_string();
+                    Some(ActionEntry { kind, params })
                 })
                 .collect();
         }
@@ -88,10 +129,11 @@ fn parse_action_entries(fields: &[String]) -> Vec<ActionEntry> {
 
     let kind = fields[0].trim().parse::<i32>().ok();
     kind.map(|kind| {
-        vec![ActionEntry {
-            kind,
-            params: fields[1..].to_vec(),
-        }]
+        let mut params = fields[1..].to_vec();
+        if let (Some(token), Some(slot)) = (raw_fields.get(7), params.get_mut(6)) {
+            *slot = (*token).to_string();
+        }
+        vec![ActionEntry { kind, params }]
     })
     .unwrap_or_default()
 }
@@ -177,5 +219,37 @@ mod tests {
     fn test_missing_actions_is_empty() {
         let ini = IniFile::from_str("[Map]\nTheater=TEMPERATE\n");
         assert!(parse_actions(&ini).is_empty());
+    }
+
+    #[test]
+    fn waypoint_tokens_follow_the_native_two_letter_decoder() {
+        for (token, expected) in [
+            ("A", Some(0)),
+            ("Z", Some(25)),
+            ("a", Some(0)),
+            ("P", Some(15)),
+            ("AA", Some(26)),
+            ("aa", Some(26)),
+            ("NZ", Some(389)),
+            ("ZZ", Some(701)),
+            ("", None),
+            ("7", None),
+            ("   ", None),
+            ("A7", Some(0)),
+            ("NZignored", Some(389)),
+        ] {
+            assert_eq!(decode_waypoint_token(token), expected, "token {token:?}");
+        }
+    }
+
+    #[test]
+    fn action_read_preserves_ctor_zero_but_not_present_whitespace() {
+        assert_eq!(read_waypoint_token(None), Some(0));
+        assert_eq!(read_waypoint_token(Some("")), Some(0));
+        assert_eq!(read_waypoint_token(Some("   ")), None);
+
+        let ini = IniFile::from_str("[Actions]\nEMPTY=1,137,0,0,0,0,0,0,\n");
+        let actions = parse_actions(&ini);
+        assert_eq!(actions["EMPTY"].entries[0].params[6], "");
     }
 }

--- a/src/map/waypoints.rs
+++ b/src/map/waypoints.rs
@@ -57,14 +57,15 @@ const WAYPOINT_SLOT_COUNT: u32 = 0x2BE;
 ///
 /// The scenario reader applies this unconditionally — there is no
 /// `NewINIFormat` branch and no legacy 128-column packing on this path.
-const WAYPOINT_COORD_FACTOR: u32 = 1000;
+const WAYPOINT_COORD_FACTOR: i32 = 1000;
 
 /// Parse `[Waypoints]` into a waypoint index -> cell mapping.
 ///
 /// Mirrors the scenario waypoint reader: it walks the fixed slot range
 /// `0..701`, reads each key as an integer defaulting to zero, treats zero as
 /// "unset" rather than as cell `(0, 0)`, and unpacks every other value as
-/// `rx = value % 1000` / `ry = value / 1000`.
+/// signed `rx = value % 1000` / `ry = value / 1000`, then stores both results
+/// as their raw wrapped 16-bit halves.
 pub fn parse_waypoints(ini: &IniFile) -> HashMap<u32, Waypoint> {
     let Some(section) = ini.section("Waypoints") else {
         return HashMap::new();
@@ -78,12 +79,10 @@ pub fn parse_waypoints(ini: &IniFile) -> HashMap<u32, Waypoint> {
         if index >= WAYPOINT_SLOT_COUNT {
             continue;
         }
-        let Some(raw_value) = section.get(key) else {
-            continue;
-        };
-        let Ok(coords) = raw_value.trim().parse::<u32>() else {
-            continue;
-        };
+        // ScenarioClass__Read_Waypoints @ 0x0068BDC0 calls
+        // CCINIClass__ReadInt with default zero. Reuse the shared native
+        // integer reader for `$FF`/`FFh`, leading atoi, and i32 wrapping.
+        let coords = section.get_i32(key).unwrap_or(0);
         // Zero is the reader's "no waypoint here" value, not the origin cell.
         if coords == 0 {
             continue;
@@ -169,6 +168,59 @@ mod tests {
             "value 0 is the reader's unset marker"
         );
         assert_eq!(waypoints.len(), 1);
+    }
+
+    #[test]
+    fn signed_waypoint_values_wrap_quotient_and_remainder_into_raw_u16_halves() {
+        let ini = IniFile::from_str(
+            "[Waypoints]\n\
+             15=$FFFFFFFF\n\
+             16=FFFFFC17h\n\
+             17=-2000junk\n\
+             18=4294967295\n\
+             19=junk\n\
+             20=$junk\n",
+        );
+        let waypoints = parse_waypoints(&ini);
+
+        assert_eq!(
+            waypoints.get(&15),
+            Some(&Waypoint {
+                index: 15,
+                rx: u16::MAX,
+                ry: 0,
+            })
+        );
+        assert_eq!(
+            waypoints.get(&16),
+            Some(&Waypoint {
+                index: 16,
+                rx: u16::MAX,
+                ry: u16::MAX,
+            })
+        );
+        assert_eq!(
+            waypoints.get(&17),
+            Some(&Waypoint {
+                index: 17,
+                rx: 0,
+                ry: u16::MAX - 1,
+            })
+        );
+        assert_eq!(
+            waypoints.get(&18),
+            Some(&Waypoint {
+                index: 18,
+                rx: u16::MAX,
+                ry: 0,
+            }),
+            "native decimal atoi wraps through i32"
+        );
+        assert!(!waypoints.contains_key(&19), "junk reads the zero default");
+        assert!(
+            !waypoints.contains_key(&20),
+            "invalid hex reads the zero default"
+        );
     }
 
     #[test]

--- a/src/map/waypoints.rs
+++ b/src/map/waypoints.rs
@@ -72,17 +72,13 @@ pub fn parse_waypoints(ini: &IniFile) -> HashMap<u32, Waypoint> {
     };
 
     let mut waypoints: HashMap<u32, Waypoint> = HashMap::new();
-    for key in section.keys() {
-        let Ok(index) = key.parse::<u32>() else {
-            continue;
-        };
-        if index >= WAYPOINT_SLOT_COUNT {
-            continue;
-        }
+    for index in 0..WAYPOINT_SLOT_COUNT {
+        let key = index.to_string();
         // ScenarioClass__Read_Waypoints @ 0x0068BDC0 calls
-        // CCINIClass__ReadInt with default zero. Reuse the shared native
-        // integer reader for `$FF`/`FFh`, leading atoi, and i32 wrapping.
-        let coords = section.get_i32(key).unwrap_or(0);
+        // CCINIClass__ReadInt with each generated canonical decimal key and
+        // default zero. Reuse the shared native integer reader for `$FF`/`FFh`,
+        // leading atoi, and i32 wrapping.
+        let coords = section.get_i32(&key).unwrap_or(0);
         // Zero is the reader's "no waypoint here" value, not the origin cell.
         if coords == 0 {
             continue;
@@ -220,6 +216,34 @@ mod tests {
         assert!(
             !waypoints.contains_key(&20),
             "invalid hex reads the zero default"
+        );
+    }
+
+    #[test]
+    fn waypoint_reader_ignores_noncanonical_numeric_key_aliases() {
+        let ini = IniFile::from_str(
+            "[Waypoints]\n\
+             1=300033\n\
+             001=100011\n\
+             +1=200022\n\
+             002=400044\n\
+             +3=500055\n",
+        );
+        let waypoints = parse_waypoints(&ini);
+
+        assert_eq!(
+            waypoints,
+            [(
+                1,
+                Waypoint {
+                    index: 1,
+                    rx: 33,
+                    ry: 300,
+                },
+            )]
+            .into_iter()
+            .collect(),
+            "only the generated exact key `1` may own slot 1; padded/plus aliases remain unread"
         );
     }
 

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -3102,6 +3102,28 @@ impl RuleSet {
         self.country_indices.get(&id.to_ascii_uppercase()).copied()
     }
 
+    /// Resolve a trigger owner token to the canonical HouseType registration.
+    ///
+    /// gamemd-derived: `TriggerTypeClass::Read` resolves token 1 through
+    /// `HouseTypeClass__FindIndexOfName @ 0x005117D0`. The source-order scan
+    /// checks each HouseType's `Name=` alias (`+0x64`) before its registry ID
+    /// (`+0x24`). Native `<none>` selects the first registered HouseType.
+    pub fn trigger_house_type_index(&self, owner: &str) -> Option<CountryIdx> {
+        if owner.eq_ignore_ascii_case("<none>") {
+            return (!self.country_ids.is_empty()).then_some(CountryIdx(0));
+        }
+        self.country_ids.iter().enumerate().find_map(|(index, id)| {
+            let alias_matches = self
+                .countries
+                .get(id)
+                .and_then(|country| country.name.as_deref())
+                .is_some_and(|name| name.eq_ignore_ascii_case(owner));
+            (alias_matches || id.eq_ignore_ascii_case(owner)).then(|| {
+                CountryIdx(u16::try_from(index).expect("[Countries] exceeds u16 identity space"))
+            })
+        })
+    }
+
     /// Resolve a country index back to its source spelling.
     pub fn country_name(&self, index: CountryIdx) -> Option<&str> {
         self.country_ids.get(index.0 as usize).map(String::as_str)
@@ -4114,6 +4136,36 @@ CellSpread=0
         assert_eq!(rules.side_index("north"), Some(SideIdx(0)));
         assert_eq!(rules.side_index("SOUTH"), Some(SideIdx(1)));
         assert_eq!(rules.side_name(SideIdx(0)), Some("North"));
+    }
+
+    #[test]
+    fn trigger_house_type_owner_uses_alias_then_id_source_order_and_none_default() {
+        let ini = IniFile::from_str(
+            "[Countries]\n0=First\n1=Second\n2=Third\n\
+             [First]\nName=Shared Alias\n\
+             [Second]\nName=Shared Alias\n\
+             [Third]\nName=Third Alias\n",
+        );
+        let rules = RuleSet::from_ini(&ini).expect("country aliases parse");
+
+        assert_eq!(
+            rules.trigger_house_type_index("shared alias"),
+            Some(CountryIdx(0)),
+            "duplicate aliases keep first registration order"
+        );
+        assert_eq!(
+            rules.trigger_house_type_index("second"),
+            Some(CountryIdx(1))
+        );
+        assert_eq!(
+            rules.trigger_house_type_index("THIRD ALIAS"),
+            Some(CountryIdx(2))
+        );
+        assert_eq!(
+            rules.trigger_house_type_index("<none>"),
+            Some(CountryIdx(0))
+        );
+        assert_eq!(rules.trigger_house_type_index("missing"), None);
     }
 
     #[test]

--- a/src/sim/house_state.rs
+++ b/src/sim/house_state.rs
@@ -290,6 +290,13 @@ pub struct HouseState {
     pub owned_unit_count: u32,
     /// Initial base location (MCV deploy point or first ConYard).
     pub base_center: Option<(u16, u16)>,
+    /// Alternate base-placement cell written by trigger actions 137/138.
+    ///
+    /// This is the packed-zero `HouseClass+0x5494` authority. It is distinct
+    /// from the launch/primary `base_center` (`HouseClass+0x5490`) and defaults
+    /// to the native invalid sentinel `(0, 0)`.
+    #[serde(default)]
+    pub alternate_base_center: (u16, u16),
     /// Native `HouseClass+0x5700` BaseClass reservation writer outputs.
     #[serde(default)]
     pub base_reservation: BaseReservationState,
@@ -426,6 +433,7 @@ impl HouseState {
             owned_building_count: 0,
             owned_unit_count: 0,
             base_center: None,
+            alternate_base_center: (0, 0),
             base_reservation: BaseReservationState::default(),
             tech_level,
             current_iq: 0,

--- a/src/sim/runtime.rs
+++ b/src/sim/runtime.rs
@@ -39,6 +39,8 @@ pub struct SimResources {
     pub triggers: crate::map::triggers::TriggerMap,
     pub events: crate::map::events::EventMap,
     pub actions: crate::map::actions::ActionMap,
+    /// Complete immutable scenario waypoint table used by trigger actions.
+    pub waypoints: std::collections::HashMap<u32, crate::map::waypoints::Waypoint>,
 }
 
 impl SimResources {
@@ -57,6 +59,7 @@ impl SimResources {
             triggers: Default::default(),
             events: Default::default(),
             actions: Default::default(),
+            waypoints: Default::default(),
         }
     }
 }
@@ -217,6 +220,7 @@ impl SimRuntime {
                 triggers: &self.resources.triggers,
                 events: &self.resources.events,
                 actions: &self.resources.actions,
+                waypoints: &self.resources.waypoints,
                 rules: Some(&self.resources.rules),
             }),
         )
@@ -252,6 +256,23 @@ mod tests {
     fn runtime_always_uses_bound_navigation_and_resources() {
         let mut resources = SimResources::empty();
         resources.height_map.insert((3, 4), 7);
+        resources.waypoints.insert(
+            0,
+            crate::map::waypoints::Waypoint {
+                index: 0,
+                rx: 93,
+                ry: 106,
+            },
+        );
+        resources.waypoints.insert(
+            701,
+            crate::map::waypoints::Waypoint {
+                index: 701,
+                rx: 122,
+                ry: 135,
+            },
+        );
+        let expected_waypoints = resources.waypoints.clone();
         let original = SimRuntime {
             simulation: Simulation::new(),
             resources,
@@ -263,11 +284,13 @@ mod tests {
             Some(&7),
             "restore must carry the match resources, never rebind empty"
         );
+        assert_eq!(rebound.resources.waypoints, expected_waypoints);
 
         // Without a surviving runtime (fixture-only path) the rebind is
         // explicitly empty rather than partially bound.
         let fresh = SimRuntime::rebind_restored(None, Simulation::new());
         assert!(fresh.resources.height_map.is_empty());
+        assert!(fresh.resources.waypoints.is_empty());
     }
 
     #[test]

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -315,7 +315,10 @@ use crate::sim::world::Simulation;
 // persistent Level and Slope without requiring a retained dummy projectile.
 // The wire shape remains unchanged, but older saves do not certify the same
 // future-affecting lockstep hash authority for those live process-global bytes.
-const SNAPSHOT_VERSION: u32 = 107;
+// Bumped 107 -> 108: HouseState gains the serialized/hash-authoritative packed
+// alternate base cell written by trigger actions 137/138. Bincode encodes the
+// HouseState layout positionally, so an older record cannot supply this field.
+const SNAPSHOT_VERSION: u32 = 108;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -2721,10 +2724,11 @@ mod tests {
     /// Drive/Ship slope-transition state; 105 -> 106 rejects saves that would
     /// resume under the corrected one-authority 104-lepton Cell ground formula
     /// despite unchanged wire shape; 106 -> 107 adds unconditional shared-
-    /// dummy level/slope hash authority for active Spark queries.
+    /// dummy level/slope hash authority for active Spark queries; 107 -> 108
+    /// adds the packed House alternate base cell.
     #[test]
-    fn phase3_spark_dummy_snapshot_version_is_107() {
-        assert_eq!(super::SNAPSHOT_VERSION, 107);
+    fn phase3_alternate_base_snapshot_version_is_108() {
+        assert_eq!(super::SNAPSHOT_VERSION, 108);
     }
 
     #[test]
@@ -2981,6 +2985,29 @@ mod tests {
             .unwrap()
             .master_id = 3;
         assert_ne!(changed_master.state_hash(), source_hash);
+    }
+
+    #[test]
+    fn alternate_base_center_roundtrips_with_primary_center_and_hash() {
+        let mut sim = Simulation::new();
+        let owner = sim.interner.intern("AMERICANS");
+        let country = sim.interner.intern("Americans");
+        let mut house =
+            crate::sim::house_state::HouseState::new(owner, 0, Some(country), false, 0, 10);
+        house.base_center = Some((40, 50));
+        house.alternate_base_center = (93, 106);
+        sim.houses.insert(owner, house);
+        sim.session.house_order.push(owner);
+        sim.scenario_rng = crate::sim::rng::SimRng::new(0);
+        let expected_hash = sim.state_hash();
+
+        let bytes = GameSnapshot::save(&sim, 0, 0, "alternate-base-center", 0);
+        assert_eq!(GameSnapshot::read_header(&bytes).unwrap().version, 108);
+        let restored = GameSnapshot::load(&bytes).expect("current snapshot").sim;
+
+        assert_eq!(restored.houses[&owner].base_center, Some((40, 50)));
+        assert_eq!(restored.houses[&owner].alternate_base_center, (93, 106));
+        assert_eq!(restored.state_hash(), expected_hash);
     }
 
     #[test]

--- a/src/sim/trigger_runtime.rs
+++ b/src/sim/trigger_runtime.rs
@@ -18,7 +18,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::hash::{Hash, Hasher};
 
-use crate::map::actions::{ActionEntry, ActionMap, read_waypoint_token};
+use crate::map::actions::{ActionEntry, ActionMap};
 use crate::map::events::{EventCondition, EventMap};
 use crate::map::trigger_graph::{LinkedTrigger, TriggerGraph};
 use crate::map::triggers::TriggerMap;
@@ -368,7 +368,7 @@ impl TriggerRuntime {
                 }
             }
             ACTION_CENTER_CAMERA => {
-                if let Some(waypoint) = parse_waypoint_param(&action.params, 6) {
+                if let Some(waypoint) = action.waypoint_index {
                     effects.push(TriggerEffect::CenterCameraAtWaypoint {
                         waypoint,
                         immediate: false,
@@ -376,7 +376,7 @@ impl TriggerRuntime {
                 }
             }
             ACTION_JUMP_CAMERA => {
-                if let Some(waypoint) = parse_waypoint_param(&action.params, 6) {
+                if let Some(waypoint) = action.waypoint_index {
                     effects.push(TriggerEffect::CenterCameraAtWaypoint {
                         waypoint,
                         immediate: true,
@@ -389,7 +389,7 @@ impl TriggerRuntime {
                 else {
                     return;
                 };
-                let Some(waypoint_index) = parse_waypoint_param(&action.params, 6) else {
+                let Some(waypoint_index) = action.waypoint_index else {
                     return;
                 };
                 let Some(waypoint) = waypoints.get(&waypoint_index) else {
@@ -465,10 +465,6 @@ fn enqueue_trigger(
 
 fn parse_u32_param(fields: &[String], index: usize) -> Option<u32> {
     fields.get(index)?.trim().parse::<u32>().ok()
-}
-
-fn parse_waypoint_param(fields: &[String], index: usize) -> Option<u32> {
-    read_waypoint_token(fields.get(index).map(String::as_str))
 }
 
 /// Resolve a trigger's canonical HouseType owner to the first registered House.

--- a/src/sim/trigger_runtime.rs
+++ b/src/sim/trigger_runtime.rs
@@ -123,30 +123,10 @@ impl TriggerRuntime {
     }
 
     /// Evaluate and apply trigger actions against one authoritative gameplay frame.
+    ///
+    /// `waypoints` is the complete immutable scenario table; action 137 cannot
+    /// resolve its native destination without that bound map input.
     pub fn advance_at_frame(
-        &mut self,
-        current_frame: u32,
-        graph: &TriggerGraph,
-        triggers: &TriggerMap,
-        events: &EventMap,
-        actions: &ActionMap,
-        simulation: Option<&mut Simulation>,
-        rules: Option<&crate::rules::ruleset::RuleSet>,
-    ) -> Vec<TriggerEffect> {
-        self.advance_at_frame_with_waypoints(
-            current_frame,
-            graph,
-            triggers,
-            events,
-            actions,
-            simulation,
-            rules,
-            &HashMap::new(),
-        )
-    }
-
-    /// Evaluate with the complete immutable scenario waypoint table.
-    pub(crate) fn advance_at_frame_with_waypoints(
         &mut self,
         current_frame: u32,
         graph: &TriggerGraph,

--- a/src/sim/trigger_runtime.rs
+++ b/src/sim/trigger_runtime.rs
@@ -10,14 +10,15 @@
 //! - Action 40: change visible map area
 //! - Action 53/54: enable/disable trigger
 //! - Action 48/112: center camera at waypoint
+//! - Action 137/138: set/clear a House's alternate base cell
 //!
 //! The goal is to turn parsed trigger data into real runtime behavior without
 //! committing to a full mission-script system yet.
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::hash::{Hash, Hasher};
 
-use crate::map::actions::{ActionEntry, ActionMap};
+use crate::map::actions::{ActionEntry, ActionMap, read_waypoint_token};
 use crate::map::events::{EventCondition, EventMap};
 use crate::map::trigger_graph::{LinkedTrigger, TriggerGraph};
 use crate::map::triggers::TriggerMap;
@@ -37,6 +38,8 @@ const ACTION_ANNOUNCE_WIN: i32 = 67;
 const ACTION_ANNOUNCE_LOSE: i32 = 68;
 const ACTION_END_SCENARIO: i32 = 69;
 const ACTION_JUMP_CAMERA: i32 = 112;
+const ACTION_SET_ALTERNATE_BASE: i32 = 137;
+const ACTION_CLEAR_ALTERNATE_BASE: i32 = 138;
 
 const EVENT_GLOBAL_IS_SET: i32 = 27;
 const EVENT_GLOBAL_IS_CLEAR: i32 = 28;
@@ -127,8 +130,32 @@ impl TriggerRuntime {
         triggers: &TriggerMap,
         events: &EventMap,
         actions: &ActionMap,
+        simulation: Option<&mut Simulation>,
+        rules: Option<&crate::rules::ruleset::RuleSet>,
+    ) -> Vec<TriggerEffect> {
+        self.advance_at_frame_with_waypoints(
+            current_frame,
+            graph,
+            triggers,
+            events,
+            actions,
+            simulation,
+            rules,
+            &HashMap::new(),
+        )
+    }
+
+    /// Evaluate with the complete immutable scenario waypoint table.
+    pub(crate) fn advance_at_frame_with_waypoints(
+        &mut self,
+        current_frame: u32,
+        graph: &TriggerGraph,
+        triggers: &TriggerMap,
+        events: &EventMap,
+        actions: &ActionMap,
         mut simulation: Option<&mut Simulation>,
         rules: Option<&crate::rules::ruleset::RuleSet>,
+        waypoints: &HashMap<u32, crate::map::waypoints::Waypoint>,
     ) -> Vec<TriggerEffect> {
         let linked_by_id: BTreeMap<&str, &LinkedTrigger> = graph
             .triggers
@@ -179,8 +206,10 @@ impl TriggerRuntime {
                         &mut queue,
                         &mut queued,
                         triggers,
+                        trigger,
                         simulation.as_deref_mut(),
                         rules,
+                        waypoints,
                     );
                 }
             }
@@ -283,8 +312,10 @@ impl TriggerRuntime {
         queue: &mut VecDeque<String>,
         queued: &mut BTreeSet<String>,
         triggers: &TriggerMap,
+        trigger: &crate::map::triggers::MapTrigger,
         simulation: Option<&mut Simulation>,
         rules: Option<&crate::rules::ruleset::RuleSet>,
+        waypoints: &HashMap<u32, crate::map::waypoints::Waypoint>,
     ) {
         match action.kind {
             ACTION_FORCE_TRIGGER => {
@@ -337,7 +368,7 @@ impl TriggerRuntime {
                 }
             }
             ACTION_CENTER_CAMERA => {
-                if let Some(waypoint) = parse_u32_param(&action.params, 6) {
+                if let Some(waypoint) = parse_waypoint_param(&action.params, 6) {
                     effects.push(TriggerEffect::CenterCameraAtWaypoint {
                         waypoint,
                         immediate: false,
@@ -345,11 +376,47 @@ impl TriggerRuntime {
                 }
             }
             ACTION_JUMP_CAMERA => {
-                if let Some(waypoint) = parse_u32_param(&action.params, 6) {
+                if let Some(waypoint) = parse_waypoint_param(&action.params, 6) {
                     effects.push(TriggerEffect::CenterCameraAtWaypoint {
                         waypoint,
                         immediate: true,
                     });
+                }
+            }
+            ACTION_SET_ALTERNATE_BASE => {
+                let Some(sim) = simulation else { return };
+                let Some(house_id) = resolve_trigger_house(sim, trigger.owner.as_deref(), rules)
+                else {
+                    return;
+                };
+                let Some(waypoint_index) = parse_waypoint_param(&action.params, 6) else {
+                    return;
+                };
+                let Some(waypoint) = waypoints.get(&waypoint_index) else {
+                    return;
+                };
+                if (waypoint.rx, waypoint.ry) == (0, 0) {
+                    return;
+                }
+                // gamemd-derived: `TriggerAction__Execute @ 0x006DD8B0`
+                // case 137 calls `FUN_006E44E0`, which rejects the packed-zero
+                // waypoint and writes only `HouseClass+0x5494` through
+                // `FUN_0050DFE0`.
+                if let Some(house) = sim.houses.get_mut(&house_id) {
+                    house.alternate_base_center = (waypoint.rx, waypoint.ry);
+                }
+            }
+            ACTION_CLEAR_ALTERNATE_BASE => {
+                let Some(sim) = simulation else { return };
+                let Some(house_id) = resolve_trigger_house(sim, trigger.owner.as_deref(), rules)
+                else {
+                    return;
+                };
+                // gamemd-derived: `TriggerAction__Execute @ 0x006DD8B0`
+                // case 138 calls `FUN_006E4540`, which writes packed zero only
+                // to `HouseClass+0x5494` through `FUN_0050DFF0`.
+                if let Some(house) = sim.houses.get_mut(&house_id) {
+                    house.alternate_base_center = (0, 0);
                 }
             }
             ACTION_ANNOUNCE_WIN => {
@@ -398,6 +465,34 @@ fn enqueue_trigger(
 
 fn parse_u32_param(fields: &[String], index: usize) -> Option<u32> {
     fields.get(index)?.trim().parse::<u32>().ok()
+}
+
+fn parse_waypoint_param(fields: &[String], index: usize) -> Option<u32> {
+    read_waypoint_token(fields.get(index).map(String::as_str))
+}
+
+/// Resolve a trigger's canonical HouseType owner to the first registered House.
+///
+/// gamemd-derived: `TriggerTypeClass::Read` canonicalizes the owner through
+/// `HouseTypeClass__FindIndexOfName @ 0x005117D0` (alias before ID in source
+/// order, with `<none>` selecting index zero). `TriggerClass::Spring @
+/// 0x007265C0` passes that type index to `HouseClass__Find_By_Country_Index @
+/// 0x00502D30`, whose global House-array scan returns the first matching
+/// registration.
+fn resolve_trigger_house(
+    sim: &Simulation,
+    trigger_owner: Option<&str>,
+    rules: Option<&crate::rules::ruleset::RuleSet>,
+) -> Option<crate::sim::intern::InternedId> {
+    let rules = rules?;
+    let trigger_house_type = rules.trigger_house_type_index(trigger_owner?)?;
+    sim.session.house_order.iter().copied().find(|house_id| {
+        sim.houses
+            .get(house_id)
+            .and_then(|house| house.country)
+            .and_then(|country| rules.country_index(sim.interner.resolve(country)))
+            == Some(trigger_house_type)
+    })
 }
 
 fn parse_i32_param(fields: &[String], index: usize) -> Option<i32> {

--- a/src/sim/trigger_runtime_tests.rs
+++ b/src/sim/trigger_runtime_tests.rs
@@ -208,6 +208,7 @@ fn trigger_action_40_normalizes_and_refreshes_authority_same_frame() {
                     .into_iter()
                     .map(str::to_string)
                     .collect(),
+                waypoint_index: Some(0),
             }],
         },
     )]
@@ -497,6 +498,8 @@ fn time_trigger_can_center_camera_at_waypoint() {
             ],
             entries: vec![ActionEntry {
                 kind: 112,
+                // Runtime owns the reader-materialized +0x44 value below;
+                // changing retained source text must not trigger re-decoding.
                 params: vec![
                     "0".to_string(),
                     "0".to_string(),
@@ -504,8 +507,9 @@ fn time_trigger_can_center_camera_at_waypoint() {
                     "0".to_string(),
                     "0".to_string(),
                     "0".to_string(),
-                    "J".to_string(),
+                    "ZZ".to_string(),
                 ],
+                waypoint_index: Some(9),
             }],
         },
     )]
@@ -576,6 +580,7 @@ fn master_frame_polls_triggers_before_logic_houses_commit_and_delete() {
                     "0".to_string(),
                     "J".to_string(),
                 ],
+                waypoint_index: Some(9),
             }],
         },
     )]
@@ -660,6 +665,7 @@ fn master_frame_save_load_continues_trigger_projectile_and_delete_state() {
             entries: vec![ActionEntry {
                 kind: 28,
                 params: vec!["13".to_string()],
+                waypoint_index: Some(0),
             }],
         },
     )]
@@ -922,6 +928,7 @@ fn global_actions_can_enable_and_force_followup_trigger() {
                             "0".to_string(),
                             "0".to_string(),
                         ],
+                        waypoint_index: None,
                     },
                     ActionEntry {
                         kind: 53,
@@ -934,6 +941,7 @@ fn global_actions_can_enable_and_force_followup_trigger() {
                             "0".to_string(),
                             "0".to_string(),
                         ],
+                        waypoint_index: None,
                     },
                     ActionEntry {
                         kind: 22,
@@ -946,6 +954,7 @@ fn global_actions_can_enable_and_force_followup_trigger() {
                             "0".to_string(),
                             "0".to_string(),
                         ],
+                        waypoint_index: None,
                     },
                 ],
             },
@@ -976,6 +985,7 @@ fn global_actions_can_enable_and_force_followup_trigger() {
                         "0".to_string(),
                         "D".to_string(),
                     ],
+                    waypoint_index: Some(3),
                 }],
             },
         ),
@@ -1077,6 +1087,7 @@ fn linked_trigger_field_queues_followup_trigger() {
                         "0".to_string(),
                         "0".to_string(),
                     ],
+                    waypoint_index: Some(0),
                 }],
             },
         ),
@@ -1106,6 +1117,7 @@ fn linked_trigger_field_queues_followup_trigger() {
                         "0".to_string(),
                         "E".to_string(),
                     ],
+                    waypoint_index: Some(4),
                 }],
             },
         ),
@@ -1207,6 +1219,7 @@ fn forced_trigger_with_unmet_conditions_does_not_fire() {
                         "0".to_string(),
                         "0".to_string(),
                     ],
+                    waypoint_index: None,
                 }],
             },
         ),
@@ -1236,6 +1249,7 @@ fn forced_trigger_with_unmet_conditions_does_not_fire() {
                         "0".to_string(),
                         "I".to_string(),
                     ],
+                    waypoint_index: Some(8),
                 }],
             },
         ),
@@ -1318,6 +1332,7 @@ fn mission_announce_then_force_end_emits_result_effects() {
                         "0".to_string(),
                         "0".to_string(),
                     ],
+                    waypoint_index: None,
                 },
                 ActionEntry {
                     kind: 69,
@@ -1330,6 +1345,7 @@ fn mission_announce_then_force_end_emits_result_effects() {
                         "0".to_string(),
                         "0".to_string(),
                     ],
+                    waypoint_index: None,
                 },
             ],
         },
@@ -1436,6 +1452,7 @@ fn local_variables_seed_and_gate_followup_triggers() {
                         "0".to_string(),
                         "0".to_string(),
                     ],
+                    waypoint_index: Some(0),
                 }],
             },
         ),
@@ -1465,6 +1482,7 @@ fn local_variables_seed_and_gate_followup_triggers() {
                         "0".to_string(),
                         "G".to_string(),
                     ],
+                    waypoint_index: Some(6),
                 }],
             },
         ),
@@ -1581,6 +1599,7 @@ fn techtype_exists_and_not_exists_query_simulation_world() {
                         "0".to_string(),
                         "L".to_string(),
                     ],
+                    waypoint_index: Some(11),
                 }],
             },
         ),
@@ -1610,6 +1629,7 @@ fn techtype_exists_and_not_exists_query_simulation_world() {
                         "0".to_string(),
                         "M".to_string(),
                     ],
+                    waypoint_index: Some(12),
                 }],
             },
         ),
@@ -1685,7 +1705,11 @@ fn run_waypoint_action(
         MapAction {
             id: "WAYPOINT_ACTION".to_string(),
             fields: Vec::new(),
-            entries: vec![ActionEntry { kind, params }],
+            entries: vec![ActionEntry {
+                kind,
+                params,
+                waypoint_index: crate::map::actions::read_waypoint_token(token),
+            }],
         },
     )]
     .into_iter()

--- a/src/sim/trigger_runtime_tests.rs
+++ b/src/sim/trigger_runtime_tests.rs
@@ -1937,6 +1937,33 @@ fn action_137_rejects_only_exact_packed_zero_cell() {
 }
 
 #[test]
+fn action_137_writes_signed_waypoint_halves_as_raw_nonzero_cell() {
+    let rules = waypoint_action_rules();
+    let mut sim = Simulation::new();
+    let house =
+        register_waypoint_action_house(&mut sim, "SignedWaypointHouse", Some("Americans"), (9, 9));
+    let waypoints = crate::map::waypoints::parse_waypoints(
+        &crate::rules::ini_parser::IniFile::from_str("[Waypoints]\n15=-1001\n"),
+    );
+
+    run_waypoint_action(
+        137,
+        Some("P"),
+        Some("Americans"),
+        &mut sim,
+        &waypoints,
+        Some(&rules),
+    );
+
+    assert_eq!(
+        sim.houses[&house].alternate_base_center,
+        (u16::MAX, u16::MAX),
+        "signed -1 quotient/remainder halves are nonzero and must be written"
+    );
+    assert_eq!(sim.houses[&house].base_center, Some((40, 50)));
+}
+
+#[test]
 fn action_137_invalid_resolution_and_waypoints_do_not_mutate_either_base_cell() {
     fn assert_no_write(
         trigger_country: Option<&str>,

--- a/src/sim/trigger_runtime_tests.rs
+++ b/src/sim/trigger_runtime_tests.rs
@@ -270,6 +270,7 @@ fn trigger_action_40_normalizes_and_refreshes_authority_same_frame() {
             triggers: &triggers,
             events: &events,
             actions: &actions,
+            waypoints: &HashMap::new(),
             rules: None,
         }),
     );
@@ -492,7 +493,7 @@ fn time_trigger_can_center_camera_at_waypoint() {
                 "0".to_string(),
                 "0".to_string(),
                 "0".to_string(),
-                "9".to_string(),
+                "J".to_string(),
             ],
             entries: vec![ActionEntry {
                 kind: 112,
@@ -503,7 +504,7 @@ fn time_trigger_can_center_camera_at_waypoint() {
                     "0".to_string(),
                     "0".to_string(),
                     "0".to_string(),
-                    "9".to_string(),
+                    "J".to_string(),
                 ],
             }],
         },
@@ -573,7 +574,7 @@ fn master_frame_polls_triggers_before_logic_houses_commit_and_delete() {
                     "0".to_string(),
                     "0".to_string(),
                     "0".to_string(),
-                    "9".to_string(),
+                    "J".to_string(),
                 ],
             }],
         },
@@ -603,6 +604,7 @@ fn master_frame_polls_triggers_before_logic_houses_commit_and_delete() {
             triggers: &triggers,
             events: &events,
             actions: &actions,
+            waypoints: &HashMap::new(),
             rules: None,
         }),
     );
@@ -671,11 +673,13 @@ fn master_frame_save_load_continues_trigger_projectile_and_delete_state() {
         &actions,
     );
     let height_map = BTreeMap::new();
+    let waypoints = HashMap::new();
     let trigger_inputs = TriggerInputs {
         graph: &graph,
         triggers: &triggers,
         events: &events,
         actions: &actions,
+        waypoints: &waypoints,
         rules: None,
     };
 
@@ -880,7 +884,7 @@ fn global_actions_can_enable_and_force_followup_trigger() {
             MapAction {
                 id: "TRIG_A".to_string(),
                 fields: vec![
-                    "3".to_string(),
+                    "D".to_string(),
                     "28".to_string(),
                     "7".to_string(),
                     "0".to_string(),
@@ -959,7 +963,7 @@ fn global_actions_can_enable_and_force_followup_trigger() {
                     "0".to_string(),
                     "0".to_string(),
                     "0".to_string(),
-                    "3".to_string(),
+                    "D".to_string(),
                 ],
                 entries: vec![ActionEntry {
                     kind: 112,
@@ -970,7 +974,7 @@ fn global_actions_can_enable_and_force_followup_trigger() {
                         "0".to_string(),
                         "0".to_string(),
                         "0".to_string(),
-                        "3".to_string(),
+                        "D".to_string(),
                     ],
                 }],
             },
@@ -1089,7 +1093,7 @@ fn linked_trigger_field_queues_followup_trigger() {
                     "0".to_string(),
                     "0".to_string(),
                     "0".to_string(),
-                    "4".to_string(),
+                    "E".to_string(),
                 ],
                 entries: vec![ActionEntry {
                     kind: 112,
@@ -1100,7 +1104,7 @@ fn linked_trigger_field_queues_followup_trigger() {
                         "0".to_string(),
                         "0".to_string(),
                         "0".to_string(),
-                        "4".to_string(),
+                        "E".to_string(),
                     ],
                 }],
             },
@@ -1219,7 +1223,7 @@ fn forced_trigger_with_unmet_conditions_does_not_fire() {
                     "0".to_string(),
                     "0".to_string(),
                     "0".to_string(),
-                    "8".to_string(),
+                    "I".to_string(),
                 ],
                 entries: vec![ActionEntry {
                     kind: 112,
@@ -1230,7 +1234,7 @@ fn forced_trigger_with_unmet_conditions_does_not_fire() {
                         "0".to_string(),
                         "0".to_string(),
                         "0".to_string(),
-                        "8".to_string(),
+                        "I".to_string(),
                     ],
                 }],
             },
@@ -1448,7 +1452,7 @@ fn local_variables_seed_and_gate_followup_triggers() {
                     "0".to_string(),
                     "0".to_string(),
                     "0".to_string(),
-                    "6".to_string(),
+                    "G".to_string(),
                 ],
                 entries: vec![ActionEntry {
                     kind: 112,
@@ -1459,7 +1463,7 @@ fn local_variables_seed_and_gate_followup_triggers() {
                         "0".to_string(),
                         "0".to_string(),
                         "0".to_string(),
-                        "6".to_string(),
+                        "G".to_string(),
                     ],
                 }],
             },
@@ -1564,7 +1568,7 @@ fn techtype_exists_and_not_exists_query_simulation_world() {
                     "0".to_string(),
                     "0".to_string(),
                     "0".to_string(),
-                    "11".to_string(),
+                    "L".to_string(),
                 ],
                 entries: vec![ActionEntry {
                     kind: 112,
@@ -1575,7 +1579,7 @@ fn techtype_exists_and_not_exists_query_simulation_world() {
                         "0".to_string(),
                         "0".to_string(),
                         "0".to_string(),
-                        "11".to_string(),
+                        "L".to_string(),
                     ],
                 }],
             },
@@ -1593,7 +1597,7 @@ fn techtype_exists_and_not_exists_query_simulation_world() {
                     "0".to_string(),
                     "0".to_string(),
                     "0".to_string(),
-                    "12".to_string(),
+                    "M".to_string(),
                 ],
                 entries: vec![ActionEntry {
                     kind: 112,
@@ -1604,7 +1608,7 @@ fn techtype_exists_and_not_exists_query_simulation_world() {
                         "0".to_string(),
                         "0".to_string(),
                         "0".to_string(),
-                        "12".to_string(),
+                        "M".to_string(),
                     ],
                 }],
             },
@@ -1645,4 +1649,405 @@ fn techtype_exists_and_not_exists_query_simulation_world() {
             },
         ]
     );
+}
+
+fn run_waypoint_action(
+    kind: i32,
+    token: Option<&str>,
+    trigger_country: Option<&str>,
+    sim: &mut Simulation,
+    waypoints: &HashMap<u32, crate::map::waypoints::Waypoint>,
+    rules: Option<&crate::rules::ruleset::RuleSet>,
+) -> Vec<TriggerEffect> {
+    let mut trigger = make_trigger("WAYPOINT_ACTION", None, "Waypoint action", true, false);
+    trigger.owner = trigger_country.map(str::to_string);
+    trigger.fields[0] = trigger_country.unwrap_or("").to_string();
+    let triggers: TriggerMap = [(trigger.id.clone(), trigger)].into_iter().collect();
+    let events: EventMap = [(
+        "WAYPOINT_ACTION".to_string(),
+        MapEvent {
+            id: "WAYPOINT_ACTION".to_string(),
+            fields: Vec::new(),
+            conditions: vec![EventCondition {
+                kind: 47,
+                params: vec!["0".to_string()],
+            }],
+        },
+    )]
+    .into_iter()
+    .collect();
+    let mut params = vec!["0".to_string(); 6];
+    if let Some(token) = token {
+        params.push(token.to_string());
+    }
+    let actions: ActionMap = [(
+        "WAYPOINT_ACTION".to_string(),
+        MapAction {
+            id: "WAYPOINT_ACTION".to_string(),
+            fields: Vec::new(),
+            entries: vec![ActionEntry { kind, params }],
+        },
+    )]
+    .into_iter()
+    .collect();
+    let graph = build_trigger_graph(
+        &HashMap::new(),
+        &HashMap::new(),
+        &triggers,
+        &events,
+        &actions,
+    );
+    let mut runtime = TriggerRuntime::from_map(&triggers, &HashMap::new());
+    runtime.advance_at_frame_with_waypoints(
+        0,
+        &graph,
+        &triggers,
+        &events,
+        &actions,
+        Some(sim),
+        rules,
+        waypoints,
+    )
+}
+
+fn waypoint_action_rules() -> crate::rules::ruleset::RuleSet {
+    crate::rules::ruleset::RuleSet::from_ini(&crate::rules::ini_parser::IniFile::from_str(
+        "[Countries]\n0=Americans\n1=Russians\n\
+         [Americans]\nName=United States\n\
+         [Russians]\nName=Russian Federation\n",
+    ))
+    .expect("waypoint-action country registry parses")
+}
+
+fn register_waypoint_action_house(
+    sim: &mut Simulation,
+    name: &str,
+    country: Option<&str>,
+    alternate_base_center: (u16, u16),
+) -> crate::sim::intern::InternedId {
+    let owner = sim.interner.intern(name);
+    let country = country.map(|country| sim.interner.intern(country));
+    let mut house = crate::sim::house_state::HouseState::new(owner, 0, country, false, 0, 10);
+    house.base_center = Some((40, 50));
+    house.alternate_base_center = alternate_base_center;
+    sim.houses.insert(owner, house);
+    sim.session.house_order.push(owner);
+    owner
+}
+
+#[test]
+fn camera_actions_use_alpha_tokens_and_ctor_zero_not_decimal_indices() {
+    for (kind, token, waypoint, immediate) in [(48, "NZ", 389, false), (112, "AA", 26, true)] {
+        let mut sim = Simulation::new();
+        assert_eq!(
+            run_waypoint_action(kind, Some(token), None, &mut sim, &HashMap::new(), None),
+            vec![TriggerEffect::CenterCameraAtWaypoint {
+                waypoint,
+                immediate,
+            }]
+        );
+    }
+
+    for token in [None, Some("")] {
+        let mut sim = Simulation::new();
+        assert_eq!(
+            run_waypoint_action(112, token, None, &mut sim, &HashMap::new(), None),
+            vec![TriggerEffect::CenterCameraAtWaypoint {
+                waypoint: 0,
+                immediate: true,
+            }]
+        );
+    }
+    for token in [Some("15"), Some("   ")] {
+        let mut sim = Simulation::new();
+        assert!(run_waypoint_action(112, token, None, &mut sim, &HashMap::new(), None).is_empty());
+    }
+}
+
+#[test]
+fn action_137_replays_all_three_retail_waypoint_fixtures() {
+    for (token, index, cell) in [
+        ("P", 15, (93, 106)),
+        ("NZ", 389, (122, 135)),
+        ("AA", 26, (105, 194)),
+    ] {
+        let mut sim = Simulation::new();
+        let rules = waypoint_action_rules();
+        let house = register_waypoint_action_house(&mut sim, "HouseA", Some("Americans"), (0, 0));
+        let waypoints = [(
+            index,
+            crate::map::waypoints::Waypoint {
+                index,
+                rx: cell.0,
+                ry: cell.1,
+            },
+        )]
+        .into_iter()
+        .collect();
+
+        assert!(
+            run_waypoint_action(
+                137,
+                Some(token),
+                Some("americans"),
+                &mut sim,
+                &waypoints,
+                Some(&rules),
+            )
+            .is_empty()
+        );
+        assert_eq!(sim.houses[&house].alternate_base_center, cell);
+        assert_eq!(sim.houses[&house].base_center, Some((40, 50)));
+    }
+}
+
+#[test]
+fn action_137_uses_first_registration_order_country_match_only() {
+    let mut sim = Simulation::new();
+    let rules = waypoint_action_rules();
+    let first = register_waypoint_action_house(&mut sim, "First", Some("Americans"), (1, 2));
+    let second = register_waypoint_action_house(&mut sim, "Second", Some("AMERICANS"), (3, 4));
+    let waypoints = [(
+        15,
+        crate::map::waypoints::Waypoint {
+            index: 15,
+            rx: 93,
+            ry: 106,
+        },
+    )]
+    .into_iter()
+    .collect();
+
+    run_waypoint_action(
+        137,
+        Some("P"),
+        Some("americans"),
+        &mut sim,
+        &waypoints,
+        Some(&rules),
+    );
+
+    assert_eq!(sim.houses[&first].alternate_base_center, (93, 106));
+    assert_eq!(sim.houses[&second].alternate_base_center, (3, 4));
+    assert_eq!(sim.houses[&first].base_center, Some((40, 50)));
+    assert_eq!(sim.houses[&second].base_center, Some((40, 50)));
+}
+
+#[test]
+fn action_137_canonicalizes_house_type_alias_and_none_owner() {
+    let rules = waypoint_action_rules();
+    let waypoints = [(
+        15,
+        crate::map::waypoints::Waypoint {
+            index: 15,
+            rx: 93,
+            ry: 106,
+        },
+    )]
+    .into_iter()
+    .collect();
+
+    let mut alias_sim = Simulation::new();
+    let alias_house =
+        register_waypoint_action_house(&mut alias_sim, "AliasHouse", Some("Americans"), (0, 0));
+    run_waypoint_action(
+        137,
+        Some("P"),
+        Some("united states"),
+        &mut alias_sim,
+        &waypoints,
+        Some(&rules),
+    );
+    assert_eq!(
+        alias_sim.houses[&alias_house].alternate_base_center,
+        (93, 106)
+    );
+
+    let mut none_sim = Simulation::new();
+    let russian =
+        register_waypoint_action_house(&mut none_sim, "RussianHouse", Some("Russians"), (7, 8));
+    let first_type =
+        register_waypoint_action_house(&mut none_sim, "AmericanHouse", Some("Americans"), (0, 0));
+    run_waypoint_action(
+        137,
+        Some("P"),
+        Some("<none>"),
+        &mut none_sim,
+        &waypoints,
+        Some(&rules),
+    );
+    assert_eq!(none_sim.houses[&russian].alternate_base_center, (7, 8));
+    assert_eq!(
+        none_sim.houses[&first_type].alternate_base_center,
+        (93, 106)
+    );
+}
+
+#[test]
+fn action_137_rejects_only_exact_packed_zero_cell() {
+    let rules = waypoint_action_rules();
+    for cell in [(0, 17), (23, 0)] {
+        let mut sim = Simulation::new();
+        let house =
+            register_waypoint_action_house(&mut sim, "AxisHouse", Some("Americans"), (9, 9));
+        let waypoints = [(
+            15,
+            crate::map::waypoints::Waypoint {
+                index: 15,
+                rx: cell.0,
+                ry: cell.1,
+            },
+        )]
+        .into_iter()
+        .collect();
+        run_waypoint_action(
+            137,
+            Some("P"),
+            Some("Americans"),
+            &mut sim,
+            &waypoints,
+            Some(&rules),
+        );
+        assert_eq!(sim.houses[&house].alternate_base_center, cell);
+    }
+}
+
+#[test]
+fn action_137_invalid_resolution_and_waypoints_do_not_mutate_either_base_cell() {
+    fn assert_no_write(
+        trigger_country: Option<&str>,
+        house_country: Option<&str>,
+        token: Option<&str>,
+        waypoints: HashMap<u32, crate::map::waypoints::Waypoint>,
+        register: bool,
+        with_rules: bool,
+    ) {
+        let mut sim = Simulation::new();
+        let rules = waypoint_action_rules();
+        let house = register
+            .then(|| register_waypoint_action_house(&mut sim, "Americans", house_country, (7, 8)));
+        run_waypoint_action(
+            137,
+            token,
+            trigger_country,
+            &mut sim,
+            &waypoints,
+            with_rules.then_some(&rules),
+        );
+        if let Some(house) = house {
+            assert_eq!(sim.houses[&house].alternate_base_center, (7, 8));
+            assert_eq!(sim.houses[&house].base_center, Some((40, 50)));
+        }
+    }
+
+    let valid = || {
+        [(
+            15,
+            crate::map::waypoints::Waypoint {
+                index: 15,
+                rx: 93,
+                ry: 106,
+            },
+        )]
+        .into_iter()
+        .collect()
+    };
+    assert_no_write(None, Some("Americans"), Some("P"), valid(), true, true);
+    assert_no_write(
+        Some("Americans"),
+        Some("Americans"),
+        Some("P"),
+        valid(),
+        true,
+        false,
+    );
+    assert_no_write(Some("Americans"), None, Some("P"), valid(), true, true);
+    assert_no_write(
+        Some("Americans"),
+        Some("Americans"),
+        Some("P"),
+        valid(),
+        false,
+        true,
+    );
+    assert_no_write(
+        Some("Americans"),
+        Some("Americans"),
+        Some("15"),
+        valid(),
+        true,
+        true,
+    );
+    assert_no_write(
+        Some("Americans"),
+        Some("Americans"),
+        Some("P"),
+        HashMap::new(),
+        true,
+        true,
+    );
+    assert_no_write(
+        Some("Americans"),
+        Some("Americans"),
+        Some("P"),
+        [(
+            15,
+            crate::map::waypoints::Waypoint {
+                index: 15,
+                rx: 0,
+                ry: 0,
+            },
+        )]
+        .into_iter()
+        .collect(),
+        true,
+        true,
+    );
+    // Matching the House name is insufficient: only HouseState.country owns
+    // the native Spring/Find_By_Country_Index resolution.
+    assert_no_write(
+        Some("Americans"),
+        Some("Russians"),
+        Some("P"),
+        valid(),
+        true,
+        true,
+    );
+}
+
+#[test]
+fn action_138_clears_only_first_country_match_without_token_or_rng_use() {
+    let mut sim = Simulation::new();
+    let rules = waypoint_action_rules();
+    let first = register_waypoint_action_house(&mut sim, "First", Some("Americans"), (93, 106));
+    let second = register_waypoint_action_house(&mut sim, "Second", Some("Americans"), (122, 135));
+    let rng_before = sim.scenario_rng.state();
+
+    run_waypoint_action(
+        138,
+        Some("present but ignored"),
+        Some("AMERICANS"),
+        &mut sim,
+        &HashMap::new(),
+        Some(&rules),
+    );
+
+    assert_eq!(sim.houses[&first].alternate_base_center, (0, 0));
+    assert_eq!(sim.houses[&second].alternate_base_center, (122, 135));
+    assert_eq!(sim.houses[&first].base_center, Some((40, 50)));
+    assert_eq!(sim.houses[&second].base_center, Some((40, 50)));
+    assert_eq!(sim.scenario_rng.state(), rng_before);
+
+    let mut no_match = Simulation::new();
+    let house =
+        register_waypoint_action_house(&mut no_match, "OnlyHouse", Some("Russians"), (105, 194));
+    run_waypoint_action(
+        138,
+        None,
+        Some("Americans"),
+        &mut no_match,
+        &HashMap::new(),
+        Some(&rules),
+    );
+    assert_eq!(no_match.houses[&house].alternate_base_center, (105, 194));
 }

--- a/src/sim/trigger_runtime_tests.rs
+++ b/src/sim/trigger_runtime_tests.rs
@@ -526,11 +526,29 @@ fn time_trigger_can_center_camera_at_waypoint() {
 
     assert!(
         runtime
-            .advance_at_frame(44, &graph, &triggers, &events, &actions, None, None)
+            .advance_at_frame(
+                44,
+                &graph,
+                &triggers,
+                &events,
+                &actions,
+                None,
+                None,
+                &HashMap::new(),
+            )
             .is_empty()
     );
     assert_eq!(
-        runtime.advance_at_frame(45, &graph, &triggers, &events, &actions, None, None),
+        runtime.advance_at_frame(
+            45,
+            &graph,
+            &triggers,
+            &events,
+            &actions,
+            None,
+            None,
+            &HashMap::new(),
+        ),
         vec![TriggerEffect::CenterCameraAtWaypoint {
             waypoint: 9,
             immediate: true,
@@ -538,7 +556,16 @@ fn time_trigger_can_center_camera_at_waypoint() {
     );
     assert!(
         runtime
-            .advance_at_frame(46, &graph, &triggers, &events, &actions, None, None)
+            .advance_at_frame(
+                46,
+                &graph,
+                &triggers,
+                &events,
+                &actions,
+                None,
+                None,
+                &HashMap::new(),
+            )
             .is_empty()
     );
 }
@@ -1002,7 +1029,16 @@ fn global_actions_can_enable_and_force_followup_trigger() {
     let mut runtime = TriggerRuntime::from_map(&triggers, &HashMap::new());
 
     assert_eq!(
-        runtime.advance_at_frame(15, &graph, &triggers, &events, &actions, None, None),
+        runtime.advance_at_frame(
+            15,
+            &graph,
+            &triggers,
+            &events,
+            &actions,
+            None,
+            None,
+            &HashMap::new(),
+        ),
         vec![TriggerEffect::CenterCameraAtWaypoint {
             waypoint: 3,
             immediate: true,
@@ -1134,7 +1170,16 @@ fn linked_trigger_field_queues_followup_trigger() {
     let mut runtime = TriggerRuntime::from_map(&triggers, &HashMap::new());
 
     assert_eq!(
-        runtime.advance_at_frame(15, &graph, &triggers, &events, &actions, None, None),
+        runtime.advance_at_frame(
+            15,
+            &graph,
+            &triggers,
+            &events,
+            &actions,
+            None,
+            None,
+            &HashMap::new(),
+        ),
         vec![TriggerEffect::CenterCameraAtWaypoint {
             waypoint: 4,
             immediate: true,
@@ -1266,7 +1311,16 @@ fn forced_trigger_with_unmet_conditions_does_not_fire() {
     let mut runtime = TriggerRuntime::from_map(&triggers, &HashMap::new());
 
     assert_eq!(
-        runtime.advance_at_frame(15, &graph, &triggers, &events, &actions, None, None),
+        runtime.advance_at_frame(
+            15,
+            &graph,
+            &triggers,
+            &events,
+            &actions,
+            None,
+            None,
+            &HashMap::new(),
+        ),
         Vec::<TriggerEffect>::new()
     );
 }
@@ -1362,7 +1416,16 @@ fn mission_announce_then_force_end_emits_result_effects() {
     let mut runtime = TriggerRuntime::from_map(&triggers, &HashMap::new());
 
     assert_eq!(
-        runtime.advance_at_frame(15, &graph, &triggers, &events, &actions, None, None),
+        runtime.advance_at_frame(
+            15,
+            &graph,
+            &triggers,
+            &events,
+            &actions,
+            None,
+            None,
+            &HashMap::new(),
+        ),
         vec![
             TriggerEffect::MissionAnnouncement {
                 text: "Mission Accomplished".to_string(),
@@ -1509,12 +1572,30 @@ fn local_variables_seed_and_gate_followup_triggers() {
     let mut runtime = TriggerRuntime::from_map(&triggers, &local_variables);
 
     assert_eq!(
-        runtime.advance_at_frame(0, &graph, &triggers, &events, &actions, None, None),
+        runtime.advance_at_frame(
+            0,
+            &graph,
+            &triggers,
+            &events,
+            &actions,
+            None,
+            None,
+            &HashMap::new(),
+        ),
         Vec::<TriggerEffect>::new()
     );
     assert!(runtime.locals_set.contains(&2));
     assert_eq!(
-        runtime.advance_at_frame(0, &graph, &triggers, &events, &actions, None, None),
+        runtime.advance_at_frame(
+            0,
+            &graph,
+            &triggers,
+            &events,
+            &actions,
+            None,
+            None,
+            &HashMap::new(),
+        ),
         vec![TriggerEffect::CenterCameraAtWaypoint {
             waypoint: 6,
             immediate: true,
@@ -1657,6 +1738,7 @@ fn techtype_exists_and_not_exists_query_simulation_world() {
             &actions,
             Some(&mut sim),
             None,
+            &HashMap::new(),
         ),
         vec![
             TriggerEffect::CenterCameraAtWaypoint {
@@ -1722,7 +1804,7 @@ fn run_waypoint_action(
         &actions,
     );
     let mut runtime = TriggerRuntime::from_map(&triggers, &HashMap::new());
-    runtime.advance_at_frame_with_waypoints(
+    runtime.advance_at_frame(
         0,
         &graph,
         &triggers,

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -320,6 +320,7 @@ pub(crate) struct TriggerInputs<'a> {
     pub triggers: &'a TriggerMap,
     pub events: &'a EventMap,
     pub actions: &'a ActionMap,
+    pub waypoints: &'a std::collections::HashMap<u32, crate::map::waypoints::Waypoint>,
     /// Bound match rules used by action callbacks that share ordinary Techno
     /// runtime calculations (not reparsed or substituted by trigger data).
     pub rules: Option<&'a RuleSet>,
@@ -3592,10 +3593,11 @@ impl Simulation {
         triggers: &TriggerMap,
         events: &EventMap,
         actions: &ActionMap,
+        waypoints: &std::collections::HashMap<u32, crate::map::waypoints::Waypoint>,
         rules: Option<&RuleSet>,
     ) -> Vec<TriggerEffect> {
         let mut rt = std::mem::take(&mut self.trigger_runtime);
-        let effects = rt.advance_at_frame(
+        let effects = rt.advance_at_frame_with_waypoints(
             self.session.binary_frame,
             graph,
             triggers,
@@ -3603,6 +3605,7 @@ impl Simulation {
             actions,
             Some(self),
             rules,
+            waypoints,
         );
         self.trigger_runtime = rt;
         effects
@@ -3829,6 +3832,7 @@ impl Simulation {
             inputs.triggers,
             inputs.events,
             inputs.actions,
+            inputs.waypoints,
             inputs.rules,
         );
         self.trigger_effects.extend(effects);

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -3597,7 +3597,7 @@ impl Simulation {
         rules: Option<&RuleSet>,
     ) -> Vec<TriggerEffect> {
         let mut rt = std::mem::take(&mut self.trigger_runtime);
-        let effects = rt.advance_at_frame_with_waypoints(
+        let effects = rt.advance_at_frame(
             self.session.binary_frame,
             graph,
             triggers,

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -391,7 +391,7 @@ impl Simulation {
     /// components in stable-entity-ID order (EntityStore keys_sorted) for determinism.
     pub fn state_hash(&self) -> u64 {
         self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
         )
     }
 
@@ -403,7 +403,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             true, false, false, false, false, false, false, false, false, false, false, false,
-            false,
+            false, false,
         )
     }
 
@@ -415,7 +415,7 @@ impl Simulation {
     pub(crate) fn state_hash_before_lifecycle_v28_and_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             false, false, false, false, false, false, false, false, false, false, false, false,
-            false,
+            false, false,
         )
     }
 
@@ -424,7 +424,7 @@ impl Simulation {
     #[cfg(test)]
     pub(crate) fn state_hash_without_spark_dummy_level_slope_v107(&self) -> u64 {
         self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, false,
+            true, true, true, true, true, true, true, true, true, true, true, true, false, false,
         )
     }
 
@@ -443,6 +443,7 @@ impl Simulation {
         include_base_defense_response_v97: bool,
         include_techno_constructor_v104: bool,
         include_spark_dummy_level_slope_v107: bool,
+        include_alternate_base_center_v108: bool,
     ) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
 
@@ -486,7 +487,11 @@ impl Simulation {
         self.substrate.fold_base_reservations(&mut hasher);
 
         self.session.fold_game_options(&mut hasher);
-        self.hash_houses(&mut hasher, include_base_defense_response_v97);
+        self.hash_houses(
+            &mut hasher,
+            include_base_defense_response_v97,
+            include_alternate_base_center_v108,
+        );
         if include_terminal_score_v46 {
             self.hash_terminal_score_snapshot(&mut hasher);
         }
@@ -697,7 +702,12 @@ impl Simulation {
     }
 
     /// Hash per-player house state (BTreeMap = deterministic order).
-    fn hash_houses(&self, hasher: &mut impl Hasher, include_base_defense_response_v97: bool) {
+    fn hash_houses(
+        &self,
+        hasher: &mut impl Hasher,
+        include_base_defense_response_v97: bool,
+        include_alternate_base_center_v108: bool,
+    ) {
         for (owner, house) in &self.houses {
             owner.hash(hasher);
             house.credits.hash(hasher);
@@ -749,6 +759,9 @@ impl Simulation {
                 ry.hash(hasher);
             } else {
                 0u8.hash(hasher);
+            }
+            if include_alternate_base_center_v108 {
+                house.alternate_base_center.hash(hasher);
             }
             house.base_reservation.hash(hasher);
             house.waypoint_edge.hash(hasher);
@@ -2489,6 +2502,29 @@ mod rally_hash_tests {
         sim_b.houses.insert(owner_b, hard_house);
 
         assert_ne!(sim_a.state_hash(), sim_b.state_hash());
+    }
+
+    #[test]
+    fn alternate_base_center_changes_state_hash_without_changing_primary_center() {
+        use crate::sim::house_state::HouseState;
+
+        let mut baseline = Simulation::new();
+        let mut changed = Simulation::new();
+        let owner = baseline.interner.intern("Computer1");
+        let changed_owner = changed.interner.intern("Computer1");
+        assert_eq!(owner, changed_owner);
+        let mut house = HouseState::new(owner, 0, None, false, 0, 10);
+        house.base_center = Some((41, 52));
+        let mut changed_house = house.clone();
+        changed_house.alternate_base_center = (93, 106);
+        baseline.houses.insert(owner, house);
+        changed.houses.insert(changed_owner, changed_house);
+
+        assert_ne!(baseline.state_hash(), changed.state_hash());
+        assert_eq!(
+            baseline.houses[&owner].base_center,
+            changed.houses[&owner].base_center
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What this integrates
- reproduces `TActionClass` alphabetic waypoint decoding and materializes its constructor/read state
- reads the canonical 702 waypoint slots with native signed integer semantics
- resolves trigger owners through source-order `HouseTypeClass` identity
- implements actions 137/138 against the distinct House alternate-base cell
- binds immutable waypoints through the sole authoritative trigger evaluator
- persists and hashes alternate-base state with snapshot version 108

## Scope
This is the Phase 3 alternate-base waypoint prerequisite only. It does not add naval or ordinary placement selection, BasePlan/AI placement, Temporal, Gattling, Explodes, trigger scheduling changes, RNG, or primary `base_center` writes. Draft PR #172 is not merged wholesale.

## Review history
- critic R1 found an implicit empty-waypoint public API; fixed in `e1d52329`
- critic R2 found transplanted-commit provenance wording incomplete; fixed without history rewriting in `a8486b6c`
- fresh critic R3: PASS with zero actionable, unverified, or residual items

## Validation
- `cargo test -p vera20k --lib trigger_runtime`: 22 passed, 0 failed
- `cargo test -p vera20k --lib waypoint`: 31 passed, 0 failed
- `cargo test -p vera20k --lib action_13`: 7 passed, 0 failed
- `cargo test -p vera20k --lib alternate_base`: 3 passed, 0 failed
- decoder, camera, owner-resolution, and resource-rebind filters: 1 passed, 0 failed each
- full `cargo test -p vera20k --lib`: 7649 passed, 0 failed, 76 ignored
- `git diff --check origin/main..HEAD`: clean
- branch audit: 6 ahead, 0 behind current `origin/main`