### PR TITLE
test(production): freeze Phase 8 wall placement spend semantics

### DIFF
--- a/src/sim/production/production_placement_tests.rs
+++ b/src/sim/production/production_placement_tests.rs
@@ -1769,10 +1769,29 @@ fn empty_cell_wall_placement_still_works_but_wall_on_overlay_rejects() {
 
     let mut overlay_sim = Simulation::new();
     spawn_structure(&mut overlay_sim, 1, "Americans", "GACNST", 10, 10);
+    overlay_sim.resolved_terrain = Some(resolved_clear_grid_with_override(64, 64, |_| {}));
     let mut overlay_grid = OverlayGrid::new(64, 64);
     overlay_grid.place_overlay(12, 10, 7, 4);
     overlay_sim.overlay_grid = Some(overlay_grid);
     ready_building(&mut overlay_sim, &rules, "Americans", "GAWALL");
+    let placement_credits = 1_337;
+    *super::credits_entry_for_owner(&mut overlay_sim, "Americans") = placement_credits;
+    assert!(overlay_sim.rebuild_dynamic_navigation(&rules));
+    let owner = overlay_sim.interner.get("Americans").expect("owner");
+    let ready_before = overlay_sim
+        .production
+        .ready_by_owner
+        .get(&owner)
+        .cloned()
+        .expect("ready queue");
+    let overlay_before = *overlay_sim
+        .overlay_grid
+        .as_ref()
+        .expect("overlay grid")
+        .cell(12, 10);
+    let navigation_before = overlay_sim
+        .path_grid_snapshot()
+        .expect("published navigation before rejected placement");
     let preview = placement_preview_for_owner_with_overlays(
         &overlay_sim,
         &rules,
@@ -1786,9 +1805,43 @@ fn empty_cell_wall_placement_still_works_but_wall_on_overlay_rejects() {
     )
     .expect("ready wall should have a preview");
     assert!(!preview.valid, "an ordinary wall must not replace ore");
+    assert!(
+        !place_ready_building_with_overlays(
+            &mut overlay_sim,
+            &rules,
+            "Americans",
+            "GAWALL",
+            12,
+            10,
+            Some(&grid),
+            &height_map,
+            Some(&registry),
+        ),
+        "the occupied primary wall commit must be rejected"
+    );
     assert_eq!(
-        ready_buildings_for_owner(&overlay_sim, &rules, "Americans").len(),
-        1
+        overlay_sim.production.ready_by_owner.get(&owner),
+        Some(&ready_before),
+        "rejection must preserve the completed wall product"
+    );
+    assert_eq!(
+        credits_for_owner(&overlay_sim, "Americans"),
+        placement_credits,
+        "rejection must preserve house credits"
+    );
+    assert_eq!(
+        overlay_sim
+            .overlay_grid
+            .as_ref()
+            .expect("overlay grid")
+            .cell(12, 10),
+        &overlay_before,
+        "rejection must preserve the occupied overlay cell"
+    );
+    assert_eq!(
+        overlay_sim.path_grid_snapshot().as_deref(),
+        Some(navigation_before.as_ref()),
+        "rejection must preserve the complete published navigation grid"
     );
 }
 
@@ -1855,6 +1908,8 @@ fn gsi_04_07_regular_wall_autofill_is_cardinal_ordered_bounded_and_consumes_once
     sim.overlay_grid = Some(OverlayGrid::new(64, 64));
     sim.resolved_terrain = Some(resolved_clear_grid_with_override(64, 64, |_| {}));
     ready_building(&mut sim, &rules, "Americans", "GAWALL");
+    let placement_credits = 1_337;
+    *super::credits_entry_for_owner(&mut sim, "Americans") = placement_credits;
     let owner = sim.interner.get("Americans").expect("owner");
     let wall_type = sim.interner.get("GAWALL").expect("wall type");
     sim.production
@@ -1862,6 +1917,8 @@ fn gsi_04_07_regular_wall_autofill_is_cardinal_ordered_bounded_and_consumes_once
         .get_mut(&owner)
         .expect("ready queue")
         .push_back(wall_type);
+    let ready_count_before = ready_buildings_for_owner(&sim, &rules, "Americans").len();
+    assert_eq!(ready_count_before, 2, "fixture must begin with two walls");
     let overlay_id = registry.id_for_name("GAWALL").expect("wall overlay");
     let origin = (18, 18);
     let endpoints = [(18, 13), (23, 18), (18, 23), (13, 18)];
@@ -1918,8 +1975,13 @@ fn gsi_04_07_regular_wall_autofill_is_cardinal_ordered_bounded_and_consumes_once
     ));
     assert_eq!(
         ready_buildings_for_owner(&sim, &rules, "Americans").len(),
-        1,
+        ready_count_before - 1,
         "the primary plus all fillers consume exactly one ready product"
+    );
+    assert_eq!(
+        credits_for_owner(&sim, "Americans"),
+        placement_credits,
+        "the paid primary plus free fillers must not debit credits at placement time"
     );
     let grid = sim.overlay_grid.as_ref().expect("overlay grid");
     for (rx, ry) in std::iter::once(origin).chain(expected.iter().copied()) {

--- a/src/sim/production/production_placement_tests.rs
+++ b/src/sim/production/production_placement_tests.rs
@@ -462,6 +462,7 @@ fn gsi_04_07_wall_placement_contract() -> (RuleSet, OverlayTypeRegistry) {
          Wall=yes\n\
          Armor=concrete\n\
          Strength=300\n\
+         Cost=100\n\
          Foundation=1x1\n\
          Adjacent=8\n\
          GuardRange=5\n\
@@ -1778,6 +1779,29 @@ fn empty_cell_wall_placement_still_works_but_wall_on_overlay_rejects() {
     *super::credits_entry_for_owner(&mut overlay_sim, "Americans") = placement_credits;
     assert!(overlay_sim.rebuild_dynamic_navigation(&rules));
     let owner = overlay_sim.interner.get("Americans").expect("owner");
+    let wall = rules.object("GAWALL").expect("wall rules");
+    assert_eq!(wall.cost, 100, "fixture must exercise a nonzero wall cost");
+    let category = super::production_tech::production_category_for_object(wall);
+    let factory_before = {
+        let view = overlay_sim
+            .production
+            .factory_shadow
+            .view(owner, category)
+            .expect("completed wall factory");
+        (
+            view.progress,
+            view.on_hold,
+            view.suspended,
+            view.object.cloned(),
+            view.queue.clone(),
+            view.ready,
+        )
+    };
+    let held_id = factory_before
+        .3
+        .as_ref()
+        .and_then(|object| object.entity_id)
+        .expect("completed wall retains Factory+0x58 identity");
     let ready_before = overlay_sim
         .production
         .ready_by_owner
@@ -1823,6 +1847,29 @@ fn empty_cell_wall_placement_still_works_but_wall_on_overlay_rejects() {
         overlay_sim.production.ready_by_owner.get(&owner),
         Some(&ready_before),
         "rejection must preserve the completed wall product"
+    );
+    let factory_after = {
+        let view = overlay_sim
+            .production
+            .factory_shadow
+            .view(owner, category)
+            .expect("rejected placement retains completed wall factory");
+        (
+            view.progress,
+            view.on_hold,
+            view.suspended,
+            view.object.cloned(),
+            view.queue.clone(),
+            view.ready,
+        )
+    };
+    assert_eq!(
+        factory_after, factory_before,
+        "rejection must preserve the authoritative completed factory object"
+    );
+    assert!(
+        overlay_sim.substrate.entities.contains(held_id),
+        "rejection must preserve the held Factory+0x58 entity"
     );
     assert_eq!(
         credits_for_owner(&overlay_sim, "Americans"),
@@ -1912,13 +1959,22 @@ fn gsi_04_07_regular_wall_autofill_is_cardinal_ordered_bounded_and_consumes_once
     *super::credits_entry_for_owner(&mut sim, "Americans") = placement_credits;
     let owner = sim.interner.get("Americans").expect("owner");
     let wall_type = sim.interner.get("GAWALL").expect("wall type");
-    sim.production
-        .ready_by_owner
-        .get_mut(&owner)
-        .expect("ready queue")
-        .push_back(wall_type);
-    let ready_count_before = ready_buildings_for_owner(&sim, &rules, "Americans").len();
-    assert_eq!(ready_count_before, 2, "fixture must begin with two walls");
+    let wall = rules.object("GAWALL").expect("wall rules");
+    assert_eq!(wall.cost, 100, "fixture must exercise a nonzero wall cost");
+    let category = super::production_tech::production_category_for_object(wall);
+    let held_id = sim
+        .production
+        .factory_shadow
+        .view(owner, category)
+        .and_then(|view| view.object)
+        .filter(|object| object.type_id == wall_type)
+        .and_then(|object| object.entity_id)
+        .expect("completed wall retains Factory+0x58 identity");
+    assert_eq!(
+        ready_buildings_for_owner(&sim, &rules, "Americans").len(),
+        1,
+        "fixture must begin with one authoritative completed wall"
+    );
     let overlay_id = registry.id_for_name("GAWALL").expect("wall overlay");
     let origin = (18, 18);
     let endpoints = [(18, 13), (23, 18), (18, 23), (13, 18)];
@@ -1973,10 +2029,20 @@ fn gsi_04_07_regular_wall_autofill_is_cardinal_ordered_bounded_and_consumes_once
         &height_map,
         Some(&registry),
     ));
-    assert_eq!(
-        ready_buildings_for_owner(&sim, &rules, "Americans").len(),
-        ready_count_before - 1,
-        "the primary plus all fillers consume exactly one ready product"
+    assert!(
+        ready_buildings_for_owner(&sim, &rules, "Americans").is_empty(),
+        "the primary plus all fillers consume the one ready product"
+    );
+    assert!(
+        sim.production
+            .factory_shadow
+            .view(owner, category)
+            .is_none_or(|view| view.object.is_none() && view.queue.is_empty()),
+        "wall placement must clear the authoritative completed factory object"
+    );
+    assert!(
+        sim.substrate.entities.get(held_id).is_none(),
+        "wall placement must destroy the consumed Factory+0x58 entity"
     );
     assert_eq!(
         credits_for_owner(&sim, "Americans"),


### PR DESCRIPTION
## Summary
- recover the Phase 8 wall placement spend and rejection coverage from `feature/phase8-parity`
- use the retail `GAWALL` cost and the authoritative `Factory+0x58` held-object identity
- preserve current production behavior; this PR changes tests only

## Evidence and review
- gamemd wall-placement dispatch: `0x004FB0E0`
- retail `rulesmd.ini`: `GAWALL Cost=100`
- fresh independent read-only critic re-review: PASS

## Validation
- `cargo test -p vera20k --lib empty_cell_wall_placement_still_works_but_wall_on_overlay_rejects`: 1 passed; 0 failed
- `cargo test -p vera20k --lib gsi_04_07_regular_wall_autofill_is_cardinal_ordered_bounded_and_consumes_once`: 1 passed; 0 failed
- `cargo test -p vera20k --lib`: 7722 passed; 0 failed; 76 ignored