### PR TITLE
Allow coherent foundational prerequisite slices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,12 @@ file adds only what is specific to autonomous runs.
 
 - **Own one slice at a time.** Finish it and hand off. Do not select another system, start
   another feature, or expand into a new dependency chain because it looks adjacent.
-- Promote a prerequisite only when its behavior is necessary to locate, implement, or
-  validate the current slice's first divergence *and* it is missing, disconnected, or
-  unverified. Close the smallest prerequisite the parent needs — not that system's whole
-  backlog. Record indirect dependencies as residuals.
+- Promote a prerequisite when it is necessary to locate, implement, or validate the
+  current slice, or when a narrower patch would create duplicate authority, a temporary
+  adapter, architectural drift, or predictable rework. Close the smallest coherent
+  foundational capability—not merely the smallest patch—needed by the parent mechanism.
+  A separable foundation is its own prerequisite slice and feature branch/PR, merged
+  before its consumer. Do not absorb that system's unrelated backlog; record it as residuals.
 - Newly discovered expert-only or scheduler-tail differences become recorded residuals
   unless they are required for correctness, determinism, architecture, or the ordinary
   player-visible loop being closed.

--- a/docs/plans/2026-07-30-clean-slate-system-implementation-order.md
+++ b/docs/plans/2026-07-30-clean-slate-system-implementation-order.md
@@ -49,10 +49,11 @@ isolated projects:
    substitute for this check.
 4. Trace the loop in its actual runtime stage order and locate its **first
    player-visible or determinism-relevant divergence**.
-5. Use this document's dependency order to identify the smallest prerequisite
-   that divergence needs, then close only that bounded mechanism in its
-   existing Rust owner. Do not implement an entire earlier phase just because
-   it appears first.
+5. Use this document's dependency order to identify the smallest coherent prerequisite
+   capability—not merely the smallest patch—that the divergence needs. This may include
+   bounded foundational work required to avoid duplicate authority, temporary adapters,
+   architectural drift, or predictable rework. Deliver a separable foundation first.
+   Do not implement an entire earlier phase or absorb unrelated backlog.
 6. Independently review the evidence-to-code mapping and run the scoped
    deterministic plus production-path check.
 7. Rerun the parent loop. If its end-to-end check passes, close it and select
@@ -190,12 +191,12 @@ Select one ordinary-stock end-to-end loop, enumerate its GSI participants,
 and reconcile current HEAD, Rust production owners, tests, research, INIs,
 parity evidence, git history, dirty files, and parallel ownership. Trace the
 participants in actual runtime stage order and locate the first player-visible
-or determinism-relevant divergence. Use the clean-slate dependency order to
-identify only the smallest prerequisite it needs. Verify active gamemd
-behavior and TS/YR reachability, then implement that bounded mechanism in the
-existing Rust owner. Do not rebuild already-present foundations or expand
-into another system's backlog. Obtain an independent review and run scoped
-deterministic and production-path checks. Rerun the parent loop: close it only
+or determinism-relevant divergence. Use the clean-slate dependency order to identify
+and close the smallest coherent foundational prerequisite capability—not merely the
+smallest patch—the loop needs. Deliver a separable foundation first, with its own
+evidence, validation, and review. Do not rebuild already-present foundations or expand
+into unrelated backlog. Obtain an independent review and run scoped deterministic and
+production-path checks. Rerun the parent loop: close it only
 if its end-to-end check passes; otherwise record residuals and leave the next
 slice in that same loop. Write the handoff, then stop.
 ```


### PR DESCRIPTION
Updates the autonomous-run and clean-slate implementation-order policies so blocked mechanisms may implement the smallest coherent foundational capability instead of a narrow patch. Separable foundations still require their own dependency PR, evidence, validation, and review; unrelated backlog remains excluded. Validation: git diff --check origin/main...HEAD.