### PR TITLE
Phase 14: deliver launcher Options parent

### DIFF
--- a/src/app/audio_runtime.rs
+++ b/src/app/audio_runtime.rs
@@ -6,11 +6,68 @@
 //! registries are reloaded on each map load today (redundant but harmless —
 //! they consume no map-specific input); that behavior is unchanged here.
 
+use crate::assets::asset_manager::AssetManager;
 use crate::audio::music::MusicPlayer;
 use crate::audio::sfx::SfxPlayer;
+use crate::audio::theme::{
+    MusicOutputState, PreparedTrack, ThemeAction, ThemeGates, ThemeRuntime,
+};
 use crate::rules::sound_ini::{EvaRegistry, SoundRegistry};
 
+pub(crate) const fn derive_launcher_audio_available(
+    audio_requested: bool,
+    music_output_ready: bool,
+    sfx_output_ready: bool,
+) -> bool {
+    audio_requested && (music_output_ready || sfx_output_ready)
+}
+
+trait ThemeMusicOutput {
+    fn set_theme_scale(&mut self, scale: f64);
+    fn stop(&mut self);
+    fn submit(&mut self, prepared: PreparedTrack) -> bool;
+}
+
+impl ThemeMusicOutput for MusicPlayer {
+    fn set_theme_scale(&mut self, scale: f64) {
+        MusicPlayer::set_theme_scale(self, scale);
+    }
+
+    fn stop(&mut self) {
+        MusicPlayer::stop(self);
+    }
+
+    fn submit(&mut self, prepared: PreparedTrack) -> bool {
+        MusicPlayer::submit(self, prepared)
+    }
+}
+
+fn apply_theme_action_to_output(
+    mut output: Option<&mut impl ThemeMusicOutput>,
+    action: ThemeAction,
+) {
+    if let Some(scale) = action.theme_scale
+        && let Some(output) = output.as_deref_mut()
+    {
+        output.set_theme_scale(scale);
+    }
+    if action.stop_output
+        && let Some(output) = output.as_deref_mut()
+    {
+        output.stop();
+    }
+    if let Some(prepared) = action.start
+        && let Some(output) = output.as_deref_mut()
+        && !output.submit(prepared)
+    {
+        // gamemd ignores PlayFile's return and still writes logical active.
+        log::warn!("Physical music submission failed after Theme admission");
+    }
+}
+
 pub(crate) struct AppAudioRuntime {
+    /// Always-present device-independent Theme owner.
+    pub(crate) theme: ThemeRuntime,
     /// Background music player (rodio). `None` when audio output is disabled
     /// or initialization failed.
     pub(crate) music_player: Option<MusicPlayer>,
@@ -23,7 +80,172 @@ pub(crate) struct AppAudioRuntime {
     pub(crate) audio_indices: Vec<crate::assets::audio_bag::AudioIndex>,
     /// The process-start audio decision persisted for later scenario reloads.
     pub(crate) audio_indices_enabled: bool,
+    /// Rust-native substitute for native's one shared DirectSound-device gate.
+    /// Frozen after both process-start output constructor attempts.
+    pub(crate) launcher_audio_available: bool,
+    /// Native has a startup-suppression gate. Current Rust has no non-default
+    /// route, so production initializes this false and keeps one explicit seam.
+    pub(crate) theme_startup_suppressed: bool,
     /// EVA announcement registry from eva.ini / evamd.ini.
     /// Maps EVA event names to per-faction audio.bag sound IDs.
     pub(crate) eva_registry: EvaRegistry,
+}
+
+impl AppAudioRuntime {
+    fn theme_gates(&self) -> ThemeGates {
+        ThemeGates {
+            launcher_audio_available: self.launcher_audio_available,
+            startup_suppressed: self.theme_startup_suppressed,
+        }
+    }
+
+    fn music_output_state(&self) -> MusicOutputState {
+        self.music_player
+            .as_ref()
+            .map_or(MusicOutputState::Unavailable, MusicPlayer::state)
+    }
+
+    fn apply_theme_action(&mut self, action: ThemeAction) {
+        apply_theme_action_to_output(self.music_player.as_mut(), action);
+    }
+
+    pub(crate) fn initialize_theme(&mut self, assets: &AssetManager) {
+        self.theme.initialize_catalog(assets);
+    }
+
+    pub(crate) fn maintain_main_menu_theme(&mut self, assets: &AssetManager, wall_ms: u64) {
+        // Let Theme AI consume a real physical completion first. A subsequent
+        // direct INTRO maintenance call then takes the native same-track no-op
+        // when AI already restarted the repeating menu theme.
+        self.update_theme(assets, wall_ms);
+        let gates = self.theme_gates();
+        let physical = self.music_output_state();
+        let action = self.theme.play_menu_theme(assets, gates, physical);
+        self.apply_theme_action(action);
+    }
+
+    pub(crate) fn update_theme(&mut self, assets: &AssetManager, wall_ms: u64) {
+        let gates = self.theme_gates();
+        let physical = self.music_output_state();
+        if physical == MusicOutputState::Finished
+            && let Some(output) = self.music_player.as_mut()
+        {
+            output.discard_finished();
+        }
+        let action = self.theme.update(assets, gates, physical, wall_ms);
+        self.apply_theme_action(action);
+    }
+
+    pub(crate) fn play_theme(&mut self, track: &str, assets: &AssetManager) -> bool {
+        let gates = self.theme_gates();
+        let physical = self.music_output_state();
+        let action = self.theme.play_track(track, assets, gates, physical);
+        let logical_started = action.start.is_some();
+        self.apply_theme_action(action);
+        logical_started
+    }
+
+    pub(crate) fn request_scenario_theme(
+        &mut self,
+        requested_section: Option<&str>,
+        assets: &AssetManager,
+        wall_ms: u64,
+    ) {
+        let gates = self.theme_gates();
+        let physical = self.music_output_state();
+        let action =
+            self.theme
+                .request_scenario_theme(requested_section, assets, gates, physical, wall_ms);
+        self.apply_theme_action(action);
+    }
+
+    pub(crate) fn cancel_scenario_theme_request(&mut self) {
+        let action = self.theme.cancel_scenario_theme_request();
+        self.apply_theme_action(action);
+    }
+
+    pub(crate) fn stop_theme(&mut self) {
+        let action = self.theme.stop(self.theme_gates());
+        self.apply_theme_action(action);
+    }
+
+    pub(crate) fn queue_then_stop_score_zero(&mut self) {
+        let gates = self.theme_gates();
+        let physical = self.music_output_state();
+        let action = self.theme.queue_then_stop_score_zero(gates, physical);
+        self.apply_theme_action(action);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    enum OutputCall {
+        Scale(f64),
+        Stop,
+        Submit(String),
+    }
+
+    struct FakeOutput {
+        calls: Vec<OutputCall>,
+        submit_succeeds: bool,
+    }
+
+    impl ThemeMusicOutput for FakeOutput {
+        fn set_theme_scale(&mut self, scale: f64) {
+            self.calls.push(OutputCall::Scale(scale));
+        }
+
+        fn stop(&mut self) {
+            self.calls.push(OutputCall::Stop);
+        }
+
+        fn submit(&mut self, prepared: PreparedTrack) -> bool {
+            self.calls.push(OutputCall::Submit(prepared.stem));
+            self.submit_succeeds
+        }
+    }
+
+    #[test]
+    fn launcher_audio_gate_uses_one_process_start_predicate() {
+        assert!(!derive_launcher_audio_available(false, false, false));
+        assert!(!derive_launcher_audio_available(false, true, true));
+        assert!(!derive_launcher_audio_available(true, false, false));
+        assert!(derive_launcher_audio_available(true, true, false));
+        assert!(derive_launcher_audio_available(true, false, true));
+        assert!(derive_launcher_audio_available(true, true, true));
+    }
+
+    #[test]
+    fn post_admission_output_failure_cannot_rewrite_theme_state() {
+        let theme = ThemeRuntime::default();
+        let before = format!("{:?}", theme);
+        let action = ThemeAction {
+            stop_output: true,
+            theme_scale: Some(0.25),
+            start: Some(PreparedTrack {
+                stem: "Drok".into(),
+                samples: vec![0.0, 0.0],
+                sample_rate: 22_050,
+            }),
+        };
+        let mut output = FakeOutput {
+            calls: Vec::new(),
+            submit_succeeds: false,
+        };
+
+        apply_theme_action_to_output(Some(&mut output), action);
+
+        assert_eq!(
+            output.calls,
+            vec![
+                OutputCall::Scale(0.25),
+                OutputCall::Stop,
+                OutputCall::Submit("Drok".into()),
+            ]
+        );
+        assert_eq!(format!("{:?}", theme), before);
+    }
 }

--- a/src/app/audio_runtime.rs
+++ b/src/app/audio_runtime.rs
@@ -91,6 +91,11 @@ pub(crate) struct AppAudioRuntime {
     pub(crate) eva_registry: EvaRegistry,
 }
 
+/// gamemd-derived: Theme admission and logical/physical command ordering come
+/// from `ThemeClass` AI `0x007209D0`, Next `0x00720A80`, Queue `0x00720B20`,
+/// Play `0x00720BB0`, and Stop `0x00720EA0`. Their shared device gate calls
+/// `FUN_00407000` (`DAT_0087E728 != 0`) alongside Theme initialization
+/// `DAT_00A8EC74 != 0` and startup suppression `DAT_00A8ED64 == 0`.
 impl AppAudioRuntime {
     fn theme_gates(&self) -> ThemeGates {
         ThemeGates {

--- a/src/app/frame.rs
+++ b/src/app/frame.rs
@@ -105,9 +105,7 @@ impl App {
                 player.set_volume(vol);
             }
             if tick.stop_music {
-                if let Some(player) = state.audio.music_player.as_mut() {
-                    player.stop();
-                }
+                state.audio.stop_theme();
             }
             if tick.finished {
                 state.frontend.quit_cascade = None;

--- a/src/app/frontend/skirmish_session.rs
+++ b/src/app/frontend/skirmish_session.rs
@@ -141,6 +141,35 @@ impl OfflineSkirmishRuntime {
         }
     }
 
+    /// Re-read only the six process-cached `[MultiPlayer]` preferences before
+    /// the launcher Options Network child route.
+    ///
+    /// gamemd-derived: `OptionsClass__ShowLauncherDialog @ 0x0055FC80` calls
+    /// `SessionClass__ReadMultiPlayerSettings @ 0x006980C0` after destroying
+    /// the `0xD5` primary and before constructing Network dialog `0xD7`.
+    /// The existing parser establishes constructor defaults first, so a
+    /// missing, unreadable, or malformed snapshot atomically replaces only
+    /// this cache with defaults and cannot perturb shell/RNG/RMG/co-op state.
+    pub(crate) fn refresh_local_multiplayer_preferences(&mut self) {
+        let refreshed = match self.ini_path.as_deref() {
+            Some(path) => match std::fs::read(path) {
+                Ok(bytes) => read_local_multiplayer_preferences(&bytes),
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    LocalMultiplayerPreferences::default()
+                }
+                Err(error) => {
+                    log::warn!(
+                        "Could not refresh Multiplayer settings from {}: {error}",
+                        path.display()
+                    );
+                    LocalMultiplayerPreferences::default()
+                }
+            },
+            None => LocalMultiplayerPreferences::default(),
+        };
+        self.local_preferences = refreshed;
+    }
+
     #[cfg(test)]
     fn snapshot(&self) -> &SkirmishPersistedSnapshot {
         &self.snapshot
@@ -919,6 +948,79 @@ mod tests {
             cooperative_country_roster: stock_cooperative_country_roster(),
             gameplay_rng_return_pending: false,
         }
+    }
+
+    #[test]
+    fn launcher_network_refresh_replaces_only_six_cached_multiplayer_fields() {
+        let unique = format!(
+            "vera20k-launcher-network-refresh-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        );
+        let directory = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&directory).expect("create refresh fixture directory");
+        let path = directory.join(RA2MD_INI);
+        let bytes = b"; preserve me\r\n\
+[MultiPlayer]\r\n\
+Handle=52,65,66,72,65,73,68,65,64,\r\n\
+Color=4\r\n\
+ColorEx=-2\r\n\
+Side=Arabs\r\n\
+SideEx=7\r\n\
+GameMode=9\r\n\
+[Skirmish]\r\n\
+Credits=12345\r\n";
+        std::fs::write(&path, bytes).expect("write refresh fixture");
+
+        let mut runtime = runtime(
+            SkirmishPersistedSnapshot {
+                credits: 22222,
+                ..SkirmishPersistedSnapshot::from_global_defaults(defaults())
+            },
+            0x1234_5678,
+        );
+        runtime.ini_path = Some(path.clone());
+        runtime.random_map_options.seed = 4242;
+        runtime.gameplay_rng_return_pending = true;
+        runtime.local_preferences = LocalMultiplayerPreferences {
+            handle_bytes: b"Old".to_vec(),
+            country: SkirmishCountry::America,
+            side_ex: 1,
+            color_index: 0,
+            color_ex: 0,
+            game_mode: 1,
+        };
+
+        let snapshot_before = runtime.snapshot.clone();
+        let rng_before = runtime.scenario_rng_state();
+        let rmg_before = runtime.random_map_options.clone();
+        let registry_before = runtime.cooperative_registry.clone();
+        let progress_before = runtime.cooperative_progress.clone();
+        let roster_before = runtime.cooperative_country_roster.clone();
+        let pending_before = runtime.gameplay_rng_return_pending;
+
+        runtime.refresh_local_multiplayer_preferences();
+
+        assert_eq!(runtime.local_preferences.handle_bytes, b"Refreshed");
+        assert_eq!(runtime.local_preferences.country, SkirmishCountry::Iraq);
+        assert_eq!(runtime.local_preferences.side_ex, 7);
+        assert_eq!(runtime.local_preferences.color_index, 4);
+        assert_eq!(runtime.local_preferences.color_ex, -2);
+        assert_eq!(runtime.local_preferences.game_mode, 9);
+        assert_eq!(runtime.snapshot, snapshot_before);
+        assert_eq!(runtime.scenario_rng_state(), rng_before);
+        assert_eq!(runtime.random_map_options, rmg_before);
+        assert_eq!(runtime.cooperative_registry, registry_before);
+        assert_eq!(runtime.cooperative_progress, progress_before);
+        assert_eq!(runtime.cooperative_country_roster, roster_before);
+        assert_eq!(runtime.gameplay_rng_return_pending, pending_before);
+        assert_eq!(
+            std::fs::read(&path).expect("reread refresh fixture"),
+            bytes,
+            "Network preparation is read-only"
+        );
+
+        std::fs::remove_dir_all(directory).expect("remove refresh fixture directory");
     }
 
     fn defaults() -> SkirmishGlobalDefaults {

--- a/src/app/frontend/state.rs
+++ b/src/app/frontend/state.rs
@@ -64,7 +64,7 @@ pub(crate) struct FrontendState {
     /// confirm quitting. The app only exits on confirm, never on the first
     /// Exit click.
     pub(crate) exit_confirm_modal: Option<crate::ui::main_menu_dialogs::ExitConfirmModalState>,
-    /// Options launcher dialog (open-level shell; real widgets not decoded).
+    /// Retained active-YR launcher Options `0xD5` parent snapshot.
     pub(crate) options_dialog: Option<crate::ui::main_menu_dialogs::OptionsDialogState>,
     /// Movies & Credits sub-panel (open-level shell; playback not implemented).
     pub(crate) movies_credits_dialog:

--- a/src/app/handler.rs
+++ b/src/app/handler.rs
@@ -62,6 +62,13 @@ fn enter_shell_window_mode_with_operations(operations: &mut impl ShellWindowMode
     operations.request_redraw();
 }
 
+/// Active YR's launcher parent ignores IDCANCEL. Taking only an immutable
+/// reference makes the no-close/no-replacement guarantee explicit at the
+/// keyboard routing seam.
+fn launcher_options_consumes_escape<T>(dialog: &Option<T>, is_escape: bool) -> bool {
+    is_escape && dialog.is_some()
+}
+
 impl App {
     fn resize_surface_for_window_size(state: &mut AppState, size: PhysicalSize<u32>) {
         state.renderer.gpu.resize(size.width, size.height);
@@ -165,6 +172,23 @@ mod tests {
         assert!(equal.requested_sizes.is_empty());
         assert!(equal.resized_surfaces.is_empty());
         assert_eq!(equal.redraw_requests, 0);
+    }
+
+    #[test]
+    fn launcher_options_escape_is_consumed_without_replacing_the_parent() {
+        let dialog = crate::ui::main_menu_dialogs::OptionsDialogState::default();
+        let mut slot = Some(dialog);
+        let identity_before = slot.as_ref().map(|value| value as *const _);
+
+        assert!(launcher_options_consumes_escape(&slot, true));
+        assert_eq!(
+            slot.as_ref().map(|value| value as *const _),
+            identity_before
+        );
+        assert!(!launcher_options_consumes_escape(&slot, false));
+
+        slot = None;
+        assert!(!launcher_options_consumes_escape(&slot, true));
     }
 }
 
@@ -372,6 +396,10 @@ impl ApplicationHandler for App {
         match event {
             WindowEvent::CloseRequested => {
                 log::info!("Close requested");
+                // Active YR treats a terminated launcher Options pump as an
+                // always-apply final result: Apply -> destroy -> one write.
+                // Complete that transaction before unrelated shell teardown.
+                Self::close_launcher_options_terminal(state);
                 if Self::native_skirmish_shell_active(state) {
                     // Pump/quit exits write the last durable snapshot after
                     // teardown, without a fresh control pack or RNG draw.
@@ -449,6 +477,13 @@ impl ApplicationHandler for App {
                                     Self::close_exit_confirm_modal_from_controller(state);
                                     state.platform.window.request_redraw();
                                 }
+                            } else if launcher_options_consumes_escape(
+                                &state.frontend.options_dialog,
+                                is_escape,
+                            ) {
+                                // `0xD5` ignores IDCANCEL=2. Preserve the same
+                                // dialog instance and emit no Apply/write/event.
+                                state.platform.window.request_redraw();
                             } else {
                                 Self::close_main_menu_dialogs(state);
                                 state.platform.window.request_redraw();

--- a/src/app/in_game.rs
+++ b/src/app/in_game.rs
@@ -38,9 +38,7 @@ impl App {
         Self::capture_returned_skirmish_rng(state);
         crate::app::loading::pump::clear_match_startup_state(state);
         state.match_state.scenario_elapsed_clock.reset();
-        if let Some(ref mut player) = state.audio.music_player {
-            player.stop();
-        }
+        state.audio.stop_theme();
         // F11: leaving a match silences match audio completely. Previously
         // only music stopped — live SFX, the voice player, and queued EVA
         // lines survived and played over the main menu, and the SFX output
@@ -598,8 +596,8 @@ impl App {
             }
         }
         if tick.stop_audio {
+            state.audio.stop_theme();
             if let Some(player) = state.audio.music_player.as_mut() {
-                player.stop();
                 player.set_output_scale(1.0);
             }
             if let Some(player) = state.audio.sfx_player.as_mut() {
@@ -612,9 +610,9 @@ impl App {
         // hard stop and output-scale restoration so ScoreX begins audible.
         if let Some(crate::app::match_runtime::scenario_exit::ScenarioExitAudioAction::PlayTheme(theme)) =
             tick.after_stop
-            && let (Some(player), Some(assets)) = (&mut state.audio.music_player, state.process_assets.manager())
+            && let Some(assets) = state.process_assets.manager()
         {
-            let _ = player.play_track(theme, assets);
+            let _ = state.audio.play_theme(theme, assets);
         }
         if !tick.finished {
             return;

--- a/src/app/initialize.rs
+++ b/src/app/initialize.rs
@@ -440,6 +440,35 @@ impl App {
             &startup_in_game_options,
         );
 
+        let music_player = startup_audio
+            .initialize_music_output
+            .then(MusicPlayer::new)
+            .flatten();
+        let sfx_player = startup_audio
+            .initialize_sfx_output
+            .then(SfxPlayer::new)
+            .flatten();
+        let launcher_audio_available =
+            crate::app::audio_runtime::derive_launcher_audio_available(
+                startup_options.audio_enabled,
+                music_player.is_some(),
+                sfx_player.is_some(),
+            );
+        let mut startup_audio_runtime = crate::app::audio_runtime::AppAudioRuntime {
+            theme: crate::audio::theme::ThemeRuntime::default(),
+            music_player,
+            sfx_player,
+            sound_registry: startup_sound_registry,
+            audio_indices: startup_audio_indices,
+            audio_indices_enabled: startup_audio.load_audio_indices,
+            launcher_audio_available,
+            theme_startup_suppressed: false,
+            eva_registry: startup_eva_registry,
+        };
+        if let Some(assets) = startup_asset_manager.as_ref() {
+            startup_audio_runtime.initialize_theme(assets);
+        }
+
         let mut state = AppState {
             platform: PlatformState::new(window, game_config, shell_client_size),
             match_state: crate::app::match_runtime::state::MatchState {
@@ -639,20 +668,7 @@ impl App {
                 startup_asset_manager,
                 startup_csf,
             ),
-            audio: crate::app::audio_runtime::AppAudioRuntime {
-                music_player: startup_audio
-                    .initialize_music_output
-                    .then(MusicPlayer::new)
-                    .flatten(),
-                sfx_player: startup_audio
-                    .initialize_sfx_output
-                    .then(SfxPlayer::new)
-                    .flatten(),
-                sound_registry: startup_sound_registry,
-                audio_indices: startup_audio_indices,
-                audio_indices_enabled: startup_audio.load_audio_indices,
-                eva_registry: startup_eva_registry,
-            },
+            audio: startup_audio_runtime,
             persistence: crate::app::persistence::PersistenceState::new(options_profile),
             diag: crate::app::diagnostics::state::DiagnosticsState {
                 debug_frame_step_requested: false,

--- a/src/app/loading/transitions.rs
+++ b/src/app/loading/transitions.rs
@@ -416,9 +416,12 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
     // leaves the current shell stream in place while Theme owns its fade and
     // deferred QueueSong/automatic request.
     let music_now_ms = sim_tick::monotonic_frame_pacer_ms(state, std::time::Instant::now());
-    if let (Some(player), Some(assets)) = (&mut state.audio.music_player, state.process_assets.manager()) {
-        let request = player.resolve_scenario_theme(state.match_state.map_basic.theme.as_deref(), assets);
-        player.request_scenario_theme(request, music_now_ms);
+    if let Some(assets) = state.process_assets.manager() {
+        state.audio.request_scenario_theme(
+            state.match_state.map_basic.theme.as_deref(),
+            assets,
+            music_now_ms,
+        );
     }
 
     if state.match_state.input.spawn_pick_pending {

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -811,8 +811,8 @@ fn advance_in_game_runtime_mode(
     // Per-frame gadget idle tick (G22 rows 2/3 drag-off/drag-back tracking).
     crate::app::input::gadget_input::idle_tick(state);
     let music_now_ms = monotonic_frame_pacer_ms(state, Instant::now());
-    if let (Some(player), Some(assets)) = (&mut state.audio.music_player, state.process_assets.manager()) {
-        player.update(assets, music_now_ms);
+    if let Some(assets) = state.process_assets.manager() {
+        state.audio.update_theme(assets, music_now_ms);
     }
     if decision.tactical_mutation {
         crate::app::input::camera::update_camera(state);

--- a/src/app/persistence/options.rs
+++ b/src/app/persistence/options.rs
@@ -12,6 +12,8 @@ use crate::ui::shell::in_game_options_state::{
 use crate::ui::shell::modal::ModalResult;
 use crate::ui::tooltips::TooltipService;
 
+pub(crate) mod launcher;
+
 /// Normal Back result. Native result 1 applies then writes; result 2 performs
 /// neither operation.
 pub(crate) const IN_GAME_OPTIONS_RESULT_BACK: i32 = 1;

--- a/src/app/persistence/options/launcher.rs
+++ b/src/app/persistence/options/launcher.rs
@@ -7,9 +7,9 @@
 
 use crate::app::persistence::options_profile::RetailOptionsProfile;
 use crate::ui::main_menu_dialogs::options::{
-    LauncherCue, LauncherOptionsEvent, LauncherOptionsPacked, LauncherOptionsValues,
-    LauncherParentResult, LauncherResolutionRow, OptionsDialogState, admitted_initial_position,
-    admitted_volume_position,
+    LauncherCue, LauncherOptionsEvent, LauncherOptionsLabels, LauncherOptionsPacked,
+    LauncherOptionsValues, LauncherParentResult, LauncherResolutionRow, OptionsDialogState,
+    admitted_initial_position, admitted_volume_position,
 };
 
 /// Pure result of substituting current-monitor Winit dimension pairs for the
@@ -82,6 +82,29 @@ pub(crate) fn project_launcher_resolutions(
         rows,
         selected_index,
     }
+}
+
+/// Build one fresh primary snapshot from already-owned platform and text facts.
+/// Child return and initial open both use this same constructor path.
+pub(crate) fn launcher_dialog_from_profile(
+    profile: &RetailOptionsProfile,
+    labels: LauncherOptionsLabels,
+    mode_pairs: impl IntoIterator<Item = (u32, u32)>,
+    launcher_audio_available: bool,
+) -> OptionsDialogState {
+    let values = launcher_values_from_profile(profile);
+    let resolutions = project_launcher_resolutions(
+        mode_pairs,
+        profile.allow_hi_res_modes,
+        (profile.screen_width, profile.screen_height),
+    );
+    OptionsDialogState::new(
+        labels,
+        values,
+        resolutions.rows,
+        resolutions.selected_index,
+        launcher_audio_available,
+    )
 }
 
 /// Concrete effects admitted by one launcher UI frame.
@@ -382,6 +405,46 @@ mod tests {
             project_launcher_resolutions([(640, 480)], false, (800, 600)).selected_index,
             None
         );
+    }
+
+    #[test]
+    fn fresh_dialog_constructor_projects_the_retained_parent_subset_and_audio_gate() {
+        let profile = RetailOptionsProfile {
+            detail_level: 0,
+            difficulty: 2,
+            scroll_rate: 0,
+            tooltips: false,
+            unit_action_lines: false,
+            show_hidden: true,
+            score_volume: 0.2,
+            sound_volume: 0.5,
+            voice_volume: 0.8,
+            screen_width: 800,
+            screen_height: 600,
+            ..RetailOptionsProfile::default()
+        };
+        let dialog = launcher_dialog_from_profile(
+            &profile,
+            LauncherOptionsLabels::resolve(&|_| None),
+            [(1024, 768), (800, 600), (800, 600)],
+            false,
+        );
+
+        assert_eq!(
+            dialog.pack(),
+            LauncherOptionsPacked {
+                detail_level: 0,
+                difficulty: 2,
+                unit_action_lines: false,
+                show_hidden: true,
+                tooltips: false,
+                scroll_rate: 0,
+                score_volume: 0.2,
+                sound_volume: 0.5,
+                voice_volume: 0.8,
+            }
+        );
+        assert!(!dialog.launcher_audio_available());
     }
 
     #[derive(Debug, Clone, PartialEq)]

--- a/src/app/persistence/options/launcher.rs
+++ b/src/app/persistence/options/launcher.rs
@@ -1,0 +1,729 @@
+//! Active-YR launcher Options parent projection and transaction ordering.
+//!
+//! The retained `RetailOptionsProfile` stays authoritative. This module owns
+//! the pure projection plus narrow operation seams for the live preview and
+//! accepted parent boundary; UI drawing, Winit enumeration, concrete audio,
+//! persistence I/O, and child routing remain with their established owners.
+
+use crate::app::persistence::options_profile::RetailOptionsProfile;
+use crate::ui::main_menu_dialogs::options::{
+    LauncherCue, LauncherOptionsEvent, LauncherOptionsPacked, LauncherOptionsValues,
+    LauncherParentResult, LauncherResolutionRow, OptionsDialogState, admitted_initial_position,
+    admitted_volume_position,
+};
+
+/// Pure result of substituting current-monitor Winit dimension pairs for the
+/// obsolete DirectDraw 16-bpp enumeration used by the retail launcher.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LauncherResolutionProjection {
+    pub(crate) rows: Vec<LauncherResolutionRow>,
+    pub(crate) selected_index: Option<usize>,
+}
+
+/// Project the retained signed profile into the fresh native-shaped controls.
+///
+/// gamemd-derived: launcher primary-proc setup at
+/// `0x0055FDB0..0x0056047A`. Trackbar set-position rejects an out-of-range
+/// request and leaves the fresh position at zero; it does not clamp.
+pub(crate) fn launcher_values_from_profile(
+    profile: &RetailOptionsProfile,
+) -> LauncherOptionsValues {
+    LauncherOptionsValues {
+        detail_position: u8::from(profile.detail_level != 0),
+        difficulty_position: admitted_initial_position(i64::from(profile.difficulty), 2),
+        scroll_position: admitted_initial_position(6_i64 - i64::from(profile.scroll_rate), 6),
+        tooltips: profile.tooltips,
+        target_lines: profile.unit_action_lines,
+        show_hidden: profile.show_hidden,
+        score_position: admitted_volume_position(profile.score_volume),
+        sound_position: admitted_volume_position(profile.sound_volume),
+        voice_position: admitted_volume_position(profile.voice_volume),
+    }
+}
+
+/// Filter/sort host mode pairs with the exact retail launcher list rules.
+///
+/// gamemd-derived: primary-proc slice `0x005601A0..0x00560270`. One Winit
+/// dimension pair explicitly substitutes for one obsolete 16-bpp DirectDraw
+/// mode. Duplicates remain; stable ascending width/height order and the last
+/// displayed matching duplicate determine the initial selection.
+pub(crate) fn project_launcher_resolutions(
+    mode_pairs: impl IntoIterator<Item = (u32, u32)>,
+    allow_hi_res_modes: bool,
+    retained_pair: (i32, i32),
+) -> LauncherResolutionProjection {
+    let mut admitted: Vec<(u32, u32)> = mode_pairs
+        .into_iter()
+        .filter(|(width, height)| {
+            if *width < 640 || *height < 480 {
+                return false;
+            }
+            if allow_hi_res_modes {
+                *width <= 4096 && *height <= 4096
+            } else {
+                matches!(*width, 640 | 800 | 1024) && *height <= 768
+            }
+        })
+        .collect();
+    admitted.sort_by_key(|&(width, height)| (width, height));
+
+    let rows: Vec<_> = admitted
+        .into_iter()
+        .map(|(width, height)| LauncherResolutionRow::new(width as i32, height as i32))
+        .collect();
+    let selected_index = rows
+        .iter()
+        .enumerate()
+        .filter(|(_, row)| (row.width, row.height) == retained_pair)
+        .map(|(index, _)| index)
+        .last();
+
+    LauncherResolutionProjection {
+        rows,
+        selected_index,
+    }
+}
+
+/// Concrete effects admitted by one launcher UI frame.
+///
+/// The common audio predicate is deliberately queried again at dispatch so a
+/// forged or stale audio event cannot store a profile value or touch output.
+pub(crate) trait LauncherPreviewOperations {
+    fn launcher_audio_available(&self) -> bool;
+    fn play_cue(&mut self, cue: LauncherCue);
+    fn store_resolution(&mut self, width: i32, height: i32);
+    fn store_score_volume(&mut self, volume: f32);
+    fn apply_score_output(&mut self, volume: f32);
+    fn store_sound_volume(&mut self, volume: f32);
+    fn apply_sound_output(&mut self, volume: f32);
+    fn store_voice_volume(&mut self, volume: f32);
+    fn apply_voice_output(&mut self, volume: f32);
+    fn play_generic_beep(&mut self, local_multiplier: f32);
+}
+
+/// Dispatch one already-ordered UI event without an INI write or display-mode
+/// change. The three audio paths preserve native profile -> output -> cue order.
+pub(crate) fn dispatch_launcher_preview_event(
+    operations: &mut impl LauncherPreviewOperations,
+    event: LauncherOptionsEvent,
+) {
+    match event {
+        LauncherOptionsEvent::Cue(cue) => operations.play_cue(cue),
+        LauncherOptionsEvent::ResolutionSelected { width, height } => {
+            operations.store_resolution(width, height);
+        }
+        LauncherOptionsEvent::ScorePreview(volume) => {
+            if !operations.launcher_audio_available() {
+                return;
+            }
+            operations.store_score_volume(volume);
+            operations.apply_score_output(volume);
+        }
+        LauncherOptionsEvent::SoundPreview(volume) => {
+            if !operations.launcher_audio_available() {
+                return;
+            }
+            operations.store_sound_volume(volume);
+            operations.apply_sound_output(volume);
+            operations.play_generic_beep(1.0);
+        }
+        LauncherOptionsEvent::VoicePreview(volume) => {
+            if !operations.launcher_audio_available() {
+                return;
+            }
+            operations.store_voice_volume(volume);
+            operations.apply_voice_output(volume);
+            operations.play_generic_beep(volume);
+        }
+    }
+}
+
+/// Narrow effect boundary for the unconditional accepted parent transaction.
+/// Production and the recorder both enter through
+/// [`dispatch_launcher_parent_result`].
+pub(crate) trait LauncherParentOperations {
+    fn observe_pack(&mut self, packed: LauncherOptionsPacked);
+    fn store_detail_level(&mut self, value: i32) -> bool;
+    fn refresh_detail(&mut self);
+    fn store_difficulty(&mut self, value: i32);
+    fn store_unit_action_lines(&mut self, value: bool);
+    fn refresh_unit_action_lines(&mut self);
+    fn store_show_hidden(&mut self, value: bool);
+    fn store_tooltips(&mut self, value: bool);
+    fn store_scroll_rate(&mut self, value: i32);
+    fn store_score_volume(&mut self, value: f32);
+    fn apply_score_output(&mut self, value: f32);
+    fn queue_then_stop_score_zero(&mut self);
+    fn store_sound_volume(&mut self, value: f32);
+    fn apply_sound_output(&mut self, value: f32);
+    fn store_voice_volume(&mut self, value: f32);
+    fn apply_voice_output(&mut self, value: f32);
+    fn primary_dropped(&mut self);
+    fn persist_profile(&mut self);
+    fn prepare_network_settings(&mut self);
+    fn route_network(&mut self);
+    fn route_keyboard(&mut self);
+    fn reopen_parent(&mut self);
+}
+
+/// Apply the packed parent subset in the literal native order.
+///
+/// gamemd-derived: `OptionsClass__ApplyFromLauncherDialog @ 0x0055FAA0`.
+/// Accepted audio setters are unconditional and cue-silent. Detail refresh is
+/// changed-only; action-line refresh is unconditional.
+fn apply_launcher_parent(
+    operations: &mut impl LauncherParentOperations,
+    packed: LauncherOptionsPacked,
+) {
+    let detail_changed = operations.store_detail_level(packed.detail_level);
+    if detail_changed {
+        operations.refresh_detail();
+    }
+    operations.store_difficulty(packed.difficulty);
+    operations.store_unit_action_lines(packed.unit_action_lines);
+    operations.refresh_unit_action_lines();
+    operations.store_show_hidden(packed.show_hidden);
+    operations.store_tooltips(packed.tooltips);
+    operations.store_scroll_rate(packed.scroll_rate);
+    operations.store_score_volume(packed.score_volume);
+    operations.apply_score_output(packed.score_volume);
+    if packed.score_volume == 0.0 {
+        operations.queue_then_stop_score_zero();
+    }
+    operations.store_sound_volume(packed.sound_volume);
+    operations.apply_sound_output(packed.sound_volume);
+    operations.store_voice_volume(packed.voice_volume);
+    operations.apply_voice_output(packed.voice_volume);
+}
+
+/// Consume one completed parent pass: Pack -> Apply -> physical dialog drop ->
+/// result-specific continuation.
+///
+/// gamemd-derived: `OptionsClass__ShowLauncherDialog @ 0x0055FC80` always
+/// applies and destroys the primary before child preparation/route or the one
+/// final write. Network/Keyboard then rebuild a fresh primary without writing.
+pub(crate) fn dispatch_launcher_parent_result(
+    operations: &mut impl LauncherParentOperations,
+    dialog: OptionsDialogState,
+    result: LauncherParentResult,
+) {
+    let packed = dialog.pack();
+    operations.observe_pack(packed);
+    apply_launcher_parent(operations, packed);
+    drop(dialog);
+    operations.primary_dropped();
+
+    match result {
+        LauncherParentResult::Back | LauncherParentResult::Terminal => {
+            operations.persist_profile();
+        }
+        LauncherParentResult::Network => {
+            operations.prepare_network_settings();
+            operations.route_network();
+            operations.reopen_parent();
+        }
+        LauncherParentResult::Keyboard => {
+            operations.route_keyboard();
+            operations.reopen_parent();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::main_menu_dialogs::options::LauncherOptionsLabels;
+
+    fn dialog(values: LauncherOptionsValues) -> OptionsDialogState {
+        OptionsDialogState::new(
+            LauncherOptionsLabels::resolve(&|_| None),
+            values,
+            Vec::new(),
+            None,
+            true,
+        )
+    }
+
+    #[test]
+    fn profile_projection_uses_reject_to_zero_edges() {
+        let default = launcher_values_from_profile(&RetailOptionsProfile::default());
+        assert_eq!(default, LauncherOptionsValues::default());
+
+        for (input, expected) in [(0, 0), (2, 2), (3, 0), (4, 0), (-1, 0)] {
+            let profile = RetailOptionsProfile {
+                difficulty: input,
+                ..RetailOptionsProfile::default()
+            };
+            assert_eq!(
+                launcher_values_from_profile(&profile).difficulty_position,
+                expected,
+                "Difficulty={input}"
+            );
+        }
+        for (input, expected) in [(-1, 0), (0, 6), (6, 0), (7, 0)] {
+            let profile = RetailOptionsProfile {
+                scroll_rate: input,
+                ..RetailOptionsProfile::default()
+            };
+            assert_eq!(
+                launcher_values_from_profile(&profile).scroll_position,
+                expected,
+                "ScrollRate={input}"
+            );
+        }
+        for input in [i32::MIN, -2, -1, 1, 2, i32::MAX] {
+            let profile = RetailOptionsProfile {
+                detail_level: input,
+                ..RetailOptionsProfile::default()
+            };
+            assert_eq!(launcher_values_from_profile(&profile).detail_position, 1);
+        }
+        assert_eq!(
+            launcher_values_from_profile(&RetailOptionsProfile {
+                detail_level: 0,
+                ..RetailOptionsProfile::default()
+            })
+            .detail_position,
+            0
+        );
+
+        for (input, expected) in [
+            (-2.0, 0),
+            (-0.05, 0),
+            (0.0, 0),
+            (0.04, 0),
+            // Stored f32 0.95 promotes slightly below 0.95, so the native
+            // x87 truncation of `v * 10 + 0.5` yields 9, not 10.
+            (0.95, 9),
+            (1.0, 10),
+            (f32::NAN, 0),
+            (f32::INFINITY, 0),
+        ] {
+            let profile = RetailOptionsProfile {
+                score_volume: input,
+                sound_volume: input,
+                voice_volume: input,
+                ..RetailOptionsProfile::default()
+            };
+            let values = launcher_values_from_profile(&profile);
+            assert_eq!(values.score_position, expected, "volume={input:?}");
+            assert_eq!(values.sound_position, expected, "volume={input:?}");
+            assert_eq!(values.voice_position, expected, "volume={input:?}");
+        }
+
+        let booleans = launcher_values_from_profile(&RetailOptionsProfile {
+            tooltips: false,
+            unit_action_lines: false,
+            show_hidden: true,
+            ..RetailOptionsProfile::default()
+        });
+        assert!(!booleans.tooltips);
+        assert!(!booleans.target_lines);
+        assert!(booleans.show_hidden);
+    }
+
+    #[test]
+    fn resolution_projection_filters_sorts_preserves_duplicates_and_selects_last_match() {
+        let modes = [
+            (1920, 1080),
+            (800, 600),
+            (639, 480),
+            (800, 600),
+            (1024, 769),
+            (1024, 768),
+            (640, 479),
+            (1280, 720),
+            (640, 480),
+            (4097, 2160),
+        ];
+        let low = project_launcher_resolutions(modes, false, (800, 600));
+        assert_eq!(
+            low.rows
+                .iter()
+                .map(|row| (row.width, row.height, row.label.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (640, 480, "640 x 480 x 16"),
+                (800, 600, "800 x 600 x 16"),
+                (800, 600, "800 x 600 x 16"),
+                (1024, 768, "1024 x 768 x 16"),
+            ]
+        );
+        assert_eq!(low.selected_index, Some(2));
+
+        let high = project_launcher_resolutions(modes, true, (1920, 1080));
+        assert!(
+            high.rows
+                .iter()
+                .any(|row| (row.width, row.height) == (1280, 720))
+        );
+        assert!(
+            high.rows
+                .iter()
+                .any(|row| (row.width, row.height) == (1920, 1080))
+        );
+        assert!(!high.rows.iter().any(|row| row.width == 4097));
+        assert_eq!(
+            high.selected_index.map(|index| {
+                let row = &high.rows[index];
+                (row.width, row.height)
+            }),
+            Some((1920, 1080))
+        );
+
+        assert_eq!(
+            project_launcher_resolutions([], false, (800, 600)),
+            LauncherResolutionProjection {
+                rows: Vec::new(),
+                selected_index: None,
+            }
+        );
+        assert_eq!(
+            project_launcher_resolutions([(640, 480)], false, (800, 600)).selected_index,
+            None
+        );
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    enum PreviewCall {
+        Cue(LauncherCue),
+        Resolution(i32, i32),
+        StoreScore(f32),
+        OutputScore(f32),
+        StoreSound(f32),
+        OutputSound(f32),
+        StoreVoice(f32),
+        OutputVoice(f32),
+        Beep(f32),
+    }
+
+    struct PreviewRecorder {
+        available: bool,
+        calls: Vec<PreviewCall>,
+    }
+
+    impl LauncherPreviewOperations for PreviewRecorder {
+        fn launcher_audio_available(&self) -> bool {
+            self.available
+        }
+
+        fn play_cue(&mut self, cue: LauncherCue) {
+            self.calls.push(PreviewCall::Cue(cue));
+        }
+
+        fn store_resolution(&mut self, width: i32, height: i32) {
+            self.calls.push(PreviewCall::Resolution(width, height));
+        }
+
+        fn store_score_volume(&mut self, volume: f32) {
+            self.calls.push(PreviewCall::StoreScore(volume));
+        }
+
+        fn apply_score_output(&mut self, volume: f32) {
+            self.calls.push(PreviewCall::OutputScore(volume));
+        }
+
+        fn store_sound_volume(&mut self, volume: f32) {
+            self.calls.push(PreviewCall::StoreSound(volume));
+        }
+
+        fn apply_sound_output(&mut self, volume: f32) {
+            self.calls.push(PreviewCall::OutputSound(volume));
+        }
+
+        fn store_voice_volume(&mut self, volume: f32) {
+            self.calls.push(PreviewCall::StoreVoice(volume));
+        }
+
+        fn apply_voice_output(&mut self, volume: f32) {
+            self.calls.push(PreviewCall::OutputVoice(volume));
+        }
+
+        fn play_generic_beep(&mut self, local_multiplier: f32) {
+            self.calls.push(PreviewCall::Beep(local_multiplier));
+        }
+    }
+
+    #[test]
+    fn preview_dispatch_rechecks_common_gate_and_preserves_native_order() {
+        let mut recorder = PreviewRecorder {
+            available: true,
+            calls: Vec::new(),
+        };
+        for event in [
+            LauncherOptionsEvent::Cue(LauncherCue::Checkbox),
+            LauncherOptionsEvent::ResolutionSelected {
+                width: 1024,
+                height: 768,
+            },
+            LauncherOptionsEvent::ScorePreview(0.4),
+            LauncherOptionsEvent::SoundPreview(0.7),
+            LauncherOptionsEvent::VoicePreview(0.3),
+        ] {
+            dispatch_launcher_preview_event(&mut recorder, event);
+        }
+        assert_eq!(
+            recorder.calls,
+            [
+                PreviewCall::Cue(LauncherCue::Checkbox),
+                PreviewCall::Resolution(1024, 768),
+                PreviewCall::StoreScore(0.4),
+                PreviewCall::OutputScore(0.4),
+                PreviewCall::StoreSound(0.7),
+                PreviewCall::OutputSound(0.7),
+                PreviewCall::Beep(1.0),
+                PreviewCall::StoreVoice(0.3),
+                PreviewCall::OutputVoice(0.3),
+                PreviewCall::Beep(0.3),
+            ]
+        );
+
+        recorder.available = false;
+        recorder.calls.clear();
+        for event in [
+            LauncherOptionsEvent::ScorePreview(0.1),
+            LauncherOptionsEvent::SoundPreview(0.2),
+            LauncherOptionsEvent::VoicePreview(0.3),
+        ] {
+            dispatch_launcher_preview_event(&mut recorder, event);
+        }
+        assert!(recorder.calls.is_empty());
+
+        dispatch_launcher_preview_event(
+            &mut recorder,
+            LauncherOptionsEvent::ResolutionSelected {
+                width: 640,
+                height: 480,
+            },
+        );
+        assert_eq!(recorder.calls, [PreviewCall::Resolution(640, 480)]);
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    enum ParentCall {
+        Pack,
+        Detail(i32),
+        RefreshDetail,
+        Difficulty(i32),
+        TargetLines(bool),
+        RefreshTargetLines,
+        ShowHidden(bool),
+        Tooltips(bool),
+        Scroll(i32),
+        StoreScore(f32),
+        OutputScore(f32),
+        QueueStopScoreZero,
+        StoreSound(f32),
+        OutputSound(f32),
+        StoreVoice(f32),
+        OutputVoice(f32),
+        DropPrimary,
+        Write,
+        PrepareNetwork,
+        RouteNetwork,
+        RouteKeyboard,
+        Reopen,
+    }
+
+    struct ParentRecorder {
+        detail: i32,
+        calls: Vec<ParentCall>,
+    }
+
+    impl LauncherParentOperations for ParentRecorder {
+        fn observe_pack(&mut self, _packed: LauncherOptionsPacked) {
+            self.calls.push(ParentCall::Pack);
+        }
+
+        fn store_detail_level(&mut self, value: i32) -> bool {
+            self.calls.push(ParentCall::Detail(value));
+            let changed = self.detail != value;
+            self.detail = value;
+            changed
+        }
+
+        fn refresh_detail(&mut self) {
+            self.calls.push(ParentCall::RefreshDetail);
+        }
+
+        fn store_difficulty(&mut self, value: i32) {
+            self.calls.push(ParentCall::Difficulty(value));
+        }
+
+        fn store_unit_action_lines(&mut self, value: bool) {
+            self.calls.push(ParentCall::TargetLines(value));
+        }
+
+        fn refresh_unit_action_lines(&mut self) {
+            self.calls.push(ParentCall::RefreshTargetLines);
+        }
+
+        fn store_show_hidden(&mut self, value: bool) {
+            self.calls.push(ParentCall::ShowHidden(value));
+        }
+
+        fn store_tooltips(&mut self, value: bool) {
+            self.calls.push(ParentCall::Tooltips(value));
+        }
+
+        fn store_scroll_rate(&mut self, value: i32) {
+            self.calls.push(ParentCall::Scroll(value));
+        }
+
+        fn store_score_volume(&mut self, value: f32) {
+            self.calls.push(ParentCall::StoreScore(value));
+        }
+
+        fn apply_score_output(&mut self, value: f32) {
+            self.calls.push(ParentCall::OutputScore(value));
+        }
+
+        fn queue_then_stop_score_zero(&mut self) {
+            self.calls.push(ParentCall::QueueStopScoreZero);
+        }
+
+        fn store_sound_volume(&mut self, value: f32) {
+            self.calls.push(ParentCall::StoreSound(value));
+        }
+
+        fn apply_sound_output(&mut self, value: f32) {
+            self.calls.push(ParentCall::OutputSound(value));
+        }
+
+        fn store_voice_volume(&mut self, value: f32) {
+            self.calls.push(ParentCall::StoreVoice(value));
+        }
+
+        fn apply_voice_output(&mut self, value: f32) {
+            self.calls.push(ParentCall::OutputVoice(value));
+        }
+
+        fn primary_dropped(&mut self) {
+            self.calls.push(ParentCall::DropPrimary);
+        }
+
+        fn persist_profile(&mut self) {
+            self.calls.push(ParentCall::Write);
+        }
+
+        fn prepare_network_settings(&mut self) {
+            self.calls.push(ParentCall::PrepareNetwork);
+        }
+
+        fn route_network(&mut self) {
+            self.calls.push(ParentCall::RouteNetwork);
+        }
+
+        fn route_keyboard(&mut self) {
+            self.calls.push(ParentCall::RouteKeyboard);
+        }
+
+        fn reopen_parent(&mut self) {
+            self.calls.push(ParentCall::Reopen);
+        }
+    }
+
+    fn expected_apply(detail_changed: bool, score_zero: bool) -> Vec<ParentCall> {
+        let mut calls = vec![ParentCall::Pack, ParentCall::Detail(2)];
+        if detail_changed {
+            calls.push(ParentCall::RefreshDetail);
+        }
+        calls.extend([
+            ParentCall::Difficulty(2),
+            ParentCall::TargetLines(false),
+            ParentCall::RefreshTargetLines,
+            ParentCall::ShowHidden(true),
+            ParentCall::Tooltips(false),
+            ParentCall::Scroll(0),
+            ParentCall::StoreScore(if score_zero { 0.0 } else { 0.4 }),
+            ParentCall::OutputScore(if score_zero { 0.0 } else { 0.4 }),
+        ]);
+        if score_zero {
+            calls.push(ParentCall::QueueStopScoreZero);
+        }
+        calls.extend([
+            ParentCall::StoreSound(0.7),
+            ParentCall::OutputSound(0.7),
+            ParentCall::StoreVoice(0.3),
+            ParentCall::OutputVoice(0.3),
+            ParentCall::DropPrimary,
+        ]);
+        calls
+    }
+
+    fn transaction_dialog(score_position: u8) -> OptionsDialogState {
+        dialog(LauncherOptionsValues {
+            detail_position: 1,
+            difficulty_position: 2,
+            scroll_position: 6,
+            tooltips: false,
+            target_lines: false,
+            show_hidden: true,
+            score_position,
+            sound_position: 7,
+            voice_position: 3,
+        })
+    }
+
+    #[test]
+    fn parent_apply_is_unconditional_interleaved_and_drops_before_final_write() {
+        let mut changed = ParentRecorder {
+            detail: 0,
+            calls: Vec::new(),
+        };
+        dispatch_launcher_parent_result(
+            &mut changed,
+            transaction_dialog(0),
+            LauncherParentResult::Back,
+        );
+        let mut expected = expected_apply(true, true);
+        expected.push(ParentCall::Write);
+        assert_eq!(changed.calls, expected);
+
+        let mut unchanged = ParentRecorder {
+            detail: 2,
+            calls: Vec::new(),
+        };
+        dispatch_launcher_parent_result(
+            &mut unchanged,
+            transaction_dialog(4),
+            LauncherParentResult::Terminal,
+        );
+        let mut expected = expected_apply(false, false);
+        expected.push(ParentCall::Write);
+        assert_eq!(unchanged.calls, expected);
+    }
+
+    #[test]
+    fn child_routes_prepare_and_reopen_only_after_primary_drop_without_write() {
+        let mut network = ParentRecorder {
+            detail: 2,
+            calls: Vec::new(),
+        };
+        dispatch_launcher_parent_result(
+            &mut network,
+            transaction_dialog(4),
+            LauncherParentResult::Network,
+        );
+        let mut expected = expected_apply(false, false);
+        expected.extend([
+            ParentCall::PrepareNetwork,
+            ParentCall::RouteNetwork,
+            ParentCall::Reopen,
+        ]);
+        assert_eq!(network.calls, expected);
+
+        let mut keyboard = ParentRecorder {
+            detail: 2,
+            calls: Vec::new(),
+        };
+        dispatch_launcher_parent_result(
+            &mut keyboard,
+            transaction_dialog(4),
+            LauncherParentResult::Keyboard,
+        );
+        let mut expected = expected_apply(false, false);
+        expected.extend([ParentCall::RouteKeyboard, ParentCall::Reopen]);
+        assert_eq!(keyboard.calls, expected);
+    }
+}

--- a/src/app/shell_main_menu.rs
+++ b/src/app/shell_main_menu.rs
@@ -57,6 +57,217 @@ fn dispatch_egui_fallback_confirmed_quit(operations: &mut impl ConfirmedQuitOper
     dispatch_confirmed_quit(operations, ConfirmedQuitOwner::EguiFallback);
 }
 
+struct AppStateLauncherPreviewOperations<'a> {
+    state: &'a mut AppState,
+}
+
+impl crate::app::persistence::options::launcher::LauncherPreviewOperations
+    for AppStateLauncherPreviewOperations<'_>
+{
+    fn launcher_audio_available(&self) -> bool {
+        self.state.audio.launcher_audio_available
+    }
+
+    fn play_cue(&mut self, cue: crate::ui::main_menu_dialogs::options::LauncherCue) {
+        App::play_launcher_options_cue(self.state, cue);
+    }
+
+    fn store_resolution(&mut self, width: i32, height: i32) {
+        self.state.persistence.options_profile.screen_width = width;
+        self.state.persistence.options_profile.screen_height = height;
+    }
+
+    fn store_score_volume(&mut self, volume: f32) {
+        self.state.persistence.options_profile.score_volume = volume;
+    }
+
+    fn apply_score_output(&mut self, volume: f32) {
+        if let Some(player) = self.state.audio.music_player.as_mut() {
+            player.set_volume(f64::from(volume));
+        }
+    }
+
+    fn store_sound_volume(&mut self, volume: f32) {
+        self.state.persistence.options_profile.sound_volume = volume;
+    }
+
+    fn apply_sound_output(&mut self, volume: f32) {
+        if let Some(player) = self.state.audio.sfx_player.as_mut() {
+            player.set_sound_volume(f64::from(volume));
+        }
+    }
+
+    fn store_voice_volume(&mut self, volume: f32) {
+        self.state.persistence.options_profile.voice_volume = volume;
+    }
+
+    fn apply_voice_output(&mut self, volume: f32) {
+        if let Some(player) = self.state.audio.sfx_player.as_mut() {
+            player.set_voice_volume(f64::from(volume));
+        }
+    }
+
+    fn play_generic_beep(&mut self, local_multiplier: f32) {
+        App::play_launcher_generic_beep(self.state, local_multiplier);
+    }
+}
+
+struct AppStateLauncherParentOperations<'a> {
+    state: &'a mut AppState,
+}
+
+impl crate::app::persistence::options::launcher::LauncherParentOperations
+    for AppStateLauncherParentOperations<'_>
+{
+    fn observe_pack(
+        &mut self,
+        _packed: crate::ui::main_menu_dialogs::options::LauncherOptionsPacked,
+    ) {
+        debug_assert!(self.state.frontend.options_dialog.is_none());
+    }
+
+    fn store_detail_level(&mut self, value: i32) -> bool {
+        let changed = self.state.persistence.options_profile.detail_level != value;
+        self.state.persistence.options_profile.detail_level = value;
+        self.state
+            .match_state
+            .match_presentation
+            .in_game_options
+            .detail_level = value.max(0) as u32;
+        changed
+    }
+
+    fn refresh_detail(&mut self) {
+        // Rust-native display invalidation for native `0x004AE450`. The live
+        // presentation reads the projection above on the requested frame.
+        self.state.platform.window.request_redraw();
+    }
+
+    fn store_difficulty(&mut self, value: i32) {
+        self.state.persistence.options_profile.difficulty = value;
+    }
+
+    fn store_unit_action_lines(&mut self, value: bool) {
+        self.state.persistence.options_profile.unit_action_lines = value;
+        self.state
+            .match_state
+            .match_presentation
+            .in_game_options
+            .unit_action_lines = value;
+    }
+
+    fn refresh_unit_action_lines(&mut self) {
+        let enabled = self
+            .state
+            .match_state
+            .match_presentation
+            .in_game_options
+            .unit_action_lines;
+        self.state
+            .match_state
+            .match_presentation
+            .target_lines
+            .set_unit_action_lines_enabled(enabled);
+    }
+
+    fn store_show_hidden(&mut self, value: bool) {
+        self.state.persistence.options_profile.show_hidden = value;
+        self.state
+            .match_state
+            .match_presentation
+            .in_game_options
+            .show_hidden = value;
+    }
+
+    fn store_tooltips(&mut self, value: bool) {
+        self.state.persistence.options_profile.tooltips = value;
+        self.state
+            .match_state
+            .match_presentation
+            .in_game_options
+            .tooltips = value;
+        self.state
+            .match_state
+            .match_presentation
+            .tooltips
+            .set_enabled(value);
+    }
+
+    fn store_scroll_rate(&mut self, value: i32) {
+        self.state.persistence.options_profile.scroll_rate = value;
+        self.state
+            .match_state
+            .match_presentation
+            .in_game_options
+            .scroll_rate = value.max(0) as u32;
+    }
+
+    fn store_score_volume(&mut self, value: f32) {
+        self.state.persistence.options_profile.score_volume = value;
+    }
+
+    fn apply_score_output(&mut self, value: f32) {
+        if let Some(player) = self.state.audio.music_player.as_mut() {
+            player.set_volume(f64::from(value));
+        }
+    }
+
+    fn queue_then_stop_score_zero(&mut self) {
+        self.state.audio.queue_then_stop_score_zero();
+    }
+
+    fn store_sound_volume(&mut self, value: f32) {
+        self.state.persistence.options_profile.sound_volume = value;
+    }
+
+    fn apply_sound_output(&mut self, value: f32) {
+        if let Some(player) = self.state.audio.sfx_player.as_mut() {
+            player.set_sound_volume(f64::from(value));
+        }
+    }
+
+    fn store_voice_volume(&mut self, value: f32) {
+        self.state.persistence.options_profile.voice_volume = value;
+    }
+
+    fn apply_voice_output(&mut self, value: f32) {
+        if let Some(player) = self.state.audio.sfx_player.as_mut() {
+            player.set_voice_volume(f64::from(value));
+        }
+    }
+
+    fn primary_dropped(&mut self) {
+        debug_assert!(self.state.frontend.options_dialog.is_none());
+    }
+
+    fn persist_profile(&mut self) {
+        crate::app::persistence::options::persist_options_profile(self.state);
+    }
+
+    fn prepare_network_settings(&mut self) {
+        self.state
+            .frontend
+            .offline_skirmish_runtime
+            .refresh_local_multiplayer_preferences();
+    }
+
+    fn route_network(&mut self) {
+        log::info!(
+            "Launcher Options Network child boundary reached; RT_DIALOG 0xD7 is not implemented"
+        );
+    }
+
+    fn route_keyboard(&mut self) {
+        log::info!(
+            "Launcher Options Keyboard child boundary reached; RT_DIALOG 0xA3 is not implemented"
+        );
+    }
+
+    fn reopen_parent(&mut self) {
+        App::open_launcher_options_dialog(self.state);
+    }
+}
+
 impl App {
     pub(super) fn single_player_shell_active(state: &AppState) -> bool {
         state.frontend.screen == GameScreen::MainMenu && state.frontend.shell_route.single_player()
@@ -293,6 +504,97 @@ impl App {
             .as_ref()
             .map(|csf| csf.text(key).into_owned())
             .unwrap_or_else(|| fallback.to_string())
+    }
+
+    /// Construct a fresh launcher Options primary from the current retained
+    /// profile, current-monitor dimension pairs, live CSF table, and frozen
+    /// process-start common audio gate. No display mode is applied here.
+    fn open_launcher_options_dialog(state: &mut AppState) {
+        use crate::app::persistence::options::launcher::launcher_dialog_from_profile;
+        use crate::ui::main_menu_dialogs::options::LauncherOptionsLabels;
+
+        let labels = LauncherOptionsLabels::resolve(&|key| {
+            state
+                .process_assets
+                .csf
+                .as_ref()
+                .and_then(|csf| csf.get(key))
+                .map(str::to_owned)
+        });
+        let mode_pairs: Vec<_> = state
+            .platform
+            .window
+            .current_monitor()
+            .map(|monitor| {
+                monitor
+                    .video_modes()
+                    .map(|mode| {
+                        let size = mode.size();
+                        (size.width, size.height)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let dialog = launcher_dialog_from_profile(
+            &state.persistence.options_profile,
+            labels,
+            mode_pairs,
+            state.audio.launcher_audio_available,
+        );
+        state.frontend.options_dialog = Some(dialog);
+    }
+
+    fn play_launcher_options_cue(
+        state: &mut AppState,
+        cue: crate::ui::main_menu_dialogs::options::LauncherCue,
+    ) {
+        use crate::ui::main_menu_dialogs::options::LauncherCue;
+
+        let sound_id = state.rules().and_then(|rules| match cue {
+            LauncherCue::MainButton => rules.general.gui_main_button_sound.as_deref(),
+            LauncherCue::GenericClick => rules.general.generic_click_sound.as_deref(),
+            LauncherCue::Checkbox => rules.general.gui_checkbox_sound.as_deref(),
+            LauncherCue::ComboOpen => rules.general.gui_combo_open_sound.as_deref(),
+        });
+        let sound_id = sound_id.map(str::to_owned);
+        Self::play_shell_ui_sound_by_id(state, sound_id.as_deref());
+    }
+
+    fn play_launcher_generic_beep(state: &mut AppState, local_multiplier: f32) {
+        let sound_id = state
+            .rules()
+            .and_then(|rules| rules.general.generic_beep_sound.as_deref())
+            .map(str::to_owned);
+        let Some(sound_id) = sound_id else {
+            return;
+        };
+        let Some(assets) = state.process_assets.manager() else {
+            return;
+        };
+        let Some(sfx) = state.audio.sfx_player.as_mut() else {
+            return;
+        };
+        sfx.play_sound_with_volume(
+            &sound_id,
+            local_multiplier,
+            &state.audio.sound_registry,
+            assets,
+            &state.audio.audio_indices,
+        );
+    }
+
+    /// Pump-terminal completion enters the same always-apply parent transaction
+    /// as Back, then writes once before the caller performs unrelated exit work.
+    pub(crate) fn close_launcher_options_terminal(state: &mut AppState) {
+        let Some(dialog) = state.frontend.options_dialog.take() else {
+            return;
+        };
+        let mut operations = AppStateLauncherParentOperations { state };
+        crate::app::persistence::options::launcher::dispatch_launcher_parent_result(
+            &mut operations,
+            dialog,
+            crate::ui::main_menu_dialogs::options::LauncherParentResult::Terminal,
+        );
     }
 
     /// Adapt the laid-out main-menu buttons into the shared controller's
@@ -627,8 +929,7 @@ impl App {
                 Self::open_single_player_shell(state);
             }
             MainMenuShellAction::Options => {
-                state.frontend.options_dialog =
-                    Some(crate::ui::main_menu_dialogs::OptionsDialogState::default());
+                Self::open_launcher_options_dialog(state);
             }
             MainMenuShellAction::MoviesAndCredits => {
                 state.frontend.movies_credits_dialog =
@@ -738,13 +1039,33 @@ impl App {
             }
         }
 
-        if state.frontend.options_dialog.is_some() {
-            let csf = |key: &str, fallback: &str| Self::csf_label(state, key, fallback);
-            if matches!(
-                dialogs::draw_options_dialog(&state.renderer.egui.ctx, &csf),
-                dialogs::OptionsDialogAction::Close
-            ) {
-                state.frontend.options_dialog = None;
+        if let Some(mut dialog) = state.frontend.options_dialog.take() {
+            debug_assert_eq!(
+                dialog.launcher_audio_available(),
+                state.audio.launcher_audio_available
+            );
+            let output = dialogs::options::draw_launcher_options_dialog(
+                &state.renderer.egui.ctx,
+                &mut dialog,
+            );
+            {
+                let mut operations = AppStateLauncherPreviewOperations { state };
+                for event in output.events {
+                    crate::app::persistence::options::launcher::dispatch_launcher_preview_event(
+                        &mut operations,
+                        event,
+                    );
+                }
+            }
+            if let Some(result) = output.result {
+                let mut operations = AppStateLauncherParentOperations { state };
+                crate::app::persistence::options::launcher::dispatch_launcher_parent_result(
+                    &mut operations,
+                    dialog,
+                    result,
+                );
+            } else {
+                state.frontend.options_dialog = Some(dialog);
             }
             return false;
         }

--- a/src/app/shell_main_menu.rs
+++ b/src/app/shell_main_menu.rs
@@ -560,9 +560,8 @@ impl App {
             return;
         }
         let now_ms = crate::app::match_runtime::sim_tick::monotonic_frame_pacer_ms(state, Instant::now());
-        if let (Some(player), Some(assets)) = (&mut state.audio.music_player, state.process_assets.manager()) {
-            player.play_menu_theme(assets);
-            player.update(assets, now_ms);
+        if let Some(assets) = state.process_assets.manager() {
+            state.audio.maintain_main_menu_theme(assets, now_ms);
         }
     }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -39,8 +39,8 @@ pub(crate) struct AppState {
 pub(crate) fn reset_scenario_exit_runtime(state: &mut AppState) {
     state.match_state.scenario_outcome = None;
     state.match_state.scenario_exit = None;
+    state.audio.cancel_scenario_theme_request();
     if let Some(player) = state.audio.music_player.as_mut() {
-        player.cancel_scenario_theme_request();
         player.set_output_scale(1.0);
     }
     if let Some(player) = state.audio.sfx_player.as_mut() {

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -11,3 +11,4 @@
 pub mod events;
 pub mod music;
 pub mod sfx;
+pub(crate) mod theme;

--- a/src/audio/music.rs
+++ b/src/audio/music.rs
@@ -1,39 +1,18 @@
-//! Music playback using rodio.
+//! Optional rodio music output.
 //!
-//! Loads theme tracks from THEME.MIX / thememd.mix, decodes WAV/AUD payloads
-//! to PCM, and plays them through rodio. Supports play, stop,
-//! next track, and live volume control.
-//!
-//! ## Track resolution
-//! Track names come from thememd.ini / theme.ini or the map's [Basic] Theme= field.
-//! The INI `Sound=` value resolves to the actual payload stem, which is looked
-//! up first as `{stem}.wav`, then as `{stem}.aud`.
-//!
-//! ## Dependency rules
-//! - Part of audio/ — depends on assets/ (aud_file decoder, AssetManager)
-//!   and rules/ini_parser for theme metadata.
-//! - Does NOT depend on render/, ui/, sidebar/, sim/.
+//! Theme catalog and lifecycle ownership live in `audio::theme`. This module
+//! owns only the physical device/player plus independent gain projections.
 
-use std::collections::HashMap;
 use std::num::NonZero;
 
 use rodio::buffer::SamplesBuffer;
 use rodio::{DeviceSinkBuilder, MixerDeviceSink, Player};
 
-use crate::assets::asset_manager::AssetManager;
-use crate::assets::aud_file;
-use crate::audio::sfx::decode_wav;
-use crate::rules::ini_parser::IniFile;
+use crate::audio::theme::{MusicOutputState, PreparedTrack};
 
-/// Engine default for the score (music) volume, applied before any user
-/// settings file is read. The original game seeds its live music volume to
-/// this same default when the saved `ScoreVolume` setting is absent.
+/// Engine default for the score (music) volume.
 pub const DEFAULT_SCORE_VOLUME: f64 = 0.4;
 
-/// Compose the independent gains that reach the music output buffer.
-///
-/// Keeping this absolute avoids reconstructing a non-zero volume from a muted
-/// player when either the lifecycle or foreground gate opens again.
 fn effective_music_volume(
     user_volume: f64,
     lifecycle_scale: f64,
@@ -43,351 +22,92 @@ fn effective_music_volume(
     (user_volume * lifecycle_scale * theme_scale * focus_output_scale) as f32
 }
 
-const SCENARIO_THEME_FADE_MS: u64 = 1_000;
-
-const FALLBACK_TRACKS: &[&str] = &[
-    "Grinder", "Power", "Fortific", "InDeep", "Tension", "EagleHun", "Industro", "Jank",
-    "200Meter", "BlowItUp", "Destroy", "Burn", "Motorize", "HM2", "Ra2-Opt", "RA2-Sco", "Drok",
-    "Bully", "OptionX", "ScoreX", "BrainFre", "Deceiver", "PhatAtta", "Defend", "Tactics",
-    "TranceLV",
-];
-
-/// Resolved Start_Scenario theme request. `Auto` is native theme index `-1`;
-/// `Specific` stores the section's resolved `Sound=` stem.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ScenarioThemeRequest {
-    Auto,
-    Specific(String),
-}
-
-#[derive(Debug, Clone)]
-struct PendingScenarioTheme {
-    request: ScenarioThemeRequest,
-    fade_started_at_ms: Option<u64>,
-}
-
-#[derive(Debug, Clone)]
-struct ScenarioThemeTransition {
-    pending: Option<PendingScenarioTheme>,
-    internal_scale: f64,
-}
-
-impl Default for ScenarioThemeTransition {
-    fn default() -> Self {
-        Self {
-            pending: None,
-            internal_scale: 1.0,
-        }
-    }
-}
-
-impl ScenarioThemeTransition {
-    fn request(
-        &mut self,
-        request: ScenarioThemeRequest,
-        wall_ms: u64,
-        current_stream_active: bool,
-    ) {
-        self.pending = Some(PendingScenarioTheme {
-            request,
-            fade_started_at_ms: current_stream_active.then_some(wall_ms),
-        });
-        self.internal_scale = 1.0;
-    }
-
-    fn cancel(&mut self) {
-        self.pending = None;
-        self.internal_scale = 1.0;
-    }
-
-    fn update(
-        &mut self,
-        wall_ms: u64,
-        current_stream_active: bool,
-    ) -> Option<ScenarioThemeRequest> {
-        let mut pending = self.pending.take()?;
-        if current_stream_active {
-            let started_at_ms = *pending.fade_started_at_ms.get_or_insert(wall_ms);
-            let elapsed_ms = wall_ms.saturating_sub(started_at_ms);
-            if elapsed_ms < SCENARIO_THEME_FADE_MS {
-                self.internal_scale = 1.0 - elapsed_ms as f64 / SCENARIO_THEME_FADE_MS as f64;
-                self.pending = Some(pending);
-                return None;
-            }
-            self.internal_scale = 0.0;
-        } else {
-            self.internal_scale = 1.0;
-        }
-        Some(pending.request)
-    }
-
-    fn complete_play(&mut self) {
-        self.internal_scale = 1.0;
-    }
-}
-
-/// Manages background music playback.
 pub struct MusicPlayer {
     /// rodio mixer device sink — must be kept alive or all audio stops.
     _device: MixerDeviceSink,
-    /// Player handle for the currently playing track, if any.
     current_player: Option<Player>,
-    /// Name of the currently playing track.
-    current_track: Option<String>,
-    /// Playlist of track names to cycle through.
-    playlist: Vec<String>,
-    /// Theme alias -> actual sound stem, uppercase keys.
-    aliases: HashMap<String, String>,
-    /// Theme section key -> sound stem, excluding sound-stem aliases. Used by
-    /// `[Basic] Theme=` which calls the retail section-key resolver.
-    scenario_theme_sections: HashMap<String, String>,
-    /// Index into the playlist for the next track.
-    playlist_index: usize,
-    /// Music volume (0.0 to 1.0).
     volume: f64,
-    /// App-owned output multiplier used by lifecycle fades. Kept separate from
-    /// the user setting so a scenario teardown never overwrites ScoreVolume.
     output_scale: f64,
-    /// Foreground-owned primary-output gate. This never pauses the stream: its
-    /// cursor and theme transition continue while the window is inactive.
+    theme_scale: f64,
     focus_output_scale: f64,
-    /// When set, the resolved sound stem to re-play on finish instead of
-    /// advancing the playlist (honors a theme's `Repeat=yes`, e.g. the menu
-    /// [INTRO] theme which loops the entire time the shell is shown).
-    looping_track: Option<String>,
-    /// Resolved sound stem of the menu [INTRO] theme, from theme INI.
-    menu_theme: Option<String>,
-    /// Whether the menu [INTRO] theme is marked `Repeat=yes` in the INI.
-    menu_theme_repeats: bool,
-    /// Start_Scenario's pending QueueSong/automatic request and Theme-owned
-    /// fade. Separate from lifecycle `output_scale`.
-    scenario_theme: ScenarioThemeTransition,
 }
 
 impl MusicPlayer {
-    /// Create a new MusicPlayer. Returns None if audio output cannot be opened.
+    /// Create a physical music output. Theme construction never depends on
+    /// this succeeding.
     pub fn new() -> Option<Self> {
         let device = DeviceSinkBuilder::open_default_sink()
-            .map_err(|e| log::error!("Failed to initialize music audio: {}", e))
+            .map_err(|error| log::error!("Failed to initialize music audio: {error}"))
             .ok()?;
-
         Some(Self {
             _device: device,
             current_player: None,
-            current_track: None,
-            playlist: FALLBACK_TRACKS.iter().map(|s| s.to_string()).collect(),
-            aliases: HashMap::new(),
-            scenario_theme_sections: HashMap::new(),
-            playlist_index: 0,
             volume: DEFAULT_SCORE_VOLUME,
             output_scale: 1.0,
+            theme_scale: 1.0,
             focus_output_scale: 1.0,
-            looping_track: None,
-            menu_theme: None,
-            menu_theme_repeats: false,
-            scenario_theme: ScenarioThemeTransition::default(),
         })
     }
 
-    /// Play a specific track by name. Loads from the AssetManager on demand.
-    /// Returns true if the track was found and playback started.
-    ///
-    /// This is the one-shot entry point used for gameplay tracks; it clears
-    /// any active looping so a menu loop does not bleed into a started map.
-    pub fn play_track(&mut self, track_name: &str, assets: &AssetManager) -> bool {
-        self.looping_track = None;
-        self.ensure_theme_config(assets);
-        self.start_track(track_name, assets)
+    pub(crate) fn state(&self) -> MusicOutputState {
+        match self.current_player.as_ref() {
+            Some(player) if player.empty() => MusicOutputState::Finished,
+            Some(_) => MusicOutputState::Playing,
+            None => MusicOutputState::Idle,
+        }
     }
 
-    /// Start the menu [INTRO] theme, looping it if the INI marks it
-    /// `Repeat=yes`. Idempotent: if the menu theme is already the current
-    /// track, this is a no-op so it is safe to call every frame the shell is
-    /// shown. Returns true if the menu theme is playing afterward.
-    ///
-    /// The theme name and repeat flag come from the theme INI ([INTRO]
-    /// section), not a hardcoded stem.
-    pub fn play_menu_theme(&mut self, assets: &AssetManager) -> bool {
-        self.ensure_theme_config(assets);
-
-        let Some(stem) = self.menu_theme.clone() else {
+    pub(crate) fn submit(&mut self, prepared: PreparedTrack) -> bool {
+        let Some(channels) = NonZero::new(2u16) else {
             return false;
         };
-
-        // Already playing the menu theme — don't restart it.
-        if self
-            .current_track
-            .as_deref()
-            .is_some_and(|t| t.eq_ignore_ascii_case(&stem))
-        {
-            return true;
-        }
-
-        let repeats = self.menu_theme_repeats;
-        let started = self.start_track(&stem, assets);
-        if started && repeats {
-            // start_track stores the resolved stem in current_track.
-            self.looping_track = self.current_track.clone();
-        }
-        started
-    }
-
-    /// Resolve, load, and begin playing a track. Does NOT touch the loop flag
-    /// — callers manage looping. Returns true if playback started.
-    fn start_track(&mut self, track_name: &str, assets: &AssetManager) -> bool {
-        // Stop the current player without clearing loop state owned by caller.
+        let Some(rate) = NonZero::new(prepared.sample_rate) else {
+            return false;
+        };
         if let Some(player) = self.current_player.take() {
             player.stop();
         }
-        self.current_track = None;
-
-        let resolved_name: String = self.resolve_track_name(track_name);
-        let (samples, sample_rate) = match load_track(&resolved_name, assets) {
-            Some(data) => data,
-            None => {
-                log::warn!(
-                    "Music track not found: requested='{}', resolved='{}'",
-                    track_name,
-                    resolved_name
-                );
-                return false;
-            }
-        };
-
-        let channels = match NonZero::new(2u16) {
-            Some(c) => c,
-            None => return false,
-        };
-        let rate = match NonZero::new(sample_rate) {
-            Some(r) => r,
-            None => return false,
-        };
-
-        let source = SamplesBuffer::new(channels, rate, samples);
-        let player: Player = Player::connect_new(self._device.mixer());
+        let source = SamplesBuffer::new(channels, rate, prepared.samples);
+        let player = Player::connect_new(self._device.mixer());
         player.set_volume(self.effective_volume());
         player.append(source);
-        log::info!(
-            "Playing music track: requested='{}', resolved='{}'",
-            track_name,
-            resolved_name
-        );
+        log::info!("Playing prepared music track: {}", prepared.stem);
         self.current_player = Some(player);
-        self.current_track = Some(resolved_name);
         true
     }
 
-    /// Stop the currently playing track. Also cancels any active loop so a
-    /// stopped menu theme does not silently re-trigger on the next update.
     pub fn stop(&mut self) {
-        self.cancel_scenario_theme_request();
-        self.looping_track = None;
         if let Some(player) = self.current_player.take() {
             player.stop();
         }
-        self.current_track = None;
     }
 
-    /// Play the next track in the playlist. Wraps around at the end.
-    /// Returns the name of the track that started playing, or None if no track loaded.
-    pub fn play_next(&mut self, assets: &AssetManager) -> Option<String> {
-        self.ensure_theme_config(assets);
-
-        if self.playlist.is_empty() {
-            return None;
-        }
-
-        let len: usize = self.playlist.len();
-        for attempt in 0..len {
-            let idx: usize = (self.playlist_index + attempt) % len;
-            let track_name: String = self.playlist[idx].clone();
-            self.playlist_index = (idx + 1) % len;
-            if self.play_track(&track_name, assets) {
-                return Some(track_name);
-            }
-        }
-        None
-    }
-
-    /// Check if the current track has finished and auto-advance to the next.
-    /// Call this once per frame from the game loop.
-    pub fn update(&mut self, assets: &AssetManager, wall_ms: u64) {
-        if self.scenario_theme.pending.is_some() {
-            // Theme::Stop(fade=1) takes the fade arm only while the stream is
-            // actually playing; a retained but empty rodio handle is the
-            // native no-playing immediate-clear path.
-            let current_stream_active = self
-                .current_player
-                .as_ref()
-                .is_some_and(|player| !player.empty());
-            let request = self.scenario_theme.update(wall_ms, current_stream_active);
-            self.apply_effective_volume();
-            if let Some(request) = request {
-                if let Some(player) = self.current_player.take() {
-                    player.stop();
-                }
-                self.current_track = None;
-                self.looping_track = None;
-                self.scenario_theme.complete_play();
-                match request {
-                    ScenarioThemeRequest::Auto => {
-                        let _ = self.play_next(assets);
-                    }
-                    ScenarioThemeRequest::Specific(stem) => {
-                        if self.play_track(&stem, assets)
-                            && let Some(next_index) =
-                                playlist_index_after_specific(&self.playlist, &stem)
-                        {
-                            self.playlist_index = next_index;
-                        }
-                    }
-                }
-            }
-            return;
-        }
-
-        let finished: bool = match &self.current_player {
-            Some(player) => player.empty(),
-            None => self.current_track.is_some(),
-        };
-
-        if finished {
+    pub(crate) fn discard_finished(&mut self) {
+        if self.state() == MusicOutputState::Finished {
             self.current_player = None;
-            self.current_track = None;
-            // A looping track (e.g. the menu [INTRO] theme, Repeat=yes)
-            // re-plays itself instead of advancing the playlist.
-            if let Some(stem) = self.looping_track.clone() {
-                if self.start_track(&stem, assets) {
-                    return;
-                }
-                // Failed to restart — fall through to playlist advance.
-                self.looping_track = None;
-            }
-            let _ = self.play_next(assets);
         }
     }
 
-    /// Set the music volume (0.0 = silent, 1.0 = full).
-    /// Applies immediately to the currently playing track.
     pub fn set_volume(&mut self, volume: f64) {
         self.volume = volume.clamp(0.0, 1.0);
         self.apply_effective_volume();
     }
 
-    /// Apply a temporary app-lifecycle multiplier without changing the saved
-    /// user volume. Existing and newly started tracks observe the same scale.
     pub fn set_output_scale(&mut self, scale: f64) {
         self.output_scale = scale.clamp(0.0, 1.0);
         self.apply_effective_volume();
     }
 
+    pub(crate) fn set_theme_scale(&mut self, scale: f64) {
+        self.theme_scale = scale.clamp(0.0, 1.0);
+        self.apply_effective_volume();
+    }
+
     /// Gate the primary music output on the application-activation edge.
     ///
-    /// gamemd-derived: the active `WM_ACTIVATEAPP` changed edge at `0x007778AC`
-    /// reaches primary-buffer Stop through `FUN_00407020 @
-    /// 0x00407020` -> `FUN_0040A940 @ 0x0040A940`, and primary-buffer restore /
-    /// looping Play through `FUN_00407040 @ 0x00407040` -> `FUN_0040A950 @
-    /// 0x0040A950`. Secondary playback cursors are not paused.
+    /// gamemd-derived: `WM_ACTIVATEAPP` at `0x007778AC` reaches primary
+    /// Stop/restore through `0x00407020`/`0x00407040`; secondary cursors keep
+    /// advancing.
     pub fn set_focus_output_active(&mut self, active: bool) {
         self.focus_output_scale = if active { 1.0 } else { 0.0 };
         self.apply_effective_volume();
@@ -397,279 +117,20 @@ impl MusicPlayer {
         effective_music_volume(
             self.volume,
             self.output_scale,
-            self.scenario_theme.internal_scale,
+            self.theme_scale,
             self.focus_output_scale,
         )
     }
 
     fn apply_effective_volume(&self) {
-        if let Some(ref player) = self.current_player {
+        if let Some(player) = self.current_player.as_ref() {
             player.set_volume(self.effective_volume());
         }
     }
 
-    /// Get the current music volume.
     pub fn volume(&self) -> f64 {
         self.volume
     }
-
-    /// Get the name of the currently playing track, if any.
-    pub fn current_track(&self) -> Option<&str> {
-        self.current_track.as_deref()
-    }
-
-    /// Replace the playlist with custom track names.
-    pub fn set_playlist(&mut self, tracks: Vec<String>) {
-        self.playlist = tracks;
-        self.playlist_index = 0;
-    }
-
-    /// Queue Start_Scenario's theme request without replacing the current
-    /// shell stream inline. The first subsequent update owns fade/start work.
-    pub(crate) fn request_scenario_theme(&mut self, request: ScenarioThemeRequest, wall_ms: u64) {
-        let current_stream_active = self
-            .current_player
-            .as_ref()
-            .is_some_and(|player| !player.empty());
-        self.scenario_theme
-            .request(request, wall_ms, current_stream_active);
-        self.apply_effective_volume();
-    }
-
-    pub(crate) fn cancel_scenario_theme_request(&mut self) {
-        self.scenario_theme.cancel();
-        self.apply_effective_volume();
-    }
-
-    /// Resolve `[Basic] Theme=` strictly as a theme-section key. Sound stems
-    /// and unknown/sentinel values retain native index `-1` and select Auto.
-    pub(crate) fn resolve_scenario_theme(
-        &mut self,
-        requested_section: Option<&str>,
-        assets: &AssetManager,
-    ) -> ScenarioThemeRequest {
-        self.ensure_theme_config(assets);
-        resolve_scenario_theme_section(requested_section, &self.scenario_theme_sections)
-    }
-
-    fn resolve_track_name(&self, track_name: &str) -> String {
-        self.aliases
-            .get(&track_name.to_ascii_uppercase())
-            .cloned()
-            .unwrap_or_else(|| track_name.to_string())
-    }
-
-    fn ensure_theme_config(&mut self, assets: &AssetManager) {
-        if !self.aliases.is_empty() {
-            return;
-        }
-
-        let base = load_theme_ini(assets, "theme.ini");
-        let md = load_theme_ini(assets, "thememd.ini");
-
-        // Build aliases from both INIs (md values override base on conflict).
-        if let Some(ref ini) = base {
-            merge_theme_aliases(&mut self.aliases, ini);
-            merge_theme_section_stems(&mut self.scenario_theme_sections, ini);
-        }
-        if let Some(ref ini) = md {
-            merge_theme_aliases(&mut self.aliases, ini);
-            merge_theme_section_stems(&mut self.scenario_theme_sections, ini);
-        }
-
-        // Merge playlists from both INIs — the original game plays RA2 and YR
-        // tracks together. thememd.ini comments out RA2 entries, so we need
-        // theme.ini to provide those tracks.
-        let mut playlist = Vec::new();
-        if let Some(ref ini) = base {
-            playlist = playlist_from_theme_ini(ini, &self.aliases);
-        }
-        if let Some(ref ini) = md {
-            for track in playlist_from_theme_ini(ini, &self.aliases) {
-                if !playlist.iter().any(|t| t.eq_ignore_ascii_case(&track)) {
-                    playlist.push(track);
-                }
-            }
-        }
-
-        if !playlist.is_empty() {
-            self.playlist = playlist;
-            self.playlist_index = 0;
-        }
-
-        // Resolve the menu [INTRO] theme (the shell loops this the whole time
-        // the player is on the main menu). md overrides base on conflict.
-        for ini in [base.as_ref(), md.as_ref()].into_iter().flatten() {
-            if let Some((stem, repeats)) = menu_theme_from_ini(ini, &self.aliases) {
-                self.menu_theme = Some(stem);
-                self.menu_theme_repeats = repeats;
-            }
-        }
-    }
-}
-
-/// Load a track and decode to interleaved f32 stereo samples.
-/// Returns (samples, sample_rate) or None if not found / decode fails.
-fn load_track(track_name: &str, assets: &AssetManager) -> Option<(Vec<f32>, u32)> {
-    for filename in [format!("{}.wav", track_name), format!("{}.aud", track_name)] {
-        let Some(data) = assets.get_ref(&filename) else {
-            continue;
-        };
-
-        if data.len() >= 44 && &data[0..4] == b"RIFF" {
-            if let Some(decoded) = decode_wav(data, &filename) {
-                return Some((decoded.samples, decoded.sample_rate));
-            }
-        }
-
-        let (header, samples) = match aud_file::decode_aud(data) {
-            Some(decoded) => decoded,
-            None => continue,
-        };
-        if samples.is_empty() {
-            log::warn!("Track {} decoded to 0 samples", track_name);
-            return None;
-        }
-
-        // Convert i16 PCM to interleaved f32 stereo.
-        let stereo: Vec<f32> = if header.is_stereo() {
-            samples.iter().map(|&s| s as f32 / 32768.0).collect()
-        } else {
-            samples
-                .iter()
-                .flat_map(|&s| {
-                    let f = s as f32 / 32768.0;
-                    [f, f]
-                })
-                .collect()
-        };
-
-        log::info!(
-            "Decoded track {} from {}: {}Hz, {} channels, {} frames ({:.1}s)",
-            track_name,
-            filename,
-            header.sample_rate,
-            header.channels(),
-            stereo.len() / 2,
-            stereo.len() as f64 / 2.0 / header.sample_rate as f64,
-        );
-
-        return Some((stereo, header.sample_rate as u32));
-    }
-
-    None
-}
-
-fn load_theme_ini(assets: &AssetManager, name: &str) -> Option<IniFile> {
-    let bytes = assets.get_ref(name)?;
-    IniFile::from_bytes(bytes).ok()
-}
-
-fn merge_theme_aliases(into: &mut HashMap<String, String>, ini: &IniFile) {
-    for section_name in ini.section_names() {
-        let Some(section) = ini.section(section_name) else {
-            continue;
-        };
-        let Some(sound) = section.get("Sound") else {
-            continue;
-        };
-        if sound.is_empty() {
-            continue;
-        }
-
-        let sound = sound.to_string();
-        into.insert(section_name.to_ascii_uppercase(), sound.clone());
-        into.insert(sound.to_ascii_uppercase(), sound);
-    }
-}
-
-fn merge_theme_section_stems(into: &mut HashMap<String, String>, ini: &IniFile) {
-    let Some(themes) = ini.section("Themes") else {
-        return;
-    };
-    for section_name in themes.get_values() {
-        let Some(sound) = ini
-            .section(section_name)
-            .and_then(|section| section.get("Sound"))
-            .filter(|sound| !sound.is_empty())
-        else {
-            continue;
-        };
-        into.insert(section_name.to_ascii_uppercase(), sound.to_string());
-    }
-}
-
-fn resolve_scenario_theme_section(
-    requested_section: Option<&str>,
-    section_aliases: &HashMap<String, String>,
-) -> ScenarioThemeRequest {
-    let Some(requested) = requested_section
-        .map(str::trim)
-        .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("No theme"))
-    else {
-        return ScenarioThemeRequest::Auto;
-    };
-    section_aliases
-        .get(&requested.to_ascii_uppercase())
-        .cloned()
-        .map(ScenarioThemeRequest::Specific)
-        .unwrap_or(ScenarioThemeRequest::Auto)
-}
-
-fn playlist_index_after_specific(playlist: &[String], stem: &str) -> Option<usize> {
-    let index = playlist
-        .iter()
-        .position(|candidate| candidate.eq_ignore_ascii_case(stem))?;
-    Some((index + 1) % playlist.len())
-}
-
-/// The section name of the main-menu shell theme in the theme INI.
-const MENU_THEME_SECTION: &str = "INTRO";
-
-/// Resolve the menu [INTRO] theme to (sound stem, repeats?) from a theme INI.
-/// `repeats` reflects the [INTRO] `Repeat=` value (defaults to no if absent).
-/// Returns None if the INI has no [INTRO] section with a resolvable sound.
-fn menu_theme_from_ini(ini: &IniFile, aliases: &HashMap<String, String>) -> Option<(String, bool)> {
-    let section = ini.section(MENU_THEME_SECTION)?;
-    // Prefer the alias-resolved stem so casing matches what load_track uses.
-    let stem = aliases
-        .get(&MENU_THEME_SECTION.to_ascii_uppercase())
-        .cloned()
-        .or_else(|| {
-            section
-                .get("Sound")
-                .filter(|s| !s.is_empty())
-                .map(|s| s.to_string())
-        })?;
-    let repeats = section.get_bool("Repeat").unwrap_or(false);
-    Some((stem, repeats))
-}
-
-fn playlist_from_theme_ini(ini: &IniFile, aliases: &HashMap<String, String>) -> Vec<String> {
-    let Some(themes) = ini.section("Themes") else {
-        return Vec::new();
-    };
-
-    themes
-        .get_values()
-        .into_iter()
-        .filter(|value| !value.is_empty())
-        .filter_map(|theme_name| {
-            let sound = aliases.get(&theme_name.to_ascii_uppercase())?;
-            // Skip non-Normal tracks (INTRO, SCORE, LOADING, CREDITS) —
-            // they're menu/loading music, not gameplay playlist entries.
-            // Normal defaults to yes if absent.
-            if let Some(section) = ini.section(theme_name) {
-                if section
-                    .get("Normal")
-                    .is_some_and(|v| v.eq_ignore_ascii_case("no"))
-                {
-                    return None;
-                }
-            }
-            Some(sound.clone())
-        })
-        .collect()
 }
 
 #[cfg(test)]
@@ -681,144 +142,10 @@ mod tests {
         let audible = effective_music_volume(0.8, 0.5, 0.25, 1.0);
         let inactive = effective_music_volume(0.8, 0.5, 0.25, 0.0);
         let restored = effective_music_volume(0.8, 0.5, 0.25, 1.0);
-
         assert!((audible - 0.1).abs() < f32::EPSILON);
         assert_eq!(inactive, 0.0);
         assert_eq!(restored, audible);
-        // Theme/lifecycle state continues changing behind a closed primary
-        // output, then contributes at its current value when output returns.
         assert_eq!(effective_music_volume(0.8, 0.75, 0.4, 0.0), 0.0);
         assert!((effective_music_volume(0.8, 0.75, 0.4, 1.0) - 0.24).abs() < f32::EPSILON);
     }
-
-    #[test]
-    fn gsi_01_04_start_theme_resolver_uses_section_keys_not_sound_aliases() {
-        let ini = IniFile::from_str(
-            "[Themes]\n0=Fortification\n1=Power\n\
-             [Fortification]\nSound=Fortific\nNormal=yes\n\
-             [Power]\nSound=Power\nNormal=yes\n",
-        );
-        let mut sections = HashMap::new();
-        merge_theme_section_stems(&mut sections, &ini);
-
-        for requested in [None, Some("No theme"), Some("Missing"), Some("Fortific")] {
-            assert_eq!(
-                resolve_scenario_theme_section(requested, &sections),
-                ScenarioThemeRequest::Auto
-            );
-        }
-        assert_eq!(
-            resolve_scenario_theme_section(Some("fOrTiFiCaTiOn"), &sections),
-            ScenarioThemeRequest::Specific("Fortific".to_string())
-        );
-    }
-
-    #[test]
-    fn gsi_01_04_start_specific_fortific_advances_cycle_to_indeep() {
-        let playlist = ["Grinder", "Power", "Fortific", "InDeep"]
-            .into_iter()
-            .map(str::to_string)
-            .collect::<Vec<_>>();
-
-        let next_index = playlist_index_after_specific(&playlist, "fOrTiFiC")
-            .expect("Fortific is in the cyclic playlist");
-
-        assert_eq!(playlist[next_index], "InDeep");
-    }
-
-    #[test]
-    fn gsi_01_04_start_explicit_and_auto_preserve_intro_until_fade_completes() {
-        for request in [
-            ScenarioThemeRequest::Auto,
-            ScenarioThemeRequest::Specific("Fortific".to_string()),
-        ] {
-            let mut transition = ScenarioThemeTransition::default();
-            transition.request(request.clone(), 125, true);
-            assert!(transition.pending.is_some(), "queueing is not inline play");
-            assert_eq!(transition.internal_scale, 1.0);
-
-            assert_eq!(transition.update(125, true), None);
-            assert_eq!(transition.internal_scale, 1.0);
-            assert_eq!(transition.update(625, true), None);
-            assert_eq!(transition.internal_scale, 0.5);
-            assert_eq!(transition.update(1_124, true), None);
-            assert!((transition.internal_scale - 0.001).abs() < f64::EPSILON * 8.0);
-            assert_eq!(transition.update(1_125, true), Some(request));
-            assert_eq!(transition.internal_scale, 0.0);
-            transition.complete_play();
-            assert_eq!(transition.internal_scale, 1.0);
-            assert!(transition.pending.is_none());
-        }
-    }
-
-    #[test]
-    fn gsi_01_04_start_without_current_stream_waits_for_next_update() {
-        let mut transition = ScenarioThemeTransition::default();
-        transition.request(ScenarioThemeRequest::Auto, 900, false);
-
-        assert!(
-            transition.pending.is_some(),
-            "request itself has no play action"
-        );
-        assert_eq!(
-            transition.update(900, false),
-            Some(ScenarioThemeRequest::Auto)
-        );
-        assert!(transition.pending.is_none());
-    }
-
-    #[test]
-    fn gsi_01_04_start_stop_or_reset_cancels_pending_and_restores_internal_scale() {
-        let mut transition = ScenarioThemeTransition::default();
-        transition.request(
-            ScenarioThemeRequest::Specific("Fortific".to_string()),
-            100,
-            true,
-        );
-        assert_eq!(transition.update(100, true), None);
-        assert_eq!(transition.update(600, true), None);
-        assert_eq!(transition.internal_scale, 0.5);
-
-        transition.cancel();
-
-        assert!(transition.pending.is_none());
-        assert_eq!(transition.internal_scale, 1.0);
-        assert_eq!(transition.update(2_000, true), None);
-    }
-
-    /// Mirrors thememd.ini [INTRO]: Sound=Drok, Repeat=yes (the looping menu
-    /// theme). Verifies we resolve the correct stem and honor Repeat=yes.
-    #[test]
-    fn menu_theme_resolves_intro_with_loop() {
-        let ini =
-            IniFile::from_str("[INTRO]\nName=THEME:Intro\nSound=Drok\nNormal=no\nRepeat=yes\n");
-        let mut aliases = HashMap::new();
-        merge_theme_aliases(&mut aliases, &ini);
-
-        let (stem, repeats) =
-            menu_theme_from_ini(&ini, &aliases).expect("INTRO theme must resolve");
-        assert_eq!(stem, "Drok");
-        assert!(repeats, "INTRO has Repeat=yes, must loop");
-    }
-
-    /// Repeat= absent defaults to no (non-looping), so we never force a loop on
-    /// a theme that did not ask for one.
-    #[test]
-    fn menu_theme_repeat_defaults_to_no() {
-        let ini = IniFile::from_str("[INTRO]\nSound=Drok\n");
-        let aliases = HashMap::new();
-        let (stem, repeats) =
-            menu_theme_from_ini(&ini, &aliases).expect("INTRO theme must resolve");
-        assert_eq!(stem, "Drok");
-        assert!(!repeats);
-    }
-
-    /// No [INTRO] section -> no menu theme.
-    #[test]
-    fn menu_theme_absent_returns_none() {
-        let ini = IniFile::from_str("[SCORE]\nSound=Score\n");
-        let aliases = HashMap::new();
-        assert!(menu_theme_from_ini(&ini, &aliases).is_none());
-    }
-
 }

--- a/src/audio/theme.rs
+++ b/src/audio/theme.rs
@@ -1,0 +1,1103 @@
+//! Device-independent ThemeClass state and track preparation.
+//!
+//! Active Yuri's Revenge keeps Theme data and the logical active/retained/
+//! pending slots alive even when its optional stream player is absent.  This
+//! module mirrors that ownership: rodio remains in `music`, while aliases,
+//! playlist selection, sentinels, scenario queueing, and lifecycle transitions
+//! remain testable without an audio device.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::assets::asset_manager::AssetManager;
+use crate::assets::aud_file;
+use crate::audio::sfx::decode_wav;
+use crate::rules::ini_parser::IniFile;
+
+const SCENARIO_THEME_FADE_MS: u64 = 1_000;
+const MENU_THEME_SECTION: &str = "INTRO";
+
+const FALLBACK_TRACKS: &[&str] = &[
+    "Grinder", "Power", "Fortific", "InDeep", "Tension", "EagleHun", "Industro", "Jank",
+    "200Meter", "BlowItUp", "Destroy", "Burn", "Motorize", "HM2", "Ra2-Opt", "RA2-Sco", "Drok",
+    "Bully", "OptionX", "ScoreX", "BrainFre", "Deceiver", "PhatAtta", "Defend", "Tactics",
+    "TranceLV",
+];
+
+/// The physical stream observation supplied to Theme's AI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MusicOutputState {
+    /// No music stream object exists. This is never a completion signal.
+    Unavailable,
+    /// A stream object exists but no source is active.
+    Idle,
+    /// The current source is still playing.
+    Playing,
+    /// The current source reached its physical end.
+    Finished,
+}
+
+/// Theme's literal pending sentinels plus a resolved track identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ThemeRequest {
+    /// Native `-1`.
+    None,
+    /// Native `-2`.
+    Auto,
+    /// Native `-3`.
+    Hold,
+    Track(String),
+}
+
+impl Default for ThemeRequest {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// Resolved Start_Scenario request. `Auto` is native index `-1` at the
+/// scenario boundary and becomes Theme's `-2` automatic pending request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ScenarioThemeRequest {
+    Auto,
+    Specific(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct ThemeSlots {
+    pub(crate) active: Option<String>,
+    pub(crate) retained: Option<String>,
+    pub(crate) pending: ThemeRequest,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ThemeGates {
+    pub(crate) launcher_audio_available: bool,
+    pub(crate) startup_suppressed: bool,
+}
+
+/// Device-independent PCM payload ready for optional physical submission.
+#[derive(Debug)]
+pub(crate) struct PreparedTrack {
+    pub(crate) stem: String,
+    pub(crate) samples: Vec<f32>,
+    pub(crate) sample_rate: u32,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ThemeAction {
+    pub(crate) stop_output: bool,
+    pub(crate) start: Option<PreparedTrack>,
+    pub(crate) theme_scale: Option<f64>,
+}
+
+impl ThemeAction {
+    fn then(mut self, next: Self) -> Self {
+        self.stop_output |= next.stop_output;
+        if next.start.is_some() {
+            self.start = next.start;
+        }
+        if next.theme_scale.is_some() {
+            self.theme_scale = next.theme_scale;
+        }
+        self
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct ScenarioFade {
+    started_at_ms: Option<u64>,
+    completion_due: bool,
+    owns_pending: bool,
+    internal_scale: f64,
+}
+
+impl ScenarioFade {
+    fn reset(&mut self) {
+        self.started_at_ms = None;
+        self.completion_due = false;
+        self.owns_pending = false;
+        self.internal_scale = 1.0;
+    }
+}
+
+/// Process-lifetime logical Theme owner.
+#[derive(Debug)]
+pub(crate) struct ThemeRuntime {
+    catalog_loaded: bool,
+    aliases: HashMap<String, String>,
+    scenario_theme_sections: HashMap<String, String>,
+    playlist: Vec<String>,
+    playlist_index: usize,
+    repeating_tracks: HashSet<String>,
+    global_repeat: bool,
+    menu_theme: Option<String>,
+    slots: ThemeSlots,
+    scenario_fade: ScenarioFade,
+}
+
+impl Default for ThemeRuntime {
+    fn default() -> Self {
+        Self {
+            catalog_loaded: false,
+            aliases: HashMap::new(),
+            scenario_theme_sections: HashMap::new(),
+            playlist: FALLBACK_TRACKS
+                .iter()
+                .map(|track| (*track).to_string())
+                .collect(),
+            playlist_index: 0,
+            repeating_tracks: HashSet::new(),
+            global_repeat: false,
+            menu_theme: None,
+            slots: ThemeSlots::default(),
+            scenario_fade: ScenarioFade {
+                internal_scale: 1.0,
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl ThemeRuntime {
+    /// Load Theme configuration once, independently of physical output.
+    pub(crate) fn initialize_catalog(&mut self, assets: &AssetManager) {
+        if self.catalog_loaded {
+            return;
+        }
+
+        let base = load_theme_ini(assets, "theme.ini");
+        let md = load_theme_ini(assets, "thememd.ini");
+        for ini in [base.as_ref(), md.as_ref()].into_iter().flatten() {
+            merge_theme_aliases(&mut self.aliases, ini);
+            merge_theme_section_stems(&mut self.scenario_theme_sections, ini);
+            merge_repeating_tracks(&mut self.repeating_tracks, ini, &self.aliases);
+        }
+
+        let mut playlist = Vec::new();
+        if let Some(ini) = base.as_ref() {
+            playlist = playlist_from_theme_ini(ini, &self.aliases);
+        }
+        if let Some(ini) = md.as_ref() {
+            for track in playlist_from_theme_ini(ini, &self.aliases) {
+                if !playlist
+                    .iter()
+                    .any(|candidate| candidate.eq_ignore_ascii_case(&track))
+                {
+                    playlist.push(track);
+                }
+            }
+        }
+        if !playlist.is_empty() {
+            self.playlist = playlist;
+            self.playlist_index = 0;
+        }
+
+        for ini in [base.as_ref(), md.as_ref()].into_iter().flatten() {
+            if let Some((stem, repeats)) = menu_theme_from_ini(ini, &self.aliases) {
+                if repeats {
+                    self.repeating_tracks.insert(stem.to_ascii_uppercase());
+                }
+                self.menu_theme = Some(stem);
+            }
+        }
+        self.catalog_loaded = true;
+    }
+
+    fn admitted(&self, gates: ThemeGates) -> bool {
+        self.catalog_loaded && gates.launcher_audio_available && !gates.startup_suppressed
+    }
+
+    fn resolve_track_name(&self, track_name: &str) -> String {
+        self.aliases
+            .get(&track_name.to_ascii_uppercase())
+            .cloned()
+            .unwrap_or_else(|| track_name.to_string())
+    }
+
+    fn track_repeats(&self, stem: &str) -> bool {
+        self.global_repeat || self.repeating_tracks.contains(&stem.to_ascii_uppercase())
+    }
+
+    pub(crate) fn play_track(
+        &mut self,
+        track_name: &str,
+        assets: &AssetManager,
+        gates: ThemeGates,
+        physical: MusicOutputState,
+    ) -> ThemeAction {
+        self.initialize_catalog(assets);
+        let mut prepare = |stem: &str| prepare_track(stem, assets);
+        self.play_request_with(
+            ThemeRequest::Track(track_name.to_string()),
+            gates,
+            physical,
+            &mut prepare,
+        )
+    }
+
+    pub(crate) fn play_menu_theme(
+        &mut self,
+        assets: &AssetManager,
+        gates: ThemeGates,
+        physical: MusicOutputState,
+    ) -> ThemeAction {
+        self.initialize_catalog(assets);
+        let Some(stem) = self.menu_theme.clone() else {
+            return ThemeAction::default();
+        };
+        let mut prepare = |resolved: &str| prepare_track(resolved, assets);
+        self.play_request_with(ThemeRequest::Track(stem), gates, physical, &mut prepare)
+    }
+
+    /// Resolve and queue Start_Scenario's Theme in one authority call.
+    pub(crate) fn request_scenario_theme(
+        &mut self,
+        requested_section: Option<&str>,
+        assets: &AssetManager,
+        gates: ThemeGates,
+        physical: MusicOutputState,
+        wall_ms: u64,
+    ) -> ThemeAction {
+        self.initialize_catalog(assets);
+        let request =
+            resolve_scenario_theme_section(requested_section, &self.scenario_theme_sections);
+        let request = match request {
+            ScenarioThemeRequest::Auto => ThemeRequest::Auto,
+            ScenarioThemeRequest::Specific(stem) => ThemeRequest::Track(stem),
+        };
+        let admitted = self.admitted(gates);
+        let action = self.queue_request(request, gates, physical, wall_ms);
+        if admitted {
+            self.scenario_fade.owns_pending = true;
+        }
+        action
+    }
+
+    pub(crate) fn queue_request(
+        &mut self,
+        request: ThemeRequest,
+        gates: ThemeGates,
+        physical: MusicOutputState,
+        wall_ms: u64,
+    ) -> ThemeAction {
+        if !self.admitted(gates) {
+            return ThemeAction::default();
+        }
+
+        let avoids_fade = matches!(request, ThemeRequest::None | ThemeRequest::Auto)
+            || matches!(
+                &request,
+                ThemeRequest::Track(track)
+                    if self
+                        .slots
+                        .retained
+                        .as_deref()
+                        .is_some_and(|retained| retained.eq_ignore_ascii_case(track))
+            );
+        self.slots.pending = request;
+        self.scenario_fade.reset();
+
+        if !avoids_fade && physical == MusicOutputState::Playing {
+            self.scenario_fade.started_at_ms = Some(wall_ms);
+        } else if physical != MusicOutputState::Unavailable
+            && physical != MusicOutputState::Playing
+            && !matches!(self.slots.pending, ThemeRequest::None | ThemeRequest::Hold)
+        {
+            self.scenario_fade.completion_due = true;
+        }
+
+        ThemeAction {
+            theme_scale: Some(1.0),
+            ..Default::default()
+        }
+    }
+
+    /// Launcher ScoreVolume zero performs the native Queue(active else
+    /// retained) followed immediately by Stop(false).
+    pub(crate) fn queue_then_stop_score_zero(
+        &mut self,
+        gates: ThemeGates,
+        physical: MusicOutputState,
+    ) -> ThemeAction {
+        if !self.admitted(gates) {
+            return ThemeAction::default();
+        }
+        let request = self
+            .slots
+            .active
+            .clone()
+            .or_else(|| self.slots.retained.clone())
+            .map(ThemeRequest::Track)
+            .unwrap_or(ThemeRequest::None);
+        let queued = self.queue_request(request, gates, physical, 0);
+        queued.then(self.stop(gates))
+    }
+
+    pub(crate) fn stop(&mut self, gates: ThemeGates) -> ThemeAction {
+        if !self.admitted(gates) || self.slots.active.is_none() {
+            return ThemeAction::default();
+        }
+        self.slots = ThemeSlots::default();
+        self.scenario_fade.reset();
+        ThemeAction {
+            stop_output: true,
+            theme_scale: Some(1.0),
+            ..Default::default()
+        }
+    }
+
+    /// Cancel only Start_Scenario's queued/fade ownership during scenario
+    /// reset. Active and retained identities remain owned by Theme.
+    pub(crate) fn cancel_scenario_theme_request(&mut self) -> ThemeAction {
+        if self.scenario_fade.owns_pending {
+            self.slots.pending = ThemeRequest::None;
+        }
+        self.scenario_fade.reset();
+        ThemeAction {
+            theme_scale: Some(1.0),
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn update(
+        &mut self,
+        assets: &AssetManager,
+        gates: ThemeGates,
+        physical: MusicOutputState,
+        wall_ms: u64,
+    ) -> ThemeAction {
+        self.initialize_catalog(assets);
+        let mut prepare = |stem: &str| prepare_track(stem, assets);
+        self.update_with(gates, physical, wall_ms, &mut prepare)
+    }
+
+    fn update_with(
+        &mut self,
+        gates: ThemeGates,
+        physical: MusicOutputState,
+        wall_ms: u64,
+        prepare: &mut impl FnMut(&str) -> Option<PreparedTrack>,
+    ) -> ThemeAction {
+        if !self.admitted(gates) {
+            return ThemeAction::default();
+        }
+
+        let mut action = ThemeAction::default();
+        let mut completion = physical == MusicOutputState::Finished;
+
+        if let Some(started_at_ms) = self.scenario_fade.started_at_ms {
+            if physical == MusicOutputState::Playing {
+                let elapsed = wall_ms.saturating_sub(started_at_ms);
+                if elapsed < SCENARIO_THEME_FADE_MS {
+                    self.scenario_fade.internal_scale =
+                        1.0 - elapsed as f64 / SCENARIO_THEME_FADE_MS as f64;
+                    action.theme_scale = Some(self.scenario_fade.internal_scale);
+                    return action;
+                }
+                action.stop_output = true;
+            }
+            self.scenario_fade.started_at_ms = None;
+            self.scenario_fade.internal_scale = 1.0;
+            action.theme_scale = Some(1.0);
+            completion = true;
+        }
+
+        completion |= self.scenario_fade.completion_due;
+        self.scenario_fade.completion_due = false;
+        if !completion {
+            return action;
+        }
+
+        let pending = self.slots.pending.clone();
+        self.scenario_fade.owns_pending = false;
+        let requested = match pending {
+            ThemeRequest::None | ThemeRequest::Hold => return action,
+            ThemeRequest::Track(track) => Some(track),
+            ThemeRequest::Auto => self.next_song(),
+        };
+
+        if let Some(track) = requested {
+            action = action.then(self.play_request_with(
+                ThemeRequest::Track(track),
+                gates,
+                MusicOutputState::Idle,
+                prepare,
+            ));
+        }
+        // ThemeClass::AI unconditionally restores Auto after attempting Play.
+        self.slots.pending = ThemeRequest::Auto;
+        action
+    }
+
+    fn next_song(&mut self) -> Option<String> {
+        if let Some(retained) = self.slots.retained.as_deref()
+            && self.track_repeats(retained)
+        {
+            return Some(retained.to_string());
+        }
+        let len = self.playlist.len();
+        if len == 0 {
+            return None;
+        }
+        let track = self.playlist[self.playlist_index % len].clone();
+        self.playlist_index = (self.playlist_index + 1) % len;
+        Some(track)
+    }
+
+    fn play_request_with(
+        &mut self,
+        request: ThemeRequest,
+        gates: ThemeGates,
+        physical: MusicOutputState,
+        prepare: &mut impl FnMut(&str) -> Option<PreparedTrack>,
+    ) -> ThemeAction {
+        if !self.admitted(gates) {
+            return ThemeAction::default();
+        }
+
+        match request {
+            ThemeRequest::Auto => {
+                self.slots.pending = ThemeRequest::Auto;
+                return ThemeAction::default();
+            }
+            ThemeRequest::None | ThemeRequest::Hold => {
+                if self.slots.active.is_none() {
+                    return ThemeAction::default();
+                }
+                self.slots = ThemeSlots::default();
+                self.scenario_fade.reset();
+                return ThemeAction {
+                    stop_output: true,
+                    theme_scale: Some(1.0),
+                    ..Default::default()
+                };
+            }
+            ThemeRequest::Track(requested) => {
+                let resolved = self.resolve_track_name(&requested);
+                if physical == MusicOutputState::Playing
+                    && self
+                        .slots
+                        .retained
+                        .as_deref()
+                        .is_some_and(|retained| retained.eq_ignore_ascii_case(&resolved))
+                {
+                    return ThemeAction::default();
+                }
+
+                let repeat = self.track_repeats(&resolved);
+                let prior_active = self.slots.active.is_some();
+                let pending_base = if prior_active {
+                    ThemeRequest::None
+                } else {
+                    self.slots.pending.clone()
+                };
+                let mut action = ThemeAction::default();
+                if prior_active {
+                    self.slots = ThemeSlots::default();
+                    action.stop_output = true;
+                }
+                self.scenario_fade.reset();
+                action.theme_scale = Some(1.0);
+                self.slots.retained = Some(resolved.clone());
+
+                let Some(prepared) = prepare(&resolved) else {
+                    self.slots.active = None;
+                    self.slots.pending = if repeat {
+                        ThemeRequest::Track(resolved.clone())
+                    } else if physical != MusicOutputState::Unavailable
+                        && matches!(pending_base, ThemeRequest::None)
+                    {
+                        // Native's stream-object resource/acquisition failure
+                        // retries when the replacement base is `-1`.
+                        ThemeRequest::Track(resolved.clone())
+                    } else {
+                        pending_base
+                    };
+                    return action;
+                };
+
+                self.slots.active = Some(resolved.clone());
+                self.slots.retained = Some(resolved.clone());
+                self.slots.pending = if repeat {
+                    ThemeRequest::Track(resolved.clone())
+                } else {
+                    pending_base
+                };
+                if let Some(next_index) = playlist_index_after_specific(&self.playlist, &resolved) {
+                    self.playlist_index = next_index;
+                }
+                action.start = Some(prepared);
+                action
+            }
+        }
+    }
+}
+
+/// Load and decode a track before optional physical submission.
+fn prepare_track(track_name: &str, assets: &AssetManager) -> Option<PreparedTrack> {
+    for filename in [format!("{track_name}.wav"), format!("{track_name}.aud")] {
+        let Some(data) = assets.get_ref(&filename) else {
+            continue;
+        };
+
+        if data.len() >= 44
+            && &data[0..4] == b"RIFF"
+            && let Some(decoded) = decode_wav(data, &filename)
+            && decoded.sample_rate != 0
+            && !decoded.samples.is_empty()
+        {
+            return Some(PreparedTrack {
+                stem: track_name.to_string(),
+                samples: decoded.samples,
+                sample_rate: decoded.sample_rate,
+            });
+        }
+
+        let Some((header, samples)) = aud_file::decode_aud(data) else {
+            continue;
+        };
+        if samples.is_empty() || header.sample_rate == 0 {
+            log::warn!("Track {track_name} decoded to 0 samples");
+            return None;
+        }
+        let stereo = if header.is_stereo() {
+            samples
+                .iter()
+                .map(|&sample| sample as f32 / 32768.0)
+                .collect()
+        } else {
+            samples
+                .iter()
+                .flat_map(|&sample| {
+                    let value = sample as f32 / 32768.0;
+                    [value, value]
+                })
+                .collect()
+        };
+        return Some(PreparedTrack {
+            stem: track_name.to_string(),
+            samples: stereo,
+            sample_rate: u32::from(header.sample_rate),
+        });
+    }
+    log::warn!("Music track not found: resolved='{track_name}'");
+    None
+}
+
+fn load_theme_ini(assets: &AssetManager, name: &str) -> Option<IniFile> {
+    let bytes = assets.get_ref(name)?;
+    IniFile::from_bytes(bytes).ok()
+}
+
+fn merge_theme_aliases(into: &mut HashMap<String, String>, ini: &IniFile) {
+    for section_name in ini.section_names() {
+        let Some(sound) = ini
+            .section(section_name)
+            .and_then(|section| section.get("Sound"))
+            .filter(|sound| !sound.is_empty())
+        else {
+            continue;
+        };
+        let sound = sound.to_string();
+        into.insert(section_name.to_ascii_uppercase(), sound.clone());
+        into.insert(sound.to_ascii_uppercase(), sound);
+    }
+}
+
+fn merge_theme_section_stems(into: &mut HashMap<String, String>, ini: &IniFile) {
+    let Some(themes) = ini.section("Themes") else {
+        return;
+    };
+    for section_name in themes.get_values() {
+        let Some(sound) = ini
+            .section(section_name)
+            .and_then(|section| section.get("Sound"))
+            .filter(|sound| !sound.is_empty())
+        else {
+            continue;
+        };
+        into.insert(section_name.to_ascii_uppercase(), sound.to_string());
+    }
+}
+
+fn merge_repeating_tracks(
+    into: &mut HashSet<String>,
+    ini: &IniFile,
+    aliases: &HashMap<String, String>,
+) {
+    for section_name in ini.section_names() {
+        let Some(section) = ini.section(section_name) else {
+            continue;
+        };
+        if !section.get_bool("Repeat").unwrap_or(false) {
+            continue;
+        }
+        if let Some(stem) = aliases.get(&section_name.to_ascii_uppercase()) {
+            into.insert(stem.to_ascii_uppercase());
+        }
+    }
+}
+
+fn resolve_scenario_theme_section(
+    requested_section: Option<&str>,
+    sections: &HashMap<String, String>,
+) -> ScenarioThemeRequest {
+    let Some(requested) = requested_section
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("No theme"))
+    else {
+        return ScenarioThemeRequest::Auto;
+    };
+    sections
+        .get(&requested.to_ascii_uppercase())
+        .cloned()
+        .map(ScenarioThemeRequest::Specific)
+        .unwrap_or(ScenarioThemeRequest::Auto)
+}
+
+fn playlist_index_after_specific(playlist: &[String], stem: &str) -> Option<usize> {
+    let index = playlist
+        .iter()
+        .position(|candidate| candidate.eq_ignore_ascii_case(stem))?;
+    Some((index + 1) % playlist.len())
+}
+
+fn menu_theme_from_ini(ini: &IniFile, aliases: &HashMap<String, String>) -> Option<(String, bool)> {
+    let section = ini.section(MENU_THEME_SECTION)?;
+    let stem = aliases
+        .get(&MENU_THEME_SECTION.to_ascii_uppercase())
+        .cloned()
+        .or_else(|| {
+            section
+                .get("Sound")
+                .filter(|sound| !sound.is_empty())
+                .map(str::to_string)
+        })?;
+    Some((stem, section.get_bool("Repeat").unwrap_or(false)))
+}
+
+fn playlist_from_theme_ini(ini: &IniFile, aliases: &HashMap<String, String>) -> Vec<String> {
+    let Some(themes) = ini.section("Themes") else {
+        return Vec::new();
+    };
+    themes
+        .get_values()
+        .into_iter()
+        .filter(|value| !value.is_empty())
+        .filter_map(|theme_name| {
+            let sound = aliases.get(&theme_name.to_ascii_uppercase())?;
+            if ini
+                .section(theme_name)
+                .and_then(|section| section.get("Normal"))
+                .is_some_and(|value| value.eq_ignore_ascii_case("no"))
+            {
+                return None;
+            }
+            Some(sound.clone())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gates(enabled: bool) -> ThemeGates {
+        ThemeGates {
+            launcher_audio_available: enabled,
+            startup_suppressed: false,
+        }
+    }
+
+    fn runtime() -> ThemeRuntime {
+        ThemeRuntime {
+            catalog_loaded: true,
+            aliases: [("INTRO".to_string(), "Drok".to_string())]
+                .into_iter()
+                .collect(),
+            scenario_theme_sections: [("FORTIFICATION".to_string(), "Fortific".to_string())]
+                .into_iter()
+                .collect(),
+            playlist: ["Grinder", "Power", "Fortific", "InDeep"]
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+            repeating_tracks: ["DROK".to_string()].into_iter().collect(),
+            menu_theme: Some("Drok".to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn prepared(stem: &str) -> Option<PreparedTrack> {
+        Some(PreparedTrack {
+            stem: stem.to_string(),
+            samples: vec![0.0, 0.0],
+            sample_rate: 22_050,
+        })
+    }
+
+    #[test]
+    fn constructor_and_failed_common_gates_preserve_all_slots() {
+        let mut theme = runtime();
+        assert_eq!(theme.slots, ThemeSlots::default());
+        theme.slots = ThemeSlots {
+            active: Some("A".into()),
+            retained: Some("R".into()),
+            pending: ThemeRequest::Hold,
+        };
+        let before = theme.slots.clone();
+        let action = theme.queue_request(
+            ThemeRequest::Track("Q".into()),
+            gates(false),
+            MusicOutputState::Playing,
+            10,
+        );
+        assert_eq!(theme.slots, before);
+        assert!(!action.stop_output && action.start.is_none());
+
+        let suppressed = ThemeGates {
+            launcher_audio_available: true,
+            startup_suppressed: true,
+        };
+        theme.stop(suppressed);
+        assert_eq!(theme.slots, before);
+    }
+
+    #[test]
+    fn queue_sentinels_and_same_retained_track_preserve_native_fade_rules() {
+        let mut theme = runtime();
+        theme.slots.active = Some("A".into());
+        theme.slots.retained = Some("R".into());
+        for request in [ThemeRequest::None, ThemeRequest::Auto] {
+            theme.queue_request(request.clone(), gates(true), MusicOutputState::Playing, 100);
+            assert_eq!(theme.slots.pending, request);
+            assert!(theme.scenario_fade.started_at_ms.is_none());
+        }
+        theme.queue_request(
+            ThemeRequest::Track("R".into()),
+            gates(true),
+            MusicOutputState::Playing,
+            200,
+        );
+        assert!(theme.scenario_fade.started_at_ms.is_none());
+        theme.queue_request(
+            ThemeRequest::Hold,
+            gates(true),
+            MusicOutputState::Playing,
+            300,
+        );
+        assert_eq!(theme.scenario_fade.started_at_ms, Some(300));
+    }
+
+    #[test]
+    fn play_success_failure_repeat_and_same_track_rows_are_literal() {
+        let mut theme = runtime();
+        theme.slots = ThemeSlots {
+            active: Some("Old".into()),
+            retained: Some("Old".into()),
+            pending: ThemeRequest::Hold,
+        };
+        let mut ok = prepared;
+        let action = theme.play_request_with(
+            ThemeRequest::Track("Power".into()),
+            gates(true),
+            MusicOutputState::Playing,
+            &mut ok,
+        );
+        assert!(action.stop_output && action.start.is_some());
+        assert_eq!(
+            theme.slots,
+            ThemeSlots {
+                active: Some("Power".into()),
+                retained: Some("Power".into()),
+                pending: ThemeRequest::None,
+            }
+        );
+
+        let before = theme.slots.clone();
+        let action = theme.play_request_with(
+            ThemeRequest::Track("Power".into()),
+            gates(true),
+            MusicOutputState::Playing,
+            &mut ok,
+        );
+        assert_eq!(theme.slots, before);
+        assert!(!action.stop_output && action.start.is_none());
+
+        theme.slots = ThemeSlots {
+            active: None,
+            retained: Some("Old".into()),
+            pending: ThemeRequest::Hold,
+        };
+        let mut missing = |_stem: &str| None;
+        theme.play_request_with(
+            ThemeRequest::Track("Power".into()),
+            gates(true),
+            MusicOutputState::Unavailable,
+            &mut missing,
+        );
+        assert_eq!(theme.slots.active, None);
+        assert_eq!(theme.slots.retained.as_deref(), Some("Power"));
+        assert_eq!(theme.slots.pending, ThemeRequest::Hold);
+
+        theme.slots.pending = ThemeRequest::None;
+        theme.play_request_with(
+            ThemeRequest::Track("Power".into()),
+            gates(true),
+            MusicOutputState::Idle,
+            &mut missing,
+        );
+        assert_eq!(theme.slots.pending, ThemeRequest::Track("Power".into()));
+
+        theme.play_request_with(
+            ThemeRequest::Track("INTRO".into()),
+            gates(true),
+            MusicOutputState::Unavailable,
+            &mut ok,
+        );
+        assert_eq!(
+            theme.slots,
+            ThemeSlots {
+                active: Some("Drok".into()),
+                retained: Some("Drok".into()),
+                pending: ThemeRequest::Track("Drok".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn replacing_active_preplay_failures_use_stream_object_specific_pending_rows() {
+        for (physical, expected_pending) in [
+            (MusicOutputState::Unavailable, ThemeRequest::None),
+            (
+                MusicOutputState::Playing,
+                ThemeRequest::Track("Power".to_string()),
+            ),
+        ] {
+            let mut theme = runtime();
+            theme.slots = ThemeSlots {
+                active: Some("Old".into()),
+                retained: Some("Old".into()),
+                pending: ThemeRequest::Hold,
+            };
+            let mut missing = |_stem: &str| None;
+            let action = theme.play_request_with(
+                ThemeRequest::Track("Power".into()),
+                gates(true),
+                physical,
+                &mut missing,
+            );
+            assert!(action.stop_output);
+            assert_eq!(theme.slots.active, None);
+            assert_eq!(theme.slots.retained.as_deref(), Some("Power"));
+            assert_eq!(theme.slots.pending, expected_pending);
+        }
+    }
+
+    #[test]
+    fn stop_and_direct_sentinel_rows_preserve_active_absent_state() {
+        let mut theme = runtime();
+        theme.slots = ThemeSlots {
+            active: None,
+            retained: Some("R".into()),
+            pending: ThemeRequest::Hold,
+        };
+        let before = theme.slots.clone();
+        assert!(!theme.stop(gates(true)).stop_output);
+        assert_eq!(theme.slots, before);
+
+        let mut ok = prepared;
+        theme.play_request_with(
+            ThemeRequest::None,
+            gates(true),
+            MusicOutputState::Idle,
+            &mut ok,
+        );
+        assert_eq!(theme.slots, before);
+        theme.slots.active = Some("A".into());
+        assert!(
+            theme
+                .play_request_with(
+                    ThemeRequest::Hold,
+                    gates(true),
+                    MusicOutputState::Playing,
+                    &mut ok,
+                )
+                .stop_output
+        );
+        assert_eq!(theme.slots, ThemeSlots::default());
+    }
+
+    #[test]
+    fn completion_auto_specific_hold_and_unavailable_are_distinct() {
+        let mut theme = runtime();
+        theme.slots = ThemeSlots {
+            active: Some("Drok".into()),
+            retained: Some("Drok".into()),
+            pending: ThemeRequest::Track("Drok".into()),
+        };
+        let mut ok = prepared;
+        let action = theme.update_with(gates(true), MusicOutputState::Finished, 1_000, &mut ok);
+        assert!(action.start.is_some());
+        assert_eq!(theme.slots.active.as_deref(), Some("Drok"));
+        assert_eq!(theme.slots.retained.as_deref(), Some("Drok"));
+        assert_eq!(theme.slots.pending, ThemeRequest::Auto);
+
+        let action = theme.update_with(gates(true), MusicOutputState::Finished, 1_500, &mut ok);
+        assert!(action.start.is_some(), "Auto repeats retained INTRO");
+        assert_eq!(theme.slots.active.as_deref(), Some("Drok"));
+        assert_eq!(theme.slots.retained.as_deref(), Some("Drok"));
+        assert_eq!(theme.slots.pending, ThemeRequest::Auto);
+
+        let before = theme.slots.clone();
+        let action = theme.update_with(gates(true), MusicOutputState::Unavailable, 2_000, &mut ok);
+        assert!(action.start.is_none());
+        assert_eq!(theme.slots, before, "Unavailable is not Finished");
+
+        theme.slots.pending = ThemeRequest::Hold;
+        let before = theme.slots.clone();
+        theme.update_with(gates(true), MusicOutputState::Finished, 3_000, &mut ok);
+        assert_eq!(theme.slots, before);
+
+        theme.slots.pending = ThemeRequest::None;
+        let before = theme.slots.clone();
+        theme.update_with(gates(true), MusicOutputState::Finished, 4_000, &mut ok);
+        assert_eq!(theme.slots, before, "None completion preserves stale A/R");
+    }
+
+    #[test]
+    fn ai_auto_success_and_failure_restore_auto_after_attempt() {
+        let mut theme = runtime();
+        theme.slots = ThemeSlots {
+            active: Some("Power".into()),
+            retained: Some("Power".into()),
+            pending: ThemeRequest::Auto,
+        };
+        theme.playlist_index = 2;
+        let mut ok = prepared;
+        theme.update_with(gates(true), MusicOutputState::Finished, 100, &mut ok);
+        assert_eq!(theme.slots.active.as_deref(), Some("Fortific"));
+        assert_eq!(theme.slots.retained.as_deref(), Some("Fortific"));
+        assert_eq!(theme.slots.pending, ThemeRequest::Auto);
+
+        theme.slots.pending = ThemeRequest::Auto;
+        let mut missing = |_stem: &str| None;
+        theme.update_with(gates(true), MusicOutputState::Finished, 200, &mut missing);
+        assert_eq!(theme.slots.active, None);
+        assert_eq!(theme.slots.retained.as_deref(), Some("InDeep"));
+        assert_eq!(theme.slots.pending, ThemeRequest::Auto);
+    }
+
+    #[test]
+    fn score_zero_is_queue_then_stop_not_unconditional_reset() {
+        let mut theme = runtime();
+        theme.slots = ThemeSlots {
+            active: Some("A".into()),
+            retained: Some("R".into()),
+            pending: ThemeRequest::Hold,
+        };
+        let action = theme.queue_then_stop_score_zero(gates(true), MusicOutputState::Playing);
+        assert!(action.stop_output);
+        assert_eq!(theme.slots, ThemeSlots::default());
+
+        theme.slots = ThemeSlots {
+            active: None,
+            retained: Some("R".into()),
+            pending: ThemeRequest::Hold,
+        };
+        let action = theme.queue_then_stop_score_zero(gates(true), MusicOutputState::Idle);
+        assert!(!action.stop_output);
+        assert_eq!(theme.slots.active, None);
+        assert_eq!(theme.slots.retained.as_deref(), Some("R"));
+        assert_eq!(theme.slots.pending, ThemeRequest::Track("R".into()));
+    }
+
+    #[test]
+    fn scenario_specific_fades_then_ai_starts_and_restores_auto() {
+        let mut theme = runtime();
+        theme.slots = ThemeSlots {
+            active: Some("Drok".into()),
+            retained: Some("Drok".into()),
+            pending: ThemeRequest::Track("Drok".into()),
+        };
+        let action = theme.queue_request(
+            ThemeRequest::Track("Fortific".into()),
+            gates(true),
+            MusicOutputState::Playing,
+            100,
+        );
+        assert_eq!(action.theme_scale, Some(1.0));
+        let mut ok = prepared;
+        assert_eq!(
+            theme
+                .update_with(gates(true), MusicOutputState::Playing, 600, &mut ok)
+                .theme_scale,
+            Some(0.5)
+        );
+        let action = theme.update_with(gates(true), MusicOutputState::Playing, 1_100, &mut ok);
+        assert!(action.stop_output && action.start.is_some());
+        assert_eq!(theme.slots.active.as_deref(), Some("Fortific"));
+        assert_eq!(theme.slots.retained.as_deref(), Some("Fortific"));
+        assert_eq!(theme.slots.pending, ThemeRequest::Auto);
+    }
+
+    #[test]
+    fn scenario_cancel_clears_only_scenario_owned_pending() {
+        let mut theme = runtime();
+        theme.slots.pending = ThemeRequest::Auto;
+        theme.cancel_scenario_theme_request();
+        assert_eq!(theme.slots.pending, ThemeRequest::Auto);
+
+        theme.queue_request(
+            ThemeRequest::Track("Fortific".into()),
+            gates(true),
+            MusicOutputState::Playing,
+            10,
+        );
+        theme.scenario_fade.owns_pending = true;
+        theme.cancel_scenario_theme_request();
+        assert_eq!(theme.slots.pending, ThemeRequest::None);
+    }
+
+    #[test]
+    fn resolver_uses_section_keys_and_playlist_specific_advances() {
+        let ini = IniFile::from_str(
+            "[Themes]\n0=Fortification\n1=Power\n\
+             [Fortification]\nSound=Fortific\nNormal=yes\n\
+             [Power]\nSound=Power\nNormal=yes\n",
+        );
+        let mut sections = HashMap::new();
+        merge_theme_section_stems(&mut sections, &ini);
+        for requested in [None, Some("No theme"), Some("Missing"), Some("Fortific")] {
+            assert_eq!(
+                resolve_scenario_theme_section(requested, &sections),
+                ScenarioThemeRequest::Auto
+            );
+        }
+        assert_eq!(
+            resolve_scenario_theme_section(Some("fOrTiFiCaTiOn"), &sections),
+            ScenarioThemeRequest::Specific("Fortific".into())
+        );
+        let playlist = ["Grinder", "Power", "Fortific", "InDeep"]
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            playlist[playlist_index_after_specific(&playlist, "fOrTiFiC").unwrap()],
+            "InDeep"
+        );
+    }
+
+    #[test]
+    fn menu_theme_metadata_honors_repeat_and_absence() {
+        let ini = IniFile::from_str("[INTRO]\nSound=Drok\nNormal=no\nRepeat=yes\n");
+        let mut aliases = HashMap::new();
+        merge_theme_aliases(&mut aliases, &ini);
+        assert_eq!(
+            menu_theme_from_ini(&ini, &aliases),
+            Some(("Drok".into(), true))
+        );
+        let absent = IniFile::from_str("[SCORE]\nSound=Score\n");
+        assert_eq!(menu_theme_from_ini(&absent, &HashMap::new()), None);
+    }
+}

--- a/src/audio/theme.rs
+++ b/src/audio/theme.rs
@@ -158,6 +158,11 @@ impl Default for ThemeRuntime {
     }
 }
 
+/// gamemd-derived: the device-independent Theme lifecycle is owned by
+/// `ThemeClass` constructor `0x00720960`, AI `0x007209D0`, Next
+/// `0x00720A80`, Queue `0x00720B20`, Play `0x00720BB0`, and Stop
+/// `0x00720EA0`. These bodies operate on logical `[active, retained, pending]`
+/// identities independently of the optional physical StreamPlayer.
 impl ThemeRuntime {
     /// Load Theme configuration once, independently of physical output.
     pub(crate) fn initialize_catalog(&mut self, assets: &AssetManager) {

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -522,6 +522,8 @@ pub struct GeneralRules {
     pub gui_move_in_sound: Option<String>,
     /// Generic shell click sound from [AudioVisual] GenericClick.
     pub generic_click_sound: Option<String>,
+    /// Launcher Options Sound/Voice preview cue from [AudioVisual] GenericBeep.
+    pub generic_beep_sound: Option<String>,
     /// Sound event for shell checkboxes from [AudioVisual] GUICheckboxSound.
     pub gui_checkbox_sound: Option<String>,
     /// Sidebar tab click sound from [AudioVisual] GUITabSound (retail
@@ -1038,6 +1040,7 @@ impl Default for GeneralRules {
             gui_main_button_sound: None,
             gui_move_in_sound: None,
             generic_click_sound: None,
+            generic_beep_sound: None,
             gui_checkbox_sound: None,
             gui_tab_sound: None,
             incoming_message_sound: None,
@@ -1792,6 +1795,11 @@ impl GeneralRules {
                 .map(str::to_string),
             generic_click_sound: audio_visual
                 .and_then(|s| s.get("GenericClick"))
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+            generic_beep_sound: audio_visual
+                .and_then(|s| s.get("GenericBeep"))
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .map(str::to_string),
@@ -5246,6 +5254,7 @@ FlightLevel=500
 [AudioVisual]
 GUIMainButtonSound=MainButtonClick
 GenericClick=GenericPress
+GenericBeep=GenericBeep
 GUICheckboxSound=CheckboxTick
 GUIComboOpenSound=ComboOpen
 GUIComboCloseSound=ComboClose
@@ -5257,6 +5266,7 @@ GUIComboCloseSound=ComboClose
             Some("MainButtonClick")
         );
         assert_eq!(general.generic_click_sound.as_deref(), Some("GenericPress"));
+        assert_eq!(general.generic_beep_sound.as_deref(), Some("GenericBeep"));
         assert_eq!(general.gui_checkbox_sound.as_deref(), Some("CheckboxTick"));
         assert_eq!(general.gui_combo_open_sound.as_deref(), Some("ComboOpen"));
         assert_eq!(general.gui_combo_close_sound.as_deref(), Some("ComboClose"));
@@ -5269,6 +5279,7 @@ GUIComboCloseSound=ComboClose
             "[AudioVisual]\n",
             "ChuteSound=  ParachuteDrop  \n",
             "GenericClick=  MenuClick  \n",
+            "GenericBeep=   \n",
             "GUICheckboxSound=\n",
             "GUIComboOpenSound=   \n",
             "GUIComboCloseSound=MenuACBClose\n",
@@ -5277,6 +5288,7 @@ GUIComboCloseSound=ComboClose
         let general = GeneralRules::from_ini(&ini);
         assert_eq!(general.chute_sound.as_deref(), Some("ParachuteDrop"));
         assert_eq!(general.generic_click_sound.as_deref(), Some("MenuClick"));
+        assert!(general.generic_beep_sound.is_none());
         assert!(general.gui_checkbox_sound.is_none());
         assert!(general.gui_combo_open_sound.is_none());
         assert_eq!(

--- a/src/ui/main_menu_dialogs.rs
+++ b/src/ui/main_menu_dialogs.rs
@@ -25,6 +25,10 @@
 
 use crate::ui::client_theme;
 
+pub(crate) mod options;
+
+pub(crate) use options::OptionsDialogState;
+
 /// Resolves a CSF string key to display text, with an English fallback when the
 /// table is missing the key. Provided by the caller (which owns the CSF table).
 pub(crate) type CsfLookup<'a> = dyn Fn(&str, &str) -> String + 'a;
@@ -118,34 +122,23 @@ pub(crate) fn draw_exit_confirm_modal(
 }
 
 // ---------------------------------------------------------------------------
-// Options launcher dialog (open-level only)
+// Options launcher dialog compatibility entry
 // ---------------------------------------------------------------------------
 
-/// CSF title key for the Options dialog. UNKNOWN: the decode pass on the
-/// options launcher dialog has not pinned the title string key, so this uses a
-/// non-CSF descriptive fallback rather than inventing a key.
-const OPTIONS_TITLE_FALLBACK: &str = "Options";
-
-/// State for the Options launcher dialog shell. The real option widgets and the
-/// ra2md.ini write-back are not decoded yet — this is an open-level shell only.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub(crate) struct OptionsDialogState;
-
+/// Temporary production adapter retained until the launcher transaction commit
+/// connects the retained semantic parent from `options` to AppState effects.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OptionsDialogAction {
     None,
-    /// Back/OK pressed — close and return to the menu.
     Close,
 }
 
 pub(crate) fn draw_options_dialog(ctx: &egui::Context, csf: &CsfLookup<'_>) -> OptionsDialogAction {
     let palette = client_theme::apply_client_theme(ctx);
     let mut action = OptionsDialogAction::None;
-    // GUI:Back is a verified shared label used by these shell dialogs.
     let back_label = csf("GUI:Back", "Back");
 
     draw_backdrop(ctx, "options_backdrop");
-
     egui::Window::new("")
         .title_bar(false)
         .collapsible(false)
@@ -158,10 +151,8 @@ pub(crate) fn draw_options_dialog(ctx: &egui::Context, csf: &CsfLookup<'_>) -> O
             ui.vertical(|ui| {
                 client_theme::section_label(ui, "OPTIONS", palette);
                 ui.add_space(4.0);
-                // Title key for this dialog is not yet decoded; use a plain
-                // fallback string rather than guessing a CSF key.
                 ui.label(
-                    egui::RichText::new(OPTIONS_TITLE_FALLBACK)
+                    egui::RichText::new("Options")
                         .size(24.0)
                         .strong()
                         .color(palette.text),
@@ -181,7 +172,6 @@ pub(crate) fn draw_options_dialog(ctx: &egui::Context, csf: &CsfLookup<'_>) -> O
                 }
             });
         });
-
     action
 }
 

--- a/src/ui/main_menu_dialogs.rs
+++ b/src/ui/main_menu_dialogs.rs
@@ -6,8 +6,7 @@
 //!
 //! - Exit Game -> a confirm message box ("are you sure?") with confirm/cancel.
 //!   The game does NOT quit on the first click; it quits only on confirm.
-//! - Options -> a launcher options dialog (open-level shell only here; the real
-//!   option widgets + INI write-back are not yet decoded).
+//! - Options -> the retained launcher Options parent in `options`.
 //! - Movies & Credits -> a sub-panel with Sneak Preview / Movies / Credits /
 //!   Back (open-level; playback + credits roller not implemented here).
 //! - Single Player -> New Campaign -> a campaign selector (Allied/Soviet +
@@ -118,60 +117,6 @@ pub(crate) fn draw_exit_confirm_modal(
             });
         });
 
-    action
-}
-
-// ---------------------------------------------------------------------------
-// Options launcher dialog compatibility entry
-// ---------------------------------------------------------------------------
-
-/// Temporary production adapter retained until the launcher transaction commit
-/// connects the retained semantic parent from `options` to AppState effects.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum OptionsDialogAction {
-    None,
-    Close,
-}
-
-pub(crate) fn draw_options_dialog(ctx: &egui::Context, csf: &CsfLookup<'_>) -> OptionsDialogAction {
-    let palette = client_theme::apply_client_theme(ctx);
-    let mut action = OptionsDialogAction::None;
-    let back_label = csf("GUI:Back", "Back");
-
-    draw_backdrop(ctx, "options_backdrop");
-    egui::Window::new("")
-        .title_bar(false)
-        .collapsible(false)
-        .resizable(false)
-        .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
-        .frame(client_theme::card_frame(palette.panel, palette.line))
-        .min_width(420.0)
-        .show(ctx, |ui| {
-            ui.set_max_width(420.0);
-            ui.vertical(|ui| {
-                client_theme::section_label(ui, "OPTIONS", palette);
-                ui.add_space(4.0);
-                ui.label(
-                    egui::RichText::new("Options")
-                        .size(24.0)
-                        .strong()
-                        .color(palette.text),
-                );
-                ui.add_space(8.0);
-                ui.label(
-                    egui::RichText::new(
-                        "Resolution, volumes, scroll rate, tooltips and game speed are not \
-                         implemented yet.",
-                    )
-                    .size(13.0)
-                    .color(palette.text_muted),
-                );
-                ui.add_space(16.0);
-                if ui.button(&back_label).clicked() {
-                    action = OptionsDialogAction::Close;
-                }
-            });
-        });
     action
 }
 

--- a/src/ui/main_menu_dialogs/options.rs
+++ b/src/ui/main_menu_dialogs/options.rs
@@ -135,9 +135,37 @@ enum LauncherRegion {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LauncherControl {
+    Detail,
+    Resolution,
+    Difficulty,
+    Tooltips,
+    TargetLines,
+    ShowHidden,
+    Scroll,
+    Score,
+    Sound,
+    Voice,
+    Keyboard,
+    Network,
+    MainMenu,
+    BlankFooter,
+    WarningDecoration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LauncherSlot {
+    Column { column: u8, order: u8 },
+    Row { order: u8 },
+    Lane { lane: u8 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct LauncherDescriptorEntry {
     id: u16,
+    control: LauncherControl,
     region: LauncherRegion,
+    slot: LauncherSlot,
 }
 
 /// gamemd-derived: the `0xD5` resource hierarchy consumed by primary-proc
@@ -146,65 +174,125 @@ struct LauncherDescriptorEntry {
 const LAUNCHER_DESCRIPTOR: [LauncherDescriptorEntry; 15] = [
     LauncherDescriptorEntry {
         id: 0x52B,
+        control: LauncherControl::Detail,
         region: LauncherRegion::Display,
+        slot: LauncherSlot::Column {
+            column: 0,
+            order: 0,
+        },
     },
     LauncherDescriptorEntry {
         id: 0x6ED,
+        control: LauncherControl::Resolution,
         region: LauncherRegion::Display,
+        slot: LauncherSlot::Column {
+            column: 1,
+            order: 0,
+        },
     },
     LauncherDescriptorEntry {
         id: 0x50F,
+        control: LauncherControl::Difficulty,
         region: LauncherRegion::Game,
+        slot: LauncherSlot::Row { order: 0 },
     },
     LauncherDescriptorEntry {
         id: 0x602,
+        control: LauncherControl::Tooltips,
         region: LauncherRegion::Ui,
+        slot: LauncherSlot::Column {
+            column: 0,
+            order: 0,
+        },
     },
     LauncherDescriptorEntry {
         id: 0x601,
+        control: LauncherControl::TargetLines,
         region: LauncherRegion::Ui,
+        slot: LauncherSlot::Column {
+            column: 0,
+            order: 1,
+        },
     },
     LauncherDescriptorEntry {
         id: 0x604,
+        control: LauncherControl::ShowHidden,
         region: LauncherRegion::Ui,
+        slot: LauncherSlot::Column {
+            column: 0,
+            order: 2,
+        },
     },
     LauncherDescriptorEntry {
         id: 0x52A,
+        control: LauncherControl::Scroll,
         region: LauncherRegion::Ui,
+        slot: LauncherSlot::Column {
+            column: 1,
+            order: 0,
+        },
     },
     LauncherDescriptorEntry {
         id: 0x52F,
+        control: LauncherControl::Score,
         region: LauncherRegion::Audio,
+        slot: LauncherSlot::Lane { lane: 0 },
     },
     LauncherDescriptorEntry {
         id: 0x532,
+        control: LauncherControl::Sound,
         region: LauncherRegion::Audio,
+        slot: LauncherSlot::Lane { lane: 1 },
     },
     LauncherDescriptorEntry {
         id: 0x536,
+        control: LauncherControl::Voice,
         region: LauncherRegion::Audio,
+        slot: LauncherSlot::Lane { lane: 2 },
     },
     LauncherDescriptorEntry {
         id: 0x5CE,
+        control: LauncherControl::Keyboard,
         region: LauncherRegion::RightRail,
+        slot: LauncherSlot::Row { order: 0 },
     },
     LauncherDescriptorEntry {
         id: 0x5CD,
+        control: LauncherControl::Network,
         region: LauncherRegion::RightRail,
+        slot: LauncherSlot::Row { order: 1 },
     },
     LauncherDescriptorEntry {
         id: 0x686,
+        control: LauncherControl::MainMenu,
         region: LauncherRegion::RightRail,
+        slot: LauncherSlot::Row { order: 2 },
     },
     LauncherDescriptorEntry {
         id: 0x695,
+        control: LauncherControl::BlankFooter,
         region: LauncherRegion::Footer,
+        slot: LauncherSlot::Row { order: 0 },
     },
     LauncherDescriptorEntry {
         id: 0x71C,
+        control: LauncherControl::WarningDecoration,
         region: LauncherRegion::Footer,
+        slot: LauncherSlot::Row { order: 1 },
     },
 ];
+
+fn launcher_entries(region: LauncherRegion) -> Vec<&'static LauncherDescriptorEntry> {
+    let mut entries = LAUNCHER_DESCRIPTOR
+        .iter()
+        .filter(|entry| entry.region == region)
+        .collect::<Vec<_>>();
+    entries.sort_by_key(|entry| match entry.slot {
+        LauncherSlot::Column { order, .. } | LauncherSlot::Row { order } => order,
+        LauncherSlot::Lane { lane } => lane,
+    });
+    entries
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LauncherTrackbarId {
@@ -247,6 +335,7 @@ pub(crate) enum LauncherCheckboxId {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LauncherCue {
+    MainButton,
     GenericClick,
     Checkbox,
     ComboOpen,
@@ -289,6 +378,9 @@ pub(crate) struct LauncherResolutionRow {
 }
 
 impl LauncherResolutionRow {
+    /// gamemd-derived: primary-proc slice `0x005601A0..0x00560270` appends
+    /// admitted dimension pairs to the `0xD5` combo using literal
+    /// `%d x %d x 16` display text.
     pub(crate) fn new(width: i32, height: i32) -> Self {
         Self {
             width,
@@ -467,6 +559,9 @@ fn trackbar_paint_geometry(
     id: LauncherTrackbarId,
     position: u8,
 ) -> TrackbarPaintGeometry {
+    // gamemd-derived: `TrackBar_ProcessMouse @ 0x0061D950` and its owner-draw
+    // path share the literal 12x22 grip, 6px rail inset, and plaque reserve;
+    // paint therefore consumes the same integer `thumb_left` as admission.
     let width = control.width();
     let height = control.height();
     let rail_right = (width - id.plaque_reserve() - 6).max(6);
@@ -521,6 +616,9 @@ impl PhysicalControlFrame {
     }
 }
 
+/// gamemd-derived: the fresh launcher trackbars created by primary-proc slice
+/// `0x0055FDB0..0x0056047A` reject an out-of-range set-position request and
+/// retain constructor position zero rather than clamping it.
 pub(crate) fn admitted_initial_position(requested: i64, maximum: u8) -> u8 {
     u8::try_from(requested)
         .ok()
@@ -528,6 +626,9 @@ pub(crate) fn admitted_initial_position(requested: i64, maximum: u8) -> u8 {
         .unwrap_or(0)
 }
 
+/// gamemd-derived: launcher volume setup in primary-proc slice
+/// `0x0055FDB0..0x0056047A`, fed by setters `0x005FA4A0/0x005FA510/0x005FA590`,
+/// forms the x87 request `trunc(volume * 10 + 0.5)` before range admission.
 pub(crate) fn admitted_volume_position(volume: f32) -> u8 {
     let request = f64::from(volume) * 10.0 + 0.5;
     if !request.is_finite() {
@@ -808,6 +909,15 @@ impl OptionsDialogState {
         }
     }
 
+    /// gamemd-derived: ordinary `0xD5` owner-draw buttons emit
+    /// `[AudioVisual] GUIMainButtonSound` on admitted primary mouse-down;
+    /// `OptionsClass__ShowLauncherDialog @ 0x0055FC80` observes the distinct
+    /// Back/Network/Keyboard result only on the later activation release.
+    pub(crate) fn main_button_mouse_down(&mut self) {
+        self.pending_events
+            .push(LauncherOptionsEvent::Cue(LauncherCue::MainButton));
+    }
+
     /// gamemd-derived: primary-proc slice `0x0055FDB0..0x0056047A` accepts only
     /// a valid combo row and publishes its width/height immediately; final
     /// accepted projection `0x0055FAA0` does not own the resolution pair.
@@ -876,26 +986,11 @@ pub(crate) fn draw_launcher_options_dialog(
                     draw_ui_group(ui, state, palette);
                     ui.add_space(10.0);
                     draw_audio_group(ui, state, palette);
-                    if !state.labels.blank.is_empty() {
-                        ui.label(&state.labels.blank);
-                    }
                 });
                 ui.separator();
-                ui.vertical_centered_justified(|ui| {
-                    ui.heading(&state.labels.options);
-                    ui.add_space(18.0);
-                    if ui.button(&state.labels.keyboard).clicked() {
-                        state.request_result(LauncherParentResult::Keyboard);
-                    }
-                    if ui.button(&state.labels.network).clicked() {
-                        state.request_result(LauncherParentResult::Network);
-                    }
-                    ui.add_space(36.0);
-                    if ui.button(&state.labels.main_menu).clicked() {
-                        state.request_result(LauncherParentResult::Back);
-                    }
-                });
+                draw_right_rail(ui, state);
             });
+            draw_footer(ui, state);
         });
 
     state.drain_output()
@@ -908,20 +1003,26 @@ fn draw_display_group(
 ) {
     client_theme::section_label(ui, &state.labels.display_options, palette);
     ui.columns(2, |columns| {
-        columns[0].label(format!(
-            "{} — {}",
-            state.labels.visual_details, state.detail_caption
-        ));
-        draw_trackbar(
-            &mut columns[0],
-            state,
-            LauncherTrackbarId::Detail,
-            180.0,
-            palette,
-        );
-
-        columns[1].label(&state.labels.set_resolution);
-        draw_resolution_combo(&mut columns[1], state, palette);
+        for entry in launcher_entries(LauncherRegion::Display) {
+            let LauncherSlot::Column { column, .. } = entry.slot else {
+                continue;
+            };
+            let column = &mut columns[usize::from(column)];
+            match entry.control {
+                LauncherControl::Detail => {
+                    column.label(format!(
+                        "{} — {}",
+                        state.labels.visual_details, state.detail_caption
+                    ));
+                    draw_trackbar(column, state, LauncherTrackbarId::Detail, 180.0, palette);
+                }
+                LauncherControl::Resolution => {
+                    column.label(&state.labels.set_resolution);
+                    draw_resolution_combo(column, state, palette);
+                }
+                _ => {}
+            }
+        }
     });
 }
 
@@ -931,11 +1032,15 @@ fn draw_game_group(
     palette: client_theme::ClientPalette,
 ) {
     client_theme::section_label(ui, &state.labels.game_options, palette);
-    ui.label(format!(
-        "{} — {}",
-        state.labels.difficulty, state.difficulty_caption
-    ));
-    draw_trackbar(ui, state, LauncherTrackbarId::Difficulty, 180.0, palette);
+    for entry in launcher_entries(LauncherRegion::Game) {
+        if entry.control == LauncherControl::Difficulty {
+            ui.label(format!(
+                "{} — {}",
+                state.labels.difficulty, state.difficulty_caption
+            ));
+            draw_trackbar(ui, state, LauncherTrackbarId::Difficulty, 180.0, palette);
+        }
+    }
 }
 
 fn draw_ui_group(
@@ -945,42 +1050,35 @@ fn draw_ui_group(
 ) {
     client_theme::section_label(ui, &state.labels.ui_options, palette);
     ui.columns(2, |columns| {
-        let tooltips = state.labels.tooltips.clone();
-        let target_lines = state.labels.target_lines.clone();
-        let show_hidden = state.labels.show_hidden.clone();
-        draw_checkbox(
-            &mut columns[0],
-            state,
-            LauncherCheckboxId::Tooltips,
-            &tooltips,
-            palette,
-        );
-        draw_checkbox(
-            &mut columns[0],
-            state,
-            LauncherCheckboxId::TargetLines,
-            &target_lines,
-            palette,
-        );
-        draw_checkbox(
-            &mut columns[0],
-            state,
-            LauncherCheckboxId::ShowHidden,
-            &show_hidden,
-            palette,
-        );
-
-        columns[1].label(format!(
-            "{} — {}",
-            state.labels.scroll_rate, state.scroll_caption
-        ));
-        draw_trackbar(
-            &mut columns[1],
-            state,
-            LauncherTrackbarId::Scroll,
-            180.0,
-            palette,
-        );
+        for entry in launcher_entries(LauncherRegion::Ui) {
+            let LauncherSlot::Column { column, .. } = entry.slot else {
+                continue;
+            };
+            let column = &mut columns[usize::from(column)];
+            let checkbox = match entry.control {
+                LauncherControl::Tooltips => {
+                    Some((LauncherCheckboxId::Tooltips, state.labels.tooltips.clone()))
+                }
+                LauncherControl::TargetLines => Some((
+                    LauncherCheckboxId::TargetLines,
+                    state.labels.target_lines.clone(),
+                )),
+                LauncherControl::ShowHidden => Some((
+                    LauncherCheckboxId::ShowHidden,
+                    state.labels.show_hidden.clone(),
+                )),
+                _ => None,
+            };
+            if let Some((id, label)) = checkbox {
+                draw_checkbox(column, state, id, &label, palette);
+            } else if entry.control == LauncherControl::Scroll {
+                column.label(format!(
+                    "{} — {}",
+                    state.labels.scroll_rate, state.scroll_caption
+                ));
+                draw_trackbar(column, state, LauncherTrackbarId::Scroll, 180.0, palette);
+            }
+        }
     });
 }
 
@@ -991,31 +1089,81 @@ fn draw_audio_group(
 ) {
     client_theme::section_label(ui, &state.labels.audio_options, palette);
     ui.columns(3, |columns| {
-        columns[0].label(&state.labels.music_volume);
-        draw_trackbar(
-            &mut columns[0],
-            state,
-            LauncherTrackbarId::Score,
-            128.0,
-            palette,
-        );
-        columns[1].label(&state.labels.sound_volume);
-        draw_trackbar(
-            &mut columns[1],
-            state,
-            LauncherTrackbarId::Sound,
-            128.0,
-            palette,
-        );
-        columns[2].label(&state.labels.voice_volume);
-        draw_trackbar(
-            &mut columns[2],
-            state,
-            LauncherTrackbarId::Voice,
-            128.0,
-            palette,
-        );
+        for entry in launcher_entries(LauncherRegion::Audio) {
+            let LauncherSlot::Lane { lane } = entry.slot else {
+                continue;
+            };
+            let (id, label) = match entry.control {
+                LauncherControl::Score => {
+                    (LauncherTrackbarId::Score, state.labels.music_volume.clone())
+                }
+                LauncherControl::Sound => {
+                    (LauncherTrackbarId::Sound, state.labels.sound_volume.clone())
+                }
+                LauncherControl::Voice => {
+                    (LauncherTrackbarId::Voice, state.labels.voice_volume.clone())
+                }
+                _ => continue,
+            };
+            let column = &mut columns[usize::from(lane)];
+            column.label(label);
+            draw_trackbar(column, state, id, 128.0, palette);
+        }
     });
+}
+
+fn draw_right_rail(ui: &mut egui::Ui, state: &mut OptionsDialogState) {
+    ui.vertical_centered_justified(|ui| {
+        ui.heading(&state.labels.options);
+        ui.add_space(18.0);
+        for entry in launcher_entries(LauncherRegion::RightRail) {
+            let (label, result) = match entry.control {
+                LauncherControl::Keyboard => (
+                    state.labels.keyboard.clone(),
+                    LauncherParentResult::Keyboard,
+                ),
+                LauncherControl::Network => {
+                    (state.labels.network.clone(), LauncherParentResult::Network)
+                }
+                LauncherControl::MainMenu => {
+                    ui.add_space(36.0);
+                    (state.labels.main_menu.clone(), LauncherParentResult::Back)
+                }
+                _ => continue,
+            };
+            draw_parent_result_button(ui, state, &label, result);
+        }
+    });
+}
+
+fn draw_parent_result_button(
+    ui: &mut egui::Ui,
+    state: &mut OptionsDialogState,
+    label: &str,
+    result: LauncherParentResult,
+) {
+    let response = ui.button(label);
+    let pressed = ui.input(|input| input.pointer.button_pressed(egui::PointerButton::Primary));
+    if pressed && response.is_pointer_button_down_on() {
+        state.main_button_mouse_down();
+    }
+    if response.clicked_by(egui::PointerButton::Primary) {
+        state.request_result(result);
+    }
+}
+
+fn draw_footer(ui: &mut egui::Ui, state: &OptionsDialogState) {
+    for entry in launcher_entries(LauncherRegion::Footer) {
+        match entry.control {
+            LauncherControl::BlankFooter if !state.labels.blank.is_empty() => {
+                ui.label(&state.labels.blank);
+            }
+            // Exact `0x71C` warning-decoration SHP/timing is a frozen visual
+            // exactification residual; the semantic parent keeps it inert.
+            LauncherControl::WarningDecoration | LauncherControl::BlankFooter => {}
+            _ => {}
+        }
+    }
 }
 
 fn draw_trackbar(
@@ -1348,19 +1496,86 @@ mod tests {
 
     #[test]
     fn exact_launcher_label_fallbacks_are_local_and_complete() {
+        const EXPECTED: [(&str, &str); 34] = [
+            ("GUI:OptionsMenu", "Options"),
+            ("GUI:MainMenu", "Main Menu"),
+            ("GUI:Keyboard", "Keyboard"),
+            ("GUI:Network", "Network"),
+            ("GUI:DisplayOptions", "Display Options"),
+            ("GUI:GameOptions", "Game Options"),
+            ("GUI:UIOptions", "UI Options"),
+            ("GUI:AudioOptions", "Audio Options"),
+            ("GUI:SetResolution", "Set Game Resolution"),
+            ("GUI:VisualDetails", "Visual Details"),
+            ("GUI:Difficulty", "Difficulty"),
+            ("GUI:Tooltips", "Tooltips"),
+            ("GUI:ScrollRate", "Scroll Rate"),
+            ("GUI:TargetLines", "Target Lines"),
+            ("GUI:ShowHidden", "See Hidden Objects"),
+            ("GUI:MusicVolume", "Music Volume"),
+            ("GUI:SoundVolume", "Sound Volume"),
+            ("GUI:VoiceVolume", "Voice Volume"),
+            ("GUI:Blank", ""),
+            ("GUI:HigherDetail", "Higher"),
+            ("GUI:Harder", "Harder"),
+            ("GUI:Faster", "Faster"),
+            ("TXT_LOW", "Low"),
+            ("TXT_HIGH", "High"),
+            ("TXT_EASY", "Easy"),
+            ("TXT_NORMAL", "Normal"),
+            ("TXT_HARD", "Hard"),
+            ("TXT_SLOWEST", "Slowest"),
+            ("TXT_SLOWER", "Slower"),
+            ("TXT_SLOW", "Slow"),
+            ("TXT_MEDIUM", "Medium"),
+            ("TXT_FAST", "Fast"),
+            ("TXT_FASTER", "Faster"),
+            ("TXT_FASTEST", "Fastest"),
+        ];
+        assert_eq!(LAUNCHER_LABEL_SPECS, EXPECTED);
         let seen = std::cell::RefCell::new(Vec::new());
         let labels = LauncherOptionsLabels::resolve(&|key| {
             seen.borrow_mut().push(key.to_string());
             None
         });
-        assert_eq!(
-            seen.into_inner(),
-            LAUNCHER_LABEL_SPECS.map(|(key, _)| key.to_string())
-        );
-        assert_eq!(labels.options, "Options");
-        assert_eq!(labels.main_menu, "Main Menu");
-        assert_eq!(labels.blank, "");
-        assert_eq!(labels.scroll_tokens[6], "Fastest");
+        assert_eq!(seen.into_inner(), EXPECTED.map(|(key, _)| key.to_string()));
+        let actual_values = [
+            labels.options.as_str(),
+            labels.main_menu.as_str(),
+            labels.keyboard.as_str(),
+            labels.network.as_str(),
+            labels.display_options.as_str(),
+            labels.game_options.as_str(),
+            labels.ui_options.as_str(),
+            labels.audio_options.as_str(),
+            labels.set_resolution.as_str(),
+            labels.visual_details.as_str(),
+            labels.difficulty.as_str(),
+            labels.tooltips.as_str(),
+            labels.scroll_rate.as_str(),
+            labels.target_lines.as_str(),
+            labels.show_hidden.as_str(),
+            labels.music_volume.as_str(),
+            labels.sound_volume.as_str(),
+            labels.voice_volume.as_str(),
+            labels.blank.as_str(),
+            labels.higher_detail.as_str(),
+            labels.harder.as_str(),
+            labels.faster.as_str(),
+            labels.low.as_str(),
+            labels.high.as_str(),
+            labels.easy.as_str(),
+            labels.normal.as_str(),
+            labels.hard.as_str(),
+            labels.scroll_tokens[0].as_str(),
+            labels.scroll_tokens[1].as_str(),
+            labels.scroll_tokens[2].as_str(),
+            labels.scroll_tokens[3].as_str(),
+            labels.scroll_tokens[4].as_str(),
+            labels.scroll_tokens[5].as_str(),
+            labels.scroll_tokens[6].as_str(),
+        ];
+        assert_eq!(actual_values, EXPECTED.map(|(_, fallback)| fallback));
     }
 
     #[test]
@@ -1378,20 +1593,142 @@ mod tests {
     }
 
     #[test]
-    fn descriptor_preserves_region_order_and_omits_dormant_603() {
-        assert_eq!(LAUNCHER_DESCRIPTOR[0].region, LauncherRegion::Display);
-        assert_eq!(LAUNCHER_DESCRIPTOR[2].region, LauncherRegion::Game);
-        assert_eq!(LAUNCHER_DESCRIPTOR[3].region, LauncherRegion::Ui);
-        assert_eq!(LAUNCHER_DESCRIPTOR[7].region, LauncherRegion::Audio);
-        assert_eq!(LAUNCHER_DESCRIPTOR[10].region, LauncherRegion::RightRail);
-        assert_eq!(LAUNCHER_DESCRIPTOR[13].region, LauncherRegion::Footer);
+    fn descriptor_is_complete_authoritative_layout_and_omits_dormant_603() {
+        let actual =
+            LAUNCHER_DESCRIPTOR.map(|entry| (entry.id, entry.control, entry.region, entry.slot));
+        let expected = [
+            (
+                0x52B,
+                LauncherControl::Detail,
+                LauncherRegion::Display,
+                LauncherSlot::Column {
+                    column: 0,
+                    order: 0,
+                },
+            ),
+            (
+                0x6ED,
+                LauncherControl::Resolution,
+                LauncherRegion::Display,
+                LauncherSlot::Column {
+                    column: 1,
+                    order: 0,
+                },
+            ),
+            (
+                0x50F,
+                LauncherControl::Difficulty,
+                LauncherRegion::Game,
+                LauncherSlot::Row { order: 0 },
+            ),
+            (
+                0x602,
+                LauncherControl::Tooltips,
+                LauncherRegion::Ui,
+                LauncherSlot::Column {
+                    column: 0,
+                    order: 0,
+                },
+            ),
+            (
+                0x601,
+                LauncherControl::TargetLines,
+                LauncherRegion::Ui,
+                LauncherSlot::Column {
+                    column: 0,
+                    order: 1,
+                },
+            ),
+            (
+                0x604,
+                LauncherControl::ShowHidden,
+                LauncherRegion::Ui,
+                LauncherSlot::Column {
+                    column: 0,
+                    order: 2,
+                },
+            ),
+            (
+                0x52A,
+                LauncherControl::Scroll,
+                LauncherRegion::Ui,
+                LauncherSlot::Column {
+                    column: 1,
+                    order: 0,
+                },
+            ),
+            (
+                0x52F,
+                LauncherControl::Score,
+                LauncherRegion::Audio,
+                LauncherSlot::Lane { lane: 0 },
+            ),
+            (
+                0x532,
+                LauncherControl::Sound,
+                LauncherRegion::Audio,
+                LauncherSlot::Lane { lane: 1 },
+            ),
+            (
+                0x536,
+                LauncherControl::Voice,
+                LauncherRegion::Audio,
+                LauncherSlot::Lane { lane: 2 },
+            ),
+            (
+                0x5CE,
+                LauncherControl::Keyboard,
+                LauncherRegion::RightRail,
+                LauncherSlot::Row { order: 0 },
+            ),
+            (
+                0x5CD,
+                LauncherControl::Network,
+                LauncherRegion::RightRail,
+                LauncherSlot::Row { order: 1 },
+            ),
+            (
+                0x686,
+                LauncherControl::MainMenu,
+                LauncherRegion::RightRail,
+                LauncherSlot::Row { order: 2 },
+            ),
+            (
+                0x695,
+                LauncherControl::BlankFooter,
+                LauncherRegion::Footer,
+                LauncherSlot::Row { order: 0 },
+            ),
+            (
+                0x71C,
+                LauncherControl::WarningDecoration,
+                LauncherRegion::Footer,
+                LauncherSlot::Row { order: 1 },
+            ),
+        ];
+        assert_eq!(actual, expected);
         assert!(!LAUNCHER_DESCRIPTOR.iter().any(|entry| entry.id == 0x603));
         assert_eq!(
-            LAUNCHER_DESCRIPTOR[7..10]
+            launcher_entries(LauncherRegion::Audio)
                 .iter()
-                .map(|entry| entry.id)
+                .map(|entry| entry.control)
                 .collect::<Vec<_>>(),
-            [0x52F, 0x532, 0x536]
+            [
+                LauncherControl::Score,
+                LauncherControl::Sound,
+                LauncherControl::Voice,
+            ]
+        );
+        assert_eq!(
+            launcher_entries(LauncherRegion::RightRail)
+                .iter()
+                .map(|entry| entry.control)
+                .collect::<Vec<_>>(),
+            [
+                LauncherControl::Keyboard,
+                LauncherControl::Network,
+                LauncherControl::MainMenu,
+            ]
         );
     }
 
@@ -1733,6 +2070,28 @@ mod tests {
         assert_eq!(packed.score_volume.to_bits(), 0.0_f32.to_bits());
         assert_eq!(packed.sound_volume.to_bits(), 0.5_f32.to_bits());
         assert_eq!(packed.voice_volume.to_bits(), 0.6_f32.to_bits());
+    }
+
+    #[test]
+    fn main_button_press_cues_before_release_result() {
+        let mut state = state(true);
+        state.main_button_mouse_down();
+        assert_eq!(
+            state.drain_output(),
+            LauncherOptionsFrameOutput {
+                events: vec![LauncherOptionsEvent::Cue(LauncherCue::MainButton)],
+                result: None,
+            }
+        );
+
+        state.request_result(LauncherParentResult::Network);
+        assert_eq!(
+            state.drain_output(),
+            LauncherOptionsFrameOutput {
+                events: Vec::new(),
+                result: Some(LauncherParentResult::Network),
+            }
+        );
     }
 
     #[test]

--- a/src/ui/main_menu_dialogs/options.rs
+++ b/src/ui/main_menu_dialogs/options.rs
@@ -1,0 +1,1360 @@
+//! Retained semantic model for launcher Options dialog resource `0xD5`.
+//!
+//! The parent owns bounded control state and emits ordered effects. It owns no
+//! profile, filesystem, audio device, window, or child-dialog callback.
+
+use super::CsfLookup;
+use crate::ui::client_theme;
+
+pub(crate) const LAUNCHER_LABEL_SPECS: [(&str, &str); 34] = [
+    ("GUI:OptionsMenu", "Options"),
+    ("GUI:MainMenu", "Main Menu"),
+    ("GUI:Keyboard", "Keyboard"),
+    ("GUI:Network", "Network"),
+    ("GUI:DisplayOptions", "Display Options"),
+    ("GUI:GameOptions", "Game Options"),
+    ("GUI:UIOptions", "UI Options"),
+    ("GUI:AudioOptions", "Audio Options"),
+    ("GUI:SetResolution", "Set Game Resolution"),
+    ("GUI:VisualDetails", "Visual Details"),
+    ("GUI:Difficulty", "Difficulty"),
+    ("GUI:Tooltips", "Tooltips"),
+    ("GUI:ScrollRate", "Scroll Rate"),
+    ("GUI:TargetLines", "Target Lines"),
+    ("GUI:ShowHidden", "See Hidden Objects"),
+    ("GUI:MusicVolume", "Music Volume"),
+    ("GUI:SoundVolume", "Sound Volume"),
+    ("GUI:VoiceVolume", "Voice Volume"),
+    ("GUI:Blank", ""),
+    ("GUI:HigherDetail", "Higher"),
+    ("GUI:Harder", "Harder"),
+    ("GUI:Faster", "Faster"),
+    ("TXT_LOW", "Low"),
+    ("TXT_HIGH", "High"),
+    ("TXT_EASY", "Easy"),
+    ("TXT_NORMAL", "Normal"),
+    ("TXT_HARD", "Hard"),
+    ("TXT_SLOWEST", "Slowest"),
+    ("TXT_SLOWER", "Slower"),
+    ("TXT_SLOW", "Slow"),
+    ("TXT_MEDIUM", "Medium"),
+    ("TXT_FAST", "Fast"),
+    ("TXT_FASTER", "Faster"),
+    ("TXT_FASTEST", "Fastest"),
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LauncherOptionsLabels {
+    pub(crate) options: String,
+    pub(crate) main_menu: String,
+    pub(crate) keyboard: String,
+    pub(crate) network: String,
+    pub(crate) display_options: String,
+    pub(crate) game_options: String,
+    pub(crate) ui_options: String,
+    pub(crate) audio_options: String,
+    pub(crate) set_resolution: String,
+    pub(crate) visual_details: String,
+    pub(crate) difficulty: String,
+    pub(crate) tooltips: String,
+    pub(crate) scroll_rate: String,
+    pub(crate) target_lines: String,
+    pub(crate) show_hidden: String,
+    pub(crate) music_volume: String,
+    pub(crate) sound_volume: String,
+    pub(crate) voice_volume: String,
+    pub(crate) blank: String,
+    higher_detail: String,
+    harder: String,
+    faster: String,
+    low: String,
+    high: String,
+    easy: String,
+    normal: String,
+    hard: String,
+    scroll_tokens: [String; 7],
+}
+
+impl LauncherOptionsLabels {
+    pub(crate) fn resolve(csf: &CsfLookup<'_>) -> Self {
+        let label = |index: usize| {
+            let (key, fallback) = LAUNCHER_LABEL_SPECS[index];
+            csf(key, fallback)
+        };
+        Self {
+            options: label(0),
+            main_menu: label(1),
+            keyboard: label(2),
+            network: label(3),
+            display_options: label(4),
+            game_options: label(5),
+            ui_options: label(6),
+            audio_options: label(7),
+            set_resolution: label(8),
+            visual_details: label(9),
+            difficulty: label(10),
+            tooltips: label(11),
+            scroll_rate: label(12),
+            target_lines: label(13),
+            show_hidden: label(14),
+            music_volume: label(15),
+            sound_volume: label(16),
+            voice_volume: label(17),
+            blank: label(18),
+            higher_detail: label(19),
+            harder: label(20),
+            faster: label(21),
+            low: label(22),
+            high: label(23),
+            easy: label(24),
+            normal: label(25),
+            hard: label(26),
+            scroll_tokens: [
+                label(27),
+                label(28),
+                label(29),
+                label(30),
+                label(31),
+                label(32),
+                label(33),
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LauncherRegion {
+    Display,
+    Game,
+    Ui,
+    Audio,
+    RightRail,
+    Footer,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LauncherDescriptorEntry {
+    id: u16,
+    region: LauncherRegion,
+}
+
+const LAUNCHER_DESCRIPTOR: [LauncherDescriptorEntry; 15] = [
+    LauncherDescriptorEntry {
+        id: 0x52B,
+        region: LauncherRegion::Display,
+    },
+    LauncherDescriptorEntry {
+        id: 0x6ED,
+        region: LauncherRegion::Display,
+    },
+    LauncherDescriptorEntry {
+        id: 0x50F,
+        region: LauncherRegion::Game,
+    },
+    LauncherDescriptorEntry {
+        id: 0x602,
+        region: LauncherRegion::Ui,
+    },
+    LauncherDescriptorEntry {
+        id: 0x601,
+        region: LauncherRegion::Ui,
+    },
+    LauncherDescriptorEntry {
+        id: 0x604,
+        region: LauncherRegion::Ui,
+    },
+    LauncherDescriptorEntry {
+        id: 0x52A,
+        region: LauncherRegion::Ui,
+    },
+    LauncherDescriptorEntry {
+        id: 0x52F,
+        region: LauncherRegion::Audio,
+    },
+    LauncherDescriptorEntry {
+        id: 0x532,
+        region: LauncherRegion::Audio,
+    },
+    LauncherDescriptorEntry {
+        id: 0x536,
+        region: LauncherRegion::Audio,
+    },
+    LauncherDescriptorEntry {
+        id: 0x5CE,
+        region: LauncherRegion::RightRail,
+    },
+    LauncherDescriptorEntry {
+        id: 0x5CD,
+        region: LauncherRegion::RightRail,
+    },
+    LauncherDescriptorEntry {
+        id: 0x686,
+        region: LauncherRegion::RightRail,
+    },
+    LauncherDescriptorEntry {
+        id: 0x695,
+        region: LauncherRegion::Footer,
+    },
+    LauncherDescriptorEntry {
+        id: 0x71C,
+        region: LauncherRegion::Footer,
+    },
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LauncherTrackbarId {
+    Detail,
+    Difficulty,
+    Scroll,
+    Score,
+    Sound,
+    Voice,
+}
+
+impl LauncherTrackbarId {
+    const fn maximum(self) -> u8 {
+        match self {
+            Self::Detail => 1,
+            Self::Difficulty => 2,
+            Self::Scroll => 6,
+            Self::Score | Self::Sound | Self::Voice => 10,
+        }
+    }
+
+    const fn plaque_reserve(self) -> i32 {
+        match self {
+            Self::Detail | Self::Difficulty | Self::Scroll => 0,
+            Self::Score | Self::Sound | Self::Voice => 50,
+        }
+    }
+
+    const fn is_audio(self) -> bool {
+        matches!(self, Self::Score | Self::Sound | Self::Voice)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LauncherCheckboxId {
+    Tooltips,
+    TargetLines,
+    ShowHidden,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LauncherCue {
+    GenericClick,
+    Checkbox,
+    ComboOpen,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum LauncherOptionsEvent {
+    Cue(LauncherCue),
+    ResolutionSelected { width: i32, height: i32 },
+    ScorePreview(f32),
+    SoundPreview(f32),
+    VoicePreview(f32),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LauncherParentResult {
+    Back,
+    Network,
+    Keyboard,
+    Terminal,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct LauncherOptionsFrameOutput {
+    pub(crate) events: Vec<LauncherOptionsEvent>,
+    pub(crate) result: Option<LauncherParentResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LauncherResolutionRow {
+    pub(crate) width: i32,
+    pub(crate) height: i32,
+    pub(crate) label: String,
+}
+
+impl LauncherResolutionRow {
+    pub(crate) fn new(width: i32, height: i32) -> Self {
+        Self {
+            width,
+            height,
+            label: format!("{width} x {height} x 16"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LauncherOptionsValues {
+    pub(crate) detail_position: u8,
+    pub(crate) difficulty_position: u8,
+    pub(crate) scroll_position: u8,
+    pub(crate) tooltips: bool,
+    pub(crate) target_lines: bool,
+    pub(crate) show_hidden: bool,
+    pub(crate) score_position: u8,
+    pub(crate) sound_position: u8,
+    pub(crate) voice_position: u8,
+}
+
+impl Default for LauncherOptionsValues {
+    fn default() -> Self {
+        Self {
+            detail_position: 1,
+            difficulty_position: 1,
+            scroll_position: 3,
+            tooltips: true,
+            target_lines: true,
+            show_hidden: false,
+            score_position: 4,
+            sound_position: 7,
+            voice_position: 7,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct LauncherOptionsPacked {
+    pub(crate) detail_level: i32,
+    pub(crate) difficulty: i32,
+    pub(crate) unit_action_lines: bool,
+    pub(crate) show_hidden: bool,
+    pub(crate) tooltips: bool,
+    pub(crate) scroll_rate: i32,
+    pub(crate) score_volume: f32,
+    pub(crate) sound_volume: f32,
+    pub(crate) voice_volume: f32,
+}
+
+/// One integer-pixel control frame derived from egui's logical point geometry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PhysicalControlFrame {
+    pub(crate) local_x: i32,
+    pub(crate) local_y: i32,
+    pub(crate) width: i32,
+    pub(crate) height: i32,
+}
+
+impl PhysicalControlFrame {
+    pub(crate) fn from_logical(
+        left: f64,
+        top: f64,
+        right: f64,
+        bottom: f64,
+        pointer_x: f64,
+        pointer_y: f64,
+        pixels_per_point: f64,
+    ) -> Option<Self> {
+        if !pixels_per_point.is_finite()
+            || pixels_per_point <= 0.0
+            || ![left, top, right, bottom, pointer_x, pointer_y]
+                .into_iter()
+                .all(f64::is_finite)
+        {
+            return None;
+        }
+        let physical = |value: f64| (value * pixels_per_point).round() as i32;
+        let left = physical(left);
+        let top = physical(top);
+        let right = physical(right);
+        let bottom = physical(bottom);
+        let width = right - left;
+        let height = bottom - top;
+        if width <= 0 || height <= 0 {
+            return None;
+        }
+        Some(Self {
+            local_x: physical(pointer_x) - left,
+            local_y: physical(pointer_y) - top,
+            width,
+            height,
+        })
+    }
+
+    fn from_egui(rect: egui::Rect, pointer: egui::Pos2, pixels_per_point: f32) -> Option<Self> {
+        Self::from_logical(
+            f64::from(rect.left()),
+            f64::from(rect.top()),
+            f64::from(rect.right()),
+            f64::from(rect.bottom()),
+            f64::from(pointer.x),
+            f64::from(pointer.y),
+            f64::from(pixels_per_point),
+        )
+    }
+}
+
+pub(crate) fn admitted_initial_position(requested: i64, maximum: u8) -> u8 {
+    u8::try_from(requested)
+        .ok()
+        .filter(|value| *value <= maximum)
+        .unwrap_or(0)
+}
+
+pub(crate) fn admitted_volume_position(volume: f32) -> u8 {
+    let request = f64::from(volume) * 10.0 + 0.5;
+    if !request.is_finite() {
+        return 0;
+    }
+    admitted_initial_position(request.trunc() as i64, 10)
+}
+
+/// gamemd-derived: `TrackBar_ProcessMouse @ 0x0061D950` uses the literal
+/// reserve/13/12/6 geometry and `(range + 1)` integer partition below.
+pub(crate) fn trackbar_position_from_x(
+    raw_mouse_x: i32,
+    client_width: i32,
+    plaque_reserve: i32,
+    maximum: u8,
+) -> u8 {
+    let usable_span = (client_width - plaque_reserve - 13).max(1);
+    let maximum_track_x = (client_width - plaque_reserve - 12).max(1);
+    let track_x = (raw_mouse_x - 6).clamp(1, maximum_track_x);
+    let relative = ((track_x - 1) * (i32::from(maximum) + 1)) / usable_span;
+    relative.min(i32::from(maximum)) as u8
+}
+
+fn thumb_left(position: u8, client_width: i32, reserve: i32, maximum: u8) -> i32 {
+    let usable_span = (client_width - reserve - 13).max(1);
+    1 + i32::from(position) * usable_span / (i32::from(maximum) + 1)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct OptionsDialogState {
+    labels: LauncherOptionsLabels,
+    values: LauncherOptionsValues,
+    resolution_rows: Vec<LauncherResolutionRow>,
+    selected_resolution: Option<usize>,
+    resolution_popup_open: bool,
+    launcher_audio_available: bool,
+    detail_caption: String,
+    difficulty_caption: String,
+    scroll_caption: String,
+    capture: Option<LauncherTrackbarId>,
+    pending_events: Vec<LauncherOptionsEvent>,
+    pending_result: Option<LauncherParentResult>,
+}
+
+impl Default for OptionsDialogState {
+    fn default() -> Self {
+        let labels = LauncherOptionsLabels::resolve(&|_, fallback| fallback.to_string());
+        Self::new(labels, LauncherOptionsValues::default(), Vec::new(), None, false)
+    }
+}
+
+impl OptionsDialogState {
+    pub(crate) fn new(
+        labels: LauncherOptionsLabels,
+        mut values: LauncherOptionsValues,
+        resolution_rows: Vec<LauncherResolutionRow>,
+        selected_resolution: Option<usize>,
+        launcher_audio_available: bool,
+    ) -> Self {
+        values.detail_position = admitted_initial_position(i64::from(values.detail_position), 1);
+        values.difficulty_position =
+            admitted_initial_position(i64::from(values.difficulty_position), 2);
+        values.scroll_position = admitted_initial_position(i64::from(values.scroll_position), 6);
+        values.score_position = admitted_initial_position(i64::from(values.score_position), 10);
+        values.sound_position = admitted_initial_position(i64::from(values.sound_position), 10);
+        values.voice_position = admitted_initial_position(i64::from(values.voice_position), 10);
+        let selected_resolution =
+            selected_resolution.filter(|index| *index < resolution_rows.len());
+        Self {
+            detail_caption: labels.higher_detail.clone(),
+            difficulty_caption: labels.harder.clone(),
+            scroll_caption: labels.faster.clone(),
+            labels,
+            values,
+            resolution_rows,
+            selected_resolution,
+            resolution_popup_open: false,
+            launcher_audio_available,
+            capture: None,
+            pending_events: Vec::new(),
+            pending_result: None,
+        }
+    }
+
+    pub(crate) const fn launcher_audio_available(&self) -> bool {
+        self.launcher_audio_available
+    }
+
+    pub(crate) fn pack(&self) -> LauncherOptionsPacked {
+        LauncherOptionsPacked {
+            detail_level: if self.values.detail_position == 0 {
+                0
+            } else {
+                2
+            },
+            difficulty: i32::from(self.values.difficulty_position),
+            unit_action_lines: self.values.target_lines,
+            show_hidden: self.values.show_hidden,
+            tooltips: self.values.tooltips,
+            scroll_rate: 6 - i32::from(self.values.scroll_position),
+            score_volume: f32::from(self.values.score_position) * 0.1,
+            sound_volume: f32::from(self.values.sound_position) * 0.1,
+            voice_volume: f32::from(self.values.voice_position) * 0.1,
+        }
+    }
+
+    pub(crate) fn trackbar_position(&self, id: LauncherTrackbarId) -> u8 {
+        match id {
+            LauncherTrackbarId::Detail => self.values.detail_position,
+            LauncherTrackbarId::Difficulty => self.values.difficulty_position,
+            LauncherTrackbarId::Scroll => self.values.scroll_position,
+            LauncherTrackbarId::Score => self.values.score_position,
+            LauncherTrackbarId::Sound => self.values.sound_position,
+            LauncherTrackbarId::Voice => self.values.voice_position,
+        }
+    }
+
+    fn set_trackbar_position(&mut self, id: LauncherTrackbarId, position: u8) {
+        if position > id.maximum() || (id.is_audio() && !self.launcher_audio_available) {
+            return;
+        }
+        let slot = match id {
+            LauncherTrackbarId::Detail => &mut self.values.detail_position,
+            LauncherTrackbarId::Difficulty => &mut self.values.difficulty_position,
+            LauncherTrackbarId::Scroll => &mut self.values.scroll_position,
+            LauncherTrackbarId::Score => &mut self.values.score_position,
+            LauncherTrackbarId::Sound => &mut self.values.sound_position,
+            LauncherTrackbarId::Voice => &mut self.values.voice_position,
+        };
+        if *slot == position {
+            return;
+        }
+        *slot = position;
+        match id {
+            LauncherTrackbarId::Detail => {
+                self.detail_caption = if position == 0 {
+                    self.labels.low.clone()
+                } else {
+                    self.labels.high.clone()
+                };
+                self.pending_events
+                    .push(LauncherOptionsEvent::Cue(LauncherCue::GenericClick));
+            }
+            LauncherTrackbarId::Difficulty => {
+                self.difficulty_caption = match position {
+                    0 => self.labels.easy.clone(),
+                    1 => self.labels.normal.clone(),
+                    _ => self.labels.hard.clone(),
+                };
+                self.pending_events
+                    .push(LauncherOptionsEvent::Cue(LauncherCue::GenericClick));
+            }
+            LauncherTrackbarId::Scroll => {
+                self.scroll_caption = self.labels.scroll_tokens[usize::from(position)].clone();
+                self.pending_events
+                    .push(LauncherOptionsEvent::Cue(LauncherCue::GenericClick));
+            }
+            LauncherTrackbarId::Score => self.pending_events.push(
+                LauncherOptionsEvent::ScorePreview(f32::from(position) * 0.1),
+            ),
+            LauncherTrackbarId::Sound => self.pending_events.push(
+                LauncherOptionsEvent::SoundPreview(f32::from(position) * 0.1),
+            ),
+            LauncherTrackbarId::Voice => self.pending_events.push(
+                LauncherOptionsEvent::VoicePreview(f32::from(position) * 0.1),
+            ),
+        }
+    }
+
+    /// gamemd-derived: the initial down row of `TrackBar_ProcessMouse @
+    /// 0x0061D950` requires `y > bottom - 18`; thumb-down captures without a
+    /// jump, while a rail down jumps once and does not capture.
+    pub(crate) fn trackbar_mouse_down(
+        &mut self,
+        id: LauncherTrackbarId,
+        frame: PhysicalControlFrame,
+    ) {
+        if (id.is_audio() && !self.launcher_audio_available)
+            || frame.local_x < 0
+            || frame.local_x >= frame.width
+            || frame.local_y <= frame.height - 18
+            || frame.local_y >= frame.height
+        {
+            return;
+        }
+        let left = thumb_left(
+            self.trackbar_position(id),
+            frame.width,
+            id.plaque_reserve(),
+            id.maximum(),
+        );
+        if (left..left + 12).contains(&frame.local_x) {
+            self.capture = Some(id);
+            return;
+        }
+        let position = trackbar_position_from_x(
+            frame.local_x,
+            frame.width,
+            id.plaque_reserve(),
+            id.maximum(),
+        );
+        self.set_trackbar_position(id, position);
+    }
+
+    pub(crate) fn trackbar_mouse_move(
+        &mut self,
+        id: LauncherTrackbarId,
+        frame: PhysicalControlFrame,
+    ) {
+        if self.capture != Some(id) {
+            return;
+        }
+        let position = trackbar_position_from_x(
+            frame.local_x,
+            frame.width,
+            id.plaque_reserve(),
+            id.maximum(),
+        );
+        self.set_trackbar_position(id, position);
+    }
+
+    pub(crate) fn trackbar_mouse_up(&mut self, id: LauncherTrackbarId) {
+        if self.capture == Some(id) {
+            self.capture = None;
+        }
+    }
+
+    /// gamemd-derived: checkbox owner `0x006163A0` admits only the unsigned
+    /// 18x18 icon square, normalizes the toggle, then emits the checkbox cue.
+    pub(crate) fn checkbox_mouse_down(
+        &mut self,
+        id: LauncherCheckboxId,
+        frame: PhysicalControlFrame,
+    ) {
+        if !(0..18).contains(&frame.local_x) || !(0..18).contains(&frame.local_y) {
+            return;
+        }
+        let slot = match id {
+            LauncherCheckboxId::Tooltips => &mut self.values.tooltips,
+            LauncherCheckboxId::TargetLines => &mut self.values.target_lines,
+            LauncherCheckboxId::ShowHidden => &mut self.values.show_hidden,
+        };
+        *slot = !*slot;
+        self.pending_events
+            .push(LauncherOptionsEvent::Cue(LauncherCue::Checkbox));
+    }
+
+    /// gamemd-derived: combo owner `0x00617250` emits GUIComboOpen before its
+    /// strict `x > client_width - 20` arrow admission test.
+    pub(crate) fn combo_mouse_down(&mut self, frame: PhysicalControlFrame) {
+        if frame.local_x < 0
+            || frame.local_x >= frame.width
+            || frame.local_y < 0
+            || frame.local_y >= frame.height
+        {
+            return;
+        }
+        self.pending_events
+            .push(LauncherOptionsEvent::Cue(LauncherCue::ComboOpen));
+        if frame.local_x > frame.width - 20 {
+            self.resolution_popup_open = !self.resolution_popup_open;
+        }
+    }
+
+    pub(crate) fn select_resolution(&mut self, index: usize) {
+        let Some(row) = self.resolution_rows.get(index) else {
+            return;
+        };
+        self.selected_resolution = Some(index);
+        self.resolution_popup_open = false;
+        self.pending_events
+            .push(LauncherOptionsEvent::ResolutionSelected {
+                width: row.width,
+                height: row.height,
+            });
+    }
+
+    pub(crate) fn request_result(&mut self, result: LauncherParentResult) {
+        if self.pending_result.is_none() {
+            self.pending_result = Some(result);
+        }
+    }
+
+    pub(crate) fn drain_output(&mut self) -> LauncherOptionsFrameOutput {
+        LauncherOptionsFrameOutput {
+            events: std::mem::take(&mut self.pending_events),
+            result: self.pending_result.take(),
+        }
+    }
+
+    fn selected_resolution_label(&self) -> &str {
+        self.selected_resolution
+            .and_then(|index| self.resolution_rows.get(index))
+            .map_or("", |row| row.label.as_str())
+    }
+}
+
+pub(crate) fn draw_launcher_options_dialog(
+    ctx: &egui::Context,
+    state: &mut OptionsDialogState,
+) -> LauncherOptionsFrameOutput {
+    let palette = client_theme::apply_client_theme(ctx);
+    super::draw_backdrop(ctx, "options_backdrop");
+
+    egui::Window::new("")
+        .title_bar(false)
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+        .frame(client_theme::card_frame(palette.panel, palette.line))
+        .min_width(720.0)
+        .show(ctx, |ui| {
+            ui.set_max_width(720.0);
+            ui.horizontal_top(|ui| {
+                ui.set_width(540.0);
+                ui.vertical(|ui| {
+                    draw_display_group(ui, state, palette);
+                    ui.add_space(10.0);
+                    draw_game_group(ui, state, palette);
+                    ui.add_space(10.0);
+                    draw_ui_group(ui, state, palette);
+                    ui.add_space(10.0);
+                    draw_audio_group(ui, state, palette);
+                    if !state.labels.blank.is_empty() {
+                        ui.label(&state.labels.blank);
+                    }
+                });
+                ui.separator();
+                ui.vertical_centered_justified(|ui| {
+                    ui.heading(&state.labels.options);
+                    ui.add_space(18.0);
+                    if ui.button(&state.labels.keyboard).clicked() {
+                        state.request_result(LauncherParentResult::Keyboard);
+                    }
+                    if ui.button(&state.labels.network).clicked() {
+                        state.request_result(LauncherParentResult::Network);
+                    }
+                    ui.add_space(36.0);
+                    if ui.button(&state.labels.main_menu).clicked() {
+                        state.request_result(LauncherParentResult::Back);
+                    }
+                });
+            });
+        });
+
+    state.drain_output()
+}
+
+fn draw_display_group(
+    ui: &mut egui::Ui,
+    state: &mut OptionsDialogState,
+    palette: client_theme::ClientPalette,
+) {
+    client_theme::section_label(ui, &state.labels.display_options, palette);
+    ui.columns(2, |columns| {
+        columns[0].label(format!(
+            "{} — {}",
+            state.labels.visual_details, state.detail_caption
+        ));
+        draw_trackbar(
+            &mut columns[0],
+            state,
+            LauncherTrackbarId::Detail,
+            180.0,
+            palette,
+        );
+
+        columns[1].label(&state.labels.set_resolution);
+        draw_resolution_combo(&mut columns[1], state, palette);
+    });
+}
+
+fn draw_game_group(
+    ui: &mut egui::Ui,
+    state: &mut OptionsDialogState,
+    palette: client_theme::ClientPalette,
+) {
+    client_theme::section_label(ui, &state.labels.game_options, palette);
+    ui.label(format!(
+        "{} — {}",
+        state.labels.difficulty, state.difficulty_caption
+    ));
+    draw_trackbar(ui, state, LauncherTrackbarId::Difficulty, 180.0, palette);
+}
+
+fn draw_ui_group(
+    ui: &mut egui::Ui,
+    state: &mut OptionsDialogState,
+    palette: client_theme::ClientPalette,
+) {
+    client_theme::section_label(ui, &state.labels.ui_options, palette);
+    ui.columns(2, |columns| {
+        let tooltips = state.labels.tooltips.clone();
+        let target_lines = state.labels.target_lines.clone();
+        let show_hidden = state.labels.show_hidden.clone();
+        draw_checkbox(
+            &mut columns[0],
+            state,
+            LauncherCheckboxId::Tooltips,
+            &tooltips,
+            palette,
+        );
+        draw_checkbox(
+            &mut columns[0],
+            state,
+            LauncherCheckboxId::TargetLines,
+            &target_lines,
+            palette,
+        );
+        draw_checkbox(
+            &mut columns[0],
+            state,
+            LauncherCheckboxId::ShowHidden,
+            &show_hidden,
+            palette,
+        );
+
+        columns[1].label(format!(
+            "{} — {}",
+            state.labels.scroll_rate, state.scroll_caption
+        ));
+        draw_trackbar(
+            &mut columns[1],
+            state,
+            LauncherTrackbarId::Scroll,
+            180.0,
+            palette,
+        );
+    });
+}
+
+fn draw_audio_group(
+    ui: &mut egui::Ui,
+    state: &mut OptionsDialogState,
+    palette: client_theme::ClientPalette,
+) {
+    client_theme::section_label(ui, &state.labels.audio_options, palette);
+    ui.columns(3, |columns| {
+        columns[0].label(&state.labels.music_volume);
+        draw_trackbar(
+            &mut columns[0],
+            state,
+            LauncherTrackbarId::Score,
+            128.0,
+            palette,
+        );
+        columns[1].label(&state.labels.sound_volume);
+        draw_trackbar(
+            &mut columns[1],
+            state,
+            LauncherTrackbarId::Sound,
+            128.0,
+            palette,
+        );
+        columns[2].label(&state.labels.voice_volume);
+        draw_trackbar(
+            &mut columns[2],
+            state,
+            LauncherTrackbarId::Voice,
+            128.0,
+            palette,
+        );
+    });
+}
+
+fn draw_trackbar(
+    ui: &mut egui::Ui,
+    state: &mut OptionsDialogState,
+    id: LauncherTrackbarId,
+    width: f32,
+    palette: client_theme::ClientPalette,
+) {
+    let enabled = !id.is_audio() || state.launcher_audio_available;
+    let (rect, response) =
+        ui.allocate_exact_size(egui::vec2(width, 24.0), egui::Sense::click_and_drag());
+    let rail_color = if enabled {
+        palette.line
+    } else {
+        palette.text_muted.gamma_multiply(0.45)
+    };
+    ui.painter().rect_filled(
+        egui::Rect::from_min_max(
+            egui::pos2(rect.left() + 6.0, rect.center().y - 2.0),
+            egui::pos2(
+                rect.right() - f32::from(id.plaque_reserve() as i16) - 6.0,
+                rect.center().y + 2.0,
+            ),
+        ),
+        1.0,
+        rail_color,
+    );
+    let fraction = f32::from(state.trackbar_position(id)) / f32::from(id.maximum());
+    let travel = (rect.width() - id.plaque_reserve() as f32 - 13.0).max(1.0);
+    let thumb_left = rect.left() + 1.0 + fraction * travel;
+    ui.painter().rect_filled(
+        egui::Rect::from_min_size(
+            egui::pos2(thumb_left, rect.top() + 1.0),
+            egui::vec2(12.0, 22.0),
+        ),
+        2.0,
+        if enabled {
+            palette.accent
+        } else {
+            palette.text_muted
+        },
+    );
+
+    let (pointer, pressed, released, down) = ui.input(|input| {
+        (
+            input.pointer.interact_pos(),
+            input.pointer.button_pressed(egui::PointerButton::Primary),
+            input.pointer.button_released(egui::PointerButton::Primary),
+            input.pointer.button_down(egui::PointerButton::Primary),
+        )
+    });
+    if let Some(pointer) = pointer
+        && let Some(frame) =
+            PhysicalControlFrame::from_egui(rect, pointer, ui.ctx().pixels_per_point())
+    {
+        if pressed && response.contains_pointer() {
+            state.trackbar_mouse_down(id, frame);
+        } else if down {
+            state.trackbar_mouse_move(id, frame);
+        }
+    }
+    if released {
+        state.trackbar_mouse_up(id);
+    }
+}
+
+fn draw_checkbox(
+    ui: &mut egui::Ui,
+    state: &mut OptionsDialogState,
+    id: LauncherCheckboxId,
+    label: &str,
+    palette: client_theme::ClientPalette,
+) {
+    let (rect, response) = ui.allocate_exact_size(egui::vec2(220.0, 20.0), egui::Sense::click());
+    let checked = match id {
+        LauncherCheckboxId::Tooltips => state.values.tooltips,
+        LauncherCheckboxId::TargetLines => state.values.target_lines,
+        LauncherCheckboxId::ShowHidden => state.values.show_hidden,
+    };
+    let icon = egui::Rect::from_min_size(rect.min, egui::vec2(18.0, 18.0));
+    ui.painter().rect_stroke(
+        icon,
+        1.0,
+        egui::Stroke::new(1.0, palette.line),
+        egui::StrokeKind::Middle,
+    );
+    if checked {
+        ui.painter().line_segment(
+            [
+                icon.left_top() + egui::vec2(3.0, 9.0),
+                icon.center_bottom() - egui::vec2(0.0, 3.0),
+            ],
+            egui::Stroke::new(2.0, palette.accent),
+        );
+        ui.painter().line_segment(
+            [
+                icon.center_bottom() - egui::vec2(0.0, 3.0),
+                icon.right_top() + egui::vec2(-2.0, 3.0),
+            ],
+            egui::Stroke::new(2.0, palette.accent),
+        );
+    }
+    ui.painter().text(
+        rect.min + egui::vec2(26.0, 1.0),
+        egui::Align2::LEFT_TOP,
+        label,
+        egui::FontId::proportional(13.0),
+        palette.text,
+    );
+    let pressed = ui.input(|input| input.pointer.button_pressed(egui::PointerButton::Primary));
+    if pressed
+        && response.contains_pointer()
+        && let Some(pointer) = ui.input(|input| input.pointer.interact_pos())
+        && let Some(frame) =
+            PhysicalControlFrame::from_egui(rect, pointer, ui.ctx().pixels_per_point())
+    {
+        state.checkbox_mouse_down(id, frame);
+    }
+}
+
+fn draw_resolution_combo(
+    ui: &mut egui::Ui,
+    state: &mut OptionsDialogState,
+    palette: client_theme::ClientPalette,
+) {
+    let (rect, response) = ui.allocate_exact_size(egui::vec2(180.0, 24.0), egui::Sense::click());
+    ui.painter().rect_filled(rect, 1.0, palette.panel_alt);
+    ui.painter().rect_stroke(
+        rect,
+        1.0,
+        egui::Stroke::new(1.0, palette.line),
+        egui::StrokeKind::Middle,
+    );
+    ui.painter().text(
+        rect.min + egui::vec2(3.0, 4.0),
+        egui::Align2::LEFT_TOP,
+        state.selected_resolution_label(),
+        egui::FontId::proportional(13.0),
+        palette.text,
+    );
+    ui.painter().text(
+        egui::pos2(rect.right() - 10.0, rect.center().y),
+        egui::Align2::CENTER_CENTER,
+        "▼",
+        egui::FontId::proportional(12.0),
+        palette.text,
+    );
+    let pressed = ui.input(|input| input.pointer.button_pressed(egui::PointerButton::Primary));
+    if pressed
+        && response.contains_pointer()
+        && let Some(pointer) = ui.input(|input| input.pointer.interact_pos())
+        && let Some(frame) =
+            PhysicalControlFrame::from_egui(rect, pointer, ui.ctx().pixels_per_point())
+    {
+        state.combo_mouse_down(frame);
+    }
+    if state.resolution_popup_open {
+        let rows: Vec<(usize, String, bool)> = state
+            .resolution_rows
+            .iter()
+            .enumerate()
+            .map(|(index, row)| {
+                (
+                    index,
+                    row.label.clone(),
+                    state.selected_resolution == Some(index),
+                )
+            })
+            .collect();
+        egui::Frame::popup(ui.style()).show(ui, |ui| {
+            for (index, label, selected) in rows {
+                if ui.selectable_label(selected, label).clicked() {
+                    state.select_resolution(index);
+                }
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels() -> LauncherOptionsLabels {
+        LauncherOptionsLabels::resolve(&|_, fallback| fallback.to_string())
+    }
+
+    fn state(audio: bool) -> OptionsDialogState {
+        OptionsDialogState::new(
+            labels(),
+            LauncherOptionsValues::default(),
+            vec![
+                LauncherResolutionRow::new(800, 600),
+                LauncherResolutionRow::new(1024, 768),
+            ],
+            Some(1),
+            audio,
+        )
+    }
+
+    fn frame(x: i32, y: i32, width: i32, height: i32) -> PhysicalControlFrame {
+        PhysicalControlFrame {
+            local_x: x,
+            local_y: y,
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn exact_launcher_label_fallbacks_are_local_and_complete() {
+        let seen = std::cell::RefCell::new(Vec::new());
+        let labels = LauncherOptionsLabels::resolve(&|key, fallback| {
+            seen.borrow_mut()
+                .push((key.to_string(), fallback.to_string()));
+            fallback.to_string()
+        });
+        assert_eq!(
+            seen.into_inner(),
+            LAUNCHER_LABEL_SPECS.map(|(key, fallback)| (key.to_string(), fallback.to_string()))
+        );
+        assert_eq!(labels.options, "Options");
+        assert_eq!(labels.main_menu, "Main Menu");
+        assert_eq!(labels.blank, "");
+        assert_eq!(labels.scroll_tokens[6], "Fastest");
+    }
+
+    #[test]
+    fn descriptor_preserves_region_order_and_omits_dormant_603() {
+        assert_eq!(LAUNCHER_DESCRIPTOR[0].region, LauncherRegion::Display);
+        assert_eq!(LAUNCHER_DESCRIPTOR[2].region, LauncherRegion::Game);
+        assert_eq!(LAUNCHER_DESCRIPTOR[3].region, LauncherRegion::Ui);
+        assert_eq!(LAUNCHER_DESCRIPTOR[7].region, LauncherRegion::Audio);
+        assert_eq!(LAUNCHER_DESCRIPTOR[10].region, LauncherRegion::RightRail);
+        assert_eq!(LAUNCHER_DESCRIPTOR[13].region, LauncherRegion::Footer);
+        assert!(!LAUNCHER_DESCRIPTOR.iter().any(|entry| entry.id == 0x603));
+        assert_eq!(
+            LAUNCHER_DESCRIPTOR[7..10]
+                .iter()
+                .map(|entry| entry.id)
+                .collect::<Vec<_>>(),
+            [0x52F, 0x532, 0x536]
+        );
+    }
+
+    #[test]
+    fn initial_captions_ignore_positions_and_only_changed_values_swap_tokens() {
+        let mut state = OptionsDialogState::new(
+            labels(),
+            LauncherOptionsValues {
+                detail_position: 0,
+                difficulty_position: 2,
+                scroll_position: 0,
+                ..Default::default()
+            },
+            Vec::new(),
+            None,
+            true,
+        );
+        assert_eq!(state.detail_caption, "Higher");
+        assert_eq!(state.difficulty_caption, "Harder");
+        assert_eq!(state.scroll_caption, "Faster");
+
+        state.set_trackbar_position(LauncherTrackbarId::Detail, 1);
+        state.set_trackbar_position(LauncherTrackbarId::Difficulty, 2);
+        state.set_trackbar_position(LauncherTrackbarId::Scroll, 6);
+        assert_eq!(state.detail_caption, "High");
+        assert_eq!(
+            state.difficulty_caption, "Harder",
+            "unchanged move retains resource caption"
+        );
+        assert_eq!(state.scroll_caption, "Fastest");
+        assert_eq!(
+            state.drain_output().events,
+            [
+                LauncherOptionsEvent::Cue(LauncherCue::GenericClick),
+                LauncherOptionsEvent::Cue(LauncherCue::GenericClick),
+            ]
+        );
+    }
+
+    #[test]
+    fn initial_control_requests_reject_out_of_range_and_nonfinite_volume() {
+        assert_eq!(admitted_initial_position(-1, 6), 0);
+        assert_eq!(admitted_initial_position(7, 6), 0);
+        assert_eq!(admitted_initial_position(6, 6), 6);
+        assert_eq!(admitted_volume_position(0.74), 7);
+        assert_eq!(admitted_volume_position(0.75), 8);
+        assert_eq!(admitted_volume_position(-0.2), 0);
+        assert_eq!(admitted_volume_position(1.1), 0);
+        assert_eq!(admitted_volume_position(f32::NAN), 0);
+        assert_eq!(admitted_volume_position(f32::INFINITY), 0);
+    }
+
+    #[test]
+    fn physical_frame_rounds_global_edges_before_subtraction_at_common_scales() {
+        for scale in [1.0, 1.25, 1.5, 2.0] {
+            let frame =
+                PhysicalControlFrame::from_logical(10.25, 20.25, 28.25, 38.25, 27.25, 37.25, scale)
+                    .unwrap();
+            assert_eq!(
+                frame.width,
+                (28.25_f64 * scale).round() as i32 - (10.25_f64 * scale).round() as i32
+            );
+            assert_eq!(
+                frame.height,
+                (38.25_f64 * scale).round() as i32 - (20.25_f64 * scale).round() as i32
+            );
+            assert_eq!(
+                frame.local_x,
+                (27.25_f64 * scale).round() as i32 - (10.25_f64 * scale).round() as i32
+            );
+            assert_eq!(
+                frame.local_y,
+                (37.25_f64 * scale).round() as i32 - (20.25_f64 * scale).round() as i32
+            );
+        }
+        assert!(PhysicalControlFrame::from_logical(0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0).is_none());
+        assert!(
+            PhysicalControlFrame::from_logical(0.0, 0.0, 1.0, 1.0, 0.0, 0.0, f64::NAN).is_none()
+        );
+    }
+
+    #[test]
+    fn trackbar_formula_matches_all_canonical_d5_thresholds() {
+        let cases = [
+            (180, 0, 1, vec![(90, 0), (91, 1)]),
+            (180, 0, 2, vec![(62, 0), (63, 1), (118, 1), (119, 2)]),
+            (
+                180,
+                0,
+                6,
+                vec![
+                    (30, 0),
+                    (31, 1),
+                    (55, 2),
+                    (79, 3),
+                    (103, 4),
+                    (127, 5),
+                    (151, 6),
+                ],
+            ),
+            (
+                128,
+                50,
+                10,
+                vec![
+                    (12, 0),
+                    (13, 1),
+                    (19, 2),
+                    (25, 3),
+                    (31, 4),
+                    (37, 5),
+                    (43, 6),
+                    (49, 7),
+                    (55, 8),
+                    (61, 9),
+                    (67, 10),
+                ],
+            ),
+        ];
+        for (width, reserve, maximum, samples) in cases {
+            for (x, expected) in samples {
+                assert_eq!(
+                    trackbar_position_from_x(x, width, reserve, maximum),
+                    expected,
+                    "width={width} reserve={reserve} x={x}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn thumb_down_captures_without_jump_and_captured_motion_is_x_only() {
+        let mut state = state(true);
+        let before = state.trackbar_position(LauncherTrackbarId::Difficulty);
+        let left = thumb_left(before, 180, 0, 2);
+        state.trackbar_mouse_down(LauncherTrackbarId::Difficulty, frame(left + 5, 23, 180, 24));
+        assert_eq!(
+            state.trackbar_position(LauncherTrackbarId::Difficulty),
+            before
+        );
+        assert_eq!(state.capture, Some(LauncherTrackbarId::Difficulty));
+        state.trackbar_mouse_move(LauncherTrackbarId::Difficulty, frame(179, -400, 180, 24));
+        assert_eq!(state.trackbar_position(LauncherTrackbarId::Difficulty), 2);
+        state.trackbar_mouse_up(LauncherTrackbarId::Difficulty);
+        assert_eq!(state.capture, None);
+    }
+
+    #[test]
+    fn rail_jump_has_lower_strip_gate_and_never_captures() {
+        let mut state = state(true);
+        state.trackbar_mouse_down(LauncherTrackbarId::Scroll, frame(151, 6, 180, 24));
+        assert_eq!(
+            state.trackbar_position(LauncherTrackbarId::Scroll),
+            3,
+            "strict lower edge rejects"
+        );
+        state.trackbar_mouse_down(LauncherTrackbarId::Scroll, frame(151, 7, 180, 24));
+        assert_eq!(state.trackbar_position(LauncherTrackbarId::Scroll), 6);
+        assert_eq!(state.capture, None);
+    }
+
+    #[test]
+    fn common_audio_gate_rejects_every_audio_input_without_mutation() {
+        let mut state = state(false);
+        let before = state.values;
+        for id in [
+            LauncherTrackbarId::Score,
+            LauncherTrackbarId::Sound,
+            LauncherTrackbarId::Voice,
+        ] {
+            state.trackbar_mouse_down(id, frame(67, 23, 128, 24));
+            state.trackbar_mouse_move(id, frame(67, 23, 128, 24));
+        }
+        assert_eq!(state.values, before);
+        assert!(state.drain_output().events.is_empty());
+    }
+
+    #[test]
+    fn checkbox_hit_is_strict_icon_square_and_cue_follows_toggle() {
+        let mut state = state(true);
+        assert!(state.values.tooltips);
+        state.checkbox_mouse_down(LauncherCheckboxId::Tooltips, frame(17, 17, 220, 20));
+        assert!(!state.values.tooltips);
+        assert_eq!(
+            state.drain_output().events,
+            [LauncherOptionsEvent::Cue(LauncherCue::Checkbox)]
+        );
+        state.checkbox_mouse_down(LauncherCheckboxId::Tooltips, frame(18, 5, 220, 20));
+        state.checkbox_mouse_down(LauncherCheckboxId::Tooltips, frame(80, 5, 220, 20));
+        assert!(!state.values.tooltips);
+        assert!(state.drain_output().events.is_empty());
+    }
+
+    #[test]
+    fn combo_cues_before_strict_arrow_toggle_and_valid_selection() {
+        let mut state = state(true);
+        state.combo_mouse_down(frame(160, 5, 180, 24));
+        assert!(!state.resolution_popup_open, "strict edge does not open");
+        assert_eq!(
+            state.drain_output().events,
+            [LauncherOptionsEvent::Cue(LauncherCue::ComboOpen)]
+        );
+        state.combo_mouse_down(frame(161, 5, 180, 24));
+        assert!(state.resolution_popup_open);
+        state.select_resolution(99);
+        assert!(
+            state
+                .drain_output()
+                .events
+                .iter()
+                .all(|event| !matches!(event, LauncherOptionsEvent::ResolutionSelected { .. }))
+        );
+        state.select_resolution(0);
+        assert_eq!(
+            state.drain_output().events,
+            [LauncherOptionsEvent::ResolutionSelected {
+                width: 800,
+                height: 600
+            }]
+        );
+    }
+
+    #[test]
+    fn audio_changes_emit_preview_without_generic_click_and_pack_exact_values() {
+        let mut state = state(true);
+        state.set_trackbar_position(LauncherTrackbarId::Score, 0);
+        state.set_trackbar_position(LauncherTrackbarId::Sound, 5);
+        state.set_trackbar_position(LauncherTrackbarId::Voice, 6);
+        assert_eq!(
+            state.drain_output().events,
+            [
+                LauncherOptionsEvent::ScorePreview(0.0),
+                LauncherOptionsEvent::SoundPreview(0.5),
+                LauncherOptionsEvent::VoicePreview(0.6),
+            ]
+        );
+        let packed = state.pack();
+        assert_eq!(packed.detail_level, 2);
+        assert_eq!(packed.difficulty, 1);
+        assert_eq!(packed.scroll_rate, 3);
+        assert_eq!(packed.score_volume.to_bits(), 0.0_f32.to_bits());
+        assert_eq!(packed.sound_volume.to_bits(), 0.5_f32.to_bits());
+        assert_eq!(packed.voice_volume.to_bits(), 0.6_f32.to_bits());
+    }
+
+    #[test]
+    fn escape_is_no_event_and_first_parent_result_wins_one_frame() {
+        let mut state = state(true);
+        assert!(state.drain_output().events.is_empty());
+        state.request_result(LauncherParentResult::Network);
+        state.request_result(LauncherParentResult::Back);
+        assert_eq!(
+            state.drain_output().result,
+            Some(LauncherParentResult::Network)
+        );
+        assert_eq!(state.drain_output().result, None);
+    }
+}

--- a/src/ui/main_menu_dialogs/options.rs
+++ b/src/ui/main_menu_dialogs/options.rs
@@ -3,9 +3,11 @@
 //! The parent owns bounded control state and emits ordered effects. It owns no
 //! profile, filesystem, audio device, window, or child-dialog callback.
 
-use super::CsfLookup;
 use crate::ui::client_theme;
 
+/// gamemd-derived: launcher owner `OptionsClass__ShowLauncherDialog @
+/// 0x0055FC80` and its primary-proc slice `0x0055FDB0..0x0056047A` bind the
+/// RT_DIALOG `0xD5` controls to these launcher-local CSF keys/fallbacks.
 pub(crate) const LAUNCHER_LABEL_SPECS: [(&str, &str); 34] = [
     ("GUI:OptionsMenu", "Options"),
     ("GUI:MainMenu", "Main Menu"),
@@ -76,10 +78,10 @@ pub(crate) struct LauncherOptionsLabels {
 }
 
 impl LauncherOptionsLabels {
-    pub(crate) fn resolve(csf: &CsfLookup<'_>) -> Self {
+    pub(crate) fn resolve(csf: &dyn Fn(&str) -> Option<String>) -> Self {
         let label = |index: usize| {
             let (key, fallback) = LAUNCHER_LABEL_SPECS[index];
-            csf(key, fallback)
+            csf(key).unwrap_or_else(|| fallback.to_string())
         };
         Self {
             options: label(0),
@@ -138,6 +140,9 @@ struct LauncherDescriptorEntry {
     region: LauncherRegion,
 }
 
+/// gamemd-derived: the `0xD5` resource hierarchy consumed by primary-proc
+/// slice `0x0055FDB0..0x0056047A`; dormant control `0x603` is not admitted by
+/// the active launcher owner `OptionsClass__ShowLauncherDialog @ 0x0055FC80`.
 const LAUNCHER_DESCRIPTOR: [LauncherDescriptorEntry; 15] = [
     LauncherDescriptorEntry {
         id: 0x52B,
@@ -248,6 +253,9 @@ pub(crate) enum LauncherCue {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+/// gamemd-derived: notification order in launcher primary-proc slice
+/// `0x0055FDB0..0x0056047A`; owner `OptionsClass__ShowLauncherDialog @
+/// 0x0055FC80` consumes these before any parent-result teardown.
 pub(crate) enum LauncherOptionsEvent {
     Cue(LauncherCue),
     ResolutionSelected { width: i32, height: i32 },
@@ -257,6 +265,9 @@ pub(crate) enum LauncherOptionsEvent {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// gamemd-derived: the distinct exits owned by
+/// `OptionsClass__ShowLauncherDialog @ 0x0055FC80`; every accepted result first
+/// projects through `OptionsClass__ApplyFromLauncherDialog @ 0x0055FAA0`.
 pub(crate) enum LauncherParentResult {
     Back,
     Network,
@@ -329,7 +340,164 @@ pub(crate) struct LauncherOptionsPacked {
     pub(crate) voice_volume: f32,
 }
 
-/// One integer-pixel control frame derived from egui's logical point geometry.
+const TRACKBAR_HEIGHT_PX: i32 = 24;
+const CHECKBOX_HEIGHT_PX: i32 = 20;
+const COMBO_HEIGHT_PX: i32 = 24;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PhysicalLocalRect {
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+}
+
+impl PhysicalLocalRect {
+    const fn from_min_size(left: i32, top: i32, width: i32, height: i32) -> Self {
+        Self {
+            left,
+            top,
+            right: left + width,
+            bottom: top + height,
+        }
+    }
+}
+
+/// One rounded physical-pixel control rectangle shared by native-style paint
+/// geometry and input admission. Each global edge is rounded before width and
+/// height subtraction, matching the Winit/egui boundary contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PhysicalControlRect {
+    left: i32,
+    top: i32,
+    right: i32,
+    bottom: i32,
+}
+
+impl PhysicalControlRect {
+    fn from_logical_edges(
+        left: f64,
+        top: f64,
+        right: f64,
+        bottom: f64,
+        pixels_per_point: f64,
+    ) -> Option<Self> {
+        if !pixels_per_point.is_finite()
+            || pixels_per_point <= 0.0
+            || ![left, top, right, bottom].into_iter().all(f64::is_finite)
+        {
+            return None;
+        }
+        let physical = |value: f64| (value * pixels_per_point).round() as i32;
+        let rect = Self {
+            left: physical(left),
+            top: physical(top),
+            right: physical(right),
+            bottom: physical(bottom),
+        };
+        (rect.width() > 0 && rect.height() > 0).then_some(rect)
+    }
+
+    fn from_egui(rect: egui::Rect, pixels_per_point: f32) -> Option<Self> {
+        Self::from_logical_edges(
+            f64::from(rect.left()),
+            f64::from(rect.top()),
+            f64::from(rect.right()),
+            f64::from(rect.bottom()),
+            f64::from(pixels_per_point),
+        )
+    }
+
+    const fn width(self) -> i32 {
+        self.right - self.left
+    }
+
+    const fn height(self) -> i32 {
+        self.bottom - self.top
+    }
+
+    fn frame_from_logical_pointer(
+        self,
+        pointer_x: f64,
+        pointer_y: f64,
+        pixels_per_point: f64,
+    ) -> Option<PhysicalControlFrame> {
+        if !pixels_per_point.is_finite()
+            || pixels_per_point <= 0.0
+            || !pointer_x.is_finite()
+            || !pointer_y.is_finite()
+        {
+            return None;
+        }
+        let physical = |value: f64| (value * pixels_per_point).round() as i32;
+        Some(PhysicalControlFrame {
+            local_x: physical(pointer_x) - self.left,
+            local_y: physical(pointer_y) - self.top,
+            width: self.width(),
+            height: self.height(),
+        })
+    }
+
+    fn local_rect_to_egui(self, rect: PhysicalLocalRect, pixels_per_point: f32) -> egui::Rect {
+        let point = |x: i32, y: i32| {
+            egui::pos2(
+                (self.left + x) as f32 / pixels_per_point,
+                (self.top + y) as f32 / pixels_per_point,
+            )
+        };
+        egui::Rect::from_min_max(point(rect.left, rect.top), point(rect.right, rect.bottom))
+    }
+
+    fn local_pos_to_egui(self, x: i32, y: i32, pixels_per_point: f32) -> egui::Pos2 {
+        egui::pos2(
+            (self.left + x) as f32 / pixels_per_point,
+            (self.top + y) as f32 / pixels_per_point,
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct TrackbarPaintGeometry {
+    rail: PhysicalLocalRect,
+    thumb: PhysicalLocalRect,
+}
+
+fn trackbar_paint_geometry(
+    control: PhysicalControlRect,
+    id: LauncherTrackbarId,
+    position: u8,
+) -> TrackbarPaintGeometry {
+    let width = control.width();
+    let height = control.height();
+    let rail_right = (width - id.plaque_reserve() - 6).max(6);
+    let rail_top = height / 2 - 2;
+    let thumb_top = (height - 22) / 2;
+    TrackbarPaintGeometry {
+        rail: PhysicalLocalRect {
+            left: 6,
+            top: rail_top,
+            right: rail_right,
+            bottom: rail_top + 4,
+        },
+        thumb: PhysicalLocalRect::from_min_size(
+            thumb_left(position, width, id.plaque_reserve(), id.maximum()),
+            thumb_top,
+            12,
+            22,
+        ),
+    }
+}
+
+fn points_for_physical_pixels(pixels: i32, pixels_per_point: f32) -> f32 {
+    if pixels_per_point.is_finite() && pixels_per_point > 0.0 {
+        pixels as f32 / pixels_per_point
+    } else {
+        pixels as f32
+    }
+}
+
+/// One integer-pixel input frame derived from the same rounded control
+/// rectangle that owns launcher custom-control paint geometry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PhysicalControlFrame {
     pub(crate) local_x: i32,
@@ -348,42 +516,8 @@ impl PhysicalControlFrame {
         pointer_y: f64,
         pixels_per_point: f64,
     ) -> Option<Self> {
-        if !pixels_per_point.is_finite()
-            || pixels_per_point <= 0.0
-            || ![left, top, right, bottom, pointer_x, pointer_y]
-                .into_iter()
-                .all(f64::is_finite)
-        {
-            return None;
-        }
-        let physical = |value: f64| (value * pixels_per_point).round() as i32;
-        let left = physical(left);
-        let top = physical(top);
-        let right = physical(right);
-        let bottom = physical(bottom);
-        let width = right - left;
-        let height = bottom - top;
-        if width <= 0 || height <= 0 {
-            return None;
-        }
-        Some(Self {
-            local_x: physical(pointer_x) - left,
-            local_y: physical(pointer_y) - top,
-            width,
-            height,
-        })
-    }
-
-    fn from_egui(rect: egui::Rect, pointer: egui::Pos2, pixels_per_point: f32) -> Option<Self> {
-        Self::from_logical(
-            f64::from(rect.left()),
-            f64::from(rect.top()),
-            f64::from(rect.right()),
-            f64::from(rect.bottom()),
-            f64::from(pointer.x),
-            f64::from(pointer.y),
-            f64::from(pixels_per_point),
-        )
+        PhysicalControlRect::from_logical_edges(left, top, right, bottom, pixels_per_point)?
+            .frame_from_logical_pointer(pointer_x, pointer_y, pixels_per_point)
     }
 }
 
@@ -440,12 +574,22 @@ pub(crate) struct OptionsDialogState {
 
 impl Default for OptionsDialogState {
     fn default() -> Self {
-        let labels = LauncherOptionsLabels::resolve(&|_, fallback| fallback.to_string());
-        Self::new(labels, LauncherOptionsValues::default(), Vec::new(), None, false)
+        let labels = LauncherOptionsLabels::resolve(&|_| None);
+        Self::new(
+            labels,
+            LauncherOptionsValues::default(),
+            Vec::new(),
+            None,
+            false,
+        )
     }
 }
 
 impl OptionsDialogState {
+    /// gamemd-derived: `OptionsClass__ShowLauncherDialog @ 0x0055FC80`
+    /// creates each fresh `0xD5` parent, while primary-proc slice
+    /// `0x0055FDB0..0x0056047A` admits initial positions and preserves the
+    /// resource Detail/Difficulty/Scroll captions until a changed notification.
     pub(crate) fn new(
         labels: LauncherOptionsLabels,
         mut values: LauncherOptionsValues,
@@ -482,6 +626,9 @@ impl OptionsDialogState {
         self.launcher_audio_available
     }
 
+    /// gamemd-derived: the parent snapshot consumed by
+    /// `OptionsClass__ApplyFromLauncherDialog @ 0x0055FAA0` maps the six
+    /// positions and three normalized checkboxes exactly as below.
     pub(crate) fn pack(&self) -> LauncherOptionsPacked {
         LauncherOptionsPacked {
             detail_level: if self.values.detail_position == 0 {
@@ -511,6 +658,9 @@ impl OptionsDialogState {
         }
     }
 
+    /// gamemd-derived: primary-proc slice `0x0055FDB0..0x0056047A` changes
+    /// captions and queues preview/cue work only after the integer position
+    /// actually changes; the accepted projection remains owned by `0x0055FAA0`.
     fn set_trackbar_position(&mut self, id: LauncherTrackbarId, position: u8) {
         if position > id.maximum() || (id.is_audio() && !self.launcher_audio_available) {
             return;
@@ -658,6 +808,9 @@ impl OptionsDialogState {
         }
     }
 
+    /// gamemd-derived: primary-proc slice `0x0055FDB0..0x0056047A` accepts only
+    /// a valid combo row and publishes its width/height immediately; final
+    /// accepted projection `0x0055FAA0` does not own the resolution pair.
     pub(crate) fn select_resolution(&mut self, index: usize) {
         let Some(row) = self.resolution_rows.get(index) else {
             return;
@@ -671,12 +824,18 @@ impl OptionsDialogState {
             });
     }
 
+    /// gamemd-derived: `OptionsClass__ShowLauncherDialog @ 0x0055FC80` gives
+    /// Back, Network, Keyboard, and terminal completion distinct parent
+    /// results; the first admitted result owns the frame's teardown path.
     pub(crate) fn request_result(&mut self, result: LauncherParentResult) {
         if self.pending_result.is_none() {
             self.pending_result = Some(result);
         }
     }
 
+    /// gamemd-derived: primary-proc slice `0x0055FDB0..0x0056047A` observes
+    /// control notifications in order before owner `0x0055FC80` dispatches a
+    /// parent result through accepted projection `0x0055FAA0`.
     pub(crate) fn drain_output(&mut self) -> LauncherOptionsFrameOutput {
         LauncherOptionsFrameOutput {
             events: std::mem::take(&mut self.pending_events),
@@ -867,39 +1026,37 @@ fn draw_trackbar(
     palette: client_theme::ClientPalette,
 ) {
     let enabled = !id.is_audio() || state.launcher_audio_available;
-    let (rect, response) =
-        ui.allocate_exact_size(egui::vec2(width, 24.0), egui::Sense::click_and_drag());
+    let pixels_per_point = ui.ctx().pixels_per_point();
+    let (rect, _response) = ui.allocate_exact_size(
+        egui::vec2(
+            width,
+            points_for_physical_pixels(TRACKBAR_HEIGHT_PX, pixels_per_point),
+        ),
+        egui::Sense::click_and_drag(),
+    );
+    let control = PhysicalControlRect::from_egui(rect, pixels_per_point);
     let rail_color = if enabled {
         palette.line
     } else {
         palette.text_muted.gamma_multiply(0.45)
     };
-    ui.painter().rect_filled(
-        egui::Rect::from_min_max(
-            egui::pos2(rect.left() + 6.0, rect.center().y - 2.0),
-            egui::pos2(
-                rect.right() - f32::from(id.plaque_reserve() as i16) - 6.0,
-                rect.center().y + 2.0,
-            ),
-        ),
-        1.0,
-        rail_color,
-    );
-    let fraction = f32::from(state.trackbar_position(id)) / f32::from(id.maximum());
-    let travel = (rect.width() - id.plaque_reserve() as f32 - 13.0).max(1.0);
-    let thumb_left = rect.left() + 1.0 + fraction * travel;
-    ui.painter().rect_filled(
-        egui::Rect::from_min_size(
-            egui::pos2(thumb_left, rect.top() + 1.0),
-            egui::vec2(12.0, 22.0),
-        ),
-        2.0,
-        if enabled {
-            palette.accent
-        } else {
-            palette.text_muted
-        },
-    );
+    if let Some(control) = control {
+        let geometry = trackbar_paint_geometry(control, id, state.trackbar_position(id));
+        ui.painter().rect_filled(
+            control.local_rect_to_egui(geometry.rail, pixels_per_point),
+            points_for_physical_pixels(1, pixels_per_point),
+            rail_color,
+        );
+        ui.painter().rect_filled(
+            control.local_rect_to_egui(geometry.thumb, pixels_per_point),
+            points_for_physical_pixels(2, pixels_per_point),
+            if enabled {
+                palette.accent
+            } else {
+                palette.text_muted
+            },
+        );
+    }
 
     let (pointer, pressed, released, down) = ui.input(|input| {
         (
@@ -910,10 +1067,14 @@ fn draw_trackbar(
         )
     });
     if let Some(pointer) = pointer
-        && let Some(frame) =
-            PhysicalControlFrame::from_egui(rect, pointer, ui.ctx().pixels_per_point())
+        && let Some(control) = control
+        && let Some(frame) = control.frame_from_logical_pointer(
+            f64::from(pointer.x),
+            f64::from(pointer.y),
+            f64::from(pixels_per_point),
+        )
     {
-        if pressed && response.contains_pointer() {
+        if pressed {
             state.trackbar_mouse_down(id, frame);
         } else if down {
             state.trackbar_mouse_move(id, frame);
@@ -931,48 +1092,70 @@ fn draw_checkbox(
     label: &str,
     palette: client_theme::ClientPalette,
 ) {
-    let (rect, response) = ui.allocate_exact_size(egui::vec2(220.0, 20.0), egui::Sense::click());
+    let pixels_per_point = ui.ctx().pixels_per_point();
+    let (rect, _response) = ui.allocate_exact_size(
+        egui::vec2(
+            220.0,
+            points_for_physical_pixels(CHECKBOX_HEIGHT_PX, pixels_per_point),
+        ),
+        egui::Sense::click(),
+    );
+    let control = PhysicalControlRect::from_egui(rect, pixels_per_point);
     let checked = match id {
         LauncherCheckboxId::Tooltips => state.values.tooltips,
         LauncherCheckboxId::TargetLines => state.values.target_lines,
         LauncherCheckboxId::ShowHidden => state.values.show_hidden,
     };
-    let icon = egui::Rect::from_min_size(rect.min, egui::vec2(18.0, 18.0));
-    ui.painter().rect_stroke(
-        icon,
-        1.0,
-        egui::Stroke::new(1.0, palette.line),
-        egui::StrokeKind::Middle,
-    );
-    if checked {
-        ui.painter().line_segment(
-            [
-                icon.left_top() + egui::vec2(3.0, 9.0),
-                icon.center_bottom() - egui::vec2(0.0, 3.0),
-            ],
-            egui::Stroke::new(2.0, palette.accent),
+    if let Some(control) = control {
+        let icon = PhysicalLocalRect::from_min_size(0, 0, 18, 18);
+        ui.painter().rect_stroke(
+            control.local_rect_to_egui(icon, pixels_per_point),
+            points_for_physical_pixels(1, pixels_per_point),
+            egui::Stroke::new(
+                points_for_physical_pixels(1, pixels_per_point),
+                palette.line,
+            ),
+            egui::StrokeKind::Middle,
         );
-        ui.painter().line_segment(
-            [
-                icon.center_bottom() - egui::vec2(0.0, 3.0),
-                icon.right_top() + egui::vec2(-2.0, 3.0),
-            ],
-            egui::Stroke::new(2.0, palette.accent),
+        if checked {
+            ui.painter().line_segment(
+                [
+                    control.local_pos_to_egui(3, 9, pixels_per_point),
+                    control.local_pos_to_egui(9, 15, pixels_per_point),
+                ],
+                egui::Stroke::new(
+                    points_for_physical_pixels(2, pixels_per_point),
+                    palette.accent,
+                ),
+            );
+            ui.painter().line_segment(
+                [
+                    control.local_pos_to_egui(9, 15, pixels_per_point),
+                    control.local_pos_to_egui(16, 3, pixels_per_point),
+                ],
+                egui::Stroke::new(
+                    points_for_physical_pixels(2, pixels_per_point),
+                    palette.accent,
+                ),
+            );
+        }
+        ui.painter().text(
+            control.local_pos_to_egui(26, 1, pixels_per_point),
+            egui::Align2::LEFT_TOP,
+            label,
+            egui::FontId::proportional(13.0),
+            palette.text,
         );
     }
-    ui.painter().text(
-        rect.min + egui::vec2(26.0, 1.0),
-        egui::Align2::LEFT_TOP,
-        label,
-        egui::FontId::proportional(13.0),
-        palette.text,
-    );
     let pressed = ui.input(|input| input.pointer.button_pressed(egui::PointerButton::Primary));
     if pressed
-        && response.contains_pointer()
         && let Some(pointer) = ui.input(|input| input.pointer.interact_pos())
-        && let Some(frame) =
-            PhysicalControlFrame::from_egui(rect, pointer, ui.ctx().pixels_per_point())
+        && let Some(control) = control
+        && let Some(frame) = control.frame_from_logical_pointer(
+            f64::from(pointer.x),
+            f64::from(pointer.y),
+            f64::from(pixels_per_point),
+        )
     {
         state.checkbox_mouse_down(id, frame);
     }
@@ -983,34 +1166,56 @@ fn draw_resolution_combo(
     state: &mut OptionsDialogState,
     palette: client_theme::ClientPalette,
 ) {
-    let (rect, response) = ui.allocate_exact_size(egui::vec2(180.0, 24.0), egui::Sense::click());
-    ui.painter().rect_filled(rect, 1.0, palette.panel_alt);
-    ui.painter().rect_stroke(
-        rect,
-        1.0,
-        egui::Stroke::new(1.0, palette.line),
-        egui::StrokeKind::Middle,
+    let pixels_per_point = ui.ctx().pixels_per_point();
+    let (rect, _response) = ui.allocate_exact_size(
+        egui::vec2(
+            180.0,
+            points_for_physical_pixels(COMBO_HEIGHT_PX, pixels_per_point),
+        ),
+        egui::Sense::click(),
     );
-    ui.painter().text(
-        rect.min + egui::vec2(3.0, 4.0),
-        egui::Align2::LEFT_TOP,
-        state.selected_resolution_label(),
-        egui::FontId::proportional(13.0),
-        palette.text,
-    );
-    ui.painter().text(
-        egui::pos2(rect.right() - 10.0, rect.center().y),
-        egui::Align2::CENTER_CENTER,
-        "▼",
-        egui::FontId::proportional(12.0),
-        palette.text,
-    );
+    let control = PhysicalControlRect::from_egui(rect, pixels_per_point);
+    if let Some(control) = control {
+        let face = PhysicalLocalRect::from_min_size(0, 0, control.width(), control.height());
+        let face = control.local_rect_to_egui(face, pixels_per_point);
+        ui.painter().rect_filled(
+            face,
+            points_for_physical_pixels(1, pixels_per_point),
+            palette.panel_alt,
+        );
+        ui.painter().rect_stroke(
+            face,
+            points_for_physical_pixels(1, pixels_per_point),
+            egui::Stroke::new(
+                points_for_physical_pixels(1, pixels_per_point),
+                palette.line,
+            ),
+            egui::StrokeKind::Middle,
+        );
+        ui.painter().text(
+            control.local_pos_to_egui(3, 4, pixels_per_point),
+            egui::Align2::LEFT_TOP,
+            state.selected_resolution_label(),
+            egui::FontId::proportional(13.0),
+            palette.text,
+        );
+        ui.painter().text(
+            control.local_pos_to_egui(control.width() - 10, control.height() / 2, pixels_per_point),
+            egui::Align2::CENTER_CENTER,
+            "▼",
+            egui::FontId::proportional(12.0),
+            palette.text,
+        );
+    }
     let pressed = ui.input(|input| input.pointer.button_pressed(egui::PointerButton::Primary));
     if pressed
-        && response.contains_pointer()
         && let Some(pointer) = ui.input(|input| input.pointer.interact_pos())
-        && let Some(frame) =
-            PhysicalControlFrame::from_egui(rect, pointer, ui.ctx().pixels_per_point())
+        && let Some(control) = control
+        && let Some(frame) = control.frame_from_logical_pointer(
+            f64::from(pointer.x),
+            f64::from(pointer.y),
+            f64::from(pixels_per_point),
+        )
     {
         state.combo_mouse_down(frame);
     }
@@ -1040,9 +1245,10 @@ fn draw_resolution_combo(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::assets::csf_file::CsfFile;
 
     fn labels() -> LauncherOptionsLabels {
-        LauncherOptionsLabels::resolve(&|_, fallback| fallback.to_string())
+        LauncherOptionsLabels::resolve(&|_| None)
     }
 
     fn state(audio: bool) -> OptionsDialogState {
@@ -1067,22 +1273,108 @@ mod tests {
         }
     }
 
+    fn physical_control(
+        scale: f64,
+        logical_width: f64,
+        physical_height: i32,
+    ) -> PhysicalControlRect {
+        PhysicalControlRect::from_logical_edges(
+            10.25,
+            20.25,
+            10.25 + logical_width,
+            20.25 + f64::from(physical_height) / scale,
+            scale,
+        )
+        .unwrap()
+    }
+
+    fn production_frame(
+        scale: f64,
+        logical_width: f64,
+        physical_height: i32,
+        local_x: i32,
+        local_y: i32,
+    ) -> PhysicalControlFrame {
+        let control = physical_control(scale, logical_width, physical_height);
+        PhysicalControlFrame::from_logical(
+            10.25,
+            20.25,
+            10.25 + logical_width,
+            20.25 + f64::from(physical_height) / scale,
+            f64::from(control.left + local_x) / scale,
+            f64::from(control.top + local_y) / scale,
+            scale,
+        )
+        .unwrap()
+    }
+
+    fn set_position_without_notification(
+        state: &mut OptionsDialogState,
+        id: LauncherTrackbarId,
+        position: u8,
+    ) {
+        match id {
+            LauncherTrackbarId::Detail => state.values.detail_position = position,
+            LauncherTrackbarId::Difficulty => state.values.difficulty_position = position,
+            LauncherTrackbarId::Scroll => state.values.scroll_position = position,
+            LauncherTrackbarId::Score => state.values.score_position = position,
+            LauncherTrackbarId::Sound => state.values.sound_position = position,
+            LauncherTrackbarId::Voice => state.values.voice_position = position,
+        }
+    }
+
+    fn build_single_label_csf(label: &str, value: &str) -> Vec<u8> {
+        let encoded_value: Vec<u8> = value
+            .encode_utf16()
+            .flat_map(u16::to_le_bytes)
+            .map(|byte| !byte)
+            .collect();
+        let mut data = Vec::new();
+        data.extend_from_slice(&0x4353_4620_u32.to_le_bytes());
+        data.extend_from_slice(&3_u32.to_le_bytes());
+        data.extend_from_slice(&1_u32.to_le_bytes());
+        data.extend_from_slice(&1_u32.to_le_bytes());
+        data.extend_from_slice(&0_u32.to_le_bytes());
+        data.extend_from_slice(&0_u32.to_le_bytes());
+        data.extend_from_slice(&0x4C42_4C20_u32.to_le_bytes());
+        data.extend_from_slice(&1_u32.to_le_bytes());
+        data.extend_from_slice(&(label.len() as u32).to_le_bytes());
+        data.extend_from_slice(label.as_bytes());
+        data.extend_from_slice(&0x5354_5220_u32.to_le_bytes());
+        data.extend_from_slice(&(value.encode_utf16().count() as u32).to_le_bytes());
+        data.extend_from_slice(&encoded_value);
+        data
+    }
+
     #[test]
     fn exact_launcher_label_fallbacks_are_local_and_complete() {
         let seen = std::cell::RefCell::new(Vec::new());
-        let labels = LauncherOptionsLabels::resolve(&|key, fallback| {
-            seen.borrow_mut()
-                .push((key.to_string(), fallback.to_string()));
-            fallback.to_string()
+        let labels = LauncherOptionsLabels::resolve(&|key| {
+            seen.borrow_mut().push(key.to_string());
+            None
         });
         assert_eq!(
             seen.into_inner(),
-            LAUNCHER_LABEL_SPECS.map(|(key, fallback)| (key.to_string(), fallback.to_string()))
+            LAUNCHER_LABEL_SPECS.map(|(key, _)| key.to_string())
         );
         assert_eq!(labels.options, "Options");
         assert_eq!(labels.main_menu, "Main Menu");
         assert_eq!(labels.blank, "");
         assert_eq!(labels.scroll_tokens[6], "Fastest");
+    }
+
+    #[test]
+    fn loaded_nonempty_csf_missing_launcher_key_uses_local_fallback() {
+        let csf = CsfFile::from_bytes(&build_single_label_csf(
+            "GUI:OptionsMenu",
+            "Localized Options",
+        ))
+        .unwrap();
+        assert!(!csf.is_empty());
+        let labels = LauncherOptionsLabels::resolve(&|key| csf.get(key).map(str::to_owned));
+        assert_eq!(labels.options, "Localized Options");
+        assert_eq!(labels.main_menu, "Main Menu");
+        assert_eq!(csf.text("GUI:MainMenu"), "MISSING:'GUI:MainMenu'");
     }
 
     #[test]
@@ -1179,6 +1471,104 @@ mod tests {
         assert!(
             PhysicalControlFrame::from_logical(0.0, 0.0, 1.0, 1.0, 0.0, 0.0, f64::NAN).is_none()
         );
+    }
+
+    #[test]
+    fn painted_thumb_centers_capture_and_drag_through_physical_frames_at_common_scales() {
+        let ids = [
+            LauncherTrackbarId::Detail,
+            LauncherTrackbarId::Difficulty,
+            LauncherTrackbarId::Scroll,
+            LauncherTrackbarId::Score,
+            LauncherTrackbarId::Sound,
+            LauncherTrackbarId::Voice,
+        ];
+        for scale in [1.0, 1.25, 1.5, 2.0] {
+            for id in ids {
+                let logical_width = if id.is_audio() { 128.0 } else { 180.0 };
+                let control = physical_control(scale, logical_width, TRACKBAR_HEIGHT_PX);
+                assert_eq!(control.height(), TRACKBAR_HEIGHT_PX);
+                for position in 0..=id.maximum() {
+                    let mut state = state(true);
+                    set_position_without_notification(&mut state, id, position);
+                    let geometry = trackbar_paint_geometry(control, id, position);
+                    assert_eq!(geometry.thumb.right - geometry.thumb.left, 12);
+                    assert_eq!(geometry.thumb.bottom - geometry.thumb.top, 22);
+                    let down = production_frame(
+                        scale,
+                        logical_width,
+                        TRACKBAR_HEIGHT_PX,
+                        (geometry.thumb.left + geometry.thumb.right) / 2,
+                        (geometry.thumb.top + geometry.thumb.bottom) / 2,
+                    );
+                    state.trackbar_mouse_down(id, down);
+                    assert_eq!(
+                        state.trackbar_position(id),
+                        position,
+                        "scale={scale} id={id:?}"
+                    );
+                    assert_eq!(state.capture, Some(id), "scale={scale} id={id:?}");
+
+                    let drag = production_frame(
+                        scale,
+                        logical_width,
+                        TRACKBAR_HEIGHT_PX,
+                        control.width() + 100,
+                        -400,
+                    );
+                    state.trackbar_mouse_move(id, drag);
+                    assert_eq!(state.trackbar_position(id), id.maximum());
+                    state.trackbar_mouse_up(id);
+                    assert_eq!(state.capture, None);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn checkbox_and_combo_paint_boundaries_drive_admission_at_common_scales() {
+        for scale in [1.0, 1.25, 1.5, 2.0] {
+            let checkbox = physical_control(scale, 220.0, CHECKBOX_HEIGHT_PX);
+            assert_eq!(checkbox.height(), CHECKBOX_HEIGHT_PX);
+            let mut checkbox_state = state(true);
+            checkbox_state.checkbox_mouse_down(
+                LauncherCheckboxId::Tooltips,
+                production_frame(scale, 220.0, CHECKBOX_HEIGHT_PX, 17, 17),
+            );
+            assert!(!checkbox_state.values.tooltips, "scale={scale}");
+            checkbox_state.drain_output();
+            checkbox_state.checkbox_mouse_down(
+                LauncherCheckboxId::Tooltips,
+                production_frame(scale, 220.0, CHECKBOX_HEIGHT_PX, 18, 5),
+            );
+            assert!(!checkbox_state.values.tooltips, "scale={scale}");
+            assert!(checkbox_state.drain_output().events.is_empty());
+
+            let combo = physical_control(scale, 180.0, COMBO_HEIGHT_PX);
+            assert_eq!(combo.height(), COMBO_HEIGHT_PX);
+            let arrow_left = combo.width() - 20;
+            let mut combo_state = state(true);
+            combo_state.combo_mouse_down(production_frame(
+                scale,
+                180.0,
+                COMBO_HEIGHT_PX,
+                arrow_left,
+                COMBO_HEIGHT_PX / 2,
+            ));
+            assert!(!combo_state.resolution_popup_open, "scale={scale}");
+            assert_eq!(
+                combo_state.drain_output().events,
+                [LauncherOptionsEvent::Cue(LauncherCue::ComboOpen)]
+            );
+            combo_state.combo_mouse_down(production_frame(
+                scale,
+                180.0,
+                COMBO_HEIGHT_PX,
+                arrow_left + 1,
+                COMBO_HEIGHT_PX / 2,
+            ));
+            assert!(combo_state.resolution_popup_open, "scale={scale}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- separate the always-present Theme state machine from physical music output
- model and render the active launcher Options parent with native control, profile, preview, Apply, persistence, and child-return ordering
- wire production shell open/frame/input/terminal-close paths and refresh Network-local preferences without disturbing match state

## Evidence
- active retail gamemd.exe and retail data verified against the frozen D5 report/implementation contract
- fresh read-only whole-mechanism critic: GREEN on c9b97157...985a0daf
- prior UI findings rechecked and closed

## Validation
- cargo test -p vera20k --lib app::persistence::options::launcher::tests — 6 passed
- cargo test -p vera20k --lib app::handler::tests::launcher_options_escape_is_consumed_without_replacing_the_parent — 1 passed
- cargo test -p vera20k --lib ui::main_menu_dialogs::options::tests — 17 passed
- cargo test -p vera20k --lib rules::ruleset::tests::shell_ui_sound_keys — 2 passed
- cargo test -p vera20k --lib app::frontend::skirmish_session::tests::launcher_network_refresh — 1 passed
- Theme prerequisite — 12 passed
- audio runtime prerequisite — 2 passed

The phase-wide full --lib suite remains reserved for final Phase 14 certification.