### PR TITLE
Integrate ordered House BasePlan lifecycle

### DIFF
--- a/docs/plans/2026-08-26-base-plan-state-lifecycle-design.md
+++ b/docs/plans/2026-08-26-base-plan-state-lifecycle-design.md
@@ -1,0 +1,179 @@
+# Phase 3 ordered BasePlan state and lifecycle design
+
+**Date:** 2026-08-26
+
+**Phase/GSI ownership hypothesis:** Phase 3, GSI-04.05
+
+**Native evidence:**
+
+- `docs/research/PHASE3_HOUSECLASS_ORDINARY_BASE_PLACEMENT_005060B0_GHIDRA_REPORT.md`, especially sections 7.6.1, 7.6.2, 7.6.8, 7.6.9, 7.6.10, 9, 11.1 item 10, and 11.2.
+- Active-retail `BaseClass`/House/Building routines cited there: `0x0042E6F0`, `0x0042EBE0`, `0x0042ED60`, `0x0042F180`, `0x0042F260`, `0x0042F380`, `0x00440580`, `0x00443C60`, and `0x0050A490`.
+
+## Verdict
+
+Rust has no native-equivalent ordered House BasePlan. The ready-building queue
+cannot own this state: native scenario loading, AI planning, Building exit,
+successful Unlimbo, placement failure, and Building Limbo all observe or mutate
+the same ordered 16-byte node vector. The next bounded mechanism establishes
+that authoritative state and the independently callable lifecycle writers. It
+does not claim that ordinary production planning or site selection is connected
+yet; those remain explicit open mechanisms under GSI-04.05.
+
+## Player-experience ledger
+
+| Native behavior | Rust result required by this mechanism |
+|---|---|
+| Campaign BasePlan nodes load in numbered order | Map house parsing preserves `PercentBuilt`, signed type/control, and signed-narrowed packed cells in source-number order |
+| Planned sites and filled/retry state survive save/load | House state owns the ordered nodes; current snapshots and the current state hash include every semantic field |
+| A successfully placed AI Building satisfies its plan node | Successful Building Unlimbo marks the exact type/cell node first, or the first unfilled same-type node only for an `UndeploysInto` type, and resets retries |
+| Removing a Building invalidates related cached sites | Building Limbo clears other nodes sharing the cell and applies the exact nonzero-mode `IsBaseDefense` replacement conversion |
+| Repeated normalized placement failure eventually abandons one node in skirmish | Retry increments with signed wrapping arithmetic, campaign never evicts, and nonzero modes remove only after strict `new_count > MaximumBuildingPlacementFailures` |
+| A failed ordinary coordinate is not retried forever | The state authority can clear every node whose packed site equals the failed coordinate without changing its other fields |
+| Native zero/empty/invalid cells are one bit pattern | Every state boundary uses packed `(0,0)`; no semantic `Option` variants are serialized or hashed |
+
+## Authoritative representation
+
+Add a small `sim::base_plan` module and make `HouseState` own one
+`BasePlanState`:
+
+```text
+BasePlanState {
+    percent_built: i32,
+    nodes: Vec<BasePlanNode>,
+}
+
+BasePlanNode {
+    type_or_control: i32,
+    packed_cell: u32,
+    filled: bool,
+    retry_count: i32,
+}
+```
+
+`type_or_control >= 0` is the native BuildingType registry index, not an
+interned-name surrogate. Negative planner controls remain literal signed values.
+Packing uses signed 16-bit X in the low word and signed 16-bit Y in the high
+word. `(0,0)` is the only stored empty/invalid-site value.
+
+The native scenario writer and `BaseClass::CalculateChecksum` fold only node
+count, type/control, X, and Y. Provide a focused native-checksum helper with that
+scope if useful for verification. This does **not** reduce Rust's authoritative
+world hash: current-schema hashing must include `PercentBuilt`, order, every
+type/control, packed cell, filled latch, and retry counter because all affect
+future deterministic behavior.
+
+## Scenario population
+
+Extend the ordered map-house representation rather than reparsing raw INI in
+sim. For every named house section:
+
+1. Read signed `PercentBuilt=` with the representation's current/default value
+   and signed `NodeCount=` with default zero.
+2. Visit `000` through `NodeCount-1` in numeric order.
+3. When the first value byte is `-`, parse the first comma token with signed
+   `atoi` semantics as the control value. Otherwise resolve the first token
+   case-insensitively to its BuildingType registry index.
+4. Parse X and Y with signed `atoi`, narrow each to signed 16 bits, and pack the
+   two words literally.
+5. Append the node with deterministic `filled=false`, `retry_count=0`. Rust
+   allocation failure is fatal rather than a recoverable branch; no speculative
+   rollback or alternate semantics are added.
+
+Install the parsed plan when `initialize_map_roster_houses` constructs each
+named scenario House, before map Buildings unlimbo. Generated skirmish Houses
+start with an empty vector and zero percent; their native `0x005054B0`
+population belongs to a later mechanism.
+
+## Lifecycle writers
+
+Fresh Buildings need immutable, snapshot-safe type facts at the rules-to-entity
+boundary: exact BuildingType registry index, `IsBaseDefense`, and whether
+`UndeploysInto` is non-null. Do not infer any of them from names or categories.
+
+After successful Building Mark/Unlimbo for a non-human owner:
+
+1. Scan nodes from zero for the first exact type index **and** packed-cell match.
+   The filled latch does not gate this exact search.
+2. Only if none matched and the placed type has non-null `UndeploysInto`, scan
+   again for the first same-type node with `filled == false`; ignore its cell.
+3. Set the selected node's filled latch to true and retry count to zero. Change
+   nothing when neither search succeeds.
+
+At the Building Limbo seam, before the common Techno Limbo loses the committed
+type/cell facts and only outside map-editor mode:
+
+1. Find the first exact type-index/cell node. If none exists, change nothing.
+2. Clear the packed cell of every *other* node sharing that cell, leaving those
+   nodes' type/control, filled, and retry fields unchanged.
+3. Leave the matched node unchanged for `IsBaseDefense=no` or campaign mode.
+4. For `IsBaseDefense=yes` in a nonzero mode, write type/control `-1` and packed
+   `(0,0)` to the matched node, retaining its filled/retry fields.
+
+Expose exact state mutations for the later Building-exit integration:
+
+- clear all sites equal to one failed packed coordinate, without touching other
+  fields;
+- on normalized final result `1`, increment a referenced node's retry counter
+  first with signed wrapping arithmetic; campaign retains it; a nonzero mode
+  stable-removes the complete node only when the new count is strictly greater
+  than the signed rule value; a missing node has no effect.
+
+Parse signed `[General] MaximumBuildingPlacementFailures=` with constructor
+default `5`, preserving negative mod values. The active retail override is `3`.
+
+## Integration and ordering constraints
+
+- Preserve the current ready queue unchanged; BasePlan is separate authority.
+- Scenario nodes must exist before map-object Unlimbo so map Buildings can fill
+  them at the native lifecycle boundary.
+- Put the Limbo writer before common concealment/pointer-expiry can erase or
+  transfer the needed owner/type/cell facts.
+- The lifecycle functions must use vector order and stable `Vec::remove` shifts.
+- Bump the snapshot schema once. Current-schema hashing includes the new House
+  and immutable entity fields; historical hash layouts remain gated exactly as
+  existing versioned fields are.
+- Do not run the full `cargo test -p vera20k --lib` suite in this mechanism.
+
+## Evidence-backed exclusions and open mechanisms
+
+The following are **not** silently approximated here and keep GSI-04.05 open:
+
+- fresh-skirmish `AI_RecalcBuildOptions` BasePlan generation;
+- runtime refinery/weapons insertion, wall expansion, projected-power splice,
+  ComputerTakeover population, and planned current/next-node site writes;
+- wildcard/explicit satisfaction lookup and the filled-node recycling policy;
+- BasePlan-center recentering and AI ConstructionYard-deploy center writes;
+- the strategy timer, AI-hate/Super/emergency chain, eight-frame chooser, and
+  economy mode transitions that schedule native planning;
+- influence-grid construction and defense type/category/quadrant selection;
+- ordinary `0x005060B0` site selection, cached-site connectivity/reselection,
+  and downstream placement-result classification;
+- wall/base-perimeter execution at `0x005082C0`, upgrade placement, the two
+  Team convoy removals, and runtime MapClass resize adjustment.
+
+The last two excluded native count-store families are evidence-backed separate
+callers per report section 7.6.10; they are not guessed inactive.
+
+## Acceptance
+
+Focused tests must prove at least:
+
+- scenario `PercentBuilt` and numbered nodes preserve numeric order;
+- negative control parsing and signed-i16 cell narrowing are literal;
+- scenario nodes normalize native undefined filled/retry bytes to false/zero;
+- native BaseClass checksum excludes filled/retry while Rust state hash includes
+  them and node order;
+- current snapshot round-trips all fields and rejects the preceding schema;
+- successful non-human Building Unlimbo exact-match priority, undeploy fallback,
+  filled-node skip, cell ignore, and retry reset;
+- human Building Unlimbo does not mutate BasePlan;
+- Limbo clears all other same-cell sites and applies the exact campaign,
+  non-defense, and skirmish-defense tails;
+- failure-site clearing preserves type/filled/retry;
+- retry post-increment, equality retention, fourth-failure retail eviction,
+  campaign no-eviction, negative-maximum first-failure eviction, and stable
+  ordered removal.
+
+The builder must run only focused `--lib` filters, report literal output, commit
+the coherent slice, and leave Cargo idle. A fresh read-only critic must receive
+this design, the native report, the complete diff, and all validation output.

--- a/src/app/frontend/skirmish.rs
+++ b/src/app/frontend/skirmish.rs
@@ -639,6 +639,7 @@ mod tests {
                     player_control: None,
                     iq: None,
                     allies: Vec::new(),
+                    base_plan: Default::default(),
                 },
                 HouseDefinition {
                     name: "Americans".to_string(),
@@ -648,6 +649,7 @@ mod tests {
                     player_control: Some(true),
                     iq: None,
                     allies: Vec::new(),
+                    base_plan: Default::default(),
                 },
             ],
         }
@@ -1712,6 +1714,7 @@ mod tests {
                 player_control: Some(true),
                 iq: None,
                 allies: Vec::new(),
+                base_plan: Default::default(),
             }],
         };
 

