### PR TITLE
docs(workflow): enforce transaction merge cadence

### DIFF
--- a/.agents/skills/goal-prompt/SKILL.md
+++ b/.agents/skills/goal-prompt/SKILL.md
@@ -118,9 +118,15 @@ Carry these controls into a goal when it spans multiple mechanisms or shared
 engine state:
 
 - Use one dependency-coherent transaction per implementation task,
-  `feature/*` branch, and PR. Start from current `origin/main`; never begin
-  new work from a merged feature branch. Keep a small inseparable prerequisite
-  with its consumer, but give a broad shared prerequisite its own transaction.
+  `feature/*` branch, and PR. Start from freshly fetched `origin/main`; never
+  begin new work from a merged feature branch. When publication is authorized,
+  carry each transaction through review and validation, then merge it before
+  starting dependent work; independent transactions may proceed only in
+  separately owned worktrees. The owning task, or its explicit continuation
+  owner, resolves conflicts and reruns affected validation; require fresh critic
+  review when the resolution changes behavior or evidence. Keep a small
+  inseparable prerequisite with its consumer, but give a broad shared
+  prerequisite its own transaction.
 - Before changing shared constructors, lifecycle, placement, production,
   pathing, schemas, snapshots, or deterministic state, define focused
   cross-system canaries. On failure, compare with `origin/main`, reproduce a

--- a/.agents/skills/sync/SKILL.md
+++ b/.agents/skills/sync/SKILL.md
@@ -18,7 +18,8 @@ There is no long-lived `dev` branch.
 
 - Require a clean working tree before switching branches or updating refs.
 - Fetch with pruning before drawing conclusions.
-- Use fast-forward-only pulls and merges. Never rebase, reset, amend, or force-push.
+- Use fast-forward-only pulls. Never rebase, reset, amend, or force-push. The only
+  non-fast-forward merge allowed is the owned PR-conflict flow below.
 - Never commit or push directly to `main`; it moves through reviewed PRs or an
   explicit user-owned GitHub action.
 - Never push an unpublished/local-ahead feature branch without user authorization.
@@ -102,7 +103,8 @@ feature/merged-task     [origin/...]  0 unique commits — delete candidate
 - **DELETE CANDIDATE** — branch has zero unique commits versus `main`, or the user
   explicitly wants a remote-only deletion while retaining a proven local copy.
 - **ANOMALY** — divergence, missing commits, unclear ownership, dirty state, or a
-  protected-branch mismatch. Stop and request direction.
+  protected-branch mismatch. Stop and request direction unless an owned PR conflict
+  meets every gate in the conflict flow below.
 
 ## 4. Execute safe catch-up
 
