### PR TITLE
Phase 14: preserve Drive fractions through Move install

### DIFF
--- a/docs/plans/2026-09-01-drive-speed-fraction-writer-ownership-design.md
+++ b/docs/plans/2026-09-01-drive-speed-fraction-writer-ownership-design.md
@@ -1,0 +1,297 @@
+# Drive Speed-Fraction Writer Ownership Design
+
+## Goal
+
+Remove the non-native Drive move-command speed-fraction mutation so ordinary
+path installation preserves existing target/current fraction state and the
+scheduled Drive movement rung remains the sole ordinary producer, closing the
+first separable prerequisite for exact crate Speed semantics.
+
+## Status and autonomous approval
+
+**Status:** APPROVED after design-review revision for proportional planning
+under the active autonomous Phase 14 goal.
+
+The first design review returned `REVISE` for two issues now corrected here:
+the ForceTrack residual no longer misstates target-only native behavior as a
+full-fraction write, and the test plan now proves the production
+`Simulation::apply_command` route before exercising the scheduled producer.
+
+Adversarial approval questions:
+
+- **Why approve this separately from the full crate runtime?** Active-retail
+  caller evidence proves path installation itself does not write either
+  fraction, while this Rust write affects every ordinary Drive move. Removing
+  it closes one complete writer-ownership mechanism and avoids building crate
+  Speed on a false mutation boundary.
+- **What could still make ordinary skirmish feel wrong?** The broader
+  `GetCurrentSpeed` staging, crate multiplier, forced-track, crush, second brake
+  band, and RawTrack work remains open. This design does not claim those are
+  solved; it preserves all existing scheduled-rung behavior and changes only
+  the disproved command-time writer.
+- **What could create expensive later rework?** Introducing a new speed API or
+  moving target calculation into command handling would duplicate the scheduled
+  producer. The chosen deletion-plus-contract-test approach does neither.
+
+Approval decision: the boundary is active-YR verified, production-routed,
+small, reversible, and dependency-coherent. No undiscoverable user choice
+remains.
+
+## Architecture Context
+
+The player/team/AI command path reaches
+`Simulation::apply_command_with_overlays` and then
+`movement::issue_move_command_with_layered` through
+`src/sim/world/world_commands.rs:600-725`. The command function plans the path,
+installs `MovementTarget`, NavCom destination, Drive path replay, initial turn,
+and optional first DriveTrack at
+`src/sim/movement/movement_commands.rs:618-726`.
+
+Drive-local speed state lives in
+`DriveLocomotionRuntime::{target_speed_fraction,current_speed_fraction}` at
+`src/sim/components.rs:440-508`; both default to zero and are serialized and
+hashed as part of the entity. The ordinary live-object movement visit is owned
+by `Simulation::advance_master_frame` at `src/sim/world/mod.rs:6530-6608`.
+During that visit, `src/sim/movement/movement_tick.rs:1969-2058` computes the
+terrain/health target fraction, calls
+`drive_locomotion::update_drive_speed_fraction`, derives current movement
+speed, and caches the owner-speed projection before DriveTrack consumption.
+
+The current extra command-time call at
+`src/sim/movement/movement_commands.rs:717-726` supplies target one and zero
+acceleration/braking inputs. For `Accelerates=false` it writes both fraction
+slots immediately; for `Accelerates=true` it at least writes the target slot.
+Active retail proves no corresponding Move-command path-install writer exists.
+The normal writers live in Drive `Process_Movement @ 0x004B2630` and
+`Process_Drive_Track @ 0x004B0F20`; separate Stop/ForceTrack/lifecycle writers
+remain separate mechanisms.
+
+This slice follows the existing architecture: command code installs intent and
+path state; the deterministic per-object movement visit owns speed-state
+mutation and consumption. It introduces no new module or cross-layer
+dependency.
+
+## Impact Analysis
+
+### Direct changes
+
+- `src/sim/movement/movement_commands.rs`
+  - remove the command-time `update_drive_speed_fraction` call;
+  - retain destination, path, turn, track, and occupation installation order;
+  - add the nearest provenance comment stating that path installation preserves
+    the two fraction slots.
+- `src/sim/movement/movement_tests.rs`
+  - extend direct command-boundary coverage with sentinel fractions;
+  - verify a mid-curve reissue preserves already-live fraction state.
+- `src/sim/world/world_tests.rs`
+  - issue `Command::Move` through `Simulation::apply_command`, prove the
+    production dispatcher preserves sentinel fractions, then run the scheduled
+    movement visit and prove the existing producer changes them.
+
+### Dependents and blast radius
+
+Every caller of `issue_move_command_with_layered` benefits from the same
+ownership fix: player Move, AI/team orders, miner/refinery navigation, factory
+exit movement, scatter, and scripted movement. No caller receives a new return
+type or parameter. Ship is unaffected because the offending call is inside the
+Drive-only branch and Ship already defers fraction mutation to its movement
+rung.
+
+The change affects deterministic state between command application and the
+entity's scheduled movement visit. That difference is intentional and native:
+reissue observers and state hashes must see the previous qwords until the
+Drive visit. Snapshot schema and hash layout do not change; only values at that
+time boundary change.
+
+No RNG, INI, asset, rendering, audio, network protocol, or persistence format is
+added. The risk is behavioral fallout in tests that accidentally relied on the
+non-native eager write; those tests must be corrected only when their assertion
+is about this ownership boundary, not massaged broadly.
+
+## Chosen Approach
+
+Delete only the disproved command-time fraction update and pin the ownership
+contract with focused command-to-first-tick tests. Keep the existing scheduled
+target computation and update function unchanged.
+
+This is preferred because it exactly matches the verified native negative
+claim, preserves Rust's current responsible owner, minimizes the state window
+changed, and creates no adapter that the full crate Speed implementation would
+later have to remove.
+
+## Player-Experience Detail Ledger
+
+- **MILESTONE-BLOCKING — command-time preservation.** A normal or reissued
+  Drive path may update destination/path/turn/track but must not write either
+  target or current speed-fraction slot. [doc:
+  `PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md` lines 1537-1546;
+  GHIDRA `Process_Movement @ 0x004B2630`, `Process_Drive_Track @ 0x004B0F20`]
+- **MILESTONE-BLOCKING — scheduled first mutation.** The entity's live-object
+  movement visit computes target from the current cell/next cell, terrain,
+  locomotor speed type, and ConditionYellow state, then applies snap/ramp before
+  speed consumption. The command must not pre-empt that live read. [Rust:
+  `movement_tick.rs:1969-2058`; doc: Phase 3 report lines 826-968]
+- **COMPOUNDING — `Accelerates=false`.** Native snaps current fraction to the
+  scheduled target in `Process_Drive_Track`; Rust currently snaps eagerly to
+  one at command time. Terrain and health can make the scheduled target non-one,
+  so preservation must be tested with non-default sentinels and a later target
+  change. [doc: Phase 3 report lines 817-968]
+- **COMPOUNDING — `Accelerates=true`.** Constructor/rest state begins at zero;
+  the scheduled rung ramps from the prior current value. A command-time target
+  one is still a state/order drift even when current remains zero. [doc:
+  `FOOTCLASS_GET_CURRENT_SPEED_EXACT_GHIDRA_REPORT.md` lines 306-329 and
+  403-430]
+- **COMPOUNDING — mid-curve reissue.** `TechnoClass::Set_Destination` preserves
+  an in-flight curve and its speed state; a new path takes over at the committed
+  head. The existing position/track preservation tests must also pin fraction
+  preservation. [Rust: `movement_tests.rs:1623-1700`; GHIDRA
+  `TechnoClass::Set_Destination @ 0x00741970`]
+- **MILESTONE-BLOCKING — crate Speed readiness.** `Foot+0x580` is an independent
+  persistent crate multiplier consumed by `GetCurrentSpeed`; it must not be
+  conflated with target/current fraction or a command-time scalar. This slice
+  only removes the false writer and does not claim the multiplier exists.
+  [doc: `FOOTCLASS_GET_CURRENT_SPEED_EXACT_GHIDRA_REPORT.md` lines 232-252]
+- **EXACTIFICATION-RESIDUAL — separate fraction writers.** Native ForceTrack
+  writes only the locomotor target qword to exact one and does not write owner
+  current fraction; Tube and Stop/lifecycle paths have their own separately
+  ordered transitions. Current Rust's ForceTrack writes to current fraction and
+  cached owner speed as well, and Tube contains additional target/current
+  writes, so those paths are known drift rather than verified behavior to pin.
+  This branch neither edits nor claims them: its diff/search audit proves only
+  that the ordinary path-install deletion is scoped. Trigger: Tank Bunker,
+  stop, and tube lifecycle. Frequency: common for stop, narrower for
+  forced/tube paths. Player effect: movement start/stop feel. Downstream risk:
+  high, so the discrepancies remain open for their own dependency-coherent
+  correction rather than being preserved by new assertions. [Rust:
+  `movement/mod.rs:159-173`, `navcom.rs:245-305`, `tube_movement.rs`; doc:
+  Phase 3 report lines 930-955]
+- **EXACTIFICATION-RESIDUAL — full GetCurrentSpeed mechanism.** House
+  SpeedUnitsMult, crate multiplier, FASTER/VeteranSpeed, current fraction, x87
+  conversion boundaries, and CTF half-speed remain a later coherent production
+  mechanism. Trigger: ordinary movement plus crate/veterancy/house modifiers.
+  Frequency: ordinary. Player effect and deterministic risk: high. This is not
+  silently downgraded; it remains open in the crate disparity report. [doc:
+  `FOOTCLASS_GET_CURRENT_SPEED_EXACT_GHIDRA_REPORT.md`]
+- **UNKNOWN-RISK — none introduced.** The selected negative writer claim has
+  exhaustive active-retail producer/caller evidence. No TS-only behavior is
+  used; the Unit/Drive path is ordinary active YR.
+
+## Design
+
+### Components
+
+No new component is introduced. `DriveLocomotionRuntime` remains the state
+owner. `issue_move_command_with_layered` remains the path/destination installer.
+`movement_tick` remains the ordinary target/current fraction producer and
+consumer coordinator.
+
+### Interfaces / Contracts
+
+The existing command API is unchanged. Its Drive postcondition becomes
+explicit:
+
+```text
+successful Drive path installation
+  may mutate destination, head, path, turn, track, and occupation
+  must preserve target_speed_fraction
+  must preserve current_speed_fraction
+  must preserve owner_current_speed until the scheduled movement visit
+```
+
+The scheduled movement visit retains its existing contract:
+
+```text
+read live terrain/health/path state
+compute target fraction
+apply native snap/ramp to target/current slots
+derive current speed and owner speed
+consume DriveTrack budget
+```
+
+`owner_current_speed` is not currently written by the offending command call,
+but the test will pin it as part of the same negative boundary so a later eager
+projection cannot recreate the drift.
+
+### Data Flow
+
+1. Command resolution computes raw top speed and acceleration inputs.
+2. Path planning succeeds.
+3. Command installation updates intent/path/turn/track state while preserving
+   all three speed projections.
+4. The live-object movement visit reads the newly installed next cell plus
+   current terrain/health facts.
+5. The existing Drive fraction producer updates target/current state.
+6. Current movement speed and Drive budget consume the updated result in the
+   same visit.
+
+No state is deferred beyond its native scheduled owner and no event queue is
+added.
+
+### Error Handling
+
+Unsuccessful pathfinding continues to return false without changing speed
+state. A successful path with no Drive runtime creates the runtime at native
+constructor-equivalent zero defaults and then preserves those defaults until
+the scheduled visit. Existing safe failure behavior for missing entity, grid,
+or path remains unchanged.
+
+### Testing Strategy
+
+Focused `--lib` tests will prove:
+
+1. `Simulation::apply_command(Command::Move)` reaches the production dispatcher
+   and a successful Drive command preserves nontrivial
+   target/current/owner-speed sentinel values exactly;
+2. a fresh default Drive command leaves both fractions zero before the first
+   scheduled visit;
+3. the next `Simulation::advance_tick` scheduled visit still applies the existing
+   `Accelerates=false` target snap and `Accelerates=true` ramp behavior;
+4. a mid-curve reissue preserves in-flight fractions as well as position,
+   track, occupation, and path anchor;
+5. diff/search confirms ForceTrack, Stop, Ship, and tube code is not changed;
+   existing tests for those paths remain regression evidence only and are not
+   presented as proof that their known residuals match native.
+
+Validation command after checking for another Cargo owner:
+
+```text
+cargo test -p vera20k --lib sim::movement::movement_tests::
+```
+
+A narrower filter may be used while iterating; no full-suite run belongs to
+this prerequisite slice until the PR certification point required by the
+active goal.
+
+## Architectural Decisions
+
+- Follow the existing command-intent versus scheduled-mutation boundary.
+- Preserve `DriveLocomotionRuntime` as the Rust-native owner rather than
+  introducing native object inheritance or a new command-time adapter.
+- Make no snapshot-version change because the serialized schema is unchanged.
+- Make no attempt to implement the full crate multiplier or native x87 speed
+  formula in this branch; those require their own dependency-coherent design
+  and evidence gates.
+- Keep all separate verified fraction writers intact.
+
+No new technical debt is introduced. The existing broader Drive speed
+exactification residual remains explicitly open.
+
+## Alternatives Considered
+
+### 1. Recommended: delete the eager writer and pin preservation
+
+Architecturally minimal and exact at the audited boundary. It lets the existing
+scheduled owner observe live terrain/health state and creates no future crate
+adapter. Risk is limited to exposing tests that depended on the drift.
+
+### 2. Move target calculation into command installation
+
+Rejected. Command time lacks the native scheduled `Process_Movement` ownership
+and would snapshot terrain/health too early, duplicate movement-tick logic, and
+still be wrong for mid-curve reissues and same-process transitions.
+
+### 3. Defer deletion into the full crate/GetCurrentSpeed implementation
+
+Rejected. The false writer is reached in ordinary movement now and is a proven
+dependency boundary. Leaving it in place would make the later crate mechanism
+depend on incorrect state ordering and enlarge that branch's review surface.

