### PR TITLE
test(rules): preserve Unit Weeder and Enslaves separation

### DIFF
--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -2314,6 +2314,28 @@ mod tests {
     }
 
     #[test]
+    fn unit_weeder_is_independent_from_slave_ownership() {
+        let ini: IniFile = IniFile::from_str(
+            "[WEED]\nWeeder=yes\n[SLAVER]\nEnslaves=SLAV\n",
+        );
+        let weeder = ObjectType::from_ini_section(
+            "WEED",
+            ini.section("WEED").unwrap(),
+            ObjectCategory::Vehicle,
+        );
+        let slaver = ObjectType::from_ini_section(
+            "SLAVER",
+            ini.section("SLAVER").unwrap(),
+            ObjectCategory::Vehicle,
+        );
+
+        assert!(weeder.weeder);
+        assert!(weeder.enslaves.is_none());
+        assert!(!slaver.weeder);
+        assert_eq!(slaver.enslaves.as_deref(), Some("SLAV"));
+    }
+
+    #[test]
     fn cloning_key_parses_and_participates_in_rally_lines() {
         let ini = IniFile::from_str("[YACLON]\nName=Cloning Vats\nStrength=1000\nCloning=yes\n");
         let section = ini.section("YACLON").unwrap();


### PR DESCRIPTION
## Summary
- recover the Phase 8 Unit `Weeder=` versus `Enslaves=` parser regression from `feature/phase8-parity`
- prove each INI key populates only its independent current Rust authority
- add no production behavior

## Evidence and review
- `UnitTypeClass::ReadINI @ 0x00747620`
- `TechnoClass::Init_Managers @ 0x006F3F40` for the separate `Enslaves=` consumer
- fresh independent read-only critic: PASS

## Validation
- `cargo test -p vera20k --lib unit_weeder_is_independent_from_slave_ownership`: 1 passed; 0 failed; 7798 filtered out
- `cargo test -p vera20k --lib`: 7723 passed; 0 failed; 76 ignored