### PR TITLE
Phase 14: reproduce scenario-start crate authority

### DIFF
--- a/docs/plans/2026-09-01-phase14-crate-authority-foundation-design.md
+++ b/docs/plans/2026-09-01-phase14-crate-authority-foundation-design.md
@@ -1,0 +1,534 @@
+# Phase 14 crate-authority foundation design
+
+**Status:** approved for implementation after design-review  
+**Phase hypothesis:** GSI-14 row 303, “Crates / powerups,” contains several independently deliverable mechanisms. This design closes only the authoritative creation and delivery of scenario-start crates. Pickup, regeneration, effects, and specific-cell producers remain separate Phase 14 mechanisms.  
+**Caller/order evidence:** `docs/research/SCENARIO_START_CRATE_POST_MAP_CALLER_GATE_GHIDRA_REPORT.md`  
+**Placement/runtime evidence:** `docs/research/PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md`  
+**Supersedes as design authority:** `docs/plans/2026-07-23-crate-authority-design.md` and `docs/plans/2026-07-23-crate-evidence-foundation-plan.md`
+
+## Outcome
+
+For an admitted stock offline Skirmish session, when the finalized global
+`Crates` option is enabled, VERA20k will create scenario-start crates through
+one persistent simulation authority that matches active retail in rule inputs,
+signed attempt count, RNG consumption, slot state, placement acceptance,
+visible-versus-ghost results, overlay mutation, snapshot/hash ownership, and
+first-frame presentation.
+
+Fixed-map campaign mode 0 will not run this scenario-start scatter. That
+negative rule is owned by the active caller gate in
+`ScenarioClass__Full_Init @ 0x00686B20`, not by an invented helper-local
+comparison. Successful playable random-map generation reaches the same
+post-map mechanism through its separate direct caller; preview generation
+does not.
+
+This replaces the current approximation, which uses a temporary local
+`[bool; 256]`, drops native timer state, draws from the wrong rectangle,
+bypasses native Mark predicates, hides newly placed crates from the initial
+presentation list, and performs AI opening credits before crates.
+
+## Player-experience ledger
+
+| Situation | Required player-visible or deterministic result |
+|---|---|
+| Stock offline Skirmish, Crates on | The human-seat-derived attempt count is scattered before AI opening credits and alliances; visible crates render on the first gameplay frame. |
+| Fixed-map campaign mode 0 | No scenario-start random-crate scatter is created by this helper, regardless of the stock minimum. Authored/specific-cell crate producers are unaffected and remain later mechanisms. |
+| Successful playable random-map generation | The direct post-map caller runs the same startup authority once generation succeeds. |
+| Random-map preview | No gameplay crate slots, overlays, or RNG side effects are created. |
+| Crates off | No slots, overlays, timer draws, or coordinate draws are created. |
+| Water/common identity | Destination land type selects the configured water or wood/common overlay identity; Mark then selects Float only when the selected identity equals the current water identity, otherwise Track. |
+| Aliased configured identities | Water identity comparison has priority. If water and wood/common resolve to the same identity, the selected identity uses Float facts. |
+| Configured `none` image | Null identity survives the hard prechecks, then becomes an accepted timed ghost; it does not retry or fail closed. |
+| Terrain object, non-exempt steep slope, occupation, speed-zero, bridge-plane, allocation, Unlimbo, or Mark failure after hard prechecks | The call is accepted as a ghost: the slot and timer persist, RNG is consumed, and no visible overlay is stamped. Raw overlay ID `0xB2` is the exact retail exception that remains Mark-eligible above slope four. |
+| Occupied overlay or snapped cell outside the playfield | The attempt is rejected before construction and retries, preserving the exact draw sequence. |
+| All 256 slots occupied | The random call returns without consuming RNG. |
+| Save/restore or lockstep hash | Every raw slot word round-trips and affects VERA's versioned state hash; retail's narrow multiplayer checksum remains unchanged. |
+| First presentation build | Visible startup crate cells enter the existing `OverlayRenderIndex`; ghosts do not, and frame zero is used for `Crate=yes`. |
+
+## Scope boundary
+
+### In this mechanism
+
+- The layered `[CrateRules]` startup-crate subset required by this path:
+  `CrateMinimum`, `CrateMaximum`, `CrateRegen`, `WoodCrateImg`,
+  `CrateImg`, and `WaterCrateImg`, including constructor state, section/key
+  retention, signed integers, exact binary64 regen bits, and overlay identity
+  allocation.
+- One persistent 256-entry crate slot table owned by `Simulation`.
+- Exact scenario-start signed count and random-placement transaction.
+- Native accepted-ghost behavior for every failure after the outside-playfield
+  and occupied-overlay hard prechecks that is representable in Rust.
+- Exact timer draw/interpolation, pre-increment frame ownership, and `aux` word.
+- Crate-specific overlay writes that preserve unrelated cell fields.
+- Snapshot version 114 and a version-gated world-hash fold for the raw slot
+  table. No change to the retail quick checksum.
+- Production post-map routing for fixed-map mode 5, the successful playable
+  random-map caller, and the negative campaign/preview gates.
+- Correct post-map order: crates, then AI opening credits, then alliances.
+- Initial render-index synchronization and runtime overlay-name
+  preregistration.
+- Active executable, installed INI, and installed CRATE/WCRATE theater-asset
+  validation.
+
+### Explicitly not in this mechanism
+
+- Unrelated `[CrateRules]`/crate-adjacent authority:
+  `FreeMCV`, `SoloCrateMoney`, `CrateRadius`, `UnitCrateType`,
+  `CrateGoodie`, fixed Silver/Wood/Water goodie mappings, heal sound, and
+  sound-registry lookup. None is consumed by scenario-start scatter.
+- `[Powerups]` parsing, weighted selection, anti-stack remaps, pickup return
+  barriers, event 49/50 emission, the eight positive-weight stock effects, and
+  their sound/animation consumers.
+- Runtime regeneration scans and crate removal/clear behavior. `CrateRegen`
+  is parsed now only because every accepted startup slot immediately needs the
+  native duration/aux state.
+- Specific-cell placement used by trigger action 108 and `CrateBeneath`.
+- `CarriesCrate`, `CrateBeneath`, `IsMoney`, `CrateTrigger`,
+  `TruckCrate`, and `TrainCrate` producers/consumers.
+- Raw modes 3/4 networking. The native fixed-map comparison admits nonzero
+  modes, but current ordinary production does not admit a network simulation
+  session.
+- The failed native Overlay allocation's orphan object-array identity and
+  UniqueID. Gameplay-observable slot/timer/RNG and cell results are retained.
+- Invalid-domain OOM, corrupt pointer graphs, and malformed nonfinite rule
+  inputs.
+
+The exclusions remain open Phase 14 work. This PR may establish shared types
+that later mechanisms reuse, but it must not claim those later consumers as
+closed.
+
+## Evidence contract
+
+| Native behavior | Decisive evidence |
+|---|---|
+| Fixed-map caller and mode/control-byte gates | `ScenarioClass__Full_Init @ 0x00686B20`, assembly `0x00687BC8..0x00687BEC`; caller/order correction report |
+| Ordinary fresh-loader control byte | `ScenarioClass__Read_Scenario_INI @ 0x00686730`, `XOR DL,DL` at `0x0068683A`, call at `0x00686845` |
+| Generated-map direct caller | `ScenarioClass__Read_Scenario @ 0x00684620`, `0x0068498E..0x00684990` |
+| Rules finalization and option/count/order | `Full_Init @ 0x00686B20`; `Post_Map_Init @ 0x00686890`, especially `0x0068695C..0x00686AF2` |
+| Rules constructor and layered reader for the six startup fields | `RulesClass__Constructor @ 0x00665650`; `RulesClass__ReadCrateRules @ 0x0066B900` |
+| Random placement, slots, and Mark facts | `MapClass__PlaceRandomCrate`, `MapClass__PlaceCrate`, and `MapClass__CrateSlot` bodies/callers in the placement/runtime report |
+| Timer formula | accepted placement body: `regen*450`, `regen*1800`, `RandomRanged(0,0x7ffffffe)`, forward interpolation, x87 truncate |
+| Slot lifetime shape | 256 entries × 16 bytes: signed start, aux word, signed duration, packed signed 16-bit x/y; `(0,0)` is the sole empty test |
+| Retail installed values | active `rulesmd.ini`: min 1, max 255, regen 3, wood/common CRATE, water WCRATE; `[MultiplayerDialogSettings] Crates=yes` |
+| Retail art | installed `ra2.mix -> temperat.mix`: `CRATE.TEM` and `WCRATE.TEM`, SHP(TS), 60×60, two frames |
+
+All simulation-behavior comments and tests introduced by implementation must
+cite the relevant body or one of the two primary reports. The caller/order
+correction report overrides the older statement that the active startup path
+has no game-mode gate. The placement/runtime report remains authoritative for
+the placement transaction where it is not contradicted.
+
+## Existing behavior to preserve
+
+- The scenario RNG is already the correct stream, and
+  `SimRng::next_range_u32_inclusive` models the active mask-and-reject
+  `RandomRanged` shape, including no draw for equal bounds.
+- `find_nearby_passable_cell` already owns the shared nearby-cell search and
+  must remain the sole FNPC implementation. Crate code supplies native query
+  facts; it does not fork the search algorithm.
+- `RawCellOccupationGrid` already exposes exact ground/deck bytes.
+- `BridgeCellFacts` already preserves native raw bridge flags, including the
+  structural `0x100` deck selector.
+- `OverlayGrid` is the simulation authority for live overlay identity/data and
+  publishes dirty cells to the existing frame-update path.
+- `OverlayRenderIndex` owns source-order install, coordinate upsert,
+  tombstones, and restore ordering.
+- Rendering forces frame zero for `Crate=yes`, and the atlas can load crate
+  body art.
+- The retail multiplayer quick-checksum deliberately excludes native crate
+  slots and remains unchanged.
+- `ScenarioPostMapOutput.crates: Option<_>` correctly carries the active
+  campaign-versus-Skirmish distinction and remains optional.
+
+## Design
+
+### 1. Layered startup-crate rules authority
+
+Move the startup subset of `CrateRules` from the monolithic `ruleset.rs`
+parser into focused `rules/crate_rules.rs` state:
+
+- `wood_crate_img`, `crate_img`, and `water_crate_img`: optional allocated
+  overlay identities;
+- `minimum` and `maximum`: signed `i32`;
+- `regen: NativeF64Bits`.
+
+Constructor values are literal native values: three null image pointers,
+minimum 1, maximum 255, and regen bits for 10.0.
+
+`RulesPassProcessor` gains a narrow accumulator. Each pass first performs the
+existing explicit registry allocations and type readers. After
+`allocate_late_global_references`, the accumulator applies
+`ReadCrateRules`-equivalent updates while the Overlay registry contains the
+identities the native reader would see. Section absence returns without writes;
+each missing key retains the current accumulated value. A valid `none` image
+stores a null identity rather than being treated as a lookup error.
+
+The accumulator is returned as semantic state in `ProcessedRulesLayers`, next
+to the compatibility projection and content hash. `RuleSet::from_processed_rules`
+builds ordinary projected fields through a private parser and installs the
+exact accumulated startup-crate state. `RuleSet::from_ini` wraps its one INI in
+a `RulesLayerStack`, so direct tests and production share one path.
+
+`CrateImg` is retained even though destination land type chooses the
+water-versus-wood/common configured identity. Native Mark classification tests
+the selected identity against the current configured image pointers, and
+configured aliasing/null values are therefore observable.
+
+No sound, unit, radius, money, FreeMCV, fixed-goodie, or unrelated crate field
+is parsed by this mechanism.
+
+### 2. Persistent crate slots
+
+Add focused `sim/crates/state.rs` authority:
+
+```text
+CrateSlot {
+    start_frame: i32,
+    aux: u32,
+    duration: i32,
+    cell_x: i16,
+    cell_y: i16,
+}
+
+CrateAuthority {
+    slots: [CrateSlot; 256],
+}
+```
+
+Fresh/reset slots are exactly `{-1, 0, 0, 0, 0}`. A slot is empty only when
+both coordinates are zero; no derived lookup from `OverlayGrid` replaces this
+test. The first empty slot is always found by ascending index.
+`CrateAuthority` is a direct `Simulation` field adjacent to overlay/map
+authorities, not a presentation cache or temporary local.
+
+This slice writes slot state during startup placement but does not advance or
+clear timers. The raw representation is nevertheless complete now so later
+regeneration and pickup do not need a migration or second authority.
+
+### 3. Count and random-cell frame
+
+`scenario_start_crate_count` accepts signed `i32` values and performs:
+
+```text
+min(maximum, max(minimum, human_node_count))
+```
+
+No clamp to zero or 256 is added. A negative requested result executes zero
+placement-loop iterations. Values over 256 continue invoking the random
+placement entry, whose full-slot early return consumes no RNG. The outer
+post-map loop consumes each requested call regardless of visible, ghost, or
+failure result; it does not top up successful overlays.
+
+The human count remains human, non-passive houses only. The active random
+rectangle has left/top 1 and width/height `SizeW + SizeH - 1`, derived with
+native signed/wrapping arithmetic from `Simulation.playfield_bounds.base` and
+`playfield_size_height`. Each coordinate is exactly:
+
+```text
+left + RandomRanged(0, width - 1)
+top  + RandomRanged(0, height - 1)
+```
+
+It never substitutes the canonical iso-array `session.map_width`.
+
+Each random-placement call consumes X then Y from `scenario_rng`, up to 1000
+search attempts. The drawn cell chooses Float versus Track for the existing
+FNPC query. The snapped destination selects the configured
+`WaterCrateImg` versus `WoodCrateImg` identity from land type.
+
+### 4. Placement transaction and ghost semantics
+
+The transaction order is explicit:
+
+1. Find the first empty slot. If none exists, return without RNG.
+2. Draw X then Y and run FNPC.
+3. Reject and retry if the snapped cell is outside the playfield or already has
+   an overlay.
+4. Select the water or wood/common configured identity.
+5. Classify Mark movement by identity, not destination surface:
+   compare the selected identity with current `WaterCrateImg` first and use
+   Float on equality; otherwise, matching `CrateImg` or `WoodCrateImg` uses
+   Track. Water-first priority preserves configured pointer aliases.
+6. Run constructor/Unlimbo/Mark facts. A null/unknown selected identity,
+   terrain object, slope above four when the selected raw overlay ID is not
+   exact `0xB2`, nonzero selected occupation byte,
+   non-bridge selected-speed zero, bridge-plane failure, allocation failure,
+   Unlimbo failure, or Mark failure is an accepted ghost.
+7. Structural bridge `raw_flags & 0x100` selects deck occupation and bypasses
+   the non-bridge terrain-speed-zero rejection.
+8. Visible success stamps overlay identity and data `0xFF`; a ghost leaves the
+   cell unchanged. Both stop retries.
+9. Record the slot coordinate, draw/install the timer, and report the outcome.
+
+Only the outside-playfield and occupied-overlay checks in step 3 are retryable
+hard rejections after a snapped candidate exists. Every later failure consumes
+the call as an accepted timed ghost. This includes valid configured `none`.
+
+Rust has no fallible native Overlay allocator or separate Unlimbo object graph.
+Production registry/grid invariants make allocation succeed; deterministic test
+injection may exercise the ghost result, but must not turn it into retry or
+fail-closed behavior.
+
+`CratePlacement` becomes signed/count-aware:
+
+```text
+requested: i32
+accepted: u32
+visible: u32
+```
+
+`accepted` includes ghosts.
+
+### 5. Exact timer math
+
+Timer calculation uses `NativeF64Bits` and `X87Chop53`, not host floating
+point in simulation:
+
+```text
+lower = regen * 450.0
+upper = regen * 1800.0
+draw = RandomRanged(0, 0x7ffffffe)
+value = lower + draw / 2147483646.0 * (upper - lower)
+duration = x87 truncate-toward-zero(value)
+start = current pre-increment binary frame
+aux = high dword of stored upper double
+```
+
+Retail `regen=3` must produce 1350 at draw zero, 5400 at the inclusive maximum,
+and aux `0x40B51800`. A narrow pure helper exposes golden vectors independent
+of placement search.
+
+### 6. Crate-specific overlay writes
+
+Do not route crate placement through generic
+`place_overlay_native_runtime`, whose wall/protection gates differ. Add the
+smallest crate-specific `OverlayGrid` primitive:
+
+- install the chosen identity and data `0xFF`;
+- preserve wall-owner and unrelated cell authority;
+- run existing synchronous passability invalidation/publication;
+- enqueue the existing dirty-cell fact once for a visible result.
+
+Ghost placement leaves the cell untouched. Native zero-rectangle dirty/redraw
+attempts map to a Rust-native no-pixel no-op; no persistent render queue is
+invented merely to record an empty rectangle. Radar invalidation is not emitted.
+
+Removal and raw low-byte postwrite primitives remain deferred with their
+consumers.
+
+### 7. Post-map production delivery and order
+
+`Simulation::finalize_scenario_post_map` preserves the earlier verified
+tiberium and navigation seams, then handles session modes as follows.
+
+For `skirmish_session: Some`:
+
+1. evaluate `session.game_options.crates`;
+2. count current human non-passive houses and make the exact startup attempts;
+3. apply Skirmish AI opening credits;
+4. apply launch alliances;
+5. return `ScenarioPostMapOutput.crates = Some(receipt)`.
+
+For fixed-map campaign `skirmish_session: None`, do not call startup crate
+placement; apply campaign-authored alliances and return `crates = None`.
+
+The existing accepted-random-map launch attaches generated map data to the
+ordinary Skirmish loading request through `with_accepted_random_map`; it must
+therefore reach this same `skirmish_session: Some` post-map seam after successful
+acceptance. Preview generation stops before that request and must not create
+simulation state. This mechanism adds regression coverage to that production
+connection rather than a second simulation API. No raw network mode is
+constructed here.
+
+The option-off Skirmish receipt remains `Some` with requested/accepted/visible
+zero so mode ownership stays distinct from option state.
+
+### 8. First-frame presentation delivery
+
+The app currently builds `overlays_connected` before post-map finalization and
+does not react to startup crates. After finalization it will query only visible
+accepted crate coordinates from simulation authority, materialize occupied
+`OverlayEntry` values from the live grid, and upsert them through
+`OverlayRenderIndex` before `AppState` construction. Ghosts have no overlay
+identity and do not appear.
+
+`preregister_runtime_overlay_names` will include every registry entry with
+`Crate=yes`, alongside existing wall and low-bridge registration. Existing
+atlas resolution and `CRATE_BODY_FRAME = 0` remain unchanged.
+
+```text
+active rules layers
+  -> startup CrateRules subset
+  -> gated and ordered post-map production command
+  -> Simulation crate slot + OverlayGrid
+  -> initial OverlayRenderIndex
+  -> existing crate atlas/frame-zero draw path
+```
+
+### 9. Snapshot and hash ownership
+
+Bump `SNAPSHOT_VERSION` from 113 to 114. `CrateAuthority` serializes its raw
+slot array rather than reconstructing from overlays, preserving ghosts, signed
+durations, and aux words.
+
+Add `include_crate_authority_v114` to the versioned world-hash schema. Current
+hashes fold all five slot fields in ascending slot order. Historical probe
+helpers disable the new field, and a
+`state_hash_without_crate_authority_v114` probe proves the version boundary.
+The pre-v114 session identity fold stays byte-for-byte stable.
+
+`compute_retail_multiplayer_checksum` is unchanged because retail's quick
+checksum excludes this array; VERA's broader state hash includes it for
+deterministic snapshot/replay protection.
+
+## Architecture fit
+
+- `rules/` owns layered INI semantics and overlay identities; it does not
+  depend on simulation, rendering, or audio.
+- `sim/` owns crate slots, RNG, placement, timers, overlay state, and
+  deterministic persistence.
+- `app/loading` supplies map/session inputs and consumes post-map receipts; it
+  does not decide crate behavior.
+- `render/` consumes overlay identities/data and registry flags.
+- No simulation module depends on app, render, UI, sidebar, audio, or network.
+- Persistent native floating rule state is stored as bits and evaluated through
+  the existing native x87 helper.
+
+## Expected file-level change set
+
+- Add `src/rules/crate_rules.rs` and export it from `src/rules/mod.rs`.
+- Update `src/rules/ini_parser.rs`, `src/rules/ruleset.rs`, and focused rule
+  tests for only the six startup fields.
+- Split `src/sim/crates.rs` into a narrow state/placement module layout, or use
+  an equivalently small layout if live-tree review shows a less disruptive fit.
+- Update the simulation owner, `src/sim/overlay_grid.rs`,
+  `src/sim/scenario_post_map.rs`, snapshot code, and world-hash schema/tests.
+- Update `src/app/loading/init.rs`, runtime overlay-name preregistration, and
+  `OverlayRenderIndex` tests.
+- Add ignored active-retail validation tests only where filesystem installation
+  evidence is required; ordinary behavior tests remain focused `--lib` tests.
+
+The write-plan gate will pin exact paths and task order against the live tree
+before implementation.
+
+## Validation design
+
+### Focused Rust `--lib` tests
+
+- Constructor versus installed values for minimum, maximum, regen, and three
+  image names.
+- Multi-pass section absence and missing-key retention for only those fields.
+- Signed/no-clamp min/max and inverted count order.
+- Image `none`, unknown allocation, aliasing, and water-first Mark
+  classification.
+- Fresh 256-slot bytes, `(0,0)` sole emptiness, first-free ordering, and
+  full-table zero-draw behavior.
+- Signed request counts, negative/inverted values, and requests above 256.
+- Exact `left + RandomRanged(0,width-1)` / Y equivalent, X/Y/timer draw
+  counts, and retry ownership.
+- Destination water/common identity selection, identity-based Float/Track
+  selection, terrain-object ghost, non-exempt slope ghost, raw-ID-`0xB2`
+  steep-slope eligibility, ground/deck raw-byte equality,
+  structural bridge bypass, non-bridge speed-zero ghost, null-image ghost,
+  visible stamp, and ghost cell preservation.
+- Timer interpolation endpoints, an interior golden vector, start frame, aux,
+  and expression-direction proof.
+- Visible-only initial overlay-index sync, name preregistration, and frame-zero
+  renderer/atlas preservation.
+- Fixed-map campaign negative gate, fixed-map Skirmish positive gate,
+  Crates-off zero-draw behavior, generated playable positive gate, and preview
+  negative gate.
+- Observable post-map ordering: startup crates before AI credits before
+  alliances.
+- Snapshot v114 round-trip of visible and ghost slots; state-hash sensitivity;
+  historical hash stability; retail quick-checksum invariance.
+
+### Literal external evidence
+
+- Re-hash active `gamemd.exe` and record exact SHA-256.
+- Re-read decisive caller/order and placement bodies from the active Ghidra
+  session when an implementation detail is ambiguous.
+- Read installed `rulesmd.ini` and compare exactly the six startup fields plus
+  `[MultiplayerDialogSettings] Crates` to the production `RuleSet`/session
+  result.
+- Use supported release `asset.exe` to prove `CRATE.TEM` and `WCRATE.TEM`
+  resolve from installed theater MIX and have expected SHP(TS) metadata.
+- Run a production-loading test proving allocated identities reach crate
+  placement and the initial presentation index, not only a unit helper.
+
+### Cargo discipline
+
+Before every Cargo command, check `Get-Process cargo,rustc`. While
+implementing, run only focused `cargo test -p vera20k --lib <filter>`
+commands. Run `cargo test -p vera20k --lib` exactly once after a fresh critic
+passes and the PR is otherwise ready.
+
+## Alternatives considered
+
+### A. Chosen: narrow layered rules subset plus persistent crate authority
+
+This follows native rules-process timing, creates one simulation owner, and
+connects it through gated production loading and presentation. Later pickup and
+regeneration mechanisms can consume the same slots without migration.
+
+### B. Parse the full crate-rule cluster now
+
+Rejected. Sound, radius, unit, money, fixed-goodie, and FreeMCV authority have
+no startup consumer. Pulling them into this PR would create disconnected,
+insufficiently evidenced state and expand review into later Phase 14
+mechanisms.
+
+### C. Flatten INI layers and patch missing values after merge
+
+Rejected. A flattened projection cannot reproduce section/key retention or
+resolve overlay identities at native Process-pass timing.
+
+### D. Keep local bool slots and add a separate timer map
+
+Rejected. It creates duplicate slot authorities and cannot represent ghosts or
+raw save/load state.
+
+### E. Implement all crate pickup/effects in the same PR
+
+Rejected. Pickup return barriers, effect consumers, triggers, audio, and
+animation are independently player-visible mechanisms.
+
+## Adversarial review record
+
+The first draft incorrectly inferred from the helper's missing internal
+game-mode comparison that campaign must receive startup crates. Active caller
+analysis disproved that hypothesis: `Full_Init` skips `Post_Map_Init` for
+raw mode 0, and generated maps have a separate direct parent. This revision
+therefore preserves `ScenarioPostMapOutput.crates: Option<_>` and the existing
+campaign exclusion.
+
+The first draft also over-bundled unrelated crate rules, put AI credits before
+crates, selected Mark movement from destination surface, treated valid
+`none` as fail-closed, and left the random coordinate upper bound open. This
+revision:
+
+- narrows rules authority to the six fields consumed at startup;
+- orders crates before AI credits and alliances;
+- makes Mark movement identity-based with water-first alias priority;
+- makes every post-precheck failure, including null identity, an accepted timed
+  ghost;
+- preserves raw overlay ID `0xB2` as the exact steep-slope Mark exception;
+- pins the inclusive coordinate as `RandomRanged(0,width-1)`.
+
+Residual risks for design-review/review-plan:
+
+1. Confirm exact slot coordinate versus timer-field write order where it affects
+   a testable returned trace or failure state.
+2. Confirm the accumulator can resolve per-pass overlay identities without
+   exposing private registry internals or re-running flattened parsing.
+3. Prove the existing
+   `start_skirmish_session -> LoadingRequest::with_accepted_random_map` path
+   retains `skirmish_session: Some` through post-map finalization, while dialog
+   preview completion alone never constructs simulation state.
+4. Keep first-presentation synchronization a consumer of simulation state,
+   never a second mutation of `OverlayGrid`.
+5. Prove all post-precheck failure cases stop retrying and still install the
+   slot timer.
+
+The fresh design-review approved this revision. The design still does not
+claim the mechanism implemented.

--- a/docs/plans/2026-09-01-phase14-crate-authority-foundation-design.md
+++ b/docs/plans/2026-09-01-phase14-crate-authority-foundation-design.md
@@ -1,9 +1,9 @@
 # Phase 14 crate-authority foundation design
 
-**Status:** approved for implementation after design-review  
-**Phase hypothesis:** GSI-14 row 303, “Crates / powerups,” contains several independently deliverable mechanisms. This design closes only the authoritative creation and delivery of scenario-start crates. Pickup, regeneration, effects, and specific-cell producers remain separate Phase 14 mechanisms.  
-**Caller/order evidence:** `docs/research/SCENARIO_START_CRATE_POST_MAP_CALLER_GATE_GHIDRA_REPORT.md`  
-**Placement/runtime evidence:** `docs/research/PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md`  
+**Status:** approved for implementation after design-review
+**Phase hypothesis:** GSI-14 row 303, “Crates / powerups,” contains several independently deliverable mechanisms. This design closes only the authoritative creation and delivery of scenario-start crates. Pickup, regeneration, effects, and specific-cell producers remain separate Phase 14 mechanisms.
+**Caller/order evidence:** `docs/research/SCENARIO_START_CRATE_POST_MAP_CALLER_GATE_GHIDRA_REPORT.md`
+**Placement/runtime evidence:** `docs/research/PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md`
 **Supersedes as design authority:** `docs/plans/2026-07-23-crate-authority-design.md` and `docs/plans/2026-07-23-crate-evidence-foundation-plan.md`
 
 ## Outcome
@@ -39,7 +39,7 @@ presentation list, and performs AI opening credits before crates.
 | Water/common identity | Destination land type selects the configured water or wood/common overlay identity; Mark then selects Float only when the selected identity equals the current water identity, otherwise Track. |
 | Aliased configured identities | Water identity comparison has priority. If water and wood/common resolve to the same identity, the selected identity uses Float facts. |
 | Configured `none` image | Null identity survives the hard prechecks, then becomes an accepted timed ghost; it does not retry or fail closed. |
-| Terrain object, non-exempt steep slope, occupation, speed-zero, bridge-plane, allocation, Unlimbo, or Mark failure after hard prechecks | The call is accepted as a ghost: the slot and timer persist, RNG is consumed, and no visible overlay is stamped. Raw overlay ID `0xB2` is the exact retail exception that remains Mark-eligible above slope four. |
+| Terrain object, non-exempt steep slope, ordinary occupation/speed-zero, allocation, Unlimbo, or Mark failure after hard prechecks | The call is accepted as a ghost: the slot and timer persist, RNG is consumed, and no visible overlay is stamped. A TerrainClass object gates the constructor before every Mark branch. Raw overlay ID `0xB2` is the exact retail exception that remains Mark-eligible above slope four; high-anchor IDs explicitly bypass ordinary ground/deck occupation and speed checks. |
 | Custom configured Mark-special identity | The selected dense runtime ID follows the active `OverlayClass::Mark` branch: high-anchor bridge stamping, Railroad bypass, wall placement/connectivity, low-bridge endpoint transaction, Road tiberium germination, and ordinary `CellAnim` are not collapsed to the default crate write. |
 | Configured TS veins/veinhole identity (`0x7E`/`0xA7`) | The startup slot is accepted and timed, but Rust creates no overlay or TS world mutation. GSI-18.01 remains explicitly excluded. |
 | Occupied overlay or snapped cell outside the playfield | The attempt is rejected before construction and retries, preserving the exact draw sequence. |
@@ -116,7 +116,9 @@ closed.
 | Rules finalization and option/count/order | `Full_Init @ 0x00686B20`; `Post_Map_Init @ 0x00686890`, especially `0x0068695C..0x00686AF2` |
 | Rules constructor and layered reader for the six startup fields | `RulesClass__Constructor @ 0x00665650`; `RulesClass__ReadCrateRules @ 0x0066B900` |
 | Random placement, slots, and Mark facts | `MapClass__PlaceRandomCrate`, `MapClass__PlaceCrate`, and `MapClass__CrateSlot` bodies/callers in the placement/runtime report |
-| Mark branch dispatch and ordering | `OverlayClass::Mark @ 0x005FC570`; high-anchor setter reports; `REGULAR_OVERLAY_WALL_AUTOFILL_COMMIT_GHIDRA_REPORT.md` |
+| Constructor TerrainClass gate | `OverlayClass::OverlayClass @ 0x005FC380`; TerrainClass hit skips Unlimbo and Mark entirely |
+| Mark branch dispatch and ordering | `OverlayClass::Mark @ 0x005FC570`; high setters `0x0047E040`/`0x0047E470`; `REGULAR_OVERLAY_WALL_AUTOFILL_COMMIT_GHIDRA_REPORT.md` |
+| CellAnim palette and Z-adjust post-writes | `OverlayClass::Mark @ 0x005FD112..0x005FD1FA`; `ECX=CellClass` before `GetTiberiumType @ 0x00485010`, then `Anim+0xD4` and `Anim+0xFC` writes |
 | Low endpoint tables, dummy alias, search, overwrites, and raw Scenario draws | `docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_FIXED_MAP_STAMP_RNG_TRANSACTION_GHIDRA_REPORT.md` |
 | Road tiberium density postwrite | `CellClass::SpreadCellGerminate @ 0x004818E0`; dword table `0x0081CD28` = `[0,1,3,4,6,7,8,10,11,7,0,1]` |
 | Timer formula | accepted placement body: `regen*450`, `regen*1800`, `RandomRanged(0,0x7ffffffe)`, forward interpolation, x87 truncate |
@@ -261,29 +263,37 @@ The transaction order is explicit:
 3. Reject and retry if the snapped cell is outside the playfield or already has
    an overlay.
 4. Select the water or wood/common configured identity.
-5. Apply the universal slope gate, then dispatch the selected dense runtime ID
-   through the same active-YR Mark branches as the native object: high bridge
-   anchors preserve prior data and stamp bridge flags; Railroad writes data
-   zero before ordinary blockers; walls use building passability and refresh
-   connectivity; low endpoint IDs run their exact fixed/search/body transaction.
+5. After the constructor's TerrainClass scan, apply the universal slope gate,
+   then dispatch the selected dense runtime ID through the same active-YR Mark
+   branches as the native object. A TerrainClass hit skips Unlimbo and therefore
+   every Mark mutation. High bridge anchors write raw data `0` (direction 0) or
+   `9` (direction 6) on anchor/F1/F2/opposite, stamp bridge flags, and then fall
+   through to Railroad/wall/low/ordinary precedence. Railroad writes data zero;
+   walls use building passability and refresh connectivity; low endpoint IDs
+   run their exact fixed/search/body transaction.
    Dense IDs `0x7E`/`0xA7` stop as accepted ghosts because their only mutation
    is excluded TS veins/veinhole behavior.
 6. For the remaining ordinary branch, classify movement by identity, not
    destination surface: compare current `WaterCrateImg` first and use Float on
    equality; otherwise matching `CrateImg` or `WoodCrateImg` uses Track.
    Water-first priority preserves configured pointer aliases.
-7. Run constructor/Unlimbo/ordinary-Mark facts. A null/unknown selected identity,
-   terrain object, slope above four when the selected raw overlay ID is not
+7. Run Unlimbo/ordinary-Mark facts. A null/unknown selected identity,
+   slope above four when the selected raw overlay ID is not
    exact `0xB2`, nonzero selected occupation byte,
    non-bridge selected-speed zero, bridge-plane failure, allocation failure,
    Unlimbo failure, or Mark failure is an accepted ghost.
 8. Structural bridge `raw_flags & 0x100` selects deck occupation and bypasses
-   the non-bridge terrain-speed-zero rejection.
+   the non-bridge terrain-speed-zero rejection for non-high ordinary overlays.
+   The four high-anchor identities instead force their ordinary passability
+   result true explicitly, bypassing both ground and deck occupation.
 9. Ordinary success writes identity and data zero, Road writes one then calls
    `SpreadCellGerminate(false)` for tiberium, `Crate=yes` finally overrides data
    with `0xFF`, and `CellAnim` spawns before the common Recalc tail. Ordinary
    Mark failures may still spawn `CellAnim`; both visible and ghost outcomes
-   stop retries.
+   stop retries. After construction, a CellAnim over a successfully installed
+   tiberium cell receives that TiberiumClass's `Color=` Convert authority and
+   the cell's ground Z-adjust. A failed/non-tiberium Mark receives neither
+   post-constructor write.
 10. Record the slot coordinate, draw/install the timer, and report the outcome.
 
 Only the outside-playfield and occupied-overlay checks in step 3 are retryable
@@ -340,9 +350,11 @@ smallest crate-specific raw-field primitive and keep branch ordering in
 - enqueue existing dirty-cell facts for every real native field write, then run
   synchronous passability publication in native write order.
 
-Ghost placement leaves the cell untouched. Native zero-rectangle dirty/redraw
-attempts map to a Rust-native no-pixel no-op; no persistent render queue is
-invented merely to record an empty rectangle. Radar invalidation is not emitted.
+An ordinary pre-stamp ghost leaves the cell untouched. A specialized branch may
+retain earlier native writes before its later rejection, notably a high setter
+whose subsequent wall admission fails. Native zero-rectangle dirty/redraw attempts
+map to a Rust-native no-pixel no-op; no persistent render queue is invented merely
+to record an empty rectangle. Radar invalidation is not emitted.
 
 Removal and raw low-byte postwrite primitives remain deferred with their
 consumers.
@@ -377,19 +389,26 @@ zero so mode ownership stays distinct from option state.
 ### 8. First-frame presentation delivery
 
 The app currently builds `overlays_connected` before post-map finalization and
-does not react to startup crates. After finalization it will query only visible
-accepted crate coordinates from simulation authority, materialize occupied
-`OverlayEntry` values from the live grid, and upsert them through
-`OverlayRenderIndex` before `AppState` construction. Ghosts have no overlay
-identity and do not appear.
+does not react to startup crates. After finalization it will inspect, without
+consuming, every pending dirty cell produced by startup Mark, materialize
+occupied `OverlayEntry` values from the live grid, and upsert them through
+`OverlayRenderIndex` before `AppState` construction. This includes low-bridge
+fixed/body extension cells and any pre-existing neighbor identity whose data a
+high setter changed. Ghosts with no live identity do not appear.
 
 `preregister_runtime_overlay_names` will include every registry entry with
 `Crate=yes` and all three resolved `CrateRules` identities, even when a
 late-allocated custom type retains constructor-default `Crate=false`, alongside
 existing wall and low-bridge registration. Atlas preload follows every output
 the selected type's actual Mark branch can create: crate frame zero, ordinary
-data, wall frames, low fixed/body IDs and states, high-anchor preserved data,
-Railroad zero, and Road-tiberium density frames.
+data, wall frames, low fixed/body IDs and states, Railroad zero, and
+Road-tiberium density frames. High-anchor identities are excluded from
+`OverlayAtlas` and rooted, with body and shadow frames, in `BridgeAtlas` before
+startup placement. Reachable crate `CellAnim` names enter the scheduler asset
+closure before construction, and live tiberium-remap variants enter the SHP
+atlas before first presentation. After the complete startup transaction, the
+derived `BridgeRuntimeState` and initial navigation projection are rebuilt from
+the final CellClass authority before AI credits and first presentation.
 
 ```text
 active rules layers
@@ -404,7 +423,9 @@ active rules layers
 
 Bump `SNAPSHOT_VERSION` from 113 to 114. `CrateAuthority` serializes its raw
 slot array rather than reconstructing from overlays, preserving ghosts, signed
-durations, and aux words.
+durations, and aux words. `AnimObject` also persists the optional tiberium
+Convert selector installed after CellAnim construction so restore does not
+silently change its palette.
 
 Add `include_crate_authority_v114` to the versioned world-hash schema. Current
 hashes fold all five slot fields in ascending slot order. Historical probe

--- a/docs/plans/2026-09-01-phase14-crate-authority-foundation-design.md
+++ b/docs/plans/2026-09-01-phase14-crate-authority-foundation-design.md
@@ -40,6 +40,8 @@ presentation list, and performs AI opening credits before crates.
 | Aliased configured identities | Water identity comparison has priority. If water and wood/common resolve to the same identity, the selected identity uses Float facts. |
 | Configured `none` image | Null identity survives the hard prechecks, then becomes an accepted timed ghost; it does not retry or fail closed. |
 | Terrain object, non-exempt steep slope, occupation, speed-zero, bridge-plane, allocation, Unlimbo, or Mark failure after hard prechecks | The call is accepted as a ghost: the slot and timer persist, RNG is consumed, and no visible overlay is stamped. Raw overlay ID `0xB2` is the exact retail exception that remains Mark-eligible above slope four. |
+| Custom configured Mark-special identity | The selected dense runtime ID follows the active `OverlayClass::Mark` branch: high-anchor bridge stamping, Railroad bypass, wall placement/connectivity, low-bridge endpoint transaction, Road tiberium germination, and ordinary `CellAnim` are not collapsed to the default crate write. |
+| Configured TS veins/veinhole identity (`0x7E`/`0xA7`) | The startup slot is accepted and timed, but Rust creates no overlay or TS world mutation. GSI-18.01 remains explicitly excluded. |
 | Occupied overlay or snapped cell outside the playfield | The attempt is rejected before construction and retries, preserving the exact draw sequence. |
 | All 256 slots occupied | The random call returns without consuming RNG. |
 | Save/restore or lockstep hash | Every raw slot word round-trips and affects VERA's versioned state hash; retail's narrow multiplayer checksum remains unchanged. |
@@ -60,6 +62,10 @@ presentation list, and performs AI opening credits before crates.
   and occupied-overlay hard prechecks that is representable in Rust.
 - Exact timer draw/interpolation, pre-increment frame ownership, and `aux` word.
 - Crate-specific overlay writes that preserve unrelated cell fields.
+- Every active-YR `OverlayClass::Mark` branch reachable through a custom
+  configured startup identity: high anchors `0x18/0x19/0xED/0xEE`, Railroad,
+  walls, low endpoint triggers `0x7A..0x7D/0xE9..0xEC`, Road+tiberium
+  germination, ordinary `CellAnim`, and the common Recalc tail.
 - Snapshot version 114 and a version-gated world-hash fold for the raw slot
   table. No change to the retail quick checksum.
 - Production post-map routing for fixed-map mode 5, the successful playable
@@ -92,6 +98,9 @@ presentation list, and performs AI opening credits before crates.
   UniqueID. Gameplay-observable slot/timer/RNG and cell results are retained.
 - Invalid-domain OOM, corrupt pointer graphs, and malformed nonfinite rule
   inputs.
+- TS veins and veinhole mutation behind dense IDs `0x7E` and `0xA7`
+  (GSI-18.01). Their reachable startup call is retained as an accepted ghost;
+  no TS mechanics are imported.
 
 The exclusions remain open Phase 14 work. This PR may establish shared types
 that later mechanisms reuse, but it must not claim those later consumers as
@@ -107,6 +116,9 @@ closed.
 | Rules finalization and option/count/order | `Full_Init @ 0x00686B20`; `Post_Map_Init @ 0x00686890`, especially `0x0068695C..0x00686AF2` |
 | Rules constructor and layered reader for the six startup fields | `RulesClass__Constructor @ 0x00665650`; `RulesClass__ReadCrateRules @ 0x0066B900` |
 | Random placement, slots, and Mark facts | `MapClass__PlaceRandomCrate`, `MapClass__PlaceCrate`, and `MapClass__CrateSlot` bodies/callers in the placement/runtime report |
+| Mark branch dispatch and ordering | `OverlayClass::Mark @ 0x005FC570`; high-anchor setter reports; `REGULAR_OVERLAY_WALL_AUTOFILL_COMMIT_GHIDRA_REPORT.md` |
+| Low endpoint tables, dummy alias, search, overwrites, and raw Scenario draws | `docs/research/bridges/01-assets-map-load-overlay/LOW_OVERLAY_MARK_FIXED_MAP_STAMP_RNG_TRANSACTION_GHIDRA_REPORT.md` |
+| Road tiberium density postwrite | `CellClass::SpreadCellGerminate @ 0x004818E0`; dword table `0x0081CD28` = `[0,1,3,4,6,7,8,10,11,7,0,1]` |
 | Timer formula | accepted placement body: `regen*450`, `regen*1800`, `RandomRanged(0,0x7ffffffe)`, forward interpolation, x87 truncate |
 | Slot lifetime shape | 256 entries × 16 bytes: signed start, aux word, signed duration, packed signed 16-bit x/y; `(0,0)` is the sole empty test |
 | Retail installed values | active `rulesmd.ini`: min 1, max 255, regen 3, wood/common CRATE, water WCRATE; `[MultiplayerDialogSettings] Crates=yes` |
@@ -249,21 +261,30 @@ The transaction order is explicit:
 3. Reject and retry if the snapped cell is outside the playfield or already has
    an overlay.
 4. Select the water or wood/common configured identity.
-5. Classify Mark movement by identity, not destination surface:
-   compare the selected identity with current `WaterCrateImg` first and use
-   Float on equality; otherwise, matching `CrateImg` or `WoodCrateImg` uses
-   Track. Water-first priority preserves configured pointer aliases.
-6. Run constructor/Unlimbo/Mark facts. A null/unknown selected identity,
+5. Apply the universal slope gate, then dispatch the selected dense runtime ID
+   through the same active-YR Mark branches as the native object: high bridge
+   anchors preserve prior data and stamp bridge flags; Railroad writes data
+   zero before ordinary blockers; walls use building passability and refresh
+   connectivity; low endpoint IDs run their exact fixed/search/body transaction.
+   Dense IDs `0x7E`/`0xA7` stop as accepted ghosts because their only mutation
+   is excluded TS veins/veinhole behavior.
+6. For the remaining ordinary branch, classify movement by identity, not
+   destination surface: compare current `WaterCrateImg` first and use Float on
+   equality; otherwise matching `CrateImg` or `WoodCrateImg` uses Track.
+   Water-first priority preserves configured pointer aliases.
+7. Run constructor/Unlimbo/ordinary-Mark facts. A null/unknown selected identity,
    terrain object, slope above four when the selected raw overlay ID is not
    exact `0xB2`, nonzero selected occupation byte,
    non-bridge selected-speed zero, bridge-plane failure, allocation failure,
    Unlimbo failure, or Mark failure is an accepted ghost.
-7. Structural bridge `raw_flags & 0x100` selects deck occupation and bypasses
+8. Structural bridge `raw_flags & 0x100` selects deck occupation and bypasses
    the non-bridge terrain-speed-zero rejection.
-8. Visible success stamps overlay identity, then Mark data: zero ordinarily,
-   one for `Land=Road`, and finally `0xFF` only when the selected type declares
-   `Crate=yes`. A ghost leaves the cell unchanged. Both stop retries.
-9. Record the slot coordinate, draw/install the timer, and report the outcome.
+9. Ordinary success writes identity and data zero, Road writes one then calls
+   `SpreadCellGerminate(false)` for tiberium, `Crate=yes` finally overrides data
+   with `0xFF`, and `CellAnim` spawns before the common Recalc tail. Ordinary
+   Mark failures may still spawn `CellAnim`; both visible and ghost outcomes
+   stop retries.
+10. Record the slot coordinate, draw/install the timer, and report the outcome.
 
 Only the outside-playfield and occupied-overlay checks in step 3 are retryable
 hard rejections after a snapped candidate exists. Every later failure consumes
@@ -309,13 +330,15 @@ duration overflow stores zero rather than aborting scenario load.
 
 Do not route crate placement through generic
 `place_overlay_native_runtime`, whose wall/protection gates differ. Add the
-smallest crate-specific `OverlayGrid` primitive:
+smallest crate-specific raw-field primitive and keep branch ordering in
+`sim::crates`:
 
-- install the chosen identity and Mark data zero, Road one, or `0xFF` only for
-  `Crate=yes`;
+- write only identity/data first; branch code owns Railroad/wall/bridge rules,
+  Road germination, the later `Crate=yes` override, `CellAnim`, and Recalc;
 - preserve wall-owner and unrelated cell authority;
-- run existing synchronous passability invalidation/publication;
-- enqueue the existing dirty-cell fact once for a visible result.
+- project runtime bridge identity/flags into the map-owned bridge cache;
+- enqueue existing dirty-cell facts for every real native field write, then run
+  synchronous passability publication in native write order.
 
 Ghost placement leaves the cell untouched. Native zero-rectangle dirty/redraw
 attempts map to a Rust-native no-pixel no-op; no persistent render queue is
@@ -363,9 +386,10 @@ identity and do not appear.
 `preregister_runtime_overlay_names` will include every registry entry with
 `Crate=yes` and all three resolved `CrateRules` identities, even when a
 late-allocated custom type retains constructor-default `Crate=false`, alongside
-existing wall and low-bridge registration. Atlas preload follows the selected
-type's actual draw path: frame zero for `Crate=yes`, otherwise ordinary Mark
-data zero or Road frame one.
+existing wall and low-bridge registration. Atlas preload follows every output
+the selected type's actual Mark branch can create: crate frame zero, ordinary
+data, wall frames, low fixed/body IDs and states, high-anchor preserved data,
+Railroad zero, and Road-tiberium density frames.
 
 ```text
 active rules layers

--- a/docs/plans/2026-09-01-phase14-crate-authority-foundation-design.md
+++ b/docs/plans/2026-09-01-phase14-crate-authority-foundation-design.md
@@ -39,7 +39,7 @@ presentation list, and performs AI opening credits before crates.
 | Water/common identity | Destination land type selects the configured water or wood/common overlay identity; Mark then selects Float only when the selected identity equals the current water identity, otherwise Track. |
 | Aliased configured identities | Water identity comparison has priority. If water and wood/common resolve to the same identity, the selected identity uses Float facts. |
 | Configured `none` image | Null identity survives the hard prechecks, then becomes an accepted timed ghost; it does not retry or fail closed. |
-| Terrain object, non-exempt steep slope, ordinary occupation/speed-zero, allocation, Unlimbo, or Mark failure after hard prechecks | The call is accepted as a ghost: the slot and timer persist, RNG is consumed, and no visible overlay is stamped. A TerrainClass object gates the constructor before every Mark branch. Raw overlay ID `0xB2` is the exact retail exception that remains Mark-eligible above slope four; high-anchor IDs explicitly bypass ordinary ground/deck occupation and speed checks. |
+| Terrain object, non-exempt steep slope, ordinary object-occupation bit `0x40`/speed-zero, allocation, Unlimbo, or Mark failure after hard prechecks | The call is accepted as a ghost: the slot and timer persist, RNG is consumed, and no visible overlay is stamped. Other raw occupation bits do not block Mark. A TerrainClass object gates the constructor before every Mark branch. Raw overlay ID `0xB2` is the exact retail exception that remains Mark-eligible above slope four; high-anchor IDs explicitly bypass ordinary ground/deck occupation and speed checks. |
 | Custom configured Mark-special identity | The selected dense runtime ID follows the active `OverlayClass::Mark` branch: high-anchor bridge stamping, Railroad bypass, wall placement/connectivity, low-bridge endpoint transaction, Road tiberium germination, and ordinary `CellAnim` are not collapsed to the default crate write. |
 | Configured TS veins/veinhole identity (`0x7E`/`0xA7`) | The startup slot is accepted and timed, but Rust creates no overlay or TS world mutation. GSI-18.01 remains explicitly excluded. |
 | Occupied overlay or snapped cell outside the playfield | The attempt is rejected before construction and retries, preserving the exact draw sequence. |
@@ -279,7 +279,7 @@ The transaction order is explicit:
    Water-first priority preserves configured pointer aliases.
 7. Run Unlimbo/ordinary-Mark facts. A null/unknown selected identity,
    slope above four when the selected raw overlay ID is not
-   exact `0xB2`, nonzero selected occupation byte,
+   exact `0xB2`, selected occupation bit `0x40`,
    non-bridge selected-speed zero, bridge-plane failure, allocation failure,
    Unlimbo failure, or Mark failure is an accepted ghost.
 8. Structural bridge `raw_flags & 0x100` selects deck occupation and bypasses

--- a/docs/plans/2026-09-01-phase14-crate-authority-foundation-design.md
+++ b/docs/plans/2026-09-01-phase14-crate-authority-foundation-design.md
@@ -229,7 +229,11 @@ left + RandomRanged(0, width - 1)
 top  + RandomRanged(0, height - 1)
 ```
 
-It never substitutes the canonical iso-array `session.map_width`.
+`RandomRanged` compares/swaps those endpoints as signed dwords even when the
+derived width is zero or negative. Each wrapping origin addition is then stored
+through a signed 16-bit coordinate before FNPC reads it. It never substitutes
+the canonical iso-array `session.map_width`, rejects a nonpositive rectangle
+before the draws, or retains high coordinate bits that native discards.
 
 Each random-placement call consumes X then Y from `scenario_rng`, up to 1000
 search attempts. The drawn cell chooses Float versus Track for the existing
@@ -256,8 +260,9 @@ The transaction order is explicit:
    Unlimbo failure, or Mark failure is an accepted ghost.
 7. Structural bridge `raw_flags & 0x100` selects deck occupation and bypasses
    the non-bridge terrain-speed-zero rejection.
-8. Visible success stamps overlay identity and data `0xFF`; a ghost leaves the
-   cell unchanged. Both stop retries.
+8. Visible success stamps overlay identity, then Mark data: zero ordinarily,
+   one for `Land=Road`, and finally `0xFF` only when the selected type declares
+   `Crate=yes`. A ghost leaves the cell unchanged. Both stop retries.
 9. Record the slot coordinate, draw/install the timer, and report the outcome.
 
 Only the outside-playfield and occupied-overlay checks in step 3 are retryable
@@ -296,7 +301,9 @@ aux = high dword of stored upper double
 
 Retail `regen=3` must produce 1350 at draw zero, 5400 at the inclusive maximum,
 and aux `0x40B51800`. A narrow pure helper exposes golden vectors independent
-of placement search.
+of placement search. Masked out-of-range `FISTP qword` stores native integer
+indefinite (`i64::MIN`); because the slot writer keeps only EAX, either-sign
+duration overflow stores zero rather than aborting scenario load.
 
 ### 6. Crate-specific overlay writes
 
@@ -304,7 +311,8 @@ Do not route crate placement through generic
 `place_overlay_native_runtime`, whose wall/protection gates differ. Add the
 smallest crate-specific `OverlayGrid` primitive:
 
-- install the chosen identity and data `0xFF`;
+- install the chosen identity and Mark data zero, Road one, or `0xFF` only for
+  `Crate=yes`;
 - preserve wall-owner and unrelated cell authority;
 - run existing synchronous passability invalidation/publication;
 - enqueue the existing dirty-cell fact once for a visible result.
@@ -353,8 +361,11 @@ accepted crate coordinates from simulation authority, materialize occupied
 identity and do not appear.
 
 `preregister_runtime_overlay_names` will include every registry entry with
-`Crate=yes`, alongside existing wall and low-bridge registration. Existing
-atlas resolution and `CRATE_BODY_FRAME = 0` remain unchanged.
+`Crate=yes` and all three resolved `CrateRules` identities, even when a
+late-allocated custom type retains constructor-default `Crate=false`, alongside
+existing wall and low-bridge registration. Atlas preload follows the selected
+type's actual draw path: frame zero for `Crate=yes`, otherwise ordinary Mark
+data zero or Road frame one.
 
 ```text
 active rules layers

--- a/docs/plans/2026-09-01-phase14-crate-authority-foundation-plan.md
+++ b/docs/plans/2026-09-01-phase14-crate-authority-foundation-plan.md
@@ -86,7 +86,8 @@ retail order, and the app consumes live overlay state through the existing
   - **Source:** active placement report `0x004A1944..0x004A1A78`.
 - **Only two retryable hard rejections:** outside playfield or pre-existing
   overlay retries. Every subsequent failure, including null identity and any
-  nonzero occupation byte, creates a timed ghost. Steep slopes are rejected by
+  selected occupation bit `0x40`, creates a timed ghost. Other occupation bits
+  remain admitted. Steep slopes are rejected by
   Mark except for exact raw overlay ID `0xB2`. — **Confidence: high**
   - **Source:** active placement report; `CrateSlot__ValidateCellAndCreateOverlay
     @ 0x004A18F0`.
@@ -195,8 +196,8 @@ audio API is introduced.
   spelling.
 - `none` can compare equal to another null configured pointer, but no object
   exists; it must still ghost after hard prechecks.
-- Occupation tests use the complete selected byte (`== 0`), not
-  `OBJECT_OCCUPATION_BIT` masking.
+- Occupation tests apply the exact `OBJECT_OCCUPATION_BIT` (`0x40`) mask to the
+  selected ground/deck byte; other raw bits remain admitted.
 - Mark rejects `slope_type > 4` unless the selected raw overlay ID is exactly
   `0xB2`.
 - Serde 1.0.229 implements direct fixed-array traits only through length 32;
@@ -649,8 +650,8 @@ After FNPC returns a snapped cell:
    current water ID first -> Float; otherwise matching current crate or wood ID
    -> Track;
 6. in the ordinary branch, a selected `None`, unresolved terrain cell,
-   `slope_type > 4` when the selected raw overlay ID is not exact `0xB2`, any
-   nonzero selected occupation byte, selected
+   `slope_type > 4` when the selected raw overlay ID is not exact `0xB2`,
+   selected occupation bit `0x40`, selected
    non-bridge speed zero, or injected allocation/Unlimbo/Mark failure ->
    accepted ghost;
 7. `bridge_facts.raw_flags & 0x100 != 0` selects
@@ -663,8 +664,9 @@ After FNPC returns a snapped cell:
    A constructed CellAnim receives Tiberium `Color=` palette authority and the
    CellClass ground Z-adjust only when the now-live cell reports tiberium.
 
-Do not use `OBJECT_OCCUPATION_BIT` masking and do not use
-`place_overlay_native_runtime` wall/protection semantics.
+Use the exact `OBJECT_OCCUPATION_BIT` mask; do not collapse it to whole-byte
+nonzero admission. Do not use `place_overlay_native_runtime` wall/protection
+semantics.
 
 **Step 4: Add the specialized raw-field stamp and branch helpers**
 
@@ -724,10 +726,11 @@ Cover:
 - destination water/land image;
 - water-first alias priority;
 - null image accepted ghost;
-- terrain object, non-exempt slopes 5+, every individual nonzero occupation
-  bit, speed-zero, and injected Mark failure accepted ghosts;
+- terrain object, non-exempt slopes 5+, selected occupation bit `0x40`,
+  speed-zero, and injected Mark failure accepted ghosts; other ground/deck
+  occupation bits remain visible;
 - exact raw overlay ID `0xB2` remains eligible on slopes 5+;
-- structural bridge selects deck, checks whole byte, and bypasses underlying
+- structural bridge selects deck, checks bit `0x40`, and bypasses underlying
   speed zero;
 - occupied overlay/outside playfield retry and do not install timer;
 - visible stamp writes zero ordinarily, one for Road, and `0xFF` for

--- a/docs/plans/2026-09-01-phase14-crate-authority-foundation-plan.md
+++ b/docs/plans/2026-09-01-phase14-crate-authority-foundation-plan.md
@@ -57,8 +57,15 @@ retail order, and the app consumes live overlay state through the existing
 - No active TS-only path is used. Network raw modes, pickup/effects,
   regeneration scans, removal, and specific-cell producers remain outside this
   PR.
-- No consequential unknown remains. Test-only injection will represent native
-  allocation/Unlimbo failure without importing a native object graph.
+- A fresh implementation critic invalidated the original “ordinary Mark only”
+  scope hypothesis: custom startup image names can resolve to every active-YR
+  special branch in `OverlayClass::Mark @ 0x005FC570`. The implementation must
+  therefore reproduce high anchors, Railroad, walls, low endpoint tables/raw
+  Scenario draws, Road tiberium germination, and `CellAnim`. Dense IDs
+  `0x7E`/`0xA7` remain accepted ghosts because GSI-18.01 TS mutation is excluded.
+- No consequential unknown remains after the special-branch correction.
+  Test-only injection represents native allocation/Unlimbo failure without
+  importing a native object graph.
 
 ## Key Technical Decisions
 
@@ -83,6 +90,13 @@ retail order, and the app consumes live overlay state through the existing
   Mark except for exact raw overlay ID `0xB2`. — **Confidence: high**
   - **Source:** active placement report; `CrateSlot__ValidateCellAndCreateOverlay
     @ 0x004A18F0`.
+- **Dispatch the complete reachable Mark body:** the universal slope gate
+  precedes high bridge, TS legacy, Railroad, wall, low endpoint, and ordinary
+  branches. Low bodies use `3*L` raw Scenario draws and exact dense-ID tables;
+  Road tiberium calls `SpreadCellGerminate(false)`. — **Confidence: high**
+  - **Source:** `OverlayClass::Mark @ 0x005FC570`;
+    `LOW_OVERLAY_MARK_FIXED_MAP_STAMP_RNG_TRANSACTION_GHIDRA_REPORT.md`;
+    `CellClass::SpreadCellGerminate @ 0x004818E0`.
 - **Use native x87 helper:** timer math uses `NativeF64Bits` and
   `X87Chop53`; no host `f64` arithmetic executes in `sim/`. — **Confidence:
   high**
@@ -616,7 +630,7 @@ It never tops up visible/accepted count.
 - Origin water selects FNPC Float; every other origin selects Track.
 - Retry at most 1,000 times.
 
-**Step 3: Implement hard prechecks and identity-based Mark**
+**Step 3: Implement hard prechecks and complete reachable Mark dispatch**
 
 After FNPC returns a snapped cell:
 
@@ -624,46 +638,59 @@ After FNPC returns a snapped cell:
 2. existing overlay identity -> retry;
 3. destination `yr_cell_land_type == Water` selects resolved
    `WaterCrateImg`, otherwise resolved `WoodCrateImg`;
-4. compare selected numeric identity with resolved current water ID first ->
-   Float; otherwise matching current crate or wood ID -> Track;
-5. a selected `None`, unresolved terrain cell, terrain object,
+4. apply the universal slope gate, then dispatch high anchors, explicit
+   `0x7E`/`0xA7` TS ghosts, Railroad, walls, and low endpoint trigger tables;
+5. only the ordinary branch compares selected numeric identity with resolved
+   current water ID first -> Float; otherwise matching current crate or wood ID
+   -> Track;
+6. in the ordinary branch, a selected `None`, unresolved terrain cell, terrain object,
    `slope_type > 4` when the selected raw overlay ID is not exact `0xB2`, any
    nonzero selected occupation byte, selected
    non-bridge speed zero, or injected allocation/Unlimbo/Mark failure ->
    accepted ghost;
-6. `bridge_facts.raw_flags & 0x100 != 0` selects
+7. `bridge_facts.raw_flags & 0x100 != 0` selects
    `raw_cell_occupation.deck_bits` and bypasses non-bridge speed-zero;
    otherwise select `ground_bits`;
-7. visible success calls only the crate-specific stamp.
+8. ordinary success preserves native write order: identity/data zero, Road data
+   one and optional tiberium germination, `Crate=yes` override, `CellAnim`, then
+   common Recalc.
 
 Do not use `OBJECT_OCCUPATION_BIT` masking and do not use
 `place_overlay_native_runtime` wall/protection semantics.
 
-**Step 4: Add the specialized stamp**
+**Step 4: Add the specialized raw-field stamp and branch helpers**
 
 ```rust
-pub(crate) fn place_crate_overlay(
+pub(crate) fn write_crate_mark_fields(
     &mut self,
     resolved_terrain: &mut ResolvedTerrainGrid,
     registry: &OverlayTypeRegistry,
     rx: u16,
     ry: u16,
     overlay_id: u8,
+    overlay_data: u8,
 ) -> bool {
     let Some(index) = index_of(self.width, self.height, rx, ry) else {
         return false;
     };
-    let Some(flags) = registry.flags(overlay_id) else {
+    let Some(name) = registry.name(overlay_id) else {
         return false;
     };
     self.cells[index].overlay_id = Some(overlay_id);
-    self.cells[index].overlay_data = native_mark_overlay_data(flags);
+    self.cells[index].overlay_data = overlay_data;
     // Preserve wall_owner/unrelated fields rather than replacing OverlayCell.
     self.dirty_cells.push((rx, ry));
-    recalc_overlay_passability(self, resolved_terrain, registry, rx, ry);
+    resolved_terrain.set_runtime_overlay_bridge_identity(
+        rx, ry, overlay_id, overlay_data, name,
+    );
     true
 }
 ```
+
+`sim::crates` owns the exact high-anchor setters, wall connectivity, low bridge
+fixed/search/body transaction and shared-dummy alias, Road tiberium density,
+`CellAnim`, and the common Recalc tail. Do not fold those branches back into a
+single `native_mark_overlay_data` approximation.
 
 **Step 5: Install accepted slot/timer in native order**
 
@@ -697,6 +724,10 @@ Cover:
 - occupied overlay/outside playfield retry and do not install timer;
 - visible stamp writes zero ordinarily, one for Road, and `0xFF` for
   `Crate=yes`, preserves wall owner, and dirties once;
+- Railroad bypass/data zero; wall passability/connectivity/data ordering; high
+  anchor flag family and preserved data; every low trigger table with exact
+  `3*L` raw draws plus occupied-row no-op; Road tiberium neighbor density;
+  visible and failed ordinary `CellAnim`; explicit TS legacy ghosts;
 - ghost preserves the cell;
 - both visible and ghost slots store coordinate then timer words;
 - 1,000 hard rejections return with empty slot.
@@ -781,10 +812,11 @@ the same index contract without constructing `AppState`.
 
 Extend `preregister_runtime_overlay_names` to accept registry entries whose
 flags have `crate_type` plus all three resolved `CrateRules` identities, in
-addition to walls and low bridges. Preload frame zero for flagged crates and
-the native Mark data frame (zero or Road one) for configured `Crate=false`
-types. Keep counters separate so crate additions are not misreported as
-bridges.
+addition to walls and low bridges. Preload the actual reachable Mark outputs:
+frame zero for flagged crates, ordinary/Railroad data, wall frames, low
+fixed/body IDs and states, all preserved high-anchor data values, and Road
+tiberium density frames. Keep counters separate so crate additions are not
+misreported as bridges.
 
 **Step 5: Add focused production tests**
 

--- a/docs/plans/2026-09-01-phase14-crate-authority-foundation-plan.md
+++ b/docs/plans/2026-09-01-phase14-crate-authority-foundation-plan.md
@@ -1,0 +1,968 @@
+# Phase 14 Crate-Authority Foundation Implementation Plan
+
+> **For Codex:** Execute this plan task-by-task. Each task is self-contained.
+
+**Review-plan status:** READY after correcting the raw-ID `0xB2` slope
+exception, signed human-count boundary, frame low-dword cast, and exact-length
+Serde codec for the 256-slot table.
+
+**Goal:** Replace the approximate scenario-start crate pass with one
+simulation-owned, persisted, hashed, retail-ordered authority for ordinary
+offline Skirmish and accepted playable random maps, while preserving the
+fixed-map campaign and preview exclusions.
+
+**Architecture:** Layered `[CrateRules]` processing owns the six startup
+inputs. `sim::crates` owns the fixed slot table, native-x87 timer, placement
+transaction, and visible/ghost result. Existing post-map loading invokes it in
+retail order, and the app consumes live overlay state through the existing
+`OverlayRenderIndex`; no presentation state feeds back into simulation.
+
+**Design Doc:** `docs/plans/2026-09-01-phase14-crate-authority-foundation-design.md`
+
+---
+
+## Grounding Summary
+
+- The active placement/runtime report verifies the 256 × 16-byte slot table,
+  first-empty scan, 1,000-attempt random placer, exact hard-precheck boundary,
+  accepted ghosts, identity-based Mark speed choice, timer formula, and no
+  retail quick-checksum fold.
+- The new caller/order correction report verifies that fixed-map
+  `Full_Init` skips `Post_Map_Init` for raw mode 0 and nonzero control byte,
+  while ordinary fresh Skirmish and successful generated-map paths reach it.
+- Live Ghidra cold caller queries found exactly two parents for
+  `Post_Map_Init`: `Full_Init` and `Read_Scenario`.
+- Live assembly `0x004A184B..0x004A18C5` fixes accepted-write order:
+  redraw, packed coordinate, timer RNG/math, start, aux, duration.
+- Current `src/sim/crates.rs` already uses Scenario RNG and the shared FNPC,
+  but owns only a local bool array, unsigned counts, the wrong rectangle, no
+  timer state, direct overlay stamping, and no ghost model.
+- Current `src/sim/scenario_post_map.rs` correctly gates crates on
+  `skirmish_session: Some`, but grants AI credits before placement.
+- Accepted random maps already enter the ordinary Skirmish load request through
+  `LoadingRequest::with_accepted_random_map` and reach post-map with
+  `Some(match_launch_descriptor)`; dialog preview does not construct a sim.
+- `RulesLayerStack -> RulesPassProcessor -> ProcessedRulesLayers` is the
+  existing native-pass projection. `allocate_late_global_references` already
+  allocates the three crate overlay names before the new semantic accumulator
+  must resolve their retained values.
+- `Simulation` derives serde directly, so a non-skipped `CrateAuthority`
+  field is the snapshot body. The current exact snapshot version is 113.
+- `state_hash_with_schema` already carries version flags through v113; crate
+  slots become the v114 field and probe.
+- Retail `ini/rulesmd.ini [CrateRules]` supplies
+  `CrateMinimum=1`, `CrateMaximum=255`, `CrateRegen=3`,
+  `WoodCrateImg=CRATE`, `CrateImg=CRATE`,
+  `WaterCrateImg=WCRATE`; `[MultiplayerDialogSettings] Crates=yes`.
+- No active TS-only path is used. Network raw modes, pickup/effects,
+  regeneration scans, removal, and specific-cell producers remain outside this
+  PR.
+- No consequential unknown remains. Test-only injection will represent native
+  allocation/Unlimbo failure without importing a native object graph.
+
+## Key Technical Decisions
+
+- **Keep the existing mode carrier:** `ScenarioPostMapOutput.crates` remains
+  optional; `None` means fixed-map campaign, while option-off Skirmish returns
+  `Some` with zero counts. — **Confidence: high**
+  - **Source:** caller/order correction report; current
+    `src/sim/scenario_post_map.rs:92-113`.
+- **Accumulate only six startup fields:** constructor null image identities,
+  signed min/max, exact regen bits, and per-pass key retention are semantic
+  state; unrelated crate fields are not added. — **Confidence: high**
+  - **Source:** active `ReadCrateRules @ 0x0066B900`; design scope; current
+    `RulesPassProcessor` pattern.
+- **Resolve Mark by allocated identity with water priority:** destination
+  chooses water versus wood/common identity; selected identity equals current
+  water first -> Float, otherwise current crate/wood -> Track. — **Confidence:
+  high**
+  - **Source:** active placement report `0x004A1944..0x004A1A78`.
+- **Only two retryable hard rejections:** outside playfield or pre-existing
+  overlay retries. Every subsequent failure, including null identity and any
+  nonzero occupation byte, creates a timed ghost. Steep slopes are rejected by
+  Mark except for exact raw overlay ID `0xB2`. — **Confidence: high**
+  - **Source:** active placement report; `CrateSlot__ValidateCellAndCreateOverlay
+    @ 0x004A18F0`.
+- **Use native x87 helper:** timer math uses `NativeF64Bits` and
+  `X87Chop53`; no host `f64` arithmetic executes in `sim/`. — **Confidence:
+  high**
+  - **Source:** active placement report `0x004A1868..0x004A18C5`; repo
+    `src/util/native_x87.rs`.
+- **Persist/hash the raw table, not overlays:** ghost slots and timer words are
+  future-affecting state even without a visible overlay. — **Confidence: high**
+  - **Source:** active runtime report; current serde/world-hash architecture.
+- **Reuse accepted-random loading:** add a production regression around the
+  existing accepted map path; do not add an RMG-specific sim entry point. —
+  **Confidence: high**
+  - **Source:** `src/app/shell_skirmish.rs:225-267`;
+    `src/app/loading/init.rs:1190-1264`.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Does campaign run startup scatter?** No; `Full_Init` skips the helper for
+  raw mode 0.
+- **Is the upper random bound inclusive width or width minus one?** Coordinate
+  is `left + RandomRanged(0, width - 1)`, with the analogous Y expression.
+- **Does `none` retry?** No; the null pointer is an accepted timed ghost after
+  hard prechecks.
+- **What is accepted write order?** Redraw, coordinate at `0x004A1859`, timer
+  RNG/math, then start/aux/duration at `0x004A18C0/2/5`.
+- **Does accepted RMG need a new sim caller?** No; it already reaches the
+  ordinary `skirmish_session: Some` post-map seam.
+
+### Deferred to Implementation
+
+- None. Compiler-driven borrow/layout adjustments may change private helper
+  arrangement, but not interfaces or behavior in this plan.
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `src/rules/crate_rules.rs` | Six-field layered startup authority |
+| Modify | `src/rules/mod.rs` | Export focused rules module |
+| Modify | `src/rules/ini_parser.rs` | Per-pass accumulator and processed semantic output |
+| Modify | `src/rules/ruleset.rs` | Install semantic crate state; private projected parser |
+| Modify | `src/sim/crates.rs` | Public crate authority, placement transaction, and focused tests |
+| Create | `src/sim/crates/state.rs` | Raw slots, timer fields, visibility queries |
+| Modify | `src/sim/world/mod.rs` | Own and initialize `CrateAuthority` |
+| Modify | `src/sim/overlay_grid.rs` | Crate-specific visible stamp primitive |
+| Modify | `src/sim/scenario_post_map.rs` | Retail order and mode/option receipts |
+| Modify | `src/sim/snapshot.rs` | Version 114 and raw-table round trip |
+| Modify | `src/sim/world/world_hash.rs` | Version-gated ordered slot fold |
+| Modify | `src/app/loading/init.rs` | First-frame occupied entry delivery and RMG regression |
+| Modify | `src/app/frontend/skirmish.rs` | Preregister `Crate=yes` overlay names |
+| Modify | `src/app/presentation/overlay_index.rs` | Focused first-frame append/order regression if needed |
+
+## Interface Changes
+
+- `CrateRules` moves to `rules::crate_rules` and changes:
+  `minimum/maximum: u32 -> i32`; three names become nullable retained overlay
+  identities; `regen: NativeF64Bits` is added.
+- `ProcessedRulesLayers` exposes `crate_rules() -> &CrateRules`.
+- `Simulation` gains `pub(crate) crate_authority: CrateAuthority`.
+- `CratePlacement` changes from `{requested: u32, placed: u32}` to
+  `{requested: i32, accepted: u32, visible: u32}`.
+- `human_player_count` changes from `u32` to `i32`, saturating only if the Rust
+  collection length exceeds `i32::MAX`.
+- `OverlayGrid` gains a crate-specific stamp that returns false out of bounds
+  and otherwise writes identity/data while preserving unrelated cell fields.
+- `ScenarioPostMapOutput` stays shape-compatible except for the nested receipt
+  fields and remains `Option<CratePlacement>`.
+
+All call sites are crate-private or internal. No public network, render, UI, or
+audio API is introduced.
+
+## Sim Checklist
+
+- [ ] Timer math uses `NativeF64Bits`/`X87Chop53`; no host float in sim logic.
+- [ ] `CrateAuthority` is serialized and included in v114 state hash.
+- [ ] `sim::crates` imports no render/UI/sidebar/audio/network module.
+- [ ] No per-tick change is introduced; startup runs before tick 0.
+- [ ] House iteration is used only for a count, so `BTreeMap` order cannot
+  alter results.
+- [ ] Slot scans are fixed ascending array order.
+- [ ] RNG draw order is X, Y per attempt and one timer draw per accepted result.
+- [ ] The `u32` session frame is passed to timer storage with `as i32`,
+  preserving the native low-dword bit pattern across wrap.
+
+## Risk Areas
+
+- The current parser's direct `RuleSet::from_ini` path can bypass per-pass
+  allocation. Refactor it to wrap one `RulesLayerStack` and keep a private
+  projected parser to avoid recursion.
+- Native pointer aliasing must compare resolved numeric overlay IDs, not raw
+  spelling.
+- `none` can compare equal to another null configured pointer, but no object
+  exists; it must still ghost after hard prechecks.
+- Occupation tests use the complete selected byte (`== 0`), not
+  `OBJECT_OCCUPATION_BIT` masking.
+- Mark rejects `slope_type > 4` unless the selected raw overlay ID is exactly
+  `0xB2`.
+- Serde 1.0.229 implements direct fixed-array traits only through length 32;
+  the 256-slot field needs an exact-length tuple codec rather than a derived
+  array implementation or a variable-length `Vec` authority.
+- Borrowing `overlay_grid`, `resolved_terrain`, occupation, and RNG from one
+  `Simulation` may require a narrow transaction-input struct or take/restore;
+  the authoritative owners and order must remain unchanged.
+- Initial presentation must read the already-mutated live grid and upsert once;
+  it must not stamp the overlay a second time.
+- Adding a serde field changes bincode positional layout; version 114 and the
+  exact-version rejection test are mandatory in the same buildable commit.
+
+## Player-Experience Critical Items
+
+| Task | Class | Item | Why it matters | Verification |
+|---|---|---|---|---|
+| 1 | COMPOUNDING | Layered signed rules and allocated image identities | Every startup count/image and later timer derives from it | Multi-pass parser tests + installed INI literal comparison |
+| 2 | MILESTONE-BLOCKING | Persistent raw slots/timer and hash | Ghosts and future regen cannot be represented otherwise | slot bytes, timer goldens, snapshot/hash tests |
+| 3 | MILESTONE-BLOCKING | Exact random/Mark/ghost transaction | Ordinary Crates-on Skirmish visibly diverges at frame zero | focused RNG, water/land, alias, null, occupation, slope tests |
+| 4 | MILESTONE-BLOCKING | Crates-before-credits-before-alliances | Wrong initialization order changes RNG/state observation | post-map trace test |
+| 4 | MILESTONE-BLOCKING | First-frame render-index delivery | Correct sim crates are otherwise invisible until another mutation | production-loading/index test |
+| 4 | UNKNOWN-RISK CLOSED | Campaign and preview negative gates | A false positive would add crates to common campaign loads/previews | negative production tests |
+| 5 | EXACTIFICATION-RESIDUAL | Native failed Overlay orphan object identity | Only malformed/failure paths; slot/timer/cell behavior is visible, orphan is not consumed | documented exclusion; ghost state test |
+
+Representative production scenario: stock `rulesmd.ini`, a two-seat offline
+Battle map, Crates checked, one land and one water-eligible region. The launch
+must create the signed requested attempts before credits/alliances, show every
+visible result in frame one, retain ghost timers, and restore/hash identically.
+
+---
+
+## Tasks
+
+### Task 1: Layered six-field `CrateRules` authority
+
+**Why:** Every later state and placement decision must consume the finalized
+native-pass values and allocated identities.
+
+**Files:**
+- Create: `src/rules/crate_rules.rs`
+- Modify: `src/rules/mod.rs`
+- Modify: `src/rules/ini_parser.rs:571-602,656-797,1049-1148`
+- Modify: `src/rules/ruleset.rs:1277-1337,2374-2375,2552-2575,2660`
+- Modify: `src/rules/ini_parser_tests.rs`
+- Modify: `src/rules/mission_data.rs` focused source-hash literal regression
+- Modify: `src/sim/crates.rs` only to keep the existing approximate placement
+  caller and its parser expectations compiling against nullable image names;
+  Task 3 replaces that implementation.
+
+**Pattern:** `RulesLayerStack` semantic sidecars and
+`NativeF64Bits` readers such as `voxel_anim_type.rs`.
+
+**Step 1: Define exact state and accumulator**
+
+```rust
+// src/rules/crate_rules.rs
+use crate::rules::ini_parser::{IniFile, is_native_none_type_name};
+use crate::util::native_x87::NativeF64Bits;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrateRules {
+    pub minimum: i32,
+    pub maximum: i32,
+    pub regen: NativeF64Bits,
+    pub wood_crate_img: Option<String>,
+    pub crate_img: Option<String>,
+    pub water_crate_img: Option<String>,
+}
+
+impl Default for CrateRules {
+    fn default() -> Self {
+        Self {
+            minimum: 1,
+            maximum: 255,
+            regen: NativeF64Bits::from_bits(10.0_f64.to_bits()),
+            wood_crate_img: None,
+            crate_img: None,
+            water_crate_img: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CrateRulesAccumulator(CrateRules);
+
+impl CrateRulesAccumulator {
+    pub(crate) fn apply_pass(&mut self, ini: &IniFile) {
+        let Some(section) = ini.section("CrateRules") else { return; };
+        if let Some(value) = section.get_i32("CrateMinimum") {
+            self.0.minimum = value;
+        }
+        if let Some(value) = section.get_i32("CrateMaximum") {
+            self.0.maximum = value;
+        }
+        if section.get("CrateRegen").is_some() {
+            self.0.regen = NativeF64Bits::from_bits(
+                section.read_double(
+                    "CrateRegen",
+                    f64::from_bits(self.0.regen.bits()),
+                ).to_bits(),
+            );
+        }
+        for (key, target) in [
+            ("WoodCrateImg", &mut self.0.wood_crate_img),
+            ("CrateImg", &mut self.0.crate_img),
+            ("WaterCrateImg", &mut self.0.water_crate_img),
+        ] {
+            if let Some(raw) = section.get(key) {
+                let value = raw.trim();
+                *target = (!is_native_none_type_name(value))
+                    .then(|| value.to_ascii_uppercase());
+            }
+        }
+    }
+
+    pub(crate) fn finish(self) -> CrateRules { self.0 }
+}
+```
+
+Use the existing native string trimming helper rather than Unicode-only
+`trim()` if tests expose control bytes; keep the public shape above.
+
+**Step 2: Attach the accumulator to native pass processing**
+
+- Add `crate_rules: CrateRulesAccumulator` to `RulesPassProcessor`.
+- Keep existing late reference allocation, including `UnitCrateType`, to
+  avoid regressing registry order outside this mechanism.
+- Immediately after `allocate_late_global_references(pass)`, call
+  `self.crate_rules.apply_pass(pass)`.
+- Return both the projected INI and `crate_rules.finish()` from
+  `RulesLayerStack::process`.
+- Add `ProcessedRulesLayers::crate_rules(&self) -> &CrateRules`.
+
+**Step 3: Remove the old parser and make every entry use the pass stack**
+
+- Delete the old unsigned/string `CrateRules` block from `ruleset.rs`.
+- Import `crate::rules::crate_rules::CrateRules`.
+- Rename the current large `RuleSet::from_ini` body to private
+  `from_projected_ini`.
+- Make public `from_ini` clone the one input into
+  `RulesLayerStack::new(ini.clone())` and call `from_rules_layers`.
+- Make `from_processed_rules` call `from_projected_ini(processed.ini())`,
+  then replace `rules.crate_rules` with `processed.crate_rules().clone()`
+  before setting `source_ini_hash`.
+- In the temporary existing `sim::crates` implementation, resolve image names
+  through `.as_deref().and_then(...)`, log `none` for null, and update only its
+  parser expectations to `Some(...)`; do not alter placement semantics in this
+  rules-only commit.
+- Update the focused mission-data source-hash regression to pin both the raw
+  `IniFile::content_hash` literal and the new one-layer
+  `RulesLayerStack::content_hash` literal used by public `RuleSet::from_ini`.
+
+**Step 4: Add focused tests**
+
+Tests must prove:
+
+- no `[CrateRules]` -> null images, 1/255, exact 10.0 bits;
+- stock section -> CRATE/CRATE/WCRATE, 1/255, exact 3.0 bits;
+- later absent section retains prior values;
+- later section with one key changes only that key;
+- negative and inverted signed min/max survive;
+- `none` becomes null and unknown non-none image is allocated into the
+  projected `[OverlayTypes]` registry;
+- alias spellings resolve to one numeric ID in `OverlayTypeRegistry`;
+- direct `RuleSet::from_ini` and one-layer `from_rules_layers` agree.
+
+**Step 5: Verify and commit**
+
+Before Cargo: `Get-Process cargo,rustc -ErrorAction SilentlyContinue`.
+
+Run:
+`cargo test -p vera20k --lib crate_rules -- --nocapture`
+
+Also run:
+`cargo test -p vera20k --lib rules_hash_and_enum_wire_values_survive_vocabulary_move -- --nocapture`
+
+Expected: every crate-rules and pass-retention test passes.
+
+Commit:
+`git commit -m "feat(rules): preserve native startup crate authority"`
+
+### Task 2: Persistent slot table, native timer, snapshot, and hash
+
+**Why:** Placement cannot be correct or reviewable while its accepted result is
+transient or derived from visible overlays.
+
+**Files:**
+- Modify: `src/sim/crates.rs`
+- Create: `src/sim/crates/state.rs`
+- Modify: `src/sim/world/mod.rs:632-840,2980-3018`
+- Modify: `src/sim/snapshot.rs:300-331` and focused tests
+- Modify: `src/sim/world/world_hash.rs:420-535` and schema fold
+
+**Pattern:** direct serde-owned `Simulation` fields plus version probes used by
+v110-v113.
+
+**Step 1: Define raw state**
+
+```rust
+// src/sim/crates/state.rs
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct CrateSlot {
+    pub start_frame: i32,
+    pub aux: u32,
+    pub duration: i32,
+    pub cell_x: i16,
+    pub cell_y: i16,
+}
+
+impl Default for CrateSlot {
+    fn default() -> Self {
+        Self { start_frame: -1, aux: 0, duration: 0, cell_x: 0, cell_y: 0 }
+    }
+}
+
+impl CrateSlot {
+    pub fn is_empty(self) -> bool { self.cell_x == 0 && self.cell_y == 0 }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CrateAuthority {
+    #[serde(with = "crate_slot_array_serde")]
+    slots: [CrateSlot; 256],
+}
+
+mod crate_slot_array_serde {
+    use super::CrateSlot;
+    use serde::de::{self, SeqAccess, Visitor};
+    use serde::ser::SerializeTuple;
+    use serde::{Deserializer, Serializer};
+    use std::fmt;
+
+    pub fn serialize<S>(slots: &[CrateSlot; 256], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(256)?;
+        for slot in slots {
+            tuple.serialize_element(slot)?;
+        }
+        tuple.end()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<[CrateSlot; 256], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SlotsVisitor;
+        impl<'de> Visitor<'de> for SlotsVisitor {
+            type Value = [CrateSlot; 256];
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("exactly 256 crate slots")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut slots = [CrateSlot::default(); 256];
+                for (index, slot) in slots.iter_mut().enumerate() {
+                    *slot = seq.next_element()?.ok_or_else(|| {
+                        de::Error::invalid_length(index, &"exactly 256 crate slots")
+                    })?;
+                }
+                Ok(slots)
+            }
+        }
+        deserializer.deserialize_tuple(256, SlotsVisitor)
+    }
+}
+
+impl Default for CrateAuthority {
+    fn default() -> Self { Self { slots: [CrateSlot::default(); 256] } }
+}
+
+impl CrateAuthority {
+    pub(crate) fn first_empty_index(&self) -> Option<usize> {
+        self.slots.iter().position(|slot| slot.is_empty())
+    }
+    pub(crate) fn slots(&self) -> &[CrateSlot; 256] { &self.slots }
+    pub(crate) fn slot_mut(&mut self, index: usize) -> &mut CrateSlot {
+        &mut self.slots[index]
+    }
+}
+```
+
+Add `pub(crate) crate_authority: CrateAuthority` beside `overlay_grid` in
+`Simulation` and initialize it with `Default`.
+
+**Step 2: Implement the pure timer helper**
+
+```rust
+pub(crate) fn crate_timer_words(
+    regen: NativeF64Bits,
+    draw: u32,
+    current_frame: i32,
+) -> (i32, u32, i32) {
+    let regen = X87Chop53::load_f64(regen).expect("validated CrateRegen");
+    let lower = X87Chop53::mul(regen, X87Chop53::load_i32(450));
+    let upper = X87Chop53::mul(regen, X87Chop53::load_i32(1800));
+    let fraction = X87Chop53::div(
+        X87Chop53::load_i32(draw as i32),
+        X87Chop53::load_i32(0x7fff_fffe),
+    ).expect("nonzero timer divisor");
+    let value = X87Chop53::add(
+        lower,
+        X87Chop53::mul(fraction, X87Chop53::sub(upper, lower)),
+    );
+    let stored_upper = X87Chop53::store_f64(upper).expect("finite CrateRegen upper");
+    let duration = X87Chop53::ftol_i64(value)
+        .expect("validated crate duration fits i64") as i32;
+    (current_frame, (stored_upper.bits() >> 32) as u32, duration)
+}
+```
+
+If the existing x87 API requires a differently named conversion for unsigned
+draw, preserve the exact nonnegative integer value before division; do not
+replace the expression with host float.
+
+**Step 3: Persist and hash**
+
+- Bump `SNAPSHOT_VERSION` to 114 with a comment naming the raw 256-slot table.
+- Add `include_crate_authority_v114` as the final
+  `state_hash_with_schema` flag.
+- When true, fold a domain tag, then every slot's five raw fields in ascending
+  index order.
+- Add `state_hash_without_crate_authority_v114` with all earlier flags true
+  and v114 false.
+- Do not modify `compute_retail_multiplayer_checksum`.
+
+**Step 4: Add focused tests**
+
+- every fresh slot is exactly `{-1,0,0,0,0}`;
+- only both-zero coordinates mean empty;
+- first-empty scan is ascending and a full table returns `None`;
+- timer draw 0 -> duration 1350 at regen 3;
+- draw `0x7fff_fffe` -> 5400 and aux `0x40B51800`;
+- one interior draw pins forward interpolation;
+- current frame is copied without increment;
+- snapshot v114 round-trips visible-shaped and ghost-shaped slots;
+- the tuple codec rejects a truncated slot sequence and never admits a
+  variable-length crate authority;
+- changing each raw slot field changes current hash;
+- v114-off probe ignores all slot differences;
+- retail quick checksum is identical when only crate slots differ;
+- version test expects 114.
+
+**Step 5: Verify and commit**
+
+Check processes, then run:
+
+- `cargo test -p vera20k --lib crate_authority -- --nocapture`
+- `cargo test -p vera20k --lib crate_timer -- --nocapture`
+- `cargo test -p vera20k --lib snapshot_version_is_current -- --nocapture`
+
+Expected: all focused tests pass.
+
+Commit:
+`git commit -m "feat(sim): persist and hash native crate slots"`
+
+### Task 3: Exact random placement, Mark, visible stamp, and ghosts
+
+**Why:** This is the player-visible/deterministic core of the mechanism.
+
+**Files:**
+- Modify: `src/sim/crates.rs`
+- Modify: `src/sim/overlay_grid.rs:298-365`
+
+**Pattern:** existing shared `find_nearby_passable_cell`, raw occupation
+authority, `ResolvedTerrainCell.bridge_facts`, and specialized overlay writers.
+
+**Step 1: Define receipts and count**
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CratePlacement {
+    pub requested: i32,
+    pub accepted: u32,
+    pub visible: u32,
+}
+
+pub fn scenario_start_crate_count(rules: &CrateRules, human_count: i32) -> i32 {
+    rules.maximum.min(rules.minimum.max(human_count))
+}
+
+pub fn human_player_count(sim: &Simulation) -> i32 {
+    i32::try_from(
+        sim.houses
+            .values()
+            .filter(|house| house.is_human && !house.multiplay_passive)
+            .count(),
+    )
+    .unwrap_or(i32::MAX)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OneCrateResult { HardRejected, AcceptedGhost, AcceptedVisible }
+```
+
+The outer loop is:
+
+```rust
+let requested = scenario_start_crate_count(&rules.crate_rules, human_count);
+for _ in 0..requested.max(0) {
+    match place_one_random_crate(/* authoritative inputs */) {
+        OneCrateResult::HardRejected => {}
+        OneCrateResult::AcceptedGhost => accepted += 1,
+        OneCrateResult::AcceptedVisible => { accepted += 1; visible += 1; }
+    }
+}
+```
+
+It never tops up visible/accepted count.
+
+**Step 2: Implement exact rectangle and FNPC**
+
+- Require `playfield_bounds` and `playfield_size_height`; malformed headless
+  fixtures return hard failure without inventing map-width coordinates.
+- Derive active left/top/width/height with the same signed wrapping helpers used
+  by current playfield normalization.
+- Draw X then Y as
+  `left + RandomRanged(0,width-1)` and
+  `top + RandomRanged(0,height-1)`.
+- Preserve the existing zero-target FNPC tuple and
+  `min(SizeW+SizeH,32)` cap.
+- Origin water selects FNPC Float; every other origin selects Track.
+- Retry at most 1,000 times.
+
+**Step 3: Implement hard prechecks and identity-based Mark**
+
+After FNPC returns a snapped cell:
+
+1. outside playfield -> retry;
+2. existing overlay identity -> retry;
+3. destination `yr_cell_land_type == Water` selects resolved
+   `WaterCrateImg`, otherwise resolved `WoodCrateImg`;
+4. compare selected numeric identity with resolved current water ID first ->
+   Float; otherwise matching current crate or wood ID -> Track;
+5. a selected `None`, unresolved terrain cell, terrain object,
+   `slope_type > 4` when the selected raw overlay ID is not exact `0xB2`, any
+   nonzero selected occupation byte, selected
+   non-bridge speed zero, or injected allocation/Unlimbo/Mark failure ->
+   accepted ghost;
+6. `bridge_facts.raw_flags & 0x100 != 0` selects
+   `raw_cell_occupation.deck_bits` and bypasses non-bridge speed-zero;
+   otherwise select `ground_bits`;
+7. visible success calls only the crate-specific stamp.
+
+Do not use `OBJECT_OCCUPATION_BIT` masking and do not use
+`place_overlay_native_runtime` wall/protection semantics.
+
+**Step 4: Add the specialized stamp**
+
+```rust
+pub(crate) fn place_crate_overlay(
+    &mut self,
+    resolved_terrain: &mut ResolvedTerrainGrid,
+    registry: &OverlayTypeRegistry,
+    rx: u16,
+    ry: u16,
+    overlay_id: u8,
+) -> bool {
+    let Some(index) = index_of(self.width, self.height, rx, ry) else {
+        return false;
+    };
+    self.cells[index].overlay_id = Some(overlay_id);
+    self.cells[index].overlay_data = u8::MAX;
+    // Preserve wall_owner/unrelated fields rather than replacing OverlayCell.
+    self.dirty_cells.push((rx, ry));
+    recalc_overlay_passability(self, resolved_terrain, registry, rx, ry);
+    true
+}
+```
+
+**Step 5: Install accepted slot/timer in native order**
+
+- The logical redraw is a Rust-native no-pixel trace/no-op.
+- Write packed coordinate to the retained first-empty slot.
+- Consume timer RNG only after acceptance.
+- Compute words with `crate_timer_words`.
+- Pass `sim.session.binary_frame as i32` as `current_frame`; this preserves the
+  native low-dword bit pattern when the unsigned Rust frame crosses `i32::MAX`.
+- Store start, aux, duration in that order.
+- Hard rejection leaves the slot byte-for-byte unchanged and consumes no timer
+  draw.
+
+**Step 6: Add focused tests**
+
+Cover:
+
+- signed/inverted/negative/>256 requested counts;
+- exact nonzero-left/top inclusive rectangle and X/Y draw order;
+- failed attempts spend X/Y; full table spends no RNG;
+- origin water/land FNPC classification independent of destination image;
+- destination water/land image;
+- water-first alias priority;
+- null image accepted ghost;
+- terrain object, non-exempt slopes 5+, every individual nonzero occupation
+  bit, speed-zero, and injected Mark failure accepted ghosts;
+- exact raw overlay ID `0xB2` remains eligible on slopes 5+;
+- structural bridge selects deck, checks whole byte, and bypasses underlying
+  speed zero;
+- occupied overlay/outside playfield retry and do not install timer;
+- visible stamp writes `0xFF`, preserves wall owner, and dirties once;
+- ghost preserves the cell;
+- both visible and ghost slots store coordinate then timer words;
+- 1,000 hard rejections return with empty slot.
+
+**Step 7: Verify and commit**
+
+Check processes, then run:
+
+- `cargo test -p vera20k --lib scenario_start_crate -- --nocapture`
+- `cargo test -p vera20k --lib crate_placement -- --nocapture`
+- `cargo test -p vera20k --lib place_crate_overlay -- --nocapture`
+
+Expected: all focused tests pass with literal RNG/slot assertions.
+
+Commit:
+`git commit -m "feat(sim): reproduce native startup crate placement"`
+
+### Task 4: Retail post-map order and first-frame production delivery
+
+**Why:** Correct internals are incomplete until the ordinary loading path and
+first presentation consume them in the native lifecycle.
+
+**Files:**
+- Modify: `src/sim/scenario_post_map.rs:41-120` and tests
+- Modify: `src/app/loading/init.rs:1190-1264,2335-2393,2485-2507`
+- Modify: `src/app/frontend/skirmish.rs:2608-2635` and tests
+- Modify: `src/app/presentation/overlay_index.rs` tests if needed
+
+**Pattern:** existing post-map receipt, generated-map launch snapshot, and
+`OverlayRenderIndex::upsert_occupied`.
+
+**Step 1: Reorder the Skirmish branch**
+
+```rust
+let crates = if let Some(descriptor) = input.skirmish_session {
+    let session = descriptor.session();
+    let human_count = crate::sim::crates::human_player_count(self);
+    let initial_path = self.path_grid_snapshot();
+    let placement = crate::sim::crates::place_scenario_start_crates(
+        self, input.rules, input.overlay_registry, initial_path.as_deref(), human_count,
+    );
+    crate::sim::scenario_bootstrap::apply_skirmish_ai_opening_credits(self);
+    crate::sim::scenario_bootstrap::apply_skirmish_launch_alliances(
+        self, input.house_roster, session,
+    );
+    Some(placement)
+} else {
+    self.house_alliances = input.house_roster.alliance_map();
+    None
+};
+```
+
+Add a test-only trace around these three calls and assert
+`Crates -> AiCredits -> Alliances`. Do not change earlier ore/navigation order.
+
+**Step 2: Preserve caller/option distinctions**
+
+- Fixed-map campaign `None` returns `crates=None` and consumes no crate RNG.
+- Skirmish with option off returns `Some({requested:0,accepted:0,visible:0})`.
+- The generated launch snapshot already calls
+  `finalize_constructed_scenario(..., Some(match_launch_descriptor))`; assert
+  its receipt is `Some`.
+- Preview-only tests assert no `Simulation` or post-map receipt is created.
+
+**Step 3: Deliver visible startup cells to the initial index**
+
+After `finalize_constructed_scenario` and before building `MapLoadResult`:
+
+- iterate accepted nonempty slot coordinates in slot order;
+- query the live `OverlayGrid`;
+- materialize `OverlayEntry {rx,ry,overlay_id,frame:overlay_data}` only when
+  identity is present;
+- upsert those entries into the initial source vector with
+  `OverlayRenderIndex::replace_from_source` then `upsert_occupied`, and move
+  the resulting vector back into `overlays_connected`;
+- never mutate `OverlayGrid` from this app step.
+
+Extract a crate-neutral helper if necessary so initial loading and runtime use
+the same index contract without constructing `AppState`.
+
+**Step 4: Preregister crate art names**
+
+Extend `preregister_runtime_overlay_names` to accept registry entries whose
+flags have `crate_type`, in addition to walls and low bridges. Keep counters
+separate or return a small struct so crate additions are not misreported as
+bridges.
+
+**Step 5: Add focused production tests**
+
+- campaign no-bootstrap/no-RNG;
+- option-off Skirmish `Some` zero receipt;
+- option-on Skirmish ordering trace;
+- accepted generated map reaches `Some` and installs slots;
+- preview lifecycle creates no sim crate state;
+- visible startup slots append after source overlays in slot order;
+- ghosts do not enter the index;
+- existing-coordinate upsert retains its source slot;
+- CRATE and WCRATE are preregistered when `Crate=yes`;
+- renderer constant remains crate frame zero.
+
+**Step 6: Verify and commit**
+
+Check processes, then run:
+
+- `cargo test -p vera20k --lib scenario_post_map -- --nocapture`
+- `cargo test -p vera20k --lib random_map_launch -- --nocapture`
+- `cargo test -p vera20k --lib runtime_overlay_names -- --nocapture`
+- `cargo test -p vera20k --lib overlay_render_index -- --nocapture`
+
+Expected: all focused production and presentation tests pass.
+
+Commit:
+`git commit -m "fix(app): deliver startup crates in retail post-map order"`
+
+### Task 5: Literal retail, asset, and production validation
+
+**Why:** Unit tests alone cannot prove the active executable, installed rules,
+and installed theater assets used by production.
+
+**Files:**
+- Modify only focused ignored validation tests if an existing test cannot emit
+  the required literals.
+- Do not add capture bundles or unrelated certification matrices.
+
+**Pattern:** existing installed-retail ignored tests and supported release
+`asset.exe`.
+
+**Step 1: Active binary**
+
+- Compute SHA-256 for
+  `C:\Users\enok\Documents\Command and Conquer Red Alert II\gamemd.exe`.
+- Record exact hash in validation output.
+- Re-read live Ghidra `Post_Map_Init`, `Full_Init`,
+  `MapClass__PlaceCrateAtRandomCell`, and
+  `CrateSlot__PlaceOverlayAndInitTimer` only where implementation comments
+  cite them.
+
+Expected literals: campaign gate, X/Y bounds, two hard prechecks, water-first
+identity comparison, accepted ghost, coordinate-before-timer stores.
+
+**Step 2: Installed rules**
+
+Read installed active rules sources and print/compare:
+
+`CrateMinimum=1`, `CrateMaximum=255`, `CrateRegen=3`,
+`WoodCrateImg=CRATE`, `CrateImg=CRATE`,
+`WaterCrateImg=WCRATE`, and launcher `Crates=yes`.
+
+Run the production rules-layer loader and assert the resulting signed values,
+exact regen bits, and resolved CRATE/WCRATE IDs match.
+
+**Step 3: Installed assets**
+
+Build only the supported release asset tool if its binary is not current, after
+the required process check. Use it to show that `CRATE.TEM` and `WCRATE.TEM`
+resolve from installed theater MIX data and are SHP(TS), 60×60, two frames.
+
+**Step 4: Focused production proof**
+
+Run the focused ignored production test proving:
+
+```text
+installed rules layers
+-> resolved CRATE/WCRATE identities
+-> accepted ordinary Skirmish post-map
+-> persistent slot + live OverlayGrid
+-> initial OverlayRenderIndex entry
+-> registered crate art name/frame zero
+```
+
+Expected: literal PASS with IDs, cells, slot timer words, and asset metadata.
+
+### Task 6: Fresh critic, fixes, final suite, and publication
+
+**Why:** The goal requires independent read-only review of every diff and
+literal validation before publication.
+
+**Files:** no planned source file; only critic-confirmed corrections.
+
+**Step 1: Prepare review evidence**
+
+- Show `git diff origin/main...HEAD`.
+- Show branch/HEAD and clean/dirty status.
+- Attach focused Cargo outputs and literal active binary/INI/asset/production
+  outputs.
+- Confirm no Cargo/Rust process remains.
+
+**Step 2: Fresh read-only critic**
+
+Give one fresh critic the entire diff and literal evidence. Require it to check:
+
+- design/plan scope and one-mechanism boundary;
+- caller gates and post-map order;
+- signed count/RNG/no-top-up behavior;
+- identity aliasing and null/post-precheck ghosts;
+- raw occupation/deck semantics;
+- native x87 timer and slot write order;
+- serde v114/hash probe/quick-checksum exclusion;
+- first-frame presentation and accepted-RMG production path;
+- no sim dependency on render/UI/sidebar/audio/network;
+- focused tests and external evidence.
+
+The critic must return PASS or actionable findings. Do not ask it to edit.
+
+**Step 3: Repair and resubmit**
+
+For every confirmed finding:
+
+- patch only the implicated mechanism;
+- rerun the smallest focused `--lib` filter;
+- refresh literal evidence if behavior changed;
+- give the new diff/evidence to a **fresh** read-only critic.
+
+Repeat until a fresh critic returns PASS. Re-review any conflict resolution.
+
+**Step 4: One final full library suite**
+
+Only after critic PASS and PR readiness:
+
+- check `Get-Process cargo,rustc`;
+- run exactly once:
+  `cargo test -p vera20k --lib`.
+
+Expected: PASS with zero failing tests.
+
+**Step 5: Publish and merge**
+
+- Ensure each incremental commit is buildable and the worktree is clean.
+- Push `feature/phase14-crate-authority-foundation`.
+- Open one PR targeting `main`, containing only this mechanism.
+- Merge only with green checks and critic PASS.
+- Refresh/fetch `origin/main`, verify the merge commit, and rederive the Phase
+  14 frontier before selecting the next mechanism.
+
+## Sources & References
+
+- **Design:** `docs/plans/2026-09-01-phase14-crate-authority-foundation-design.md`
+- **Caller/order correction:** `docs/research/SCENARIO_START_CRATE_POST_MAP_CALLER_GATE_GHIDRA_REPORT.md` — HIGH
+- **Primary placement/runtime:** `docs/research/PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md` — HIGH, with caller wording overridden by the correction report
+- **Supporting system report:** `docs/research/CRATE_SYSTEM_GHIDRA_REPORT.md` — verified context; newer reports override conflicts
+- **Ghidra:** `ScenarioClass__Read_Scenario @ 0x00684620`,
+  `ScenarioClass__Read_Scenario_INI @ 0x00686730`,
+  `ScenarioClass__Post_Map_Init @ 0x00686890`,
+  `ScenarioClass__Full_Init @ 0x00686B20`,
+  `MapClass__PlaceCrateAtRandomCell @ 0x0056BD40`,
+  `CrateSlot__PlaceOverlayAndInitTimer @ 0x004A17C0`,
+  `CrateSlot__ValidateCellAndCreateOverlay @ 0x004A18F0`.
+- **INI:** `ini/rulesmd.ini:782-796`,
+  `ini/rulesmd.ini:3017-3034`.
+- **Current Rust:** `src/rules/ini_parser.rs:571-797,1049-1148`;
+  `src/rules/ruleset.rs:1277-1337,2552-2575`;
+  `src/sim/crates.rs`; `src/sim/scenario_post_map.rs:41-120`;
+  `src/sim/world/mod.rs:630-840`; `src/sim/snapshot.rs:300-360`;
+  `src/sim/world/world_hash.rs:420-535`;
+  `src/app/loading/init.rs:1190-1264,2335-2393`;
+  `src/app/frontend/skirmish.rs:2608-2635`;
+  `src/app/presentation/overlay_index.rs`.
+- **Recent relevant commits:** `35a5fdbf` FNPC anchor gate,
+  `5b3792fe` playfield contract, `f0ab8731` sim-owned post-map,
+  `39996b98` accepted random-map launch regeneration,
+  `db76065a` latest snapshot/hash schema.
+
+## Post-Plan Self-Review
+
+- [x] Every design requirement maps to Tasks 1-5.
+- [x] No TBD/TODO/placeholder step remains.
+- [x] Interfaces precede their consumers.
+- [x] Sim code remains below render/UI/audio/network.
+- [x] Signed counts, exact RNG, ghost semantics, persistence, and first-frame
+  delivery have focused regressions.
+- [x] Current git history and current files were re-read after design approval.
+- [x] Research index, primary reports, live Ghidra, INI, assets, production
+  paths, and Rust touchpoints are cited.
+- [x] All technical decisions are high confidence.
+- [x] No behavioral question is deferred.
+- [x] Common player-visible, deterministic, residual, and negative-gate risks
+  are classified.
+- [x] Incremental commits and one final full `--lib` suite follow `AGENTS.md`.
+
+**Autonomous approval:** The fresh skeptical `review-plan` gate returned READY.
+The plan is dependency-coherent and implements one Phase 14 mechanism.

--- a/docs/plans/2026-09-01-phase14-crate-authority-foundation-plan.md
+++ b/docs/plans/2026-09-01-phase14-crate-authority-foundation-plan.md
@@ -133,7 +133,8 @@ retail order, and the app consumes live overlay state through the existing
 | Modify | `src/sim/snapshot.rs` | Version 114 and raw-table round trip |
 | Modify | `src/sim/world/world_hash.rs` | Version-gated ordered slot fold |
 | Modify | `src/app/loading/init.rs` | First-frame occupied entry delivery and RMG regression |
-| Modify | `src/app/frontend/skirmish.rs` | Preregister `Crate=yes` overlay names |
+| Modify | `src/app/frontend/skirmish.rs` | Preregister flagged and resolved crate overlay names |
+| Modify | `src/render/overlay_atlas.rs` | Preload all resolved startup image frames |
 | Modify | `src/app/presentation/overlay_index.rs` | Focused first-frame append/order regression if needed |
 
 ## Interface Changes
@@ -287,9 +288,9 @@ impl CrateRulesAccumulator {
             ("CrateImg", &mut self.0.crate_img),
             ("WaterCrateImg", &mut self.0.water_crate_img),
         ] {
-            if let Some(raw) = section.get(key) {
-                let value = raw.trim();
-                *target = (!is_native_none_type_name(value))
+            if section.get(key).is_some() {
+                let value = section.read_string(key, "", 0x80);
+                *target = (!is_native_none_type_name(&value))
                     .then(|| value.to_ascii_uppercase());
             }
         }
@@ -299,8 +300,9 @@ impl CrateRulesAccumulator {
 }
 ```
 
-Use the existing native string trimming helper rather than Unicode-only
-`trim()` if tests expose control bytes; keep the public shape above.
+Use the exact `ReadString` capacity `0x80` for both semantic retention and late
+OverlayType allocation, so 127-byte and 128-byte image-name boundaries resolve
+to one identity.
 
 **Step 2: Attach the accumulator to native pass processing**
 
@@ -490,8 +492,7 @@ pub(crate) fn crate_timer_words(
         X87Chop53::mul(fraction, X87Chop53::sub(upper, lower)),
     );
     let stored_upper = X87Chop53::store_f64(upper).expect("finite CrateRegen upper");
-    let duration = X87Chop53::ftol_i64(value)
-        .expect("validated crate duration fits i64") as i32;
+    let duration = X87Chop53::ftol_i64(value).unwrap_or(i64::MIN) as i32;
     (current_frame, (stored_upper.bits() >> 32) as u32, duration)
 }
 ```
@@ -499,6 +500,9 @@ pub(crate) fn crate_timer_words(
 If the existing x87 API requires a differently named conversion for unsigned
 draw, preserve the exact nonnegative integer value before division; do not
 replace the expression with host float.
+
+The fallback is native masked `FISTP qword` integer-indefinite. The slot stores
+only its low dword, which is zero for both positive and negative overflow.
 
 **Step 3: Persist and hash**
 
@@ -604,6 +608,9 @@ It never tops up visible/accepted count.
 - Draw X then Y as
   `left + RandomRanged(0,width-1)` and
   `top + RandomRanged(0,height-1)`.
+- Compare/swap the range endpoints as signed dwords, perform both draws even
+  for zero/negative widths, use wrapping dword addition, and narrow each result
+  through signed `i16` before FNPC.
 - Preserve the existing zero-target FNPC tuple and
   `min(SizeW+SizeH,32)` cap.
 - Origin water selects FNPC Float; every other origin selects Track.
@@ -646,8 +653,11 @@ pub(crate) fn place_crate_overlay(
     let Some(index) = index_of(self.width, self.height, rx, ry) else {
         return false;
     };
+    let Some(flags) = registry.flags(overlay_id) else {
+        return false;
+    };
     self.cells[index].overlay_id = Some(overlay_id);
-    self.cells[index].overlay_data = u8::MAX;
+    self.cells[index].overlay_data = native_mark_overlay_data(flags);
     // Preserve wall_owner/unrelated fields rather than replacing OverlayCell.
     self.dirty_cells.push((rx, ry));
     recalc_overlay_passability(self, resolved_terrain, registry, rx, ry);
@@ -672,7 +682,8 @@ pub(crate) fn place_crate_overlay(
 Cover:
 
 - signed/inverted/negative/>256 requested counts;
-- exact nonzero-left/top inclusive rectangle and X/Y draw order;
+- exact nonzero-left/top inclusive rectangle, signed reversed endpoints, low-i16
+  narrowing, and X/Y draw order;
 - failed attempts spend X/Y; full table spends no RNG;
 - origin water/land FNPC classification independent of destination image;
 - destination water/land image;
@@ -684,7 +695,8 @@ Cover:
 - structural bridge selects deck, checks whole byte, and bypasses underlying
   speed zero;
 - occupied overlay/outside playfield retry and do not install timer;
-- visible stamp writes `0xFF`, preserves wall owner, and dirties once;
+- visible stamp writes zero ordinarily, one for Road, and `0xFF` for
+  `Crate=yes`, preserves wall owner, and dirties once;
 - ghost preserves the cell;
 - both visible and ghost slots store coordinate then timer words;
 - 1,000 hard rejections return with empty slot.
@@ -768,8 +780,10 @@ the same index contract without constructing `AppState`.
 **Step 4: Preregister crate art names**
 
 Extend `preregister_runtime_overlay_names` to accept registry entries whose
-flags have `crate_type`, in addition to walls and low bridges. Keep counters
-separate or return a small struct so crate additions are not misreported as
+flags have `crate_type` plus all three resolved `CrateRules` identities, in
+addition to walls and low bridges. Preload frame zero for flagged crates and
+the native Mark data frame (zero or Road one) for configured `Crate=false`
+types. Keep counters separate so crate additions are not misreported as
 bridges.
 
 **Step 5: Add focused production tests**
@@ -782,7 +796,8 @@ bridges.
 - visible startup slots append after source overlays in slot order;
 - ghosts do not enter the index;
 - existing-coordinate upsert retains its source slot;
-- CRATE and WCRATE are preregistered when `Crate=yes`;
+- CRATE/WCRATE and a late-allocated configured `Crate=false` identity are
+  preregistered/preloaded before scatter;
 - renderer constant remains crate frame zero.
 
 **Step 6: Verify and commit**

--- a/docs/plans/2026-09-01-phase14-crate-authority-foundation-plan.md
+++ b/docs/plans/2026-09-01-phase14-crate-authority-foundation-plan.md
@@ -90,10 +90,13 @@ retail order, and the app consumes live overlay state through the existing
   Mark except for exact raw overlay ID `0xB2`. — **Confidence: high**
   - **Source:** active placement report; `CrateSlot__ValidateCellAndCreateOverlay
     @ 0x004A18F0`.
-- **Dispatch the complete reachable Mark body:** the universal slope gate
+- **Dispatch the complete reachable Mark body:** the constructor TerrainClass
+  scan precedes Unlimbo and every Mark branch. The universal slope gate then
   precedes high bridge, TS legacy, Railroad, wall, low endpoint, and ordinary
-  branches. Low bodies use `3*L` raw Scenario draws and exact dense-ID tables;
-  Road tiberium calls `SpreadCellGerminate(false)`. — **Confidence: high**
+  branches. High setters write raw `0`/`9` data before falling through and the
+  four high IDs explicitly bypass ordinary passability. Low bodies use `3*L`
+  raw Scenario draws and exact dense-ID tables; Road tiberium calls
+  `SpreadCellGerminate(false)`. — **Confidence: high**
   - **Source:** `OverlayClass::Mark @ 0x005FC570`;
     `LOW_OVERLAY_MARK_FIXED_MAP_STAMP_RNG_TRANSACTION_GHIDRA_REPORT.md`;
     `CellClass::SpreadCellGerminate @ 0x004818E0`.
@@ -638,22 +641,27 @@ After FNPC returns a snapped cell:
 2. existing overlay identity -> retry;
 3. destination `yr_cell_land_type == Water` selects resolved
    `WaterCrateImg`, otherwise resolved `WoodCrateImg`;
-4. apply the universal slope gate, then dispatch high anchors, explicit
-   `0x7E`/`0xA7` TS ghosts, Railroad, walls, and low endpoint trigger tables;
+4. apply the constructor TerrainClass gate, then the universal slope gate;
+   dispatch high anchors, explicit `0x7E`/`0xA7` TS ghosts, Railroad, walls,
+   and low endpoint trigger tables. High setters write anchor/F1/F2/opposite
+   data `0` or `9`, stamp flags, and continue through later precedence;
 5. only the ordinary branch compares selected numeric identity with resolved
    current water ID first -> Float; otherwise matching current crate or wood ID
    -> Track;
-6. in the ordinary branch, a selected `None`, unresolved terrain cell, terrain object,
+6. in the ordinary branch, a selected `None`, unresolved terrain cell,
    `slope_type > 4` when the selected raw overlay ID is not exact `0xB2`, any
    nonzero selected occupation byte, selected
    non-bridge speed zero, or injected allocation/Unlimbo/Mark failure ->
    accepted ghost;
 7. `bridge_facts.raw_flags & 0x100 != 0` selects
-   `raw_cell_occupation.deck_bits` and bypasses non-bridge speed-zero;
-   otherwise select `ground_bits`;
-8. ordinary success preserves native write order: identity/data zero, Road data
-   one and optional tiberium germination, `Crate=yes` override, `CellAnim`, then
-   common Recalc.
+   `raw_cell_occupation.deck_bits` and bypasses non-bridge speed-zero for a
+   non-high ordinary overlay; otherwise select `ground_bits`. Exact high IDs
+   bypass both occupation planes and speed checks explicitly;
+8. ordinary success preserves native write order: identity/data zero (except
+   high anchors, whose setter data is retained), Road data one and optional
+   tiberium germination, `Crate=yes` override, `CellAnim`, then common Recalc.
+   A constructed CellAnim receives Tiberium `Color=` palette authority and the
+   CellClass ground Z-adjust only when the now-live cell reports tiberium.
 
 Do not use `OBJECT_OCCUPATION_BIT` masking and do not use
 `place_overlay_native_runtime` wall/protection semantics.
@@ -725,10 +733,13 @@ Cover:
 - visible stamp writes zero ordinarily, one for Road, and `0xFF` for
   `Crate=yes`, preserves wall owner, and dirties once;
 - Railroad bypass/data zero; wall passability/connectivity/data ordering; high
-  anchor flag family and preserved data; every low trigger table with exact
+  anchor raw setter data, fallthrough overrides, explicit passability bypass,
+  and flag family; every low trigger table with exact
   `3*L` raw draws plus occupied-row no-op; Road tiberium neighbor density;
-  visible and failed ordinary `CellAnim`; explicit TS legacy ghosts;
-- ghost preserves the cell;
+  visible and failed ordinary `CellAnim`, including conditional tiberium
+  palette/Z post-writes; explicit TS legacy ghosts;
+- ordinary pre-stamp ghosts preserve the cell; specialized branches retain any
+  native writes that precede a later rejection;
 - both visible and ghost slots store coordinate then timer words;
 - 1,000 hard rejections return with empty slot.
 
@@ -796,8 +807,9 @@ Add a test-only trace around these three calls and assert
 
 After `finalize_constructed_scenario` and before building `MapLoadResult`:
 
-- iterate accepted nonempty slot coordinates in slot order;
-- query the live `OverlayGrid`;
+- inspect the `OverlayGrid` pending dirty-cell receipt without consuming it;
+- de-duplicate coordinates in first-write order so low-bridge extensions and
+  high-setter neighbor writes are included;
 - materialize `OverlayEntry {rx,ry,overlay_id,frame:overlay_data}` only when
   identity is present;
 - upsert those entries into the initial source vector with
@@ -814,9 +826,12 @@ Extend `preregister_runtime_overlay_names` to accept registry entries whose
 flags have `crate_type` plus all three resolved `CrateRules` identities, in
 addition to walls and low bridges. Preload the actual reachable Mark outputs:
 frame zero for flagged crates, ordinary/Railroad data, wall frames, low
-fixed/body IDs and states, all preserved high-anchor data values, and Road
-tiberium density frames. Keep counters separate so crate additions are not
-misreported as bridges.
+fixed/body IDs and states, and Road tiberium density frames. Route selected
+high-anchor identities to `BridgeAtlas` body/shadow roots before startup
+placement rather than generating `OverlayAtlas` keys. Add reachable crate
+`CellAnim` names to the scheduler asset closure and live tiberium-remap keys to
+the SHP atlas. Keep counters separate so crate additions are not misreported as
+bridges.
 
 **Step 5: Add focused production tests**
 
@@ -825,11 +840,15 @@ misreported as bridges.
 - option-on Skirmish ordering trace;
 - accepted generated map reaches `Some` and installs slots;
 - preview lifecycle creates no sim crate state;
-- visible startup slots append after source overlays in slot order;
+- every visible startup Mark dirty cell appends after source overlays in
+  first-write order without consuming the sim/navigation receipt;
+- startup bridge writes rebuild `BridgeRuntimeState` and republish initial
+  navigation before AI credits, while leaving that dirty receipt pending;
 - ghosts do not enter the index;
 - existing-coordinate upsert retains its source slot;
 - CRATE/WCRATE and a late-allocated configured `Crate=false` identity are
-  preregistered/preloaded before scatter;
+  preregistered/preloaded before scatter; high roots use BridgeAtlas and a
+  crate CellAnim is bound before construction with its remap variant covered;
 - renderer constant remains crate frame zero.
 
 **Step 6: Verify and commit**

--- a/docs/research/SCENARIO_START_CRATE_POST_MAP_CALLER_GATE_GHIDRA_REPORT.md
+++ b/docs/research/SCENARIO_START_CRATE_POST_MAP_CALLER_GATE_GHIDRA_REPORT.md
@@ -1,0 +1,201 @@
+# Scenario-Start Crate Post-Map Caller Gate — Ghidra Report
+
+**Date:** 2026-09-01  
+**Investigation mode:** exhaustive slice  
+**Claimed scope:** the active callers, caller gates, count loop, and relative order of scenario-start random-crate placement around `ScenarioClass__Post_Map_Init @ 0x00686890`.  
+**Explicit non-scope:** random-cell placement internals, crate pickup/effects, death drops, regeneration cadence, network-mode implementation, and unrelated post-map house mechanics.  
+**Active binary:** installed Yuri's Revenge `gamemd.exe`, PE image base `0x00400000`, Ghidra program `/gamemd.exe`.  
+**Confidence:** HIGH for every implementation-facing conclusion below.
+
+## 1. Overview
+
+`ScenarioClass__Post_Map_Init` contains no internal game-mode comparison around its crate loop, but the normal fixed-map caller does. `ScenarioClass__Full_Init @ 0x00686B20` calls the helper only when raw game mode is nonzero and its second control byte is zero. The ordinary fresh fixed-map loader passes that byte as zero. Consequently, campaign mode `0` does **not** receive scenario-start random-crate scatter from this helper, while ordinary offline Skirmish mode `5` does when the lobby `Crates` option is enabled.
+
+Generated random maps have a separate successful-generation path in `ScenarioClass__Read_Scenario @ 0x00684620`; that path calls `ScenarioClass__Post_Map_Init(1)` directly. Synthetic-INI preview initialization does not use the in-game `Full_Init` path and therefore does not seed gameplay crates.
+
+Within `Post_Map_Init`, the initial crate loop completes before AI opening-credit work and before the later selected-mode alliance callback. This is the required scenario-start ordering seam for Rust.
+
+This report corrects the broader wording in `PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md` that treated the helper's missing internal comparison as if the active call path had no game-mode gate.
+
+## 2. Verified fields and globals
+
+| Address / offset | Verified role in this slice | Evidence |
+|---|---|---|
+| `0x00A8B238` | raw game-mode global read by `Full_Init` | `0x00687BC8..0x00687BCE` |
+| `0x00A8B261` | lobby/session `Crates` boolean read by `Post_Map_Init` | `0x0068695C..0x00686963` |
+| `0x00A8B54C` | pregame human-node count used as one signed lower-bound candidate | `0x00686965..0x00686972` |
+| Rules `+0x1470` | signed `CrateMinimum` | `0x0068696D..0x00686978` |
+| Rules `+0x1474` | signed `CrateMaximum` | `0x0068697A..0x00686989` |
+| Scenario `+0x34BD` | `IsRandom` branch flag in `Read_Scenario` | branch leading to `0x0068498E` |
+| `Full_Init` second control byte | zero admits the fixed-map post-map call; nonzero skips it | `0x00687BD0..0x00687BD6` |
+
+`[MultiplayerDialogSettings] Crates=yes` in the repository retail `ini/rulesmd.ini` supplies the stock launcher default. `[Basic] Official` is read immediately before the fixed-map helper call and passed in `CL`; it is not the crate enable gate and does not change the crate-count loop described here.
+
+## 3. Active call paths
+
+### 3.1 Ordinary fixed-map load
+
+`ScenarioClass__Read_Scenario_INI @ 0x00686730` prepares the fresh-load call with `XOR DL,DL` at `0x0068683A`, loads the scenario object into `ECX`, and calls `ScenarioClass__Full_Init` at `0x00686845`.
+
+Near the end of `Full_Init`:
+
+1. the optional scenario rules (`TMCJ4F`) have already been processed at `0x00687B76`;
+2. map-cell attributes and late initialization milestones run through the `90` progress/service point;
+3. `CMP [0x00A8B238],ESI` / `JZ 0x00687BF1` at `0x00687BC8..0x00687BCE` skips the helper when raw mode is zero;
+4. the second control byte is checked at `0x00687BD0..0x00687BD6`, and a nonzero value also skips the helper;
+5. `[Basic] Official` is read at `0x00687BE5`, moved to `CL`, and `ScenarioClass__Post_Map_Init` is called at `0x00687BEC`.
+
+Therefore the active fixed-map rule is:
+
+```text
+call Post_Map_Init iff raw_game_mode != 0 and second_control_byte == 0
+```
+
+Among Phase 14's admitted ordinary production sessions, this includes offline Skirmish raw mode `5` and excludes campaign raw mode `0`. Raw network modes are outside this slice's production scope even though the native comparison itself admits any nonzero value.
+
+### 3.2 Generated random map
+
+`ScenarioClass__Read_Scenario @ 0x00684620` tests `Scenario+0x34BD`. On the random branch it invokes the random-map generation path; after successful generation, assembly at `0x0068498E..0x00684990` loads `CL=1` and calls `ScenarioClass__Post_Map_Init` directly.
+
+This is a distinct active parent, not an escape around the fixed-map campaign gate: it is reached only by the generated-random-map branch after generation succeeds.
+
+`RandomMapGenerator__InitMapFromSyntheticINI @ 0x00599650` calls `Full_Init` only for its in-game `param_2 == 0` path. Its nonzero preview path follows preview reset/finalization instead and does not seed gameplay crates.
+
+### 3.3 Exhaustive parent check
+
+The live Ghidra `get_function_callers` results were re-read cold after the branch analysis:
+
+- `ScenarioClass__Post_Map_Init @ 0x00686890` has exactly two function parents: `ScenarioClass__Full_Init @ 0x00686B20` and `ScenarioClass__Read_Scenario @ 0x00684620`.
+- `ScenarioClass__Full_Init @ 0x00686B20` has exactly two function parents: `ScenarioClass__Read_Scenario_INI @ 0x00686730` and `RandomMapGenerator__InitMapFromSyntheticINI @ 0x00599650`.
+
+No third startup caller was found.
+
+## 4. Crate loop and ordering
+
+The crate bootstrap begins after the earlier selected-mode/start-unit portion of `Post_Map_Init`:
+
+1. `0x0068695C` loads `DAT_00A8B261`; zero jumps past the entire loop at `0x00686963`.
+2. Signed comparisons select `max(CrateMinimum, pregame_human_node_count)` and then cap it by `CrateMaximum` at `0x00686965..0x00686989`.
+3. `TEST EAX,EAX` / `JLE` skips placement for a nonpositive final count.
+4. Each positive iteration calls the random-cell crate placer at `0x00686994`.
+5. The outer counter is decremented regardless of the placer's return value. This is a fixed number of attempts, not a top-up-until-success loop.
+6. The helper then reaches its service call at `0x0068699C` and only afterward enters house/AI preparation.
+7. `HouseClass__Add_Credits @ 0x004F9950` is called later at `0x00686A73`.
+8. The selected-mode alliance callback runs later still in the `0x00686AD4..0x00686AF2` region.
+
+The signed count is therefore:
+
+```text
+attempts = min(CrateMaximum, max(CrateMinimum, pregame_human_node_count))
+if attempts <= 0: make zero attempts
+otherwise: make exactly attempts calls, without retrying failed calls
+```
+
+For ordinary Skirmish startup, Rust must preserve the native relative order: initial crate attempts, then AI opening credits, then post-start alliance work.
+
+## 5. INI and option authority
+
+| Input | Authority in this slice | Verified effect |
+|---|---|---|
+| `[MultiplayerDialogSettings] Crates=` | launcher/session option, stock `yes` | gates the entire initial attempt loop through `0x00A8B261` |
+| `[General] CrateMinimum=` | finalized Rules object | signed lower bound for attempts |
+| `[General] CrateMaximum=` | finalized Rules object | signed upper cap for attempts |
+| `[Basic] Official=` | scenario input passed to `Post_Map_Init` | not the crate gate or count source |
+
+Scenario-specific rule overrides are finalized before the fixed-map caller decides whether to invoke `Post_Map_Init`, so startup crate bounds must be read from the same final layered rules authority used by the launched scenario.
+
+## 6. Rust status at investigation time
+
+Direct inspection of `src/sim/scenario_post_map.rs` found:
+
+- `skirmish_session` already distinguishes the ordinary fixed-map Skirmish path from campaign and returns `ScenarioPostMapOutput.crates: Option<_>` accordingly. That gate is directionally correct and must remain.
+- the function applies Skirmish AI opening credits before initial crate placement. That order contradicts active retail and is the implementation-facing defect found by this slice.
+- a pending Phase 14 design draft proposed moving startup crates outside the Skirmish branch because `Post_Map_Init` has no internal game-mode check. This investigation falsifies that proposal before code was written.
+
+No Rust file was changed during this investigation.
+
+## 7. Coverage ledger
+
+| Sub-area | Status | Evidence / boundary |
+|---|---|---|
+| fixed-map active parent | verified | `Read_Scenario_INI -> Full_Init`, `0x0068683A..0x00686845` |
+| fixed-map raw-mode gate | verified | `0x00687BC8..0x00687BCE` |
+| fixed-map second-byte gate | verified | `0x00687BD0..0x00687BD6` |
+| scenario-rules finalization before post-map | verified | `0x00687B76` before `0x00687BEC` |
+| generated-map direct parent | verified | `Read_Scenario`, `0x0068498E..0x00684990` |
+| synthetic-INI preview exclusion | verified | `InitMapFromSyntheticINI` branch split |
+| exhaustive function-parent set | verified | cold `get_function_callers` for `0x00686890` and `0x00686B20` |
+| lobby crate option | verified | `0x0068695C..0x00686963`; retail `Crates=yes` |
+| signed count selection | verified | `0x00686965..0x00686989` |
+| nonpositive-count skip | verified | `TEST` / `JLE` before placer loop |
+| attempt versus success ownership | verified | unconditional outer decrement after placer call |
+| crate/AI-credit/alliance order | verified | placer `0x00686994`, credits `0x00686A73`, alliance callback later |
+| random-cell placement semantics | excluded | owned by the active retail crate-runtime report |
+| pickup/effect/regeneration semantics | excluded | separate Phase 14 mechanisms |
+| network-mode Rust support | excluded | not admitted by the current production launch path |
+
+## 8. Open Questions Log
+
+- `[RESOLVED] Q1 — Does fixed-map campaign raw mode 0 reach Post_Map_Init?` No. `Full_Init` jumps over the call when `g_GameMode == 0`.
+- `[RESOLVED] Q2 — What does the ordinary fresh fixed-map loader pass as the second control byte?` Zero, via `XOR DL,DL` before the call to `Full_Init`.
+- `[RESOLVED] Q3 — What does a nonzero second control byte do?` It skips the `Post_Map_Init` call. A broader semantic name for the byte is unnecessary for this slice.
+- `[RESOLVED] Q4 — Is there a separate generated-map caller?` Yes. Successful random generation calls `Post_Map_Init(1)` directly from `Read_Scenario`.
+- `[RESOLVED] Q5 — Does synthetic-INI preview initialization seed crates?` No. The preview branch does not enter the in-game `Full_Init` path.
+- `[RESOLVED] Q6 — What gates the crate loop and what is the stock setting?` `DAT_00A8B261`, sourced from the lobby/session `Crates` option; retail rules specify `Crates=yes`.
+- `[RESOLVED] Q7 — Are the count comparisons signed?` Yes, including the final nonpositive skip.
+- `[RESOLVED] Q8 — What is the order relative to AI credits and alliances?` Crate attempts first, AI credits second, alliance callback later.
+- `[RESOLVED] Q9 — Are scenario rule overrides finalized first?` Yes, the optional scenario rules process occurs before the fixed-map post-map gate and call.
+- `[RESOLVED] Q10 — Does the native gate admit nonzero raw modes other than offline Skirmish?` Yes, subject to the second byte, but current production network admission is outside scope.
+- `[RESOLVED] Q11 — Does a failed random-cell placement get retried?` No. The requested attempt is consumed.
+- `[RESOLVED] Q12 — Does `[Basic] Official` own the crate gate/count?` No. It is passed into the helper for other post-map behavior.
+
+## 9. Adversarial checks
+
+- **Crates disabled:** the global option jump bypasses the loop completely.
+- **Campaign fixed map:** raw mode zero bypasses the entire helper at the caller.
+- **Inverted or negative bounds:** the signed native comparisons and final `<= 0` skip are normative; Rust must not silently reinterpret them as unsigned.
+- **Preview versus playable generated map:** preview does not seed; successful playable random generation does.
+- **Placement failure:** one call still consumes one outer attempt; no hidden top-up loop exists.
+
+The zero-add pass re-read both caller sets after these checks and produced no new unresolved question.
+
+## 10. Implementation handoff
+
+### Exact Rust obligations for the scenario-start seam
+
+1. Preserve the existing campaign/Skirmish distinction: do not create scenario-start random crates for fixed-map campaign mode `0` from this helper.
+2. Keep the lobby `Crates` option as the top-level bootstrap gate.
+3. Derive signed attempts from the finalized layered Rules authority using `min(max(CrateMinimum, human_count), CrateMaximum)`, with `<= 0` making zero calls.
+4. Make exactly that many placement calls; do not retry a failed/ghost attempt merely to reach a successful-overlay count.
+5. In ordinary Skirmish post-map work, execute initial crate attempts before AI opening credits and before alliance application.
+6. Admit the successful generated-random-map path once that production path supplies the same finalized rules/session inputs; do not seed crate state during preview generation.
+
+### Required focused regressions
+
+- fixed-map campaign produces no scenario-start crate bootstrap output;
+- fixed-map Skirmish with `Crates=false` makes zero attempts;
+- fixed-map Skirmish with `Crates=true` uses signed min/human/max attempt ownership;
+- failed placement consumes one attempt rather than triggering top-up;
+- an observable order test proves crates precede AI credits and alliances;
+- preview random-map initialization has no gameplay crate side effect, while successful playable generation enters the post-map seam.
+
+### Stale-document correction wording
+
+Replace the `PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md` statement that `Post_Map_Init` has no game-mode gate with:
+
+> `Post_Map_Init` itself has no internal mode comparison, but ordinary fixed-map activation is caller-gated: `Full_Init` skips it for raw mode 0 and when its second control byte is nonzero; fresh fixed-map nonzero modes call it. Generated random maps have a separate successful-generation caller. Therefore fixed-map campaign mode 0 does not receive startup scatter from this helper.
+
+The placement, pickup, effect, and regeneration findings in that report remain authoritative unless separately contradicted.
+
+## 11. Ghidra annotation candidates
+
+None. Existing function names are adequate, and no metadata synchronization was requested. This investigation was read-only.
+
+## Sources
+
+- Live Ghidra disassembly/call graph for `ScenarioClass__Read_Scenario @ 0x00684620`, `ScenarioClass__Read_Scenario_INI @ 0x00686730`, `ScenarioClass__Post_Map_Init @ 0x00686890`, `ScenarioClass__Full_Init @ 0x00686B20`, and `RandomMapGenerator__InitMapFromSyntheticINI @ 0x00599650`.
+- Live Ghidra caller queries for `0x00686890` and `0x00686B20`, repeated during the zero-add pass.
+- `docs/research/PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md` for the previously verified placement/runtime mechanisms and the statement corrected here.
+- `docs/research/SCENARIO_INIT_DEEP_DIVE.md` and `docs/research/LOADING_FUN_0069AE90_SKIRMISH_CALLERS_AFTER_FIRST_RENDERER_GHIDRA_REPORT.md` for corroborating fixed-map mode-gate context.
+- `ini/rulesmd.ini` for active repository retail `CrateMinimum`, `CrateMaximum`, `CrateRegen`, and `Crates=yes` values.
+- Direct Rust inspection of `src/sim/scenario_post_map.rs` at the Phase 14 frontier.

--- a/docs/research/SCENARIO_START_CRATE_POST_MAP_CALLER_GATE_GHIDRA_REPORT.md
+++ b/docs/research/SCENARIO_START_CRATE_POST_MAP_CALLER_GATE_GHIDRA_REPORT.md
@@ -1,10 +1,14 @@
 # Scenario-Start Crate Post-Map Caller Gate — Ghidra Report
 
-**Date:** 2026-09-01  
-**Investigation mode:** exhaustive slice  
-**Claimed scope:** the active callers, caller gates, count loop, and relative order of scenario-start random-crate placement around `ScenarioClass__Post_Map_Init @ 0x00686890`.  
-**Explicit non-scope:** random-cell placement internals, crate pickup/effects, death drops, regeneration cadence, network-mode implementation, and unrelated post-map house mechanics.  
-**Active binary:** installed Yuri's Revenge `gamemd.exe`, PE image base `0x00400000`, Ghidra program `/gamemd.exe`.  
+**Date:** 2026-09-01
+
+**Investigation mode:** exhaustive slice
+
+**Claimed scope:** the active callers, caller gates, count loop, and relative order of scenario-start random-crate placement around `ScenarioClass__Post_Map_Init @ 0x00686890`.
+
+**Explicit non-scope:** random-cell placement internals, crate pickup/effects, death drops, regeneration cadence, network-mode implementation, and unrelated post-map house mechanics.
+
+**Active binary:** installed Yuri's Revenge `gamemd.exe`, PE image base `0x00400000`, Ghidra program `/gamemd.exe`.
 **Confidence:** HIGH for every implementation-facing conclusion below.
 
 ## 1. Overview

--- a/docs/research/SCENARIO_START_CRATE_POST_MAP_CALLER_GATE_GHIDRA_REPORT.md
+++ b/docs/research/SCENARIO_START_CRATE_POST_MAP_CALLER_GATE_GHIDRA_REPORT.md
@@ -98,8 +98,8 @@ For ordinary Skirmish startup, Rust must preserve the native relative order: ini
 | Input | Authority in this slice | Verified effect |
 |---|---|---|
 | `[MultiplayerDialogSettings] Crates=` | launcher/session option, stock `yes` | gates the entire initial attempt loop through `0x00A8B261` |
-| `[General] CrateMinimum=` | finalized Rules object | signed lower bound for attempts |
-| `[General] CrateMaximum=` | finalized Rules object | signed upper cap for attempts |
+| `[CrateRules] CrateMinimum=` | finalized Rules object | signed lower bound for attempts |
+| `[CrateRules] CrateMaximum=` | finalized Rules object | signed upper cap for attempts |
 | `[Basic] Official=` | scenario input passed to `Post_Map_Init` | not the crate gate or count source |
 
 Scenario-specific rule overrides are finalized before the fixed-map caller decides whether to invoke `Post_Map_Init`, so startup crate bounds must be read from the same final layered rules authority used by the launched scenario.

--- a/src/app/frontend/skirmish.rs
+++ b/src/app/frontend/skirmish.rs
@@ -2442,7 +2442,11 @@ mod tests {
         let mut names = BTreeMap::new();
 
         let (wall_count, low_bridge_count, crate_count) =
-            preregister_runtime_overlay_names(&registry, &mut names);
+            preregister_runtime_overlay_names(
+                &registry,
+                &crate::rules::crate_rules::CrateRules::default(),
+                &mut names,
+            );
 
         assert_eq!(wall_count, 0);
         assert_eq!(low_bridge_count, 64);
@@ -2467,12 +2471,22 @@ mod tests {
         );
         let mut names = BTreeMap::new();
 
-        let counts = preregister_runtime_overlay_names(&registry, &mut names);
+        let crate_rules = crate::rules::crate_rules::CrateRules {
+            wood_crate_img: Some("CRATE".to_owned()),
+            crate_img: Some("PLAIN".to_owned()),
+            water_crate_img: Some("WCRATE".to_owned()),
+            ..crate::rules::crate_rules::CrateRules::default()
+        };
+        let counts = preregister_runtime_overlay_names(&registry, &crate_rules, &mut names);
 
-        assert_eq!(counts, (0, 0, 2));
+        assert_eq!(counts, (0, 0, 3));
         assert_eq!(names.get(&0).map(String::as_str), Some("CRATE"));
         assert_eq!(names.get(&1).map(String::as_str), Some("WCRATE"));
-        assert!(!names.contains_key(&2));
+        assert_eq!(
+            names.get(&2).map(String::as_str),
+            Some("PLAIN"),
+            "late-allocated configured identity registers even with Crate=false"
+        );
     }
 }
 
@@ -2627,15 +2641,31 @@ pub fn deployable_building_types<'a>(
 
 pub(crate) fn preregister_runtime_overlay_names(
     overlay_registry: &OverlayTypeRegistry,
+    crate_rules: &crate::rules::crate_rules::CrateRules,
     overlay_names: &mut BTreeMap<u8, String>,
 ) -> (u32, u32, u32) {
+    let selected_crate_ids = [
+        crate_rules
+            .wood_crate_img
+            .as_deref()
+            .and_then(|name| overlay_registry.id_for_name(name)),
+        crate_rules
+            .crate_img
+            .as_deref()
+            .and_then(|name| overlay_registry.id_for_name(name)),
+        crate_rules
+            .water_crate_img
+            .as_deref()
+            .and_then(|name| overlay_registry.id_for_name(name)),
+    ];
     let mut wall_ids_added: u32 = 0;
     let mut low_bridge_ids_added: u32 = 0;
     let mut crate_ids_added: u32 = 0;
     for overlay_id in 0u8..=u8::MAX {
         let flags = overlay_registry.flags(overlay_id);
         let is_wall = flags.is_some_and(|flags| flags.wall);
-        let is_crate = flags.is_some_and(|flags| flags.crate_type);
+        let is_crate = flags.is_some_and(|flags| flags.crate_type)
+            || selected_crate_ids.contains(&Some(overlay_id));
         let is_low_bridge =
             is_bridge_overlay_index(overlay_id) && !is_high_bridge_index(overlay_id);
         if !is_wall && !is_low_bridge && !is_crate {
@@ -2668,6 +2698,7 @@ pub(crate) fn build_overlay_atlas_from_map(
     batch: &BatchRenderer,
     theater_ext: &str,
     rules_ini: &IniFile,
+    crate_rules: &crate::rules::crate_rules::CrateRules,
     art_registry: &ArtRegistry,
     theater_iso_palette: Option<&Palette>,
     theater_unit_palette: Option<&Palette>,
@@ -2763,7 +2794,7 @@ pub(crate) fn build_overlay_atlas_from_map(
     // be placed by production; low bridges replace their CellClass identity as
     // damage/collapse/repair advances while the map-pack entry stays fixed.
     let (wall_ids_added, low_bridge_ids_added, crate_ids_added) =
-        preregister_runtime_overlay_names(&overlay_registry, &mut overlay_names);
+        preregister_runtime_overlay_names(&overlay_registry, crate_rules, &mut overlay_names);
     if wall_ids_added > 0 {
         log::info!(
             "Pre-registered {} wall overlay type(s) in overlay_names for player placement",
@@ -2845,6 +2876,7 @@ pub(crate) fn build_overlay_atlas_from_map(
             &map_data.header.theater,
             &overlay_registry,
             &tiberium_types,
+            crate_rules,
             rules_ini,
             art_registry,
             smudge_types,

--- a/src/app/frontend/skirmish.rs
+++ b/src/app/frontend/skirmish.rs
@@ -2896,6 +2896,7 @@ pub(crate) fn build_overlay_atlas_from_map(
             theater_ext,
             &map_data.header.theater,
             &overlay_registry,
+            crate_rules,
             rules_ini,
             art_registry,
         )

--- a/src/app/frontend/skirmish.rs
+++ b/src/app/frontend/skirmish.rs
@@ -2441,11 +2441,12 @@ mod tests {
         let registry = OverlayTypeRegistry::from_ini(&IniFile::from_str(&text), None);
         let mut names = BTreeMap::new();
 
-        let (wall_count, low_bridge_count) =
+        let (wall_count, low_bridge_count, crate_count) =
             preregister_runtime_overlay_names(&registry, &mut names);
 
         assert_eq!(wall_count, 0);
         assert_eq!(low_bridge_count, 64);
+        assert_eq!(crate_count, 0);
         assert_eq!(names.get(&0x50).map(String::as_str), Some("LOBRDG07"));
         assert_eq!(names.get(&0x64).map(String::as_str), Some("LOBRDG27"));
         assert_eq!(names.get(&0xE7).map(String::as_str), Some("LOBRDB27"));
@@ -2453,6 +2454,25 @@ mod tests {
             !names.contains_key(&24) && !names.contains_key(&237),
             "high bridges remain owned by the dedicated bridge renderer"
         );
+    }
+
+    #[test]
+    fn runtime_overlay_names_include_every_crate_identity_before_startup_scatter() {
+        let registry = OverlayTypeRegistry::from_ini(
+            &IniFile::from_str(
+                "[OverlayTypes]\n0=CRATE\n1=WCRATE\n2=PLAIN\n\
+                 [CRATE]\nCrate=yes\n[WCRATE]\nCrate=yes\n[PLAIN]\n",
+            ),
+            None,
+        );
+        let mut names = BTreeMap::new();
+
+        let counts = preregister_runtime_overlay_names(&registry, &mut names);
+
+        assert_eq!(counts, (0, 0, 2));
+        assert_eq!(names.get(&0).map(String::as_str), Some("CRATE"));
+        assert_eq!(names.get(&1).map(String::as_str), Some("WCRATE"));
+        assert!(!names.contains_key(&2));
     }
 }
 
@@ -2608,16 +2628,17 @@ pub fn deployable_building_types<'a>(
 fn preregister_runtime_overlay_names(
     overlay_registry: &OverlayTypeRegistry,
     overlay_names: &mut BTreeMap<u8, String>,
-) -> (u32, u32) {
+) -> (u32, u32, u32) {
     let mut wall_ids_added: u32 = 0;
     let mut low_bridge_ids_added: u32 = 0;
+    let mut crate_ids_added: u32 = 0;
     for overlay_id in 0u8..=u8::MAX {
-        let is_wall = overlay_registry
-            .flags(overlay_id)
-            .is_some_and(|flags| flags.wall);
+        let flags = overlay_registry.flags(overlay_id);
+        let is_wall = flags.is_some_and(|flags| flags.wall);
+        let is_crate = flags.is_some_and(|flags| flags.crate_type);
         let is_low_bridge =
             is_bridge_overlay_index(overlay_id) && !is_high_bridge_index(overlay_id);
-        if !is_wall && !is_low_bridge {
+        if !is_wall && !is_low_bridge && !is_crate {
             continue;
         }
         let Some(name) = resolve_overlay_name_for_render(overlay_registry, overlay_id) else {
@@ -2627,12 +2648,16 @@ fn preregister_runtime_overlay_names(
             entry.insert(name);
             if is_wall {
                 wall_ids_added += 1;
-            } else {
+            }
+            if is_low_bridge {
                 low_bridge_ids_added += 1;
+            }
+            if is_crate {
+                crate_ids_added += 1;
             }
         }
     }
-    (wall_ids_added, low_bridge_ids_added)
+    (wall_ids_added, low_bridge_ids_added, crate_ids_added)
 }
 
 /// Build overlay sprite atlas and name mapping from map data + rules.ini.
@@ -2737,7 +2762,7 @@ pub(crate) fn build_overlay_atlas_from_map(
     // Register overlay identities the sim can create after map load. Walls can
     // be placed by production; low bridges replace their CellClass identity as
     // damage/collapse/repair advances while the map-pack entry stays fixed.
-    let (wall_ids_added, low_bridge_ids_added) =
+    let (wall_ids_added, low_bridge_ids_added, crate_ids_added) =
         preregister_runtime_overlay_names(&overlay_registry, &mut overlay_names);
     if wall_ids_added > 0 {
         log::info!(
@@ -2749,6 +2774,12 @@ pub(crate) fn build_overlay_atlas_from_map(
         log::info!(
             "Pre-registered {} low-bridge overlay variant(s) in overlay_names",
             low_bridge_ids_added
+        );
+    }
+    if crate_ids_added > 0 {
+        log::info!(
+            "Pre-registered {} crate overlay type(s) in overlay_names for startup/runtime placement",
+            crate_ids_added
         );
     }
 

--- a/src/app/frontend/skirmish.rs
+++ b/src/app/frontend/skirmish.rs
@@ -2625,7 +2625,7 @@ pub fn deployable_building_types<'a>(
     result
 }
 
-fn preregister_runtime_overlay_names(
+pub(crate) fn preregister_runtime_overlay_names(
     overlay_registry: &OverlayTypeRegistry,
     overlay_names: &mut BTreeMap<u8, String>,
 ) -> (u32, u32, u32) {

--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -97,6 +97,87 @@ fn resolved_overlay_shp_ids(
     available
 }
 
+/// Append visible accepted startup crates to the initial presentation index.
+/// Ghost slots remain authoritative simulation state but have no live overlay
+/// identity and therefore produce no render entry.
+fn connect_startup_crate_overlays(
+    overlays: &mut Vec<OverlayEntry>,
+    simulation: &Simulation,
+) -> usize {
+    let Some(grid) = simulation.overlay_grid.as_ref() else {
+        return 0;
+    };
+    let candidates = simulation
+        .crate_authority
+        .occupied_cells()
+        .filter_map(|(rx, ry)| {
+            let cell = grid.cell(rx, ry);
+            Some(OverlayEntry {
+                rx,
+                ry,
+                overlay_id: cell.overlay_id?,
+                frame: cell.overlay_data,
+            })
+        })
+        .collect();
+    let mut index = crate::app::presentation::overlay_index::OverlayRenderIndex::default();
+    index.replace_from_source(std::mem::take(overlays));
+    let synced = index.upsert_occupied(candidates);
+    *overlays = index.as_slice().to_vec();
+    synced
+}
+
+#[cfg(test)]
+mod startup_crate_presentation_tests {
+    use super::*;
+    use crate::sim::crates::CrateSlot;
+    use crate::sim::overlay_grid::OverlayGrid;
+
+    #[test]
+    fn startup_crate_presentation_appends_visible_slots_and_excludes_ghosts() {
+        let mut simulation = Simulation::new();
+        simulation.overlay_grid = Some(OverlayGrid::new(16, 16));
+        *simulation.crate_authority.slot_mut(0) = CrateSlot {
+            start_frame: 0,
+            aux: 1,
+            duration: 2,
+            cell_x: 9,
+            cell_y: 4,
+        };
+        *simulation.crate_authority.slot_mut(1) = CrateSlot {
+            start_frame: 0,
+            aux: 3,
+            duration: 4,
+            cell_x: 7,
+            cell_y: 8,
+        };
+        simulation
+            .overlay_grid
+            .as_mut()
+            .unwrap()
+            .place_overlay(9, 4, 33, u8::MAX);
+        let mut source = vec![OverlayEntry {
+            rx: 2,
+            ry: 3,
+            overlay_id: 5,
+            frame: 6,
+        }];
+
+        assert_eq!(connect_startup_crate_overlays(&mut source, &simulation), 1);
+        assert_eq!(
+            source
+                .iter()
+                .map(|entry| (entry.rx, entry.ry, entry.overlay_id, entry.frame))
+                .collect::<Vec<_>>(),
+            vec![(2, 3, 5, 6), (9, 4, 33, u8::MAX),]
+        );
+        assert!(
+            source.iter().all(|entry| (entry.rx, entry.ry) != (7, 8)),
+            "a timed ghost has no initial render entry"
+        );
+    }
+}
+
 #[cfg(test)]
 mod native_overlay_shp_tests {
     use super::*;
@@ -910,6 +991,7 @@ pub(crate) struct RandomMapLaunchSnapshot {
     pub(crate) mapgen_continuation: crate::sim::rng::SimRngLogicalState,
     pub(crate) final_rng: crate::sim::world::SimulationRngState,
     pub(crate) post_map_output: crate::sim::scenario_post_map::ScenarioPostMapOutput,
+    pub(crate) startup_crate_slots: Vec<(usize, crate::sim::crates::CrateSlot, Option<(u8, u8)>)>,
 }
 
 #[cfg(test)]
@@ -1251,6 +1333,24 @@ impl MapLoadInitial {
             &house_roster,
             Some(match_launch_descriptor),
         );
+        let startup_crate_slots = simulation
+            .crate_authority
+            .slots()
+            .iter()
+            .copied()
+            .enumerate()
+            .filter(|(_, slot)| !slot.is_empty())
+            .map(|(index, slot)| {
+                let live_overlay = u16::try_from(slot.cell_x)
+                    .ok()
+                    .zip(u16::try_from(slot.cell_y).ok())
+                    .and_then(|(rx, ry)| {
+                        let cell = simulation.overlay_grid.as_ref()?.cell(rx, ry);
+                        Some((cell.overlay_id?, cell.overlay_data))
+                    });
+                (index, slot, live_overlay)
+            })
+            .collect();
         let final_rng = simulation.rng_state();
         RandomMapLaunchSnapshot {
             map,
@@ -1261,6 +1361,7 @@ impl MapLoadInitial {
             mapgen_continuation,
             final_rng,
             post_map_output,
+            startup_crate_slots,
         }
     }
 }
@@ -2359,12 +2460,13 @@ pub(crate) fn load_map_from_initial(
     // authoritative post-map tail — runs through the same sim-owned function
     // the headless loader uses.
     //
-    // The overlay render entries are filtered BEFORE the call, against the
+    // The source overlay render entries are filtered BEFORE the call, against the
     // grid state the entries were derived from: the shared finalization's only
     // pre-install grid mutation is wall-owner reconstruction (wall_owner
     // fields, never overlay ids), while its post-map tail may place
-    // scenario-start crates — new overlay occupancy this presentation filter
-    // must not react to.
+    // scenario-start crates. Visible accepted crate coordinates are appended
+    // from the live post-map grid immediately afterward through the same
+    // coordinate-retaining OverlayRenderIndex used by runtime updates.
     overlays_connected
         .retain(|entry| overlay_grid.cell(entry.rx, entry.ry).overlay_id == Some(entry.overlay_id));
     let rules_for_post_map = rules
@@ -2389,6 +2491,12 @@ pub(crate) fn load_map_from_initial(
         }
         if !output.navigation_published {
             log::error!("Initial navigation rebuild failed: resolved terrain is unavailable");
+        }
+        let connected_crates = connect_startup_crate_overlays(&mut overlays_connected, sim);
+        if connected_crates != 0 {
+            log::info!(
+                "Connected {connected_crates} visible startup crate cell(s) to initial overlay presentation"
+            );
         }
     }
 

--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -1357,12 +1357,19 @@ impl MapLoadInitial {
         let mut runtime_names = BTreeMap::new();
         crate::app::frontend::skirmish::preregister_runtime_overlay_names(
             &overlay_registry,
+            &rules.crate_rules,
             &mut runtime_names,
         );
+        let selected_ids = [
+            crate_name_id(rules.crate_rules.wood_crate_img.as_deref()),
+            crate_name_id(rules.crate_rules.crate_img.as_deref()),
+            crate_name_id(rules.crate_rules.water_crate_img.as_deref()),
+        ];
         runtime_names.retain(|id, _| {
             overlay_registry
                 .flags(*id)
                 .is_some_and(|flags| flags.crate_type)
+                || selected_ids.contains(&Some(*id))
         });
         let mut presented = Vec::new();
         connect_startup_crate_overlays(&mut presented, &simulation);
@@ -2499,6 +2506,10 @@ pub(crate) fn load_map_from_initial(
         batch,
         theater_ext,
         &rules_ini,
+        &rules
+            .as_ref()
+            .expect("merged rules were installed before atlas construction")
+            .crate_rules,
         art.as_ref().unwrap_or(&art_fallback),
         overlay_iso_palette.as_ref(),
         unit_palette.as_ref(),

--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -982,6 +982,24 @@ pub(crate) struct RandomMapProjection {
 
 #[cfg(test)]
 #[derive(Debug, PartialEq, Eq)]
+pub(crate) struct RandomMapStartupCrateProjection {
+    pub(crate) crates_enabled: bool,
+    pub(crate) minimum: i32,
+    pub(crate) maximum: i32,
+    pub(crate) regen_bits: u64,
+    pub(crate) wood_name: Option<String>,
+    pub(crate) common_name: Option<String>,
+    pub(crate) water_name: Option<String>,
+    pub(crate) wood_id: Option<u8>,
+    pub(crate) common_id: Option<u8>,
+    pub(crate) water_id: Option<u8>,
+    pub(crate) runtime_names: Vec<(u8, String)>,
+    pub(crate) presented: Vec<(u16, u16, u8, u8)>,
+    pub(crate) body_frame: u8,
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct RandomMapLaunchSnapshot {
     pub(crate) map: RandomMapProjection,
     pub(crate) trace: crate::map::rmg::RmgConstructionTrace,
@@ -992,6 +1010,7 @@ pub(crate) struct RandomMapLaunchSnapshot {
     pub(crate) final_rng: crate::sim::world::SimulationRngState,
     pub(crate) post_map_output: crate::sim::scenario_post_map::ScenarioPostMapOutput,
     pub(crate) startup_crate_slots: Vec<(usize, crate::sim::crates::CrateSlot, Option<(u8, u8)>)>,
+    pub(crate) startup_crate: RandomMapStartupCrateProjection,
 }
 
 #[cfg(test)]
@@ -1333,6 +1352,38 @@ impl MapLoadInitial {
             &house_roster,
             Some(match_launch_descriptor),
         );
+        let crate_name_id =
+            |name: Option<&str>| name.and_then(|name| overlay_registry.id_for_name(name));
+        let mut runtime_names = BTreeMap::new();
+        crate::app::frontend::skirmish::preregister_runtime_overlay_names(
+            &overlay_registry,
+            &mut runtime_names,
+        );
+        runtime_names.retain(|id, _| {
+            overlay_registry
+                .flags(*id)
+                .is_some_and(|flags| flags.crate_type)
+        });
+        let mut presented = Vec::new();
+        connect_startup_crate_overlays(&mut presented, &simulation);
+        let startup_crate = RandomMapStartupCrateProjection {
+            crates_enabled: simulation.session.game_options.crates,
+            minimum: rules.crate_rules.minimum,
+            maximum: rules.crate_rules.maximum,
+            regen_bits: rules.crate_rules.regen.bits(),
+            wood_id: crate_name_id(rules.crate_rules.wood_crate_img.as_deref()),
+            common_id: crate_name_id(rules.crate_rules.crate_img.as_deref()),
+            water_id: crate_name_id(rules.crate_rules.water_crate_img.as_deref()),
+            wood_name: rules.crate_rules.wood_crate_img.clone(),
+            common_name: rules.crate_rules.crate_img.clone(),
+            water_name: rules.crate_rules.water_crate_img.clone(),
+            runtime_names: runtime_names.into_iter().collect(),
+            presented: presented
+                .into_iter()
+                .map(|entry| (entry.rx, entry.ry, entry.overlay_id, entry.frame))
+                .collect(),
+            body_frame: crate::render::overlay_atlas::CRATE_BODY_FRAME,
+        };
         let startup_crate_slots = simulation
             .crate_authority
             .slots()
@@ -1362,6 +1413,7 @@ impl MapLoadInitial {
             final_rng,
             post_map_output,
             startup_crate_slots,
+            startup_crate,
         }
     }
 }

--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -97,9 +97,9 @@ fn resolved_overlay_shp_ids(
     available
 }
 
-/// Append visible accepted startup crates to the initial presentation index.
-/// Ghost slots remain authoritative simulation state but have no live overlay
-/// identity and therefore produce no render entry.
+/// Append every visible real-cell write made by startup crate Mark to the
+/// initial presentation index. Ghost slots have no live overlay identity, while
+/// low-bridge Mark may write many cells for one timed slot.
 fn connect_startup_crate_overlays(
     overlays: &mut Vec<OverlayEntry>,
     simulation: &Simulation,
@@ -107,9 +107,12 @@ fn connect_startup_crate_overlays(
     let Some(grid) = simulation.overlay_grid.as_ref() else {
         return 0;
     };
-    let candidates = simulation
-        .crate_authority
-        .occupied_cells()
+    let mut seen = BTreeSet::new();
+    let candidates = grid
+        .pending_dirty_cells()
+        .iter()
+        .copied()
+        .filter(|cell| seen.insert(*cell))
         .filter_map(|(rx, ry)| {
             let cell = grid.cell(rx, ry);
             Some(OverlayEntry {
@@ -174,6 +177,43 @@ mod startup_crate_presentation_tests {
         assert!(
             source.iter().all(|entry| (entry.rx, entry.ry) != (7, 8)),
             "a timed ghost has no initial render entry"
+        );
+    }
+
+    #[test]
+    fn startup_crate_presentation_includes_low_bridge_extension_without_consuming_dirty_receipt() {
+        let mut simulation = Simulation::new();
+        simulation.overlay_grid = Some(OverlayGrid::new(32, 32));
+        *simulation.crate_authority.slot_mut(0) = CrateSlot {
+            start_frame: 10,
+            aux: 20,
+            duration: 30,
+            cell_x: 12,
+            cell_y: 12,
+        };
+        let grid = simulation.overlay_grid.as_mut().unwrap();
+        grid.place_overlay(12, 11, 0x5C, 0);
+        grid.place_overlay(12, 12, 0x4A, 1);
+        grid.place_overlay(12, 13, 0x4B, 2);
+        let dirty_before = grid.pending_dirty_cells().to_vec();
+        let mut source = Vec::new();
+
+        assert_eq!(connect_startup_crate_overlays(&mut source, &simulation), 3);
+        assert_eq!(
+            source
+                .iter()
+                .map(|entry| (entry.rx, entry.ry, entry.overlay_id, entry.frame))
+                .collect::<Vec<_>>(),
+            vec![(12, 11, 0x5C, 0), (12, 12, 0x4A, 1), (12, 13, 0x4B, 2)]
+        );
+        assert_eq!(
+            simulation
+                .overlay_grid
+                .as_ref()
+                .unwrap()
+                .pending_dirty_cells(),
+            dirty_before,
+            "initial presentation must not consume the sim/navigation receipt"
         );
     }
 }
@@ -1166,7 +1206,11 @@ impl MapLoadInitial {
             || theater_ext_for(&map_data.header.theater),
             |td| td.extension,
         );
-        let scheduler_roots = scheduler_anim_roots(&rules, resolved_terrain.tile_animations());
+        let scheduler_roots = scheduler_anim_roots(
+            &rules,
+            &overlay_registry,
+            resolved_terrain.tile_animations(),
+        );
         art.bind_scheduler_anim_assets(
             &scheduler_roots,
             asset_manager,
@@ -2046,7 +2090,7 @@ pub(crate) fn load_map_from_initial(
     // have resolved, but before any atlas or AnimClass construction. Missing
     // tile art is a load error rather than a silently invisible map feature.
     if let (Some(r), Some(a)) = (rules.as_mut(), art.as_mut()) {
-        let roots = scheduler_anim_roots(r, resolved_terrain.tile_animations());
+        let roots = scheduler_anim_roots(r, &overlay_registry, resolved_terrain.tile_animations());
         a.bind_scheduler_anim_assets(
             &roots,
             &asset_manager,
@@ -2309,6 +2353,7 @@ pub(crate) fn load_map_from_initial(
         &map_data.header.theater,
         rules.as_ref(),
         art.as_ref(),
+        &overlay_registry,
         &house_color_map,
         unit_palette.as_ref(),
         overlay_iso_palette.as_ref(),
@@ -2403,6 +2448,7 @@ pub(crate) fn load_map_from_initial(
                     &map_data.header.theater,
                     rules.as_ref(),
                     art.as_ref(),
+                    &overlay_registry,
                     &house_color_map,
                     unit_palette.as_ref(),
                     overlay_iso_palette.as_ref(),

--- a/src/app/loading/init_helpers.rs
+++ b/src/app/loading/init_helpers.rs
@@ -483,6 +483,7 @@ pub(crate) fn generate_unverified_legacy_match_seed() -> u32 {
 /// names take the same path without a WA/TUNTOP name table in Rust.
 pub(crate) fn scheduler_anim_roots(
     rules: &RuleSet,
+    overlay_registry: &crate::map::overlay_types::OverlayTypeRegistry,
     tile_animations: &[TerrainTileAnimation],
 ) -> Vec<String> {
     let mut roots = BTreeSet::new();
@@ -500,7 +501,53 @@ pub(crate) fn scheduler_anim_roots(
             .map(|anim| anim.anim_name.trim().to_ascii_uppercase())
             .filter(|name| !name.is_empty()),
     );
+    roots.extend(
+        [
+            rules.crate_rules.wood_crate_img.as_deref(),
+            rules.crate_rules.crate_img.as_deref(),
+            rules.crate_rules.water_crate_img.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .filter_map(|name| overlay_registry.id_for_name(name))
+        .filter_map(|overlay_id| overlay_registry.flags(overlay_id))
+        .filter_map(|flags| flags.cell_anim.as_deref())
+        .map(|name| name.trim().to_ascii_uppercase())
+        .filter(|name| !name.is_empty()),
+    );
     roots.into_iter().collect()
+}
+
+/// Palette variants reachable from scenario-start crate CellAnim before the
+/// post-map placer has constructed those AnimObjects. Initial atlases are built
+/// earlier in the loading funnel, so live-object discovery alone is too late.
+pub(crate) fn startup_crate_anim_remap_keys(
+    rules: &RuleSet,
+    overlay_registry: &crate::map::overlay_types::OverlayTypeRegistry,
+) -> HashSet<(String, crate::rules::house_colors::HouseColorIndex)> {
+    [
+        rules.crate_rules.wood_crate_img.as_deref(),
+        rules.crate_rules.crate_img.as_deref(),
+        rules.crate_rules.water_crate_img.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .filter_map(|name| overlay_registry.id_for_name(name))
+    .filter_map(|overlay_id| {
+        let flags = overlay_registry.flags(overlay_id)?;
+        let anim = flags.cell_anim.as_deref()?;
+        let tiberium = overlay_registry
+            .tiberium_type_for_overlay(&rules.tiberium_types, overlay_id)
+            .and_then(|type_id| rules.tiberium_types.get(type_id))?;
+        let color = tiberium.color.as_deref()?;
+        let entry = crate::rules::color_scheme::scheme_entry_by_name(&rules.color_schemes, color)?;
+        let color = u8::try_from(entry)
+            .ok()
+            .map(crate::rules::house_colors::HouseColorIndex)?;
+        Some((anim.trim().to_ascii_uppercase(), color))
+    })
+    .filter(|(anim, _)| !anim.is_empty())
+    .collect()
 }
 
 /// The presentation-side atlas bundle the app builds AFTER GPU-free scenario
@@ -574,6 +621,7 @@ pub(crate) fn build_presentation_manifest(
     theater_name: &str,
     rules: Option<&RuleSet>,
     art: Option<&ArtRegistry>,
+    overlay_registry: &crate::map::overlay_types::OverlayTypeRegistry,
     house_colors: &HouseColorMap,
     theater_unit_palette: Option<&Palette>,
     theater_iso_palette: Option<&Palette>,
@@ -588,6 +636,7 @@ pub(crate) fn build_presentation_manifest(
         theater_name,
         rules,
         art,
+        overlay_registry,
         house_colors,
         theater_unit_palette,
         theater_iso_palette,
@@ -609,6 +658,7 @@ pub(crate) fn build_entity_atlases(
     theater_name: &str,
     rules: Option<&RuleSet>,
     art: Option<&ArtRegistry>,
+    overlay_registry: &crate::map::overlay_types::OverlayTypeRegistry,
     house_colors: &HouseColorMap,
     theater_unit_palette: Option<&Palette>,
     theater_iso_palette: Option<&Palette>,
@@ -649,6 +699,10 @@ pub(crate) fn build_entity_atlases(
     // Pre-load building types that can be spawned at runtime (e.g., ConYards from MCV deploy).
     let extra_buildings: Vec<&str> =
         deployable_building_types(sim.entities(), rules, Some(&sim.interner));
+    let mut anim_remap_keys = sprite_atlas::collect_anim_remap_base_keys(sim);
+    if let Some(rules) = rules {
+        anim_remap_keys.extend(startup_crate_anim_remap_keys(rules, overlay_registry));
+    }
     let cell_drawer_type_ids: HashSet<String> = sim
         .resolved_terrain
         .as_ref()
@@ -676,6 +730,7 @@ pub(crate) fn build_entity_atlases(
             art,
             house_colors,
             &extra_buildings,
+            &anim_remap_keys,
             &cell_drawer_type_ids,
             cell_palette,
             None, // initial build — no existing cache
@@ -706,11 +761,13 @@ mod retail_placement_oracle_tests;
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::path::PathBuf;
 
     use super::{
         LoadedRules, compose_rules_layers, load_rules_with_merged_ini,
         missing_active_team_ai_registry_sections, scheduler_anim_roots,
+        startup_crate_anim_remap_keys,
     };
     use crate::assets::asset_manager::AssetManager;
     use crate::map::entities::EntityCategory;
@@ -751,10 +808,14 @@ mod tests {
 
     #[test]
     fn gsi_13_04_scheduler_roots_include_generic_resolved_tile_names() {
-        let rules = RuleSet::from_ini(&IniFile::from_str(
-            "[General]\nDamageFireTypes=FIRE_A,FIRE_B\n",
-        ))
-        .expect("rules");
+        let ini = IniFile::from_str(
+            "[General]\nDamageFireTypes=FIRE_A,FIRE_B\n\
+             [Animations]\n0=crate_spark\n\
+             [OverlayTypes]\n0=STARTBOX\n[STARTBOX]\nCellAnim=crate_spark\n\
+             [CrateRules]\nCrateImg=STARTBOX\nWoodCrateImg=STARTBOX\nWaterCrateImg=STARTBOX\n",
+        );
+        let rules = RuleSet::from_ini(&ini).expect("rules");
+        let overlay_registry = crate::map::overlay_types::OverlayTypeRegistry::from_ini(&ini, None);
         let tiles = vec![
             TerrainTileAnimation {
                 rx: 4,
@@ -777,8 +838,60 @@ mod tests {
         ];
 
         assert_eq!(
-            scheduler_anim_roots(&rules, &tiles),
-            vec!["CUSTOM_FALLS", "CUSTOM_MOUTH", "FIRE_A", "FIRE_B"]
+            scheduler_anim_roots(&rules, &overlay_registry, &tiles),
+            vec![
+                "CRATE_SPARK",
+                "CUSTOM_FALLS",
+                "CUSTOM_MOUTH",
+                "FIRE_A",
+                "FIRE_B"
+            ]
+        );
+    }
+
+    #[test]
+    fn startup_crate_cell_anim_remap_is_rooted_before_post_map_construction() {
+        let ini = IniFile::from_str(
+            "[Colors]\nGold=43,239,255\nNeonGreen=104,241,195\n\
+             [Tiberiums]\n0=Riparius\n[Riparius]\nImage=1\nColor=NeonGreen\n\
+             [Animations]\n0=crate_spark\n\
+             [OverlayTypes]\n0=STARTBOX\n[STARTBOX]\nTiberium=yes\nCellAnim=crate_spark\n\
+             [CrateRules]\nCrateImg=STARTBOX\nWoodCrateImg=STARTBOX\nWaterCrateImg=STARTBOX\n",
+        );
+        let rules = RuleSet::from_ini(&ini).expect("rules");
+        let overlay_registry = crate::map::overlay_types::OverlayTypeRegistry::from_ini(&ini, None);
+
+        assert_eq!(
+            rules.crate_rules.crate_img.as_deref(),
+            Some("STARTBOX"),
+            "the processed CrateRules identity must drive pre-atlas discovery"
+        );
+        let overlay_id = overlay_registry
+            .id_for_name("STARTBOX")
+            .expect("startup crate overlay identity");
+        let flags = overlay_registry
+            .flags(overlay_id)
+            .expect("startup crate overlay flags");
+        assert_eq!(flags.cell_anim.as_deref(), Some("CRATE_SPARK"));
+        let tiberium = overlay_registry
+            .tiberium_type_for_overlay(&rules.tiberium_types, overlay_id)
+            .and_then(|type_id| rules.tiberium_types.get(type_id))
+            .expect("tiberium authority for startup crate CellAnim");
+        assert_eq!(tiberium.color.as_deref(), Some("NeonGreen"));
+        assert_eq!(
+            crate::rules::color_scheme::scheme_entry_by_name(
+                &rules.color_schemes,
+                tiberium.color.as_deref().unwrap(),
+            ),
+            Some(1)
+        );
+
+        assert_eq!(
+            startup_crate_anim_remap_keys(&rules, &overlay_registry),
+            HashSet::from([(
+                "CRATE_SPARK".to_string(),
+                crate::rules::house_colors::HouseColorIndex(1),
+            )])
         );
     }
 

--- a/src/app/loading/init_helpers.rs
+++ b/src/app/loading/init_helpers.rs
@@ -1235,7 +1235,8 @@ mod tests {
     ///   One record per case-insensitive name, last definition wins
     ///   (Strength 200, not 100), and lookup is case-insensitive.
     /// - **Sectionless registry entry:** GHOST is listed in [VehicleTypes] but
-    ///   has no [GHOST] section — silently skipped, no record.
+    ///   has no [GHOST] section. The registry allocation pass still creates its
+    ///   constructor-default record before the later body-read pass.
     #[test]
     fn resolution_order_matches_engine() {
         let ini = IniFile::from_str(
@@ -1257,8 +1258,9 @@ mod tests {
         assert!(rules.object("htnk").is_some());
         assert_eq!(rules.object("HTNK").map(|o| o.strength), Some(100));
 
-        // Registry entry with no section produced no record.
-        assert!(rules.object("GHOST").is_none());
+        // Registry allocation precedes the body-read pass, so a sectionless
+        // entry retains its constructor-default record.
+        assert!(rules.object("GHOST").is_some());
     }
 
     /// AT-11 (RC-3): every ported scalar default that maps to a verified

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -1693,12 +1693,14 @@ pub(crate) fn refresh_entity_atlases(state: &mut AppState) {
         bound_rules,
         Some(&sim.interner),
     );
-    let sprite_base_keys = sprite_atlas::collect_needed_base_keys(
+    let mut sprite_base_keys = sprite_atlas::collect_needed_base_keys(
         sim.entities(),
         &state.match_state.match_presentation.house_color_map,
         &extra_buildings,
         Some(&sim.interner),
     );
+    let anim_remap_keys = sprite_atlas::collect_anim_remap_base_keys(sim);
+    sprite_base_keys.extend(anim_remap_keys.iter().cloned());
     let sprite_rebuild: bool = match &state.match_state.match_presentation.sprite_atlas {
         Some(atlas) => !sprite_atlas::atlas_covers_base_keys(atlas, &sprite_base_keys),
         None => !sprite_base_keys.is_empty(),
@@ -1757,6 +1759,7 @@ pub(crate) fn refresh_entity_atlases(state: &mut AppState) {
             bound_rules.map(|rules| &rules.art_registry),
             &state.match_state.match_presentation.house_color_map,
             &extra_buildings,
+            &anim_remap_keys,
             &cell_drawer_type_ids,
             cell_palette.as_ref(),
             existing,

--- a/src/app/presentation/instances/bridges.rs
+++ b/src/app/presentation/instances/bridges.rs
@@ -17,7 +17,7 @@ use crate::app::AppState;
 use crate::map::lighting::{self, CellLightGrid};
 use crate::map::terrain::{self, TILE_HEIGHT, TILE_WIDTH};
 use crate::render::batch::SpriteInstance;
-use crate::render::bridge_atlas::{BridgeAtlasLookup, is_high_bridge_body_name};
+use crate::render::bridge_atlas::{BridgeAtlasLookup, is_high_bridge_body_identity};
 use crate::render::bridge_railing_atlas::BridgeKind;
 use crate::render::draw_state::DrawState;
 use crate::sim::bridge_state::{Axis, BridgeRuntimeCell, BridgeRuntimeState, DamageState};
@@ -152,7 +152,7 @@ pub fn build_bridge_body_instances_inner(
         let Some(name) = overlay_names.get(&cell.overlay_byte) else {
             continue;
         };
-        if !is_high_bridge_body_name(name) {
+        if !is_high_bridge_body_identity(cell.overlay_byte, name) {
             continue;
         }
 
@@ -237,28 +237,20 @@ pub(crate) fn build_bridge_body_instances(
 /// Step 5 pass 2). Shadow frame = `(frame_count / 2) + state`. EW states
 /// 9..17 get a `(BRIDGE_SHADOW_EW_DX, +BRIDGE_SHADOW_EW_DY)` shift per
 /// ledger #9–10. Drawn passthrough (Z-test ON, Z-write OFF, neutral tint).
-pub(crate) fn build_bridge_shadow_instances(
-    state: &AppState,
+#[allow(clippy::too_many_arguments)]
+fn build_bridge_shadow_instances_inner(
+    bridge_state: &BridgeRuntimeState,
+    atlas: &dyn BridgeAtlasLookup,
+    overlay_names: &BTreeMap<u8, String>,
+    height_map: &BTreeMap<(u16, u16), u8>,
+    origin_y: f32,
+    world_height: f32,
+    cam_x: f32,
+    cam_y: f32,
     sw: f32,
     sh: f32,
     out: &mut Vec<SpriteInstance>,
 ) {
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
-        return;
-    };
-    let Some(bridge_state) = sim.bridge_state.as_ref() else {
-        return;
-    };
-    let Some(atlas) = state.match_state.match_presentation.bridge_atlas.as_ref() else {
-        return;
-    };
-    let (origin_y, world_height) = state
-        .match_state.match_presentation.terrain_grid
-        .as_ref()
-        .map(|g| (g.origin_y, g.world_height))
-        .unwrap_or((0.0, 1.0));
-    let (cam_x, cam_y) = (state.match_state.input.camera_x, state.match_state.input.camera_y);
-
     for ((rx, ry), cell) in bridge_state.iter_cells() {
         if !cell.deck_present {
             continue;
@@ -267,10 +259,10 @@ pub(crate) fn build_bridge_shadow_instances(
             continue;
         };
         let Some(axis) = cell.axis else { continue };
-        let Some(name) = state.match_state.match_presentation.overlay_names.get(&cell.overlay_byte) else {
+        let Some(name) = overlay_names.get(&cell.overlay_byte) else {
             continue;
         };
-        if !is_high_bridge_body_name(name) {
+        if !is_high_bridge_body_identity(cell.overlay_byte, name) {
             continue;
         }
 
@@ -283,8 +275,7 @@ pub(crate) fn build_bridge_shadow_instances(
         let frame = compute_bridge_body_shp_frame(render_state, axis, rx, ry);
         let y_offset = compute_bridge_body_y_offset(render_state, axis);
 
-        let z: u8 = state
-            .height_map()
+        let z: u8 = height_map
             .get(&(rx, ry))
             .copied()
             .unwrap_or(cell.deck_level);
@@ -324,6 +315,43 @@ pub(crate) fn build_bridge_shadow_instances(
             ..Default::default()
         });
     }
+}
+
+pub(crate) fn build_bridge_shadow_instances(
+    state: &AppState,
+    sw: f32,
+    sh: f32,
+    out: &mut Vec<SpriteInstance>,
+) {
+    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+        return;
+    };
+    let Some(bridge_state) = sim.bridge_state.as_ref() else {
+        return;
+    };
+    let Some(atlas) = state.match_state.match_presentation.bridge_atlas.as_ref() else {
+        return;
+    };
+    let (origin_y, world_height) = state
+        .match_state.match_presentation.terrain_grid
+        .as_ref()
+        .map(|g| (g.origin_y, g.world_height))
+        .unwrap_or((0.0, 1.0));
+    let (cam_x, cam_y) = (state.match_state.input.camera_x, state.match_state.input.camera_y);
+    let height_map = state.height_map();
+    build_bridge_shadow_instances_inner(
+        bridge_state,
+        atlas,
+        &state.match_state.match_presentation.overlay_names,
+        &height_map,
+        origin_y,
+        world_height,
+        cam_x,
+        cam_y,
+        sw,
+        sh,
+        out,
+    );
 }
 
 /// Build sprite instances for the bridge railing pass (RE doc §3.4.1, Step 7).
@@ -682,6 +710,10 @@ mod tests {
                     None
                 }
             }
+
+            fn shadow_entry(&self, _name: &str, _frame: u8) -> Option<&OverlaySpriteEntry> {
+                None
+            }
         }
 
         // Seed three visible EW cells. Their 0xDC overlay byte is the render
@@ -729,7 +761,7 @@ mod tests {
         };
 
         // Map every overlay byte the walker may have written to "BRIDGE1" so
-        // `is_high_bridge_body_name` accepts it.
+        // the canonical destroy-band route accepts it.
         let mut overlay_names: BTreeMap<u8, String> = BTreeMap::new();
         for byte in 0xCDu8..=0xE8u8 {
             overlay_names.insert(byte, "BRIDGE1".to_string());
@@ -793,6 +825,114 @@ mod tests {
         assert_eq!(
             instance.draw_state.fx_params[3],
             bridge_body_depth_scale(world_height)
+        );
+    }
+
+    #[test]
+    fn startup_numeric_high_identity_emits_custom_named_body_and_shadow() {
+        use crate::map::lighting::CellLightGrid;
+        use crate::render::overlay_atlas::OverlaySpriteEntry;
+        use crate::sim::bridge_state::{BridgeCellRole, BridgeheadAnchorClass};
+
+        struct MockAtlas {
+            entry: OverlaySpriteEntry,
+            body_queries: std::cell::RefCell<Vec<(String, u8)>>,
+            shadow_queries: std::cell::RefCell<Vec<(String, u8)>>,
+        }
+        impl BridgeAtlasLookup for MockAtlas {
+            fn body_entry(&self, name: &str, frame: u8) -> Option<&OverlaySpriteEntry> {
+                self.body_queries
+                    .borrow_mut()
+                    .push((name.to_string(), frame));
+                (name == "HIGHANCHOR" && frame == 1).then_some(&self.entry)
+            }
+
+            fn shadow_entry(&self, name: &str, frame: u8) -> Option<&OverlaySpriteEntry> {
+                self.shadow_queries
+                    .borrow_mut()
+                    .push((name.to_string(), frame));
+                (name == "HIGHANCHOR" && frame == 1).then_some(&self.entry)
+            }
+        }
+
+        let mut bridge_state = BridgeRuntimeState::default();
+        bridge_state.test_seed_cell(
+            5,
+            5,
+            BridgeRuntimeCell {
+                deck_present: true,
+                destroyable: true,
+                deck_level: 4,
+                bridge_group_id: Some(1),
+                damage_state: DamageState::Healthy { variant: 1 },
+                axis: Some(Axis::NS),
+                role: BridgeCellRole::Body,
+                anchor_span_id: Some(1),
+                overlay_byte: 0x18,
+                damaged_variant: false,
+                bridgehead_anchor_class: BridgeheadAnchorClass::Variant0,
+            },
+        );
+        let atlas = MockAtlas {
+            entry: OverlaySpriteEntry {
+                uv_origin: [0.0, 0.0],
+                uv_size: [1.0, 1.0],
+                pixel_size: [60.0, 30.0],
+                offset_x: 0.0,
+                offset_y: 0.0,
+            },
+            body_queries: std::cell::RefCell::new(Vec::new()),
+            shadow_queries: std::cell::RefCell::new(Vec::new()),
+        };
+        let overlay_names = BTreeMap::from([(0x18, "HIGHANCHOR".to_string())]);
+        let height_map = BTreeMap::new();
+        let lighting_grid = CellLightGrid::new();
+        let (cell_x, cell_y) = terrain::iso_to_screen(5, 5, 4);
+        let (cam_x, cam_y) = (cell_x - 400.0, cell_y - 300.0);
+        let mut bodies = Vec::new();
+        let mut shadows = Vec::new();
+
+        build_bridge_body_instances_inner(
+            &bridge_state,
+            &atlas,
+            &overlay_names,
+            &height_map,
+            &lighting_grid,
+            0.0,
+            5000.0,
+            cam_x,
+            cam_y,
+            800.0,
+            600.0,
+            &mut bodies,
+        );
+        build_bridge_shadow_instances_inner(
+            &bridge_state,
+            &atlas,
+            &overlay_names,
+            &height_map,
+            0.0,
+            5000.0,
+            cam_x,
+            cam_y,
+            800.0,
+            600.0,
+            &mut shadows,
+        );
+
+        assert_eq!(bodies.len(), 1, "numeric high identity must emit one body");
+        assert_eq!(
+            shadows.len(),
+            1,
+            "numeric high identity must emit one shadow"
+        );
+        assert_eq!(
+            atlas.body_queries.into_inner(),
+            vec![("HIGHANCHOR".to_string(), 1)]
+        );
+        assert_eq!(
+            atlas.shadow_queries.into_inner(),
+            vec![("HIGHANCHOR".to_string(), 1)]
         );
     }
 

--- a/src/app/presentation/instances/overlays.rs
+++ b/src/app/presentation/instances/overlays.rs
@@ -15,7 +15,7 @@ use crate::map::lighting::DEFAULT_TINT;
 use crate::map::overlay_types::is_bridge_overlay_index;
 use crate::map::terrain::{self, TILE_HEIGHT, TILE_WIDTH};
 use crate::render::batch::SpriteInstance;
-use crate::render::bridge_atlas::is_high_bridge_body_name;
+use crate::render::bridge_atlas::is_high_bridge_body_identity;
 use crate::render::overlay_atlas::{CRATE_BODY_FRAME, OverlaySpriteKey};
 use crate::render::sprite_atlas::ShpSpriteKey;
 use crate::render::tactical_draw_plan::{
@@ -85,6 +85,13 @@ fn overlay_body_frame(is_crate: bool, overlay_data: u8) -> u8 {
     } else {
         overlay_data
     }
+}
+
+/// The ordinary overlay pass must not own any identity whose live numeric ID
+/// dispatches through native high-bridge Mark, even when layered rules rename
+/// its art away from the stock BRIDGE1/2 family.
+fn ordinary_overlay_accepts_identity(overlay_id: u8, name: &str) -> bool {
+    !is_high_bridge_body_identity(overlay_id, name)
 }
 
 /// Resolve the CellClass overlay identity/data used by the tactical overlay
@@ -624,7 +631,7 @@ pub(crate) fn build_overlay_instances(
         // High-bridge bodies are emitted by `instances::bridges` reading
         // `BridgeRuntimeCell` post-tick. Skip them here so they don't double-
         // render via the static map overlay list.
-        if is_high_bridge_body_name(static_name) {
+        if !ordinary_overlay_accepts_identity(entry.overlay_id, static_name) {
             continue;
         }
 
@@ -671,7 +678,7 @@ pub(crate) fn build_overlay_instances(
         let Some(name) = name else {
             continue;
         };
-        if is_high_bridge_body_name(&name) {
+        if !ordinary_overlay_accepts_identity(live_overlay_id, &name) {
             continue;
         }
 
@@ -1387,8 +1394,8 @@ mod tests {
     use super::{
         ANIM_DRAW_DEPTH_BIAS_PX, AnimRenderDestination, CRATE_BODY_FRAME, anim_instance_alpha,
         anim_render_destination, apply_shape_z_adjust, garrison_flash_depth, overlay_body_frame,
-        overlay_display_identity, overlay_render_identity, terrain_object_is_render_visible,
-        weapon_muzzle_flash_key, world_effect_screen_position,
+        ordinary_overlay_accepts_identity, overlay_display_identity, overlay_render_identity,
+        terrain_object_is_render_visible, weapon_muzzle_flash_key, world_effect_screen_position,
     };
     use crate::map::overlay::TerrainObject;
     use crate::map::overlay_types::OverlayTypeRegistry;
@@ -1402,6 +1409,15 @@ mod tests {
     use crate::sim::production::ProductionState;
     use crate::sim::terrain_object::{TerrainObjectLifecycle, TerrainObjectState};
     use crate::util::fixed_math::SimFixed;
+
+    #[test]
+    fn numeric_high_bridge_identity_has_no_ordinary_overlay_instance_route() {
+        assert!(!ordinary_overlay_accepts_identity(0x18, "HIGHANCHOR"));
+        assert!(!ordinary_overlay_accepts_identity(0x19, "RENAMED_EW"));
+        assert!(!ordinary_overlay_accepts_identity(0xED, "RENAMED_NS"));
+        assert!(!ordinary_overlay_accepts_identity(0xEE, "BRIDGEB2"));
+        assert!(ordinary_overlay_accepts_identity(0x20, "HIGHANCHOR"));
+    }
 
     #[test]
     fn gsi_05_12_owner_attached_anim_is_forced_onto_the_sorted_ground_layer() {

--- a/src/app/presentation/instances/overlays.rs
+++ b/src/app/presentation/instances/overlays.rs
@@ -378,7 +378,7 @@ pub(crate) fn build_anim_class_instances(
             type_id: type_name.to_string(),
             facing: 0,
             frame,
-            house_color: HouseColorIndex(0),
+            house_color: anim.remap_color.unwrap_or(HouseColorIndex(0)),
         };
         let Some(entry) = atlas.get(&key) else {
             continue;

--- a/src/app/presentation/spawn_pick.rs
+++ b/src/app/presentation/spawn_pick.rs
@@ -119,6 +119,7 @@ pub(crate) fn handle_spawn_pick_click(state: &mut AppState) -> bool {
                     &state.match_state.match_presentation.theater_name,
                     bound_rules,
                     bound_rules.map(|rules| &rules.art_registry),
+                    &rt.resources.overlay_registry,
                     &state.match_state.match_presentation.house_color_map,
                     None, // entity_unit_palette — atlas builder loads it from assets
                     None, // cell palette reloads from the active theater archive

--- a/src/app/random_map_lifecycle_tests.rs
+++ b/src/app/random_map_lifecycle_tests.rs
@@ -503,6 +503,28 @@ fn gsi_04_12_random_map_ui_to_sed_launch_lifecycle_converges() {
         ui_launch.post_map_output.tiberium_queues.is_some(),
         "shared Post_Map_Init must rebuild the generated overlay queues"
     );
+    assert_eq!(
+        ui_launch.post_map_output.crates,
+        Some(crate::sim::crates::CratePlacement {
+            requested: 1,
+            accepted: 1,
+            visible: ui_launch
+                .startup_crate_slots
+                .iter()
+                .filter(|(_, _, overlay)| overlay.is_some())
+                .count() as u32,
+        }),
+        "accepted playable RMG must reach the ordinary startup-crate post-map seam"
+    );
+    assert_eq!(ui_launch.startup_crate_slots.len(), 1);
+    let (slot_index, slot, live_overlay) = ui_launch.startup_crate_slots[0];
+    assert_eq!(slot_index, 0, "first accepted crate owns slot zero");
+    assert!(!slot.is_empty());
+    assert_eq!(slot.start_frame, 0);
+    assert_ne!(slot.aux, 0);
+    assert!(slot.duration > 0);
+    let (_, data) = live_overlay.expect("retail lifecycle fixture places a visible startup crate");
+    assert_eq!(data, u8::MAX);
 
     std::fs::remove_file(seed_dir.join(seed_name)).expect("remove lifecycle .SED");
     std::fs::remove_file(randmap_img).expect("remove common-teardown preview");

--- a/src/app/random_map_lifecycle_tests.rs
+++ b/src/app/random_map_lifecycle_tests.rs
@@ -525,6 +525,84 @@ fn gsi_04_12_random_map_ui_to_sed_launch_lifecycle_converges() {
     assert!(slot.duration > 0);
     let (_, data) = live_overlay.expect("retail lifecycle fixture places a visible startup crate");
     assert_eq!(data, u8::MAX);
+    assert!(ui_launch.startup_crate.crates_enabled);
+    assert_eq!(ui_launch.startup_crate.minimum, 1);
+    assert_eq!(ui_launch.startup_crate.maximum, 255);
+    assert_eq!(ui_launch.startup_crate.regen_bits, 3.0_f64.to_bits());
+    assert_eq!(ui_launch.startup_crate.wood_name.as_deref(), Some("CRATE"));
+    assert_eq!(
+        ui_launch.startup_crate.common_name.as_deref(),
+        Some("CRATE")
+    );
+    assert_eq!(
+        ui_launch.startup_crate.water_name.as_deref(),
+        Some("WCRATE")
+    );
+    assert_eq!(
+        ui_launch.startup_crate.wood_id, ui_launch.startup_crate.common_id,
+        "stock wood/common image aliases resolve to one overlay identity"
+    );
+    let wood_id = ui_launch
+        .startup_crate
+        .wood_id
+        .expect("installed CRATE overlay identity");
+    let water_id = ui_launch
+        .startup_crate
+        .water_id
+        .expect("installed WCRATE overlay identity");
+    assert_ne!(wood_id, water_id);
+    assert_eq!(ui_launch.startup_crate.body_frame, 0);
+    assert!(
+        ui_launch
+            .startup_crate
+            .runtime_names
+            .contains(&(wood_id, "CRATE".to_string()))
+    );
+    assert!(
+        ui_launch
+            .startup_crate
+            .runtime_names
+            .contains(&(water_id, "WCRATE".to_string()))
+    );
+    assert_eq!(ui_launch.startup_crate.presented.len(), 1);
+    assert_eq!(
+        ui_launch.startup_crate.presented[0],
+        (
+            u16::try_from(slot.cell_x).expect("positive crate x"),
+            u16::try_from(slot.cell_y).expect("positive crate y"),
+            live_overlay.expect("visible overlay").0,
+            u8::MAX,
+        )
+    );
+    println!(
+        "STARTUP_CRATE_PRODUCTION rules=min:{} max:{} regen_bits:{:#018X} wood:{} common:{} water:{} ids:{wood_id}/{water_id} frame:{}",
+        ui_launch.startup_crate.minimum,
+        ui_launch.startup_crate.maximum,
+        ui_launch.startup_crate.regen_bits,
+        ui_launch.startup_crate.wood_name.as_deref().unwrap(),
+        ui_launch.startup_crate.common_name.as_deref().unwrap(),
+        ui_launch.startup_crate.water_name.as_deref().unwrap(),
+        ui_launch.startup_crate.body_frame,
+    );
+    println!(
+        "STARTUP_CRATE_SLOT index:{slot_index} cell:{},{} start:{} aux:{:#010X} duration:{} overlay:{:?}",
+        slot.cell_x, slot.cell_y, slot.start_frame, slot.aux, slot.duration, live_overlay
+    );
+    for asset_name in ["CRATE.TEM", "WCRATE.TEM"] {
+        let bytes = assets
+            .get_ref(asset_name)
+            .unwrap_or_else(|| panic!("active theater archive resolves {asset_name}"));
+        let shp = crate::assets::shp_file::ShpFile::from_bytes(bytes)
+            .unwrap_or_else(|err| panic!("parse active {asset_name} as SHP(TS): {err}"));
+        assert_eq!((shp.width, shp.height, shp.frames.len()), (60, 60, 2));
+        println!(
+            "STARTUP_CRATE_ASSET name:{asset_name} bytes:{} format:SHP(TS) canvas:{}x{} frames:{}",
+            bytes.len(),
+            shp.width,
+            shp.height,
+            shp.frames.len()
+        );
+    }
 
     std::fs::remove_file(seed_dir.join(seed_name)).expect("remove lifecycle .SED");
     std::fs::remove_file(randmap_img).expect("remove common-teardown preview");

--- a/src/headless_scenario.rs
+++ b/src/headless_scenario.rs
@@ -201,6 +201,7 @@ pub fn load(retail_dir: &Path, map_file_name: &str, seed: u32) -> Result<Headles
     // separate loads remain isolated.
     let scheduler_roots = crate::app::loading::init_helpers::scheduler_anim_roots(
         &rules,
+        &overlay_registry,
         terrain_bootstrap.resolved.tile_animations(),
     );
     art.bind_scheduler_anim_assets(

--- a/src/map/lighting.rs
+++ b/src/map/lighting.rs
@@ -638,6 +638,18 @@ where
     build_cell_light_grid_from_heights_and_units_with_detail(heights, profile, 2)
 }
 
+/// Exact initial `CellClass +0x10A` ground Z-adjust for one elevation level.
+/// This is the value `OverlayClass::Mark` copies to a newly constructed
+/// `CellAnim` after its delay-zero constructor has completed.
+pub fn cell_ground_z_adjust(profile: LightingProfileUnits, level: u8) -> i32 {
+    let units = scenario_units_from_profile(profile);
+    units
+        .ambient
+        .wrapping_add(units.level.wrapping_mul(i32::from(level)))
+        .wrapping_sub(units.ground)
+        .clamp(LIGHT_CLAMP_MIN, LIGHT_CLAMP_MAX)
+}
+
 /// Build a cell-light grid using the native Options detail-level RGB cache mask.
 pub fn build_cell_light_grid_from_heights_and_units_with_detail<I>(
     heights: I,
@@ -1413,6 +1425,10 @@ mod tests {
         assert_eq!(light.common_scalar, 982);
         assert_eq!(light.top_scalar, 982);
         assert_eq!(light.bottom_scalar, 1014);
+        assert_eq!(
+            cell_ground_z_adjust(parse_lighting_profiles(&IniFile::from_str("")).normal, 4),
+            982
+        );
     }
 
     #[test]

--- a/src/map/overlay_types.rs
+++ b/src/map/overlay_types.rs
@@ -12,7 +12,8 @@ pub use crate::rules::overlay_types::{
     OverlayTypeFlags, OverlayTypeRegistry, is_bridge_overlay_index, is_high_bridge_index,
 };
 pub(crate) use crate::rules::overlay_types::{
-    clears_tiberium_on_slope, retained_overlay_land, uses_early_recalc_land_branch,
+    clears_tiberium_on_slope, native_mark_overlay_data, retained_overlay_land,
+    uses_early_recalc_land_branch,
 };
 
 /// Check if an overlay index is one of the four high-bridge map-load anchors

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -1278,6 +1278,23 @@ impl ResolvedTerrainGrid {
             || cell.has_bridge_deck;
     }
 
+    /// Project a direct `CellClass::OverlayData` write into the derived bridge
+    /// facts without inventing an overlay identity. The native high-bridge
+    /// setters write this byte on four cells before `OverlayClass::Mark`
+    /// decides whether the anchor itself receives an overlay.
+    pub(crate) fn set_runtime_overlay_bridge_state_byte(
+        &mut self,
+        rx: u16,
+        ry: u16,
+        overlay_data: u8,
+    ) -> bool {
+        let Some(cell) = self.cell_mut(rx, ry) else {
+            return false;
+        };
+        cell.bridge_facts.state_byte = overlay_data;
+        true
+    }
+
     /// Project only allocated real-cell values for a setter that already ran
     /// synchronously through [`CellClassBridgeFlagState`]. This performs no
     /// GetCell fallback and cannot stamp or mutate the shared dummy.

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -783,6 +783,11 @@ pub(crate) struct DestroyableCliffMutation {
 #[derive(Debug, Clone)]
 pub struct SharedCellDummy {
     state: Arc<AtomicU64>,
+    /// OverlayClass::Mark can read and write the fallback CellClass's
+    /// `+0x44/+0x11E` fields independently of the coordinate/terrain/bridge
+    /// word above. This is process state, not Scenario payload, and therefore
+    /// follows the same shared identity without entering snapshots or hashes.
+    overlay_state: Arc<std::sync::atomic::AtomicU32>,
 }
 
 impl Default for SharedCellDummy {
@@ -795,6 +800,7 @@ impl SharedCellDummy {
     pub fn fresh() -> Self {
         Self {
             state: Arc::new(AtomicU64::new(0)),
+            overlay_state: Arc::new(std::sync::atomic::AtomicU32::new(0)),
         }
     }
 
@@ -808,6 +814,7 @@ impl SharedCellDummy {
     /// fields are not represented by this handle yet.
     pub(crate) fn reconstruct_for_map_resize(&self) {
         self.state.store(0, Ordering::Relaxed);
+        self.overlay_state.store(0, Ordering::Relaxed);
     }
 
     pub fn snapshot(&self) -> SharedCellDummySnapshot {
@@ -835,6 +842,24 @@ impl SharedCellDummy {
 
     pub fn same_identity(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.state, &other.state)
+    }
+
+    /// Read the fallback CellClass overlay identity/data pair. Bit 16 is the
+    /// explicit `OverlayTypeIndex != -1` discriminator, allowing runtime ID
+    /// zero to remain distinct from the native empty sentinel.
+    pub(crate) fn overlay_fields(&self) -> (Option<u8>, u8) {
+        let packed = self.overlay_state.load(Ordering::Relaxed);
+        let overlay_id = (packed & (1 << 16) != 0).then_some(packed as u8);
+        (overlay_id, (packed >> 8) as u8)
+    }
+
+    /// Write only fallback `CellClass+0x44/+0x11E`, preserving every other
+    /// process-global dummy field.
+    pub(crate) fn set_overlay_fields(&self, overlay_id: Option<u8>, overlay_data: u8) {
+        let packed = u32::from(overlay_id.unwrap_or(0))
+            | (u32::from(overlay_data) << 8)
+            | u32::from(overlay_id.is_some()) << 16;
+        self.overlay_state.store(packed, Ordering::Relaxed);
     }
 
     /// Apply one exact `SetBridgeDirection_*` slot to the modeled flag subset
@@ -989,6 +1014,33 @@ fn apply_planned_bridge_flag_stamp_to_real_parts(
         real_cell_updates.push((index, facts.raw_flags & MODELED_CELLCLASS_BRIDGE_FLAG_MASK));
     }
     real_cell_updates
+}
+
+fn refresh_runtime_bridge_projection(cell: &mut ResolvedTerrainCell) {
+    let facts = cell.bridge_facts;
+    if facts.has_structural_bridge() {
+        cell.has_bridge_deck = true;
+        cell.bridge_walkable = !cell.terrain_object_blocks && !cell.overlay_blocks;
+        cell.bridge_deck_level = cell.level.saturating_add(4);
+        cell.build_blocked = cell.base_build_blocked
+            || cell.terrain_object_blocks
+            || cell.overlay_blocks
+            || cell.bridge_walkable;
+    } else if facts.family != BridgeStampFamily::None
+        && cell
+            .bridge_layer
+            .as_ref()
+            .is_some_and(|layer| layer.direction != BridgeDirection::Low)
+    {
+        cell.has_bridge_deck = false;
+        cell.bridge_walkable = false;
+        cell.bridge_deck_level = cell.level;
+        cell.build_blocked =
+            cell.base_build_blocked || cell.terrain_object_blocks || cell.overlay_blocks;
+    }
+    if facts.has_transition_flag() {
+        cell.bridge_transition = true;
+    }
 }
 
 /// Convert a `Tile%02dXOffset` / `YOffset` screen-pixel pair into the world
@@ -1152,6 +1204,78 @@ impl ResolvedTerrainGrid {
             stamp,
             None,
         )
+    }
+
+    /// Apply the high-anchor `OverlayClass::Mark` setter and refresh the
+    /// Rust-native bridge projection carried beside the literal CellClass
+    /// flag word. Unlike damage/repair runtime setters, a newly constructed
+    /// anchor establishes its family/anchor relations at this call site.
+    pub(crate) fn apply_runtime_bridge_mark_stamp(
+        &mut self,
+        stamp: BridgeFlagStamp,
+        family: BridgeStampFamily,
+    ) -> Vec<(usize, u32)> {
+        let updates = apply_native_bridge_flag_stamp_to_parts(
+            &mut self.cells,
+            self.width,
+            self.height,
+            self.native_allocated.as_deref(),
+            &self.shared_cell_dummy,
+            stamp,
+            Some(family),
+        );
+        for &(index, _) in &updates {
+            if let Some(cell) = self.cells.get_mut(index) {
+                refresh_runtime_bridge_projection(cell);
+            }
+        }
+        updates
+    }
+
+    /// Project a direct runtime overlay-field write into the map-owned bridge
+    /// cache. The literal identity/data remain owned by OverlayGrid; this is
+    /// only the derived bridge metadata that pathing and bridge damage read.
+    pub(crate) fn set_runtime_overlay_bridge_identity(
+        &mut self,
+        rx: u16,
+        ry: u16,
+        overlay_id: u8,
+        overlay_data: u8,
+        overlay_name: &str,
+    ) {
+        let Some(cell) = self.cell_mut(rx, ry) else {
+            return;
+        };
+        cell.bridge_facts.overlay_id = Some(overlay_id);
+        cell.bridge_facts.state_byte = overlay_data;
+        if !crate::map::overlay_types::is_bridge_overlay_index(overlay_id) {
+            return;
+        }
+
+        let direction = match overlay_id {
+            0x18 | 0xED => BridgeDirection::EastWest,
+            0x19 | 0xEE => BridgeDirection::NorthSouth,
+            _ => BridgeDirection::Low,
+        };
+        let deck_level = match direction {
+            BridgeDirection::EastWest | BridgeDirection::NorthSouth => cell.level.saturating_add(4),
+            BridgeDirection::Low => cell.level,
+        };
+        cell.bridge_layer = Some(BridgeLayer {
+            overlay_id,
+            overlay_name: overlay_name.to_string(),
+            deck_level,
+            direction,
+        });
+        cell.has_bridge_deck = true;
+        cell.bridge_walkable = direction != BridgeDirection::Low
+            && !cell.terrain_object_blocks
+            && !cell.overlay_blocks;
+        cell.bridge_deck_level = deck_level;
+        cell.build_blocked = cell.base_build_blocked
+            || cell.terrain_object_blocks
+            || cell.overlay_blocks
+            || cell.has_bridge_deck;
     }
 
     /// Project only allocated real-cell values for a setter that already ran

--- a/src/render/bridge_atlas.rs
+++ b/src/render/bridge_atlas.rs
@@ -6,7 +6,7 @@ use crate::assets::asset_manager::AssetManager;
 use crate::assets::pal_file::Palette;
 use crate::assets::shp_file::ShpFile;
 use crate::map::overlay::OverlayEntry;
-use crate::map::overlay_types::{OverlayTypeFlags, OverlayTypeRegistry};
+use crate::map::overlay_types::{OverlayTypeFlags, OverlayTypeRegistry, is_high_bridge_index};
 use crate::render::batch::{BatchRenderer, BatchTexture};
 use crate::render::gpu::GpuContext;
 use crate::render::overlay_atlas::OverlaySpriteEntry;
@@ -59,11 +59,16 @@ impl BridgeAtlas {
 /// instance builders can be exercised in unit tests with a pure-data mock.
 pub trait BridgeAtlasLookup {
     fn body_entry(&self, name: &str, frame: u8) -> Option<&OverlaySpriteEntry>;
+    fn shadow_entry(&self, name: &str, frame: u8) -> Option<&OverlaySpriteEntry>;
 }
 
 impl BridgeAtlasLookup for BridgeAtlas {
     fn body_entry(&self, name: &str, frame: u8) -> Option<&OverlaySpriteEntry> {
         BridgeAtlas::body_entry(self, name, frame)
+    }
+
+    fn shadow_entry(&self, name: &str, frame: u8) -> Option<&OverlaySpriteEntry> {
+        BridgeAtlas::shadow_entry(self, name, frame)
     }
 }
 
@@ -83,6 +88,16 @@ pub fn is_high_bridge_body_name(name: &str) -> bool {
     )
 }
 
+/// Route a live high-bridge body by the CellClass numeric identity first.
+///
+/// Native `OverlayClass::Mark @ 0x005FC570` dispatches the four high-anchor
+/// setters by numeric OverlayType index, so a layered rules file may retain
+/// high-bridge semantics under a noncanonical art name. Canonical names remain
+/// accepted for the established destroy-band cells written by bridge runtime.
+pub fn is_high_bridge_body_identity(overlay_id: u8, name: &str) -> bool {
+    is_high_bridge_index(overlay_id) || is_high_bridge_body_name(name)
+}
+
 fn needed_bridge_sprite_keys(
     overlays: &[OverlayEntry],
     overlay_names: &BTreeMap<u8, String>,
@@ -92,7 +107,7 @@ fn needed_bridge_sprite_keys(
     let mut names = HashSet::new();
     for entry in overlays {
         if let Some(name) = overlay_names.get(&entry.overlay_id)
-            && is_high_bridge_body_name(name)
+            && is_high_bridge_body_identity(entry.overlay_id, name)
         {
             names.insert(name.clone());
         }
@@ -115,7 +130,7 @@ fn needed_bridge_sprite_keys(
             .get(&overlay_id)
             .map(String::as_str)
             .or_else(|| overlay_registry.name(overlay_id));
-        if let Some(name) = name.filter(|name| is_high_bridge_body_name(name)) {
+        if let Some(name) = name {
             names.insert(name.to_string());
         }
     }
@@ -513,17 +528,18 @@ mod tests {
         let mut rules_text = String::from("[OverlayTypes]\n");
         for id in 0..=0x18u8 {
             let name = if id == 0x18 {
-                "BRIDGE1".to_string()
+                "HIGHANCHOR".to_string()
             } else {
                 format!("OV{id:03}")
             };
             writeln!(&mut rules_text, "{id}={name}").unwrap();
         }
+        rules_text.push_str("[HIGHANCHOR]\nCrate=yes\n");
         let registry = OverlayTypeRegistry::from_ini(&IniFile::from_str(&rules_text), None);
         let crate_rules = CrateRules {
-            wood_crate_img: Some("BRIDGE1".to_string()),
-            crate_img: Some("BRIDGE1".to_string()),
-            water_crate_img: Some("BRIDGE1".to_string()),
+            wood_crate_img: Some("HIGHANCHOR".to_string()),
+            crate_img: Some("HIGHANCHOR".to_string()),
+            water_crate_img: Some("HIGHANCHOR".to_string()),
             ..CrateRules::default()
         };
 
@@ -533,7 +549,7 @@ mod tests {
         for frame in 0..18 {
             for kind in [BridgeFrameKind::Body, BridgeFrameKind::Shadow] {
                 assert!(keys.contains(&BridgeAtlasKey {
-                    name: "BRIDGE1".to_string(),
+                    name: "HIGHANCHOR".to_string(),
                     frame,
                     kind,
                 }));

--- a/src/render/bridge_atlas.rs
+++ b/src/render/bridge_atlas.rs
@@ -11,6 +11,7 @@ use crate::render::batch::{BatchRenderer, BatchTexture};
 use crate::render::gpu::GpuContext;
 use crate::render::overlay_atlas::OverlaySpriteEntry;
 use crate::rules::art_data::{self, ArtRegistry};
+use crate::rules::crate_rules::CrateRules;
 use crate::rules::ini_parser::IniFile;
 use wgpu::util::DeviceExt;
 
@@ -82,29 +83,45 @@ pub fn is_high_bridge_body_name(name: &str) -> bool {
     )
 }
 
-pub fn build_bridge_atlas(
-    gpu: &GpuContext,
-    batch: &BatchRenderer,
+fn needed_bridge_sprite_keys(
     overlays: &[OverlayEntry],
     overlay_names: &BTreeMap<u8, String>,
-    asset_manager: &AssetManager,
-    theater_palette: &Palette,
-    unit_palette: &Palette,
-    theater_ext: &str,
-    theater_name: &str,
     overlay_registry: &OverlayTypeRegistry,
-    rules_ini: &IniFile,
-    art_registry: &ArtRegistry,
-) -> Option<BridgeAtlas> {
-    let mut needed: HashSet<BridgeAtlasKey> = HashSet::new();
+    crate_rules: &CrateRules,
+) -> HashSet<BridgeAtlasKey> {
+    let mut names = HashSet::new();
     for entry in overlays {
-        let Some(name) = overlay_names.get(&entry.overlay_id) else {
+        if let Some(name) = overlay_names.get(&entry.overlay_id)
+            && is_high_bridge_body_name(name)
+        {
+            names.insert(name.clone());
+        }
+    }
+    for selected_name in [
+        crate_rules.wood_crate_img.as_deref(),
+        crate_rules.crate_img.as_deref(),
+        crate_rules.water_crate_img.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        let Some(overlay_id) = overlay_registry.id_for_name(selected_name) else {
             continue;
         };
-        if !is_high_bridge_body_name(name) {
+        if crate::map::bridge_facts::high_bridge_stamp_for_overlay(overlay_id).is_none() {
             continue;
         }
-        // Pack body half (frames 0..18) AND shadow half (frames 18..36) — RE doc §3.3.2.
+        let name = overlay_names
+            .get(&overlay_id)
+            .map(String::as_str)
+            .or_else(|| overlay_registry.name(overlay_id));
+        if let Some(name) = name.filter(|name| is_high_bridge_body_name(name)) {
+            names.insert(name.to_string());
+        }
+    }
+
+    let mut needed = HashSet::new();
+    for name in names {
         for frame in 0u8..18u8 {
             needed.insert(BridgeAtlasKey {
                 name: name.clone(),
@@ -118,6 +135,25 @@ pub fn build_bridge_atlas(
             });
         }
     }
+    needed
+}
+
+pub fn build_bridge_atlas(
+    gpu: &GpuContext,
+    batch: &BatchRenderer,
+    overlays: &[OverlayEntry],
+    overlay_names: &BTreeMap<u8, String>,
+    asset_manager: &AssetManager,
+    theater_palette: &Palette,
+    unit_palette: &Palette,
+    theater_ext: &str,
+    theater_name: &str,
+    overlay_registry: &OverlayTypeRegistry,
+    crate_rules: &CrateRules,
+    rules_ini: &IniFile,
+    art_registry: &ArtRegistry,
+) -> Option<BridgeAtlas> {
+    let needed = needed_bridge_sprite_keys(overlays, overlay_names, overlay_registry, crate_rules);
     if needed.is_empty() {
         return None;
     }
@@ -453,6 +489,8 @@ fn create_r8_texture(gpu: &GpuContext, data: &[u8], width: u32, height: u32) -> 
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
+
     use super::*;
 
     #[test]
@@ -468,6 +506,39 @@ mod tests {
             kind: BridgeFrameKind::Shadow,
         };
         assert_ne!(body, shadow);
+    }
+
+    #[test]
+    fn startup_high_bridge_crate_roots_body_and_shadow_without_map_authored_high_overlay() {
+        let mut rules_text = String::from("[OverlayTypes]\n");
+        for id in 0..=0x18u8 {
+            let name = if id == 0x18 {
+                "BRIDGE1".to_string()
+            } else {
+                format!("OV{id:03}")
+            };
+            writeln!(&mut rules_text, "{id}={name}").unwrap();
+        }
+        let registry = OverlayTypeRegistry::from_ini(&IniFile::from_str(&rules_text), None);
+        let crate_rules = CrateRules {
+            wood_crate_img: Some("BRIDGE1".to_string()),
+            crate_img: Some("BRIDGE1".to_string()),
+            water_crate_img: Some("BRIDGE1".to_string()),
+            ..CrateRules::default()
+        };
+
+        let keys = needed_bridge_sprite_keys(&[], &BTreeMap::new(), &registry, &crate_rules);
+
+        assert_eq!(keys.len(), 36);
+        for frame in 0..18 {
+            for kind in [BridgeFrameKind::Body, BridgeFrameKind::Shadow] {
+                assert!(keys.contains(&BridgeAtlasKey {
+                    name: "BRIDGE1".to_string(),
+                    frame,
+                    kind,
+                }));
+            }
+        }
     }
 
     #[test]

--- a/src/render/overlay_atlas.rs
+++ b/src/render/overlay_atlas.rs
@@ -240,6 +240,7 @@ fn runtime_crate_sprite_keys(
             continue;
         };
         if flags.crate_type
+            && crate::map::bridge_facts::high_bridge_stamp_for_overlay(overlay_id).is_none()
             && let Some(name) = resolve_overlay_name_for_render(overlay_registry, overlay_id)
         {
             keys.insert(OverlaySpriteKey {
@@ -1206,6 +1207,7 @@ mod tests {
             };
             writeln!(&mut high_ini, "{id}={name}").unwrap();
         }
+        high_ini.push_str("[HIGHANCHOR]\nCrate=yes\n");
         let high_registry = OverlayTypeRegistry::from_ini(&IniFile::from_str(&high_ini), None);
         let high_rules = CrateRules {
             wood_crate_img: Some("HIGHANCHOR".to_owned()),

--- a/src/render/overlay_atlas.rs
+++ b/src/render/overlay_atlas.rs
@@ -253,6 +253,12 @@ fn runtime_crate_sprite_keys(
         let Some(flags) = overlay_registry.flags(selected_id) else {
             continue;
         };
+        // High-bridge bodies and their shadow halves are drawn exclusively by
+        // BridgeAtlas. Rooting 256 ordinary OverlayAtlas frames here cannot
+        // make that production draw path reachable.
+        if crate::map::bridge_facts::high_bridge_stamp_for_overlay(selected_id).is_some() {
+            continue;
+        }
         let mut reachable: Vec<(u8, std::ops::RangeInclusive<u8>)> = Vec::new();
         match selected_id {
             // Active-YR low endpoint Mark replaces the trigger with one fixed
@@ -304,10 +310,6 @@ fn runtime_crate_sprite_keys(
                 for id in 0xD6..=0xD9 {
                     reachable.push((id, 0..=2));
                 }
-            }
-            // High-anchor Mark preserves the target cell's prior raw data.
-            0x18 | 0x19 | 0xED | 0xEE => {
-                reachable.push((selected_id, 0..=u8::MAX));
             }
             _ if flags.wall => {
                 // The general wall preload below owns the complete frame set.
@@ -1212,12 +1214,10 @@ mod tests {
             ..CrateRules::default()
         };
         let high_keys = runtime_crate_sprite_keys(&high_registry, &high_rules);
-        for frame in [0, 7, u8::MAX] {
-            assert!(high_keys.contains(&OverlaySpriteKey {
-                name: "HIGHANCHOR".to_owned(),
-                frame,
-            }));
-        }
+        assert!(
+            high_keys.is_empty(),
+            "high startup identities are rooted in BridgeAtlas, never OverlayAtlas"
+        );
     }
 
     #[test]

--- a/src/render/overlay_atlas.rs
+++ b/src/render/overlay_atlas.rs
@@ -234,24 +234,114 @@ fn runtime_crate_sprite_keys(
     .flatten()
     .filter_map(|name| overlay_registry.id_for_name(name))
     .collect();
-
-    (0u8..=u8::MAX)
-        .filter_map(|overlay_id| {
-            let flags = overlay_registry.flags(overlay_id)?;
-            if !flags.crate_type && !selected_ids.contains(&overlay_id) {
-                return None;
-            }
-            let name = resolve_overlay_name_for_render(overlay_registry, overlay_id)?;
-            Some(OverlaySpriteKey {
+    let mut keys = HashSet::new();
+    for overlay_id in 0u8..=u8::MAX {
+        let Some(flags) = overlay_registry.flags(overlay_id) else {
+            continue;
+        };
+        if flags.crate_type
+            && let Some(name) = resolve_overlay_name_for_render(overlay_registry, overlay_id)
+        {
+            keys.insert(OverlaySpriteKey {
                 name,
-                frame: if flags.crate_type {
-                    CRATE_BODY_FRAME
-                } else {
-                    native_mark_overlay_data(flags)
-                },
-            })
-        })
-        .collect()
+                frame: CRATE_BODY_FRAME,
+            });
+        }
+    }
+
+    for selected_id in selected_ids {
+        let Some(flags) = overlay_registry.flags(selected_id) else {
+            continue;
+        };
+        let mut reachable: Vec<(u8, std::ops::RangeInclusive<u8>)> = Vec::new();
+        match selected_id {
+            // Active-YR low endpoint Mark replaces the trigger with one fixed
+            // identity and may fill four body variants, all with states 0/1/2.
+            0x7A => {
+                reachable.push((0x5C, 0..=2));
+                for id in 0x4A..=0x4D {
+                    reachable.push((id, 0..=2));
+                }
+            }
+            0x7B => {
+                reachable.push((0x5E, 0..=2));
+                for id in 0x4A..=0x4D {
+                    reachable.push((id, 0..=2));
+                }
+            }
+            0x7C => {
+                reachable.push((0x60, 0..=2));
+                for id in 0x53..=0x56 {
+                    reachable.push((id, 0..=2));
+                }
+            }
+            0x7D => {
+                reachable.push((0x62, 0..=2));
+                for id in 0x53..=0x56 {
+                    reachable.push((id, 0..=2));
+                }
+            }
+            0xE9 => {
+                reachable.push((0xDF, 0..=2));
+                for id in 0xCD..=0xD0 {
+                    reachable.push((id, 0..=2));
+                }
+            }
+            0xEA => {
+                reachable.push((0xE1, 0..=2));
+                for id in 0xCD..=0xD0 {
+                    reachable.push((id, 0..=2));
+                }
+            }
+            0xEB => {
+                reachable.push((0xE3, 0..=2));
+                for id in 0xD6..=0xD9 {
+                    reachable.push((id, 0..=2));
+                }
+            }
+            0xEC => {
+                reachable.push((0xE5, 0..=2));
+                for id in 0xD6..=0xD9 {
+                    reachable.push((id, 0..=2));
+                }
+            }
+            // High-anchor Mark preserves the target cell's prior raw data.
+            0x18 | 0x19 | 0xED | 0xEE => {
+                reachable.push((selected_id, 0..=u8::MAX));
+            }
+            _ if flags.wall => {
+                // The general wall preload below owns the complete frame set.
+            }
+            _ if flags.crate_type => {
+                // Crate=yes stores 0xFF but the draw path selects the crate
+                // body frame; the general crate preload above owns that key.
+            }
+            _ if flags.land == crate::rules::terrain_rules::LandType::Railroad => {
+                reachable.push((selected_id, 0..=0));
+            }
+            _ if flags.land == crate::rules::terrain_rules::LandType::Road && flags.tiberium => {
+                reachable.push((selected_id, 0..=11));
+            }
+            _ => {
+                reachable.push((
+                    selected_id,
+                    native_mark_overlay_data(flags)..=native_mark_overlay_data(flags),
+                ));
+            }
+        }
+        for (overlay_id, frames) in reachable {
+            let Some(name) = resolve_overlay_name_for_render(overlay_registry, overlay_id) else {
+                continue;
+            };
+            for frame in frames {
+                keys.insert(OverlaySpriteKey {
+                    name: name.clone(),
+                    frame,
+                });
+            }
+        }
+    }
+    keys
 }
 
 /// UV and offset data for one overlay sprite within the atlas.
@@ -1014,6 +1104,8 @@ mod radar_tests;
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
+
     use super::{
         MAX_OVERLAY_FRAME_COUNT, OverlaySpriteKey, OverlayTypeFlags, body_frame_count,
         decrement_numeric_suffix, resolve_body_frame, runtime_flat_tiberium_sprite_keys,
@@ -1072,6 +1164,60 @@ mod tests {
             frame: 1,
         }));
         assert_eq!(keys.len(), 3);
+    }
+
+    #[test]
+    fn startup_crate_preload_includes_special_mark_outputs() {
+        let mut low_ini = String::from("[OverlayTypes]\n");
+        for id in 0..=0x7Au8 {
+            let name = if id == 0x7A {
+                "LOWTRIGGER".to_owned()
+            } else {
+                format!("OV{id:03}")
+            };
+            writeln!(&mut low_ini, "{id}={name}").unwrap();
+        }
+        let low_registry = OverlayTypeRegistry::from_ini(&IniFile::from_str(&low_ini), None);
+        let low_rules = CrateRules {
+            wood_crate_img: Some("LOWTRIGGER".to_owned()),
+            crate_img: Some("LOWTRIGGER".to_owned()),
+            water_crate_img: Some("LOWTRIGGER".to_owned()),
+            ..CrateRules::default()
+        };
+        let low_keys = runtime_crate_sprite_keys(&low_registry, &low_rules);
+        for id in [0x5C, 0x4A, 0x4B, 0x4C, 0x4D] {
+            let name = low_registry.name(id).unwrap().to_owned();
+            for frame in 0..=2 {
+                assert!(low_keys.contains(&OverlaySpriteKey {
+                    name: name.clone(),
+                    frame,
+                }));
+            }
+        }
+
+        let mut high_ini = String::from("[OverlayTypes]\n");
+        for id in 0..=0x18u8 {
+            let name = if id == 0x18 {
+                "HIGHANCHOR".to_owned()
+            } else {
+                format!("OV{id:03}")
+            };
+            writeln!(&mut high_ini, "{id}={name}").unwrap();
+        }
+        let high_registry = OverlayTypeRegistry::from_ini(&IniFile::from_str(&high_ini), None);
+        let high_rules = CrateRules {
+            wood_crate_img: Some("HIGHANCHOR".to_owned()),
+            crate_img: Some("HIGHANCHOR".to_owned()),
+            water_crate_img: Some("HIGHANCHOR".to_owned()),
+            ..CrateRules::default()
+        };
+        let high_keys = runtime_crate_sprite_keys(&high_registry, &high_rules);
+        for frame in [0, 7, u8::MAX] {
+            assert!(high_keys.contains(&OverlaySpriteKey {
+                name: "HIGHANCHOR".to_owned(),
+                frame,
+            }));
+        }
     }
 
     #[test]

--- a/src/render/overlay_atlas.rs
+++ b/src/render/overlay_atlas.rs
@@ -19,11 +19,13 @@ use crate::assets::shp_file::ShpFile;
 use crate::map::overlay::{OverlayEntry, TerrainObject};
 use crate::map::overlay_types::{
     OverlayTypeFlags, OverlayTypeRegistry, is_bridge_overlay_index, is_high_bridge_index,
+    native_mark_overlay_data,
 };
 use crate::render::overlay_assets::resolve_overlay_name_for_render;
 use crate::render::batch::{BatchRenderer, BatchTexture};
 use crate::render::gpu::GpuContext;
 use crate::rules::art_data::{self, ArtRegistry};
+use crate::rules::crate_rules::CrateRules;
 use crate::rules::ini_parser::IniFile;
 use crate::rules::tiberium_type::TiberiumTypeRegistry;
 
@@ -215,6 +217,43 @@ fn runtime_flat_tiberium_sprite_keys(
     keys
 }
 
+/// Sprite keys reachable when scenario-start placement selects one of the
+/// three resolved `[CrateRules]` identities. The selected type need not itself
+/// declare `Crate=yes`: native allocates the name first, then Mark uses that
+/// type's ordinary data rule and the draw path follows its actual flags.
+fn runtime_crate_sprite_keys(
+    overlay_registry: &OverlayTypeRegistry,
+    crate_rules: &CrateRules,
+) -> HashSet<OverlaySpriteKey> {
+    let selected_ids: HashSet<u8> = [
+        crate_rules.wood_crate_img.as_deref(),
+        crate_rules.crate_img.as_deref(),
+        crate_rules.water_crate_img.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .filter_map(|name| overlay_registry.id_for_name(name))
+    .collect();
+
+    (0u8..=u8::MAX)
+        .filter_map(|overlay_id| {
+            let flags = overlay_registry.flags(overlay_id)?;
+            if !flags.crate_type && !selected_ids.contains(&overlay_id) {
+                return None;
+            }
+            let name = resolve_overlay_name_for_render(overlay_registry, overlay_id)?;
+            Some(OverlaySpriteKey {
+                name,
+                frame: if flags.crate_type {
+                    CRATE_BODY_FRAME
+                } else {
+                    native_mark_overlay_data(flags)
+                },
+            })
+        })
+        .collect()
+}
+
 /// UV and offset data for one overlay sprite within the atlas.
 #[derive(Debug, Clone, Copy)]
 pub struct OverlaySpriteEntry {
@@ -286,6 +325,7 @@ pub fn build_overlay_atlas(
     theater_name: &str,
     overlay_registry: &OverlayTypeRegistry,
     tiberium_types: &TiberiumTypeRegistry,
+    crate_rules: &CrateRules,
     rules_ini: &IniFile,
     art_registry: &ArtRegistry,
     smudge_types: Option<&crate::rules::smudge_type::SmudgeTypeRegistry>,
@@ -338,37 +378,33 @@ pub fn build_overlay_atlas(
     //   overlay grid well after map load, so no crate ever appears in the map
     //   pack. The native crate branch always draws frame 0.
     let mut wall_names_loaded: HashSet<String> = HashSet::new();
-    let mut crate_names_loaded: HashSet<String> = HashSet::new();
     let mut wall_frames_loaded: u32 = 0;
     for overlay_id in 0u8..=u8::MAX {
         let Some(flags) = overlay_registry.flags(overlay_id) else {
             continue;
         };
-        if !flags.wall && !flags.crate_type {
+        if !flags.wall {
             continue;
         }
         let Some(mapped_name) = resolve_overlay_name_for_render(overlay_registry, overlay_id)
         else {
             continue;
         };
-        if flags.wall {
-            if wall_names_loaded.insert(mapped_name.clone()) {
-                let frame_count: u32 = wall_body_frame_count(flags.damage_levels);
-                wall_frames_loaded += frame_count;
-                for frame in 0..frame_count {
-                    needed.insert(OverlaySpriteKey {
-                        name: mapped_name.clone(),
-                        frame: frame as u8,
-                    });
-                }
+        if wall_names_loaded.insert(mapped_name.clone()) {
+            let frame_count: u32 = wall_body_frame_count(flags.damage_levels);
+            wall_frames_loaded += frame_count;
+            for frame in 0..frame_count {
+                needed.insert(OverlaySpriteKey {
+                    name: mapped_name.clone(),
+                    frame: frame as u8,
+                });
             }
-        } else if crate_names_loaded.insert(mapped_name.clone()) {
-            needed.insert(OverlaySpriteKey {
-                name: mapped_name,
-                frame: CRATE_BODY_FRAME,
-            });
         }
     }
+    let crate_keys = runtime_crate_sprite_keys(overlay_registry, crate_rules);
+    let crate_names_loaded: HashSet<String> =
+        crate_keys.iter().map(|key| key.name.clone()).collect();
+    needed.extend(crate_keys);
     if !wall_names_loaded.is_empty() {
         log::info!(
             "Pre-loaded {} damage/connectivity frames for {} wall type(s): {:?}",
@@ -981,11 +1017,12 @@ mod tests {
     use super::{
         MAX_OVERLAY_FRAME_COUNT, OverlaySpriteKey, OverlayTypeFlags, body_frame_count,
         decrement_numeric_suffix, resolve_body_frame, runtime_flat_tiberium_sprite_keys,
-        runtime_low_bridge_sprite_keys, wall_body_frame_count,
+        runtime_crate_sprite_keys, runtime_low_bridge_sprite_keys, wall_body_frame_count,
     };
     use crate::map::overlay::OverlayEntry;
     use crate::map::overlay_types::OverlayTypeRegistry;
     use crate::rules::ini_parser::IniFile;
+    use crate::rules::crate_rules::CrateRules;
     use crate::rules::tiberium_type::TiberiumTypeRegistry;
 
     #[test]
@@ -1006,6 +1043,36 @@ mod tests {
     /// same shape.
     const LOW_BRIDGE_FRAME_SIZES: [(u16, u16); 6] =
         [(0, 0), (120, 70), (0, 0), (0, 0), (0, 0), (0, 0)];
+
+    #[test]
+    fn startup_crate_preload_follows_resolved_identity_and_native_mark_data() {
+        let ini = IniFile::from_str(
+            "[OverlayTypes]\n0=FLAGGED\n1=PLAIN\n2=ROADBOX\n\
+             [FLAGGED]\nCrate=yes\n[PLAIN]\n[ROADBOX]\nLand=Road\n",
+        );
+        let registry = OverlayTypeRegistry::from_ini(&ini, None);
+        let rules = CrateRules {
+            wood_crate_img: Some("PLAIN".to_owned()),
+            crate_img: Some("FLAGGED".to_owned()),
+            water_crate_img: Some("ROADBOX".to_owned()),
+            ..CrateRules::default()
+        };
+
+        let keys = runtime_crate_sprite_keys(&registry, &rules);
+        assert!(keys.contains(&OverlaySpriteKey {
+            name: "FLAGGED".to_owned(),
+            frame: 0,
+        }));
+        assert!(keys.contains(&OverlaySpriteKey {
+            name: "PLAIN".to_owned(),
+            frame: 0,
+        }));
+        assert!(keys.contains(&OverlaySpriteKey {
+            name: "ROADBOX".to_owned(),
+            frame: 1,
+        }));
+        assert_eq!(keys.len(), 3);
+    }
 
     #[test]
     fn low_bridge_flank_columns_draw_nothing() {

--- a/src/render/sprite_atlas.rs
+++ b/src/render/sprite_atlas.rs
@@ -353,6 +353,43 @@ pub fn collect_needed_base_keys(
     base_keys
 }
 
+/// Live AnimClass palette variants that must exist in the atlas. Producers
+/// install these after construction (notably OverlayClass CellAnim over a
+/// Tiberium cell), so entity ownership cannot supply the color key.
+pub fn collect_anim_remap_base_keys(
+    sim: &crate::sim::world::Simulation,
+) -> HashSet<(String, HouseColorIndex)> {
+    sim.anims()
+        .filter_map(|(_, anim)| {
+            Some((
+                sim.interner.resolve(anim.type_id).to_ascii_uppercase(),
+                anim.remap_color?,
+            ))
+        })
+        .collect()
+}
+
+fn insert_anim_remap_frame_keys(
+    needed: &mut HashSet<ShpSpriteKey>,
+    type_id: &str,
+    frame_count: u16,
+    anim_remap_keys: &HashSet<(String, HouseColorIndex)>,
+) {
+    for &(_, color) in anim_remap_keys
+        .iter()
+        .filter(|(anim_type, _)| anim_type.eq_ignore_ascii_case(type_id))
+    {
+        for frame in 0..frame_count {
+            needed.insert(ShpSpriteKey {
+                type_id: type_id.to_string(),
+                facing: 0,
+                frame,
+                house_color: color,
+            });
+        }
+    }
+}
+
 /// Check if an existing sprite atlas already covers all the given base keys.
 ///
 /// A base key (type_id, color) is "covered" if the atlas contains at least one
@@ -461,6 +498,7 @@ pub fn build_sprite_atlas(
     art: Option<&ArtRegistry>,
     house_colors: &HouseColorMap,
     extra_building_types: &[&str],
+    anim_remap_keys: &HashSet<(String, HouseColorIndex)>,
     cell_drawer_type_ids: &HashSet<String>,
     cell_palette: Option<&Palette>,
     existing: Option<SpriteAtlas>,
@@ -897,6 +935,7 @@ pub fn build_sprite_atlas(
                             scheduler_owned,
                             shadow,
                         );
+                        insert_anim_remap_frame_keys(&mut needed, name, count, anim_remap_keys);
                         effect_type_ids.insert(name.clone());
                         log::info!("WorldEffect SHP {}: {} frames loaded", name, count);
                     }

--- a/src/render/sprite_atlas_tests.rs
+++ b/src/render/sprite_atlas_tests.rs
@@ -259,6 +259,28 @@ fn gsi_13_08_effect_frame_count_halves_only_shadowed_non_scheduler_assets() {
 }
 
 #[test]
+fn cell_anim_remap_registration_covers_every_bound_frame_for_its_color() {
+    let remaps = HashSet::from([
+        ("CRATE_SPARK".to_string(), HouseColorIndex(1)),
+        ("OTHER".to_string(), HouseColorIndex(2)),
+    ]);
+    let mut needed = HashSet::new();
+
+    insert_anim_remap_frame_keys(&mut needed, "CRATE_SPARK", 3, &remaps);
+
+    assert_eq!(needed.len(), 3);
+    for frame in 0..3 {
+        assert!(needed.contains(&ShpSpriteKey {
+            type_id: "CRATE_SPARK".to_string(),
+            facing: 0,
+            frame,
+            house_color: HouseColorIndex(1),
+        }));
+    }
+    assert!(needed.iter().all(|key| key.house_color != HouseColorIndex(2)));
+}
+
+#[test]
 fn gsi_13_08_warpout_keeps_all_frames_and_drives_the_progressive_alpha_ladder() {
     let ini = crate::rules::ini_parser::IniFile::from_str("[WARPOUT]\nTranslucent=yes\nRate=120\n");
     let art = ArtRegistry::from_ini(&ini);

--- a/src/rules/crate_rules.rs
+++ b/src/rules/crate_rules.rs
@@ -4,7 +4,7 @@
 //! after late global references have been allocated. Missing sections and keys
 //! retain the already-live fields; native no-type sentinels resolve to null.
 
-use crate::rules::ini_parser::{IniFile, is_native_none_type_name, trim_ascii_controls};
+use crate::rules::ini_parser::{IniFile, is_native_none_type_name};
 use crate::util::native_x87::NativeF64Bits;
 
 /// The six `[CrateRules]` fields consumed by scenario-start scatter.
@@ -62,11 +62,14 @@ impl CrateRulesAccumulator {
             ("CrateImg", &mut self.0.crate_img),
             ("WaterCrateImg", &mut self.0.water_crate_img),
         ] {
-            let Some(raw) = section.get(key) else {
+            if section.get(key).is_none() {
                 continue;
-            };
-            let value = trim_ascii_controls(raw);
-            *target = (!is_native_none_type_name(value)).then(|| value.to_ascii_uppercase());
+            }
+            // `RulesClass__ReadCrateRules @ 0x0066B900` supplies capacity
+            // 0x80 to all three ReadString calls. Truncation therefore owns
+            // both the retained identity and the earlier late allocation.
+            let value = section.read_string(key, "", 0x80);
+            *target = (!is_native_none_type_name(&value)).then(|| value.to_ascii_uppercase());
         }
     }
 

--- a/src/rules/crate_rules.rs
+++ b/src/rules/crate_rules.rs
@@ -1,0 +1,76 @@
+//! Scenario-start crate rule authority.
+//!
+//! `RulesClass__ReadCrateRules @ 0x0066B900` runs once per ordered rules pass
+//! after late global references have been allocated. Missing sections and keys
+//! retain the already-live fields; native no-type sentinels resolve to null.
+
+use crate::rules::ini_parser::{IniFile, is_native_none_type_name, trim_ascii_controls};
+use crate::util::native_x87::NativeF64Bits;
+
+/// The six `[CrateRules]` fields consumed by scenario-start scatter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrateRules {
+    pub minimum: i32,
+    pub maximum: i32,
+    pub regen: NativeF64Bits,
+    pub wood_crate_img: Option<String>,
+    pub crate_img: Option<String>,
+    pub water_crate_img: Option<String>,
+}
+
+impl Default for CrateRules {
+    fn default() -> Self {
+        // RulesClass constructor values verified in active gamemd.exe. Image
+        // pointers begin null; stock rulesmd.ini fills them during Process.
+        Self {
+            minimum: 1,
+            maximum: 255,
+            regen: NativeF64Bits::from_bits(10.0_f64.to_bits()),
+            wood_crate_img: None,
+            crate_img: None,
+            water_crate_img: None,
+        }
+    }
+}
+
+/// Live fields retained across successive `RulesClass::Process` passes.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CrateRulesAccumulator(CrateRules);
+
+impl CrateRulesAccumulator {
+    pub(crate) fn apply_pass(&mut self, ini: &IniFile) {
+        let Some(section) = ini.section("CrateRules") else {
+            return;
+        };
+
+        if section.get("CrateMinimum").is_some() {
+            self.0.minimum = section.read_int("CrateMinimum", self.0.minimum);
+        }
+        if section.get("CrateMaximum").is_some() {
+            self.0.maximum = section.read_int("CrateMaximum", self.0.maximum);
+        }
+        if section.get("CrateRegen").is_some() {
+            self.0.regen = NativeF64Bits::from_bits(
+                section
+                    .read_double("CrateRegen", f64::from_bits(self.0.regen.bits()))
+                    .to_bits(),
+            );
+        }
+
+        for (key, target) in [
+            ("WoodCrateImg", &mut self.0.wood_crate_img),
+            ("CrateImg", &mut self.0.crate_img),
+            ("WaterCrateImg", &mut self.0.water_crate_img),
+        ] {
+            let Some(raw) = section.get(key) else {
+                continue;
+            };
+            let value = trim_ascii_controls(raw);
+            *target = (!is_native_none_type_name(value)).then(|| value.to_ascii_uppercase());
+        }
+    }
+
+    pub(crate) fn finish(self) -> CrateRules {
+        self.0
+    }
+}

--- a/src/rules/house_colors.rs
+++ b/src/rules/house_colors.rs
@@ -22,7 +22,9 @@ use crate::rules::color_scheme::{ColorSchemeEntry, hsv_to_rgb};
 /// Stored as u8 for cheap hashing in atlas keys (HashMap lookups every frame) and
 /// reused as the GPU ramp-texture row key (`row = index + 1`). Default (0) is the
 /// first `[Colors]` entry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
+)]
 pub struct HouseColorIndex(pub u8);
 
 /// Sentinel value meaning "do not apply house color remap — use raw palette."

--- a/src/rules/ini_parser.rs
+++ b/src/rules/ini_parser.rs
@@ -1151,8 +1151,11 @@ impl RulesPassProcessor {
                 self.find_or_allocate(RulesTypeFamily::Vehicle, value);
             }
             for key in ["WoodCrateImg", "CrateImg", "WaterCrateImg"] {
-                if let Some(value) = section.get(key) {
-                    self.find_or_allocate(RulesTypeFamily::Overlay, value);
+                if section.get(key).is_some() {
+                    // Same caller capacity as the semantic CrateRules pass:
+                    // ReadCrateRules @ 0x0066B956/0x0066B989/0x0066B9C7.
+                    let value = section.read_string(key, "", 0x80);
+                    self.find_or_allocate(RulesTypeFamily::Overlay, &value);
                 }
             }
         }

--- a/src/rules/ini_parser.rs
+++ b/src/rules/ini_parser.rs
@@ -10,6 +10,7 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
+use crate::rules::crate_rules::{CrateRules, CrateRulesAccumulator};
 use crate::rules::error::RulesError;
 
 const READ_LINE_PAYLOAD: usize = 511;
@@ -573,8 +574,10 @@ impl RulesLayerStack {
         for (_, ini) in self.iter_passes() {
             processor.apply_pass(ini);
         }
+        let (ini, crate_rules) = processor.finish();
         ProcessedRulesLayers {
-            ini: processor.finish(),
+            ini,
+            crate_rules,
             content_hash: self.content_hash(),
         }
     }
@@ -584,6 +587,7 @@ impl RulesLayerStack {
 #[derive(Debug, Clone)]
 pub struct ProcessedRulesLayers {
     ini: IniFile,
+    crate_rules: CrateRules,
     content_hash: u64,
 }
 
@@ -598,6 +602,10 @@ impl ProcessedRulesLayers {
 
     pub fn content_hash(&self) -> u64 {
         self.content_hash
+    }
+
+    pub fn crate_rules(&self) -> &CrateRules {
+        &self.crate_rules
     }
 }
 
@@ -656,6 +664,7 @@ impl ProcessedType {
 #[derive(Debug, Default)]
 struct RulesPassProcessor {
     ordinary: Option<IniFile>,
+    crate_rules: CrateRulesAccumulator,
     families: HashMap<RulesTypeFamily, Vec<ProcessedType>>,
     tiberiums: Vec<ProcessedType>,
     colors: Vec<(String, String)>,
@@ -787,6 +796,7 @@ impl RulesPassProcessor {
         // ReadSpecialWeapons then explicitly re-runs every Warhead ReadINI, so
         // late-created warheads do consume their body in this same pass.
         self.allocate_late_global_references(pass);
+        self.crate_rules.apply_pass(pass);
         if pass.section("SpecialWeapons").is_some() {
             self.apply_family(RulesTypeFamily::Warhead, pass);
         }
@@ -1148,7 +1158,7 @@ impl RulesPassProcessor {
         }
     }
 
-    fn finish(mut self) -> IniFile {
+    fn finish(mut self) -> (IniFile, CrateRules) {
         let mut ini = self.ordinary.take().unwrap_or_else(IniFile::empty);
 
         for &(registry, family) in RULE_TYPE_FAMILIES {
@@ -1206,11 +1216,11 @@ impl RulesPassProcessor {
             ini.replace_first_section(member.body);
         }
 
-        ini
+        (ini, self.crate_rules.finish())
     }
 }
 
-fn trim_ascii_controls(value: &str) -> &str {
+pub(crate) fn trim_ascii_controls(value: &str) -> &str {
     value.trim_matches(|character| u32::from(character) <= 0x20)
 }
 

--- a/src/rules/ini_parser_tests.rs
+++ b/src/rules/ini_parser_tests.rs
@@ -444,6 +444,40 @@ fn crate_rule_images_allocate_and_alias_by_overlay_identity() {
 }
 
 #[test]
+fn crate_rule_image_readstring_capacity_owns_retention_and_allocation() {
+    let exact = "A".repeat(127);
+    let over = "B".repeat(128);
+    let processed = RulesLayerStack::new(IniFile::from_str(&format!(
+        "[CrateRules]\nWoodCrateImg={exact}\nCrateImg={over}\nWaterCrateImg={over}Z\n"
+    )))
+    .process();
+
+    assert_eq!(
+        processed.crate_rules().wood_crate_img.as_deref(),
+        Some(exact.as_str())
+    );
+    let truncated = "B".repeat(127);
+    assert_eq!(
+        processed.crate_rules().crate_img.as_deref(),
+        Some(truncated.as_str())
+    );
+    assert_eq!(
+        processed.crate_rules().water_crate_img.as_deref(),
+        Some(truncated.as_str()),
+        "capacity includes the forced NUL, so only 127 ASCII bytes survive"
+    );
+    assert_eq!(
+        processed
+            .ini()
+            .section("OverlayTypes")
+            .expect("truncated references allocate")
+            .get_values(),
+        vec![exact.as_str(), truncated.as_str()],
+        "late allocation and retained semantic identity must truncate identically"
+    );
+}
+
+#[test]
 fn crate_rules_direct_and_one_layer_entry_points_agree() {
     let ini = IniFile::from_str(
         "[CrateRules]\nCrateMinimum=-2\nCrateMaximum=6\nCrateRegen=3\n\

--- a/src/rules/ini_parser_tests.rs
+++ b/src/rules/ini_parser_tests.rs
@@ -369,6 +369,95 @@ fn process_rules_passes(root: &str, later: &str) -> ProcessedRulesLayers {
 }
 
 #[test]
+fn crate_rules_constructor_and_stock_fields_keep_native_bits() {
+    let defaults = RulesLayerStack::new(IniFile::from_str("")).process();
+    assert_eq!(defaults.crate_rules().minimum, 1);
+    assert_eq!(defaults.crate_rules().maximum, 255);
+    assert_eq!(defaults.crate_rules().regen.bits(), 10.0_f64.to_bits());
+    assert_eq!(defaults.crate_rules().wood_crate_img, None);
+    assert_eq!(defaults.crate_rules().crate_img, None);
+    assert_eq!(defaults.crate_rules().water_crate_img, None);
+
+    let stock = RulesLayerStack::new(IniFile::from_str(
+        "[CrateRules]\nCrateMinimum=1\nCrateMaximum=255\nCrateRegen=3\n\
+         WoodCrateImg=CRATE\nCrateImg=CRATE\nWaterCrateImg=WCRATE\n",
+    ))
+    .process();
+    assert_eq!(stock.crate_rules().minimum, 1);
+    assert_eq!(stock.crate_rules().maximum, 255);
+    assert_eq!(stock.crate_rules().regen.bits(), 3.0_f64.to_bits());
+    assert_eq!(stock.crate_rules().wood_crate_img.as_deref(), Some("CRATE"));
+    assert_eq!(stock.crate_rules().crate_img.as_deref(), Some("CRATE"));
+    assert_eq!(
+        stock.crate_rules().water_crate_img.as_deref(),
+        Some("WCRATE")
+    );
+}
+
+#[test]
+fn crate_rules_retain_per_pass_and_preserve_signed_values() {
+    let processed = process_rules_passes(
+        "[CrateRules]\nCrateMinimum=-7\nCrateMaximum=-12\nCrateRegen=3\n\
+         WoodCrateImg=WOOD\nCrateImg=COMMON\nWaterCrateImg=WATER\n",
+        "[CrateRules]\nCrateMaximum=2\nWaterCrateImg=none\n",
+    );
+    let rules = processed.crate_rules();
+    assert_eq!(rules.minimum, -7, "missing later key retains signed value");
+    assert_eq!(rules.maximum, 2);
+    assert_eq!(rules.regen.bits(), 3.0_f64.to_bits());
+    assert_eq!(rules.wood_crate_img.as_deref(), Some("WOOD"));
+    assert_eq!(rules.crate_img.as_deref(), Some("COMMON"));
+    assert_eq!(rules.water_crate_img, None);
+
+    let absent = process_rules_passes(
+        "[CrateRules]\nCrateMinimum=9\nCrateMaximum=3\nCrateImg=FIRST\n",
+        "[General]\nBuildSpeed=.7\n",
+    );
+    assert_eq!(absent.crate_rules().minimum, 9);
+    assert_eq!(absent.crate_rules().maximum, 3);
+    assert_eq!(absent.crate_rules().crate_img.as_deref(), Some("FIRST"));
+}
+
+#[test]
+fn crate_rule_images_allocate_and_alias_by_overlay_identity() {
+    let processed = RulesLayerStack::new(IniFile::from_str(
+        "[CrateRules]\nWoodCrateImg=AliasCrate\nCrateImg=aliascrate\n\
+         WaterCrateImg=NewWater\n",
+    ))
+    .process();
+    let overlays = processed
+        .ini()
+        .section("OverlayTypes")
+        .expect("crate references allocate overlays");
+    assert_eq!(overlays.get_values(), vec!["AliasCrate", "NewWater"]);
+
+    let registry =
+        crate::rules::overlay_types::OverlayTypeRegistry::from_ini(processed.ini(), None);
+    assert_eq!(
+        registry.id_for_name("AliasCrate"),
+        registry.id_for_name("aliascrate")
+    );
+    assert_ne!(
+        registry.id_for_name("AliasCrate"),
+        registry.id_for_name("NewWater")
+    );
+}
+
+#[test]
+fn crate_rules_direct_and_one_layer_entry_points_agree() {
+    let ini = IniFile::from_str(
+        "[CrateRules]\nCrateMinimum=-2\nCrateMaximum=6\nCrateRegen=3\n\
+         WoodCrateImg=WOOD\nCrateImg=COMMON\nWaterCrateImg=WATER\n",
+    );
+    let direct = crate::rules::ruleset::RuleSet::from_ini(&ini).expect("direct rules");
+    let layered =
+        crate::rules::ruleset::RuleSet::from_rules_layers(&RulesLayerStack::new(ini.clone()))
+            .expect("layered rules");
+    assert_eq!(direct.crate_rules, layered.crate_rules);
+    assert_eq!(direct.source_ini_hash(), layered.source_ini_hash());
+}
+
+#[test]
 fn later_malformed_weapon_bool_preserves_current_field_default() {
     use crate::rules::weapon_type::WeaponType;
 

--- a/src/rules/mission_data.rs
+++ b/src/rules/mission_data.rs
@@ -956,10 +956,11 @@ mod acceptance_tests {
         // comparing two hashes produced by the relocated Rust definitions.
         const RULES_SOURCE: &str = "[Guard]\nRate=.030\nAARate=.016\nRetaliate=yes\n\
                                     [Area Guard]\nRate=.040\nAARate=.032\nScatter=no\n";
-        const EXPECTED_SOURCE_HASH: u64 = 0x4635_CE56_7472_58B8;
+        const EXPECTED_INI_HASH: u64 = 0x4635_CE56_7472_58B8;
+        const EXPECTED_ONE_LAYER_HASH: u64 = 0x37E7_F896_E2C0_585E;
         let ini = IniFile::from_str(RULES_SOURCE);
-        assert_eq!(ini.content_hash(), EXPECTED_SOURCE_HASH);
+        assert_eq!(ini.content_hash(), EXPECTED_INI_HASH);
         let rules = RuleSet::from_ini(&ini).expect("fixed mission rules source parses");
-        assert_eq!(rules.source_ini_hash(), EXPECTED_SOURCE_HASH);
+        assert_eq!(rules.source_ini_hash(), EXPECTED_ONE_LAYER_HASH);
     }
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -16,14 +16,14 @@
 //! - rules/ does NOT depend on: sim/, render/, ui/, sidebar/, audio/, net/
 
 pub mod animation_sequence;
-pub mod overlay_types;
 pub mod art_data;
 pub mod bridge_warheads;
 pub mod color_add;
 pub mod color_scheme;
 pub mod combat_damage;
-pub mod error;
+pub mod crate_rules;
 pub mod effect_asset_catalog;
+pub mod error;
 pub mod flh;
 pub mod foundation;
 pub mod house_colors;
@@ -36,6 +36,7 @@ pub mod locomotor_type;
 pub mod missile_spawn;
 pub mod mission_data;
 pub mod object_type;
+pub mod overlay_types;
 pub mod particle_system_type;
 pub mod particle_type;
 pub mod projectile_type;

--- a/src/rules/overlay_types.rs
+++ b/src/rules/overlay_types.rs
@@ -230,6 +230,21 @@ impl OverlayTypeFlags {
     }
 }
 
+/// Cell overlay-data byte written by the successful ordinary Mark tail.
+///
+/// `OverlayClass__Mark @ 0x005FC570` writes zero at `0x005FD0CC`, replaces it
+/// with one for `Land=Road` at `0x005FD0E5`, then replaces either value with
+/// `0xFF` when `OverlayType+0x2AA` (`Crate=yes`) at `0x005FD0FB..0x005FD105`.
+pub(crate) fn native_mark_overlay_data(flags: &OverlayTypeFlags) -> u8 {
+    if flags.crate_type {
+        u8::MAX
+    } else if flags.land == LandType::Road {
+        1
+    } else {
+        0
+    }
+}
+
 /// Registry of overlay type names indexed by overlay ID.
 ///
 /// Built from the [OverlayTypes] section of rules.ini.

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -21,6 +21,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 
 use crate::rules::combat_damage::CombatDamageDefaults;
+use crate::rules::crate_rules::CrateRules;
 use crate::rules::error::RulesError;
 use crate::rules::ini_parser::{IniFile, ProcessedRulesLayers, RulesLayerStack};
 use crate::rules::mission_data::MissionControl;
@@ -1274,68 +1275,6 @@ impl BridgeRules {
     }
 }
 
-/// Scenario-start crate counts and crate overlay images from `[CrateRules]`.
-///
-/// gamemd reads these into RulesClass and `Post_Map_Init` clamps the lobby
-/// player count between `CrateMinimum` and `CrateMaximum` to decide how many
-/// crates to scatter. Pickup effects (`SilverCrate`, `UnitCrateType`, the
-/// per-goodie weights) belong to the crate system and are deliberately not
-/// parsed here.
-#[derive(Debug, Clone)]
-pub struct CrateRules {
-    /// `CrateMinimum=` — floor on the scenario-start crate count (stock 1).
-    pub minimum: u32,
-    /// `CrateMaximum=` — ceiling on the scenario-start crate count (stock 255).
-    pub maximum: u32,
-    /// `CrateImg=` — overlay type used for the ordinary land crate (stock CRATE).
-    pub crate_img: String,
-    /// `WoodCrateImg=` — overlay type used for random land crates (stock CRATE).
-    pub wood_crate_img: String,
-    /// `WaterCrateImg=` — overlay type used over water (stock WCRATE).
-    pub water_crate_img: String,
-}
-
-impl Default for CrateRules {
-    fn default() -> Self {
-        Self {
-            minimum: 1,
-            maximum: 255,
-            crate_img: "CRATE".to_string(),
-            wood_crate_img: "CRATE".to_string(),
-            water_crate_img: "WCRATE".to_string(),
-        }
-    }
-}
-
-impl CrateRules {
-    fn from_ini(ini: &IniFile) -> Self {
-        let defaults = Self::default();
-        let Some(section) = ini.section("CrateRules") else {
-            return defaults;
-        };
-        let name = |key: &str, fallback: String| -> String {
-            section
-                .get(key)
-                .map(|value| value.trim().to_uppercase())
-                .filter(|value| !value.is_empty())
-                .unwrap_or(fallback)
-        };
-        Self {
-            minimum: section
-                .get_i32("CrateMinimum")
-                .unwrap_or(defaults.minimum as i32)
-                .max(0) as u32,
-            maximum: section
-                .get_i32("CrateMaximum")
-                .unwrap_or(defaults.maximum as i32)
-                .max(0) as u32,
-            crate_img: name("CrateImg", defaults.crate_img),
-            wood_crate_img: name("WoodCrateImg", defaults.wood_crate_img),
-            water_crate_img: name("WaterCrateImg", defaults.water_crate_img),
-        }
-    }
-}
-
 /// Global radiation-field constants parsed from the `[Radiation]` section.
 /// Consumed by the per-cell radiation service (`sim::radiation`) and the
 /// per-foot-unit damage step. Render-only keys (light/tint/color) are parsed
@@ -2559,7 +2498,8 @@ impl RuleSet {
     pub(crate) fn from_processed_rules(
         processed: &ProcessedRulesLayers,
     ) -> Result<Self, RulesError> {
-        let mut rules = Self::from_ini(processed.ini())?;
+        let mut rules = Self::from_projected_ini(processed.ini())?;
+        rules.crate_rules = processed.crate_rules().clone();
         rules.source_ini_hash = processed.content_hash();
         Ok(rules)
     }
@@ -2571,6 +2511,10 @@ impl RuleSet {
     /// are logged as warnings but don't cause errors — RA2's rules.ini
     /// sometimes references sections that don't exist.
     pub fn from_ini(ini: &IniFile) -> Result<Self, RulesError> {
+        Self::from_rules_layers(&RulesLayerStack::new(ini.clone()))
+    }
+
+    fn from_projected_ini(ini: &IniFile) -> Result<Self, RulesError> {
         let mut object_list: Vec<ObjectType> = Vec::new();
         let mut object_index: HashMap<String, TypeHandle> = HashMap::new();
         let mut object_category_index: HashMap<(ObjectCategory, String), TypeHandle> =
@@ -2657,7 +2601,7 @@ impl RuleSet {
         let terrain_rules: TerrainRules = TerrainRules::from_ini(ini);
         let tiberium_types = TiberiumTypeRegistry::from_ini(ini);
         let bridge_rules: BridgeRules = BridgeRules::from_ini(ini);
-        let crate_rules: CrateRules = CrateRules::from_ini(ini);
+        let crate_rules = CrateRules::default();
         let garrison_rules: GarrisonRules = GarrisonRules::from_ini(ini);
         let radiation: RadiationRules = RadiationRules::from_ini(ini);
         let radar_event_config: RadarEventConfig = RadarEventConfig::from_ini(ini);

--- a/src/rules/tiberium_type.rs
+++ b/src/rules/tiberium_type.rs
@@ -21,6 +21,9 @@ pub struct TiberiumType {
     pub id: TiberiumTypeId,
     pub section: String,
     pub display_name: Option<String>,
+    /// `[TiberiumType] Color=` selector for the ConvertClass installed on a
+    /// CellAnim created over this resource.
+    pub color: Option<String>,
     /// `Image=` selector: 1 = TIB, 2 = GEM, 3 = TIB2, 4 = TIB3.
     pub image: u8,
     /// Credit value per harvested density unit.
@@ -98,6 +101,7 @@ impl TiberiumType {
             id,
             section: section_name.to_string(),
             display_name: section.get("Name").map(str::to_string),
+            color: section.get("Color").map(str::to_string),
             image,
             value: section.get_i32("Value").unwrap_or(0),
             growth: section
@@ -147,6 +151,7 @@ mod tests {
 
 [Riparius]
 Name=Tiberium Riparius
+Color=NeonGreen
 Image=1
 Value=25
 Growth=2200
@@ -186,6 +191,7 @@ SpreadPercentage=.06
         assert_eq!(registry.len(), 4);
         let riparius = registry.get(TiberiumTypeId(0)).expect("Riparius");
         assert_eq!(riparius.section, "Riparius");
+        assert_eq!(riparius.color.as_deref(), Some("NeonGreen"));
         assert_eq!(riparius.image, 1);
         assert_eq!(riparius.value, 25);
         assert_eq!(riparius.growth, 2200);

--- a/src/sim/anim_class.rs
+++ b/src/sim/anim_class.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::rules::art_data::AnimTypeRuntimeConfig;
+use crate::rules::house_colors::HouseColorIndex;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::components::AnimClassSpawnDescriptor;
 use crate::sim::intern::InternedId;
@@ -320,6 +321,10 @@ pub struct AnimObject {
     pub world_coord: AnimWorldCoord,
     pub draw_flags: u32,
     pub z_adjust: i32,
+    /// Optional ConvertClass palette selected by a producer after construction
+    /// (for example OverlayClass CellAnim over a Tiberium cell).
+    #[serde(default)]
+    pub remap_color: Option<HouseColorIndex>,
     pub effective_end: i32,
     pub effective_loop_end: i32,
     pub runtime: AnimRuntime,
@@ -560,6 +565,7 @@ impl Simulation {
             world_coord,
             draw_flags: descriptor.draw_flags,
             z_adjust: descriptor.z_adjust,
+            remap_color: None,
             effective_end,
             effective_loop_end,
             runtime: AnimRuntime {
@@ -636,6 +642,7 @@ impl Simulation {
             world_coord,
             draw_flags: TRAILER_DRAW_FLAGS,
             z_adjust: MULTIPLAYER_FEEDBACK_Z_ADJUST,
+            remap_color: None,
             effective_end,
             effective_loop_end,
             runtime: AnimRuntime {
@@ -1169,6 +1176,23 @@ impl Simulation {
             anim.runtime.current_frame = frame;
             anim.z_adjust = z_adjust;
         }
+    }
+
+    /// Apply OverlayClass's post-constructor CellAnim writes: `+0xD4` selects
+    /// the Tiberium ConvertClass when present and `+0xFC` receives CellClass's
+    /// current ground Z-adjust (`+0x10A`).
+    pub(crate) fn set_cell_anim_draw_authority(
+        &mut self,
+        id: AnimId,
+        remap_color: Option<HouseColorIndex>,
+        z_adjust: i32,
+    ) -> bool {
+        let Some(anim) = self.anim_mut_by_id(id) else {
+            return false;
+        };
+        anim.remap_color = remap_color;
+        anim.z_adjust = z_adjust;
+        true
     }
 
     /// Apply CellClass's producer-owned `AnimClass +0x100` write after the

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -3774,7 +3774,7 @@ fn gsi_04_07_damage_postmortem_fresh_null_expiry_does_not_recredit_initial_kille
 fn gsi_04_07_damage_death_weapon_gate_selection_and_native_damage() {
     let ini = IniFile::from_str(
         "[InfantryTypes]\n\
-         [VehicleTypes]\n0=FV\n1=NANRCT\n2=SLOTGATE\n3=DEFAULTED\n4=CURRENT\n\
+         [VehicleTypes]\n0=FV\n1=NANRCT\n2=SLOTGATE\n3=DEFAULTED\n4=CURRENT\n5=EARLYDEFAULT\n\
          [AircraftTypes]\n\
          [BuildingTypes]\n\
          [FV]\nStrength=200\nArmor=light\nPrimary=HoverMissile\nDeathWeapon=CRNuke\n\
@@ -3782,6 +3782,7 @@ fn gsi_04_07_damage_death_weapon_gate_selection_and_native_damage() {
          [SLOTGATE]\nStrength=100\nArmor=light\nPrimary=Ordinary\nSecondary=SuicideGun\nDeathWeapon=SlotBoom\n\
          [DEFAULTED]\nStrength=601\nArmor=light\nExplodes=yes\n\
          [CURRENT]\nStrength=100\nArmor=light\nExplodes=yes\nPrimary=Ordinary\nDeathWeaponDamageModifier=.5\n\
+         [EARLYDEFAULT]\nStrength=1\nSecondary=DefaultDeath\n\
          [HoverMissile]\nDamage=25\nWarhead=OrdinaryWH\n\
          [CRNuke]\nDamage=999\nWarhead=NukeWH\n\
          [NukePayload]\nDamage=600\nWarhead=NukeWH\n\
@@ -7189,7 +7190,7 @@ fn score_award_is_zero_without_a_cost_or_a_resolvable_type() {
 #[test]
 fn projectile_shrapnel_targets_hostile_head_before_random_cell_child() {
     let rules = RuleSet::from_ini(&IniFile::from_str(
-        "[VehicleTypes]\n0=MTNK\n\n[MTNK]\nStrength=100\nArmor=heavy\nPrimary=PARENT\n\n[PARENT]\nDamage=20\nROF=10\nRange=6\nSpeed=30\nProjectile=PARENTPROJ\nWarhead=WH\n\n[PARENTPROJ]\nAirburst=yes\nShrapnelWeapon=CHILD\nShrapnelCount=2\n\n[CHILD]\nDamage=5\nROF=10\nRange=3\nSpeed=40\nProjectile=CHILDPROJ\nWarhead=WH\n\n[CHILDPROJ]\nSubjectToWalls=yes\n\n[WH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+        "[VehicleTypes]\n0=MTNK\n\n[MTNK]\nStrength=100\nArmor=heavy\nPrimary=PARENT\nSecondary=CHILD\n\n[PARENT]\nDamage=20\nROF=10\nRange=6\nSpeed=30\nProjectile=PARENTPROJ\nWarhead=WH\n\n[PARENTPROJ]\nAirburst=yes\nShrapnelWeapon=CHILD\nShrapnelCount=2\n\n[CHILD]\nDamage=5\nROF=10\nRange=3\nSpeed=40\nProjectile=CHILDPROJ\nWarhead=WH\n\n[CHILDPROJ]\nSubjectToWalls=yes\n\n[WH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
     ))
     .expect("shrapnel rules");
     let mut entities = EntityStore::new();
@@ -7275,7 +7276,7 @@ fn gsi_04_01_projectile_shrapnel_captures_each_shared_dummy_lookup() {
     use crate::util::lepton::{BRIDGE_HEIGHT_DELTA_LEPTONS, ground_height_leptons};
 
     let rules = RuleSet::from_ini(&IniFile::from_str(
-        "[VehicleTypes]\n0=MTNK\n\n[MTNK]\nStrength=100\nArmor=heavy\nPrimary=PARENT\n\n[PARENT]\nDamage=20\nROF=10\nRange=6\nSpeed=30\nProjectile=PARENTPROJ\nWarhead=WH\n\n[PARENTPROJ]\nAirburst=yes\nShrapnelWeapon=CHILD\nShrapnelCount=3\n\n[CHILD]\nDamage=5\nROF=10\nRange=3\nSpeed=40\nProjectile=CHILDPROJ\nWarhead=WH\n\n[CHILDPROJ]\nSubjectToWalls=yes\n\n[WH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+        "[VehicleTypes]\n0=MTNK\n\n[MTNK]\nStrength=100\nArmor=heavy\nPrimary=PARENT\nSecondary=CHILD\n\n[PARENT]\nDamage=20\nROF=10\nRange=6\nSpeed=30\nProjectile=PARENTPROJ\nWarhead=WH\n\n[PARENTPROJ]\nAirburst=yes\nShrapnelWeapon=CHILD\nShrapnelCount=3\n\n[CHILD]\nDamage=5\nROF=10\nRange=3\nSpeed=40\nProjectile=CHILDPROJ\nWarhead=WH\n\n[CHILDPROJ]\nSubjectToWalls=yes\n\n[WH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
     ))
     .expect("shrapnel rules");
     let mut entities = EntityStore::new();

--- a/src/sim/crates.rs
+++ b/src/sim/crates.rs
@@ -25,7 +25,9 @@ mod state;
 
 pub use state::{CrateAuthority, CrateSlot};
 
-use crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL;
+use crate::map::bridge_facts::{
+    BRIDGE_FLAG_STRUCTURAL, BridgeFlagStamp, high_bridge_stamp_for_overlay,
+};
 use crate::map::overlay_types::OverlayTypeRegistry;
 use crate::rules::crate_rules::CrateRules;
 use crate::rules::locomotor_type::{MovementZone, SpeedType};
@@ -37,6 +39,7 @@ use crate::sim::find_nearby_cell::{
 };
 use crate::sim::pathfinding::PathGrid;
 use crate::sim::world::Simulation;
+use crate::util::fixed_math::SimFixed;
 
 /// Retry budget inside one placer call. Every attempt spends its two draws
 /// whether or not the cell works out; after this many failures the call gives up
@@ -179,7 +182,7 @@ fn place_scenario_start_crates_with_failure(
     for _ in 0..requested {
         match place_one_random_crate(
             sim,
-            &rules.crate_rules,
+            rules,
             overlay_registry,
             path_grid,
             forced_failure,
@@ -191,6 +194,26 @@ fn place_scenario_start_crates_with_failure(
                 visible = visible.wrapping_add(1);
             }
         }
+    }
+    if visible != 0 {
+        // Post_Map_Init publishes navigation before crate placement. Native
+        // Mark mutates live CellClass land/zone/bridge state synchronously;
+        // refresh Rust's derived bridge and path projections once after the
+        // ordered crate batch, without introducing another RNG boundary.
+        if let (Some(bridge_state), Some(terrain)) =
+            (sim.bridge_state.as_ref(), sim.resolved_terrain.as_ref())
+        {
+            let destroyable = bridge_state.is_destroyable();
+            let bridge_strength = bridge_state.bridge_strength();
+            sim.bridge_state = Some(
+                crate::sim::bridge_state::BridgeRuntimeState::from_resolved_terrain(
+                    terrain,
+                    destroyable,
+                    bridge_strength,
+                ),
+            );
+        }
+        let _ = sim.rebuild_dynamic_navigation(rules);
     }
     log::info!(
         "Scenario-start crates: requested {requested}, accepted {accepted}, visible {visible}"
@@ -213,7 +236,7 @@ enum CrateSurface {
 /// One `MapClass__PlaceCrateAtRandomCell @ 0x0056BD40` call.
 fn place_one_random_crate(
     sim: &mut Simulation,
-    rules: &CrateRules,
+    rules: &RuleSet,
     overlay_registry: &OverlayTypeRegistry,
     path_grid: Option<&PathGrid>,
     forced_failure: ForcedPostPrecheckFailure,
@@ -260,8 +283,13 @@ fn place_one_random_crate(
         {
             continue;
         }
-        let accepted =
-            validate_and_stamp_candidate(sim, rules, overlay_registry, cell, forced_failure);
+        let accepted = validate_and_stamp_candidate_with_rules(
+            sim,
+            rules,
+            overlay_registry,
+            cell,
+            forced_failure,
+        );
 
         // `CrateSlot__PlaceOverlayAndInitTimer @ 0x004A17C0`: accepted ghosts
         // and visible overlays both write the packed coordinate before drawing
@@ -272,8 +300,11 @@ fn place_one_random_crate(
             slot.cell_y = cell.1 as i16;
         }
         let timer_draw = sim.scenario_rng.next_range_u32_inclusive(0, 0x7fff_fffe);
-        let (start_frame, aux, duration) =
-            state::crate_timer_words(rules.regen, timer_draw, sim.session.binary_frame as i32);
+        let (start_frame, aux, duration) = state::crate_timer_words(
+            rules.crate_rules.regen,
+            timer_draw,
+            sim.session.binary_frame as i32,
+        );
         let slot = sim.crate_authority.slot_mut(slot_index);
         slot.start_frame = start_frame;
         slot.aux = aux;
@@ -350,6 +381,41 @@ fn validate_and_stamp_candidate(
     cell: (u16, u16),
     forced_failure: ForcedPostPrecheckFailure,
 ) -> AcceptedCellResult {
+    validate_and_stamp_candidate_inner(
+        sim,
+        rules,
+        None,
+        overlay_registry,
+        cell,
+        forced_failure,
+    )
+}
+
+fn validate_and_stamp_candidate_with_rules(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    overlay_registry: &OverlayTypeRegistry,
+    cell: (u16, u16),
+    forced_failure: ForcedPostPrecheckFailure,
+) -> AcceptedCellResult {
+    validate_and_stamp_candidate_inner(
+        sim,
+        &rules.crate_rules,
+        Some(rules),
+        overlay_registry,
+        cell,
+        forced_failure,
+    )
+}
+
+fn validate_and_stamp_candidate_inner(
+    sim: &mut Simulation,
+    rules: &CrateRules,
+    full_rules: Option<&RuleSet>,
+    overlay_registry: &OverlayTypeRegistry,
+    cell: (u16, u16),
+    forced_failure: ForcedPostPrecheckFailure,
+) -> AcceptedCellResult {
     let water_id = rules
         .water_crate_img
         .as_deref()
@@ -370,6 +436,103 @@ fn validate_and_stamp_candidate(
         return AcceptedCellResult::Ghost;
     };
 
+    if forced_failure != ForcedPostPrecheckFailure::None {
+        return AcceptedCellResult::Ghost;
+    }
+
+    let Some(selected_flags) = overlay_registry.flags(selected_id).cloned() else {
+        return AcceptedCellResult::Ghost;
+    };
+    let Some(slope_type) = sim
+        .resolved_terrain
+        .as_ref()
+        .and_then(|terrain| terrain.cell(cell.0, cell.1))
+        .map(|terrain_cell| terrain_cell.slope_type)
+    else {
+        return AcceptedCellResult::Ghost;
+    };
+    // `OverlayClass::Mark @ 0x005FC5E0..0x005FC5F4`: every derived branch,
+    // including the hard-coded bridge and TS-legacy identities, shares this
+    // gate before any overlay write or branch-local Scenario draw.
+    if slope_type > 4 && selected_id != 0xB2 {
+        return AcceptedCellResult::Ghost;
+    }
+
+    if let Some((family, direction)) = high_bridge_stamp_for_overlay(selected_id) {
+        let preserved_data = sim
+            .overlay_grid
+            .as_ref()
+            .map(|grid| grid.cell(cell.0, cell.1).overlay_data)
+            .unwrap_or(0);
+        sim.apply_runtime_bridge_mark_stamp(BridgeFlagStamp::new(cell, direction, true), family);
+        let wrote =
+            write_real_crate_mark_fields(sim, overlay_registry, cell, selected_id, preserved_data);
+        recalc_real_crate_mark_cell(sim, overlay_registry, cell);
+        return if wrote {
+            AcceptedCellResult::Visible
+        } else {
+            AcceptedCellResult::Ghost
+        };
+    }
+
+    // GSI-18.01 is explicitly excluded by the Phase 14 contract: these two
+    // hard-coded branches are the TS veins/veinhole carryover. Preserve crate
+    // admission/timer behavior but do not port their legacy world mutation.
+    if matches!(selected_id, 0x7E | 0xA7) {
+        recalc_real_crate_mark_cell(sim, overlay_registry, cell);
+        return AcceptedCellResult::Ghost;
+    }
+
+    if selected_flags.land == LandType::Railroad {
+        let wrote = write_real_crate_mark_fields(sim, overlay_registry, cell, selected_id, 0);
+        recalc_real_crate_mark_cell(sim, overlay_registry, cell);
+        return if wrote {
+            AcceptedCellResult::Visible
+        } else {
+            AcceptedCellResult::Ghost
+        };
+    }
+
+    if selected_flags.wall {
+        // `Cell_passability_building_placement @ 0x0047C620` receives
+        // `(cell, 1, 0, 0)` here. The crate caller already proved allocated,
+        // in-playfield, and overlay-empty; with the null object argument the
+        // surviving admission is Track speed, not terrain-object/occupation.
+        let wall_passes = sim
+            .resolved_terrain
+            .as_ref()
+            .and_then(|terrain| terrain.cell(cell.0, cell.1))
+            .is_some_and(|terrain_cell| terrain_cell.speed_costs.track != Some(0));
+        if !wall_passes {
+            recalc_real_crate_mark_cell(sim, overlay_registry, cell);
+            return AcceptedCellResult::Ghost;
+        }
+        let wrote = write_real_crate_mark_fields(sim, overlay_registry, cell, selected_id, 0);
+        if wrote && let Some(grid) = sim.overlay_grid.as_mut() {
+            crate::sim::overlay_grid::refresh_wall_connectivity_after_placement(
+                grid,
+                overlay_registry,
+                cell.0,
+                cell.1,
+            );
+        }
+        recalc_real_crate_mark_cell(sim, overlay_registry, cell);
+        return if wrote {
+            AcceptedCellResult::Visible
+        } else {
+            AcceptedCellResult::Ghost
+        };
+    }
+
+    if let Some(spec) = LowBridgeCrateSpec::for_trigger(selected_id) {
+        let visible = execute_low_bridge_crate_mark(sim, overlay_registry, cell, spec);
+        return if visible {
+            AcceptedCellResult::Visible
+        } else {
+            AcceptedCellResult::Ghost
+        };
+    }
+
     // `OverlayClass__Mark @ 0x005FC570` compares live Rules pointers, with
     // Water first. Numeric registry identity is the Rust-native pointer alias.
     let mark_speed = if Some(selected_id) == water_id {
@@ -388,9 +551,10 @@ fn validate_and_stamp_candidate(
         return AcceptedCellResult::Ghost;
     };
     if sim.production.terrain_object_cells.contains_key(&cell) {
-        return AcceptedCellResult::Ghost;
-    }
-    if terrain_cell.slope_type > 4 && selected_id != 0xB2 {
+        if let Some(full_rules) = full_rules {
+            spawn_crate_cell_anim(sim, full_rules, cell, selected_flags.cell_anim.as_deref());
+        }
+        recalc_real_crate_mark_cell(sim, overlay_registry, cell);
         return AcceptedCellResult::Ghost;
     }
     let bridge_layer_selected = terrain_cell.bridge_facts.raw_flags & BRIDGE_FLAG_STRUCTURAL != 0;
@@ -402,32 +566,386 @@ fn validate_and_stamp_candidate(
             .ground_bits(cell.0, cell.1)
     };
     if selected_occupation != 0 {
+        if let Some(full_rules) = full_rules {
+            spawn_crate_cell_anim(sim, full_rules, cell, selected_flags.cell_anim.as_deref());
+        }
+        recalc_real_crate_mark_cell(sim, overlay_registry, cell);
         return AcceptedCellResult::Ghost;
     }
     if !bridge_layer_selected && terrain_cell.speed_costs.cost_for_speed_type(mark_speed) == Some(0)
     {
-        return AcceptedCellResult::Ghost;
-    }
-    if forced_failure != ForcedPostPrecheckFailure::None {
+        if let Some(full_rules) = full_rules {
+            spawn_crate_cell_anim(sim, full_rules, cell, selected_flags.cell_anim.as_deref());
+        }
+        recalc_real_crate_mark_cell(sim, overlay_registry, cell);
         return AcceptedCellResult::Ghost;
     }
 
-    let (Some(overlay_grid), Some(resolved_terrain)) =
-        (sim.overlay_grid.as_mut(), sim.resolved_terrain.as_mut())
-    else {
-        return AcceptedCellResult::Ghost;
-    };
-    if overlay_grid.place_crate_overlay(
-        resolved_terrain,
-        overlay_registry,
-        cell.0,
-        cell.1,
-        selected_id,
-    ) {
+    let wrote = write_real_crate_mark_fields(sim, overlay_registry, cell, selected_id, 0);
+    if wrote && selected_flags.land == LandType::Road {
+        set_crate_mark_data(sim, cell, 1);
+        if let Some(full_rules) = full_rules {
+            spread_cell_germinate_without_randomization(
+                sim,
+                full_rules,
+                overlay_registry,
+                (cell.0 as i16, cell.1 as i16),
+            );
+        }
+    }
+    if wrote && selected_flags.crate_type {
+        set_crate_mark_data(sim, cell, u8::MAX);
+    }
+    if let Some(full_rules) = full_rules {
+        spawn_crate_cell_anim(sim, full_rules, cell, selected_flags.cell_anim.as_deref());
+    }
+    recalc_real_crate_mark_cell(sim, overlay_registry, cell);
+    if wrote
+        && sim
+            .overlay_grid
+            .as_ref()
+            .is_some_and(|grid| grid.cell(cell.0, cell.1).overlay_id.is_some())
+    {
         AcceptedCellResult::Visible
     } else {
         AcceptedCellResult::Ghost
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LowBridgeCrateSpec {
+    start_offset: (i16, i16),
+    row_direction: u8,
+    join_direction: u8,
+    fixed_id: u8,
+    opposite_id: u8,
+    body_base: u8,
+}
+
+impl LowBridgeCrateSpec {
+    /// Dense active-YR runtime IDs from the literal tables read by
+    /// `OverlayClass::Mark @ 0x005FC790..0x005FD1FA`.
+    fn for_trigger(id: u8) -> Option<Self> {
+        Some(match id {
+            0x7A => Self::new((0, -1), 4, 6, 0x5C, 0x5E, 0x4A),
+            0x7B => Self::new((0, -1), 4, 2, 0x5E, 0x5C, 0x4A),
+            0x7C => Self::new((-1, 0), 2, 4, 0x60, 0x62, 0x53),
+            0x7D => Self::new((-1, 0), 2, 0, 0x62, 0x60, 0x53),
+            0xE9 => Self::new((0, -1), 4, 6, 0xDF, 0xE1, 0xCD),
+            0xEA => Self::new((0, -1), 4, 2, 0xE1, 0xDF, 0xCD),
+            0xEB => Self::new((-1, 0), 2, 4, 0xE3, 0xE5, 0xD6),
+            0xEC => Self::new((-1, 0), 2, 0, 0xE5, 0xE3, 0xD6),
+            _ => return None,
+        })
+    }
+
+    const fn new(
+        start_offset: (i16, i16),
+        row_direction: u8,
+        join_direction: u8,
+        fixed_id: u8,
+        opposite_id: u8,
+        body_base: u8,
+    ) -> Self {
+        Self {
+            start_offset,
+            row_direction,
+            join_direction,
+            fixed_id,
+            opposite_id,
+            body_base,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum CrateMarkCellRef {
+    Real(u16, u16),
+    Dummy(crate::map::resolved_terrain::SharedCellDummy),
+}
+
+fn resolve_crate_mark_cell(sim: &Simulation, cell: (i16, i16)) -> CrateMarkCellRef {
+    let x = i32::from(cell.0);
+    let y = i32::from(cell.1);
+    if let Some((rx, ry)) = crate::map::cell_index::canonical_cell_coord(x, y)
+        && sim
+            .resolved_terrain
+            .as_ref()
+            .and_then(|terrain| terrain.cell(rx, ry))
+            .is_some()
+        && sim
+            .overlay_grid
+            .as_ref()
+            .is_some_and(|grid| rx < grid.width() && ry < grid.height())
+    {
+        return CrateMarkCellRef::Real(rx, ry);
+    }
+    let dummy = sim.effective_shared_cell_dummy();
+    dummy.stamp_coord(x, y);
+    CrateMarkCellRef::Dummy(dummy)
+}
+
+fn read_crate_mark_fields(sim: &Simulation, cell: (i16, i16)) -> (Option<u8>, u8) {
+    match resolve_crate_mark_cell(sim, cell) {
+        CrateMarkCellRef::Real(rx, ry) => {
+            let cell = sim
+                .overlay_grid
+                .as_ref()
+                .expect("real crate Mark cell requires OverlayGrid")
+                .cell(rx, ry);
+            (cell.overlay_id, cell.overlay_data)
+        }
+        CrateMarkCellRef::Dummy(dummy) => dummy.overlay_fields(),
+    }
+}
+
+fn write_crate_mark_fields(
+    sim: &mut Simulation,
+    registry: &OverlayTypeRegistry,
+    cell: (i16, i16),
+    overlay_id: u8,
+    overlay_data: u8,
+) -> bool {
+    match resolve_crate_mark_cell(sim, cell) {
+        CrateMarkCellRef::Real(rx, ry) => {
+            write_real_crate_mark_fields(sim, registry, (rx, ry), overlay_id, overlay_data)
+        }
+        CrateMarkCellRef::Dummy(dummy) => {
+            dummy.set_overlay_fields(Some(overlay_id), overlay_data);
+            false
+        }
+    }
+}
+
+fn write_real_crate_mark_fields(
+    sim: &mut Simulation,
+    registry: &OverlayTypeRegistry,
+    cell: (u16, u16),
+    overlay_id: u8,
+    overlay_data: u8,
+) -> bool {
+    let (Some(grid), Some(terrain)) = (sim.overlay_grid.as_mut(), sim.resolved_terrain.as_mut())
+    else {
+        return false;
+    };
+    grid.write_crate_mark_fields(terrain, registry, cell.0, cell.1, overlay_id, overlay_data)
+}
+
+fn recalc_real_crate_mark_cell(
+    sim: &mut Simulation,
+    registry: &OverlayTypeRegistry,
+    cell: (u16, u16),
+) {
+    let (Some(grid), Some(terrain)) = (sim.overlay_grid.as_mut(), sim.resolved_terrain.as_mut())
+    else {
+        return;
+    };
+    let changed = crate::sim::overlay_grid::recalc_overlay_passability(
+        grid, terrain, registry, cell.0, cell.1,
+    );
+    grid.record_synchronous_passability_change_at(cell.0, cell.1, changed);
+}
+
+fn set_crate_mark_data(sim: &mut Simulation, cell: (u16, u16), data: u8) {
+    if let Some(grid) = sim.overlay_grid.as_mut() {
+        let target = grid.cell_mut(cell.0, cell.1);
+        if target.overlay_id.is_some() {
+            target.overlay_data = data;
+        }
+    }
+}
+
+fn packed_step(cell: (i16, i16), direction: u8) -> (i16, i16) {
+    let (dx, dy) = crate::util::direction::direction_delta(direction)
+        .expect("low bridge tables use cardinal directions");
+    (
+        cell.0.wrapping_add(dx as i16),
+        cell.1.wrapping_add(dy as i16),
+    )
+}
+
+fn packed_offset(cell: (i16, i16), offset: (i16, i16)) -> (i16, i16) {
+    (cell.0.wrapping_add(offset.0), cell.1.wrapping_add(offset.1))
+}
+
+fn low_bridge_search_in_bounds(sim: &Simulation, cell: (i16, i16)) -> bool {
+    let (Some(bounds), Some(height)) = (sim.playfield_bounds, sim.playfield_size_height) else {
+        return false;
+    };
+    let x = i32::from(cell.0);
+    let y = i32::from(cell.1);
+    let sum = x.wrapping_add(y);
+    let width = bounds.base;
+    width < sum
+        && x.wrapping_sub(y) < width
+        && y.wrapping_sub(x) < width
+        && sum <= width.wrapping_add(height.wrapping_mul(2))
+}
+
+fn execute_low_bridge_crate_mark(
+    sim: &mut Simulation,
+    registry: &OverlayTypeRegistry,
+    origin: (u16, u16),
+    spec: LowBridgeCrateSpec,
+) -> bool {
+    let origin = (origin.0 as i16, origin.1 as i16);
+    let row_start = packed_offset(origin, spec.start_offset);
+    let mut probe = row_start;
+    let mut row_clear = true;
+    for _ in 0..3 {
+        let (overlay_id, _) = read_crate_mark_fields(sim, probe);
+        row_clear &= overlay_id.is_none();
+        probe = packed_step(probe, spec.row_direction);
+    }
+
+    if row_clear {
+        let mut target = row_start;
+        for data in 0..3u8 {
+            let _ = write_crate_mark_fields(sim, registry, target, spec.fixed_id, data);
+            if let CrateMarkCellRef::Real(rx, ry) = resolve_crate_mark_cell(sim, target) {
+                recalc_real_crate_mark_cell(sim, registry, (rx, ry));
+            }
+            target = packed_step(target, spec.row_direction);
+        }
+
+        let mut search = packed_step(origin, spec.join_direction);
+        let mut found = None;
+        while low_bridge_search_in_bounds(sim, search) {
+            let fields = read_crate_mark_fields(sim, search);
+            if fields == (Some(spec.opposite_id), 1) {
+                found = Some(search);
+                break;
+            }
+            search = packed_step(search, spec.join_direction);
+        }
+
+        if let Some(found) = found {
+            let reverse = spec.join_direction.wrapping_sub(4) & 7;
+            let mut work = packed_step(found, reverse);
+            let dx = i32::from(work.0).wrapping_sub(i32::from(row_start.0));
+            let dy = i32::from(work.1).wrapping_sub(i32::from(row_start.1));
+            let length = dx.wrapping_abs().max(dy.wrapping_abs());
+            let cross_offsets: [(i16, i16); 3] = if matches!(reverse, 0 | 4) {
+                [(-1, 0), (0, 0), (1, 0)]
+            } else {
+                [(0, -1), (0, 0), (0, 1)]
+            };
+            for _ in 0..length {
+                for (data, offset) in cross_offsets.into_iter().enumerate() {
+                    let target = packed_offset(work, offset);
+                    let variant = (sim.scenario_rng.next_u32() & 3) as u8;
+                    let overlay_id = spec.body_base.wrapping_add(variant);
+                    let _ = write_crate_mark_fields(sim, registry, target, overlay_id, data as u8);
+                    if let CrateMarkCellRef::Real(rx, ry) = resolve_crate_mark_cell(sim, target) {
+                        recalc_real_crate_mark_cell(sim, registry, (rx, ry));
+                    }
+                }
+                work = packed_step(work, reverse);
+            }
+        }
+    }
+
+    let origin_real = (origin.0 as u16, origin.1 as u16);
+    recalc_real_crate_mark_cell(sim, registry, origin_real);
+    sim.overlay_grid
+        .as_ref()
+        .is_some_and(|grid| grid.cell(origin_real.0, origin_real.1).overlay_id.is_some())
+}
+
+fn spread_cell_germinate_without_randomization(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    registry: &OverlayTypeRegistry,
+    cell: (i16, i16),
+) {
+    const DENSITY_BY_NEIGHBOR_COUNT: [u8; 12] = [0, 1, 3, 4, 6, 7, 8, 10, 11, 7, 0, 1];
+    const ADJACENT: [(i16, i16); 8] = [
+        (-1, -1),
+        (0, -1),
+        (1, -1),
+        (1, 0),
+        (1, 1),
+        (0, 1),
+        (-1, 1),
+        (-1, 0),
+    ];
+    let (Some(overlay_id), _) = read_crate_mark_fields(sim, cell) else {
+        return;
+    };
+    let Some(tiberium_type) = registry
+        .tiberium_type_for_overlay(&rules.tiberium_types, overlay_id)
+        .and_then(|id| rules.tiberium_types.get(id))
+    else {
+        return;
+    };
+    if tiberium_type.max_density == 0 {
+        return;
+    }
+    let mut matching = 0u8;
+    for offset in ADJACENT {
+        let (neighbor_id, _) = read_crate_mark_fields(sim, packed_offset(cell, offset));
+        if neighbor_id.and_then(|id| registry.tiberium_type_for_overlay(&rules.tiberium_types, id))
+            == Some(tiberium_type.id)
+        {
+            matching = matching.wrapping_add(1);
+        }
+    }
+    let density = DENSITY_BY_NEIGHBOR_COUNT[usize::from(matching % tiberium_type.max_density)
+        .min(DENSITY_BY_NEIGHBOR_COUNT.len() - 1)];
+    match resolve_crate_mark_cell(sim, cell) {
+        CrateMarkCellRef::Real(rx, ry) => set_crate_mark_data(sim, (rx, ry), density),
+        CrateMarkCellRef::Dummy(dummy) => dummy.set_overlay_fields(Some(overlay_id), density),
+    }
+}
+
+fn spawn_crate_cell_anim(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    cell: (u16, u16),
+    cell_anim: Option<&str>,
+) {
+    let Some(cell_anim) = cell_anim else {
+        return;
+    };
+    let center_x = i32::from(cell.0).wrapping_mul(256).wrapping_add(128);
+    let center_y = i32::from(cell.1).wrapping_mul(256).wrapping_add(128);
+    let ground_z = sim
+        .resolved_terrain
+        .as_ref()
+        .and_then(|terrain| terrain.cell(cell.0, cell.1))
+        .and_then(|terrain_cell| {
+            crate::util::lepton::ground_height_leptons(
+                terrain_cell.level,
+                terrain_cell.slope_type,
+                center_x,
+                center_y,
+            )
+            .ok()
+        })
+        .unwrap_or(0);
+    let type_name = sim.interner.intern(cell_anim);
+    let mut descriptor = crate::sim::components::AnimClassSpawnDescriptor::new(
+        type_name,
+        cell.0,
+        cell.1,
+        SimFixed::from_num(0),
+        SimFixed::from_num(0),
+        0,
+    );
+    descriptor.delay = 0;
+    descriptor.loop_count = 1;
+    descriptor.draw_flags = 0x600;
+    descriptor.z_adjust = 0;
+    descriptor.reverse = false;
+    let _ = sim.spawn_anim_at_world(
+        rules,
+        descriptor,
+        crate::sim::anim_class::AnimWorldCoord {
+            x: center_x.wrapping_add(0x180),
+            y: center_y.wrapping_add(0x180),
+            z: ground_z,
+        },
+    );
 }
 
 fn crate_surface_at(sim: &Simulation, cell: (u16, u16)) -> CrateSurface {
@@ -512,6 +1030,7 @@ fn snap_to_passable_with_radius(
 mod tests {
     use super::*;
     use std::collections::BTreeSet;
+    use std::fmt::Write as _;
 
     use crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL;
     use crate::map::overlay_types::OverlayTypeRegistry;
@@ -548,8 +1067,6 @@ mod tests {
     }
 
     fn crate_registry_with_raw_b2() -> OverlayTypeRegistry {
-        use std::fmt::Write as _;
-
         let mut ini_text = String::from("[OverlayTypes]\n");
         for index in 0..=0xB2u16 {
             let name = if index == 0xB2 {
@@ -560,6 +1077,30 @@ mod tests {
             writeln!(&mut ini_text, "{index}={name}").expect("string write");
         }
         ini_text.push_str("[STEEPCRATE]\nCrate=yes\n");
+        OverlayTypeRegistry::from_ini(&IniFile::from_str(&ini_text), None)
+    }
+
+    fn dense_registry(last: u8, overrides: &[(u8, &str, &str)]) -> OverlayTypeRegistry {
+        let mut names: Vec<String> = (0..=last).map(|id| format!("OV{id:03}")).collect();
+        for &(id, name, _) in overrides {
+            names[usize::from(id)] = name.to_owned();
+        }
+        let mut ini_text = String::from("[OverlayTypes]\n");
+        for (id, name) in names.iter().enumerate() {
+            writeln!(&mut ini_text, "{id}={name}").unwrap();
+        }
+        for (id, name) in names.iter().enumerate() {
+            let override_section = overrides.iter().find_map(|(candidate, _, section)| {
+                (usize::from(*candidate) == id).then_some(*section)
+            });
+            let default_low_bridge = crate::map::overlay_types::is_bridge_overlay_index(id as u8)
+                && !crate::map::overlay_types::is_high_bridge_index(id as u8);
+            let section = override_section.or(default_low_bridge.then_some("Land=Road\n"));
+            if let Some(section) = section {
+                writeln!(&mut ini_text, "[{name}]").unwrap();
+                ini_text.push_str(section);
+            }
+        }
         OverlayTypeRegistry::from_ini(&IniFile::from_str(&ini_text), None)
     }
 
@@ -1363,6 +1904,420 @@ mod tests {
             let written = sim.overlay_grid.as_ref().unwrap().cell(cell.0, cell.1);
             assert_eq!(written.overlay_id, registry.id_for_name(name));
             assert_eq!(written.overlay_data, expected_data, "configured {name}");
+        }
+    }
+
+    #[test]
+    fn railroad_crate_mark_bypasses_ordinary_blockers_and_forces_data_zero() {
+        let registry = dense_registry(0, &[(0, "RAILCRATE", "Land=Railroad\nCrate=yes\n")]);
+        let rules = CrateRules {
+            wood_crate_img: Some("RAILCRATE".to_owned()),
+            crate_img: Some("RAILCRATE".to_owned()),
+            water_crate_img: Some("RAILCRATE".to_owned()),
+            ..CrateRules::default()
+        };
+        let mut sim = sim_with_grid(0x14_09_0001);
+        let cell = (12, 13);
+        sim.production.terrain_object_cells.insert(cell, 77);
+        sim.substrate
+            .raw_cell_occupation
+            .mark_ground(cell.0, cell.1, 0xFF);
+        sim.resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .unwrap()
+            .speed_costs
+            .track = Some(0);
+
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut sim,
+                &rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Visible
+        );
+        let written = sim.overlay_grid.as_ref().unwrap().cell(cell.0, cell.1);
+        assert_eq!(written.overlay_id, Some(0));
+        assert_eq!(written.overlay_data, 0, "Railroad wins over Crate=yes");
+    }
+
+    #[test]
+    fn wall_crate_mark_uses_building_passability_and_crate_never_overrides_data() {
+        let registry = dense_registry(0, &[(0, "WALLCRATE", "Wall=yes\nLand=Wall\nCrate=yes\n")]);
+        let rules = CrateRules {
+            wood_crate_img: Some("WALLCRATE".to_owned()),
+            crate_img: Some("WALLCRATE".to_owned()),
+            water_crate_img: Some("WALLCRATE".to_owned()),
+            ..CrateRules::default()
+        };
+        let cell = (12, 13);
+        let mut visible = sim_with_grid(0x14_09_0002);
+        visible.production.terrain_object_cells.insert(cell, 88);
+        visible
+            .substrate
+            .raw_cell_occupation
+            .mark_ground(cell.0, cell.1, 0xFF);
+        visible
+            .overlay_grid
+            .as_mut()
+            .unwrap()
+            .place_overlay(cell.0 + 1, cell.1, 0, 0);
+
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut visible,
+                &rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Visible
+        );
+        let grid = visible.overlay_grid.as_ref().unwrap();
+        assert_eq!(grid.cell(cell.0, cell.1).overlay_data, 0x02);
+        assert_eq!(grid.cell(cell.0 + 1, cell.1).overlay_data, 0x08);
+
+        let mut blocked = sim_with_grid(0x14_09_0003);
+        blocked
+            .resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .unwrap()
+            .speed_costs
+            .track = Some(0);
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut blocked,
+                &rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Ghost
+        );
+        assert_eq!(
+            blocked
+                .overlay_grid
+                .as_ref()
+                .unwrap()
+                .cell(cell.0, cell.1)
+                .overlay_id,
+            None
+        );
+    }
+
+    #[test]
+    fn road_tiberium_crate_mark_germinates_from_same_type_neighbors() {
+        let ini = IniFile::from_str(
+            "[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
+             [OverlayTypes]\n0=ROADORE\n\
+             [ROADORE]\nTiberium=yes\nLand=Road\n\
+             [Tiberiums]\n0=Riparius\n[Riparius]\nImage=1\n\
+             [CrateRules]\nCrateImg=ROADORE\nWoodCrateImg=ROADORE\nWaterCrateImg=ROADORE\n",
+        );
+        let registry = OverlayTypeRegistry::from_ini(&ini, None);
+        let rules = RuleSet::from_ini(&ini).unwrap();
+        let mut sim = sim_with_grid(0x14_09_0004);
+        let cell = (12, 13);
+        for neighbor in [(11, 12), (12, 12), (13, 13), (12, 14)] {
+            sim.overlay_grid
+                .as_mut()
+                .unwrap()
+                .place_overlay(neighbor.0, neighbor.1, 0, 1);
+        }
+
+        assert_eq!(
+            validate_and_stamp_candidate_with_rules(
+                &mut sim,
+                &rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Visible
+        );
+        assert_eq!(
+            sim.overlay_grid
+                .as_ref()
+                .unwrap()
+                .cell(cell.0, cell.1)
+                .overlay_data,
+            6,
+            "four matching neighbors index the retail [0,1,3,4,6,...] table"
+        );
+    }
+
+    #[test]
+    fn ordinary_cell_anim_spawns_after_visible_or_failed_ordinary_mark() {
+        let ini = IniFile::from_str(
+            "[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
+             [Animations]\n0=SPARK\n\
+             [OverlayTypes]\n0=ANIMBOX\n[ANIMBOX]\nCellAnim=SPARK\n\
+             [CrateRules]\nCrateImg=ANIMBOX\nWoodCrateImg=ANIMBOX\nWaterCrateImg=ANIMBOX\n",
+        );
+        let registry = OverlayTypeRegistry::from_ini(&ini, None);
+        let mut rules = RuleSet::from_ini(&ini).unwrap();
+        let mut art = crate::rules::art_data::ArtRegistry::from_ini(&IniFile::from_str(
+            "[SPARK]\nRate=1\nEnd=2\nLoopCount=1\n",
+        ));
+        art.bind_anim_frame_count_for_test("SPARK", 2);
+        rules.art_registry = art;
+        let cell = (12, 13);
+
+        let mut visible = sim_with_grid(0x14_09_0005);
+        assert_eq!(
+            validate_and_stamp_candidate_with_rules(
+                &mut visible,
+                &rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Visible
+        );
+        let visible_anim = visible.substrate.anims.iter().next().unwrap().1;
+        assert_eq!(
+            visible_anim.world_coord,
+            crate::sim::anim_class::AnimWorldCoord {
+                x: i32::from(cell.0) * 256 + 128 + 0x180,
+                y: i32::from(cell.1) * 256 + 128 + 0x180,
+                z: 0,
+            }
+        );
+        assert_eq!(visible_anim.draw_flags, 0x600);
+
+        let mut ghost = sim_with_grid(0x14_09_0006);
+        ghost.production.terrain_object_cells.insert(cell, 99);
+        assert_eq!(
+            validate_and_stamp_candidate_with_rules(
+                &mut ghost,
+                &rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Ghost
+        );
+        assert_eq!(ghost.substrate.anims.iter().count(), 1);
+        assert_eq!(
+            ghost
+                .overlay_grid
+                .as_ref()
+                .unwrap()
+                .cell(cell.0, cell.1)
+                .overlay_id,
+            None
+        );
+    }
+
+    #[test]
+    fn high_bridge_crate_mark_stamps_family_and_preserves_existing_data() {
+        let registry = dense_registry(0x18, &[(0x18, "HIGHCRATE", "Crate=yes\n")]);
+        let rules = CrateRules {
+            wood_crate_img: Some("HIGHCRATE".to_owned()),
+            crate_img: Some("HIGHCRATE".to_owned()),
+            water_crate_img: Some("HIGHCRATE".to_owned()),
+            ..CrateRules::default()
+        };
+        let cell = (12, 13);
+        let mut sim = sim_with_grid(0x14_09_0007);
+        sim.overlay_grid
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .overlay_data = 7;
+        sim.production.terrain_object_cells.insert(cell, 100);
+        sim.substrate
+            .raw_cell_occupation
+            .mark_ground(cell.0, cell.1, 0xFF);
+        sim.resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .unwrap()
+            .speed_costs
+            .track = Some(0);
+
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut sim,
+                &rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Visible
+        );
+        let written = sim.overlay_grid.as_ref().unwrap().cell(cell.0, cell.1);
+        assert_eq!((written.overlay_id, written.overlay_data), (Some(0x18), 7));
+        let facts = sim
+            .resolved_terrain
+            .as_ref()
+            .unwrap()
+            .cell(cell.0, cell.1)
+            .unwrap()
+            .bridge_facts;
+        assert!(facts.is_anchor_self());
+        assert!(facts.has_structural_bridge());
+    }
+
+    #[test]
+    fn low_bridge_crate_mark_uses_exact_table_raw_draws_and_success_noop() {
+        let registry = dense_registry(0x7A, &[(0x7A, "LOWTRIGGER", "Land=Road\n")]);
+        let rules = CrateRules {
+            wood_crate_img: Some("LOWTRIGGER".to_owned()),
+            crate_img: Some("LOWTRIGGER".to_owned()),
+            water_crate_img: Some("LOWTRIGGER".to_owned()),
+            ..CrateRules::default()
+        };
+        let origin = (20, 20);
+        let mut sim = sim_with_grid(0x14_09_0008);
+        sim.overlay_grid
+            .as_mut()
+            .unwrap()
+            .place_overlay(15, 20, 0x5E, 1);
+        let mut replay = sim.scenario_rng.clone();
+        let body_draws: Vec<u8> = (0..12).map(|_| (replay.next_u32() & 3) as u8).collect();
+
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut sim,
+                &rules,
+                &registry,
+                origin,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Visible
+        );
+        assert_eq!(sim.scenario_rng.state(), replay.state());
+        let grid = sim.overlay_grid.as_ref().unwrap();
+        assert_eq!(
+            (grid.cell(20, 20).overlay_id, grid.cell(20, 20).overlay_data),
+            (Some(0x5C), 1)
+        );
+        assert_eq!(grid.cell(16, 19).overlay_id, Some(0x4A + body_draws[0]));
+        assert_eq!(grid.cell(16, 19).overlay_data, 0);
+        assert_eq!(grid.cell(19, 21).overlay_id, Some(0x4A + body_draws[11]));
+        assert_eq!(grid.cell(19, 21).overlay_data, 2);
+        let origin_terrain = sim
+            .resolved_terrain
+            .as_ref()
+            .unwrap()
+            .cell(origin.0, origin.1)
+            .unwrap();
+        assert!(origin_terrain.has_bridge_deck);
+        assert!(!origin_terrain.bridge_walkable);
+        assert!(origin_terrain.build_blocked);
+        assert_eq!(
+            origin_terrain.bridge_layer.as_ref().map(|layer| layer.direction),
+            Some(crate::map::resolved_terrain::BridgeDirection::Low)
+        );
+
+        let mut occupied = sim_with_grid(0x14_09_0009);
+        occupied
+            .overlay_grid
+            .as_mut()
+            .unwrap()
+            .place_overlay(20, 19, 0, 0);
+        let before = occupied.scenario_rng.state();
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut occupied,
+                &rules,
+                &registry,
+                origin,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Ghost
+        );
+        assert_eq!(occupied.scenario_rng.state(), before);
+        assert_eq!(
+            occupied
+                .overlay_grid
+                .as_ref()
+                .unwrap()
+                .cell(origin.0, origin.1)
+                .overlay_id,
+            None
+        );
+    }
+
+    #[test]
+    fn low_bridge_crate_mark_preserves_shared_dummy_overlay_alias() {
+        let registry = dense_registry(0x7C, &[(0x7C, "EDGELOW", "Land=Road\n")]);
+        let rules = CrateRules {
+            wood_crate_img: Some("EDGELOW".to_owned()),
+            crate_img: Some("EDGELOW".to_owned()),
+            water_crate_img: Some("EDGELOW".to_owned()),
+            ..CrateRules::default()
+        };
+        let mut sim = sim_with_grid(0x14_09_0012);
+        let before = sim.scenario_rng.state();
+
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut sim,
+                &rules,
+                &registry,
+                (0, 1),
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Visible
+        );
+        let dummy = sim.effective_shared_cell_dummy();
+        assert_eq!(dummy.overlay_fields(), (Some(0x60), 0));
+        assert_eq!(dummy.snapshot().coord, (-1, 1));
+
+        // A different missing coordinate aliases that same native fallback
+        // cell. Its retained overlay makes the later three-probe row occupied,
+        // so the real trigger cell remains an accepted timed ghost.
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut sim,
+                &rules,
+                &registry,
+                (0, 2),
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Ghost
+        );
+        assert_eq!(dummy.overlay_fields(), (Some(0x60), 0));
+        assert_eq!(dummy.snapshot().coord, (-1, 2));
+        assert_eq!(sim.scenario_rng.state(), before);
+    }
+
+    #[test]
+    fn ts_legacy_veins_crate_ids_are_explicit_accepted_ghosts() {
+        for (id, name) in [(0x7E, "VEINS"), (0xA7, "VEINHOLE")] {
+            let registry = dense_registry(id, &[(id, name, "Crate=yes\n")]);
+            let rules = CrateRules {
+                wood_crate_img: Some(name.to_owned()),
+                crate_img: Some(name.to_owned()),
+                water_crate_img: Some(name.to_owned()),
+                ..CrateRules::default()
+            };
+            let mut sim = sim_with_grid(0x14_09_0010 + u64::from(id));
+            let before = sim.scenario_rng.state();
+            assert_eq!(
+                validate_and_stamp_candidate(
+                    &mut sim,
+                    &rules,
+                    &registry,
+                    (12, 13),
+                    ForcedPostPrecheckFailure::None,
+                ),
+                AcceptedCellResult::Ghost
+            );
+            assert_eq!(sim.scenario_rng.state(), before);
+            assert_eq!(
+                sim.overlay_grid.as_ref().unwrap().cell(12, 13).overlay_id,
+                None
+            );
         }
     }
 

--- a/src/sim/crates.rs
+++ b/src/sim/crates.rs
@@ -39,6 +39,7 @@ use crate::sim::cell_rect::cell_is_in_playfield_height_aware;
 use crate::sim::find_nearby_cell::{
     NearbyAnchorGate, NearbyFootprint, NearbyQuery, PassabilityArgs, find_nearby_passable_cell,
 };
+use crate::sim::occupancy::OBJECT_OCCUPATION_BIT;
 use crate::sim::pathfinding::PathGrid;
 use crate::sim::world::Simulation;
 use crate::util::fixed_math::SimFixed;
@@ -615,7 +616,10 @@ fn validate_and_stamp_candidate_inner(
                 .raw_cell_occupation
                 .ground_bits(cell.0, cell.1)
         };
-        if selected_occupation != 0 {
+        // `CellClass::CheckCellPassability @ 0x004834A0` applies both native
+        // occupation filters; their intersection is exactly bit 0x40. Other
+        // raw occupation bits do not reject this Mark admission.
+        if selected_occupation & OBJECT_OCCUPATION_BIT != 0 {
             if let Some(full_rules) = full_rules {
                 spawn_crate_cell_anim(
                     sim,
@@ -1657,7 +1661,7 @@ mod tests {
     }
 
     #[test]
-    fn scenario_start_crate_any_ground_occupation_bit_accepts_a_timed_ghost() {
+    fn scenario_start_crate_object_ground_occupation_accepts_a_timed_ghost() {
         let rules = crate_ruleset("CrateMinimum=1\nCrateMaximum=1\n");
         let registry = crate_registry();
         let grid = PathGrid::test_all_passable(MAP, MAP);
@@ -1669,7 +1673,7 @@ mod tests {
         sim.substrate.raw_cell_occupation.mark_ground(
             rx,
             ry,
-            crate::sim::occupancy::OBJECT_OCCUPATION_BIT,
+            OBJECT_OCCUPATION_BIT,
         );
 
         let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 1);
@@ -1698,7 +1702,7 @@ mod tests {
     }
 
     #[test]
-    fn scenario_start_crate_every_nonzero_ground_occupation_bit_ghosts() {
+    fn scenario_start_crate_only_object_ground_occupation_bit_ghosts() {
         let rules = crate_ruleset("CrateMinimum=1\nCrateMaximum=1\n");
         let registry = crate_registry();
         let grid = PathGrid::test_all_passable(MAP, MAP);
@@ -1712,10 +1716,15 @@ mod tests {
             let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 1);
             assert_eq!(
                 (result.accepted, result.visible),
-                (1, 0),
-                "raw occupation bit {bit:#04x} must reject Mark"
+                (1, u32::from(bit != OBJECT_OCCUPATION_BIT)),
+                "only raw occupation bit 0x40 may reject Mark; tested {bit:#04x}"
             );
             assert!(sim.crate_authority.slots()[0].cell_x != 0);
+            assert_eq!(
+                crate_cells(&sim, &registry).contains(&cell),
+                bit != OBJECT_OCCUPATION_BIT,
+                "non-object occupation bits must retain the visible crate"
+            );
         }
     }
 
@@ -1934,8 +1943,8 @@ mod tests {
             "structural bridge chooses empty deck and bypasses ground speed zero"
         );
 
-        let mut ghost = sim_with_grid(0xB21D_0002);
-        let terrain_cell = ghost
+        let mut non_object_deck = sim_with_grid(0xB21D_0002);
+        let terrain_cell = non_object_deck
             .resolved_terrain
             .as_mut()
             .unwrap()
@@ -1943,20 +1952,45 @@ mod tests {
             .unwrap();
         terrain_cell.bridge_facts.raw_flags = BRIDGE_FLAG_STRUCTURAL;
         terrain_cell.speed_costs.track = Some(100);
-        ghost
+        non_object_deck
             .substrate
             .raw_cell_occupation
             .mark_deck(cell.0, cell.1, 0x01);
         assert_eq!(
             validate_and_stamp_candidate(
-                &mut ghost,
+                &mut non_object_deck,
+                &rules.crate_rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Visible,
+            "a selected deck byte without object bit 0x40 passes Mark"
+        );
+
+        let mut object_deck = sim_with_grid(0xB21D_0003);
+        let terrain_cell = object_deck
+            .resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .unwrap();
+        terrain_cell.bridge_facts.raw_flags = BRIDGE_FLAG_STRUCTURAL;
+        terrain_cell.speed_costs.track = Some(100);
+        object_deck
+            .substrate
+            .raw_cell_occupation
+            .mark_deck(cell.0, cell.1, OBJECT_OCCUPATION_BIT);
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut object_deck,
                 &rules.crate_rules,
                 &registry,
                 cell,
                 ForcedPostPrecheckFailure::None,
             ),
             AcceptedCellResult::Ghost,
-            "any nonzero selected deck byte rejects Mark"
+            "selected deck object bit 0x40 rejects Mark"
         );
     }
 
@@ -2290,7 +2324,7 @@ mod tests {
         ghost
             .substrate
             .raw_cell_occupation
-            .mark_ground(cell.0, cell.1, 1);
+            .mark_ground(cell.0, cell.1, OBJECT_OCCUPATION_BIT);
         assert_eq!(
             validate_and_stamp_candidate_with_rules(
                 &mut ghost,

--- a/src/sim/crates.rs
+++ b/src/sim/crates.rs
@@ -26,8 +26,10 @@ mod state;
 pub use state::{CrateAuthority, CrateSlot};
 
 use crate::map::bridge_facts::{
-    BRIDGE_FLAG_STRUCTURAL, BridgeFlagStamp, high_bridge_stamp_for_overlay,
+    BRIDGE_FLAG_STRUCTURAL, BridgeFlagStamp, BridgeStampFamily, BridgeStampSlot,
+    high_bridge_stamp_for_overlay,
 };
+use crate::map::lighting::{LightingProfileUnits, ParsedLightingProfiles};
 use crate::map::overlay_types::OverlayTypeRegistry;
 use crate::rules::crate_rules::CrateRules;
 use crate::rules::locomotor_type::{MovementZone, SpeedType};
@@ -143,12 +145,34 @@ pub fn place_scenario_start_crates(
     path_grid: Option<&PathGrid>,
     player_count: i32,
 ) -> CratePlacement {
+    place_scenario_start_crates_with_lighting(
+        sim,
+        rules,
+        overlay_registry,
+        path_grid,
+        player_count,
+        ParsedLightingProfiles::default().normal,
+    )
+}
+
+/// Production entry carrying the already parsed ordinary ScenarioClass
+/// lighting profile. `OverlayClass::Mark` copies each target CellClass's
+/// `+0x10A` value into a spawned CellAnim after construction.
+pub(crate) fn place_scenario_start_crates_with_lighting(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    overlay_registry: &OverlayTypeRegistry,
+    path_grid: Option<&PathGrid>,
+    player_count: i32,
+    lighting_profile: LightingProfileUnits,
+) -> CratePlacement {
     place_scenario_start_crates_with_failure(
         sim,
         rules,
         overlay_registry,
         path_grid,
         player_count,
+        lighting_profile,
         ForcedPostPrecheckFailure::None,
     )
 }
@@ -159,6 +183,7 @@ fn place_scenario_start_crates_with_failure(
     overlay_registry: &OverlayTypeRegistry,
     path_grid: Option<&PathGrid>,
     player_count: i32,
+    lighting_profile: LightingProfileUnits,
     forced_failure: ForcedPostPrecheckFailure,
 ) -> CratePlacement {
     if !sim.session.game_options.crates {
@@ -185,6 +210,7 @@ fn place_scenario_start_crates_with_failure(
             rules,
             overlay_registry,
             path_grid,
+            lighting_profile,
             forced_failure,
         ) {
             OneCrateResult::HardRejected => {}
@@ -239,6 +265,7 @@ fn place_one_random_crate(
     rules: &RuleSet,
     overlay_registry: &OverlayTypeRegistry,
     path_grid: Option<&PathGrid>,
+    lighting_profile: LightingProfileUnits,
     forced_failure: ForcedPostPrecheckFailure,
 ) -> OneCrateResult {
     let Some(slot_index) = sim.crate_authority.first_empty_index() else {
@@ -283,11 +310,12 @@ fn place_one_random_crate(
         {
             continue;
         }
-        let accepted = validate_and_stamp_candidate_with_rules(
+        let accepted = validate_and_stamp_candidate_with_rules_and_lighting(
             sim,
             rules,
             overlay_registry,
             cell,
+            lighting_profile,
             forced_failure,
         );
 
@@ -387,6 +415,7 @@ fn validate_and_stamp_candidate(
         None,
         overlay_registry,
         cell,
+        ParsedLightingProfiles::default().normal,
         forced_failure,
     )
 }
@@ -398,12 +427,31 @@ fn validate_and_stamp_candidate_with_rules(
     cell: (u16, u16),
     forced_failure: ForcedPostPrecheckFailure,
 ) -> AcceptedCellResult {
+    validate_and_stamp_candidate_with_rules_and_lighting(
+        sim,
+        rules,
+        overlay_registry,
+        cell,
+        ParsedLightingProfiles::default().normal,
+        forced_failure,
+    )
+}
+
+fn validate_and_stamp_candidate_with_rules_and_lighting(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    overlay_registry: &OverlayTypeRegistry,
+    cell: (u16, u16),
+    lighting_profile: LightingProfileUnits,
+    forced_failure: ForcedPostPrecheckFailure,
+) -> AcceptedCellResult {
     validate_and_stamp_candidate_inner(
         sim,
         &rules.crate_rules,
         Some(rules),
         overlay_registry,
         cell,
+        lighting_profile,
         forced_failure,
     )
 }
@@ -414,6 +462,7 @@ fn validate_and_stamp_candidate_inner(
     full_rules: Option<&RuleSet>,
     overlay_registry: &OverlayTypeRegistry,
     cell: (u16, u16),
+    lighting_profile: LightingProfileUnits,
     forced_failure: ForcedPostPrecheckFailure,
 ) -> AcceptedCellResult {
     let water_id = rules
@@ -443,6 +492,12 @@ fn validate_and_stamp_candidate_inner(
     let Some(selected_flags) = overlay_registry.flags(selected_id).cloned() else {
         return AcceptedCellResult::Ghost;
     };
+    // `OverlayClass::OverlayClass @ 0x005FC380` performs the TerrainClass scan
+    // before calling Unlimbo. A hit skips Unlimbo, so Mark never reaches its
+    // slope, bridge, CellAnim, or common RecalcAttributes paths.
+    if sim.production.terrain_object_cells.contains_key(&cell) {
+        return AcceptedCellResult::Ghost;
+    }
     let Some(slope_type) = sim
         .resolved_terrain
         .as_ref()
@@ -458,22 +513,15 @@ fn validate_and_stamp_candidate_inner(
         return AcceptedCellResult::Ghost;
     }
 
-    if let Some((family, direction)) = high_bridge_stamp_for_overlay(selected_id) {
-        let preserved_data = sim
-            .overlay_grid
-            .as_ref()
-            .map(|grid| grid.cell(cell.0, cell.1).overlay_data)
-            .unwrap_or(0);
-        sim.apply_runtime_bridge_mark_stamp(BridgeFlagStamp::new(cell, direction, true), family);
-        let wrote =
-            write_real_crate_mark_fields(sim, overlay_registry, cell, selected_id, preserved_data);
-        recalc_real_crate_mark_cell(sim, overlay_registry, cell);
-        return if wrote {
-            AcceptedCellResult::Visible
-        } else {
-            AcceptedCellResult::Ghost
-        };
-    }
+    // The four high-anchor identities call their bridge setter first, then
+    // continue through Mark's ordinary precedence. The setters write raw data
+    // on anchor/F1/F2/opposite even before any overlay identity exists.
+    let high_bridge_data = high_bridge_stamp_for_overlay(selected_id).map(|(family, direction)| {
+        let stamp = BridgeFlagStamp::new(cell, direction, true);
+        let data = if direction == 0 { 0 } else { 9 };
+        apply_high_bridge_crate_setter(sim, stamp, family, data);
+        data
+    });
 
     // GSI-18.01 is explicitly excluded by the Phase 14 contract: these two
     // hard-coded branches are the TS veins/veinhole carryover. Preserve crate
@@ -504,7 +552,6 @@ fn validate_and_stamp_candidate_inner(
             .and_then(|terrain| terrain.cell(cell.0, cell.1))
             .is_some_and(|terrain_cell| terrain_cell.speed_costs.track != Some(0));
         if !wall_passes {
-            recalc_real_crate_mark_cell(sim, overlay_registry, cell);
             return AcceptedCellResult::Ghost;
         }
         let wrote = write_real_crate_mark_fields(sim, overlay_registry, cell, selected_id, 0);
@@ -543,45 +590,68 @@ fn validate_and_stamp_candidate_inner(
         return AcceptedCellResult::Ghost;
     };
 
-    let Some(terrain_cell) = sim
-        .resolved_terrain
-        .as_ref()
-        .and_then(|terrain| terrain.cell(cell.0, cell.1))
-    else {
-        return AcceptedCellResult::Ghost;
-    };
-    if sim.production.terrain_object_cells.contains_key(&cell) {
-        if let Some(full_rules) = full_rules {
-            spawn_crate_cell_anim(sim, full_rules, cell, selected_flags.cell_anim.as_deref());
+    // `OverlayClass::Mark @ 0x005FCFE7..0x005FD003` forces passability true
+    // for the four high-anchor IDs after their setter. This is an explicit
+    // identity bypass, not an inferred consequence of selecting deck facts;
+    // even a nonzero deck occupation byte does not reject the ordinary tail.
+    if high_bridge_data.is_none() {
+        let Some((bridge_layer_selected, selected_speed_cost)) = sim
+            .resolved_terrain
+            .as_ref()
+            .and_then(|terrain| terrain.cell(cell.0, cell.1))
+            .map(|terrain_cell| {
+                (
+                    terrain_cell.bridge_facts.raw_flags & BRIDGE_FLAG_STRUCTURAL != 0,
+                    terrain_cell.speed_costs.cost_for_speed_type(mark_speed),
+                )
+            })
+        else {
+            return AcceptedCellResult::Ghost;
+        };
+        let selected_occupation = if bridge_layer_selected {
+            sim.substrate.raw_cell_occupation.deck_bits(cell.0, cell.1)
+        } else {
+            sim.substrate
+                .raw_cell_occupation
+                .ground_bits(cell.0, cell.1)
+        };
+        if selected_occupation != 0 {
+            if let Some(full_rules) = full_rules {
+                spawn_crate_cell_anim(
+                    sim,
+                    full_rules,
+                    overlay_registry,
+                    cell,
+                    selected_flags.cell_anim.as_deref(),
+                    lighting_profile,
+                );
+            }
+            recalc_real_crate_mark_cell(sim, overlay_registry, cell);
+            return AcceptedCellResult::Ghost;
         }
-        recalc_real_crate_mark_cell(sim, overlay_registry, cell);
-        return AcceptedCellResult::Ghost;
-    }
-    let bridge_layer_selected = terrain_cell.bridge_facts.raw_flags & BRIDGE_FLAG_STRUCTURAL != 0;
-    let selected_occupation = if bridge_layer_selected {
-        sim.substrate.raw_cell_occupation.deck_bits(cell.0, cell.1)
-    } else {
-        sim.substrate
-            .raw_cell_occupation
-            .ground_bits(cell.0, cell.1)
-    };
-    if selected_occupation != 0 {
-        if let Some(full_rules) = full_rules {
-            spawn_crate_cell_anim(sim, full_rules, cell, selected_flags.cell_anim.as_deref());
+        if !bridge_layer_selected && selected_speed_cost == Some(0) {
+            if let Some(full_rules) = full_rules {
+                spawn_crate_cell_anim(
+                    sim,
+                    full_rules,
+                    overlay_registry,
+                    cell,
+                    selected_flags.cell_anim.as_deref(),
+                    lighting_profile,
+                );
+            }
+            recalc_real_crate_mark_cell(sim, overlay_registry, cell);
+            return AcceptedCellResult::Ghost;
         }
-        recalc_real_crate_mark_cell(sim, overlay_registry, cell);
-        return AcceptedCellResult::Ghost;
-    }
-    if !bridge_layer_selected && terrain_cell.speed_costs.cost_for_speed_type(mark_speed) == Some(0)
-    {
-        if let Some(full_rules) = full_rules {
-            spawn_crate_cell_anim(sim, full_rules, cell, selected_flags.cell_anim.as_deref());
-        }
-        recalc_real_crate_mark_cell(sim, overlay_registry, cell);
-        return AcceptedCellResult::Ghost;
     }
 
-    let wrote = write_real_crate_mark_fields(sim, overlay_registry, cell, selected_id, 0);
+    let wrote = write_real_crate_mark_fields(
+        sim,
+        overlay_registry,
+        cell,
+        selected_id,
+        high_bridge_data.unwrap_or(0),
+    );
     if wrote && selected_flags.land == LandType::Road {
         set_crate_mark_data(sim, cell, 1);
         if let Some(full_rules) = full_rules {
@@ -597,7 +667,14 @@ fn validate_and_stamp_candidate_inner(
         set_crate_mark_data(sim, cell, u8::MAX);
     }
     if let Some(full_rules) = full_rules {
-        spawn_crate_cell_anim(sim, full_rules, cell, selected_flags.cell_anim.as_deref());
+        spawn_crate_cell_anim(
+            sim,
+            full_rules,
+            overlay_registry,
+            cell,
+            selected_flags.cell_anim.as_deref(),
+            lighting_profile,
+        );
     }
     recalc_real_crate_mark_cell(sim, overlay_registry, cell);
     if wrote
@@ -717,6 +794,53 @@ fn write_crate_mark_fields(
     }
 }
 
+fn write_crate_mark_raw_data(sim: &mut Simulation, cell: (i16, i16), overlay_data: u8) {
+    match resolve_crate_mark_cell(sim, cell) {
+        CrateMarkCellRef::Real(rx, ry) => {
+            let (Some(grid), Some(terrain)) =
+                (sim.overlay_grid.as_mut(), sim.resolved_terrain.as_mut())
+            else {
+                return;
+            };
+            let _ = grid.write_crate_mark_data_field(terrain, rx, ry, overlay_data);
+        }
+        CrateMarkCellRef::Dummy(dummy) => {
+            let (overlay_id, _) = dummy.overlay_fields();
+            dummy.set_overlay_fields(overlay_id, overlay_data);
+        }
+    }
+}
+
+fn apply_high_bridge_crate_setter(
+    sim: &mut Simulation,
+    stamp: BridgeFlagStamp,
+    family: BridgeStampFamily,
+    overlay_data: u8,
+) {
+    let Some(slots) = stamp.slots() else {
+        return;
+    };
+    // `SetBridgeDirection_NESW/NWSE @ 0x0047E040/0x0047E470` write the
+    // data byte on exactly these four visits. Perform those writes before the
+    // flag transaction so the shared dummy ends on the setter's final visit.
+    for (slot, coord) in slots {
+        if !matches!(
+            slot,
+            BridgeStampSlot::Anchor
+                | BridgeStampSlot::Forward1
+                | BridgeStampSlot::Forward2
+                | BridgeStampSlot::Opposite
+        ) {
+            continue;
+        }
+        let Some((x, y)) = coord else {
+            continue;
+        };
+        write_crate_mark_raw_data(sim, (x as i16, y as i16), overlay_data);
+    }
+    sim.apply_runtime_bridge_mark_stamp(stamp, family);
+}
+
 fn write_real_crate_mark_fields(
     sim: &mut Simulation,
     registry: &OverlayTypeRegistry,
@@ -747,11 +871,19 @@ fn recalc_real_crate_mark_cell(
 }
 
 fn set_crate_mark_data(sim: &mut Simulation, cell: (u16, u16), data: u8) {
-    if let Some(grid) = sim.overlay_grid.as_mut() {
+    let wrote = if let Some(grid) = sim.overlay_grid.as_mut() {
         let target = grid.cell_mut(cell.0, cell.1);
         if target.overlay_id.is_some() {
             target.overlay_data = data;
+            true
+        } else {
+            false
         }
+    } else {
+        false
+    };
+    if wrote && let Some(terrain) = sim.resolved_terrain.as_mut() {
+        let _ = terrain.set_runtime_overlay_bridge_state_byte(cell.0, cell.1, data);
     }
 }
 
@@ -901,15 +1033,17 @@ fn spread_cell_germinate_without_randomization(
 fn spawn_crate_cell_anim(
     sim: &mut Simulation,
     rules: &RuleSet,
+    overlay_registry: &OverlayTypeRegistry,
     cell: (u16, u16),
     cell_anim: Option<&str>,
+    lighting_profile: LightingProfileUnits,
 ) {
     let Some(cell_anim) = cell_anim else {
         return;
     };
     let center_x = i32::from(cell.0).wrapping_mul(256).wrapping_add(128);
     let center_y = i32::from(cell.1).wrapping_mul(256).wrapping_add(128);
-    let ground_z = sim
+    let (ground_z, level) = sim
         .resolved_terrain
         .as_ref()
         .and_then(|terrain| terrain.cell(cell.0, cell.1))
@@ -921,7 +1055,30 @@ fn spawn_crate_cell_anim(
                 center_y,
             )
             .ok()
+            .map(|ground_z| (ground_z, terrain_cell.level))
         })
+        .unwrap_or((0, 0));
+    // `OverlayClass::Mark @ 0x005FD1B9..0x005FD1F4` calls
+    // `CellClass::GetTiberiumType` with ECX = the target CellClass. Only a
+    // successfully installed tiberium identity enters the palette/+0xFC
+    // post-write block; a failed or non-tiberium Mark leaves constructor zero.
+    let tiberium_type = sim
+        .overlay_grid
+        .as_ref()
+        .and_then(|grid| grid.cell(cell.0, cell.1).overlay_id)
+        .and_then(|overlay_id| {
+            overlay_registry.tiberium_type_for_overlay(&rules.tiberium_types, overlay_id)
+        })
+        .and_then(|type_id| rules.tiberium_types.get(type_id));
+    let remap_color = tiberium_type
+        .and_then(|tiberium| tiberium.color.as_deref())
+        .and_then(|color| {
+            crate::rules::color_scheme::scheme_entry_by_name(&rules.color_schemes, color)
+        })
+        .and_then(|entry| u8::try_from(entry).ok())
+        .map(crate::rules::house_colors::HouseColorIndex);
+    let z_adjust = tiberium_type
+        .map(|_| crate::map::lighting::cell_ground_z_adjust(lighting_profile, level))
         .unwrap_or(0);
     let type_name = sim.interner.intern(cell_anim);
     let mut descriptor = crate::sim::components::AnimClassSpawnDescriptor::new(
@@ -937,14 +1094,24 @@ fn spawn_crate_cell_anim(
     descriptor.draw_flags = 0x600;
     descriptor.z_adjust = 0;
     descriptor.reverse = false;
-    let _ = sim.spawn_anim_at_world(
-        rules,
-        descriptor,
-        crate::sim::anim_class::AnimWorldCoord {
-            x: center_x.wrapping_add(0x180),
-            y: center_y.wrapping_add(0x180),
-            z: ground_z,
-        },
+    let anim_id = sim
+        .spawn_anim_at_world(
+            rules,
+            descriptor,
+            crate::sim::anim_class::AnimWorldCoord {
+                x: center_x.wrapping_add(0x180),
+                y: center_y.wrapping_add(0x180),
+                z: ground_z,
+            },
+        )
+        .unwrap_or_else(|error| {
+            panic!(
+                "startup crate CellAnim [{cell_anim}] must be bound before OverlayClass::Mark: {error}"
+            )
+        });
+    assert!(
+        sim.set_cell_anim_draw_authority(anim_id, remap_color, z_adjust),
+        "startup crate CellAnim {anim_id} disappeared before OverlayClass post-constructor writes"
     );
 }
 
@@ -1634,6 +1801,7 @@ mod tests {
                 &registry,
                 Some(&grid),
                 1,
+                ParsedLightingProfiles::default().normal,
                 failure,
             );
             assert_eq!((result.accepted, result.visible), (1, 0));
@@ -1918,10 +2086,12 @@ mod tests {
         };
         let mut sim = sim_with_grid(0x14_09_0001);
         let cell = (12, 13);
-        sim.production.terrain_object_cells.insert(cell, 77);
         sim.substrate
             .raw_cell_occupation
             .mark_ground(cell.0, cell.1, 0xFF);
+        sim.substrate
+            .raw_cell_occupation
+            .mark_deck(cell.0, cell.1, 0xFF);
         sim.resolved_terrain
             .as_mut()
             .unwrap()
@@ -1956,7 +2126,6 @@ mod tests {
         };
         let cell = (12, 13);
         let mut visible = sim_with_grid(0x14_09_0002);
-        visible.production.terrain_object_cells.insert(cell, 88);
         visible
             .substrate
             .raw_cell_occupation
@@ -2056,8 +2225,10 @@ mod tests {
     fn ordinary_cell_anim_spawns_after_visible_or_failed_ordinary_mark() {
         let ini = IniFile::from_str(
             "[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
+             [Colors]\nGold=43,239,255\nNeonGreen=104,241,195\n\
+             [Tiberiums]\n0=Riparius\n[Riparius]\nImage=1\nColor=NeonGreen\n\
              [Animations]\n0=SPARK\n\
-             [OverlayTypes]\n0=ANIMBOX\n[ANIMBOX]\nCellAnim=SPARK\n\
+             [OverlayTypes]\n0=ANIMBOX\n[ANIMBOX]\nTiberium=yes\nCellAnim=SPARK\n\
              [CrateRules]\nCrateImg=ANIMBOX\nWoodCrateImg=ANIMBOX\nWaterCrateImg=ANIMBOX\n",
         );
         let registry = OverlayTypeRegistry::from_ini(&ini, None);
@@ -2070,12 +2241,21 @@ mod tests {
         let cell = (12, 13);
 
         let mut visible = sim_with_grid(0x14_09_0005);
+        let lighting = LightingProfileUnits {
+            ambient_percent: 80,
+            red_percent: 100,
+            green_percent: 100,
+            blue_percent: 100,
+            ground_units: 25,
+            level_units: 5,
+        };
         assert_eq!(
-            validate_and_stamp_candidate_with_rules(
+            validate_and_stamp_candidate_with_rules_and_lighting(
                 &mut visible,
                 &rules,
                 &registry,
                 cell,
+                lighting,
                 ForcedPostPrecheckFailure::None,
             ),
             AcceptedCellResult::Visible
@@ -2090,9 +2270,27 @@ mod tests {
             }
         );
         assert_eq!(visible_anim.draw_flags, 0x600);
+        assert_eq!(
+            visible_anim.remap_color,
+            Some(crate::rules::house_colors::HouseColorIndex(1)),
+            "the constructed CellAnim uses the live tiberium Color scheme"
+        );
+        assert_eq!(
+            visible_anim.z_adjust, 775,
+            "CellClass +0x10A is ambient*10 + level*height - ground"
+        );
+        let encoded = bincode::serialize(&visible).expect("serialize CellAnim remap state");
+        let restored: Simulation =
+            bincode::deserialize(&encoded).expect("restore CellAnim remap state");
+        let restored_anim = restored.substrate.anims.iter().next().unwrap().1;
+        assert_eq!(restored_anim.remap_color, visible_anim.remap_color);
+        assert_eq!(restored_anim.z_adjust, visible_anim.z_adjust);
 
         let mut ghost = sim_with_grid(0x14_09_0006);
-        ghost.production.terrain_object_cells.insert(cell, 99);
+        ghost
+            .substrate
+            .raw_cell_occupation
+            .mark_ground(cell.0, cell.1, 1);
         assert_eq!(
             validate_and_stamp_candidate_with_rules(
                 &mut ghost,
@@ -2103,9 +2301,40 @@ mod tests {
             ),
             AcceptedCellResult::Ghost
         );
-        assert_eq!(ghost.substrate.anims.iter().count(), 1);
+        let ghost_anim = ghost.substrate.anims.iter().next().unwrap().1;
+        assert_eq!(ghost_anim.remap_color, None);
+        assert_eq!(
+            ghost_anim.z_adjust, 0,
+            "failed Mark leaves the Cell without tiberium, so native skips both post-writes"
+        );
         assert_eq!(
             ghost
+                .overlay_grid
+                .as_ref()
+                .unwrap()
+                .cell(cell.0, cell.1)
+                .overlay_id,
+            None
+        );
+
+        let mut terrain_object = sim_with_grid(0x14_09_0007);
+        terrain_object
+            .production
+            .terrain_object_cells
+            .insert(cell, 99);
+        assert_eq!(
+            validate_and_stamp_candidate_with_rules(
+                &mut terrain_object,
+                &rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Ghost
+        );
+        assert_eq!(terrain_object.substrate.anims.iter().count(), 0);
+        assert_eq!(
+            terrain_object
                 .overlay_grid
                 .as_ref()
                 .unwrap()
@@ -2116,7 +2345,7 @@ mod tests {
     }
 
     #[test]
-    fn high_bridge_crate_mark_stamps_family_and_preserves_existing_data() {
+    fn high_bridge_crate_mark_writes_setter_data_then_falls_through_crate_override() {
         let registry = dense_registry(0x18, &[(0x18, "HIGHCRATE", "Crate=yes\n")]);
         let rules = CrateRules {
             wood_crate_img: Some("HIGHCRATE".to_owned()),
@@ -2125,16 +2354,17 @@ mod tests {
             ..CrateRules::default()
         };
         let cell = (12, 13);
-        let mut sim = sim_with_grid(0x14_09_0007);
-        sim.overlay_grid
-            .as_mut()
-            .unwrap()
-            .cell_mut(cell.0, cell.1)
-            .overlay_data = 7;
-        sim.production.terrain_object_cells.insert(cell, 100);
+        let mut sim = sim_with_grid(0x14_09_0008);
+        for target in [(12, 13), (12, 12), (12, 11), (12, 10), (12, 14)] {
+            write_crate_mark_raw_data(&mut sim, (target.0 as i16, target.1 as i16), 7);
+        }
+        let _ = sim.overlay_grid.as_mut().unwrap().take_dirty_cells();
         sim.substrate
             .raw_cell_occupation
             .mark_ground(cell.0, cell.1, 0xFF);
+        sim.substrate
+            .raw_cell_occupation
+            .mark_deck(cell.0, cell.1, 0xFF);
         sim.resolved_terrain
             .as_mut()
             .unwrap()
@@ -2153,17 +2383,130 @@ mod tests {
             ),
             AcceptedCellResult::Visible
         );
-        let written = sim.overlay_grid.as_ref().unwrap().cell(cell.0, cell.1);
-        assert_eq!((written.overlay_id, written.overlay_data), (Some(0x18), 7));
-        let facts = sim
-            .resolved_terrain
-            .as_ref()
+        let grid = sim.overlay_grid.as_ref().unwrap();
+        assert_eq!(
+            (grid.cell(12, 13).overlay_id, grid.cell(12, 13).overlay_data),
+            (Some(0x18), u8::MAX),
+            "Crate=yes runs after the direction-0 setter writes zero"
+        );
+        for target in [(12, 12), (12, 11), (12, 14)] {
+            assert_eq!(grid.cell(target.0, target.1).overlay_data, 0, "{target:?}");
+        }
+        assert_eq!(grid.cell(12, 10).overlay_data, 7, "F3 gets flags, not data");
+
+        let terrain = sim.resolved_terrain.as_ref().unwrap();
+        let anchor = terrain.cell(12, 13).unwrap().bridge_facts;
+        assert!(anchor.is_anchor_self());
+        assert!(anchor.has_structural_bridge());
+        assert_eq!(anchor.state_byte, u8::MAX);
+        for target in [(12, 12), (12, 11), (12, 14)] {
+            assert_eq!(
+                terrain
+                    .cell(target.0, target.1)
+                    .unwrap()
+                    .bridge_facts
+                    .state_byte,
+                0,
+                "derived state follows raw setter data at {target:?}"
+            );
+        }
+        assert_eq!(terrain.cell(12, 10).unwrap().bridge_facts.state_byte, 7);
+
+        let mut terrain_blocked = sim_with_grid(0x14_09_0009);
+        write_crate_mark_raw_data(&mut terrain_blocked, (12, 13), 7);
+        let _ = terrain_blocked
+            .overlay_grid
+            .as_mut()
             .unwrap()
-            .cell(cell.0, cell.1)
-            .unwrap()
-            .bridge_facts;
-        assert!(facts.is_anchor_self());
-        assert!(facts.has_structural_bridge());
+            .take_dirty_cells();
+        terrain_blocked
+            .production
+            .terrain_object_cells
+            .insert(cell, 100);
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut terrain_blocked,
+                &rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Ghost
+        );
+        assert_eq!(
+            terrain_blocked
+                .overlay_grid
+                .as_ref()
+                .unwrap()
+                .cell(cell.0, cell.1)
+                .overlay_data,
+            7,
+            "TerrainClass constructor gate runs before the high setter"
+        );
+        assert_eq!(
+            terrain_blocked
+                .resolved_terrain
+                .as_ref()
+                .unwrap()
+                .cell(cell.0, cell.1)
+                .unwrap()
+                .bridge_facts
+                .raw_flags
+                & BRIDGE_FLAG_STRUCTURAL,
+            0
+        );
+        assert!(
+            terrain_blocked
+                .overlay_grid
+                .as_ref()
+                .unwrap()
+                .pending_dirty_cells()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn direction_six_high_bridge_setter_data_precedes_road_override() {
+        let registry = dense_registry(0x19, &[(0x19, "HIGHROAD", "Land=Road\n")]);
+        let rules = CrateRules {
+            wood_crate_img: Some("HIGHROAD".to_owned()),
+            crate_img: Some("HIGHROAD".to_owned()),
+            water_crate_img: Some("HIGHROAD".to_owned()),
+            ..CrateRules::default()
+        };
+        let cell = (12, 13);
+        let mut sim = sim_with_grid(0x14_09_000A);
+
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut sim,
+                &rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Visible
+        );
+        let grid = sim.overlay_grid.as_ref().unwrap();
+        assert_eq!(
+            (grid.cell(12, 13).overlay_id, grid.cell(12, 13).overlay_data),
+            (Some(0x19), 1),
+            "Road runs after the direction-6 setter writes nine"
+        );
+        for target in [(11, 13), (10, 13), (13, 13)] {
+            assert_eq!(grid.cell(target.0, target.1).overlay_data, 9, "{target:?}");
+            assert_eq!(
+                sim.resolved_terrain
+                    .as_ref()
+                    .unwrap()
+                    .cell(target.0, target.1)
+                    .unwrap()
+                    .bridge_facts
+                    .state_byte,
+                9,
+                "derived state follows raw setter data at {target:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/sim/crates.rs
+++ b/src/sim/crates.rs
@@ -23,8 +23,9 @@
 //! modules only. Never on render/, ui/, sidebar/, audio/, net/.
 
 use crate::map::overlay_types::OverlayTypeRegistry;
+use crate::rules::crate_rules::CrateRules;
 use crate::rules::locomotor_type::{MovementZone, SpeedType};
-use crate::rules::ruleset::{CrateRules, RuleSet};
+use crate::rules::ruleset::RuleSet;
 use crate::rules::terrain_rules::LandType;
 use crate::sim::cell_rect::cell_is_in_playfield_height_aware;
 use crate::sim::find_nearby_cell::{
@@ -67,7 +68,9 @@ pub struct CratePlacement {
 /// below `CrateMinimum` wins — the clamp is not symmetric and must not be
 /// rewritten as a single `clamp()` call with the arguments in rules order.
 pub fn scenario_start_crate_count(rules: &CrateRules, player_count: u32) -> u32 {
-    rules.maximum.min(rules.minimum.max(player_count))
+    let minimum = rules.minimum.max(0) as u32;
+    let maximum = rules.maximum.max(0) as u32;
+    maximum.min(minimum.max(player_count))
 }
 
 /// The human seat count the crate clamp is applied to.
@@ -118,12 +121,24 @@ pub fn place_scenario_start_crates(
             placed: 0,
         };
     }
-    let land_overlay_id = overlay_registry.id_for_name(&rules.crate_rules.wood_crate_img);
-    let water_overlay_id = overlay_registry.id_for_name(&rules.crate_rules.water_crate_img);
+    let land_overlay_id = rules
+        .crate_rules
+        .wood_crate_img
+        .as_deref()
+        .and_then(|name| overlay_registry.id_for_name(name));
+    let water_overlay_id = rules
+        .crate_rules
+        .water_crate_img
+        .as_deref()
+        .and_then(|name| overlay_registry.id_for_name(name));
     if land_overlay_id.is_none() {
         log::warn!(
             "No overlay type named '{}' ([CrateRules] WoodCrateImg)",
-            rules.crate_rules.wood_crate_img
+            rules
+                .crate_rules
+                .wood_crate_img
+                .as_deref()
+                .unwrap_or("none")
         );
     }
     if sim.overlay_grid.is_none() {
@@ -403,9 +418,9 @@ mod tests {
         let rules = crate_ruleset("CrateMinimum=2\nCrateMaximum=9\n");
         assert_eq!(rules.crate_rules.minimum, 2);
         assert_eq!(rules.crate_rules.maximum, 9);
-        assert_eq!(rules.crate_rules.crate_img, "SILVER");
-        assert_eq!(rules.crate_rules.wood_crate_img, "WOOD");
-        assert_eq!(rules.crate_rules.water_crate_img, "WATER");
+        assert_eq!(rules.crate_rules.crate_img.as_deref(), Some("SILVER"));
+        assert_eq!(rules.crate_rules.wood_crate_img.as_deref(), Some("WOOD"));
+        assert_eq!(rules.crate_rules.water_crate_img.as_deref(), Some("WATER"));
 
         let defaults = crate_ruleset("");
         assert_eq!(defaults.crate_rules.minimum, 1);

--- a/src/sim/crates.rs
+++ b/src/sim/crates.rs
@@ -22,6 +22,10 @@
 //! Part of `sim/` — depends on `rules/`, `map/` grid types and other `sim/`
 //! modules only. Never on render/, ui/, sidebar/, audio/, net/.
 
+mod state;
+
+pub use state::{CrateAuthority, CrateSlot};
+
 use crate::map::overlay_types::OverlayTypeRegistry;
 use crate::rules::crate_rules::CrateRules;
 use crate::rules::locomotor_type::{MovementZone, SpeedType};

--- a/src/sim/crates.rs
+++ b/src/sim/crates.rs
@@ -1,4 +1,4 @@
-//! Scenario-start crate placement — gamemd `ScenarioClass::Post_Map_Init` step 3.
+//! Scenario-start crate placement — gamemd `ScenarioClass::Post_Map_Init`.
 //!
 //! When the lobby "Crates" option is on (stock default), the scenario clamps the
 //! player count between `[CrateRules] CrateMinimum` and `CrateMaximum` and calls
@@ -6,17 +6,16 @@
 //! first looks for a free entry in the map's 256-entry crate-slot array and
 //! returns immediately — spending no draws — if there is none. Otherwise it walks
 //! a bounded retry loop; every attempt draws a random X then a random Y inside
-//! the map's `Size.Width + Size.Height` cell-coordinate extent, snaps the result
-//! to a nearby passable cell, and
-//! places the crate overlay there.
+//! the active Map rectangle, snaps the result to a nearby passable cell, and
+//! submits the destination to the crate-specific native Mark transaction.
 //!
 //! The drawn cell decides the snap movement: water uses *float*, anything else
 //! uses *track*. After snapping, the destination cell independently chooses
 //! `WaterCrateImg` or `WoodCrateImg` from its own land type.
 //!
-//! This module owns *placement only*. Crate contents, pickup effects and
-//! `CrateRegen` respawn belong to the crate-effect system and are not modelled
-//! here — a placed crate is an ordinary overlay cell until that lands.
+//! This module owns startup placement and its persistent slot/timer result.
+//! Crate contents, pickup effects, removal, and `CrateRegen` scanning remain
+//! later crate-system mechanisms.
 //!
 //! ## Dependency rules
 //! Part of `sim/` — depends on `rules/`, `map/` grid types and other `sim/`
@@ -26,6 +25,7 @@ mod state;
 
 pub use state::{CrateAuthority, CrateSlot};
 
+use crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL;
 use crate::map::overlay_types::OverlayTypeRegistry;
 use crate::rules::crate_rules::CrateRules;
 use crate::rules::locomotor_type::{MovementZone, SpeedType};
@@ -38,16 +38,6 @@ use crate::sim::find_nearby_cell::{
 use crate::sim::pathfinding::PathGrid;
 use crate::sim::world::Simulation;
 
-/// Entries in the map's crate-slot array. The placer scans it for a free slot
-/// before drawing anything, and gives up without a single draw when all 256 are
-/// taken.
-///
-/// The array is a MapClass member, *not* derived from overlay contents. Whether
-/// a crate the map preplaced in its overlay pack registers a slot is
-/// **UNCHECKED**, so this pass counts only the crates it places itself — at
-/// scenario start the array is empty, which is the only case this pass runs in.
-const CRATE_SLOT_CAPACITY: usize = 256;
-
 /// Retry budget inside one placer call. Every attempt spends its two draws
 /// whether or not the cell works out; after this many failures the call gives up
 /// and no crate is placed.
@@ -59,11 +49,12 @@ const CRATE_SNAP_RADIUS_CAP: u16 = 32;
 /// Outcome of one scenario-start crate pass.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CratePlacement {
-    /// Crates the clamp asked for (0 when the lobby option is off).
-    pub requested: u32,
-    /// Crates actually placed; lower than `requested` only when the placer ran
-    /// out of retries or crate slots.
-    pub placed: u32,
+    /// Signed attempts selected by native minimum/human/maximum comparisons.
+    pub requested: i32,
+    /// Accepted calls, including timed ghosts whose overlay Mark failed.
+    pub accepted: u32,
+    /// Accepted calls that installed a visible overlay.
+    pub visible: u32,
 }
 
 /// `min(max(CrateMinimum, player_count), CrateMaximum)`.
@@ -71,10 +62,8 @@ pub struct CratePlacement {
 /// gamemd applies the floor first and the ceiling second, so a `CrateMaximum`
 /// below `CrateMinimum` wins — the clamp is not symmetric and must not be
 /// rewritten as a single `clamp()` call with the arguments in rules order.
-pub fn scenario_start_crate_count(rules: &CrateRules, player_count: u32) -> u32 {
-    let minimum = rules.minimum.max(0) as u32;
-    let maximum = rules.maximum.max(0) as u32;
-    maximum.min(minimum.max(player_count))
+pub fn scenario_start_crate_count(rules: &CrateRules, player_count: i32) -> i32 {
+    rules.maximum.min(rules.minimum.max(player_count))
 }
 
 /// The human seat count the crate clamp is applied to.
@@ -84,11 +73,50 @@ pub fn scenario_start_crate_count(rules: &CrateRules, player_count: u32) -> u32 
 /// budget gate adds the AI count to that same value — so it is human seats only.
 /// In a 1v3 skirmish this is 1, not 4. Passive houses (Neutral, Special) are
 /// never seats.
-pub fn human_player_count(sim: &Simulation) -> u32 {
-    sim.houses
-        .values()
-        .filter(|house| house.is_human && !house.multiplay_passive)
-        .count() as u32
+pub fn human_player_count(sim: &Simulation) -> i32 {
+    i32::try_from(
+        sim.houses
+            .values()
+            .filter(|house| house.is_human && !house.multiplay_passive)
+            .count(),
+    )
+    .unwrap_or(i32::MAX)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OneCrateResult {
+    HardRejected,
+    AcceptedGhost,
+    AcceptedVisible,
+}
+
+/// Native allocation, Unlimbo, and Mark failures all collapse to the same
+/// gameplay result after the two hard prechecks: an accepted timed ghost.
+/// Production invariants select `None`; focused tests inject the other cases
+/// without importing gamemd's object allocator into simulation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg_attr(not(test), allow(dead_code))]
+enum ForcedPostPrecheckFailure {
+    #[default]
+    None,
+    Allocation,
+    Unlimbo,
+    Mark,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AcceptedCellResult {
+    Ghost,
+    Visible,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CrateRandomFrame {
+    left: i32,
+    top: i32,
+    width: i32,
+    height: i32,
+    radius_cap: u16,
 }
 
 /// Place the scenario-start crates.
@@ -110,86 +138,68 @@ pub fn place_scenario_start_crates(
     rules: &RuleSet,
     overlay_registry: &OverlayTypeRegistry,
     path_grid: Option<&PathGrid>,
-    player_count: u32,
+    player_count: i32,
+) -> CratePlacement {
+    place_scenario_start_crates_with_failure(
+        sim,
+        rules,
+        overlay_registry,
+        path_grid,
+        player_count,
+        ForcedPostPrecheckFailure::None,
+    )
+}
+
+fn place_scenario_start_crates_with_failure(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    overlay_registry: &OverlayTypeRegistry,
+    path_grid: Option<&PathGrid>,
+    player_count: i32,
+    forced_failure: ForcedPostPrecheckFailure,
 ) -> CratePlacement {
     if !sim.session.game_options.crates {
         return CratePlacement {
             requested: 0,
-            placed: 0,
+            accepted: 0,
+            visible: 0,
         };
     }
     let requested = scenario_start_crate_count(&rules.crate_rules, player_count);
-    if requested == 0 {
+    if requested <= 0 {
         return CratePlacement {
             requested,
-            placed: 0,
-        };
-    }
-    let land_overlay_id = rules
-        .crate_rules
-        .wood_crate_img
-        .as_deref()
-        .and_then(|name| overlay_registry.id_for_name(name));
-    let water_overlay_id = rules
-        .crate_rules
-        .water_crate_img
-        .as_deref()
-        .and_then(|name| overlay_registry.id_for_name(name));
-    if land_overlay_id.is_none() {
-        log::warn!(
-            "No overlay type named '{}' ([CrateRules] WoodCrateImg)",
-            rules
-                .crate_rules
-                .wood_crate_img
-                .as_deref()
-                .unwrap_or("none")
-        );
-    }
-    if sim.overlay_grid.is_none() {
-        log::warn!("No overlay grid — placing no scenario-start crates");
-        return CratePlacement {
-            requested,
-            placed: 0,
+            accepted: 0,
+            visible: 0,
         };
     }
 
-    // This pass owns the fresh Post_Map_Init slot table. Runtime timer fields
-    // are deferred, but the native 256-entry free-slot scan and its no-draw
-    // full case are load-bearing here.
-    let mut crate_slots = [false; CRATE_SLOT_CAPACITY];
-    let mut placed = 0u32;
+    let mut accepted = 0u32;
+    let mut visible = 0u32;
     for _ in 0..requested {
-        let Some(crate_slot) = crate_slots.iter().position(|occupied| !*occupied) else {
-            // No free crate slot: the native placer returns before drawing.
-            continue;
-        };
-        let Some(cell) = draw_one_crate_cell(sim, path_grid) else {
-            continue;
-        };
-        // PlaceCrate chooses Float/Track from the drawn cell, but CrateSlot
-        // independently chooses Water/Wood from the snapped destination.
-        let destination_surface = crate_surface_at(sim, cell);
-        let overlay_id = match destination_surface {
-            CrateSurface::Water => water_overlay_id,
-            CrateSurface::Land => land_overlay_id,
-        };
-        let (Some(overlay_id), Some(grid)) = (overlay_id, sim.overlay_grid.as_mut()) else {
-            continue;
-        };
-        // CrateSlot stamps the already-validated destination directly. It does
-        // not run ordinary OverlayClass::Mark's terrain-object, occupation,
-        // slope or Track-passability gates; in particular stock water has
-        // Track=0% and must still accept a Float-snapped water crate.
-        grid.place_overlay(cell.0, cell.1, overlay_id, u8::MAX);
-        placed += 1;
-        crate_slots[crate_slot] = true;
-        // `CrateSlot` consumes the timer seed only after the overlay succeeds.
-        // Timer storage/formula belongs to the runtime crate-system slice; the
-        // scenario-stream draw does not.
-        let _ = sim.scenario_rng.next_range_u32_inclusive(0, 0x7fff_fffe);
+        match place_one_random_crate(
+            sim,
+            &rules.crate_rules,
+            overlay_registry,
+            path_grid,
+            forced_failure,
+        ) {
+            OneCrateResult::HardRejected => {}
+            OneCrateResult::AcceptedGhost => accepted = accepted.wrapping_add(1),
+            OneCrateResult::AcceptedVisible => {
+                accepted = accepted.wrapping_add(1);
+                visible = visible.wrapping_add(1);
+            }
+        }
     }
-    log::info!("Scenario-start crates: requested {requested}, placed {placed}");
-    CratePlacement { requested, placed }
+    log::info!(
+        "Scenario-start crates: requested {requested}, accepted {accepted}, visible {visible}"
+    );
+    CratePlacement {
+        requested,
+        accepted,
+        visible,
+    }
 }
 
 /// Native water-vs-land classification, evaluated independently at the drawn
@@ -200,32 +210,46 @@ enum CrateSurface {
     Water,
 }
 
-/// One placer call: up to [`MAX_PLACEMENT_ATTEMPTS`] attempts, each spending
-/// exactly two draws (X then Y) on the scenario stream before the cell is judged.
-fn draw_one_crate_cell(sim: &mut Simulation, path_grid: Option<&PathGrid>) -> Option<(u16, u16)> {
-    // Production's canonical cell-array extent is Size.Width + Size.Height.
-    // Both ranged calls use the same inclusive 1..extent-1 bounds; LocalSize
-    // does not participate.
-    let extent = sim.session.map_width;
-    if extent <= 1 {
-        return None;
-    }
-
+/// One `MapClass__PlaceCrateAtRandomCell @ 0x0056BD40` call.
+fn place_one_random_crate(
+    sim: &mut Simulation,
+    rules: &CrateRules,
+    overlay_registry: &OverlayTypeRegistry,
+    path_grid: Option<&PathGrid>,
+    forced_failure: ForcedPostPrecheckFailure,
+) -> OneCrateResult {
+    let Some(slot_index) = sim.crate_authority.first_empty_index() else {
+        // The native full-table return precedes every random draw.
+        return OneCrateResult::HardRejected;
+    };
+    let Some(frame) = crate_random_frame(sim) else {
+        return OneCrateResult::HardRejected;
+    };
     for _ in 0..MAX_PLACEMENT_ATTEMPTS {
-        // Draw order is load-bearing: X first, then Y.
-        let x = sim
+        let x_offset = sim
             .scenario_rng
-            .next_range_u32_inclusive(1, u32::from(extent - 1)) as u16;
-        let y = sim
+            .next_range_u32_inclusive(0, (frame.width - 1) as u32);
+        let y_offset = sim
             .scenario_rng
-            .next_range_u32_inclusive(1, u32::from(extent - 1)) as u16;
+            .next_range_u32_inclusive(0, (frame.height - 1) as u32);
+        let drawn_x = frame.left.wrapping_add(x_offset as i32);
+        let drawn_y = frame.top.wrapping_add(y_offset as i32);
+        let (Ok(x), Ok(y)) = (u16::try_from(drawn_x), u16::try_from(drawn_y)) else {
+            continue;
+        };
 
         // The drawn cell's own land type selects the snap, before any snapping
         // happens. A draw outside the grid takes the land branch, matching the
         // native fallback cell.
         let movement_surface = crate_surface_at(sim, (x, y));
 
-        let Some(cell) = snap_to_passable(sim, path_grid, (x, y), movement_surface) else {
+        let Some(cell) = snap_to_passable_with_radius(
+            sim,
+            path_grid,
+            (x, y),
+            movement_surface,
+            frame.radius_cap,
+        ) else {
             continue;
         };
         if cell == (0, 0)
@@ -246,9 +270,137 @@ fn draw_one_crate_cell(sim: &mut Simulation, path_grid: Option<&PathGrid>) -> Op
         {
             continue;
         }
-        return Some(cell);
+        let accepted =
+            validate_and_stamp_candidate(sim, rules, overlay_registry, cell, forced_failure);
+
+        // `CrateSlot__PlaceOverlayAndInitTimer @ 0x004A17C0`: accepted ghosts
+        // and visible overlays both write the packed coordinate before drawing
+        // and installing start/aux/duration timer words.
+        {
+            let slot = sim.crate_authority.slot_mut(slot_index);
+            slot.cell_x = cell.0 as i16;
+            slot.cell_y = cell.1 as i16;
+        }
+        let timer_draw = sim.scenario_rng.next_range_u32_inclusive(0, 0x7fff_fffe);
+        let (start_frame, aux, duration) =
+            state::crate_timer_words(rules.regen, timer_draw, sim.session.binary_frame as i32);
+        let slot = sim.crate_authority.slot_mut(slot_index);
+        slot.start_frame = start_frame;
+        slot.aux = aux;
+        slot.duration = duration;
+        return match accepted {
+            AcceptedCellResult::Ghost => OneCrateResult::AcceptedGhost,
+            AcceptedCellResult::Visible => OneCrateResult::AcceptedVisible,
+        };
     }
-    None
+    OneCrateResult::HardRejected
+}
+
+/// Active Map rectangle used by random placement. `MapClass` constructs it as
+/// `(1, 1, SizeW + SizeH - 1, SizeW + SizeH - 1)`; LocalSize and the canonical
+/// Rust cell-array extent do not own these draws.
+fn crate_random_frame(sim: &Simulation) -> Option<CrateRandomFrame> {
+    let size_width = sim.playfield_bounds?.base;
+    let size_height = sim.playfield_size_height?;
+    let size_sum = size_width.wrapping_add(size_height);
+    let width = size_sum.wrapping_sub(1);
+    if width <= 0 || size_sum <= 0 {
+        return None;
+    }
+    Some(CrateRandomFrame {
+        left: 1,
+        top: 1,
+        width,
+        height: width,
+        radius_cap: u16::try_from(size_sum.min(i32::from(CRATE_SNAP_RADIUS_CAP))).ok()?,
+    })
+}
+
+fn validate_and_stamp_candidate(
+    sim: &mut Simulation,
+    rules: &CrateRules,
+    overlay_registry: &OverlayTypeRegistry,
+    cell: (u16, u16),
+    forced_failure: ForcedPostPrecheckFailure,
+) -> AcceptedCellResult {
+    let water_id = rules
+        .water_crate_img
+        .as_deref()
+        .and_then(|name| overlay_registry.id_for_name(name));
+    let wood_id = rules
+        .wood_crate_img
+        .as_deref()
+        .and_then(|name| overlay_registry.id_for_name(name));
+    let crate_id = rules
+        .crate_img
+        .as_deref()
+        .and_then(|name| overlay_registry.id_for_name(name));
+    let selected_id = match crate_surface_at(sim, cell) {
+        CrateSurface::Water => water_id,
+        CrateSurface::Land => wood_id,
+    };
+    let Some(selected_id) = selected_id else {
+        return AcceptedCellResult::Ghost;
+    };
+
+    // `OverlayClass__Mark @ 0x005FC570` compares live Rules pointers, with
+    // Water first. Numeric registry identity is the Rust-native pointer alias.
+    let mark_speed = if Some(selected_id) == water_id {
+        SpeedType::Float
+    } else if Some(selected_id) == crate_id || Some(selected_id) == wood_id {
+        SpeedType::Track
+    } else {
+        return AcceptedCellResult::Ghost;
+    };
+
+    let Some(terrain_cell) = sim
+        .resolved_terrain
+        .as_ref()
+        .and_then(|terrain| terrain.cell(cell.0, cell.1))
+    else {
+        return AcceptedCellResult::Ghost;
+    };
+    if sim.production.terrain_object_cells.contains_key(&cell) {
+        return AcceptedCellResult::Ghost;
+    }
+    if terrain_cell.slope_type > 4 && selected_id != 0xB2 {
+        return AcceptedCellResult::Ghost;
+    }
+    let bridge_layer_selected = terrain_cell.bridge_facts.raw_flags & BRIDGE_FLAG_STRUCTURAL != 0;
+    let selected_occupation = if bridge_layer_selected {
+        sim.substrate.raw_cell_occupation.deck_bits(cell.0, cell.1)
+    } else {
+        sim.substrate
+            .raw_cell_occupation
+            .ground_bits(cell.0, cell.1)
+    };
+    if selected_occupation != 0 {
+        return AcceptedCellResult::Ghost;
+    }
+    if !bridge_layer_selected && terrain_cell.speed_costs.cost_for_speed_type(mark_speed) == Some(0)
+    {
+        return AcceptedCellResult::Ghost;
+    }
+    if forced_failure != ForcedPostPrecheckFailure::None {
+        return AcceptedCellResult::Ghost;
+    }
+
+    let (Some(overlay_grid), Some(resolved_terrain)) =
+        (sim.overlay_grid.as_mut(), sim.resolved_terrain.as_mut())
+    else {
+        return AcceptedCellResult::Ghost;
+    };
+    if overlay_grid.place_crate_overlay(
+        resolved_terrain,
+        overlay_registry,
+        cell.0,
+        cell.1,
+        selected_id,
+    ) {
+        AcceptedCellResult::Visible
+    } else {
+        AcceptedCellResult::Ghost
+    }
 }
 
 fn crate_surface_at(sim: &Simulation, cell: (u16, u16)) -> CrateSurface {
@@ -271,6 +423,17 @@ fn snap_to_passable(
     drawn: (u16, u16),
     surface: CrateSurface,
 ) -> Option<(u16, u16)> {
+    let radius_cap = crate_random_frame(sim)?.radius_cap;
+    snap_to_passable_with_radius(sim, path_grid, drawn, surface, radius_cap)
+}
+
+fn snap_to_passable_with_radius(
+    sim: &Simulation,
+    path_grid: Option<&PathGrid>,
+    drawn: (u16, u16),
+    surface: CrateSurface,
+    radius_cap: u16,
+) -> Option<(u16, u16)> {
     let query = NearbyQuery {
         passability: PassabilityArgs {
             // Verified: the placer passes native speed type 5 (float) when the
@@ -291,7 +454,7 @@ fn snap_to_passable(
         allow_bridge_cells: true,
         check_height: false,
         check_occupancy: false,
-        radius_cap: sim.session.map_width.min(CRATE_SNAP_RADIUS_CAP),
+        radius_cap,
         // gamemd-derived: PlaceCrateAtRandomCell @ 0x0056BD40 initializes
         // this reference to the engine zero cell. FNPC @ 0x0056DC20 treats
         // that zero sentinel as "no target" and selects by live frame modulo.
@@ -342,6 +505,30 @@ mod tests {
         RuleSet::from_ini(&ini).expect("rules")
     }
 
+    fn crate_ruleset_with_images(wood: &str, common: &str, water: &str, extra: &str) -> RuleSet {
+        let ini = IniFile::from_str(&format!(
+            "[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
+             [CrateRules]\nCrateImg={common}\nWoodCrateImg={wood}\nWaterCrateImg={water}\n{extra}",
+        ));
+        RuleSet::from_ini(&ini).expect("rules")
+    }
+
+    fn crate_registry_with_raw_b2() -> OverlayTypeRegistry {
+        use std::fmt::Write as _;
+
+        let mut ini_text = String::from("[OverlayTypes]\n");
+        for index in 0..=0xB2u16 {
+            let name = if index == 0xB2 {
+                "STEEPCRATE".to_owned()
+            } else {
+                format!("OV{index:03}")
+            };
+            writeln!(&mut ini_text, "{index}={name}").expect("string write");
+        }
+        ini_text.push_str("[STEEPCRATE]\nCrate=yes\n");
+        OverlayTypeRegistry::from_ini(&IniFile::from_str(&ini_text), None)
+    }
+
     /// `seed` positions the scenario cursor; the placer draws from there.
     fn sim_with_grid(seed: u64) -> Simulation {
         let mut sim = Simulation::new();
@@ -353,12 +540,13 @@ mod tests {
         // crate placement. Keep this focused fixture intentionally broad while
         // exercising the same required mode-one gate.
         sim.playfield_bounds = Some(PlayfieldBounds {
-            base: 0,
+            base: 20,
             off_fc: -128,
             off_100: -128,
             off_104: 256,
             off_108: 256,
         });
+        sim.playfield_size_height = Some(20);
         sim.session.game_options.crates = true;
         sim.overlay_grid = Some(OverlayGrid::new(MAP, MAP));
         sim.resolved_terrain = Some(uniform_terrain(false));
@@ -385,6 +573,21 @@ mod tests {
 
     fn crate_cells(sim: &Simulation, registry: &OverlayTypeRegistry) -> Vec<(u16, u16)> {
         cells_with_overlay(sim, registry, "WOOD")
+    }
+
+    fn first_random_cell(sim: &Simulation) -> ((u16, u16), crate::sim::rng::SimRng) {
+        let frame = crate_random_frame(sim).expect("valid crate random frame");
+        let mut replay = sim.scenario_rng.clone();
+        let cell =
+            (
+                frame.left.wrapping_add(
+                    replay.next_range_u32_inclusive(0, (frame.width - 1) as u32) as i32,
+                ) as u16,
+                frame.top.wrapping_add(
+                    replay.next_range_u32_inclusive(0, (frame.height - 1) as u32) as i32,
+                ) as u16,
+            );
+        (cell, replay)
     }
 
     #[test]
@@ -415,6 +618,21 @@ mod tests {
             ..CrateRules::default()
         };
         assert_eq!(scenario_start_crate_count(&inverted, 1), 3);
+
+        let signed = CrateRules {
+            minimum: -9,
+            maximum: -3,
+            ..CrateRules::default()
+        };
+        assert_eq!(scenario_start_crate_count(&signed, -7), -7);
+        assert_eq!(scenario_start_crate_count(&signed, 4), -3);
+
+        let uncapped_slot_count = CrateRules {
+            minimum: 300,
+            maximum: i32::MAX,
+            ..CrateRules::default()
+        };
+        assert_eq!(scenario_start_crate_count(&uncapped_slot_count, 1), 300);
     }
 
     #[test]
@@ -442,7 +660,7 @@ mod tests {
         let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 5);
 
         assert_eq!(result.requested, 3);
-        assert_eq!(result.placed, 3);
+        assert_eq!((result.accepted, result.visible), (3, 3));
         let cells = crate_cells(&sim, &registry);
         assert_eq!(cells.len(), 3);
         let unique: BTreeSet<(u16, u16)> = cells.iter().copied().collect();
@@ -462,7 +680,7 @@ mod tests {
         let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 1);
 
         assert_eq!(result.requested, 4);
-        assert_eq!(result.placed, 4);
+        assert_eq!((result.accepted, result.visible), (4, 4));
         assert_eq!(crate_cells(&sim, &registry).len(), 4);
     }
 
@@ -481,11 +699,28 @@ mod tests {
             result,
             CratePlacement {
                 requested: 0,
-                placed: 0
+                accepted: 0,
+                visible: 0,
             }
         );
         assert!(crate_cells(&sim, &registry).is_empty());
         assert_eq!(sim.scenario_rng.state(), rng_before);
+    }
+
+    #[test]
+    fn scenario_start_crate_missing_map_size_authority_invents_no_rectangle() {
+        let rules = crate_ruleset("CrateMinimum=1\nCrateMaximum=1\n");
+        let registry = crate_registry();
+        let grid = PathGrid::test_all_passable(MAP, MAP);
+        let mut sim = sim_with_grid(0xBAD5_1E00);
+        sim.playfield_size_height = None;
+        let before = sim.scenario_rng.state();
+
+        let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 1);
+
+        assert_eq!((result.accepted, result.visible), (0, 0));
+        assert_eq!(sim.scenario_rng.state(), before);
+        assert!(sim.crate_authority.slots()[0].is_empty());
     }
 
     /// A successful request spends X, Y, then the crate-slot timer draw.
@@ -555,7 +790,7 @@ mod tests {
 
         let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 1);
 
-        assert_eq!(result.placed, 1);
+        assert_eq!((result.accepted, result.visible), (1, 1));
         assert_eq!(crate_cells(&sim, &registry), vec![second]);
         assert_eq!(sim.scenario_rng.state(), replay.state());
     }
@@ -591,7 +826,7 @@ mod tests {
 
         let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 2);
 
-        assert_eq!(result.placed, 2);
+        assert_eq!((result.accepted, result.visible), (2, 2));
         assert_eq!(
             crate_cells(&sim, &registry)
                 .into_iter()
@@ -610,7 +845,7 @@ mod tests {
         // Empty diamond: every FNPC candidate fails the mandatory anchor gate
         // (and the independent final playfield gate would reject it too).
         sim.playfield_bounds = Some(PlayfieldBounds {
-            base: 0,
+            base: 20,
             off_fc: 0,
             off_100: 0,
             off_104: 0,
@@ -624,8 +859,9 @@ mod tests {
 
         let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 1);
 
-        assert_eq!(result.placed, 0);
+        assert_eq!((result.accepted, result.visible), (0, 0));
         assert!(crate_cells(&sim, &registry).is_empty());
+        assert_eq!(sim.crate_authority.slots()[0], CrateSlot::default());
         assert_eq!(sim.scenario_rng.state(), replay.state());
     }
 
@@ -637,7 +873,7 @@ mod tests {
         let mut sim = sim_with_grid(0x5107_0256);
         let mut replay = sim.scenario_rng.clone();
         let mut occupied = BTreeSet::new();
-        while occupied.len() < CRATE_SLOT_CAPACITY {
+        while occupied.len() < state::CRATE_SLOT_CAPACITY {
             let cell = (
                 replay.next_range_u32_inclusive(1, u32::from(MAP - 1)) as u16,
                 replay.next_range_u32_inclusive(1, u32::from(MAP - 1)) as u16,
@@ -650,12 +886,36 @@ mod tests {
         let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 300);
 
         assert_eq!(result.requested, 300);
-        assert_eq!(result.placed, CRATE_SLOT_CAPACITY as u32);
+        assert_eq!(
+            (result.accepted, result.visible),
+            (
+                state::CRATE_SLOT_CAPACITY as u32,
+                state::CRATE_SLOT_CAPACITY as u32,
+            )
+        );
         assert_eq!(sim.scenario_rng.state(), replay.state());
     }
 
     #[test]
-    fn gsi_01_04_crate_slot_commit_skips_generic_mark_occupation_gate() {
+    fn scenario_start_crate_preexisting_full_slot_table_spends_no_rng() {
+        let rules = crate_ruleset("CrateMinimum=4\nCrateMaximum=4\n");
+        let registry = crate_registry();
+        let grid = PathGrid::test_all_passable(MAP, MAP);
+        let mut sim = sim_with_grid(0x5107_F011);
+        for index in 0..state::CRATE_SLOT_CAPACITY {
+            sim.crate_authority.slot_mut(index).cell_x = (index as i16).wrapping_add(1);
+        }
+        let before = sim.scenario_rng.state();
+
+        let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 1);
+
+        assert_eq!(result.requested, 4);
+        assert_eq!((result.accepted, result.visible), (0, 0));
+        assert_eq!(sim.scenario_rng.state(), before);
+    }
+
+    #[test]
+    fn scenario_start_crate_any_ground_occupation_bit_accepts_a_timed_ghost() {
         let rules = crate_ruleset("CrateMinimum=1\nCrateMaximum=1\n");
         let registry = crate_registry();
         let grid = PathGrid::test_all_passable(MAP, MAP);
@@ -673,18 +933,147 @@ mod tests {
         let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 1);
 
         assert_eq!(result.requested, 1);
-        assert_eq!(result.placed, 1);
-        assert_eq!(crate_cells(&sim, &registry), vec![(rx, ry)]);
+        assert_eq!((result.accepted, result.visible), (1, 0));
+        assert!(crate_cells(&sim, &registry).is_empty());
         assert_eq!(
             sim.overlay_grid
                 .as_ref()
                 .expect("overlay grid")
                 .cell(rx, ry)
-                .overlay_data,
-            u8::MAX,
-            "crate-slot stamp writes Cell+0x11E = 0xFF",
+                .overlay_id,
+            None,
+            "a post-precheck Mark failure leaves the Cell unchanged",
         );
         assert_eq!(sim.scenario_rng.state(), replay.state());
+        let slot = sim.crate_authority.slots()[0];
+        assert_eq!((slot.cell_x, slot.cell_y), (rx as i16, ry as i16));
+        assert_eq!(slot.start_frame, sim.session.binary_frame as i32);
+        assert_eq!(
+            slot.aux, 0x40d1_9400,
+            "constructor regen 10 owns upper=18000"
+        );
+        assert!(slot.duration > 0);
+    }
+
+    #[test]
+    fn scenario_start_crate_every_nonzero_ground_occupation_bit_ghosts() {
+        let rules = crate_ruleset("CrateMinimum=1\nCrateMaximum=1\n");
+        let registry = crate_registry();
+        let grid = PathGrid::test_all_passable(MAP, MAP);
+
+        for bit in [1, 2, 4, 8, 16, 32, 64, 128] {
+            let mut sim = sim_with_grid(0x0CC0_0000 + u64::from(bit));
+            let (cell, _) = first_random_cell(&sim);
+            sim.substrate
+                .raw_cell_occupation
+                .mark_ground(cell.0, cell.1, bit);
+            let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 1);
+            assert_eq!(
+                (result.accepted, result.visible),
+                (1, 0),
+                "raw occupation bit {bit:#04x} must reject Mark"
+            );
+            assert!(sim.crate_authority.slots()[0].cell_x != 0);
+        }
+    }
+
+    #[test]
+    fn scenario_start_crate_null_image_and_terrain_object_are_accepted_ghosts() {
+        let null_rules = crate_ruleset_with_images(
+            "none",
+            "SILVER",
+            "WATER",
+            "CrateMinimum=1\nCrateMaximum=1\nCrateRegen=3\n",
+        );
+        let ordinary_rules = crate_ruleset("CrateMinimum=1\nCrateMaximum=1\nCrateRegen=3\n");
+        let registry = crate_registry();
+        let grid = PathGrid::test_all_passable(MAP, MAP);
+
+        let mut null_sim = sim_with_grid(0xA011_0001);
+        null_sim.session.binary_frame = u32::MAX;
+        let (null_cell, mut null_replay) = first_random_cell(&null_sim);
+        let timer_draw = null_replay.next_range_u32_inclusive(0, 0x7fff_fffe);
+        let expected_timer = state::crate_timer_words(
+            null_rules.crate_rules.regen,
+            timer_draw,
+            null_sim.session.binary_frame as i32,
+        );
+        let null_result =
+            place_scenario_start_crates(&mut null_sim, &null_rules, &registry, Some(&grid), 1);
+        assert_eq!((null_result.accepted, null_result.visible), (1, 0));
+        assert!(
+            null_sim
+                .overlay_grid
+                .as_ref()
+                .unwrap()
+                .iter_occupied()
+                .next()
+                .is_none()
+        );
+        let null_slot = null_sim.crate_authority.slots()[0];
+        assert_eq!(
+            (null_slot.cell_x, null_slot.cell_y),
+            (null_cell.0 as i16, null_cell.1 as i16)
+        );
+        assert_eq!(
+            (null_slot.start_frame, null_slot.aux, null_slot.duration),
+            expected_timer
+        );
+        assert_eq!(null_sim.scenario_rng.state(), null_replay.state());
+
+        let mut terrain_sim = sim_with_grid(0xA011_0002);
+        let (cell, _) = first_random_cell(&terrain_sim);
+        terrain_sim.production.terrain_object_cells.insert(cell, 77);
+        let terrain_result = place_scenario_start_crates(
+            &mut terrain_sim,
+            &ordinary_rules,
+            &registry,
+            Some(&grid),
+            1,
+        );
+        assert_eq!((terrain_result.accepted, terrain_result.visible), (1, 0));
+        assert_eq!(
+            (
+                terrain_sim.crate_authority.slots()[0].cell_x,
+                terrain_sim.crate_authority.slots()[0].cell_y
+            ),
+            (cell.0 as i16, cell.1 as i16)
+        );
+    }
+
+    #[test]
+    fn crate_placement_forced_post_precheck_failures_are_timed_ghosts() {
+        let rules = crate_ruleset("CrateMinimum=1\nCrateMaximum=1\nCrateRegen=3\n");
+        let registry = crate_registry();
+        let grid = PathGrid::test_all_passable(MAP, MAP);
+
+        for failure in [
+            ForcedPostPrecheckFailure::Allocation,
+            ForcedPostPrecheckFailure::Unlimbo,
+            ForcedPostPrecheckFailure::Mark,
+        ] {
+            let mut sim = sim_with_grid(0xFA11_0000 + failure as u64);
+            let result = place_scenario_start_crates_with_failure(
+                &mut sim,
+                &rules,
+                &registry,
+                Some(&grid),
+                1,
+                failure,
+            );
+            assert_eq!((result.accepted, result.visible), (1, 0));
+            let slot = sim.crate_authority.slots()[0];
+            assert!(!slot.is_empty());
+            assert_eq!(slot.aux, 0x40b5_1800);
+            assert!(
+                sim.overlay_grid
+                    .as_ref()
+                    .unwrap()
+                    .iter_occupied()
+                    .next()
+                    .is_none()
+            );
+        }
     }
 
     #[test]
@@ -707,12 +1096,206 @@ mod tests {
 
         let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 1);
 
-        assert_eq!(result.placed, 1);
+        assert_eq!((result.accepted, result.visible), (1, 1));
         assert_eq!(
             cells_with_overlay(&sim, &registry, "WATER"),
             vec![destination]
         );
         assert_eq!(sim.scenario_rng.state(), replay.state());
+    }
+
+    #[test]
+    fn crate_placement_mark_uses_water_first_numeric_identity_alias() {
+        let rules =
+            crate_ruleset_with_images("WOOD", "SILVER", "WOOD", "CrateMinimum=1\nCrateMaximum=1\n");
+        let registry = crate_registry();
+        let mut sim = sim_with_grid(0xA11A_5001);
+        let cell = (7, 9);
+        let terrain_cell = sim
+            .resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .unwrap();
+        terrain_cell.speed_costs.track = Some(0);
+        terrain_cell.speed_costs.float = Some(100);
+
+        let result = validate_and_stamp_candidate(
+            &mut sim,
+            &rules.crate_rules,
+            &registry,
+            cell,
+            ForcedPostPrecheckFailure::None,
+        );
+
+        assert_eq!(result, AcceptedCellResult::Visible);
+        assert_eq!(
+            sim.overlay_grid
+                .as_ref()
+                .unwrap()
+                .cell(cell.0, cell.1)
+                .overlay_id,
+            registry.id_for_name("WOOD")
+        );
+
+        let mut zero_float = sim_with_grid(0xA11A_5002);
+        let zero_cell = zero_float
+            .resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .unwrap();
+        zero_cell.speed_costs.track = Some(100);
+        zero_cell.speed_costs.float = Some(0);
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut zero_float,
+                &rules.crate_rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Ghost,
+            "the aliased selected identity must use Water/Float, not Wood/Track"
+        );
+    }
+
+    #[test]
+    fn crate_placement_bridge_selects_full_deck_byte_and_bypasses_speed_zero() {
+        let rules = crate_ruleset("CrateMinimum=1\nCrateMaximum=1\n");
+        let registry = crate_registry();
+        let cell = (8, 11);
+
+        let mut visible = sim_with_grid(0xB21D_0001);
+        let terrain_cell = visible
+            .resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .unwrap();
+        terrain_cell.bridge_facts.raw_flags = BRIDGE_FLAG_STRUCTURAL;
+        terrain_cell.speed_costs.track = Some(0);
+        visible
+            .substrate
+            .raw_cell_occupation
+            .mark_ground(cell.0, cell.1, 0x80);
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut visible,
+                &rules.crate_rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Visible,
+            "structural bridge chooses empty deck and bypasses ground speed zero"
+        );
+
+        let mut ghost = sim_with_grid(0xB21D_0002);
+        let terrain_cell = ghost
+            .resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .unwrap();
+        terrain_cell.bridge_facts.raw_flags = BRIDGE_FLAG_STRUCTURAL;
+        terrain_cell.speed_costs.track = Some(100);
+        ghost
+            .substrate
+            .raw_cell_occupation
+            .mark_deck(cell.0, cell.1, 0x01);
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut ghost,
+                &rules.crate_rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Ghost,
+            "any nonzero selected deck byte rejects Mark"
+        );
+    }
+
+    #[test]
+    fn crate_placement_steep_slope_uses_exact_raw_b2_exception() {
+        let ordinary_rules = crate_ruleset("CrateMinimum=1\nCrateMaximum=1\n");
+        let ordinary_registry = crate_registry();
+        let cell = (12, 12);
+        let mut ordinary = sim_with_grid(0xB200_0001);
+        ordinary
+            .resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .unwrap()
+            .slope_type = 5;
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut ordinary,
+                &ordinary_rules.crate_rules,
+                &ordinary_registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Ghost
+        );
+
+        let b2_registry = crate_registry_with_raw_b2();
+        assert_eq!(b2_registry.id_for_name("STEEPCRATE"), Some(0xB2));
+        let b2_rules = CrateRules {
+            wood_crate_img: Some("STEEPCRATE".to_owned()),
+            crate_img: Some("STEEPCRATE".to_owned()),
+            water_crate_img: Some("STEEPCRATE".to_owned()),
+            ..CrateRules::default()
+        };
+        let mut exempt = sim_with_grid(0xB200_0002);
+        exempt
+            .resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(cell.0, cell.1)
+            .unwrap()
+            .slope_type = u8::MAX;
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut exempt,
+                &b2_rules,
+                &b2_registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Visible
+        );
+    }
+
+    #[test]
+    fn place_crate_overlay_preserves_wall_owner_and_publishes_one_dirty_cell() {
+        let rules = crate_ruleset("CrateMinimum=1\nCrateMaximum=1\n");
+        let registry = crate_registry();
+        let mut sim = sim_with_grid(0xD117_0001);
+        let cell = (6, 13);
+        let owner = sim.interner.intern("Owner");
+        let grid = sim.overlay_grid.as_mut().unwrap();
+        grid.cell_mut(cell.0, cell.1).wall_owner = Some(owner);
+        assert!(grid.take_dirty_cells().is_empty());
+
+        assert_eq!(
+            validate_and_stamp_candidate(
+                &mut sim,
+                &rules.crate_rules,
+                &registry,
+                cell,
+                ForcedPostPrecheckFailure::None,
+            ),
+            AcceptedCellResult::Visible
+        );
+        let grid = sim.overlay_grid.as_mut().unwrap();
+        let written = grid.cell(cell.0, cell.1);
+        assert_eq!(written.overlay_id, registry.id_for_name("WOOD"));
+        assert_eq!(written.overlay_data, u8::MAX);
+        assert_eq!(written.wall_owner, Some(owner));
+        assert_eq!(grid.take_dirty_cells(), vec![cell]);
     }
 
     /// With a uniform surface, destination image selection still follows the
@@ -733,7 +1316,7 @@ mod tests {
             }
 
             let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 4);
-            assert_eq!(result.placed, 4);
+            assert_eq!((result.accepted, result.visible), (4, 4));
 
             let silver_crates = cells_with_overlay(&sim, &registry, "SILVER");
             let land_crates = cells_with_overlay(&sim, &registry, "WOOD");
@@ -778,17 +1361,15 @@ mod tests {
                 LandType::Clear.as_index()
             };
 
-            // The real destination admits only the drawn cell's movement type.
-            // The nearer-to-(0,0) decoy admits only the opposite type, so
-            // choosing movement from anywhere but the draw lands on the decoy.
+            // The real destination admits the drawn-cell FNPC movement and the
+            // independently selected image's Mark movement. The nearer-to-(0,0)
+            // decoy admits only the opposite FNPC type, so choosing the search
+            // movement from anywhere but the draw lands on the decoy.
             let destination_cell = terrain
                 .cell_mut(destination.0, destination.1)
                 .expect("destination cell");
-            if drawn_is_water {
-                destination_cell.speed_costs.float = Some(100);
-            } else {
-                destination_cell.speed_costs.track = Some(100);
-            }
+            destination_cell.speed_costs.float = Some(100);
+            destination_cell.speed_costs.track = Some(100);
             destination_cell.yr_cell_land_type = if drawn_is_water {
                 LandType::Clear.as_index()
             } else {
@@ -806,7 +1387,7 @@ mod tests {
 
             let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 1);
 
-            assert_eq!(result.placed, 1);
+            assert_eq!((result.accepted, result.visible), (1, 1));
             let expected_image = if drawn_is_water { "WOOD" } else { "WATER" };
             let drawn_image = if drawn_is_water { "WATER" } else { "WOOD" };
             assert_eq!(
@@ -1037,21 +1618,22 @@ mod tests {
         let result =
             place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), player_count);
         assert_eq!(result.requested, 1);
-        assert_eq!(result.placed, 1);
+        assert_eq!((result.accepted, result.visible), (1, 1));
     }
 
-    /// Both coordinates use the canonical Size.Width + Size.Height extent;
-    /// LocalSize is irrelevant to the two ranged calls.
     #[test]
-    fn gsi_01_04_crate_draws_use_size_extent_not_localsize() {
+    fn scenario_start_crate_draws_exact_active_rectangle_not_session_extent_or_localsize() {
         let rules = crate_ruleset("CrateMinimum=1\nCrateMaximum=1\n");
         let registry = crate_registry();
         let grid = PathGrid::test_all_passable(MAP, MAP);
         let mut sim = sim_with_grid(0x2468);
+        sim.playfield_bounds.as_mut().unwrap().base = 14;
+        sim.playfield_size_height = Some(9);
+        sim.session.map_width = 37;
         let mut replay = sim.scenario_rng.clone();
         let expected = (
-            replay.next_range_u32_inclusive(1, u32::from(MAP - 1)) as u16,
-            replay.next_range_u32_inclusive(1, u32::from(MAP - 1)) as u16,
+            1 + replay.next_range_u32_inclusive(0, 21) as u16,
+            1 + replay.next_range_u32_inclusive(0, 21) as u16,
         );
         replay.next_range_u32_inclusive(0, 0x7fff_fffe);
         sim.session.local_left = 0;
@@ -1061,8 +1643,9 @@ mod tests {
 
         let result = place_scenario_start_crates(&mut sim, &rules, &registry, Some(&grid), 1);
 
-        assert_eq!(result.placed, 1);
+        assert_eq!((result.accepted, result.visible), (1, 1));
         assert_eq!(crate_cells(&sim, &registry), vec![expected]);
+        assert!((1..=22).contains(&expected.0) && (1..=22).contains(&expected.1));
         assert_ne!(expected, (0, 0), "draw lies outside the 1x1 LocalSize");
         assert_eq!(sim.scenario_rng.state(), replay.state());
     }

--- a/src/sim/crates.rs
+++ b/src/sim/crates.rs
@@ -226,27 +226,17 @@ fn place_one_random_crate(
         return OneCrateResult::HardRejected;
     };
     for _ in 0..MAX_PLACEMENT_ATTEMPTS {
-        let x_offset = sim
-            .scenario_rng
-            .next_range_u32_inclusive(0, (frame.width - 1) as u32);
-        let y_offset = sim
-            .scenario_rng
-            .next_range_u32_inclusive(0, (frame.height - 1) as u32);
-        let drawn_x = frame.left.wrapping_add(x_offset as i32);
-        let drawn_y = frame.top.wrapping_add(y_offset as i32);
-        let (Ok(x), Ok(y)) = (u16::try_from(drawn_x), u16::try_from(drawn_y)) else {
-            continue;
-        };
+        let drawn = draw_crate_candidate(&mut sim.scenario_rng, frame);
 
         // The drawn cell's own land type selects the snap, before any snapping
         // happens. A draw outside the grid takes the land branch, matching the
         // native fallback cell.
-        let movement_surface = crate_surface_at(sim, (x, y));
+        let movement_surface = crate_surface_at_packed(sim, drawn);
 
         let Some(cell) = snap_to_passable_with_radius(
             sim,
             path_grid,
-            (x, y),
+            drawn,
             movement_surface,
             frame.radius_cap,
         ) else {
@@ -304,16 +294,53 @@ fn crate_random_frame(sim: &Simulation) -> Option<CrateRandomFrame> {
     let size_height = sim.playfield_size_height?;
     let size_sum = size_width.wrapping_add(size_height);
     let width = size_sum.wrapping_sub(1);
-    if width <= 0 || size_sum <= 0 {
-        return None;
-    }
     Some(CrateRandomFrame {
         left: 1,
         top: 1,
         width,
         height: width,
-        radius_cap: u16::try_from(size_sum.min(i32::from(CRATE_SNAP_RADIUS_CAP))).ok()?,
+        // Native forwards min(SizeW + SizeH, 32) as a signed loop cap. A
+        // nonpositive cap scans no FNPC rings, but the X/Y draws above still
+        // occur. Zero is the Rust-native representation of that empty scan.
+        radius_cap: size_sum.clamp(0, i32::from(CRATE_SNAP_RADIUS_CAP)) as u16,
     })
+}
+
+/// Signed `Random__RandomRanged` projection used by the crate rectangle.
+/// Reversed endpoints are compared and swapped as signed dwords before the
+/// shared native mask/rejection sampler sees their nonnegative span.
+fn crate_random_ranged_i32(
+    rng: &mut crate::sim::rng::SimRng,
+    low: i32,
+    high: i32,
+) -> i32 {
+    let (lo, hi) = if low <= high {
+        (low, high)
+    } else {
+        (high, low)
+    };
+    let span = (i64::from(hi) - i64::from(lo)) as u32;
+    lo.wrapping_add(rng.next_range_u32_inclusive(0, span) as i32)
+}
+
+/// `MapClass__PlaceCrateAtRandomCell @ 0x0056BD8B..0x0056BDD3` always draws
+/// X then Y, adds the signed rectangle origin with dword wrapping, and stores
+/// each result through a 16-bit word before the later MOVSX reads it back.
+fn draw_crate_candidate(
+    rng: &mut crate::sim::rng::SimRng,
+    frame: CrateRandomFrame,
+) -> (i32, i32) {
+    let x = frame.left.wrapping_add(crate_random_ranged_i32(
+        rng,
+        0,
+        frame.width.wrapping_sub(1),
+    ));
+    let y = frame.top.wrapping_add(crate_random_ranged_i32(
+        rng,
+        0,
+        frame.height.wrapping_sub(1),
+    ));
+    (x as i16 as i32, y as i16 as i32)
 }
 
 fn validate_and_stamp_candidate(
@@ -416,11 +443,18 @@ fn crate_surface_at(sim: &Simulation, cell: (u16, u16)) -> CrateSurface {
     }
 }
 
+fn crate_surface_at_packed(sim: &Simulation, cell: (i32, i32)) -> CrateSurface {
+    let Some((rx, ry)) = crate::map::cell_index::canonical_cell_coord(cell.0, cell.1) else {
+        return CrateSurface::Land;
+    };
+    crate_surface_at(sim, (rx, ry))
+}
+
 /// Snap a drawn cell onto a nearby passable cell of the matching surface.
 fn snap_to_passable(
     sim: &Simulation,
     path_grid: Option<&PathGrid>,
-    drawn: (u16, u16),
+    drawn: (i32, i32),
     surface: CrateSurface,
 ) -> Option<(u16, u16)> {
     let radius_cap = crate_random_frame(sim)?.radius_cap;
@@ -430,7 +464,7 @@ fn snap_to_passable(
 fn snap_to_passable_with_radius(
     sim: &Simulation,
     path_grid: Option<&PathGrid>,
-    drawn: (u16, u16),
+    drawn: (i32, i32),
     surface: CrateSurface,
     radius_cap: u16,
 ) -> Option<(u16, u16)> {
@@ -468,7 +502,7 @@ fn snap_to_passable_with_radius(
         playfield_bounds: sim.playfield_bounds,
     };
     find_nearby_passable_cell(
-        (i32::from(drawn.0), i32::from(drawn.1)),
+        drawn,
         &query,
         sim.session.binary_frame,
     )
@@ -1296,6 +1330,132 @@ mod tests {
         assert_eq!(written.overlay_data, u8::MAX);
         assert_eq!(written.wall_owner, Some(owner));
         assert_eq!(grid.take_dirty_cells(), vec![cell]);
+    }
+
+    #[test]
+    fn configured_noncrate_images_keep_native_mark_zero_and_road_data() {
+        let registry = OverlayTypeRegistry::from_ini(
+            &IniFile::from_str(
+                "[OverlayTypes]\n0=PLAIN\n1=ROADBOX\n[PLAIN]\n[ROADBOX]\nLand=Road\n",
+            ),
+            None,
+        );
+        for (name, expected_data) in [("PLAIN", 0), ("ROADBOX", 1)] {
+            let rules = CrateRules {
+                wood_crate_img: Some(name.to_owned()),
+                crate_img: Some(name.to_owned()),
+                water_crate_img: Some(name.to_owned()),
+                ..CrateRules::default()
+            };
+            let mut sim = sim_with_grid(0xDA7A_0000 + u64::from(expected_data));
+            let cell = (6, 13);
+
+            assert_eq!(
+                validate_and_stamp_candidate(
+                    &mut sim,
+                    &rules,
+                    &registry,
+                    cell,
+                    ForcedPostPrecheckFailure::None,
+                ),
+                AcceptedCellResult::Visible
+            );
+            let written = sim.overlay_grid.as_ref().unwrap().cell(cell.0, cell.1);
+            assert_eq!(written.overlay_id, registry.id_for_name(name));
+            assert_eq!(written.overlay_data, expected_data, "configured {name}");
+        }
+    }
+
+    #[test]
+    fn crate_random_rectangle_draws_signed_reversed_ranges_then_narrows_to_i16() {
+        let mut sum_one = crate::sim::rng::SimRng::new(0x1401);
+        let mut sum_one_expected = sum_one.clone();
+        let sum_one_frame = CrateRandomFrame {
+            left: 1,
+            top: 1,
+            width: 0,
+            height: 0,
+            radius_cap: 1,
+        };
+        let sum_one_cell = draw_crate_candidate(&mut sum_one, sum_one_frame);
+        let expected_sum_one = (
+            sum_one_expected.next_range_u32_inclusive(0, 1) as i32,
+            sum_one_expected.next_range_u32_inclusive(0, 1) as i32,
+        );
+        assert_eq!(sum_one_cell, expected_sum_one);
+        assert_eq!(sum_one.state(), sum_one_expected.state());
+
+        let mut negative = crate::sim::rng::SimRng::new(0x1402);
+        let mut negative_expected = negative.clone();
+        let negative_frame = CrateRandomFrame {
+            left: i32::MAX,
+            top: i32::MIN,
+            width: -2,
+            height: -2,
+            radius_cap: 0,
+        };
+        let negative_cell = draw_crate_candidate(&mut negative, negative_frame);
+        let expected_negative = (
+            i32::MAX
+                .wrapping_add(-3 + negative_expected.next_range_u32_inclusive(0, 3) as i32)
+                as i16 as i32,
+            i32::MIN
+                .wrapping_add(-3 + negative_expected.next_range_u32_inclusive(0, 3) as i32)
+                as i16 as i32,
+        );
+        assert_eq!(negative_cell, expected_negative);
+        assert_eq!(negative.state(), negative_expected.state());
+
+        let mut wide = crate::sim::rng::SimRng::new(0x1403);
+        let mut wide_expected = wide.clone();
+        let wide_frame = CrateRandomFrame {
+            left: 30_000,
+            top: -30_000,
+            width: 70_000,
+            height: 70_000,
+            radius_cap: CRATE_SNAP_RADIUS_CAP,
+        };
+        let wide_cell = draw_crate_candidate(&mut wide, wide_frame);
+        let expected_wide = (
+            30_000i32
+                .wrapping_add(wide_expected.next_range_u32_inclusive(0, 69_999) as i32)
+                as i16 as i32,
+            (-30_000i32)
+                .wrapping_add(wide_expected.next_range_u32_inclusive(0, 69_999) as i32)
+                as i16 as i32,
+        );
+        assert_eq!(wide_cell, expected_wide);
+        assert_eq!(wide.state(), wide_expected.state());
+    }
+
+    #[test]
+    fn crate_random_frame_retains_nonpositive_signed_size_for_rng_before_empty_snap() {
+        let mut sim = sim_with_grid(1);
+        sim.playfield_bounds.as_mut().unwrap().base = 1;
+        sim.playfield_size_height = Some(0);
+        assert_eq!(
+            crate_random_frame(&sim),
+            Some(CrateRandomFrame {
+                left: 1,
+                top: 1,
+                width: 0,
+                height: 0,
+                radius_cap: 1,
+            })
+        );
+
+        sim.playfield_bounds.as_mut().unwrap().base = -3;
+        sim.playfield_size_height = Some(-2);
+        assert_eq!(
+            crate_random_frame(&sim),
+            Some(CrateRandomFrame {
+                left: 1,
+                top: 1,
+                width: -6,
+                height: -6,
+                radius_cap: 0,
+            })
+        );
     }
 
     /// With a uniform surface, destination image selection still follows the

--- a/src/sim/crates/state.rs
+++ b/src/sim/crates/state.rs
@@ -61,6 +61,20 @@ impl CrateAuthority {
     pub(crate) fn slot_mut(&mut self, index: usize) -> &mut CrateSlot {
         &mut self.slots[index]
     }
+
+    /// Accepted coordinates in native ascending slot order. Negative packed
+    /// values are malformed snapshot state and cannot name a Rust grid cell.
+    pub(crate) fn occupied_cells(&self) -> impl Iterator<Item = (u16, u16)> + '_ {
+        self.slots.iter().filter_map(|slot| {
+            if slot.is_empty() {
+                return None;
+            }
+            Some((
+                u16::try_from(slot.cell_x).ok()?,
+                u16::try_from(slot.cell_y).ok()?,
+            ))
+        })
+    }
 }
 
 /// Compute the accepted-slot timer words in the verified x87 expression
@@ -178,6 +192,10 @@ mod tests {
             slot.cell_x = i16::try_from(index + 1).expect("slot index fits i16");
         }
         assert_eq!(authority.first_empty_index(), None);
+        assert_eq!(
+            authority.occupied_cells().take(3).collect::<Vec<_>>(),
+            vec![(1, 0), (2, 0), (3, 0)]
+        );
     }
 
     #[test]

--- a/src/sim/crates/state.rs
+++ b/src/sim/crates/state.rs
@@ -1,0 +1,274 @@
+//! Persistent MapClass crate-slot authority and native timer words.
+//!
+//! Active `gamemd.exe` owns 256 consecutive 16-byte slots. The coordinate
+//! pair is the sole emptiness discriminator; accepted ghosts retain the same
+//! coordinate/timer state as visible crates.
+
+use crate::util::native_x87::{NativeF64Bits, X87Chop53};
+
+pub(crate) const CRATE_SLOT_CAPACITY: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct CrateSlot {
+    pub start_frame: i32,
+    pub aux: u32,
+    pub duration: i32,
+    pub cell_x: i16,
+    pub cell_y: i16,
+}
+
+impl Default for CrateSlot {
+    fn default() -> Self {
+        Self {
+            start_frame: -1,
+            aux: 0,
+            duration: 0,
+            cell_x: 0,
+            cell_y: 0,
+        }
+    }
+}
+
+impl CrateSlot {
+    pub fn is_empty(self) -> bool {
+        self.cell_x == 0 && self.cell_y == 0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CrateAuthority {
+    #[serde(with = "crate_slot_array_serde")]
+    slots: [CrateSlot; CRATE_SLOT_CAPACITY],
+}
+
+impl Default for CrateAuthority {
+    fn default() -> Self {
+        Self {
+            slots: [CrateSlot::default(); CRATE_SLOT_CAPACITY],
+        }
+    }
+}
+
+impl CrateAuthority {
+    pub(crate) fn first_empty_index(&self) -> Option<usize> {
+        self.slots.iter().position(|slot| slot.is_empty())
+    }
+
+    pub(crate) fn slots(&self) -> &[CrateSlot; CRATE_SLOT_CAPACITY] {
+        &self.slots
+    }
+
+    pub(crate) fn slot_mut(&mut self, index: usize) -> &mut CrateSlot {
+        &mut self.slots[index]
+    }
+}
+
+/// Compute the accepted-slot timer words in the verified x87 expression
+/// direction from `CrateSlot__PlaceOverlayAndInitTimer @ 0x004A17C0`.
+pub(crate) fn crate_timer_words(
+    regen: NativeF64Bits,
+    draw: u32,
+    current_frame: i32,
+) -> (i32, u32, i32) {
+    debug_assert!(draw <= 0x7fff_fffe);
+    let regen = X87Chop53::load_f64(regen).expect("validated CrateRegen");
+    let lower = X87Chop53::mul(regen, X87Chop53::load_i32(450));
+    let upper = X87Chop53::mul(regen, X87Chop53::load_i32(1800));
+    let fraction = X87Chop53::div(
+        X87Chop53::load_i32(draw as i32),
+        X87Chop53::load_i32(0x7fff_fffe),
+    )
+    .expect("nonzero crate timer divisor");
+    let value = X87Chop53::add(
+        lower,
+        X87Chop53::mul(fraction, X87Chop53::sub(upper, lower)),
+    );
+    let stored_upper = X87Chop53::store_f64(upper).expect("finite CrateRegen upper");
+    let duration = X87Chop53::ftol_i64(value).expect("validated crate duration fits i64") as i32;
+    (current_frame, (stored_upper.bits() >> 32) as u32, duration)
+}
+
+mod crate_slot_array_serde {
+    use super::{CRATE_SLOT_CAPACITY, CrateSlot};
+    use serde::de::{self, SeqAccess, Visitor};
+    use serde::ser::SerializeTuple;
+    use serde::{Deserializer, Serializer};
+    use std::fmt;
+
+    pub fn serialize<S>(
+        slots: &[CrateSlot; CRATE_SLOT_CAPACITY],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(CRATE_SLOT_CAPACITY)?;
+        for slot in slots {
+            tuple.serialize_element(slot)?;
+        }
+        tuple.end()
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<[CrateSlot; CRATE_SLOT_CAPACITY], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SlotsVisitor;
+
+        impl<'de> Visitor<'de> for SlotsVisitor {
+            type Value = [CrateSlot; CRATE_SLOT_CAPACITY];
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(formatter, "exactly {CRATE_SLOT_CAPACITY} crate slots")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut slots = [CrateSlot::default(); CRATE_SLOT_CAPACITY];
+                for (index, slot) in slots.iter_mut().enumerate() {
+                    *slot = seq.next_element()?.ok_or_else(|| {
+                        de::Error::invalid_length(index, &"exactly 256 crate slots")
+                    })?;
+                }
+                Ok(slots)
+            }
+        }
+
+        deserializer.deserialize_tuple(CRATE_SLOT_CAPACITY, SlotsVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crate_authority_fresh_slots_and_first_empty_are_exact() {
+        let mut authority = CrateAuthority::default();
+        assert!(authority.slots().iter().all(|slot| {
+            *slot
+                == CrateSlot {
+                    start_frame: -1,
+                    aux: 0,
+                    duration: 0,
+                    cell_x: 0,
+                    cell_y: 0,
+                }
+        }));
+        assert_eq!(authority.first_empty_index(), Some(0));
+
+        authority.slot_mut(0).cell_x = 7;
+        assert_eq!(authority.first_empty_index(), Some(1));
+        authority.slot_mut(0).cell_x = 0;
+        authority.slot_mut(0).cell_y = -2;
+        assert_eq!(authority.first_empty_index(), Some(1));
+        authority.slot_mut(0).cell_y = 0;
+        authority.slot_mut(0).duration = 99;
+        assert_eq!(
+            authority.first_empty_index(),
+            Some(0),
+            "timer words do not make a zero-coordinate slot occupied"
+        );
+
+        for (index, slot) in authority.slots.iter_mut().enumerate() {
+            slot.cell_x = i16::try_from(index + 1).expect("slot index fits i16");
+        }
+        assert_eq!(authority.first_empty_index(), None);
+    }
+
+    #[test]
+    fn crate_timer_native_endpoints_and_interior_vector() {
+        let regen = NativeF64Bits::from_bits(3.0_f64.to_bits());
+        assert_eq!(crate_timer_words(regen, 0, -1), (-1, 0x40b5_1800, 1350));
+        assert_eq!(
+            crate_timer_words(regen, 0x7fff_fffe, i32::MIN),
+            (i32::MIN, 0x40b5_1800, 5400)
+        );
+        assert_eq!(
+            crate_timer_words(regen, 0x3fff_ffff, 77),
+            (77, 0x40b5_1800, 3375)
+        );
+    }
+
+    #[test]
+    fn crate_authority_tuple_codec_rejects_truncated_storage() {
+        let authority = CrateAuthority::default();
+        let mut value = serde_json::to_value(&authority).expect("authority serializes");
+        let slots = value
+            .get_mut("slots")
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("slots serialize as a tuple sequence");
+        assert_eq!(slots.len(), CRATE_SLOT_CAPACITY);
+        slots.pop();
+        let error = serde_json::from_value::<CrateAuthority>(value)
+            .expect_err("255 slots must not deserialize");
+        assert!(error.to_string().contains("256 crate slots"));
+    }
+
+    #[test]
+    fn crate_authority_every_raw_word_changes_v114_hash_only() {
+        use crate::sim::world::Simulation;
+
+        let baseline = Simulation::new();
+        let baseline_current = baseline.state_hash();
+        let baseline_v113 = baseline.state_hash_without_crate_authority_v114();
+        for slot in [
+            CrateSlot {
+                start_frame: 8,
+                ..CrateSlot::default()
+            },
+            CrateSlot {
+                aux: 9,
+                ..CrateSlot::default()
+            },
+            CrateSlot {
+                duration: -10,
+                ..CrateSlot::default()
+            },
+            CrateSlot {
+                cell_x: -11,
+                ..CrateSlot::default()
+            },
+            CrateSlot {
+                cell_y: 12,
+                ..CrateSlot::default()
+            },
+        ] {
+            let mut changed = Simulation::new();
+            *changed.crate_authority.slot_mut(73) = slot;
+            assert_ne!(baseline_current, changed.state_hash());
+            assert_eq!(
+                baseline_v113,
+                changed.state_hash_without_crate_authority_v114()
+            );
+        }
+    }
+
+    #[test]
+    fn crate_authority_is_excluded_from_retail_multiplayer_checksum() {
+        use crate::sim::world::Simulation;
+
+        let mut baseline = Simulation::with_seed(0x1414);
+        let mut changed = Simulation::with_seed(0x1414);
+        *changed.crate_authority.slot_mut(4) = CrateSlot {
+            start_frame: i32::MAX,
+            aux: u32::MAX,
+            duration: i32::MIN,
+            cell_x: -7,
+            cell_y: 31,
+        };
+        let empty_families = [&[][..], &[][..], &[][..], &[][..], &[][..]];
+        assert_eq!(
+            baseline
+                .compute_retail_multiplayer_checksum(empty_families)
+                .expect("baseline checksum"),
+            changed
+                .compute_retail_multiplayer_checksum(empty_families)
+                .expect("changed checksum")
+        );
+    }
+}

--- a/src/sim/crates/state.rs
+++ b/src/sim/crates/state.rs
@@ -98,7 +98,10 @@ pub(crate) fn crate_timer_words(
         X87Chop53::mul(fraction, X87Chop53::sub(upper, lower)),
     );
     let stored_upper = X87Chop53::store_f64(upper).expect("finite CrateRegen upper");
-    let duration = X87Chop53::ftol_i64(value).expect("validated crate duration fits i64") as i32;
+    // `Math__ftol @ 0x007C5F00` executes masked `FISTP qword`; an
+    // out-of-range conversion stores integer-indefinite i64::MIN. The crate
+    // writer at 0x004A18C5 keeps only EAX, so either-sign overflow becomes 0.
+    let duration = X87Chop53::ftol_i64(value).unwrap_or(i64::MIN) as i32;
     (current_frame, (stored_upper.bits() >> 32) as u32, duration)
 }
 
@@ -210,6 +213,21 @@ mod tests {
             crate_timer_words(regen, 0x3fff_ffff, 77),
             (77, 0x40b5_1800, 3375)
         );
+    }
+
+    #[test]
+    fn crate_timer_out_of_range_fistp_stores_integer_indefinite_low_dword() {
+        for regen in [1.0e20_f64, -1.0e20_f64] {
+            let (_, _, duration) = crate_timer_words(
+                NativeF64Bits::from_bits(regen.to_bits()),
+                0x3fff_ffff,
+                91,
+            );
+            assert_eq!(
+                duration, 0,
+                "masked FISTP qword writes i64::MIN and the native slot keeps low EAX"
+            );
+        }
     }
 
     #[test]

--- a/src/sim/multiplayer_checksum.rs
+++ b/src/sim/multiplayer_checksum.rs
@@ -380,6 +380,7 @@ mod tests {
             world_coord: AnimWorldCoord { x, y, z: 0 },
             draw_flags: 0,
             z_adjust: 0,
+            remap_color: None,
             effective_end: 1,
             effective_loop_end: 1,
             runtime: AnimRuntime {

--- a/src/sim/overlay_grid.rs
+++ b/src/sim/overlay_grid.rs
@@ -10,7 +10,7 @@
 use crate::map::overlay::{OverlayDataPack, OverlayEntry};
 use crate::map::overlay_types::{
     OverlayTypeRegistry, clears_tiberium_on_slope, is_bridge_overlay_index,
-    native_mark_overlay_data, retained_overlay_land,
+    retained_overlay_land,
 };
 use crate::map::resolved_terrain::{
     ResolvedTerrainGrid, overlay_reduced_zone_type, recalc_zone_type,
@@ -366,34 +366,38 @@ impl OverlayGrid {
         NativeOverlayPlacementResult::Placed
     }
 
-    /// Commit a crate overlay after `CrateSlot__ValidateCellAndCreateOverlay`
-    /// has accepted its native Mark predicates.
-    ///
-    /// This is deliberately narrower than [`Self::place_overlay_native_runtime`]:
-    /// the crate validator owns terrain, slope, occupation, speed, and identity
-    /// checks, while this writer only reproduces the successful CellClass
-    /// mutation: identity, then ordinary data zero / Road data one / Crate data
-    /// `0xFF`. A cleared wall's inert owner is unrelated Cell authority and
-    /// therefore survives the write.
-    pub(crate) fn place_crate_overlay(
+    /// Write the two literal CellClass overlay fields without running the
+    /// common `RecalcAttributes` tail yet. Ordinary Mark needs this split so
+    /// Road germination, the Crate-data override, and CellAnim construction
+    /// occur in their native order before the tail recalc.
+    pub(crate) fn write_crate_mark_fields(
         &mut self,
         resolved_terrain: &mut ResolvedTerrainGrid,
         registry: &OverlayTypeRegistry,
         rx: u16,
         ry: u16,
         overlay_id: u8,
+        overlay_data: u8,
     ) -> bool {
         let Some(idx) = index_of(self.width, self.height, rx, ry) else {
             return false;
         };
-        let Some(flags) = registry.flags(overlay_id) else {
+        if registry.flags(overlay_id).is_none() {
+            return false;
+        }
+        let Some(name) = registry.name(overlay_id) else {
             return false;
         };
         self.cells[idx].overlay_id = Some(overlay_id);
-        self.cells[idx].overlay_data = native_mark_overlay_data(flags);
+        self.cells[idx].overlay_data = overlay_data;
         self.dirty_cells.push((rx, ry));
-        let changed = recalc_overlay_passability(self, resolved_terrain, registry, rx, ry);
-        self.record_synchronous_passability_change_at(rx, ry, changed);
+        resolved_terrain.set_runtime_overlay_bridge_identity(
+            rx,
+            ry,
+            overlay_id,
+            overlay_data,
+            name,
+        );
         true
     }
 

--- a/src/sim/overlay_grid.rs
+++ b/src/sim/overlay_grid.rs
@@ -401,6 +401,34 @@ impl OverlayGrid {
         true
     }
 
+    /// Write only the raw `CellClass::OverlayData` byte and emit the setter's
+    /// immediate radar-dirty event. High-bridge setters do this even when the
+    /// target cell has no overlay identity yet.
+    pub(crate) fn write_crate_mark_data_field(
+        &mut self,
+        resolved_terrain: &mut ResolvedTerrainGrid,
+        rx: u16,
+        ry: u16,
+        overlay_data: u8,
+    ) -> bool {
+        let Some(idx) = index_of(self.width, self.height, rx, ry) else {
+            return false;
+        };
+        if !resolved_terrain.set_runtime_overlay_bridge_state_byte(rx, ry, overlay_data) {
+            return false;
+        }
+        self.cells[idx].overlay_data = overlay_data;
+        self.dirty_cells.push((rx, ry));
+        true
+    }
+
+    /// Pending overlay/radar dirty coordinates without consuming the runtime
+    /// receipt. Initial presentation uses this to include every real cell
+    /// written by a multi-cell startup Mark transaction.
+    pub(crate) fn pending_dirty_cells(&self) -> &[(u16, u16)] {
+        &self.dirty_cells
+    }
+
     /// Reconstruct owners for map-loaded wall overlays after buildings exist.
     /// Strict distance improvement preserves the first candidate on ties.
     pub fn reconstruct_map_wall_owners(

--- a/src/sim/overlay_grid.rs
+++ b/src/sim/overlay_grid.rs
@@ -365,6 +365,33 @@ impl OverlayGrid {
         NativeOverlayPlacementResult::Placed
     }
 
+    /// Commit a crate overlay after `CrateSlot__ValidateCellAndCreateOverlay`
+    /// has accepted its native Mark predicates.
+    ///
+    /// This is deliberately narrower than [`Self::place_overlay_native_runtime`]:
+    /// the crate validator owns terrain, slope, occupation, speed, and identity
+    /// checks, while this writer only reproduces the successful CellClass
+    /// mutation (`identity`, then data `0xFF`). A cleared wall's inert owner is
+    /// unrelated Cell authority and therefore survives the write.
+    pub(crate) fn place_crate_overlay(
+        &mut self,
+        resolved_terrain: &mut ResolvedTerrainGrid,
+        registry: &OverlayTypeRegistry,
+        rx: u16,
+        ry: u16,
+        overlay_id: u8,
+    ) -> bool {
+        let Some(idx) = index_of(self.width, self.height, rx, ry) else {
+            return false;
+        };
+        self.cells[idx].overlay_id = Some(overlay_id);
+        self.cells[idx].overlay_data = u8::MAX;
+        self.dirty_cells.push((rx, ry));
+        let changed = recalc_overlay_passability(self, resolved_terrain, registry, rx, ry);
+        self.record_synchronous_passability_change_at(rx, ry, changed);
+        true
+    }
+
     /// Reconstruct owners for map-loaded wall overlays after buildings exist.
     /// Strict distance improvement preserves the first candidate on ties.
     pub fn reconstruct_map_wall_owners(

--- a/src/sim/overlay_grid.rs
+++ b/src/sim/overlay_grid.rs
@@ -9,7 +9,8 @@
 
 use crate::map::overlay::{OverlayDataPack, OverlayEntry};
 use crate::map::overlay_types::{
-    OverlayTypeRegistry, clears_tiberium_on_slope, is_bridge_overlay_index, retained_overlay_land,
+    OverlayTypeRegistry, clears_tiberium_on_slope, is_bridge_overlay_index,
+    native_mark_overlay_data, retained_overlay_land,
 };
 use crate::map::resolved_terrain::{
     ResolvedTerrainGrid, overlay_reduced_zone_type, recalc_zone_type,
@@ -371,8 +372,9 @@ impl OverlayGrid {
     /// This is deliberately narrower than [`Self::place_overlay_native_runtime`]:
     /// the crate validator owns terrain, slope, occupation, speed, and identity
     /// checks, while this writer only reproduces the successful CellClass
-    /// mutation (`identity`, then data `0xFF`). A cleared wall's inert owner is
-    /// unrelated Cell authority and therefore survives the write.
+    /// mutation: identity, then ordinary data zero / Road data one / Crate data
+    /// `0xFF`. A cleared wall's inert owner is unrelated Cell authority and
+    /// therefore survives the write.
     pub(crate) fn place_crate_overlay(
         &mut self,
         resolved_terrain: &mut ResolvedTerrainGrid,
@@ -384,8 +386,11 @@ impl OverlayGrid {
         let Some(idx) = index_of(self.width, self.height, rx, ry) else {
             return false;
         };
+        let Some(flags) = registry.flags(overlay_id) else {
+            return false;
+        };
         self.cells[idx].overlay_id = Some(overlay_id);
-        self.cells[idx].overlay_data = u8::MAX;
+        self.cells[idx].overlay_data = native_mark_overlay_data(flags);
         self.dirty_cells.push((rx, ry));
         let changed = recalc_overlay_passability(self, resolved_terrain, registry, rx, ry);
         self.record_synchronous_passability_change_at(rx, ry, changed);

--- a/src/sim/runtime.rs
+++ b/src/sim/runtime.rs
@@ -818,6 +818,7 @@ pub(crate) fn finalize_constructed_scenario(
         map_height: map_data.header.height as u16,
         basic: &map_data.basic,
         special_flags: &map_data.special_flags,
+        normal_lighting: crate::map::lighting::parse_lighting_profiles(&map_data.ini).normal,
         rules,
         overlay_registry,
         house_roster,

--- a/src/sim/scenario_bootstrap.rs
+++ b/src/sim/scenario_bootstrap.rs
@@ -3698,6 +3698,7 @@ mod tests {
             map_height: SIZE,
             basic: &map.basic,
             special_flags: &map.special_flags,
+            normal_lighting: crate::map::lighting::parse_lighting_profiles(&map.ini).normal,
             rules: &rules,
             overlay_registry: &overlays,
             house_roster: &house_roster,

--- a/src/sim/scenario_bootstrap.rs
+++ b/src/sim/scenario_bootstrap.rs
@@ -3707,7 +3707,8 @@ mod tests {
             output.crates,
             Some(crate::sim::crates::CratePlacement {
                 requested: 1,
-                placed: 1,
+                accepted: 1,
+                visible: 1,
             })
         );
         let wood = overlays.id_for_name("WOOD").expect("WOOD crate overlay");

--- a/src/sim/scenario_post_map.rs
+++ b/src/sim/scenario_post_map.rs
@@ -303,12 +303,13 @@ mod tests {
         // post-map command. Model that prerequisite instead of relying on the
         // now-removed permissive headless fallback.
         sim.playfield_bounds = Some(crate::sim::cell_rect::PlayfieldBounds {
-            base: 0,
+            base: 4,
             off_fc: -32,
             off_100: -32,
             off_104: 64,
             off_108: 64,
         });
+        sim.playfield_size_height = Some(4);
         sim.session.game_options.crates = true;
         sim.resolved_terrain = Some(flat_terrain());
         sim.overlay_grid = Some(OverlayGrid::new(MAP_SIZE, MAP_SIZE));
@@ -372,7 +373,8 @@ mod tests {
             output.crates,
             Some(CratePlacement {
                 requested: 1,
-                placed: 1,
+                accepted: 1,
+                visible: 1,
             })
         );
         let wood = overlays.id_for_name("WOOD").expect("WOOD overlay");

--- a/src/sim/scenario_post_map.rs
+++ b/src/sim/scenario_post_map.rs
@@ -24,6 +24,7 @@ pub(crate) struct ScenarioPostMapInput<'a> {
     pub(crate) map_height: u16,
     pub(crate) basic: &'a BasicSection,
     pub(crate) special_flags: &'a SpecialFlagsSection,
+    pub(crate) normal_lighting: crate::map::lighting::LightingProfileUnits,
     pub(crate) rules: &'a RuleSet,
     pub(crate) overlay_registry: &'a OverlayTypeRegistry,
     pub(crate) house_roster: &'a HouseRoster,
@@ -97,7 +98,7 @@ impl Simulation {
 
         // Runtime rebuilds use this same sim-owned publication seam. Crate
         // placement below pins the newly published path snapshot.
-        let navigation_published = self.rebuild_dynamic_navigation(input.rules);
+        let mut navigation_published = self.rebuild_dynamic_navigation(input.rules);
 
         #[cfg(test)]
         let mut skirmish_order = [None; 3];
@@ -109,13 +110,22 @@ impl Simulation {
             {
                 skirmish_order[0] = Some(ScenarioPostMapStep::StartupCrates);
             }
-            let placement = crate::sim::crates::place_scenario_start_crates(
+            let placement = crate::sim::crates::place_scenario_start_crates_with_lighting(
                 self,
                 input.rules,
                 input.overlay_registry,
                 initial_path.as_deref(),
                 player_count,
+                input.normal_lighting,
             );
+            // Startup OverlayClass::Mark completes synchronously before native
+            // proceeds to AI credits. Rust's BridgeRuntimeState is a derived
+            // cache built earlier in the load funnel, so rebuild it from the
+            // now-final CellClass projection and publish matching first-frame
+            // navigation without consuming OverlayGrid's dirty receipt.
+            if self.refresh_bridge_runtime_after_startup_crates() {
+                navigation_published = self.rebuild_dynamic_navigation(input.rules);
+            }
             #[cfg(test)]
             {
                 skirmish_order[1] = Some(ScenarioPostMapStep::AiOpeningCredits);
@@ -144,6 +154,27 @@ impl Simulation {
             skirmish_order,
         }
     }
+
+    fn refresh_bridge_runtime_after_startup_crates(&mut self) -> bool {
+        let Some((destroyable, bridge_strength)) = self
+            .bridge_state
+            .as_ref()
+            .map(|state| (state.is_destroyable(), state.bridge_strength()))
+        else {
+            return false;
+        };
+        let Some(terrain) = self.resolved_terrain.as_ref() else {
+            return false;
+        };
+        self.bridge_state = Some(
+            crate::sim::bridge_state::BridgeRuntimeState::from_resolved_terrain(
+                terrain,
+                destroyable,
+                bridge_strength,
+            ),
+        );
+        true
+    }
 }
 
 #[cfg(test)]
@@ -151,6 +182,7 @@ mod tests {
     use super::*;
 
     use std::collections::BTreeSet;
+    use std::fmt::Write as _;
 
     use crate::map::bridge_facts::BridgeCellFacts;
     use crate::map::houses::HouseDefinition;
@@ -374,6 +406,7 @@ mod tests {
             map_height: MAP_SIZE,
             basic: &basic,
             special_flags: &special_flags,
+            normal_lighting: crate::map::lighting::ParsedLightingProfiles::default().normal,
             rules: &rules,
             overlay_registry: &overlays,
             house_roster: &roster,
@@ -434,6 +467,104 @@ mod tests {
     }
 
     #[test]
+    fn startup_high_bridge_reaches_bridge_runtime_and_initial_navigation() {
+        let mut ini_text = String::from(
+            "[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
+             [OverlayTypes]\n",
+        );
+        for overlay_id in 0..=0x18u8 {
+            let name = if overlay_id == 0x18 {
+                "BRIDGE1".to_string()
+            } else {
+                format!("OV{overlay_id:03}")
+            };
+            writeln!(&mut ini_text, "{overlay_id}={name}").unwrap();
+        }
+        ini_text.push_str(
+            "[BRIDGE1]\nCrate=yes\n\
+             [CrateRules]\nCrateImg=BRIDGE1\nWoodCrateImg=BRIDGE1\n\
+             WaterCrateImg=BRIDGE1\nCrateMinimum=1\nCrateMaximum=1\n",
+        );
+        let ini = IniFile::from_str(&ini_text);
+        let rules = RuleSet::from_ini(&ini).expect("high startup crate rules");
+        let overlays = OverlayTypeRegistry::from_ini(&ini, None);
+        let mut sim = Simulation::with_seed(0x51C0_0414);
+        sim.session.map_width = MAP_SIZE;
+        sim.session.map_height = MAP_SIZE;
+        sim.playfield_bounds = Some(crate::sim::cell_rect::PlayfieldBounds {
+            base: 4,
+            off_fc: -32,
+            off_100: -32,
+            off_104: 64,
+            off_108: 64,
+        });
+        sim.playfield_size_height = Some(4);
+        sim.session.game_options.crates = true;
+        let terrain = flat_terrain();
+        sim.bridge_state = Some(
+            crate::sim::bridge_state::BridgeRuntimeState::from_resolved_terrain(
+                &terrain, true, 300,
+            ),
+        );
+        sim.resolved_terrain = Some(terrain);
+        sim.overlay_grid = Some(OverlayGrid::new(MAP_SIZE, MAP_SIZE));
+        let player = sim.interner.intern("Player");
+        sim.houses
+            .insert(player, HouseState::new(player, 0, None, true, 5_000, 10));
+        let descriptor = crate::sim::scenario_bootstrap::MatchLaunchDescriptor::from_resolved(
+            allied_skirmish_session(),
+        )
+        .expect("fixture session is fully resolved");
+
+        let output = sim.finalize_scenario_post_map(ScenarioPostMapInput {
+            map_width: MAP_SIZE,
+            map_height: MAP_SIZE,
+            basic: &BasicSection::default(),
+            special_flags: &SpecialFlagsSection::default(),
+            normal_lighting: crate::map::lighting::ParsedLightingProfiles::default().normal,
+            rules: &rules,
+            overlay_registry: &overlays,
+            house_roster: &HouseRoster::default(),
+            skirmish_session: Some(&descriptor),
+        });
+
+        assert_eq!(
+            output.crates,
+            Some(CratePlacement {
+                requested: 1,
+                accepted: 1,
+                visible: 1,
+            })
+        );
+        let anchor = sim
+            .crate_authority
+            .occupied_cells()
+            .next()
+            .expect("one startup crate anchor");
+        let bridge_cell = sim
+            .bridge_state
+            .as_ref()
+            .and_then(|state| state.cell(anchor.0, anchor.1))
+            .expect("startup high anchor reaches BridgeRuntimeState");
+        assert!(bridge_cell.deck_present);
+        assert_eq!(bridge_cell.overlay_byte, 0x18);
+        let path_cell = sim
+            .path_grid()
+            .and_then(|grid| grid.cell(anchor.0, anchor.1))
+            .expect("republished initial path cell");
+        assert!(path_cell.bridge_structural);
+        assert!(path_cell.bridge_walkable);
+        assert!(
+            !sim.overlay_grid
+                .as_ref()
+                .unwrap()
+                .pending_dirty_cells()
+                .is_empty(),
+            "bridge/nav rebuild must not consume the first-frame overlay receipt"
+        );
+    }
+
+    #[test]
     fn generic_post_map_preserves_rng_and_credits_when_overlay_authority_is_absent() {
         let (rules, overlays) = post_map_rules_and_overlays();
         let mut sim = Simulation::with_seed(0x51C0_0402);
@@ -476,6 +607,7 @@ mod tests {
             map_height: MAP_SIZE,
             basic: &BasicSection::default(),
             special_flags: &SpecialFlagsSection::default(),
+            normal_lighting: crate::map::lighting::ParsedLightingProfiles::default().normal,
             rules: &rules,
             overlay_registry: &overlays,
             house_roster: &roster,

--- a/src/sim/scenario_post_map.rs
+++ b/src/sim/scenario_post_map.rs
@@ -36,6 +36,16 @@ pub(crate) struct ScenarioPostMapOutput {
     pub(crate) tiberium_queues: Option<NativeTiberiumRebuildStats>,
     pub(crate) navigation_published: bool,
     pub(crate) crates: Option<CratePlacement>,
+    #[cfg(test)]
+    pub(crate) skirmish_order: [Option<ScenarioPostMapStep>; 3],
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ScenarioPostMapStep {
+    StartupCrates,
+    AiOpeningCredits,
+    LaunchAlliances,
 }
 
 impl Simulation {
@@ -89,11 +99,16 @@ impl Simulation {
         // placement below pins the newly published path snapshot.
         let navigation_published = self.rebuild_dynamic_navigation(input.rules);
 
+        #[cfg(test)]
+        let mut skirmish_order = [None; 3];
         let crates = if let Some(descriptor) = input.skirmish_session {
             let session = descriptor.session();
-            crate::sim::scenario_bootstrap::apply_skirmish_ai_opening_credits(self);
             let player_count = crate::sim::crates::human_player_count(self);
             let initial_path = self.path_grid_snapshot();
+            #[cfg(test)]
+            {
+                skirmish_order[0] = Some(ScenarioPostMapStep::StartupCrates);
+            }
             let placement = crate::sim::crates::place_scenario_start_crates(
                 self,
                 input.rules,
@@ -101,6 +116,15 @@ impl Simulation {
                 initial_path.as_deref(),
                 player_count,
             );
+            #[cfg(test)]
+            {
+                skirmish_order[1] = Some(ScenarioPostMapStep::AiOpeningCredits);
+            }
+            crate::sim::scenario_bootstrap::apply_skirmish_ai_opening_credits(self);
+            #[cfg(test)]
+            {
+                skirmish_order[2] = Some(ScenarioPostMapStep::LaunchAlliances);
+            }
             crate::sim::scenario_bootstrap::apply_skirmish_launch_alliances(
                 self,
                 input.house_roster,
@@ -116,6 +140,8 @@ impl Simulation {
             tiberium_queues,
             navigation_published,
             crates,
+            #[cfg(test)]
+            skirmish_order,
         }
     }
 }
@@ -387,6 +413,14 @@ mod tests {
             .collect();
         assert_eq!(crate_cells, vec![expected_crate_cell]);
         assert_eq!(sim.scenario_rng.state(), expected_rng.state());
+        assert_eq!(
+            output.skirmish_order,
+            [
+                Some(ScenarioPostMapStep::StartupCrates),
+                Some(ScenarioPostMapStep::AiOpeningCredits),
+                Some(ScenarioPostMapStep::LaunchAlliances),
+            ]
+        );
         assert!(
             sim.house_alliances
                 .get("PLAYER")
@@ -451,6 +485,7 @@ mod tests {
         assert_eq!(output.tiberium_queues, None);
         assert!(output.navigation_published);
         assert_eq!(output.crates, None);
+        assert_eq!(output.skirmish_order, [None; 3]);
         assert_eq!(sim.scenario_rng.state(), rng_before);
         assert_eq!(sim.houses[&owner].credits, 7_500);
         assert!(

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -328,7 +328,9 @@ use crate::sim::world::Simulation;
 // latches co-enabled by successful qualifying base-unit deployment.
 // Bumped 112 -> 113: persist House AutocreateAllowed beside the three deploy
 // latches in native conceptual byte order.
-const SNAPSHOT_VERSION: u32 = 113;
+// Bumped 113 -> 114: persist the raw 256-entry MapClass crate-slot table,
+// including accepted ghosts and all native timer words.
+const SNAPSHOT_VERSION: u32 = 114;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -2741,10 +2743,35 @@ mod tests {
     /// House BuildConst vector and immutable entity membership; 109 -> 110
     /// adds ordered BasePlan state and immutable BuildingType facts; 110 -> 111
     /// adds the distinct BaseClass plan center; 111 -> 112 adds the three House
-    /// AI activation latches; 112 -> 113 adds House AutocreateAllowed.
+    /// AI activation latches; 112 -> 113 adds House AutocreateAllowed;
+    /// 113 -> 114 adds the raw 256-entry scenario-crate slot table.
     #[test]
-    fn phase3_house_ai_activation_snapshot_version_is_113() {
-        assert_eq!(super::SNAPSHOT_VERSION, 113);
+    fn phase14_crate_authority_snapshot_version_is_114() {
+        assert_eq!(super::SNAPSHOT_VERSION, 114);
+    }
+
+    #[test]
+    fn phase14_crate_authority_roundtrips_visible_and_ghost_slots() {
+        let mut sim = Simulation::with_seed(0);
+        *sim.crate_authority.slot_mut(0) = crate::sim::crates::CrateSlot {
+            start_frame: 17,
+            aux: 0x40b5_1800,
+            duration: 3375,
+            cell_x: 6,
+            cell_y: 9,
+        };
+        *sim.crate_authority.slot_mut(1) = crate::sim::crates::CrateSlot {
+            start_frame: -2,
+            aux: u32::MAX,
+            duration: i32::MIN,
+            cell_x: -4,
+            cell_y: 12,
+        };
+        let expected = sim.crate_authority.clone();
+
+        let bytes = GameSnapshot::save(&sim, 0, 0, "test_map", 0);
+        let loaded = GameSnapshot::load(&bytes).expect("v114 crate authority snapshot");
+        assert_eq!(loaded.sim.crate_authority, expected);
     }
 
     #[test]

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -329,7 +329,8 @@ use crate::sim::world::Simulation;
 // Bumped 112 -> 113: persist House AutocreateAllowed beside the three deploy
 // latches in native conceptual byte order.
 // Bumped 113 -> 114: persist the raw 256-entry MapClass crate-slot table,
-// including accepted ghosts and all native timer words.
+// including accepted ghosts and all native timer words, plus the per-Anim
+// Convert palette selector installed by startup crate CellAnim.
 const SNAPSHOT_VERSION: u32 = 114;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
@@ -2744,7 +2745,8 @@ mod tests {
     /// adds ordered BasePlan state and immutable BuildingType facts; 110 -> 111
     /// adds the distinct BaseClass plan center; 111 -> 112 adds the three House
     /// AI activation latches; 112 -> 113 adds House AutocreateAllowed;
-    /// 113 -> 114 adds the raw 256-entry scenario-crate slot table.
+    /// 113 -> 114 adds the raw 256-entry scenario-crate slot table and the
+    /// per-Anim Convert palette selector used by startup crate CellAnim.
     #[test]
     fn phase14_crate_authority_snapshot_version_is_114() {
         assert_eq!(super::SNAPSHOT_VERSION, 114);

--- a/src/sim/world/bridge_parity_harness_tests.rs
+++ b/src/sim/world/bridge_parity_harness_tests.rs
@@ -108,8 +108,12 @@ const MIN_DISTINCT_DECK_CELLS: usize = 6;
 /// Re-baselined 2026-08-30 for v110's unconditional ordered BasePlan authority.
 /// The dedicated pre-v110 probe below reproduces the prior baseline exactly;
 /// path, bridge tripwires, RNG streams, and tick-for-tick replay remain exact.
+/// Re-baselined 2026-09-01 for v114's unconditional raw 256-slot crate authority.
+/// The dedicated pre-v114 probe reproduces the prior current baseline exactly;
+/// the same crossing, tripwires, streams, and replay equality remain exact.
 const BRIDGE_HARNESS_PRE_BASE_PLAN_V110_HASH: u64 = 0x5B44_6C68_9BC2_F0AF;
-const BRIDGE_HARNESS_FINAL_HASH: u64 = 0x6AFB_F54C_7397_0202;
+const BRIDGE_HARNESS_PRE_CRATE_AUTHORITY_V114_HASH: u64 = 0x6AFB_F54C_7397_0202;
+const BRIDGE_HARNESS_FINAL_HASH: u64 = 0x874E_6F7E_7BF1_F8D6;
 
 fn bridge_ini() -> IniFile {
     // One armed ground vehicle and one distant infantryman on a second house, so
@@ -503,8 +507,9 @@ fn bridge_crossing_replay_is_deterministic_and_baseline_stable() {
 
     let final_hash = *replayed.last().expect("at least one tick replayed");
     let pre_base_plan_hash = rep.state_hash_without_base_plan_v110();
+    let pre_crate_authority_hash = rep.state_hash_without_crate_authority_v114();
     println!(
-        "[bridge parity] final_hash={final_hash:016X} pre-v110:{pre_base_plan_hash:016X} streams={:016X},{:016X},{:016X}",
+        "[bridge parity] final_hash={final_hash:016X} pre-v110:{pre_base_plan_hash:016X} pre-v114:{pre_crate_authority_hash:016X} streams={:016X},{:016X},{:016X}",
         rep.scenario_rng.state(),
         rep.main_rng.state(),
         rep.mapgen_rng.state(),
@@ -512,6 +517,10 @@ fn bridge_crossing_replay_is_deterministic_and_baseline_stable() {
     assert_eq!(
         pre_base_plan_hash, BRIDGE_HARNESS_PRE_BASE_PLAN_V110_HASH,
         "the dedicated pre-v110 probe must reproduce the prior bridge baseline"
+    );
+    assert_eq!(
+        pre_crate_authority_hash, BRIDGE_HARNESS_PRE_CRATE_AUTHORITY_V114_HASH,
+        "the dedicated pre-v114 probe must reproduce the prior bridge current baseline"
     );
     assert_eq!(
         final_hash, BRIDGE_HARNESS_FINAL_HASH,

--- a/src/sim/world/global_parity_harness_tests.rs
+++ b/src/sim/world/global_parity_harness_tests.rs
@@ -518,8 +518,12 @@ const GLOBAL_HARNESS_PRE_MISSION_V29_HASH: u64 = 0xE2B3_9FAA_432F_4A75;
 // Re-baselined 2026-08-30 for v110's unconditional ordered BasePlan authority.
 // The dedicated pre-v110 probe reproduces the prior baseline exactly; the RNG
 // tuple and tick-for-tick replay remain exact, proving composition-only drift.
+// Re-baselined 2026-09-01 for v114's unconditional raw 256-slot crate authority.
+// The dedicated pre-v114 probe reproduces the prior current baseline exactly;
+// the RNG tuple and tick-for-tick replay remain exact, proving composition-only drift.
 const GLOBAL_HARNESS_PRE_BASE_PLAN_V110_HASH: u64 = 0x254E_775C_65A2_B50A;
-const GLOBAL_HARNESS_FINAL_HASH: u64 = 0x0E44_D6C4_D418_D99A;
+const GLOBAL_HARNESS_PRE_CRATE_AUTHORITY_V114_HASH: u64 = 0x0E44_D6C4_D418_D99A;
+const GLOBAL_HARNESS_FINAL_HASH: u64 = 0x08C7_02E3_A11C_9F70;
 
 fn harness_ini() -> IniFile {
     // Multi-faction vehicles + infantry + buildings (war factory, refinery) plus a
@@ -814,8 +818,9 @@ fn global_skirmish_replay_is_deterministic_and_baseline_stable() {
     let pre_lifecycle_hash = rep.state_hash_before_lifecycle_v28_and_mission_v29();
     let pre_mission_hash = rep.state_hash_without_mission_v29();
     let pre_base_plan_hash = rep.state_hash_without_base_plan_v110();
+    let pre_crate_authority_hash = rep.state_hash_without_crate_authority_v114();
     println!(
-        "[global parity] probes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},pre-v110:{pre_base_plan_hash:016X}"
+        "[global parity] probes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},pre-v110:{pre_base_plan_hash:016X},pre-v114:{pre_crate_authority_hash:016X}"
     );
     assert_eq!(
         pre_lifecycle_hash, GLOBAL_HARNESS_PRE_LIFECYCLE_V28_HASH,
@@ -828,6 +833,10 @@ fn global_skirmish_replay_is_deterministic_and_baseline_stable() {
     assert_eq!(
         pre_base_plan_hash, GLOBAL_HARNESS_PRE_BASE_PLAN_V110_HASH,
         "the dedicated pre-v110 probe must reproduce the prior global-harness baseline"
+    );
+    assert_eq!(
+        pre_crate_authority_hash, GLOBAL_HARNESS_PRE_CRATE_AUTHORITY_V114_HASH,
+        "the dedicated pre-v114 probe must reproduce the prior global-harness current baseline"
     );
     assert_eq!(
         final_hash, GLOBAL_HARNESS_FINAL_HASH,

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -1394,6 +1394,7 @@ fn insert_anim(sim: &mut Simulation, stable_id: u64, inactive: bool) {
         world_coord: AnimWorldCoord { x: 0, y: 0, z: 0 },
         draw_flags: 0,
         z_adjust: 0,
+        remap_color: None,
         effective_end: 1,
         effective_loop_end: 1,
         runtime: AnimRuntime {

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -4480,7 +4480,7 @@ fn gsi_05_04_intact_bridge_cell_target_reaches_shrapnel_consumer() {
              [AircraftTypes]\n\
              [BuildingTypes]\n\
              [Warheads]\n0=WH\n\
-             [MTNK]\nStrength=100\nArmor=heavy\nPrimary=PARENT\n\
+             [MTNK]\nStrength=100\nArmor=heavy\nPrimary=PARENT\nSecondary=CHILD\n\
              [PARENT]\nDamage=0\nROF=10\nRange=6\nSpeed=30\nProjectile=PARENTPROJ\nWarhead=WH\n\
              [PARENTPROJ]\nAirburst=yes\nShrapnelWeapon=CHILD\nShrapnelCount=-2\n\
              [CHILD]\nDamage=5\nROF=10\nRange=3\nSpeed=40\nProjectile=CHILDPROJ\nWarhead=WH\n\

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -2820,6 +2820,31 @@ impl Simulation {
         }
     }
 
+    /// High-bridge anchor construction uses the same literal setter as bridge
+    /// damage/repair, but it additionally creates the family/anchor relations
+    /// from which Rust derives live bridge topology.
+    pub(crate) fn apply_runtime_bridge_mark_stamp(
+        &mut self,
+        stamp: crate::map::bridge_facts::BridgeFlagStamp,
+        family: crate::map::bridge_facts::BridgeStampFamily,
+    ) {
+        let Some(terrain) = self.resolved_terrain.as_ref() else {
+            return;
+        };
+        if !terrain.bridge_flag_authority_matches_shape(&self.real_cell_bridge_flags_0x1180) {
+            self.real_cell_bridge_flags_0x1180 = terrain.capture_real_cell_bridge_flags_0x1180();
+        }
+        let updates = self
+            .resolved_terrain
+            .as_mut()
+            .expect("terrain presence checked before runtime bridge Mark setter")
+            .apply_runtime_bridge_mark_stamp(stamp, family);
+        for (index, flags) in updates {
+            self.real_cell_bridge_flags_0x1180
+                .set_allocated_cell(index, flags);
+        }
+    }
+
     /// Commit the allocated real-cell half of a runtime setter that already
     /// executed synchronously through `CellClassBridgeFlagState`. Dummy
     /// coordinate/flag effects are live at the native call point and must not

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -819,6 +819,9 @@ pub struct Simulation {
     /// Per-cell mutable overlay state (ore density, wall damage, bridge frames).
     /// Seeded from map [OverlayPack] at init, mutated during gameplay.
     pub overlay_grid: Option<crate::sim::overlay_grid::OverlayGrid>,
+    /// Persistent MapClass scenario-crate slots, including accepted ghosts and
+    /// their native timer words. This is authoritative save/hash state.
+    pub(crate) crate_authority: crate::sim::crates::CrateAuthority,
     /// Per-cell smudge state (craters, scorches). Seeded from map [Smudge]
     /// entries at init, mutated by combat death-handling at runtime.
     pub smudge_grid: Option<crate::sim::smudge_grid::SmudgeGrid>,
@@ -3011,6 +3014,7 @@ impl Simulation {
             dynamic_terrain_cells: BTreeMap::new(),
             bridge_state: None,
             overlay_grid: None,
+            crate_authority: crate::sim::crates::CrateAuthority::default(),
             smudge_grid: None,
             radiation: crate::sim::radiation::RadiationState::default(),
             playfield_bounds: None,

--- a/src/sim/world/slice6_retask_tests.rs
+++ b/src/sim/world/slice6_retask_tests.rs
@@ -323,8 +323,12 @@ const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x9856_E7DA_D9F1_676A;
 // Re-baselined 2026-08-30 for v110's unconditional ordered BasePlan authority.
 // The dedicated pre-v110 probe reproduces the prior baseline exactly, isolating
 // the measured shift to current-schema composition.
+// Re-baselined 2026-09-01 for v114's unconditional raw 256-slot crate authority.
+// The dedicated pre-v114 probe reproduces the prior current baseline exactly;
+// this fixture's behavior and record/replay equality remain unchanged.
 const SLICE6_PRE_BASE_PLAN_V110_HASH: u64 = 0x214E_DE3E_7939_F143;
-const SLICE6_BASELINE_HASH: u64 = 0x4397_FA88_D95E_5208;
+const SLICE6_PRE_CRATE_AUTHORITY_V114_HASH: u64 = 0x4397_FA88_D95E_5208;
+const SLICE6_BASELINE_HASH: u64 = 0xE61A_9D19_669A_1B9C;
 
 #[test]
 fn replay_hash_stable_through_slice6() {
@@ -402,9 +406,10 @@ fn replay_hash_stable_through_slice6() {
     let pre_lifecycle_hash = sim.state_hash_before_lifecycle_v28_and_mission_v29();
     let pre_mission_hash = sim.state_hash_without_mission_v29();
     let pre_base_plan_hash = sim.state_hash_without_base_plan_v110();
+    let pre_crate_authority_hash = sim.state_hash_without_crate_authority_v114();
     let hash = sim.state_hash();
     println!(
-        "[slice6] hashes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},pre-v110:{pre_base_plan_hash:016X},current:{hash:016X}"
+        "[slice6] hashes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},pre-v110:{pre_base_plan_hash:016X},pre-v114:{pre_crate_authority_hash:016X},current:{hash:016X}"
     );
     assert_eq!(
         pre_lifecycle_hash, SLICE6_PRE_LIFECYCLE_V28_HASH,
@@ -417,6 +422,10 @@ fn replay_hash_stable_through_slice6() {
     assert_eq!(
         pre_base_plan_hash, SLICE6_PRE_BASE_PLAN_V110_HASH,
         "the dedicated pre-v110 probe must reproduce the prior Slice 6 baseline"
+    );
+    assert_eq!(
+        pre_crate_authority_hash, SLICE6_PRE_CRATE_AUTHORITY_V114_HASH,
+        "the dedicated pre-v114 probe must reproduce the prior Slice 6 current baseline"
     );
     assert_eq!(
         hash, SLICE6_BASELINE_HASH,

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -424,7 +424,7 @@ impl Simulation {
     pub fn state_hash(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true,
+            true, true, true, true, true, true,
         )
     }
 
@@ -436,7 +436,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             true, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
         )
     }
 
@@ -448,7 +448,7 @@ impl Simulation {
     pub(crate) fn state_hash_before_lifecycle_v28_and_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             false, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
         )
     }
 
@@ -458,7 +458,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_spark_dummy_level_slope_v107(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, false, false,
-            false, false, false, false, false,
+            false, false, false, false, false, false,
         )
     }
 
@@ -469,7 +469,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_naval_build_const_v109(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            false, false, false, false, false,
+            false, false, false, false, false, false,
         )
     }
 
@@ -480,7 +480,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_base_plan_v110(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, false, false, false, false,
+            true, false, false, false, false, false,
         )
     }
 
@@ -489,7 +489,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_base_plan_center_v111(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, false, false, false,
+            true, true, false, false, false, false,
         )
     }
 
@@ -498,7 +498,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_house_deploy_latches_v112(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, false, false,
+            true, true, true, false, false, false,
         )
     }
 
@@ -508,7 +508,16 @@ impl Simulation {
     pub(crate) fn state_hash_without_house_update_activation_v113(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, false,
+            true, true, true, true, false, false,
+        )
+    }
+
+    /// Test-only provenance probe for the schema-v114 raw crate-slot fold.
+    #[cfg(test)]
+    pub(crate) fn state_hash_without_crate_authority_v114(&self) -> u64 {
+        self.state_hash_with_schema(
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, false,
         )
     }
 
@@ -533,6 +542,7 @@ impl Simulation {
         include_base_plan_center_v111: bool,
         include_house_deploy_latches_v112: bool,
         include_house_update_activation_v113: bool,
+        include_crate_authority_v114: bool,
     ) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
 
@@ -604,6 +614,9 @@ impl Simulation {
             self.dynamic_terrain_cells.hash(&mut hasher);
         }
         self.hash_overlay_grid(&mut hasher);
+        if include_crate_authority_v114 {
+            self.hash_crate_authority(&mut hasher);
+        }
         self.hash_smudge_grid(&mut hasher);
         self.hash_radiation(&mut hasher);
         if include_master_frame_v43 {
@@ -1133,6 +1146,20 @@ impl Simulation {
                 cell.overlay_data.hash(hasher);
                 cell.wall_owner.hash(hasher);
             }
+        }
+    }
+
+    /// Fold every raw MapClass crate-slot word in fixed ascending order.
+    /// Visible overlays are deliberately not the authority: accepted ghosts
+    /// retain future timer behavior without mutating `OverlayGrid`.
+    fn hash_crate_authority(&self, hasher: &mut impl Hasher) {
+        b"crate-authority-v1".hash(hasher);
+        for slot in self.crate_authority.slots() {
+            slot.start_frame.hash(hasher);
+            slot.aux.hash(hasher);
+            slot.duration.hash(hasher);
+            slot.cell_x.hash(hasher);
+            slot.cell_y.hash(hasher);
         }
     }
 


### PR DESCRIPTION
## Mechanism\n\nReproduces active-YR scenario-start crate creation and production delivery: layered crate rules, deterministic raw 256-slot authority, normal/high OverlayClass Mark behavior, CellAnim side effects, bridge/navigation refresh ordering, retail asset routing, and snapshot/hash persistence.\n\nPickup, effects, removal, regeneration, and specific-cell crate producers remain later Phase 14 mechanisms. TS-only behavior is excluded.\n\n## Evidence and validation\n\n- Fresh read-only full-diff critic: PASS at 716f372677b25d8ef9a74321755af9819d95405b\n- Active gamemd callers and decisive bodies rechecked\n- Retail CRATE/WCRATE and numeric high bridge assets verified\n- cargo test -p vera20k --lib: 7836 passed; 0 failed; 76 ignored\n- git diff --check origin/main...HEAD: clean