--- a/docs/plans/2026-09-01-drive-speed-fraction-writer-ownership-plan.md
+++ b/docs/plans/2026-09-01-drive-speed-fraction-writer-ownership-plan.md
@@ -224,8 +224,9 @@ path-replay block with the nearest ownership/provenance comment:
 
 ```rust
 // Drive path installation preserves the target/current speed fractions.
-// Active YR produces the target only in DriveLocomotionClass::Process_Movement
-// @ 0x004B2630 and applies it in Process_Drive_Track @ 0x004B0F20.
+// On the ordinary Move path, active YR produces the target in
+// DriveLocomotionClass::Process_Movement @ 0x004B2630 and applies it in
+// Process_Drive_Track @ 0x004B0F20.
 ```
 
 Do not change destination, path replay, turn fields, first-track selection,

--- a/docs/plans/2026-09-01-drive-speed-fraction-writer-ownership-plan.md
+++ b/docs/plans/2026-09-01-drive-speed-fraction-writer-ownership-plan.md
@@ -1,0 +1,425 @@
+# Drive Speed-Fraction Writer Ownership Implementation Plan
+
+> **For Codex:** Execute this plan task-by-task. Each task is self-contained.
+
+**Goal:** Remove the non-native Drive move-command speed-fraction mutation so
+path installation preserves the existing fractions and the scheduled movement
+visit remains their ordinary producer.
+
+**Architecture:** `Simulation::apply_command` dispatches `Command::Move` into
+`movement::issue_move_command_with_layered`, which owns path/destination
+installation. `movement_tick` already owns the scheduled Drive target/current
+fraction update and speed projection. This transaction deletes the duplicate
+command-time write without changing interfaces, state layout, or tick order.
+
+**Design Doc:**
+`docs/plans/2026-09-01-drive-speed-fraction-writer-ownership-design.md`
+
+---
+
+## Grounding Summary
+
+- Active-retail `DriveLocomotionClass::Process_Movement @ 0x004B2630` produces
+  the target fraction; `Process_Drive_Track @ 0x004B0F20` applies the
+  target/current transition and queries current speed.
+- `PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md:1537-1546` explicitly
+  reports no native Move-command path-install fraction writer and calls for the
+  Rust update at `movement_commands.rs:717-726` to be deleted.
+- `FOOTCLASS_GET_CURRENT_SPEED_EXACT_GHIDRA_REPORT.md:306-329,403-430`
+  verifies constructor zero, `SetSpeedFraction` ownership, and the scheduled
+  DriveTrack call order.
+- The reports are active-YR verified, and the active executable remains
+  `gamemd.exe` SHA-256
+  `1CDD1180E49024FBDA8AD568CAAC2E86E856063FF67AB38F62B7D2C7BB84298C`.
+- No consequential native uncertainty remains, so a ritual live decompile would
+  not change this plan. Ghidra metadata mutation is not authorized or needed.
+- `src/sim/movement/movement_commands.rs:686-737` currently installs Drive
+  destination/path/turn state and then eagerly calls
+  `update_drive_speed_fraction` with target one and zero ramp inputs.
+- `src/sim/movement/movement_tick.rs:1950-2058` already performs the scheduled
+  target computation, fraction transition, and owner-speed projection before
+  DriveTrack budget consumption.
+- `src/sim/world/world_commands.rs:540-730` is the production command
+  dispatcher and stamps parsed ramp parameters only after successful path
+  installation.
+- `DriveLocomotionRuntime` owns and hashes the target/current fractions and
+  cached owner speed; no schema or snapshot version changes.
+- The production test fixture parses only active movement keys and deliberately
+  omits `SlowdownDistance`, exercising the existing verified default of 500.
+  No new INI key, asset, RNG draw, or external data path is introduced.
+- ForceTrack and Tube contain separate known fraction drift. They are excluded
+  from this diff and remain open; existing tests for them are regression checks,
+  not parity proof.
+
+## Key Technical Decisions
+
+- Delete the eager call; do not replace it with another command-time helper. —
+  **Confidence:** high
+  - **Source:** `PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md:1537-1546`
+- Preserve `DriveLocomotionRuntime` as the Rust-native state owner and
+  `movement_tick` as the scheduled producer. — **Confidence:** high
+  - **Source:** `src/sim/components.rs:440-508`,
+    `src/sim/movement/movement_tick.rs:1950-2058`
+- Prove the production dispatch boundary with `Simulation::apply_command` and
+  prove the next scheduled mutation with `Simulation::advance_tick`. —
+  **Confidence:** high
+  - **Source:** `src/sim/world/world_commands.rs:540-730`,
+    `src/sim/world/mod.rs:6424-6608`
+- Leave ForceTrack, Stop, Ship, and Tube source untouched; do not add assertions
+  that bless their known discrepancies as native. — **Confidence:** high
+  - **Source:** `PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md:930-955`
+
+No low-confidence implementation decision remains.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Does a move command legitimately initialize either fraction?** No. The
+  active-retail producer/caller scan confines ordinary production/application
+  to the scheduled Drive bodies.
+- **Should cached `owner_current_speed` be recomputed at command time?** No. It
+  is a Rust projection of the applied fraction and remains unchanged until the
+  same scheduled visit that updates the applied fraction.
+- **Must the known ForceTrack and Tube drift be fixed in this transaction?**
+  No. They are separate writer/lifecycle mechanisms with different callers and
+  ordering. Preserving their files in the diff prevents scope confusion while
+  keeping those residuals explicitly open.
+
+### Deferred to Later Mechanisms
+
+- Exact ForceTrack selector and target-only writes, Tube fraction ordering,
+  crush clamp, passive/selector bypass, second brake band, full
+  `GetCurrentSpeed`, and crate Speed multiplier/consumer integration remain
+  separate dependency-coherent mechanisms.
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `src/sim/movement/movement_commands.rs` | Remove the disproved command-time fraction writer and document the native ownership boundary. |
+| Modify | `src/sim/movement/movement_tests.rs` | Pin default and mid-curve path-install preservation at the direct command boundary. |
+| Modify | `src/sim/world/world_tests.rs` | Prove production command dispatch preserves sentinels and the next scheduled visit mutates them. |
+| Add | `docs/plans/2026-09-01-drive-speed-fraction-writer-ownership-design.md` | Record the approved evidence-backed design. |
+| Add | `docs/plans/2026-09-01-drive-speed-fraction-writer-ownership-plan.md` | Record this reviewed execution plan. |
+
+All modified Rust files remain within deterministic `sim/`; no dependency on
+render, UI, sidebar, audio, or net is introduced.
+
+## Interface Changes
+
+None. Function signatures, structs, serialization, state hashing, snapshot
+version, and command schemas remain unchanged. Only the postcondition of an
+existing Drive path installation is corrected: it preserves the two fraction
+slots and cached owner-speed value.
+
+## Sim Checklist
+
+- [x] No new math; existing `SimFixed` values only.
+- [x] No new state; hash/schema work is unnecessary.
+- [x] No render/UI/sidebar/audio/net dependency.
+- [x] Tick order is unchanged; one non-native earlier mutation is removed.
+- [x] No iteration or `BTreeMap` ordering change.
+
+## Risk Areas
+
+- A test may have accidentally depended on the eager target-one write. Update
+  only assertions about the disproved ownership boundary; do not broadly
+  rebaseline movement behavior.
+- A fresh Drive runtime must remain zero until the first scheduled visit.
+- An in-flight Drive reissue must preserve nonzero fractions in addition to its
+  already-tested curve/path/occupation state.
+- The production command test must call `Simulation::apply_command`, not only
+  the helper, or it cannot prove delivery.
+- ForceTrack/Stop/Ship/Tube files must not appear in the implementation diff.
+
+## Player-Experience Critical Items
+
+| Task | Class | Item | Why it matters | Verification |
+|---|---|---|---|---|
+| 1-2 | MILESTONE-BLOCKING | Command-time preservation | Every ordinary Drive move/reissue currently mutates deterministic speed state too early. | Direct sentinel tests plus `Simulation::apply_command` production test. |
+| 2 | MILESTONE-BLOCKING | Scheduled first mutation | Terrain/health and acceleration must be read by the live movement visit, not snapshotted by the command. | Follow production command with `Simulation::advance_tick`; assert scheduled snap/ramp result. |
+| 1-2 | COMPOUNDING | Fresh `Accelerates=true/false` | Wrong early target/current values affect every departure and state hash. | Fresh-default and parsed true/false fixture cases. |
+| 1 | COMPOUNDING | Mid-curve reissue | Frequent player retasking must not reset live speed state. | Extend the existing in-flight curve test with exact sentinel assertions. |
+| Audit | EXACTIFICATION-RESIDUAL | ForceTrack/Stop/Tube writers | Their triggers are narrower or independently ordered; folding them here would mix mechanisms. | Confirm their files are absent from the diff and keep the residual named. |
+| Later | EXACTIFICATION-RESIDUAL | Full `GetCurrentSpeed` and crate multiplier | Ordinary and crate movement remain incomplete after this prerequisite. | Remains open in the crate disparity scan; no closure claim in this PR. |
+
+Representative production scenario: an ordinary stock Drive vehicle is moving
+or stationary, receives a player/team/AI Move order, and reaches its next live
+movement visit. The command installs the new path without touching speed
+fractions; the movement visit then computes and applies them.
+
+---
+
+## Tasks
+
+### Task 1: Pin the path-install preservation contract
+
+**Why:** Tests must fail on the current eager writer and distinguish fresh
+constructor state from a reissued in-flight state before implementation.
+
+**Files:**
+
+- Modify: `src/sim/movement/movement_tests.rs:1526-1587`
+- Modify: `src/sim/movement/movement_tests.rs:1623-1701`
+
+**Pattern:** Extend the existing Drive command and mid-curve tests; introduce no
+new fixture abstraction.
+
+**Step 1: Extend the fresh Drive command test**
+
+After the existing `let drive = ...` assertion block in
+`test_issue_move_command_starts_drive_track_for_drive_locomotor`, assert:
+
+```rust
+assert_eq!(drive.target_speed_fraction, SIM_ZERO);
+assert_eq!(drive.current_speed_fraction, SIM_ZERO);
+assert_eq!(drive.owner_current_speed, 0);
+```
+
+This must fail before Task 2 because the current eager call writes the target to
+one.
+
+**Step 2: Extend the mid-curve reissue test**
+
+After the first order and before the second order, write exact sentinels:
+
+```rust
+{
+    let drive = entities
+        .get_mut(1)
+        .and_then(|entity| entity.drive_locomotion.as_mut())
+        .expect("drive state");
+    drive.target_speed_fraction = SimFixed::lit("0.4");
+    drive.current_speed_fraction = SimFixed::lit("0.25");
+    drive.owner_current_speed = 7;
+}
+```
+
+After the second order, add:
+
+```rust
+assert_eq!(drive.target_speed_fraction, SimFixed::lit("0.4"));
+assert_eq!(drive.current_speed_fraction, SimFixed::lit("0.25"));
+assert_eq!(drive.owner_current_speed, 7);
+```
+
+These assertions must fail before Task 2 and pass after it.
+
+### Task 2: Remove the command-time writer
+
+**Why:** This is the complete implementation delta proved by the active binary.
+
+**Files:**
+
+- Modify: `src/sim/movement/movement_commands.rs:702-727`
+
+**Pattern:** Keep command handling as intent/path installation and leave
+scheduled deterministic mutation in `movement_tick`.
+
+**Step 1: Delete the eager update call**
+
+Replace the entire `update_drive_speed_fraction` call at the end of the Drive
+path-replay block with the nearest ownership/provenance comment:
+
+```rust
+// Drive path installation preserves the target/current speed fractions.
+// Active YR produces the target only in DriveLocomotionClass::Process_Movement
+// @ 0x004B2630 and applies it in Process_Drive_Track @ 0x004B0F20.
+```
+
+Do not change destination, path replay, turn fields, first-track selection,
+occupation, Ship handling, or any helper signature.
+
+### Task 3: Prove production dispatch and scheduled ownership
+
+**Why:** A helper-only assertion cannot prove the player/team/AI command path
+reaches the corrected code or that scheduled movement remains connected.
+
+**Files:**
+
+- Modify: `src/sim/world/world_tests.rs` near the existing Move command tests
+
+**Pattern:** Use the existing `Simulation`, `RuleSet::from_ini`, `spawn_object`,
+`apply_command`, and `advance_tick` test patterns.
+
+**Step 1: Add a minimal parsed rules helper**
+
+```rust
+fn drive_fraction_writer_rules(accelerates: bool) -> RuleSet {
+    let ini = IniFile::from_str(&format!(
+        "[InfantryTypes]\n\
+         [VehicleTypes]\n\
+         0=DRIVE\n\
+         [AircraftTypes]\n\
+         [BuildingTypes]\n\
+         [DRIVE]\n\
+         Strength=300\n\
+         Speed=6\n\
+         Locomotor={{4A582741-9839-11d1-B709-00A024DDAFD1}}\n\
+         MovementZone=Normal\n\
+         Accelerates={}\n\
+         AccelerationFactor=0.03\n\
+         DeaccelerationFactor=0.002\n",
+        if accelerates { "yes" } else { "no" }
+    ));
+    RuleSet::from_ini(&ini).expect("Drive fraction writer rules")
+}
+```
+
+**Step 2: Add the production-route test**
+
+For both `Accelerates=false` and `Accelerates=true`:
+
+1. create `Simulation::new()` and the rules fixture;
+2. `spawn_object("DRIVE", "Americans", 2, 3, 64, ...)`;
+3. materialize Rust's lazily-created `DriveLocomotionRuntime`, then set
+   target/current/owner sentinels to `0.4`, `0.25`, and `7` (the direct fresh
+   command test separately proves the missing-runtime zero-default path);
+4. call `Simulation::apply_command` with `Command::Move` to `(7, 3)` and a
+   `16x16` `PathGrid`;
+5. assert all sentinels remain exact immediately after the call;
+6. call `Simulation::advance_tick` once with no commands and the same rules/grid;
+7. assert target becomes one; current becomes one for nonaccelerating Drive and
+   `0.28` for accelerating Drive; compute the expected cached owner speed from
+   the `MovementTarget.speed` integer stage and the expected current fraction,
+   then assert exact equality.
+
+The expected owner-speed calculation in the test is:
+
+```rust
+let raw_stage = (movement_speed / SimFixed::from_num(15)).to_num::<i32>();
+let expected_owner =
+    (SimFixed::from_num(raw_stage) * expected_current).to_num::<i32>();
+```
+
+If the first scheduled visit is gated by an unexpected turn/track setup, fix the
+fixture alignment so it reaches the existing production DriveTrack visit; do
+not weaken the assertion to an arbitrary multi-tick wait.
+
+### Task 4: Format and run focused validation
+
+**Why:** Prove the exact mechanism without running unrelated side binaries or
+parallel Cargo.
+
+**Files:** Only the three edited Rust files.
+
+**Step 1: Inspect ownership and diff**
+
+Confirm the branch/worktree is task-owned, `origin/main` is the base, and only
+the planned files plus the two plan documents are changed.
+
+**Step 2: Format only edited leaf files**
+
+Run direct `rustfmt --edition 2024` only when it produces no unrelated churn.
+Never run crate-wide `cargo fmt` and never format a `mod.rs`.
+
+**Step 3: Check Cargo ownership**
+
+Run `Get-Process cargo,rustc -ErrorAction SilentlyContinue`. If another session
+owns Cargo, wait; never kill it.
+
+**Step 4: Run focused tests**
+
+```text
+cargo test -p vera20k --lib sim::movement::movement_tests::test_issue_move_command_starts_drive_track_for_drive_locomotor -- --exact
+cargo test -p vera20k --lib sim::movement::movement_tests::test_reissue_mid_curve_keeps_track_and_anchors_path_at_head -- --exact
+cargo test -p vera20k --lib sim::world::tests::phase14_drive_move_command_preserves_fractions_until_scheduled_visit -- --exact
+```
+
+Record each literal `test result:` line. If exact module paths differ after
+compilation identifies the registered name, correct the filter rather than
+running a bare or side-binary test.
+
+**Step 5: Focused module sweep**
+
+```text
+cargo test -p vera20k --lib sim::movement::movement_tests::
+```
+
+Record the literal result. Do not run the full library suite during iteration.
+
+### Task 5: Commit, obtain fresh read-only review, and publish only green
+
+**Why:** The active goal requires one reviewed dependency-coherent mechanism
+per feature branch/PR.
+
+**Step 1: Audit the final diff**
+
+- Compare against the exact `origin/main` base.
+- Confirm no ForceTrack, Stop, Ship, Tube, unrelated test, generated, or local
+  evidence file is included.
+- Confirm the sim-behavior commit names
+  `PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md` and the two native
+  function addresses.
+
+**Step 2: Commit the coherent mechanism**
+
+Use a descriptive commit such as:
+
+```text
+Phase 14: preserve Drive speed fractions through path install
+```
+
+The commit body cites the active Phase 3 report and
+`Process_Movement @ 0x004B2630` / `Process_Drive_Track @ 0x004B0F20`.
+
+**Step 3: Fresh read-only critic**
+
+Give a critic who did not build the change the exact base/head SHAs, design,
+plan, native report sections, full diff, and literal focused validation output.
+Require findings-first review of semantics, production delivery, scope,
+provenance, and test strength.
+
+If the critic finds a confirmed issue, fix it, rerun affected focused tests,
+commit, and submit the new head to a different fresh critic. Recheck every prior
+finding. Stop only on a green verdict.
+
+**Step 4: PR certification and publication**
+
+After critic green, check Cargo ownership and run the one PR-certification
+command required by AGENTS/ENGINE:
+
+```text
+cargo test -p vera20k --lib
+```
+
+Record the literal result, push the feature branch, open a PR targeting `main`,
+wait for checks, merge only green, and re-review any conflict resolution before
+merging. Refresh `origin/main` after merge before selecting the next Phase 14
+mechanism.
+
+## Sources & References
+
+- **Design:**
+  `docs/plans/2026-09-01-drive-speed-fraction-writer-ownership-design.md`
+- **Primary active-binary report:**
+  `docs/research/PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md:817-968,1537-1546`
+- **Current-speed report:**
+  `docs/research/FOOTCLASS_GET_CURRENT_SPEED_EXACT_GHIDRA_REPORT.md:232-252,306-329,403-430`
+- **Native addresses:** Drive `Process_Movement @ 0x004B2630`, Drive
+  `Process_Drive_Track @ 0x004B0F20`, owner
+  `TechnoClass::SetSpeedFraction @ 0x004D3710`
+- **Rust command boundary:** `src/sim/movement/movement_commands.rs:686-737`
+- **Rust scheduled owner:** `src/sim/movement/movement_tick.rs:1950-2058`
+- **Production command route:** `src/sim/world/world_commands.rs:540-730`
+- **State owner:** `src/sim/components.rs:440-508`
+- **Test patterns:** `src/sim/movement/movement_tests.rs:1493-1701`,
+  `src/sim/world/world_tests.rs:5555-5697`
+- **Fixture INI keys:** `[DRIVE] Speed=`, `Locomotor=`, `MovementZone=`,
+  `Accelerates=`, `AccelerationFactor=`, `DeaccelerationFactor=`,
+  plus the existing `ObjectType` `SlowdownDistance` default of `500`
+
+## Post-Plan Self-Review
+
+- [x] Every design requirement maps to a task.
+- [x] No placeholders or vague implementation steps remain.
+- [x] Existing module ownership and interfaces are preserved.
+- [x] No interface task is needed because there is no interface change.
+- [x] Fresh/default/reissue/production/scheduled risks have explicit tests.
+- [x] Each task is self-contained and ordered tests → implementation → proof.
+- [x] Sim boundary, fixed-point, state-hash, tick-order, and iteration checks pass.
+- [x] Grounding cites current Rust and the decisive active-YR reports.
+- [x] Every technical decision is high confidence; no live binary gap remains.
+- [x] Deferred mechanisms are explicit and not mislabeled as complete.
+- [x] The production scenario and every blocking/compounding item are populated.

