### PR TITLE
Phase 14 crates: live regeneration, slot clear and identity-specific removal

### DIFF
--- a/docs/gap-scans/2026-09-01-disparity-scan-crate-runtime.md
+++ b/docs/gap-scans/2026-09-01-disparity-scan-crate-runtime.md
@@ -1,0 +1,404 @@
+---
+title: Disparity Scan - Remaining Phase 14 Crate Runtime
+date: 2026-09-01
+scope: Pickup admission and continuation, selection, removal and regeneration, active ordinary-retail effects and modifiers, and specific-cell producers after scenario-start placement
+methodology: docs-first discovery, direct Rust verification, selective active-YR verification, and installed-retail INI/map census
+---
+
+# Disparity Scan - Remaining Phase 14 Crate Runtime
+
+## Scope and evidence basis
+
+This scan covers the remaining ownership hypotheses in **GSI-04.23 Crates and
+powerups** and **GSI-08.34 Crate combat modifiers** after scenario-start crate
+creation/delivery merged in PR #209. It includes:
+
+- the complete active pickup admission, selection, remove/replace, effect, and
+  return transaction;
+- all thirteen active `CrateClass__PickupDispatch` calls in eleven native
+  movement bodies and their caller-specific continuations;
+- `[Powerups]`, the remaining `[CrateRules]` fields, and independent crate type
+  metadata required by those paths;
+- slot clear/removal and the per-tick regeneration scan;
+- the eight positive-weight ordinary-retail outcomes: Money, Unit, HealBase,
+  Reveal, Armor, Speed, Firepower, and Veteran;
+- common animation/sound/EVA consequences of those outcomes; and
+- specific-cell placement through active ordinary-retail trigger action 108 and
+  destruction-only `CrateBeneath` producers.
+
+It deliberately excludes the already-reviewed scenario-start random-placement
+mechanism, every non-crate Phase 14 row, TS gameplay handlers, and network-only
+WOL bookkeeping. Evidence-backed exclusions are enumerated below rather than
+silently removed from the model.
+
+The research-index preflight selected these sources, all read directly:
+
+- `docs/research/PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md`;
+- `docs/research/CRATE_SYSTEM_GHIDRA_REPORT.md`;
+- `docs/research/FUN_00481A00_CRATE_PICKUP_WARP_ARRIVAL_GHIDRA_REPORT.md`
+  (stale/superseded pickup ABI, caller closure, and effect-index assignments;
+  navigation only);
+- `docs/research/RULESCLASS_POWERUPS_TABLE.md`;
+- `docs/research/PERTICKUPDATE_NON_OBJECT_GLOBAL_LOOPS_GHIDRA_REPORT.md`;
+- `docs/research/MAPCLASS_GHIDRA_REPORT.md`; and
+- `docs/research/traces/SKIRMISH_CRATES_OFF_INITIAL_CRATES_TRACE.md`
+  (native Crates-off trace retained, but its pre-PR-#209 Rust-state claims are
+  stale).
+
+The 2026-07-23 crate design and evidence-foundation plan were also read as
+hypotheses. They are not specifications and several of their scope/semantic
+claims have been superseded by the active-retail report. The decisive gamemd
+evidence is the active-binary address/caller evidence in the 2026-08-31 report,
+plus the later live `CellClass__CheckCellPassability @ 0x004834A0` occupation
+recheck used for PR #209. Installed retail data was checked directly at
+`ini/rules.ini:642`, `ini/rules.ini:22496`, `ini/rulesmd.ini:782`, and
+`ini/rulesmd.ini:30345`; the installed-map census in the active-retail report
+binds action 108 and `CrateBeneath` to ordinary maps.
+
+Current Rust was inspected from `origin/main` merge commit
+`15a48e55325ea0902c71accede1397395ea2a2c3`. Every Rust-state claim below comes
+from that tree rather than from a research document's older Rust-divergence
+section.
+
+## Summary
+
+- 25 documented candidate behavior groups inventoried
+- 25 active-YR claims verified or evidence-excluded at the admitted retail boundary
+- 7 verified gaps (2 prerequisite-blocked)
+- 0 doc-derived candidates awaiting verification
+- 7 verified matches / corrected false positives
+- 6 evidence-backed inactive, invalid-domain, or out-of-boundary groups
+
+The already-merged startup mechanism is a verified match at its audited
+boundary, not proof that pickup or regeneration exists. Current
+`src/sim/crates.rs:16-18` explicitly leaves contents, pickup, removal, and
+regeneration to later mechanisms.
+
+This report is a dated disparity snapshot, not a parity percentage or a
+completion certificate.
+
+## Verified gaps
+
+### HIGH priority
+
+**G1. Runtime crate rules and the fixed nineteen-entry Powerups authority are missing**
+
+- **Active-YR evidence:** `RulesClass__ReadPowerups @ 0x00673E80` owns the fixed
+  canonical nineteen-entry table. The third token is over-water eligibility;
+  the fourth is the native binary64 magnitude. Installed weights in canonical
+  order are `[20,20,10,0,0,0,0,0,10,10,10,10,0,0,20,0,0,0,0]`, total 110.
+  `RulesClass__ReadCrateRules @ 0x0066B900` also owns radius, fixed mappings,
+  solo money, Unit type, sound, and FreeMCV fields beyond the startup subset.
+  RulesClass separately owns the seven `[AudioVisual]` effect-sound identities
+  `CrateMoneySound`, `CrateRevealSound`, `CrateFireSound`, `CrateArmourSound`,
+  `CrateSpeedSound`, `CrateUnitSound`, and `CratePromoteSound`. Scenario data
+  owns the inactive-by-default `TruckCrate` and `TrainCrate` producer gates.
+- **Retail evidence:** the full stock sections are present at
+  `ini/rulesmd.ini:782-796` and `ini/rulesmd.ini:30345-30365`; the seven stock
+  effect-sound mappings are at `ini/rulesmd.ini:635-641`.
+- **Research pointer:** active-retail report, **Rules authority** and
+  **Selection and guard order**; `RULESCLASS_POWERUPS_TABLE.md` is a navigation
+  aid only because its token-three interpretation is stale.
+- **Rust state:** `src/rules/crate_rules.rs:10-18` owns only minimum, maximum,
+  regen, and three image names. There is no `PowerupTable`, canonical
+  `CrateType`, remaining CrateRules fields, `CrateGoodie`, `CarriesCrate`,
+  `CrateBeneath`, `CrateBeneathIsMoney`, or `CrateTrigger` in current rules.
+  `src/rules/overlay_types.rs:123,361` parses only `Crate=`. Current rules own
+  none of the seven `[AudioVisual]` crate sound identities, and current
+  scenario data owns neither `TruckCrate` nor `TrainCrate`. In contrast,
+  `[CombatDamage] C4Warhead` is already parsed by
+  `src/rules/bridge_warheads.rs:29,53` and retained in RuleSet; it is an
+  existing HealBase prerequisite, not part of this missing-authority claim.
+- **Exact verdict:** DRIFT.
+- **Priority rationale:** every pickup selection/effect depends on this fixed
+  authority; Unit and specific-cell producers cannot be implemented exactly
+  without it.
+
+**G2. Synchronous pickup dispatch and all caller-specific movement continuations are absent**
+
+- **Active-YR evidence:** `CrateClass__PickupDispatch @ 0x00481A00` has exactly
+  thirteen calls in eleven bodies at `0x5153E9`, `0x5B1894`, `0x4B405D`,
+  `0x4B46E6`, `0x4B0D1B`, `0x6A3689`, `0x6A3D15`, `0x6A03EB`, `0x71972E`,
+  `0x75C56C`, `0x6A1401`, `0x4B1DBE`, and `0x54C9F6`. Drive/Ship ForceTrack,
+  ProcessDriveTrack, both ProcessMovement calls, Hover, both Jumpjet calls,
+  Walk, and Teleport do not share one generic continuation. The return value
+  controls the native locomotor continuation; Unit success and event-49 death
+  return zero, while most consumed outcomes return one.
+- **Research pointer:** active-retail report, **Complete pickup caller closure**
+  and **Return-value matrix**.
+- **Rust state:** exact search finds no `pickup_crate`, `crate_pickup`,
+  `process_committed_cell_entry`, or `committed_cell_entry` in `src/sim/`.
+  Current movement remains driven through
+  `src/sim/movement/movement_tick.rs:1380,1436,1494`, with separate Drive track
+  (`src/sim/movement/drive_track.rs:3995-4031`), air
+  (`src/sim/movement/air_movement.rs:189`), and Teleport
+  (`src/sim/movement/teleport_movement.rs:311`) paths. None calls the crate
+  authority after a committed arrival.
+- **Exact verdict:** DRIFT.
+- **Priority rationale:** every ordinary crate pickup is missing; deferring the
+  transaction to a phase tail would also perturb same-call-stack state and RNG.
+
+**G3. Slot clear/removal, immediate replacement, and per-tick regeneration are missing**
+
+- **Active-YR evidence:** `CrateSlot__ClearAndPreserveTimer @ 0x004A1750`
+  attempts identity-specific overlay removal, clears the coordinate regardless,
+  preserves remaining signed/wrapping duration, and sets start to `-1`.
+  `MapClass__RemoveCrateAtCell @ 0x0056C020` uses mode-zero overlay identity or
+  the first ascending occupied slot in nonzero mode. Pickup ignores remove
+  failure and, when nonzero mode plus Crates is enabled, calls one immediate
+  random replacement before the effect. `MapClass__UpdateCrateRegenTimers @
+  0x0056BBE0` scans all 256 slots ascending and performs live first-free
+  replacement, including possible later-index same-scan cascades.
+- **Scheduler evidence:** sole caller `LogicClass__PerTickUpdate @ 0x0055AFB0`,
+  direct call `0x0055B655`, after AlphaShape purge and before Tactical, Factory,
+  and House. At the current Rust partition the exact insertion point is before
+  the first factory sweep at `src/sim/world/mod.rs:7352`, using the current
+  pre-increment `binary_frame` (which commits at `src/sim/world/mod.rs:6287`).
+- **Research pointer:** active-retail report, **Exact timer and regeneration**
+  and **Clear and removal**; per-tick report lines 44-47.
+- **Rust state:** `src/sim/crates/state.rs:52-77` exposes only first-empty,
+  slots, mutation by index, and occupied-cell iteration. Exact search finds no
+  runtime clear/remove/regen function. `src/sim/world/mod.rs:7352-7385` enters
+  production directly with no crate regeneration rung.
+- **Exact verdict:** DRIFT.
+- **Priority rationale:** every startup crate currently remains forever unless
+  another future mechanism mutates it; ordinary three-minute regeneration and
+  every pickup replacement are absent and RNG-ordering-critical.
+
+**G4. Money, Unit, HealBase, Reveal, and their presentation tails are absent**
+
+- **Active-YR evidence:** the handlers at `0x00482463`, `0x00482041`,
+  `0x00482B8F`, and `0x00481F9D` respectively perform the verified credit RNG,
+  unbounded CrateGoodie selection/spawn retry, live Logic owner-heal through
+  `C4Warhead`, and ordered shroud/radar writes. Mutation precedes
+  sound/animation; Unit placement success alone returns zero and skips the
+  common animation tail at `0x004832F5`.
+- **Research pointer:** active-retail report, **Eight active-retail effects**,
+  Money through Reveal.
+- **Rust state:** there is no effect dispatch in `src/sim/crates.rs`; its only
+  production functions end with startup placement helpers before the test
+  module. House credits and object-spawn/damage primitives exist, but no crate
+  path calls them. The exact `C4Warhead` identity is already parsed at
+  `src/rules/bridge_warheads.rs:29,53` and retained at
+  `src/rules/ruleset.rs:2328,2925-2928`; the missing HealBase part is the crate
+  caller and live Logic traversal, not this rules prerequisite.
+  `src/sim/house_state.rs:294` has `map_is_clear`, but no `Visionary` latch;
+  current fog reveal does not implement the crate handler's four ordered
+  per-cell writes. No crate sound/EVA/common-animation producer exists.
+- **Exact verdict:** DRIFT.
+- **Priority rationale:** these are four of the eight stock weighted outcomes,
+  including economy, unit creation, base recovery, and full-map information;
+  all are immediately player-visible and outcome-changing.
+
+**G5. GSI-08.34 Armor, Speed, Firepower, and Veteran crate modifiers are not delivered**
+
+- **Active-YR evidence:** the handlers at `0x00482D56`, `0x00482F36`,
+  `0x00483125`, and `0x00482972` scan the live Ground display buffer without an
+  owner filter, use strict 3-D `ftol(sqrt(...)) < CrateRadius`, and apply the
+  parsed magnitudes in live order. Armor, Speed, and Firepower own independent
+  persistent binary64 instance multipliers; Veteran runs the verified tier
+  helper loop. Speed excludes Aircraft, and the exact Foot speed consumer uses
+  `Foot+0x580` between native truncation stages.
+- **Research pointer:** active-retail report, **Shared radius contract** and
+  Armor/Speed/Firepower/Veteran sections.
+- **Rust state:** `src/sim/game_entity.rs:426-429` has a persistent native-bit
+  armor multiplier, folded into current damage at `src/sim/combat/mod.rs:2806`
+  and hashed at `src/sim/world/world_hash.rs:1381`. There is no persistent
+  crate Speed or Firepower field on `GameEntity`, and both effects also lack an
+  exact production consumer. Production movement reaches the reduced
+  `owner_current_speed_from_fraction` helper through
+  `src/sim/movement/movement_tick.rs:2027-2032`; the helper at
+  `src/sim/movement/drive_locomotion.rs:296-322` has no persistent crate
+  multiplier stage and explicitly records other unresolved native terms. The
+  locomotor `SimFixed` fraction is a different owner.
+  `CombatMods::attacker_unit_firepower` exists only as a transient/default
+  input (`src/sim/combat/damage/mod.rs:47-53`) with no GameEntity writer, while
+  `src/sim/combat/damage/attacker.rs:18-28` labels `fire_damage` staged and
+  non-authoritative and no production caller reaches it; production currently
+  reads defender fields only (`src/sim/combat/damage/mod.rs:45-46`). Veterancy
+  state exists, but no crate radius/tier transaction invokes it. No current
+  code performs the native live Ground scan or the effect presentation order.
+- **Exact verdict:** DRIFT (Armor substrate is a verified prerequisite match,
+  not a delivered effect).
+- **Priority rationale:** four of eight stock random outcomes are missing;
+  three permanently change combat/movement results and all can affect enemies
+  inside the radius.
+
+### MEDIUM priority
+
+**G6. Specific-cell placement and ordinary-retail action 108 are missing and trigger-blocked**
+
+- **Active-YR evidence:** helper `0x0056BEC0` performs one FNPC snap, one
+  ascending free-slot scan, no duplicate suppression, exact full-dword data
+  handling, and at most one placement. `TriggerAction__Execute @ 0x006DD8B0`
+  case `0x6C` (`0x006DF69B..0x006DF6CD`) resolves `TAction+0x44`, passes signed
+  `+0x90`, has no mode/Crates gate, and returns the helper boolean. Installed
+  ordinary retail contains thirteen calls: eleven in `xxmas.map` and two in
+  `xarena.map`, all selecting positive-weight outcomes.
+- **Retail evidence:** active-retail report lines 1034-1041 records exact cells
+  and data values, including full-dword sentinel behavior.
+- **Research pointer:** active-retail report, **Specific-cell placement** and
+  **Trigger action 108**.
+- **Rust state:** `src/sim/crates.rs` exposes no specific-cell placement entry.
+  `src/sim/trigger_runtime.rs:28-42,300-431` has no action 108 case and drops
+  unknown actions. `src/map/actions.rs:11-21` does not retain the exact signed
+  `TAction+0x90` operand. More fundamentally, current trigger state is aggregate
+  by Trigger ID and lacks per-Tag/TriggerInstance ownership, Events 1/8, and
+  native Spring/action ordering.
+- **Exact verdict:** DRIFT - BLOCKED by the verified trigger-ownership
+  prerequisite for production action delivery. The specific-placement primitive
+  itself is not blocked.
+- **Priority rationale:** active in ordinary retail but limited to two stock
+  skirmish maps; the prerequisite also unblocks broader Phase 14 campaign
+  scripting.
+
+**G7. Destruction-only CrateBeneath ingress is missing**
+
+- **Active-YR evidence:** `BuildingClass__Place_OccupyMap @ 0x00441F60` is
+  reached only from the two fatal destruction continuations, after UnInit while
+  the Building remains allocated. It reads `BuildingType+0x1767`, derives the
+  northwest render-coordinate cell, and invokes specific placement with data
+  zero for `CrateBeneathIsMoney` or exact `0x14` otherwise. It has no
+  Crates/mode/owner gate. Voluntary sale, construction, capture, direct despawn,
+  and ordinary placement are verified negative paths.
+- **Retail evidence:** fourteen types set the flag; 58 placed instances across
+  sixteen ordinary maps are active, 55 Money and three random.
+- **Research pointer:** active-retail report, **Building CrateBeneath**.
+- **Rust state:** exact search finds no `CrateBeneath` field in rules or sim and
+  no building-fatal crate adapter. Current generic trigger/lifecycle deletion
+  is not an equivalent owner. This path also needs G6's specific-placement
+  primitive, but not the action-108 trigger rewrite.
+- **Exact verdict:** DRIFT - BLOCKED only by the shared specific-placement
+  prerequisite.
+- **Priority rationale:** narrower than random pickup but materially visible on
+  sixteen ordinary maps and deterministic once one of those props is destroyed.
+
+### LOW priority / exactification residuals
+
+No active ordinary-retail crate difference was demoted to LOW. The remaining
+bounded differences below are exclusions or prerequisite-blocked verified gaps,
+not low-severity parity claims.
+
+## Doc-derived candidates needing verification
+
+None in this bounded scan. The fresh active-retail report closes the active
+ordinary behaviors needed to choose the next implementation mechanism. Older
+unverified or contradicted claims were rejected rather than promoted.
+
+## Deferred / blocked by prerequisites
+
+- **Action 108 production delivery (G6)** - ACTIVE-YR VERIFIED GAP; blocked by
+  replacement of aggregate Trigger-ID state with per-Tag/TriggerInstance
+  ownership and correct Event 1/8/action order. Adding an isolated `108` match
+  to the current dispatcher would be known architectural drift.
+- **CrateBeneath production delivery (G7)** - ACTIVE-YR VERIFIED GAP; blocked by
+  the exact shared specific-cell placement primitive, then attachable to the
+  already-identified fatal Building destruction transaction.
+- **CrateTrigger events 49/50** - ACTIVE-YR VERIFIED but no ordinary stock map
+  defines those conditions. Parse/index/latch shape remains a regression
+  surface; campaign/custom action consequences wait for the same trigger-owner
+  prerequisite and are not required for ordinary-stock crate activation.
+
+## Evidence-backed exclusions
+
+- **Scenario-start random placement:** closed by reviewed PR #209. Current
+  production reaches it at `src/sim/scenario_post_map.rs:105-120`; the fixed
+  256-slot state is serialized/hash-authoritative. This scan does not reopen it.
+- **Authored CRATE/WCRATE OverlayPack bootstrap:** all 184 named installed maps
+  contain zero such identities. Native deliberately filters crate identities in
+  nonzero mode. Current `src/sim/overlay_grid.rs:207-242` preserves that gate.
+- **Weight-zero gameplay handlers:** Cloak, Explosion, Napalm, Darkness, ICBM,
+  Gas, Tiberium, and TS carryover slots are never selected by stock weights and
+  no ordinary action 108 requests them. Keep all nineteen indices parsed and
+  testable; do not implement TS Squad/Invulnerability/IonStorm/Pod gameplay.
+- **CarriesCrate runtime:** only TRUCKB sets the type flag, but both native
+  scenario gates default false and every installed `TruckCrate`/`TrainCrate`
+  value is `no`. Current Rust lacks all three inputs: `CarriesCrate`,
+  `TruckCrate`, and `TrainCrate`. Parse them and retain synthetic gate
+  regression; do not add an ordinary-retail death producer.
+- **LAN/WOL modes 3/4:** Phase 14's admitted offline boundary is raw mode 0/5.
+  The WOL pickup counter and network-specific Reveal cells are verified but
+  belong to the later online-service rows. Current `game_mode_nonzero` is enough
+  for the admitted crate branch; do not synthesize a partial WOL counter.
+- **Allocator/orphan/invalid-domain state:** native Overlay allocator OOM orphan
+  identity, zero-total malformed Powerups, invalid pointer graphs, and memory
+  corruption are outside valid retail gameplay. Persistent ghost slot/timer/RNG
+  behavior remains required and is already represented.
+
+## Doc errors discovered
+
+- **`PHASE3_ACTIVE_RETAIL_CRATE_RUNTIME_GHIDRA_REPORT.md`, Rust divergence
+  lines 1526-1535** - stale after PR #209. Current Rust now owns the exact fixed
+  slots, signed rule subset, Map rectangle, Mark/ghost path, timer, save/hash,
+  and production startup delivery. Only the later runtime items remain absent.
+- **Same report, Mark occupation lines 369-375** - the statement that any
+  nonzero selected occupation byte rejects is wrong. The later live
+  `CellClass__CheckCellPassability @ 0x004834A0` recheck proves the intersecting
+  filters reduce to exact bit `0x40`; current Rust implements this at
+  `src/sim/crates.rs:619-634`.
+- **`CRATE_SYSTEM_GHIDRA_REPORT.md` older sections** - several claims are
+  superseded: third Powerups token is over-water eligibility, radius effects do
+  not owner-filter, `CrateBeneath` has no global Crates/mode gate, stock
+  CarriesCrate producer gates are false, and initial count uses human seats.
+- **`RULESCLASS_POWERUPS_TABLE.md`** - token three is mislabeled as a generic
+  enabled flag and its stock-active summary is stale.
+- **`MAPCLASS_GHIDRA_REPORT.md` current-Rust table** - `Crate system — Not
+  implemented` is stale after PR #209; its own header already warns that the
+  report is superseded. The raw slot layout remains a useful pointer.
+- **`FUN_00481A00_CRATE_PICKUP_WARP_ARRIVAL_GHIDRA_REPORT.md` lines 14-49 and
+  82-115** - the pickup ABI, caller closure, and effect-index assignments are
+  stale/superseded. The later active-retail recheck proves
+  `CrateClass__PickupDispatch @ 0x00481A00` receives `CellClass*` in `ECX` plus
+  the collector argument and has thirteen calls in eleven movement bodies,
+  whose continuations are not interchangeable. The canonical active indices
+  are Money 0, Unit 1, HealBase 2, Reveal 8, Armor 9, Speed 10, Firepower 11,
+  and Veteran 14; in particular, HealBase is not index 18.
+- **`traces/SKIRMISH_CRATES_OFF_INITIAL_CRATES_TRACE.md` lines 12, 62, 71, and
+  86-87** - its statements that Rust has no crate slots or scenario-start
+  placement are stale after PR #209. Current `src/sim/crates/state.rs:11-77`
+  owns the fixed slots and `src/sim/scenario_post_map.rs:105-120` reaches
+  scenario-start placement in production. The trace's native option-off
+  observation remains useful; its older Rust divergence does not.
+- **2026-07-23 crate design/plan hypotheses** - over-scope weight-zero gameplay
+  handlers and CarriesCrate as ordinary-runtime obligations, and older FreeMCV
+  wording conflates parsed `[CrateRules] FreeMCV` with the actually-read session
+  `Bases` option. They must not drive implementation without the newer report.
+
+## Appendix - verified matches and false positives
+
+| Preliminary claim | Evidence state | Actual Rust state |
+|---|---|---|
+| Crate state is wholly absent | ACTIVE-YR VERIFIED false positive after PR #209 | `src/sim/crates/state.rs:11-77`, `src/sim/world/mod.rs:819-824`, snapshot v114, and `src/sim/world/world_hash.rs:1152-1162` own the 256 raw slots. |
+| Scenario-start crates are disconnected/test-only | ACTIVE-YR and production-path verified | `src/sim/scenario_post_map.rs:105-120` calls the production placer; accepted random-map startup reaches the same path. |
+| Crates-off still spends startup RNG | ACTIVE-YR VERIFIED false positive | `src/sim/crates.rs:190-204` returns before placement/RNG; the reviewed option-off trace remains matched. |
+| Map-authored crates need slot bootstrap | ACTIVE-YR VERIFIED exclusion | Installed census is zero and native nonzero-mode load filters them; `src/sim/overlay_grid.rs:228-231` matches. |
+| Session Bases authority is absent | ACTIVE-YR/Rust VERIFIED false positive | `src/sim/game_options.rs:29-38,71-81` persists stock-default `bases` and `crates`; the missing item is the pickup guard consumer. |
+| Armor instance state must be invented in crates | ACTIVE-YR/Rust VERIFIED false positive | Persistent `NativeF64Bits` armor authority already exists at `src/sim/game_entity.rs:426-429`, is consumed and hashed; only the crate writer/radius transaction is absent. |
+| Every nonzero occupation bit blocks startup Mark | ACTIVE-YR VERIFIED false positive | Later live recheck proves exact `0x40`; current `src/sim/crates.rs:619-634` matches. |
+
+## Ghidra annotation candidates
+
+None. The scan discovered documentation corrections, not a new metadata label or
+signature that passes ENGINE.md's synchronization gate.
+
+## Recommendations
+
+The next complete, production-reachable mechanism should be **slot clear,
+identity-specific removal, and the live per-tick regeneration rung**. It builds
+directly on PR #209's persisted slots and verified random placer, reaches
+ordinary production without waiting for movement/effect work, and supplies the
+same removal primitive later pickup needs. Its design must preserve ascending
+live scan/reinsertion semantics and run immediately before the first factory
+sweep on the pre-increment frame.
+
+After that, close the rules/Powerups/metadata authority, then the synchronous
+pickup/caller barrier plus the eight active effects and presentation. Treat
+the missing persistent Speed/Firepower state and their exact production
+consumer integrations as prerequisites within the corresponding effect
+mechanism, not as already-delivered combat or movement behavior. Treat
+specific-cell placement as a shared primitive: attach `CrateBeneath` to the
+fatal Building transaction independently, while leaving action 108 unpublished
+until the per-Tag trigger ownership prerequisite is green and reviewed.
+
+Do not broaden any of these mechanisms into weight-zero TS handlers, inactive
+CarriesCrate production, authored-overlay bootstrap, or WOL bookkeeping.

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -878,6 +878,7 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
         let mut drained_lifecycle_outputs: Vec<LifecycleOutput> = Vec::new();
         let mut drained_combat_lights = Vec::new();
         let mut frame_overlay_updates = Vec::new();
