### PR TITLE
fix(skirmish): match active-retail Scenario prefix

### DIFF
--- a/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
+++ b/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
@@ -2,15 +2,15 @@
 
 ## Goal
 
-Parity-close VERA20k's complete active-retail Yuri's Revenge bridge system, including GSI-04.12 high bridges, GSI-04.13 low/water bridges, GSI-04.14 destruction/repair/CABHUT behavior, GSI-04.15 TubeClass, and every active cross-system bridge consumer established by the frozen coverage map.
+Parity-close VERA20k's complete active-retail Yuri's Revenge bridge system, including GSI-04.12 high bridges, GSI-04.13 low/water bridges, GSI-04.14 destruction/repair/CABHUT behavior, GSI-04.15 TubeClass, and every active cross-system bridge consumer established by the bounded coverage baseline and its living follow-up inventory.
 
 The result must preserve behavior that already matches, replace behavior that conflicts with active `gamemd.exe` or retail data, implement missing behavior, and leave no approximate, unchecked, missing, or residual bridge mechanism behind.
 
 ## Status and Scope Decision
 
-**Revision 14 after the fifth 2026-08-30 REVISE design-review verdict; pending a new fresh re-review. No further Rust implementation is authorized by this document until that review passes.**
+**Revision 15 after the sixth 2026-08-30 REVISE design-review verdict; pending a new fresh re-review. No further Rust implementation is authorized by this document until that review passes.**
 
-Discovery is frozen by `docs/research/bridges/00-system-models/ACTIVE_RETAIL_BRIDGE_COVERAGE_REINVESTIGATION_GHIDRA_REPORT.md` at commit `50d0ef8a`. Ten successive read-only omission audits expanded the boundary to 27 mechanism rows and 31 explicit open questions; the tenth pass added nothing.
+`docs/research/bridges/00-system-models/ACTIVE_RETAIL_BRIDGE_COVERAGE_REINVESTIGATION_GHIDRA_REPORT.md` at commit `50d0ef8a` is the bounded discovery baseline. Ten successive read-only omission audits expanded that baseline to 27 mechanism rows and 31 explicit open questions; the tenth pass added nothing. The working inventory is nevertheless living: before every transaction it is refreshed against then-current `main`, active-retail `gamemd.exe`, retail data, named validation, and critic evidence. A newly proved writer, consumer, contradiction, or exclusion reopens the affected mechanism and transaction routing. Status comes from cited evidence and commits, never a hand-maintained parity percentage.
 
 The fourth review's random-map blocker and the Revision-4/Revision-5 critics' launch, projection,
 trace-schema and authored-constructor blockers are closed by
@@ -30,19 +30,30 @@ it needs a persistent owner. Those generator-phase findings remain closed; the s
 pre-Fill House/Gather prefix and non-offline Mark-entry contexts are routed below.
 
 The design treats those rows as a coverage map, not as implementation modules. It uses 21 narrower
-implementation transactions to preserve dependency order, but the 27 `BR-M` rows are the closure,
-builder, critic, and publication gates required by this project. A transaction may supply part of
-more than one mechanism, and a mechanism may span more than one transaction; neither fact permits a
-mechanism to inherit another row's pass.
+implementation transactions to preserve dependency order. Each transaction is its own branch,
+builder, critic, validation, PR, and merge gate; the 27 `BR-M` rows remain the cumulative behavior-
+closure gates. A transaction may supply part of more than one mechanism, and a mechanism may span
+more than one transaction; neither fact permits a mechanism to inherit another row's pass.
 
-Current implementation baseline is `origin/main` commit `a3e4ce9a` (2026-08-30), not the pre-implementation
-snapshot used by Revision 7. PR #170 has merged P0, transaction 1 (load inputs/raw facts), and
+Current implementation baseline is freshly fetched `origin/main` commit
+`5062bceaf15fe5139218d7f3375d34cc8e1d6139` (2026-08-30), with PR #170 merge
+`f4baff6e` confirmed as an ancestor. PR #170 merged P0, transaction 1 (load inputs/raw facts), and
 transaction 2 (RMG low-bridge launch construction), including their focused validation and critic
 corrections. Later merged work also changed ground-height ownership, Drive/Ship slope handling,
-radar-overlay projection, FNPC bridge projection, and waypoint handling. Those changes are evidence
-to preserve, not proof that any remaining `BR-M` row is closed. Before each remaining mechanism is
-contracted, its owner must run a fresh direct disparity scan against then-current `main`; stale Rust
-gap descriptions in the frozen coverage report are historical hypotheses only.
+radar-overlay projection, FNPC bridge projection, waypoint handling, final House `BasePlan`/AI state,
+snapshot schema v113, lifecycle/deploy seams, and bridge-harness hashes. No post-`a3e4ce9a` merge
+closed a remaining core bridge, Tube, RMG, pathfinding, combat, or render mechanism. Those changes are
+evidence to preserve, not proof that any remaining `BR-M` row is closed. Before each remaining
+transaction is contracted, its builder runs a fresh direct disparity scan against then-current
+`main`; stale Rust gap descriptions in the bounded coverage report are historical hypotheses only.
+
+Living status at this baseline is explicit. P0 and transactions 1 and 2 are merged. BR-M02 and
+BR-M03 passed their bounded PR #170 gates but remain subject to the final reverse audit. BR-M01,
+BR-M06, and BR-M24 have landed contributions but remain open at their routed later consumer or
+reverse-audit gates. P0-R1 is reopened as the next prerequisite. Every other required contribution
+remains open, and GSI-04.12, GSI-04.13, GSI-04.14, and GSI-04.15 remain aggregate-open until all of
+their mechanisms and cross-system consumers pass. This ledger is replaced with current evidence
+after each merged transaction rather than appended as historical prose.
 
 The completed P0-R1 reinvestigation disproves Revision 9's eligible/ineligible split. Current `main`
 does not reproduce the active stock-offline prefix even when a `PreloadedBattleStartPlan` exists:
@@ -56,6 +67,13 @@ passes plus common `+0x80`, with LAN using selected `+0x84` and WOL state `2` us
 noncampaign family; stream restore and generated `.SED` do not run Mark; and shipped
 `gamemd.exe` has no persistent editor load mode. Transaction 3 must use this typed matrix rather
 than allowing any non-offline context to inherit the stock-offline plan by analogy.
+
+The first House pass is disposable except for its Scenario cursor effect. It cannot overwrite or
+leak into the final House `BasePlan`, AI activation latches, lifecycle state, or snapshot/hash state.
+The zero-draw reset deletes that pass, and only the second pass supplies final House state. A focused
+oracle must continue past installation through Fill, any applicable Mark/generated replay,
+authored/Post-Map work, and the current runtime `recalc_base_plan` Scenario consumer so the new
+BasePlan path proves both state preservation and downstream cursor continuity.
 
 In scope:
 
@@ -273,15 +291,41 @@ it must not consult later resolved terrain, overlays, occupancy, or bridge state
 start entries below the target count remain in order and the plan retains both Gather vectors and the
 final assignment/chooser result rather than collapsing them into one completed vector.
 
+App setup normalizes the constructor roster before compact launch-session projection; it cannot be
+reconstructed from `opponents.len()` or from the one-local-human `SkirmishLaunchSession` shape. The
+simulation-facing value has the following semantic fields (exact Rust names may follow existing
+style):
+
+```rust
+struct PreFillHouseRoster {
+    human_nodes_in_native_priority_order: Vec<PreFillHumanHouse>, // observers retained
+    ai_slots_in_native_slot_order: Vec<PreFillAiHouseSlot>,       // validity retained
+    neutral: PreFillHouse,
+    special: PreFillHouse,
+}
+```
+
+Both passes traverse that same immutable value. Each human node consumes regardless of observer
+status; only valid AI slots construct and consume; invalid AI slots remain represented so a compacted
+opponent vector cannot silently change order or count. Neutral and Special are always last. Final
+House `BasePlan`, AI latches, lifecycle fields, snapshots, and hashes are installed only from the
+second pass; first-pass outcomes may be retained in the plan for cursor/equivalence proof but are
+never projected into the live world.
+
 The accepted generated-map path is not a filename/content inference. A valid preview writes start
 staging in `Scenario + 0x11C0`; successful Start copies that staging before `.SED` regeneration.
-The plan records explicit `AcceptedRmgStartStaging` provenance (or the separately proved authored
-source) so a fresh external `.SED`, a cancelled preview, and an authored map cannot borrow those
-entries. This provenance is independent of the later generated-vs-authored overlay load-source
-discriminator.
+Setup acceptance extracts only those staged start entries plus explicit
+`AcceptedRmgStartStaging` provenance into a consumed-once loading value. Preview terrain, MapGen
+continuation, constructor bindings, and display entities remain presentation/file artifacts and are
+not carried as gameplay authority. Loading consumes the staged-start value exactly once when making
+the prefix plan. A cancelled/replaced preview, authored map, fresh external `.SED`, regenerated
+waypoint inference, construction-trace presence, or unsupported generated/mode combination cannot
+manufacture or borrow this provenance. This gate is independent of the later generated-vs-authored
+overlay load-source discriminator.
 
-The plan contains the complete logical pre-state/fingerprint `S0`, pass-1 House outcomes, both
-Gather outcomes, final assignments, pass-2 House outcomes, and complete post-state/cursor `S1`.
+The plan contains the complete logical pre-state/fingerprint `S0`, pass-1 House outcomes for
+equivalence checking only, both Gather outcomes, final assignments, pass-2 House outcomes as the
+sole live-House projection source, and complete post-state/cursor `S1`.
 `MapLoadInitial` creates one `ScenarioBootstrapRng` from the same match seed, requires exact full-state
 equality with `S0`, installs `S1` once, and rejects a second installation because the pre-state no
 longer matches. The plan exposes no RNG interface and is consumed from `LoadingRequest`; later House
@@ -582,11 +626,13 @@ architecture layers and not mechanism pass gates.
 
 ### Mechanism closure gates
 
-Every `BR-M` row has one persistent builder identity, one complete mechanism contract, and its own
-fresh-critic chain. The builder may work through several dependency transactions, but another
-builder's transaction or critic result cannot close the row. If a builder must be replaced, the
-handoff records the reason, complete evidence/diff/output bundle, and new owner; the row is then
-recriticized from its full requirement rather than only the replacement's last diff.
+Every dependency-coherent transaction has one builder and its own fresh read-only critic chain on a
+short-lived transaction branch. Builder identity need not persist across nonadjacent transactions;
+the durable owner is the cumulative evidence bundle for each `BR-M` row. A transaction critic checks
+the full transaction requirement and every mechanism contribution it touches. When a transaction is
+the last contributor to a split row, a fresh critic also receives that row's complete native/retail
+requirement, all earlier contributing diffs and outputs, routed questions, exclusions, and current
+preservation evidence. No earlier transaction or different row's critic result can close it.
 
 | Mechanism gate | Contributing transaction(s) |
 |---|---|
@@ -621,17 +667,17 @@ recriticized from its full requirement rather than only the replacement's last d
 A row passes only after all of its contributing transactions, preservation tests, routed open
 questions, and negative facts are exact and a critic who did not build it returns no material
 finding. Split rows therefore remain open after an early transaction. Bundled transactions must be
-decomposed into reviewable mechanism-scoped deltas or a separately named prerequisite commit; a
-shared commit never grants a shared pass.
+decomposed into reviewable mechanism-scoped deltas or a separately named prerequisite commit within
+that transaction; a shared commit never grants a shared pass.
 
-BR-M04's persistent builder begins its shared high-load contribution in transaction 3 and continues
-the same mechanism through transaction 4. Transaction 3 cannot close BR-M04. Its evidence/output
-bundle must nevertheless include the native interleaving, OverlayData/global-Recalc order,
-finalized-payload handoff and high-anchor retail preservation fixtures; BR-M05's fresh critic checks
-that contribution for escaped high-load regressions. After transaction 4, a different fresh critic
-receives BR-M04's complete transactions-3-and-4 requirement, native evidence, cumulative diff and
-validation output. Neither the BR-M05 pass nor the earlier preservation check substitutes for that
-full BR-M04 critic gate.
+Transaction 3 begins BR-M04's shared high-load contribution but cannot close BR-M04. Its
+evidence/output bundle must nevertheless include the native interleaving,
+OverlayData/global-Recalc order, finalized-payload handoff and high-anchor retail preservation
+fixtures; transaction 3's fresh critic checks that contribution for escaped high-load regressions.
+After transaction 3 merges, transaction 4 uses a new short-lived branch and may use a different
+builder. Its fresh critic receives BR-M04's complete transactions-3-and-4 requirement, native
+evidence, cumulative diff and validation output. Neither BR-M05's pass nor transaction 3's
+preservation check substitutes for that full BR-M04 critic gate.
 
 ### Open-question routing
 
@@ -710,21 +756,22 @@ Negative facts are closure requirements, not prose-only cautions. Each routed un
 
 ## Builder, Critic, and Publication Protocol
 
-For every `BR-M` mechanism:
+For every dependency-coherent implementation transaction:
 
-1. Resolve every contributing transaction and open question against live `gamemd.exe` and retail data into one sourced mechanism contract. OpenTS may locate functions but supplies no required behavior.
-2. Assign one persistent builder for the mechanism. The builder may preserve correct code, replace wrong code, and implement missing code only within that mechanism and its smallest verified prerequisite.
-3. Check `cargo`/`rustc` ownership before validation. Run focused `cargo test -p vera20k --lib <filter>` commands only; never a bare Cargo test.
-4. Commit the coherent evidence-backed slice after focused validation.
-5. Give a fresh read-only critic who did not build the mechanism its complete requirement, native/retail evidence, exact diff, and literal validation output. For a split mechanism, the bundle includes every earlier contributing transaction and preservation test.
-6. If it fails, fix the largest finding, commit the correction, and give the full updated bundle to a new critic. The new critic must recheck prior findings as well as the new diff.
-7. Repeat until a fresh critic passes with no material finding. Approximate or unverified behavior cannot be relabeled residual; the mechanism and every owning row stay open.
-8. After the mechanism pass, push its dedicated `feature/<mechanism>` branch and open a draft PR targeting `main`; publication is preauthorized. Record the contract, exact commits, critic pass, and focused literal output in the PR.
-9. A mechanism PR remains draft because `ENGINE.md` reserves the one full `cargo test -p vera20k --lib` certification for the bridge-wide completion boundary. Do not declare an intermediate PR ready by substituting focused tests for that suite. Opening is authorized here; readiness and merging are not. After opening the first such PR, this autonomous run must stop, report the authority blocker, and request the user/reviewer decision needed to certify and merge it. It may resume the next mechanism only after then-current `main` contains the preceding mechanism; stacking or rewriting around the boundary is forbidden. The design does not claim an internally automatic draft-to-merge transition.
+1. Refresh its living-inventory rows against then-current `main`. Resolve every material behavior and routed open question needed by the transaction against active `gamemd.exe` and retail data into one sourced transaction contract. OpenTS may locate functions but supplies no required behavior.
+2. Create one short-lived `feature/<transaction>` branch from freshly fetched current `origin/main`. Assign one builder for the transaction. It may preserve correct code, replace wrong code, and implement missing code only within that transaction and its smallest verified prerequisite.
+3. Check `cargo`/`rustc` ownership before validation. While building, run focused `cargo test -p vera20k --lib <filter>` commands only; never a bare Cargo test.
+4. Commit each coherent evidence-backed slice after focused validation. Keep the branch reviewable and buildable; do not defer a multi-slice transaction into one giant commit.
+5. Give a fresh read-only critic who did not build the transaction its complete requirement, native/retail evidence, exact cumulative diff, preservation obligations, and literal validation output. If the transaction is the last contributor to a split mechanism, include that mechanism's complete earlier transaction history and row-level closure bundle.
+6. If it fails, the builder fixes the largest finding and commits the correction. Give the full updated bundle to a new fresh critic, who must recheck every prior finding plus the new diff. Repeat until a fresh critic passes with no material finding.
+7. After the fresh pass, check Cargo ownership and run `cargo test -p vera20k --lib` exactly once as that PR's full readiness certification. Do not rerun it for the same PR unless a later code correction invalidates the certification; such a correction reopens readiness and requires the rule in `ENGINE.md` to decide the new certification boundary.
+8. Push the dedicated branch and open or update its PR targeting `main`; publication is preauthorized by this goal. Record the contract, exact commits, critic chain, focused literal output, and full-suite literal output. Take the PR through review and merge before beginning any dependent transaction. Never stack a dependent branch or rewrite around this boundary.
+9. Refresh the living inventory from the resulting `main`. A passed transaction closes only the exact contributions it contains. Approximate, unverified, missing, or residual behavior keeps its mechanism and owning GSI row open; a split mechanism closes only at its final cumulative row review.
 
-Critics do not edit. Builders do not self-approve. A critic pass proves only the bounded mechanism,
-not the bridge system. The final bridge-wide audit runs the full `--lib` suite exactly once and is the
-only point at which the aggregate completion PR may be declared ready for `main`.
+Critics do not edit. Builders do not self-approve. A critic pass and PR certification prove only the
+bounded transaction and any explicitly completed cumulative row gate, not the bridge system. The
+final bridge-wide reverse audit consumes the per-PR certifications; it does not rerun a blanket full
+suite unless it discovers a correction requiring a new transaction and PR.
 
 ## Player-Experience Detail Ledger
 
@@ -780,7 +827,10 @@ only point at which the aggregate completion PR may be declared ready for `main`
 
 ## Validation Strategy
 
-During mechanism work, use only focused `--lib` tests after confirming no other session owns Cargo. Favor native-trace tables and small retail fixtures over broad certification matrices.
+During transaction implementation and critic correction, use only focused `--lib` tests after
+confirming no other session owns Cargo. Favor native-trace tables and small retail fixtures over
+broad certification matrices. After the final fresh critic passes and before that transaction PR is
+declared ready, run the full `cargo test -p vera20k --lib` exactly once for that PR.
 
 Required fixture families:
 
@@ -793,7 +843,10 @@ Required fixture families:
   including observer and invalid-AI-slot cases, two independent Battle/Cooperative Gathers, sparse and
   deficient default-cell inputs, zero-draw reset, accepted-RMG staging provenance permitted only for
   Battle id `1`/FFA id `2`, rejection for other generated/mode combinations, exact full-state single
-  installation, duplicate/tampered rejection, and draw-free later assignment projection;
+  installation, duplicate/tampered rejection, and draw-free later assignment projection; the first
+  pass must leave no live `BasePlan`/AI/lifecycle/snapshot/hash state, the second pass must preserve
+  current final-House state, and the reference cursor must match through Fill, applicable Mark or
+  generated replay, authored/Post-Map work, and runtime `recalc_base_plan`;
 - typed non-offline fresh-load-context fixtures: campaign single House pass and no Gather; LAN full
   House1/`+0x80`/selected-`+0x84`/reset/House2 sequence; WOL full House1/`+0x80`/common-assignment/
   reset/House2 sequence with both gated chooser arms; replay adds zero before its recorded family;
@@ -806,7 +859,9 @@ Required fixture families:
   draw zero, and no ranged helper or cloned cursor is accepted;
 - source mapping fixtures: Loose and Mix map to authored Mark; Generated maps to materialized/no-Mark
   even with missing or empty construction trace; LegacyFallback and untyped Generic reject rather
-  than guessing; accepted generated start staging is distinct from both map source and trace;
+  than guessing; accepted generated start staging is distinct from both map source and trace,
+  consumed once, and cannot be inferred from a cancelled/replaced preview, authored map, external
+  `.SED`, regenerated waypoints, or generated construction events;
 - one interleaved authored OverlayPack fixture where an earlier low trigger writes cells and a later
   packed coordinate observes/overwrites them, including a high anchor in the same y/x traversal;
   then a conflicting OverlayData byte must win before the final global Recalc produces the exact Road,
@@ -847,9 +902,9 @@ Required fixture families:
   seed-zero Scenario poststate and separately contracted Main/MapGen behavior rather than unchanged
   generic RNG continuation.
 
-The full suite `cargo test -p vera20k --lib` runs exactly once after P0 and all 27 bridge mechanisms
-and their critic cycles pass, immediately before the bridge-wide reverse audit is declared ready. It
-is not rerun per transaction, mechanism iteration, or intermediate draft PR.
+The full suite is a per-transaction PR readiness gate, not a per-edit or per-critic-iteration tool.
+Each transaction records its one final literal full-library result after focused validation and its
+fresh critic chain. A later dependent transaction begins only after that PR merges into `main`.
 
 ## Bridge-Wide Reverse Audit
 
@@ -860,7 +915,7 @@ After P0 and all bridge-mechanism passes:
 3. Re-run the OpenTS correspondence ledger as leads and confirm no active YR mechanism disappeared between unit boundaries.
 4. Recheck all 27 mechanism rows, all 31 open questions, and every entry in the complete frozen negative-fact ledger; every open item must be resolved and every exclusion preserved, not deferred.
 5. Re-run named retail fixture traces for load, move, target, damage, collapse, repair, render and restore.
-6. Run the full `--lib` suite once, record literal output, update only verified System Map connections, and produce the final handoff.
+6. Reconcile every merged transaction's full-suite certification and current `main` ancestry, update only verified System Map connections, and produce the final handoff. If the audit discovers any code correction, route it through a new dependency-coherent transaction, fresh critic chain, one PR-readiness full-suite run, and merge before repeating the affected audit rows.
 
 Any omission or regression reopens its owning unit and requires the builder/fresh-critic loop again.
 
@@ -901,7 +956,10 @@ The preferred approach is distributed exact-delta closure in current owners. It 
 - the universal stock-offline pre-Fill substitution includes both House passes, both mode-family
   Gather calls, exact default-cell deficient retries, zero-draw reset and explicit generated-staging
   provenance limited to accepted Battle/FFA on one native Scenario stream, and cannot install stale
-  state, install twice, or leave a parallel downstream owner;
+  state, install twice, or leave a parallel downstream owner; its normalized roster preserves native-
+  priority human nodes including observers, AI slot identity/validity, Neutral and Special without an
+  `opponents.len()` reconstruction; pass 1 leaks no final House state, pass 2 preserves current
+  `BasePlan`/AI/lifecycle/snapshot/hash state, and the cursor oracle reaches runtime BasePlan draws;
 - the app-owned fresh-load-context descriptor is orthogonal to physical `LoadedMapSource` and has no
   restore variant; persistence owns a separate no-Mark restore context with no conversion into the
   fresh pipeline; Loose/Mix map
@@ -915,8 +973,9 @@ The preferred approach is distributed exact-delta closure in current owners. It 
   clone or reseed, and edge writes alias one extended persistent shared dummy;
 - restore asserts Scenario's verified seed-zero poststate while leaving Main/MapGen explicitly
   OQ-19-gated rather than claiming generic unchanged continuation;
-- intermediate mechanism publication remains draft and merge-gated, while the full `--lib` suite
-  runs exactly once at bridge-wide completion;
+- each dependency-coherent transaction owns one short-lived branch, builder, fresh-critic chain,
+  one final full `--lib` PR-readiness run, and merge before dependent work; split mechanism rows
+  remain open until their cumulative final-contributor review;
 - P0 has a bounded all-ingress constructor requirement and its merged builder/fresh-critic evidence;
   P0-R1's universal stock-offline prefix correction and fresh critic pass before transaction 3 uses
   that shared Scenario cursor; and transaction 3 preserves the completed campaign/LAN/WOL/replay/
@@ -935,6 +994,7 @@ Until that review passes, implementation remains blocked by design rather than b
 - `docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_SCENARIO_LOAD_ACTIVATION_BOUNDARY_GHIDRA_REPORT.md`
 - `docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_ALL_LOAD_CONTEXT_SCENARIO_RNG_LIFECYCLE_GHIDRA_REPORT.md`
 - active `gamemd.exe` addresses and retail inputs enumerated by that report
-- current Rust owners at `origin/main` snapshot `a3e4ce9a`
+- current Rust owners at freshly fetched `origin/main` snapshot
+  `5062bceaf15fe5139218d7f3375d34cc8e1d6139`
 - `docs/system-map/topology.v2.json` `bridge-helpers` service boundary
 - `C:\Users\enok\Documents\OpenTS` correspondence ledger, as navigation leads only

--- a/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
+++ b/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
@@ -8,7 +8,7 @@ The result must preserve behavior that already matches, replace behavior that co
 
 ## Status and Scope Decision
 
-**Revision 12 after the third 2026-08-30 REVISE design-review verdict; pending a new fresh re-review. No further Rust implementation is authorized by this document until that review passes.**
+**Revision 13 after the fourth 2026-08-30 REVISE design-review verdict; pending a new fresh re-review. No further Rust implementation is authorized by this document until that review passes.**
 
 Discovery is frozen by `docs/research/bridges/00-system-models/ACTIVE_RETAIL_BRIDGE_COVERAGE_REINVESTIGATION_GHIDRA_REPORT.md` at commit `50d0ef8a`. Ten successive read-only omission audits expanded the boundary to 27 mechanism rows and 31 explicit open questions; the tenth pass added nothing.
 
@@ -328,45 +328,69 @@ exclusion rather than widening the trace for dormant RMG-shaped code.
      replay-only draw.
    Fill consumes from and returns the same cursor. A stream restore is a separate no-Full_Init/no-Mark
    transaction and retains native seed-zero Scenario restore behavior; it never enters this list.
-3. Apply high structural stamps and later overlay-data replacement in their verified section order,
-   only when native `NewINIFormat > 1` permits the pack reader.
-4. On fixed authored maps only, run low endpoint/body `OverlayClass::Mark` expansion inline in decoded
-   y-major/x-minor OverlayPack order using the exact continuation after the selected prefix and Fill.
-   Its successful body cells consume raw Scenario words before authored Techno constructors. On
-   generated maps, preserve the generator's complete direct three-wide overlay/data rectangle and
-   skip Mark entirely; the generated source flag is explicit rather than inferred from overlay ids.
-   This branch follows `InitMapFromSyntheticINI @ 0x00599650` and direct deck writer `0x0058F2C0`:
-   the successful `.SED` arm in `Read_Scenario @ 0x00684620` is exclusive with the ordinary
-   INI/overlay-pack path, so it has no later Mark replay.
-5. Parse explicit `[Tubes]` independently; classify automatic same-cell shells from final theater land data without synthesizing traversal.
-6. Recalculate terrain, records, zones and hierarchy only at the verified load boundary established by units 1, 3, 4 and 5.
+3. On the authored Full_Init arm, parse explicit `[Tubes]` after Fill and before overlays. Keep them
+   independent of low Road behavior; classify automatic same-cell shells from final theater land data
+   without synthesizing traversal.
+4. When native `NewINIFormat > 1` permits the pack reader, execute one decoded OverlayPack traversal,
+   `y=0..511` outer then `x=0..511` inner. Each coordinate completes synchronously before the next:
+   ordinary overlays run ordinary Mark, the four high anchors run their high structural stamp, and
+   the eight low procedural triggers run the exact low Mark transaction on the same Scenario cursor
+   continuation after prefix and Fill. Later packed coordinates can observe or overwrite earlier
+   procedural writes; there is no component post-pass and no high-before-low phase split.
+5. Only after the entire OverlayPack traversal, execute the complete OverlayDataPack traversal and
+   overwrite each allocated/in-bounds cell's state byte. Then run the whole-map `RecalcAttributes`
+   pass before Terrain and authored Unit/Aircraft/Infantry/Structure construction. Every procedural
+   write still recalculates immediately in step 4; the final Recalc projects the later data overwrite.
+6. On generated `.SED`, the early synthetic Full_Init defaults `NewINIFormat` to `0`, so steps 4/5
+   are inert. Later preserve the generator's complete direct three-wide overlay/data rectangle and
+   skip authored high/low Mark entirely. The explicit successful `.SED`/generated provenance, not
+   overlay ids or construction-trace presence, selects this arm.
+7. Rebuild records, zones and hierarchy only at the verified load boundary established by units 1,
+   3, 4 and 5.
 
-The app layer owns one explicit `ScenarioLoadContextDescriptor`, orthogonal to
-`LoadedMapSource::{Authored, Generated}`. `LoadingRequest` creates it from proven startup/session/
-replay/stream provenance and `MapLoadInitial` carries it through the load. Its normalized prefix kind
-is one of stock offline, campaign, LAN, WOL-state-2, replay-with-recorded-family, or stream restore;
-it contains only the roster/mode/House/start inputs the simulation prefix needs. Network transport,
-replay I/O and UI session types remain in `app`; `sim::scenario_bootstrap` receives the normalized
-kind and inputs, not app or networking dependencies. A seedless/generic current Rust entry may not
-guess stock offline: a surface without proved context provenance returns an explicit unsupported
-load-context result and cannot enter authored Mark. Tests and headless callers must supply a typed
-context deliberately.
+The app layer owns one explicit `ScenarioLoadContextDescriptor`, orthogonal to physical map source.
+`LoadingRequest` creates it from proven startup/session/replay/stream provenance and
+`MapLoadInitial` carries it through the load. Its normalized prefix kind is one of stock offline,
+campaign, LAN, WOL-state-2, replay-with-recorded-family, or stream restore; it contains only the
+roster/mode/House/start inputs the simulation prefix needs. Network transport, replay I/O and UI
+session types remain in `app`; `sim::scenario_bootstrap` receives the normalized kind and inputs,
+not app or networking dependencies. A seedless/generic current Rust entry may not guess stock
+offline: a surface without proved context provenance returns an explicit unsupported-load-context
+result and cannot enter authored Mark. Tests and headless callers must supply a typed context.
 
-Map provenance and load context form two independent gates. A stock-offline context with
-`Generated` source runs the verified prefix but skips authored Mark; an authored campaign/LAN/WOL/
-replay source can run Mark when `NewINIFormat > 1`; stream restore never runs Full_Init or Mark.
-This prevents construction-trace presence, filenames after materialization, or a generic app startup
-variant from standing in for either authority.
+The actual app source enum is `LoadedMapSource::{Loose, Mix, Generated, LegacyFallback}`. App loading
+derives the map-layer `OverlayLoadSource` exactly once and carries it explicitly:
 
-`ScenarioBootstrapRng` remains the sole cursor owner. After Fill returns, loading creates a narrow
-borrowed `ScenarioOverlayMarkRng<'_>` (name illustrative) that exposes raw `Next` only, not a ranged
-substitute or a clonable cursor. Inline OverlayPack processing consumes `raw & 3` exactly `3*L`
-times on successful procedural body writes and zero on every fixed/search/no-op/failure arm, then
-returns the same borrow before authored Techno construction. `src/sim/scenario_bootstrap.rs` owns the
-borrow seam; `src/map/overlay.rs` or the narrow low-Mark owner owns the exact tables/loop;
-`src/map/resolved_terrain.rs` receives mutations/recalc results but does not own or reseed Scenario.
-Full logical-state tests bracket prefix, Fill, Mark and the first authored constructor so a hidden
-second cursor, ranged helper or reordered batch cannot pass.
+```text
+Loose | Mix    -> OverlayLoadSource::Authored
+Generated      -> OverlayLoadSource::GeneratedMaterialized
+LegacyFallback -> unsupported for exact OverlayPack Mark until explicit provenance is supplied
+```
+
+This mapping is independent of `generated_construction_trace`: a `Generated` load with a missing or
+empty trace still skips authored Mark, while Loose/Mix remain authored. Load context is a second,
+orthogonal gate. A stock-offline `Generated` path is accepted only for the proved chooser boundary,
+Battle id `1` or FFA id `2`, with explicit accepted-preview start staging; arbitrary generated/mode
+combinations and fresh external `.SED` injection are rejected. An authored campaign/LAN/WOL/replay
+source can run Mark when `NewINIFormat > 1`; stream restore never runs Full_Init or Mark.
+
+`ScenarioBootstrapRng` remains the sole cursor owner. After Fill returns, app orchestration retains a
+non-clonable borrowed raw-only adapter from `sim::scenario_bootstrap`, but **no sim type crosses into
+`map`**. The app invokes the map-owned inline OverlayPack routine with a map-native
+`&mut dyn FnMut() -> u32`/equivalent raw-call interface backed by that borrow. `map` cannot range-wrap,
+clone, reseed or import `sim`; it can only request the next raw word at the exact low-body write.
+Inline processing applies `raw & 3` exactly `3*L` times on successful procedural body writes and
+zero on every fixed/search/no-op/failure arm, then app releases the same borrow before authored
+Techno construction. `src/map/overlay.rs` or the narrow low-Mark owner owns the recovered tables and
+loop; `src/map/resolved_terrain.rs` owns overlay/state mutation and Recalc projection, not Scenario.
+
+Every invalid coordinate returned by the native lookup aliases one persistent shared dummy across
+the whole pass. Transaction 3 therefore extends the existing `SharedCellDummy` owner with the
+overlay ID/state, Land/zone and cache fields actually read or written by low Mark/Recalc; it must not
+allocate a fresh default per lookup. Occupied-body writes, missing lookups and edge rows still consume
+their exact raw words and mutate that dummy in longitudinal/j order, while dummy Recalc remains a
+no-op. Full-state tests bracket prefix, Fill, Mark and the first authored constructor so a hidden
+second cursor, ranged helper, reordered batch or lost dummy alias cannot pass.
 
 #### Path-planning transaction
 
@@ -737,8 +761,9 @@ Required fixture families:
   retaining words/upgrade links without a constructor draw;
 - P0-R1 stock-offline prefix fixtures for all ids `1..9`, two identical native-roster House passes
   including observer and invalid-AI-slot cases, two independent Battle/Cooperative Gathers, sparse and
-  deficient default-cell inputs, zero-draw reset, accepted-RMG staging provenance, exact full-state
-  single installation, duplicate/tampered rejection, and draw-free later assignment projection;
+  deficient default-cell inputs, zero-draw reset, accepted-RMG staging provenance permitted only for
+  Battle id `1`/FFA id `2`, rejection for other generated/mode combinations, exact full-state single
+  installation, duplicate/tampered rejection, and draw-free later assignment projection;
 - typed non-offline load-context fixtures: campaign single House pass and no Gather; LAN full
   House1/`+0x80`/selected-`+0x84`/reset/House2 sequence; WOL full House1/`+0x80`/common-assignment/
   reset/House2 sequence with both gated chooser arms; replay adds zero before its recorded family;
@@ -748,6 +773,17 @@ Required fixture families:
 - authored low-Mark raw-seam fixtures bracketing full cursor states after prefix, after Fill, after
   exact `3*L` `raw & 3` writes, and before the first authored Techno; fixed/search/no-op/failure arms
   draw zero, and no ranged helper or cloned cursor is accepted;
+- source mapping fixtures: Loose and Mix map to authored Mark; Generated maps to materialized/no-Mark
+  even with missing or empty construction trace; LegacyFallback and untyped Generic reject rather
+  than guessing; accepted generated start staging is distinct from both map source and trace;
+- one interleaved authored OverlayPack fixture where an earlier low trigger writes cells and a later
+  packed coordinate observes/overwrites them, including a high anchor in the same y/x traversal;
+  then a conflicting OverlayData byte must win before the final global Recalc produces the exact Road,
+  LAT/CliffBack, zone and compact-cache result with no per-cell radar dirty or Tube creation;
+- low-Mark adversarial geometry fixtures for adjacent endpoints, first of two exact opposites, wrong
+  ID/state pass-through, occupied fixed-row successful no-op, missing opposite partial fixed end,
+  occupied/missing body overwrite, and edge lookups aliasing one persistent extended dummy in exact
+  row/j order while preserving draw count and return/tail behavior;
 - Lost Lake and Killer: intact low crossings;
 - Bay of Pigs and Hills: high deck, under-span, dual-plane and AttackMove;
 - Deadman's Ridge: high collapse gap;
@@ -830,12 +866,16 @@ The preferred approach is distributed exact-delta closure in current owners. It 
 - the critic protocol cannot close a mechanism with unresolved evidence;
 - the universal stock-offline pre-Fill substitution includes both House passes, both mode-family
   Gather calls, exact default-cell deficient retries, zero-draw reset and explicit generated-staging
-  provenance on one native Scenario stream, and cannot install stale state, install twice, or leave
-  a parallel downstream owner;
-- the app-owned load-context descriptor is orthogonal to authored/generated map provenance, rejects
-  untyped generic fallback, and normalizes into `sim` without importing app/network dependencies;
-- low Mark borrows the one Scenario owner after Fill through a raw-only seam and returns it before
-  authored Techno construction, with no ranged substitute, clone or second cursor;
+  provenance limited to accepted Battle/FFA on one native Scenario stream, and cannot install stale
+  state, install twice, or leave a parallel downstream owner;
+- the app-owned load-context descriptor is orthogonal to physical `LoadedMapSource`; Loose/Mix map
+  to authored, Generated maps to materialized even without a trace, LegacyFallback/Generic reject,
+  and normalized prefix inputs enter `sim` without app/network dependencies;
+- one y/x OverlayPack traversal interleaves high/low Mark, followed by the complete OverlayData pass
+  and global Recalc before Terrain/Technos;
+- app retains the one Scenario borrow after Fill and backs a map-native raw-call interface, so `map`
+  imports no `sim` type; the same cursor returns before authored Technos with no ranged substitute,
+  clone or reseed, and edge writes alias one extended persistent shared dummy;
 - restore asserts Scenario's verified seed-zero poststate while leaving Main/MapGen explicitly
   OQ-19-gated rather than claiming generic unchanged continuation;
 - intermediate mechanism publication remains draft and merge-gated, while the full `--lib` suite

--- a/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
+++ b/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
@@ -8,7 +8,7 @@ The result must preserve behavior that already matches, replace behavior that co
 
 ## Status and Scope Decision
 
-**Revision 13 after the fourth 2026-08-30 REVISE design-review verdict; pending a new fresh re-review. No further Rust implementation is authorized by this document until that review passes.**
+**Revision 14 after the fifth 2026-08-30 REVISE design-review verdict; pending a new fresh re-review. No further Rust implementation is authorized by this document until that review passes.**
 
 Discovery is frozen by `docs/research/bridges/00-system-models/ACTIVE_RETAIL_BRIDGE_COVERAGE_REINVESTIGATION_GHIDRA_REPORT.md` at commit `50d0ef8a`. Ten successive read-only omission audits expanded the boundary to 27 mechanism rows and 31 explicit open questions; the tenth pass added nothing.
 
@@ -331,7 +331,8 @@ exclusion rather than widening the trace for dormant RMG-shaped code.
 3. On the authored Full_Init arm, parse explicit `[Tubes]` after Fill and before overlays. Keep them
    independent of low Road behavior; classify automatic same-cell shells from final theater land data
    without synthesizing traversal.
-4. When native `NewINIFormat > 1` permits the pack reader, execute one decoded OverlayPack traversal,
+4. When native `NewINIFormat > 1` permits the pack reader, create one map-native
+   `FinalizedOverlayPayload` and execute one decoded OverlayPack traversal,
    `y=0..511` outer then `x=0..511` inner. Each coordinate completes synchronously before the next:
    ordinary overlays run ordinary Mark, the four high anchors run their high structural stamp, and
    the eight low procedural triggers run the exact low Mark transaction on the same Scenario cursor
@@ -341,22 +342,33 @@ exclusion rather than widening the trace for dormant RMG-shaped code.
    overwrite each allocated/in-bounds cell's state byte. Then run the whole-map `RecalcAttributes`
    pass before Terrain and authored Unit/Aircraft/Infantry/Structure construction. Every procedural
    write still recalculates immediately in step 4; the final Recalc projects the later data overwrite.
-6. On generated `.SED`, the early synthetic Full_Init defaults `NewINIFormat` to `0`, so steps 4/5
-   are inert. Later preserve the generator's complete direct three-wide overlay/data rectangle and
-   skip authored high/low Mark entirely. The explicit successful `.SED`/generated provenance, not
-   overlay ids or construction-trace presence, selects this arm.
-7. Rebuild records, zones and hierarchy only at the verified load boundary established by units 1,
+6. The completed map pass retains the exact final identity/state vector inside
+   `ResolvedTerrainGrid` as its consumed-once `FinalizedOverlayPayload`; its Recalc-derived Land,
+   zone, cache and bridge facts are already the projection of those bytes. App orchestration moves
+   that payload into `sim::overlay_grid::OverlayGrid::from_finalized_map_payload` one-for-one. That
+   constructor accepts no OverlayPack, OverlayDataPack, registry or Scenario interface and performs
+   no Mark, filtering, Recalc or second decode. Thus runtime overlay authority begins from the same
+   procedural fixed/body identities and post-OverlayData state bytes that produced resolved terrain.
+   The existing production `OverlayGrid::from_native_overlay_packs` rebuild is removed from this
+   handoff; later native Terrain-object clearing and gameplay mutations continue through the ordinary
+   synchronized OverlayGrid/ResolvedTerrain mutation owners.
+7. On generated `.SED`, the early synthetic Full_Init defaults `NewINIFormat` to `0`, so steps 4/5
+   are inert. Later preserve the generator's complete direct three-wide overlay/data rectangle in the
+   same finalized-payload shape and skip authored high/low Mark entirely. The explicit successful
+   `.SED`/generated provenance, not overlay ids or construction-trace presence, selects this arm.
+8. Rebuild records, zones and hierarchy only at the verified load boundary established by units 1,
    3, 4 and 5.
 
-The app layer owns one explicit `ScenarioLoadContextDescriptor`, orthogonal to physical map source.
-`LoadingRequest` creates it from proven startup/session/replay/stream provenance and
-`MapLoadInitial` carries it through the load. Its normalized prefix kind is one of stock offline,
-campaign, LAN, WOL-state-2, replay-with-recorded-family, or stream restore; it contains only the
-roster/mode/House/start inputs the simulation prefix needs. Network transport, replay I/O and UI
-session types remain in `app`; `sim::scenario_bootstrap` receives the normalized kind and inputs,
-not app or networking dependencies. A seedless/generic current Rust entry may not guess stock
-offline: a surface without proved context provenance returns an explicit unsupported-load-context
-result and cannot enter authored Mark. Tests and headless callers must supply a typed context.
+The app layer owns one explicit `FreshScenarioLoadContextDescriptor`, orthogonal to physical map
+source. `LoadingRequest` creates it only for a fresh scenario from proven startup/session/replay
+provenance, and `MapLoadInitial` carries it through that fresh-map load. Its normalized prefix kind
+is one of stock offline, campaign, LAN, WOL-state-2, or replay-with-recorded-family; it contains only
+the roster/mode/House/start inputs the simulation prefix needs. Stream restore is deliberately not a
+variant. Network transport, replay I/O and UI session types remain in `app`;
+`sim::scenario_bootstrap` receives the normalized fresh kind and inputs, not app or networking
+dependencies. A seedless/generic current Rust entry may not guess stock offline: a fresh-load surface
+without proved context provenance returns an explicit unsupported-load-context result and cannot
+enter authored Mark. Tests and headless callers must supply a typed fresh context.
 
 The actual app source enum is `LoadedMapSource::{Loose, Mix, Generated, LegacyFallback}`. App loading
 derives the map-layer `OverlayLoadSource` exactly once and carries it explicitly:
@@ -374,6 +386,13 @@ Battle id `1` or FFA id `2`, with explicit accepted-preview start staging; arbit
 combinations and fresh external `.SED` injection are rejected. An authored campaign/LAN/WOL/replay
 source can run Mark when `NewINIFormat > 1`; stream restore never runs Full_Init or Mark.
 
+Persistence owns a separate `ScenarioRestoreContext`/equivalent no-Mark guard. It is created only by
+the snapshot reader, never enters `LoadingRequest`, `MapLoadInitial`, the fresh prefix dispatcher or
+the map pack routine, and applies the proved seed-zero Scenario poststate while transaction 21
+reinstalls serialized authoritative overlay/runtime state and rebuilds only verified derived state.
+There is no conversion from restore context to fresh-load descriptor. A regression fixture must fail
+if restore invokes any Full_Init, Fill, OverlayPack Mark or fresh constructor-prefix entry.
+
 `ScenarioBootstrapRng` remains the sole cursor owner. After Fill returns, app orchestration retains a
 non-clonable borrowed raw-only adapter from `sim::scenario_bootstrap`, but **no sim type crosses into
 `map`**. The app invokes the map-owned inline OverlayPack routine with a map-native
@@ -382,7 +401,9 @@ clone, reseed or import `sim`; it can only request the next raw word at the exac
 Inline processing applies `raw & 3` exactly `3*L` times on successful procedural body writes and
 zero on every fixed/search/no-op/failure arm, then app releases the same borrow before authored
 Techno construction. `src/map/overlay.rs` or the narrow low-Mark owner owns the recovered tables and
-loop; `src/map/resolved_terrain.rs` owns overlay/state mutation and Recalc projection, not Scenario.
+loop; `src/map/resolved_terrain.rs` owns the map-native finalized payload, overlay/state mutation and
+Recalc projection, not Scenario. `sim::overlay_grid` may depend on and consume the map payload;
+`map` never depends on `sim`.
 
 Every invalid coordinate returned by the native lookup aliases one persistent shared dummy across
 the whole pass. Transaction 3 therefore extends the existing `SharedCellDummy` owner with the
@@ -539,7 +560,7 @@ architecture layers and not mechanism pass gates.
 |---|---|---|---|
 | 1 | Theater/rules/assets, raw flags, automatic-shell theater classification, TIBTRE mask preservation | BR-M01, BR-M06, BR-M24 | exact ten piece keys; raw-mask fixtures; automatic-shell corpus verdict; TIBTRE rejects `0x500`; retain raw SpecialFlags/session inputs for unit 10 |
 | 2 | Active RMG preview/accept/`.SED` launch lifecycle, low deck/end/CABHUT production, and waterfall-topology exclusion | BR-M02, BR-M03 | P0 and unit 1; `7fee6929`, `4a63fa15`, `f1e6054b`, `a776f270`; fresh MapGen per run; first-entry/re-entry and no-preview gates; location-free discarded trace events; one launch `ScenarioBootstrapRng`; validated `GeneratedTechnoInitTable`; active-phase-only trace; complete stamped output; no generated Mark replay; `BuildRiverBridge` negative characterization |
-| 3 | Fixed-map low overlay procedural load and Road mutation | BR-M05, BR-M11 | P0/P0-R1 and unit 1; complete active load-context cursor audit; Lost Lake/Killer plus destroyed low fixture; exact `NewINIFormat` activation; generated-source bypass preserving its full direct deck payload and zero Mark draws |
+| 3 | Shared authored OverlayPack/OverlayData/global-Recalc pass, fixed-map low procedural load and Road mutation | BR-M04 (shared high-load contribution only), BR-M05, BR-M11 | P0/P0-R1 and unit 1; complete active load-context cursor audit; exact y/x high/low interleaving and finalized-payload handoff; Lost Lake/Killer plus destroyed low fixture; exact `NewINIFormat` activation; generated-source bypass preserving its full direct deck payload and zero Mark draws |
 | 4 | High topology, records, zones, hierarchy and edge restamp | BR-M04, BR-M10, BR-M17 | unit 1; Bay of Pigs/Hills and Deadman's Ridge |
 | 5 | Explicit TubeClass load/hierarchy/direction-8/persistence and automatic-shell non-traversal | BR-M12, part of BR-M22 | units 1/4; sealed valid custom tube fixture; zero-length shell negative case |
 | 6 | Dual occupancy, entry, A*, peer markers and locomotor transitions | BR-M07, BR-M09, BR-M13 | units 4/5; deck, under-span, ramp, gap |
@@ -572,7 +593,7 @@ recriticized from its full requirement rather than only the replacement's last d
 | BR-M01 | 1 and 10 |
 | BR-M02 | 2 |
 | BR-M03 | 2 (negative characterization) |
-| BR-M04 | 4 |
+| BR-M04 | 3 (shared high OverlayPack/OverlayData/global-Recalc contribution) and 4 |
 | BR-M05 | 3 |
 | BR-M06 | 1 |
 | BR-M07 | 6 |
@@ -602,6 +623,15 @@ questions, and negative facts are exact and a critic who did not build it return
 finding. Split rows therefore remain open after an early transaction. Bundled transactions must be
 decomposed into reviewable mechanism-scoped deltas or a separately named prerequisite commit; a
 shared commit never grants a shared pass.
+
+BR-M04's persistent builder begins its shared high-load contribution in transaction 3 and continues
+the same mechanism through transaction 4. Transaction 3 cannot close BR-M04. Its evidence/output
+bundle must nevertheless include the native interleaving, OverlayData/global-Recalc order,
+finalized-payload handoff and high-anchor retail preservation fixtures; BR-M05's fresh critic checks
+that contribution for escaped high-load regressions. After transaction 4, a different fresh critic
+receives BR-M04's complete transactions-3-and-4 requirement, native evidence, cumulative diff and
+validation output. Neither the BR-M05 pass nor the earlier preservation check substitutes for that
+full BR-M04 critic gate.
 
 ### Open-question routing
 
@@ -764,12 +794,13 @@ Required fixture families:
   deficient default-cell inputs, zero-draw reset, accepted-RMG staging provenance permitted only for
   Battle id `1`/FFA id `2`, rejection for other generated/mode combinations, exact full-state single
   installation, duplicate/tampered rejection, and draw-free later assignment projection;
-- typed non-offline load-context fixtures: campaign single House pass and no Gather; LAN full
+- typed non-offline fresh-load-context fixtures: campaign single House pass and no Gather; LAN full
   House1/`+0x80`/selected-`+0x84`/reset/House2 sequence; WOL full House1/`+0x80`/common-assignment/
   reset/House2 sequence with both gated chooser arms; replay adds zero before its recorded family;
-  stream restore performs no Mark and ends Scenario at seed zero; a generic unsupported context
-  cannot guess stock offline; and generated `.SED` retains the stock-offline prefix while its source
-  provenance suppresses Mark;
+  a generic unsupported fresh context cannot guess stock offline; and generated `.SED` retains the
+  stock-offline prefix while its source provenance suppresses Mark; a separate persistence fixture
+  proves restore has no fresh descriptor, Full_Init, Fill, prefix or Mark call and ends Scenario at
+  seed zero;
 - authored low-Mark raw-seam fixtures bracketing full cursor states after prefix, after Fill, after
   exact `3*L` `raw & 3` writes, and before the first authored Techno; fixed/search/no-op/failure arms
   draw zero, and no ranged helper or cloned cursor is accepted;
@@ -779,7 +810,10 @@ Required fixture families:
 - one interleaved authored OverlayPack fixture where an earlier low trigger writes cells and a later
   packed coordinate observes/overwrites them, including a high anchor in the same y/x traversal;
   then a conflicting OverlayData byte must win before the final global Recalc produces the exact Road,
-  LAT/CliffBack, zone and compact-cache result with no per-cell radar dirty or Tube creation;
+  LAT/CliffBack, zone and compact-cache result with no per-cell radar dirty or Tube creation; assert
+  exact identity/data through `ResolvedTerrainGrid`'s finalized payload before transfer and through
+  runtime `OverlayGrid` after consumed-once direct installation, while an instrumented production
+  handoff proves zero second pack decode, Mark or Recalc;
 - low-Mark adversarial geometry fixtures for adjacent endpoints, first of two exact opposites, wrong
   ID/state pass-through, occupied fixed-row successful no-op, missing opposite partial fixed end,
   occupied/missing body overwrite, and edge lookups aliasing one persistent extended dummy in exact
@@ -868,11 +902,14 @@ The preferred approach is distributed exact-delta closure in current owners. It 
   Gather calls, exact default-cell deficient retries, zero-draw reset and explicit generated-staging
   provenance limited to accepted Battle/FFA on one native Scenario stream, and cannot install stale
   state, install twice, or leave a parallel downstream owner;
-- the app-owned load-context descriptor is orthogonal to physical `LoadedMapSource`; Loose/Mix map
+- the app-owned fresh-load-context descriptor is orthogonal to physical `LoadedMapSource` and has no
+  restore variant; persistence owns a separate no-Mark restore context with no conversion into the
+  fresh pipeline; Loose/Mix map
   to authored, Generated maps to materialized even without a trace, LegacyFallback/Generic reject,
   and normalized prefix inputs enter `sim` without app/network dependencies;
 - one y/x OverlayPack traversal interleaves high/low Mark, followed by the complete OverlayData pass
-  and global Recalc before Terrain/Technos;
+  and global Recalc before Terrain/Technos; its map-native finalized identity/data payload transfers
+  consumed-once into runtime `OverlayGrid` without a second pack decode, Mark, filter or Recalc;
 - app retains the one Scenario borrow after Fill and backs a map-native raw-call interface, so `map`
   imports no `sim` type; the same cursor returns before authored Technos with no ranged substitute,
   clone or reseed, and edge writes alias one extended persistent shared dummy;
@@ -883,7 +920,9 @@ The preferred approach is distributed exact-delta closure in current owners. It 
 - P0 has a bounded all-ingress constructor requirement and its merged builder/fresh-critic evidence;
   P0-R1's universal stock-offline prefix correction and fresh critic pass before transaction 3 uses
   that shared Scenario cursor; and transaction 3 preserves the completed campaign/LAN/WOL/replay/
-  save/generated/editor context matrix without an untyped offline fallback.
+  save/generated/editor context matrix without an untyped offline fallback; BR-M04's persistent
+  builder and eventual full critic bundle cover both its transaction-3 shared high-load contribution
+  and transaction 4 rather than inheriting BR-M05's pass.
 
 Until that review passes, implementation remains blocked by design rather than by user authority.
 

--- a/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
+++ b/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
@@ -8,7 +8,7 @@ The result must preserve behavior that already matches, replace behavior that co
 
 ## Status and Scope Decision
 
-**Revision 15 after the sixth 2026-08-30 REVISE design-review verdict; pending a new fresh re-review. No further Rust implementation is authorized by this document until that review passes.**
+**Revision 15 is APPROVED by a fresh read-only design review on 2026-08-30 with no material findings. P0-R1 implementation is authorized; transaction 3 and every later transaction remain gated by P0-R1 merge and their own current evidence contracts.**
 
 `docs/research/bridges/00-system-models/ACTIVE_RETAIL_BRIDGE_COVERAGE_REINVESTIGATION_GHIDRA_REPORT.md` at commit `50d0ef8a` is the bounded discovery baseline. Ten successive read-only omission audits expanded that baseline to 27 mechanism rows and 31 explicit open questions; the tenth pass added nothing. The working inventory is nevertheless living: before every transaction it is refreshed against then-current `main`, active-retail `gamemd.exe`, retail data, named validation, and critic evidence. A newly proved writer, consumer, contradiction, or exclusion reopens the affected mechanism and transaction routing. Status comes from cited evidence and commits, never a hand-maintained parity percentage.
 
@@ -983,7 +983,9 @@ The preferred approach is distributed exact-delta closure in current owners. It 
   builder and eventual full critic bundle cover both its transaction-3 shared high-load contribution
   and transaction 4 rather than inheriting BR-M05's pass.
 
-Until that review passes, implementation remains blocked by design rather than by user authority.
+The fresh Revision-15 review passed. P0-R1 may proceed on its transaction branch; this approval does
+not close any bridge mechanism or waive a later transaction's evidence, critic, validation, PR, or
+merge gate.
 
 ## Sources
 

--- a/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
+++ b/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
@@ -8,7 +8,7 @@ The result must preserve behavior that already matches, replace behavior that co
 
 ## Status and Scope Decision
 
-**Revision 7 after the latest REVISE design-review verdict; pending a new fresh re-review. No Rust implementation is authorized by this document yet.**
+**Revision 11 after the second 2026-08-30 REVISE design-review verdict, the completed P0-R1 reinvestigation, and the all-active-load-context Mark audit; pending a new fresh re-review. No further Rust implementation is authorized by this document until that review passes.**
 
 Discovery is frozen by `docs/research/bridges/00-system-models/ACTIVE_RETAIL_BRIDGE_COVERAGE_REINVESTIGATION_GHIDRA_REPORT.md` at commit `50d0ef8a`. Ten successive read-only omission audits expanded the boundary to 27 mechanism rows and 31 explicit open questions; the tenth pass added nothing.
 
@@ -26,9 +26,35 @@ decks are already fully stamped and never pass through fixed-map `OverlayClass::
 proves the dormant RMG helper exclusions, the fixed authored-Techno constructor order, the active
 Post-Map starting-force paths, and the class-level constructor invariant that covers every runtime
 Techno creation ingress. The stored constructor word is later read for report-sound selection, so
-it needs a persistent owner. No open or deferred lifecycle term remains.
+it needs a persistent owner. Those generator-phase findings remain closed; the separately discovered
+pre-Fill House/Gather prefix and non-offline Mark-entry contexts are routed below.
 
-The design treats those rows as a coverage map, not as implementation modules. It uses 21 narrower closure units so each builder owns one coherent transaction and every critic receives a bounded requirement, native evidence, diff, and literal validation output.
+The design treats those rows as a coverage map, not as implementation modules. It uses 21 narrower
+implementation transactions to preserve dependency order, but the 27 `BR-M` rows are the closure,
+builder, critic, and publication gates required by this project. A transaction may supply part of
+more than one mechanism, and a mechanism may span more than one transaction; neither fact permits a
+mechanism to inherit another row's pass.
+
+Current implementation baseline is `origin/main` commit `a3e4ce9a` (2026-08-30), not the pre-implementation
+snapshot used by Revision 7. PR #170 has merged P0, transaction 1 (load inputs/raw facts), and
+transaction 2 (RMG low-bridge launch construction), including their focused validation and critic
+corrections. Later merged work also changed ground-height ownership, Drive/Ship slope handling,
+radar-overlay projection, FNPC bridge projection, and waypoint handling. Those changes are evidence
+to preserve, not proof that any remaining `BR-M` row is closed. Before each remaining mechanism is
+contracted, its owner must run a fresh direct disparity scan against then-current `main`; stale Rust
+gap descriptions in the frozen coverage report are historical hypotheses only.
+
+The completed P0-R1 reinvestigation disproves Revision 9's eligible/ineligible split. Current `main`
+does not reproduce the active stock-offline prefix even when a `PreloadedBattleStartPlan` exists:
+native runs a first disposable House construction pass, both active mode Gather callbacks, a zero-draw
+House/type reset, and a second final House construction pass before terrain Fill. P0-R1 must replace
+the optional Battle-only plan with the universal stock-offline transaction below and pass an
+independent builder/critic cycle before transaction 3. The follow-up all-context audit now proves
+the remaining boundary: campaign uses a single `[Houses]`-driven pass; LAN uses the selected
+two-Gather family; WOL state `2` uses common `AssignStartingPoints`; replay inherits its recorded
+campaign/noncampaign family; stream restore and generated `.SED` do not run Mark; and shipped
+`gamemd.exe` has no persistent editor load mode. Transaction 3 must use this typed matrix rather
+than allowing any non-offline context to inherit the stock-offline plan by analogy.
 
 In scope:
 
@@ -170,16 +196,19 @@ Where a consumer currently receives an impoverished Boolean, extend that consume
    and commits neither `.SED` nor sentinel, while accepted result `1` writes `RandMap.Sed`, rebuilds
    the chooser preview, and commits the ordinary sentinel selection.
 5. The accepted preview map and its MapGen continuation are UI/file artifacts, never gameplay map
-   authority. Successful Start creates exactly one gameplay `ScenarioBootstrapRng` in
-   `LoadingRequest` from the match seed. `prepare_battle_start_plan` consumes that owner directly and
-   retains resolved plan outcomes, not a separately seeded cursor. `MapLoadInitial` then carries the
-   same owner into `load_map_from_initial`.
+   authority. Successful Start has exactly one *logical* gameplay Scenario stream beginning at the
+   match seed. Before terrain Fill, every active stock offline noncampaign mode performs the complete
+   two-House-pass/two-Gather transaction defined below. Rust may partially evaluate that transaction
+   into one immutable `PreFillScenarioPrefixPlan`, including default-cell deficient-start retries,
+   only under the full-state equivalence proof below. `LoadingRequest` retains the consumed-once plan
+   and `MapLoadInitial` constructs the sole downstream `ScenarioBootstrapRng` from the same match
+   seed before adopting its validated continuation.
 6. `.SED` reader success runs a second complete generator call from the stored map seed. Native
    launch enters `Full_Init` before the generator's bridge/CABHUT/neutral-Techno phases. Rust matches
-   this nesting by advancing the one `ScenarioBootstrapRng` through house/start-plan work and terrain
-   Fill first, then replaying the launch `RmgConstructionTrace`. `into_simulation` transfers that
-   same cursor so Post-Map and gameplay consumers continue it; no match-seeded parallel cursor or
-   cursor replacement is permitted.
+   this nesting by continuing the one logical Scenario stream through the complete pre-Fill prefix, terrain
+   Fill, and then the launch `RmgConstructionTrace`. `into_simulation` transfers that cursor so
+   Post-Map and gameplay consumers continue it. No independently seeded parallel authority,
+   unchecked cursor substitution, or second downstream continuation is permitted.
 7. Launch replay builds a `GeneratedTechnoInitTable` keyed by stable generated entity index. A
    successful event stores the consumed low word as `techno_ctor_random_word`; a discarded event has
    no binding. `MapLoadInitial` carries the completed table to projection.
@@ -216,8 +245,58 @@ struct GeneratedTechnoInit {
 }
 ```
 
-`LoadingRequest` owns `scenario_bootstrap_rng: ScenarioBootstrapRng`. `MapLoadInitial` carries the
-generated-source identity, `RmgConstructionTrace`, and then the validated generated-init table.
+`LoadingRequest` owns exactly one consumed-once `PreFillScenarioPrefixPlan` for every valid active
+stock offline noncampaign launch. There is no valid no-plan fallthrough and no Battle/FFA
+terrain-independence eligibility gate. The plan is a partial evaluation of this exact native
+transaction on the one match-seeded Scenario stream:
+
+```text
+S0
+  -> House pass 1: H * RandomRanged(450, 1800)
+  -> selected-mode vtable +0x80 Gather/preassignment
+  -> selected-mode vtable +0x84 Gather/assignment/chooser
+  -> rules/type reset and deletion of every pass-1 House (zero draws)
+  -> House pass 2: H * RandomRanged(450, 1800)
+S1
+  -> Fill_In_Data
+```
+
+`H` is the same ordered set in both passes: every human node including observers, every valid AI
+slot, then Neutral and Special. Stock mode IDs `1, 2, 4, 5, 6, 7, 8, 9` use the Battle family and
+ID `3` uses Cooperative; both families execute the `+0x80` and `+0x84` Gather calls. Each deficient
+Gather retry consumes exactly two ranged Scenario draws, Y then X, with no retry cap. It evaluates
+the already-resized but otherwise default `CellClass` state: clear cells, overlay `-1`, level `0`,
+and no occupier, before Fill, Iso, overlays, Terrain, or Technos. A narrow pre-Fill view may therefore
+derive bounds from the verified Size/LocalSize inputs and answer only those default-cell predicates;
+it must not consult later resolved terrain, overlays, occupancy, or bridge state. Sparse preassigned
+start entries below the target count remain in order and the plan retains both Gather vectors and the
+final assignment/chooser result rather than collapsing them into one completed vector.
+
+The accepted generated-map path is not a filename/content inference. A valid preview writes start
+staging in `Scenario + 0x11C0`; successful Start copies that staging before `.SED` regeneration.
+The plan records explicit `AcceptedRmgStartStaging` provenance (or the separately proved authored
+source) so a fresh external `.SED`, a cancelled preview, and an authored map cannot borrow those
+entries. This provenance is independent of the later generated-vs-authored overlay load-source
+discriminator.
+
+The plan contains the complete logical pre-state/fingerprint `S0`, pass-1 House outcomes, both
+Gather outcomes, final assignments, pass-2 House outcomes, and complete post-state/cursor `S1`.
+`MapLoadInitial` creates one `ScenarioBootstrapRng` from the same match seed, requires exact full-state
+equality with `S0`, installs `S1` once, and rejects a second installation because the pre-state no
+longer matches. The plan exposes no RNG interface and is consumed from `LoadingRequest`; later House
+and assignment installation is draw-free. After installation the bootstrap owner alone supplies
+Fill, fixed-map low Mark or generated-construction replay as applicable, Post-Map, and simulation
+draws. This is the same transition as direct execution, not a second gameplay RNG.
+
+Focused tests must compare an independent reference stream across both H-sized House passes, both
+mode-family callbacks, zero/one/many deficient retries, the zero-draw reset, Fill, RMG emitted and
+discarded constructors, Post-Map, and simulation. They must include observers, AI/Neutral/Special,
+Cooperative, sparse input, duplicate-install rejection, tampered pre-state, and accepted generated
+staging provenance. The fresh design critic must recheck this universal transaction,
+single-installation, and downstream-owner model against current `main`; any failure keeps P0-R1 and
+transaction 3 blocked.
+
+`MapLoadInitial` also carries the generated-source identity, `RmgConstructionTrace`, and then the validated generated-init table.
 `GameEntity` owns the installed constructor word. Authored structure upgrades are distinct
 `GameEntity` owners linked by stable parent ID and upgrade slot. The stable generated entity index
 plus type/cell tuple makes a stale or misordered RMG binding a load error rather than silently
@@ -233,15 +312,31 @@ exclusion rather than widening the trace for dormant RMG-shaped code.
 1. After a fixed map is selected, parse it through the normal scenario loader. For `.SED`, first read
    seed/options and run the launch generator inside the load path after the successful-Start RNG reset;
    do not substitute the accepted preview payload.
-2. Apply high structural stamps and later overlay-data replacement in their verified section order.
-3. On fixed authored maps only, run low endpoint/body `OverlayClass::Mark` expansion and its
-   scenario-load RNG draws. On generated maps, preserve the generator's complete direct three-wide
-   overlay/data rectangle and skip Mark entirely; the generated source flag is explicit rather than
-   inferred from overlay ids. This branch follows `InitMapFromSyntheticINI @ 0x00599650` and direct
-   deck writer `0x0058F2C0`: the successful `.SED` arm in `Read_Scenario @ 0x00684620` is exclusive
-   with the ordinary INI/overlay-pack path, so it has no later Mark replay.
-4. Parse explicit `[Tubes]` independently; classify automatic same-cell shells from final theater land data without synthesizing traversal.
-5. Recalculate terrain, records, zones and hierarchy only at the verified load boundary established by units 1, 3, 4 and 5.
+2. For a fresh authored load, initialize the complete Scenario state from the authoritative launch
+   seed before `Start_Scenario`, then select exactly one typed pre-Fill context:
+   - stock offline noncampaign: P0-R1's two House passes, selected `+0x80`, selected `+0x84`, and
+     zero-draw reset;
+   - campaign: one constructor invocation per `[Houses]` row (or every registered HouseType when the
+     section is empty), no multiplayer Gather/chooser and no second pass;
+   - LAN/IPX: network seed plus the selected Battle/Cooperative two-Gather callback family;
+   - WOL state `2`: network seed plus common `AssignStartingPoints`, whose only chooser draws are the
+     zero-occupied player and exactly-two-occupied AI arms;
+   - replay: recorded seed/session and the corresponding campaign/noncampaign family, with no
+     replay-only draw.
+   Fill consumes from and returns the same cursor. A stream restore is a separate no-Full_Init/no-Mark
+   transaction and retains native seed-zero Scenario restore behavior; it never enters this list.
+3. Apply high structural stamps and later overlay-data replacement in their verified section order,
+   only when native `NewINIFormat > 1` permits the pack reader.
+4. On fixed authored maps only, run low endpoint/body `OverlayClass::Mark` expansion inline in decoded
+   y-major/x-minor OverlayPack order using the exact continuation after the selected prefix and Fill.
+   Its successful body cells consume raw Scenario words before authored Techno constructors. On
+   generated maps, preserve the generator's complete direct three-wide overlay/data rectangle and
+   skip Mark entirely; the generated source flag is explicit rather than inferred from overlay ids.
+   This branch follows `InitMapFromSyntheticINI @ 0x00599650` and direct deck writer `0x0058F2C0`:
+   the successful `.SED` arm in `Read_Scenario @ 0x00684620` is exclusive with the ordinary
+   INI/overlay-pack path, so it has no later Mark replay.
+5. Parse explicit `[Tubes]` independently; classify automatic same-cell shells from final theater land data without synthesizing traversal.
+6. Recalculate terrain, records, zones and hierarchy only at the verified load boundary established by units 1, 3, 4 and 5.
 
 #### Path-planning transaction
 
@@ -288,20 +383,26 @@ Explicit `[Tubes]`, bridge trigger actions/events and Psychic Sensor enemy actio
 
 ### 5. Carry evidence and closure state alongside work
 
-Each closure unit progresses through:
+Each mechanism progresses through:
 
 ```text
 FROZEN-COVERAGE -> CONTRACTED -> BUILT+FOCUSED-VALIDATION
                 -> CRITIC-N FINDING/FIX -> CRITIC-N+1 PASS -> CLOSED
 ```
 
-Any new active caller reopens coverage. Any unresolved native term keeps the contract blocked. Any critic finding keeps the unit open. Passing a subset of tests never changes the owning GSI row to closed while another required mechanism is open.
+Any new active caller reopens coverage. Any unresolved native term keeps the contract blocked. Any critic finding keeps the mechanism open. Passing a subset of tests never changes the owning GSI row to closed while another required mechanism is open.
 
-### P0 — shared Techno-constructor RNG prerequisite
+### P0 — shared Techno-constructor RNG prerequisite and P0-R1 prefix correction
 
-Before RMG unit 2 or fixed-low-load unit 3 begins, one builder closes the smallest shared
-constructor prerequisite needed to keep their Scenario continuation exact. This is not a new bridge
-mechanism or a general Techno rewrite. It models the one unconditional raw Scenario draw at
+Before fixed-low-load transaction 3 begins, one builder closes the smallest shared Scenario-prefix
+correction needed to keep its first Mark draw exact. The original constructor P0 and transaction 2
+are merged on current `main`, but P0-R1 is reopened because the merged optional plan omits the first
+House pass, the second Gather in Cooperative, and every valid no-plan stock-offline path. P0-R1 must
+generalize that substrate to the universal transaction above and pass a fresh critic. The completed
+all-context audit supplies transaction 3's campaign/LAN/WOL/replay/save/generated/editor matrix; its
+typed preservation fixtures remain mandatory and cannot be waived by a correct offline fixture. The
+original constructor prerequisite is not a new bridge mechanism or a general Techno rewrite. It
+models the one unconditional raw Scenario draw at
 `TechnoClass__Constructor @ 0x006F3254`, stores the low word as
 `GameEntity::techno_ctor_random_word`, and makes one internal construction funnel assign that field
 exactly once.
@@ -367,22 +468,23 @@ Its required fixtures assert:
 P0 remains open if any active fresh-construction ingress, section/entry order, upgrade event,
 failure boundary, persistent owner, source mode, or cursor transfer is approximate.
 
-## Closure Units and Dependency Order
+## Implementation Transactions and Dependency Order
 
-P0 plus the 21 bridge units below are implementation boundaries, not new architecture layers.
+P0 plus the 21 bridge transactions below are dependency and native-transaction boundaries, not new
+architecture layers and not mechanism pass gates.
 
 | Order | Closure unit | Primary coverage | Dependency / ordinary-play oracle |
 |---|---|---|---|
 | 1 | Theater/rules/assets, raw flags, automatic-shell theater classification, TIBTRE mask preservation | BR-M01, BR-M06, BR-M24 | exact ten piece keys; raw-mask fixtures; automatic-shell corpus verdict; TIBTRE rejects `0x500`; retain raw SpecialFlags/session inputs for unit 10 |
 | 2 | Active RMG preview/accept/`.SED` launch lifecycle, low deck/end/CABHUT production, and waterfall-topology exclusion | BR-M02, BR-M03 | P0 and unit 1; `7fee6929`, `4a63fa15`, `f1e6054b`, `a776f270`; fresh MapGen per run; first-entry/re-entry and no-preview gates; location-free discarded trace events; one launch `ScenarioBootstrapRng`; validated `GeneratedTechnoInitTable`; active-phase-only trace; complete stamped output; no generated Mark replay; `BuildRiverBridge` negative characterization |
-| 3 | Fixed-map low overlay procedural load and Road mutation | BR-M05, BR-M11 | P0 and unit 1; Lost Lake/Killer plus destroyed low fixture; generated-source bypass preserving its full direct deck payload and zero Mark draws |
+| 3 | Fixed-map low overlay procedural load and Road mutation | BR-M05, BR-M11 | P0/P0-R1 and unit 1; complete active load-context cursor audit; Lost Lake/Killer plus destroyed low fixture; exact `NewINIFormat` activation; generated-source bypass preserving its full direct deck payload and zero Mark draws |
 | 4 | High topology, records, zones, hierarchy and edge restamp | BR-M04, BR-M10, BR-M17 | unit 1; Bay of Pigs/Hills and Deadman's Ridge |
 | 5 | Explicit TubeClass load/hierarchy/direction-8/persistence and automatic-shell non-traversal | BR-M12, part of BR-M22 | units 1/4; sealed valid custom tube fixture; zero-length shell negative case |
 | 6 | Dual occupancy, entry, A*, peer markers and locomotor transitions | BR-M07, BR-M09, BR-M13 | units 4/5; deck, under-span, ramp, gap |
 | 7 | Two native post-A* smoothing passes | BR-M25 | unit 6; no wrong-plane shortcut |
 | 8 | Selected-layer scatter/crusher and stuck safety | BR-M23 | unit 6; ten-object order and bridge exemption |
 | 9 | Spawn, Unlimbo, landing, paradrop, teleport and relayers | BR-M08, part of BR-M13/BR-M21 | unit 6; correct list/height after placement |
-| 10 | Impact admission, destruction-authority matrix, Z/family gates and four-path RNG | BR-M16 | units 1/3/4; campaign/editor SpecialFlags vs session option authority, CombatDamage non-owner, CABHUT bypass, strict impact boundary and negative family |
+| 10 | Impact admission, destruction-authority matrix, Z/family gates and four-path RNG | BR-M01, BR-M16 | units 1/3/4; campaign/editor SpecialFlags, complete skirmish and true-network session `BridgeDestruction` handoff, CombatDamage non-owner, CABHUT bypass, strict impact boundary and negative family |
 | 11 | CellSpread bridge-object tolerance | BR-M27 | unit 10; V3WH/V3EWH/DMISLWH plane fixtures |
 | 12 | AoE Rocker admission, enumeration, selected-plane dispatch and exact impulse/timer state | BR-M26 | units 10/11; native numeric attenuation/timer/order oracle plus Rocker-negative case |
 | 13 | High/low ladders, setters and direct walkers | BR-M17 | units 3/4/10; exact mutation/state trace |
@@ -394,6 +496,50 @@ P0 plus the 21 bridge units below are implementation boundaries, not new archite
 | 19 | Tactical inverse, acquisition, Mirage, placement, orders and triggers | BR-M21 | units 4/6/18; deck/under-span interaction fixtures |
 | 20 | Render, split, shadow/railing, PixelFX, action lines, radar/audio | BR-M20 | all sim facts stable; frame/order and raw-bit fixtures |
 | 21 | Save/load/checksum/rebuild and deterministic projection | BR-M22 | all authoritative state stable; continuation oracle |
+
+### Mechanism closure gates
+
+Every `BR-M` row has one persistent builder identity, one complete mechanism contract, and its own
+fresh-critic chain. The builder may work through several dependency transactions, but another
+builder's transaction or critic result cannot close the row. If a builder must be replaced, the
+handoff records the reason, complete evidence/diff/output bundle, and new owner; the row is then
+recriticized from its full requirement rather than only the replacement's last diff.
+
+| Mechanism gate | Contributing transaction(s) |
+|---|---|
+| BR-M01 | 1 and 10 |
+| BR-M02 | 2 |
+| BR-M03 | 2 (negative characterization) |
+| BR-M04 | 4 |
+| BR-M05 | 3 |
+| BR-M06 | 1 |
+| BR-M07 | 6 |
+| BR-M08 | 9 |
+| BR-M09 | 6 |
+| BR-M10 | 4 |
+| BR-M11 | 3 and later mutation-preservation checks in 13/15 |
+| BR-M12 | 5 |
+| BR-M13 | 6 and 9 |
+| BR-M14 | 18 |
+| BR-M15 | 14 and 18 |
+| BR-M16 | 10 and 18 |
+| BR-M17 | 4 and 13 |
+| BR-M18 | 14 and 17 |
+| BR-M19 | 15, 16 and 17 |
+| BR-M20 | 20 |
+| BR-M21 | 9, 18 and 19 |
+| BR-M22 | 5 and 21 |
+| BR-M23 | 8 |
+| BR-M24 | 1 |
+| BR-M25 | 7 |
+| BR-M26 | 12 |
+| BR-M27 | 11 |
+
+A row passes only after all of its contributing transactions, preservation tests, routed open
+questions, and negative facts are exact and a critic who did not build it returns no material
+finding. Split rows therefore remain open after an early transaction. Bundled transactions must be
+decomposed into reviewable mechanism-scoped deltas or a separately named prerequisite commit; a
+shared commit never grants a shared pass.
 
 ### Open-question routing
 
@@ -429,6 +575,14 @@ Every frozen question has a pre-implementation owner. A unit cannot become `CONT
 | OQ-30 Rocker secondary effect | 12 |
 | OQ-31 CellSpread tolerance | 11 |
 
+The destruction-authority matrix has an additional mandatory deferred evidence term already present
+in the frozen source set: the complete UI/session writer chain into `DAT_00A8B260` and the true
+network-multiplayer handoff are not yet proved. Transaction 10 and the BR-M01/BR-M16 mechanism
+contracts must resolve `0x006B8AE0`, `0x006B8CA0`, `0x00671EA0`, and `Full_Init` branches
+`0x0068794D..0x00687966`/`0x00687C16..0x00687C29` against active retail modes. Until that proof or an
+evidence-backed exclusion exists, neither BR-M01 nor BR-M16 may pass. This corrects the design's
+earlier claim of a fully settled matrix; it does not silently add or waive a frozen open question.
+
 The fourth-review prerequisite concerning preview/cancel/accept/`.SED` dual-RNG ownership and the
 Revision-4 critic findings concerning one launch cursor, generated-object bindings and generated
 overlay replay, plus Revision-5 findings concerning discarded-event shape, dormant helper exclusion
@@ -462,19 +616,23 @@ Negative facts are closure requirements, not prose-only cautions. Each routed un
 | no-xref RMG-shaped `0x005A6510`/`0x005A82E0`/`0x005A91E0` are not active generator phases; discarded neutral-Techno events do not invent a final cell | 2 |
 | fixed authored, Post-Map and runtime Techno construction are not RNG-free; generated projection and snapshot restore are not allowed to draw a constructor word again | P0 and 2 |
 
-## Builder and Critic Protocol
+## Builder, Critic, and Publication Protocol
 
-For every closure unit:
+For every `BR-M` mechanism:
 
-1. Resolve its open questions against live `gamemd.exe` and retail data into a sourced implementation contract. OpenTS may locate functions but supplies no required behavior.
-2. Assign one builder. The builder may preserve correct code, replace wrong code, and implement missing code only within that unit and its smallest verified prerequisite.
+1. Resolve every contributing transaction and open question against live `gamemd.exe` and retail data into one sourced mechanism contract. OpenTS may locate functions but supplies no required behavior.
+2. Assign one persistent builder for the mechanism. The builder may preserve correct code, replace wrong code, and implement missing code only within that mechanism and its smallest verified prerequisite.
 3. Check `cargo`/`rustc` ownership before validation. Run focused `cargo test -p vera20k --lib <filter>` commands only; never a bare Cargo test.
 4. Commit the coherent evidence-backed slice after focused validation.
-5. Give a fresh read-only critic who did not build the unit its requirement, native/retail evidence, exact diff, and literal validation output.
+5. Give a fresh read-only critic who did not build the mechanism its complete requirement, native/retail evidence, exact diff, and literal validation output. For a split mechanism, the bundle includes every earlier contributing transaction and preservation test.
 6. If it fails, fix the largest finding, commit the correction, and give the full updated bundle to a new critic. The new critic must recheck prior findings as well as the new diff.
-7. Repeat until a fresh critic passes with no material finding. Approximate or unverified behavior cannot be relabeled residual; the unit and owning rows stay open.
+7. Repeat until a fresh critic passes with no material finding. Approximate or unverified behavior cannot be relabeled residual; the mechanism and every owning row stay open.
+8. After the mechanism pass, push its dedicated `feature/<mechanism>` branch and open a draft PR targeting `main`; publication is preauthorized. Record the contract, exact commits, critic pass, and focused literal output in the PR.
+9. A mechanism PR remains draft because `ENGINE.md` reserves the one full `cargo test -p vera20k --lib` certification for the bridge-wide completion boundary. Do not declare an intermediate PR ready by substituting focused tests for that suite. Opening is authorized here; readiness and merging are not. After opening the first such PR, this autonomous run must stop, report the authority blocker, and request the user/reviewer decision needed to certify and merge it. It may resume the next mechanism only after then-current `main` contains the preceding mechanism; stacking or rewriting around the boundary is forbidden. The design does not claim an internally automatic draft-to-merge transition.
 
-Critics do not edit. Builders do not self-approve. A critic pass proves only the bounded unit, not the bridge system.
+Critics do not edit. Builders do not self-approve. A critic pass proves only the bounded mechanism,
+not the bridge system. The final bridge-wide audit runs the full `--lib` suite exactly once and is the
+only point at which the aggregate completion PR may be declared ready for `main`.
 
 ## Player-Experience Detail Ledger
 
@@ -502,9 +660,14 @@ Critics do not edit. Builders do not self-approve. A critic pass proves only the
 - Every RMG call reconstructs MapGen from the stored map seed. Preview consumes and returns the
   process shell Scenario cursor; successful Start discards that cursor by constructing the gameplay
   Scenario/Main streams from the match seed before `.SED` regeneration.
-- `LoadingRequest` owns one match-seeded `ScenarioBootstrapRng`. Battle-start preloading consumes it
-  in place; `MapLoadInitial` moves it through terrain Fill and ordered RMG construction replay;
-  `into_simulation` transfers it without reseeding, replacement, or a parallel `SimRng`.
+- Every valid active stock offline noncampaign launch owns one immutable
+  `PreFillScenarioPrefixPlan`. It evaluates both H-sized House passes, both mode-family Gather calls,
+  default-cell deficient retries and the zero-draw reset from the match-seeded `S0`; load validates
+  the complete pre-state, installs the exact `S1` once, and then owns every downstream draw. A
+  no-plan stock-offline fallthrough, one-House-pass plan, Battle-only plan, or Cooperative one-Gather
+  path is explicitly nonconforming. Non-offline contexts use the separately proved typed matrix:
+  campaign single House pass, LAN selected callbacks, WOL common assignment, replay inheritance,
+  and save/generated no-Mark boundaries. None may substitute the offline prefix.
 - Generation-time constructor events are authoritative even when the attempted object is later
   deleted. `RmgConstructionTrace` records all attempts. `GeneratedTechnoInitTable` binds the one
   consumed low word for each emitted entity, and validated projection installs
@@ -524,7 +687,7 @@ Critics do not edit. Builders do not self-approve. A critic pass proves only the
 
 ## Validation Strategy
 
-During closure units, use only focused `--lib` tests after confirming no other session owns Cargo. Favor native-trace tables and small retail fixtures over broad certification matrices.
+During mechanism work, use only focused `--lib` tests after confirming no other session owns Cargo. Favor native-trace tables and small retail fixtures over broad certification matrices.
 
 Required fixture families:
 
@@ -559,13 +722,13 @@ Required fixture families:
 - selected and Psychic Sensor action lines;
 - snapshot continuation across active movement, collapse debris and repair.
 
-The full suite `cargo test -p vera20k --lib` runs exactly once after P0 and all 21 bridge units and
-their critic cycles pass, immediately before the bridge-wide reverse audit is declared ready. It is
-not rerun per unit.
+The full suite `cargo test -p vera20k --lib` runs exactly once after P0 and all 27 bridge mechanisms
+and their critic cycles pass, immediately before the bridge-wide reverse audit is declared ready. It
+is not rerun per transaction, mechanism iteration, or intermediate draft PR.
 
 ## Bridge-Wide Reverse Audit
 
-After P0 and all bridge-unit passes:
+After P0 and all bridge-mechanism passes:
 
 1. Start from each active native writer/consumer and prove a Rust owner, exact test or evidence-backed exclusion.
 2. Start from every Rust bridge field, helper, ignored test, approximation marker and branch and prove current active-retail authority or remove/correct it.
@@ -605,13 +768,21 @@ The preferred approach is distributed exact-delta closure in current owners. It 
 - every behavior claim is cited to the frozen native/retail coverage report, the closed dual-RNG
   lifecycle/follow-up report at `7fee6929`, `4a63fa15`, `f1e6054b`, and `a776f270`, or explicitly
   open;
-- all 27 mechanisms map to a closure unit;
+- all 27 mechanisms map to explicit mechanism gates and contributing implementation transactions;
 - all 31 open questions route to a pre-implementation owner and final audit;
 - no chosen interface collapses distinct native facts;
 - the player-experience ledger covers ordinary high/low traversal, combat, collapse/repair, RMG, presentation, content-conditional tubes/triggers and restore;
-- the critic protocol cannot close a unit with unresolved evidence.
-- P0 has a bounded all-ingress constructor requirement and its own builder/fresh-critic cycle before
-  unit 2 or unit 3 can rely on the shared Scenario cursor.
+- the critic protocol cannot close a mechanism with unresolved evidence;
+- the universal stock-offline pre-Fill substitution includes both House passes, both mode-family
+  Gather calls, exact default-cell deficient retries, zero-draw reset and explicit generated-staging
+  provenance on one native Scenario stream, and cannot install stale state, install twice, or leave
+  a parallel downstream owner;
+- intermediate mechanism publication remains draft and merge-gated, while the full `--lib` suite
+  runs exactly once at bridge-wide completion.
+- P0 has a bounded all-ingress constructor requirement and its merged builder/fresh-critic evidence;
+  P0-R1's universal stock-offline prefix correction and fresh critic pass before transaction 3 uses
+  that shared Scenario cursor; and transaction 3 preserves the completed campaign/LAN/WOL/replay/
+  save/generated/editor context matrix without an untyped offline fallback.
 
 Until that review passes, implementation remains blocked by design rather than by user authority.
 
@@ -619,7 +790,11 @@ Until that review passes, implementation remains blocked by design rather than b
 
 - `docs/research/bridges/00-system-models/ACTIVE_RETAIL_BRIDGE_COVERAGE_REINVESTIGATION_GHIDRA_REPORT.md`
 - `docs/research/bridges/00-system-models/RMG_BRIDGE_DUAL_RNG_LIFECYCLE_REINVESTIGATION_GHIDRA_REPORT.md`
+- `docs/research/bridges/00-system-models/SCENARIO_PREFIX_PLAN_INELIGIBLE_FALLBACK_REINVESTIGATION_GHIDRA_REPORT.md`
+- `docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_FIXED_MAP_STAMP_RNG_TRANSACTION_GHIDRA_REPORT.md`
+- `docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_SCENARIO_LOAD_ACTIVATION_BOUNDARY_GHIDRA_REPORT.md`
+- `docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_ALL_LOAD_CONTEXT_SCENARIO_RNG_LIFECYCLE_GHIDRA_REPORT.md`
 - active `gamemd.exe` addresses and retail inputs enumerated by that report
-- current Rust owners at `origin/main` snapshot `0a6e6742`
+- current Rust owners at `origin/main` snapshot `a3e4ce9a`
 - `docs/system-map/topology.v2.json` `bridge-helpers` service boundary
 - `C:\Users\enok\Documents\OpenTS` correspondence ledger, as navigation leads only

--- a/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
+++ b/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
@@ -36,7 +36,7 @@ closure gates. A transaction may supply part of more than one mechanism, and a m
 more than one transaction; neither fact permits a mechanism to inherit another row's pass.
 
 Current implementation baseline is freshly fetched `origin/main` commit
-`5062bceaf15fe5139218d7f3375d34cc8e1d6139` (2026-08-30), with PR #170 merge
+`33a91dae6108868ed8dd52640ca9ec0f387a8e7b` (2026-08-30), with PR #170 merge
 `f4baff6e` confirmed as an ancestor. PR #170 merged P0, transaction 1 (load inputs/raw facts), and
 transaction 2 (RMG low-bridge launch construction), including their focused validation and critic
 corrections. Later merged work also changed ground-height ownership, Drive/Ship slope handling,
@@ -50,10 +50,14 @@ transaction is contracted, its builder runs a fresh direct disparity scan agains
 Living status at this baseline is explicit. P0 and transactions 1 and 2 are merged. BR-M02 and
 BR-M03 passed their bounded PR #170 gates but remain subject to the final reverse audit. BR-M01,
 BR-M06, and BR-M24 have landed contributions but remain open at their routed later consumer or
-reverse-audit gates. P0-R1 is reopened as the next prerequisite. Every other required contribution
-remains open, and GSI-04.12, GSI-04.13, GSI-04.14, and GSI-04.15 remain aggregate-open until all of
-their mechanisms and cross-system consumers pass. This ledger is replaced with current evidence
-after each merged transaction rather than appended as historical prose.
+reverse-audit gates. P0-R1 is the active transaction: its first fresh implementation critic reopened
+accepted-RMG active-waypoint ownership because the builder retained staging for Gather but let the
+regenerated table own loading markers and session/hash. The correction now routes the consumed-once
+active Scenario copy through both consumers; P0-R1 remains open until a subsequent fresh critic
+passes and its PR merges. Every other required contribution remains open, and GSI-04.12, GSI-04.13,
+GSI-04.14, and GSI-04.15 remain aggregate-open until all of their mechanisms and cross-system
+consumers pass. This ledger is replaced with current evidence after each merged transaction rather
+than appended as historical prose.
 
 The completed P0-R1 reinvestigation disproves Revision 9's eligible/ineligible split. Current `main`
 does not reproduce the active stock-offline prefix even when a `PreloadedBattleStartPlan` exists:
@@ -318,14 +322,18 @@ Setup acceptance extracts only those staged start entries plus explicit
 `AcceptedRmgStartStaging` provenance into a consumed-once loading value. Preview terrain, MapGen
 continuation, constructor bindings, and display entities remain presentation/file artifacts and are
 not carried as gameplay authority. Loading consumes the staged-start value exactly once when making
-the prefix plan. A cancelled/replaced preview, authored map, fresh external `.SED`, regenerated
-waypoint inference, construction-trace presence, or unsupported generated/mode combination cannot
-manufacture or borrow this provenance. This gate is independent of the later generated-vs-authored
-overlay load-source discriminator.
+the prefix plan, which retains a raw active-Scenario waypoint table independently of both Gather
+vectors. Random-map loading markers and the live `ScenarioDescriptor` start table read this retained
+copy; `.SED` regeneration may supply the launch map and playfield bounds but cannot retroactively
+replace the active starts already copied by Full Init. A cancelled/replaced preview, authored map,
+fresh external `.SED`, regenerated waypoint inference, construction-trace presence, or unsupported
+generated/mode combination cannot manufacture or borrow this provenance. This gate is independent
+of the later generated-vs-authored overlay load-source discriminator.
 
-The plan contains the complete logical pre-state/fingerprint `S0`, pass-1 House outcomes for
-equivalence checking only, both Gather outcomes, final assignments, pass-2 House outcomes as the
-sole live-House projection source, and complete post-state/cursor `S1`.
+The plan contains the complete logical pre-state/fingerprint `S0`, the retained raw active-Scenario
+waypoint table, pass-1 House outcomes for equivalence checking only, both Gather outcomes, final
+assignments, pass-2 House outcomes as the sole live-House projection source, and complete
+post-state/cursor `S1`.
 `MapLoadInitial` creates one `ScenarioBootstrapRng` from the same match seed, requires exact full-state
 equality with `S0`, installs `S1` once, and rejects a second installation because the pre-state no
 longer matches. The plan exposes no RNG interface and is consumed from `LoadingRequest`; later House
@@ -860,8 +868,9 @@ Required fixture families:
 - source mapping fixtures: Loose and Mix map to authored Mark; Generated maps to materialized/no-Mark
   even with missing or empty construction trace; LegacyFallback and untyped Generic reject rather
   than guessing; accepted generated start staging is distinct from both map source and trace,
-  consumed once, and cannot be inferred from a cancelled/replaced preview, authored map, external
-  `.SED`, regenerated waypoints, or generated construction events;
+  consumed once, retained as the active Scenario start table for loading markers and session/hash,
+  and cannot be inferred from a cancelled/replaced preview, authored map, external `.SED`,
+  regenerated waypoints, or generated construction events;
 - one interleaved authored OverlayPack fixture where an earlier low trigger writes cells and a later
   packed coordinate observes/overwrites them, including a high anchor in the same y/x traversal;
   then a conflicting OverlayData byte must win before the final global Recalc produces the exact Road,

--- a/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
+++ b/docs/plans/2026-08-28-active-retail-bridge-parity-design.md
@@ -8,7 +8,7 @@ The result must preserve behavior that already matches, replace behavior that co
 
 ## Status and Scope Decision
 
-**Revision 11 after the second 2026-08-30 REVISE design-review verdict, the completed P0-R1 reinvestigation, and the all-active-load-context Mark audit; pending a new fresh re-review. No further Rust implementation is authorized by this document until that review passes.**
+**Revision 12 after the third 2026-08-30 REVISE design-review verdict; pending a new fresh re-review. No further Rust implementation is authorized by this document until that review passes.**
 
 Discovery is frozen by `docs/research/bridges/00-system-models/ACTIVE_RETAIL_BRIDGE_COVERAGE_REINVESTIGATION_GHIDRA_REPORT.md` at commit `50d0ef8a`. Ten successive read-only omission audits expanded the boundary to 27 mechanism rows and 31 explicit open questions; the tenth pass added nothing.
 
@@ -50,9 +50,10 @@ native runs a first disposable House construction pass, both active mode Gather 
 House/type reset, and a second final House construction pass before terrain Fill. P0-R1 must replace
 the optional Battle-only plan with the universal stock-offline transaction below and pass an
 independent builder/critic cycle before transaction 3. The follow-up all-context audit now proves
-the remaining boundary: campaign uses a single `[Houses]`-driven pass; LAN uses the selected
-two-Gather family; WOL state `2` uses common `AssignStartingPoints`; replay inherits its recorded
-campaign/noncampaign family; stream restore and generated `.SED` do not run Mark; and shipped
+the remaining boundary: campaign uses a single `[Houses]`-driven pass; LAN and WOL retain both House
+passes plus common `+0x80`, with LAN using selected `+0x84` and WOL state `2` using common
+`AssignStartingPoints` as the second Gather/chooser; replay inherits its recorded campaign/
+noncampaign family; stream restore and generated `.SED` do not run Mark; and shipped
 `gamemd.exe` has no persistent editor load mode. Transaction 3 must use this typed matrix rather
 than allowing any non-offline context to inherit the stock-offline plan by analogy.
 
@@ -318,9 +319,11 @@ exclusion rather than widening the trace for dormant RMG-shaped code.
      zero-draw reset;
    - campaign: one constructor invocation per `[Houses]` row (or every registered HouseType when the
      section is empty), no multiplayer Gather/chooser and no second pass;
-   - LAN/IPX: network seed plus the selected Battle/Cooperative two-Gather callback family;
-   - WOL state `2`: network seed plus common `AssignStartingPoints`, whose only chooser draws are the
-     zero-occupied player and exactly-two-occupied AI arms;
+   - LAN/IPX: network seed -> House pass 1 -> common `+0x80` Gather -> selected Battle or
+     Cooperative `+0x84` second Gather/chooser -> zero-draw reset -> identical House pass 2;
+   - WOL state `2`: network seed -> House pass 1 -> common `+0x80` Gather -> common
+     `AssignStartingPoints` (second Gather plus only the zero-occupied player and exactly-two-occupied
+     AI chooser draws) -> zero-draw reset -> identical House pass 2;
    - replay: recorded seed/session and the corresponding campaign/noncampaign family, with no
      replay-only draw.
    Fill consumes from and returns the same cursor. A stream restore is a separate no-Full_Init/no-Mark
@@ -337,6 +340,33 @@ exclusion rather than widening the trace for dormant RMG-shaped code.
    INI/overlay-pack path, so it has no later Mark replay.
 5. Parse explicit `[Tubes]` independently; classify automatic same-cell shells from final theater land data without synthesizing traversal.
 6. Recalculate terrain, records, zones and hierarchy only at the verified load boundary established by units 1, 3, 4 and 5.
+
+The app layer owns one explicit `ScenarioLoadContextDescriptor`, orthogonal to
+`LoadedMapSource::{Authored, Generated}`. `LoadingRequest` creates it from proven startup/session/
+replay/stream provenance and `MapLoadInitial` carries it through the load. Its normalized prefix kind
+is one of stock offline, campaign, LAN, WOL-state-2, replay-with-recorded-family, or stream restore;
+it contains only the roster/mode/House/start inputs the simulation prefix needs. Network transport,
+replay I/O and UI session types remain in `app`; `sim::scenario_bootstrap` receives the normalized
+kind and inputs, not app or networking dependencies. A seedless/generic current Rust entry may not
+guess stock offline: a surface without proved context provenance returns an explicit unsupported
+load-context result and cannot enter authored Mark. Tests and headless callers must supply a typed
+context deliberately.
+
+Map provenance and load context form two independent gates. A stock-offline context with
+`Generated` source runs the verified prefix but skips authored Mark; an authored campaign/LAN/WOL/
+replay source can run Mark when `NewINIFormat > 1`; stream restore never runs Full_Init or Mark.
+This prevents construction-trace presence, filenames after materialization, or a generic app startup
+variant from standing in for either authority.
+
+`ScenarioBootstrapRng` remains the sole cursor owner. After Fill returns, loading creates a narrow
+borrowed `ScenarioOverlayMarkRng<'_>` (name illustrative) that exposes raw `Next` only, not a ranged
+substitute or a clonable cursor. Inline OverlayPack processing consumes `raw & 3` exactly `3*L`
+times on successful procedural body writes and zero on every fixed/search/no-op/failure arm, then
+returns the same borrow before authored Techno construction. `src/sim/scenario_bootstrap.rs` owns the
+borrow seam; `src/map/overlay.rs` or the narrow low-Mark owner owns the exact tables/loop;
+`src/map/resolved_terrain.rs` receives mutations/recalc results but does not own or reseed Scenario.
+Full logical-state tests bracket prefix, Fill, Mark and the first authored constructor so a hidden
+second cursor, ranged helper or reordered batch cannot pass.
 
 #### Path-planning transaction
 
@@ -372,10 +402,17 @@ Selected-layer scatter/crusher dispatch and stopped-blocked safety are distinct 
 
 #### Restore transaction
 
-1. Deserialize authoritative cell/object/tube/hut/effect/RNG state.
-2. Reconstruct raw/mutable bridge projections without retaining stale derived pointers.
-3. Rebuild records, zones, hierarchy, radar dirties and render snapshots deterministically.
-4. Validate that save/load does not change object plane, tube progress, pending debris or RNG continuation.
+1. Deserialize authoritative cell/object/tube/hut/effect state and the raw serialized RNG fields as
+   separate inputs; do not assume every serialized RNG byte remains the post-load authority.
+2. Apply the proved per-stream restore rule. Scenario's serialized `+0x218` bytes are read and then
+   overwritten by native `Random::Seed(0)`, so the required poststate is the complete seed-zero
+   Scenario state and the restore path runs no Mark. Main and MapGen restore behavior remains open
+   under OQ-19 and transaction 21 until separately proved; neither may inherit Scenario's rule or an
+   unchanged-continuation assumption.
+3. Reconstruct raw/mutable bridge projections without retaining stale derived pointers.
+4. Rebuild records, zones, hierarchy, radar dirties and render snapshots deterministically.
+5. Validate unchanged object plane, tube progress and pending debris; validate Scenario's seed-zero
+   poststate exactly, and validate Main/MapGen only against the later OQ-19 contract.
 
 ### 4. Keep content-conditional mechanisms installed but dormant without data
 
@@ -439,7 +476,8 @@ A later Unlimbo/placement failure never rolls the cursor back. Malformed rows, u
 allocation failure, or another rejection before the native constructor consume zero.
 `PreconsumedGenerated` validates the stable-index/type/cell binding from
 `GeneratedTechnoInitTable`, installs its word and consumes zero. `Restored` reinstates the serialized
-word under the existing native-verified restore cursor contract and consumes zero.
+constructor word and consumes zero; this object-field preservation is independent of the separately
+proved seed-zero Scenario RNG poststate.
 
 Current `parse_map_entities` already preserves the four base section groups, but it must retain the
 structure upgrade count and three type slots. After a base structure successfully Unlimbos, each
@@ -495,7 +533,7 @@ architecture layers and not mechanism pass gates.
 | 18 | Projectile, fire, superweapon and remaining effect-plane consumers | BR-M14, parts of BR-M15/BR-M16/BR-M21 | units 6/10; preserve Bullet crossing and close gates |
 | 19 | Tactical inverse, acquisition, Mirage, placement, orders and triggers | BR-M21 | units 4/6/18; deck/under-span interaction fixtures |
 | 20 | Render, split, shadow/railing, PixelFX, action lines, radar/audio | BR-M20 | all sim facts stable; frame/order and raw-bit fixtures |
-| 21 | Save/load/checksum/rebuild and deterministic projection | BR-M22 | all authoritative state stable; continuation oracle |
+| 21 | Save/load/checksum/rebuild and deterministic projection | BR-M22 | authoritative state/derived rebuild stable; per-stream restore oracle with proved Scenario seed-zero and OQ-19-gated Main/MapGen |
 
 ### Mechanism closure gates
 
@@ -651,7 +689,7 @@ only point at which the aggregate completion PR may be declared ready for `main`
 - `PRESERVATION-BLOCKING` — TIBTRE-driven ore placement must continue rejecting raw structural/destroyed mask `0x500` rather than generalized walkability. Trigger: each `TIBTRE01..03` spread attempt near a bridge. Player effect: ore appears on structural or destroyed bridge cells and changes economy/pathing. Frequency: periodic on maps containing the stock spawning terrain. [BR-M24]
 - `CONTENT-CONDITIONAL-BLOCKING` — valid explicit tubes must load, connect hierarchy, move and persist exactly. Trigger: a valid custom map with `[Tubes]`. Player effect: unusable or nondeterministic tunnel routes. Frequency: zero in scanned shipped maps, guaranteed when authored. [BR-M12, M22]
 - `CONTENT-CONDITIONAL-BLOCKING` — tagged bridge collapse events/actions must reach only the verified footprint. Trigger: authored campaign/custom trigger content. Player effect: scripts fail or unrelated tags fire. Frequency: map-dependent. [BR-M18, M21]
-- `COMPOUNDING` — snapshot/restore must retain authoritative state and rebuild derived state. Trigger: every save/load. Player effect: plane, path, debris or RNG divergence immediately or later. Frequency: every restored bridge-bearing game. [BR-M22]
+- `COMPOUNDING` — snapshot/restore must apply each native persistence transformation and rebuild derived state; Scenario specifically becomes seed-zero rather than retaining its serialized cursor. Trigger: every save/load. Player effect: plane, path, debris or RNG divergence immediately or later. Frequency: every restored bridge-bearing game. [BR-M22]
 - `RESOLVED-EXCLUSION` — TS-only, dormant, editor-only and name-only mechanisms remain excluded. Trigger: future code searches or OpenTS comparison. Player effect if violated: invented behavior and architecture drift. Frequency: development-time risk rather than retail runtime. [negative-fact ledger]
 
 ## Determinism and Persistence
@@ -666,8 +704,9 @@ only point at which the aggregate completion PR may be declared ready for `main`
   the complete pre-state, installs the exact `S1` once, and then owns every downstream draw. A
   no-plan stock-offline fallthrough, one-House-pass plan, Battle-only plan, or Cooperative one-Gather
   path is explicitly nonconforming. Non-offline contexts use the separately proved typed matrix:
-  campaign single House pass, LAN selected callbacks, WOL common assignment, replay inheritance,
-  and save/generated no-Mark boundaries. None may substitute the offline prefix.
+  campaign single House pass; LAN House1/`+0x80`/selected-`+0x84`/reset/House2; WOL
+  House1/`+0x80`/common-assignment/reset/House2; replay inheritance; and save/generated no-Mark
+  boundaries. None may substitute the offline prefix.
 - Generation-time constructor events are authoritative even when the attempted object is later
   deleted. `RmgConstructionTrace` records all attempts. `GeneratedTechnoInitTable` binds the one
   consumed low word for each emitted entity, and validated projection installs
@@ -696,6 +735,19 @@ Required fixture families:
   upgrade; Post-Map starting MCV/extra-unit order including failure; ordinary placed and limbo
   runtime spawns; generated projection spending zero additional draws; and snapshot round trip
   retaining words/upgrade links without a constructor draw;
+- P0-R1 stock-offline prefix fixtures for all ids `1..9`, two identical native-roster House passes
+  including observer and invalid-AI-slot cases, two independent Battle/Cooperative Gathers, sparse and
+  deficient default-cell inputs, zero-draw reset, accepted-RMG staging provenance, exact full-state
+  single installation, duplicate/tampered rejection, and draw-free later assignment projection;
+- typed non-offline load-context fixtures: campaign single House pass and no Gather; LAN full
+  House1/`+0x80`/selected-`+0x84`/reset/House2 sequence; WOL full House1/`+0x80`/common-assignment/
+  reset/House2 sequence with both gated chooser arms; replay adds zero before its recorded family;
+  stream restore performs no Mark and ends Scenario at seed zero; a generic unsupported context
+  cannot guess stock offline; and generated `.SED` retains the stock-offline prefix while its source
+  provenance suppresses Mark;
+- authored low-Mark raw-seam fixtures bracketing full cursor states after prefix, after Fill, after
+  exact `3*L` `raw & 3` writes, and before the first authored Techno; fixed/search/no-op/failure arms
+  draw zero, and no ranged helper or cloned cursor is accepted;
 - Lost Lake and Killer: intact low crossings;
 - Bay of Pigs and Hills: high deck, under-span, dual-plane and AttackMove;
 - Deadman's Ridge: high collapse gap;
@@ -705,7 +757,8 @@ Required fixture families:
   continuing shell Scenario cursor across repeated previews and Cancel; no third Generate on Use Map
   with a preview and exactly one generation on Use Map without one; `.img` versus `.SED` commit gates;
   successful-Start Scenario/Main reseed; unconditional `.SED` regeneration; one launch cursor through
-  plan preload, Fill, ordered construction replay, projection, Post-Map and Simulation; complete
+  the complete stock-offline pre-Fill prefix, Fill, ordered construction replay, projection, Post-Map
+  and Simulation; complete
   constructor-event order including failures; failed-event consume/no-binding and emitted-event
   consume-once/bind/no-double-draw rules; stored `Techno+0x3C8` value per CABHUT; final
   MapGen/gameplay-Scenario continuations; and generated low-deck projection preserving every direct
@@ -720,7 +773,9 @@ Required fixture families:
 - V3WH/V3EWH/DMISLWH AoE tolerance cases plus native-derived Rocker admission, 7x7 enumeration, numeric attenuation, timer jitter, selected-plane and dispatch-order oracles;
 - TIBTRE ore placement and raw-mask negative cases;
 - selected and Psychic Sensor action lines;
-- snapshot continuation across active movement, collapse debris and repair.
+- snapshot restore across active movement, collapse debris and repair, asserting the complete
+  seed-zero Scenario poststate and separately contracted Main/MapGen behavior rather than unchanged
+  generic RNG continuation.
 
 The full suite `cargo test -p vera20k --lib` runs exactly once after P0 and all 27 bridge mechanisms
 and their critic cycles pass, immediately before the bridge-wide reverse audit is declared ready. It
@@ -766,8 +821,8 @@ Yes. A builder may promote only the smallest missing prerequisite necessary for 
 The preferred approach is distributed exact-delta closure in current owners. It is approved only after a separate design-review pass verifies:
 
 - every behavior claim is cited to the frozen native/retail coverage report, the closed dual-RNG
-  lifecycle/follow-up report at `7fee6929`, `4a63fa15`, `f1e6054b`, and `a776f270`, or explicitly
-  open;
+  lifecycle/follow-up report at `7fee6929`, `4a63fa15`, `f1e6054b`, and `a776f270`, the P0-R1 and
+  three low-Mark follow-up reports in Sources, or explicitly open;
 - all 27 mechanisms map to explicit mechanism gates and contributing implementation transactions;
 - all 31 open questions route to a pre-implementation owner and final audit;
 - no chosen interface collapses distinct native facts;
@@ -777,8 +832,14 @@ The preferred approach is distributed exact-delta closure in current owners. It 
   Gather calls, exact default-cell deficient retries, zero-draw reset and explicit generated-staging
   provenance on one native Scenario stream, and cannot install stale state, install twice, or leave
   a parallel downstream owner;
+- the app-owned load-context descriptor is orthogonal to authored/generated map provenance, rejects
+  untyped generic fallback, and normalizes into `sim` without importing app/network dependencies;
+- low Mark borrows the one Scenario owner after Fill through a raw-only seam and returns it before
+  authored Techno construction, with no ranged substitute, clone or second cursor;
+- restore asserts Scenario's verified seed-zero poststate while leaving Main/MapGen explicitly
+  OQ-19-gated rather than claiming generic unchanged continuation;
 - intermediate mechanism publication remains draft and merge-gated, while the full `--lib` suite
-  runs exactly once at bridge-wide completion.
+  runs exactly once at bridge-wide completion;
 - P0 has a bounded all-ingress constructor requirement and its merged builder/fresh-critic evidence;
   P0-R1's universal stock-offline prefix correction and fresh critic pass before transaction 3 uses
   that shared Scenario cursor; and transaction 3 preserves the completed campaign/LAN/WOL/replay/

--- a/docs/research/.swarm-claims.md
+++ b/docs/research/.swarm-claims.md
@@ -2678,3 +2678,24 @@ No code or source-doc patches were applied during this reconciliation per re-swa
 - 2026-08-17T15:43:36+02:00 - slot-1 - RADIO_TECHNO_MISSION_LIFECYCLE_SLOTS - claimed
 - 2026-08-17T15:43:36+02:00 - slot-2 - FOOT_UNIT_MISSION_LIFECYCLE_SLOTS - claimed
 - 2026-08-17T15:43:36+02:00 - slot-3 - AIRCRAFT_BUILDING_MISSION_LIFECYCLE_SLOTS - claimed
+
+## Swarm 2026-08-30T14:07:43+02:00 (Active-retail bridge closure unit 3)
+
+- 2026-08-30T14:07:43+02:00 - slot-1 - LOW_OVERLAY_MARK_FIXED_MAP_STAMP_RNG_TRANSACTION - claimed
+- 2026-08-30T14:07:43+02:00 - slot-2 - LOW_OVERLAY_MARK_SCENARIO_LOAD_ACTIVATION_BOUNDARY - claimed
+- 2026-08-30T14:32:00+02:00 - slot-2 - LOW_OVERLAY_MARK_SCENARIO_LOAD_ACTIVATION_BOUNDARY - done (COMPLETE; authored y-major/x-minor Mark-before-data/recalc/Terrain/Techno ordering and mutually exclusive generated direct-stamp boundary resolved)
+- 2026-08-30T14:34:00+02:00 - slot-3 - SCENARIO_PREFIX_PLAN_INELIGIBLE_FALLBACK - claimed
+- 2026-08-30T14:47:00+02:00 - slot-1 - LOW_OVERLAY_MARK_FIXED_MAP_STAMP_RNG_TRANSACTION - done (COMPLETE; both endpoint families, signed bounds, fixed/search/body geometry, exact 3*L raw Scenario draws, Recalc and all failure/no-op tails resolved)
+- 2026-08-30T15:24:00+02:00 - slot-3 - SCENARIO_PREFIX_PLAN_INELIGIBLE_FALLBACK - done (COMPLETE; active offline two-House-pass prefix, first-pass destruction, two Gather calls/mode chooser, default-cell deficient fallback, and accepted .SED staging provenance resolved; arbitrary external .SED excluded from stock chooser)
+- 2026-08-30T15:24:00+02:00 - parent collection - 3/3 COMPLETE reports present; reconciliation and cold spot-checks in progress
+- 2026-08-30T15:31:00+02:00 - parent spot-check - PASS (Mark trigger bounds/family tables/read-memory constants, first-opposite scan/body loop and raw Scenario+0x218 `Random__Next & 3` inner-three order; ReadMapOverlayPacks sole Full_Init caller, y-major/x-minor pass and later data overwrite; Full_Init first House/callback/reset/Read_INI_Basic/Fill order, second noncampaign Create_Houses, House `RandomRanged(450,1800)`, deleting reset loop, and generated start-staging writes independently rechecked)
+- 2026-08-30T15:31:00+02:00 - swarm complete - 3/3 COMPLETE; no load-bearing BLOCKED/UNKNOWN terms; Unit 3 native transaction is contract-ready after P0-R1 corrects the universal active-offline pre-Fill Scenario prefix
+- 2026-08-30T15:38:00+02:00 - metadata sync - PASS (after all workers stopped: dry-run/apply/save/read-back succeeded for certainty-gated EOL comments at `0x0068745E`, `0x0068ACFF`, `0x0066899F`, `0x00687558`, and `0x00688528`; no speculative rename or type change applied)
+
+## Swarm 2026-08-30T15:40:00+02:00 (Active-retail bridge Unit 3 load-context RNG closure)
+
+- 2026-08-30T15:40:00+02:00 - slot-1 - LOW_OVERLAY_MARK_ALL_LOAD_CONTEXT_SCENARIO_RNG_LIFECYCLE - claimed
+- 2026-08-30T16:12:00+02:00 - slot-1 - LOW_OVERLAY_MARK_ALL_LOAD_CONTEXT_SCENARIO_RNG_LIFECYCLE - done (COMPLETE; fresh campaign, LAN/IPX, WOL, replay, save restore, generated `.SED`, and shipped-gamemd editor boundaries resolved; no behavioral BLOCKED/UNKNOWN remains)
+- 2026-08-30T16:16:00+02:00 - parent spot-check - PASS (`0x0052E619` fresh RNG initialization and `0xFD`-dword Scenario/Main copies; common network picker Scenario receivers at `0x005EE748`/`0x005EE792`; raw stream read then reset-helper call at `0x006894AC..0x006894C5` and seed-zero receiver `0x00683564..0x0068356C`; startup editor flag clear at `0x0052F63E`; campaign `[Houses]` entry loop owner `0x005009B0`)
+- 2026-08-30T16:16:00+02:00 - swarm complete - 1/1 COMPLETE; Unit 3 all-active-load-context first-Mark/no-Mark Scenario authority is contract-ready with the offline-prefix and inner-Mark reports
+- 2026-08-30T16:18:00+02:00 - metadata sync - PASS (after worker completion: dry-run/apply/save/read-back succeeded at `0x005EE748`, `0x005EE792`, `0x006894C5`, and `0x0052F63E`; no rename/type change/speculative metadata applied)

--- a/docs/research/bridges/00-system-models/SCENARIO_PREFIX_PLAN_INELIGIBLE_FALLBACK_REINVESTIGATION_GHIDRA_REPORT.md
+++ b/docs/research/bridges/00-system-models/SCENARIO_PREFIX_PLAN_INELIGIBLE_FALLBACK_REINVESTIGATION_GHIDRA_REPORT.md
@@ -1,0 +1,593 @@
+# Scenario Prefix Plan-Ineligible Fallback — Ghidra Re-investigation
+
+**Address(es):** `0x00686B20`, `0x00687F10`, `0x004F54A0`, `0x004F631F..0x004F634F`,
+`0x00688380`, `0x005D6BE0`, `0x005D6C70`, `0x005D6890`, `0x005C2EF0`,
+`0x005C2D00`, `0x006686C0`, `0x0066899F..0x006689C1`, `0x0068ACAA..0x0068AD04`,
+`0x00565C10`, `0x0047BBF0`, `0x0056DC20`, `0x0056E7C0`, `0x004834A0`,
+`0x00684620`, `0x00598960`, `0x00599650`, `0x00594870`, `0x006F3254`
+**Investigation Mode:** exhaustive-slice
+**Claimed Scope:** The active-retail offline multiplayer Scenario-RNG prefix from the successful
+Start reseed through the first terrain-Fill draw, especially every case for which current Rust
+`preload_standard_battle_start_plan` returns `None`: sparse or deficient starts, custom fixed
+maps, stock non-Battle/FFA modes, Cooperative, and the stock accepted `RandMap.Sed` launch path.
+The report also fixes the exact relative boundary of Fill, authored overlay `Mark`, Terrain and
+Techno construction, without taking ownership of those downstream mechanisms.
+**Non-Scope:** Campaign (`g_GameMode == 0`), online/network assignment when
+`DAT_00A8B244 == 2`, replay playback, malformed external seed files, full terrain-Fill formulas,
+full overlay-Mark parity, Post-Map starting-unit formulas, and runtime gameplay RNG.
+**Confidence:** High. Every load-bearing order edge, active stock mode callback, House count/order,
+House destruction, Gather draw, pre-Fill cell-state dependency, and ordinary `.SED` provenance is
+direct active-binary or YR retail-data evidence. Current Rust findings are from `origin/main`
+`a3e4ce9a`; the investigation worktree remained at `7143d171`, and the relevant production files
+have no intervening diff.
+**Active in YR:** Yes. The prefix runs for every stock offline skirmish launch (`g_GameMode == 5`).
+
+## 0. Working Notes Gate
+
+- **Target question:** What exact Scenario-RNG work must occur before Fill when the current optional
+  preload plan is ineligible, and what is the smallest exact Rust correction?
+- **Prior hypothesis:** Complete Battle/FFA starts could be preloaded, while sparse/deficient and
+  other modes had to wait for a resolved terrain grid after Fill.
+- **Decisive contrary evidence:** Retail creates and destroys a complete first House set, executes
+  both start callbacks, reloads rules, then creates a second complete House set, all before Fill.
+  Deficient Gather sees newly resized default `CellClass` objects, not resolved authored terrain.
+- **Stop condition:** exact first/second House count and order, destruction semantics, both Gather
+  calls, mode dispatch, deficient-cell authority, generated-source provenance, and the first Fill
+  boundary all resolved. This condition is met for the active offline bridge scope.
+
+## 1. Verdict
+
+Current Rust is not cursor-exact in either branch.
+
+The eligible Battle/FFA preload advances only one House-constructor pass. Retail advances two
+identical House-constructor passes, with the start callbacks between them, because the rules/type
+registry reset destroys the first set and `Read_INI_Basic` creates it again. The current
+plan-ineligible fallback is more displaced: it begins Fill with a pristine Scenario cursor, then
+runs Gather and assignment after terrain, overlay, Terrain and authored Techno construction. Native
+runs all of those start-prefix draws before Fill.
+
+Sparse and deficient starts do **not** require resolved terrain. Full Init has already applied
+`[Map] Size`/`LocalSize` and `MapClass__Resize`, so Gather operates on allocated `CellClass` objects,
+but Fill/IsoMapPack, OverlayPack, TerrainClass and Technos have not run. Those fresh cells have the
+constructor defaults: clear land, no overlay, no occupation and no object. The fallback result is
+therefore a function of the match Scenario cursor, authored waypoint slots, session roster,
+MapClass cell-array rectangle, LocalSize/playfield geometry, frame zero, and the native nearby-cell
+scan—not the authored isometric terrain payload.
+
+The smallest exact correction is to replace the eligibility-gated plan with one universal
+stock-offline pre-Fill prefix transaction. It must advance a single `ScenarioBootstrapRng` through:
+
+1. first House pass;
+2. selected mode `+0x80` Gather/preassignment;
+3. selected mode or offline `+0x84` second Gather/assignment;
+4. the draw-free destroy/reset boundary;
+5. second House pass;
+6. then hand the same cursor to Fill.
+
+The transaction retains gathered/assignment outcomes for later House projection; applying them
+after map construction must draw nothing. It uses a narrow default-cell pre-Fill MapClass view,
+not `ResolvedTerrainGrid`.
+
+No load-bearing `BLOCKED` or `UNKNOWN` item remains inside the claimed scope. A filename ending in
+`.SED` is a low-level suffix trigger, but a fresh external `.SED` is not an active stock offline
+chooser boundary: retail loose-map discovery does not add it. The only stock chooser record is the
+synthetic `RandMap.Sed`, created only after the random-map setup has generated/accepted a preview;
+that preview has already populated Scenario start staging. This is an evidence-backed exclusion,
+not an approximation.
+
+## 2. Exact Native Full-Init Order
+
+The noncampaign path through `ScenarioClass__Full_Init @ 0x00686B20` has this fixed order:
+
+| Ordinal | Native operation | Scenario-RNG consequence |
+|---:|---|---|
+| 1 | Scenario clear/default work | no prefix draw established here |
+| 2 | Read active/authored waypoints; random path copies eight staging starts `+0x11C0..+0x11DF` into active waypoint storage `+0x632` | none |
+| 3 | Read general/rule HouseType input | none established |
+| 4 | first `ScenarioClass__Create_Houses @ 0x0068745E` | exactly one ranged invocation per created House |
+| 5 | read `[Map] Size`/`LocalSize`; `MapClass__Resize @ 0x00565C10`; radar/playfield bounds | none |
+| 6 | selected mode vtable `+0x80` at `0x00687558` | first Gather; two ranged invocations per deficient retry |
+| 7 | `DAT_00A8B244 == 2` common assign, otherwise selected mode `+0x84` at `0x0068756B` | offline stock: second Gather plus mode chooser draws |
+| 8 | draw loading screen and reload theater/rules | no Scenario draw found |
+| 9 | `RulesClass__ResetTypeRegistriesAndReloadRules @ 0x006686C0`, call `0x006876AC` | destroys every first-pass House; no Scenario draw |
+| 10 | `Read_INI_Basic`, call `0x00687853`; noncampaign branch calls second `Create_Houses @ 0x0068ACFF` | same one ranged invocation per House |
+| 11 | selected mode vtable `+0x7C` | no Scenario draw in active stock callbacks |
+| 12 | map Read/Fill at `0x006879FF` | first downstream Fill draws |
+| 13 | OverlayPack/OverlayDataPack reader at `0x00687A34` | conditional authored Overlay `Mark` draws after Fill |
+| 14 | cell recalculation and `[Terrain]` | after Overlay packs |
+| 15 | `[Units]`, `[Aircraft]`, `[Infantry]`, `[Structures]` at `0x00687AA7`, `0x00687ABF`, `0x00687ACB`, `0x00687AEA` | each constructed Techno reaches the constructor raw draw |
+
+This is the order the Rust cursor owner must preserve. A later projection may retain precomputed
+outcomes, but no second cursor or cursor replacement can cross these steps.
+
+## 3. The Two House Passes
+
+### 3.1 Count and stable order
+
+`ScenarioClass__Create_Houses @ 0x00687F10` uses the same inputs on both calls:
+
+1. all session human nodes in stable ascending signed node-priority byte `+0x53`; equal priorities
+   retain source order;
+2. valid AI slots in ascending session-slot order, skipping the `-1`/`-3` invalid markers;
+3. `Neutral`;
+4. `Special`.
+
+Let `N_human_nodes = DAT_00A8DA84` and let `N_valid_ai` be the number of valid entries in the AI
+slot range represented by the session AI count (`DAT_00A8B274` in a valid packed stock session).
+Then each pass constructs
+
+```text
+H = N_human_nodes + N_valid_ai + 2
+```
+
+Houses. Observer nodes are included in `N_human_nodes` and therefore consume the House-constructor
+timer draw even though Gather excludes observer humans from its required-start count.
+
+The registry reload replaces HouseType objects but does not mutate the human-node array, AI slot
+array, their ordering keys, or the valid AI count. Consequently the second pass has the same `H`
+and the same semantic roster order as the first. In ordinary offline Rust, where the local human
+and every configured opponent are the packed participants and no observer UI is exposed, this
+reduces to `participants + Neutral + Special`; the implementation should retain the native formula
+rather than bake in that reduced UI assumption.
+
+### 3.2 Exact draw per House
+
+`HouseClass__Constructor @ 0x004F54A0` contains:
+
+```text
+004F631F  PUSH 0x708              ; 1800
+004F6334  PUSH 0x1C2              ; 450
+004F6343  MOV  ECX,[0x00A8B230]
+004F6349  ADD  ECX,0x218           ; Scenario RandomClass
+004F634F  CALL 0x0065C7E0         ; Random__RandomRanged
+```
+
+Thus each pass is `H` logical `RandomRanged(450,1800)` invocations. Each invocation may consume
+more than one raw R250 word because native ranged selection rejects out-of-range samples. Tests
+must compare logical RNG state/cursor, not assume `H` raw words.
+
+### 3.3 The first set is actually destroyed
+
+The reset is not a harmless type reload. Assembly `0x0066899F..0x006689C1` repeatedly:
+
+1. reads `g_HouseClass_Array_Count @ 0x00A80238`;
+2. reads the first pointer from `g_HouseClass_Array @ 0x00A8022C`;
+3. invokes its deleting virtual at vtable `+0x20` with argument `1`;
+4. repeats until the global count is zero.
+
+The deleting destructor removes the entry from the global array, so the loop reaches zero. No
+first-pass House survives into the final scenario. `Read_INI_Basic` then tests
+`g_GameMode @ 0x00A8B238` at `0x0068ACAA`; every nonzero mode reaches
+`ScenarioClass__Create_Houses @ 0x0068ACFF`. Campaign zero takes the separate campaign player path
+and is outside this bridge scope.
+
+This destruction changes object identity but consumes no Scenario RNG. Rust need not allocate and
+delete throwaway House objects if it reproduces their constructor draws and retains no first-pass
+object state as final state.
+
+## 4. Active Stock Mode Dispatch
+
+Retail `MPModesMD.ini` plus direct vtable bytes give the active offline set:
+
+| Stock id(s) | Retail category / display rows | vtable | `+0x80` | `+0x84` | Assignment family |
+|---|---|---:|---:|---:|---|
+| `1`, `9` | Battle, Team Game | `0x007EE184` | `0x005D6BE0` | `0x005D6C70` | Battle-family |
+| `5`, `6`, `7`, `8` | Megawealth, Duel, Meat Grinder, Naval War (`ManBattle`) | `0x007EE50C` | `0x005D6BE0` | `0x005D6C70` | Battle-family |
+| `4` | Unholy Alliance | `0x007EE814` | `0x005D6BE0` | `0x005D6C70` | Battle-family |
+| `2` | Free For All | `0x007EE424` | `0x005D6BE0` | `0x005D6C70` | Battle-family |
+| `3` | Cooperative | `0x007EE27C` | `0x005D6BE0` | `0x005C2EF0` | Cooperative |
+
+All active stock categories therefore execute the common `+0x80` Gather/preassignment first.
+Every Battle-family category executes the common `+0x84`, which gathers again before final House
+assignment. Cooperative `+0x84 @ 0x005C2EF0` also begins by gathering again; it then uses its
+custom chooser `0x005C2D00`. Current Rust's Cooperative fallback reuses the first vector and is one
+Gather short.
+
+Siege has an implemented vtable (`0x007EE6FC`) but no stock retail `MPModesMD.ini` row. It is not an
+active stock offline owner and is excluded rather than inferred into the roster.
+
+`DAT_00A8B244 == 2` selects `AssignStartingPoints @ 0x005EE9D0` instead of the selected `+0x84`.
+The global defaults to zero; complete write-xref review found its writes in network/WOL paths, not
+the offline skirmish shell. Standard `g_GameMode == 5` therefore uses the selected `+0x84` path.
+That network branch is not a reason to approximate or delay the offline correction.
+
+## 5. Gather: Authored, Sparse and Deficient Starts
+
+`ScenarioClass__Gather_Start_Positions @ 0x00688380` executes identically each time it is called.
+
+### 5.1 Target and sparse-slot behavior
+
+1. Scan waypoint indices `0..7` until the first sentinel. This yields `authored_prefix`.
+2. Compute `required = nonobserver_human_nodes + valid_ai_count`.
+3. Set `target = max(authored_prefix, required)`.
+4. Visit waypoint indices `0..target-1`; append every nonsentinel entry encountered.
+5. Generate fallback cells until the vector length reaches `target`.
+
+This is not equivalent to requiring one contiguous vector. A sparse waypoint within
+`0..target-1` is retained even if an earlier slot is sentinel; a sparse waypoint at or above
+`target` is ignored. Explicit-start ownership is by vector/start-slot index after this collection,
+not by a Rust-normalized list that silently closes holes.
+
+### 5.2 Exact draw block
+
+Every fallback attempt at `0x00688528..0x006885B5` performs, in order:
+
+```text
+Y = RandomRanged(0, cell_array_height - 10) + 10 + cell_array_top
+X = RandomRanged(10, cell_array_width  - 10)      + cell_array_left
+candidate = FootClass__Find_Nearby_Passable_Cell((X,Y), footprint=8x8, ...)
+```
+
+The seed rectangle is the MapClass cell-array bounds (`0x0087F90C..0x0087F918`), not LocalSize.
+The nearby helper separately applies the LocalSize/playfield diamond. Each attempt is exactly two
+logical ranged invocations; either may be rejection-capable. A sentinel result retains both draws
+and retries. There is no artificial retry cap.
+
+The first and second Gather calls are independent. Deficient maps can produce different vectors,
+and all retries from the first remain in the cursor before the second begins. The `+0x80` table
+stores explicit ownership by start-vector index; `+0x84` applies those table indices to its fresh
+second vector.
+
+## 6. Why Gather Must Precede Fill
+
+### 6.1 Cell lifetime at the callback
+
+The exact native boundary is:
+
+```text
+Clear_Scene deletes/nulls old CellClass objects
+  -> read [Map] Size / LocalSize
+  -> MapClass__Resize @ 0x00565C10 allocates new CellClass objects
+  -> both start callbacks and both Gather calls
+  -> rules reset and second Houses
+  -> Read/Fill @ 0x006879FF
+```
+
+`MapClass__Resize` constructs a fresh `CellClass @ 0x0047BBF0` for each valid cell in the Size
+diamond. At Gather time the relevant constructor state is:
+
+- `OverlayType = -1` at `Cell+0x44`;
+- land type/default passability class `0` at `Cell+0xEC`;
+- level `0`;
+- occupation fields `Cell+0x124/+0x128 = 0`;
+- no object/Terrain/overlay lists;
+- clear flags.
+
+`CellRect` validation at `0x0056E7C0` and cell passability at `0x004834A0` therefore see clear
+default cells, limited by the MapClass Size/LocalSize geometry. The current frame was reset to zero
+by the scenario-start preparation path, so the nearby search's frame-dependent scan begins from the
+native frame-zero state.
+
+### 6.2 Evidence-backed negative dependencies
+
+The following data cannot affect native deficient Gather because it does not exist yet:
+
+- IsoMapPack tile/subtile/slope or resolved land type;
+- authored OverlayPack/OverlayDataPack;
+- overlay `Mark` expansion;
+- TerrainClass objects;
+- authored Units, Aircraft, Infantry or Structures;
+- any occupancy derived from those objects.
+
+Consequently current Rust's `native_gather_start_positions` dependency on
+`ResolvedTerrainGrid`, post-projection `OccupancyGrid`, and a post-Fill Simulation owner is not a
+native dependency. It both delays the draws and makes the chosen cell sensitive to data retail had
+not loaded.
+
+The correct support object is a narrow pre-Fill MapClass view built from parsed `Size`/`LocalSize`
+and default CellClass values. Reusing the common nearby-search implementation is acceptable only if
+its query can explicitly select that view and reproduce the native 8x8 scan without reading
+resolved terrain, overlays or object occupancy.
+
+## 7. Assignment-Chooser Scenario Draws
+
+### 7.1 Common `+0x80`
+
+`0x005D6BE0` performs the first Gather and writes the explicit ownership/preassignment table at
+Scenario `+0x1180`. It does not own a separate private RNG. Duplicate explicit requests resolve in
+the native House/table order; later `+0x84` reads the completed table.
+
+### 7.2 Battle family
+
+`0x005D6C70` performs the second Gather, builds the occupied table, then walks non-Special Houses.
+An explicitly owned slot is deterministic. For ordinary automatic placement,
+`0x005D6890` uses one `RandomRanged(0,n-1)` when no start is occupied; subsequent automatic choices
+are deterministic maximum-sum-distance selections. If the explicit table is already nonempty, the
+first automatic choice is also deterministic. Observer-specific branches remain represented by
+the native House/session model; the ordinary offline Rust UI currently exposes no observer launch.
+
+### 7.3 Cooperative
+
+`0x005C2EF0` performs the second Gather, then `0x005C2D00` partitions starts by
+`Scenario+0x11E4` (`NumCoopHumanStartSpots`). While the occupied count is below the human House
+count, each automatically assigned human draws `RandomRanged(0,human_start_spots-1)` and linearly
+probes to a free entry. Remaining AI Houses deterministically take the first free suffix entry.
+The Cooperative `+0x7C` callback has no Scenario draw.
+
+These chooser invocations occur between the two House passes. Raw word count remains
+rejection-dependent.
+
+## 8. Generated `.SED` Launch Boundary
+
+### 8.1 Ordinary active retail path
+
+The stock offline chooser does not discover arbitrary `.SED` files as loose maps. Its only random
+record is the synthetic `RandMap.Sed` record created or updated by
+`ChooseMap__AcceptRandomMapSetup @ 0x005E8590`, and that routine is reached only after the modal
+setup returns accepted result `1`. Setup acceptance requires a valid generated preview; Use Map
+with no preview calls the generator once before accepting.
+
+Preview generation reaches `RandomMapGenerator__Generate @ 0x00598960` and
+`RmgRegion__PlaceStartingPoints @ 0x00594870`. The latter clears the eight staging entries to the
+sentinel and then writes generated start cells into Scenario `+0x11C0..+0x11DF`. No path between
+accepted setup and `Main__PrepareSession` clears that staging array. The successful Start reseeds
+Scenario/Main RNG, but the reseed does not overwrite start staging.
+
+At launch, `ScenarioClass__Read_Scenario @ 0x00684620` recognizes the `.SED` suffix, loads the seed
+options, and calls `RandomMapGenerator__Generate(0,0)`. Its nonpreview initialization
+`0x00599650` calls Full Init before launch-time region/start generation. Full Init sees
+`Scenario+0x34BD`, copies the accepted preview staging starts into active waypoint slots, and runs
+the same double-House/two-callback prefix proved above. Later launch generation deterministically
+regenerates terrain and overwrites staging for future use, but that later write cannot retroactively
+change the prefix.
+
+Thus the active accepted `.SED` prefix is fully specified. Rust's regenerated `MapFile` may contain
+the same start cells in a deterministic successful run, but the prefix input should be modeled as
+accepted random-map start staging/source provenance, not inferred from construction-trace presence.
+
+### 8.2 Direct external `.SED` exclusion
+
+The low-level suffix predicate is generic and would accept an externally supplied `.SED` filename
+if some nonstock caller injected it. That is not an active stock offline chooser mechanism:
+
+- loose-map scanning does not create `.SED` scenario records;
+- the synthetic `RandMap.Sed` record is created only after accepted setup;
+- the selected-record loader receives only the chooser's committed record;
+- stock random-map allowance further limits that sentinel to Battle id `1` and FFA id `2`.
+
+Therefore a fresh-process, no-preview direct `.SED` launch is excluded from this bridge row. It is
+not a basis for leaving the active accepted-RMG mechanism approximate. Replay playback and editor
+filename injection are separate owners and remain outside this report's stated scope.
+
+### 8.3 Generated overlay boundary
+
+Synthetic Full Init has no authored OverlayPack payload to replay. Generated low decks are stamped
+directly later by RMG and do not invoke fixed-map `OverlayClass::Mark`. The generated branch must
+therefore execute this prefix, then Fill and the recorded RMG construction trace, without adding an
+authored low/high Mark pass.
+
+## 9. Downstream Fill, Mark and Techno Boundary
+
+This report does not re-own the formulas of GSI-04.12/04.13/04.15; it fixes their cursor entry.
+
+- Fill begins only after the second House pass. Its Scenario draws therefore continue from the
+  complete prefix cursor.
+- Authored OverlayPack reading follows Fill. Procedural low-endpoint `Mark` expansion can consume
+  three Scenario words per longitudinal step, and Mark-created animation construction may consume
+  further Scenario draws. Those belong after Fill, never before either Gather.
+- Cell recalculation and `[Terrain]` follow overlay packs.
+- authored `[Units]`, `[Aircraft]`, `[Infantry]`, `[Structures]` follow Terrain in that order.
+  `TechnoClass__Constructor @ 0x006F3254` takes one raw Scenario word per constructed Techno before
+  later Unlimbo success/failure.
+- generated `.SED` construction events occur after synthetic Full Init on the same owner; they do
+  not justify replaying authored Overlay `Mark`.
+
+Any downstream owner that currently starts from the match seed or the one-pass plan cursor must be
+fed the corrected post-second-House cursor. This report does not certify the downstream mechanism's
+own internal completeness.
+
+## 10. Complete Pre-Fill Scenario Invocation Ledger
+
+For one active offline noncampaign load, the bounded interval from successful-Start reseed to the
+first Fill invocation contains these Scenario consumers, in this order:
+
+| Consumer | Logical ranged invocations |
+|---|---:|
+| first House pass | `H` times `RandomRanged(450,1800)` |
+| `+0x80` first Gather | `2 * A1`, where `A1` is its total fallback attempt count |
+| selected `+0x84` second Gather | `2 * A2`, independently determined |
+| Battle-family chooser | `0` or the conditional first-automatic invocation described above |
+| Cooperative chooser | one invocation for each automatic human-prefix assignment reached |
+| reset/destroy/reload | `0` |
+| second House pass | `H` times `RandomRanged(450,1800)` |
+
+No Scenario call was found in the active stock `+0x7C` callbacks, the House destruction loop,
+Rules registry reload, or the intervening pre-Fill metadata readers. Network-service paths that
+reach random functions in this interval load the distinct Main RNG object `0x00886B88`; they are
+not hidden Scenario draws. Logical invocation counts must be advanced with native rejection, so
+the raw-word delta is seed-dependent.
+
+## 11. Current Rust at `origin/main` `a3e4ce9a`
+
+### 11.1 Production paths
+
+| Rust surface | Current behavior | Exact mismatch |
+|---|---|---|
+| `src/sim/scenario_bootstrap.rs::preload_standard_battle_start_plan` | eligible only for exact metadata identities of Battle id `1` or FFA id `2`, nonempty/non-`auto` selected filename, and a complete contiguous start prefix | excludes ids `3..9`, sparse/deficient/custom identity cases despite active callbacks |
+| same preload | seeds a temporary `SimRng`, advances `participant_count + 2` House ranged calls once, then Battle assignment | omits the second identical House pass; reduced count has no observer/valid-slot model |
+| `PreloadedBattleStartPlan::install_before_terrain` | replaces the fresh loading cursor with the plan's after-cursor | transfer shape is usable, but transferred cursor is incomplete |
+| `src/app/loading/init.rs` | creates `ScenarioBootstrapRng` immediately before terrain Fill and optionally installs the plan | no universal pre-Fill House/start transaction exists |
+| `native_gather_start_positions` | requires `ResolvedTerrainGrid`, occupancy, playfield state and a Simulation-owned cursor | retail Gather uses fresh default cells before Fill; current result can depend on later authored state |
+| `initialize_skirmish_scenario` no-plan branch | after map construction, gathers once for preassignment and again only when non-Cooperative, then assigns | all draws occur after Fill/Mark/Technos; Cooperative is missing its second Gather |
+| House initialization | creates final Rust Houses for projection but spends no second House timer pass | neither plan branch represents both retail construction passes |
+| mode model | `SkirmishGameMode` retains id, override, filter and flags but not the parsed category/vtable family | exact stock family can be recovered from validated stock ids/override; retaining category is cleaner but not required for smallest fix |
+| generated launch | regenerates `.SED`, carries start waypoints and a construction trace | start provenance should explicitly distinguish accepted staging; construction trace cannot stand in for start staging or overlay source |
+
+The relevant files have no `7143d171..a3e4ce9a` diff, so inspecting `origin/main` was not defeated by
+the older worktree checkout.
+
+### 11.2 Existing useful pieces to preserve
+
+- `ScenarioBootstrapRng` is the correct single owner for Scenario/Main/MapGen continuation.
+- `native_assign_launch_starts` models the common Battle-family final chooser.
+- `native_assign_cooperative_launch_starts` models the Cooperative partition/chooser shape.
+- Gather's asymmetric Y-then-X ranged block, uncapped retry, and sparse `0..target` scan are already
+  represented in Rust.
+- loading already has a pre-Fill cursor installation boundary and downstream Fill handoff.
+
+The correction should move and generalize these pieces, not create a bridge-private RNG.
+
+## 12. Smallest Exact Rust Correction
+
+### 12.1 Required production delta
+
+1. Generalize `PreloadedBattleStartPlan` into a stock-offline pre-Fill plan/transaction that is not
+   optional for a valid offline launch. Preserve its prestate fingerprint and immutable outcome
+   handoff.
+2. Derive `H` from the normalized native session roster: human nodes including observers, valid AI
+   slots, then Neutral/Special. Advance first-pass `RandomRanged(450,1800)` in stable House order.
+3. Parse/retain MapClass `Size` and `LocalSize` early enough to create a default-cell pre-Fill view.
+   Run the first Gather and `+0x80` explicit table against that view.
+4. Dispatch the second callback by active stock mode family. Ids `1,2,4,5,6,7,8,9` use the common
+   Battle path; id `3` uses Cooperative. All perform a second Gather.
+5. Preserve both vectors or the exact data needed to apply the `+0x80` table to the second vector;
+   preserve final assignment/start table for later House/base projection.
+6. Cross the reset boundary without RNG, discard all first-pass object identity, then advance the
+   identical second House pass.
+7. Install/continue that exact cursor before terrain Fill. Later scenario initialization consumes
+   the retained assignment and performs zero Gather, chooser or House-timer draws.
+8. Remove filename trimming/`auto` and contiguous-start eligibility as RNG-ownership gates. Invalid
+   launch data should fail at its actual validation boundary, not silently move native prefix draws
+   after Fill.
+9. For accepted generated maps, carry explicit start-staging/source provenance. Continue to suppress
+   authored Overlay Mark for materialized generated decks.
+
+The only new substrate required by this correction is the narrow default-cell pre-Fill MapClass
+view. Full resolved-terrain construction is not a prerequisite.
+
+### 12.2 Required tests
+
+- `scenario_prefix_runs_two_identical_house_passes_before_fill`: include multiple AI slots and an
+  observer-capable roster fixture; assert cursor state after each rejection-capable pass.
+- `scenario_prefix_sparse_waypoints_preserve_only_entries_below_target`: exercise `{0,2}` with
+  target `2` and target `3`.
+- `scenario_prefix_deficient_gathers_are_independent_and_pre_fill`: force a rejected nearby result
+  in each Gather; assert exact two-draw retry continuation and that Fill receives the cursor after
+  the second House pass.
+- `scenario_prefix_gather_ignores_authored_iso_overlay_terrain_and_technos`: two maps with identical
+  Size/LocalSize/waypoints but different downstream payloads must yield the same prefix outcome and
+  cursor.
+- `scenario_prefix_stock_battle_family_ids_share_callbacks`: ids `1,2,4,5,6,7,8,9` all execute two
+  Gathers and the common chooser; id `3` executes two Gathers and Cooperative chooser.
+- `scenario_prefix_coop_does_not_reuse_first_gather`: deficient first/second vectors differ under
+  the same cursor and final assignment uses the second.
+- `scenario_prefix_generated_accept_uses_staged_starts`: accepted `RandMap.Sed` launch consumes the
+  double-House prefix from accepted staging, then performs no fixed-map Mark replay.
+- `scenario_prefix_apply_is_draw_free_after_fill`: applying retained assignments during final House
+  projection must not advance Scenario RNG.
+- one interleaved order oracle: `house1 -> gather1 -> gather2/chooser -> house2 -> fill -> authored
+  low Mark -> Units/Aircraft/Infantry/Structures`, comparing full logical cursor states rather than
+  invocation counters alone.
+
+Focused implementation validation belongs in the relevant `--lib` modules. This research-only
+pass ran no Cargo command and changed no Rust.
+
+## 13. Coverage Ledger
+
+| Mechanism / question | Status | Direct evidence | Remaining work |
+|---|---|---|---|
+| Full Init order through Fill | VERIFIED | `0x00686B20`, call sites listed in section 2 | implementation only |
+| first/second House call activation | VERIFIED | `0x0068745E`, `0x0068ACAA..0x0068AD04` | none |
+| House count and stable order both passes | VERIFIED | `0x00687F10`, session arrays and loop order | none |
+| observer House draw vs Gather exclusion | VERIFIED | `0x00687F10`; Gather node `+0x6B` test | none |
+| House timer RNG owner/range | VERIFIED | `0x004F631F..0x004F634F` | none |
+| first set destruction | VERIFIED | `0x0066899F..0x006689C1` | none |
+| registry reload hidden Scenario draws | VERIFIED NEGATIVE | `0x006686C0` call graph plus direct receiver checks | none |
+| active stock mode callback table | VERIFIED | vtable bytes plus retail `MPModesMD.ini` fixture | none |
+| offline `DAT_00A8B244 != 2` | VERIFIED | initialization and complete write-xref census | network branch out of scope |
+| two Gather calls in Battle family | VERIFIED | `0x005D6BE0`, `0x005D6C70` | none |
+| two Gather calls in Cooperative | VERIFIED | `0x005D6BE0`, `0x005C2EF0` | none |
+| sparse/deficient target algorithm | VERIFIED | `0x00688380` | none |
+| exact fallback draw order/ranges/retry | VERIFIED | `0x00688528..0x006885B5` | none |
+| fallback cell-state authority | VERIFIED | Full Init order, `0x00565C10`, `0x0047BBF0`, `0x0056E7C0`, `0x004834A0` | Rust substrate implementation |
+| fixed authored map activation | VERIFIED | normal `Read_Scenario_INI -> Full_Init` | none |
+| accepted generated `.SED` staging | VERIFIED | `0x00596300`, `0x00594870`, `0x00684620`, `0x00598960`, `0x00599650` | explicit Rust provenance |
+| fresh external `.SED` active chooser reachability | VERIFIED NEGATIVE | sentinel-only creation and no loose `.SED` discovery | excluded |
+| Fill/Mark/Terrain/Techno relative order | VERIFIED | `0x006879FF..0x00687AEA`, `0x006F3254` | downstream owners remain separate |
+| current `origin/main` production/test state | VERIFIED | direct `git show origin/main` reads; no relevant commit diff | implementation only |
+
+## 14. Open Questions — Final State
+
+- `[RESOLVED] OQ-1 - Is there one House pass or two? -> Two for every noncampaign game mode; both
+  precede Fill.`
+- `[RESOLVED] OQ-2 - Does reset retain the first Houses? -> No; the global array is deleting-looped
+  to count zero, then rebuilt.`
+- `[RESOLVED] OQ-3 - Can the second pass differ in roster count/order? -> Not in a valid unchanged
+  session; it uses the same node/AI arrays and stable order after HouseType reload.`
+- `[RESOLVED] OQ-4 - Does Cooperative Gather once? -> No; common +0x80 and Cooperative +0x84 each
+  call Gather.`
+- `[RESOLVED] OQ-5 - Does deficient Gather depend on resolved terrain? -> No; it runs after Resize
+  on default cells and before Fill/overlay/Terrain/Technos.`
+- `[RESOLVED] OQ-6 - Are sparse waypoints rejected wholesale? -> No; nonsentinel entries below the
+  computed target are retained even after a prefix hole.`
+- `[RESOLVED] OQ-7 - Which stock modes share Battle assignment? -> ids 1,2,4,5,6,7,8,9; id 3 is
+  Cooperative.`
+- `[RESOLVED] OQ-8 - What supplies generated launch starts before launch regeneration reaches its
+  start phase? -> accepted preview staging at Scenario +0x11C0, copied by synthetic Full Init.`
+- `[RESOLVED] OQ-9 - Can stock offline launch a fresh external .SED without preview staging? -> No;
+  `.SED` is not loose-map discovered, and the only chooser sentinel is installed after accepted
+  generated preview.`
+
+**BLOCKED:** none inside claimed scope.
+
+**UNKNOWN:** none inside claimed scope.
+
+**Evidence-backed exclusions:** Campaign, network state `DAT_00A8B244 == 2`, Siege without a retail
+row, replay playback, editor/direct filename injection, malformed external seed files, and
+downstream Fill/Mark/Techno internal formulas.
+
+## 15. Ghidra Annotation Candidates
+
+This pass was read-only and changed no Ghidra metadata. Candidates for a later certainty-gated sync:
+
+- `0x0068745E`: comment as first, disposable noncampaign House pass.
+- `0x0068ACFF`: comment as second/final noncampaign House pass after registry reset.
+- `0x0066899F`: comment that the loop deletes House array element zero until count reaches zero.
+- `0x00687558`: comment that all active stock categories enter first Gather through `+0x80`.
+- `0x00688528`: comment that deficient Gather sees resized default cells before Fill.
+
+No rename is required to implement the Rust correction.
+
+## 16. Implementation Handoff
+
+**Implementation readiness:** READY for the active offline bridge scope. The current design's
+optional plan/no-plan split must not be implemented as written; use the universal pre-Fill
+transaction in section 12.
+
+**Primary affected owners:**
+
+- `src/sim/scenario_bootstrap.rs` — plan type, House-pass advancement, Gather input view, mode
+  dispatch, draw-free later application;
+- `src/app/loading/init.rs` — construct/execute the universal transaction before Fill and preserve
+  one cursor;
+- `src/skirmish_modes.rs` or validated launch-mode adapter — retain/derive active stock callback
+  family;
+- map header/pre-Fill substrate — expose Size/LocalSize default-cell MapClass geometry without
+  resolving authored terrain;
+- generated-map launch state — retain accepted start-staging/source provenance.
+
+**Largest regression risks:** advancing House timer calls as raw words instead of native ranged
+invocations; performing only one Cooperative Gather; reading resolved terrain/occupancy during
+fallback; applying retained assignment with a second draw; and replaying fixed-map Overlay Mark on
+generated materialized decks.
+
+## 17. Sources
+
+- Fresh read-only Ghidra decompile/disassembly/callgraph/xref work in active retail
+  `gamemd.exe`: all addresses in the report header, plus `ScenarioClass__Constructor @ 0x006832C0`,
+  `ScenarioClass__Set_Defaults @ 0x00683610`, and `Main__PrepareSession @ 0x0052D9A0`.
+- YR retail roster fixture derived from `MPModesMD.ini`:
+  `tests/fixtures/ini/mpmodesmd_stock_contract.ini`.
+- Current Rust at `origin/main` `a3e4ce9a`: `src/sim/scenario_bootstrap.rs`,
+  `src/app/loading/init.rs`, `src/skirmish_modes.rs`, `src/app/random_map_lifecycle_tests.rs`.
+- Reconciled prior native reports:
+  `RMG_BRIDGE_DUAL_RNG_LIFECYCLE_REINVESTIGATION_GHIDRA_REPORT.md`,
+  `RANDOM_SCENARIO_ENGINE_SUBSTRATE_SERVICE_STUDY.md`,
+  `SKIRMISH_GATHER_START_POSITIONS_AND_BATTLE_ASSIGNMENT_GHIDRA_REPORT.md`,
+  `SKIRMISH_START_TO_FULL_INIT_SPAWN_TRACE.md`,
+  `SKIRMISH_SELECTED_MPMODE_OBJECT_INI_OVERRIDE_LOAD_GHIDRA_REPORT.md`,
+  `SKIRMISH_RANDMAP_SED_RANDOM_MAP_BEHAVIOR_GHIDRA_REPORT.md`, and
+  `SKIRMISH_RANDOM_MAP_BRANCH_AFTER_SELECTED_MAP_LOAD_GHIDRA_REPORT.md`.
+- `C:\Users\enok\Documents\OpenTS` was consulted only as a readable navigation lead for inherited
+  scenario/map/start concepts. Every material conclusion above was independently verified in active
+  YR `gamemd.exe` and retail data; no OpenTS behavior is parity authority.

--- a/docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_ALL_LOAD_CONTEXT_SCENARIO_RNG_LIFECYCLE_GHIDRA_REPORT.md
+++ b/docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_ALL_LOAD_CONTEXT_SCENARIO_RNG_LIFECYCLE_GHIDRA_REPORT.md
@@ -1,0 +1,165 @@
+# Low Overlay Mark: All Active Load-Context Scenario RNG Lifecycle
+
+Date: 2026-08-30
+Status: **COMPLETE**
+System: active-retail YR authored low-overlay Mark ordering and Scenario RNG authority (GSI-04.13; shared GSI-04.12 load boundary)
+
+## Verdict
+
+Every active `gamemd.exe` path that can reach authored `OverlayClass::Mark @ 0x005FC570` now has an exact incoming Scenario-RNG owner and prefix disposition. Fresh campaign, LAN/IPX, WOL, and replay loads all use the ordinary `Read_Scenario -> Full_Init -> ReadMapOverlayPacks` path and run Mark only when `[Basic] NewINIFormat > 1`. They do not share one pre-Fill prefix:
+
+- campaign constructs one `[Houses]`-driven House set before Fill and skips multiplayer Gather/assignment;
+- active LAN/IPX and ordinary noncampaign modes construct a disposable House set, run two Gather/assignment callbacks, delete the first set without RNG, and construct the final House set before Fill;
+- WOL state `2` replaces the selected `+0x84` callback with common `AssignStartingPoints`, including two tightly gated chooser draws;
+- replay supplies the recorded seed/session, then follows the matching campaign or noncampaign family without an extra Scenario draw;
+- savegame restore, accepted generated `.SED`, and a `gamemd.exe` editor load are evidence-backed no-Mark/excluded boundaries.
+
+After the context prefix, native Fill owns any Fill draws and passes the same `Scenario+0x218` cursor to the y-major/x-minor OverlayPack pass. Successful procedural low triggers then consume exactly `3*L` raw words before authored Techno construction. There is no mode-local replacement cursor at Mark.
+
+No load-bearing `BLOCKED`, `UNKNOWN`, approximate, or residual behavior remains in this load-context slice.
+
+## Evidence discipline
+
+- Active-retail authority is the live `gamemd.exe` program plus retail INI/map data.
+- `C:\Users\enok\Documents\OpenTS` was used only to navigate inherited scenario-start families. No OpenTS behavior is accepted without active-YR proof.
+- This report extends the bounded offline proof in `SCENARIO_PREFIX_PLAN_INELIGIBLE_FALLBACK_REINVESTIGATION_GHIDRA_REPORT.md`; it does not weaken or replace that report's exact stock-offline transaction.
+- The parent cold-checked the fresh seed copy, both common network picker draw sites, stream-load seed-zero reset, startup editor-flag clear, and first Start_Scenario call sites after the worker completed.
+
+## Common fresh-start owner
+
+`Main_Game @ 0x0052D9A0` calls `Init_Random_Number_System @ 0x0052FC20` at `0x0052E619`, before either `Start_Scenario` call at `0x0052E718` and `0x0052E745`.
+
+Both arms of `Init_Random_Number_System` seed a local Random object from current `g_RngSeed`, copy exactly `0xFD` dwords into `ScenarioClass + 0x218`, reseed from the same value, and copy `0xFD` dwords into Main RNG. MapGen is not involved. Therefore every fresh-load prefix below starts from a complete Scenario logical state produced from the authoritative launch seed, not from a draw count or a reconstructed partial cursor.
+
+## Active context matrix
+
+| Context | Seed authority | Prefix before Fill | Mark disposition |
+|---|---|---|---|
+| Campaign authored map | fresh `g_RngSeed` through `0x0052FC20` | one campaign House construction pass; no multiplayer callbacks | ordinary reader; Mark iff `NewINIFormat > 1` |
+| LAN/IPX Battle-family | host/guest network seed | House pass 1 -> Gather `+0x80` -> selected Battle `+0x84` Gather/chooser -> zero-draw reset -> House pass 2 | ordinary reader; Mark iff `NewINIFormat > 1` |
+| LAN/IPX Cooperative | host/guest network seed | House pass 1 -> Gather `+0x80` -> Cooperative `+0x84` Gather/chooser -> zero-draw reset -> House pass 2 | ordinary reader; Mark iff `NewINIFormat > 1` |
+| WOL state `2` | network session seed | House pass 1 -> Gather `+0x80` -> common `AssignStartingPoints` (second Gather + gated chooser) -> zero-draw reset -> House pass 2 | ordinary reader; Mark iff `NewINIFormat > 1` |
+| Replay playback | recorded `g_RngSeed`, scenario filename and session block | corresponding recorded campaign/noncampaign family; no replay-only draw | ordinary reader; Mark iff recorded map has `NewINIFormat > 1` |
+| Savegame stream restore | serialized stream, then native seed-zero reset | no Full_Init prefix | **No Mark**; stream content loader never enters the scenario/overlay-pack reader |
+| Accepted generated `.SED` | match seed for Scenario; independent MapGen seed for geometry | synthetic Full_Init is followed by direct generation | **No Mark**; synthetic `NewINIFormat` defaults to `0`, later deck writer is direct |
+| Map editor | none in shipped `gamemd.exe` | persistent flag is forced off | **Excluded**; FinalAlert is a separate executable |
+
+## Campaign prefix
+
+Campaign reaches the same ordinary `Full_Init` overlay call at `0x00687A34`, but it does not execute the noncampaign two-House/two-Gather transaction.
+
+Its exact pre-Fill Scenario order is:
+
+```text
+Seed
+  -> one RandomRanged(450,1800) House constructor invocation per [Houses] row
+     (if the section is empty, FUN_005009B0 constructs every registered HouseType instead)
+  -> Fill_In_Data
+  -> authored OverlayPack Mark, when NewINIFormat > 1
+```
+
+There is no disposable House set, no multiplayer Gather callback, no multiplayer chooser, and no second House pass. Retail campaign maps inspected for this boundary use `NewINIFormat=4` with both overlay packs, so this is active rather than a hypothetical branch.
+
+Fill is on the same cursor. The inspected Scenario-RNG receiver set shows clear/missing Fill consumes zero; Water consumes one rejection-capable `RandomRanged(0,3)` per allocated cell. Mark must receive the actual continuation after those calls rather than a campaign seed or House-only reconstructed cursor.
+
+## LAN/IPX and WOL prefixes
+
+LAN/IPX seed authority is network-owned: the host path is rooted at `0x005B82F0`; the guest reads the packet seed at offset `+0x92` in `0x005B67F0`. LAN sets `g_GameMode=3` and adjacent state `0x00A8B24C=2`; it does **not** set WOL selector `0x00A8B244=2`. Active LAN therefore uses the selected mode `+0x84` callback after the common `+0x80` callback.
+
+Battle-family and Cooperative both Gather twice. Each deficient Gather retry consumes its exact Y-then-X ranged calls against the resized default-cell map, as proved by the offline prefix report. Their chooser differences are retained:
+
+- Battle-family automatically draws `RandomRanged(0,N-1)` only for the first automatic non-Special House when no start is occupied; later choices are deterministic maximum-distance selections.
+- Cooperative automatically assigned humans draw within the human-start prefix and probe forward; AI suffix assignment is deterministic.
+
+The compiled WOL-state-`2` branch calls `AssignStartingPoints @ 0x005EE9D0`. That function first Gathers, then uses picker `0x005EE6F0`. Its only Scenario chooser draws are:
+
+1. player-controlled pass, receiver `0x005EE748`: an unassigned House draws rejection-capable `RandomRanged(0,N-1)` only while occupied count is zero; at most one such draw can occur;
+2. AI pass, receiver `0x005EE792`: an unassigned AI draws rejection-capable `RandomRanged(0,N-3)` only while exactly two starts are occupied, selecting that ordinal among free starts; at most one such draw can occur.
+
+Every other common picker arm is deterministic. After the selected or common assignment callback, rules/type reset deletes the first House set without Scenario RNG, `Read_INI_Basic` creates the same ordered final House set with the same `RandomRanged(450,1800)` constructor invocation per House, and Fill continues the cursor.
+
+## Replay
+
+Replay playback is a fresh scenario start, not savegame restoration. Its header supplies `g_RngSeed`, scenario filename, and the recorded session block. Playback calls the normal RNG initializer and then `Start_Scenario(-1)`. It adds zero Scenario calls before Mark and inherits the corresponding campaign/noncampaign prefix selected by the recorded session. A recorded ordinary authored map reaches Mark only when `NewINIFormat > 1`.
+
+## No-Mark and excluded contexts
+
+### Savegame restore
+
+`ScenarioClass::Save_To_Stream @ 0x00689310` writes the raw `0x3740`-byte Scenario block, physically including `+0x218`. `ScenarioClass::Load_From_Stream @ 0x00689470` reads it at `0x006894AC..0x006894B7` and immediately calls `0x00683560` at `0x006894C5`; `0x00683564..0x0068356C` pushes `0`, takes `Scenario+0x218`, and calls `Random::Seed`.
+
+Thus native overwrites the serialized Scenario cursor with seed-zero state. More importantly for this mechanism, `Load_Game_Content_From_Stream @ 0x0067E730` does not call `Read_Scenario`, `Full_Init`, `ReadMapOverlayPacks`, or `OverlayClass::Mark`. Restore has no first-Mark cursor and must not replay low endpoint expansion.
+
+### Accepted generated `.SED`
+
+The `.SED` arm and ordinary INI reader are mutually exclusive. Its early synthetic Full_Init omits `NewINIFormat`, so the default `0` makes `ReadMapOverlayPacks @ 0x005FD2E0` return. Later MapGen stamps complete low decks directly without Overlay construction, Unlimbo, or Mark. Generated materialization consumes exactly zero authored-Mark Scenario words.
+
+### Editor
+
+Persistent `g_IsMapEditor @ 0x00A8ED6B` is unconditionally cleared at startup parser `0x0052F63E`; no enable switch was found. The only other writer in `0x005A91E0` saves, temporarily sets, and restores the byte inside gameplay and is not a load entry. FinalAlert is a separate executable. Shipped `gamemd.exe` therefore has no active editor scenario-load context to implement.
+
+## Mark boundary shared by every positive context
+
+- Fill `0x004ACE70` precedes the sole `ReadMapOverlayPacks @ 0x005FD2E0` call at `Full_Init + 0xF14 @ 0x00687A34`.
+- Pack traversal is fixed 512x512, y-major then x-minor.
+- Ordinary low body/end identities call ordinary Mark and consume zero low-procedural RNG.
+- Successful triggers `0x7A..0x7D` and `0xE9..0xEC` consume exactly `3*L` raw `Scenario+0x218 Random::Next` calls, opposite-end toward trigger, with inner order `j=0,1,2`.
+- Fixed-row writes, scans, occupied no-op, missing opposite, all failure arms, and generated direct decks consume zero low-Mark words.
+- Mark completes before authored Unit, Aircraft, Infantry, and Structure constructors consume their own Scenario words.
+
+The 385-payload shipped-data census contains zero procedural low triggers, so shipped maps execute zero `3*L` transactions while still exercising ordinary low-row Mark. Procedural expansion remains active content-conditional retail behavior and requires a synthetic authored retail-rules fixture.
+
+## Current Rust mismatch and implementation handoff
+
+Current `origin/main` has one optional Battle/FFA `PreloadedBattleStartPlan` and an incidental generated-source proxy. It does not own the complete context matrix above.
+
+Required deltas before BR-M05 can pass:
+
+1. Replace the optional stock-offline plan with the universal two-House/two-Gather P0-R1 transaction from the companion report.
+2. Give campaign and network/replay entry points typed, provenance-bearing prefix owners. Do not substitute the offline callback family for campaign or WOL state `2`.
+3. Pass one complete Scenario cursor through context prefix and Fill, then expose a narrow raw-word seam to inline low Mark before authored Techno construction.
+4. Preserve savegame restore as no-Mark with native seed-zero Scenario restoration behavior.
+5. Preserve `GeneratedMaterialized` as no-Mark, derived from explicit `.SED`/generation provenance plus native `NewINIFormat > 1`, never from construction-trace presence or overlay geometry.
+6. Test full logical cursor states, not invocation counters, across campaign, LAN Battle, LAN Cooperative, WOL state `2`, replay inheritance, save restore, generated `.SED`, and authored successful/no-op/failure low triggers.
+
+The narrow bridge requirement is the exact cursor at Mark. This report does not require inventing unsupported network transport or campaign UI; it requires any active loader context VERA20k exposes to carry the correct typed native prefix, and requires unsupported surfaces to remain explicit rather than silently borrowing offline state.
+
+## Coverage closure
+
+| Question | Verdict |
+|---|---|
+| common fresh Scenario seed owner | VERIFIED |
+| campaign first-Mark prefix | VERIFIED |
+| LAN/IPX seed and selected callback family | VERIFIED |
+| WOL common assignment draws | VERIFIED |
+| replay extra-draw question | VERIFIED NEGATIVE |
+| savegame Mark replay | VERIFIED NEGATIVE |
+| generated `.SED` Mark replay | VERIFIED NEGATIVE |
+| shipped `gamemd.exe` editor load | VERIFIED EXCLUDED |
+| Fill-to-Mark shared cursor | VERIFIED |
+| procedural Mark draw owner/order | VERIFIED |
+
+**BLOCKED:** none.
+
+**UNKNOWN:** none.
+**Implementation readiness:** READY when combined with the offline prefix and low-Mark inner-algorithm reports.
+
+## Certainty-gated metadata sync
+
+After all workers stopped, the parent dry-ran, applied, saved, and read back EOL comments at:
+
+- `0x005EE748` and `0x005EE792` for the two gated common network picker draws;
+- `0x006894C5` for stream-load seed-zero/no-Mark behavior;
+- `0x0052F63E` for the shipped `gamemd.exe` editor exclusion.
+
+No rename, type change, speculative comment, or concurrent metadata mutation was applied.
+
+## Sources
+
+- active-retail `gamemd.exe` addresses enumerated above;
+- retail `rulesmd.ini`, `MPModesMD.ini`, and inspected campaign/map payloads;
+- `LOW_OVERLAY_MARK_SCENARIO_LOAD_ACTIVATION_BOUNDARY_GHIDRA_REPORT.md`;
+- `LOW_OVERLAY_MARK_FIXED_MAP_STAMP_RNG_TRANSACTION_GHIDRA_REPORT.md`;
+- `SCENARIO_PREFIX_PLAN_INELIGIBLE_FALLBACK_REINVESTIGATION_GHIDRA_REPORT.md`;
+- current Rust owners on `origin/main`;
+- `C:\Users\enok\Documents\OpenTS` as navigation leads only.

--- a/docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_FIXED_MAP_STAMP_RNG_TRANSACTION_GHIDRA_REPORT.md
+++ b/docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_FIXED_MAP_STAMP_RNG_TRANSACTION_GHIDRA_REPORT.md
@@ -1,0 +1,161 @@
+# Low Overlay Mark: Fixed-Map Stamp and Scenario-RNG Transaction
+
+Date: 2026-08-30
+Status: **COMPLETE for the bounded inner-algorithm slice**
+System rows: GSI-04.13 primary; GSI-04.12 source exclusion; GSI-04.15 negative Tube separation
+
+Activity vocabulary in this report is literal. **Active in YR: Yes** means the behavior is reached by stock YR content. **Conditional** means active executable code plus retail-declared data/art can reach it, but the scanned shipped-map corpus does not contain its trigger. **No** marks a disproved/foreign mechanism. Every binary behavior below carries one of those labels; OpenTS is never parity evidence.
+
+## Target question
+
+Resolve the complete active-retail `OverlayClass::Mark @ 0x005FC570` transaction for authored low/water-bridge endpoint triggers: entry/activation predicates; both endpoint families and exact tables; signed coordinate and lookup order; three-cell fixed-end clear/write behavior; opposite-end search and termination; body length, traversal, overwrites, variants, exact RNG owner/calls/order; `RecalcAttributes`, LAT, zone, radar, and dirty effects; return/failure state; loader ordering; and evidence-backed exclusions.
+
+## Non-goals
+
+- Rust implementation, RMG generation internals, damage/repair, high-bridge stamping, or explicit/automatic Tube implementation.
+- Declaring OpenTS behavior to be YR behavior. `C:\Users\enok\Documents\OpenTS\code\overlay.cpp:234..302` was used only to locate candidate tables and control flow; all facts were independently checked in active `gamemd.exe` and retail YR rules/data.
+- Expanding the neighboring scenario-load report's Techno/RNG timeline except where it proves this transaction's owner and ordering.
+
+## Evidence needed to mark COMPLETE / stop conditions
+
+COMPLETE required: (1) decompile plus instruction evidence for every activation bound, signed coordinate operation, table, loop bound, lookup/write order, draw site, return arm, and side-effect call; (2) caller/xref proof for authored loading and RNG ownership; (3) INI/default plus binary reader proof for every load-bearing low-overlay property; (4) a read-only retail-map census; (5) direct current-Rust read; (6) five adversarial cases, two cold binary rechecks, and a zero-additional-mechanism pass. Any unresolved activation, loop-bound, RNG, Recalc, radar/dirty, or source term was a PARTIAL stop. None remains.
+
+## Primary evidence ledger
+
+- **Active in YR: Conditional.** Ghidra MCP read-only calls: `decompile_function(0x005FC570)`, `disassemble_function(0x005FC570)` (load-bearing ranges `0x005FC570..0x005FD227`, wood `0x005FC790..0x005FCB9F`, concrete `0x005FCBB9..0x005FCFCD`, common tail `0x005FD1FA..0x005FD227`), `get_function_callees(0x005FC570)`, and `read_memory(0x008333C0..0x00833447)`. No Ghidra metadata was mutated.
+- **Active in YR: Conditional.** Supporting read-only decompile/disassembly: `ObjectClass::Mark 0x005F5850`, `ObjectClass::Unlimbo 0x005F4EC0`, `ObjectClass::MarkNeedsRedraw 0x005F4D10`, dirty owner `0x004F42F0`, `ObjectClass::UnInit 0x005F65F0`, `MapClass::Get_CellClass 0x005657A0`, bounds `0x00568300`, `CellClass::RecalcAttributes 0x0047D2B0`, LAT/slope `0x0047CA80`, zone `0x00483C80`, `Random::Next 0x0065C780`, and `ReadMapOverlayPacks 0x005FD2E0`.
+- **Active in YR: Conditional.** Table construction is corroborated by disassembly stores into lazy statics at `0x00AC154C..0x00AC15B7`, guarded by bits `1/2/4/8` of `0x00AC1548`. `FUN_007C978A -> 0x007C970C` only registers static destructors with CRT `atexit`; it is not RNG or gameplay work.
+- **Active in YR: Conditional.** Runtime IDs were mapped to names by dense registry order from retail-derived `C:\Users\enok\Documents\ra2-oracle-movement-emitter\ini\rulesmd.ini:[OverlayTypes]`, not by sparse numeric key. Properties were checked in sections `LOBRDG01..25`, `LOBRDGE1..4`, `LOBRDB01..25`, and `LOBRDGB1..4`; binary readers/defaults are `OverlayTypeClass::ReadINI 0x005FE770` and constructor `0x005FE250`.
+- **Active in YR: Conditional.** The companion activation report proves `Full_Init -> ReadMapOverlayPacks @ 0x00687A34`, y-major/x-minor construction, constructor -> Unlimbo -> virtual `Mark(1)`, and the later OverlayData pass. This report independently rechecked the relevant bodies and call sites.
+
+## Activation and lifetime
+
+- **Active in YR: Conditional.** Authored packed overlays reach the function only when `[Basic] NewINIFormat>1`, the decoded ID is not `0xFF`, the cell is accepted/in-bounds and allocated, the type exists, and it has SHP art or `CellAnim`; the reader constructs one ephemeral `OverlayClass` synchronously in decoded order. Retail endpoint sections name loadable images. (`ReadMapOverlayPacks 0x005FD2E0`, constructor call `0x005FD4D2`, `Unlimbo` dispatch `0x005F4FB0..0x005F4FB4`.)
+- **Active in YR: Conditional.** Inside `Mark`, `ObjectClass::Mark(this,mark)` must first return true; derived processing then requires `mark==1 || mark==3`. The packed-loader call is `mark=1`. (`0x005FC58A..0x005FC5A4`.)
+- **Active in YR: Conditional.** The coordinate is obtained through vtable `+0x1B8`; the ordinary object coordinate converts world X/Y to cells with signed, toward-zero division by 256 and is packed as two signed i16 components. (`ObjectClass::Get_Cell_Packed 0x0041BEA0`; entry call `0x005FC5AA..0x005FC5C6`.) All endpoint additions are 16-bit stores/adds; lookups and distance arithmetic sign-extend those i16 values.
+- **Active in YR: Conditional.** Universal derived gate: if initiating `Cell+0x11C SlopeIndex > 4`, return false unless the unrelated overlay runtime ID is exactly `0xB2`. Both low trigger ranges therefore reject slopes 5..255 before any low fixed/body write. (`0x005FC5E0..0x005FC5F4`.) Loading suppression bypasses later ordinary placement checks, but not this gate.
+- **Active in YR: Conditional.** The only procedural low trigger ranges are inclusive `0x7A..0x7D = LOBRDGE1..4` and `0xE9..0xEC = LOBRDGB1..4`; comparisons are `0x005FC790..0x005FC7A2` and `0x005FCBB9..0x005FCBCB`. Body/fixed IDs outside those ranges take ordinary Mark and never recurse into this transaction.
+- **Active in YR: Conditional.** Once either family branch is selected, it bypasses ordinary passability/`Overrides` placement checks. After any branch-local no-op or writes, it always uses the common success tail, returns true, and logically deletes the ephemeral overlay object.
+- **Active in YR: No (stock shipped-map activation).** A read-only LCW OverlayPack census found zero trigger bytes in 385 shipped/installed payloads: 53 loose maps; `mapsmd03.mix` 14; `multimd.mix` 173; `MAPS01.MIX` 17; `MAPS02.MIX` 17; `MULTI.MIX` 97; `expandmd01.mix` 13; plus `RandMap.Sed` 1. The branch is therefore content-conditional for authored/editor/custom YR maps, not stock-map-active and not dormant/TS-only.
+
+## Exact family tables
+
+**Active in YR: Conditional for every row.** Direction enum was independently recovered from startup writes in `InitializeDirectionOffsets 0x0049F2F0..0x0049F39B`: `0=N(0,-1)`, `2=E(1,0)`, `4=S(0,1)`, `6=W(-1,0)`.
+
+| Trigger / index | New fixed row, states 0/1/2 | Search direction | Exact required opposite center (`state==1`) | Body orientation/base |
+|---|---|---|---|---|
+| `LOBRDGE1 0x7A` / 0 | N,origin,S = `LOBRDG19 0x5C` | W | `LOBRDG21 0x5E` | EW, `LOBRDG01 0x4A` |
+| `LOBRDGE2 0x7B` / 1 | N,origin,S = `LOBRDG21 0x5E` | E | `LOBRDG19 0x5C` | EW, `LOBRDG01 0x4A` |
+| `LOBRDGE3 0x7C` / 2 | W,origin,E = `LOBRDG23 0x60` | S | `LOBRDG25 0x62` | NS, `LOBRDG10 0x53` |
+| `LOBRDGE4 0x7D` / 3 | W,origin,E = `LOBRDG25 0x62` | N | `LOBRDG23 0x60` | NS, `LOBRDG10 0x53` |
+| `LOBRDGB1 0xE9` / 0 | N,origin,S = `LOBRDB19 0xDF` | W | `LOBRDB21 0xE1` | EW, `LOBRDB01 0xCD` |
+| `LOBRDGB2 0xEA` / 1 | N,origin,S = `LOBRDB21 0xE1` | E | `LOBRDB19 0xDF` | EW, `LOBRDB01 0xCD` |
+| `LOBRDGB3 0xEB` / 2 | W,origin,E = `LOBRDB23 0xE3` | S | `LOBRDB25 0xE5` | NS, `LOBRDB10 0xD6` |
+| `LOBRDGB4 0xEC` / 3 | W,origin,E = `LOBRDB25 0xE5` | N | `LOBRDB23 0xE3` | NS, `LOBRDB10 0xD6` |
+
+**Active in YR: Conditional.** Raw table evidence: fixed row directions `[4,4,2,2]` at `0x008333C0/0x00833408`; fixed IDs at `0x008333D0/0x00833418`; join directions `[6,2,4,0]` at `0x008333E0/0x00833428`; body bases at `0x008333F0/0x00833438`; opposite tables indexed by `join/2`, wood `[0x60,0x5C,0x62,0x5E]` at `0x008333F8`, concrete `[0xE3,0xDF,0xE5,0xE1]` at `0x00833440`. Lazy start offsets are `[(0,-1),(0,-1),(-1,0),(-1,0)]`; body cross-offset rows are `[(-1,0),(0,0),(1,0)]` and `[(0,-1),(0,0),(0,1)]` at `0x00AC1588/0x00AC15A0` after initialization.
+
+## Fixed-end transaction
+
+- **Active in YR: Conditional.** The clear probe begins at `origin + start_offset`, performs exactly three `MapClass::Get_CellClass` calls in fixed-row direction, and checks `Cell+0x44 == -1`. It does not short-circuit after a conflict; all three lookups occur in N/origin/S or W/origin/E order. (`0x005FC8C0..0x005FC930`, concrete `0x005FCCE9..0x005FCD54`.)
+- **Active in YR: Conditional.** If any probe is occupied, the transaction makes no fixed/body write and no RNG call, skips search, then enters common success cleanup. The fake trigger is not persisted. The original cell is nevertheless Recalc'd once at the tail using its pre-existing overlay.
+- **Active in YR: Conditional.** If clear, it restarts from the same first coordinate and makes exactly three writes in the same order. Each write stores the row's one fixed overlay ID at `Cell+0x44`, writes ordinal `j=0,1,2` to `Cell+0x11E`, then immediately calls `RecalcAttributes(cell,-1)` before advancing. (`0x005FC930..0x005FC9AD`, concrete `0x005FCD54..0x005FCDD1`.)
+- **Active in YR: Conditional.** The triggering origin is ordinal 1, so its fake endpoint ID is overwritten by the fixed center ID. Fixed-end writes consume **zero** RNG calls—raw, ranged, fixed-range, or otherwise.
+- **Active in YR: Conditional.** `Get_CellClass 0x005657A0` computes `index=(signed y*512)+signed x`, accepts only `0..0x3FFFF` with a non-null sparse pointer, otherwise returns the one dummy at `0x00ABDC50` after stamping only dummy coordinate `+0x24`. Clear/write rows do not bounds-check, so multiple missing coordinates alias one persistent dummy. Dummy overlay/state writes are observable to later probes; its `RecalcAttributes` immediately returns. Current normal retail map geometry generally keeps the trigger row allocated, but exact alias/order is native behavior, not license to drop edge writes.
+
+## Opposite-end search and termination
+
+- **Active in YR: Conditional.** Search begins at `origin + join_direction`, not at the fixed-row start. Before the first lookup and after every advance it calls `Cell_in_bounds_check 0x00568300`. This signed i16 diamond predicate is: `W < x+y`, `x-y < W`, `y-x < W`, and `x+y <= W+2H`, using `Map+0xF4 W` and `Map+0xF8 H`.
+- **Active in YR: Conditional.** At each in-bounds coordinate, the loop gets the cell and succeeds only when both `Cell+0x44 == exact family/direction opposite ID` and byte `Cell+0x11E == 1`. Wrong state, other fixed ends, other family, body overlays, and arbitrary blockers are ignored and scanned through. First exact match wins. (`0x005FC9D1..0x005FCA82`, concrete `0x005FCDF5..0x005FCEB0`.)
+- **Active in YR: Conditional.** There is no bridge-length limit, blocker termination, wrap, or second direction. The sole failure termination is leaving the playfield predicate. A miss leaves the newly written three-cell fixed end in place, consumes no RNG, and returns true after common cleanup.
+
+## Body geometry, order, and overwrites
+
+- **Active in YR: Conditional.** On match, compute `reverse=(join-4)&7` (the direction from found end toward the trigger), then step once from the found center. This is the first body-row center. (`0x005FCA82..0x005FCAA5`, concrete `0x005FCEB0..0x005FCED3`.)
+- **Active in YR: Conditional.** Length is **not** measured to the trigger center. It is the Chebyshev distance from that first body center to the first transverse cell of the newly written fixed row: `L=max(abs(signext_i16(work.x)-signext_i16(start.x)), abs(signext_i16(work.y)-signext_i16(start.y)))`. x86 `CDQ/XOR/SUB` implements signed absolute value. (`0x005FCAA5..0x005FCAE4`, concrete `0x005FCED3..0x005FCF12`.)
+- **Active in YR: Conditional.** For valid cardinal tables and center separation `D>=1`, this simplifies to `L=max(D-1,1)`. The defensive `if L>0` branch is always taken after a real match under active map bounds. For normal `D>=2`, it writes all centerline rows strictly between endpoints, starting beside the previously found end and moving toward the new trigger.
+- **Active in YR: Conditional.** Exact adversarial edge: adjacent centers (`D=1`) still yield `L=1` because the transverse start-cell difference is one. The one body row is centered on the newly written trigger and overwrites all three just-written fixed cells with body variants/states 0/1/2. This is not an approximation or an OpenTS-only quirk; the disassembly operands use the retained start-row x/y.
+- **Active in YR: Conditional.** Body orientation is `((reverse & 3)/2)`: reverse N/S selects base `LOBRDG10/LOBRDB10` and j offsets W,center,E; reverse E/W selects base `LOBRDG01/LOBRDB01` and j offsets N,center,S. Outer order is opposite-end side toward trigger; inner order is exactly j=0,1,2 in those offset orders.
+- **Active in YR: Conditional.** Body cells are neither bounds-checked nor tested for occupancy. Each `Get_CellClass` result is overwritten even if it already contains an overlay. Missing rows alias the shared dummy exactly as above. After every three writes, work advances one reverse-direction cell; outer loop executes exactly `L` times.
+
+## Variant selection and exact RNG transaction
+
+- **Active in YR: Conditional.** Each body cell performs this exact order: lookup cell; call `Random::Next`; store `body_base + (raw & 3)` at `+0x44`; store j at `+0x11E`; call `RecalcAttributes(cell,-1)`. Wood assembly is `0x005FCB44..0x005FCB70`; concrete is `0x005FCF72..0x005FCF9E`.
+- **Active in YR: Conditional.** The receiver is exactly `[g_ScenarioClass_Instance @ 0x00A8B230] + 0x218`, loaded immediately before `Random::Next @ 0x0065C780`. It is neither Main RNG nor MapGen RNG. A successful body consumes exactly `3*L` **raw Scenario calls** in outer/inner order.
+- **Active in YR: Conditional.** There is no `RandomRanged` helper, rejection, modulo, or `next_range(0,3)` call. There are also no fixed-range draws: fixed-end rows, static-table initialization, clear probes, search probes, occupied-row success-no-op, missing opposite, and common cleanup each consume zero RNG.
+- **Active in YR: Conditional.** `Random::Next` checks receiver byte `+0`: if nonzero, it returns zero and does not advance. Otherwise it XOR-updates one of 250 state dwords at `+0xC` using dword indices `+4/+8`, returns the updated raw u32, increments both indices, and wraps each after 249. Thus disabled RNG still receives exactly `3*L` calls and selects each base variant, but its cursor is unchanged. (`decompile_function/disassemble_function 0x0065C780..0x0065C7D0`.)
+- **Active in YR: Conditional.** OverlayPack construction is y=0..511 outer, x=0..511 inner; each endpoint transaction completes before the next packed coordinate. The endpoint encountered later in that row-major order normally finds the earlier fixed center and owns the `3*L` draw sequence. Later packed overlay rows may overwrite procedural writes without undoing draws.
+
+## Recalc, LAT, zone, radar, dirty, and cleanup
+
+- **Active in YR: Yes when any declared low overlay is Recalc'd; Conditional for trigger-generated calls.** Every successful fixed/body write calls `CellClass::RecalcAttributes(cell,-1)` immediately; `-1` preserves `Cell+0x11B Level`. The common tail calls it once more on the original initiating cell, so a clear trigger center is Recalc'd as fixed ordinal 1 and then again at cleanup. Dummy Recalc returns immediately. (`0x0047D2B0`, Mark call sites above and `0x005FD1FA`.)
+- **Active in YR: Yes.** Retail endpoint/fixed/body types declare `Land=Road`, `NoUseTileLandType=true`, `RadarColor=92,92,92`; constructor defaults are Land Clear, Tiberium=false, and NoUse=true, and `ReadINI @ 0x005FE798..0x005FE7B7/0x005FE958..0x005FE973` supplies the retail values. Dense runtime IDs, not sparse INI keys, select metadata.
+- **Active in YR: Yes.** For these types Recalc stores overlay Land at `Cell+0xEC`, refreshes slope from the pristine TMP when available, cannot take the Tiberium-on-slope clear because retail low types have Tiberium=false, applies the active `CliffBackImpassability` neighbor test (stock mode 2 may reclassify qualifying land to 3), calls `ApplyLAT_and_SlopeFixup 0x0047CA80`, calls `RecalcZoneType 0x00483C80`, then updates compact zone/level buffers. LAT/slope fixup reads neighbors and can replace only this cell's tile ID `+0x38`; zone writes `Cell+0x4C` and the compact buffers.
+- **Active in YR: No.** The later automatic `TubeClass` construction branch in Recalc requires `LandType==10`. Low overlay `NoUseTileLandType=true` takes the earlier overlay-owned return path after LAT/zone, so no automatic Tube is created. Explicit `[Tubes]` are loaded by a separate earlier owner. GSI-04.15 must not model fixed low decks as tube-backed.
+- **Active in YR: No (direct per-cell invalidation).** Neither the low branch nor Recalc/LAT/zone calls a radar-pixel/cache invalidator. `RadarColor` is metadata consumed by normal radar rendering; it does not cause an immediate per-written-cell dirty action. The Mark callee list contains no radar routine.
+- **Active in YR: Yes once per accepted ephemeral trigger object.** Before the derived branch, successful `ObjectClass::Mark` sets `IsOnMap +0x74=1` and invokes `MarkNeedsRedraw 0x005F4D10`; with the constructor-cleared flag it sets `NeedsRedraw +0x80=1` and calls `0x004F42F0(0)`, which sets `g_Tactical+0xD7D=1`. Argument zero means no bridge counter increment. There is no additional tactical dirty call per fixed/body cell.
+- **Active in YR: Conditional.** Common tail `0x005FD1FA..0x005FD227`: Recalc original cell; clear object `IsOnMap +0x74=0`; set `InLimbo +0x81=1`; dispatch primary vtable `+0xF8 = ObjectClass::UnInit 0x005F65F0`; return 1. Constructor/vtable proof: constructor writes primary vtable `0x007EF3D4`; `+0x124` is Mark and `+0xF8` is UnInit; RTTI descriptor at `0x00833458` is `.?AVOverlayClass@@`.
+- **Active in YR: Conditional.** Entry failures (base Mark false, mark not 1/3, or slope gate) return 0 without low writes, low RNG, tail Recalc, or tail deletion. `Unlimbo` then restores only `InLimbo +0x81=1`; the coordinate write, base Mark's `IsOnMap/NeedsRedraw`, and tactical dirty side effects are not transactionally rolled back. Branch-local failures after family selection are success-no-ops/partial success, not false.
+- **Active in YR: Yes for authored format>1 loads.** After all Mark calls, `ReadMapOverlayPacks` makes a second complete y/x pass and blindly writes decoded OverlayData bytes to allocated cells' `+0x11E` (`0x005FD5F7..0x005FD656`) without RNG or immediate Recalc; Full_Init's later global Recalc observes those final state bytes. OverlayData therefore overrides procedural 0/1/2 states.
+
+## Adversarial closure cases
+
+1. **Active in YR: Conditional.** One of three fixed-row cells occupied: all three probes still occur; zero writes/search/draws; original-cell tail Recalc; return true.
+2. **Active in YR: Conditional.** Clear row, no opposite before bounds: exactly three fixed writes/Recalcs persist; zero draws; original center gets a second Recalc; return true.
+3. **Active in YR: Conditional.** Wrong opposite ID or correct ID with state 0/2: scan passes through it; only exact ID+state1 terminates; first exact candidate wins.
+4. **Active in YR: Conditional.** Adjacent exact endpoints: `L=1`; three raw Scenario calls overwrite the newly fixed trigger row with body variants; tail Recalc follows.
+5. **Active in YR: Conditional.** Body crosses occupied/missing cells: existing overlays are overwritten; missing lookups mutate the one dummy in exact j/row order; dummy Recalc is a no-op; draws are still consumed.
+
+## Current Rust implication (direct read, not implementation)
+
+- **Active in YR mismatch: Conditional.** `src/map/overlay.rs:138..176` decodes OverlayPack row-major and captures OverlayData, but `src/map/resolved_terrain.rs:2438..2481` only dispatches authored high-anchor stamps and then applies OverlayData. No `0x7A..0x7D/0xE9..0xEC` transaction exists.
+- **Active in YR mismatch: Conditional.** `ResolvedTerrainGrid` currently derives overlay terrain/passability before the late bridge-facts overlay loop. Exact low Mark must mutate the owning cell overlay identity/state and apply the same Recalc/LAT/zone consequences in write order, not merely synthesize structural bridge facts afterward.
+- **Active in YR mismatch: Conditional.** `ScenarioFillRng` at `src/sim/scenario_bootstrap.rs:1722..1729` exposes only inclusive ranged draws, and headless terrain wiring at `src/headless_scenario.rs:90..121` passes only that ranged callback. Low Mark needs a narrowly owned raw Scenario call seam; routing through Main, MapGen, or the ranged helper is wrong.
+- **Active in YR mismatch: Conditional.** `SharedCellDummySnapshot` / `SharedCellDummy` at `src/map/resolved_terrain.rs:421..429,774..883` models coord, level, slope, and selected bridge flags, but not overlay ID/state/Land/zone. Exact low edge semantics require extending the same persistent identity or proving the affected coordinates unreachable at the accepted source boundary.
+- **Active in YR preservation requirement: Yes.** Keep `OverlayLoadSource::GeneratedMaterialized` and `gsi_04_12_generated_materialized_overlays_never_replay_fixed_map_mark`: accepted `.SED` generation directly stamps completed low decks and must consume zero fixed-Mark Scenario draws.
+
+## Implementation handoff
+
+| # | Behavior -> Rust delta -> surface | Acceptance -> proposed test | Risk |
+|---:|---|---|---|
+| 1 | **Conditional:** authored format>1 packed endpoints execute synchronously in decoded order; generated-materialized never does -> add one authored provenance/format-gated low-Mark owner inside the overlay traversal -> map source/load gate + `resolved_terrain` | Earlier endpoint leaves fixed row; later endpoint finds it and materializes both families in y/x order -> `gsi_04_13_authored_low_endpoint_pairs_expand_in_overlaypack_order` | High: wrong phase changes topology and all later RNG. |
+| 2 | **Conditional:** exact signed i16 rows/search/first-match/`L=max(D-1,1)` plus dummy alias and partial-success arms -> encode recovered tables and native lookup semantics, preserving three clear probes, writes, overwrites, and common-tail result -> narrow low-stamp module + shared dummy | occupied row, no opposite, wrong state, first-of-two candidates, adjacent endpoints, and edge dummy fixtures match exact IDs/states/returns -> `gsi_04_13_low_endpoint_search_failure_and_adjacent_overwrite_edges` | High: ordinary custom maps diverge; edge aliases can alter later probes. |
+| 3 | **Conditional:** body uses `3*L` raw Scenario words, raw&3, opposite-to-trigger/j order; every other arm zero -> expose a raw draw only to the authored low-Mark owner and borrow it before later Scenario consumers -> `ScenarioFillRng`, headless/app terrain bootstrap | Seeded family A/B variants and post-load cursor match a reference raw stream; fixed/no-op cases preserve cursor -> `gsi_04_13_low_endpoint_rng_is_three_raw_scenario_draws_per_body_row` | Critical: a ranged draw shifts deterministic later consumers. |
+| 4 | **Yes/Conditional:** every write immediately recalculates; tail repeats origin; data pack later wins; no per-cell radar dirty or Tube -> route writes through the existing exact overlay land/LAT/CliffBack/zone projection, retain one object-level tactical dirty semantic only if that state is modeled -> overlay registry/resolved terrain/data phase | Road/zone/tile consequences match after conflicting OverlayData; zero automatic tubes and zero per-cell dirty counts -> `gsi_04_13_overlaydatapack_overwrites_mark_state_without_recalc_then_final_recalc` | High: IDs can look right while passability/LAT/zone is stale. |
+| 5 | **Yes preservation:** body IDs and generated `.SED` decks never enter trigger dispatch -> restrict dispatch to the two four-ID ranges and authored provenance -> overlay type dispatch/source tests | Lostlake/Killer/Shrapnel body rows remain unchanged; generated materialized test remains green -> `retail_low_body_ids_never_expand_or_consume_scenario_rng` plus existing GSI-04.12 test | High-frequency stock regression if ordinary bodies are misclassified. |
+
+## Negative facts / do not do
+
+- **Active in YR: No.** Do not port OpenTS enums, TS map bounds, TS RNG ownership, or TS Tube interpretation; it was a navigation lead only.
+- **Active in YR: No.** Do not dispatch body ranges `0x4A..0x65/0xCD..0xE8`, high anchors `0x18/0x19/0xED/0xEE`, generated direct decks, damage/repair overlays, or Tube rows through this endpoint mechanism.
+- **Active in YR: No.** Do not use a post-load connected-component pass, nearest-end search, blocker stop, length cap, second-direction retry, center-to-center length, per-row variant, deterministic coordinate hash, fixed-range draw, or inclusive-range RNG call.
+- **Active in YR: No.** Do not roll back the fixed end when no opposite exists, roll back RNG after overwrites, short-circuit the three clear probes, skip occupied body cells, or clamp body writes to the Rust rectangle without reproducing shared-dummy semantics.
+- **Active in YR: No.** Do not infer immediate radar invalidation from `RadarColor`, per-cell tactical dirties from Recalc, bridge-counter increments from the base dirty call, or automatic Tube creation from the word “bridge.”
+
+## Remaining uncertainty
+
+- **No parity-blocking uncertainty remains** for activation, family/range mapping, signed coordinates, lookup/write/search/body order, opposite termination, body bound, RNG owner/call kind/count/order, Recalc/LAT/CliffBack/zone effects, radar/dirty effects, return/failure state, OverlayData precedence, or source exclusions.
+- **Non-load-bearing:** decompiler local variable names and some recovered C++ prototypes remain provisional; all handoff-critical claims above are tied to instruction ranges, memory tables, callers, defaults/readers, and retail data rather than those names.
+- **Corpus boundary:** zero triggers is a complete result for the 385 installed/shipped payloads scanned, not a claim that arbitrary retail-compatible custom/editor maps cannot activate the code. Hence the mechanism remains **Conditional**, not dormant.
+
+## Stale-document wording to correct
+
+- Replace any “low bridges are Tube-backed / Recalc constructs a Tube for low deck overlays” wording (including inherited wording in `BRIDGE_LOW_AND_ZONE_RECORDS_GHIDRA_SUPPLEMENT.md` or `BRIDGE_SETBRIDGEDIRECTION_STAMPING_GHIDRA_REPORT.md`) with: “Retail low endpoint/fixed/body overlays are `Land=Road, NoUseTileLandType=true`; Recalc takes its early overlay LAT/zone return and cannot reach automatic `LandType==10` Tube construction.”
+- Replace “fixed low endpoint Mark is TS-only/dormant” with: “active YR executable and retail-declared authored-content mechanism, conditional because zero trigger cells occur in the 385 shipped payloads scanned.”
+- Replace any “fixed IDs are the sparse `[OverlayTypes]` key minus one” wording with dense runtime insertion mapping; e.g. runtime `0x5C` is `LOBRDG19`, and runtime `0x7A` is `LOBRDGE1`.
+- Replace any “length is endpoint-center distance” or “body starts at the new trigger” wording with the retained-start-cell Chebyshev formula and opposite-to-trigger traversal, including the adjacent-end one-row overwrite.
+- Replace any “low variants use ranged Scenario draw 0..3” wording with “one raw `Random::Next` per body cell, variant `raw&3`; no fixed/ranged draw.”
+
+## Ghidra annotation candidates (do not apply)
+
+- `OverlayClass::Mark @ 0x005FC570`: prototype candidate `bool __thiscall OverlayClass::Mark(int mark)`; plate candidate `low triggers 7A..7D/E9..EC: fixed row, first exact opposite, raw Scenario body transaction`.
+- `0x008333C0/0x00833408`: `low_fixed_row_direction_by_trigger`; `0x008333D0/0x00833418`: `low_fixed_overlay_by_trigger`; `0x008333E0/0x00833428`: `low_join_direction_by_trigger`.
+- `0x008333F0/0x00833438`: `low_body_variant_base_by_orientation`; `0x008333F8/0x00833440`: `low_opposite_fixed_center_by_join_halfdir`.
+- `0x00AC154C/0x00AC155C`: `low_fixed_start_offsets_lazy`; `0x00AC1588/0x00AC15A0`: `low_body_cross_offsets_lazy`; `0x00AC1548`: `low_mark_static_table_init_guard_bits`.
+- `FUN_004F42F0 @ 0x004F42F0`: candidate `MapClass::SetTacticalDirtyAndOptionalBridgeState`; its Mark caller passes zero.
+
+## Closure checks
+
+1. Cold re-decompile of `Mark 0x005FC570` and `Random::Next 0x0065C780` reproduced the tables, exact `raw&3` draw sites, start-cell length operands, and zero ranged/fixed-range calls.
+2. Cold raw-memory read of `0x008333B0..0x0083345F` reproduced both families' fixed/join/base/opposite constants; dense retail `[OverlayTypes]` enumeration reproduced every runtime name.
+3. Zero-additional-mechanism pass over `get_function_callees(0x005FC570)` found no radar, Tube, ranged RNG, per-cell dirty, alternative search, or rollback call. The complete relevant callee set is `ObjectClass::Mark`, `MapClass::Get_CellClass`, bounds, `Random::Next`, `RecalcAttributes`, and lifecycle support; unrelated overlay branches were excluded by ID control flow.

--- a/docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_SCENARIO_LOAD_ACTIVATION_BOUNDARY_GHIDRA_REPORT.md
+++ b/docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_SCENARIO_LOAD_ACTIVATION_BOUNDARY_GHIDRA_REPORT.md
@@ -1,0 +1,133 @@
+# Low Overlay Mark: Scenario-Load Activation Boundary
+
+Date: 2026-08-30
+Status: **COMPLETE for the bounded activation/order/source-discriminator slice**
+System: active YR low/water bridge map loading (GSI-04.13; GSI-04.12 interaction only where the shared high-stamp pass establishes order)
+
+`[ACTIVE-YR]` means decompiled active-retail `gamemd.exe` control flow plus disassembly/caller evidence, not an OpenTS inference. Unless a paragraph is explicitly labelled `NEGATIVE`, `RUST`, `RETAIL-DATA`, or `UNCERTAINTY`, every binary behavior claim below is `[ACTIVE-YR]`.
+
+## Target question
+
+Prove the complete scenario-load activation and ordering boundary around `OverlayClass::Mark @ 0x005FC570`: which authored low endpoint/body rows reach it; where high stamping, `[OverlayDataPack]`, final terrain recalculation, authored Techno construction, and their RNG draws occur; why accepted `.SED` generation instead keeps the RMG's already-materialized deck and never replays low Mark; and what exact source discriminator Rust must preserve.
+
+## Non-goals
+
+- The endpoint tables' exact coordinate geometry, scan direction, opposing-end identity, and variant-table contents beyond call-boundary/draw-count facts.
+- RMG bridge eligibility/geometry, high-bridge stamp implementation, bridge damage/repair, TubeClass behavior after parsing, or Rust edits.
+- TS/OpenTS behavior as parity authority. `C:\Users\enok\Documents\OpenTS\code\overlay.cpp`, `scenario.cpp`, and `mapgen.cpp` were used only to locate candidate inherited owners; every conclusion was re-proved below in active YR and retail data.
+
+## COMPLETE evidence and stop conditions
+
+This slice is complete only if all of the following are closed: direct caller/xref and disassembly proof for authored `Read_Scenario -> Full_Init -> ReadMapOverlayPacks -> OverlayClass ctor -> Unlimbo -> virtual Mark`; exact low ID families from retail rules plus Mark comparisons; overlay/data/recalc/Terrain/Techno order; Scenario RNG ownership and order; `.SED` branch exclusivity; synthetic-INI overlay no-op; direct-stamp caller path and absence of Mark/post-stamp pack replay; current Rust source/gate state; and three retail fixtures. Stop/mark PARTIAL if any activation gate, owner, order edge, RNG owner, or source discriminator remains inferred. None does.
+
+## Evidence base
+
+- `[ACTIVE-YR]` Ghidra read-only decompile + disassembly + xrefs: `Read_Scenario 0x00684620`, `Read_Scenario_INI 0x00686730`, `Full_Init 0x00686B20`, `ReadMapOverlayPacks 0x005FD2E0`, `OverlayClass::Constructor 0x005FC380`, `ObjectClass::Unlimbo 0x005F4EC0`, `OverlayClass::Mark 0x005FC570`, `InitMapFromSyntheticINI 0x00599650`, `RandomMapGenerator::Generate 0x00598960`, `PlaceLowBridgeDeck 0x0058F2C0`, `PlaceBridgeRepairHut 0x005904B0`, and `TechnoClass::Constructor 0x006F2B40` (RNG site `0x006F3254`). No metadata was changed.
+- `[ACTIVE-YR]` load-bearing xrefs: `ReadMapOverlayPacks` has one call, `Full_Init+0xF14 @ 0x00687A34`; `Full_Init` has calls from ordinary `Read_Scenario_INI @ 0x00686845` and synthetic RMG init @ `0x00599A56`; synthetic init has sole caller `Generate @ 0x00598A74`; direct deck writer has sole call @ `0x005906D5`.
+- `[RETAIL-DATA]` extracted retail `rulesmd.ini` at `C:\Users\enok\Documents\ra2-rust-game\ini\rulesmd.ini`; installed loose `Lostlake.mmx`, `Killer.mmx`, `Shrapnel.mmx` decoded read-only with the repository LCW chunk format. All three declare `NewINIFormat=4`.
+- `[RUST]` direct read of `src/map/overlay.rs`, `src/map/resolved_terrain.rs`, `src/map/rmg/*`, `src/app/loading/init.rs`, `src/app/frontend/list_maps.rs`, and `src/sim/movement/movement_bridge_retail_tests.rs` in this worktree.
+
+## Verified authored-load timeline
+
+| Order | Active YR event | Exact evidence / consequence |
+|---:|---|---|
+| 1 | `[ACTIVE-YR]` non-`.SED` source chooses the ordinary reader | `Read_Scenario`: byte `Scenario+0x34BD` is tested @ `0x00684961`; false jumps to `Read_Scenario_INI @ 0x006849C9`, which unconditionally calls `Full_Init @ 0x00686845`. |
+| 2 | `[ACTIVE-YR]` map/Iso and explicit tubes precede overlays | `Full_Init` calls `Read_Map_Section_And_IsoMapPacks @ 0x006879FF`, then `ReadTubesINI @ 0x00687A0B`. Tube parsing is a separate mechanism, not low-overlay Mark. |
+| 3 | `[ACTIVE-YR]` one overlay owner runs | `ReadMapOverlayPacks @ 0x00687A34`; it returns immediately when `[Basic] NewINIFormat <= 1` (`CMP ... 1/JLE @ 0x005FD2EC..F3`). |
+| 4 | `[ACTIVE-YR]` `[OverlayPack]` is traversed deterministically | Fixed 512x512 traversal, `y=0..511` outer and `x=0..511` inner (`0x005FD3F4..0x005FD51C`). Each eligible non-`0xFF` row is handled synchronously before the next coordinate. Textual pack-key order is only compressed-payload assembly; activation order is decoded cell order. |
+| 5 | `[ACTIVE-YR]` each accepted packed row reaches virtual `Mark(1)` | Filters require a render image or CellAnim, reject multiplayer crates, and require allocated/in-bounds cell. It allocates 0xB0 and calls `OverlayClass::Constructor @ 0x005FD4D2`; constructor calls `ObjectClass::Unlimbo @ 0x005FC4B1`; Unlimbo dispatches vtable `+0x124` with argument 1 @ `0x005F4FB0..B4`, whose Overlay slot is `Mark @ 0x005FC570`. Terrain objects cannot block this constructor path because `[Terrain]` is read later. |
+| 6 | `[ACTIVE-YR]` Mark executes at the packed row, not in a later bridge pass | During `Full_Init`, the load-suppression counter is nonzero: ordinary passability/`Overrides` checks are bypassed, but Mark's universal `SlopeIndex > 4` rejection remains (except unrelated id `0xB2`). A successful ordinary row or every procedural write calls `RecalcAttributes @ 0x0047D2B0` immediately. |
+| 7 | `[ACTIVE-YR]` `[OverlayDataPack]` is a second, later 512x512 pass | `0x005FD5F7..0x005FD656`; every allocated/in-bounds cell receives decoded byte `Cell+0x11E` @ `0x005FD640`, including cells generated procedurally or absent/rejected in pass one. Thus data-pack bytes win over Mark-written data. |
+| 8 | `[ACTIVE-YR]` global terrain recalculation follows both packs | `Full_Init` iterates all cells and calls `RecalcAttributes @ 0x00687A5A`, after overlay data and before `[Terrain] @ 0x00687A74`. |
+| 9 | `[ACTIVE-YR]` authored objects are later and category/entry-ordered | Tiberium growth/spread init @ `0x00687A85/8A`; `[Units] @ 0x00687AA7`, `[Aircraft] @ 0x00687ABF`, `[Infantry] @ 0x00687ACB`, `[Structures] @ 0x00687AEA`, then `[Smudge] @ 0x00687B0E`. Each of the four Techno readers gets section entry count, starts index 0, and calls `GetEntryNameByIndex(section,index)` while incrementing to count. Low Mark cannot occur after any authored Techno constructor in this load. |
+
+## Which bridge rows call Mark
+
+`[RETAIL-DATA]` The stock `[OverlayTypes]` declarations are body keys `77..104=LOBRDG01..28`, endpoint keys `125..128=LOBRDGE1..4`, concrete body keys `209..236=LOBRDB01..28`, and concrete endpoint keys `237..240=LOBRDGB1..4`. Registry insertion is dense; active runtime IDs are proven by Mark's comparisons, not by subtracting one from sparse INI keys.
+
+| Runtime IDs | Retail identities | `[ACTIVE-YR]` behavior when accepted from authored OverlayPack |
+|---|---|---|
+| `0x4A..0x65` | `LOBRDG01..28` wood bodies/end pieces, including destroyed sinks `0x64/0x65` | Constructor calls Mark once at that packed coordinate. They do **not** enter the procedural endpoint branch; ordinary Mark stores the identity/data then recalculates. |
+| `0x7A..0x7D` | `LOBRDGE1..4` wood procedural triggers | Constructor calls Mark; comparisons @ `0x005FC796..A2` select the wood endpoint branch. If its target three-cell endpoint row is empty, Mark writes/recalculates all three, scans for the opposing end, then may materialize body rows. The trigger is not an independent later pass. |
+| `0xCD..0xE8` | `LOBRDB01..28` concrete bodies/end pieces | Same ordinary one-row Mark behavior as wood bodies; no procedural expansion. |
+| `0xE9..0xEC` | `LOBRDGB1..4` concrete procedural triggers | Comparisons @ `0x005FCBB9..CB` select the concrete endpoint branch with the same boundary conditions. |
+| `0x18,0x19,0xED,0xEE` | high bridge anchors (`BRIDGE1/2`, `BRIDGEB1/2`) | High dispatch occurs earlier in the same Mark call and invokes `SetBridgeDirection_*`; these are **not** low bridge variants. Only these four have their prior `+0x11E` saved/restored around construction @ `0x005FD4DB..0x005FD502`. Low rows do not. |
+
+`[ACTIVE-YR]` Because each packed coordinate completes before the next, procedural writes can be observed or overwritten by later non-`0xFF` packed coordinates. Earlier packed coordinates are never revisited. The later full `[OverlayDataPack]` pass then overwrites `+0x11E` globally. Implementing endpoint expansion as a component-wide post-pass is therefore not equivalent.
+
+## RNG boundary and authored Technos
+
+- `[ACTIVE-YR]` Successful low endpoint body materialization draws once for each of the three cross-row body cells at each longitudinal step. Assembly @ `0x005FCB44..70` and `0x005FCF72..9E` loads `ScenarioClass* [0x00A8B230]`, sets `ECX=Scenario+0x218`, calls `Random__Next`, masks `&3`, writes `+0x44/+0x11E`, then recalculates. Empty-row failure, missing opposing endpoint, body-only rows, and high stamps consume zero low-Mark draws.
+- `[ACTIVE-YR]` Every Techno constructor later draws unconditionally from that same `Scenario+0x218` stream @ `0x006F3249..59` and stores the low word at `Techno+0x3C8`. `BuildingClass::Constructor` directly reaches this base constructor; Unit/Aircraft/Infantry do through their inheritance path.
+- `[ACTIVE-YR]` Therefore fixed-map low-Mark draws advance the shared Scenario cursor before authored Unit -> Aircraft -> Infantry -> Structure constructor words, with each category retaining INI entry-index order. Deferring Mark, using MapGen/Main RNG, batching variants after object construction, or rolling failed Unlimbo back changes every later consumer.
+
+## Mutually exclusive generated `.SED` path
+
+1. `[ACTIVE-YR]` `Read_Scenario` takes the last four filename bytes and compares them case-insensitively with bytes `".SED\0"` at `0x0083DA88`; comparator `0x007C8D20` folds ASCII case. It sets `Scenario+0x34BD=1` @ `0x006846AA`, otherwise zero @ `0x006846BE`.
+2. `[ACTIVE-YR]` Random=true calls the seed reader @ `0x00684975`; success calls `RandomMapGenerator::Generate(0,0) @ 0x00684989` and post-map init @ `0x00684990`. Random=false alone calls ordinary `Read_Scenario_INI @ 0x006849C9`. These arms are mutually exclusive.
+3. `[ACTIVE-YR]` Generate initializes `g_MapGenRng`, then unconditionally calls `InitMapFromSyntheticINI @ 0x00598A74` **before** water/regions/bridges. For non-preview launch, synthetic init calls `Full_Init @ 0x00599A56`.
+4. `[ACTIVE-YR]` That pre-generation Full_Init does not replay overlays: the synthetic INI writes only `[Map]`, `[Basic] Player`, a House `TechLevel`, and `[Lighting]`; it omits `[Basic] NewINIFormat`. `ScenarioClass::Read_INI_Basic` reads that key with default 0 @ `0x0068A13D..56`, so nested `ReadMapOverlayPacks` returns at `0x005FD2F3`. There are no authored Techno section rows either.
+5. `[ACTIVE-YR]` Later call graph is `Generate -> BridgeAndConnectorPass 0x0058EF10 -> CarveConnectorsOrBridges 0x005905D0 -> PlaceLowBridgeDeck 0x0058F2C0`. The writer stores complete three-wide overlay rectangles directly to `Cell+0x44` and cross indices to `Cell+0x11E`; its callee list contains no Overlay constructor, Unlimbo, or Mark.
+6. `[ACTIVE-YR]` Direct-deck identities are deterministic from coordinates (`EW 0x5E ... 0x5C`, interiors `0x4A+(x%4)`; `NS 0x60 ... 0x62`, interiors `0x53+(y%4)`). Deck search/end coins use `g_MapGenRng @ 0x00ABE890`, not Scenario. Repair-hut placement then calls `BuildingClass::Constructor`, so successful generated CABHUT construction consumes Scenario at the normal Techno base site—but still no low Mark draw.
+7. `[ACTIVE-YR]` After direct stamping, Generate performs recalculation/generation tails but never calls Full_Init or ReadMapOverlayPacks again. Xrefs prove the only Full_Init inside Generate's call tree is the earlier synthetic-init call. Thus the completed deck is not input to authored Mark.
+
+### Exact discriminator Rust must retain
+
+`[ACTIVE-YR]` The discriminator is **load provenance: the successful `.SED`/Random branch which generated the live map**, carried across materialization. It is not overlay identity, endpoint/body content, `OverlayDataPack` presence, filename of a serialized in-memory `MapFile`, successful CABHUT count, constructor-trace presence, or a guessed “looks generated” geometry predicate. Generated and authored maps legitimately contain the same body IDs and data.
+
+`[RUST]` Rust already has the right types: `LoadedMapSource::Generated { seed_name }` and `OverlayLoadSource::{Authored, GeneratedMaterialized}`. However, production chooses `GeneratedMaterialized` using `generated_construction_trace.is_some()` in `src/app/loading/init.rs`, an incidental proxy; `MapFile::from_bytes` calls `parse_overlay_packs` regardless of parsed `basic.new_ini_format`; and `ResolvedTerrainGrid` currently gates only `high_bridge_stamp_for_overlay`. No `0x7A..0x7D/0xE9..0xEC` low endpoint implementation exists. The low Mark owner must require authored provenance **and** native `NewINIFormat>1`, share the authored-only source gate with high Mark, and leave generated overlays/data byte-for-byte materialized.
+
+## Retail fixtures and what each proves
+
+- `[RETAIL-DATA]` `Lostlake.mmx`, SHA-256 `39AE274E92A64CA1D5534876DE81DFFAF7153A696900B22A288D3EDB52C81143`: intact wood EW lane `y=117,x=39..51` (three-wide deck; `0x5E` west end, `0x5C` east end). It proves ordinary body/end-piece rows survive authored row-major Mark/data ordering.
+- `[RETAIL-DATA]` `Killer.mmx`, SHA-256 `423C7A997D80F964B4490910DA17124EFB3B42D49E14B191BBB281D3AE565845`: intact wood NS deck, lanes `x=93..95,y=130..151` (22 cells; `0x60` north row and `0x62` south row). It supplies the orthogonal body-order/data fixture.
+- `[RETAIL-DATA]` `Shrapnel.mmx`, SHA-256 `3D0955DAA3CC146688D88555C6D0938A2E58648DEB25AFF51592EB5D8DAC77E0`: terminal destroyed wood rows `0x64` at `(107,46..48)` and `0x65` at `(114..116,59)`, matching the in-repo movement fixture rectangles `(106..108,46..48)` and `(114..116,58..60)`. These are body-range ordinary Mark rows, never procedural triggers.
+- `[RETAIL-DATA]` The decoded packs in all three named fixtures contain zero `0x7A..0x7D`/`0xE9..0xEC` trigger cells. They validate preservation/negative dispatch, not successful trigger expansion; that acceptance case must be a synthetic authored-map fixture using retail rules. The pre-existing 184-map census's zero trigger count is not used to call the executable path dormant.
+
+## Implementation handoff
+
+| # | Behavior -> Rust delta -> surface | Acceptance -> proposed test | Risk if wrong |
+|---:|---|---|---|
+| 1 | `[ACTIVE-YR]` provenance gates authored Mark -> derive `OverlayLoadSource` directly from `LoadedMapSource`, not construction-trace presence; feed one shared authored-only gate to high and low Mark -> `src/app/loading/init.rs`, `src/map/resolved_terrain.rs` | A generated complete EW/NS deck retains every id/data and consumes zero Mark Scenario words, even with an empty/missing construction trace -> `gsi_04_13_generated_source_never_replays_low_or_high_mark` | Every accepted `.SED` bridge can be corrupted and the match RNG shifted. |
+| 2 | `[ACTIVE-YR]` pack Mark requires `NewINIFormat>1`, then low triggers execute inline in decoded row-major order -> suppress pack Mark at missing/0/1, otherwise dispatch at the current overlay loop rather than a component post-pass; body ranges take ordinary Mark only -> `src/map/map_file.rs` or load gate, `src/map/resolved_terrain.rs`, narrow low-Mark owner | Missing/1 formats perform zero pack Mark; two format-4 trigger arrangements prove earlier/later overwrite order and exact draws -> `gsi_04_13_authored_low_mark_requires_format_and_runs_inline_in_pack_order` | Legacy/synthetic inputs activate wrongly, or fixture-dependent topology/variants diverge. |
+| 3 | `[ACTIVE-YR]` low writes recalc immediately, then data pack wins, then global recalc -> preserve the three phase boundaries -> resolved terrain/overlay-data application | Synthetic authored endpoints with conflicting data bytes finish with pack data and final Road-derived attributes -> `gsi_04_13_low_mark_data_pack_then_final_recalc_order` | Cross-row frame/land/cache state differs even when ids look right. |
+| 4 | `[ACTIVE-YR]` Mark and Techno use one Scenario cursor -> thread the established scenario bootstrap owner into low Mark before authored map-object construction; consume three words per generated longitudinal row and none on rejected/no-op arms -> low-Mark owner + scenario bootstrap/map spawn boundary | Seeded endpoint map followed by Unit/Aircraft/Infantry/Structure rows matches exact variant words and constructor low words in native order -> `gsi_04_13_low_mark_draws_precede_authored_techno_constructor_words` | Essentially every authored match with active endpoints shifts later deterministic RNG. |
+| 5 | `[ACTIVE-YR]` body/destroyed rows never expand -> retain exact retail identities/data -> retail ignored tests | Lostlake and Killer retain their complete orthogonal decks; Shrapnel retains both 0x64/0x65 three-cell strips with no extra draw -> `retail_low_mark_preserves_lostlake_killer_and_shrapnel_body_rows` | Common stock low decks or the only destroyed-low loose fixture regress. |
+
+## Negative facts / do not do
+
+- `[NEGATIVE, ACTIVE-YR]` Do not call procedural endpoint support TS-only/dormant merely because the scanned stock-map corpus has zero trigger cells. Retail YR rules declare the types and active YR Mark reaches them from accepted authored content; activity is content-conditional.
+- `[NEGATIVE, ACTIVE-YR]` Do not treat `0xED/0xEE` as low; they are high `BRIDGEB1/2` anchors. Do not give low rows the high-only `+0x11E` save/restore gate.
+- `[NEGATIVE, ACTIVE-YR]` Do not run a second low-Mark pass after OverlayDataPack, Terrain, Techno construction, or RMG direct stamping.
+- `[NEGATIVE, ACTIVE-YR]` Do not infer source from overlay ids/data, `.SED` text after materialization, or construction outcomes. Preserve the branch provenance.
+- `[NEGATIVE, ACTIVE-YR]` Do not use MapGen/Main RNG for fixed authored low Mark, or Scenario RNG for deterministic direct deck identities. Do not roll back draws after later placement failure.
+- `[NEGATIVE, ACTIVE-YR]` Do not merge explicit `[Tubes]` with low overlay loading; it is read earlier by a separate owner.
+- `[NEGATIVE]` Do not port OpenTS `TrainBridgeSet`, generator phases, or load lifetime. OpenTS was navigation evidence only.
+
+## Remaining uncertainty
+
+- `[UNCERTAINTY / intentionally out of scope]` Exact endpoint direction tables, opposing-end termination identity, dummy-cell behavior at each generated coordinate, and variant table bases still belong to the separate low-Mark inner-algorithm investigation. No activation/order/source conclusion here depends on guessing them.
+- `[UNCERTAINTY / non-load-bearing]` This pass independently decoded only the three required retail maps, not the earlier 184-map census. The census's zero-trigger statement is treated as a fixture-selection fact, not evidence of dormancy.
+- No unresolved activation gate, section order, RNG owner, generated-vs-authored exclusivity, or discriminator remains in this bounded report.
+
+## Stale-document wording to correct
+
+- `ASSET_PARSING_BRIDGES_GHIDRA_REPORT.md` rows calling `0xED/0xEE` “Low bridge variant” are wrong: they are active high `BRIDGEB1/2` Mark anchors.
+- `docs/plans/bridge-movement-matrix.md` X-11's “Zero cells ... TS heritage” is too strong. Replace with: “zero cells in the scanned stock loose-map corpus; active YR retail-rules-declared authored-content path, therefore content-conditional, not dormant.”
+- Any wording that the `.SED` branch “does not call Full_Init/ReadMapOverlayPacks” is misleading. It calls synthetic `Full_Init` **before generation**; omission/default `NewINIFormat=0` makes the overlay reader inert. The exact negative is: no ordinary file reader in the random arm and no pack/Mark replay after direct stamping.
+- `BRIDGE_MAP_LOAD_AND_BRIDGEHEAD_TRANSITIONS_GHIDRA_REPORT.md`'s low-bridge “deserves a separate pass” caveat is superseded for activation/order by this report; its low inner-algorithm caveat remains valid.
+
+## Annotation candidates (not applied)
+
+- `ReadMapOverlayPacks @ 0x005FD2E0`: `authored_overlay_pack_y_major_x_minor_mark_then_overlay_data_owner`
+- `OverlayClass::Mark @ 0x005FC570`: `low_endpoint_triggers_7A_7D_E9_EC_use_scenario_rng_before_techno_sections`
+- `ScenarioClass::Full_Init @ 0x00686B20`: `overlay_mark_data_final_recalc_terrain_units_aircraft_infantry_structures_order`
+- `RandomMapGenerator::InitMapFromSyntheticINI @ 0x00599650`: `launch_synthetic_basic_defaults_new_ini_format_zero_overlay_reader_inert`
+- `ScenarioClass::Read_Scenario @ 0x00684620`: `case_insensitive_sed_provenance_excludes_ordinary_ini_reader`
+- `RandomMapGenerator::PlaceLowBridgeDeck @ 0x0058F2C0`: `direct_materialized_low_deck_no_overlay_mark_or_post_stamp_pack_replay`
+
+## Cold checks
+
+1. Re-ran `get_function_xrefs` after forming the timeline: the only `ReadMapOverlayPacks` call remains `Full_Init @ 0x00687A34`, and the only direct writer call remains `CarveConnectorsOrBridges @ 0x005906D5`.
+2. Re-read current Rust after forming the discriminator verdict: `LoadedMapSource::Generated` exists, but production still selects `OverlayLoadSource` from `generated_construction_trace.is_some()`, pack parsing ignores `basic.new_ini_format`, and the overlay loop still implements only high anchors.
+3. Decoded the three retail packs independently of the pre-existing fixture prose; hashes, `NewINIFormat=4`, both orthogonal intact spans, and Shrapnel's two destroyed terminal strips agree.

--- a/src/app/diagnostics/tactical_capture/profile.rs
+++ b/src/app/diagnostics/tactical_capture/profile.rs
@@ -596,6 +596,10 @@ impl TacticalCaptureProfile {
                     difficulty: AiDifficulty::Easy,
                 })
                 .collect(),
+            pre_fill_house_roster:
+                crate::skirmish_launch::PreFillHouseRoster::from_compact_skirmish(
+                    self.launch.opponents.len(),
+                ),
             options: self.launch.options.to_launch_options(),
         }
     }

--- a/src/app/frontend/skirmish.rs
+++ b/src/app/frontend/skirmish.rs
@@ -194,6 +194,8 @@ mod tests {
                 team: LaunchTeam::None,
                 difficulty: Default::default(),
             }],
+            pre_fill_house_roster:
+                crate::skirmish_launch::PreFillHouseRoster::from_compact_skirmish(1),
             options: SkirmishLaunchOptions::default(),
         }
     }
@@ -948,51 +950,36 @@ mod tests {
         };
         let map = test_map_with_starts(&[authored]);
         let terrain = test_terrain(64, 64);
-        let mut sim = Simulation::new();
-        sim.scenario_rng = SimRng::new(9);
         let mut session = test_session();
         session.local.start_position = LaunchStartPosition::Position(0);
         session.opponents[0].start_position = LaunchStartPosition::Position(1);
         session.options.bases = false;
         session.options.unit_count = 0;
-        assert!(
-            preload_standard_battle_start_plan(&launch_descriptor(&session), &map, 9).is_none(),
-            "terrain-dependent deficient starts must not guess a loading plan"
+        let plan = prepare_stock_offline_scenario_prefix_plan(
+            &launch_descriptor(&session),
+            &map,
+            &map.waypoints,
+            9,
+        )
+        .expect("deficient starts are resolved before Fill");
+        assert_ne!(
+            plan.first_gathered_starts()[1],
+            plan.final_gathered_starts()[1]
         );
-        assert!(
-            crate::app::loading::pump::selected_map_start_assignments(&session, None).is_empty(),
-            "no exact plan means no colored loading assignment markers"
-        );
-        let bounds = NativeStartBounds::from_session(&sim, &terrain);
-        let playfield_bounds = Some(PlayfieldBounds::from_map_header(&map.header));
-        let empty_occupancy = crate::sim::occupancy::OccupancyGrid::new();
+
+        let mut bootstrap_rng = ScenarioBootstrapRng::new(9);
+        bootstrap_rng
+            .install_pre_fill_scenario_prefix_plan(&plan)
+            .expect("matching pre-Fill prefix");
+        let mut sim =
+            bootstrap_rng.into_simulation(&crate::sim::scenario_session::ScenarioDescriptor {
+                seed: 9,
+                ..Default::default()
+            });
         let mut expected_rng = sim.scenario_rng.clone();
-        let provisional = native_gather_start_positions(
-            &map.waypoints,
-            2,
-            &terrain,
-            &empty_occupancy,
-            bounds,
-            playfield_bounds,
-            Some(map.header.height as i32),
-            sim.session.binary_frame,
-            &mut expected_rng,
-        );
-        let final_starts = native_gather_start_positions(
-            &map.waypoints,
-            2,
-            &terrain,
-            &empty_occupancy,
-            bounds,
-            playfield_bounds,
-            Some(map.header.height as i32),
-            sim.session.binary_frame,
-            &mut expected_rng,
-        );
-        assert_ne!(provisional[1], final_starts[1]);
         let _ = expected_rng.next_range_u32_inclusive(0, 0xffff);
 
-        apply_explicit_skirmish_launch_session(
+        apply_pre_fill_scenario_prefix_launch_session(
             &mut sim,
             &map,
             &roster_with_neutral_and_playable(),
@@ -1000,6 +987,7 @@ mod tests {
             &test_height_map(),
             &terrain,
             &launch_descriptor(&session),
+            &plan,
         );
 
         assert_eq!(
@@ -1014,7 +1002,10 @@ mod tests {
                 &sim.interner,
             )
             .and_then(|house| house.base_center),
-            Some((final_starts[1].rx, final_starts[1].ry))
+            Some((
+                plan.final_gathered_starts()[1].rx,
+                plan.final_gathered_starts()[1].ry,
+            ))
         );
         assert_eq!(
             sim.scenario_rng.logical_state(),
@@ -1425,9 +1416,13 @@ mod tests {
         let map = test_map_with_starts(&starts);
         let terrain = test_terrain(64, 64);
         let rules = test_standard_launch_rules();
-        let plan =
-            preload_standard_battle_start_plan(&launch_descriptor(&session), &map, launch_seed)
-                .expect("complete standard Battle starts preload");
+        let plan = prepare_stock_offline_scenario_prefix_plan(
+            &launch_descriptor(&session),
+            &map,
+            &map.waypoints,
+            launch_seed,
+        )
+        .expect("complete stock-offline Scenario prefix");
 
         let loading_assignments =
             crate::app::loading::pump::selected_map_start_assignments(&session, Some(&plan));
@@ -1449,7 +1444,7 @@ mod tests {
 
         let mut bootstrap_rng = ScenarioBootstrapRng::new(launch_seed);
         bootstrap_rng
-            .install_preloaded_battle_plan(&plan)
+            .install_pre_fill_scenario_prefix_plan(&plan)
             .expect("fresh launch cursor matches plan prestate");
         let descriptor = crate::sim::scenario_session::ScenarioDescriptor {
             seed: launch_seed,
@@ -1457,17 +1452,17 @@ mod tests {
         };
         let mut sim = bootstrap_rng.into_simulation(&descriptor);
         let mut expected_rng = SimRng::new(u64::from(launch_seed));
-        for _ in 0..4 {
+        for _ in 0..8 {
             let _ = expected_rng
                 .next_range_u32_inclusive(HOUSE_CONSTRUCTOR_TIMER_MIN, HOUSE_CONSTRUCTOR_TIMER_MAX);
         }
         assert_eq!(
             sim.scenario_rng.logical_state(),
             expected_rng.logical_state(),
-            "one human, one AI, Neutral, and Special burn once before loading"
+            "one human, one AI, Neutral, and Special burn twice before loading"
         );
 
-        let result = apply_preloaded_battle_launch_session(
+        let result = apply_pre_fill_scenario_prefix_launch_session(
             &mut sim,
             &map,
             &roster_with_neutral_and_playable(),

--- a/src/app/frontend/skirmish_session.rs
+++ b/src/app/frontend/skirmish_session.rs
@@ -255,6 +255,7 @@ impl OfflineSkirmishRuntime {
             player_name: session.player_name.clone(),
             local: session.local.clone(),
             opponents: Vec::new(),
+            pre_fill_house_roster: session.pre_fill_house_roster.clone(),
             options: session.options.clone(),
         };
         let cooperative = is_cooperative_mode(session);
@@ -946,6 +947,8 @@ mod tests {
                 team: LaunchTeam::None,
                 difficulty: AiDifficulty::Easy,
             }],
+            pre_fill_house_roster:
+                crate::skirmish_launch::PreFillHouseRoster::from_compact_skirmish(1),
             options: SkirmishLaunchOptions::default(),
         }
     }

--- a/src/app/loading/composition.rs
+++ b/src/app/loading/composition.rs
@@ -934,6 +934,8 @@ mod tests {
                 team: LaunchTeam::None,
             },
             opponents: Vec::new(),
+            pre_fill_house_roster:
+                crate::skirmish_launch::PreFillHouseRoster::from_compact_skirmish(0),
             options: SkirmishLaunchOptions::default(),
         }
     }

--- a/src/app/loading/composition.rs
+++ b/src/app/loading/composition.rs
@@ -390,15 +390,19 @@ pub(crate) fn build_loading_composition(
 ///
 /// gamemd provenance: DrawLoadingScreen 0x00552D60 loads `RandMap.img` at
 /// 0x00553592/0x00553599, then unconditionally calls compositor 0x00640A40 at
-/// 0x00553687 with launch-scenario waypoints and resolved assignments. Rust's
-/// optional setup preview below is presentation fallback only; it never enters
-/// map loading or start assignment.
+/// 0x00553687 with the active Scenario waypoint array and resolved assignments.
+/// For an accepted RMG launch, Full Init copied setup staging into that array
+/// before `.SED` regeneration; the regenerated map supplies current playfield
+/// bounds, but its waypoint table does not replace that earlier active copy.
+/// Rust's optional setup preview below is presentation fallback only; it never
+/// enters map loading or start assignment.
 pub(crate) fn build_random_map_loading_composition(
     session: &SkirmishLaunchSession,
     csf: Option<&CsfFile>,
     render_size: [u32; 2],
     preview_image: Option<DecodedPreview>,
-    preview_map: Option<&MapFile>,
+    launch_map: &MapFile,
+    active_scenario_waypoints: &HashMap<u32, Waypoint>,
     assignments: &[LoadingStartAssignment],
 ) -> LoadingCompositionSnapshot {
     let region = mmpb_region_rect(render_size[0]);
@@ -407,12 +411,10 @@ pub(crate) fn build_random_map_loading_composition(
         .filter(valid_preview_buffer)
         .and_then(|mut image| {
             let fit = aspect_fit_preview(region, image.width, image.height)?;
-            if let Some(map) = preview_map {
-                let prefix = native_loading_waypoint_prefix(&map.waypoints);
-                if let Some(bounds) = projected_playfield_bounds(map) {
-                    burn_black_start_indicators(&mut image, &prefix, bounds);
-                    markers = build_mmpb_marker_records(&prefix, assignments, bounds, region, fit);
-                }
+            let prefix = native_loading_waypoint_prefix(active_scenario_waypoints);
+            if let Some(bounds) = projected_playfield_bounds(launch_map) {
+                burn_black_start_indicators(&mut image, &prefix, bounds);
+                markers = build_mmpb_marker_records(&prefix, assignments, bounds, region, fit);
             }
             Some(PreparedLoadingPreview { image, region, fit })
         });
@@ -981,12 +983,18 @@ mod tests {
             ("LoadBrief:USA", "A briefing."),
             ("GUI:LoadingEx", "Loading..."),
         ]);
+        let map = crate::map::rmg::emit::empty_map_file(
+            &crate::map::rmg::RmgOptions::default(),
+            32,
+            32,
+        );
         let composition = build_random_map_loading_composition(
             &test_launch_session(),
             Some(&csf),
             [800, 600],
             None,
-            None,
+            &map,
+            &map.waypoints,
             &[],
         );
 
@@ -1009,12 +1017,18 @@ mod tests {
             height: 80,
             rgba: vec![255; 200 * 80 * 4],
         };
+        let map = crate::map::rmg::emit::empty_map_file(
+            &crate::map::rmg::RmgOptions::default(),
+            32,
+            32,
+        );
         let composition = build_random_map_loading_composition(
             &test_launch_session(),
             None,
             [800, 600],
             Some(image),
-            None,
+            &map,
+            &map.waypoints,
             &[],
         );
 
@@ -1145,7 +1159,8 @@ mod tests {
             Some(&csf),
             [800, 600],
             Some(image),
-            Some(&map),
+            &map,
+            &map.waypoints,
             &assignments,
         );
 

--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -25,10 +25,9 @@ use crate::app::loading::init_helpers::{
 };
 use crate::match_bootstrap::LoadingStartup;
 use crate::sim::scenario_bootstrap::{
-    PreloadedBattleStartPlan, ScenarioBootstrapRng,
-    apply_explicit_skirmish_launch_session_with_overlay_registry,
-    apply_preloaded_battle_launch_session_with_overlay_registry, initialize_map_roster_houses,
-    initialize_skirmish_launch_houses,
+    PreFillScenarioPrefixPlan, ScenarioBootstrapRng,
+    apply_pre_fill_scenario_prefix_launch_session_with_overlay_registry,
+    initialize_map_roster_houses, initialize_skirmish_launch_houses,
 };
 
 use crate::assets::asset_manager::AssetManager;
@@ -821,6 +820,20 @@ impl MapLoadInitial {
     pub(crate) fn map_data(&self) -> &MapFile {
         &self.map_data
     }
+
+    pub(crate) fn map_source(&self) -> &LoadedMapSource {
+        &self.map_source
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_map_source(map_data: MapFile, map_source: LoadedMapSource) -> Self {
+        Self {
+            map_data,
+            map_source,
+            mapgen_rng_continuation: None,
+            generated_construction_trace: None,
+        }
+    }
 }
 
 fn replay_launch_generated_construction(
@@ -891,7 +904,7 @@ impl MapLoadInitial {
         asset_manager: &mut AssetManager,
         match_seed: u32,
         match_launch_descriptor: &crate::sim::scenario_bootstrap::MatchLaunchDescriptor,
-        preloaded_battle_start_plan: &PreloadedBattleStartPlan,
+        scenario_prefix_plan: &PreFillScenarioPrefixPlan,
     ) -> RandomMapLaunchSnapshot {
         let MapLoadInitial {
             map_data,
@@ -979,8 +992,8 @@ impl MapLoadInitial {
             mapgen_rng_continuation.expect("random-map initial receipt carries MapGen"),
         );
         bootstrap_rng
-            .install_preloaded_battle_plan(preloaded_battle_start_plan)
-            .expect("matching preloaded Battle prefix");
+            .install_pre_fill_scenario_prefix_plan(scenario_prefix_plan)
+            .expect("matching stock-offline Scenario prefix");
         let mapgen_continuation = bootstrap_rng
             .logical_states_for_test()
             .2
@@ -1199,7 +1212,7 @@ impl MapLoadInitial {
             .collect();
         simulation.intern_rule_type_ids(&rules);
         simulation.resolve_type_handles(&rules);
-        let _ = apply_preloaded_battle_launch_session_with_overlay_registry(
+        let _ = apply_pre_fill_scenario_prefix_launch_session_with_overlay_registry(
             &mut simulation,
             &map_data,
             &house_roster,
@@ -1208,7 +1221,7 @@ impl MapLoadInitial {
             &resolved_terrain,
             match_launch_descriptor,
             &overlay_registry,
-            preloaded_battle_start_plan,
+            scenario_prefix_plan,
         );
         let post_map_output = crate::sim::runtime::finalize_constructed_scenario(
             &mut simulation,
@@ -1634,7 +1647,7 @@ pub(crate) fn load_map_from_initial(
     asset_manager: &mut AssetManager,
     initial: MapLoadInitial,
     startup: LoadingStartup,
-    preloaded_battle_start_plan: Option<PreloadedBattleStartPlan>,
+    scenario_prefix_plan: Option<PreFillScenarioPrefixPlan>,
     skirmish_settings: &crate::ui::main_menu::SkirmishSettings,
     theater_cache_mismatch: bool,
     runtime_color_scheme_count: usize,
@@ -1804,12 +1817,23 @@ pub(crate) fn load_map_from_initial(
     if let Some(continuation) = mapgen_rng_continuation {
         bootstrap_rng.install_generated_mapgen_continuation(continuation);
     }
-    if let Some(plan) = preloaded_battle_start_plan.as_ref() {
-        // Native constructs houses and resolves Battle starts before the first
-        // loading composition; terrain Fill continues that same Scenario
-        // stream afterwards. Validate the launch cursor before installing the
-        // immutable pre-render prefix so it can never be consumed twice.
-        bootstrap_rng.install_preloaded_battle_plan(plan)?;
+    match (
+        match_launch_descriptor.as_ref(),
+        scenario_prefix_plan.as_ref(),
+    ) {
+        (Some(_), Some(plan)) => {
+            // Native resolves both House passes and both selected-mode start
+            // callbacks before Fill. Validate and transfer that complete
+            // cursor exactly once before any terrain draw.
+            bootstrap_rng.install_pre_fill_scenario_prefix_plan(plan)?;
+        }
+        (Some(_), None) => {
+            anyhow::bail!("stock offline launch reached Fill without a Scenario prefix plan")
+        }
+        (None, Some(_)) => {
+            anyhow::bail!("generic map load cannot carry a stock offline Scenario prefix plan")
+        }
+        (None, None) => {}
     }
     let (mut scenario_fill_rng, mut variant_main_rng) = bootstrap_rng.terrain_draws();
     let mut scenario_fill_ranged =
@@ -1869,8 +1893,8 @@ pub(crate) fn load_map_from_initial(
     drop(variant_main_rng);
     drop(scenario_fill_rng);
     // Launch-time `.SED` generation already chose all geometry. Replay only
-    // its Techno constructor effects now, after the Full-Init/Battle prefix and
-    // terrain Fill, on the one Scenario owner later moved into Simulation.
+    // its Techno constructor effects now, after the Full-Init stock-offline
+    // prefix and terrain Fill, on the one Scenario owner later moved into Simulation.
     let generated_techno_inits = replay_launch_generated_construction(
         &mut bootstrap_rng,
         generated_construction_trace.as_ref(),
@@ -2154,54 +2178,41 @@ pub(crate) fn load_map_from_initial(
     let mut initial_local_owner: Option<String> = None;
     if !spawn_pick_pending {
         if let (Some(sim), Some(ruleset)) = (&mut simulation, rules.as_ref()) {
-            let should_rebuild_entity_atlases =
-                if let Some(descriptor) = match_launch_descriptor.as_ref() {
-                    // Complete standard-Battle vectors were resolved before the
-                    // first loading frame and terrain continued their post-plan
-                    // Scenario cursor. Other modes/deficient maps retain the
-                    // terrain-dependent runtime resolver below.
-                    let result = if let Some(plan) = preloaded_battle_start_plan.as_ref() {
-                        apply_preloaded_battle_launch_session_with_overlay_registry(
-                            sim,
-                            &map_data,
-                            &house_roster,
-                            ruleset,
-                            &height_map,
-                            &resolved_terrain,
-                            descriptor,
-                            &overlay_registry,
-                            plan,
-                        )
-                    } else {
-                        apply_explicit_skirmish_launch_session_with_overlay_registry(
-                            sim,
-                            &map_data,
-                            &house_roster,
-                            ruleset,
-                            &height_map,
-                            &resolved_terrain,
-                            descriptor,
-                            &overlay_registry,
-                        )
-                    };
-                    initial_local_owner = result.local_owner;
-                    result.spawned_mcvs > 0
-                } else {
-                    initial_local_owner = seed_skirmish_opening_if_needed(
-                        sim,
-                        &map_data,
-                        &house_roster,
-                        ruleset,
-                        &height_map,
-                        &overlay_registry,
-                        skirmish_settings,
-                    );
-                    // Set up AI players: all playable houses except the local (first) player.
-                    if let Some(ref local_owner) = initial_local_owner {
-                        sim.register_ai_players_from_roster(&house_roster, local_owner);
-                    }
-                    initial_local_owner.is_some()
-                };
+            let should_rebuild_entity_atlases = if let Some(descriptor) =
+                match_launch_descriptor.as_ref()
+            {
+                let plan = scenario_prefix_plan
+                    .as_ref()
+                    .expect("stock offline prefix was required and installed before Fill");
+                let result = apply_pre_fill_scenario_prefix_launch_session_with_overlay_registry(
+                    sim,
+                    &map_data,
+                    &house_roster,
+                    ruleset,
+                    &height_map,
+                    &resolved_terrain,
+                    descriptor,
+                    &overlay_registry,
+                    plan,
+                );
+                initial_local_owner = result.local_owner;
+                result.spawned_mcvs > 0
+            } else {
+                initial_local_owner = seed_skirmish_opening_if_needed(
+                    sim,
+                    &map_data,
+                    &house_roster,
+                    ruleset,
+                    &height_map,
+                    &overlay_registry,
+                    skirmish_settings,
+                );
+                // Set up AI players: all playable houses except the local (first) player.
+                if let Some(ref local_owner) = initial_local_owner {
+                    sim.register_ai_players_from_roster(&house_roster, local_owner);
+                }
+                initial_local_owner.is_some()
+            };
 
             if should_rebuild_entity_atlases {
                 let (new_unit_atlas, new_sprite_atlas, new_palette_set) = build_entity_atlases(

--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -836,6 +836,25 @@ impl MapLoadInitial {
     }
 }
 
+/// Snapshot the active Scenario multiplayer-start table into the live session.
+///
+/// Authored loads retain their parsed waypoint table. Accepted RMG loads have
+/// already copied setup staging into the active Scenario array before `.SED`
+/// regeneration, so the prefix plan—not regenerated map content—owns these
+/// eight entries for loading markers, save/restore, and deterministic hashing.
+pub(crate) fn scenario_start_waypoints_for_load(
+    map_data: &MapFile,
+    scenario_prefix_plan: Option<&PreFillScenarioPrefixPlan>,
+) -> BTreeMap<u32, (u16, u16)> {
+    let active_waypoints = scenario_prefix_plan
+        .map(PreFillScenarioPrefixPlan::active_scenario_waypoints)
+        .unwrap_or(&map_data.waypoints);
+    waypoints::multiplayer_start_waypoints(active_waypoints)
+        .into_iter()
+        .map(|waypoint| (waypoint.index, (waypoint.rx, waypoint.ry)))
+        .collect()
+}
+
 fn replay_launch_generated_construction(
     bootstrap_rng: &mut ScenarioBootstrapRng,
     trace: Option<&crate::map::rmg::RmgConstructionTrace>,
@@ -1131,10 +1150,10 @@ impl MapLoadInitial {
             local_top: map_data.header.local_top as u16,
             local_width: map_data.header.local_width as u16,
             local_height: map_data.header.local_height as u16,
-            mp_start_waypoints: waypoints::multiplayer_start_waypoints(&map_data.waypoints)
-                .into_iter()
-                .map(|waypoint| (waypoint.index, (waypoint.rx, waypoint.ry)))
-                .collect(),
+            mp_start_waypoints: scenario_start_waypoints_for_load(
+                &map_data,
+                Some(scenario_prefix_plan),
+            ),
             lighting: crate::sim::scenario_session::ScenarioLightingState::new(
                 crate::sim::scenario_session::ScenarioLightProfileUnits {
                     ambient_percent: lighting_profiles.normal.ambient_percent,
@@ -2068,10 +2087,10 @@ pub(crate) fn load_map_from_initial(
         local_top: map_data.header.local_top as u16,
         local_width: map_data.header.local_width as u16,
         local_height: map_data.header.local_height as u16,
-        mp_start_waypoints: waypoints::multiplayer_start_waypoints(&map_data.waypoints)
-            .into_iter()
-            .map(|wp| (wp.index, (wp.rx, wp.ry)))
-            .collect(),
+        mp_start_waypoints: scenario_start_waypoints_for_load(
+            &map_data,
+            scenario_prefix_plan.as_ref(),
+        ),
         lighting: crate::sim::scenario_session::ScenarioLightingState::new(
             crate::sim::scenario_session::ScenarioLightProfileUnits {
                 ambient_percent: lighting_profiles.normal.ambient_percent,

--- a/src/app/loading/pump.rs
+++ b/src/app/loading/pump.rs
@@ -15,7 +15,7 @@ use crate::app::loading::progress_row::{
     LoadingProgressRowLayout, LoadingProgressRowSnapshot, layout_standard_skirmish_progress_row,
 };
 use crate::sim::scenario_bootstrap::{
-    PreloadedBattleStartPlan, preload_standard_battle_start_plan,
+    PreFillScenarioPrefixPlan, prepare_stock_offline_scenario_prefix_plan,
 };
 use crate::assets::asset_manager::AssetManager;
 use crate::assets::pal_file::Color;
@@ -178,15 +178,17 @@ impl NativeLoadingProgressCadence {
         }
     }
 
-    /// Whether the map has to be parsed before the first displayed frame.
+    /// Whether native has resolved Scenario inputs before the first loading frame.
     ///
-    /// gamemd derives a selected map's loading preview from the scenario, so
-    /// VERA parses the map file first and lets the pump hand over the swallowed
-    /// first milestone afterwards. The random-map branch takes its preview from
-    /// the `RandMap.img` bitmap the setup dialog wrote, so there is nothing to
-    /// parse up front and the loader's own first milestone reaches the sink.
-    fn preloads_scenario_before_first_frame(self) -> bool {
-        matches!(self, Self::SelectedMap)
+    /// Selected maps also need their parsed preview. Random maps take pixels
+    /// from `RandMap.img`, but Full Init has already regenerated the `.SED`,
+    /// copied accepted start staging, and run both selected-mode callbacks
+    /// before DrawLoadingScreen. Both branches therefore swallow the loader's
+    /// raw 8 here and hand it to the first post-frame pump.
+    fn prepares_scenario_before_first_frame(self) -> bool {
+        match self {
+            Self::SelectedMap | Self::RandomMapHalved => true,
+        }
     }
 }
 
@@ -212,17 +214,20 @@ impl LoadingProgressSink for NoopProgressSink {
     fn milestone(&mut self, _percent: u32) {}
 }
 
-enum PreloadedBattleStartPlanState {
+enum ScenarioPrefixPlanState {
     Pending,
-    Unavailable,
-    Ready(PreloadedBattleStartPlan),
+    NotApplicable,
+    Ready(PreFillScenarioPrefixPlan),
 }
 
 pub(crate) struct LoadingRequest {
     /// `None` is an internal terminal-transfer marker only. Every live request
     /// owns exactly one explicit startup variant.
     startup: Option<LoadingStartup>,
-    preloaded_battle_start_plan: PreloadedBattleStartPlanState,
+    scenario_prefix_plan: ScenarioPrefixPlanState,
+    /// Accepted setup start staging is small, provenance-bearing gameplay
+    /// input. It is never reconstructed from the presentation preview.
+    accepted_rmg_start_staging: Option<crate::app::shell_random_map::AcceptedRmgStartStaging>,
     /// Setup-generated preview retained only as a loading-composition fallback.
     /// It never supplies gameplay map data, RNG continuation, or constructors.
     random_map_preview: Option<crate::map::rmg::GeneratedMap>,
@@ -237,7 +242,8 @@ impl LoadingRequest {
     ) -> Self {
         Self {
             startup: Some(LoadingStartup::Accepted(startup)),
-            preloaded_battle_start_plan: PreloadedBattleStartPlanState::Pending,
+            scenario_prefix_plan: ScenarioPrefixPlanState::Pending,
+            accepted_rmg_start_staging: None,
             random_map_preview: None,
             presentation: LoadingPresentation::NativeSelectedSkirmish,
             fallback_skirmish_settings,
@@ -254,7 +260,8 @@ impl LoadingRequest {
                 session: skirmish_launch_session,
                 seed,
             }),
-            preloaded_battle_start_plan: PreloadedBattleStartPlanState::Pending,
+            scenario_prefix_plan: ScenarioPrefixPlanState::Pending,
+            accepted_rmg_start_staging: None,
             random_map_preview: None,
             presentation: LoadingPresentation::NativeSelectedSkirmish,
             fallback_skirmish_settings,
@@ -269,7 +276,8 @@ impl LoadingRequest {
             startup: Some(LoadingStartup::Generic {
                 selected_map_file: selected_map_file.into(),
             }),
-            preloaded_battle_start_plan: PreloadedBattleStartPlanState::Pending,
+            scenario_prefix_plan: ScenarioPrefixPlanState::Pending,
+            accepted_rmg_start_staging: None,
             random_map_preview: None,
             presentation: LoadingPresentation::GenericMapLoad,
             fallback_skirmish_settings,
@@ -310,7 +318,8 @@ impl LoadingRequest {
 
     /// Attach the setup preview for presentation fallback only. Scenario read
     /// 0x00684620 regenerates the accepted `.SED`; that launch result, not this
-    /// preview, resolves Battle starts and initializes gameplay.
+    /// preview, resolves the stock Scenario prefix and initializes gameplay.
+    #[cfg(test)]
     pub(crate) fn with_random_map_preview(
         mut self,
         random_map_preview: Option<crate::map::rmg::GeneratedMap>,
@@ -319,52 +328,111 @@ impl LoadingRequest {
         self
     }
 
+    /// Transfer one accepted setup transaction into loading. Preview terrain,
+    /// MapGen continuation, and construction trace remain presentation-only;
+    /// the separately extracted staging is the sole generated start authority.
+    pub(crate) fn with_accepted_random_map(
+        mut self,
+        accepted: Option<crate::app::shell_random_map::AcceptedRandomMapLaunch>,
+    ) -> Self {
+        if let Some(accepted) = accepted {
+            let (preview, start_staging) = accepted.into_parts();
+            self.random_map_preview = Some(preview);
+            self.accepted_rmg_start_staging = Some(start_staging);
+        }
+        self
+    }
+
     fn random_map_preview(&self) -> Option<&crate::map::rmg::GeneratedMap> {
         self.random_map_preview.as_ref()
     }
 
-    fn prepare_battle_start_plan(&mut self, map: &crate::map::map_file::MapFile) {
-        if !matches!(
-            &self.preloaded_battle_start_plan,
-            PreloadedBattleStartPlanState::Pending
-        ) {
-            return;
+    pub(crate) fn prepare_scenario_prefix_plan(
+        &mut self,
+        initial: &MapLoadInitial,
+    ) -> anyhow::Result<()> {
+        if !matches!(&self.scenario_prefix_plan, ScenarioPrefixPlanState::Pending) {
+            return Ok(());
         }
-        let plan = self.skirmish_launch_session().and_then(|session| {
-            let seed = self
-                .startup()
-                .seed_or_else(|| unreachable!("a launch session always owns a launch seed"));
-            // The shell close transaction resolved every random before the
-            // first loading frame; the descriptor proves it at this boundary.
-            let descriptor = crate::sim::scenario_bootstrap::MatchLaunchDescriptor::from_resolved(
-                session.clone(),
-            )
-            .expect("shell close transaction resolves every random choice before loading");
-            preload_standard_battle_start_plan(&descriptor, map, seed)
-        });
-        self.preloaded_battle_start_plan = plan.map_or(
-            PreloadedBattleStartPlanState::Unavailable,
-            PreloadedBattleStartPlanState::Ready,
-        );
-    }
-
-    fn preloaded_battle_start_plan(&self) -> Option<&PreloadedBattleStartPlan> {
-        match &self.preloaded_battle_start_plan {
-            PreloadedBattleStartPlanState::Ready(plan) => Some(plan),
-            PreloadedBattleStartPlanState::Pending | PreloadedBattleStartPlanState::Unavailable => {
+        let Some(session) = self.skirmish_launch_session().cloned() else {
+            self.scenario_prefix_plan = ScenarioPrefixPlanState::NotApplicable;
+            return Ok(());
+        };
+        let seed = self
+            .startup()
+            .seed_or_else(|| unreachable!("a launch session always owns a launch seed"));
+        let descriptor =
+            crate::sim::scenario_bootstrap::MatchLaunchDescriptor::from_resolved(session.clone())
+                .expect("shell close transaction resolves every random choice before loading");
+        let map = initial.map_data();
+        let selected_map = session
+            .selected_map_file
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("stock offline launch has no selected map"))?;
+        let staged_waypoints = match initial.map_source() {
+            crate::app::frontend::list_maps::LoadedMapSource::Generated { seed_name } => {
+                if !seed_name.eq_ignore_ascii_case(selected_map) {
+                    anyhow::bail!(
+                        "generated source {seed_name:?} does not match selected record {selected_map:?}"
+                    );
+                }
+                if !session.mode.random_maps_allowed || !matches!(session.mode.id, 1 | 2) {
+                    anyhow::bail!(
+                        "accepted random-map staging is unsupported for stock mode id {}",
+                        session.mode.id
+                    );
+                }
+                Some(
+                    self.accepted_rmg_start_staging
+                        .take()
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("generated launch has no accepted setup start staging")
+                        })?
+                        .to_waypoint_table(),
+                )
+            }
+            crate::app::frontend::list_maps::LoadedMapSource::Loose { .. }
+            | crate::app::frontend::list_maps::LoadedMapSource::Mix { .. } => {
+                if self.accepted_rmg_start_staging.is_some() {
+                    anyhow::bail!(
+                        "accepted random-map staging cannot attach to an authored map source"
+                    );
+                }
                 None
             }
+            crate::app::frontend::list_maps::LoadedMapSource::LegacyFallback { .. } => {
+                anyhow::bail!(
+                    "stock offline Scenario prefix requires an exact authored or generated map source"
+                )
+            }
+        };
+        let start_waypoints = staged_waypoints.as_ref().unwrap_or(&map.waypoints);
+        let plan =
+            prepare_stock_offline_scenario_prefix_plan(&descriptor, map, start_waypoints, seed)?;
+        self.scenario_prefix_plan = ScenarioPrefixPlanState::Ready(plan);
+        Ok(())
+    }
+
+    pub(crate) fn scenario_prefix_plan(&self) -> Option<&PreFillScenarioPrefixPlan> {
+        match &self.scenario_prefix_plan {
+            ScenarioPrefixPlanState::Ready(plan) => Some(plan),
+            ScenarioPrefixPlanState::Pending | ScenarioPrefixPlanState::NotApplicable => None,
         }
     }
 
-    fn take_preloaded_battle_start_plan(&mut self) -> Option<PreloadedBattleStartPlan> {
+    fn take_scenario_prefix_plan(&mut self) -> anyhow::Result<Option<PreFillScenarioPrefixPlan>> {
+        let owns_launch_session = self.skirmish_launch_session().is_some();
         match std::mem::replace(
-            &mut self.preloaded_battle_start_plan,
-            PreloadedBattleStartPlanState::Unavailable,
+            &mut self.scenario_prefix_plan,
+            ScenarioPrefixPlanState::NotApplicable,
         ) {
-            PreloadedBattleStartPlanState::Ready(plan) => Some(plan),
-            PreloadedBattleStartPlanState::Pending | PreloadedBattleStartPlanState::Unavailable => {
-                None
+            ScenarioPrefixPlanState::Ready(plan) => Ok(Some(plan)),
+            ScenarioPrefixPlanState::NotApplicable if !owns_launch_session => Ok(None),
+            ScenarioPrefixPlanState::Pending => {
+                anyhow::bail!("loading transfer attempted before Scenario prefix preparation")
+            }
+            ScenarioPrefixPlanState::NotApplicable => {
+                anyhow::bail!("stock offline launch cannot transfer without a Scenario prefix plan")
             }
         }
     }
@@ -691,13 +759,13 @@ pub(crate) fn pump_loading_after_present(state: &mut AppState) -> LoadingPump {
                 Err(err) => Err(err),
             };
             match initial {
-                Ok(initial) => {
-                    session
-                        .request
-                        .prepare_battle_start_plan(initial.map_data());
-                    session.job.phase = LoadingJobPhase::RemainingLegacyLoad(Some(initial));
-                    LoadingPump::Pending
-                }
+                Ok(initial) => match session.request.prepare_scenario_prefix_plan(&initial) {
+                    Ok(()) => {
+                        session.job.phase = LoadingJobPhase::RemainingLegacyLoad(Some(initial));
+                        LoadingPump::Pending
+                    }
+                    Err(err) => LoadingPump::Failed(err),
+                },
                 Err(err) => LoadingPump::Failed(err),
             }
         }
@@ -726,12 +794,11 @@ pub(crate) fn pump_loading_after_present(state: &mut AppState) -> LoadingPump {
             // hold simultaneously.
             let render_size = [state.renderer.gpu.config.width, state.renderer.gpu.config.height];
             // The pre-parse swallowed the loader's raw 8 so it could not present
-            // before the first frame; hand it over now. The random-map branch
-            // pre-parses nothing, so its loader still emits raw 8 itself.
+            // before the first frame; hand it over now for either native cadence.
             if let Some(native) = session.native.as_mut()
                 && native
                     .progress_cadence
-                    .preloads_scenario_before_first_frame()
+                    .prepares_scenario_before_first_frame()
             {
                 advance_and_present_native_progress(
                     &state.renderer.gpu,
@@ -746,8 +813,14 @@ pub(crate) fn pump_loading_after_present(state: &mut AppState) -> LoadingPump {
             }
             // `session.native` and `session.request` are disjoint fields, so the
             // launch-session/settings borrows below coexist with the native split.
+            let scenario_prefix_plan = match session.request.take_scenario_prefix_plan() {
+                Ok(plan) => plan,
+                Err(err) => {
+                    restore_job_asset_manager(state, &mut session);
+                    return LoadingPump::Failed(err);
+                }
+            };
             let startup = session.request.take_startup();
-            let preloaded_battle_start_plan = session.request.take_preloaded_battle_start_plan();
             let Some(asset_manager) = session.job.asset_manager.as_mut() else {
                 restore_job_asset_manager(state, &mut session);
                 return LoadingPump::Failed(anyhow::anyhow!(
@@ -786,7 +859,7 @@ pub(crate) fn pump_loading_after_present(state: &mut AppState) -> LoadingPump {
                         asset_manager,
                         initial,
                         startup,
-                        preloaded_battle_start_plan,
+                        scenario_prefix_plan,
                         &session.request.fallback_skirmish_settings,
                         native_theater_cache_mismatch,
                         runtime_color_scheme_count,
@@ -809,7 +882,7 @@ pub(crate) fn pump_loading_after_present(state: &mut AppState) -> LoadingPump {
                         asset_manager,
                         initial,
                         startup,
-                        preloaded_battle_start_plan,
+                        scenario_prefix_plan,
                         &session.request.fallback_skirmish_settings,
                         native_theater_cache_mismatch,
                         runtime_color_scheme_count,
@@ -825,7 +898,7 @@ pub(crate) fn pump_loading_after_present(state: &mut AppState) -> LoadingPump {
                     asset_manager,
                     initial,
                     startup,
-                    preloaded_battle_start_plan,
+                    scenario_prefix_plan,
                     &session.request.fallback_skirmish_settings,
                     false,
                     0,
@@ -928,13 +1001,14 @@ fn restore_job_asset_manager(state: &mut AppState, session: &mut LoadingSession)
     }
 }
 
-/// Parse a selected map before constructing its first loading frame.
+/// Resolve native Scenario inputs before constructing the first loading frame.
 ///
-/// Native selected-map composition consumes the parsed preview/waypoint data
-/// before the first confirmed 3% display. The loader's raw 8 milestone is
-/// intentionally swallowed here and visibly handed off by the first pump only
-/// after that 3% frame has been presented.
-fn prepare_selected_map_initial_before_first_frame(state: &mut AppState) -> anyhow::Result<()> {
+/// Full Init runs both selected-mode callbacks before DrawLoadingScreen. Fixed
+/// maps additionally derive their preview from the parsed scenario; random maps
+/// use `RandMap.img` pixels but still require regenerated header data and the
+/// accepted staged starts. The loader's raw 8 is intentionally swallowed here
+/// and visibly handed off only after the first frame has been presented.
+fn prepare_scenario_initial_before_first_frame(state: &mut AppState) -> anyhow::Result<()> {
     let should_prepare = state
         .frontend.loading_session
         .as_ref()
@@ -942,7 +1016,7 @@ fn prepare_selected_map_initial_before_first_frame(state: &mut AppState) -> anyh
         .is_some_and(|native| {
             native
                 .progress_cadence
-                .preloads_scenario_before_first_frame()
+                .prepares_scenario_before_first_frame()
         })
         && state.frontend.loading_session.as_ref().is_some_and(|session| {
             matches!(session.job.phase, LoadingJobPhase::InitialMapSelection)
@@ -971,9 +1045,10 @@ fn prepare_selected_map_initial_before_first_frame(state: &mut AppState) -> anyh
     });
     match result {
         Ok(initial) => {
-            session
-                .request
-                .prepare_battle_start_plan(initial.map_data());
+            if let Err(err) = session.request.prepare_scenario_prefix_plan(&initial) {
+                state.frontend.loading_session = Some(session);
+                return Err(err);
+            }
             session.job.phase = LoadingJobPhase::RemainingLegacyLoad(Some(initial));
             state.frontend.loading_session = Some(session);
             Ok(())
@@ -1022,7 +1097,7 @@ fn decode_random_map_loading_preview(ra2_dir: &Path) -> Option<DecodedPreview> {
 /// Resolve the assigned start waypoints the marker layer draws for a selected map.
 pub(crate) fn selected_map_start_assignments(
     launch_session: &SkirmishLaunchSession,
-    plan: Option<&PreloadedBattleStartPlan>,
+    plan: Option<&PreFillScenarioPrefixPlan>,
 ) -> Vec<LoadingStartAssignment> {
     let Some(plan) = plan else {
         return Vec::new();
@@ -1032,7 +1107,7 @@ pub(crate) fn selected_map_start_assignments(
         .enumerate()
         .filter_map(|(start_index, participant_index)| {
             let participant_index = (*participant_index)?;
-            let waypoint = plan.gathered_starts().get(start_index)?;
+            plan.final_gathered_starts().get(start_index)?;
             let (participant, color_priority) = if participant_index == 0 {
                 (
                     LoadingParticipantId::Local,
@@ -1047,7 +1122,7 @@ pub(crate) fn selected_map_start_assignments(
                 )
             };
             Some(LoadingStartAssignment {
-                start_index: waypoint.index,
+                start_index: u32::try_from(start_index).ok()?,
                 participant,
                 color_priority,
             })
@@ -1075,16 +1150,16 @@ fn ensure_loading_composition_snapshot(state: &mut AppState) {
         let Some(launch_session) = session.request.skirmish_launch_session() else {
             return;
         };
+        let Some(plan) = session.request.scenario_prefix_plan() else {
+            return;
+        };
         let render_size = [state.renderer.gpu.config.width, state.renderer.gpu.config.height];
         match native.progress_cadence {
             NativeLoadingProgressCadence::SelectedMap => {
                 let LoadingJobPhase::RemainingLegacyLoad(Some(initial)) = &session.job.phase else {
                     return;
                 };
-                let assignments = selected_map_start_assignments(
-                    launch_session,
-                    session.request.preloaded_battle_start_plan(),
-                );
+                let assignments = selected_map_start_assignments(launch_session, Some(plan));
                 build_loading_composition(
                     initial.map_data(),
                     launch_session,
@@ -1099,10 +1174,7 @@ fn ensure_loading_composition_snapshot(state: &mut AppState) {
                     .ra2_dir
                     .as_deref()
                     .and_then(decode_random_map_loading_preview);
-                let assignments = selected_map_start_assignments(
-                    launch_session,
-                    session.request.preloaded_battle_start_plan(),
-                );
+                let assignments = selected_map_start_assignments(launch_session, Some(plan));
                 build_random_map_loading_composition(
                     launch_session,
                     state.process_assets.csf.as_ref(),
@@ -1191,7 +1263,7 @@ pub(crate) fn ensure_native_loading_atlas(state: &mut AppState) -> anyhow::Resul
             "native loading archives LOADMD.MIX and LOAD.MIX are unavailable"
         ));
     }
-    prepare_selected_map_initial_before_first_frame(state)?;
+    prepare_scenario_initial_before_first_frame(state)?;
     ensure_loading_composition_snapshot(state);
     let Some(assets) = state
         .frontend.loading_session
@@ -2190,6 +2262,8 @@ mod tests {
                 team: LaunchTeam::None,
                 difficulty: AiDifficulty::Easy,
             }],
+            pre_fill_house_roster:
+                crate::skirmish_launch::PreFillHouseRoster::from_compact_skirmish(1),
             options: SkirmishLaunchOptions::default(),
         }
     }
@@ -2228,6 +2302,52 @@ mod tests {
             source: crate::match_bootstrap::MatchSeedSource::Controlled,
             seed_authority_certifying: false,
         }
+    }
+
+    fn prefix_test_map(starts: &[(u8, u16, u16)]) -> crate::map::map_file::MapFile {
+        let mut map =
+            crate::map::rmg::emit::empty_map_file(&crate::map::rmg::RmgOptions::default(), 32, 32);
+        map.waypoints.extend(starts.iter().map(|&(slot, rx, ry)| {
+            (
+                u32::from(slot),
+                crate::map::waypoints::Waypoint {
+                    index: u32::from(slot),
+                    rx,
+                    ry,
+                },
+            )
+        }));
+        map
+    }
+
+    fn generated_preview_with_starts(
+        seed: u16,
+        starts: &[(u8, u16, u16)],
+    ) -> crate::map::rmg::GeneratedMap {
+        crate::map::rmg::GeneratedMap {
+            map_file: prefix_test_map(starts),
+            mapgen_continuation: crate::map::rmg::RmgRng::new(seed).into_continuation(),
+            construction_trace: crate::map::rmg::RmgConstructionTrace::default(),
+            start_waypoints: starts.to_vec(),
+            stages_run: Vec::new(),
+            unfilled_start_slots: 0,
+        }
+    }
+
+    fn accepted_random_map_with_starts(
+        selected_map_file: &str,
+        seed: u16,
+        preview_waypoints: &[(u8, u16, u16)],
+        staged_starts: &[(u8, u16, u16)],
+    ) -> crate::app::shell_random_map::AcceptedRandomMapLaunch {
+        let mut retention = crate::app::shell_random_map::RandomMapGenerationRetention::default();
+        let mut generated = generated_preview_with_starts(seed, staged_starts);
+        generated.map_file = prefix_test_map(preview_waypoints);
+        retention.finish_generation(generated);
+        retention.accept_setup(selected_map_file);
+        retention
+            .take_acceptance_for_loading(Some(selected_map_file))
+            .expect("matching accepted random-map fixture")
     }
 
     fn receipt_for(
@@ -2373,10 +2493,320 @@ mod tests {
             vec![(0, 10, 20), (1, 30, 40)]
         );
         let assignments =
-            selected_map_start_assignments(&launch, request.preloaded_battle_start_plan());
+            selected_map_start_assignments(&launch, request.scenario_prefix_plan());
         assert!(
             assignments.is_empty(),
             "preview waypoints cannot resolve gameplay starts"
+        );
+    }
+
+    #[test]
+    fn gsi_04_12_generated_prefix_uses_accepted_staging_once() {
+        let selected = "RandMap.Sed";
+        let staged = [(0, 20, 24), (1, 42, 46)];
+        let preview_waypoints = [(0, 8, 12), (1, 14, 18)];
+        let regenerated = [(0, 60, 64), (1, 72, 76)];
+        let mut launch = test_launch_session(LaunchCountry::America);
+        launch.selected_map_file = Some(selected.to_string());
+        let accepted =
+            accepted_random_map_with_starts(selected, 0x1212, &preview_waypoints, &staged);
+        let initial = crate::app::loading::init::MapLoadInitial::from_test_map_source(
+            prefix_test_map(&regenerated),
+            crate::app::frontend::list_maps::LoadedMapSource::Generated {
+                seed_name: selected.to_ascii_lowercase(),
+            },
+        );
+        let mut request = LoadingRequest::unverified_legacy_skirmish(
+            launch,
+            unverified_seed(0x1212),
+            SkirmishSettings::default(),
+        )
+        .with_accepted_random_map(Some(accepted));
+
+        request.prepare_scenario_prefix_plan(&initial).unwrap();
+        let final_starts = request
+            .scenario_prefix_plan()
+            .expect("generated launch prepares a required prefix")
+            .final_gathered_starts()
+            .iter()
+            .map(|waypoint| (waypoint.index as u8, waypoint.rx, waypoint.ry))
+            .collect::<Vec<_>>();
+        assert_eq!(final_starts, staged);
+        assert_ne!(final_starts, preview_waypoints);
+        assert_ne!(final_starts, regenerated);
+        assert!(
+            request.accepted_rmg_start_staging.is_none(),
+            "accepted setup staging transfers exactly once"
+        );
+        assert!(
+            request.random_map_preview().is_some(),
+            "presentation preview remains available to loading composition"
+        );
+        request
+            .prepare_scenario_prefix_plan(&initial)
+            .expect("re-entry observes the already prepared plan without another transfer");
+        assert!(request.accepted_rmg_start_staging.is_none());
+    }
+
+    #[test]
+    fn loading_assignments_keep_gather_table_slots_separate_from_sparse_waypoint_indices() {
+        use crate::app::loading::composition::{
+            PreviewAspectFit, ProjectedPlayfieldBounds, build_mmpb_marker_records,
+            native_loading_waypoint_prefix,
+        };
+
+        let mut launch = test_launch_session(LaunchCountry::America);
+        let mut second_opponent = launch.opponents[0].clone();
+        second_opponent.color_index = 2;
+        second_opponent.start_position = LaunchStartPosition::Position(2);
+        launch.opponents.push(second_opponent);
+        launch.pre_fill_house_roster =
+            crate::skirmish_launch::PreFillHouseRoster::from_compact_skirmish(2);
+
+        // Gather target 3 retains raw slots 0 and 2, then appends a fallback
+        // at vector position 2. The retained slot and fallback consequently
+        // carry the same Waypoint::index even though the assignment table has
+        // three distinct positions.
+        let map = prefix_test_map(&[(0, 20, 24), (2, 42, 46), (3, 54, 58)]);
+        let descriptor = crate::sim::scenario_bootstrap::MatchLaunchDescriptor::from_resolved(
+            launch.clone(),
+        )
+        .unwrap();
+        let plan = prepare_stock_offline_scenario_prefix_plan(
+            &descriptor,
+            &map,
+            &map.waypoints,
+            0x1223,
+        )
+        .unwrap();
+        assert_eq!(
+            plan.final_gathered_starts()
+                .iter()
+                .map(|waypoint| waypoint.index)
+                .collect::<Vec<_>>(),
+            vec![0, 2, 2]
+        );
+
+        let assignments = selected_map_start_assignments(&launch, Some(&plan));
+        assert_eq!(
+            assignments
+                .iter()
+                .map(|assignment| (assignment.start_index, assignment.participant))
+                .collect::<Vec<_>>(),
+            vec![
+                (0, LoadingParticipantId::Local),
+                (1, LoadingParticipantId::Opponent(0)),
+                (2, LoadingParticipantId::Opponent(1)),
+            ],
+            "loading assignments are keyed by Scenario start-table position"
+        );
+
+        // The compositor still reads original Scenario geometry. Native's odd
+        // sparse-prefix rule visits raw waypoint 2 and colors it from table[2],
+        // not from the retained Gather vector entry at position 1.
+        let raw_prefix = native_loading_waypoint_prefix(&map.waypoints);
+        let markers = build_mmpb_marker_records(
+            &raw_prefix,
+            &assignments,
+            ProjectedPlayfieldBounds {
+                min_x: 0,
+                min_y: 0,
+                extent_x: 1_000,
+                extent_y: 1_000,
+            },
+            MmpbRegionRect {
+                x: 0,
+                y: 0,
+                width: 200,
+                height: 200,
+            },
+            PreviewAspectFit {
+                scale_1000: 1_000,
+                width: 200,
+                height: 200,
+                pad_x: 0,
+                pad_y: 0,
+            },
+        );
+        assert_eq!(markers.len(), 2);
+        assert_eq!(markers[1].waypoint.index, 2);
+        assert_eq!(
+            markers[1].participant,
+            LoadingParticipantId::Opponent(1)
+        );
+    }
+
+    #[test]
+    fn gsi_04_12_generated_prefix_rejects_presentation_only_preview() {
+        let selected = "RandMap.Sed";
+        let starts = [(0, 20, 24), (1, 42, 46)];
+        let mut launch = test_launch_session(LaunchCountry::America);
+        launch.selected_map_file = Some(selected.to_string());
+        let initial = crate::app::loading::init::MapLoadInitial::from_test_map_source(
+            prefix_test_map(&starts),
+            crate::app::frontend::list_maps::LoadedMapSource::Generated {
+                seed_name: selected.to_string(),
+            },
+        );
+        let mut request = LoadingRequest::unverified_legacy_skirmish(
+            launch,
+            unverified_seed(0x1313),
+            SkirmishSettings::default(),
+        )
+        .with_random_map_preview(Some(generated_preview_with_starts(0x1313, &starts)));
+
+        let err = request.prepare_scenario_prefix_plan(&initial).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("no accepted setup start staging"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn generated_prefix_rejects_mismatched_source_name() {
+        let selected = "RandMap.Sed";
+        let starts = [(0, 20, 24), (1, 42, 46)];
+        let mut launch = test_launch_session(LaunchCountry::America);
+        launch.selected_map_file = Some(selected.to_string());
+        let accepted = accepted_random_map_with_starts(selected, 0x1414, &starts, &starts);
+        let initial = crate::app::loading::init::MapLoadInitial::from_test_map_source(
+            prefix_test_map(&starts),
+            crate::app::frontend::list_maps::LoadedMapSource::Generated {
+                seed_name: "Other.Sed".to_string(),
+            },
+        );
+        let mut request = LoadingRequest::unverified_legacy_skirmish(
+            launch,
+            unverified_seed(0x1414),
+            SkirmishSettings::default(),
+        )
+        .with_accepted_random_map(Some(accepted));
+
+        let err = request.prepare_scenario_prefix_plan(&initial).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("does not match selected record"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn generated_prefix_rejects_cooperative_mode() {
+        let selected = "RandMap.Sed";
+        let starts = [(0, 20, 24), (1, 42, 46)];
+        let mut launch = test_launch_session(LaunchCountry::America);
+        launch.selected_map_file = Some(selected.to_string());
+        let cooperative = crate::skirmish_modes::stock_skirmish_modes()
+            .into_iter()
+            .find(|mode| mode.id == 3)
+            .expect("retail Cooperative row");
+        launch.mode = SkirmishLaunchMode::from_game_mode(&cooperative);
+        let accepted = accepted_random_map_with_starts(selected, 0x1515, &starts, &starts);
+        let initial = crate::app::loading::init::MapLoadInitial::from_test_map_source(
+            prefix_test_map(&starts),
+            crate::app::frontend::list_maps::LoadedMapSource::Generated {
+                seed_name: selected.to_string(),
+            },
+        );
+        let mut request = LoadingRequest::unverified_legacy_skirmish(
+            launch,
+            unverified_seed(0x1515),
+            SkirmishSettings::default(),
+        )
+        .with_accepted_random_map(Some(accepted));
+
+        let err = request.prepare_scenario_prefix_plan(&initial).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("unsupported for stock mode id 3"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn authored_prefix_rejects_random_map_staging_for_loose_and_mix_sources() {
+        let selected = "mp01t4.map";
+        let starts = [(0, 20, 24), (1, 42, 46)];
+        let sources = [
+            crate::app::frontend::list_maps::LoadedMapSource::Loose {
+                path: std::path::PathBuf::from(selected),
+                payload_len: 1,
+            },
+            crate::app::frontend::list_maps::LoadedMapSource::Mix {
+                logical_name: selected.to_string(),
+                source_archive: "mapsmd03.mix".to_string(),
+                entry_id: 7,
+                payload_len: 1,
+            },
+        ];
+        for source in sources {
+            let mut launch = test_launch_session(LaunchCountry::America);
+            launch.selected_map_file = Some(selected.to_string());
+            let accepted = accepted_random_map_with_starts(selected, 0x1616, &starts, &starts);
+            let initial = crate::app::loading::init::MapLoadInitial::from_test_map_source(
+                prefix_test_map(&starts),
+                source,
+            );
+            let mut request = LoadingRequest::unverified_legacy_skirmish(
+                launch,
+                unverified_seed(0x1616),
+                SkirmishSettings::default(),
+            )
+            .with_accepted_random_map(Some(accepted));
+
+            let err = request.prepare_scenario_prefix_plan(&initial).unwrap_err();
+            assert!(
+                format!("{err:#}").contains("cannot attach to an authored map source"),
+                "unexpected error: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn stock_prefix_rejects_legacy_fallback_source() {
+        let starts = [(0, 20, 24), (1, 42, 46)];
+        let launch = test_launch_session(LaunchCountry::America);
+        let initial = crate::app::loading::init::MapLoadInitial::from_test_map_source(
+            prefix_test_map(&starts),
+            crate::app::frontend::list_maps::LoadedMapSource::LegacyFallback {
+                label: "fixture".to_string(),
+            },
+        );
+        let mut request = LoadingRequest::unverified_legacy_skirmish(
+            launch,
+            unverified_seed(0x1717),
+            SkirmishSettings::default(),
+        );
+
+        let err = request.prepare_scenario_prefix_plan(&initial).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("requires an exact authored or generated map source"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn stock_launch_terminal_transfer_requires_ready_prefix() {
+        let mut pending = LoadingRequest::unverified_legacy_skirmish(
+            test_launch_session(LaunchCountry::America),
+            unverified_seed(0x1818),
+            SkirmishSettings::default(),
+        );
+        let pending_err = pending.take_scenario_prefix_plan().unwrap_err();
+        assert!(
+            format!("{pending_err:#}").contains("before Scenario prefix preparation"),
+            "unexpected error: {pending_err:#}"
+        );
+
+        let mut not_applicable = LoadingRequest::unverified_legacy_skirmish(
+            test_launch_session(LaunchCountry::America),
+            unverified_seed(0x1919),
+            SkirmishSettings::default(),
+        );
+        not_applicable.scenario_prefix_plan = ScenarioPrefixPlanState::NotApplicable;
+        let not_applicable_err = not_applicable.take_scenario_prefix_plan().unwrap_err();
+        assert!(
+            format!("{not_applicable_err:#}")
+                .contains("cannot transfer without a Scenario prefix plan"),
+            "unexpected error: {not_applicable_err:#}"
         );
     }
 
@@ -2466,12 +2896,11 @@ mod tests {
         )
         .with_random_map_preview(Some(generated));
         let assignments =
-            selected_map_start_assignments(&launch, request.preloaded_battle_start_plan());
+            selected_map_start_assignments(&launch, request.scenario_prefix_plan());
         assert!(
             assignments.is_empty(),
             "only the launch-time `.SED` regeneration may resolve participants"
         );
-
         let preview = DecodedPreview {
             width: 300,
             height: 100,
@@ -2899,10 +3328,10 @@ mod tests {
     }
 
     #[test]
-    fn only_the_selected_map_cadence_preloads_the_scenario() {
-        assert!(NativeLoadingProgressCadence::SelectedMap.preloads_scenario_before_first_frame());
+    fn both_native_loading_cadences_prepare_scenario_before_first_frame() {
+        assert!(NativeLoadingProgressCadence::SelectedMap.prepares_scenario_before_first_frame());
         assert!(
-            !NativeLoadingProgressCadence::RandomMapHalved.preloads_scenario_before_first_frame()
+            NativeLoadingProgressCadence::RandomMapHalved.prepares_scenario_before_first_frame()
         );
     }
 

--- a/src/app/loading/pump.rs
+++ b/src/app/loading/pump.rs
@@ -330,7 +330,8 @@ impl LoadingRequest {
 
     /// Transfer one accepted setup transaction into loading. Preview terrain,
     /// MapGen continuation, and construction trace remain presentation-only;
-    /// the separately extracted staging is the sole generated start authority.
+    /// the separately extracted staging becomes the active Scenario waypoint
+    /// authority for Gather, loading markers, and the live session snapshot.
     pub(crate) fn with_accepted_random_map(
         mut self,
         accepted: Option<crate::app::shell_random_map::AcceptedRandomMapLaunch>,
@@ -343,6 +344,7 @@ impl LoadingRequest {
         self
     }
 
+    #[cfg(test)]
     fn random_map_preview(&self) -> Option<&crate::map::rmg::GeneratedMap> {
         self.random_map_preview.as_ref()
     }
@@ -1169,6 +1171,9 @@ fn ensure_loading_composition_snapshot(state: &mut AppState) {
                 )
             }
             NativeLoadingProgressCadence::RandomMapHalved => {
+                let LoadingJobPhase::RemainingLegacyLoad(Some(initial)) = &session.job.phase else {
+                    return;
+                };
                 let preview = session
                     .job
                     .ra2_dir
@@ -1180,10 +1185,8 @@ fn ensure_loading_composition_snapshot(state: &mut AppState) {
                     state.process_assets.csf.as_ref(),
                     render_size,
                     preview,
-                    session
-                        .request
-                        .random_map_preview()
-                        .map(|generated| &generated.map_file),
+                    initial.map_data(),
+                    plan.active_scenario_waypoints(),
                     &assignments,
                 )
             }
@@ -2502,31 +2505,62 @@ mod tests {
 
     #[test]
     fn gsi_04_12_generated_prefix_uses_accepted_staging_once() {
+        use crate::map::map_file::MapCell;
+
         let selected = "RandMap.Sed";
-        let staged = [(0, 20, 24), (1, 42, 46)];
-        let preview_waypoints = [(0, 8, 12), (1, 14, 18)];
-        let regenerated = [(0, 60, 64), (1, 72, 76)];
+        let staged = [(0, 70, 70), (1, 90, 70)];
+        let preview_waypoints = [(0, 110, 110), (1, 130, 110)];
+        let regenerated = [(0, 70, 90), (1, 90, 90)];
         let mut launch = test_launch_session(LaunchCountry::America);
         launch.selected_map_file = Some(selected.to_string());
         let accepted =
             accepted_random_map_with_starts(selected, 0x1212, &preview_waypoints, &staged);
+        let mut regenerated_map = crate::map::rmg::emit::empty_map_file(
+            &crate::map::rmg::RmgOptions::default(),
+            100,
+            100,
+        );
+        regenerated_map
+            .waypoints
+            .extend(regenerated.iter().map(|&(slot, rx, ry)| {
+                (
+                    u32::from(slot),
+                    crate::map::waypoints::Waypoint {
+                        index: u32::from(slot),
+                        rx,
+                        ry,
+                    },
+                )
+            }));
+        regenerated_map.cells = [(60, 60), (60, 140), (140, 60), (140, 140)]
+            .into_iter()
+            .map(|(rx, ry)| MapCell {
+                rx,
+                ry,
+                tile_index: 0,
+                sub_tile: 0,
+                z: 0,
+            })
+            .collect();
         let initial = crate::app::loading::init::MapLoadInitial::from_test_map_source(
-            prefix_test_map(&regenerated),
+            regenerated_map,
             crate::app::frontend::list_maps::LoadedMapSource::Generated {
                 seed_name: selected.to_ascii_lowercase(),
             },
         );
         let mut request = LoadingRequest::unverified_legacy_skirmish(
-            launch,
+            launch.clone(),
             unverified_seed(0x1212),
             SkirmishSettings::default(),
         )
         .with_accepted_random_map(Some(accepted));
 
         request.prepare_scenario_prefix_plan(&initial).unwrap();
-        let final_starts = request
+        let plan = request
             .scenario_prefix_plan()
             .expect("generated launch prepares a required prefix")
+            .clone();
+        let final_starts = plan
             .final_gathered_starts()
             .iter()
             .map(|waypoint| (waypoint.index as u8, waypoint.rx, waypoint.ry))
@@ -2534,6 +2568,88 @@ mod tests {
         assert_eq!(final_starts, staged);
         assert_ne!(final_starts, preview_waypoints);
         assert_ne!(final_starts, regenerated);
+        let active_starts = crate::map::waypoints::multiplayer_start_waypoints(
+            plan.active_scenario_waypoints(),
+        )
+        .into_iter()
+        .map(|waypoint| (waypoint.index as u8, waypoint.rx, waypoint.ry))
+        .collect::<Vec<_>>();
+        assert_eq!(active_starts, staged);
+
+        let assignments = selected_map_start_assignments(&launch, Some(&plan));
+        let composition = build_random_map_loading_composition(
+            &launch,
+            None,
+            [800, 600],
+            Some(DecodedPreview {
+                width: 300,
+                height: 100,
+                rgba: vec![255; 300 * 100 * 4],
+            }),
+            initial.map_data(),
+            plan.active_scenario_waypoints(),
+            &assignments,
+        );
+        assert_eq!(
+            composition
+                .markers
+                .iter()
+                .map(|marker| {
+                    (
+                        marker.waypoint.index as u8,
+                        marker.waypoint.rx,
+                        marker.waypoint.ry,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            staged,
+            "random loading markers read the active Scenario staging copy"
+        );
+
+        let staged_session = crate::app::loading::init::scenario_start_waypoints_for_load(
+            initial.map_data(),
+            Some(&plan),
+        );
+        let regenerated_session = crate::app::loading::init::scenario_start_waypoints_for_load(
+            initial.map_data(),
+            None,
+        );
+        assert_eq!(
+            staged_session
+                .iter()
+                .map(|(&index, &(rx, ry))| (index as u8, rx, ry))
+                .collect::<Vec<_>>(),
+            staged
+        );
+        assert_ne!(staged_session, regenerated_session);
+        let staged_sim = crate::sim::world::Simulation::from_descriptor(
+            &crate::sim::scenario_session::ScenarioDescriptor {
+                seed: 0x1212,
+                map_width: 256,
+                map_height: 256,
+                mp_start_waypoints: staged_session,
+                ..Default::default()
+            },
+        );
+        let regenerated_sim = crate::sim::world::Simulation::from_descriptor(
+            &crate::sim::scenario_session::ScenarioDescriptor {
+                seed: 0x1212,
+                map_width: 256,
+                map_height: 256,
+                mp_start_waypoints: regenerated_session,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            staged_sim
+                .session
+                .mp_start_waypoints
+                .iter()
+                .map(|(&index, &(rx, ry))| (index as u8, rx, ry))
+                .collect::<Vec<_>>(),
+            staged
+        );
+        assert_ne!(staged_sim.state_hash(), regenerated_sim.state_hash());
         assert!(
             request.accepted_rmg_start_staging.is_none(),
             "accepted setup staging transfers exactly once"
@@ -2880,6 +2996,13 @@ mod tests {
                 ry: 90,
             },
         );
+        let mut launch_map = crate::map::rmg::emit::empty_map_file(
+            &crate::map::rmg::RmgOptions::default(),
+            100,
+            100,
+        );
+        launch_map.cells = map.cells.clone();
+        let active_scenario_waypoints = map.waypoints.clone();
         let generated = crate::map::rmg::GeneratedMap {
             map_file: map,
             mapgen_continuation:
@@ -2911,9 +3034,8 @@ mod tests {
             None,
             [800, 600],
             Some(preview),
-            request
-                .random_map_preview()
-                .map(|retained| &retained.map_file),
+            &launch_map,
+            &active_scenario_waypoints,
             &assignments,
         );
         let prepared = composition.preview.expect("FFA retained preview");

--- a/src/app/loading/pump.rs
+++ b/src/app/loading/pump.rs
@@ -2508,7 +2508,7 @@ mod tests {
         use crate::map::map_file::MapCell;
 
         let selected = "RandMap.Sed";
-        let staged = [(0, 70, 70), (1, 90, 70)];
+        let staged = [(0, 70, 70)];
         let preview_waypoints = [(0, 110, 110), (1, 130, 110)];
         let regenerated = [(0, 70, 90), (1, 90, 90)];
         let mut launch = test_launch_session(LaunchCountry::America);
@@ -2565,7 +2565,15 @@ mod tests {
             .iter()
             .map(|waypoint| (waypoint.index as u8, waypoint.rx, waypoint.ry))
             .collect::<Vec<_>>();
-        assert_eq!(final_starts, staged);
+        assert_eq!(final_starts.len(), 2);
+        assert_eq!(final_starts[0], staged[0]);
+        let gathered_fallback = final_starts[1];
+        assert!(
+            !staged.contains(&gathered_fallback)
+                && !preview_waypoints.contains(&gathered_fallback)
+                && !regenerated.contains(&gathered_fallback),
+            "deficient Gather must add a distinct temporary start"
+        );
         assert_ne!(final_starts, preview_waypoints);
         assert_ne!(final_starts, regenerated);
         let active_starts = crate::map::waypoints::multiplayer_start_waypoints(
@@ -2622,6 +2630,14 @@ mod tests {
             staged
         );
         assert_ne!(staged_session, regenerated_session);
+        let gathered_session = final_starts
+            .iter()
+            .map(|&(index, rx, ry)| (u32::from(index), (rx, ry)))
+            .collect();
+        assert_ne!(
+            staged_session, gathered_session,
+            "the active Scenario table excludes Gather-only fallback starts"
+        );
         let staged_sim = crate::sim::world::Simulation::from_descriptor(
             &crate::sim::scenario_session::ScenarioDescriptor {
                 seed: 0x1212,
@@ -2640,6 +2656,15 @@ mod tests {
                 ..Default::default()
             },
         );
+        let gathered_sim = crate::sim::world::Simulation::from_descriptor(
+            &crate::sim::scenario_session::ScenarioDescriptor {
+                seed: 0x1212,
+                map_width: 256,
+                map_height: 256,
+                mp_start_waypoints: gathered_session,
+                ..Default::default()
+            },
+        );
         assert_eq!(
             staged_sim
                 .session
@@ -2649,6 +2674,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             staged
         );
+        assert_ne!(staged_sim.state_hash(), gathered_sim.state_hash());
         assert_ne!(staged_sim.state_hash(), regenerated_sim.state_hash());
         assert!(
             request.accepted_rmg_start_staging.is_none(),

--- a/src/app/persistence/mod.rs
+++ b/src/app/persistence/mod.rs
@@ -528,6 +528,8 @@ mod tests {
                 team: LaunchTeam::None,
                 difficulty: AiDifficulty::Easy,
             }],
+            pre_fill_house_roster:
+                crate::skirmish_launch::PreFillHouseRoster::from_compact_skirmish(1),
             options: SkirmishLaunchOptions::default(),
         };
         let accepted = match crate::match_bootstrap::classify_startup_session(&launch) {

--- a/src/app/random_map_lifecycle_tests.rs
+++ b/src/app/random_map_lifecycle_tests.rs
@@ -52,6 +52,7 @@ fn launch_session(seed_name: &str) -> SkirmishLaunchSession {
             team: LaunchTeam::None,
             difficulty: AiDifficulty::Easy,
         }],
+        pre_fill_house_roster: crate::skirmish_launch::PreFillHouseRoster::from_compact_skirmish(1),
         options: SkirmishLaunchOptions::default(),
     }
 }
@@ -368,6 +369,22 @@ fn gsi_04_12_random_map_ui_to_sed_launch_lifecycle_converges() {
     // through the same retention/request boundary used by Start. The request's
     // production initial-map entry must regenerate from .SED and converge with
     // a direct .SED launch in every generated gameplay fact.
+    let direct_initial = super::loading::init::load_map_initial_with_assets(
+        seed_dir.clone(),
+        &mut assets,
+        Some(seed_name),
+        &mut SilentProgress,
+    )
+    .expect("direct .SED launch regeneration");
+    let accepted_start_waypoints: Vec<_> = (0..crate::skirmish_launch::SKIRMISH_PLAYER_SLOT_COUNT)
+        .filter_map(|slot| {
+            direct_initial
+                .map_data()
+                .waypoints
+                .get(&(slot as u32))
+                .map(|waypoint| (slot as u8, waypoint.rx, waypoint.ry))
+        })
+        .collect();
     let mut poison_options = options.clone();
     poison_options.seed = 0x7BAD;
     let mut poison_map = crate::map::rmg::emit::empty_map_file(&poison_options, 32, 32);
@@ -383,7 +400,7 @@ fn gsi_04_12_random_map_ui_to_sed_launch_lifecycle_converges() {
         map_file: poison_map,
         mapgen_continuation: RmgRng::new(poison_options.seed_u16()).into_continuation(),
         construction_trace: poison_trace,
-        start_waypoints: vec![(0, 1, 1)],
+        start_waypoints: accepted_start_waypoints,
         stages_run: Vec::new(),
         unfilled_start_slots: 0,
     };
@@ -392,10 +409,10 @@ fn gsi_04_12_random_map_ui_to_sed_launch_lifecycle_converges() {
     retention.accept_setup(seed_name);
     retention.destroy_map_storage();
     let accepted_poison = retention
-        .take_preview_for_loading(Some(seed_name))
-        .expect("accepted setup transfers presentation preview once");
+        .take_acceptance_for_loading(Some(seed_name))
+        .expect("accepted setup transfers preview and staged starts once");
     let launch = launch_session(seed_name);
-    let ui_request = LoadingRequest::unverified_legacy_skirmish(
+    let mut ui_request = LoadingRequest::unverified_legacy_skirmish(
         launch.clone(),
         crate::match_bootstrap::MatchSeed {
             value: MATCH_SEED,
@@ -404,34 +421,29 @@ fn gsi_04_12_random_map_ui_to_sed_launch_lifecycle_converges() {
         },
         crate::ui::main_menu::SkirmishSettings::default(),
     )
-    .with_random_map_preview(Some(accepted_poison));
+    .with_accepted_random_map(Some(accepted_poison));
     let ui_initial = ui_request
         .load_initial_with_assets(seed_dir.clone(), &mut assets, &mut SilentProgress)
         .expect("accepted UI .SED launch regeneration");
     let descriptor =
         crate::sim::scenario_bootstrap::MatchLaunchDescriptor::from_resolved(launch.clone())
             .expect("resolved random-map launch descriptor");
-    let ui_plan = crate::sim::scenario_bootstrap::preload_standard_battle_start_plan(
-        &descriptor,
-        ui_initial.map_data(),
-        MATCH_SEED,
-    )
-    .expect("generated map supplies complete Battle starts");
+    ui_request
+        .prepare_scenario_prefix_plan(&ui_initial)
+        .expect("accepted generated source prepares its mandatory prefix");
+    let ui_plan = ui_request
+        .scenario_prefix_plan()
+        .expect("accepted generated prefix")
+        .clone();
     let ui_launch =
         ui_initial.into_random_map_launch_snapshot(&mut assets, MATCH_SEED, &descriptor, &ui_plan);
-    let direct_initial = super::loading::init::load_map_initial_with_assets(
-        seed_dir.clone(),
-        &mut assets,
-        Some(seed_name),
-        &mut SilentProgress,
-    )
-    .expect("direct .SED launch regeneration");
-    let direct_plan = crate::sim::scenario_bootstrap::preload_standard_battle_start_plan(
+    let direct_plan = crate::sim::scenario_bootstrap::prepare_stock_offline_scenario_prefix_plan(
         &descriptor,
         direct_initial.map_data(),
+        &direct_initial.map_data().waypoints,
         MATCH_SEED,
     )
-    .expect("direct generated map supplies complete Battle starts");
+    .expect("direct generated fixture supplies the same staged start table");
     let direct_launch = direct_initial.into_random_map_launch_snapshot(
         &mut assets,
         MATCH_SEED,

--- a/src/app/shell_random_map.rs
+++ b/src/app/shell_random_map.rs
@@ -115,17 +115,68 @@ pub(crate) struct RandomMapGenerationJob {
     accept_on_finish: bool,
 }
 
-/// Preview ownership across the setup dialog and loading composition.
+/// Provenance-bearing copy of the eight Scenario start-staging cells written
+/// by the accepted random-map setup run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AcceptedRmgStartStaging {
+    starts: Vec<crate::map::waypoints::Waypoint>,
+}
+
+impl AcceptedRmgStartStaging {
+    fn from_generated(generated: &crate::map::rmg::GeneratedMap) -> Self {
+        let mut slots = [None; crate::skirmish_launch::SKIRMISH_PLAYER_SLOT_COUNT];
+        for &(slot, rx, ry) in &generated.start_waypoints {
+            if let Some(entry) = slots.get_mut(usize::from(slot)) {
+                *entry = Some(crate::map::waypoints::Waypoint {
+                    index: u32::from(slot),
+                    rx,
+                    ry,
+                });
+            }
+        }
+        Self {
+            starts: slots.into_iter().flatten().collect(),
+        }
+    }
+
+    pub(crate) fn to_waypoint_table(
+        &self,
+    ) -> std::collections::HashMap<u32, crate::map::waypoints::Waypoint> {
+        self.starts
+            .iter()
+            .copied()
+            .map(|waypoint| (waypoint.index, waypoint))
+            .collect()
+    }
+}
+
+/// Accepted random-map artifacts split at the app/loading boundary. The large
+/// generated map remains presentation-only; only `start_staging` may supply
+/// gameplay start cells.
+#[derive(Debug)]
+pub(crate) struct AcceptedRandomMapLaunch {
+    presentation_preview: crate::map::rmg::GeneratedMap,
+    start_staging: AcceptedRmgStartStaging,
+}
+
+impl AcceptedRandomMapLaunch {
+    pub(crate) fn into_parts(self) -> (crate::map::rmg::GeneratedMap, AcceptedRmgStartStaging) {
+        (self.presentation_preview, self.start_staging)
+    }
+}
+
+/// Accepted launch-artifact ownership across setup and loading composition.
 ///
-/// The candidate belongs only to the open setup dialog. An accepted preview may
-/// accompany the matching `.SED` only as a presentation fallback; gameplay
-/// always regenerates through the seed-file reader after the match reseed.
+/// The candidate belongs only to the open setup dialog. The accepted bundle
+/// carries both presentation fallback and exact start staging for the matching
+/// `.SED`; gameplay map data still regenerates through the seed-file reader
+/// after the match reseed.
 /// gamemd provenance: accepted caller 0x005E8590 persists `RandMap.Sed`, while
 /// Scenario read 0x00684620 unconditionally reaches the generator again.
 #[derive(Default)]
 pub(crate) struct RandomMapGenerationRetention {
     candidate: Option<crate::map::rmg::GeneratedMap>,
-    accepted_preview: Option<(String, crate::map::rmg::GeneratedMap)>,
+    accepted_launch: Option<(String, AcceptedRandomMapLaunch)>,
     /// The native MapSeed+0x178 clone survives repeated Generate/OK work while
     /// the dialog is open. A four-field mismatch replaces its backing storage,
     /// and common dialog teardown destroys it before a later reopen.
@@ -156,7 +207,7 @@ impl RandomMapGenerationRetention {
 
     pub(super) fn begin_generation(&mut self) {
         self.candidate = None;
-        self.accepted_preview = None;
+        self.accepted_launch = None;
     }
 
     pub(super) fn finish_generation(&mut self, generated: crate::map::rmg::GeneratedMap) {
@@ -165,36 +216,54 @@ impl RandomMapGenerationRetention {
 
     fn cancel_setup(&mut self) {
         self.candidate = None;
-        self.accepted_preview = None;
+        self.accepted_launch = None;
     }
 
     pub(super) fn accept_setup(&mut self, selected_map_file: &str) {
-        self.accepted_preview = self
-            .candidate
-            .take()
-            .map(|generated| (selected_map_file.to_owned(), generated));
+        self.accepted_launch = self.candidate.take().map(|generated| {
+            let start_staging = AcceptedRmgStartStaging::from_generated(&generated);
+            (
+                selected_map_file.to_owned(),
+                AcceptedRandomMapLaunch {
+                    presentation_preview: generated,
+                    start_staging,
+                },
+            )
+        });
     }
 
     pub(super) fn select_map(&mut self, selected_map_file: &str) {
         if self
-            .accepted_preview
+            .accepted_launch
             .as_ref()
             .is_some_and(|(accepted_file, _)| {
                 !accepted_file.eq_ignore_ascii_case(selected_map_file)
             })
         {
-            self.accepted_preview = None;
+            self.accepted_launch = None;
         }
     }
 
+    pub(super) fn take_acceptance_for_loading(
+        &mut self,
+        selected_map_file: Option<&str>,
+    ) -> Option<AcceptedRandomMapLaunch> {
+        let (accepted_file, accepted) = self.accepted_launch.take()?;
+        selected_map_file
+            .is_some_and(|selected| accepted_file.eq_ignore_ascii_case(selected))
+            .then_some(accepted)
+    }
+
+    /// Presentation-only compatibility accessor used by lifecycle tests.
+    /// Production transfers the complete accepted value so staging cannot be
+    /// dropped or reconstructed from the preview.
+    #[cfg(test)]
     pub(super) fn take_preview_for_loading(
         &mut self,
         selected_map_file: Option<&str>,
     ) -> Option<crate::map::rmg::GeneratedMap> {
-        let (accepted_file, generated) = self.accepted_preview.take()?;
-        selected_map_file
-            .is_some_and(|selected| accepted_file.eq_ignore_ascii_case(selected))
-            .then_some(generated)
+        self.take_acceptance_for_loading(selected_map_file)
+            .map(|accepted| accepted.presentation_preview)
     }
 }
 
@@ -325,7 +394,7 @@ pub(super) fn finish_random_map_generation_owners(
 
 /// The non-presentation state transition at each Generate/implicit-OK entry.
 /// It is shared by the live App entry and the retail lifecycle harness so a
-/// repeated run always invalidates the same candidate and accepted preview.
+/// repeated run always invalidates the same candidate and accepted launch.
 pub(super) fn begin_random_map_generation_owners(
     runtime: &mut crate::app::frontend::skirmish_session::OfflineSkirmishRuntime,
     retention: &mut RandomMapGenerationRetention,
@@ -699,12 +768,13 @@ impl App {
         state.frontend.random_map_generation = None;
         match Self::commit_random_map_setup(state, &options) {
             Ok(()) => {
-                // Teardown retained only the accepted presentation preview;
-                // launch remains owned by the `.SED` reader.
+                // Teardown retained both accepted start staging and its
+                // presentation preview; map construction remains owned by the
+                // `.SED` reader.
             }
             Err(err) => {
                 // The native dialog has already torn down at this point. Do
-                // not leave an accepted preview attached when the seed/options
+                // not leave an accepted launch attached when the seed/options
                 // commit failed and no random-map selection was installed.
                 state.frontend.random_map_retention.cancel_setup();
                 log::error!("random map: could not write {RANDMAP_SED_FILE}: {err}");
@@ -1692,7 +1762,7 @@ mod tests {
         accepted_after_successful_close.finish_generation(generated_preview(44, 40));
         accepted_after_successful_close.accept_setup("RandMap.Sed");
         // Common dialog teardown destroys only the cached RMG map storage; it
-        // must not discard the accepted presentation preview awaiting loading.
+        // must not discard the accepted launch bundle awaiting loading.
         accepted_after_successful_close.destroy_map_storage();
         accepted_after_successful_close.select_map("RANDMAP.SED");
         let transferred = accepted_after_successful_close

--- a/src/app/shell_skirmish.rs
+++ b/src/app/shell_skirmish.rs
@@ -226,9 +226,9 @@ impl App {
         state: &mut AppState,
         session: crate::skirmish_launch::SkirmishLaunchSession,
     ) {
-        let random_map_preview = state
+        let accepted_random_map = state
             .frontend.random_map_retention
-            .take_preview_for_loading(session.selected_map_file.as_deref());
+            .take_acceptance_for_loading(session.selected_map_file.as_deref());
         let request = match crate::match_bootstrap::classify_startup_session(&session) {
             crate::match_bootstrap::StartupSessionClassification::AcceptedExplicitFixedBattle(
                 accepted,
@@ -264,7 +264,7 @@ impl App {
                 )
             }
         }
-        .with_random_map_preview(random_map_preview);
+        .with_accepted_random_map(accepted_random_map);
         state.frontend.skirmish_shell_state.pressed_owner_draw_button = None;
         state.frontend.skirmish_shell_last_painted_pressed_button = None;
         state.frontend.shell_route = crate::app::shell_route::ShellRoute::MainMenu;

--- a/src/match_bootstrap.rs
+++ b/src/match_bootstrap.rs
@@ -1,6 +1,6 @@
 //! App-owned match startup authority and pre-first-tick evidence.
 //!
-//! This module sits above `sim/`: it classifies explicit fixed-map Battle
+//! This module sits above `sim/`: it classifies explicit-start Battle
 //! sessions, reads the ordinary Windows seed once, and observes an already
 //! initialized `Simulation` without mutating it.
 
@@ -45,7 +45,7 @@ impl AcceptedBattleSession {
         self.launch
             .selected_map_file
             .as_deref()
-            .expect("accepted sessions always own a selected fixed map")
+            .expect("accepted sessions always own a selected map record")
     }
 }
 
@@ -436,6 +436,8 @@ mod tests {
                 team: LaunchTeam::None,
                 difficulty: AiDifficulty::Easy,
             }],
+            pre_fill_house_roster:
+                crate::skirmish_launch::PreFillHouseRoster::from_compact_skirmish(1),
             options: SkirmishLaunchOptions::default(),
         }
     }

--- a/src/sim/scenario_bootstrap.rs
+++ b/src/sim/scenario_bootstrap.rs
@@ -329,6 +329,11 @@ pub(crate) enum StockOfflineStartCallbackFamily {
 /// assignment are projected later; projection is deliberately draw-free.
 #[derive(Debug, Clone)]
 pub(crate) struct PreFillScenarioPrefixPlan {
+    /// Raw active Scenario waypoint table after the authored read or accepted
+    /// RMG staging copy. Gather may derive fallback cells from this table, but
+    /// loading markers and the live Scenario/session owner retain these exact
+    /// entries rather than the Gather result or regenerated `.SED` table.
+    active_scenario_waypoints: HashMap<u32, Waypoint>,
     first_gathered_starts: Vec<Waypoint>,
     final_gathered_starts: Vec<Waypoint>,
     assignment: NativeStartAssignment,
@@ -372,6 +377,10 @@ pub(crate) enum PreFillScenarioPrefixPlanError {
 }
 
 impl PreFillScenarioPrefixPlan {
+    pub(crate) fn active_scenario_waypoints(&self) -> &HashMap<u32, Waypoint> {
+        &self.active_scenario_waypoints
+    }
+
     #[cfg(test)]
     pub(crate) fn first_gathered_starts(&self) -> &[Waypoint] {
         &self.first_gathered_starts
@@ -512,6 +521,7 @@ pub(crate) fn prepare_stock_offline_scenario_prefix_plan(
     let after_second_house_pass = scenario_rng_after.clone();
 
     Ok(PreFillScenarioPrefixPlan {
+        active_scenario_waypoints: start_waypoints.clone(),
         first_gathered_starts,
         final_gathered_starts,
         assignment,

--- a/src/sim/scenario_bootstrap.rs
+++ b/src/sim/scenario_bootstrap.rs
@@ -1,16 +1,15 @@
 //! Simulation-owned offline-skirmish world bootstrap.
 //!
-//! Active Battle startup resolves participant starts before terrain loading when
-//! every authored start exists, then carries the same Scenario RNG cursor into
-//! terrain Fill and the live world. House construction, runtime/deficient-map
-//! start assignment, opening forces, shroud, AI credits, and alliances remain
-//! behind the same simulation authority boundary.
+//! Active-stock offline startup resolves both House passes and both selected-mode
+//! start callbacks before terrain Fill, then carries the same Scenario RNG cursor
+//! into the live world. Final House projection, opening forces, shroud, AI
+//! credits, and alliances remain behind the same simulation authority boundary.
 
 use std::collections::{BTreeMap, HashMap};
 
 use crate::map::entities::EntityCategory;
 use crate::map::houses::HouseRoster;
-use crate::map::map_file::MapFile;
+use crate::map::map_file::{MapFile, MapHeader};
 use crate::map::overlay_types::OverlayTypeRegistry;
 use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use crate::map::waypoints::Waypoint;
@@ -29,7 +28,7 @@ use crate::sim::rng::{SimRng, SimRngLogicalState};
 use crate::sim::scenario_session::ScenarioDescriptor;
 use crate::sim::world::{PlacementEvidence, Simulation};
 use crate::skirmish_launch::{
-    LaunchCountry, LaunchStartPosition, LaunchTeam, SkirmishLaunchSession,
+    LaunchCountry, LaunchStartPosition, LaunchTeam, PreFillHouseRoster, SkirmishLaunchSession,
 };
 use crate::util::native_x87::{X87Chop53, sqrt_approx_f32};
 
@@ -42,6 +41,25 @@ pub(crate) struct NativeStartBounds {
 }
 
 impl NativeStartBounds {
+    /// Construct the post-Resize cell-array rectangle directly from parsed
+    /// `[Map] Size`, before Fill has produced a resolved terrain grid.
+    pub(crate) fn from_map_header(header: &MapHeader) -> Option<Self> {
+        if header.width == 0 || header.height == 0 {
+            return None;
+        }
+        let extent = header.width.checked_add(header.height)?;
+        if extent > 512 {
+            return None;
+        }
+        let extent = u16::try_from(extent).ok()?;
+        (extent > 1).then_some(Self {
+            min_rx: 1,
+            min_ry: 1,
+            width: extent - 1,
+            height: extent - 1,
+        })
+    }
+
     /// gamemd-derived: active YR start placement is bounded by the MapClass
     /// CELL-ARRAY rect, never by `LocalSize=`. `MapClass::Resize @ 0x00565C10` writes
     /// `MapClass+0x124..0x130` as `(1, 1, SizeW+SizeH-1, SizeW+SizeH-1)`, and
@@ -94,6 +112,7 @@ impl NativeStartBounds {
 /// authored starts are deficient, each retry consumes the two asymmetric
 /// ranged draws and runs the 8x8 nearby-passable search; invalid searches do
 /// not advance the vector and have no artificial retry cap.
+#[cfg(test)]
 pub(crate) fn native_gather_start_positions(
     waypoints: &HashMap<u32, Waypoint>,
     participant_count: usize,
@@ -104,6 +123,51 @@ pub(crate) fn native_gather_start_positions(
     map_size_height: Option<i32>,
     binary_frame: u32,
     rng: &mut SimRng,
+) -> Vec<Waypoint> {
+    gather_start_positions_with_search(
+        waypoints,
+        participant_count,
+        bounds,
+        rng,
+        |seed_rx, seed_ry| {
+            find_nearby_start_rect(
+                terrain,
+                occupancy,
+                playfield_bounds,
+                map_size_height,
+                binary_frame,
+                seed_rx,
+                seed_ry,
+            )
+        },
+    )
+}
+
+/// Run Gather in the exact pre-Fill cell lifetime: MapClass has resized and
+/// normalized Size/LocalSize, but every CellClass still has constructor
+/// defaults and no Iso/overlay/Terrain/Techno/occupation authority exists.
+pub(crate) fn native_gather_pre_fill_start_positions(
+    waypoints: &HashMap<u32, Waypoint>,
+    required_start_count: usize,
+    header: &MapHeader,
+    rng: &mut SimRng,
+) -> Option<Vec<Waypoint>> {
+    let bounds = NativeStartBounds::from_map_header(header)?;
+    Some(gather_start_positions_with_search(
+        waypoints,
+        required_start_count,
+        bounds,
+        rng,
+        |seed_rx, seed_ry| find_nearby_pre_fill_start_rect(header, seed_rx, seed_ry),
+    ))
+}
+
+fn gather_start_positions_with_search(
+    waypoints: &HashMap<u32, Waypoint>,
+    participant_count: usize,
+    bounds: NativeStartBounds,
+    rng: &mut SimRng,
+    mut find_nearby: impl FnMut(u16, u16) -> Option<(u16, u16)>,
 ) -> Vec<Waypoint> {
     let authored_prefix = (0..8u32)
         .take_while(|index| waypoints.contains_key(index))
@@ -136,15 +200,7 @@ pub(crate) fn native_gather_start_positions(
             .next_range_u32_inclusive(10, x_high)
             .wrapping_add(u32::from(bounds.min_rx)) as u16;
 
-        let Some((rx, ry)) = find_nearby_start_rect(
-            terrain,
-            occupancy,
-            playfield_bounds,
-            map_size_height,
-            binary_frame,
-            seed_rx,
-            seed_ry,
-        ) else {
+        let Some((rx, ry)) = find_nearby(seed_rx, seed_ry) else {
             continue;
         };
         starts.push(Waypoint {
@@ -157,6 +213,40 @@ pub(crate) fn native_gather_start_positions(
     starts
 }
 
+fn find_nearby_pre_fill_start_rect(
+    header: &MapHeader,
+    seed_rx: u16,
+    seed_ry: u16,
+) -> Option<(u16, u16)> {
+    let playfield_bounds = crate::map::playfield::PlayfieldBounds::from_map_header(header);
+    let query = NearbyQuery {
+        passability: PassabilityArgs {
+            speed_type: SpeedType::Track,
+            required_zone_id: None,
+            movement_zone: MovementZone::Normal,
+            bridge_aware_zone: false,
+        },
+        footprint: NearbyFootprint::new(
+            i32::from(DEFICIENT_START_RECT_W),
+            i32::from(DEFICIENT_START_RECT_H),
+        ),
+        anchor_gate: NearbyAnchorGate::NativeHeightAware,
+        allow_bridge_cells: true,
+        check_height: false,
+        check_occupancy: false,
+        radius_cap: map_owned_radius_cap(playfield_bounds.base, header.height as i32),
+        target_cell: None,
+        path_grid: None,
+        resolved_terrain: None,
+        overlay_grid: None,
+        occupancy: None,
+        entities: None,
+        zone_grid: None,
+        playfield_bounds: Some(playfield_bounds),
+    };
+    find_nearby_passable_cell((i32::from(seed_rx), i32::from(seed_ry)), &query, 0)
+}
+
 /// Exact deficient-start adapter over the shared MapClass FNPC mechanism.
 ///
 /// The caller's `8,8` are top-left CellRect dimensions, not a search radius.
@@ -167,6 +257,7 @@ pub(crate) fn native_gather_start_positions(
 // reject-overlay=0, height=0, obstacle=0, allow-bridge=1, null-reference,
 // param15=0, final-occupancy=0)` to
 // `MapClass::Find_Nearby_Passable_Cell @ 0x0056DC20`.
+#[cfg(test)]
 pub(crate) fn find_nearby_start_rect(
     terrain: &ResolvedTerrainGrid,
     occupancy: &crate::sim::occupancy::OccupancyGrid,
@@ -212,47 +303,82 @@ pub(crate) fn find_nearby_start_rect(
     )
 }
 
-/// Assign the gathered vector through standard Battle mode's `+0x84` callback.
-/// Explicit starts populate a last-writer-wins table before the HouseClass
-/// pass; every non-special House then honors its table entry or uses the
-/// Battle selector's first-random/then-farthest rule.
+/// Retain the native start-table ownership and resolved placement for one
+/// stock-offline assignment callback.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct NativeStartAssignment {
     pub(crate) placements: Vec<(usize, Waypoint)>,
     pub(crate) start_table: Vec<Option<usize>>,
 }
 
-const NATIVE_MULTIPLAYER_START_LIMIT: usize = 8;
 pub(crate) const HOUSE_CONSTRUCTOR_TIMER_MIN: u32 = 450;
 pub(crate) const HOUSE_CONSTRUCTOR_TIMER_MAX: u32 = 1800;
 
-/// Immutable standard-Battle state prepared before the first loading frame.
+/// The selected active-retail start callback used by offline noncampaign Full Init.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StockOfflineStartCallbackFamily {
+    Battle,
+    Cooperative,
+}
+
+/// Immutable stock-offline Scenario prefix prepared before terrain Fill.
 ///
-/// Complete authored start vectors need no terrain-dependent fallback, so the
-/// frontend can reproduce the native pre-render constructor and assignment RNG
-/// prefix once. The resulting table is then shared by loading composition and
-/// gameplay initialization.
+/// This plan is the sole owner of the disposable first House pass, both
+/// selected-mode Gather callbacks, the final chooser, the zero-draw reset, and
+/// the second House pass. Only the second Gather vector and its retained
+/// assignment are projected later; projection is deliberately draw-free.
 #[derive(Debug, Clone)]
-pub(crate) struct PreloadedBattleStartPlan {
-    gathered_starts: Vec<Waypoint>,
+pub(crate) struct PreFillScenarioPrefixPlan {
+    first_gathered_starts: Vec<Waypoint>,
+    final_gathered_starts: Vec<Waypoint>,
     assignment: NativeStartAssignment,
+    first_house_timers: Vec<u32>,
+    second_house_timers: Vec<u32>,
     scenario_rng_before: SimRngLogicalState,
     scenario_rng_before_fingerprint: u64,
     scenario_rng_after: SimRngLogicalState,
     scenario_rng_after_cursor: SimRng,
+    #[cfg(test)]
+    rng_checkpoints: ScenarioPrefixRngCheckpoints,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ScenarioPrefixRngCheckpoints {
+    pub(crate) after_first_house_pass: SimRngLogicalState,
+    pub(crate) after_first_gather: SimRngLogicalState,
+    pub(crate) after_second_gather_and_chooser: SimRngLogicalState,
+    pub(crate) after_zero_draw_reset: SimRngLogicalState,
+    pub(crate) after_second_house_pass: SimRngLogicalState,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-pub(crate) enum PreloadedBattleStartPlanError {
+pub(crate) enum PreFillScenarioPrefixPlanError {
     #[error(
-        "preloaded Battle plan expected Scenario RNG fingerprint {expected:#018x}, got {actual:#018x}"
+        "pre-Fill Scenario prefix expected RNG fingerprint {expected:#018x}, got {actual:#018x}"
     )]
     ScenarioRngPrestateMismatch { expected: u64, actual: u64 },
+    #[error("launch mode id {id} is not the validated active-retail stock row")]
+    UnsupportedStockMode { id: i32 },
+    #[error(
+        "pre-Fill roster requires {roster_start_count} starts but the compact launch session has {launch_participant_count} participants"
+    )]
+    RosterParticipantMismatch {
+        roster_start_count: usize,
+        launch_participant_count: usize,
+    },
+    #[error("map Size does not produce a valid resized pre-Fill cell rectangle")]
+    InvalidMapCellExtent,
 }
 
-impl PreloadedBattleStartPlan {
-    pub(crate) fn gathered_starts(&self) -> &[Waypoint] {
-        &self.gathered_starts
+impl PreFillScenarioPrefixPlan {
+    #[cfg(test)]
+    pub(crate) fn first_gathered_starts(&self) -> &[Waypoint] {
+        &self.first_gathered_starts
+    }
+
+    pub(crate) fn final_gathered_starts(&self) -> &[Waypoint] {
+        &self.final_gathered_starts
     }
 
     pub(crate) fn start_table(&self) -> &[Option<usize>] {
@@ -263,17 +389,34 @@ impl PreloadedBattleStartPlan {
         &self.assignment
     }
 
+    #[cfg(test)]
+    pub(crate) fn first_house_timers(&self) -> &[u32] {
+        &self.first_house_timers
+    }
+
+    #[cfg(test)]
+    pub(crate) fn second_house_timers(&self) -> &[u32] {
+        &self.second_house_timers
+    }
+
+    #[cfg(test)]
+    pub(crate) fn rng_checkpoints(&self) -> &ScenarioPrefixRngCheckpoints {
+        &self.rng_checkpoints
+    }
+
     /// Validate and transfer the one pre-loading RNG prefix to the stream that
     /// later terrain Fill and Simulation construction will continue.
     fn install_before_terrain(
         &self,
         scenario_rng: &mut SimRng,
-    ) -> Result<(), PreloadedBattleStartPlanError> {
+    ) -> Result<(), PreFillScenarioPrefixPlanError> {
         if scenario_rng.logical_state() != self.scenario_rng_before {
-            return Err(PreloadedBattleStartPlanError::ScenarioRngPrestateMismatch {
-                expected: self.scenario_rng_before_fingerprint,
-                actual: scenario_rng.state(),
-            });
+            return Err(
+                PreFillScenarioPrefixPlanError::ScenarioRngPrestateMismatch {
+                    expected: self.scenario_rng_before_fingerprint,
+                    actual: scenario_rng.state(),
+                },
+            );
         }
         *scenario_rng = self.scenario_rng_after_cursor.clone();
         debug_assert_eq!(scenario_rng.logical_state(), self.scenario_rng_after);
@@ -281,106 +424,294 @@ impl PreloadedBattleStartPlan {
     }
 }
 
-/// Prepare the terrain-independent stock Battle/FFA prefix exactly once.
+/// Prepare the complete active-stock offline prefix exactly once.
 ///
-/// Sparse or deficient authored starts deliberately return `None`: their two
-/// Gather passes depend on resolved terrain and must stay runtime-owned.
-/// Random maps are eligible after the launch-time `.SED` reader regenerates
-/// their MapFile: gamemd Full_Init 0x00686B20 assigns those fresh RmgRegion
-/// start waypoints before DrawLoadingScreen 0x00552D60 consumes the table.
-/// FFA provenance: constructor 0x005C5CE0 installs vtable 0x007EE424, whose
-/// +0x80 (0x005D6BE0), +0x84 (0x005D6C70), and +0xC4 (0x005D6890) callbacks
-/// are byte-identical to Battle's active start-assignment callbacks. Full_Init
-/// 0x00686B20 calls +0x80 and ordinarily +0x84 for offline g_GameMode 5 before
-/// DrawLoadingScreen.
-pub(crate) fn preload_standard_battle_start_plan(
+/// `start_waypoints` is an explicit source selected by the app boundary:
+/// authored maps pass the parsed map table, while accepted Battle/FFA `.SED`
+/// launches pass the provenance-bearing setup staging. Both Gather callbacks
+/// operate only on the resized default-cell view derived from `[Map]`.
+pub(crate) fn prepare_stock_offline_scenario_prefix_plan(
     descriptor: &MatchLaunchDescriptor,
     map_data: &MapFile,
+    start_waypoints: &HashMap<u32, Waypoint>,
     launch_seed: u32,
-) -> Option<PreloadedBattleStartPlan> {
+) -> Result<PreFillScenarioPrefixPlan, PreFillScenarioPrefixPlanError> {
     let session = descriptor.session();
-    if !has_verified_preload_start_callbacks(session) {
-        return None;
-    }
-    let selected_map = session.selected_map_file.as_deref()?;
-    if selected_map.trim() != selected_map
-        || selected_map.is_empty()
-        || selected_map.eq_ignore_ascii_case("auto")
-    {
-        return None;
-    }
-
-    let participant_count = 1usize.checked_add(session.opponents.len())?;
-    let authored_prefix = (0..NATIVE_MULTIPLAYER_START_LIMIT)
-        .take_while(|index| map_data.waypoints.contains_key(&(*index as u32)))
-        .count();
-    let authored_count = (0..NATIVE_MULTIPLAYER_START_LIMIT)
-        .filter(|index| map_data.waypoints.contains_key(&(*index as u32)))
-        .count();
-    if authored_prefix != authored_count || authored_prefix < participant_count {
-        return None;
+    let family = stock_offline_start_callback_family(session)?;
+    let launch_participant_count = 1usize + session.opponents.len();
+    let roster_start_count = session.pre_fill_house_roster.required_start_count();
+    if roster_start_count != launch_participant_count {
+        return Err(PreFillScenarioPrefixPlanError::RosterParticipantMismatch {
+            roster_start_count,
+            launch_participant_count,
+        });
     }
 
-    let gathered_starts: Vec<Waypoint> = (0..authored_prefix)
-        .filter_map(|index| map_data.waypoints.get(&(index as u32)).copied())
-        .collect();
     let mut scenario_rng = SimRng::new(u64::from(launch_seed));
     let scenario_rng_before = scenario_rng.logical_state();
     let scenario_rng_before_fingerprint = scenario_rng.state();
 
-    // HouseClass construction precedes both Battle/FFA callbacks. Every generated
-    // participant plus Neutral and Special consumes one rejection-capable
-    // RandomRanged(450,1800), in HouseClass order.
-    for _ in 0..participant_count + 2 {
-        let _ = scenario_rng
-            .next_range_u32_inclusive(HOUSE_CONSTRUCTOR_TIMER_MIN, HOUSE_CONSTRUCTOR_TIMER_MAX);
-    }
+    let first_house_timers =
+        advance_pre_fill_house_constructor_pass(&session.pre_fill_house_roster, &mut scenario_rng);
+    #[cfg(test)]
+    let after_first_house_pass = scenario_rng.logical_state();
+    let first_gathered_starts = native_gather_pre_fill_start_positions(
+        start_waypoints,
+        roster_start_count,
+        &map_data.header,
+        &mut scenario_rng,
+    )
+    .ok_or(PreFillScenarioPrefixPlanError::InvalidMapCellExtent)?;
+    #[cfg(test)]
+    let after_first_gather = scenario_rng.logical_state();
+    let preassignment = native_preassign_launch_start_table(session, first_gathered_starts.len());
 
-    // Battle and FFA +0x80/+0x84 each Gather. With a complete contiguous
-    // authored vector both calls return this same data and consume no RNG.
-    let assignment = native_assign_launch_starts(session, &gathered_starts, &mut scenario_rng);
+    let final_gathered_starts = native_gather_pre_fill_start_positions(
+        start_waypoints,
+        roster_start_count,
+        &map_data.header,
+        &mut scenario_rng,
+    )
+    .ok_or(PreFillScenarioPrefixPlanError::InvalidMapCellExtent)?;
+    let assignment = match family {
+        StockOfflineStartCallbackFamily::Battle => native_assign_launch_starts_from_preassignment(
+            session,
+            &final_gathered_starts,
+            &preassignment,
+            &mut scenario_rng,
+        ),
+        StockOfflineStartCallbackFamily::Cooperative => {
+            let human_start_spots = map_data
+                .ini
+                .section("Header")
+                .and_then(|header| header.get_i32("NumCoopHumanStartSpots"))
+                .unwrap_or(0)
+                .max(0) as usize;
+            native_assign_cooperative_starts_from_preassignment(
+                session,
+                &final_gathered_starts,
+                &preassignment,
+                human_start_spots,
+                session.pre_fill_house_roster.nonobserver_human_count(),
+                &mut scenario_rng,
+            )
+        }
+    };
+    #[cfg(test)]
+    let after_second_gather_and_chooser = scenario_rng.logical_state();
+
+    // Native deletes every disposable first-pass House here. Destruction and
+    // the following rules/basic reset consume no Scenario draw, so the second
+    // pass begins at the chooser's exact cursor.
+    #[cfg(test)]
+    let after_zero_draw_reset = scenario_rng.logical_state();
+    let second_house_timers =
+        advance_pre_fill_house_constructor_pass(&session.pre_fill_house_roster, &mut scenario_rng);
     let scenario_rng_after = scenario_rng.logical_state();
+    #[cfg(test)]
+    let after_second_house_pass = scenario_rng_after.clone();
 
-    Some(PreloadedBattleStartPlan {
-        gathered_starts,
+    Ok(PreFillScenarioPrefixPlan {
+        first_gathered_starts,
+        final_gathered_starts,
         assignment,
+        first_house_timers,
+        second_house_timers,
         scenario_rng_before,
         scenario_rng_before_fingerprint,
         scenario_rng_after,
         scenario_rng_after_cursor: scenario_rng,
+        #[cfg(test)]
+        rng_checkpoints: ScenarioPrefixRngCheckpoints {
+            after_first_house_pass,
+            after_first_gather,
+            after_second_gather_and_chooser,
+            after_zero_draw_reset,
+            after_second_house_pass,
+        },
     })
 }
 
-fn has_verified_preload_start_callbacks(session: &SkirmishLaunchSession) -> bool {
-    let mode = &session.mode;
-    if !mode.map_filter.eq_ignore_ascii_case("standard")
-        || !mode.random_maps_allowed
-        || mode.must_ally
-    {
-        return false;
+fn advance_pre_fill_house_constructor_pass(
+    roster: &PreFillHouseRoster,
+    rng: &mut SimRng,
+) -> Vec<u32> {
+    let mut timers = Vec::with_capacity(roster.created_house_count());
+    for _human in roster.human_nodes() {
+        timers.push(
+            rng.next_range_u32_inclusive(HOUSE_CONSTRUCTOR_TIMER_MIN, HOUSE_CONSTRUCTOR_TIMER_MAX),
+        );
     }
-    match mode.id {
-        1 => {
-            mode.ui_name_key.eq_ignore_ascii_case("GUI:Battle")
-                && mode.tooltip_key.eq_ignore_ascii_case("STT:ModeBattle")
-                && mode.override_file.eq_ignore_ascii_case("MPBattleMD.ini")
-                && mode.allies_allowed
+    for _slot in roster.ai_slots().iter().filter(|slot| slot.valid) {
+        timers.push(
+            rng.next_range_u32_inclusive(HOUSE_CONSTRUCTOR_TIMER_MIN, HOUSE_CONSTRUCTOR_TIMER_MAX),
+        );
+    }
+    for _fixed in roster.fixed_tail() {
+        timers.push(
+            rng.next_range_u32_inclusive(HOUSE_CONSTRUCTOR_TIMER_MIN, HOUSE_CONSTRUCTOR_TIMER_MAX),
+        );
+    }
+    timers
+}
+
+pub(crate) fn stock_offline_start_callback_family(
+    session: &SkirmishLaunchSession,
+) -> Result<StockOfflineStartCallbackFamily, PreFillScenarioPrefixPlanError> {
+    let mode = &session.mode;
+    let expected = match mode.id {
+        1 => (
+            "GUI:Battle",
+            "STT:ModeBattle",
+            "MPBattleMD.ini",
+            "standard",
+            true,
+            true,
+            false,
+            StockOfflineStartCallbackFamily::Battle,
+        ),
+        2 => (
+            "GUI:FreeForAll",
+            "STT:ModeFreeForAll",
+            "MPFreeForAllMD.ini",
+            "standard",
+            true,
+            false,
+            false,
+            StockOfflineStartCallbackFamily::Battle,
+        ),
+        3 => (
+            "GUI:Cooperative",
+            "STT:ModeCooperative",
+            "MPCoopMD.ini",
+            "cooperative",
+            false,
+            false,
+            false,
+            StockOfflineStartCallbackFamily::Cooperative,
+        ),
+        4 => (
+            "GUI:UnholyAlliance",
+            "STT:ModeUnholyAlliance",
+            "MPUnholyMD.ini",
+            "standard",
+            false,
+            true,
+            false,
+            StockOfflineStartCallbackFamily::Battle,
+        ),
+        5 => (
+            "GUI:Megawealth",
+            "STT:ModeMegawealth",
+            "MPMWMD.ini",
+            "megawealth",
+            false,
+            true,
+            false,
+            StockOfflineStartCallbackFamily::Battle,
+        ),
+        6 => (
+            "GUI:Duel",
+            "STT:ModeDuel",
+            "MPDuelMD.ini",
+            "duel",
+            false,
+            true,
+            false,
+            StockOfflineStartCallbackFamily::Battle,
+        ),
+        7 => (
+            "GUI:MeatGrind",
+            "STT:ModeMeatGrind",
+            "MPMeatMD.ini",
+            "meatgrind",
+            false,
+            true,
+            false,
+            StockOfflineStartCallbackFamily::Battle,
+        ),
+        8 => (
+            "GUI:NavalWar",
+            "STT:ModeNavalWar",
+            "MPNavalMD.ini",
+            "navalwar",
+            false,
+            true,
+            false,
+            StockOfflineStartCallbackFamily::Battle,
+        ),
+        9 => (
+            "GUI:TeamGame",
+            "STT:ModeTeamGame",
+            "MPTeamMD.ini",
+            "teamgame",
+            false,
+            true,
+            true,
+            StockOfflineStartCallbackFamily::Battle,
+        ),
+        _ => {
+            return Err(PreFillScenarioPrefixPlanError::UnsupportedStockMode { id: mode.id });
         }
-        2 => {
-            mode.ui_name_key.eq_ignore_ascii_case("GUI:FreeForAll")
-                && mode.tooltip_key.eq_ignore_ascii_case("STT:ModeFreeForAll")
-                && mode
-                    .override_file
-                    .eq_ignore_ascii_case("MPFreeForAllMD.ini")
-                && !mode.allies_allowed
-        }
-        _ => false,
+    };
+    let (ui_name, tooltip, override_file, map_filter, random_maps, allies, must_ally, family) =
+        expected;
+    if mode.ui_name_key.eq_ignore_ascii_case(ui_name)
+        && mode.tooltip_key.eq_ignore_ascii_case(tooltip)
+        && mode.override_file.eq_ignore_ascii_case(override_file)
+        && mode.map_filter.eq_ignore_ascii_case(map_filter)
+        && mode.random_maps_allowed == random_maps
+        && mode.allies_allowed == allies
+        && mode.must_ally == must_ally
+    {
+        Ok(family)
+    } else {
+        Err(PreFillScenarioPrefixPlanError::UnsupportedStockMode { id: mode.id })
     }
 }
 
+#[cfg(test)]
 pub(crate) fn native_assign_launch_starts(
     session: &SkirmishLaunchSession,
     starts: &[Waypoint],
+    rng: &mut SimRng,
+) -> NativeStartAssignment {
+    let preassignment = native_preassign_launch_start_table(session, starts.len());
+    native_assign_launch_starts_from_preassignment(session, starts, &preassignment, rng)
+}
+
+fn launch_start_requests(session: &SkirmishLaunchSession) -> Vec<LaunchStartPosition> {
+    std::iter::once(session.local.start_position)
+        .chain(
+            session
+                .opponents
+                .iter()
+                .map(|opponent| opponent.start_position),
+        )
+        .collect()
+}
+
+pub(crate) fn native_preassign_launch_start_table(
+    session: &SkirmishLaunchSession,
+    start_count: usize,
+) -> Vec<Option<usize>> {
+    let requested = launch_start_requests(session);
+    let mut explicit_owner = vec![None; start_count];
+    for (slot, request) in requested.iter().enumerate() {
+        let LaunchStartPosition::Position(index) = request else {
+            continue;
+        };
+        if let Some(owner) = explicit_owner.get_mut(usize::from(*index)) {
+            *owner = Some(slot);
+        }
+    }
+    explicit_owner
+}
+
+fn native_assign_launch_starts_from_preassignment(
+    session: &SkirmishLaunchSession,
+    starts: &[Waypoint],
+    preassignment: &[Option<usize>],
     rng: &mut SimRng,
 ) -> NativeStartAssignment {
     if starts.is_empty() {
@@ -390,23 +721,9 @@ pub(crate) fn native_assign_launch_starts(
         };
     }
 
-    let requested: Vec<LaunchStartPosition> = std::iter::once(session.local.start_position)
-        .chain(
-            session
-                .opponents
-                .iter()
-                .map(|opponent| opponent.start_position),
-        )
-        .collect();
-    let mut explicit_owner = vec![None; starts.len()];
-    for (slot, request) in requested.iter().enumerate() {
-        let LaunchStartPosition::Position(index) = request else {
-            continue;
-        };
-        if let Some(owner) = explicit_owner.get_mut(usize::from(*index)) {
-            *owner = Some(slot);
-        }
-    }
+    assert_eq!(starts.len(), preassignment.len());
+    let requested = launch_start_requests(session);
+    let mut explicit_owner = preassignment.to_vec();
 
     // Battle +0x84 builds its occupied-byte array from the complete
     // Scenario+0x1180 table before its HouseClass pass begins. The selected
@@ -443,10 +760,30 @@ pub(crate) fn native_assign_launch_starts(
 /// all of its entries before HouseClass iteration; automatic human placement
 /// draws within the prefix and probes forward, while the remaining houses
 /// take the first free suffix entry without a draw.
+#[cfg(test)]
 pub(crate) fn native_assign_cooperative_launch_starts(
     session: &SkirmishLaunchSession,
     starts: &[Waypoint],
     human_start_spots: usize,
+    rng: &mut SimRng,
+) -> NativeStartAssignment {
+    let preassignment = native_preassign_launch_start_table(session, starts.len());
+    native_assign_cooperative_starts_from_preassignment(
+        session,
+        starts,
+        &preassignment,
+        human_start_spots,
+        1,
+        rng,
+    )
+}
+
+fn native_assign_cooperative_starts_from_preassignment(
+    session: &SkirmishLaunchSession,
+    starts: &[Waypoint],
+    preassignment: &[Option<usize>],
+    human_start_spots: usize,
+    human_house_count: usize,
     rng: &mut SimRng,
 ) -> NativeStartAssignment {
     if starts.is_empty() {
@@ -456,26 +793,11 @@ pub(crate) fn native_assign_cooperative_launch_starts(
         };
     }
 
-    let requested: Vec<LaunchStartPosition> = std::iter::once(session.local.start_position)
-        .chain(
-            session
-                .opponents
-                .iter()
-                .map(|opponent| opponent.start_position),
-        )
-        .collect();
-    let mut explicit_owner = vec![None; starts.len()];
-    for (slot, request) in requested.iter().enumerate() {
-        let LaunchStartPosition::Position(index) = request else {
-            continue;
-        };
-        if let Some(owner) = explicit_owner.get_mut(usize::from(*index)) {
-            *owner = Some(slot);
-        }
-    }
+    assert_eq!(starts.len(), preassignment.len());
+    let requested = launch_start_requests(session);
+    let mut explicit_owner = preassignment.to_vec();
 
     let mut occupied: Vec<bool> = explicit_owner.iter().map(Option::is_some).collect();
-    let human_house_count = 1usize;
     let human_start_spots = human_start_spots.min(starts.len());
     let mut assigned = vec![None; requested.len()];
 
@@ -590,8 +912,8 @@ pub(crate) struct NormalizedSkirmishSlot {
 /// receive an unresolved frontend session and silently launch with the
 /// placeholder country/color a random slot still carries. Start positions
 /// remain potentially random by design: gamemd assigns them at scenario load
-/// with the gameplay Scenario RNG (see `assign_native_battle_starts`), not in
-/// the shell.
+/// with the gameplay Scenario RNG (see
+/// `prepare_stock_offline_scenario_prefix_plan`), not in the shell.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MatchLaunchDescriptor {
     session: SkirmishLaunchSession,
@@ -694,7 +1016,8 @@ pub(crate) fn apply_skirmish_launch_alliances(
     sim.house_alliances = launch_alliance_map(house_roster, &slots, &session.mode);
 }
 
-/// Apply an already validated explicit session without placeholder RNG draws.
+/// Test-only compatibility path for direct post-Fill launch fixtures.
+#[cfg(test)]
 pub(crate) fn apply_explicit_skirmish_launch_session(
     sim: &mut Simulation,
     map_data: &MapFile,
@@ -713,10 +1036,11 @@ pub(crate) fn apply_explicit_skirmish_launch_session(
         resolved_terrain,
         descriptor,
         None,
-        None,
+        LaunchStartResolution::PostFillTestCompatibility,
     )
 }
 
+#[cfg(test)]
 pub(crate) fn apply_explicit_skirmish_launch_session_with_overlay_registry(
     sim: &mut Simulation,
     map_data: &MapFile,
@@ -736,12 +1060,15 @@ pub(crate) fn apply_explicit_skirmish_launch_session_with_overlay_registry(
         resolved_terrain,
         descriptor,
         Some(overlay_registry),
-        None,
+        LaunchStartResolution::PostFillTestCompatibility,
     )
 }
 
-/// Apply the exact Battle assignment prepared before the first loading frame.
-pub(crate) fn apply_preloaded_battle_launch_session(
+/// Apply the retained stock-offline House/start projection without repeating
+/// any prefix draw. Existing starting-force and later initialization draws
+/// remain after this projection.
+#[cfg(test)]
+pub(crate) fn apply_pre_fill_scenario_prefix_launch_session(
     sim: &mut Simulation,
     map_data: &MapFile,
     house_roster: &HouseRoster,
@@ -749,7 +1076,7 @@ pub(crate) fn apply_preloaded_battle_launch_session(
     height_map: &BTreeMap<(u16, u16), u8>,
     resolved_terrain: &ResolvedTerrainGrid,
     descriptor: &MatchLaunchDescriptor,
-    plan: &PreloadedBattleStartPlan,
+    plan: &PreFillScenarioPrefixPlan,
 ) -> SkirmishLaunchApplyResult {
     apply_resolved_skirmish_launch_session(
         sim,
@@ -760,12 +1087,12 @@ pub(crate) fn apply_preloaded_battle_launch_session(
         resolved_terrain,
         descriptor,
         None,
-        Some(plan),
+        LaunchStartResolution::Prefix(plan),
     )
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn apply_preloaded_battle_launch_session_with_overlay_registry(
+pub(crate) fn apply_pre_fill_scenario_prefix_launch_session_with_overlay_registry(
     sim: &mut Simulation,
     map_data: &MapFile,
     house_roster: &HouseRoster,
@@ -774,7 +1101,7 @@ pub(crate) fn apply_preloaded_battle_launch_session_with_overlay_registry(
     resolved_terrain: &ResolvedTerrainGrid,
     descriptor: &MatchLaunchDescriptor,
     overlay_registry: &OverlayTypeRegistry,
-    plan: &PreloadedBattleStartPlan,
+    plan: &PreFillScenarioPrefixPlan,
 ) -> SkirmishLaunchApplyResult {
     apply_resolved_skirmish_launch_session(
         sim,
@@ -785,8 +1112,14 @@ pub(crate) fn apply_preloaded_battle_launch_session_with_overlay_registry(
         resolved_terrain,
         descriptor,
         Some(overlay_registry),
-        Some(plan),
+        LaunchStartResolution::Prefix(plan),
     )
+}
+
+enum LaunchStartResolution<'a> {
+    Prefix(&'a PreFillScenarioPrefixPlan),
+    #[cfg(test)]
+    PostFillTestCompatibility,
 }
 
 fn apply_resolved_skirmish_launch_session(
@@ -798,7 +1131,7 @@ fn apply_resolved_skirmish_launch_session(
     resolved_terrain: &ResolvedTerrainGrid,
     descriptor: &MatchLaunchDescriptor,
     overlay_registry: Option<&OverlayTypeRegistry>,
-    preloaded_battle_plan: Option<&PreloadedBattleStartPlan>,
+    start_resolution: LaunchStartResolution<'_>,
 ) -> SkirmishLaunchApplyResult {
     // Direct frontend/unit-test launch paths can enter before the shared
     // scenario construction funnel. Retail has already completed
@@ -839,69 +1172,55 @@ fn apply_resolved_skirmish_launch_session(
     }
 
     let bounds = NativeStartBounds::from_session(sim, resolved_terrain);
-    let cooperative = session
-        .mode
-        .override_file
-        .eq_ignore_ascii_case("MPCoopMD.ini");
-    let (_starts, start_assignment) = if let Some(plan) = preloaded_battle_plan {
-        debug_assert!(!cooperative, "Cooperative never owns a Battle preload plan");
-        // The same immutable table already drove the first loading markers.
-        // Its constructor/assignment RNG prefix was installed before terrain
-        // Fill, so consuming it here must not draw or replace the live cursor.
-        (plan.gathered_starts().to_vec(), plan.assignment().clone())
-    } else {
-        let preassignment_starts = sim.gather_native_start_positions(
-            &map_data.waypoints,
-            slots.len(),
-            resolved_terrain,
-            bounds,
-        );
-        // Standard Battle +0x80 gathers once before explicit preassignment,
-        // then +0x84 gathers again before final assignment. The first vector's
-        // cells are only provisional; deficient-map draws remain runtime-owned.
-        let starts = if cooperative {
-            preassignment_starts
-        } else {
-            sim.gather_native_start_positions(
+    let (_starts, start_assignment) = match start_resolution {
+        LaunchStartResolution::Prefix(plan) => {
+            // The same immutable table already drove the first loading markers.
+            // Its complete House/Gather/assignment prefix was installed before
+            // Fill, so projecting it here cannot draw or replace the live cursor.
+            (
+                plan.final_gathered_starts().to_vec(),
+                plan.assignment().clone(),
+            )
+        }
+        #[cfg(test)]
+        LaunchStartResolution::PostFillTestCompatibility => {
+            let cooperative = session
+                .mode
+                .override_file
+                .eq_ignore_ascii_case("MPCoopMD.ini");
+            // Direct unit fixtures historically enter with a constructed map.
+            // Keep their compatibility resolver outside production compilation,
+            // while still modeling two independent Gather callbacks.
+            let _first_gather = sim.gather_native_start_positions(
                 &map_data.waypoints,
                 slots.len(),
                 resolved_terrain,
                 bounds,
-            )
-        };
-        let assignment = if cooperative {
-            let human_start_spots = map_data
-                .ini
-                .section("Header")
-                .and_then(|header| header.get_i32("NumCoopHumanStartSpots"))
-                .unwrap_or(0)
-                .max(0) as usize;
-            sim.assign_native_cooperative_starts(session, &starts, human_start_spots)
-        } else {
-            sim.assign_native_battle_starts(session, &starts)
-        };
-        (starts, assignment)
+            );
+            let starts = sim.gather_native_start_positions(
+                &map_data.waypoints,
+                slots.len(),
+                resolved_terrain,
+                bounds,
+            );
+            let assignment = if cooperative {
+                let human_start_spots = map_data
+                    .ini
+                    .section("Header")
+                    .and_then(|header| header.get_i32("NumCoopHumanStartSpots"))
+                    .unwrap_or(0)
+                    .max(0) as usize;
+                sim.assign_native_cooperative_starts(session, &starts, human_start_spots)
+            } else {
+                sim.assign_native_battle_starts(session, &starts)
+            };
+            (starts, assignment)
+        }
     };
-    // Session start-slot -> house table: filled after the random-assignment
-    // draws, before tick 0 — lockstep state (hashed + serialized).
-    sim.session.start_slot_houses.clear();
-    for (start_idx, slot_idx) in start_assignment.start_table.iter().enumerate() {
-        let Some(slot_idx) = *slot_idx else {
-            continue;
-        };
-        let Some(slot) = slots.get(slot_idx) else {
-            continue;
-        };
-        let owner = sim.interner.intern(&slot.owner_name);
-        sim.session
-            .start_slot_houses
-            .insert(start_idx as u32, owner);
-    }
+    project_pre_fill_start_assignment(sim, &slots, &start_assignment);
     let assignments = &start_assignment.placements;
     let mut spawned_mcvs = 0;
     let mut local_owner = slots.first().map(|slot| slot.owner_name.clone());
-
-    assign_launch_base_centers(sim, &slots, assignments);
 
     if session.options.bases {
         for (slot_idx, waypoint) in assignments {
@@ -978,6 +1297,32 @@ fn apply_resolved_skirmish_launch_session(
         spawned_mcvs,
         active_slots: slots.len(),
     }
+}
+
+/// Project the already-resolved start table and base centers. This boundary is
+/// intentionally incapable of drawing: the selected-mode chooser completed in
+/// the pre-Fill plan, while starting Technos and the force tail remain later.
+fn project_pre_fill_start_assignment(
+    sim: &mut Simulation,
+    slots: &[NormalizedSkirmishSlot],
+    start_assignment: &NativeStartAssignment,
+) {
+    // Session start-slot -> house table: filled after the random-assignment
+    // draws, before tick 0 — lockstep state (hashed + serialized).
+    sim.session.start_slot_houses.clear();
+    for (start_idx, slot_idx) in start_assignment.start_table.iter().enumerate() {
+        let Some(slot_idx) = *slot_idx else {
+            continue;
+        };
+        let Some(slot) = slots.get(slot_idx) else {
+            continue;
+        };
+        let owner = sim.interner.intern(&slot.owner_name);
+        sim.session
+            .start_slot_houses
+            .insert(start_idx as u32, owner);
+    }
+    assign_launch_base_centers(sim, slots, &start_assignment.placements);
 }
 
 /// Apply the lobby's one-shot unexplored-shroud choice to the local human
@@ -1762,11 +2107,11 @@ impl ScenarioBootstrapRng {
         self.mapgen = Some(SimRng::from_mapgen_continuation(continuation));
     }
 
-    /// Install the already-resolved pre-render Battle prefix exactly once.
-    pub(crate) fn install_preloaded_battle_plan(
+    /// Install the already-resolved stock-offline pre-Fill prefix exactly once.
+    pub(crate) fn install_pre_fill_scenario_prefix_plan(
         &mut self,
-        plan: &PreloadedBattleStartPlan,
-    ) -> Result<(), PreloadedBattleStartPlanError> {
+        plan: &PreFillScenarioPrefixPlan,
+    ) -> Result<(), PreFillScenarioPrefixPlanError> {
         plan.install_before_terrain(&mut self.scenario)
     }
 
@@ -1784,8 +2129,8 @@ impl ScenarioBootstrapRng {
     }
 
     /// Consume the launch generation's ordered Building constructor trace on
-    /// the same Scenario owner that already passed through Battle/FFA preload
-    /// and terrain Fill. Successful rows retain their low word for later
+    /// the same Scenario owner that already passed through the stock-offline
+    /// prefix and terrain Fill. Successful rows retain their low word for later
     /// projection; discarded rows spend the word and deliberately bind none.
     ///
     /// gamemd provenance: TechnoClass constructor 0x006F3254 consumes one raw
@@ -1853,6 +2198,7 @@ impl ScenarioBootstrapRng {
 }
 
 impl Simulation {
+    #[cfg(test)]
     pub(crate) fn gather_native_start_positions(
         &mut self,
         waypoints: &HashMap<u32, Waypoint>,
@@ -1875,6 +2221,7 @@ impl Simulation {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn assign_native_battle_starts(
         &mut self,
         session: &SkirmishLaunchSession,
@@ -1883,6 +2230,7 @@ impl Simulation {
         native_assign_launch_starts(session, starts, &mut self.scenario_rng)
     }
 
+    #[cfg(test)]
     pub(crate) fn assign_native_cooperative_starts(
         &mut self,
         session: &SkirmishLaunchSession,
@@ -2017,6 +2365,52 @@ mod tests {
             seed,
             ..ScenarioDescriptor::default()
         }
+    }
+
+    fn one_player_battle_launch(selected_map_file: &str) -> MatchLaunchDescriptor {
+        use crate::skirmish_launch::{
+            PreFillHouseRoster, SkirmishLaunchMode, SkirmishLaunchOptions, SkirmishLocalSlot,
+        };
+
+        MatchLaunchDescriptor::from_resolved(SkirmishLaunchSession {
+            mode: SkirmishLaunchMode {
+                id: 1,
+                ui_name_key: "GUI:Battle".to_string(),
+                tooltip_key: "STT:ModeBattle".to_string(),
+                override_file: "MPBattleMD.ini".to_string(),
+                map_filter: "standard".to_string(),
+                random_maps_allowed: true,
+                allies_allowed: true,
+                must_ally: false,
+            },
+            selected_map_file: Some(selected_map_file.to_string()),
+            player_name: "Player".to_string(),
+            local: SkirmishLocalSlot {
+                country: LaunchCountry::America,
+                country_random: false,
+                color_index: 0,
+                color_random: false,
+                start_position: LaunchStartPosition::Auto,
+                team: LaunchTeam::None,
+            },
+            opponents: Vec::new(),
+            pre_fill_house_roster: PreFillHouseRoster::from_compact_skirmish(0),
+            options: SkirmishLaunchOptions::default(),
+        })
+        .expect("one-player Battle fixture is fully resolved")
+    }
+
+    fn prefix_map_with_starts(starts: &[Waypoint]) -> MapFile {
+        let mut map =
+            crate::map::rmg::emit::empty_map_file(&crate::map::rmg::RmgOptions::default(), 40, 40);
+        map.waypoints.clear();
+        map.waypoints
+            .extend(starts.iter().copied().map(|start| (start.index, start)));
+        map
+    }
+
+    fn one_start_prefix_map(start: Waypoint) -> MapFile {
+        prefix_map_with_starts(&[start])
     }
 
     fn techno_constructor_start_rules() -> RuleSet {
@@ -2470,31 +2864,481 @@ mod tests {
     }
 
     #[test]
-    fn preloaded_battle_prefix_transfers_once_before_terrain() {
+    fn scenario_prefix_runs_two_identical_house_passes_before_fill() {
+        use crate::skirmish_launch::{
+            AiDifficulty, PreFillAiHouseSlot, PreFillHouseRoster, PreFillHumanHouse, SkirmishAiSlot,
+        };
+
+        let seed = (0..100_000u32)
+            .find(|seed| {
+                let mut rng = SimRng::new(u64::from(*seed));
+                let before = rng.logical_state().index_a;
+                let _ = rng.next_range_u32_inclusive(
+                    HOUSE_CONSTRUCTOR_TIMER_MIN,
+                    HOUSE_CONSTRUCTOR_TIMER_MAX,
+                );
+                (rng.logical_state().index_a - before).rem_euclid(250) > 1
+            })
+            .expect("the native ranged domain has a rejection seed");
+        let roster = PreFillHouseRoster::new(
+            vec![
+                PreFillHumanHouse {
+                    priority: 4,
+                    source_order: 1,
+                    observer: false,
+                },
+                PreFillHumanHouse {
+                    priority: -7,
+                    source_order: 0,
+                    observer: true,
+                },
+            ],
+            vec![
+                PreFillAiHouseSlot {
+                    slot_index: 3,
+                    valid: true,
+                },
+                PreFillAiHouseSlot {
+                    slot_index: 1,
+                    valid: false,
+                },
+                PreFillAiHouseSlot {
+                    slot_index: 0,
+                    valid: true,
+                },
+            ],
+        );
+        assert_eq!(roster.human_nodes()[0].priority, -7);
+        assert_eq!(
+            roster
+                .ai_slots()
+                .iter()
+                .map(|slot| slot.slot_index)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 3]
+        );
+        assert_eq!(roster.required_start_count(), 3);
+        assert_eq!(roster.created_house_count(), 6);
+
+        let mut session = one_player_battle_launch("prefix-roster.mmx")
+            .session()
+            .clone();
+        session.local.start_position = LaunchStartPosition::Position(0);
+        session.opponents = (0..2)
+            .map(|index| SkirmishAiSlot {
+                country: LaunchCountry::Russia,
+                country_random: false,
+                color_index: index + 1,
+                color_random: false,
+                start_position: LaunchStartPosition::Position(index + 1),
+                team: LaunchTeam::None,
+                difficulty: AiDifficulty::Easy,
+            })
+            .collect();
+        session.pre_fill_house_roster = roster;
+        let launch = MatchLaunchDescriptor::from_resolved(session).unwrap();
+        let starts = [
+            Waypoint {
+                index: 0,
+                rx: 30,
+                ry: 30,
+            },
+            Waypoint {
+                index: 1,
+                rx: 40,
+                ry: 40,
+            },
+            Waypoint {
+                index: 2,
+                rx: 50,
+                ry: 50,
+            },
+        ];
+        let map = prefix_map_with_starts(&starts);
+        let plan = prepare_stock_offline_scenario_prefix_plan(&launch, &map, &map.waypoints, seed)
+            .unwrap();
+
+        let mut reference = SimRng::new(u64::from(seed));
+        let first_timers: Vec<_> = (0..6)
+            .map(|_| {
+                reference.next_range_u32_inclusive(
+                    HOUSE_CONSTRUCTOR_TIMER_MIN,
+                    HOUSE_CONSTRUCTOR_TIMER_MAX,
+                )
+            })
+            .collect();
+        let after_first = reference.logical_state();
+        let second_timers: Vec<_> = (0..6)
+            .map(|_| {
+                reference.next_range_u32_inclusive(
+                    HOUSE_CONSTRUCTOR_TIMER_MIN,
+                    HOUSE_CONSTRUCTOR_TIMER_MAX,
+                )
+            })
+            .collect();
+        let checkpoints = plan.rng_checkpoints();
+        assert_eq!(plan.first_house_timers(), first_timers);
+        assert_eq!(plan.second_house_timers(), second_timers);
+        assert_eq!(checkpoints.after_first_house_pass, after_first);
+        assert_eq!(checkpoints.after_first_gather, after_first);
+        assert_eq!(
+            checkpoints.after_second_gather_and_chooser, after_first,
+            "complete explicit starts make both callbacks draw-free"
+        );
+        assert_eq!(
+            checkpoints.after_zero_draw_reset,
+            checkpoints.after_second_gather_and_chooser
+        );
+        assert_eq!(
+            checkpoints.after_second_house_pass,
+            reference.logical_state()
+        );
+
+        let mut owner = ScenarioBootstrapRng::new(seed);
+        owner.install_pre_fill_scenario_prefix_plan(&plan).unwrap();
+        let sim = owner.into_simulation(&descriptor(seed));
+        assert!(
+            sim.houses.is_empty(),
+            "prefix emulation retains no disposable first-pass House state"
+        );
+    }
+
+    #[test]
+    fn scenario_prefix_sparse_waypoints_preserve_only_entries_below_target() {
+        let map = prefix_map_with_starts(&[]);
+        let starts = HashMap::from([
+            (
+                0,
+                Waypoint {
+                    index: 0,
+                    rx: 30,
+                    ry: 30,
+                },
+            ),
+            (
+                2,
+                Waypoint {
+                    index: 2,
+                    rx: 50,
+                    ry: 50,
+                },
+            ),
+        ]);
+        let mut target_two_rng = SimRng::new(0x5200);
+        let target_two =
+            native_gather_pre_fill_start_positions(&starts, 2, &map.header, &mut target_two_rng)
+                .unwrap();
+        assert_eq!(target_two.len(), 2);
+        assert_eq!((target_two[0].rx, target_two[0].ry), (30, 30));
+        assert!(
+            !target_two
+                .iter()
+                .any(|start| (start.rx, start.ry) == (50, 50))
+        );
+
+        let mut target_three_rng = SimRng::new(0x5200);
+        let target_three =
+            native_gather_pre_fill_start_positions(&starts, 3, &map.header, &mut target_three_rng)
+                .unwrap();
+        assert_eq!(target_three.len(), 3);
+        assert_eq!((target_three[0].rx, target_three[0].ry), (30, 30));
+        assert_eq!((target_three[1].rx, target_three[1].ry), (50, 50));
+    }
+
+    #[test]
+    fn scenario_prefix_all_stock_mode_families_gather_twice() {
+        let map = prefix_map_with_starts(&[]);
+        let modes = crate::skirmish_modes::stock_skirmish_modes();
+        assert_eq!(modes.len(), 9);
+        for mode in modes {
+            let mut session = one_player_battle_launch("stock-mode.mmx").session().clone();
+            session.mode = crate::skirmish_launch::SkirmishLaunchMode::from_game_mode(&mode);
+            let launch = MatchLaunchDescriptor::from_resolved(session).unwrap();
+            let expected_family = if mode.id == 3 {
+                StockOfflineStartCallbackFamily::Cooperative
+            } else {
+                StockOfflineStartCallbackFamily::Battle
+            };
+            assert_eq!(
+                stock_offline_start_callback_family(launch.session()).unwrap(),
+                expected_family
+            );
+            let plan = prepare_stock_offline_scenario_prefix_plan(
+                &launch,
+                &map,
+                &map.waypoints,
+                0x5300 + mode.id as u32,
+            )
+            .unwrap_or_else(|err| panic!("stock mode {} prefix failed: {err}", mode.id));
+            assert_eq!(plan.first_gathered_starts().len(), 1);
+            assert_eq!(plan.final_gathered_starts().len(), 1);
+            assert_ne!(
+                plan.rng_checkpoints().after_first_gather,
+                plan.rng_checkpoints().after_second_gather_and_chooser,
+                "stock mode {} must execute its second deficient Gather",
+                mode.id
+            );
+        }
+    }
+
+    #[test]
+    fn scenario_prefix_rejects_mutated_stock_mode_metadata() {
+        let session = one_player_battle_launch("mutated-mode.mmx")
+            .session()
+            .clone();
+        let mutations: [fn(&mut crate::skirmish_launch::SkirmishLaunchMode); 7] = [
+            |mode| mode.ui_name_key = "GUI:Cooperative".to_string(),
+            |mode| mode.tooltip_key = "STT:ModeCooperative".to_string(),
+            |mode| mode.override_file = "MPCoopMD.ini".to_string(),
+            |mode| mode.map_filter = "cooperative".to_string(),
+            |mode| mode.random_maps_allowed = false,
+            |mode| mode.allies_allowed = false,
+            |mode| mode.must_ally = true,
+        ];
+        let mut cases = Vec::new();
+        for mutate in mutations {
+            let mut mutated = session.clone();
+            mutate(&mut mutated.mode);
+            cases.push(mutated);
+        }
+        let mut unknown_id = session;
+        unknown_id.mode.id = 10;
+        cases.push(unknown_id);
+
+        for mutated in cases {
+            let id = mutated.mode.id;
+            assert_eq!(
+                stock_offline_start_callback_family(&mutated).unwrap_err(),
+                PreFillScenarioPrefixPlanError::UnsupportedStockMode { id }
+            );
+        }
+    }
+
+    #[test]
+    fn scenario_prefix_rejects_invalid_map_cell_extents() {
+        let launch = one_player_battle_launch("invalid-size.mmx");
+        for (width, height) in [(0, 64), (64, 0), (400, 200), (u32::MAX, 1)] {
+            let mut map = one_start_prefix_map(Waypoint {
+                index: 0,
+                rx: 30,
+                ry: 30,
+            });
+            map.header.width = width;
+            map.header.height = height;
+            assert_eq!(
+                prepare_stock_offline_scenario_prefix_plan(&launch, &map, &map.waypoints, 0x5320,)
+                    .unwrap_err(),
+                PreFillScenarioPrefixPlanError::InvalidMapCellExtent,
+                "Size={width},{height}"
+            );
+        }
+
+        let mut boundary = one_start_prefix_map(Waypoint {
+            index: 0,
+            rx: 30,
+            ry: 30,
+        });
+        boundary.header.width = 256;
+        boundary.header.height = 256;
+        prepare_stock_offline_scenario_prefix_plan(&launch, &boundary, &boundary.waypoints, 0x5320)
+            .expect("Size sum 512 is the inclusive native cell-array boundary");
+    }
+
+    #[test]
+    fn scenario_prefix_ignores_later_map_payload() {
+        use crate::map::entities::{EntityCategory, MapEntity};
+        use crate::map::map_file::MapCell;
+        use crate::map::overlay::{OverlayEntry, TerrainObject};
+
+        let start = Waypoint {
+            index: 0,
+            rx: 35,
+            ry: 35,
+        };
+        let map_a = one_start_prefix_map(start);
+        let mut map_b = one_start_prefix_map(start);
+        map_b.header.fill = "Water".to_string();
+        map_b.header.level = 9;
+        map_b.cells.push(MapCell {
+            rx: 36,
+            ry: 36,
+            tile_index: 777,
+            sub_tile: 3,
+            z: 9,
+        });
+        map_b.overlays.push(OverlayEntry {
+            rx: 36,
+            ry: 36,
+            overlay_id: 24,
+            frame: 7,
+        });
+        map_b.terrain_objects.push(TerrainObject {
+            rx: 37,
+            ry: 37,
+            name: "TREE01".to_string(),
+        });
+        map_b.entities.push(MapEntity {
+            owner: "Neutral".to_string(),
+            type_id: "CAOILD".to_string(),
+            health: 256,
+            cell_x: 38,
+            cell_y: 38,
+            facing: 0,
+            category: EntityCategory::Structure,
+            sub_cell: 0,
+            veterancy: 0,
+            high: false,
+            mission: None,
+            recruitable_a: true,
+            recruitable_b: true,
+            structure_upgrades: [None, None, None],
+        });
+        let launch = one_player_battle_launch("payload.mmx");
+        let plan_a =
+            prepare_stock_offline_scenario_prefix_plan(&launch, &map_a, &map_a.waypoints, 0x5400)
+                .unwrap();
+        let plan_b =
+            prepare_stock_offline_scenario_prefix_plan(&launch, &map_b, &map_b.waypoints, 0x5400)
+                .unwrap();
+        assert_eq!(plan_a.first_gathered_starts, plan_b.first_gathered_starts);
+        assert_eq!(plan_a.final_gathered_starts, plan_b.final_gathered_starts);
+        assert_eq!(plan_a.assignment, plan_b.assignment);
+        assert_eq!(plan_a.scenario_rng_after, plan_b.scenario_rng_after);
+    }
+
+    #[test]
+    fn scenario_prefix_projection_is_draw_free() {
+        let seed = 0x5500;
+        let start = Waypoint {
+            index: 0,
+            rx: 40,
+            ry: 40,
+        };
+        let map = one_start_prefix_map(start);
+        let mut session = one_player_battle_launch("projection.mmx").session().clone();
+        session.local.start_position = LaunchStartPosition::Position(0);
+        let launch = MatchLaunchDescriptor::from_resolved(session).unwrap();
+        let plan = prepare_stock_offline_scenario_prefix_plan(&launch, &map, &map.waypoints, seed)
+            .unwrap();
+        let mut owner = ScenarioBootstrapRng::new(seed);
+        owner.install_pre_fill_scenario_prefix_plan(&plan).unwrap();
+        let mut sim = owner.into_simulation(&descriptor(seed));
+        let rules = techno_constructor_start_rules();
+        initialize_skirmish_launch_houses(&mut sim, &HouseRoster::default(), &rules, &launch);
+        let before = sim.scenario_rng.logical_state();
+        let slots = normalized_launch_slots(launch.session());
+        project_pre_fill_start_assignment(&mut sim, &slots, plan.assignment());
+        assert_eq!(sim.scenario_rng.logical_state(), before);
+        assert_eq!(
+            sim.houses
+                .get(&sim.session.house_order[0])
+                .and_then(|house| house.base_center),
+            Some((40, 40))
+        );
+    }
+
+    #[test]
+    fn scenario_prefix_cursor_reaches_base_plan_consumer() {
+        use crate::sim::base_plan::BasePlanState;
+        use crate::sim::base_plan_generation::recalc_base_plan;
+
+        let seed = 0x5600;
+        let start = Waypoint {
+            index: 0,
+            rx: 40,
+            ry: 40,
+        };
+        let map = one_start_prefix_map(start);
+        let mut session = one_player_battle_launch("base-plan.mmx").session().clone();
+        session.local.start_position = LaunchStartPosition::Position(0);
+        let launch = MatchLaunchDescriptor::from_resolved(session).unwrap();
+        let plan = prepare_stock_offline_scenario_prefix_plan(&launch, &map, &map.waypoints, seed)
+            .unwrap();
+        let rules = RuleSet::from_ini(&IniFile::from_str(
+            "[General]\n\
+             HarvesterUnit=HARV\n\
+             AIExtraRefineries=1,1,1\n\
+             AISlaveMinerNumber=1,1,1\n\
+             AlliedBaseDefenseCounts=1,1,1\n\
+             SovietBaseDefenseCounts=0,0,0\n\
+             ThirdBaseDefenseCounts=0,0,0\n\
+             [AI]\n\
+             BuildConst=CON\nBuildPower=POW\nBuildRefinery=REF\n\
+             BuildBarracks=BAR\nBuildWeapons=WEAP\nBuildRadar=RAD\nBuildTech=TECH\n\
+             [Countries]\n0=Americans\n[Sides]\nAllied=Americans\n\
+             [Americans]\nSide=Allied\n\
+             [VehicleTypes]\n0=HARV\n[HARV]\nOwner=Americans\nStrength=1\n\
+             [BuildingTypes]\n0=CON\n1=POW\n2=REF\n3=BAR\n4=WEAP\n5=RAD\n6=TECH\n\
+             [CON]\nOwner=Americans\nAIBuildThis=yes\nTechLevel=1\nFoundation=1x1\n\
+             [POW]\nOwner=Americans\nAIBuildThis=yes\nTechLevel=1\nFoundation=1x1\n\
+             [REF]\nOwner=Americans\nAIBuildThis=yes\nTechLevel=1\nFoundation=1x1\n\
+             [BAR]\nOwner=Americans\nAIBuildThis=yes\nTechLevel=1\nFoundation=1x1\n\
+             [WEAP]\nOwner=Americans\nAIBuildThis=yes\nTechLevel=1\nFoundation=1x1\n\
+             [RAD]\nOwner=Americans\nAIBuildThis=no\nFoundation=1x1\n\
+             [TECH]\nOwner=Americans\nAIBuildThis=no\nFoundation=1x1\n",
+        ))
+        .unwrap();
+
+        let mut owner = ScenarioBootstrapRng::new(seed);
+        owner.install_pre_fill_scenario_prefix_plan(&plan).unwrap();
+        let mut sim = owner.into_simulation(&descriptor(seed));
+        let mut expected_rng = SimRng::new(u64::from(seed));
+        for _ in 0..6 {
+            let _ = expected_rng
+                .next_range_u32_inclusive(HOUSE_CONSTRUCTOR_TIMER_MIN, HOUSE_CONSTRUCTOR_TIMER_MAX);
+        }
+        let mut actual_plan = BasePlanState::default();
+        let mut expected_plan = BasePlanState::default();
+        recalc_base_plan(
+            &mut actual_plan,
+            &rules,
+            "Americans",
+            0,
+            HouseDifficulty::Normal,
+            10,
+            true,
+            &mut sim.scenario_rng,
+        );
+        recalc_base_plan(
+            &mut expected_plan,
+            &rules,
+            "Americans",
+            0,
+            HouseDifficulty::Normal,
+            10,
+            true,
+            &mut expected_rng,
+        );
+        assert_eq!(actual_plan.nodes, expected_plan.nodes);
+        assert_eq!(actual_plan.percent_built, expected_plan.percent_built);
+        assert_eq!(
+            sim.scenario_rng.logical_state(),
+            expected_rng.logical_state()
+        );
+    }
+
+    #[test]
+    fn scenario_prefix_transfers_once_before_terrain() {
         let seed = 0x51C0_1004;
         let before = SimRng::new(u64::from(seed));
-        let mut after = before.clone();
-        let _ = after
-            .next_range_u32_inclusive(HOUSE_CONSTRUCTOR_TIMER_MIN, HOUSE_CONSTRUCTOR_TIMER_MAX);
-        let plan = PreloadedBattleStartPlan {
-            gathered_starts: Vec::new(),
-            assignment: NativeStartAssignment {
-                placements: Vec::new(),
-                start_table: Vec::new(),
-            },
-            scenario_rng_before: before.logical_state(),
-            scenario_rng_before_fingerprint: before.state(),
-            scenario_rng_after: after.logical_state(),
-            scenario_rng_after_cursor: after.clone(),
+        let start = Waypoint {
+            index: 0,
+            rx: 40,
+            ry: 40,
         };
+        let map = one_start_prefix_map(start);
+        let launch = one_player_battle_launch("mp01t4.map");
+        let plan = prepare_stock_offline_scenario_prefix_plan(&launch, &map, &map.waypoints, seed)
+            .expect("stock Battle prefix");
+        let after = plan.scenario_rng_after_cursor.clone();
         let mut owner = ScenarioBootstrapRng::new(seed);
 
         owner
-            .install_preloaded_battle_plan(&plan)
+            .install_pre_fill_scenario_prefix_plan(&plan)
             .expect("fresh bootstrap owner accepts the plan prefix");
         assert!(
-            owner.install_preloaded_battle_plan(&plan).is_err(),
-            "the same constructor/assignment prefix cannot be installed twice"
+            owner.install_pre_fill_scenario_prefix_plan(&plan).is_err(),
+            "the same stock-offline prefix cannot be installed twice"
         );
         let actual = owner.into_simulation(&descriptor(seed)).rng_state();
 
@@ -2503,28 +3347,24 @@ mod tests {
     }
 
     #[test]
-    fn gsi_04_12_preload_fill_and_generated_trace_share_one_scenario_owner() {
+    fn gsi_04_12_prefix_fill_and_generated_trace_share_one_scenario_owner() {
         use crate::map::construction_trace::{RmgConstructionPhase, RmgConstructionTrace};
 
         let seed = 0x51C0_1006;
         let before = SimRng::new(u64::from(seed));
-        let mut reference = before.clone();
-        let _ = reference
-            .next_range_u32_inclusive(HOUSE_CONSTRUCTOR_TIMER_MIN, HOUSE_CONSTRUCTOR_TIMER_MAX);
-        let plan = PreloadedBattleStartPlan {
-            gathered_starts: Vec::new(),
-            assignment: NativeStartAssignment {
-                placements: Vec::new(),
-                start_table: Vec::new(),
-            },
-            scenario_rng_before: before.logical_state(),
-            scenario_rng_before_fingerprint: before.state(),
-            scenario_rng_after: reference.logical_state(),
-            scenario_rng_after_cursor: reference.clone(),
+        let start = Waypoint {
+            index: 0,
+            rx: 40,
+            ry: 40,
         };
+        let map = one_start_prefix_map(start);
+        let launch = one_player_battle_launch("RandMap.SED");
+        let plan = prepare_stock_offline_scenario_prefix_plan(&launch, &map, &map.waypoints, seed)
+            .expect("generated stock prefix");
+        let mut reference = plan.scenario_rng_after_cursor.clone();
         let mut owner = ScenarioBootstrapRng::new(seed);
         owner
-            .install_preloaded_battle_plan(&plan)
+            .install_pre_fill_scenario_prefix_plan(&plan)
             .expect("fresh launch owner accepts the Full-Init prefix");
         {
             let (mut scenario_fill, main) = owner.terrain_draws();
@@ -2657,6 +3497,8 @@ mod tests {
                 team: LaunchTeam::None,
             },
             opponents: Vec::new(),
+            pre_fill_house_roster:
+                crate::skirmish_launch::PreFillHouseRoster::from_compact_skirmish(0),
             options: SkirmishLaunchOptions {
                 unit_count: 0,
                 bases: true,
@@ -2667,32 +3509,19 @@ mod tests {
         let launch = MatchLaunchDescriptor::from_resolved(session)
             .expect("fixture contains no unresolved shell choices");
 
-        let before = SimRng::new(u64::from(seed));
-        let mut reference = before.clone();
-        // One participant, then Neutral and Special, in native House order.
-        for _ in 0..3 {
-            let _ = reference
-                .next_range_u32_inclusive(HOUSE_CONSTRUCTOR_TIMER_MIN, HOUSE_CONSTRUCTOR_TIMER_MAX);
-        }
         let start = Waypoint {
             index: 0,
             rx: 40,
             ry: 40,
         };
-        let plan = PreloadedBattleStartPlan {
-            gathered_starts: vec![start],
-            assignment: NativeStartAssignment {
-                placements: vec![(0, start)],
-                start_table: vec![Some(0)],
-            },
-            scenario_rng_before: before.logical_state(),
-            scenario_rng_before_fingerprint: before.state(),
-            scenario_rng_after: reference.logical_state(),
-            scenario_rng_after_cursor: reference.clone(),
-        };
+        let before = SimRng::new(u64::from(seed));
+        let staged_starts = HashMap::from([(0, start)]);
+        let plan = prepare_stock_offline_scenario_prefix_plan(&launch, &map, &staged_starts, seed)
+            .expect("accepted generated prefix");
+        let mut reference = plan.scenario_rng_after_cursor.clone();
         let mut owner = ScenarioBootstrapRng::new(seed);
         owner
-            .install_preloaded_battle_plan(&plan)
+            .install_pre_fill_scenario_prefix_plan(&plan)
             .expect("one authoritative Full-Init prefix");
         {
             let (mut scenario_fill, main) = owner.terrain_draws();
@@ -2784,7 +3613,7 @@ mod tests {
 
         let starting_techno_word = (reference.next_u32() & 0xFFFF) as u16;
         let _starting_force_tail = reference.next_range_u32_inclusive(0, 0xFFFF);
-        let launch_result = apply_preloaded_battle_launch_session_with_overlay_registry(
+        let launch_result = apply_pre_fill_scenario_prefix_launch_session_with_overlay_registry(
             &mut sim,
             &map,
             &house_roster,

--- a/src/sim/scenario_bootstrap.rs
+++ b/src/sim/scenario_bootstrap.rs
@@ -2411,12 +2411,44 @@ mod tests {
     }
 
     fn prefix_map_with_starts(starts: &[Waypoint]) -> MapFile {
-        let mut map =
-            crate::map::rmg::emit::empty_map_file(&crate::map::rmg::RmgOptions::default(), 40, 40);
-        map.waypoints.clear();
-        map.waypoints
-            .extend(starts.iter().copied().map(|start| (start.index, start)));
-        map
+        MapFile {
+            header: crate::map::map_file::MapHeader {
+                theater: "TEMPERATE".to_string(),
+                fill: "Clear".to_string(),
+                level: 0,
+                width: 44,
+                height: 52,
+                local_left: 2,
+                local_top: 5,
+                local_width: 40,
+                local_height: 40,
+            },
+            basic: Default::default(),
+            briefing: Default::default(),
+            preview: Default::default(),
+            cells: Vec::new(),
+            iso_map_pack_lookups: Vec::new(),
+            entities: Vec::new(),
+            overlays: Vec::new(),
+            overlay_data: Default::default(),
+            smudges: Vec::new(),
+            terrain_objects: Vec::new(),
+            waypoints: starts
+                .iter()
+                .copied()
+                .map(|start| (start.index, start))
+                .collect(),
+            cell_tags: Default::default(),
+            tags: Default::default(),
+            triggers: Default::default(),
+            events: Default::default(),
+            actions: Default::default(),
+            local_variables: Default::default(),
+            trigger_graph: Default::default(),
+            special_flags: Default::default(),
+            explicit_tubes: Vec::new(),
+            ini: IniFile::from_str(""),
+        }
     }
 
     fn one_start_prefix_map(start: Waypoint) -> MapFile {

--- a/src/sim/scenario_post_map.rs
+++ b/src/sim/scenario_post_map.rs
@@ -287,6 +287,8 @@ mod tests {
                 team: LaunchTeam::Team(0),
                 difficulty: AiDifficulty::Easy,
             }],
+            pre_fill_house_roster:
+                crate::skirmish_launch::PreFillHouseRoster::from_compact_skirmish(1),
             options: SkirmishLaunchOptions::default(),
         }
     }

--- a/src/skirmish_launch.rs
+++ b/src/skirmish_launch.rs
@@ -1,7 +1,7 @@
 //! App-level skirmish launch contract.
 //!
 //! This module is intentionally data-only: it packages the lobby state the app
-//! needs to create Battle-mode houses and initial spawns without making `sim/`
+//! needs to create stock-offline houses and initial spawns without making `sim/`
 //! depend on UI, rendering, audio, or networking modules.
 
 use crate::sim::game_options::GameOptions;
@@ -11,6 +11,107 @@ use crate::skirmish_modes::SkirmishGameMode;
 pub const SKIRMISH_PLAYER_SLOT_COUNT: usize = 8;
 pub const SKIRMISH_AI_SLOT_COUNT: usize = SKIRMISH_PLAYER_SLOT_COUNT - 1;
 pub const HOUSE_COLOR_COUNT: usize = 8;
+
+/// One human node in the native pre-Fill House-construction roster.
+///
+/// Nodes are stably sorted by the signed priority byte. Observers still
+/// construct a House (and therefore consume the constructor timer draw), but
+/// do not increase Gather's required-start count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreFillHumanHouse {
+    pub priority: i8,
+    pub source_order: u8,
+    pub observer: bool,
+}
+
+/// One native AI session slot before active opponents are compacted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreFillAiHouseSlot {
+    pub slot_index: u8,
+    pub valid: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreFillFixedHouse {
+    Neutral,
+    Special,
+}
+
+/// Immutable House roster consumed identically by both noncampaign pre-Fill
+/// construction passes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreFillHouseRoster {
+    human_nodes: Vec<PreFillHumanHouse>,
+    ai_slots: Vec<PreFillAiHouseSlot>,
+    fixed_tail: [PreFillFixedHouse; 2],
+}
+
+impl PreFillHouseRoster {
+    pub fn new(
+        mut human_nodes: Vec<PreFillHumanHouse>,
+        mut ai_slots: Vec<PreFillAiHouseSlot>,
+    ) -> Self {
+        // Native sorts by the signed priority byte and preserves source-list
+        // order for ties. `source_order` makes that ordering independent of
+        // whichever app adapter assembled this normalized value.
+        human_nodes.sort_by_key(|node| (node.priority, node.source_order));
+        ai_slots.sort_by_key(|slot| slot.slot_index);
+        Self {
+            human_nodes,
+            ai_slots,
+            fixed_tail: [PreFillFixedHouse::Neutral, PreFillFixedHouse::Special],
+        }
+    }
+
+    /// Compatibility constructor for callers that already hold the compact
+    /// ordinary-skirmish session. Production shell packing retains all seven
+    /// raw AI slots and does not use this shortcut.
+    pub fn from_compact_skirmish(active_ai_count: usize) -> Self {
+        let ai_slots = (0..SKIRMISH_AI_SLOT_COUNT)
+            .map(|slot_index| PreFillAiHouseSlot {
+                slot_index: slot_index as u8,
+                valid: slot_index < active_ai_count,
+            })
+            .collect();
+        Self::new(
+            vec![PreFillHumanHouse {
+                priority: 0,
+                source_order: 0,
+                observer: false,
+            }],
+            ai_slots,
+        )
+    }
+
+    pub fn human_nodes(&self) -> &[PreFillHumanHouse] {
+        &self.human_nodes
+    }
+
+    pub fn ai_slots(&self) -> &[PreFillAiHouseSlot] {
+        &self.ai_slots
+    }
+
+    pub fn fixed_tail(&self) -> &[PreFillFixedHouse; 2] {
+        &self.fixed_tail
+    }
+
+    pub fn created_house_count(&self) -> usize {
+        self.human_nodes.len()
+            + self.ai_slots.iter().filter(|slot| slot.valid).count()
+            + self.fixed_tail.len()
+    }
+
+    pub fn required_start_count(&self) -> usize {
+        self.nonobserver_human_count() + self.ai_slots.iter().filter(|slot| slot.valid).count()
+    }
+
+    pub fn nonobserver_human_count(&self) -> usize {
+        self.human_nodes
+            .iter()
+            .filter(|node| !node.observer)
+            .count()
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SkirmishLaunchMode {
@@ -284,6 +385,9 @@ pub struct SkirmishLaunchSession {
     pub player_name: String,
     pub local: SkirmishLocalSlot,
     pub opponents: Vec<SkirmishAiSlot>,
+    /// Native pre-compaction House constructor roster used by both pre-Fill
+    /// passes. It deliberately retains inactive AI slots and observer state.
+    pub pre_fill_house_roster: PreFillHouseRoster,
     pub options: SkirmishLaunchOptions,
 }
 
@@ -558,6 +662,63 @@ mod tests {
         assert_eq!(LaunchTeam::from_shell_value(3), LaunchTeam::Team(3));
     }
 
+    #[test]
+    fn pre_fill_roster_orders_signed_humans_and_raw_ai_slots() {
+        let roster = PreFillHouseRoster::new(
+            vec![
+                PreFillHumanHouse {
+                    priority: 4,
+                    source_order: 2,
+                    observer: false,
+                },
+                PreFillHumanHouse {
+                    priority: -1,
+                    source_order: 1,
+                    observer: true,
+                },
+                PreFillHumanHouse {
+                    priority: -1,
+                    source_order: 0,
+                    observer: false,
+                },
+            ],
+            vec![
+                PreFillAiHouseSlot {
+                    slot_index: 6,
+                    valid: true,
+                },
+                PreFillAiHouseSlot {
+                    slot_index: 1,
+                    valid: false,
+                },
+                PreFillAiHouseSlot {
+                    slot_index: 3,
+                    valid: true,
+                },
+            ],
+        );
+
+        assert_eq!(
+            roster
+                .human_nodes()
+                .iter()
+                .map(|node| (node.priority, node.source_order))
+                .collect::<Vec<_>>(),
+            vec![(-1, 0), (-1, 1), (4, 2)]
+        );
+        assert_eq!(
+            roster
+                .ai_slots()
+                .iter()
+                .map(|slot| (slot.slot_index, slot.valid))
+                .collect::<Vec<_>>(),
+            vec![(1, false), (3, true), (6, true)]
+        );
+        assert_eq!(roster.nonobserver_human_count(), 2);
+        assert_eq!(roster.required_start_count(), 4);
+        assert_eq!(roster.created_house_count(), 7);
+    }
+
     fn random_test_session() -> SkirmishLaunchSession {
         SkirmishLaunchSession {
             mode: SkirmishLaunchMode {
@@ -600,6 +761,7 @@ mod tests {
                     difficulty: AiDifficulty::Easy,
                 },
             ],
+            pre_fill_house_roster: PreFillHouseRoster::from_compact_skirmish(2),
             options: SkirmishLaunchOptions::default(),
         }
     }

--- a/src/ui/skirmish_shell/state/launch.rs
+++ b/src/ui/skirmish_shell/state/launch.rs
@@ -3,8 +3,8 @@
 use crate::map::scenario_menu::MapMenuEntry;
 use crate::skirmish_launch::{
     HOUSE_COLOR_COUNT, LaunchCountry, LaunchStartPosition, LaunchTeam, LaunchValidationError,
-    SKIRMISH_PLAYER_SLOT_COUNT, SkirmishAiSlot, SkirmishLaunchMode, SkirmishLaunchSession,
-    SkirmishLocalSlot,
+    PreFillAiHouseSlot, PreFillHouseRoster, PreFillHumanHouse, SKIRMISH_PLAYER_SLOT_COUNT,
+    SkirmishAiSlot, SkirmishLaunchMode, SkirmishLaunchSession, SkirmishLocalSlot,
 };
 use crate::skirmish_modes::{SkirmishGameMode, mode_by_id};
 use crate::ui::main_menu::{SkirmishCountry, SkirmishSettings, StartPosition};
@@ -143,6 +143,25 @@ pub fn pack_launch_session_without_start_validation(
         team: LaunchTeam::from_shell_value(state.player_team),
     };
 
+    // Retain the native pre-compaction slot roster before closed AI rows are
+    // omitted from the gameplay-facing opponent vector.
+    let pre_fill_house_roster = PreFillHouseRoster::new(
+        vec![PreFillHumanHouse {
+            priority: 0,
+            source_order: 0,
+            observer: false,
+        }],
+        state
+            .opponents
+            .iter()
+            .enumerate()
+            .map(|(slot_index, opponent)| PreFillAiHouseSlot {
+                slot_index: slot_index as u8,
+                valid: opponent.is_active(),
+            })
+            .collect(),
+    );
+
     let mut opponents = Vec::new();
     for (idx, opponent) in state.opponents.iter().enumerate() {
         let Some(difficulty) = opponent.row_type.difficulty() else {
@@ -180,6 +199,7 @@ pub fn pack_launch_session_without_start_validation(
         player_name: state.player_name_edit.text.clone(),
         local,
         opponents,
+        pre_fill_house_roster,
         options,
     })
 }

--- a/src/ui/skirmish_shell/state/tests.rs
+++ b/src/ui/skirmish_shell/state/tests.rs
@@ -1262,6 +1262,44 @@ fn raw_pack_skips_start_only_validation_for_back_transaction() {
 }
 
 #[test]
+fn raw_pack_retains_sparse_ai_house_slots_before_compaction() {
+    let mut shell = SkirmishShellState::default();
+    for opponent in &mut shell.opponents {
+        opponent.row_type = SkirmishAiRowType::None;
+    }
+    shell.opponents[1].row_type = SkirmishAiRowType::Normal;
+    shell.opponents[4].row_type = SkirmishAiRowType::Hard;
+    let maps = [test_map_entry("map.mmx")];
+    let packed = pack_launch_session_without_start_validation(
+        &shell,
+        &maps,
+        &stock_skirmish_modes(),
+    )
+    .expect("sparse raw AI slots pack before gameplay compaction");
+
+    assert_eq!(packed.opponents.len(), 2);
+    assert_eq!(
+        packed
+            .pre_fill_house_roster
+            .ai_slots()
+            .iter()
+            .map(|slot| (slot.slot_index, slot.valid))
+            .collect::<Vec<_>>(),
+        vec![
+            (0, false),
+            (1, true),
+            (2, false),
+            (3, false),
+            (4, true),
+            (5, false),
+            (6, false),
+        ]
+    );
+    assert_eq!(packed.pre_fill_house_roster.required_start_count(), 3);
+    assert_eq!(packed.pre_fill_house_roster.created_house_count(), 5);
+}
+
+#[test]
 fn launch_session_rejects_no_active_opponents() {
     let mut shell = SkirmishShellState::default();
     for opponent in &mut shell.opponents {


### PR DESCRIPTION
## What changed

- Runs the active-retail Scenario prefix before random-map Fill for every stock offline size id 1..9.
- Reproduces the verified two-pass House/Gather/preassignment/chooser/reset transaction over the exact offline roster, with a single consumed Scenario RNG cursor and draw-free projection.
- Keeps accepted RMG staging starts as Scenario's active start table for loading markers and both session/descriptor paths; regenerated map data owns content and bounds, while preview data remains presentation-only.
- Adds the reviewed native-evidence/design updates and focused regression coverage, including distinct staging, Gather fallback, preview, and regenerated waypoint tables.

## Evidence

Material behavior is grounded in active-retail gamemd.exe and YR retail data. OpenTS was used only to navigate inherited design. The implementation commits cite the load-bearing gamemd entry points/callsites.

## Validation

- `scenario_prefix`: 9 passed
- `gsi_04_12`: 79 passed, 1 ignored
- accepted-staging ownership fixture: 1 passed
- real-retail ignored lifecycle fixture: 1 passed
- both native loading cadences: 1 passed
- sim/generator architecture guard: 1 passed
- setup-dependent reruns: MIX 13 passed; loading art 1 passed; CLSID 5 passed
- four successive fresh read-only critic passes after the two largest findings were fixed; final verdict: no material P0-R1 gap remains

The single required local `cargo test -p vera20k --lib` gate ran once: 7735 passed, 76 ignored, and 6 failed. One failure was the test-only sim-to-generator architecture dependency fixed in the final commit. The other five were worktree setup omissions; after restoring ignored retail INI/install configuration, every failed case passed in the focused reruns above. Per ENGINE.md, the full local gate was not repeated.

## Nonblocking evidence debt

The retained House constructor values are raw `RandomRanged(450,1800)` samples rather than the later AttackDelay-scaled dormant native fields. Exhaustive evidence found no active readers and House hashing excludes those fields; terminology cleanup remains separate from this active behavior transaction.