--- a/src/sim/movement/movement_commands.rs
+++ b/src/sim/movement/movement_commands.rs
@@ -714,16 +714,9 @@ pub(crate) fn issue_move_command_with_layered(
                 .map(|(dx, dy)| crate::util::fixed_math::facing_from_delta_int_u16(dx, dy));
             drive.turn.rate_timer = 0;
             drive.turn.first_movement_allowed = false;
-            super::drive_locomotion::update_drive_speed_fraction(
-                drive,
-                crate::util::fixed_math::SIM_ONE,
-                entity_mut.drive_accelerates,
-                SIM_ZERO,
-                SIM_ZERO,
-                SIM_ZERO,
-                SIM_ZERO,
-                SIM_ZERO,
-            );
+            // Drive path installation preserves the target/current speed fractions.
+            // Active YR produces the target only in DriveLocomotionClass::Process_Movement
+            // @ 0x004B2630 and applies it in Process_Drive_Track @ 0x004B0F20.
         } else if uses_ship_locomotor {
             let ship = entity_mut
                 .ship_locomotion

--- a/src/sim/movement/movement_commands.rs
+++ b/src/sim/movement/movement_commands.rs
@@ -715,8 +715,9 @@ pub(crate) fn issue_move_command_with_layered(
             drive.turn.rate_timer = 0;
             drive.turn.first_movement_allowed = false;
             // Drive path installation preserves the target/current speed fractions.
-            // Active YR produces the target only in DriveLocomotionClass::Process_Movement
-            // @ 0x004B2630 and applies it in Process_Drive_Track @ 0x004B0F20.
+            // On the ordinary Move path, active YR produces the target in
+            // DriveLocomotionClass::Process_Movement @ 0x004B2630 and applies it in
+            // Process_Drive_Track @ 0x004B0F20.
         } else if uses_ship_locomotor {
             let ship = entity_mut
                 .ship_locomotion

--- a/src/sim/movement/movement_tests.rs
+++ b/src/sim/movement/movement_tests.rs
@@ -1584,6 +1584,9 @@ fn test_issue_move_command_starts_drive_track_for_drive_locomotor() {
         Some(0x3fff),
         "computed east is 16,383 on the active-retail 65,534 scale"
     );
+    assert_eq!(drive.target_speed_fraction, SIM_ZERO);
+    assert_eq!(drive.current_speed_fraction, SIM_ZERO);
+    assert_eq!(drive.owner_current_speed, 0);
 }
 
 #[test]
@@ -1655,6 +1658,15 @@ fn test_reissue_mid_curve_keeps_track_and_anchors_path_at_head() {
         drive.occupation_head_to.map(|head| (head.rx, head.ry)),
         Some((3, 3)),
     );
+    {
+        let drive = entities
+            .get_mut(1)
+            .and_then(|entity| entity.drive_locomotion.as_mut())
+            .expect("drive state");
+        drive.target_speed_fraction = SimFixed::lit("0.4");
+        drive.current_speed_fraction = SimFixed::lit("0.25");
+        drive.owner_current_speed = 7;
+    }
 
     // Re-order behind the body while the curve is in flight. Pre-fix this
     // cleared/replaced the curve; the curve must survive untouched and the new
@@ -1697,6 +1709,9 @@ fn test_reissue_mid_curve_keeps_track_and_anchors_path_at_head() {
     );
     assert_eq!(drive.path.reference_cell, Some((3, 3)));
     assert_eq!(drive.path.cursor, 0);
+    assert_eq!(drive.target_speed_fraction, SimFixed::lit("0.4"));
+    assert_eq!(drive.current_speed_fraction, SimFixed::lit("0.25"));
+    assert_eq!(drive.owner_current_speed, 7);
     assert_eq!(entity.navigation.nav_com, Some(NavTargetRef::cell(0, 3)));
 }
 

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -5552,6 +5552,109 @@ fn test_deploy_mcv_replaces_vehicle_with_conyard() {
     );
 }
 
