### PR TITLE
feat(sim): activate House AI latches during update

### DIFF
--- a/docs/plans/2026-08-27-house-update-ai-activation-design.md
+++ b/docs/plans/2026-08-27-house-update-ai-activation-design.md
@@ -1,0 +1,266 @@
+# House-update AI activation design
+
+**Date:** 2026-08-27  
+**Phase:** 3 / GSI-04.05 bounded mechanism  
+**Status:** Approved after read-only design review  
+**Native evidence:** `docs/research/PHASE3_HOUSE_UPDATE_AI_ACTIVATION_GHIDRA_REPORT.md`
+
+## Goal
+
+Implement the active-retail `HouseClass__Update @ 0x004F8440` activation transition at
+`0x004F8564..0x004F85B7`, including its signed `[IQ] Production` input, fourth persistent House
+latch, ordered House-array execution, snapshot representation, and direct House CRC shape.
+
+This is one bounded House mechanism, not closure of all GSI-04.05 ownership. Trigger action 13,
+factory-production policy, ordinary AutoBase consumers/action 30, AITriggersActive selection,
+computer takeover, deploy dispersal, and the broader network-modal scheduler remain distinct
+mechanisms and keep the row open.
+
+## Verified retail contract
+
+For each non-null House reached in forward live House-array order:
+
+```text
+controlled = CurrentPlayer || (GameMode == 0 && PlayerControl)
+if !controlled && (AutoBaseBuilding != 0 || CurrentIQ >= Rules.IQ.Production) {
+    AutoBaseBuilding = 1
+    Production = 1
+    AutocreateAllowed = 1
+}
+```
+
+The comparison is signed and inclusive. Any nonzero AutoBase value bypasses the IQ read. The
+three stores are adjacent, ordered, literal-one writes and have no intervening call, branch, RNG,
+timer, or side effect. Controlled, defeated, passive, low-power, and difficulty state add no gate.
+The transition never writes AITriggersActive.
+
+`[IQ] Production` is a signed dword with constructor default `5`; a present INI value replaces it
+without clamp. Stock retail `rules.ini` and `rulesmd.ini` both resolve to `5`.
+
+`AutocreateAllowed` is constructor-cleared, raw-save/load persistent, and directly included in
+the House CRC between Production and AITriggersActive. Its exhaustive direct-access census finds
+no ordinary gameplay reader. TeamType `Autocreate=` is a separate mechanism and must not be wired
+to this byte.
+
+Offline mode-0/5 Menu, Abort Confirm, and Options own blocking service-pump loops that never call
+`Main_Tick`; they therefore freeze this transition and the frame. An eligible network modal can
+run the transition only as part of the complete PerTick/House/late-tail path. This design does not
+change app admission or create a selective modal pass.
+
+## Architecture fit
+
+The existing ownership is correct:
+
+- `GeneralRules` owns signed `[IQ]` thresholds.
+- `HouseState` owns `CurrentIQ`, the exact control predicate, and persistent House latches.
+- `ScenarioSession::house_order` owns native House registration order.
+- `Simulation::run_late_region` is the current House-tail seam after factory/production work and
+  before defeat and strategic AI command generation.
+- `snapshot.rs` and `world_hash.rs` own versioned persistence and canonical deterministic folding.
+
+The transition therefore belongs on `HouseState`, invoked by one Simulation House-order pass. It
+must not be routed through `AiPlayerState`: Neutral/Special and scenario Houses are still native
+House-array members.
+
+## Data changes
+
+### Rules
+
+Add `GeneralRules::iq_production: i32` beside the existing `[IQ]` fields.
+
+- `GeneralRules::default`: `5`.
+- `GeneralRules::from_ini`: `[IQ] Production` through `get_i32`, falling back to the constructor
+  value, with no clamp or normalization.
+- The current parser returns `Self::default()` before binding `[IQ]` when `[General]` is absent,
+  although native `ReadIQ` is independent. Resolve this for the new field without broadening the
+  slice: compute the optional `[IQ] Production` override before the `[General]` early return and
+  return `Self { iq_production, ..Self::default() }` on that path. The ordinary `[General]` path
+  reuses the same parsed value. Existing IQ-only behavior for the older IQ fields is a separately
+  recorded rules-ingress residual, not a reason to make the new native input wrong.
+- Parser tests must cover missing section/key, stock value `5`, negative value, value above
+  `MaxIQLevels`, and an `[IQ]`-only file with no `[General]`; custom signed values must survive
+  verbatim.
+
+### House latches
+
+Extend `HouseAiActivationLatches` to four independent booleans in native conceptual byte order:
+
+```rust
+production
+autocreate_allowed
+ai_triggers_active
+auto_base_building
+```
+
+All default false. Snapshot schema 109 rejects prior positional records, so reordering the three
+existing fields into native order does not create an accepted mixed layout. Update every explicit
+fixture literal so the compiler proves the fourth state was considered.
+
+`enable_ai_deploy_latches` remains the deploy transaction and still writes exactly Production,
+AITriggersActive, AutoBaseBuilding in that order. It must not write or clear AutocreateAllowed.
+
+## Transition API and scheduling
+
+Add a House-owned helper, named to local convention, with inputs
+`(game_mode_nonzero: bool, iq_production: i32)`. It performs the verified control test, AutoBase
+bypass, signed inclusive IQ comparison, then assigns:
+
+1. `auto_base_building = true`;
+2. `production = true`;
+3. `autocreate_allowed = true`.
+
+It leaves `ai_triggers_active` unchanged. Repeated eligible calls execute the same assignments and
+remain idempotent. No return value should imply a native “changed” edge that does not exist.
+
+Add one private Simulation pass that walks `ScenarioSession::house_order` by increasing index and
+reloads the current vector length each iteration. Missing/null-equivalent map entries are skipped.
+For each present House it calls the helper with `self.session.game_mode_nonzero` and
+`rules.general.iq_production`.
+
+Call the pass in `run_late_region`:
+
+1. after the existing early House-like vision reconciliation;
+2. after the factory/production sweep that precedes `run_late_region`;
+3. before `check_defeat`;
+4. before `ai::tick_ai`.
+
+Rules-less fixtures perform no activation, matching the absence of a live native Rules owner in
+that artificial path. Both `TickLane::Ordinary` and any already-admitted future
+`TickLane::NetworkModal` reach the same House tail; app-level offline modal admission remains
+unchanged and continues to call neither lane.
+
+## Persistence and hash contract
+
+### Snapshot
+
+Bump `SNAPSHOT_VERSION` from 108 to 109 and document the addition of
+`AutocreateAllowed`. Replace the eight-combination latch test with all 16 combinations. Current
+snapshot assertions must refer to the current constant except for the explicit 109 contract test.
+
+### Hash
+
+Add a v109 schema switch after the v108 deploy-latch switch. Native places CurrentIQ after the
+three direct activation booleans, while committed Rust v108 placed CurrentIQ before Production and
+AITriggersActive. Correct the native-relative position only for current v109; preserve the exact
+historical v108 and pre-v108 streams.
+
+After the existing `tech_level` fold, the current v109 direct House fold must be:
+
+```text
+Production
+AutocreateAllowed
+AITriggersActive
+CurrentIQ
+```
+
+AutoBaseBuilding remains directly excluded. Implement this by separating the existing v108
+Production and AITriggers folds around the new conditional Autocreate fold and conditionally
+placing CurrentIQ:
+
+- when v109 is disabled, fold CurrentIQ at the old position before any v108 latch fields;
+- when v108 is enabled, fold Production;
+- when v109 is enabled, fold AutocreateAllowed;
+- when v108 is enabled, fold AITriggersActive;
+- when v109 is enabled, fold CurrentIQ at the corrected native position.
+
+Thus the v108 historical probe remains `CurrentIQ -> Production -> AITriggersActive`; pre-v108
+remains `CurrentIQ` only; current v109 becomes
+`Production -> AutocreateAllowed -> AITriggersActive -> CurrentIQ`.
+
+Extract the four-field fold into a small private helper if needed so an ordering-sensitive unit
+test can compare its output to a manually constructed `DefaultHasher` stream with deliberately
+distinct values. Differential whole-state hashes alone cannot prove sequence order.
+
+Differential tests must show:
+
+- current hash changes for Production, AutocreateAllowed, or AITriggersActive;
+- current hash does not change for AutoBaseBuilding alone;
+- the pre-v109 probe ignores AutocreateAllowed;
+- the v109 helper/current fold equals the manual native sequence above;
+- the v108 historical helper/probe equals the manual committed sequence above;
+- the existing pre-v108 probe remains stable and omits all latch additions.
+
+## Expected files
+
+- `src/rules/ruleset.rs`
+- `src/sim/house_state.rs`
+- `src/sim/world/mod.rs`
+- `src/sim/deploy_tests.rs`
+- `src/sim/snapshot.rs`
+- `src/sim/world/world_hash.rs`
+- optionally one focused test module under `src/sim/world/` if keeping the House-tail scenarios
+  out of `world_tests.rs` materially improves clarity
+
+No app, UI, TeamType, trigger-runtime, AI-player, or map-data file changes are authorized by this
+design.
+
+## Validation ledger
+
+Focused tests should share the `house_ai_activation` name fragment where practical so one scoped
+Cargo filter exercises the mechanism.
+
+### House helper
+
+- fresh state: four false latches and zero CurrentIQ;
+- below/equal/above signed threshold;
+- negative threshold with zero IQ;
+- AutoBase bypass far below threshold;
+- campaign CurrentPlayer and PlayerControl exclusions;
+- nonzero-mode PlayerControl ignored, CurrentPlayer still excludes;
+- repeated eligible visit idempotence without RNG/timer/counter mutation;
+- eligible Houses already marked defeated or passive, across at least two difficulty values, still
+  activate; these common neighboring gates must not leak in from `tick_ai`;
+- split state after AutoBase clear below threshold remains split;
+- split state at threshold restores AutoBase/Production/Autocreate;
+- deploy-produced `{Production, AITriggers, AutoBase}=true, Autocreate=false` gains only the missing
+  Autocreate semantic state on the next eligible House visit;
+- AITriggersActive is preserved in every path.
+
+### House-tail integration
+
+- forward `house_order` visits human, computer, and Neutral/Special fixtures once and activates
+  only eligible members;
+- a House eligible on the same frame as later defeat is activated before defeat processing;
+- the full-frame call reaches activation after the production sweep and before AI command
+  generation;
+- `advance_master_frame(..., TickLane::NetworkModal, ...)` with an empty command slice runs
+  activation as part of the admitted complete frame; this pins House activation without blessing
+  the lane's known generic due-command mismatch;
+- rules-less fixture is unchanged;
+- existing offline modal decision tests continue to prove zero admitted frame/activation while a
+  mode-0/5 modal is open; no app change is needed.
+
+### Persistence/hash and regressions
+
+- all 16 latch combinations round-trip schema 109;
+- current/direct, manual-order, and historical hash tests above;
+- existing qualifying deploy, facing-only deploy, controlled deploy, malformed/blocked deploy,
+  and BasePlan tests remain green and prove deploy never writes AutocreateAllowed;
+- existing BasePlan/BuildConst/naval placement behavior remains unchanged;
+- `git diff --check` is clean.
+
+Run only focused `cargo test -p vera20k --lib <filter>` commands for this mechanism. The parent
+Phase-3 run owns the single final full `cargo test -p vera20k --lib` certification.
+
+## Evidence-backed exclusions and open ownership
+
+- Trigger action 13 is not part of this builder slice. It is absent from the 310 effective shipped
+  map payloads surveyed, but remains required for compiled/custom parity and keeps GSI-04.05 open.
+- No House AutocreateAllowed consumer is added: none exists in the active executable.
+- TeamType `Autocreate=` remains independent.
+- Offline modal admission is preserved; no House-only service lane is invented.
+- Broader NetworkModal phase partitioning is not necessary to implement or validate the ordinary
+  House transition and remains a scheduler residual. In particular, native admitted network
+  modals still dispatch generic queued commands after PerTick, while current Rust suppresses the
+  entire late command slice. Only the Rust-specific offline Options `SetGameSpeed` ingress is
+  correctly Ordinary-only. This builder must neither change nor assert the generic suppression.
+- Production consumers, AutoBase consumers/action 30, AITriggersActive, takeover, and deploy
+  dispersal retain their existing owners and remain row residuals until separately closed.
+
+## Completion condition for this mechanism
+
+The mechanism is ready for a builder only after a read-only design critic approves this document
+against the native report and current source. After implementation, a fresh critic who did not
+build it must receive the requirement, native evidence, commit diff, and literal focused outputs.
+Any finding reopens the mechanism; repair the largest finding first and submit the repaired result
+to a new critic who also rechecks prior fixes.