+        let mut frame_overlay_removals: Vec<(u16, u16)> = Vec::new();
         let mut trigger_effects: Vec<TriggerEffect> = Vec::new();
         // Carried out of the sim borrow so the census can read `state` freely below.
         let mut census_tick: Option<u64> = None;
@@ -898,6 +899,7 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                 trigger_effects: frame_trigger_effects,
                 lifecycle_outputs: frame_lifecycle_outputs,
                 overlay_updates,
+                overlay_removals,
                 sound_events: frame_sound_events,
                 fire_events: frame_fire_events,
                 invulnerability_impacts,
@@ -906,6 +908,7 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
             let sim = &mut rt.simulation;
             trigger_effects = frame_trigger_effects;
             frame_overlay_updates = overlay_updates;
+            frame_overlay_removals = overlay_removals;
             frame_committed = tick_result.frame_committed;
             if tick_result.frame_committed {
                 drained_combat_lights = crate::app::presentation::combat_lights::materialize_simulation_impacts(
@@ -1450,6 +1453,18 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
 
         // Simulation has already finalized identity, passability, navigation,
         // and the returned hash. The app only updates its render-side list.
+        // Removals first: a cell can be erased and re-marked in one frame, and
+        // the upsert must win.
+        if !frame_overlay_removals.is_empty() {
+            let dropped = state
+                .match_state
+                .match_presentation
+                .overlays
+                .remove_cells(&frame_overlay_removals);
+            if dropped != 0 {
+                log::trace!("Dropped {dropped} erased overlay cells from state.overlays");
+            }
+        }
         if !frame_overlay_updates.is_empty() {
             upsert_occupied_overlay_render_entries(state, frame_overlay_updates);
         }

--- a/src/app/presentation/overlay_index.rs
+++ b/src/app/presentation/overlay_index.rs
@@ -61,6 +61,22 @@ impl OverlayRenderIndex {
         synced
     }
 
+    /// Drop the render entries for cells whose overlay identity was erased.
+    ///
+    /// [`OverlayRenderIndex::upsert_occupied`] only ever adds or rewrites an
+    /// occupied cell, so a removal has to arrive on its own channel. Returns the
+    /// number of entries actually dropped.
+    pub(crate) fn remove_cells(&mut self, cells: &[(u16, u16)]) -> usize {
+        if cells.is_empty() {
+            return 0;
+        }
+        let removed: std::collections::HashSet<(u16, u16)> = cells.iter().copied().collect();
+        let before = self.entries.len();
+        self.entries
+            .retain(|entry| !removed.contains(&(entry.rx, entry.ry)));
+        before - self.entries.len()
+    }
+
     pub(crate) fn iter(&self) -> std::slice::Iter<'_, OverlayEntry> {
         self.entries.iter()
     }
@@ -95,14 +111,20 @@ mod tests {
         assert_eq!(coords, vec![(5, 5), (3, 3)]);
 
         // First dynamic appearances append in update order.
-        assert_eq!(index.upsert_occupied(vec![entry(9, 9, 20, 1), entry(1, 1, 21, 2)]), 2);
+        assert_eq!(
+            index.upsert_occupied(vec![entry(9, 9, 20, 1), entry(1, 1, 21, 2)]),
+            2
+        );
         let coords: Vec<_> = index.iter().map(|e| (e.rx, e.ry)).collect();
         assert_eq!(coords, vec![(5, 5), (3, 3), (9, 9), (1, 1)]);
 
         // Updating an existing coordinate retains its slot.
         assert_eq!(index.upsert_occupied(vec![entry(3, 3, 12, 4)]), 1);
         let third = &index.as_slice()[1];
-        assert_eq!((third.rx, third.ry, third.overlay_id, third.frame), (3, 3, 12, 4));
+        assert_eq!(
+            (third.rx, third.ry, third.overlay_id, third.frame),
+            (3, 3, 12, 4)
+        );
         assert_eq!(index.as_slice().len(), 4);
 
         // Reoccupation with a different ID reuses the slot (tombstoned

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -2224,6 +2224,24 @@ impl ResolvedTerrainGrid {
         true
     }
 
+    /// Project the two literal field writes a crate removal performs.
+    ///
+    /// `CrateSlot__RemoveCrateOverlayFromCell @ 0x004A1AA0` stores
+    /// `CellClass+0x44 = -1` at `0x004A1BE1` and `CellClass+0x11E = 0` at
+    /// `0x004A1BE8` and touches nothing else — no `RecalcAttributes` tail and
+    /// no bridge setter. The derived bridge layer/deck projection therefore
+    /// stays as it is: the random placer only admits cells that already carry
+    /// no overlay, so a removal can never be undoing a bridge identity in
+    /// stock rules.
+    pub(crate) fn clear_runtime_overlay_identity(&mut self, rx: u16, ry: u16) -> bool {
+        let Some(cell) = self.cell_mut(rx, ry) else {
+            return false;
+        };
+        cell.bridge_facts.overlay_id = None;
+        cell.bridge_facts.state_byte = 0;
+        true
+    }
+
     /// Project only allocated real-cell values for a setter that already ran
     /// synchronously through [`CellClassBridgeFlagState`]. This performs no
     /// GetCell fallback and cannot stamp or mutate the shared dummy.

--- a/src/sim/crates.rs
+++ b/src/sim/crates.rs
@@ -161,7 +161,9 @@ pub fn place_scenario_start_crates(
 
 /// Production entry carrying the already parsed ordinary ScenarioClass
 /// lighting profile. `OverlayClass::Mark` copies each target CellClass's
-/// `+0x10A` value into a spawned CellAnim after construction.
+/// `+0x10A` value into a spawned CellAnim after construction. The runtime
+/// regeneration rung reaches the same Mark path every tick, so the shared
+/// helpers below are no longer scenario-start-only.
 pub(crate) fn place_scenario_start_crates_with_lighting(
     sim: &mut Simulation,
     rules: &RuleSet,
@@ -1118,12 +1120,12 @@ fn spawn_crate_cell_anim(
         )
         .unwrap_or_else(|error| {
             panic!(
-                "startup crate CellAnim [{cell_anim}] must be bound before OverlayClass::Mark: {error}"
+                "crate CellAnim [{cell_anim}] must be bound before OverlayClass::Mark: {error}"
             )
         });
     assert!(
         sim.set_cell_anim_draw_authority(anim_id, remap_color, z_adjust),
-        "startup crate CellAnim {anim_id} disappeared before OverlayClass post-constructor writes"
+        "crate CellAnim {anim_id} disappeared before OverlayClass post-constructor writes"
     );
 }
 
@@ -1206,7 +1208,7 @@ fn snap_to_passable_with_radius(
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use std::collections::BTreeSet;
     use std::fmt::Write as _;
@@ -1237,7 +1239,12 @@ mod tests {
         RuleSet::from_ini(&ini).expect("rules")
     }
 
-    fn crate_ruleset_with_images(wood: &str, common: &str, water: &str, extra: &str) -> RuleSet {
+    pub(crate) fn crate_ruleset_with_images(
+        wood: &str,
+        common: &str,
+        water: &str,
+        extra: &str,
+    ) -> RuleSet {
         let ini = IniFile::from_str(&format!(
             "[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
              [CrateRules]\nCrateImg={common}\nWoodCrateImg={wood}\nWaterCrateImg={water}\n{extra}",

--- a/src/sim/crates.rs
+++ b/src/sim/crates.rs
@@ -14,16 +14,19 @@
 //! `WaterCrateImg` or `WoodCrateImg` from its own land type.
 //!
 //! This module owns startup placement and its persistent slot/timer result.
-//! Crate contents, pickup effects, removal, and `CrateRegen` scanning remain
-//! later crate-system mechanisms.
+//! The [`runtime`] submodule owns the live slot clear, the identity-specific
+//! overlay removal, and the per-tick `CrateRegen` scan. Crate contents and
+//! pickup effects remain later crate-system mechanisms.
 //!
 //! ## Dependency rules
 //! Part of `sim/` — depends on `rules/`, `map/` grid types and other `sim/`
 //! modules only. Never on render/, ui/, sidebar/, audio/, net/.
 
+mod runtime;
 mod state;
 
 pub use state::{CrateAuthority, CrateSlot};
+pub(crate) use runtime::{CrateRegeneration, tick_crate_regeneration};
 
 use crate::map::bridge_facts::{
     BRIDGE_FLAG_STRUCTURAL, BridgeFlagStamp, BridgeStampFamily, BridgeStampSlot,
@@ -905,7 +908,11 @@ fn packed_offset(cell: (i16, i16), offset: (i16, i16)) -> (i16, i16) {
     (cell.0.wrapping_add(offset.0), cell.1.wrapping_add(offset.1))
 }
 
-fn low_bridge_search_in_bounds(sim: &Simulation, cell: (i16, i16)) -> bool {
+/// `MapClass::In_Bounds @ 0x00568300` — the active diamond test against
+/// `MapClass+0xF4` (size width) and `MapClass+0xF8` (size height). The low
+/// bridge search and `CrateSlot__RemoveCrateOverlayFromCell @ 0x004A1AA0` both
+/// call it before touching a CellClass.
+fn map_cell_in_bounds(sim: &Simulation, cell: (i16, i16)) -> bool {
     let (Some(bounds), Some(height)) = (sim.playfield_bounds, sim.playfield_size_height) else {
         return false;
     };
@@ -947,7 +954,7 @@ fn execute_low_bridge_crate_mark(
 
         let mut search = packed_step(origin, spec.join_direction);
         let mut found = None;
-        while low_bridge_search_in_bounds(sim, search) {
+        while map_cell_in_bounds(sim, search) {
             let fields = read_crate_mark_fields(sim, search);
             if fields == (Some(spec.opposite_id), 1) {
                 found = Some(search);
@@ -1213,7 +1220,7 @@ mod tests {
 
     const MAP: u16 = 40;
 
-    fn crate_registry() -> OverlayTypeRegistry {
+    pub(crate) fn crate_registry() -> OverlayTypeRegistry {
         let ini = IniFile::from_str(
             "[OverlayTypes]\n0=TIB01\n1=SILVER\n2=WOOD\n3=WATER\n\
              [TIB01]\nTiberium=yes\n[SILVER]\nCrate=yes\n\
@@ -1222,7 +1229,7 @@ mod tests {
         OverlayTypeRegistry::from_ini(&ini, None)
     }
 
-    fn crate_ruleset(extra: &str) -> RuleSet {
+    pub(crate) fn crate_ruleset(extra: &str) -> RuleSet {
         let ini = IniFile::from_str(&format!(
             "[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
              [CrateRules]\nCrateImg=SILVER\nWoodCrateImg=WOOD\nWaterCrateImg=WATER\n{extra}",
@@ -1277,7 +1284,7 @@ mod tests {
     }
 
     /// `seed` positions the scenario cursor; the placer draws from there.
-    fn sim_with_grid(seed: u64) -> Simulation {
+    pub(crate) fn sim_with_grid(seed: u64) -> Simulation {
         let mut sim = Simulation::new();
         sim.session.seed = seed;
         sim.scenario_rng = crate::sim::rng::SimRng::new(seed);
@@ -1318,7 +1325,7 @@ mod tests {
         cells
     }
 
-    fn crate_cells(sim: &Simulation, registry: &OverlayTypeRegistry) -> Vec<(u16, u16)> {
+    pub(crate) fn crate_cells(sim: &Simulation, registry: &OverlayTypeRegistry) -> Vec<(u16, u16)> {
         cells_with_overlay(sim, registry, "WOOD")
     }
 

--- a/src/sim/crates/runtime.rs
+++ b/src/sim/crates/runtime.rs
@@ -204,8 +204,13 @@ pub(crate) fn tick_crate_regeneration(
 /// A paused slot (`start == -1`) expires only once its stored duration has
 /// already reached zero — and then it re-fires on every following tick until a
 /// replacement takes the slot. A running slot expires as soon as the signed
-/// elapsed frame count reaches its duration; the remaining-frames recheck below
-/// that branch only ever fires on signed wraparound.
+/// elapsed frame count reaches its duration.
+///
+/// Native reaches the shared `TEST ECX,ECX` at `0x0056BC33` from both branches,
+/// but for a running slot it is dead: `remaining == 0` would need
+/// `duration == elapsed`, which the preceding `JGE` already took. The shared
+/// tail is reproduced as one expression because it is the paused branch's whole
+/// test, not because the running branch can reach it.
 fn crate_slot_timer_expired(slot: CrateSlot, current_frame: i32) -> bool {
     let mut remaining = slot.duration;
     if slot.start_frame != -1 {
@@ -252,13 +257,18 @@ mod tests {
         assert!(!crate_slot_timer_expired(running(-1, 1), i32::MAX));
         assert!(crate_slot_timer_expired(running(-1, 0), 0));
         assert!(crate_slot_timer_expired(running(-1, 0), i32::MIN));
-        // Negative duration is already past due for a running slot.
+        // Negative duration is already past due for a running slot — this is
+        // the assertion that pins the native `JGE` over an unsigned compare.
         assert!(crate_slot_timer_expired(running(100, -5), 100));
-        // Signed wraparound reaches the remaining-frames recheck: elapsed is
-        // "less than" duration only because the subtraction wrapped.
+        // Elapsed is computed with wrapping subtraction across the signed
+        // boundary, and the comparison stays signed.
         assert!(crate_slot_timer_expired(
-            running(1, i32::MIN),
-            i32::MIN.wrapping_add(1)
+            running(i32::MAX, 4),
+            i32::MIN.wrapping_add(3)
+        ));
+        assert!(!crate_slot_timer_expired(
+            running(i32::MAX, 6),
+            i32::MIN.wrapping_add(3)
         ));
     }
 
@@ -395,9 +405,12 @@ mod tests {
             "removal writes CellClass+0x44 and +0x11E only"
         );
         assert_eq!(
-            sim.overlay_grid.as_mut().unwrap().take_dirty_cells(),
+            sim.overlay_grid
+                .as_mut()
+                .unwrap()
+                .take_removed_render_cells(),
             vec![(15, 15)],
-            "the removed cell publishes exactly one dirty receipt"
+            "the removed cell publishes exactly one presentation receipt"
         );
     }
 
@@ -598,10 +611,90 @@ mod tests {
         assert_eq!(regen.visible, 1);
         let now = sim.crate_authority.slots()[0];
         assert_eq!(now.start_frame, 500, "the replacement armed a fresh timer");
+        assert_ne!(
+            (now.cell_x, now.cell_y),
+            (15, 15),
+            "fixture precondition: the replacement drew a different cell, so the              assertions below actually distinguish removal from a no-op"
+        );
+        assert_eq!(
+            sim.overlay_grid.as_ref().unwrap().cell(15, 15).overlay_id,
+            None,
+            "the expired crate's overlay identity was erased"
+        );
         assert_eq!(
             crate_cells(&sim, &registry),
             vec![(now.cell_x as u16, now.cell_y as u16)],
             "the expired crate overlay is gone and only the replacement remains"
+        );
+    }
+
+    /// Retail names the same overlay for two of the three image slots
+    /// (`CrateImg` and `WoodCrateImg` are both `CRATE`), and all three are
+    /// accepted identities. Pin every slot, including the duplicate case the
+    /// stock pointer table actually produces.
+    #[test]
+    fn crate_overlay_removal_accepts_every_rules_image_including_duplicates() {
+        let registry = crate_registry();
+        for (wood, common, water) in [
+            ("WOOD", "SILVER", "WATER"),
+            // The stock shape: WoodCrateImg == CrateImg == CRATE.
+            ("SILVER", "SILVER", "WATER"),
+        ] {
+            let rules = super::super::tests::crate_ruleset_with_images(wood, common, water, "");
+            for name in [wood, common, water] {
+                let mut sim = sim_with_grid(0x60);
+                let id = registry.id_for_name(name).expect("configured overlay");
+                sim.overlay_grid
+                    .as_mut()
+                    .expect("grid")
+                    .place_overlay(15, 15, id, 0xFF);
+                assert!(
+                    remove_crate_overlay_from_cell(&mut sim, &rules, &registry, (15, 15)),
+                    "identity {name} is one of the three live Rules crate images"
+                );
+                assert_eq!(
+                    sim.overlay_grid.as_ref().unwrap().cell(15, 15).overlay_id,
+                    None
+                );
+            }
+        }
+    }
+
+    /// `CrateSlot__RemoveCrateOverlayFromCell` ends at its two field writes with
+    /// no `CellClass::RecalcAttributes` tail, so the cell keeps the land type
+    /// the crate gave it. The erased coordinate must therefore reach
+    /// presentation through the removal channel and NOT through `dirty_cells`,
+    /// whose frame-tail drain re-derives land from the pristine tile.
+    #[test]
+    fn crate_overlay_removal_publishes_a_removal_and_never_a_recalc_dirty_cell() {
+        let mut sim = sim_with_grid(0x61);
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+        let wood = registry.id_for_name("WOOD").expect("WOOD overlay");
+        {
+            let grid = sim.overlay_grid.as_mut().expect("grid");
+            grid.place_overlay(15, 15, wood, 0xFF);
+            let _ = grid.take_dirty_cells();
+            let _ = grid.take_removed_render_cells();
+        }
+
+        assert!(remove_crate_overlay_from_cell(
+            &mut sim,
+            &rules,
+            &registry,
+            (15, 15)
+        ));
+
+        let grid = sim.overlay_grid.as_mut().expect("grid");
+        assert_eq!(
+            grid.take_dirty_cells(),
+            Vec::new(),
+            "a removal must not enter the attribute-recalc queue"
+        );
+        assert_eq!(
+            grid.take_removed_render_cells(),
+            vec![(15, 15)],
+            "presentation learns about the erased cell on its own channel"
         );
     }
 
@@ -644,6 +737,12 @@ mod tests {
         assert!(
             !regenerated.is_empty(),
             "the replacement took the free slot"
+        );
+
+        assert!(
+            on.take_master_frame_test_trace()
+                .contains(&crate::sim::world::MasterFrameTestRung::CrateRegen),
+            "the rung is an observable master-frame position, not an incidental call"
         );
 
         let mut off = sim_with_grid(0x5C);

--- a/src/sim/crates/runtime.rs
+++ b/src/sim/crates/runtime.rs
@@ -1,0 +1,704 @@
+//! Live crate slot clear, identity-specific overlay removal, and the per-tick
+//! `CrateRegen` scan.
+//!
+//! `MapClass__UpdateCrateRegenTimers @ 0x0056BBE0` is the only runtime owner of
+//! the 256 persistent crate slots after scenario start. `LogicClass__PerTickUpdate
+//! @ 0x0055AFB0` calls it once per tick at `0x0055B65A`, after
+//! `AlphaShapeClass::PurgeDisabled` and before the Tactical, Factory and House
+//! callbacks, and it does nothing at all unless the game mode is nonzero and the
+//! lobby Crates option byte is set.
+//!
+//! One ascending pass over all 256 slots expires every slot whose timer is up.
+//! Each expiry runs `CrateSlot__ClearAndPreserveTimer @ 0x004A1750` — which
+//! removes the crate overlay from the cell, frees the coordinate and rebases the
+//! remaining duration — and then exactly one
+//! `MapClass__PlaceCrateAtRandomCell @ 0x0056BD40`, the same placer scenario
+//! start uses. Because the clear always frees the slot the scan is standing on,
+//! the placer's lowest-free scan can only reinstall at an index at or below it:
+//! a replacement is never revisited later in the same pass, and there is no
+//! cascade. Several slots can still expire in one pass, each spending its own
+//! placement draws in ascending slot order.
+//!
+//! ## Dependency rules
+//! Part of `sim/` — depends on `rules/`, `map/` grid types and other `sim/`
+//! modules only. Never on render/, ui/, sidebar/, audio/, net/.
+
+use crate::map::lighting::LightingProfileUnits;
+use crate::map::overlay_types::OverlayTypeRegistry;
+use crate::rules::crate_rules::CrateRules;
+use crate::rules::ruleset::RuleSet;
+use crate::sim::pathfinding::PathGrid;
+use crate::sim::world::Simulation;
+
+use super::state::{CRATE_SLOT_CAPACITY, CrateSlot};
+use super::{
+    CrateMarkCellRef, ForcedPostPrecheckFailure, OneCrateResult, map_cell_in_bounds,
+    place_one_random_crate, resolve_crate_mark_cell,
+};
+
+/// Outcome of one `MapClass__UpdateCrateRegenTimers` pass.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct CrateRegeneration {
+    /// Slots whose timer expired and were cleared this pass.
+    pub expired: u32,
+    /// Replacement placer calls that took a slot, including timed ghosts.
+    pub accepted: u32,
+    /// Replacement calls that installed a visible overlay.
+    pub visible: u32,
+}
+
+/// `CrateSlot__RemoveCrateOverlayFromCell @ 0x004A1AA0`.
+///
+/// Native order is `MapClass::In_Bounds @ 0x00568300`,
+/// `MapClass::Get_CellClass @ 0x005657A0`, the `CellClass+0x44` identity test at
+/// `0x004A1ACD..0x004A1AFE`, one screen-dirty request, and only then the two
+/// field writes. The identity test is exact pointer equality against the three
+/// live `RulesClass` crate images at `Rules+0xF8`, `+0xFC` and `+0x100` — an
+/// unrelated overlay, or a crate overlay after the images were re-read to other
+/// names, is left alone and the caller still frees the slot.
+///
+/// The rectangle union and `TacticalClass::DirtyScreenRect(..., force = 0)` at
+/// `0x004A1B04..0x004A1BDC` are screen-space presentation; the sim-visible
+/// effect is exactly `CellClass+0x44 = -1` and `CellClass+0x11E = 0`, published
+/// through the OverlayGrid dirty receipt.
+pub(crate) fn remove_crate_overlay_from_cell(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    registry: &OverlayTypeRegistry,
+    cell: (i16, i16),
+) -> bool {
+    if !map_cell_in_bounds(sim, cell) {
+        return false;
+    }
+    let cell_ref = resolve_crate_mark_cell(sim, cell);
+    let overlay_id = match &cell_ref {
+        CrateMarkCellRef::Real(rx, ry) => sim
+            .overlay_grid
+            .as_ref()
+            .and_then(|grid| grid.cell(*rx, *ry).overlay_id),
+        CrateMarkCellRef::Dummy(dummy) => dummy.overlay_fields().0,
+    };
+    let Some(overlay_id) = overlay_id else {
+        return false;
+    };
+    if !is_live_crate_image(&rules.crate_rules, registry, overlay_id) {
+        return false;
+    }
+    match cell_ref {
+        CrateMarkCellRef::Real(rx, ry) => {
+            let (Some(grid), Some(terrain)) =
+                (sim.overlay_grid.as_mut(), sim.resolved_terrain.as_mut())
+            else {
+                return false;
+            };
+            grid.clear_crate_mark_fields(terrain, rx, ry)
+        }
+        CrateMarkCellRef::Dummy(dummy) => {
+            dummy.set_overlay_fields(None, 0);
+            true
+        }
+    }
+}
+
+/// Exact `Rules+0xF8`/`+0xFC`/`+0x100` pointer identity, expressed over the
+/// OverlayType ids those three `RulesClass` image pointers resolve to. A rules
+/// image that names no live OverlayType is a null pointer natively and can
+/// never match a live cell identity.
+fn is_live_crate_image(rules: &CrateRules, registry: &OverlayTypeRegistry, overlay_id: u8) -> bool {
+    [
+        rules.wood_crate_img.as_deref(),
+        rules.crate_img.as_deref(),
+        rules.water_crate_img.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .filter_map(|name| registry.id_for_name(name))
+    .any(|id| id == overlay_id)
+}
+
+/// `CrateSlot__ClearAndPreserveTimer @ 0x004A1750`.
+///
+/// An already-empty coordinate returns false with no mutation at all — no
+/// removal attempt and no timer touch (`0x004A1754..0x004A176F`). Otherwise the
+/// overlay removal runs first, its result is discarded, and the coordinate is
+/// freed unconditionally. The timer is then rebased only when a start frame is
+/// live: an unexpired timer keeps `duration - elapsed`, an already-expired one
+/// is zeroed at `0x004A17AB`, and a slot that is already paused at `start == -1`
+/// keeps its stored duration untouched.
+pub(crate) fn clear_crate_slot(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    registry: &OverlayTypeRegistry,
+    slot_index: usize,
+    current_frame: i32,
+) -> bool {
+    let slot = sim.crate_authority.slots()[slot_index];
+    if slot.is_empty() {
+        return false;
+    }
+    let _ = remove_crate_overlay_from_cell(sim, rules, registry, (slot.cell_x, slot.cell_y));
+    let slot = sim.crate_authority.slot_mut(slot_index);
+    slot.cell_x = 0;
+    slot.cell_y = 0;
+    if slot.start_frame != -1 {
+        let elapsed = current_frame.wrapping_sub(slot.start_frame);
+        slot.duration = if elapsed < slot.duration {
+            slot.duration.wrapping_sub(elapsed)
+        } else {
+            0
+        };
+        slot.start_frame = -1;
+    }
+    true
+}
+
+/// `MapClass__UpdateCrateRegenTimers @ 0x0056BBE0`.
+///
+/// The two gate reads at `0x0056BBE0` and `0x0056BBEC` are the live game mode
+/// and the lobby Crates option; either one clear makes the whole call a no-op,
+/// so paused crates never regenerate and never spend a draw. The scan itself is
+/// a fixed ascending walk of the 256 slots on the pre-increment frame counter,
+/// the same one the accepted-placement timer stored as its start.
+pub(crate) fn tick_crate_regeneration(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    overlay_registry: &OverlayTypeRegistry,
+    path_grid: Option<&PathGrid>,
+    lighting_profile: LightingProfileUnits,
+) -> CrateRegeneration {
+    let mut result = CrateRegeneration::default();
+    if !sim.session.game_mode_nonzero || !sim.session.game_options.crates {
+        return result;
+    }
+    let current_frame = sim.session.binary_frame as i32;
+    for index in 0..CRATE_SLOT_CAPACITY {
+        // Reload the live slot: an earlier expiry in this same pass may have
+        // reinstalled a crate at or below this index.
+        let slot = sim.crate_authority.slots()[index];
+        if slot.is_empty() || !crate_slot_timer_expired(slot, current_frame) {
+            continue;
+        }
+        result.expired = result.expired.wrapping_add(1);
+        clear_crate_slot(sim, rules, overlay_registry, index, current_frame);
+        match place_one_random_crate(
+            sim,
+            rules,
+            overlay_registry,
+            path_grid,
+            lighting_profile,
+            ForcedPostPrecheckFailure::None,
+        ) {
+            OneCrateResult::HardRejected => {}
+            OneCrateResult::AcceptedGhost => result.accepted = result.accepted.wrapping_add(1),
+            OneCrateResult::AcceptedVisible => {
+                result.accepted = result.accepted.wrapping_add(1);
+                result.visible = result.visible.wrapping_add(1);
+            }
+        }
+    }
+    result
+}
+
+/// The expiry predicate at `0x0056BC1C..0x0056BC35`.
+///
+/// A paused slot (`start == -1`) expires only once its stored duration has
+/// already reached zero — and then it re-fires on every following tick until a
+/// replacement takes the slot. A running slot expires as soon as the signed
+/// elapsed frame count reaches its duration; the remaining-frames recheck below
+/// that branch only ever fires on signed wraparound.
+fn crate_slot_timer_expired(slot: CrateSlot, current_frame: i32) -> bool {
+    let mut remaining = slot.duration;
+    if slot.start_frame != -1 {
+        let elapsed = current_frame.wrapping_sub(slot.start_frame);
+        if elapsed >= remaining {
+            return true;
+        }
+        remaining = remaining.wrapping_sub(elapsed);
+    }
+    remaining == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::map::lighting::ParsedLightingProfiles;
+    use crate::sim::crates::state::CrateSlot;
+
+    use super::super::tests::{crate_cells, crate_registry, crate_ruleset, sim_with_grid};
+
+    fn lighting() -> LightingProfileUnits {
+        ParsedLightingProfiles::default().normal
+    }
+
+    /// The three timer shapes the native predicate distinguishes, including the
+    /// paused-at-zero slot that re-fires every tick.
+    #[test]
+    fn crate_regen_expiry_predicate_matches_native_branches() {
+        let running = |start: i32, duration: i32| CrateSlot {
+            start_frame: start,
+            aux: 0,
+            duration,
+            cell_x: 3,
+            cell_y: 4,
+        };
+        // Running: expires exactly when elapsed reaches duration.
+        assert!(!crate_slot_timer_expired(running(100, 50), 149));
+        assert!(crate_slot_timer_expired(running(100, 50), 150));
+        assert!(crate_slot_timer_expired(running(100, 50), 151));
+        // Zero-duration running slot expires on its own placement frame.
+        assert!(crate_slot_timer_expired(running(100, 0), 100));
+        // Paused: only a zero remainder expires, and it keeps expiring.
+        assert!(!crate_slot_timer_expired(running(-1, 1), i32::MAX));
+        assert!(crate_slot_timer_expired(running(-1, 0), 0));
+        assert!(crate_slot_timer_expired(running(-1, 0), i32::MIN));
+        // Negative duration is already past due for a running slot.
+        assert!(crate_slot_timer_expired(running(100, -5), 100));
+        // Signed wraparound reaches the remaining-frames recheck: elapsed is
+        // "less than" duration only because the subtraction wrapped.
+        assert!(crate_slot_timer_expired(
+            running(1, i32::MIN),
+            i32::MIN.wrapping_add(1)
+        ));
+    }
+
+    /// Clear frees the coordinate, rebases a live timer, and pauses the slot.
+    #[test]
+    fn crate_slot_clear_rebases_live_timer_and_pauses() {
+        let mut sim = sim_with_grid(0x51);
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+        *sim.crate_authority.slot_mut(2) = CrateSlot {
+            start_frame: 100,
+            aux: 0x1234,
+            duration: 500,
+            cell_x: 9,
+            cell_y: 11,
+        };
+
+        assert!(clear_crate_slot(&mut sim, &rules, &registry, 2, 380));
+
+        let slot = sim.crate_authority.slots()[2];
+        assert_eq!(slot.cell_x, 0);
+        assert_eq!(slot.cell_y, 0);
+        assert_eq!(slot.start_frame, -1);
+        assert_eq!(slot.duration, 220, "500 - (380 - 100) remaining frames");
+        assert_eq!(slot.aux, 0x1234, "the auxiliary word is never rewritten");
+    }
+
+    /// An expired timer is zeroed, not carried negative, and an already-paused
+    /// slot keeps its stored duration.
+    #[test]
+    fn crate_slot_clear_zeroes_expired_and_preserves_paused_duration() {
+        let mut sim = sim_with_grid(0x52);
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+
+        *sim.crate_authority.slot_mut(0) = CrateSlot {
+            start_frame: 10,
+            aux: 0,
+            duration: 30,
+            cell_x: 4,
+            cell_y: 4,
+        };
+        assert!(clear_crate_slot(&mut sim, &rules, &registry, 0, 900));
+        assert_eq!(sim.crate_authority.slots()[0].duration, 0);
+        assert_eq!(sim.crate_authority.slots()[0].start_frame, -1);
+
+        *sim.crate_authority.slot_mut(1) = CrateSlot {
+            start_frame: -1,
+            aux: 0,
+            duration: 77,
+            cell_x: 5,
+            cell_y: 5,
+        };
+        assert!(clear_crate_slot(&mut sim, &rules, &registry, 1, 900));
+        assert_eq!(
+            sim.crate_authority.slots()[1].duration,
+            77,
+            "a paused slot keeps its remaining frames verbatim"
+        );
+        assert_eq!(sim.crate_authority.slots()[1].start_frame, -1);
+    }
+
+    /// An empty coordinate returns false and mutates nothing at all.
+    #[test]
+    fn crate_slot_clear_on_empty_slot_is_a_total_no_op() {
+        let mut sim = sim_with_grid(0x53);
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+        *sim.crate_authority.slot_mut(7) = CrateSlot {
+            start_frame: 42,
+            aux: 8,
+            duration: 9,
+            cell_x: 0,
+            cell_y: 0,
+        };
+
+        assert!(!clear_crate_slot(&mut sim, &rules, &registry, 7, 1000));
+
+        assert_eq!(
+            sim.crate_authority.slots()[7],
+            CrateSlot {
+                start_frame: 42,
+                aux: 8,
+                duration: 9,
+                cell_x: 0,
+                cell_y: 0,
+            }
+        );
+    }
+
+    /// Removal accepts only the three live Rules crate images and writes exactly
+    /// the two CellClass overlay fields, keeping the cell's wall owner.
+    ///
+    /// Both cells sit inside the `MapClass::In_Bounds @ 0x00568300` diamond
+    /// (`size_width < x + y`), which removal tests before it looks at any
+    /// CellClass at all.
+    #[test]
+    fn crate_overlay_removal_is_identity_specific_and_two_fields_wide() {
+        let mut sim = sim_with_grid(0x54);
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+        let wood = registry.id_for_name("WOOD").expect("WOOD overlay");
+        let tiberium = registry.id_for_name("TIB01").expect("TIB01 overlay");
+
+        {
+            let grid = sim.overlay_grid.as_mut().expect("grid");
+            grid.place_overlay(15, 15, wood, 0xFF);
+            grid.place_overlay(16, 15, tiberium, 3);
+            grid.cell_mut(15, 15).wall_owner = Some(crate::sim::intern::InternedId::from_index(5));
+            let _ = grid.take_dirty_cells();
+        }
+
+        assert!(
+            !remove_crate_overlay_from_cell(&mut sim, &rules, &registry, (16, 15)),
+            "a non-crate identity is never removed"
+        );
+        assert_eq!(
+            sim.overlay_grid.as_ref().unwrap().cell(16, 15).overlay_id,
+            Some(tiberium)
+        );
+
+        assert!(remove_crate_overlay_from_cell(
+            &mut sim,
+            &rules,
+            &registry,
+            (15, 15)
+        ));
+        let cleared = sim.overlay_grid.as_ref().unwrap().cell(15, 15);
+        assert_eq!(cleared.overlay_id, None);
+        assert_eq!(cleared.overlay_data, 0);
+        assert_eq!(
+            cleared.wall_owner,
+            Some(crate::sim::intern::InternedId::from_index(5)),
+            "removal writes CellClass+0x44 and +0x11E only"
+        );
+        assert_eq!(
+            sim.overlay_grid.as_mut().unwrap().take_dirty_cells(),
+            vec![(15, 15)],
+            "the removed cell publishes exactly one dirty receipt"
+        );
+    }
+
+    /// A cell outside the native In_Bounds diamond is refused before any
+    /// CellClass read, exactly as `0x004A1AB6` does.
+    #[test]
+    fn crate_overlay_removal_refuses_an_out_of_bounds_cell() {
+        let mut sim = sim_with_grid(0x5B);
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+        let wood = registry.id_for_name("WOOD").expect("WOOD overlay");
+        {
+            let grid = sim.overlay_grid.as_mut().expect("grid");
+            grid.place_overlay(5, 5, wood, 0xFF);
+            let _ = grid.take_dirty_cells();
+        }
+
+        assert!(!remove_crate_overlay_from_cell(
+            &mut sim,
+            &rules,
+            &registry,
+            (5, 5)
+        ));
+        assert_eq!(
+            sim.overlay_grid.as_ref().unwrap().cell(5, 5).overlay_id,
+            Some(wood),
+            "In_Bounds rejects 5 + 5 <= size width before Get_CellClass"
+        );
+    }
+
+    /// Removal that finds no matching identity still lets the caller free the
+    /// slot: a ghost slot's cell never carried a crate overlay.
+    #[test]
+    fn crate_slot_clear_ignores_removal_failure_on_a_ghost_cell() {
+        let mut sim = sim_with_grid(0x55);
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+        *sim.crate_authority.slot_mut(0) = CrateSlot {
+            start_frame: 5,
+            aux: 0,
+            duration: 60,
+            cell_x: 12,
+            cell_y: 13,
+        };
+
+        assert!(clear_crate_slot(&mut sim, &rules, &registry, 0, 20));
+
+        assert!(sim.crate_authority.slots()[0].is_empty());
+        assert_eq!(sim.crate_authority.slots()[0].duration, 45);
+    }
+
+    /// The two gates are the whole function: a zero game mode or a cleared
+    /// Crates option spends no draw and expires nothing.
+    #[test]
+    fn crate_regen_gates_on_game_mode_and_the_crates_option() {
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+        for (game_mode_nonzero, crates) in [(false, true), (true, false), (false, false)] {
+            let mut sim = sim_with_grid(0x56);
+            sim.session.game_mode_nonzero = game_mode_nonzero;
+            sim.session.game_options.crates = crates;
+            *sim.crate_authority.slot_mut(0) = CrateSlot {
+                start_frame: -1,
+                aux: 0,
+                duration: 0,
+                cell_x: 8,
+                cell_y: 8,
+            };
+            let rng_before = sim.scenario_rng.state();
+
+            let regen = tick_crate_regeneration(&mut sim, &rules, &registry, None, lighting());
+
+            assert_eq!(regen, CrateRegeneration::default());
+            assert_eq!(sim.crate_authority.slots()[0].cell_x, 8);
+            assert_eq!(
+                sim.scenario_rng.state(),
+                rng_before,
+                "a gated call draws nothing"
+            );
+        }
+    }
+
+    /// An unexpired slot is skipped without a draw; the expired one clears and
+    /// takes exactly one replacement placer call.
+    #[test]
+    fn crate_regen_expires_only_due_slots_and_replaces_each_once() {
+        let mut sim = sim_with_grid(0x57);
+        sim.session.game_mode_nonzero = true;
+        sim.session.game_options.crates = true;
+        sim.session.binary_frame = 1_000;
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+
+        *sim.crate_authority.slot_mut(0) = CrateSlot {
+            start_frame: 900,
+            aux: 0,
+            duration: 5_000,
+            cell_x: 6,
+            cell_y: 6,
+        };
+        *sim.crate_authority.slot_mut(1) = CrateSlot {
+            start_frame: 100,
+            aux: 0,
+            duration: 200,
+            cell_x: 7,
+            cell_y: 7,
+        };
+        let untouched = sim.crate_authority.slots()[0];
+
+        let regen = tick_crate_regeneration(&mut sim, &rules, &registry, None, lighting());
+
+        assert_eq!(regen.expired, 1, "only the due slot expires");
+        assert_eq!(regen.accepted, 1, "one replacement placer call");
+        assert_eq!(
+            sim.crate_authority.slots()[0],
+            untouched,
+            "an unexpired slot is not touched"
+        );
+        let replaced = sim.crate_authority.slots()[1];
+        assert!(
+            !replaced.is_empty(),
+            "the freed slot is the lowest free one"
+        );
+        assert_eq!(
+            replaced.start_frame, 1_000,
+            "the new timer starts this frame"
+        );
+    }
+
+    /// The replacement lands at or below the expiring index, so one ascending
+    /// pass never revisits it and never cascades.
+    #[test]
+    fn crate_regen_replacement_never_lands_above_the_expiring_slot() {
+        let mut sim = sim_with_grid(0x58);
+        sim.session.game_mode_nonzero = true;
+        sim.session.game_options.crates = true;
+        sim.session.binary_frame = 4_000;
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+
+        for index in [0usize, 1, 2] {
+            *sim.crate_authority.slot_mut(index) = CrateSlot {
+                start_frame: -1,
+                aux: 0,
+                duration: 0,
+                cell_x: 5 + index as i16,
+                cell_y: 5,
+            };
+        }
+
+        let regen = tick_crate_regeneration(&mut sim, &rules, &registry, None, lighting());
+
+        assert_eq!(regen.expired, 3, "each due slot expires exactly once");
+        assert_eq!(regen.accepted, 3);
+        for index in 3..CRATE_SLOT_CAPACITY {
+            assert!(
+                sim.crate_authority.slots()[index].is_empty(),
+                "no replacement may appear above the expiring indices"
+            );
+        }
+        for index in [0usize, 1, 2] {
+            assert_eq!(
+                sim.crate_authority.slots()[index].start_frame,
+                4_000,
+                "every replacement re-armed its timer this frame"
+            );
+        }
+    }
+
+    /// A regenerated crate really moves on the map: the expired cell's overlay
+    /// is gone and the only crate left is the one the replacement marked.
+    #[test]
+    fn crate_regen_removes_the_old_overlay_and_marks_the_new_cell() {
+        let mut sim = sim_with_grid(0x59);
+        sim.session.game_mode_nonzero = true;
+        sim.session.game_options.crates = true;
+        sim.session.binary_frame = 500;
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+        let wood = registry.id_for_name("WOOD").expect("WOOD overlay");
+
+        {
+            let grid = sim.overlay_grid.as_mut().expect("grid");
+            grid.place_overlay(15, 15, wood, 0xFF);
+            let _ = grid.take_dirty_cells();
+        }
+        *sim.crate_authority.slot_mut(0) = CrateSlot {
+            start_frame: -1,
+            aux: 0,
+            duration: 0,
+            cell_x: 15,
+            cell_y: 15,
+        };
+
+        let regen = tick_crate_regeneration(&mut sim, &rules, &registry, None, lighting());
+
+        assert_eq!(regen.expired, 1);
+        assert_eq!(regen.visible, 1);
+        let now = sim.crate_authority.slots()[0];
+        assert_eq!(now.start_frame, 500, "the replacement armed a fresh timer");
+        assert_eq!(
+            crate_cells(&sim, &registry),
+            vec![(now.cell_x as u16, now.cell_y as u16)],
+            "the expired crate overlay is gone and only the replacement remains"
+        );
+    }
+
+    /// Production delivery: the ordinary `advance_tick` master frame reaches the
+    /// regeneration rung, and the same tick with the Crates option off does not.
+    #[test]
+    fn advance_tick_reaches_crate_regeneration_only_while_crates_are_on() {
+        use std::collections::BTreeMap;
+
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+        let height_map: BTreeMap<(u16, u16), u8> = BTreeMap::new();
+
+        let due_slot = CrateSlot {
+            start_frame: -1,
+            aux: 0,
+            duration: 0,
+            cell_x: 15,
+            cell_y: 15,
+        };
+
+        let mut on = sim_with_grid(0x5C);
+        on.session.game_mode_nonzero = true;
+        on.session.game_options.crates = true;
+        *on.crate_authority.slot_mut(0) = due_slot;
+        on.advance_tick(&[], Some(&rules), &height_map, None, Some(&registry), 33);
+        let regenerated = on.crate_authority.slots()[0];
+        assert_ne!(
+            regenerated, due_slot,
+            "the master frame must reach MapClass__UpdateCrateRegenTimers"
+        );
+        assert_eq!(
+            regenerated.start_frame, 0,
+            "the rung runs on the pre-increment frame this tick observed"
+        );
+        assert_eq!(
+            on.session.binary_frame, 1,
+            "the frame counter still commits after every phase"
+        );
+        assert!(
+            !regenerated.is_empty(),
+            "the replacement took the free slot"
+        );
+
+        let mut off = sim_with_grid(0x5C);
+        off.session.game_mode_nonzero = true;
+        off.session.game_options.crates = false;
+        *off.crate_authority.slot_mut(0) = due_slot;
+        off.advance_tick(&[], Some(&rules), &height_map, None, Some(&registry), 33);
+        assert_eq!(
+            off.crate_authority.slots()[0],
+            due_slot,
+            "a paused-crates session never regenerates"
+        );
+    }
+
+    /// A paused, already-zero slot re-fires every tick until a placement takes
+    /// it — the native `start == -1, duration == 0` branch.
+    #[test]
+    fn crate_regen_paused_zero_slot_refires_until_a_placement_succeeds() {
+        let mut sim = sim_with_grid(0x5A);
+        sim.session.game_mode_nonzero = true;
+        sim.session.game_options.crates = true;
+        let rules = crate_ruleset("");
+        let registry = crate_registry();
+
+        // Fill every slot above index 0 so the replacement can only reuse the
+        // slot the scan just freed, then keep zeroing its timer.
+        for index in 1..CRATE_SLOT_CAPACITY {
+            *sim.crate_authority.slot_mut(index) = CrateSlot {
+                start_frame: 0,
+                aux: 0,
+                duration: i32::MAX,
+                cell_x: 1,
+                cell_y: 1,
+            };
+        }
+        *sim.crate_authority.slot_mut(0) = CrateSlot {
+            start_frame: -1,
+            aux: 0,
+            duration: 0,
+            cell_x: 9,
+            cell_y: 9,
+        };
+
+        for _ in 0..3 {
+            let regen = tick_crate_regeneration(&mut sim, &rules, &registry, None, lighting());
+            assert_eq!(
+                regen.expired, 1,
+                "the paused zero-duration slot expires on every pass"
+            );
+            *sim.crate_authority.slot_mut(0) = CrateSlot {
+                start_frame: -1,
+                aux: 0,
+                duration: 0,
+                ..sim.crate_authority.slots()[0]
+            };
+        }
+    }
+}

--- a/src/sim/overlay_grid.rs
+++ b/src/sim/overlay_grid.rs
@@ -603,6 +603,29 @@ impl OverlayGrid {
         true
     }
 
+    /// Erase the two literal CellClass overlay fields a crate removal clears.
+    ///
+    /// `CrateSlot__RemoveCrateOverlayFromCell @ 0x004A1AA0` writes
+    /// `CellClass+0x44 = -1` and `CellClass+0x11E = 0` after its screen-dirty
+    /// request and changes no other field, so this deliberately keeps
+    /// `wall_owner` and runs no passability recalc of its own — unlike
+    /// [`OverlayGrid::clear_overlay`], which resets the whole cell.
+    pub(crate) fn clear_crate_mark_fields(
+        &mut self,
+        resolved_terrain: &mut ResolvedTerrainGrid,
+        rx: u16,
+        ry: u16,
+    ) -> bool {
+        let Some(idx) = index_of(self.width, self.height, rx, ry) else {
+            return false;
+        };
+        self.cells[idx].overlay_id = None;
+        self.cells[idx].overlay_data = 0;
+        self.dirty_cells.push((rx, ry));
+        resolved_terrain.clear_runtime_overlay_identity(rx, ry);
+        true
+    }
+
     /// Write only the raw `CellClass::OverlayData` byte and emit the setter's
     /// immediate radar-dirty event. High-bridge setters do this even when the
     /// target cell has no overlay identity yet.

--- a/src/sim/overlay_grid.rs
+++ b/src/sim/overlay_grid.rs
@@ -132,6 +132,16 @@ pub struct OverlayGrid {
     /// before the authoritative hash. Not part of game state; never serialized.
     #[serde(skip, default)]
     dirty_cells: Vec<(u16, u16)>,
+    /// Cells whose overlay identity was erased this tick *without* a native
+    /// attribute recalc. Presentation must drop their render entry, but
+    /// `CrateSlot__RemoveCrateOverlayFromCell @ 0x004A1AA0` ends at its two
+    /// field writes with no `CellClass::RecalcAttributes @ 0x0047D2B0` tail —
+    /// so the cell keeps the land type the removed overlay gave it, and these
+    /// coordinates must NOT enter `dirty_cells`, whose frame-tail drain
+    /// re-derives land, speed and zone from the pristine tile.
+    /// Not part of game state; never serialized.
+    #[serde(skip, default)]
+    removed_render_cells: Vec<(u16, u16)>,
     /// A synchronous sim-side recalc already observed a passability change for
     /// one of the dirty cells. The frame finalizer must preserve that first result
     /// even though recalculating the now-current terrain returns `false`.
@@ -154,6 +164,7 @@ impl OverlayGrid {
             retained_wall_neighbor_counts: None,
             dirty_cells: Vec::new(),
             synchronous_passability_changed: false,
+            removed_render_cells: Vec::new(),
             synchronous_navigation_cells: Vec::new(),
         }
     }
@@ -184,6 +195,7 @@ impl OverlayGrid {
             retained_wall_neighbor_counts: Some(retained_wall_neighbor_counts),
             dirty_cells: Vec::new(),
             synchronous_passability_changed: false,
+            removed_render_cells: Vec::new(),
             synchronous_navigation_cells: Vec::new(),
         }
     }
@@ -621,9 +633,16 @@ impl OverlayGrid {
         };
         self.cells[idx].overlay_id = None;
         self.cells[idx].overlay_data = 0;
-        self.dirty_cells.push((rx, ry));
+        self.removed_render_cells.push((rx, ry));
         resolved_terrain.clear_runtime_overlay_identity(rx, ry);
         true
+    }
+
+    /// Drain the coordinates whose overlay identity was erased without a
+    /// recalc. The frame finalizer forwards these to presentation so the
+    /// removed sprite stops drawing.
+    pub(crate) fn take_removed_render_cells(&mut self) -> Vec<(u16, u16)> {
+        std::mem::take(&mut self.removed_render_cells)
     }
 
     /// Write only the raw `CellClass::OverlayData` byte and emit the setter's

--- a/src/sim/runtime.rs
+++ b/src/sim/runtime.rs
@@ -293,6 +293,45 @@ mod tests {
         assert!(fresh.resources.waypoints.is_empty());
     }
 
+    /// The crate regeneration rung is guarded in the master frame by
+    /// `if let Some(overlay_registry)`, a Rust availability gate with no native
+    /// counterpart. Prove the SOLE production frame entry point always binds
+    /// one, so that gate can never silently disable
+    /// `MapClass__UpdateCrateRegenTimers @ 0x0056BBE0` in a real match.
+    #[test]
+    fn crate_regen_rung_runs_in_every_production_frame() {
+        use crate::sim::crates::CrateSlot;
+        use crate::sim::crates::tests::{crate_registry, crate_ruleset, sim_with_grid};
+
+        let mut simulation = sim_with_grid(0x62);
+        simulation.session.game_mode_nonzero = true;
+        simulation.session.game_options.crates = true;
+        let due = CrateSlot {
+            start_frame: -1,
+            aux: 0,
+            duration: 0,
+            cell_x: 15,
+            cell_y: 15,
+        };
+        *simulation.crate_authority.slot_mut(0) = due;
+
+        let mut resources = SimResources::empty();
+        resources.rules = crate_ruleset("");
+        resources.overlay_registry = crate_registry();
+        let mut runtime = SimRuntime {
+            simulation,
+            resources,
+        };
+
+        let _ = runtime.advance_frame(&[], 33, crate::sim::world::TickLane::Ordinary);
+
+        assert_ne!(
+            runtime.simulation.crate_authority.slots()[0],
+            due,
+            "SimRuntime::advance_frame must reach the crate regeneration rung"
+        );
+    }
+
     #[test]
     fn gsi_04_12_generated_funnel_projects_preconsumed_words_without_scenario_draw() {
         use crate::map::entities::{EntityCategory, MapEntity};

--- a/src/sim/scenario_post_map.rs
+++ b/src/sim/scenario_post_map.rs
@@ -65,6 +65,10 @@ impl Simulation {
         &mut self,
         input: ScenarioPostMapInput<'_>,
     ) -> ScenarioPostMapOutput {
+        // Retain the scenario's parsed ordinary lighting so the runtime crate
+        // regeneration rung reaches `OverlayClass::Mark` with the same source
+        // this startup pass uses.
+        self.scenario_normal_lighting = input.normal_lighting;
         let tiberium_queues = if input.tiberium_queues_preinitialized {
             None
         } else if let Some(overlay_grid) = self.overlay_grid.as_ref() {
@@ -137,7 +141,7 @@ impl Simulation {
             // cache built earlier in the load funnel, so rebuild it from the
             // now-final CellClass projection and publish matching first-frame
             // navigation without consuming OverlayGrid's dirty receipt.
-            if self.refresh_bridge_runtime_after_startup_crates() {
+            if self.refresh_bridge_runtime_after_crate_mark() {
                 navigation_published = self.rebuild_dynamic_navigation(input.rules);
             }
             #[cfg(test)]
@@ -180,7 +184,12 @@ impl Simulation {
         }
     }
 
-    fn refresh_bridge_runtime_after_startup_crates(&mut self) -> bool {
+    /// Rebuild the derived bridge runtime cache after a crate `OverlayClass::Mark`
+    /// batch. Native Mark mutates live CellClass state synchronously; Rust builds
+    /// `BridgeRuntimeState` earlier in the load funnel, so both the startup batch
+    /// and the per-tick regeneration rung refresh it from the now-final CellClass
+    /// projection.
+    pub(crate) fn refresh_bridge_runtime_after_crate_mark(&mut self) -> bool {
         let Some((destroyable, bridge_strength)) = self
             .bridge_state
             .as_ref()

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -307,6 +307,10 @@ pub(crate) struct SimFrameOutput {
     pub trigger_effects: Vec<TriggerEffect>,
     pub lifecycle_outputs: Vec<LifecycleOutput>,
     pub overlay_updates: Vec<OverlayEntry>,
+    /// Coordinates whose overlay identity was erased this frame. Presentation
+    /// drops their render entry; `overlay_updates` only ever upserts occupied
+    /// cells and can never express a removal.
+    pub overlay_removals: Vec<(u16, u16)>,
     pub sound_events: Vec<SimSoundEvent>,
     pub fire_events: Vec<SimFireEvent>,
     pub invulnerability_impacts: Vec<crate::sim::combat::InvulnerabilityImpactEffect>,
@@ -344,6 +348,7 @@ pub(crate) enum MasterFrameTestRung {
     SessionCommands,
     Triggers,
     LogicVector,
+    CrateRegen,
     Houses,
     TeamScript,
     FrameCommit,
@@ -735,6 +740,11 @@ pub struct Simulation {
     /// boundary. The app drains these into its render-only overlay list.
     #[serde(skip)]
     frame_overlay_updates: Vec<OverlayEntry>,
+    /// Ordered coordinates whose overlay identity was erased at the
+    /// authoritative frame boundary. Drained into `SimFrameOutput` beside the
+    /// occupied upserts.
+    #[serde(skip)]
+    frame_overlay_removals: Vec<(u16, u16)>,
     /// One-shot raw post-match score result. Serialized and hashed so a save at
     /// the outcome wait cannot repeat its Scenario RNG draws after load.
     pub(super) terminal_score_snapshot: Option<crate::sim::score::TerminalScoreSnapshot>,
@@ -3297,6 +3307,7 @@ impl Simulation {
             substrate: ObjectSubstrate::new(),
             lifecycle_outputs: Vec::new(),
             frame_overlay_updates: Vec::new(),
+            frame_overlay_removals: Vec::new(),
             terminal_score_snapshot: None,
             pending_lifecycle_requests: Vec::new(),
             pending_rocket_detonations: Vec::new(),
@@ -5188,8 +5199,14 @@ impl Simulation {
     }
 
     /// Finalize mutable overlay identity, passability, and canonical navigation
-    /// before the frame hash is latched. Only occupied cells cross the app
-    /// boundary; cleared cells remain render-inert through OverlayGrid authority.
+    /// before the frame hash is latched.
+    ///
+    /// `dirty_cells` carries mutations that also re-derive CellClass attributes,
+    /// mirroring `OverlayClass::Mark`'s `RecalcAttributes` tail; only its
+    /// occupied cells produce an upsert. Identity erasures that native performs
+    /// *without* a recalc arrive separately through `take_removed_render_cells`
+    /// and cross the boundary as removals, since an upsert list cannot express
+    /// one.
     fn finalize_frame_overlays_and_navigation(
         &mut self,
         rules: Option<&RuleSet>,
@@ -5200,6 +5217,7 @@ impl Simulation {
         let overlay_ready =
             rules.is_some() && self.resolved_terrain.is_some() && overlay_registry.is_some();
         if overlay_ready && let Some(grid) = self.overlay_grid.as_mut() {
+            self.frame_overlay_removals = grid.take_removed_render_cells();
             let (dirty_cells, synchronous_passability_changed) =
                 grid.take_dirty_cells_with_passability_signal();
             let synchronous_navigation_cells = grid.take_synchronous_navigation_cells();
@@ -6703,6 +6721,7 @@ impl Simulation {
         };
         let lifecycle_outputs = std::mem::take(&mut self.lifecycle_outputs);
         let overlay_updates = std::mem::take(&mut self.frame_overlay_updates);
+        let overlay_removals = std::mem::take(&mut self.frame_overlay_removals);
         let fire_events = std::mem::take(&mut self.fire_events);
         let sound_events = std::mem::take(&mut self.sound_events);
         SimFrameOutput {
@@ -6710,6 +6729,7 @@ impl Simulation {
             trigger_effects,
             lifecycle_outputs,
             overlay_updates,
+            overlay_removals,
             sound_events,
             fire_events,
             invulnerability_impacts,
@@ -7613,7 +7633,14 @@ impl Simulation {
             // between `AlphaShapeClass::PurgeDisabled` and the Tactical,
             // Factory and House callbacks, on the pre-increment frame counter
             // this tick's phases have all observed.
+            // The `Option` is a Rust availability gate with no native
+            // counterpart: `MapClass__UpdateCrateRegenTimers` owns its own two
+            // gates and nothing else. The sole production caller
+            // (`SimRuntime::advance_frame`) always binds the registry, and
+            // `crate_regen_rung_runs_in_every_production_frame` pins that.
             if let Some(overlay_registry) = overlay_registry {
+                #[cfg(test)]
+                self.trace_master_frame_rung(MasterFrameTestRung::CrateRegen);
                 let regen = crate::sim::crates::tick_crate_regeneration(
                     self,
                     rules,
@@ -7627,6 +7654,12 @@ impl Simulation {
                     // cache, so refresh it once per pass that installed an
                     // overlay and let the existing frame-boundary navigation
                     // seam republish; this adds no RNG or ordering boundary.
+                    //
+                    // Deliberately not refreshed on a removal-only pass: only a
+                    // Mark can stamp bridge topology, and the random placer
+                    // refuses any cell that already carries an overlay, so a
+                    // crate can never sit on — or un-stamp — a bridge piece
+                    // under stock rules.
                     bridge_state_changed |= self.refresh_bridge_runtime_after_crate_mark();
                 }
             }

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -636,6 +636,13 @@ where
     Ok(SimRng::new(0))
 }
 
+/// Constructor-time lighting for a Simulation that has not reached Post_Map_Init
+/// yet, and the value a deserialized snapshot starts from before the load path
+/// re-supplies the live scenario profile.
+fn default_scenario_normal_lighting() -> crate::map::lighting::LightingProfileUnits {
+    crate::map::lighting::ParsedLightingProfiles::default().normal
+}
+
 /// The game simulation - owns all authoritative game state.
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct Simulation {
@@ -859,6 +866,13 @@ pub struct Simulation {
     /// Persistent MapClass scenario-crate slots, including accepted ghosts and
     /// their native timer words. This is authoritative save/hash state.
     pub(crate) crate_authority: crate::sim::crates::CrateAuthority,
+    /// The scenario's ordinary `[Lighting]` profile, retained so the runtime
+    /// crate-regeneration rung reaches `OverlayClass::Mark` with the same
+    /// CellClass `+0x10A` source scenario start used. Static map data, not
+    /// simulation state: NOT serialized, NOT hashed, and carried across an
+    /// in-scenario load beside the other process-scoped values.
+    #[serde(skip, default = "default_scenario_normal_lighting")]
+    pub(crate) scenario_normal_lighting: crate::map::lighting::LightingProfileUnits,
     /// Per-cell smudge state (craters, scorches). Seeded from map [Smudge]
     /// entries at init, mutated by combat death-handling at runtime.
     pub smudge_grid: Option<crate::sim::smudge_grid::SmudgeGrid>,
@@ -3028,6 +3042,9 @@ impl Simulation {
         self.main_rng = live.main_rng.clone();
         self.mapgen_rng = live.mapgen_rng.clone();
         self.bind_shared_cell_dummy(live.effective_shared_cell_dummy());
+        // Static map data, not saved state: the live scenario is still the one
+        // being reloaded, so its parsed lighting profile carries over.
+        self.scenario_normal_lighting = live.scenario_normal_lighting;
     }
 
     /// Apply the successful load's native MapClass Resize reconstruction to
@@ -3317,6 +3334,7 @@ impl Simulation {
             bridge_state: None,
             overlay_grid: None,
             crate_authority: crate::sim::crates::CrateAuthority::default(),
+            scenario_normal_lighting: default_scenario_normal_lighting(),
             smudge_grid: None,
             radiation: crate::sim::radiation::RadiationState::default(),
             playfield_bounds: None,
@@ -7590,6 +7608,29 @@ impl Simulation {
                 overlay_registry,
                 &tube_turn_owned_ids,
             );
+            // `LogicClass__PerTickUpdate @ 0x0055AFB0` calls
+            // `MapClass__UpdateCrateRegenTimers @ 0x0056BBE0` at `0x0055B65A`,
+            // between `AlphaShapeClass::PurgeDisabled` and the Tactical,
+            // Factory and House callbacks, on the pre-increment frame counter
+            // this tick's phases have all observed.
+            if let Some(overlay_registry) = overlay_registry {
+                let regen = crate::sim::crates::tick_crate_regeneration(
+                    self,
+                    rules,
+                    overlay_registry,
+                    phase_six_path_grid,
+                    self.scenario_normal_lighting,
+                );
+                if regen.visible != 0 {
+                    // Native Mark mutates live CellClass land/zone/bridge state
+                    // synchronously. Rust's BridgeRuntimeState is a derived
+                    // cache, so refresh it once per pass that installed an
+                    // overlay and let the existing frame-boundary navigation
+                    // seam republish; this adds no RNG or ordering boundary.
+                    bridge_state_changed |= self.refresh_bridge_runtime_after_crate_mark();
+                }
+            }
+
             // --- Phase 7: Scatter + Production + Repairs + Docks + Ore ---
             // DEPENDS ON: combat (dead entities removed), movement (positions stable).
             // PRODUCES: new entities (spawned units), credit changes, ore growth.


### PR DESCRIPTION
Closes the first mechanism of the remaining Phase 14 crate work (GSI-04.23).
PR #209 gave the 256 `MapClass` crate slots their scenario-start contents, but
nothing ever expired them — every startup crate sat on the map for the rest of
the match, and no crate ever regenerated.

## What this delivers

`MapClass__UpdateCrateRegenTimers @ 0x0056BBE0`, its slot clear
(`CrateSlot__ClearAndPreserveTimer @ 0x004A1750`) and the identity-specific
overlay removal (`CrateSlot__RemoveCrateOverlayFromCell @ 0x004A1AA0`), wired at
the native scheduler position: `LogicClass__PerTickUpdate @ 0x0055AFB0` calls the
scan at `0x0055B65A`, after `AlphaShapeClass::PurgeDisabled` and before the
Tactical, Factory and House callbacks, on the pre-increment frame counter.

Player-visible effect: with the stock lobby default `Crates=yes`, crates now
expire on their `CrateRegen` timer and one replacement is placed immediately,
through the same random placer scenario start uses and the same scenario RNG
stream.

## Exactness worth calling out

Four semantics the originating disparity scan under-specified were taken from
the disassembly instead of its prose:

- The expiry predicate has **two** disjuncts. A paused slot (`start == -1`)
  expires only when its stored duration is already zero — and then re-fires every
  tick until a replacement takes it.
- Clear has **three** timer branches, including zeroing an already-expired timer
  at `0x004A17AB`, plus an early `return 0` on an empty coordinate that mutates
  nothing at all.
- There is **no** same-scan cascade. The clear always frees the slot the scan is
  standing on, so the placer's lowest-free scan can only reinstall at or below the
  current index. Several slots can still expire in one pass, each spending its own
  draws in ascending order.
- Removal is exact pointer identity against the three live Rules crate images and
  writes only `CellClass+0x44 = -1` and `CellClass+0x11E = 0` — no
  `RecalcAttributes` tail, so the cell keeps the land type the crate gave it. The
  removal therefore does **not** enter the passability-recalc dirty queue; routing
  it there would have re-derived land, speed and zone from the pristine tile and
  produced a one-cell wheeled-speed divergence on every rough/beach/ice cell a
  crate expires on.

A gap found while acting on review feedback: `OverlayRenderIndex::upsert_occupied`
only ever adds or rewrites an occupied cell, and the frame finalizer emitted an
entry only for cells that still had an identity — so a cleared cell reached the
app as nothing and its sprite stayed on screen. `SimFrameOutput` now carries an
`overlay_removals` channel applied before the upserts.

## Deliberately excluded

`MapClass__RemoveCrateAtCell @ 0x0056C020` and pickup's immediate replacement:
their only caller is `CrateClass__PickupDispatch @ 0x00481D97`, so landing them
now would be dead code. They belong to the pickup mechanism.

## Validation

`cargo test -p vera20k --lib`: **7964 passed; 0 failed; 76 ignored**, on this
branch rebased onto `cef481d7`.

Production delivery is traced, not assumed: `crate_regen_rung_runs_in_every_production_frame`
drives `SimRuntime::advance_frame` — the sole production frame entry — and proves
it binds the overlay registry the rung's `Option` gate depends on. The rung also
has a `MasterFrameTestRung` anchor like every other spine rung.

## Review

Two fresh read-only critics: one over the frozen disparity scan before any code
was written, one over the implementation. Every finding from both is fixed in this
branch rather than deferred, including two of my own comment/test claims that were
wrong (a "signed wraparound" case that is unreachable, and a test that passed for
the wrong reason).