+fn drive_fraction_writer_rules(accelerates: bool) -> RuleSet {
+    let ini = IniFile::from_str(&format!(
+        "[InfantryTypes]\n\
+         [VehicleTypes]\n\
+         0=DRIVE\n\
+         [AircraftTypes]\n\
+         [BuildingTypes]\n\
+         [DRIVE]\n\
+         Strength=300\n\
+         Speed=6\n\
+         Locomotor={{4A582741-9839-11d1-B709-00A024DDAFD1}}\n\
+         MovementZone=Normal\n\
+         Accelerates={}\n\
+         AccelerationFactor=0.03\n\
+         DeaccelerationFactor=0.002\n",
+        if accelerates { "yes" } else { "no" }
+    ));
+    RuleSet::from_ini(&ini).expect("Drive fraction writer rules")
+}
+
+#[test]
+fn phase14_drive_move_command_preserves_fractions_until_scheduled_visit() {
+    let heights = empty_heights();
+    let grid = PathGrid::new(16, 16);
+
+    for accelerates in [false, true] {
+        let rules = drive_fraction_writer_rules(accelerates);
+        let mut sim = Simulation::new();
+        let entity_id = sim
+            .spawn_object("DRIVE", "Americans", 2, 3, 64, &rules, &heights)
+            .expect("spawn Drive vehicle");
+        {
+            let entity = sim
+                .substrate
+                .entities
+                .get_mut(entity_id)
+                .expect("Drive vehicle remains live");
+            assert_eq!(
+                entity.locomotor.as_ref().map(|locomotor| locomotor.kind),
+                Some(LocomotorKind::Drive),
+            );
+            let drive = entity
+                .drive_locomotion
+                .get_or_insert_with(DriveLocomotionRuntime::default);
+            drive.target_speed_fraction = SimFixed::lit("0.4");
+            drive.current_speed_fraction = SimFixed::lit("0.25");
+            drive.owner_current_speed = 7;
+        }
+
+        assert!(sim.apply_command(
+            "Americans",
+            &Command::Move {
+                entity_id,
+                target_rx: 7,
+                target_ry: 3,
+                queue: false,
+                group_id: None,
+            },
+            Some(&rules),
+            Some(&grid),
+            &heights,
+        ));
+
+        let movement_speed = {
+            let entity = sim
+                .substrate
+                .entities
+                .get(entity_id)
+                .expect("Drive vehicle remains live");
+            let drive = entity.drive_locomotion.as_ref().expect("drive state");
+            assert_eq!(drive.target_speed_fraction, SimFixed::lit("0.4"));
+            assert_eq!(drive.current_speed_fraction, SimFixed::lit("0.25"));
+            assert_eq!(drive.owner_current_speed, 7);
+            let movement = entity
+                .movement_target
+                .as_ref()
+                .expect("Move command installs movement target");
+            assert_eq!(movement.slowdown_distance, SimFixed::from_num(500));
+            movement.speed
+        };
+
+        let _ = sim.advance_tick(&[], Some(&rules), &heights, Some(&grid), None, 100);
+
+        let entity = sim
+            .substrate
+            .entities
+            .get(entity_id)
+            .expect("Drive vehicle remains live");
+        let drive = entity.drive_locomotion.as_ref().expect("drive state");
+        let expected_current = if accelerates {
+            SimFixed::lit("0.28")
+        } else {
+            SIM_ONE
+        };
+        assert_eq!(drive.target_speed_fraction, SIM_ONE);
+        assert_eq!(drive.current_speed_fraction, expected_current);
+        let raw_stage = (movement_speed / SimFixed::from_num(15)).to_num::<i32>();
+        let expected_owner =
+            (SimFixed::from_num(raw_stage) * expected_current).to_num::<i32>();
+        assert_eq!(drive.owner_current_speed, expected_owner);
+    }
+}
+
 #[test]
 fn test_execute_tick_delay_blocks_early_execution() {
     let mut sim: Simulation = Simulation::new();


### PR DESCRIPTION
## Mechanism

Preserve Drive target/current speed fractions and cached owner speed when an ordinary Move command installs a path. The scheduled Drive visit remains the producer/consumer of those values.

## Evidence

- Active-retail DriveLocomotionClass::Process_Movement at 0x004B2630 produces the ordinary Move-path target.
- Process_Drive_Track at 0x004B0F20 applies/consumes it.
- The active retail INIs contain no SlowdownDistance assignment; Rust's 500 default is retained.
- Production coverage proves Command::Move preserves the existing fractions until Simulation::advance_tick reaches the scheduled Drive update.

ForceTrack, sinking/crushing, Tube, Ship, and full GetCurrentSpeed/crate-multiplier behavior remain explicitly outside this prerequisite.

## Validation

- Focused movement module: 84 passed, 0 failed
- Production route and sentinel tests: green
- Full library suite: 7792 passed, 0 failed, 76 ignored
- Fresh read-only critic: GREEN, with the earlier writer-provenance wording correction rechecked by a different critic