--- a/docs/plans/2026-08-27-house-update-ai-activation-design.md
+++ b/docs/plans/2026-08-27-house-update-ai-activation-design.md
@@ -92,7 +92,7 @@ ai_triggers_active
 auto_base_building
 ```
 
-All default false. Snapshot schema 109 rejects prior positional records, so reordering the three
+All default false. Snapshot schema 113 rejects prior positional records, so reordering the three
 existing fields into native order does not create an accepted mixed layout. Update every explicit
 fixture literal so the compiler proves the fourth state was considered.
 
@@ -133,18 +133,18 @@ unchanged and continues to call neither lane.
 
 ### Snapshot
 
-Bump `SNAPSHOT_VERSION` from 108 to 109 and document the addition of
+Bump `SNAPSHOT_VERSION` from the current-main 112 to 113 and document the addition of
 `AutocreateAllowed`. Replace the eight-combination latch test with all 16 combinations. Current
-snapshot assertions must refer to the current constant except for the explicit 109 contract test.
+snapshot assertions must refer to the current constant except for the explicit 113 contract test.
 
 ### Hash
 
-Add a v109 schema switch after the v108 deploy-latch switch. Native places CurrentIQ after the
-three direct activation booleans, while committed Rust v108 placed CurrentIQ before Production and
-AITriggersActive. Correct the native-relative position only for current v109; preserve the exact
-historical v108 and pre-v108 streams.
+Add a v113 schema switch after the v112 deploy-latch switch. Native places CurrentIQ after the
+three direct activation booleans, while committed Rust v112 placed CurrentIQ before Production and
+AITriggersActive. Correct the native-relative position only for current v113; preserve the exact
+historical v112 and pre-v112 streams.
 
-After the existing `tech_level` fold, the current v109 direct House fold must be:
+After the existing `tech_level` fold, the current v113 direct House fold must be:
 
 ```text
 Production