--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -1970,7 +1970,8 @@ pub(crate) fn load_map_from_initial(
         .as_ref()
         .map(|r| r.color_schemes.as_slice())
         .unwrap_or(&[]);
-    let house_roster: HouseRoster = houses::parse_house_roster(&map_data.ini, color_schemes);
+    let house_roster: HouseRoster =
+        houses::parse_house_roster(&map_data.ini, color_schemes, rules.as_ref());
     let house_color_map: HouseColorMap = skirmish_launch_session.map_or_else(
         || house_roster.color_map(),
         |session| house_color_map_for_launch_session(session, &house_roster),

--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -1097,7 +1097,8 @@ impl MapLoadInitial {
             &rules,
             &overlay_registry,
         );
-        let house_roster = houses::parse_house_roster(&map_data.ini, &rules.color_schemes);
+        let house_roster =
+            houses::parse_house_roster(&map_data.ini, &rules.color_schemes, Some(&rules));
         let height_map = resolved_terrain.build_height_map();
         let lighting_profiles = lighting::parse_lighting_profiles(&map_data.ini);
         let scenario_descriptor = crate::sim::scenario_session::ScenarioDescriptor {

--- a/src/headless_scenario.rs
+++ b/src/headless_scenario.rs
@@ -221,8 +221,11 @@ pub fn load(retail_dir: &Path, map_file_name: &str, seed: u32) -> Result<Headles
     rules.bind_effect_assets(&assets, theater.extension, &map.header.theater);
     rules.bind_terrain_spawner_assets(&rules_ini, &assets, theater.extension, &map.header.theater);
     rules.bind_animation_sequences(&infantry_sequences);
-    let house_roster =
-        crate::map::houses::parse_house_roster(&map.ini, rules.color_schemes.as_slice());
+    let house_roster = crate::map::houses::parse_house_roster(
+        &map.ini,
+        rules.color_schemes.as_slice(),
+        Some(&rules),
+    );
     let mut overlay_grid = OverlayGrid::from_overlay_entries(
         &map.overlays,
         terrain_bootstrap.resolved.width(),

--- a/src/map/houses.rs
+++ b/src/map/houses.rs
@@ -241,6 +241,18 @@ pub fn parse_house_roster(
     HouseRoster { houses }
 }
 
+/// Parse the ordered scenario BasePlan through native
+/// `FUN_0042EBE0 @ 0x0042EBE0`. `HouseClass__Read_Scenario_INI @ 0x00500B40`
+/// calls it on the embedded base constructed by
+/// `HouseClass__Constructor @ 0x004F54A0` through
+/// `BaseClass__Constructor @ 0x0042E6F0`.
+///
+/// Native formats numeric keys as `%03d`, reads each value into `char[128]`
+/// (127 payload bytes before NUL), classifies a control only when byte zero is
+/// `'-'`, otherwise resolves `BuildingTypeClass__FindIndexByName @ 0x0045E7B0`,
+/// comma-tokenizes, applies signed `atoi`, narrows X/Y to 16 bits, and appends
+/// in numeric-key order. Its undefined trailing node locals are not scenario
+/// fields, so Rust deterministically normalizes filled/retry below.
 fn parse_scenario_base_plan(
     section: Option<&crate::rules::ini_parser::IniSection>,
     rules: Option<&RuleSet>,
@@ -274,8 +286,8 @@ fn parse_scenario_base_plan(
         nodes.push(ScenarioBasePlanNode {
             type_or_control,
             packed_cell: pack_scenario_base_plan_cell(x, y),
-            // Native stack bytes are undefined at this read boundary. Rust
-            // normalizes them once instead of propagating nondeterminism.
+            // FUN_0042EBE0 assembly 0x0042ED23..0x0042ED2E copies undefined
+            // stack locals here; its writer and checksum omit both fields.
             filled: false,
             retry_count: 0,
         });
@@ -286,8 +298,8 @@ fn parse_scenario_base_plan(
     }
 }
 
-/// Coordinate-token projection through the CRT `atoi @ 0x007C9B72` reached
-/// by native BasePlan loading. CRT `atoi` skips only its ASCII whitespace set
+/// Coordinate-token projection through the CRT `atoi @ 0x007C9B72` reached by
+/// `FUN_0042EBE0 @ 0x0042EBE0`. CRT `atoi` skips only its ASCII whitespace set
 /// before inspecting the optional sign and leading decimal digits.
 fn atoi_scenario_base_plan_coordinate(value: &[u8]) -> i32 {
     let leading_whitespace = value

--- a/src/map/houses.rs
+++ b/src/map/houses.rs
@@ -263,8 +263,8 @@ fn parse_scenario_base_plan(
                 .and_then(|rules| rules.building_type_index(type_token))
                 .unwrap_or(-1)
         };
-        let x = crate::rules::ini_value::atoi_lenient(tokens.next().unwrap_or(""));
-        let y = crate::rules::ini_value::atoi_lenient(tokens.next().unwrap_or(""));
+        let x = atoi_scenario_base_plan_coordinate(tokens.next().unwrap_or(""));
+        let y = atoi_scenario_base_plan_coordinate(tokens.next().unwrap_or(""));
         nodes.push(ScenarioBasePlanNode {
             type_or_control,
             packed_cell: pack_scenario_base_plan_cell(x, y),
@@ -278,6 +278,17 @@ fn parse_scenario_base_plan(
         percent_built,
         nodes,
     }
+}
+
+/// Coordinate-token projection through the CRT `atoi @ 0x007C9B72` reached
+/// by native BasePlan loading. CRT `atoi` skips only its ASCII whitespace set
+/// before inspecting the optional sign and leading decimal digits.
+fn atoi_scenario_base_plan_coordinate(value: &str) -> i32 {
+    let leading_whitespace = value
+        .bytes()
+        .take_while(|byte| matches!(*byte, b'\t'..=b'\r' | b' '))
+        .count();
+    crate::rules::ini_value::atoi_lenient(&value[leading_whitespace..])
 }
 
 #[cfg(test)]
@@ -438,5 +449,35 @@ mod tests {
         assert_eq!(plan.nodes[2].packed_cell, 32_768u32 | (32_766u32 << 16));
         assert!(plan.nodes.iter().all(|node| !node.filled));
         assert!(plan.nodes.iter().all(|node| node.retry_count == 0));
+    }
+
+    #[test]
+    fn gsi_04_05_scenario_base_plan_coordinates_use_crt_atoi_whitespace() {
+        let rules = base_plan_rules();
+        let ini = IniFile::from_str(
+            "[Houses]\n0=AIHouse\n\
+             [AIHouse]\nNodeCount=3\n\
+             000=GAPOWR, 10, -11\n\
+             001=GACNST,\t+12,\t-13\n\
+             002=GAPOWR, 32768, -32770\n",
+        );
+        let roster = parse_house_roster(&ini, &test_schemes(), Some(&rules));
+        let plan = &roster.houses[0].base_plan;
+
+        assert_eq!(plan.nodes[0].packed_cell, 10u32 | (65_525u32 << 16));
+        assert_eq!(plan.nodes[1].packed_cell, 12u32 | (65_523u32 << 16));
+        assert_eq!(plan.nodes[2].packed_cell, 32_768u32 | (32_766u32 << 16));
+        assert_eq!(
+            plan.nodes
+                .iter()
+                .map(|node| node.type_or_control)
+                .collect::<Vec<_>>(),
+            [0, 1, 0]
+        );
+
+        assert_eq!(
+            atoi_scenario_base_plan_coordinate(" \t\n\u{000b}\u{000c}\r-14tail"),
+            -14
+        );
     }
 }

--- a/src/map/houses.rs
+++ b/src/map/houses.rs
@@ -271,9 +271,7 @@ fn parse_scenario_base_plan(
         let value = value.as_bytes();
         let value = &value[..value.len().min(NATIVE_ROW_PAYLOAD_BYTES)];
         let mut tokens = value.split(|byte| *byte == b',');
-        let type_token = std::str::from_utf8(tokens.next().unwrap_or_default())
-            .unwrap_or("")
-            .trim();
+        let type_token = std::str::from_utf8(tokens.next().unwrap_or_default()).unwrap_or("");
         let type_or_control = if value.first() == Some(&b'-') {
             crate::rules::ini_value::atoi_lenient(type_token)
         } else {
@@ -508,6 +506,29 @@ mod tests {
         assert_eq!(
             atoi_scenario_base_plan_coordinate(b" \t\n\x0b\x0c\r-14tail"),
             -14
+        );
+    }
+
+    #[test]
+    fn gsi_04_05_scenario_base_plan_type_lookup_preserves_native_token_whitespace() {
+        let rules = base_plan_rules();
+        let ini = IniFile::from_str(
+            "[Houses]\n0=AIHouse\n\
+             [AIHouse]\nNodeCount=3\n\
+             000=GAPOWR,1,2\n\
+             001=GAPOWR ,3,4\n\
+             002=GACNST\t,5,6\n",
+        );
+        let roster = parse_house_roster(&ini, &test_schemes(), Some(&rules));
+        let plan = &roster.houses[0].base_plan;
+
+        assert_eq!(
+            plan.nodes
+                .iter()
+                .map(|node| node.type_or_control)
+                .collect::<Vec<_>>(),
+            [0, -1, -1],
+            "native passes the comma-delimited type token to FindIndexByName without trimming"
         );
     }
 

--- a/src/map/houses.rs
+++ b/src/map/houses.rs
@@ -245,6 +245,8 @@ fn parse_scenario_base_plan(
     section: Option<&crate::rules::ini_parser::IniSection>,
     rules: Option<&RuleSet>,
 ) -> ScenarioBasePlanDefinition {
+    const NATIVE_ROW_PAYLOAD_BYTES: usize = 127;
+
     let Some(section) = section else {
         return ScenarioBasePlanDefinition::default();
     };
@@ -254,17 +256,21 @@ fn parse_scenario_base_plan(
     for index in 0..node_count.max(0) {
         let key = format!("{index:03}");
         let value = section.get(&key).unwrap_or("");
-        let mut tokens = value.split(',');
-        let type_token = tokens.next().unwrap_or("").trim();
-        let type_or_control = if value.as_bytes().first() == Some(&b'-') {
+        let value = value.as_bytes();
+        let value = &value[..value.len().min(NATIVE_ROW_PAYLOAD_BYTES)];
+        let mut tokens = value.split(|byte| *byte == b',');
+        let type_token = std::str::from_utf8(tokens.next().unwrap_or_default())
+            .unwrap_or("")
+            .trim();
+        let type_or_control = if value.first() == Some(&b'-') {
             crate::rules::ini_value::atoi_lenient(type_token)
         } else {
             rules
                 .and_then(|rules| rules.building_type_index(type_token))
                 .unwrap_or(-1)
         };
-        let x = atoi_scenario_base_plan_coordinate(tokens.next().unwrap_or(""));
-        let y = atoi_scenario_base_plan_coordinate(tokens.next().unwrap_or(""));
+        let x = atoi_scenario_base_plan_coordinate(tokens.next().unwrap_or_default());
+        let y = atoi_scenario_base_plan_coordinate(tokens.next().unwrap_or_default());
         nodes.push(ScenarioBasePlanNode {
             type_or_control,
             packed_cell: pack_scenario_base_plan_cell(x, y),
@@ -283,12 +289,24 @@ fn parse_scenario_base_plan(
 /// Coordinate-token projection through the CRT `atoi @ 0x007C9B72` reached
 /// by native BasePlan loading. CRT `atoi` skips only its ASCII whitespace set
 /// before inspecting the optional sign and leading decimal digits.
-fn atoi_scenario_base_plan_coordinate(value: &str) -> i32 {
+fn atoi_scenario_base_plan_coordinate(value: &[u8]) -> i32 {
     let leading_whitespace = value
-        .bytes()
-        .take_while(|byte| matches!(*byte, b'\t'..=b'\r' | b' '))
+        .iter()
+        .take_while(|&&byte| matches!(byte, b'\t'..=b'\r' | b' '))
         .count();
-    crate::rules::ini_value::atoi_lenient(&value[leading_whitespace..])
+    let value = &value[leading_whitespace..];
+    let sign_bytes = usize::from(
+        value
+            .first()
+            .is_some_and(|byte| matches!(*byte, b'-' | b'+')),
+    );
+    let digit_bytes = value[sign_bytes..]
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    let numeric_bytes = &value[..sign_bytes + digit_bytes];
+    let numeric = std::str::from_utf8(numeric_bytes).expect("BasePlan numeric grammar is ASCII");
+    crate::rules::ini_value::atoi_lenient(numeric)
 }
 
 #[cfg(test)]
@@ -476,8 +494,36 @@ mod tests {
         );
 
         assert_eq!(
-            atoi_scenario_base_plan_coordinate(" \t\n\u{000b}\u{000c}\r-14tail"),
+            atoi_scenario_base_plan_coordinate(b" \t\n\x0b\x0c\r-14tail"),
             -14
         );
+    }
+
+    #[test]
+    fn gsi_04_05_scenario_base_plan_row_uses_native_127_byte_prefix() {
+        let rules = base_plan_rules();
+        let oversized = format!("GAPOWR,{}98,77", " ".repeat(119));
+        assert_eq!(oversized.as_bytes()[126], b'9');
+        assert_eq!(oversized.as_bytes()[127], b'8');
+        let ini = IniFile::from_str(&format!(
+            "[Houses]\n0=AIHouse\n\
+             [AIHouse]\nNodeCount=3\n\
+             000={oversized}\n\
+             001=-5, 32768, -32770\n\
+             002=GACNST,\t+12,\t-13\n"
+        ));
+        let roster = parse_house_roster(&ini, &test_schemes(), Some(&rules));
+        let plan = &roster.houses[0].base_plan;
+
+        assert_eq!(
+            plan.nodes
+                .iter()
+                .map(|node| node.type_or_control)
+                .collect::<Vec<_>>(),
+            [0, -5, 1]
+        );
+        assert_eq!(plan.nodes[0].packed_cell, 9);
+        assert_eq!(plan.nodes[1].packed_cell, 32_768u32 | (32_766u32 << 16));
+        assert_eq!(plan.nodes[2].packed_cell, 12u32 | (65_523u32 << 16));
     }
 }

--- a/src/map/houses.rs
+++ b/src/map/houses.rs
@@ -13,6 +13,27 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use crate::rules::color_scheme::{ColorSchemeEntry, scheme_entry_by_name};
 use crate::rules::house_colors::{DEFAULT_SCHEME_ENTRY, HouseColorIndex};
 use crate::rules::ini_parser::IniFile;
+use crate::rules::ruleset::RuleSet;
+
+/// Ordered map-side BasePlan node, installed into House simulation state before
+/// map objects are spawned.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ScenarioBasePlanNode {
+    pub type_or_control: i32,
+    pub packed_cell: u32,
+    pub filled: bool,
+    pub retry_count: i32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ScenarioBasePlanDefinition {
+    pub percent_built: i32,
+    pub nodes: Vec<ScenarioBasePlanNode>,
+}
+
+const fn pack_scenario_base_plan_cell(x: i32, y: i32) -> u32 {
+    (x as i16 as u16 as u32) | ((y as i16 as u16 as u32) << 16)
+}
 
 /// Mapping from owner name (e.g., "Americans") to house color index.
 ///
@@ -39,6 +60,8 @@ pub struct HouseDefinition {
     pub iq: Option<i32>,
     /// Allies listed in the house section.
     pub allies: Vec<String>,
+    /// Scenario-authored BasePlan in numeric node order.
+    pub base_plan: ScenarioBasePlanDefinition,
 }
 
 impl HouseDefinition {
@@ -150,7 +173,7 @@ fn normalize_house_name(name: &str) -> String {
 /// `schemes` is the parsed `[Colors]` list used to resolve each house's
 /// `Color=<name>` to a `[Colors]` entry index.
 pub fn parse_house_colors(ini: &IniFile, schemes: &[ColorSchemeEntry]) -> HouseColorMap {
-    parse_house_roster(ini, schemes).color_map()
+    parse_house_roster(ini, schemes, None).color_map()
 }
 
 /// Parse the ordered active-house roster from a map's INI data.
@@ -158,7 +181,11 @@ pub fn parse_house_colors(ini: &IniFile, schemes: &[ColorSchemeEntry]) -> HouseC
 /// `schemes` is the parsed `[Colors]` list; a house's `Color=<name>` resolves to
 /// that entry's index (case-insensitive). Houses with no/unknown color fall back
 /// to [`DEFAULT_SCHEME_ENTRY`].
-pub fn parse_house_roster(ini: &IniFile, schemes: &[ColorSchemeEntry]) -> HouseRoster {
+pub fn parse_house_roster(
+    ini: &IniFile,
+    schemes: &[ColorSchemeEntry],
+    rules: Option<&RuleSet>,
+) -> HouseRoster {
     let houses_section = match ini.section("Houses") {
         Some(s) => s,
         None => {
@@ -196,6 +223,7 @@ pub fn parse_house_roster(ini: &IniFile, schemes: &[ColorSchemeEntry]) -> HouseR
             .filter(|s| !s.is_empty())
             .map(str::to_string)
             .collect();
+        let base_plan = parse_scenario_base_plan(section, rules);
 
         houses.push(HouseDefinition {
             name: house_name,
@@ -205,6 +233,7 @@ pub fn parse_house_roster(ini: &IniFile, schemes: &[ColorSchemeEntry]) -> HouseR
             player_control,
             iq,
             allies,
+            base_plan,
         });
     }
 
@@ -212,9 +241,57 @@ pub fn parse_house_roster(ini: &IniFile, schemes: &[ColorSchemeEntry]) -> HouseR
     HouseRoster { houses }
 }
 
+fn parse_scenario_base_plan(
+    section: Option<&crate::rules::ini_parser::IniSection>,
+    rules: Option<&RuleSet>,
+) -> ScenarioBasePlanDefinition {
+    let Some(section) = section else {
+        return ScenarioBasePlanDefinition::default();
+    };
+    let percent_built = section.get_i32("PercentBuilt").unwrap_or(0);
+    let node_count = section.get_i32("NodeCount").unwrap_or(0);
+    let mut nodes = Vec::new();
+    for index in 0..node_count.max(0) {
+        let key = format!("{index:03}");
+        let value = section.get(&key).unwrap_or("");
+        let mut tokens = value.split(',');
+        let type_token = tokens.next().unwrap_or("").trim();
+        let type_or_control = if value.as_bytes().first() == Some(&b'-') {
+            crate::rules::ini_value::atoi_lenient(type_token)
+        } else {
+            rules
+                .and_then(|rules| rules.building_type_index(type_token))
+                .unwrap_or(-1)
+        };
+        let x = crate::rules::ini_value::atoi_lenient(tokens.next().unwrap_or(""));
+        let y = crate::rules::ini_value::atoi_lenient(tokens.next().unwrap_or(""));
+        nodes.push(ScenarioBasePlanNode {
+            type_or_control,
+            packed_cell: pack_scenario_base_plan_cell(x, y),
+            // Native stack bytes are undefined at this read boundary. Rust
+            // normalizes them once instead of propagating nondeterminism.
+            filled: false,
+            retry_count: 0,
+        });
+    }
+    ScenarioBasePlanDefinition {
+        percent_built,
+        nodes,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn base_plan_rules() -> RuleSet {
+        RuleSet::from_ini(&IniFile::from_str(
+            "[BuildingTypes]\n0=GAPOWR\n1=GACNST\n\
+             [GAPOWR]\nStrength=750\n\
+             [GACNST]\nStrength=1000\n",
+        ))
+        .expect("base-plan rules")
+    }
 
     /// Retail `[Colors]` list (declaration order) — only the entries the tests
     /// reference need exact positions: DarkRed = entry 5, DarkBlue = entry 10.
@@ -251,7 +328,7 @@ mod tests {
              [Americans]\nColor=DarkBlue\nSide=Allies\nCountry=America\nPlayerControl=yes\n\
              [Russians]\nColor=DarkRed\nSide=Soviet\nCountry=Russia\nAllies=Confederation,YuriCountry\n",
         );
-        let roster = parse_house_roster(&ini, &test_schemes());
+        let roster = parse_house_roster(&ini, &test_schemes(), None);
         let map = roster.color_map();
         assert_eq!(map.len(), 2);
         // Color=name resolves to the [Colors] entry index.
@@ -306,7 +383,7 @@ mod tests {
     #[test]
     fn test_missing_color_defaults_to_default_scheme() {
         let ini: IniFile = IniFile::from_str("[Houses]\n0=Neutral\n[Neutral]\nIQ=5\n");
-        let roster = parse_house_roster(&ini, &test_schemes());
+        let roster = parse_house_roster(&ini, &test_schemes(), None);
         let map = roster.color_map();
         assert_eq!(map["Neutral"], HouseColorIndex(DEFAULT_SCHEME_ENTRY as u8));
         assert_eq!(roster.houses[0].iq, Some(5));
@@ -325,7 +402,7 @@ mod tests {
     #[test]
     fn test_missing_houses_section() {
         let ini: IniFile = IniFile::from_str("[General]\nKey=Value\n");
-        let roster = parse_house_roster(&ini, &test_schemes());
+        let roster = parse_house_roster(&ini, &test_schemes(), None);
         assert!(roster.houses.is_empty());
     }
 
@@ -334,5 +411,32 @@ mod tests {
         let ini: IniFile = IniFile::from_str("[Houses]\n0=Ghost\n");
         let map = parse_house_colors(&ini, &test_schemes());
         assert_eq!(map["Ghost"], HouseColorIndex(DEFAULT_SCHEME_ENTRY as u8));
+    }
+
+    #[test]
+    fn gsi_04_05_scenario_nodecount_parses_percent_and_numbered_nodes_in_source_order() {
+        let rules = base_plan_rules();
+        let ini = IniFile::from_str(
+            "[Houses]\n0=AIHouse\n\
+             [AIHouse]\nPercentBuilt=-17\nNodeCount=3\n\
+             002=GACNST,32768,-32770\n\
+             000=GAPOWR,1,2\n\
+             001=-5,-32769,65535\n",
+        );
+        let roster = parse_house_roster(&ini, &test_schemes(), Some(&rules));
+        let plan = &roster.houses[0].base_plan;
+        assert_eq!(plan.percent_built, -17);
+        assert_eq!(
+            plan.nodes
+                .iter()
+                .map(|node| node.type_or_control)
+                .collect::<Vec<_>>(),
+            [0, -5, 1]
+        );
+        assert_eq!(plan.nodes[0].packed_cell, 1u32 | (2u32 << 16));
+        assert_eq!(plan.nodes[1].packed_cell, 32_767u32 | (65_535u32 << 16));
+        assert_eq!(plan.nodes[2].packed_cell, 32_768u32 | (32_766u32 << 16));
+        assert!(plan.nodes.iter().all(|node| !node.filled));
+        assert!(plan.nodes.iter().all(|node| node.retry_count == 0));
     }
 }

--- a/src/rules/ini_parser.rs
+++ b/src/rules/ini_parser.rs
@@ -804,10 +804,7 @@ impl RulesPassProcessor {
         let identity = trim_ascii_controls(identity);
         // UnitTypeClass::FindOrAllocate @ 0x007480D0 rejects both native
         // no-type sentinels before the per-family case-insensitive lookup.
-        if identity.is_empty()
-            || identity.eq_ignore_ascii_case("none")
-            || identity.eq_ignore_ascii_case("<none>")
-        {
+        if is_native_none_type_name(identity) {
             return;
         }
         let members = self.family_mut(family);
@@ -1215,6 +1212,16 @@ impl RulesPassProcessor {
 
 fn trim_ascii_controls(value: &str) -> &str {
     value.trim_matches(|character| u32::from(character) <= 0x20)
+}
+
+/// Whether a type-name reader resolves the input to native null.
+///
+/// `UnitTypeClass__FindOrAllocate @ 0x007480D0`, reached for
+/// `UndeploysInto=` by `TechnoTypeClass__ReadINI @ 0x00712170` at
+/// `0x0071329D..0x007132E4`, rejects these names before lookup/allocation.
+pub(crate) fn is_native_none_type_name(value: &str) -> bool {
+    let value = trim_ascii_controls(value);
+    value.is_empty() || value.eq_ignore_ascii_case("none") || value.eq_ignore_ascii_case("<none>")
 }
 
 fn parse_bool_value(value: &str) -> Option<bool> {

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -664,6 +664,11 @@ pub struct ObjectType {
     /// `0x00672B14..0x00672C01`). `RuleSet` stamps this after all type
     /// registries exist.
     pub build_const_eligible: bool,
+    /// Native BuildingType registry index used by ordered House BasePlan nodes.
+    /// Non-building types retain `-1`.
+    pub base_plan_type_index: i32,
+    /// BuildingType `IsBaseDefense=` immutable lifecycle input.
+    pub is_base_defense: bool,
 
     /// Whether this unit can be crushed by vehicles with Crusher movement zones.
     /// Default: false for all types. Parsed from `Crushable=` in rules.ini.
@@ -1484,6 +1489,8 @@ impl ObjectType {
                 .unwrap_or(0x80),
             construction_yard: section.get_bool("ConstructionYard").unwrap_or(false),
             build_const_eligible: false,
+            base_plan_type_index: -1,
+            is_base_defense: section.get_bool("IsBaseDefense").unwrap_or(false),
             factory: section.get("Factory").and_then(FactoryType::from_ini),
             weapons_factory: section.get_bool("WeaponsFactory").unwrap_or(false),
             cloning: section.get_bool("Cloning").unwrap_or(false),

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -667,7 +667,10 @@ pub struct ObjectType {
     /// Native BuildingType registry index used by ordered House BasePlan nodes.
     /// Non-building types retain `-1`.
     pub base_plan_type_index: i32,
-    /// BuildingType `IsBaseDefense=` immutable lifecycle input.
+    /// BuildingType `IsBaseDefense=` immutable lifecycle input at
+    /// `BuildingType+0x1706`. The BuildingType constructor store at
+    /// `0x0045E225` defaults it false; reader block
+    /// `0x00460FFC..0x00461010` binds it.
     pub is_base_defense: bool,
 
     /// Whether this unit can be crushed by vehicles with Crusher movement zones.
@@ -1490,6 +1493,8 @@ impl ObjectType {
             construction_yard: section.get_bool("ConstructionYard").unwrap_or(false),
             build_const_eligible: false,
             base_plan_type_index: -1,
+            // BuildingTypeClass__ReadINI 0x00460FFC..0x00461010 writes
+            // `IsBaseDefense=` to BuildingType+0x1706; constructor default false.
             is_base_defense: section.get_bool("IsBaseDefense").unwrap_or(false),
             factory: section.get("Factory").and_then(FactoryType::from_ini),
             weapons_factory: section.get_bool("WeaponsFactory").unwrap_or(false),

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -651,8 +651,11 @@ pub struct ObjectType {
     /// What this unit deploys into (e.g., AMCV DeploysInto=GACNST).
     /// Parsed from rules.ini `DeploysInto=`. Used for MCV→ConYard and similar transforms.
     pub deploys_into: Option<String>,
-    /// What this building undeploys into (e.g., GACNST UndeploysInto=AMCV).
-    /// Parsed from rules.ini `UndeploysInto=`. Used for ConYard→MCV sell-back.
+    /// Resolved non-null `UndeploysInto=` UnitType identity (e.g. GACNST→AMCV).
+    /// `TechnoTypeClass__ReadINI @ 0x00712170`, block
+    /// `0x0071329D..0x007132E4`, calls
+    /// `UnitTypeClass__FindOrAllocate @ 0x007480D0` and stores its pointer at
+    /// `BuildingType+0x408`; native `none`/`<none>` therefore remain `None`.
     pub undeploys_into: Option<String>,
     /// Raw 8-bit facing required before a unit can deploy into this building type.
     /// Parsed from building-side `DeployFacing=` as INI value << 5; default is 0x80.
@@ -1485,7 +1488,10 @@ impl ObjectType {
             immune_to_poison: section.get_bool("ImmuneToPoison").unwrap_or(false),
 
             deploys_into: section.get("DeploysInto").map(|s| s.to_string()),
-            undeploys_into: section.get("UndeploysInto").map(|s| s.to_string()),
+            undeploys_into: section
+                .get("UndeploysInto")
+                .filter(|target| !crate::rules::ini_parser::is_native_none_type_name(target))
+                .map(str::to_string),
             deploy_facing: section
                 .get_i32("DeployFacing")
                 .map(|v| (v.clamp(0, 7) as u8) << 5)

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -288,8 +288,10 @@ pub struct GeneralRules {
     /// `[General] ComputerBaseDefenseResponse=`. The active House responder
     /// forms its signed/wrapping budget as `attacker Cost * this value`.
     pub computer_base_defense_response: i32,
-    /// Signed `[General] MaximumBuildingPlacementFailures=`. The Building-exit
-    /// retry writer compares strictly after incrementing; negative mods remain literal.
+    /// Signed `[General] MaximumBuildingPlacementFailures=` at `Rules+0xE48`.
+    /// Native constructor default is `5`; both active retail rules files
+    /// override it with `3`. Building exit compares strictly after incrementing;
+    /// negative mod values remain literal.
     pub maximum_building_placement_failures: i32,
     /// `[General] BaseDefenseDelay=` in minutes. A strict responder-budget
     /// overshoot arms the attacker cooldown for `ftol(value * 900)` frames.
@@ -923,6 +925,7 @@ impl Default for GeneralRules {
             veteran_cap: VETERAN_CAP_DEFAULT,
             difficulty_armor: [1.0; 3],
             computer_base_defense_response: 3,
+            // Native Rules+0xE48 constructor default; active retail overrides to 3.
             maximum_building_placement_failures: 5,
             base_defense_delay_minutes: 0.25,
             suspend_priority: 20,
@@ -1566,6 +1569,8 @@ impl GeneralRules {
             computer_base_defense_response: general
                 .get_i32("ComputerBaseDefenseResponse")
                 .unwrap_or(defaults.computer_base_defense_response),
+            // Signed [General] binding for native Rules+0xE48. The verified
+            // report establishes default 5 and active-retail override 3.
             maximum_building_placement_failures: general
                 .get_i32("MaximumBuildingPlacementFailures")
                 .unwrap_or(defaults.maximum_building_placement_failures),
@@ -3042,7 +3047,9 @@ impl RuleSet {
     }
 
     /// Resolve one scenario BasePlan token through the native BuildingType
-    /// registry only, returning its ordered registry index.
+    /// registry only, matching
+    /// `BuildingTypeClass__FindIndexByName @ 0x0045E7B0` used by
+    /// `FUN_0042EBE0`, and return its ordered index.
     pub(crate) fn building_type_index(&self, id: &str) -> Option<i32> {
         self.building_type_indices
             .get(&id.to_ascii_uppercase())

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -288,6 +288,9 @@ pub struct GeneralRules {
     /// `[General] ComputerBaseDefenseResponse=`. The active House responder
     /// forms its signed/wrapping budget as `attacker Cost * this value`.
     pub computer_base_defense_response: i32,
+    /// Signed `[General] MaximumBuildingPlacementFailures=`. The Building-exit
+    /// retry writer compares strictly after incrementing; negative mods remain literal.
+    pub maximum_building_placement_failures: i32,
     /// `[General] BaseDefenseDelay=` in minutes. A strict responder-budget
     /// overshoot arms the attacker cooldown for `ftol(value * 900)` frames.
     pub base_defense_delay_minutes: f64,
@@ -920,6 +923,7 @@ impl Default for GeneralRules {
             veteran_cap: VETERAN_CAP_DEFAULT,
             difficulty_armor: [1.0; 3],
             computer_base_defense_response: 3,
+            maximum_building_placement_failures: 5,
             base_defense_delay_minutes: 0.25,
             suspend_priority: 20,
             suspend_delay_minutes: 2.0,
@@ -1562,6 +1566,9 @@ impl GeneralRules {
             computer_base_defense_response: general
                 .get_i32("ComputerBaseDefenseResponse")
                 .unwrap_or(defaults.computer_base_defense_response),
+            maximum_building_placement_failures: general
+                .get_i32("MaximumBuildingPlacementFailures")
+                .unwrap_or(defaults.maximum_building_placement_failures),
             base_defense_delay_minutes: general
                 .read_double("BaseDefenseDelay", defaults.base_defense_delay_minutes),
             suspend_priority: general
@@ -2238,6 +2245,8 @@ pub struct RuleSet {
     /// this retains distinct types when malformed/custom rules list the same
     /// ID in more than one category.
     object_category_index: HashMap<(ObjectCategory, String), TypeHandle>,
+    /// Case-insensitive native BuildingType registry identity to its ordered index.
+    building_type_indices: HashMap<String, i32>,
     /// All weapons indexed by ID (e.g., "105mm" → WeaponType).
     weapons: HashMap<String, WeaponType>,
     /// All warheads indexed by ID (e.g., "AP" → WarheadType).
@@ -2452,6 +2461,7 @@ impl RuleSet {
         let mut object_index: HashMap<String, TypeHandle> = HashMap::new();
         let mut object_category_index: HashMap<(ObjectCategory, String), TypeHandle> =
             HashMap::new();
+        let mut building_type_indices: HashMap<String, i32> = HashMap::new();
         let mut infantry_ids: Vec<String> = Vec::new();
         let mut vehicle_ids: Vec<String> = Vec::new();
         let mut aircraft_ids: Vec<String> = Vec::new();
@@ -2530,9 +2540,20 @@ impl RuleSet {
             let ids: Vec<String> = parse_registry(ini, registry_name);
             log::info!("Registry [{}]: {} entries", registry_name, ids.len());
 
-            for id in &ids {
+            for (registry_index, id) in ids.iter().enumerate() {
+                if category == ObjectCategory::Building {
+                    building_type_indices
+                        .entry(id.to_ascii_uppercase())
+                        .or_insert(registry_index as i32);
+                }
                 if let Some(section) = ini.section(id) {
                     let mut obj: ObjectType = ObjectType::from_ini_section(id, section, category);
+                    if category == ObjectCategory::Building {
+                        obj.base_plan_type_index = building_type_indices
+                            .get(&id.to_ascii_uppercase())
+                            .copied()
+                            .expect("BuildingType index was registered above");
+                    }
                     if obj.base_reservation_writer_eligible() {
                         obj.base_reservation_spacing = Some(ai_base_spacing);
                     }
@@ -2911,6 +2932,7 @@ impl RuleSet {
             object_list,
             object_index,
             object_category_index,
+            building_type_indices,
             weapons,
             warheads,
             projectiles,
@@ -3017,6 +3039,14 @@ impl RuleSet {
         self.object_category_index
             .get(&(category, id.to_ascii_uppercase()))
             .map(|handle| self.object_by_handle(*handle))
+    }
+
+    /// Resolve one scenario BasePlan token through the native BuildingType
+    /// registry only, returning its ordered registry index.
+    pub(crate) fn building_type_index(&self, id: &str) -> Option<i32> {
+        self.building_type_indices
+            .get(&id.to_ascii_uppercase())
+            .copied()
     }
 
     /// Resolve a TaskForce member through the exact native family order used
@@ -4407,6 +4437,37 @@ CellSpread=0
         assert_eq!(parsed.base_defense_delay_minutes, 0.125_f32 as f64);
         assert_eq!(parsed.suspend_priority, -2);
         assert_eq!(parsed.suspend_delay_minutes, 1.5_f32 as f64);
+    }
+
+    #[test]
+    fn gsi_04_05_base_plan_rules_preserve_signed_retry_limit_and_building_identity() {
+        assert_eq!(
+            GeneralRules::default().maximum_building_placement_failures,
+            5
+        );
+        let rules = RuleSet::from_ini(&IniFile::from_str(
+            "[General]\nMaximumBuildingPlacementFailures=-4\n\
+             [BuildingTypes]\n0=GAPOWR\n1=GACNST\n\
+             [GAPOWR]\nStrength=750\nIsBaseDefense=yes\n\
+             [GACNST]\nStrength=1000\nUndeploysInto=AMCV\n",
+        ))
+        .expect("base-plan rules");
+
+        assert_eq!(rules.general.maximum_building_placement_failures, -4);
+        assert_eq!(rules.building_type_index("gapowr"), Some(0));
+        assert_eq!(rules.building_type_index("GACNST"), Some(1));
+        let defense = rules
+            .object_in_category(ObjectCategory::Building, "GAPOWR")
+            .unwrap();
+        assert_eq!(defense.base_plan_type_index, 0);
+        assert!(defense.is_base_defense);
+        assert!(
+            rules
+                .object_in_category(ObjectCategory::Building, "GACNST")
+                .unwrap()
+                .undeploys_into
+                .is_some()
+        );
     }
 
     #[test]

--- a/src/sim/base_plan.rs
+++ b/src/sim/base_plan.rs
@@ -1,0 +1,319 @@
+//! Ordered House `BaseClass` plan state and its bounded lifecycle mutations.
+//!
+//! The vector is independent of production's ready queues. Ordinary planning,
+//! node selection, and placement-result classification remain deliberately
+//! outside this module.
+
+use std::hash::{Hash, Hasher};
+
+/// One native 16-byte BasePlan node represented without pointer aliases.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub struct BasePlanNode {
+    /// BuildingType registry index, or a literal negative planner control.
+    pub type_or_control: i32,
+    /// Signed-i16 X in the low word and signed-i16 Y in the high word.
+    pub packed_cell: u32,
+    pub filled: bool,
+    pub retry_count: i32,
+}
+
+/// The authoritative ordered `HouseClass` BasePlan.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct BasePlanState {
+    pub percent_built: i32,
+    pub nodes: Vec<BasePlanNode>,
+}
+
+/// Pack the native `CellStruct` words after signed-16 narrowing.
+pub(crate) const fn pack_base_plan_cell(x: i32, y: i32) -> u32 {
+    (x as i16 as u16 as u32) | ((y as i16 as u16 as u32) << 16)
+}
+
+/// Recover the two signed `CellStruct` words.
+pub(crate) const fn unpack_base_plan_cell(packed: u32) -> (i16, i16) {
+    (packed as u16 as i16, (packed >> 16) as u16 as i16)
+}
+
+impl BasePlanState {
+    /// Fold the exact fields consumed by `BaseClass::CalculateChecksum`.
+    ///
+    /// PercentBuilt, filled latches, and retry counters are intentionally not
+    /// part of this native compatibility helper. Rust's authoritative world
+    /// hash covers them separately.
+    pub(crate) fn hash_native_checksum_fields(&self, hasher: &mut impl Hasher) {
+        (self.nodes.len() as i32).hash(hasher);
+        for node in &self.nodes {
+            node.type_or_control.hash(hasher);
+            let (x, y) = unpack_base_plan_cell(node.packed_cell);
+            x.hash(hasher);
+            y.hash(hasher);
+        }
+    }
+
+    /// Apply successful non-human Building Unlimbo satisfaction.
+    pub(crate) fn fill_successful_building(
+        &mut self,
+        building_type_index: i32,
+        packed_cell: u32,
+        has_undeploy_target: bool,
+    ) -> Option<usize> {
+        let selected = self.nodes.iter().position(|node| {
+            node.type_or_control == building_type_index && node.packed_cell == packed_cell
+        });
+        let selected = selected.or_else(|| {
+            has_undeploy_target.then(|| {
+                self.nodes
+                    .iter()
+                    .position(|node| node.type_or_control == building_type_index && !node.filled)
+            })?
+        });
+        if let Some(index) = selected {
+            self.nodes[index].filled = true;
+            self.nodes[index].retry_count = 0;
+        }
+        selected
+    }
+
+    /// Apply the BuildingClass Limbo BasePlan invalidation pass.
+    pub(crate) fn invalidate_limbo_building(
+        &mut self,
+        building_type_index: i32,
+        packed_cell: u32,
+        is_base_defense: bool,
+        game_mode_nonzero: bool,
+    ) -> Option<usize> {
+        let matched = self.nodes.iter().position(|node| {
+            node.type_or_control == building_type_index && node.packed_cell == packed_cell
+        })?;
+
+        for (index, node) in self.nodes.iter_mut().enumerate() {
+            if index != matched && node.packed_cell == packed_cell {
+                node.packed_cell = 0;
+            }
+        }
+
+        if is_base_defense && game_mode_nonzero {
+            self.nodes[matched].type_or_control = -1;
+            self.nodes[matched].packed_cell = 0;
+        }
+        Some(matched)
+    }
+
+    /// Clear every cached site equal to one failed ordinary coordinate.
+    pub(crate) fn clear_failed_site(&mut self, packed_cell: u32) -> usize {
+        let mut cleared = 0;
+        for node in &mut self.nodes {
+            if node.packed_cell == packed_cell {
+                node.packed_cell = 0;
+                cleared += 1;
+            }
+        }
+        cleared
+    }
+
+    /// Apply the normalized Building-exit result to one referenced node.
+    ///
+    /// Only final result `1` increments. The increment precedes the signed,
+    /// strict threshold test; `Vec::remove` preserves native tail order.
+    pub(crate) fn apply_normalized_placement_result(
+        &mut self,
+        node_index: usize,
+        normalized_final_result: i32,
+        game_mode_nonzero: bool,
+        maximum_failures: i32,
+    ) -> bool {
+        if normalized_final_result != 1 || node_index >= self.nodes.len() {
+            return false;
+        }
+        let retry_count = self.nodes[node_index].retry_count.wrapping_add(1);
+        self.nodes[node_index].retry_count = retry_count;
+        if game_mode_nonzero && retry_count > maximum_failures {
+            self.nodes.remove(node_index);
+            return true;
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::hash::Hasher;
+
+    use super::*;
+
+    fn node(type_or_control: i32, x: i32, y: i32, filled: bool, retry_count: i32) -> BasePlanNode {
+        BasePlanNode {
+            type_or_control,
+            packed_cell: pack_base_plan_cell(x, y),
+            filled,
+            retry_count,
+        }
+    }
+
+    fn native_checksum(plan: &BasePlanState) -> u64 {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        plan.hash_native_checksum_fields(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn gsi_04_05_native_base_plan_checksum_excludes_runtime_fields() {
+        let mut plan = BasePlanState {
+            percent_built: 73,
+            nodes: vec![node(8, -2, 32_769, false, -10)],
+        };
+        let expected = native_checksum(&plan);
+        plan.percent_built = -9;
+        plan.nodes[0].filled = true;
+        plan.nodes[0].retry_count = i32::MAX;
+        assert_eq!(native_checksum(&plan), expected);
+
+        let mut changed_order = plan.clone();
+        changed_order.nodes.push(node(-3, 7, 9, false, 0));
+        let mut reverse = changed_order.clone();
+        reverse.nodes.reverse();
+        assert_ne!(native_checksum(&changed_order), native_checksum(&reverse));
+    }
+
+    #[test]
+    fn gsi_04_05_unlimbo_fill_prioritizes_exact_then_undeploy_fallback() {
+        let exact_cell = pack_base_plan_cell(20, 30);
+        let mut exact = BasePlanState {
+            percent_built: 0,
+            nodes: vec![node(4, 1, 1, false, 11), node(4, 20, 30, true, -7)],
+        };
+        assert_eq!(exact.fill_successful_building(4, exact_cell, true), Some(1));
+        assert_eq!(exact.nodes[0].retry_count, 11);
+        assert!(exact.nodes[1].filled, "filled does not gate the exact scan");
+        assert_eq!(exact.nodes[1].retry_count, 0);
+
+        let mut fallback = BasePlanState {
+            percent_built: 0,
+            nodes: vec![
+                node(4, 2, 3, true, 9),
+                node(4, 88, 99, false, 6),
+                node(4, 21, 31, false, 5),
+            ],
+        };
+        assert_eq!(
+            fallback.fill_successful_building(4, exact_cell, true),
+            Some(1),
+            "fallback skips filled nodes and ignores cell"
+        );
+        assert!(fallback.nodes[1].filled);
+        assert_eq!(fallback.nodes[1].retry_count, 0);
+
+        let unchanged = fallback.clone();
+        assert_eq!(
+            fallback.fill_successful_building(4, pack_base_plan_cell(7, 7), false),
+            None
+        );
+        assert_eq!(fallback, unchanged);
+    }
+
+    #[test]
+    fn gsi_04_05_limbo_invalidation_preserves_required_node_fields() {
+        let cell = pack_base_plan_cell(5, 6);
+        let original = BasePlanState {
+            percent_built: 12,
+            nodes: vec![
+                node(7, 5, 6, true, 4),
+                node(9, 5, 6, true, -8),
+                node(7, 5, 6, false, 2),
+            ],
+        };
+
+        for (is_defense, nonzero_mode) in [(false, true), (true, false)] {
+            let mut plan = original.clone();
+            assert_eq!(
+                plan.invalidate_limbo_building(7, cell, is_defense, nonzero_mode),
+                Some(0)
+            );
+            assert_eq!(plan.nodes[0], original.nodes[0]);
+            assert_eq!(plan.nodes[1].packed_cell, 0);
+            assert_eq!(plan.nodes[1].type_or_control, 9);
+            assert!(plan.nodes[1].filled);
+            assert_eq!(plan.nodes[1].retry_count, -8);
+            assert_eq!(plan.nodes[2].packed_cell, 0);
+        }
+
+        let mut skirmish_defense = original;
+        skirmish_defense.invalidate_limbo_building(7, cell, true, true);
+        assert_eq!(skirmish_defense.nodes[0].type_or_control, -1);
+        assert_eq!(skirmish_defense.nodes[0].packed_cell, 0);
+        assert!(skirmish_defense.nodes[0].filled);
+        assert_eq!(skirmish_defense.nodes[0].retry_count, 4);
+    }
+
+    #[test]
+    fn gsi_04_05_failure_site_clear_preserves_non_cell_fields() {
+        let target = pack_base_plan_cell(-9, 14);
+        let mut plan = BasePlanState {
+            percent_built: 1,
+            nodes: vec![
+                node(-3, -9, 14, true, -6),
+                node(5, 8, 8, false, 2),
+                node(7, -9, 14, false, 11),
+            ],
+        };
+        assert_eq!(plan.clear_failed_site(target), 2);
+        assert_eq!(plan.nodes[0], node(-3, 0, 0, true, -6));
+        assert_eq!(plan.nodes[1], node(5, 8, 8, false, 2));
+        assert_eq!(plan.nodes[2], node(7, 0, 0, false, 11));
+    }
+
+    #[test]
+    fn gsi_04_05_retry_is_postincrement_signed_strict_and_stable() {
+        let source = BasePlanState {
+            percent_built: 0,
+            nodes: vec![
+                node(1, 1, 1, false, 0),
+                node(2, 2, 2, true, 2),
+                node(3, 3, 3, false, 7),
+            ],
+        };
+
+        let mut retail = source.clone();
+        assert!(!retail.apply_normalized_placement_result(1, 1, true, 3));
+        assert_eq!(retail.nodes[1].retry_count, 3);
+        assert!(retail.apply_normalized_placement_result(1, 1, true, 3));
+        assert_eq!(
+            retail
+                .nodes
+                .iter()
+                .map(|n| n.type_or_control)
+                .collect::<Vec<_>>(),
+            [1, 3]
+        );
+
+        let mut equality = source.clone();
+        equality.nodes[1].retry_count = 2;
+        assert!(!equality.apply_normalized_placement_result(1, 1, true, 3));
+        assert_eq!(equality.nodes[1].retry_count, 3);
+
+        let mut campaign = source.clone();
+        assert!(!campaign.apply_normalized_placement_result(1, 1, false, -100));
+        assert_eq!(campaign.nodes[1].retry_count, 3);
+
+        let mut negative = source.clone();
+        negative.nodes[0].retry_count = 0;
+        assert!(negative.apply_normalized_placement_result(0, 1, true, -1));
+        assert_eq!(
+            negative
+                .nodes
+                .iter()
+                .map(|n| n.type_or_control)
+                .collect::<Vec<_>>(),
+            [2, 3]
+        );
+
+        let mut wrapping = source;
+        wrapping.nodes[0].retry_count = i32::MAX;
+        assert!(!wrapping.apply_normalized_placement_result(0, 1, true, 3));
+        assert_eq!(wrapping.nodes[0].retry_count, i32::MIN);
+        assert!(!wrapping.apply_normalized_placement_result(99, 1, true, 3));
+        assert!(!wrapping.apply_normalized_placement_result(0, 0, true, -1));
+    }
+}

--- a/src/sim/base_plan.rs
+++ b/src/sim/base_plan.rs
@@ -37,7 +37,8 @@ pub(crate) const fn unpack_base_plan_cell(packed: u32) -> (i16, i16) {
 }
 
 impl BasePlanState {
-    /// Fold the exact fields consumed by `BaseClass::CalculateChecksum`.
+    /// Fold the exact fields consumed by `FUN_0042F180 @ 0x0042F180`
+    /// (`BaseClass::CalculateChecksum`).
     ///
     /// PercentBuilt, filled latches, and retry counters are intentionally not
     /// part of this native compatibility helper. Rust's authoritative world
@@ -53,6 +54,11 @@ impl BasePlanState {
     }
 
     /// Apply successful non-human Building Unlimbo satisfaction.
+    ///
+    /// Native `FUN_0042F260 @ 0x0042F260` scans exact type/cell first, then
+    /// the undeploy fallback at `0x0042F2DE..0x0042F31F`; the selected node's
+    /// filled/retry writes are `0x0042F321..0x0042F325`. Its active caller is
+    /// `BuildingClass::Unlimbo @ 0x00440580`, `0x0044159D..0x004415B3`.
     pub(crate) fn fill_successful_building(
         &mut self,
         building_type_index: i32,
@@ -77,6 +83,9 @@ impl BasePlanState {
     }
 
     /// Apply the BuildingClass Limbo BasePlan invalidation pass.
+    ///
+    /// Native authority is `FUN_0050A490 @ 0x0050A490`, called by
+    /// `BuildingClass__Limbo @ 0x00445880` before `TechnoClass__Limbo`.
     pub(crate) fn invalidate_limbo_building(
         &mut self,
         building_type_index: i32,
@@ -102,6 +111,9 @@ impl BasePlanState {
     }
 
     /// Clear every cached site equal to one failed ordinary coordinate.
+    ///
+    /// Native `BuildingClass__ExitObject_Main @ 0x00443C60` performs this
+    /// ordinary-node clear at `0x0044552D..0x004455A2`.
     pub(crate) fn clear_failed_site(&mut self, packed_cell: u32) -> usize {
         let mut cleared = 0;
         for node in &mut self.nodes {
@@ -115,8 +127,10 @@ impl BasePlanState {
 
     /// Apply the normalized Building-exit result to one referenced node.
     ///
-    /// Only final result `1` increments. The increment precedes the signed,
-    /// strict threshold test; `Vec::remove` preserves native tail order.
+    /// `FUN_0042F380 @ 0x0042F380` increments the signed retry field first; the
+    /// `BuildingClass__ExitObject_Main` result block at
+    /// `0x00445237..0x004452C3` then applies the mode/strict-threshold gates
+    /// and ordered shift-left removal. `Vec::remove` preserves that tail order.
     pub(crate) fn apply_normalized_placement_result(
         &mut self,
         node_index: usize,

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -6777,7 +6777,11 @@ fn gsi_04_07_damage_hostile_building_hit_latches_was_attacked_for_ai_repair() {
     let ally_owner = sim.interner.intern("ALLY");
     let scenario_ini = IniFile::from_str("[Houses]\n0=AI\n[AI]\nIQ=1\n");
     let scenario_houses =
-        crate::map::houses::parse_house_roster(&scenario_ini, &rules.color_schemes);
+        crate::map::houses::parse_house_roster(
+            &scenario_ini,
+            &rules.color_schemes,
+            Some(&rules),
+        );
     let mut ai_house = HouseState::new(ai_owner, 0, None, false, 0, 51);
     ai_house.current_iq =
         scenario_houses.houses[0].scenario_current_iq(rules.general.max_iq_levels);

--- a/src/sim/game_entity.rs
+++ b/src/sim/game_entity.rs
@@ -86,6 +86,10 @@ fn default_foundation() -> String {
     "1x1".to_string()
 }
 
+fn default_base_plan_type_index() -> i32 {
+    -1
+}
+
 /// Persistent TechnoClass state used by the active House base-defence
 /// responder. The two admission bytes are constructor-true; archive/cooldown
 /// writes occur only after a responder assignment or strict budget overshoot.
@@ -389,6 +393,15 @@ pub struct GameEntity {
     /// native acquisition order exactly.
     #[serde(default)]
     pub build_const_eligible: bool,
+    /// Immutable native BuildingType registry index for BasePlan lifecycle writers.
+    #[serde(default = "default_base_plan_type_index")]
+    pub base_plan_type_index: i32,
+    /// Immutable BuildingType `IsBaseDefense=` fact.
+    #[serde(default)]
+    pub base_plan_is_defense: bool,
+    /// Immutable non-null `UndeploysInto` fact used by successful Unlimbo fallback.
+    #[serde(default)]
+    pub base_plan_has_undeploy_target: bool,
     /// Veterancy level: 0 = rookie, 100 = veteran, 200 = elite.
     ///
     /// A projection of [`Self::veterancy_raw`], refreshed wherever the raw
@@ -1085,6 +1098,9 @@ impl GameEntity {
             base_reservation_spacing: None,
             determines_waypoint_edge: false,
             build_const_eligible: false,
+            base_plan_type_index: -1,
+            base_plan_is_defense: false,
+            base_plan_has_undeploy_target: false,
             veterancy,
             veterancy_raw: crate::sim::combat::veterancy::raw_for_rank(veterancy),
             veterancy_rank_cache: veterancy_rank_cache_default(),

--- a/src/sim/house_state.rs
+++ b/src/sim/house_state.rs
@@ -303,6 +303,10 @@ pub struct HouseState {
     /// append at the tail; Limbo and old-owner transfer stable-remove in place.
     #[serde(default)]
     pub build_const_order: Vec<u64>,
+    /// Ordered native `BaseClass` plan authority. Scenario nodes are installed
+    /// before map-object Unlimbo; later ordinary planning remains disconnected.
+    #[serde(default)]
+    pub base_plan: crate::sim::base_plan::BasePlanState,
     /// Native `HouseClass+0x5700` BaseClass reservation writer outputs.
     #[serde(default)]
     pub base_reservation: BaseReservationState,
@@ -441,6 +445,7 @@ impl HouseState {
             base_center: None,
             alternate_base_center: (0, 0),
             build_const_order: Vec::new(),
+            base_plan: crate::sim::base_plan::BasePlanState::default(),
             base_reservation: BaseReservationState::default(),
             tech_level,
             current_iq: 0,

--- a/src/sim/house_state.rs
+++ b/src/sim/house_state.rs
@@ -365,6 +365,12 @@ impl HouseState {
         self.is_human || self.player_control
     }
 
+    /// Native `HouseClass::IsControlledByHuman @ 0x0050B730` result consumed
+    /// by successful Building Unlimbo BasePlan satisfaction.
+    pub(crate) const fn is_controlled_by_human(&self, game_mode_nonzero: bool) -> bool {
+        self.is_human || (!game_mode_nonzero && self.player_control)
+    }
+
     /// Accept a victory and arm its deterministic grace interval.
     ///
     /// gamemd provenance: HouseClass::Flag_To_Win @ `0x004FC9E0` accepts only

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -22,6 +22,7 @@
 
 // --- Core types: entity storage, components, commands, RNG, interning ---
 pub mod anim_class;
+pub(crate) mod base_plan;
 pub mod capture_manager;
 pub mod cloak_disguise;
 pub mod command;

--- a/src/sim/movement/locomotor_tests.rs
+++ b/src/sim/movement/locomotor_tests.rs
@@ -187,6 +187,8 @@ fn make_obj(locomotor: LocomotorKind, category: ObjectCategory) -> ObjectType {
         deploy_facing: 0x80,
         construction_yard: false,
         build_const_eligible: false,
+        base_plan_type_index: -1,
+        is_base_defense: false,
         factory: None,
         weapons_factory: false,
         cloning: false,

--- a/src/sim/movement/teleport_movement.rs
+++ b/src/sim/movement/teleport_movement.rs
@@ -650,6 +650,8 @@ mod tests {
             deploy_facing: 0x80,
             construction_yard: false,
             build_const_eligible: false,
+            base_plan_type_index: -1,
+            is_base_defense: false,
             factory: None,
             weapons_factory: false,
             cloning: false,

--- a/src/sim/scenario_bootstrap.rs
+++ b/src/sim/scenario_bootstrap.rs
@@ -1976,6 +1976,18 @@ pub(crate) fn initialize_map_roster_houses(
             sim.session.game_options.tech_level,
         );
         house_state.player_control = player_control;
+        house_state.base_plan.percent_built = house.base_plan.percent_built;
+        house_state.base_plan.nodes = house
+            .base_plan
+            .nodes
+            .iter()
+            .map(|node| crate::sim::base_plan::BasePlanNode {
+                type_or_control: node.type_or_control,
+                packed_cell: node.packed_cell,
+                filled: node.filled,
+                retry_count: node.retry_count,
+            })
+            .collect();
         // HouseClass::Read_Scenario_INI reads `IQ=` from this exact named
         // house section, defaults it to zero, and changes a value above
         // MaxIQLevels to literal one before storing CurrentIQ (+0x24C).

--- a/src/sim/scenario_post_map.rs
+++ b/src/sim/scenario_post_map.rs
@@ -418,6 +418,7 @@ mod tests {
                     player_control: Some(false),
                     iq: None,
                     allies: vec!["HouseB".to_string()],
+                    base_plan: Default::default(),
                 },
                 HouseDefinition {
                     name: "HouseB".to_string(),
@@ -427,6 +428,7 @@ mod tests {
                     player_control: Some(true),
                     iq: None,
                     allies: Vec::new(),
+                    base_plan: Default::default(),
                 },
             ],
         };

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -320,7 +320,9 @@ use crate::sim::world::Simulation;
 // HouseState layout positionally, so an older record cannot supply this field.
 // Bumped 108 -> 109: persist the lifecycle-maintained per-House BuildConst
 // acquisition order and each entity's immutable resolved membership bit.
-const SNAPSHOT_VERSION: u32 = 109;
+// Bumped 109 -> 110: persist ordered House BasePlan authority and the immutable
+// BuildingType facts consumed by its Unlimbo/Limbo lifecycle writers.
+const SNAPSHOT_VERSION: u32 = 110;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -2730,10 +2732,11 @@ mod tests {
     /// despite unchanged wire shape; 106 -> 107 adds unconditional shared-
     /// dummy level/slope hash authority for active Spark queries; 107 -> 108
     /// adds the packed House alternate base cell; 108 -> 109 adds the ordered
-    /// House BuildConst vector and immutable entity membership.
+    /// House BuildConst vector and immutable entity membership; 109 -> 110
+    /// adds ordered BasePlan state and immutable BuildingType facts.
     #[test]
-    fn phase3_naval_build_const_snapshot_version_is_109() {
-        assert_eq!(super::SNAPSHOT_VERSION, 109);
+    fn phase3_base_plan_snapshot_version_is_110() {
+        assert_eq!(super::SNAPSHOT_VERSION, 110);
     }
 
     #[test]
@@ -3007,7 +3010,7 @@ mod tests {
         let expected_hash = sim.state_hash();
 
         let bytes = GameSnapshot::save(&sim, 0, 0, "alternate-base-center", 0);
-        assert_eq!(GameSnapshot::read_header(&bytes).unwrap().version, 109);
+        assert_eq!(GameSnapshot::read_header(&bytes).unwrap().version, 110);
         let restored = GameSnapshot::load(&bytes).expect("current snapshot").sim;
 
         assert_eq!(restored.houses[&owner].base_center, Some((40, 50)));
@@ -3082,12 +3085,12 @@ mod tests {
         assert_eq!(
             sim.state_hash_before_lifecycle_v28_and_mission_v29(),
             historical_pre_v28,
-            "the historical pre-v28 probe excludes v109 state"
+            "the historical pre-v28 probe excludes current-schema state"
         );
         assert_eq!(
             sim.state_hash_without_mission_v29(),
             historical_pre_v29,
-            "the historical pre-v29 probe excludes v109 state"
+            "the historical pre-v29 probe excludes current-schema state"
         );
         sim.houses
             .get_mut(&owner)
@@ -3123,7 +3126,7 @@ mod tests {
         assert_eq!(sim.state_hash(), ordered_hash);
 
         let bytes = GameSnapshot::save(&sim, 0, 0, "naval-build-const", 0);
-        assert_eq!(GameSnapshot::read_header(&bytes).unwrap().version, 109);
+        assert_eq!(GameSnapshot::read_header(&bytes).unwrap().version, 110);
         let restored = GameSnapshot::load(&bytes).expect("current snapshot").sim;
 
         assert_eq!(restored.houses[&owner].build_const_order, vec![9, 3]);
@@ -3136,6 +3139,66 @@ mod tests {
                 .build_const_eligible
         );
         assert_eq!(restored.state_hash(), ordered_hash);
+    }
+
+    #[test]
+    fn gsi_04_05_base_plan_and_building_facts_roundtrip_current_snapshot() {
+        let mut sim = Simulation::new();
+        let owner = sim.interner.intern("Computer1");
+        let type_ref = sim.interner.intern("GAPOWR");
+        let mut house = crate::sim::house_state::HouseState::new(owner, 0, None, false, 0, 10);
+        house.base_plan.percent_built = -17;
+        house.base_plan.nodes = vec![
+            crate::sim::base_plan::BasePlanNode {
+                type_or_control: 2,
+                packed_cell: crate::sim::base_plan::pack_base_plan_cell(-4, 9),
+                filled: true,
+                retry_count: -8,
+            },
+            crate::sim::base_plan::BasePlanNode {
+                type_or_control: -3,
+                packed_cell: 0,
+                filled: false,
+                retry_count: 6,
+            },
+        ];
+        sim.houses.insert(owner, house);
+        sim.session.house_order.push(owner);
+        let mut entity = crate::sim::game_entity::GameEntity::new_at_frame_zero_for_test(
+            1,
+            12,
+            14,
+            0,
+            0,
+            owner,
+            crate::sim::components::Health {
+                current: 750,
+                max: 750,
+            },
+            type_ref,
+            crate::map::entities::EntityCategory::Structure,
+            0,
+            5,
+            false,
+        );
+        entity.base_plan_type_index = 2;
+        entity.base_plan_is_defense = true;
+        entity.base_plan_has_undeploy_target = true;
+        sim.substrate.entities.insert(entity);
+        sim.scenario_rng = crate::sim::rng::SimRng::new(0);
+        let expected_hash = sim.state_hash();
+
+        let bytes = GameSnapshot::save(&sim, 0, 0, "base-plan", 0);
+        assert_eq!(GameSnapshot::read_header(&bytes).unwrap().version, 110);
+        let restored = GameSnapshot::load(&bytes).expect("v110 snapshot").sim;
+        assert_eq!(restored.houses[&owner].base_plan.percent_built, -17);
+        assert_eq!(restored.houses[&owner].base_plan.nodes.len(), 2);
+        assert_eq!(restored.houses[&owner].base_plan.nodes[0].retry_count, -8);
+        let restored_entity = restored.substrate.entities.get(1).unwrap();
+        assert_eq!(restored_entity.base_plan_type_index, 2);
+        assert!(restored_entity.base_plan_is_defense);
+        assert!(restored_entity.base_plan_has_undeploy_target);
+        assert_eq!(restored.state_hash(), expected_hash);
     }
 
     #[test]

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -3049,10 +3049,15 @@ mod tests {
         sim.substrate.entities.insert(entity);
 
         let v108_default_hash = sim.state_hash_without_naval_build_const_v109();
+        let v109_default_hash = sim.state_hash_without_base_plan_v110();
         assert_eq!(
+            v109_default_hash, v108_default_hash,
+            "empty BuildConst vectors and false membership preserve the v108 hash stream through v109"
+        );
+        assert_ne!(
             sim.state_hash(),
-            v108_default_hash,
-            "empty BuildConst vectors and false membership preserve the v108 hash stream"
+            v109_default_hash,
+            "the v110 schema adds BasePlan authority even when BuildConst state is empty"
         );
 
         sim.houses.get_mut(&owner).unwrap().build_const_order = vec![9, 3];

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -3068,6 +3068,7 @@ mod tests {
             .build_const_eligible = true;
 
         let ordered_hash = sim.state_hash();
+        let v109_ordered_hash = sim.state_hash_without_base_plan_v110();
         let historical_pre_v109 = sim.state_hash_without_naval_build_const_v109();
         assert_ne!(ordered_hash, historical_pre_v109);
         let historical_pre_v28 = sim.state_hash_before_lifecycle_v28_and_mission_v29();
@@ -3081,6 +3082,11 @@ mod tests {
             sim.state_hash(),
             ordered_hash,
             "stored vector order is hashed"
+        );
+        assert_ne!(
+            sim.state_hash_without_base_plan_v110(),
+            v109_ordered_hash,
+            "the v109 provenance schema retained by the v110 probe hashes BuildConst order"
         );
         assert_eq!(
             sim.state_hash_without_naval_build_const_v109(),
@@ -3113,6 +3119,11 @@ mod tests {
             ordered_hash,
             "entity membership is hashed"
         );
+        assert_ne!(
+            sim.state_hash_without_base_plan_v110(),
+            v109_ordered_hash,
+            "the v109 provenance schema retained by the v110 probe hashes BuildConst membership"
+        );
         assert_eq!(
             sim.state_hash_without_naval_build_const_v109(),
             historical_pre_v109,
@@ -3129,6 +3140,7 @@ mod tests {
             .unwrap()
             .build_const_eligible = true;
         assert_eq!(sim.state_hash(), ordered_hash);
+        assert_eq!(sim.state_hash_without_base_plan_v110(), v109_ordered_hash);
 
         let bytes = GameSnapshot::save(&sim, 0, 0, "naval-build-const", 0);
         assert_eq!(GameSnapshot::read_header(&bytes).unwrap().version, 110);

--- a/src/sim/world/bridge_parity_harness_tests.rs
+++ b/src/sim/world/bridge_parity_harness_tests.rs
@@ -105,7 +105,11 @@ const MIN_DISTINCT_DECK_CELLS: usize = 6;
 /// hash composition moved from retired body-rocking bytes to the locomotor.
 /// Re-baselined 2026-08-30 for v107's Spark shared-dummy tag plus level/slope
 /// folds. The path, bridge tripwires, and RNG streams remain byte-identical.
-const BRIDGE_HARNESS_FINAL_HASH: u64 = 0x5B44_6C68_9BC2_F0AF;
+/// Re-baselined 2026-08-30 for v110's unconditional ordered BasePlan authority.
+/// The dedicated pre-v110 probe below reproduces the prior baseline exactly;
+/// path, bridge tripwires, RNG streams, and tick-for-tick replay remain exact.
+const BRIDGE_HARNESS_PRE_BASE_PLAN_V110_HASH: u64 = 0x5B44_6C68_9BC2_F0AF;
+const BRIDGE_HARNESS_FINAL_HASH: u64 = 0x6AFB_F54C_7397_0202;
 
 fn bridge_ini() -> IniFile {
     // One armed ground vehicle and one distant infantryman on a second house, so
@@ -498,11 +502,16 @@ fn bridge_crossing_replay_is_deterministic_and_baseline_stable() {
     }
 
     let final_hash = *replayed.last().expect("at least one tick replayed");
+    let pre_base_plan_hash = rep.state_hash_without_base_plan_v110();
     println!(
-        "[bridge parity] final_hash={final_hash:016X} streams={:016X},{:016X},{:016X}",
+        "[bridge parity] final_hash={final_hash:016X} pre-v110:{pre_base_plan_hash:016X} streams={:016X},{:016X},{:016X}",
         rep.scenario_rng.state(),
         rep.main_rng.state(),
         rep.mapgen_rng.state(),
+    );
+    assert_eq!(
+        pre_base_plan_hash, BRIDGE_HARNESS_PRE_BASE_PLAN_V110_HASH,
+        "the dedicated pre-v110 probe must reproduce the prior bridge baseline"
     );
     assert_eq!(
         final_hash, BRIDGE_HARNESS_FINAL_HASH,

--- a/src/sim/world/global_parity_harness_tests.rs
+++ b/src/sim/world/global_parity_harness_tests.rs
@@ -515,7 +515,11 @@ const GLOBAL_HARNESS_PRE_MISSION_V29_HASH: u64 = 0xE2B3_9FAA_432F_4A75;
 // Re-baselined 2026-08-30 for v107's Spark shared-dummy tag plus level/slope
 // folds. Both historical probes and all three RNG streams remain byte-identical,
 // isolating the shift to current-schema composition.
-const GLOBAL_HARNESS_FINAL_HASH: u64 = 0x254E_775C_65A2_B50A;
+// Re-baselined 2026-08-30 for v110's unconditional ordered BasePlan authority.
+// The dedicated pre-v110 probe reproduces the prior baseline exactly; the RNG
+// tuple and tick-for-tick replay remain exact, proving composition-only drift.
+const GLOBAL_HARNESS_PRE_BASE_PLAN_V110_HASH: u64 = 0x254E_775C_65A2_B50A;
+const GLOBAL_HARNESS_FINAL_HASH: u64 = 0x0E44_D6C4_D418_D99A;
 
 fn harness_ini() -> IniFile {
     // Multi-faction vehicles + infantry + buildings (war factory, refinery) plus a
@@ -809,8 +813,9 @@ fn global_skirmish_replay_is_deterministic_and_baseline_stable() {
 
     let pre_lifecycle_hash = rep.state_hash_before_lifecycle_v28_and_mission_v29();
     let pre_mission_hash = rep.state_hash_without_mission_v29();
+    let pre_base_plan_hash = rep.state_hash_without_base_plan_v110();
     println!(
-        "[global parity] probes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X}"
+        "[global parity] probes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},pre-v110:{pre_base_plan_hash:016X}"
     );
     assert_eq!(
         pre_lifecycle_hash, GLOBAL_HARNESS_PRE_LIFECYCLE_V28_HASH,
@@ -819,6 +824,10 @@ fn global_skirmish_replay_is_deterministic_and_baseline_stable() {
     assert_eq!(
         pre_mission_hash, GLOBAL_HARNESS_PRE_MISSION_V29_HASH,
         "v29 provenance probe must reproduce the prior live v28 baseline; otherwise this is behavior drift"
+    );
+    assert_eq!(
+        pre_base_plan_hash, GLOBAL_HARNESS_PRE_BASE_PLAN_V110_HASH,
+        "the dedicated pre-v110 probe must reproduce the prior global-harness baseline"
     );
     assert_eq!(
         final_hash, GLOBAL_HARNESS_FINAL_HASH,

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -773,8 +773,8 @@ impl Simulation {
             self.append_live_build_const(stable_id);
             self.refresh_waypoint_edge_from_committed_structure(stable_id);
             self.mark_building_base_reservation(stable_id);
+            self.fill_base_plan_from_successful_building_unlimbo(stable_id);
         }
-        self.fill_base_plan_from_successful_building_unlimbo(stable_id);
         self.lifecycle_outputs
             .push(LifecycleOutput::RevealDisplay { stable_id });
         #[cfg(test)]
@@ -2842,9 +2842,11 @@ mod base_plan_lifecycle_tests {
     use crate::rules::object_type::ObjectCategory as RulesObjectCategory;
     use crate::rules::ruleset::RuleSet;
     use crate::sim::base_plan::{BasePlanNode, pack_base_plan_cell};
+    use crate::sim::game_entity::{GameEntity, StructureUpgradeLink};
     use crate::sim::house_state::HouseState;
     use crate::sim::scenario_bootstrap::initialize_map_roster_houses;
-    use crate::sim::world::Simulation;
+    use crate::sim::world::{PlacementEvidence, RevealPosition, RevealRequest, Simulation};
+    use crate::util::fixed_math::SimFixed;
 
     fn rules() -> RuleSet {
         RuleSet::from_ini(&IniFile::from_str(
@@ -2943,6 +2945,69 @@ mod base_plan_lifecycle_tests {
             })
             .expect("BasePlan fill trace");
         assert!(build_const < base_plan);
+    }
+
+    #[test]
+    fn gsi_04_05_attached_upgrade_early_return_does_not_fill_base_plan() {
+        let mut sim = Simulation::new();
+        let owner = sim.interner.intern("Computer1");
+        let type_ref = sim.interner.intern("GAPOWR");
+        let mut house = HouseState::new(owner, 0, None, false, 0, 10);
+        house.base_plan.nodes.push(BasePlanNode {
+            type_or_control: 0,
+            packed_cell: pack_base_plan_cell(10, 11),
+            filled: false,
+            retry_count: 7,
+        });
+        sim.houses.insert(owner, house);
+
+        let mut upgrade = GameEntity::new_at_frame_zero_for_test(
+            1,
+            10,
+            11,
+            0,
+            0,
+            owner,
+            crate::sim::components::Health {
+                current: 100,
+                max: 100,
+            },
+            type_ref,
+            EntityCategory::Structure,
+            0,
+            5,
+            false,
+        );
+        upgrade.base_plan_type_index = 0;
+        upgrade.structure_upgrade_link = Some(StructureUpgradeLink {
+            parent_stable_id: 99,
+            slot: 0,
+        });
+        sim.substrate.entities.insert(upgrade);
+
+        let outcome = sim.try_reveal_entity(
+            1,
+            RevealRequest {
+                position: RevealPosition {
+                    rx: 10,
+                    ry: 11,
+                    z: 0,
+                    sub_x: SimFixed::from_num(0),
+                    sub_y: SimFixed::from_num(0),
+                },
+                placement: PlacementEvidence::AttachedUpgrade,
+                logic_eligible: true,
+            },
+        );
+
+        assert!(matches!(outcome, super::RevealOutcome::Revealed { .. }));
+        assert!(!sim.houses[&owner].base_plan.nodes[0].filled);
+        assert_eq!(sim.houses[&owner].base_plan.nodes[0].retry_count, 7);
+        assert!(
+            !sim.lifecycle_test_events_for_test().iter().any(|event| {
+                *event == super::LifecycleTestEvent::BasePlanFilled { stable_id: 1 }
+            })
+        );
     }
 
     #[test]

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -250,6 +250,12 @@ pub(crate) enum LifecycleTestEvent {
     BaseReservationMarked,
     RawOccupationMarked,
     CellMarked,
+    BuildConstAppended {
+        stable_id: u64,
+    },
+    BasePlanFilled {
+        stable_id: u64,
+    },
     RevealDisplayBoundary,
     LogicAppended,
     LogicMembershipSet,
@@ -753,7 +759,6 @@ impl Simulation {
                 self.session.binary_frame,
             );
         }
-        self.fill_base_plan_from_successful_building_unlimbo(stable_id);
         if !self
             .substrate
             .entities
@@ -769,6 +774,7 @@ impl Simulation {
             self.refresh_waypoint_edge_from_committed_structure(stable_id);
             self.mark_building_base_reservation(stable_id);
         }
+        self.fill_base_plan_from_successful_building_unlimbo(stable_id);
         self.lifecycle_outputs
             .push(LifecycleOutput::RevealDisplay { stable_id });
         #[cfg(test)]
@@ -809,9 +815,14 @@ impl Simulation {
         if house.is_controlled_by_human(game_mode_nonzero) {
             return;
         }
-        house
+        let _filled = house
             .base_plan
-            .fill_successful_building(type_index, packed_cell, has_undeploy_target);
+            .fill_successful_building(type_index, packed_cell, has_undeploy_target)
+            .is_some();
+        #[cfg(test)]
+        if _filled {
+            self.trace_lifecycle_for_test(LifecycleTestEvent::BasePlanFilled { stable_id });
+        }
     }
 
     /// `BuildingClass__Limbo @ 0x00445880` calls
@@ -2885,6 +2896,53 @@ mod base_plan_lifecycle_tests {
             .expect("human building");
         assert!(!sim.houses[&human].base_plan.nodes[0].filled);
         assert_eq!(sim.houses[&human].base_plan.nodes[0].retry_count, 7);
+    }
+
+    #[test]
+    fn gsi_04_05_build_const_append_precedes_base_plan_fill() {
+        let rules = RuleSet::from_ini(&IniFile::from_str(
+            "[General]\nMaximumBuildingPlacementFailures=3\n\
+             [AI]\nBuildConst=GACNST\n\
+             [BuildingTypes]\n0=GACNST\n\
+             [GACNST]\nStrength=1000\nUndeploysInto=AMCV\n",
+        ))
+        .expect("combined BuildConst/BasePlan rules");
+        let scenario = IniFile::from_str(
+            "[Houses]\n0=Computer1\n\
+             [Computer1]\nNodeCount=1\n000=GACNST,10,11\n",
+        );
+        let roster =
+            crate::map::houses::parse_house_roster(&scenario, &rules.color_schemes, Some(&rules));
+        let mut sim = Simulation::new();
+        initialize_map_roster_houses(&mut sim, &roster, Some(&rules));
+        let owner = sim.interner.get("Computer1").unwrap();
+
+        let building = sim
+            .spawn_object("GACNST", "Computer1", 10, 11, 0, &rules, &BTreeMap::new())
+            .expect("combined BuildConst/BasePlan Building");
+
+        assert_eq!(sim.houses[&owner].build_const_order, [building]);
+        assert!(sim.houses[&owner].base_plan.nodes[0].filled);
+        let events = sim.lifecycle_test_events_for_test();
+        let build_const = events
+            .iter()
+            .position(|event| {
+                *event
+                    == (super::LifecycleTestEvent::BuildConstAppended {
+                        stable_id: building,
+                    })
+            })
+            .expect("BuildConst append trace");
+        let base_plan = events
+            .iter()
+            .position(|event| {
+                *event
+                    == (super::LifecycleTestEvent::BasePlanFilled {
+                        stable_id: building,
+                    })
+            })
+            .expect("BasePlan fill trace");
+        assert!(build_const < base_plan);
     }
 
     #[test]

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -753,6 +753,7 @@ impl Simulation {
                 self.session.binary_frame,
             );
         }
+        self.fill_base_plan_from_successful_building_unlimbo(stable_id);
         if !self
             .substrate
             .entities
@@ -779,6 +780,69 @@ impl Simulation {
             false
         };
         RevealOutcome::Revealed { logic_registered }
+    }
+
+    /// `BuildingClass::Unlimbo @ 0x00440580` successful-plan satisfaction.
+    fn fill_base_plan_from_successful_building_unlimbo(&mut self, stable_id: u64) {
+        let Some((owner, type_index, packed_cell, has_undeploy_target)) =
+            self.substrate.entities.get(stable_id).and_then(|entity| {
+                (entity.category == EntityCategory::Structure && entity.base_plan_type_index >= 0)
+                    .then_some((
+                        entity.owner,
+                        entity.base_plan_type_index,
+                        crate::sim::base_plan::pack_base_plan_cell(
+                            i32::from(entity.position.rx),
+                            i32::from(entity.position.ry),
+                        ),
+                        entity.base_plan_has_undeploy_target,
+                    ))
+            })
+        else {
+            return;
+        };
+        let Some(house) = self.houses.get_mut(&owner) else {
+            return;
+        };
+        if house.event_dispatch_eligible() {
+            return;
+        }
+        house
+            .base_plan
+            .fill_successful_building(type_index, packed_cell, has_undeploy_target);
+    }
+
+    /// `BuildingClass::Limbo @ 0x00443C60` BasePlan invalidation, before the
+    /// common Techno/Object concealment path. VERA has no map-editor runtime;
+    /// every call to this lifecycle seam is therefore outside editor mode.
+    fn invalidate_base_plan_from_building_limbo(&mut self, stable_id: u64) {
+        let Some((owner, type_index, packed_cell, is_base_defense, in_limbo)) =
+            self.substrate.entities.get(stable_id).and_then(|entity| {
+                (entity.category == EntityCategory::Structure && entity.base_plan_type_index >= 0)
+                    .then_some((
+                        entity.owner,
+                        entity.base_plan_type_index,
+                        crate::sim::base_plan::pack_base_plan_cell(
+                            i32::from(entity.position.rx),
+                            i32::from(entity.position.ry),
+                        ),
+                        entity.base_plan_is_defense,
+                        entity.lifecycle.in_limbo,
+                    ))
+            })
+        else {
+            return;
+        };
+        if in_limbo {
+            return;
+        }
+        if let Some(house) = self.houses.get_mut(&owner) {
+            house.base_plan.invalidate_limbo_building(
+                type_index,
+                packed_cell,
+                is_base_defense,
+                self.session.game_mode_nonzero,
+            );
+        }
     }
 
     /// Refresh the owning house's navigation edge from a live, map-committed
@@ -1799,6 +1863,9 @@ impl Simulation {
         if !self.substrate.entities.contains(stable_id) {
             return ConcealOutcome::MissingOrDead;
         }
+        // BuildingClass owns this pass before the common TechnoClass Limbo can
+        // clear committed type/cell facts or broadcast another expiry callback.
+        self.invalidate_base_plan_from_building_limbo(stable_id);
         // FootClass::Limbo @ 0x004DB260 and BuildingClass::Limbo @
         // 0x00445880 remove the exact deposited footprint before conceal.
         if let Some(rules) = context.rules() {
@@ -2748,5 +2815,110 @@ impl Simulation {
     #[cfg(test)]
     pub(crate) fn flush_pending_delete(&mut self) {
         self.process_pending_delete();
+    }
+}
+
+#[cfg(test)]
+mod base_plan_lifecycle_tests {
+    use std::collections::BTreeMap;
+
+    use crate::map::entities::EntityCategory;
+    use crate::rules::ini_parser::IniFile;
+    use crate::rules::ruleset::RuleSet;
+    use crate::sim::base_plan::{BasePlanNode, pack_base_plan_cell};
+    use crate::sim::house_state::HouseState;
+    use crate::sim::scenario_bootstrap::initialize_map_roster_houses;
+    use crate::sim::world::Simulation;
+
+    fn rules() -> RuleSet {
+        RuleSet::from_ini(&IniFile::from_str(
+            "[General]\nMaximumBuildingPlacementFailures=3\n\
+             [BuildingTypes]\n0=GAPOWR\n1=GACNST\n\
+             [GAPOWR]\nStrength=750\nIsBaseDefense=yes\n\
+             [GACNST]\nStrength=1000\nUndeploysInto=AMCV\n",
+        ))
+        .expect("base-plan lifecycle rules")
+    }
+
+    #[test]
+    fn gsi_04_05_scenario_plan_precedes_unlimbo_and_human_unlimbo_is_excluded() {
+        let rules = rules();
+        let scenario = IniFile::from_str(
+            "[Houses]\n0=Computer1\n\
+             [Computer1]\nPercentBuilt=44\nNodeCount=1\n000=GACNST,10,11\n",
+        );
+        let roster =
+            crate::map::houses::parse_house_roster(&scenario, &rules.color_schemes, Some(&rules));
+        let mut sim = Simulation::new();
+        initialize_map_roster_houses(&mut sim, &roster, Some(&rules));
+        let ai = sim.interner.get("Computer1").unwrap();
+        assert_eq!(sim.houses[&ai].base_plan.percent_built, 44);
+        assert!(!sim.houses[&ai].base_plan.nodes[0].filled);
+
+        let building = sim
+            .spawn_object("GACNST", "Computer1", 10, 11, 0, &rules, &BTreeMap::new())
+            .expect("scenario building");
+        assert!(sim.houses[&ai].base_plan.nodes[0].filled);
+        assert_eq!(sim.houses[&ai].base_plan.nodes[0].retry_count, 0);
+        let entity = sim.entities().get(building).unwrap();
+        assert_eq!(entity.category, EntityCategory::Structure);
+        assert_eq!(entity.base_plan_type_index, 1);
+        assert!(!entity.base_plan_is_defense);
+        assert!(entity.base_plan_has_undeploy_target);
+
+        let human = sim.interner.intern("Human1");
+        let mut human_house = HouseState::new(human, 0, None, true, 0, 10);
+        human_house.base_plan.nodes.push(BasePlanNode {
+            type_or_control: 0,
+            packed_cell: pack_base_plan_cell(20, 21),
+            filled: false,
+            retry_count: 7,
+        });
+        sim.houses.insert(human, human_house);
+        sim.session.house_order.push(human);
+        sim.spawn_object("GAPOWR", "Human1", 20, 21, 0, &rules, &BTreeMap::new())
+            .expect("human building");
+        assert!(!sim.houses[&human].base_plan.nodes[0].filled);
+        assert_eq!(sim.houses[&human].base_plan.nodes[0].retry_count, 7);
+    }
+
+    #[test]
+    fn gsi_04_05_building_limbo_runs_base_plan_invalidation_before_conceal() {
+        let rules = rules();
+        let mut sim = Simulation::new();
+        sim.session.game_mode_nonzero = true;
+        let owner = sim.interner.intern("Computer1");
+        sim.houses
+            .insert(owner, HouseState::new(owner, 0, None, false, 0, 10));
+        let building = sim
+            .spawn_object("GAPOWR", "Computer1", 30, 31, 0, &rules, &BTreeMap::new())
+            .expect("defense building");
+        let cell = pack_base_plan_cell(30, 31);
+        sim.houses.get_mut(&owner).unwrap().base_plan.nodes = vec![
+            BasePlanNode {
+                type_or_control: 0,
+                packed_cell: cell,
+                filled: true,
+                retry_count: 8,
+            },
+            BasePlanNode {
+                type_or_control: 1,
+                packed_cell: cell,
+                filled: false,
+                retry_count: -2,
+            },
+        ];
+
+        assert_eq!(sim.techno_limbo(building), super::ConcealOutcome::Concealed);
+        let plan = &sim.houses[&owner].base_plan;
+        assert_eq!(plan.nodes[0].type_or_control, -1);
+        assert_eq!(plan.nodes[0].packed_cell, 0);
+        assert!(plan.nodes[0].filled);
+        assert_eq!(plan.nodes[0].retry_count, 8);
+        assert_eq!(plan.nodes[1].type_or_control, 1);
+        assert_eq!(plan.nodes[1].packed_cell, 0);
+        assert!(!plan.nodes[1].filled);
+        assert_eq!(plan.nodes[1].retry_count, -2);
+        assert!(sim.entities().get(building).unwrap().lifecycle.in_limbo);
     }
 }

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -2828,6 +2828,7 @@ mod base_plan_lifecycle_tests {
 
     use crate::map::entities::EntityCategory;
     use crate::rules::ini_parser::IniFile;
+    use crate::rules::object_type::ObjectCategory as RulesObjectCategory;
     use crate::rules::ruleset::RuleSet;
     use crate::sim::base_plan::{BasePlanNode, pack_base_plan_cell};
     use crate::sim::house_state::HouseState;
@@ -2948,6 +2949,103 @@ mod base_plan_lifecycle_tests {
             campaign.houses[&campaign_owner].base_plan.nodes[0].retry_count,
             6
         );
+    }
+
+    #[test]
+    fn gsi_04_05_undeploys_into_resolution_controls_base_plan_fallback() {
+        let rules = RuleSet::from_ini(&IniFile::from_str(
+            "[VehicleTypes]\n0=AMCV\n\
+             [BuildingTypes]\n0=NONEYARD\n1=ANGLEYARD\n2=REALYARD\n\
+             [AMCV]\nStrength=1000\n\
+             [NONEYARD]\nStrength=1000\nUndeploysInto=NoNe\n\
+             [ANGLEYARD]\nStrength=1000\nUndeploysInto=<nOnE>\n\
+             [REALYARD]\nStrength=1000\nUndeploysInto=amcv\n",
+        ))
+        .expect("UndeploysInto resolution rules");
+
+        assert!(rules.object("NONEYARD").unwrap().undeploys_into.is_none());
+        assert!(rules.object("ANGLEYARD").unwrap().undeploys_into.is_none());
+        let resolved = rules
+            .object("REALYARD")
+            .unwrap()
+            .undeploys_into
+            .as_deref()
+            .expect("real UnitType identity remains resolved");
+        assert!(
+            rules
+                .object_in_category(RulesObjectCategory::Vehicle, resolved)
+                .is_some()
+        );
+
+        let mut sim = Simulation::new();
+        let owner = sim.interner.intern("Computer1");
+        let mut house = HouseState::new(owner, 0, None, false, 0, 10);
+        house.base_plan.nodes = vec![
+            BasePlanNode {
+                type_or_control: 0,
+                packed_cell: pack_base_plan_cell(70, 71),
+                filled: false,
+                retry_count: 4,
+            },
+            BasePlanNode {
+                type_or_control: 1,
+                packed_cell: pack_base_plan_cell(80, 81),
+                filled: false,
+                retry_count: 5,
+            },
+            BasePlanNode {
+                type_or_control: 2,
+                packed_cell: pack_base_plan_cell(90, 91),
+                filled: false,
+                retry_count: 6,
+            },
+        ];
+        sim.houses.insert(owner, house);
+        sim.session.house_order.push(owner);
+
+        let none = sim
+            .spawn_object("NONEYARD", "Computer1", 10, 11, 0, &rules, &BTreeMap::new())
+            .expect("none-sentinel Building");
+        let angle = sim
+            .spawn_object(
+                "ANGLEYARD",
+                "Computer1",
+                12,
+                13,
+                0,
+                &rules,
+                &BTreeMap::new(),
+            )
+            .expect("angle-sentinel Building");
+        let real = sim
+            .spawn_object("REALYARD", "Computer1", 14, 15, 0, &rules, &BTreeMap::new())
+            .expect("resolved-undeploy Building");
+
+        assert!(
+            !sim.entities()
+                .get(none)
+                .unwrap()
+                .base_plan_has_undeploy_target
+        );
+        assert!(
+            !sim.entities()
+                .get(angle)
+                .unwrap()
+                .base_plan_has_undeploy_target
+        );
+        assert!(
+            sim.entities()
+                .get(real)
+                .unwrap()
+                .base_plan_has_undeploy_target
+        );
+        let plan = &sim.houses[&owner].base_plan.nodes;
+        assert!(!plan[0].filled, "none sentinel must not enable fallback");
+        assert_eq!(plan[0].retry_count, 4);
+        assert!(!plan[1].filled, "<none> sentinel must not enable fallback");
+        assert_eq!(plan[1].retry_count, 5);
+        assert!(plan[2].filled, "resolved UnitType enables fallback");
+        assert_eq!(plan[2].retry_count, 0);
     }
 
     #[test]

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -782,7 +782,9 @@ impl Simulation {
         RevealOutcome::Revealed { logic_registered }
     }
 
-    /// `BuildingClass::Unlimbo @ 0x00440580` successful-plan satisfaction.
+    /// `BuildingClass::Unlimbo @ 0x00440580` calls
+    /// `FUN_0042F260 @ 0x0042F260` at `0x0044159D..0x004415B3` for
+    /// successful non-human BasePlan satisfaction.
     fn fill_base_plan_from_successful_building_unlimbo(&mut self, stable_id: u64) {
         let Some((owner, type_index, packed_cell, has_undeploy_target)) =
             self.substrate.entities.get(stable_id).and_then(|entity| {
@@ -812,9 +814,10 @@ impl Simulation {
             .fill_successful_building(type_index, packed_cell, has_undeploy_target);
     }
 
-    /// `BuildingClass::Limbo @ 0x00443C60` BasePlan invalidation, before the
-    /// common Techno/Object concealment path. VERA has no map-editor runtime;
-    /// every call to this lifecycle seam is therefore outside editor mode.
+    /// `BuildingClass__Limbo @ 0x00445880` calls
+    /// `FUN_0050A490 @ 0x0050A490` for BasePlan invalidation before the common
+    /// Techno/Object concealment path. VERA has no map-editor runtime; every
+    /// call to this lifecycle seam is therefore outside editor mode.
     fn invalidate_base_plan_from_building_limbo(&mut self, stable_id: u64) {
         let Some((owner, type_index, packed_cell, is_base_defense, in_limbo)) =
             self.substrate.entities.get(stable_id).and_then(|entity| {

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -800,10 +800,11 @@ impl Simulation {
         else {
             return;
         };
+        let game_mode_nonzero = self.session.game_mode_nonzero;
         let Some(house) = self.houses.get_mut(&owner) else {
             return;
         };
-        if house.event_dispatch_eligible() {
+        if house.is_controlled_by_human(game_mode_nonzero) {
             return;
         }
         house
@@ -2880,6 +2881,70 @@ mod base_plan_lifecycle_tests {
             .expect("human building");
         assert!(!sim.houses[&human].base_plan.nodes[0].filled);
         assert_eq!(sim.houses[&human].base_plan.nodes[0].retry_count, 7);
+    }
+
+    #[test]
+    fn gsi_04_05_unlimbo_human_control_gate_is_mode_sensitive() {
+        fn player_control_only_house(
+            sim: &mut Simulation,
+            owner_name: &str,
+            packed_cell: u32,
+        ) -> crate::sim::intern::InternedId {
+            let owner = sim.interner.intern(owner_name);
+            let mut house = HouseState::new(owner, 0, None, false, 0, 10);
+            house.player_control = true;
+            house.base_plan.nodes.push(BasePlanNode {
+                type_or_control: 0,
+                packed_cell,
+                filled: false,
+                retry_count: 6,
+            });
+            sim.houses.insert(owner, house);
+            sim.session.house_order.push(owner);
+            owner
+        }
+
+        let rules = rules();
+        let mut nonzero = Simulation::new();
+        nonzero.session.game_mode_nonzero = true;
+        let nonzero_owner =
+            player_control_only_house(&mut nonzero, "SkirmishSlot", pack_base_plan_cell(40, 41));
+        nonzero
+            .spawn_object(
+                "GAPOWR",
+                "SkirmishSlot",
+                40,
+                41,
+                0,
+                &rules,
+                &BTreeMap::new(),
+            )
+            .expect("nonzero-mode Building");
+        assert!(nonzero.houses[&nonzero_owner].base_plan.nodes[0].filled);
+        assert_eq!(
+            nonzero.houses[&nonzero_owner].base_plan.nodes[0].retry_count,
+            0
+        );
+
+        let mut campaign = Simulation::new();
+        let campaign_owner =
+            player_control_only_house(&mut campaign, "CampaignPlayer", pack_base_plan_cell(50, 51));
+        campaign
+            .spawn_object(
+                "GAPOWR",
+                "CampaignPlayer",
+                50,
+                51,
+                0,
+                &rules,
+                &BTreeMap::new(),
+            )
+            .expect("campaign Building");
+        assert!(!campaign.houses[&campaign_owner].base_plan.nodes[0].filled);
+        assert_eq!(
+            campaign.houses[&campaign_owner].base_plan.nodes[0].retry_count,
+            6
+        );
     }
 
     #[test]

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -4402,10 +4402,17 @@ impl Simulation {
         }) else {
             return;
         };
-        if let Some(house) = self.houses.get_mut(&owner)
+        let _appended = if let Some(house) = self.houses.get_mut(&owner)
             && !house.build_const_order.contains(&stable_id)
         {
             house.build_const_order.push(stable_id);
+            true
+        } else {
+            false
+        };
+        #[cfg(test)]
+        if _appended {
+            self.trace_lifecycle_for_test(LifecycleTestEvent::BuildConstAppended { stable_id });
         }
     }
 

--- a/src/sim/world/slice6_retask_tests.rs
+++ b/src/sim/world/slice6_retask_tests.rs
@@ -320,7 +320,11 @@ const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x9856_E7DA_D9F1_676A;
 // Re-baselined 2026-08-30 for v107's Spark shared-dummy tag plus level/slope
 // folds. Both historical probes remain byte-identical, so only current-schema
 // composition moved.
-const SLICE6_BASELINE_HASH: u64 = 0x214E_DE3E_7939_F143;
+// Re-baselined 2026-08-30 for v110's unconditional ordered BasePlan authority.
+// The dedicated pre-v110 probe reproduces the prior baseline exactly, isolating
+// the measured shift to current-schema composition.
+const SLICE6_PRE_BASE_PLAN_V110_HASH: u64 = 0x214E_DE3E_7939_F143;
+const SLICE6_BASELINE_HASH: u64 = 0x4397_FA88_D95E_5208;
 
 #[test]
 fn replay_hash_stable_through_slice6() {
@@ -397,9 +401,10 @@ fn replay_hash_stable_through_slice6() {
 
     let pre_lifecycle_hash = sim.state_hash_before_lifecycle_v28_and_mission_v29();
     let pre_mission_hash = sim.state_hash_without_mission_v29();
+    let pre_base_plan_hash = sim.state_hash_without_base_plan_v110();
     let hash = sim.state_hash();
     println!(
-        "[slice6] hashes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},current:{hash:016X}"
+        "[slice6] hashes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},pre-v110:{pre_base_plan_hash:016X},current:{hash:016X}"
     );
     assert_eq!(
         pre_lifecycle_hash, SLICE6_PRE_LIFECYCLE_V28_HASH,
@@ -408,6 +413,10 @@ fn replay_hash_stable_through_slice6() {
     assert_eq!(
         pre_mission_hash, SLICE6_PRE_MISSION_V29_HASH,
         "v29 provenance probe must reproduce the prior live v28 baseline; otherwise this is behavior drift"
+    );
+    assert_eq!(
+        pre_base_plan_hash, SLICE6_PRE_BASE_PLAN_V110_HASH,
+        "the dedicated pre-v110 probe must reproduce the prior Slice 6 baseline"
     );
     assert_eq!(
         hash, SLICE6_BASELINE_HASH,

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -443,6 +443,17 @@ impl Simulation {
         )
     }
 
+    /// Test-only provenance probe for the v110 BasePlan folds. It reconstructs
+    /// the committed v109 hash layout while retaining every earlier schema
+    /// addition, including naval BuildConst order and membership.
+    #[cfg(test)]
+    pub(crate) fn state_hash_without_base_plan_v110(&self) -> u64 {
+        self.state_hash_with_schema(
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, false,
+        )
+    }
+
     fn state_hash_with_schema(
         &self,
         include_lifecycle_v28: bool,
@@ -2626,10 +2637,20 @@ mod rally_hash_tests {
         let baseline = house_sim(vec![first, second], 50);
         let reversed = house_sim(vec![second, first], 50);
         assert_ne!(baseline.state_hash(), reversed.state_hash());
+        assert_ne!(
+            baseline.state_hash(),
+            baseline.state_hash_without_base_plan_v110(),
+            "the v110 schema folds BasePlan state even when earlier schema state is unchanged"
+        );
+        assert_eq!(
+            baseline.state_hash_without_base_plan_v110(),
+            reversed.state_hash_without_base_plan_v110(),
+            "the v109 provenance schema excludes BasePlan node order"
+        );
         assert_eq!(
             baseline.state_hash_before_lifecycle_v28_and_mission_v29(),
             reversed.state_hash_before_lifecycle_v28_and_mission_v29(),
-            "historical schemas exclude the complete v107 authority"
+            "historical schemas exclude the complete v110 authority"
         );
 
         for changed in [

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -394,7 +394,7 @@ impl Simulation {
     pub fn state_hash(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true,
+            true, true, true, true,
         )
     }
 
@@ -406,7 +406,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             true, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false,
+            false, false, false, false,
         )
     }
 
@@ -418,7 +418,7 @@ impl Simulation {
     pub(crate) fn state_hash_before_lifecycle_v28_and_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             false, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false,
+            false, false, false, false,
         )
     }
 
@@ -428,7 +428,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_spark_dummy_level_slope_v107(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, false, false,
-            false,
+            false, false,
         )
     }
 
@@ -439,7 +439,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_naval_build_const_v109(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            false,
+            false, false,
         )
     }
 
@@ -460,6 +460,7 @@ impl Simulation {
         include_spark_dummy_level_slope_v107: bool,
         include_alternate_base_center_v108: bool,
         include_naval_build_const_v109: bool,
+        include_base_plan_v110: bool,
     ) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
 
@@ -508,6 +509,7 @@ impl Simulation {
             include_base_defense_response_v97,
             include_alternate_base_center_v108,
             include_naval_build_const_v109,
+            include_base_plan_v110,
         );
         if include_terminal_score_v46 {
             self.hash_terminal_score_snapshot(&mut hasher);
@@ -574,6 +576,7 @@ impl Simulation {
             include_base_defense_response_v97,
             include_techno_constructor_v104,
             include_naval_build_const_v109,
+            include_base_plan_v110,
         );
         self.hash_anims(&mut hasher);
         self.hash_particle_systems(&mut hasher);
@@ -724,6 +727,7 @@ impl Simulation {
         include_base_defense_response_v97: bool,
         include_alternate_base_center_v108: bool,
         include_naval_build_const_v109: bool,
+        include_base_plan_v110: bool,
     ) {
         for (owner, house) in &self.houses {
             owner.hash(hasher);
@@ -785,6 +789,16 @@ impl Simulation {
                 house.build_const_order.len().hash(hasher);
                 for stable_id in &house.build_const_order {
                     stable_id.hash(hasher);
+                }
+            }
+            if include_base_plan_v110 {
+                house.base_plan.percent_built.hash(hasher);
+                house.base_plan.nodes.len().hash(hasher);
+                for node in &house.base_plan.nodes {
+                    node.type_or_control.hash(hasher);
+                    node.packed_cell.hash(hasher);
+                    node.filled.hash(hasher);
+                    node.retry_count.hash(hasher);
                 }
             }
             house.base_reservation.hash(hasher);
@@ -1121,6 +1135,7 @@ impl Simulation {
         include_base_defense_response_v97: bool,
         include_techno_constructor_v104: bool,
         include_naval_build_const_v109: bool,
+        include_base_plan_v110: bool,
     ) {
         for entity in self.substrate.entities.values() {
             entity.stable_id.hash(hasher);
@@ -1238,6 +1253,11 @@ impl Simulation {
             if include_naval_build_const_v109 && entity.build_const_eligible {
                 b"naval-build-const-entity-v1".hash(hasher);
                 entity.build_const_eligible.hash(hasher);
+            }
+            if include_base_plan_v110 {
+                entity.base_plan_type_index.hash(hasher);
+                entity.base_plan_is_defense.hash(hasher);
+                entity.base_plan_has_undeploy_target.hash(hasher);
             }
             entity.veterancy.hash(hasher);
             // The raw accumulator is authoritative — `veterancy` is only its
@@ -2574,6 +2594,101 @@ mod rally_hash_tests {
         sim_b.houses.insert(owner_b, changed);
 
         assert_ne!(sim_a.state_hash(), sim_b.state_hash());
+    }
+
+    #[test]
+    fn gsi_04_05_base_plan_state_and_entity_facts_are_current_schema_hash_authority() {
+        use crate::sim::base_plan::{BasePlanNode, pack_base_plan_cell};
+        use crate::sim::house_state::HouseState;
+
+        fn house_sim(nodes: Vec<BasePlanNode>, percent_built: i32) -> Simulation {
+            let mut sim = Simulation::new();
+            let owner = sim.interner.intern("Computer1");
+            let mut house = HouseState::new(owner, 0, None, false, 0, 10);
+            house.base_plan.percent_built = percent_built;
+            house.base_plan.nodes = nodes;
+            sim.houses.insert(owner, house);
+            sim
+        }
+
+        let first = BasePlanNode {
+            type_or_control: 4,
+            packed_cell: pack_base_plan_cell(7, 8),
+            filled: false,
+            retry_count: 2,
+        };
+        let second = BasePlanNode {
+            type_or_control: -3,
+            packed_cell: pack_base_plan_cell(-1, 5),
+            filled: true,
+            retry_count: -9,
+        };
+        let baseline = house_sim(vec![first, second], 50);
+        let reversed = house_sim(vec![second, first], 50);
+        assert_ne!(baseline.state_hash(), reversed.state_hash());
+        assert_eq!(
+            baseline.state_hash_before_lifecycle_v28_and_mission_v29(),
+            reversed.state_hash_before_lifecycle_v28_and_mission_v29(),
+            "historical schemas exclude the complete v107 authority"
+        );
+
+        for changed in [
+            house_sim(vec![first, second], 51),
+            house_sim(
+                vec![
+                    BasePlanNode {
+                        type_or_control: 5,
+                        ..first
+                    },
+                    second,
+                ],
+                50,
+            ),
+            house_sim(
+                vec![
+                    BasePlanNode {
+                        packed_cell: pack_base_plan_cell(9, 8),
+                        ..first
+                    },
+                    second,
+                ],
+                50,
+            ),
+            house_sim(
+                vec![
+                    BasePlanNode {
+                        filled: true,
+                        ..first
+                    },
+                    second,
+                ],
+                50,
+            ),
+            house_sim(
+                vec![
+                    BasePlanNode {
+                        retry_count: 3,
+                        ..first
+                    },
+                    second,
+                ],
+                50,
+            ),
+        ] {
+            assert_ne!(baseline.state_hash(), changed.state_hash());
+        }
+
+        let mut entity_a = Simulation::new();
+        let mut entity_b = Simulation::new();
+        let mut a = GameEntity::test_default(1, "GAPOWR", "Computer1", 10, 10);
+        let mut b = a.clone();
+        a.base_plan_type_index = 2;
+        a.base_plan_is_defense = true;
+        a.base_plan_has_undeploy_target = true;
+        b.base_plan_type_index = 3;
+        entity_a.substrate.entities.insert(a);
+        entity_b.substrate.entities.insert(b);
+        assert_ne!(entity_a.state_hash(), entity_b.state_hash());
     }
 
     #[test]

--- a/src/sim/world/world_spawn.rs
+++ b/src/sim/world/world_spawn.rs
@@ -2138,6 +2138,9 @@ fn stamp_building_cell_profile(
         ge.build_const_eligible = obj.build_const_eligible;
         ge.base_plan_type_index = obj.base_plan_type_index;
         ge.base_plan_is_defense = obj.is_base_defense;
+        // Projection of native BuildingType+0x408 after
+        // UnitTypeClass__FindOrAllocate @ 0x007480D0 has resolved
+        // `none`/`<none>` to a null pointer.
         ge.base_plan_has_undeploy_target = obj.undeploys_into.is_some();
     }
 }

--- a/src/sim/world/world_spawn.rs
+++ b/src/sim/world/world_spawn.rs
@@ -2136,6 +2136,9 @@ fn stamp_building_cell_profile(
         ge.base_reservation_spacing = obj.base_reservation_spacing;
         ge.determines_waypoint_edge = obj.factory == Some(FactoryType::BuildingType);
         ge.build_const_eligible = obj.build_const_eligible;
+        ge.base_plan_type_index = obj.base_plan_type_index;
+        ge.base_plan_is_defense = obj.is_base_defense;
+        ge.base_plan_has_undeploy_target = obj.undeploys_into.is_some();
     }
 }
 


### PR DESCRIPTION
## Summary

- preserve native BuildConst data before loading an ordered BasePlan for each house
- resolve BasePlan entries against rules types without trimming native tokens or treating attached upgrades as buildable plan objects
- persist the plan lifecycle through snapshots and deterministic world hashing
- ratchet the three current v110 parity harness hashes with explicit pre-v110 composition proofs

## Evidence

This is the completed BasePlan state/lifecycle portion recovered from the Phase 3 session work. The implementation follows the evidence recorded in the included design document and keeps BasePlan generation/MCV anchoring, deploy latches, triggers, crates, anger, and later-phase systems out of this PR.

Fresh independent review passed after fixes for BuildConst ordering, token fidelity, v110 hash isolation, and attached-upgrade exclusion.

## Validation

- `cargo test -p vera20k --lib base_plan`: 18 passed, 0 failed
- focused naval snapshot, Slice 6, bridge, and global v110 ratchets: 1 passed each, 0 failed
- `cargo test -p vera20k --lib`: 7681 passed, 0 failed, 76 ignored