### PR TITLE
docs(readme): remove title and status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-
-# VERA20K
-
-![PRs Welcome](https://img.shields.io/badge/PRs-welcome-blue.svg)[![Docs](https://img.shields.io/badge/Docs-GitHub%20Pages-blue)](https://yrvera.github.io/vera20k/)
-
 <img src="docs/images/new-conscirpt-hero-image.png" alt="VERA20k hero image" width="100%">
 
 Red Alert 2: Yuri's Revenge — rebuilt from scratch in Rust for large multiplayer battles.


### PR DESCRIPTION
Removes the duplicate VERA20K heading and the PRs Welcome / Docs badges from the top of the README. The hero image now opens the page directly.\n\nValidation: git diff --check