@@ -153,18 +153,18 @@ AITriggersActive
 CurrentIQ
 ```
 
-AutoBaseBuilding remains directly excluded. Implement this by separating the existing v108
+AutoBaseBuilding remains directly excluded. Implement this by separating the existing v112
 Production and AITriggers folds around the new conditional Autocreate fold and conditionally
 placing CurrentIQ:
 
-- when v109 is disabled, fold CurrentIQ at the old position before any v108 latch fields;
-- when v108 is enabled, fold Production;
-- when v109 is enabled, fold AutocreateAllowed;
-- when v108 is enabled, fold AITriggersActive;
-- when v109 is enabled, fold CurrentIQ at the corrected native position.
+- when v113 is disabled, fold CurrentIQ at the old position before any v112 latch fields;
+- when v112 is enabled, fold Production;
+- when v113 is enabled, fold AutocreateAllowed;
+- when v112 is enabled, fold AITriggersActive;
+- when v113 is enabled, fold CurrentIQ at the corrected native position.
 
-Thus the v108 historical probe remains `CurrentIQ -> Production -> AITriggersActive`; pre-v108
-remains `CurrentIQ` only; current v109 becomes
+Thus the v112 historical probe remains `CurrentIQ -> Production -> AITriggersActive`; pre-v112
+remains `CurrentIQ` only; current v113 becomes
 `Production -> AutocreateAllowed -> AITriggersActive -> CurrentIQ`.
 
 Extract the four-field fold into a small private helper if needed so an ordering-sensitive unit
@@ -175,10 +175,10 @@ Differential tests must show:
 
 - current hash changes for Production, AutocreateAllowed, or AITriggersActive;
 - current hash does not change for AutoBaseBuilding alone;
-- the pre-v109 probe ignores AutocreateAllowed;
-- the v109 helper/current fold equals the manual native sequence above;
-- the v108 historical helper/probe equals the manual committed sequence above;
-- the existing pre-v108 probe remains stable and omits all latch additions.
+- the pre-v113 probe ignores AutocreateAllowed;
+- the v113 helper/current fold equals the manual native sequence above;
+- the v112 historical helper/probe equals the manual committed sequence above;
+- the existing pre-v112 probe remains stable and omits all latch additions.
 
 ## Expected files
 
@@ -232,7 +232,7 @@ Cargo filter exercises the mechanism.
 
 ### Persistence/hash and regressions
 
-- all 16 latch combinations round-trip schema 109;
+- all 16 latch combinations round-trip schema 113;
 - current/direct, manual-order, and historical hash tests above;
 - existing qualifying deploy, facing-only deploy, controlled deploy, malformed/blocked deploy,
   and BasePlan tests remain green and prove deploy never writes AutocreateAllowed;

--- a/docs/plans/2026-08-27-house-update-ai-activation-design.md
+++ b/docs/plans/2026-08-27-house-update-ai-activation-design.md
@@ -1,8 +1,8 @@
 # House-update AI activation design
 
-**Date:** 2026-08-27  
-**Phase:** 3 / GSI-04.05 bounded mechanism  
-**Status:** Approved after read-only design review  
+**Date:** 2026-08-27
+**Phase:** 3 / GSI-04.05 bounded mechanism
+**Status:** Approved after read-only design review
 **Native evidence:** `docs/research/PHASE3_HOUSE_UPDATE_AI_ACTIVATION_GHIDRA_REPORT.md`
 
 ## Goal

--- a/docs/research/PHASE3_HOUSE_UPDATE_AI_ACTIVATION_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_HOUSE_UPDATE_AI_ACTIVATION_GHIDRA_REPORT.md
@@ -1,10 +1,10 @@
 # Phase 3 House-update AI activation — exhaustive active-retail Ghidra report
 
-**Date:** 2026-08-27  
-**Binary:** installed active Yuri's Revenge `gamemd.exe` in live project `testProsjekt`  
-**Primary code:** `HouseClass__Update @ 0x004F8440`, activation block `0x004F8564..0x004F85B7`  
-**Investigation class:** exhaustive-slice; research only  
-**Status:** COMPLETE for the bounded House-update activation mechanism  
+**Date:** 2026-08-27
+**Binary:** installed active Yuri's Revenge `gamemd.exe` in live project `testProsjekt`
+**Primary code:** `HouseClass__Update @ 0x004F8440`, activation block `0x004F8564..0x004F85B7`
+**Investigation class:** exhaustive-slice; research only
+**Status:** COMPLETE for the bounded House-update activation mechanism
 **Confidence:** High. The transition, direct field census, tick owner, initialization, parsers,
 save/load/CRC lifecycle, retail inputs, and current Rust delta were all checked directly.
 
@@ -367,7 +367,8 @@ could gate it. Do not connect the two merely because their names resemble each o
 ### Evidence-backed exclusions
 
 - No TS executable or TS-only behavior is used as authority. The report is based on active YR
-  `gamemd.exe`; installed base/RA2 INI is consulted only because YR's effective data inherits it.
+  `gamemd.exe`; installed base/RA2 INI is only a comparative, non-authoritative reference. Active
+  YR loads standalone `RULESMD.INI`, whose explicit `Production=5` is authoritative here.
 - No hidden “autocreate team selector” is inferred. The exhaustive field census disproves a direct
   House-byte consumer in this binary.
 - Trigger action 13 is absent from shipped mounted maps. It is a valid compiled/custom-map writer,

--- a/docs/research/PHASE3_HOUSE_UPDATE_AI_ACTIVATION_GHIDRA_REPORT.md
+++ b/docs/research/PHASE3_HOUSE_UPDATE_AI_ACTIVATION_GHIDRA_REPORT.md
@@ -1,0 +1,630 @@
+# Phase 3 House-update AI activation — exhaustive active-retail Ghidra report
+
+**Date:** 2026-08-27  
+**Binary:** installed active Yuri's Revenge `gamemd.exe` in live project `testProsjekt`  
+**Primary code:** `HouseClass__Update @ 0x004F8440`, activation block `0x004F8564..0x004F85B7`  
+**Investigation class:** exhaustive-slice; research only  
+**Status:** COMPLETE for the bounded House-update activation mechanism  
+**Confidence:** High. The transition, direct field census, tick owner, initialization, parsers,
+save/load/CRC lifecycle, retail inputs, and current Rust delta were all checked directly.
+
+## Overview and verdict
+
+Every non-null `HouseClass` is visited from the House-array tail of
+`LogicClass__PerTickUpdate @ 0x0055AFB0`. Near the start of
+`HouseClass__Update`, after early power/radar/anger/extension work and before
+victory/defeat/strategy/production management, the active binary performs this exact transition:
+
+```text
+controlled = CurrentPlayer || (GameMode == 0 && PlayerControl)
+if !controlled && (AutoBaseBuilding != 0 || CurrentIQ >= Rules.IQ.Production) {
+    AutoBaseBuilding = 1
+    Production = 1
+    AutocreateAllowed = 1
+}
+```
+
+The IQ comparison is signed and inclusive. `AutoBaseBuilding != 0` bypasses IQ entirely.
+The three literal-one stores are adjacent and ordered exactly as shown. The block has no RNG,
+timer, defeated/passive, power, difficulty, scenario-type, or additional mode gate and makes no
+calls. Repeated eligible updates rewrite the same bytes; there is no expiry or toggle.
+
+The most important negative finding is that `House+0x1EF AutocreateAllowed` has **no direct
+ordinary-gameplay reader in the entire active executable**. Its direct accesses are constructor
+clear, this update's set, trigger action 13's set, and House CRC. It is also persisted through the
+raw House save block. It must therefore exist, save, and hash, but it must not be invented as a
+gate for TeamType creation or another subsystem.
+
+The current Rust implementation already has the correct control predicate, CurrentIQ load paths,
+factory-before-House-tail order, and three neighboring deploy latches. It lacks `[IQ] Production`,
+the fourth `AutocreateAllowed` latch, this House-tail transition, its snapshot/hash coverage, and
+trigger action 13. Current offline modal admission correctly freezes the entire simulation: native
+Menu, Abort Confirm, and Options are blocking `ProcessModalServicePump` owners, and modes 0/5 never
+reenter `Main_Tick` from that pump. If an eligible network-mode modal does reenter `Main_Tick`,
+`g_GameState != 0` skips only the normal input/render block and still executes the entire PerTick,
+including this transition as part of the full House update; it is not an activation-only lane.
+
+## Scope boundary and prior-work relation
+
+This report extends only the explicit gap left by:
+
+- `docs/research/PHASE3_UNIT_DEPLOY_HOUSE_FLAGS_GHIDRA_REPORT.md` — deploy, takeover, and the
+  three neighboring latch families; it left the House-update/Autocreate mechanism open.
+- `docs/research/PHASE3_HOUSECLASS_ORDINARY_BASE_PLACEMENT_005060B0_GHIDRA_REPORT.md` — ordinary
+  BasePlan selection/placement and `AutoBaseBuilding` placement consumers; it left this update
+  transition open.
+
+This report rechecks only the neighboring accesses needed to prove the transition. It does not
+re-open ordinary base placement, MCV deploy geometry/dispersal, the AITrigger selector,
+factory-production behavior beyond its `Production` gate, or computer-takeover setup.
+
+## Field and global map
+
+| Owner | Offset/address | Width | Meaning in this slice | Evidence |
+|---|---:|---:|---|---|
+| House | `+0x1EC` | byte | `CurrentPlayer`; always participates in control gate | `0x004F856B` |
+| House | `+0x1ED` | byte | `PlayerControl`; participates only when `GameMode == 0` | `0x004F8577` |
+| House | `+0x1EE` | byte | `Production`; second activation store | `0x004F85B0` |
+| House | `+0x1EF` | byte | `AutocreateAllowed`; third activation store | `0x004F85B7` |
+| House | `+0x1F2` | byte | `AITriggersActive`; neighboring deploy/takeover latch, **not touched here** | full operand census |
+| House | `+0x1F3` | byte | `AutoBaseBuilding`; precondition/bypass and first store | `0x004F858B`, `0x004F85A9` |
+| House | `+0x1F7` | byte | next `Savour`/result-state block; proves transition boundary | `0x004F85BE` |
+| House | `+0x24C` | signed dword | `CurrentIQ` | `0x004F859B` |
+| Rules | `+0x1434` | signed dword | `[IQ] MaxIQLevels`; distinct from activation threshold | ctor/read/create-Houses |
+| Rules | `+0x143C` | signed dword | `[IQ] Production`; activation threshold | `0x004F85A1` |
+| global | `0x00A8B238` | dword | `GameMode`; zero is campaign-family control semantics | `0x004F8564` |
+| global | `0x008871E0` | pointer | live `RulesClass` | `0x004F8595` |
+
+`HouseClass` size is `0x160B8` (`0x00504730: MOV EAX,0x160B8; RET`), so every listed House
+field is inside the raw persisted object block.
+
+## Exact activation disassembly and branch semantics
+
+```asm
+004F8564  MOV EAX,[00A8B238]          ; GameMode
+004F8569  CMP EAX,EBP                 ; EBP == 0
+004F856B  MOV AL,[ESI+1EC]            ; CurrentPlayer
+004F8571  JNZ 004F8587                ; nonzero mode ignores PlayerControl
+004F8573  TEST AL,AL
+004F8575  JNZ 004F8585
+004F8577  MOV AL,[ESI+1ED]            ; campaign-only PlayerControl
+004F857D  TEST AL,AL
+004F857F  JNZ 004F8585
+004F8581  XOR AL,AL
+004F8583  JMP 004F8587
+004F8585  MOV AL,1
+004F8587  TEST AL,AL
+004F8589  JNZ 004F85BE                ; controlled House skips all work
+004F858B  MOV AL,[ESI+1F3]            ; AutoBaseBuilding
+004F8591  TEST AL,AL
+004F8593  JNZ 004F85A9                ; any nonzero bypasses IQ
+004F8595  MOV ECX,[008871E0]           ; Rules
+004F859B  MOV EAX,[ESI+24C]            ; signed CurrentIQ
+004F85A1  CMP EAX,[ECX+143C]           ; signed [IQ] Production
+004F85A7  JL  004F85BE                ; strictly below skips; equality passes
+004F85A9  MOV byte ptr [ESI+1F3],1
+004F85B0  MOV byte ptr [ESI+1EE],1
+004F85B7  MOV byte ptr [ESI+1EF],1
+004F85BE  MOV AL,[ESI+1F7]             ; next independent block
+```
+
+### Mode/control truth table
+
+| Game mode | CurrentPlayer | PlayerControl | Controlled for this block? | Can activate? |
+|---:|---:|---:|---:|---:|
+| `0` | `0` | `0` | no | yes, by AutoBase/IQ |
+| `0` | `0` | nonzero | yes | no |
+| `0` | nonzero | either | yes | no |
+| nonzero | `0` | either | no (`PlayerControl` ignored) | yes, by AutoBase/IQ |
+| nonzero | nonzero | either | yes | no |
+
+The control result matches Rust `HouseState::is_controlled_by_human` at
+`src/sim/house_state.rs:395-397` exactly.
+
+## Tick owner, ordering, and pause/mode activation
+
+### Scheduler owner
+
+`LogicClass__PerTickUpdate @ 0x0055AFB0` reaches the House array at
+`0x0055B68D..0x0055B6B1`. It:
+
+1. loads live House count from `0x00A80238`;
+2. walks forward from index zero;
+3. reloads the array base (`0x00A8022C`) for each item;
+4. null-checks the item;
+5. calls vtable slot `+0x5C`;
+6. reloads the live count after the callback before the next comparison.
+
+The House vtable entry at `0x007EA8FC` contains little-endian `0x004F8440`, proving that slot
+is `HouseClass__Update`. Global FactoryClass updates finish immediately before the House loop.
+The activation is therefore House-owned, once per reached House visit, not an AI-player pass and
+not a factory callback.
+
+### Position inside `HouseClass__Update`
+
+The full live decompile places activation after:
+
+- blackout/power timer handling and power assessment;
+- radar/low-power recheck;
+- the 100-frame anger-score decay;
+- the optional `House+0x57E0` callback.
+
+It is before:
+
+- `House+0x1F7` victory/result (`Savour`) work;
+- rally/scatter and alert work;
+- superweapon readiness;
+- multiplayer defeat processing and trigger events;
+- strategy and later production/chooser management.
+
+Thus a House can become activated on the same House visit before all later House AI/defeat work.
+The block does not check `is_defeated`; eligibility is evaluated first.
+
+### Caller-level modal ownership and special-frame matrix
+
+`Main_Tick @ 0x0055D360` has one direct call to `LogicClass__PerTickUpdate`, at
+`0x0055DC9E`. Its internal `g_GameState != 0` branch skips the normal gameplay block but not
+PerTick. That fact does **not** establish that every modal owner calls `Main_Tick`.
+`Main_Game @ 0x0048CCC0` calls `State_Machine @ 0x0048C8B0` after its ordinary Main Tick;
+states 1, 3, and 5 enter blocking Menu, Abort Confirm, and Options owners, each looping
+`ProcessModalServicePump @ 0x00623120`. The pump's caller-level admission establishes:
+
+| Native outer state | Main Tick / PerTick / House activation? |
+|---|---|
+| `g_GameActive == 0` | no Main Tick |
+| `g_GameRunning == 0` focus/network wait | no PerTick |
+| `Scenario+0x62C != 0` intro/delay early-return | no PerTick |
+| offline mode 0/5 Menu, Abort Confirm, or Options open | **no reentrant Main Tick**; pump runs network-message/service work only, so activation and frame advance are frozen |
+| eligible network-mode modal, blockers clear and not reentrant | **yes**; reentrant Main Tick skips the normal gameplay block, then runs the entire PerTick/House update and late frame tail |
+| modal pump blocked or already reentrant | no Main Tick from that pump iteration |
+| replay playback | yes |
+| ordinary active frame | yes |
+
+There is no pause check in the House block itself, but offline modal exclusion occurs above it at
+the blocking pump's caller boundary. Current Rust `src/app/match_runtime/sim_tick.rs` admits modal
+simulation only for network mode and therefore correctly freezes offline campaign/skirmish. The
+activation pass belongs on every admitted full House-update frame: ordinary active frames and any
+future eligible network-modal frame, never a special offline or activation-only modal lane.
+
+## Construction, rules, scenario parsing, and overrides
+
+### House defaults
+
+`HouseClass__Constructor` clears the contiguous flags:
+
+- `+0x1EC = 0` at `0x004F56E5`;
+- `+0x1ED = 0` at `0x004F56EB`;
+- `+0x1EE = 0` at `0x004F56F1`;
+- `+0x1EF = 0` at `0x004F56F7`;
+- `+0x1F3 = 0` at `0x004F5710`.
+
+Constructor `CurrentIQ +0x24C` is also zero: `0x004F57BB` copies the already-zero House
+`+0x1D0` seed. The scenario parser does not parse or override `+0x1EE/+0x1EF/+0x1F3`.
+
+### `[IQ] Production`
+
+`RulesClass` construction uses the same `EDX=5` for `MaxIQLevels +0x1434` and
+`Production +0x143C` (`0x006671A1..0x006671C1`). `RulesClass__ReadIQ @ 0x00674240`:
+
+- leaves constructor values unchanged if `[IQ]` is absent;
+- supplies the current stored value as the `ReadInt` default;
+- reads the `Production` string at `0x0083D4F0` (memory bytes decode to `Production\0`);
+- writes the signed result directly at `0x006742C1` with no clamp.
+
+Consequently custom negative or above-five thresholds are valid native inputs. Hardcoding 5 or
+clamping to `MaxIQLevels` is wrong. Installed `ini/rules.ini:2630` and
+`ini/rulesmd.ini:3160` both explicitly set `Production=5`; both also set
+`MaxIQLevels=5` (`rules.ini:2628`, `rulesmd.ini:3158`).
+
+### House `IQ=` parser
+
+`HouseClass__Read_Scenario_INI @ 0x00500B40` reads the named House section's `IQ=` with
+default zero (`0x00500D94..0x00500DA2`). It signed-compares the result to
+`Rules.MaxIQLevels +0x1434`:
+
+- value `<= MaxIQLevels`: retain it, including negatives;
+- value `> MaxIQLevels`: replace it with literal `1`, **not** with MaxIQLevels;
+- store the same value to `House+0x1D0` and `CurrentIQ +0x24C` at
+  `0x00500DBA/0x00500DC0`.
+
+Current Rust already reproduces this quirk through
+`scenario_current_iq` and `src/sim/scenario_bootstrap.rs:1816-1822`.
+
+### Generated noncampaign Houses
+
+`ScenarioClass__Create_Houses @ 0x00687F10` leaves generated humans at constructor IQ zero.
+For a generated computer House in nonzero game mode, it loads Rules `+0x1434` and stores it to
+House `+0x24C` at `0x0068828D`. Stock skirmish therefore creates computer Houses at IQ 5,
+equal to Production 5, so each activates on its first reached House update even without an MCV
+deploy. Generated neutral/special Houses normally remain IQ 0 and do not activate unless another
+writer sets AutoBaseBuilding or IQ/threshold makes them eligible.
+
+`HouseClass__ComputerTakeover` clears `+0x1EC/+0x1ED`, stamps CurrentIQ from MaxIQLevels at
+`0x0050A614`, and later writes Production/AITriggersActive/AutoBaseBuilding when its base-unit
+path succeeds. It never directly writes `+0x1EF`; either the newly high IQ or nonzero AutoBase
+causes the next eligible House update to add AutocreateAllowed.
+
+## Complete `AutocreateAllowed +0x1EF` access census
+
+A zero-add whole-program `search_instructions` pass scanned 1,161,572 instructions for operand
+`0x1ef`. It returned six textual matches; two are unrelated immediate constants (`PUSH 0x1EFC`
+and `PUSH 0x1EFE`). The four real field accesses are exhaustive:
+
+| Address | Owner | Access | Exact behavior |
+|---:|---|---|---|
+| `0x004F56F7` | House constructor | write | clear to zero through zeroed `BL` |
+| `0x004F85B7` | House update | write | set literal one, third activation store |
+| `0x00502E66` | raw House CRC boundary | read | pass byte to `CRCEngine__AddBool @ 0x004A1CA0` |
+| `0x006DEB41` | `TriggerAction__Execute` case 13 | write | set literal one after nonnull House resolution |
+
+No instruction clears it after construction. No direct ordinary gameplay function reads it.
+Raw save/load accesses it indirectly as part of the object block and are covered below.
+
+### Trigger action 13
+
+Case 13 reads its target parameter from `TActionClass+0x90`, calls the shared House resolver
+`FUN_006E45E0`, returns false on null, otherwise writes `House+0x1EF=1` at `0x006DEB41` and
+returns true. It does not touch Production, AITriggersActive, or AutoBaseBuilding.
+
+`FUN_006E45E0` is the same House-resolution boundary used by trigger action 3 in the parent
+deploy-latch report. Its active paths reject a null context and parameter `-1`, handle special
+parameter `0x2325`, otherwise resolve through scenario/country House lookup. Exact generic House
+resolution belongs to the shared trigger-runtime action layer, not to House-update activation.
+
+An effective mounted-name census of 310 map payloads from `expandmd01.mix`, `mapsmd03.mix`,
+`multimd.mix`, `MAPS01.MIX`, `MAPS02.MIX`, and `MULTI.MIX` parsed every counted eight-token
+`[Actions]` chunk and found **zero action-13 chunks**. The writer is valid compiled active code,
+but no shipped map in that mounted corpus invokes it.
+
+## Relevant neighboring field census
+
+### `Production +0x1EE`
+
+The whole-program operand census found these real accesses:
+
+- constructor clear `0x004F56F1`;
+- House-update set `0x004F85B0`;
+- direct CRC read `0x00502E58`;
+- computer-takeover set `0x0050A7EF`;
+- trigger action 3 set `0x006DEAC0`;
+- Team script opcode 29 path set `0x006E99CC`;
+- MCV/base-unit deploy set `0x007398FF`;
+- two reads in `FUN_004500F0` at `0x0045024E/0x004502FA`.
+
+`FUN_004500F0` is a factory/production-tail routine. Both tests return immediately when the
+owning House's Production byte is zero; after the gate it can acquire a primary factory, create a
+`FactoryClass`, and start/resume production. This proves Production is a real downstream latch,
+not merely diagnostic state. Its full production policy remains owned by the parent production
+row. No direct later zero writer was found.
+
+### `AutoBaseBuilding +0x1F3`
+
+The complete real-access set is:
+
+- constructor clear `0x004F5710`;
+- House-update read/set `0x004F858B/0x004F85A9`;
+- computer-takeover set `0x0050A7FD`;
+- trigger action 30 set/clear `0x006DE21B/0x006DE29F`;
+- `UnitClass__AI` read `0x0073641A`;
+- successful deploy set `0x00739919`;
+- `UnitClass__Mission_Guard` read `0x007409FE`.
+
+One unrelated `MOV EAX,0x1F3` immediate at `0x00640CF1` is not a field access. The Unit AI/Guard
+consumers and action-30 semantics are already closed in the parent deploy/base-placement reports.
+The important interaction here is:
+
+- any nonzero AutoBase forces this update's three stores regardless of IQ;
+- action 30 clear can leave Production/Autocreate true and AutoBase false;
+- if IQ is still at/above Production, the next update restores AutoBase;
+- if IQ is below threshold, that split state persists;
+- deploy writes Production, AITriggersActive, AutoBase but not Autocreate, so this update fills
+  the missing Autocreate latch on the first subsequent eligible House visit.
+
+`AITriggersActive +0x1F2` is deliberately not written by this block.
+
+## Save, load, and CRC lifecycle
+
+`HouseClass__Save @ 0x00504080` first calls `AbstractClass__Save`; the base serializer writes the
+raw virtual-sized House block. `HouseClass__Load @ 0x00503040` calls `AbstractClass__Load` before
+reconstruction/swizzling of dynamic members. With House size `0x160B8`, Production,
+AutocreateAllowed, AutoBaseBuilding, and CurrentIQ all persist through save/load.
+
+The raw House CRC routine occupies a missed function boundary at
+`0x00502D60..0x0050303F`:
+
+- `+0x1EE Production` -> `CRCEngine__AddBool` at `0x00502E58..0x00502E61`;
+- `+0x1EF AutocreateAllowed` -> `CRCEngine__AddBool` at `0x00502E66..0x00502E6F`;
+- `+0x1F2 AITriggersActive` -> `CRCEngine__AddBool` at `0x00502E74..0x00502E7D`;
+- `+0x24C CurrentIQ` -> integer CRC helper at `0x00502E90..0x00502E99`;
+- exhaustive `+0x1F3` census: no direct CRC read.
+
+`CRCEngine__AddBool @ 0x004A1CA0` normalizes any nonzero input byte to boolean one before folding.
+Raw save/load preserves a noncanonical byte exactly, but all active code writers emit only 0/1.
+On the next eligible noncontrolled update, a noncanonical nonzero AutoBase is normalized to literal
+one and causes Production/Autocreate to be set. Arbitrarily hand-mutated native save bytes are not
+a reachable active-retail writer surface and do not require Rust to replace its boolean state with
+raw bytes.
+
+The correct compatibility-hash shape is therefore Production, AutocreateAllowed,
+AITriggersActive included; AutoBaseBuilding persisted but not directly hashed. It can affect later
+hashes indirectly by causing this transition.
+
+## Retail data, TS legacy, and custom exclusions
+
+### Shipped active YR data
+
+- `[IQ] Production=5` and `MaxIQLevels=5` in both installed base `rules.ini` and YR
+  `rulesmd.ini`.
+- The 310-map mounted corpus contains House `IQ=` values in `{0,1,2,3,4,5}` only; 42 maps have
+  at least one nonzero House IQ, and none has a negative or above-five House IQ.
+- The same corpus contains zero trigger-action-13 chunks.
+- Installed `aimd.ini` contains 163 TeamTypes and all 163 say `Autocreate=yes`.
+
+That TeamType key is a **different field and mechanism**. Rust currently loads it into
+`TeamTypeMetadata.autocreate`, but active `gamemd.exe` contains no read of House `+0x1EF` that
+could gate it. Do not connect the two merely because their names resemble each other.
+
+### Evidence-backed exclusions
+
+- No TS executable or TS-only behavior is used as authority. The report is based on active YR
+  `gamemd.exe`; installed base/RA2 INI is consulted only because YR's effective data inherits it.
+- No hidden “autocreate team selector” is inferred. The exhaustive field census disproves a direct
+  House-byte consumer in this binary.
+- Trigger action 13 is absent from shipped mounted maps. It is a valid compiled/custom-map writer,
+  but is separable from the stock House-update transaction and shares the generic trigger House
+  resolver.
+- Custom `[IQ] Production` is **not excluded**: the active parser accepts signed integers with no
+  clamp, so Rust must parse and use the effective value.
+- Corrupt/hand-edited noncanonical native save bytes are excluded as unreachable from all active
+  writers; ordinary reachable save states are exactly boolean.
+- This transition does not inherit neighboring TS/RA2 assumptions about `AITriggersActive`; it
+  does not touch `+0x1F2` at all.
+
+## Current Rust parity status
+
+### Already matching and must be preserved
+
+- `src/sim/house_state.rs:395-397` implements the exact mode-aware control predicate.
+- `src/sim/house_state.rs:341` owns signed `current_iq`.
+- `src/sim/scenario_bootstrap.rs:1816-1822` reproduces named-House `IQ=` default/above-max-to-one.
+- `src/sim/scenario_bootstrap.rs:1070-1075` stamps nonhuman noncampaign Houses from
+  `MaxIQLevels`.
+- `src/sim/house_state.rs:222-226` owns three independent persistent neighboring latches;
+  deploy writes Production/AITriggersActive/AutoBase in native deploy order.
+- `src/sim/world/mod.rs:7188-7224` advances factories/production before
+  `run_late_region`; `run_late_region` begins the House tail and performs defeat/AI work.
+- `src/sim/world/world_hash.rs:603-608` correctly excludes AutoBaseBuilding from the direct hash.
+
+### Missing or wrong
+
+1. `GeneralRules` parses `MaxIQLevels`, `RepairSell`, and `SellBack`, but no signed
+   `[IQ] Production` field/default.
+2. `HouseAiActivationLatches` has no `autocreate_allowed` fourth field; its comment currently maps
+   only `+0x1EE/+0x1F2/+0x1F3`.
+3. No call site reads `ai_activation.auto_base_building` or `current_iq` to run this activation.
+4. `run_late_region` starts with vision reconciliation and then defeat; there is no ordered
+   House activation pass between early House-like work and defeat/AI.
+5. Snapshot version 108 round-trips only eight combinations of the three existing latches.
+6. `world_hash` includes Production and AITriggersActive only; it omits native-direct
+   AutocreateAllowed.
+7. `trigger_runtime.rs` does not dispatch action 13.
+8. TeamType `autocreate` is loaded but should remain separate; using it as the missing House byte
+   would be architecture and evidence drift.
+
+## Exact bounded implementation partition
+
+### Partition A — mandatory House-update activation row
+
+1. Add signed `iq_production` (name may follow local convention) to the `[IQ]` rules owner:
+   constructor/default 5, effective INI `Production` override, no clamp.
+2. Add `autocreate_allowed: bool` to `HouseAiActivationLatches`, default false. Preserve existing
+   three fields and deploy helper behavior; deploy must still not set it directly.
+3. Add one House-owned transition helper with the exact control/AutoBase/IQ gates and literal-one
+   stores in native order: AutoBase, Production, Autocreate. It must not touch AITriggersActive.
+4. Visit Houses in `ScenarioSession.house_order` at the House-tail point after the factory/
+   production sweep and early House-like reconciliation, before defeat and AI command generation.
+   Do not route this through `AiPlayerState`; neutral/special/non-AI-player Houses are still House
+   array members and must be evaluated.
+5. Extend snapshot serialization and bump the current schema once. Round-trip all 16 combinations
+   of the four independent booleans.
+6. Extend the House hash with AutocreateAllowed between Production and AITriggersActive; keep
+   AutoBase excluded directly. Preserve CurrentIQ hashing.
+7. Do not admit offline modal frames for this transition. Preserve the current mode-0/5 freeze.
+   If future network-modal simulation is enabled, it must run this transition only as part of the
+   complete native-equivalent PerTick/House update and late frame tail, not as a selective pass.
+
+### Partition B — alternate compiled writer
+
+Implement trigger action 13 as a small separate trigger-runtime writer once the shared exact House
+resolver is available: null target -> failure/no mutation; nonnull -> set only
+`autocreate_allowed`, success. Its absence from shipped maps is sufficient to keep it out of the
+ordinary stock-skirmish critical path, but not sufficient to claim full compiled/custom action
+parity.
+
+Production's factory consumer, AutoBase's Unit AI/Guard consumers, action 30, AITriggersActive,
+computer takeover, and MCV deploy behavior remain owned by their existing parent rows. They must
+use these shared House latches, not duplicate state.
+
+## Acceptance scenarios
+
+| ID | Scenario | Required result |
+|---|---|---|
+| A1 | fresh House | all four latches false; CurrentIQ zero |
+| A2 | noncontrolled, AutoBase false, IQ one below threshold | no field changes |
+| A3 | noncontrolled, AutoBase false, IQ exactly threshold | AutoBase then Production then Autocreate true; AITriggers unchanged |
+| A4 | noncontrolled, IQ above threshold | same as A3 |
+| A5 | noncontrolled, AutoBase true, IQ far below threshold | same as A3; proves bypass |
+| A6 | campaign CurrentPlayer true | skip even with AutoBase/high IQ |
+| A7 | campaign PlayerControl true but not CurrentPlayer | skip |
+| A8 | nonzero mode, PlayerControl true but CurrentPlayer false | PlayerControl ignored; activate if latch/IQ qualifies |
+| A9 | nonzero mode CurrentPlayer true | skip |
+| A10 | repeated eligible visits | idempotent final state, no RNG/counter/timer change |
+| A11 | action-30-like clear after split state, IQ below threshold | AutoBase remains false; Production/Autocreate remain independently true |
+| A12 | same clear with IQ equal/above threshold | next House visit restores AutoBase and rewrites the other two |
+| A13 | deploy state `{Production=1, AITriggers=1, AutoBase=1, Autocreate=0}` | next eligible House visit sets only missing Autocreate semantically; AITriggers retained |
+| A14 | computer-takeover high IQ with/without AutoBase | next eligible visit sets Autocreate |
+| A15 | threshold `-1`, CurrentIQ `0` | activate; proves signed/unclamped rule input |
+| A16 | threshold `6`, generated stock-like AI IQ `5`, AutoBase false | no activation |
+| A17 | forward `house_order` with human, AI, neutral | every House evaluated once; only eligible noncontrolled members change |
+| A18 | factory completes immediately before House tail | activation still runs after factory sweep and before defeat/AI |
+| A19 | House becomes defeated later on same visit | activation precedes defeat processing |
+| A20 | offline mode-0/5 Menu, Abort Confirm, or Options remains open across service pumps | no activation, world/session frame advance, trigger polling, House AI, or pending-delete drain; activation resumes on the next ordinarily admitted frame after close |
+| A20N | eligible future network modal reenters Main Tick | the full PerTick/House update runs, including activation, triggers, later House AI, command tail, frame commit, and pending-delete drain; no activation-only subset |
+| A21 | snapshot all 16 latch combinations | exact round trip under bumped schema |
+| A22 | hash delta | toggling Production, Autocreate, or AITriggers changes hash; toggling only AutoBase does not |
+| A23 | action 13 null/non-null fixture | null no-op/failure; nonnull sets only Autocreate/success |
+| A24 | TeamType `Autocreate=yes/no` with House byte varied | no invented coupling |
+
+Focused implementation validation should use scoped `cargo test -p vera20k --lib <filter>` while
+working; the parent run owns the one final full `cargo test -p vera20k --lib` certification.
+
+## Adversarial review questions
+
+1. **Could `CMP/JL` be unsigned or strict-greater?** No. `JL` is signed-less, so equality activates.
+2. **Could AutoBase merely skip this mechanism?** No. Its nonzero branch jumps directly to the
+   three stores, bypassing the IQ load/compare.
+3. **Could AutocreateAllowed secretly gate TeamType autocreation through an indirect named
+   consumer?** No direct field operand exists beyond CRC, and the complete 1.16M-instruction census
+   is untruncated. Raw save/load is the only indirect access found.
+4. **Could controlled Houses activate through deploy-set AutoBase?** No. The control branch occurs
+   first and jumps beyond all three stores.
+5. **Does `g_GameState != 0` inside `Main_Tick` prove that offline ESC/Options executes this pass?**
+   No. Offline states 1/3/5 are blocking pump owners, and modes 0/5 never call `Main_Tick` from
+   that pump. The internal branch applies only after a caller admits Main Tick, notably an eligible
+   network modal; such an admitted tick executes the complete PerTick, not this block alone.
+
+All five adversarial questions are resolved by direct evidence; none remains open.
+
+## Tiny-details ledger
+
+1. `PlayerControl` is read only when `GameMode == 0`.
+2. `CurrentPlayer` is read in every mode.
+3. Any nonzero control byte is true; no `==1` test is used.
+4. Any nonzero AutoBase byte is true.
+5. The IQ comparison is signed.
+6. Equality activates.
+7. AutoBase bypasses both Rules pointer use and IQ comparison.
+8. The block performs no call and consumes no RNG.
+9. The three stores have no intervening branch.
+10. AITriggersActive is not one of the three stores.
+11. Repeated visits rewrite literal one; there is no “already fully active” early-out.
+12. A controlled House skips even if AutoBase is nonzero.
+13. Constructor CurrentIQ and all four reachable latch states start at zero/false.
+14. House `IQ=` above MaxIQLevels becomes one rather than max.
+15. Rules Production has an independent default even when `[IQ]` is absent.
+16. Stock skirmish AI reaches equality because Create_Houses uses MaxIQLevels.
+17. `+0x1EF` has no post-constructor zero writer.
+18. CRC normalizes its byte as boolean, but raw save/load preserves it.
+19. AutoBase is persisted yet omitted from direct House CRC.
+20. Trigger action 13 changes only AutocreateAllowed.
+21. Trigger action 13 is absent from the 310 effective shipped map payloads checked.
+22. `aimd.ini` TeamType `Autocreate=` is not the House byte.
+23. House count is reloaded after each native House callback.
+24. The next instruction after the transition begins a distinct `+0x1F7` result block.
+25. Offline modal exclusion is a caller-level pump decision, not a House-update pause predicate.
+26. States 1, 3, and 5 all own blocking pump loops in active retail.
+27. An admitted network-modal Main Tick runs trigger polling and the rest of House AI alongside
+    this transition; native provides no selective activation-only modal path.
+
+## Coverage Ledger
+
+| Surface | Evidence method | Result | Status |
+|---|---|---|---|
+| activation `0x004F8564..0x004F85B7` | live assembly + full decompile | exact gates/order | complete |
+| control-mode matrix | live assembly | campaign/nonzero behavior exact | complete |
+| signed IQ boundary | live assembly | `JL`, equality passes | complete |
+| position in House update | live full-function decompile | before result/defeat/AI tail | complete |
+| House scheduler owner | live PerTick assembly + vtable bytes | forward House array, slot `+0x5C` | complete |
+| modal owner/caller matrix | live `Main_Game`, `State_Machine`, states 1/3/5 owners, and modal-pump decompile | offline 0/5 no Main Tick; eligible network modal full PerTick | complete |
+| House constructor | live assembly/census | latch/IQ defaults | complete |
+| Rules constructor | live assembly | Production default 5 | complete |
+| Rules `[IQ]` parser | live assembly/string bytes | signed no-clamp override | complete |
+| House `IQ=` parser | live assembly | default 0, above-max -> 1 | complete |
+| nonzero-mode computer IQ | live Create_Houses assembly | MaxIQLevels stamp | complete |
+| `+0x1EF` all direct accesses | 1.16M-instruction operand census | 4 real, 2 false constants | complete |
+| trigger action 13 | live dispatch/resolver decompile | nonnull set-only writer | complete |
+| `+0x1EE` relevant accesses | whole-program operand census + consumer decompile | writers, CRC, factory gates | complete |
+| `+0x1F3` all direct accesses | whole-program operand census | writers/readers/false constant split | complete |
+| save/load/size | live decompile/assembly | raw-block persistence | complete |
+| CRC | live raw-boundary assembly + bool-helper decompile | Production/Autocreate/AITriggers in; AutoBase out | complete |
+| installed rules data | direct `ini/rules*.ini` scan | both Production 5 | complete |
+| shipped map action/data use | six-archive effective map extraction/parser census | 310 maps, action13 zero, IQ range known | complete |
+| TeamType name collision | installed `aimd.ini` + executable negative census | distinct mechanism | complete |
+| Rust House/rules/tick | direct source scan | exact matches/gaps enumerated | complete |
+| Rust snapshot/hash | direct source scan | v108 three-bit state, missing Autocreate | complete |
+| Rust modal admission | direct source scan vs native caller matrix | current offline freeze matches; future NetworkModal must retain full-PerTick semantics | complete |
+| zero-add pass | repeated `+0x1EF/+0x1EE/+0x1F3` census and nearby CRC/action checks | no new material surface | complete |
+| cold spot 1 | decompile `CRCEngine__AddBool` | nonzero normalization proven | complete |
+| cold spot 2 | decompile action-13 House resolver | null/special/general branches proven | complete |
+
+Coverage deferrals: **0/26 (0%)** inside the stated exhaustive slice.
+
+## Open Questions — final state
+
+Initial question set and disposition:
+
+1. exact control predicate — resolved;
+2. campaign versus nonzero mode use of PlayerControl — resolved;
+3. AutoBase short-circuit direction — resolved;
+4. signedness and equality boundary — resolved;
+5. store order and fields touched — resolved;
+6. repeated/idempotent behavior — resolved;
+7. passive/defeated/power/timer/RNG gates — resolved absent;
+8. PerTick owner and House visit order — resolved;
+9. position relative to factories/defeat/AI — resolved;
+10. pause/modal/replay activation — resolved;
+11. constructor and parser defaults — resolved;
+12. Rules/House override and clamp behavior — resolved;
+13. every `+0x1EF` reader/writer — resolved exhaustive;
+14. relevant `+0x1EE/+0x1F3` interactions — resolved;
+15. save/load/CRC behavior — resolved;
+16. stock YR rule/map/script activation — resolved;
+17. TeamType `Autocreate` relationship — resolved as no direct coupling;
+18. TS/custom boundary — resolved;
+19. current Rust owner/tick/state delta — resolved;
+20. bounded implementation and tests — resolved.
+
+**Open:** 0. **Deferred inside scope:** 0. **Unverified:** 0. **Approximate:** 0.
+
+## Ghidra annotation candidates
+
+No metadata was changed. Existing labels for `HouseClass__Update`, `LogicClass__PerTickUpdate`,
+`TriggerAction__Execute`, save/load, and CRC helpers were adequate. The raw House CRC boundary
+`0x00502D60..0x0050303F` remains a structural create-function candidate, but creating it was not
+authorized for this research-only run and is not required to implement the mechanism.
+
+## Sources
+
+### Live active-retail Ghidra
+
+- `HouseClass__Update @ 0x004F8440`, especially `0x004F8564..0x004F85BE`
+- `Main_Game @ 0x0048CCC0`, `State_Machine @ 0x0048C8B0`
+- Menu `FUN_004F10E0`, Abort Confirm `FUN_004F1840`, Options `0x004E1D00`
+- `ProcessModalServicePump @ 0x00623120`, `Main_Tick @ 0x0055D360`
+- `LogicClass__PerTickUpdate @ 0x0055AFB0`, House loop `0x0055B68D..0x0055B6B1`
+- House vtable entry `0x007EA8FC -> 0x004F8440`
+- `HouseClass__Constructor @ 0x004F56D0`
+- `HouseClass__Read_Scenario_INI @ 0x00500B40`
+- `ScenarioClass__Create_Houses @ 0x00687F10`
+- `HouseClass__ComputerTakeover @ 0x0050A5C0`
+- `RulesClass` constructor `0x00665EB0`, initialization `0x006671A1..0x006671C1`
+- `RulesClass__ReadIQ @ 0x00674240`
+- `TriggerAction__Execute @ 0x006DD8B0`, case 13 `0x006DEB18..0x006DEB54`
+- shared House resolver `FUN_006E45E0`
+- `FUN_004500F0` Production consumer
+- `HouseClass__Save @ 0x00504080`, `HouseClass__Load @ 0x00503040`, SizeOf `0x00504730`
+- raw House CRC `0x00502D60..0x0050303F`
+- `CRCEngine__AddBool @ 0x004A1CA0`
+
+### Repository/data
+
+- `ENGINE.md`, `AGENTS.md`, `.agents/skills/re-investigate/SKILL.md`
+- `docs/research/ghidra-workflow.md`
+- the two parent Phase-3 reports named in Scope
+- `docs/research/MODAL_PUMP_00623120_SERVICE_TICK_CONTRACT_GHIDRA_REPORT.md`
+- `docs/research/FRAME_COUNTER_NONADVANCE_PAUSE_SCENARIO_MATRIX_GHIDRA_REPORT.md`
+- installed `ini/rules.ini`, `ini/rulesmd.ini`, `ini/aimd.ini`
+- direct Rust scans of `src/rules/ruleset.rs`, `src/sim/house_state.rs`,
+  `src/sim/scenario_bootstrap.rs`, `src/sim/world/mod.rs`, `src/sim/world/world_hash.rs`,
+  `src/sim/snapshot.rs`, `src/sim/trigger_runtime.rs`, `src/app/match_runtime/sim_tick.rs`
+- read-only `asset.exe` mounted-map extraction/census; all temporary extraction files were removed.

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -5419,8 +5419,7 @@ ChuteSound=
             "Production is not clamped to MaxIQLevels"
         );
         assert_eq!(
-            GeneralRules::from_ini(&IniFile::from_str("[IQ]\nProduction=-3\n"))
-                .iq_production,
+            GeneralRules::from_ini(&IniFile::from_str("[IQ]\nProduction=-3\n")).iq_production,
             -3,
             "ReadIQ remains authoritative when [General] is absent"
         );

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -734,6 +734,10 @@ pub struct GeneralRules {
     pub iq_scatter: i32,
     /// `[IQ] MaxIQLevels` stamped onto ordinary skirmish AI houses.
     pub max_iq_levels: i32,
+    /// Signed `[IQ] Production` threshold for the House-update AI activation
+    /// transaction. Native accepts the constructor default `5` or the parsed
+    /// dword verbatim, without clamping it to `MaxIQLevels`.
+    pub iq_production: i32,
     /// `[IQ] RepairSell` outer gate for BuildingClass repair/sell AI.
     pub iq_repair_sell: i32,
     /// `[IQ] SellBack` gate for the red-health low-credit sell decision.
@@ -1098,6 +1102,7 @@ impl Default for GeneralRules {
             player_scatter: false,
             iq_scatter: 3,
             max_iq_levels: 5,
+            iq_production: 5,
             iq_repair_sell: 3,
             iq_sell_back: 2,
             credit_reserve: 1000,
@@ -1441,8 +1446,19 @@ impl GeneralRules {
     }
 
     fn from_ini(ini: &IniFile) -> Self {
+        let defaults = Self::default();
+        // gamemd-derived: `RulesClass__ReadIQ @ 0x00674240` reads signed
+        // `[IQ] Production` into `Rules+0x143C` at `0x006742C1`, independently
+        // of the `[General]` pass and without clamping the parsed dword.
+        let iq_production = ini
+            .section("IQ")
+            .and_then(|section| section.get_i32("Production"))
+            .unwrap_or(defaults.iq_production);
         let Some(general) = ini.section("General") else {
-            return Self::default();
+            return Self {
+                iq_production,
+                ..defaults
+            };
         };
         // ConditionYellow/ConditionRed live in [AudioVisual], not [General].
         let audio_visual = ini.section("AudioVisual");
@@ -1466,7 +1482,6 @@ impl GeneralRules {
                 .unwrap_or(default)
                 .to_string()
         };
-        let defaults = Self::default();
         let mut infantry_death_anims = defaults.infantry_death_anims.clone();
         for (index, key, fallback) in [
             (3, "InfantryExplode", "S_BANG34"),
@@ -2023,6 +2038,7 @@ impl GeneralRules {
             max_iq_levels: iq
                 .and_then(|s| s.get_i32("MaxIQLevels"))
                 .unwrap_or(defaults.max_iq_levels),
+            iq_production,
             iq_repair_sell: iq
                 .and_then(|s| s.get_i32("RepairSell"))
                 .unwrap_or(defaults.iq_repair_sell),
@@ -5362,6 +5378,52 @@ ChuteSound=
         let general = GeneralRules::from_ini(&ini);
         assert!(general.player_scatter);
         assert_eq!(general.iq_scatter, 4);
+    }
+
+    #[test]
+    fn house_ai_activation_iq_production_preserves_native_signed_iq_binding() {
+        assert_eq!(
+            GeneralRules::from_ini(&IniFile::from_str("")).iq_production,
+            5,
+            "missing [IQ] retains the RulesClass constructor default"
+        );
+        assert_eq!(
+            GeneralRules::from_ini(&IniFile::from_str(
+                "[General]\nProduction=-12\n[IQ]\nFixtureOnly=1\n"
+            ))
+            .iq_production,
+            5,
+            "the same key under [General] is not an IQ input"
+        );
+        assert_eq!(
+            GeneralRules::from_ini(&IniFile::from_str(
+                "[General]\nFixtureOnly=1\n[IQ]\nProduction=5\n"
+            ))
+            .iq_production,
+            5
+        );
+        assert_eq!(
+            GeneralRules::from_ini(&IniFile::from_str(
+                "[General]\nFixtureOnly=1\n[IQ]\nProduction=-7\n"
+            ))
+            .iq_production,
+            -7,
+            "negative custom thresholds remain signed and unclamped"
+        );
+        assert_eq!(
+            GeneralRules::from_ini(&IniFile::from_str(
+                "[General]\nFixtureOnly=1\n[IQ]\nMaxIQLevels=5\nProduction=9\n"
+            ))
+            .iq_production,
+            9,
+            "Production is not clamped to MaxIQLevels"
+        );
+        assert_eq!(
+            GeneralRules::from_ini(&IniFile::from_str("[IQ]\nProduction=-3\n"))
+                .iq_production,
+            -3,
+            "ReadIQ remains authoritative when [General] is absent"
+        );
     }
 
     #[test]

--- a/src/sim/deploy_tests.rs
+++ b/src/sim/deploy_tests.rs
@@ -21,12 +21,14 @@ use crate::sim::world::{SimSoundEvent, Simulation};
 
 const SPLIT_AI_ACTIVATION: HouseAiActivationLatches = HouseAiActivationLatches {
     production: true,
+    autocreate_allowed: false,
     ai_triggers_active: false,
     auto_base_building: true,
 };
 
 const ENABLED_AI_ACTIVATION: HouseAiActivationLatches = HouseAiActivationLatches {
     production: true,
+    autocreate_allowed: false,
     ai_triggers_active: true,
     auto_base_building: true,
 };

--- a/src/sim/house_state.rs
+++ b/src/sim/house_state.rs
@@ -210,18 +210,20 @@ impl BaseReservationState {
     }
 }
 
-/// Independent persistent House latches co-enabled by successful AI base-unit
-/// deployment. Their other native writers and consumers remain separate
-/// mechanisms.
+/// Independent persistent House AI-activation latches. Successful AI base-unit
+/// deployment co-enables three of them; House update owns the separate
+/// AutocreateAllowed writer and its three-store activation transaction.
 ///
 /// gamemd-derived: `HouseClass__Constructor` clears the corresponding bytes at
-/// `0x004F56F1`, `0x004F570A`, and `0x004F5710`; `HouseClass__Save @
-/// 0x00504080` and `HouseClass__Load @ 0x00503040` persist the raw House block.
+/// `0x004F56F1`, `0x004F56F7`, `0x004F570A`, and `0x004F5710`;
+/// `HouseClass__Save @ 0x00504080` and `HouseClass__Load @ 0x00503040`
+/// persist the raw House block.
 #[derive(
     Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize,
 )]
 pub struct HouseAiActivationLatches {
     pub production: bool,
+    pub autocreate_allowed: bool,
     pub ai_triggers_active: bool,
     pub auto_base_building: bool,
 }
