### PR TITLE
feat(skills): add goal-prompt-fable for direction-only Fable 5.1 goal prompts

### DIFF
--- a/.claude/skills/goal-prompt-fable/SKILL.md
+++ b/.claude/skills/goal-prompt-fable/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: goal-prompt-fable
+description: >
+  Write a short, direction-only goal prompt for an autonomous Fable 5.1 run on
+  VERA20k — reason, goal at full ambition, a real bar, and a builder /
+  fresh-critic loop, with no method prescribed. Use for any Fable goal prompt,
+  builder/critic prompt, minimal goal prompt, or "just give it the direction"
+  request. The older /goal-prompt over-prescribes for Fable. Never launches
+  the run.
+---
+
+# Goal Prompt for Fable
+
+Destination, not route, in 60–150 words.
+
+**The Task.** Why it matters, and the goal at full ambition. A real bar —
+named, fetchable, comparable: the verified gamemd decompile for sim, hash or
+byte identity for refactors and tooling. One boundary. No real bar? Propose
+two or three and stop.
+
+**The Build Method.** Divide into the smallest pieces that can be improved
+and judged independently. Each gets a builder and its own fresh-context
+critic that inspects the real output against the bar, names the biggest
+remaining gap, and sends it back until no gap is worth a round. Gate:
+`cargo test -p vera20k --lib`, `/rust-scan --changed`, then the PR.
+
+Say "Read ENGINE.md first"; it carries every other rule. Prescribe no files,
+steps, or self-verification. Output a fenced prompt with word count and
+effort. Example: [references/profiler-example.md](references/profiler-example.md).

--- a/.claude/skills/goal-prompt-fable/references/profiler-example.md
+++ b/.claude/skills/goal-prompt-fable/references/profiler-example.md
@@ -1,0 +1,49 @@
+# Calibration example
+
+## The prompt (133 words)
+
+Written 2026-09-01 for the VERA20k per-phase sim profiler, after a nine-agent
+research and adversarial-review pass had produced a detailed contract-style
+recommendation. This is that recommendation with every "how" removed.
+
+```
+We're targeting 20,000 units and nothing in this repo measures where sim tick
+time goes. Build a per-phase profiler suitable for VERA20k: research the
+options yourself and pick. Read ENGINE.md first; fresh feature branch. Bar:
+zero cost when disabled; state hash identical enabled vs disabled; per-phase
+timings at rising unit counts on a real map with combat. Out of scope:
+optimising what it finds. Divide the goal into the smallest pieces that can be
+built and judged independently; each gets a builder and its own fresh-context
+critic that inspects the real output against the bar, names the biggest
+remaining gap, and sends it back. Keep going until no gap is worth a round;
+`cargo test -p vera20k --lib` green and `/rust-scan --changed` clean before
+opening the PR. Operate autonomously; note learnings in
+docs/plans/profiler-notes.md.
+```
+
+Run at **high**: it has to research tooling, read the tick spine, and make a
+design call.
+
+## Annotated
+
+| Sentence | Part | Why it earns its place |
+|---|---|---|
+| "We're targeting 20,000 units and nothing in this repo measures where sim tick time goes." | reason | Fable does measurably better told why; also tells it the *scale* that matters without prescribing a benchmark size |
+| "Build a per-phase profiler suitable for VERA20k: research the options yourself and pick." | goal | outcome only; "research yourself" is permission, not method |
+| "Read ENGINE.md first; fresh feature branch." | rulebook + git | one line carries every project rule; the branch clause is the single git rule most likely to be tripped |
+| "zero cost when disabled" | bar (property) | fetchable: build without the feature and inspect |
+| "state hash identical enabled vs disabled" | bar (the load-bearing one) | named, fetchable, comparable — the critic runs both and diffs; it cannot be waved through |
+| "produces per-phase timings at rising unit counts on a real map with combat" | bar (representativeness) | encodes the replication failure "optimised a synthetic benchmark" as a property of the artifact, not as advice |
+| "Out of scope: optimising what it finds." | boundary | without it Fable starts fixing the first hot spot it sees |
+| "Divide the goal into the smallest pieces … each gets a builder and its own fresh-context critic … names the biggest remaining gap, and sends it back." | Build Method | the decomposition instruction and the per-piece loop — the only structural instruction the prompt gives, and it leaves the split to the agent |
+| "Keep going until no gap is worth a round; … clean before opening the PR." | keep going + gate | no round count; the gate is the one place project process belongs |
+| "Operate autonomously; …" | autonomy | Fable otherwise asks permission it does not need deep in a run |
+| "Note learnings in docs/plans/profiler-notes.md." | memory | tracked, so present in every worktree |
+
+What was removed from the contract version, and why each was method: the
+`[profile.release]` line and the dependency opt-level (settings Fable will
+discover); `src/util/perf.rs` and the `profile` feature name (layout); the CSV
+column list (schema — the artifact the critic reads, not a prescription);
+"place new scope pairs, don't reuse `trace_master_frame_rung`" (a trap the
+adversarial pass found — real, but Fable reading the code will find it too,
+and an instruction about it anchors the design to one approach).


### PR DESCRIPTION
Adds `.claude/skills/goal-prompt-fable`: a ~140-word skill that writes short, direction-only goal prompts for autonomous Fable 5.1 runs.

**Two halves.** The Task — why it matters, the goal at full ambition, a real bar (named / fetchable / comparable, with the project defaults: the verified gamemd decompile for sim, hash or byte identity for refactors and tooling), one boundary. The Build Method — divide into the smallest independently judgeable pieces; each gets a builder and its own fresh-context critic that inspects the real output against the bar, names the biggest remaining gap, and sends it back until no gap is worth a round; then the `cargo test --lib` / `/rust-scan --changed` / PR gate.

Method, file layout and steps are deliberately not prescribed — "Read ENGINE.md first" carries every project rule. The older `/goal-prompt` remains for Codex and Opus-era executors.

Also adds `references/profiler-example.md`, the calibration prompt annotated sentence by sentence.

No Rust changes; skill files only.