@@ -120,9 +122,25 @@ git switch feature/<topic>
 git pull --ff-only
 ```
 
-If `--ff-only` refuses, stop. Do not substitute a merge commit or rebase.
+If `--ff-only` refuses, stop. Do not substitute a merge commit or rebase except through
+the owned PR-conflict flow below.
 
-## 5. Clean up confirmed branches
+## 5. Resolve an owned PR conflict
+
+Use this only when an open, publication-authorized PR reports an actual conflict with
+`main`. The current task must own the clean feature worktree and branch, or be its
+explicit continuation owner. Fetch first and verify the PR base, head, and current
+`origin/main`; otherwise stop.
+
+Merge current `origin/main` into the feature branch without rebasing or force-pushing.
+Resolve each conflict from both sides' intended behavior; do not accept `ours` or `theirs`
+wholesale without inspecting and justifying that conflicted file. If ownership is unclear
+or the conflict expands beyond the transaction, abort the merge and report the boundary.
+Otherwise rerun affected validation, obtain fresh critic review when behavior or evidence
+changed, ensure final PR certification covers the resolved tree, commit the merge, and
+push normally. Never leave a merge in progress.
+
+## 6. Clean up confirmed branches
 
 After rechecking unique commits and worktree ownership:
 
@@ -147,7 +165,7 @@ For worktree removal, first run the local-only backup preflight and the bundled
 cleanup check. `git worktree remove --force` is forbidden while the check reports
 external reparse points, dirty files, or unclassified ignored content.
 
-## 6. Verify and report
+## 7. Verify and report
 
 Verify exact local/remote tips, absence of deleted refs, a clean working tree, and no
 unexpected branch switch. Report kept, updated, deleted, skipped, and unpublished

--- a/ENGINE.md
+++ b/ENGINE.md
@@ -67,6 +67,10 @@ any conflict: **binary → Ghidra → docs**.
 
 **It is common for research-doc details to be wrong.**
 
+External engines, reimplementations, and earlier-game codebases are navigation aids only. They do
+not establish active YR behavior or exclusions; verify material conclusions against active
+`gamemd.exe` and retail data.
+
 Skill instructions write `<main-checkout>` for the primary repository root. `docs/research/`,
 `docs/plans/`, and the research-index *code* are tracked, so every worktree, clone, and fork
 has them. Gitignored corpora — `ini/`, the rest of `docs/` (`scans/`, `gap-scans/`,
@@ -230,7 +234,16 @@ touches, then run `python -m tools.system_map check --require-sources`.
   GitHub action).
 - When this checkout has a sole owner, create or switch the feature branch here. When another
   task owns the checkout, use a separate worktree and feature branch. Continue an existing
-  task-owned feature branch rather than creating a second branch for the same work.
+  task-owned feature branch rather than creating a second branch for the same work. A checkout
+  with uncommitted or untracked task work remains owned by that task; do not reuse it until the
+  owner commits, transfers, or explicitly classifies the work.
+- When publication is authorized, carry one dependency-coherent transaction per feature branch
+  and PR through review and validation, and merge it before starting dependent work. A transaction
+  may include a small inseparable prerequisite; it is not one branch per function, plan row, or
+  critic iteration. Independent work may proceed in separately owned worktrees.
+- The transaction owner, or its explicitly named continuation owner, resolves PR conflicts on that
+  feature branch, reruns affected validation, and obtains fresh review if the resolution changes
+  behavior or evidence. Other tasks do not resolve its conflicts.
 - Push a feature branch or open/update its PR only when the user or goal authorizes publication.
   Every PR targets `main`. Delete merged feature branches when safe. Do not create a long-lived
   `dev` branch; use a temporary integration branch only when the user explicitly requests one.
@@ -244,6 +257,10 @@ touches, then run `python -m tools.system_map check --require-sources`.
 
 - Package is `vera20k`; a wrong `-p` exits 101 without running anything. Read and report the
   literal `test result:` line rather than inferring success from completion.
+- Before the first validation in a fresh worktree, identify which machine-local configuration,
+  retail archives, and main-checkout INIs it requires and confirm they are readable. On failure,
+  verify the environment and compare the same command on `origin/main` under equivalent conditions
+  before calling it a branch regression.
 - **Run the cheapest test tier that answers the question.** *Working:* `cargo check -p vera20k`
   plus the touched module only, `cargo test -p vera20k --lib <module_path>::` — always `--lib`, or
   you also link 13 unrelated side binaries. *PR integration/merge certification:* one full


### PR DESCRIPTION
## Summary
- require dependency-coherent transactions to merge before dependent work starts
- keep independent work allowed in separately owned worktrees
- assign PR conflict resolution to the transaction or continuation owner
- classify dirty checkouts as owned and add fresh-worktree fixture preflight
- keep external engines as navigation aids rather than parity authority
- add a narrowly gated, no-rebase conflict path to the sync skill

## Validation
- git diff --check
- goal-prompt and sync skill frontmatter/body checks passed with a no-install fallback
- official quick_validate.py could not start because available Python runtimes lack PyYAML
- documentation and skill instructions only; Cargo tests not run