@@ -379,8 +381,9 @@ pub struct HouseState {
     /// Snapshot/hash authority for the Strategy emergency-state block.
     #[serde(default)]
     pub strategy_emergency: HouseStrategyEmergencyState,
-    /// Native House bytes `+0x1EE`, `+0x1F2`, and `+0x1F3`. All three persist,
-    /// while only Production and AITriggersActive directly enter House CRC.
+    /// Native House bytes `+0x1EE`, `+0x1EF`, `+0x1F2`, and `+0x1F3`. All four
+    /// persist, while Production, AutocreateAllowed, and AITriggersActive
+    /// directly enter House CRC.
     #[serde(default)]
     pub ai_activation: HouseAiActivationLatches,
 }
@@ -391,8 +394,10 @@ impl HouseState {
         self.is_human || self.player_control
     }
 
-    /// Native `HouseClass::IsControlledByHuman @ 0x0050B730` result consumed
-    /// by successful Building Unlimbo BasePlan satisfaction.
+    /// Native mode-aware House-control predicate shared by successful Building
+    /// Unlimbo BasePlan satisfaction and the early House-update activation.
+    /// `HouseClass::IsControlledByHuman @ 0x0050B730` supplies the former;
+    /// `HouseClass__Update @ 0x004F8440` inlines the same branch shape.
     pub(crate) const fn is_controlled_by_human(&self, game_mode_nonzero: bool) -> bool {
         self.is_human || (!game_mode_nonzero && self.player_control)
     }
@@ -406,6 +411,28 @@ impl HouseState {
         self.ai_activation.production = true;
         self.ai_activation.ai_triggers_active = true;
         self.ai_activation.auto_base_building = true;
+    }
+
+    /// Run the early `HouseClass__Update` AI-activation transition.
+    ///
+    /// gamemd-derived: `HouseClass__Update @ 0x004F8440`, block
+    /// `0x004F8564..0x004F85B7`, rejects the mode-aware controlled House,
+    /// accepts any nonzero AutoBaseBuilding or signed `CurrentIQ >=
+    /// Rules+0x143C`, then writes AutoBaseBuilding, Production, and
+    /// AutocreateAllowed in that order without touching AITriggersActive.
+    pub(crate) fn update_ai_activation(
+        &mut self,
+        game_mode_nonzero: bool,
+        iq_production: i32,
+    ) {
+        if self.is_controlled_by_human(game_mode_nonzero)
+            || (!self.ai_activation.auto_base_building && self.current_iq < iq_production)
+        {
+            return;
+        }
+        self.ai_activation.auto_base_building = true;
+        self.ai_activation.production = true;
+        self.ai_activation.autocreate_allowed = true;
     }
 
     /// Accept a victory and arm its deterministic grace interval.
@@ -724,15 +751,17 @@ pub(crate) fn determine_waypoint_edge(anchor: (u16, u16), bounds: PlayfieldBound
 
 #[cfg(test)]
 mod ai_activation_latch_tests {
-    use super::{HouseAiActivationLatches, HouseState};
+    use super::{HouseAiActivationLatches, HouseDifficulty, HouseState};
 
     #[test]
     fn house_ai_activation_latches_default_false() {
         let house = HouseState::new(Default::default(), 0, None, false, 0, 10);
         assert_eq!(house.ai_activation, HouseAiActivationLatches::default());
         assert!(!house.ai_activation.production);
+        assert!(!house.ai_activation.autocreate_allowed);
         assert!(!house.ai_activation.ai_triggers_active);
         assert!(!house.ai_activation.auto_base_building);
+        assert_eq!(house.current_iq, 0);
     }
 
     #[test]
@@ -740,6 +769,7 @@ mod ai_activation_latch_tests {
         let mut house = HouseState::new(Default::default(), 0, None, false, 0, 10);
         house.ai_activation = HouseAiActivationLatches {
             production: true,
+            autocreate_allowed: false,
             ai_triggers_active: false,
             auto_base_building: true,
         };
@@ -749,6 +779,7 @@ mod ai_activation_latch_tests {
             house.ai_activation,
             HouseAiActivationLatches {
                 production: true,
+                autocreate_allowed: false,
                 ai_triggers_active: true,
                 auto_base_building: true,
             }
@@ -756,6 +787,147 @@ mod ai_activation_latch_tests {
         let once = house.ai_activation;
         house.enable_ai_deploy_latches();
         assert_eq!(house.ai_activation, once);
+    }
+
+    #[test]
+    fn house_ai_activation_signed_threshold_and_auto_base_bypass() {
+        for (current_iq, threshold, auto_base, expected) in [
+            (4, 5, false, false),
+            (5, 5, false, true),
+            (6, 5, false, true),
+            (0, -1, false, true),
+            (-100, 5, true, true),
+        ] {
+            let mut house = HouseState::new(Default::default(), 0, None, false, 0, 10);
+            house.current_iq = current_iq;
+            house.ai_activation.ai_triggers_active = true;
+            house.ai_activation.auto_base_building = auto_base;
+
+            house.update_ai_activation(true, threshold);
+
+            assert_eq!(house.ai_activation.production, expected);
+            assert_eq!(house.ai_activation.autocreate_allowed, expected);
+            assert_eq!(house.ai_activation.auto_base_building, expected);
+            assert!(
+                house.ai_activation.ai_triggers_active,
+                "House update never writes AITriggersActive"
+            );
+        }
+    }
+
+    #[test]
+    fn house_ai_activation_uses_mode_sensitive_control_predicate() {
+        let mut campaign_current =
+            HouseState::new(Default::default(), 0, None, true, 0, 10);
+        campaign_current.current_iq = 5;
+        campaign_current.update_ai_activation(false, 5);
+        assert_eq!(
+            campaign_current.ai_activation,
+            HouseAiActivationLatches::default()
+        );
+
+        let mut campaign_player_control =
+            HouseState::new(Default::default(), 0, None, false, 0, 10);
+        campaign_player_control.player_control = true;
+        campaign_player_control.current_iq = 5;
+        campaign_player_control.update_ai_activation(false, 5);
+        assert_eq!(
+            campaign_player_control.ai_activation,
+            HouseAiActivationLatches::default()
+        );
+
+        let mut skirmish_player_control = campaign_player_control.clone();
+        skirmish_player_control.update_ai_activation(true, 5);
+        assert!(skirmish_player_control.ai_activation.production);
+        assert!(skirmish_player_control.ai_activation.autocreate_allowed);
+        assert!(skirmish_player_control.ai_activation.auto_base_building);
+
+        let mut skirmish_current =
+            HouseState::new(Default::default(), 0, None, true, 0, 10);
+        skirmish_current.current_iq = 5;
+        skirmish_current.update_ai_activation(true, 5);
+        assert_eq!(
+            skirmish_current.ai_activation,
+            HouseAiActivationLatches::default()
+        );
+    }
+
+    #[test]
+    fn house_ai_activation_preserves_split_states_and_completes_deploy_state() {
+        let mut split = HouseState::new(Default::default(), 0, None, false, 0, 10);
+        split.current_iq = 4;
+        split.ai_activation = HouseAiActivationLatches {
+            production: true,
+            autocreate_allowed: true,
+            ai_triggers_active: false,
+            auto_base_building: false,
+        };
+        let below_threshold = split.ai_activation;
+        split.update_ai_activation(true, 5);
+        assert_eq!(split.ai_activation, below_threshold);
+
+        split.current_iq = 5;
+        split.update_ai_activation(true, 5);
+        assert_eq!(
+            split.ai_activation,
+            HouseAiActivationLatches {
+                production: true,
+                autocreate_allowed: true,
+                ai_triggers_active: false,
+                auto_base_building: true,
+            }
+        );
+
+        let mut deployed = HouseState::new(Default::default(), 0, None, false, 0, 10);
+        deployed.current_iq = i32::MIN;
+        deployed.enable_ai_deploy_latches();
+        assert!(!deployed.ai_activation.autocreate_allowed);
+        deployed.update_ai_activation(true, 5);
+        assert_eq!(
+            deployed.ai_activation,
+            HouseAiActivationLatches {
+                production: true,
+                autocreate_allowed: true,
+                ai_triggers_active: true,
+                auto_base_building: true,
+            }
+        );
+    }
+
+    #[test]
+    fn house_ai_activation_has_no_defeat_passive_or_difficulty_gate_and_is_idempotent() {
+        for difficulty in [HouseDifficulty::Hard, HouseDifficulty::Easy] {
+            let mut house = HouseState::new(Default::default(), 0, None, false, 0, 10);
+            house.current_iq = 5;
+            house.is_defeated = true;
+            house.multiplay_passive = true;
+            house.difficulty = difficulty;
+            house.credits = 4321;
+            house.owned_building_count = 7;
+            house.owned_unit_count = 11;
+
+            house.update_ai_activation(true, 5);
+            let once = house.ai_activation;
+            house.update_ai_activation(true, 5);
+
+            assert_eq!(house.ai_activation, once);
+            assert_eq!(
+                once,
+                HouseAiActivationLatches {
+                    production: true,
+                    autocreate_allowed: true,
+                    ai_triggers_active: false,
+                    auto_base_building: true,
+                }
+            );
+            assert_eq!(house.current_iq, 5);
+            assert_eq!(house.credits, 4321);
+            assert_eq!(house.owned_building_count, 7);
+            assert_eq!(house.owned_unit_count, 11);
+            assert!(house.is_defeated);
+            assert!(house.multiplay_passive);
+            assert_eq!(house.difficulty, difficulty);
+        }
     }
 }
 

--- a/src/sim/house_state.rs
+++ b/src/sim/house_state.rs
@@ -218,9 +218,7 @@ impl BaseReservationState {
 /// `0x004F56F1`, `0x004F56F7`, `0x004F570A`, and `0x004F5710`;
 /// `HouseClass__Save @ 0x00504080` and `HouseClass__Load @ 0x00503040`
 /// persist the raw House block.
-#[derive(
-    Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct HouseAiActivationLatches {
     pub production: bool,
     pub autocreate_allowed: bool,
@@ -420,11 +418,7 @@ impl HouseState {
     /// accepts any nonzero AutoBaseBuilding or signed `CurrentIQ >=
     /// Rules+0x143C`, then writes AutoBaseBuilding, Production, and
     /// AutocreateAllowed in that order without touching AITriggersActive.
-    pub(crate) fn update_ai_activation(
-        &mut self,
-        game_mode_nonzero: bool,
-        iq_production: i32,
-    ) {
+    pub(crate) fn update_ai_activation(&mut self, game_mode_nonzero: bool, iq_production: i32) {
         if self.is_controlled_by_human(game_mode_nonzero)
             || (!self.ai_activation.auto_base_building && self.current_iq < iq_production)
         {
@@ -817,8 +811,7 @@ mod ai_activation_latch_tests {
 
     #[test]
     fn house_ai_activation_uses_mode_sensitive_control_predicate() {
-        let mut campaign_current =
-            HouseState::new(Default::default(), 0, None, true, 0, 10);
+        let mut campaign_current = HouseState::new(Default::default(), 0, None, true, 0, 10);
         campaign_current.current_iq = 5;
         campaign_current.update_ai_activation(false, 5);
         assert_eq!(
@@ -842,8 +835,7 @@ mod ai_activation_latch_tests {
         assert!(skirmish_player_control.ai_activation.autocreate_allowed);
         assert!(skirmish_player_control.ai_activation.auto_base_building);
 
-        let mut skirmish_current =
-            HouseState::new(Default::default(), 0, None, true, 0, 10);
+        let mut skirmish_current = HouseState::new(Default::default(), 0, None, true, 0, 10);
         skirmish_current.current_iq = 5;
         skirmish_current.update_ai_activation(true, 5);
         assert_eq!(

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -326,7 +326,9 @@ use crate::sim::world::Simulation;
 // a successful non-controlled ConstructionYard deployment.
 // Bumped 111 -> 112: persist the three independent House AI activation
 // latches co-enabled by successful qualifying base-unit deployment.
-const SNAPSHOT_VERSION: u32 = 112;
+// Bumped 112 -> 113: persist House AutocreateAllowed beside the three deploy
+// latches in native conceptual byte order.
+const SNAPSHOT_VERSION: u32 = 113;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -2739,10 +2741,10 @@ mod tests {
     /// House BuildConst vector and immutable entity membership; 109 -> 110
     /// adds ordered BasePlan state and immutable BuildingType facts; 110 -> 111
     /// adds the distinct BaseClass plan center; 111 -> 112 adds the three House
-    /// AI activation latches.
+    /// AI activation latches; 112 -> 113 adds House AutocreateAllowed.
     #[test]
-    fn phase3_house_ai_activation_snapshot_version_is_112() {
-        assert_eq!(super::SNAPSHOT_VERSION, 112);
+    fn phase3_house_ai_activation_snapshot_version_is_113() {
+        assert_eq!(super::SNAPSHOT_VERSION, 113);
     }
 
     #[test]
@@ -3002,16 +3004,17 @@ mod tests {
     }
 
     #[test]
-    fn house_ai_activation_all_combinations_roundtrip_v112() {
+    fn house_ai_activation_all_combinations_roundtrip_v113() {
         use crate::sim::house_state::{HouseAiActivationLatches, HouseState};
 
-        for bits in 0u8..8 {
+        for bits in 0u8..16 {
             let mut sim = Simulation::new();
             let owner = sim.interner.intern("Computer1");
             let latches = HouseAiActivationLatches {
                 production: bits & 1 != 0,
-                ai_triggers_active: bits & 2 != 0,
-                auto_base_building: bits & 4 != 0,
+                autocreate_allowed: bits & 2 != 0,
+                ai_triggers_active: bits & 4 != 0,
+                auto_base_building: bits & 8 != 0,
             };
             let mut house = HouseState::new(owner, 0, None, false, 0, 10);
             house.ai_activation = latches;
@@ -3024,7 +3027,7 @@ mod tests {
                 GameSnapshot::read_header(&bytes).unwrap().version,
                 super::SNAPSHOT_VERSION
             );
-            let restored = GameSnapshot::load(&bytes).expect("current v112 snapshot").sim;
+            let restored = GameSnapshot::load(&bytes).expect("current v113 snapshot").sim;
             assert_eq!(restored.houses[&owner].ai_activation, latches);
         }
     }

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -3027,7 +3027,9 @@ mod tests {
                 GameSnapshot::read_header(&bytes).unwrap().version,
                 super::SNAPSHOT_VERSION
             );
-            let restored = GameSnapshot::load(&bytes).expect("current v113 snapshot").sim;
+            let restored = GameSnapshot::load(&bytes)
+                .expect("current v113 snapshot")
+                .sim;
             assert_eq!(restored.houses[&owner].ai_activation, latches);
         }
     }

--- a/src/sim/world/house_ai_activation_tests.rs
+++ b/src/sim/world/house_ai_activation_tests.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use super::{Simulation, TickLane};
+use super::{HouseAiActivationOrderTestEvent, Simulation, TickLane};
 use crate::rules::ini_parser::IniFile;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::house_state::{HouseDifficulty, HouseState};
@@ -76,21 +76,28 @@ fn house_ai_activation_forward_house_order_reaches_computer_and_passive_houses()
 }
 
 #[test]
-fn house_ai_activation_runs_before_same_frame_defeat_processing() {
+fn house_ai_activation_full_frame_order_is_production_then_activation_defeat_and_ai() {
     let rules = activation_rules(5);
     let mut sim = Simulation::new();
     sim.session.game_mode_nonzero = true;
     sim.session.tick = 1;
     let owner = insert_house(&mut sim, "Computer1", false, 5);
     sim.session.house_order.push(owner);
+    sim.ai_players
+        .push(crate::sim::ai::AiPlayerState::new(owner));
 
     advance(&mut sim, Some(&rules), TickLane::Ordinary);
 
-    let house = &sim.houses[&owner];
-    assert!(house.ai_activation.production);
-    assert!(house.ai_activation.autocreate_allowed);
-    assert!(house.ai_activation.auto_base_building);
-    assert!(house.is_defeated, "the later defeat pass still ran this frame");
+    assert_eq!(
+        sim.take_house_ai_activation_order_test_trace(),
+        vec![
+            HouseAiActivationOrderTestEvent::ProductionCompleted,
+            HouseAiActivationOrderTestEvent::HouseActivation,
+            HouseAiActivationOrderTestEvent::DefeatProcessed,
+            HouseAiActivationOrderTestEvent::AiGenerated,
+        ],
+        "moving activation across production, defeat, or actual tick_ai dispatch must fail"
+    );
 }
 
 #[test]

--- a/src/sim/world/house_ai_activation_tests.rs
+++ b/src/sim/world/house_ai_activation_tests.rs
@@ -28,16 +28,7 @@ fn insert_house(
 }
 
 fn advance(sim: &mut Simulation, rules: Option<&RuleSet>, lane: TickLane) {
-    let result = sim.advance_master_frame(
-        &[],
-        rules,
-        &BTreeMap::new(),
-        None,
-        None,
-        67,
-        lane,
-        None,
-    );
+    let result = sim.advance_master_frame(&[], rules, &BTreeMap::new(), None, None, 67, lane, None);
     assert!(result.frame_committed);
 }
 

--- a/src/sim/world/house_ai_activation_tests.rs
+++ b/src/sim/world/house_ai_activation_tests.rs
@@ -1,0 +1,128 @@
+//! Focused House-tail integration tests for native AI activation latches.
+
+use std::collections::BTreeMap;
+
+use super::{Simulation, TickLane};
+use crate::rules::ini_parser::IniFile;
+use crate::rules::ruleset::RuleSet;
+use crate::sim::house_state::{HouseDifficulty, HouseState};
+
+fn activation_rules(iq_production: i32) -> RuleSet {
+    RuleSet::from_ini(&IniFile::from_str(&format!(
+        "[General]\nFixtureOnly=1\n[IQ]\nProduction={iq_production}\n"
+    )))
+    .expect("House activation rules fixture parses")
+}
+
+fn insert_house(
+    sim: &mut Simulation,
+    name: &str,
+    is_human: bool,
+    current_iq: i32,
+) -> crate::sim::intern::InternedId {
+    let owner = sim.interner.intern(name);
+    let mut house = HouseState::new(owner, 0, None, is_human, 0, 10);
+    house.current_iq = current_iq;
+    sim.houses.insert(owner, house);
+    owner
+}
+
+fn advance(sim: &mut Simulation, rules: Option<&RuleSet>, lane: TickLane) {
+    let result = sim.advance_master_frame(
+        &[],
+        rules,
+        &BTreeMap::new(),
+        None,
+        None,
+        67,
+        lane,
+        None,
+    );
+    assert!(result.frame_committed);
+}
+
+#[test]
+fn house_ai_activation_forward_house_order_reaches_computer_and_passive_houses() {
+    let rules = activation_rules(5);
+    let mut sim = Simulation::new();
+    sim.session.game_mode_nonzero = true;
+
+    let human = insert_house(&mut sim, "CurrentPlayer", true, 9);
+    let missing = sim.interner.intern("MissingHouse");
+    let computer = insert_house(&mut sim, "Computer1", false, 5);
+    let neutral = insert_house(&mut sim, "Neutral", false, 5);
+    {
+        let house = sim.houses.get_mut(&neutral).unwrap();
+        house.multiplay_passive = true;
+        house.is_defeated = true;
+        house.difficulty = HouseDifficulty::Easy;
+    }
+    sim.session.house_order = vec![human, missing, computer, neutral];
+
+    advance(&mut sim, Some(&rules), TickLane::Ordinary);
+
+    assert_eq!(
+        sim.houses[&human].ai_activation,
+        Default::default(),
+        "CurrentPlayer is the only neighboring state that gates this fixture"
+    );
+    for owner in [computer, neutral] {
+        let latches = sim.houses[&owner].ai_activation;
+        assert!(latches.production);
+        assert!(latches.autocreate_allowed);
+        assert!(!latches.ai_triggers_active);
+        assert!(latches.auto_base_building);
+    }
+}
+
+#[test]
+fn house_ai_activation_runs_before_same_frame_defeat_processing() {
+    let rules = activation_rules(5);
+    let mut sim = Simulation::new();
+    sim.session.game_mode_nonzero = true;
+    sim.session.tick = 1;
+    let owner = insert_house(&mut sim, "Computer1", false, 5);
+    sim.session.house_order.push(owner);
+
+    advance(&mut sim, Some(&rules), TickLane::Ordinary);
+
+    let house = &sim.houses[&owner];
+    assert!(house.ai_activation.production);
+    assert!(house.ai_activation.autocreate_allowed);
+    assert!(house.ai_activation.auto_base_building);
+    assert!(house.is_defeated, "the later defeat pass still ran this frame");
+}
+
+#[test]
+fn house_ai_activation_empty_network_modal_runs_full_tail_but_rulesless_skips() {
+    let rules = activation_rules(5);
+    let mut modal = Simulation::new();
+    modal.session.game_mode_nonzero = true;
+    let modal_owner = insert_house(&mut modal, "Computer1", false, 5);
+    modal.session.house_order.push(modal_owner);
+
+    advance(&mut modal, Some(&rules), TickLane::NetworkModal);
+
+    assert!(modal.houses[&modal_owner].ai_activation.production);
+    assert!(modal.houses[&modal_owner].ai_activation.autocreate_allowed);
+    assert!(modal.houses[&modal_owner].ai_activation.auto_base_building);
+
+    let mut rulesless = Simulation::new();
+    rulesless.session.game_mode_nonzero = true;
+    let rulesless_owner = insert_house(&mut rulesless, "Computer1", false, i32::MAX);
+    rulesless
+        .houses
+        .get_mut(&rulesless_owner)
+        .unwrap()
+        .ai_activation
+        .auto_base_building = true;
+    rulesless.session.house_order.push(rulesless_owner);
+
+    advance(&mut rulesless, None, TickLane::Ordinary);
+
+    let latches = rulesless.houses[&rulesless_owner].ai_activation;
+    assert!(!latches.production);
+    assert!(!latches.autocreate_allowed);
+    assert!(!latches.ai_triggers_active);
+    assert!(latches.auto_base_building);
+}

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -340,6 +340,15 @@ pub(crate) enum MasterFrameTestRung {
     PendingDelete,
 }
 
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HouseAiActivationOrderTestEvent {
+    ProductionCompleted,
+    HouseActivation,
+    DefeatProcessed,
+    AiGenerated,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct MovementSoundProbe {
     rx: u16,
@@ -718,6 +727,10 @@ pub struct Simulation {
     #[cfg(test)]
     #[serde(skip)]
     master_frame_test_trace: Vec<MasterFrameTestRung>,
+    /// Focused ordering observer for the bounded House-update activation seam.
+    #[cfg(test)]
+    #[serde(skip)]
+    house_ai_activation_order_test_trace: Vec<HouseAiActivationOrderTestEvent>,
     /// Sound events produced during the current tick and moved into the owned
     /// app-frame output batch.
     #[serde(skip)]
@@ -2967,6 +2980,8 @@ impl Simulation {
             trigger_effects: Vec::new(),
             #[cfg(test)]
             master_frame_test_trace: Vec::new(),
+            #[cfg(test)]
+            house_ai_activation_order_test_trace: Vec::new(),
             sound_events: Vec::new(),
             fire_events: Vec::new(),
             invulnerability_impact_effects: Vec::new(),
@@ -3908,6 +3923,18 @@ impl Simulation {
     #[cfg(test)]
     fn trace_master_frame_rung(&mut self, rung: MasterFrameTestRung) {
         self.master_frame_test_trace.push(rung);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_house_ai_activation_order_test_trace(
+        &mut self,
+    ) -> Vec<HouseAiActivationOrderTestEvent> {
+        std::mem::take(&mut self.house_ai_activation_order_test_trace)
+    }
+
+    #[cfg(test)]
+    fn trace_house_ai_activation_order(&mut self, event: HouseAiActivationOrderTestEvent) {
+        self.house_ai_activation_order_test_trace.push(event);
     }
 
     /// Returns true if the given house name is human-controlled.
@@ -5326,6 +5353,10 @@ impl Simulation {
             }
             index += 1;
         }
+        #[cfg(test)]
+        self.trace_house_ai_activation_order(
+            HouseAiActivationOrderTestEvent::HouseActivation,
+        );
     }
 
     fn refresh_fog(
@@ -6050,6 +6081,10 @@ impl Simulation {
         // flagged defeated via its is_defeated gate.
         if self.session.tick > 0 {
             self.check_defeat(rules);
+            #[cfg(test)]
+            self.trace_house_ai_activation_order(
+                HouseAiActivationOrderTestEvent::DefeatProcessed,
+            );
         }
 
         // --- Phase 8 (cont.): AI ---
@@ -6067,6 +6102,8 @@ impl Simulation {
                 height_map,
                 overlay_registry,
             );
+            #[cfg(test)]
+            self.trace_house_ai_activation_order(HouseAiActivationOrderTestEvent::AiGenerated);
             self.ai_players = ai_state;
             let mut ai_tail_path_grid = path_grid
                 .cloned()
@@ -7272,6 +7309,10 @@ impl Simulation {
                 height_map,
                 phase_six_path_grid,
                 overlay_registry,
+            );
+            #[cfg(test)]
+            self.trace_house_ai_activation_order(
+                HouseAiActivationOrderTestEvent::ProductionCompleted,
             );
             production::tick_repairs(self, rules);
             building_dock::tick_building_docks(self, rules);

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -27,6 +27,8 @@ mod world_spawn;
 #[cfg(test)]
 mod gsi_04_18_tests;
 #[cfg(test)]
+mod house_ai_activation_tests;
+#[cfg(test)]
 mod lifecycle_tests;
 #[cfg(test)]
 mod team_script_vm_tests;
@@ -5306,6 +5308,26 @@ impl Simulation {
         self.apply_active_vision_structures(&effects);
     }
 
+    /// Visit the live House registry for the early AI-activation transition.
+    ///
+    /// gamemd-derived: `LogicClass__PerTickUpdate @ 0x0055AFB0`, House loop
+    /// `0x0055B68D..0x0055B6B1`, walks the House array forward, skips nulls,
+    /// and reloads the live count after every `HouseClass__Update @ 0x004F8440`
+    /// call. The bounded Rust transition is the verified update block
+    /// `0x004F8564..0x004F85B7`.
+    fn update_house_ai_activation_latches(&mut self, rules: &RuleSet) {
+        let game_mode_nonzero = self.session.game_mode_nonzero;
+        let iq_production = rules.general.iq_production;
+        let mut index = 0;
+        while index < self.session.house_order.len() {
+            let owner = self.session.house_order[index];
+            if let Some(house) = self.houses.get_mut(&owner) {
+                house.update_ai_activation(game_mode_nonzero, iq_production);
+            }
+            index += 1;
+        }
+    }
+
     fn refresh_fog(
         &mut self,
         path_grid: Option<&PathGrid>,
@@ -6015,6 +6037,10 @@ impl Simulation {
         self.trace_master_frame_rung(MasterFrameTestRung::Houses);
         if let Some(rules) = rules {
             self.reconcile_active_vision_structures(rules);
+            // Factory/production work has already completed in Phase 7. This
+            // early House update follows vision reconciliation and precedes
+            // both defeat processing and strategic AI command generation.
+            self.update_house_ai_activation_latches(rules);
         }
         // --- Phase 8: Defeat detection (runs BEFORE AI) ---
         // gamemd evaluates each house's defeat before its AI manage/produce step,

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -423,8 +423,8 @@ impl Simulation {
     /// components in stable-entity-ID order (EntityStore keys_sorted) for determinism.
     pub fn state_hash(&self) -> u64 {
         self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true,
         )
     }
 
@@ -457,8 +457,8 @@ impl Simulation {
     #[cfg(test)]
     pub(crate) fn state_hash_without_spark_dummy_level_slope_v107(&self) -> u64 {
         self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true,
-            false, false, false, false, false, false, false,
+            true, true, true, true, true, true, true, true, true, true, true, true, false, false,
+            false, false, false, false, false,
         )
     }
 
@@ -488,8 +488,8 @@ impl Simulation {
     #[cfg(test)]
     pub(crate) fn state_hash_without_base_plan_center_v111(&self) -> u64 {
         self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, false, false, false,
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, false, false, false,
         )
     }
 
@@ -497,8 +497,8 @@ impl Simulation {
     #[cfg(test)]
     pub(crate) fn state_hash_without_house_deploy_latches_v112(&self) -> u64 {
         self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, false, false,
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, false, false,
         )
     }
 
@@ -507,8 +507,8 @@ impl Simulation {
     #[cfg(test)]
     pub(crate) fn state_hash_without_house_update_activation_v113(&self) -> u64 {
         self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, false,
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, false,
         )
     }
 

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -33,6 +33,36 @@ fn hash_projectile_target(
     }
 }
 
+/// Fold the versioned direct House CRC fields around CurrentIQ.
+///
+/// gamemd-derived: raw House CRC `0x00502D60..0x0050303F` folds Production at
+/// `0x00502E58`, AutocreateAllowed at `0x00502E66`, AITriggersActive at
+/// `0x00502E74`, and CurrentIQ at `0x00502E90`; exhaustive census finds no
+/// direct AutoBaseBuilding (`House+0x1F3`) feed. Schema v112 retains its
+/// committed CurrentIQ-before-two-latches stream, while v113 uses native order.
+fn hash_house_ai_activation_fields(
+    house: &crate::sim::house_state::HouseState,
+    include_house_deploy_latches_v112: bool,
+    include_house_update_activation_v113: bool,
+    hasher: &mut impl Hasher,
+) {
+    if !include_house_update_activation_v113 {
+        house.current_iq.hash(hasher);
+    }
+    if include_house_deploy_latches_v112 {
+        house.ai_activation.production.hash(hasher);
+    }
+    if include_house_update_activation_v113 {
+        house.ai_activation.autocreate_allowed.hash(hasher);
+    }
+    if include_house_deploy_latches_v112 {
+        house.ai_activation.ai_triggers_active.hash(hasher);
+    }
+    if include_house_update_activation_v113 {
+        house.current_iq.hash(hasher);
+    }
+}
+
 #[cfg(test)]
 mod drive_ship_slope_hash_tests {
     use super::Simulation;
@@ -394,7 +424,7 @@ impl Simulation {
     pub fn state_hash(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true,
+            true, true, true, true, true, true, true,
         )
     }
 
@@ -406,7 +436,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             true, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false, false, false, false,
+            false, false, false, false, false, false, false,
         )
     }
 
@@ -418,7 +448,7 @@ impl Simulation {
     pub(crate) fn state_hash_before_lifecycle_v28_and_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             false, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false, false, false, false,
+            false, false, false, false, false, false, false,
         )
     }
 
@@ -428,7 +458,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_spark_dummy_level_slope_v107(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true,
-            false, false, false, false, false, false,
+            false, false, false, false, false, false, false,
         )
     }
 
@@ -439,7 +469,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_naval_build_const_v109(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            false, false, false, false,
+            false, false, false, false, false,
         )
     }
 
@@ -450,7 +480,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_base_plan_v110(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, false, false, false,
+            true, false, false, false, false,
         )
     }
 
@@ -459,7 +489,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_base_plan_center_v111(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, false, false,
+            true, true, true, true, false, false, false,
         )
     }
 
@@ -468,7 +498,17 @@ impl Simulation {
     pub(crate) fn state_hash_without_house_deploy_latches_v112(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, false,
+            true, true, true, true, true, false, false,
+        )
+    }
+
+    /// Test-only provenance probe for the schema-v113 House-update activation
+    /// fold. It reconstructs the committed v112 CurrentIQ/latch order.
+    #[cfg(test)]
+    pub(crate) fn state_hash_without_house_update_activation_v113(&self) -> u64 {
+        self.state_hash_with_schema(
+            true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, false,
         )
     }
 
@@ -492,6 +532,7 @@ impl Simulation {
         include_base_plan_v110: bool,
         include_base_plan_center_v111: bool,
         include_house_deploy_latches_v112: bool,
+        include_house_update_activation_v113: bool,
     ) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
 
@@ -543,6 +584,7 @@ impl Simulation {
             include_base_plan_v110,
             include_base_plan_center_v111,
             include_house_deploy_latches_v112,
+            include_house_update_activation_v113,
         );
         if include_terminal_score_v46 {
             self.hash_terminal_score_snapshot(&mut hasher);
@@ -763,6 +805,7 @@ impl Simulation {
         include_base_plan_v110: bool,
         include_base_plan_center_v111: bool,
         include_house_deploy_latches_v112: bool,
+        include_house_update_activation_v113: bool,
     ) {
         for (owner, house) in &self.houses {
             owner.hash(hasher);
@@ -785,15 +828,12 @@ impl Simulation {
             house.owned_building_count.hash(hasher);
             house.owned_unit_count.hash(hasher);
             house.tech_level.hash(hasher);
-            house.current_iq.hash(hasher);
-            if include_house_deploy_latches_v112 {
-                // gamemd-derived: raw House CRC `0x00502D60..0x0050303F`
-                // directly folds Production at `0x00502E58` and
-                // AITriggersActive at `0x00502E74`. Its exhaustive field census
-                // finds no direct AutoBaseBuilding (`House+0x1F3`) feed.
-                house.ai_activation.production.hash(hasher);
-                house.ai_activation.ai_triggers_active.hash(hasher);
-            }
+            hash_house_ai_activation_fields(
+                house,
+                include_house_deploy_latches_v112,
+                include_house_update_activation_v113,
+                hasher,
+            );
             if include_base_defense_response_v97 {
                 house.strategy_emergency.hash(hasher);
             } else {
@@ -2511,7 +2551,7 @@ mod mission_authority_hash_tests {
 
 #[cfg(test)]
 mod rally_hash_tests {
-    use super::Simulation;
+    use super::{Simulation, hash_house_ai_activation_fields};
     use crate::sim::components::{DriveCoord, DriveLocomotionRuntime};
     use crate::sim::game_entity::GameEntity;
 
@@ -2786,23 +2826,52 @@ mod rally_hash_tests {
         let baseline = fixture(HouseAiActivationLatches::default());
         let production = fixture(HouseAiActivationLatches {
             production: true,
-            ..HouseAiActivationLatches::default()
+            autocreate_allowed: false,
+            ai_triggers_active: false,
+            auto_base_building: false,
+        });
+        let autocreate = fixture(HouseAiActivationLatches {
+            production: false,
+            autocreate_allowed: true,
+            ai_triggers_active: false,
+            auto_base_building: false,
         });
         let ai_triggers = fixture(HouseAiActivationLatches {
+            production: false,
+            autocreate_allowed: false,
             ai_triggers_active: true,
-            ..HouseAiActivationLatches::default()
+            auto_base_building: false,
         });
         let auto_base = fixture(HouseAiActivationLatches {
+            production: false,
+            autocreate_allowed: false,
+            ai_triggers_active: false,
             auto_base_building: true,
-            ..HouseAiActivationLatches::default()
         });
 
         assert_ne!(baseline.state_hash(), production.state_hash());
+        assert_ne!(baseline.state_hash(), autocreate.state_hash());
         assert_ne!(baseline.state_hash(), ai_triggers.state_hash());
         assert_eq!(baseline.state_hash(), auto_base.state_hash());
+        assert_ne!(
+            baseline.state_hash_without_house_update_activation_v113(),
+            production.state_hash_without_house_update_activation_v113()
+        );
+        assert_eq!(
+            baseline.state_hash_without_house_update_activation_v113(),
+            autocreate.state_hash_without_house_update_activation_v113()
+        );
+        assert_ne!(
+            baseline.state_hash_without_house_update_activation_v113(),
+            ai_triggers.state_hash_without_house_update_activation_v113()
+        );
         assert_eq!(
             baseline.state_hash_without_house_deploy_latches_v112(),
             production.state_hash_without_house_deploy_latches_v112()
+        );
+        assert_eq!(
+            baseline.state_hash_without_house_deploy_latches_v112(),
+            autocreate.state_hash_without_house_deploy_latches_v112()
         );
         assert_eq!(
             baseline.state_hash_without_house_deploy_latches_v112(),
@@ -2812,6 +2881,61 @@ mod rally_hash_tests {
             baseline.state_hash_without_house_deploy_latches_v112(),
             auto_base.state_hash_without_house_deploy_latches_v112()
         );
+    }
+
+    #[test]
+    fn house_ai_activation_hash_field_order_preserves_v113_and_v112_streams() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        use crate::sim::house_state::{HouseAiActivationLatches, HouseState};
+
+        for (current_iq, production, autocreate_allowed, ai_triggers_active) in [
+            (0x1357_2468, true, false, false),
+            (-0x0246_1357, false, true, false),
+            (0x1020_3040, false, false, true),
+        ] {
+            let mut house = HouseState::new(Default::default(), 0, None, false, 0, 10);
+            house.current_iq = current_iq;
+            house.ai_activation = HouseAiActivationLatches {
+                production,
+                autocreate_allowed,
+                ai_triggers_active,
+                auto_base_building: true,
+            };
+
+            let mut actual_v113 = DefaultHasher::new();
+            hash_house_ai_activation_fields(&house, true, true, &mut actual_v113);
+            let mut manual_v113 = DefaultHasher::new();
+            house.ai_activation.production.hash(&mut manual_v113);
+            house
+                .ai_activation
+                .autocreate_allowed
+                .hash(&mut manual_v113);
+            house
+                .ai_activation
+                .ai_triggers_active
+                .hash(&mut manual_v113);
+            house.current_iq.hash(&mut manual_v113);
+            assert_eq!(actual_v113.finish(), manual_v113.finish());
+
+            let mut actual_v112 = DefaultHasher::new();
+            hash_house_ai_activation_fields(&house, true, false, &mut actual_v112);
+            let mut manual_v112 = DefaultHasher::new();
+            house.current_iq.hash(&mut manual_v112);
+            house.ai_activation.production.hash(&mut manual_v112);
+            house
+                .ai_activation
+                .ai_triggers_active
+                .hash(&mut manual_v112);
+            assert_eq!(actual_v112.finish(), manual_v112.finish());
+
+            let mut actual_pre_v112 = DefaultHasher::new();
+            hash_house_ai_activation_fields(&house, false, false, &mut actual_pre_v112);
+            let mut manual_pre_v112 = DefaultHasher::new();
+            house.current_iq.hash(&mut manual_pre_v112);
+            assert_eq!(actual_pre_v112.finish(), manual_pre_v112.finish());
+        }
     }
 
     #[test]


### PR DESCRIPTION
Implements the evidence-backed HouseClass update activation transaction, signed IQ Production binding, AutocreateAllowed persistence, snapshot v113, and native House hash order. Preserves deploy as the separate three-latch writer and excludes action 13, anger, and adjacent consumers. Focused validation is green, a fresh independent critic returned PASS, and the full library suite passed with 7716 passed, 0 failed, and 76 ignored.