### PR TITLE
Phase 14 crates: the fixed Powerups table and full CrateRules authority

### DIFF
--- a/docs/research/RULESCLASS_POWERUPS_TABLE.md
+++ b/docs/research/RULESCLASS_POWERUPS_TABLE.md
@@ -21,7 +21,7 @@ runtime) and the save/load routines at `FUN_0067F7E0` / `FUN_0067F9C0`.
 INI line format:
 
 ```
-<PowerupName>=<weight>, <anim>, <enabled>, <value>
+<PowerupName>=<weight>, <anim>, <over-water>, <value>
 ; e.g. Money=20,MONEY,yes,2000
 ;      Armor=10,ARMOR,yes,1.5
 ;      Napalm=0,<none>,no,600
@@ -86,7 +86,7 @@ Each has **exactly 19 entries**, layout confirmed by the loop bound in
 
 | Global base | Array type | Size (bytes) | Field source | Semantics |
 |---|---|---:|---|---|
-| `DAT_0081DA8C` | `int32[19]` | `0x4C` (76) | 1st token, via `atoi` | **drop weight** — summed across all enabled slots for random selection |
+| `DAT_0081DA8C` | `int32[19]` | `0x4C` (76) | 1st token, via `atoi` | **drop weight** — summed across **all nineteen** slots for random selection; a zero weight is the only thing that makes a slot unrollable |
 | `DAT_0081DAD8` | `int32[19]` | `0x4C` (76) | 2nd token, via `AnimTypeClass::Find_Index` (`FUN_00422B20`) | **pickup anim index** — index into `g_AnimTypes_Array`, or `-1` for `<none>` |
 | `DAT_0089ECC0` | `u8[19]` | `0x13` (19) | 3rd token, literal strcmp | **over-water eligibility** — `1` if `yes`, `0` if `no`, otherwise unchanged. Byte-wide: the writes at `0x00673F64`/`0x00673F7F` are `MOV byte ptr [EDI + 0x89ecc0], ...` and the read at `0x00481D5B` is `MOV AL, byte ptr [EBX + 0x89ecc0]` |
 | `DAT_0089EC28` | `double[19]` | `0x98` (152) | 4th token, via `atof` (× `0.01` if `%` present) | **effect parameter** — see per-powerup table above |
@@ -206,7 +206,7 @@ HIGH — all 19 name pointers resolved to ASCII literals, all 4 global
 arrays bounded and sized from the ReadPowerups loop bound, every field
 extractor (atoi / AnimType::Find_Index / yes-no strcmp / atof+%-scale)
 confirmed in the decomp, CrateClass consumer xrefs match the
-expected access patterns (weight-sum, enabled-gate, parameter-load).
+expected access patterns (weight-sum, over-water gate, parameter-load).
 
 ## Cross-refs
 

--- a/docs/research/RULESCLASS_POWERUPS_TABLE.md
+++ b/docs/research/RULESCLASS_POWERUPS_TABLE.md
@@ -4,7 +4,7 @@ source_addr: 0x00673E80
 owner_report: RULESCLASS_GHIDRA_REPORT.md §5 (Master orchestrators, step 32)
 yr_active_in_stock_game: YES
 writes_to_rulesclass: NO (writes to 4 parallel globals, not a RulesClass field)
-verified_from: gamemd.exe live decompilation (Ghidra MCP, 2026-04-24); cross-checked against ini/rulesmd.ini §[Powerups]
+verified_from: gamemd.exe live decompilation (Ghidra MCP, 2026-04-24); token-3 semantics, flag-array width, default string, and static defaults re-verified 2026-09-02 against the live binary; cross-checked against ini/rulesmd.ini §[Powerups]
 ---
 
 # `[Powerups]` crate-bonus table
@@ -30,8 +30,13 @@ INI line format:
 - `weight` — int, crate-drop weight used for random powerup selection
 - `anim` — string, matches an `AnimType` name (`<none>` → `-1` via the
   `AnimTypeClass::Find_Index` helper at `FUN_00422B20`)
-- `enabled` — `yes`/`no`, whether this powerup can actually drop; anything
-  other than the two literal strings leaves the flag at its ctor default
+- `over-water eligibility` — `yes`/`no`. **NOT an "enabled" flag.** Verified
+  2026-09-02 at `CrateClass__PickupDispatch 0x00481D52`: the byte is read only
+  when the crate cell's land type is water (`CMP dword [ESI+0xEC], 0x2`), and a
+  cleared flag redirects the outcome to slot 0 (Money) rather than suppressing
+  the crate. Stock `Unit=20,<none>,no` therefore still drops on land — the older
+  "enabled" reading would have forbidden that. Anything other than the two
+  literal strings leaves the flag at its previous value.
 - `value` — double, the powerup's per-kind effect parameter. If the token
   contains a `%`, the raw `atof` is multiplied by `0.01` (so `50%` becomes
   `0.5`); otherwise it is stored verbatim. Interpreted per-powerup:
@@ -83,13 +88,27 @@ Each has **exactly 19 entries**, layout confirmed by the loop bound in
 |---|---|---:|---|---|
 | `DAT_0081DA8C` | `int32[19]` | `0x4C` (76) | 1st token, via `atoi` | **drop weight** — summed across all enabled slots for random selection |
 | `DAT_0081DAD8` | `int32[19]` | `0x4C` (76) | 2nd token, via `AnimTypeClass::Find_Index` (`FUN_00422B20`) | **pickup anim index** — index into `g_AnimTypes_Array`, or `-1` for `<none>` |
-| `DAT_0089ECC0` | `int32[19]` | `0x4C` (76) | 3rd token, literal strcmp | **enabled flag** — `1` if `yes`, `0` if `no`, otherwise unchanged |
+| `DAT_0089ECC0` | `u8[19]` | `0x13` (19) | 3rd token, literal strcmp | **over-water eligibility** — `1` if `yes`, `0` if `no`, otherwise unchanged. Byte-wide: the writes at `0x00673F64`/`0x00673F7F` are `MOV byte ptr [EDI + 0x89ecc0], ...` and the read at `0x00481D5B` is `MOV AL, byte ptr [EBX + 0x89ecc0]` |
 | `DAT_0089EC28` | `double[19]` | `0x98` (152) | 4th token, via `atof` (× `0.01` if `%` present) | **effect parameter** — see per-powerup table above |
 
 `DAT_0081DA8C` and `DAT_0081DAD8` are contiguous (`0x0081DA8C..0x0081DB24`)
 — a single `int32[38]` area split logically in two. `DAT_0089EC28` and
-`DAT_0089ECC0` are also contiguous (double[19] immediately followed by
-int32[19], running `0x0089EC28..0x0089ED0C`).
+`DAT_0089ECC0` are also contiguous: `double[19]` (`0x0089EC28..0x0089ECC0`)
+immediately followed by `u8[19]` (`0x0089ECC0..0x0089ECD3`). The `f64` cursor's
+loop bound `pdVar5 < 0x0089ECC0` is exactly the start of the flag array.
+
+## Static image defaults (read 2026-09-02)
+
+The four globals are initialized in the image, not by the RulesClass
+constructor — `get_xrefs_to` on each base shows only ReadPowerups and the
+save/load pair. Pre-INI values:
+
+| Global | Default |
+|---|---|
+| `DAT_0081DA8C` weights | `[50,20,1,3,5,5,20,1,1,10,10,10,1,3,1,1,1,1,1]` |
+| `DAT_0081DAD8` anim | all `-1` |
+| `DAT_0089ECC0` over-water | all `0` |
+| `DAT_0089EC28` magnitude | all `0.0` |
 
 ## Function body
 
@@ -104,7 +123,7 @@ undefined4 FUN_00673E80(void) {
     do {
         if (CCINIClass__ReadString("Powerups",
                                    (&PTR_s_Money_007E523C)[iVar1],   // name from fixed table
-                                   "0,NONE,0",                       // default string
+                                   "0,NONE",                         // default string @ 0x0083D4AC
                                    local_80, 0x80) != 0) {
             // Field 1: drop weight (atoi)
             char* tok = CRT__strtok(local_80, ",");
@@ -114,12 +133,12 @@ undefined4 FUN_00673E80(void) {
             tok = CRT__strtok(0, ",");
             if (tok) { strtrim(); (&DAT_0081DAD8)[iVar1] = AnimTypeClass::Find_Index(tok); }
 
-            // Field 3: enabled flag
+            // Field 3: over-water eligibility
             tok = CRT__strtok(0, ",");
             if (tok) {
                 strtrim();
-                if      (strcmp(tok, "yes") == 0) (&DAT_0089ECC0)[iVar1] = 1;
-                else if (strcmp(tok, "no")  == 0) (&DAT_0089ECC0)[iVar1] = 0;
+                if      (strcmpi(tok, "yes") == 0) *(u8*)(&DAT_0089ECC0 + iVar1) = 1;
+                else if (strcmpi(tok, "no")  == 0) *(u8*)(&DAT_0089ECC0 + iVar1) = 0;
                 // else leave previous value untouched
             }
 
@@ -152,10 +171,10 @@ undefined4 FUN_00673E80(void) {
   - `0x00481B06` — same `DAT_0081DA8C` base, secondary pass that compares
     a running sum against a previously-generated random value to pick the
     winning slot.
-  - `0x00481D5B` — `MOV AL, byte ptr [EBX + 0x89ECC0]; TEST AL, AL; JNZ
-    skip; XOR EBX, EBX; MOV [ESP+0x2C], EBX` → if the selected slot's
-    enabled flag is zero, the dispatcher zeros the bonus-result local
-    (disables the powerup effect).
+  - `0x00481D52..0x00481D67` — `CMP dword ptr [ESI+0xEC], 0x2; JNZ skip;
+    MOV AL, byte ptr [EBX + 0x89ECC0]; TEST AL, AL; JNZ skip; XOR EBX, EBX;
+    MOV [ESP+0x2C], EBX` → **only on a water cell**, a cleared flag rewrites
+    the selected slot to 0 (Money). It does not disable the powerup.
   - `0x00481DC3` — `FLD double ptr [EBX*0x8 + 0x89EC28]` → loads the
     effect parameter as a double for application.
 - **Save/load at `0x0067F7E0` and `0x0067F9C0`** — read/write all four
@@ -167,13 +186,19 @@ undefined4 FUN_00673E80(void) {
 
 ## YR-active status — **live**
 
-Every entry is reachable from crate pickup at runtime. Most bonuses are
-enabled in stock YR (`Armor`, `Firepower`, `HealBase`, `Money`, `Reveal`,
-`Speed`, `Veteran`, `Cloak`, `Darkness`, `Explosion`, `ICBM`, `Gas`). A
-handful are disabled by default (`Unit`, `Tiberium`, `Pod`, `Napalm`,
-`Squad` — all shipped as `no`). `IonStorm`, `Invulnerability` are
-configured with `0` weight, so they're effectively never rolled but
-the slot is kept allocated.
+Every entry is reachable from crate pickup at runtime, but **weight alone
+decides what is rolled**. Exactly eight stock slots carry a positive weight —
+`Money` 20, `Unit` 20, `HealBase` 10, `Reveal` 10, `Armor` 10, `Speed` 10,
+`Firepower` 10, `Veteran` 20 — totalling **110**. Full canonical-order vector:
+`[20,20,10,0,0,0,0,0,10,10,10,10,0,0,20,0,0,0,0]`.
+
+The earlier claim that `Unit`, `Tiberium`, `Pod`, `Napalm` and `Squad` are
+"disabled by default because they ship as `no`" is **wrong** and was corrected
+2026-09-02: that token is over-water eligibility. `Unit` is one of the eight
+positive-weight outcomes and drops normally on land; over water it is redirected
+to `Money`. `Tiberium`, `Pod`, `Napalm` and `Squad` are unreachable because
+their weight is `0`, exactly like `Cloak`, `Darkness`, `Explosion`, `ICBM`,
+`Gas`, `IonStorm` and `Invulnerability`.
 
 ## Confidence
 

--- a/docs/research/RULESCLASS_POWERUPS_TABLE.md
+++ b/docs/research/RULESCLASS_POWERUPS_TABLE.md
@@ -40,7 +40,12 @@ INI line format:
 - `value` — double, the powerup's per-kind effect parameter. If the token
   contains a `%`, the raw `atof` is multiplied by `0.01` (so `50%` becomes
   `0.5`); otherwise it is stored verbatim. Interpreted per-powerup:
-  - Money → maximum cash granted
+  - Money → the **minimum** cash granted, not the maximum. The Money branch
+    does `EAX = ftol(magnitude); EDX = EAX + 0x384; RandomRanged(EAX, EDX)`
+    (`0x00482484..0x004824A0`), so stock `Money=20,MONEY,yes,2000` pays
+    **2000–2900**. The retail INI's own trailing comment `(maximum cash)` is
+    wrong and this doc inherited it. In game mode zero the draw is skipped
+    entirely and `[CrateRules] SoloCrateMoney` is paid flat.
   - Armor/Firepower/Speed → multiplier applied to nearby units
   - Veteran → veteran levels added
   - Invulnerability → duration in minutes

--- a/docs/research/RULESCLASS_POWERUPS_TABLE.md
+++ b/docs/research/RULESCLASS_POWERUPS_TABLE.md
@@ -44,8 +44,11 @@ INI line format:
     does `EAX = ftol(magnitude); EDX = EAX + 0x384; RandomRanged(EAX, EDX)`
     (`0x00482484..0x004824A0`), so stock `Money=20,MONEY,yes,2000` pays
     **2000–2900**. The retail INI's own trailing comment `(maximum cash)` is
-    wrong and this doc inherited it. In game mode zero the draw is skipped
-    entirely and `[CrateRules] SoloCrateMoney` is paid flat.
+    wrong and this doc inherited it. The solo override is narrower than it
+    looks: `PickupDispatch` loads `SoloCrateMoney` only when `g_GameMode == 0`
+    **and** the cell's overlay data byte is zero, and the draw is then skipped
+    only when that loaded value is non-zero — a `SoloCrateMoney=0` still rolls
+    the random amount.
   - Armor/Firepower/Speed → multiplier applied to nearby units
   - Veteran → veteran levels added
   - Invulnerability → duration in minutes

--- a/src/rules/crate_rules.rs
+++ b/src/rules/crate_rules.rs
@@ -115,7 +115,16 @@ impl CrateRulesAccumulator {
             }
             // Every ReadString call in this body is given capacity 0x80, so
             // truncation owns both the retained identity and the earlier late
-            // allocation.
+            // allocation. `OverlayTypeClass__FindOrCreate @ 0x005FEC70` returns
+            // 0 for both `<none>` and `none` and the result is stored
+            // unconditionally, so unlike the sound below these keys really do
+            // null on a sentinel.
+            //
+            // VERA-internal, gamemd equivalent UNCHECKED: native keeps an
+            // OverlayTypeClass pointer and no string at all, so there is no
+            // native casing to match. Upper-casing makes the retained name a
+            // stable lookup key for the later consumer; every comparison
+            // against it is case-insensitive regardless.
             let value = section.read_string(key, "", 0x80);
             *target = (!is_native_none_type_name(&value)).then(|| value.to_ascii_uppercase());
         }

--- a/src/rules/crate_rules.rs
+++ b/src/rules/crate_rules.rs
@@ -23,10 +23,14 @@ pub struct CrateRules {
     /// `HealCrateSound` -> `Rules+0x718`, a Voc index natively.
     ///
     /// Native resolves the name through `VocClass__FindByName` at parse time and
-    /// keeps the previous index when the lookup fails, so an unresolvable name
-    /// is indistinguishable from an absent key. VERA retains the name and
-    /// resolves against the sound registry at use; the two differ only for a
-    /// name no sound defines, which cannot occur in stock data.
+    /// keeps the PREVIOUS index when the lookup fails, so an unresolvable name
+    /// is indistinguishable from an absent key. A no-type sentinel is modelled
+    /// exactly — it retains the live value instead of clearing it. What cannot
+    /// be modelled here is an ordinary name that no sound defines: VERA has no
+    /// Voc registry at rules-parse time, so it stores the name and resolves at
+    /// use, where native would already have kept the earlier sound. Reaching
+    /// that needs two passes, the first naming a real sound and the second an
+    /// undefined one; recorded as a deferred DRIFT.
     pub heal_crate_sound: Option<String>,
     /// `CrateMinimum` -> `Rules+0x1470`.
     pub minimum: i32,
@@ -105,7 +109,6 @@ impl CrateRulesAccumulator {
             ("WoodCrateImg", &mut self.0.wood_crate_img),
             ("CrateImg", &mut self.0.crate_img),
             ("WaterCrateImg", &mut self.0.water_crate_img),
-            ("HealCrateSound", &mut self.0.heal_crate_sound),
         ] {
             if section.get(key).is_none() {
                 continue;
@@ -115,6 +118,16 @@ impl CrateRulesAccumulator {
             // allocation.
             let value = section.read_string(key, "", 0x80);
             *target = (!is_native_none_type_name(&value)).then(|| value.to_ascii_uppercase());
+        }
+        if section.get("HealCrateSound").is_some() {
+            // `if ((read == 0) || (index = VocClass__FindByName(), index == -1))
+            //  { index = previous; }` — a failed lookup RETAINS the live index
+            // rather than clearing it, so a no-type sentinel must not null the
+            // field the way the image keys above do.
+            let value = section.read_string("HealCrateSound", "", 0x80);
+            if !is_native_none_type_name(&value) {
+                self.0.heal_crate_sound = Some(value.to_ascii_uppercase());
+            }
         }
         if section.get("CrateMinimum").is_some() {
             self.0.minimum = section.read_int("CrateMinimum", self.0.minimum);
@@ -243,6 +256,36 @@ mod tests {
         assert_eq!(rules.radius, 768);
         assert_eq!(rules.silver_crate, POWERUP_VETERAN);
         assert_eq!(rules.minimum, 4);
+    }
+
+    /// A failed `VocClass__FindByName` retains the live index, so a no-type
+    /// sentinel must not clear the sound the way the three image keys are.
+    #[test]
+    fn heal_crate_sound_sentinel_retains_the_live_value() {
+        let mut accumulator = CrateRulesAccumulator::default();
+        accumulator.apply_pass(&IniFile::from_str(
+            "[CrateRules]
+HealCrateSound=HealCrate
+CrateImg=CRATE
+",
+        ));
+        accumulator.apply_pass(&IniFile::from_str(
+            "[CrateRules]
+HealCrateSound=<none>
+CrateImg=<none>
+",
+        ));
+        let rules = accumulator.finish();
+
+        assert_eq!(
+            rules.heal_crate_sound.as_deref(),
+            Some("HEALCRATE"),
+            "a sentinel keeps the previously resolved sound"
+        );
+        assert_eq!(
+            rules.crate_img, None,
+            "the image keys DO null on a sentinel — FindOrCreate has no retain branch"
+        );
     }
 
     /// An unmatched solo-crate mapping resolves to Money rather than failing —

--- a/src/rules/crate_rules.rs
+++ b/src/rules/crate_rules.rs
@@ -94,15 +94,38 @@ impl CrateRulesAccumulator {
             return;
         };
 
-        // Native read order, one key at a time; a missing key keeps the live
-        // field because every reader is handed the current value as its default.
+        // `RulesClass__ReadCrateRules @ 0x0066B900` reads its keys in exactly
+        // this order. Every reader is handed the live value as its default, so
+        // a missing key keeps the field. The order is behaviourally inert today
+        // because the fields are independent, but native allocates OverlayType
+        // and UnitType objects while reading the string keys, so a future
+        // consumer reproducing those allocations needs the sequence to be right.
         self.0.free_mcv = section.read_bool("FreeMCV", self.0.free_mcv);
+        for (key, target) in [
+            ("WoodCrateImg", &mut self.0.wood_crate_img),
+            ("CrateImg", &mut self.0.crate_img),
+            ("WaterCrateImg", &mut self.0.water_crate_img),
+            ("HealCrateSound", &mut self.0.heal_crate_sound),
+        ] {
+            if section.get(key).is_none() {
+                continue;
+            }
+            // Every ReadString call in this body is given capacity 0x80, so
+            // truncation owns both the retained identity and the earlier late
+            // allocation.
+            let value = section.read_string(key, "", 0x80);
+            *target = (!is_native_none_type_name(&value)).then(|| value.to_ascii_uppercase());
+        }
         if section.get("CrateMinimum").is_some() {
             self.0.minimum = section.read_int("CrateMinimum", self.0.minimum);
         }
         if section.get("CrateMaximum").is_some() {
             self.0.maximum = section.read_int("CrateMaximum", self.0.maximum);
         }
+        // `CrateRadius` is stored in leptons; the stock `3.0` is three cells.
+        // ReadRange owns the absent-key and `-1` sentinel cases itself, so this
+        // needs no presence guard of its own.
+        self.0.radius = section.read_range("CrateRadius", self.0.radius);
         if section.get("CrateRegen").is_some() {
             self.0.regen = NativeF64Bits::from_bits(
                 section
@@ -110,11 +133,10 @@ impl CrateRulesAccumulator {
                     .to_bits(),
             );
         }
-
-        if section.get("CrateRadius").is_some() {
-            // `CCINIClass__ReadRange` yields the stored lepton value; the stock
-            // `3.0` is three cells.
-            self.0.radius = read_range_leptons(section, "CrateRadius", self.0.radius);
+        if section.get("UnitCrateType").is_some() {
+            let value = section.read_string("UnitCrateType", "", 0x80);
+            self.0.unit_crate_type =
+                (!is_native_none_type_name(&value)).then(|| value.to_ascii_uppercase());
         }
         if section.get("SoloCrateMoney").is_some() {
             self.0.solo_crate_money = section.read_int("SoloCrateMoney", self.0.solo_crate_money);
@@ -130,41 +152,13 @@ impl CrateRulesAccumulator {
             // `FUN_004759F0` reads the string, then `Powerup_From_Name` maps it
             // to a slot; an unmatched name resolves to Money rather than failing.
             let value = section.read_string(key, "", 0x80);
-            *target = crate::rules::powerups::powerup_from_name(value.trim());
-        }
-
-        for (key, target) in [
-            ("WoodCrateImg", &mut self.0.wood_crate_img),
-            ("CrateImg", &mut self.0.crate_img),
-            ("WaterCrateImg", &mut self.0.water_crate_img),
-            ("HealCrateSound", &mut self.0.heal_crate_sound),
-            ("UnitCrateType", &mut self.0.unit_crate_type),
-        ] {
-            if section.get(key).is_none() {
-                continue;
-            }
-            // `RulesClass__ReadCrateRules @ 0x0066B900` supplies capacity
-            // 0x80 to all three ReadString calls. Truncation therefore owns
-            // both the retained identity and the earlier late allocation.
-            let value = section.read_string(key, "", 0x80);
-            *target = (!is_native_none_type_name(&value)).then(|| value.to_ascii_uppercase());
+            *target = crate::rules::powerups::powerup_from_name(&value);
         }
     }
 
     pub(crate) fn finish(self) -> CrateRules {
         self.0
     }
-}
-
-/// `CCINIClass__ReadRange` stores a cell-denominated key in leptons.
-fn read_range_leptons(
-    section: &crate::rules::ini_parser::IniSection,
-    key: &str,
-    default: i32,
-) -> i32 {
-    let cells = section.read_double(key, f64::from(default) / 256.0);
-    // Native multiplies by the 256-lepton cell and truncates toward zero.
-    (cells * 256.0) as i32
 }
 
 #[cfg(test)]

--- a/src/rules/crate_rules.rs
+++ b/src/rules/crate_rules.rs
@@ -7,28 +7,79 @@
 use crate::rules::ini_parser::{IniFile, is_native_none_type_name};
 use crate::util::native_x87::NativeF64Bits;
 
-/// The six `[CrateRules]` fields consumed by scenario-start scatter.
+/// Every `[CrateRules]` field `RulesClass__ReadCrateRules @ 0x0066B900` reads,
+/// in its native read order.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CrateRules {
-    pub minimum: i32,
-    pub maximum: i32,
-    pub regen: NativeF64Bits,
+    /// `FreeMCV` -> `Rules+0x40`. Gates the pickup pre-empt that forces a Unit
+    /// crate for a player with credits but no buildings.
+    pub free_mcv: bool,
+    /// `WoodCrateImg` -> `Rules+0xF8`.
     pub wood_crate_img: Option<String>,
+    /// `CrateImg` -> `Rules+0xFC`.
     pub crate_img: Option<String>,
+    /// `WaterCrateImg` -> `Rules+0x100`.
     pub water_crate_img: Option<String>,
+    /// `HealCrateSound` -> `Rules+0x718`, a Voc index natively.
+    ///
+    /// Native resolves the name through `VocClass__FindByName` at parse time and
+    /// keeps the previous index when the lookup fails, so an unresolvable name
+    /// is indistinguishable from an absent key. VERA retains the name and
+    /// resolves against the sound registry at use; the two differ only for a
+    /// name no sound defines, which cannot occur in stock data.
+    pub heal_crate_sound: Option<String>,
+    /// `CrateMinimum` -> `Rules+0x1470`.
+    pub minimum: i32,
+    /// `CrateMaximum` -> `Rules+0x1474`.
+    pub maximum: i32,
+    /// `CrateRadius` -> `Rules+0x172C`, read by `CCINIClass::ReadRange` and
+    /// stored in leptons. Every radius crate effect compares a 3-D distance
+    /// against this value with a strict `<`.
+    pub radius: i32,
+    /// `CrateRegen` -> `Rules+0x1678`.
+    pub regen: NativeF64Bits,
+    /// `UnitCrateType` -> `Rules+0x1148`. A named type overrides the Unit
+    /// effect's random `CrateGoodie` selection.
+    pub unit_crate_type: Option<String>,
+    /// `SoloCrateMoney` -> `Rules+0x1140`, paid flat by the Money effect in
+    /// game mode zero instead of drawing a random amount.
+    pub solo_crate_money: i32,
+    /// `SilverCrate` -> `Rules+0x1464`: the fixed outcome a `CrateImg` crate
+    /// yields in game mode zero. Stored as a slot index in the fixed
+    /// `[Powerups]` table via `Powerup_From_Name @ 0x0048DE70`.
+    pub silver_crate: usize,
+    /// `WoodCrate` -> `Rules+0x1468`, the same mapping for `WoodCrateImg`.
+    pub wood_crate: usize,
+    /// `WaterCrate` -> `Rules+0x146C`, the same mapping for `WaterCrateImg`.
+    pub water_crate: usize,
 }
 
 impl Default for CrateRules {
     fn default() -> Self {
-        // RulesClass constructor values verified in active gamemd.exe. Image
-        // pointers begin null; stock rulesmd.ini fills them during Process.
+        // `RulesClass__Constructor @ 0x00665650` immediate stores, each read
+        // this session: `+0x40 = BL` with `EBX` zeroed at `0x00665663`;
+        // `+0x718 = EBP` with `EBP` set to -1 at `0x0066585F` (no sound);
+        // `+0x1140 = ECX` loaded `0x7D0` at `0x00666DD7`; `+0x1148 = EBX`;
+        // `+0x1464 = EDX` loaded `2` at `0x006671CD`; `+0x1468`/`+0x146C = EBX`;
+        // `+0x1470 = EAX` loaded `1`; `+0x1474 = 0xFF`; `+0x172C = 0x280`.
+        // Image pointers begin null; stock rulesmd.ini fills them during Process.
         Self {
-            minimum: 1,
-            maximum: 255,
-            regen: NativeF64Bits::from_bits(10.0_f64.to_bits()),
+            free_mcv: false,
             wood_crate_img: None,
             crate_img: None,
             water_crate_img: None,
+            heal_crate_sound: None,
+            minimum: 1,
+            maximum: 255,
+            radius: 0x280,
+            regen: NativeF64Bits::from_bits(10.0_f64.to_bits()),
+            unit_crate_type: None,
+            solo_crate_money: 2000,
+            // The constructor's own defaults already agree with the stock INI:
+            // silver -> HealBase, wood and water -> Money.
+            silver_crate: crate::rules::powerups::POWERUP_HEAL_BASE,
+            wood_crate: crate::rules::powerups::POWERUP_MONEY,
+            water_crate: crate::rules::powerups::POWERUP_MONEY,
         }
     }
 }
@@ -43,6 +94,9 @@ impl CrateRulesAccumulator {
             return;
         };
 
+        // Native read order, one key at a time; a missing key keeps the live
+        // field because every reader is handed the current value as its default.
+        self.0.free_mcv = section.read_bool("FreeMCV", self.0.free_mcv);
         if section.get("CrateMinimum").is_some() {
             self.0.minimum = section.read_int("CrateMinimum", self.0.minimum);
         }
@@ -57,10 +111,34 @@ impl CrateRulesAccumulator {
             );
         }
 
+        if section.get("CrateRadius").is_some() {
+            // `CCINIClass__ReadRange` yields the stored lepton value; the stock
+            // `3.0` is three cells.
+            self.0.radius = read_range_leptons(section, "CrateRadius", self.0.radius);
+        }
+        if section.get("SoloCrateMoney").is_some() {
+            self.0.solo_crate_money = section.read_int("SoloCrateMoney", self.0.solo_crate_money);
+        }
+        for (key, target) in [
+            ("SilverCrate", &mut self.0.silver_crate),
+            ("WoodCrate", &mut self.0.wood_crate),
+            ("WaterCrate", &mut self.0.water_crate),
+        ] {
+            if section.get(key).is_none() {
+                continue;
+            }
+            // `FUN_004759F0` reads the string, then `Powerup_From_Name` maps it
+            // to a slot; an unmatched name resolves to Money rather than failing.
+            let value = section.read_string(key, "", 0x80);
+            *target = crate::rules::powerups::powerup_from_name(value.trim());
+        }
+
         for (key, target) in [
             ("WoodCrateImg", &mut self.0.wood_crate_img),
             ("CrateImg", &mut self.0.crate_img),
             ("WaterCrateImg", &mut self.0.water_crate_img),
+            ("HealCrateSound", &mut self.0.heal_crate_sound),
+            ("UnitCrateType", &mut self.0.unit_crate_type),
         ] {
             if section.get(key).is_none() {
                 continue;
@@ -75,5 +153,109 @@ impl CrateRulesAccumulator {
 
     pub(crate) fn finish(self) -> CrateRules {
         self.0
+    }
+}
+
+/// `CCINIClass__ReadRange` stores a cell-denominated key in leptons.
+fn read_range_leptons(
+    section: &crate::rules::ini_parser::IniSection,
+    key: &str,
+    default: i32,
+) -> i32 {
+    let cells = section.read_double(key, f64::from(default) / 256.0);
+    // Native multiplies by the 256-lepton cell and truncates toward zero.
+    (cells * 256.0) as i32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rules::powerups::{POWERUP_HEAL_BASE, POWERUP_MONEY, POWERUP_VETERAN};
+
+    fn parse(section: &str) -> CrateRules {
+        let mut accumulator = CrateRulesAccumulator::default();
+        accumulator.apply_pass(&IniFile::from_str(section));
+        accumulator.finish()
+    }
+
+    /// The stock section, read exactly. `CrateRadius` is stored in leptons and
+    /// the three solo mappings become fixed `[Powerups]` slot indices.
+    #[test]
+    fn stock_crate_rules_section_parses_every_native_field() {
+        let rules = parse(
+            "[CrateRules]\n\
+             CrateMaximum=255\n\
+             CrateMinimum=1\n\
+             CrateRadius=3.0\n\
+             CrateRegen=3\n\
+             SilverCrate=HealBase\n\
+             SoloCrateMoney=5000\n\
+             UnitCrateType=none\n\
+             WoodCrate=Money\n\
+             WaterCrate=Money\n\
+             HealCrateSound=HealCrate\n\
+             WoodCrateImg=CRATE\n\
+             CrateImg=CRATE\n\
+             WaterCrateImg=WCRATE\n\
+             FreeMCV=yes\n",
+        );
+
+        assert!(rules.free_mcv);
+        assert_eq!(rules.minimum, 1);
+        assert_eq!(rules.maximum, 255);
+        assert_eq!(rules.radius, 768, "3.0 cells is 768 leptons");
+        assert_eq!(f64::from_bits(rules.regen.bits()), 3.0);
+        assert_eq!(rules.solo_crate_money, 5000);
+        assert_eq!(rules.heal_crate_sound.as_deref(), Some("HEALCRATE"));
+        assert_eq!(
+            rules.unit_crate_type, None,
+            "`none` is the native no-type sentinel"
+        );
+        assert_eq!(rules.silver_crate, POWERUP_HEAL_BASE);
+        assert_eq!(rules.wood_crate, POWERUP_MONEY);
+        assert_eq!(rules.water_crate, POWERUP_MONEY);
+        // Retail names the same overlay for two of the three image slots.
+        assert_eq!(rules.wood_crate_img.as_deref(), Some("CRATE"));
+        assert_eq!(rules.crate_img.as_deref(), Some("CRATE"));
+        assert_eq!(rules.water_crate_img.as_deref(), Some("WCRATE"));
+    }
+
+    /// A missing section leaves every constructor default in place.
+    #[test]
+    fn missing_section_retains_the_constructor_defaults() {
+        let rules = parse("[General]\n");
+        assert_eq!(rules, CrateRules::default());
+        assert!(!rules.free_mcv, "the constructor stores BL with EBX zeroed");
+        assert_eq!(rules.radius, 0x280, "2.5 cells");
+        assert_eq!(rules.solo_crate_money, 2000);
+        assert_eq!(rules.heal_crate_sound, None, "EBP is -1: no sound");
+        assert_eq!(rules.silver_crate, POWERUP_HEAL_BASE);
+        assert_eq!(rules.wood_crate, POWERUP_MONEY);
+    }
+
+    /// Each key is read with the live value as its default, so an absent key in
+    /// a later pass never resets an earlier one.
+    #[test]
+    fn later_pass_without_a_key_retains_the_live_value() {
+        let mut accumulator = CrateRulesAccumulator::default();
+        accumulator.apply_pass(&IniFile::from_str(
+            "[CrateRules]\nFreeMCV=yes\nSoloCrateMoney=5000\nCrateRadius=3.0\nSilverCrate=Veteran\n",
+        ));
+        accumulator.apply_pass(&IniFile::from_str("[CrateRules]\nCrateMinimum=4\n"));
+        let rules = accumulator.finish();
+
+        assert!(rules.free_mcv);
+        assert_eq!(rules.solo_crate_money, 5000);
+        assert_eq!(rules.radius, 768);
+        assert_eq!(rules.silver_crate, POWERUP_VETERAN);
+        assert_eq!(rules.minimum, 4);
+    }
+
+    /// An unmatched solo-crate mapping resolves to Money rather than failing —
+    /// `Powerup_From_Name` has no error path.
+    #[test]
+    fn unmatched_solo_mapping_falls_back_to_money() {
+        let rules = parse("[CrateRules]\nSilverCrate=NotAPowerup\n");
+        assert_eq!(rules.silver_crate, POWERUP_MONEY);
     }
 }

--- a/src/rules/ini_parser.rs
+++ b/src/rules/ini_parser.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 use crate::rules::crate_rules::{CrateRules, CrateRulesAccumulator};
+use crate::rules::powerups::{PowerupTable, PowerupsAccumulator};
 use crate::rules::error::RulesError;
 
 const READ_LINE_PAYLOAD: usize = 511;
@@ -624,17 +625,18 @@ impl RulesLayerStack {
         let mut processor = RulesPassProcessor::with_registry_state(registry_state);
         for (_, ini) in self.iter_passes() {
             if let Err(error) = processor.apply_pass(ini, fixed_art) {
-                let (_, partial_trace, _) = processor.finish();
+                let (_, partial_trace, _, _) = processor.finish();
                 return Err(NativeRulesProcessingFailure {
                     error,
                     partial_trace,
                 });
             }
         }
-        let (ini, native_type_construction_trace, crate_rules) = processor.finish();
+        let (ini, native_type_construction_trace, crate_rules, powerups) = processor.finish();
         Ok(ProcessedRulesLayers {
             ini,
             crate_rules,
+            powerups,
             content_hash: self.content_hash(),
             native_type_construction_trace,
         })
@@ -721,7 +723,7 @@ fn process_native_rules_cold_start_inner(
         fixed_art,
     );
     let after_building_bodies = processor.native_type_construction_events.len();
-    let (_, trace, _) = processor.finish();
+    let (_, trace, _, _) = processor.finish();
     Ok((
         trace,
         [
@@ -766,7 +768,7 @@ fn process_native_noncampaign_rules_prepass_inner(
     let after_general = processor.native_type_construction_events.len();
     processor.process_house_family(selected_rules_root);
     let after_house_bodies = processor.native_type_construction_events.len();
-    let (_, trace, _) = processor.finish();
+    let (_, trace, _, _) = processor.finish();
     (
         trace,
         [after_countries, after_general, after_house_bodies],
@@ -778,6 +780,7 @@ fn process_native_noncampaign_rules_prepass_inner(
 pub struct ProcessedRulesLayers {
     ini: IniFile,
     crate_rules: CrateRules,
+    powerups: PowerupTable,
     content_hash: u64,
     native_type_construction_trace: NativeTypeConstructionTrace,
 }
@@ -802,6 +805,10 @@ impl ProcessedRulesLayers {
 
     pub fn crate_rules(&self) -> &CrateRules {
         &self.crate_rules
+    }
+
+    pub fn powerups(&self) -> &PowerupTable {
+        &self.powerups
     }
 
     pub(crate) fn native_type_construction_trace(&self) -> &NativeTypeConstructionTrace {
@@ -1060,6 +1067,7 @@ impl ProcessedType {
 struct RulesPassProcessor {
     ordinary: Option<IniFile>,
     crate_rules: CrateRulesAccumulator,
+    powerups: PowerupsAccumulator,
     families: HashMap<RulesTypeFamily, Vec<ProcessedType>>,
     native_type_construction_events: Vec<NativeTypeConstructionEvent>,
     tiberiums: Vec<ProcessedType>,
@@ -1103,6 +1111,7 @@ impl RulesPassProcessor {
         // ReadCrateRules @ 0x0066B8F0 reads the semantic crate values in the
         // same Process pass; it allocates no Type and spends no ID.
         self.crate_rules.apply_pass(pass);
+        self.powerups.apply_pass(pass);
         self.allocate_combat_references(pass);
         self.allocate_radiation_references(pass);
         // Elevation and Wall contain no Type factories.
@@ -1995,7 +2004,7 @@ impl RulesPassProcessor {
         Ok(())
     }
 
-    fn finish(mut self) -> (IniFile, NativeTypeConstructionTrace, CrateRules) {
+    fn finish(mut self) -> (IniFile, NativeTypeConstructionTrace, CrateRules, PowerupTable) {
         let allocated_super_weapon_type_count = self
             .families
             .get(&RulesTypeFamily::SuperWeapon)
@@ -2068,6 +2077,7 @@ impl RulesPassProcessor {
                 },
             },
             self.crate_rules.finish(),
+            self.powerups.finish(),
         )
     }
 }

--- a/src/rules/ini_parser.rs
+++ b/src/rules/ini_parser.rs
@@ -1108,7 +1108,7 @@ impl RulesPassProcessor {
 
         // Difficulty readers contain no Type factories.
         self.allocate_crate_references(pass);
-        // ReadCrateRules @ 0x0066B8F0 reads the semantic crate values in the
+        // ReadCrateRules @ 0x0066B900 reads the semantic crate values in the
         // same Process pass; it allocates no Type and spends no ID.
         self.crate_rules.apply_pass(pass);
         self.powerups.apply_pass(pass);

--- a/src/rules/ini_value.rs
+++ b/src/rules/ini_value.rs
@@ -151,17 +151,31 @@ impl IniSection {
         })
     }
 
-    /// ReadRange (P20): `read_double(-1.0)` sentinel; ==-1.0 -> default; else ftol
-    /// TRUNCATE-TOWARD-ZERO. NOT `util::sim_to_i32` (that floors toward −∞ — DRIFT
-    /// on negatives, ledger #18). `f64 as i32` truncates toward zero (saturating,
-    /// NaN->0), matching gamemd ftol RC=11. `5.9→5`.
+    /// `CCINIClass__ReadRange @ 0x00474620`: read the key through
+    /// `ReadDouble` with a hardcoded `-1.0` default (`0x00474628`), compare
+    /// against `0x007E4900` (= `-1.0`) and return the CALLER's default
+    /// unconverted on a match — covering both an absent key and a literal `-1`.
+    ///
+    /// Otherwise the value is a CELL count that the reader converts to leptons:
+    /// `FMUL double ptr [0x007E1710]` at `0x0047464C`, where that address holds
+    /// `0x4070000000000000` = `256.0`, then `Math__ftol @ 0x007C5F00`, whose
+    /// control word `0x0E7F` selects chop. `f64 as i32` truncates toward zero
+    /// (saturating, NaN->0) and matches it; NOT `util::sim_to_i32`, which
+    /// floors toward −∞ (DRIFT on negatives, ledger #18).
+    ///
+    /// The lepton scale is load-bearing and was missing here until it was
+    /// re-derived from the disassembly on 2026-09-02 — the Ghidra decompiler
+    /// elides the `FMUL` because it is folded into the x87 argument chain that
+    /// `Math__ftol` consumes, so the pseudocode shows a bare `ftol`. Stock
+    /// `[CrateRules] CrateRadius=3.0` is 768 leptons, consistent with the
+    /// RulesClass constructor default of `0x280` (2.5 cells).
     pub fn read_range(&self, key: &str, default: i32) -> i32 {
         self.fold_rules_values(key, default, |current, raw| {
             let parsed = parse_read_double(raw);
             if parsed == -1.0 {
                 current
             } else {
-                parsed as i32
+                (parsed * 256.0) as i32
             }
         })
     }
@@ -206,7 +220,7 @@ pub(crate) fn parse_read_double(raw: &str) -> f64 {
 
 /// strtrim equivalent (P5): strip bytes <= 0x20 from BOTH ends. ASCII-only by
 /// design (RA2 INI is ASCII); does NOT use `str::trim` (Unicode whitespace).
-fn strtrim_ascii(s: &str) -> &str {
+pub(crate) fn strtrim_ascii(s: &str) -> &str {
     let b = s.as_bytes();
     let mut start = 0usize;
     while start < b.len() && b[start] <= STRTRIM_MAX {
@@ -484,9 +498,11 @@ mod tests {
     fn test_read_range_truncates() {
         let ini = sec("[S]\nA=5.9\nB=5\nC=0.4\n");
         let s = ini.section("S").unwrap();
-        assert_eq!(s.read_range("A", -1), 5); // 5.9 -> 5 (never rounds to 6)
-        assert_eq!(s.read_range("B", -1), 5);
-        assert_eq!(s.read_range("C", -1), 0);
+        // Values are cells; the reader scales to leptons and truncates toward
+        // zero. 5.9 cells is 1510.4 leptons -> 1510, never 1511.
+        assert_eq!(s.read_range("A", -1), 1510);
+        assert_eq!(s.read_range("B", -1), 1280, "5 cells");
+        assert_eq!(s.read_range("C", -1), 102, "0.4 cells is 102.4 leptons");
         assert_eq!(s.read_range("MISSING", 7), 7); // absent -> default (sentinel -1.0)
     }
 }

--- a/src/rules/ini_value.rs
+++ b/src/rules/ini_value.rs
@@ -62,13 +62,17 @@ impl IniSection {
     /// ReadString (P5, P18): copy at most `capacity - 1` bytes, force the final
     /// NUL, then trim bytes ≤0x20 at both ends. Capacities are caller-specific
     /// in retail, so they are explicit here too.
+    ///
+    /// `CCINIClass__ReadString @ 0x00528A10` is `strncpy(dst, src, capacity)`
+    /// followed by `dst[capacity - 1] = 0`, so the cut is by BYTE, not by
+    /// character. Truncating by `char` would keep text native discards on any
+    /// value whose first `capacity - 1` characters span more bytes than that.
     pub fn read_string(&self, key: &str, default: &str, capacity: usize) -> String {
         if capacity == 0 {
             return String::new();
         }
         let raw = self.get(key).unwrap_or(default);
-        let copied: String = raw.chars().take(capacity - 1).collect();
-        strtrim_ascii(&copied).to_string()
+        strtrim_ascii(truncate_bytes(raw, capacity - 1)).to_string()
     }
 
     /// Read3Int (P8): comma "%d,%d,%d". All-defaults on ABSENT key. Each field
@@ -160,8 +164,13 @@ impl IniSection {
     /// `FMUL double ptr [0x007E1710]` at `0x0047464C`, where that address holds
     /// `0x4070000000000000` = `256.0`, then `Math__ftol @ 0x007C5F00`, whose
     /// control word `0x0E7F` selects chop. `f64 as i32` truncates toward zero
-    /// (saturating, NaN->0) and matches it; NOT `util::sim_to_i32`, which
-    /// floors toward −∞ (DRIFT on negatives, ledger #18).
+    /// like it does, and NOT `util::sim_to_i32`, which floors toward −∞ (DRIFT
+    /// on negatives, ledger #18).
+    ///
+    /// One residual: `Math__ftol` executes `FISTP qword` and keeps only the low
+    /// dword, so an out-of-range magnitude WRAPS, while `f64 as i32` saturates.
+    /// Reaching it needs |value| >= 8388608 cells; NaN agrees either way,
+    /// because x87 integer-indefinite has a zero low dword.
     ///
     /// The lepton scale is load-bearing and was missing here until it was
     /// re-derived from the disassembly on 2026-09-02 — the Ghidra decompiler
@@ -216,6 +225,21 @@ pub(crate) fn parse_read_double(raw: &str) -> f64 {
     } else {
         widened
     }
+}
+
+/// Byte-wise `strncpy` truncation. A cut that would land inside a multi-byte
+/// sequence backs up to the preceding boundary: native writes the partial bytes
+/// and the forced NUL, which is not representable as a Rust `str`, and no INI
+/// value in retail data is non-ASCII.
+pub(crate) fn truncate_bytes(value: &str, max_bytes: usize) -> &str {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
 }
 
 /// strtrim equivalent (P5): strip bytes <= 0x20 from BOTH ends. ASCII-only by

--- a/src/rules/ini_value.rs
+++ b/src/rules/ini_value.rs
@@ -167,10 +167,18 @@ impl IniSection {
     /// like it does, and NOT `util::sim_to_i32`, which floors toward −∞ (DRIFT
     /// on negatives, ledger #18).
     ///
-    /// One residual: `Math__ftol` executes `FISTP qword` and keeps only the low
-    /// dword, so an out-of-range magnitude WRAPS, while `f64 as i32` saturates.
-    /// Reaching it needs |value| >= 8388608 cells; NaN agrees either way,
-    /// because x87 integer-indefinite has a zero low dword.
+    /// Two residuals at the extremes, both out of reach of retail data:
+    ///
+    /// * `Math__ftol` executes `FISTP qword` and the caller keeps only the low
+    ///   dword, so a magnitude past `i32` WRAPS while `f64 as i32` saturates.
+    ///   That band starts at |value| >= 8388608 cells and ends at 2^63, beyond
+    ///   which `FISTP` stores integer-indefinite and the low dword is zero.
+    ///   `±inf` therefore yields 0 natively against `i32::MAX` here.
+    /// * A NaN never reaches `ftol` at all: `FCOM` against `-1.0` sets C3 for
+    ///   unordered as well as equal, and the `TEST AH,0x40` at `0x0047463E`
+    ///   takes the sentinel exit, returning the caller's default. Rust returns
+    ///   `0`. Inert in practice because `parse_read_double` scans a numeric
+    ///   prefix and cannot produce NaN.
     ///
     /// The lepton scale is load-bearing and was missing here until it was
     /// re-derived from the disassembly on 2026-09-02 — the Ghidra decompiler

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -39,6 +39,7 @@ pub mod object_type;
 pub mod overlay_types;
 pub mod particle_system_type;
 pub mod particle_type;
+pub mod powerups;
 pub(crate) mod process_owner;
 pub mod projectile_type;
 pub mod radar_event_config;

--- a/src/rules/overlay_types.rs
+++ b/src/rules/overlay_types.rs
@@ -121,6 +121,12 @@ pub struct OverlayTypeFlags {
     pub crushable: bool,
     /// Crate=yes — gets -12px Y offset.
     pub crate_type: bool,
+    /// `CrateTrigger=` -> `OverlayTypeClass+0x2AB`, read beside `Crate=` at
+    /// `OverlayTypeClass::Read_INI @ 0x005FE82E`. A set flag makes
+    /// `CrateClass__PickupDispatch` spring trigger event `0x31` and latch
+    /// `ScenarioClass+0x34BE`, which `LogicClass__PerTickUpdate` consumes and
+    /// clears. Both stock crate overlays set it.
+    pub crate_trigger: bool,
     /// `Overrides=yes` protects an existing overlay from ordinary runtime placement.
     pub overrides: bool,
     /// Parsed `CellAnim=` AnimType identity (`OverlayTypeClass+0x29C`).
@@ -188,6 +194,7 @@ impl Default for OverlayTypeFlags {
             is_gate: false,
             crushable: false,
             crate_type: false,
+            crate_trigger: false,
             overrides: false,
             cell_anim: None,
             is_rubble: false,
@@ -368,6 +375,7 @@ impl OverlayTypeRegistry {
                     is_gate: type_section.get_bool("Gate").unwrap_or(false),
                     crushable: type_section.get_bool("Crushable").unwrap_or(false),
                     crate_type: type_section.get_bool("Crate").unwrap_or(false),
+                    crate_trigger: type_section.get_bool("CrateTrigger").unwrap_or(false),
                     overrides: type_section.get_bool("Overrides").unwrap_or(false),
                     cell_anim: type_section
                         .get("CellAnim")

--- a/src/rules/powerups.rs
+++ b/src/rules/powerups.rs
@@ -20,14 +20,16 @@
 //! rows that stop after three tokens (`HealBase`, `Reveal`, `Veteran`, `Unit`,
 //! …) never write a magnitude, and a token-three value that is neither literal
 //! leaves the flag alone. Because the default string carries only two tokens, a
-//! `[Powerups]` section that omits a name still zeroes its weight and clears its
-//! animation.
+//! `[Powerups]` section that omits a name still zeroes its weight and leaves it
+//! with no animation — via the default's bare `NONE`, which is not
+//! `Find_Index`'s `<none>` sentinel and reaches -1 only by failing the type
+//! search, exactly as [`PowerupTable::anim_for`] does.
 //!
 //! ## Dependency rules
 //! Part of `rules/` — INI parsing and rule data only.
 
 use crate::rules::ini_parser::IniFile;
-use crate::rules::ini_value::strtrim_ascii;
+use crate::rules::ini_value::{strtrim_ascii, truncate_bytes};
 use crate::util::native_x87::NativeF64Bits;
 
 /// Slots in the hardcoded name table at `0x007E523C`. The loop bound is
@@ -83,8 +85,8 @@ const DEFAULT_WEIGHTS: [i32; POWERUP_COUNT] = [
 const READ_STRING_CAPACITY: usize = 0x80;
 
 /// The default handed to every `ReadString` call, verified at `0x0083D4AC`.
-/// Two tokens only: an absent row zeroes the weight and clears the animation
-/// while leaving the flag and magnitude untouched.
+/// Two tokens only: an absent row zeroes the weight and leaves the slot with no
+/// resolvable animation, while the flag and magnitude keep their live values.
 const DEFAULT_ROW: &str = "0,NONE";
 
 /// `Powerup_From_Name @ 0x0048DE70`: case-insensitive walk of the same fixed
@@ -138,8 +140,14 @@ impl PowerupTable {
     ///
     /// Native resolves at parse time through `AnimTypeClass::Find_Index`, so an
     /// unregistered name is stored as `-1` and can never spawn. VERA keeps the
-    /// parsed name and applies the same filter here; the anim-type set is fixed
-    /// once rules finish loading, so the two agree at every observable point.
+    /// parsed name and applies the same filter here.
+    ///
+    /// These agree for the final rules state, which is the only state gameplay
+    /// reads. They differ for one intermediate case: if a later INI layer
+    /// registers an AnimType that an earlier layer's `[Powerups]` row already
+    /// named, native has already stored `-1` and keeps it, while VERA resolves
+    /// the name against the finished set. That needs a multi-layer mod to
+    /// reach; recorded as a deferred DRIFT rather than claimed equivalent.
     pub fn anim_for(&self, slot: usize, registered: &[String]) -> Option<&str> {
         let name = self.anims.get(slot)?.as_deref()?;
         registered
@@ -164,14 +172,12 @@ impl PowerupsAccumulator {
             // Native always parses, falling back to the literal `"0,NONE"`, so
             // an absent row still zeroes the weight and clears the animation
             // while leaving the flag and magnitude untouched.
-            // `CCINIClass__ReadString` copies at most `capacity - 1` bytes and
-            // forces the terminator, so an over-long value truncates at 127.
-            let raw: String = section
-                .get(name)
-                .unwrap_or(DEFAULT_ROW)
-                .chars()
-                .take(READ_STRING_CAPACITY - 1)
-                .collect();
+            // `CCINIClass__ReadString` is `strncpy` plus a forced terminator, so
+            // an over-long value is cut at 127 BYTES, not 127 characters.
+            let raw = truncate_bytes(
+                section.get(name).unwrap_or(DEFAULT_ROW),
+                READ_STRING_CAPACITY - 1,
+            );
             // `CRT__strtok` collapses runs of the delimiter and skips leading
             // ones, so an empty field is not a token at all: `20,,yes,2000`
             // yields three tokens, not four.

--- a/src/rules/powerups.rs
+++ b/src/rules/powerups.rs
@@ -1,0 +1,454 @@
+//! `[Powerups]` — the fixed nineteen-entry crate outcome table.
+//!
+//! `RulesClass__ReadPowerups @ 0x00673E80` does not read the INI section's own
+//! keys. It walks a hardcoded nineteen-pointer name table at `0x007E523C` and
+//! asks the INI for each name in turn, so the slot order is a property of the
+//! binary and never of the file. Every value lands in one of four parallel
+//! globals rather than in `RulesClass` itself.
+//!
+//! The read is `CCINIClass::ReadString` with default `"0,NONE"` (verified at
+//! `0x0083D4AC`), then up to four comma-separated tokens:
+//!
+//! | Token | Global | Width | Extractor |
+//! |---|---|---|---|
+//! | 1 | `0x0081DA8C` | `i32[19]` | `strtrim` then `atoi` |
+//! | 2 | `0x0081DAD8` | `i32[19]` | `strtrim` then `AnimTypeClass::Find_Index @ 0x00422B20` |
+//! | 3 | `0x0089ECC0` | `u8[19]` | `strtrim`, then exact `"yes"`/`"no"` compare |
+//! | 4 | `0x0089EC28` | `f64[19]` | `atof`, scaled by `0.01` when the token contains `%` |
+//!
+//! A missing token leaves that slot's previous value untouched — so the stock
+//! rows that stop after three tokens (`HealBase`, `Reveal`, `Veteran`, `Unit`,
+//! …) never write a magnitude, and a token-three value that is neither literal
+//! leaves the flag alone. Because the default string carries only two tokens, a
+//! `[Powerups]` section that omits a name still zeroes its weight and clears its
+//! animation.
+//!
+//! ## Dependency rules
+//! Part of `rules/` — INI parsing and rule data only.
+
+use crate::rules::ini_parser::{IniFile, is_native_none_type_name};
+use crate::util::native_x87::NativeF64Bits;
+
+/// Slots in the hardcoded name table at `0x007E523C`. The loop bound is
+/// `pdVar5 < 0x0089ECC0` over an `f64` cursor starting at `0x0089EC28`:
+/// `(0x0089ECC0 - 0x0089EC28) / 8 = 19`.
+pub const POWERUP_COUNT: usize = 19;
+
+/// Canonical slot order, read directly from the pointer table at `0x007E523C`
+/// and its target literals. This ordering is load-bearing: `CrateClass__PickupDispatch`
+/// indexes all four globals, the `[CrateRules]` solo mappings, and its own jump
+/// table by these positions, and the INI's own line order is irrelevant.
+pub const POWERUP_NAMES: [&str; POWERUP_COUNT] = [
+    "Money",
+    "Unit",
+    "HealBase",
+    "Cloak",
+    "Explosion",
+    "Napalm",
+    "Squad",
+    "Darkness",
+    "Reveal",
+    "Armor",
+    "Speed",
+    "Firepower",
+    "ICBM",
+    "Invulnerability",
+    "Veteran",
+    "IonStorm",
+    "Gas",
+    "Tiberium",
+    "Pod",
+];
+
+/// Slot indices the rest of the crate system names directly.
+pub const POWERUP_MONEY: usize = 0;
+pub const POWERUP_UNIT: usize = 1;
+pub const POWERUP_HEAL_BASE: usize = 2;
+pub const POWERUP_SQUAD: usize = 6;
+pub const POWERUP_REVEAL: usize = 8;
+pub const POWERUP_ARMOR: usize = 9;
+pub const POWERUP_SPEED: usize = 10;
+pub const POWERUP_FIREPOWER: usize = 11;
+pub const POWERUP_VETERAN: usize = 14;
+
+/// Static image defaults for the weight global at `0x0081DA8C`, read from the
+/// binary's initialized `.data`. These are the pre-INI values; stock
+/// `rulesmd.ini` overwrites every one of them.
+const DEFAULT_WEIGHTS: [i32; POWERUP_COUNT] = [
+    50, 20, 1, 3, 5, 5, 20, 1, 1, 10, 10, 10, 1, 3, 1, 1, 1, 1, 1,
+];
+
+/// `Powerup_From_Name @ 0x0048DE70`: case-insensitive walk of the same fixed
+/// name table, returning the slot index. A null or unmatched name yields slot
+/// zero — `Money` — rather than a failure, which is what the `[CrateRules]`
+/// solo-play mappings rely on.
+pub fn powerup_from_name(name: &str) -> usize {
+    POWERUP_NAMES
+        .iter()
+        .position(|candidate| candidate.eq_ignore_ascii_case(name))
+        .unwrap_or(POWERUP_MONEY)
+}
+
+/// The four parallel `[Powerups]` globals.
+///
+/// Native keeps these outside `RulesClass`; VERA keeps them beside the other
+/// crate rule data because the ownership distinction has no player-visible
+/// consequence, while the fixed slot order does.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PowerupTable {
+    /// Token 1 — selection weight. `CrateClass__PickupDispatch` sums all
+    /// nineteen and draws `RandomRanged(1, total)`.
+    pub weights: [i32; POWERUP_COUNT],
+    /// Token 2 — the pickup animation. `None` is native's `-1`: either the
+    /// no-type sentinel or a name `AnimTypeClass::Find_Index` cannot resolve.
+    pub anims: [Option<String>; POWERUP_COUNT],
+    /// Token 3 — over-water eligibility, NOT an "enabled" switch. It is read
+    /// only when the crate's cell land type is water (`0x00481D52`), and a
+    /// cleared flag falls the outcome back to `Money` instead of suppressing
+    /// the crate.
+    pub over_water: [bool; POWERUP_COUNT],
+    /// Token 4 — the per-outcome magnitude, in native binary64.
+    pub magnitudes: [NativeF64Bits; POWERUP_COUNT],
+}
+
+impl Default for PowerupTable {
+    fn default() -> Self {
+        Self {
+            weights: DEFAULT_WEIGHTS,
+            // `0x0081DAD8` is initialized to -1 across all nineteen slots.
+            anims: [const { None }; POWERUP_COUNT],
+            // `0x0089ECC0` and `0x0089EC28` live in zero-initialized storage.
+            over_water: [false; POWERUP_COUNT],
+            magnitudes: [NativeF64Bits::from_bits(0); POWERUP_COUNT],
+        }
+    }
+}
+
+impl PowerupTable {
+    /// Resolve a slot's animation against the registered `[AnimTypes]` names.
+    ///
+    /// Native resolves at parse time through `AnimTypeClass::Find_Index`, so an
+    /// unregistered name is stored as `-1` and can never spawn. VERA keeps the
+    /// parsed name and applies the same filter here; the anim-type set is fixed
+    /// once rules finish loading, so the two agree at every observable point.
+    pub fn anim_for(&self, slot: usize, registered: &[String]) -> Option<&str> {
+        let name = self.anims.get(slot)?.as_deref()?;
+        registered
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(name))
+            .then_some(name)
+    }
+}
+
+/// Live table retained across successive `RulesClass::Process` passes.
+#[derive(Debug, Default)]
+pub(crate) struct PowerupsAccumulator(PowerupTable);
+
+impl PowerupsAccumulator {
+    pub(crate) fn apply_pass(&mut self, ini: &IniFile) {
+        // `INIClass__FindSectionByName` gates the whole read: with no
+        // `[Powerups]` section the function returns before touching a slot.
+        let Some(section) = ini.section("Powerups") else {
+            return;
+        };
+        for (slot, name) in POWERUP_NAMES.iter().enumerate() {
+            // Native always parses, falling back to the literal `"0,NONE"`, so
+            // an absent row still zeroes the weight and clears the animation
+            // while leaving the flag and magnitude untouched.
+            let raw = section
+                .get(name)
+                .map(str::to_owned)
+                .unwrap_or_else(|| "0,NONE".to_owned());
+            let mut tokens = raw.split(',');
+
+            if let Some(token) = tokens.next() {
+                self.0.weights[slot] = native_atoi(token.trim());
+            }
+            if let Some(token) = tokens.next() {
+                let token = token.trim();
+                self.0.anims[slot] =
+                    (!is_native_none_type_name(token)).then(|| token.to_ascii_uppercase());
+            }
+            if let Some(token) = tokens.next() {
+                // Exactly two literals are recognised (`0x00825BF8` "yes" and
+                // `0x00825BF4` "no"); anything else leaves the slot as it was.
+                let token = token.trim();
+                if token.eq_ignore_ascii_case("yes") {
+                    self.0.over_water[slot] = true;
+                } else if token.eq_ignore_ascii_case("no") {
+                    self.0.over_water[slot] = false;
+                }
+            }
+            if let Some(token) = tokens.next() {
+                // The percent branch skips `strtrim` and scales by 0.01; the
+                // plain branch trims first. Both then run the same `atof`.
+                let value = if token.contains('%') {
+                    native_atof(token) * 0.01
+                } else {
+                    native_atof(token.trim())
+                };
+                self.0.magnitudes[slot] = NativeF64Bits::from_bits(value.to_bits());
+            }
+        }
+    }
+
+    pub(crate) fn finish(self) -> PowerupTable {
+        self.0
+    }
+}
+
+/// CRT `atoi`: leading sign and digits only, everything from the first
+/// non-digit onward ignored, no failure mode.
+fn native_atoi(token: &str) -> i32 {
+    let bytes = token.as_bytes();
+    let mut index = 0;
+    let negative = match bytes.first() {
+        Some(b'-') => {
+            index = 1;
+            true
+        }
+        Some(b'+') => {
+            index = 1;
+            false
+        }
+        _ => false,
+    };
+    let mut value: i32 = 0;
+    while let Some(digit) = bytes
+        .get(index)
+        .and_then(|byte| (*byte as char).to_digit(10))
+    {
+        value = value.wrapping_mul(10).wrapping_add(digit as i32);
+        index += 1;
+    }
+    if negative {
+        value.wrapping_neg()
+    } else {
+        value
+    }
+}
+
+/// CRT `atof`: the longest leading floating-point prefix, or zero.
+fn native_atof(token: &str) -> f64 {
+    let token = token.trim_start();
+    let bytes = token.as_bytes();
+    let mut end = 0;
+    if matches!(bytes.first(), Some(b'+' | b'-')) {
+        end = 1;
+    }
+    while matches!(bytes.get(end), Some(byte) if byte.is_ascii_digit()) {
+        end += 1;
+    }
+    if matches!(bytes.get(end), Some(b'.')) {
+        end += 1;
+        while matches!(bytes.get(end), Some(byte) if byte.is_ascii_digit()) {
+            end += 1;
+        }
+    }
+    token[..end].parse::<f64>().unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table(section: &str) -> PowerupTable {
+        let mut accumulator = PowerupsAccumulator::default();
+        accumulator.apply_pass(&IniFile::from_str(section));
+        accumulator.finish()
+    }
+
+    /// The nineteen slots and their order come from the binary's pointer table,
+    /// not from the INI. Pin the exact sequence and the indices the crate system
+    /// names directly.
+    #[test]
+    fn powerup_slot_order_is_the_fixed_native_name_table() {
+        assert_eq!(POWERUP_NAMES.len(), 19);
+        assert_eq!(POWERUP_NAMES[POWERUP_MONEY], "Money");
+        assert_eq!(POWERUP_NAMES[POWERUP_UNIT], "Unit");
+        assert_eq!(POWERUP_NAMES[POWERUP_HEAL_BASE], "HealBase");
+        assert_eq!(POWERUP_NAMES[POWERUP_SQUAD], "Squad");
+        assert_eq!(POWERUP_NAMES[POWERUP_REVEAL], "Reveal");
+        assert_eq!(POWERUP_NAMES[POWERUP_ARMOR], "Armor");
+        assert_eq!(POWERUP_NAMES[POWERUP_SPEED], "Speed");
+        assert_eq!(POWERUP_NAMES[POWERUP_FIREPOWER], "Firepower");
+        assert_eq!(POWERUP_NAMES[POWERUP_VETERAN], "Veteran");
+        assert_eq!(POWERUP_NAMES[15], "IonStorm");
+        assert_eq!(POWERUP_NAMES[17], "Tiberium");
+        assert_eq!(POWERUP_NAMES[18], "Pod");
+    }
+
+    /// `Powerup_From_Name` never fails: an unmatched or empty name is Money.
+    #[test]
+    fn powerup_from_name_is_case_insensitive_and_falls_back_to_money() {
+        assert_eq!(powerup_from_name("HealBase"), POWERUP_HEAL_BASE);
+        assert_eq!(powerup_from_name("healbase"), POWERUP_HEAL_BASE);
+        assert_eq!(powerup_from_name("MONEY"), POWERUP_MONEY);
+        assert_eq!(powerup_from_name("Veteran"), POWERUP_VETERAN);
+        assert_eq!(powerup_from_name("NotAPowerup"), POWERUP_MONEY);
+        assert_eq!(powerup_from_name(""), POWERUP_MONEY);
+    }
+
+    /// No section at all leaves every static image default in place.
+    #[test]
+    fn missing_section_retains_the_static_image_defaults() {
+        let parsed = table("[General]\n");
+        assert_eq!(parsed, PowerupTable::default());
+        assert_eq!(parsed.weights[POWERUP_MONEY], 50);
+        assert_eq!(parsed.weights[POWERUP_SQUAD], 20);
+        assert_eq!(parsed.weights[18], 1);
+        assert!(parsed.anims.iter().all(Option::is_none));
+        assert!(parsed.over_water.iter().all(|flag| !flag));
+    }
+
+    /// A present section but an absent row still applies the `"0,NONE"`
+    /// default's first two tokens, and leaves the last two alone.
+    #[test]
+    fn absent_row_zeroes_weight_and_anim_but_keeps_flag_and_magnitude() {
+        let mut accumulator = PowerupsAccumulator::default();
+        accumulator.apply_pass(&IniFile::from_str("[Powerups]\nMoney=20,MONEY,yes,2000\n"));
+        // Second pass: the section exists but Money is gone.
+        accumulator.apply_pass(&IniFile::from_str("[Powerups]\nArmor=10,ARMOR,yes,1.5\n"));
+        let parsed = accumulator.finish();
+        assert_eq!(
+            parsed.weights[POWERUP_MONEY], 0,
+            "the default's first token"
+        );
+        assert_eq!(parsed.anims[POWERUP_MONEY], None, "NONE clears the anim");
+        assert!(
+            parsed.over_water[POWERUP_MONEY],
+            "no third token, so the live flag survives"
+        );
+        assert_eq!(
+            f64::from_bits(parsed.magnitudes[POWERUP_MONEY].bits()),
+            2000.0,
+            "no fourth token, so the live magnitude survives"
+        );
+    }
+
+    /// The stock section, parsed exactly. Weights are the selection authority,
+    /// so pin the whole vector and its total.
+    #[test]
+    fn stock_section_parses_the_verified_weight_vector() {
+        let parsed = table(
+            "[Powerups]\n\
+             Armor=10,ARMOR,yes,1.5\n\
+             Firepower=10,FIREPOWR,yes,2.0\n\
+             HealBase=10,HEALALL,yes\n\
+             Money=20,MONEY,yes,2000\n\
+             Reveal=10,REVEAL,yes\n\
+             Speed=10,SPEED,yes,1.2\n\
+             Veteran=20,VETERAN,yes,1\n\
+             Unit=20,<none>,no\n\
+             Invulnerability=0,ARMOR,yes,1.0\n\
+             IonStorm=0,<none>,yes\n\
+             Gas=0,<none>,yes,100\n\
+             Tiberium=0,<none>,no\n\
+             Pod=0,<none>,no\n\
+             Cloak=0,CLOAK,yes\n\
+             Darkness=0,SHROUDX,yes\n\
+             Explosion=0,<none>,yes,500\n\
+             ICBM=0,CHEMISLE,yes\n\
+             Napalm=0,<none>,no,600\n\
+             Squad=0,<none>,no\n",
+        );
+
+        assert_eq!(
+            parsed.weights,
+            [
+                20, 20, 10, 0, 0, 0, 0, 0, 10, 10, 10, 10, 0, 0, 20, 0, 0, 0, 0
+            ]
+        );
+        assert_eq!(parsed.weights.iter().sum::<i32>(), 110);
+
+        // `<none>` is the no-type sentinel; a real name is retained uppercased.
+        assert_eq!(parsed.anims[POWERUP_UNIT], None);
+        assert_eq!(parsed.anims[POWERUP_MONEY].as_deref(), Some("MONEY"));
+        assert_eq!(parsed.anims[POWERUP_FIREPOWER].as_deref(), Some("FIREPOWR"));
+
+        // Over-water eligibility, not an enable switch: Unit is weighted 20 and
+        // still drops on land, but is redirected to Money over water.
+        assert!(!parsed.over_water[POWERUP_UNIT]);
+        assert!(parsed.over_water[POWERUP_MONEY]);
+        assert!(!parsed.over_water[17], "Tiberium");
+        assert!(!parsed.over_water[POWERUP_SQUAD]);
+
+        assert_eq!(
+            f64::from_bits(parsed.magnitudes[POWERUP_MONEY].bits()),
+            2000.0
+        );
+        assert_eq!(f64::from_bits(parsed.magnitudes[POWERUP_ARMOR].bits()), 1.5);
+        assert_eq!(f64::from_bits(parsed.magnitudes[POWERUP_SPEED].bits()), 1.2);
+        assert_eq!(
+            f64::from_bits(parsed.magnitudes[POWERUP_VETERAN].bits()),
+            1.0
+        );
+        // Three-token rows never write a magnitude.
+        assert_eq!(
+            f64::from_bits(parsed.magnitudes[POWERUP_HEAL_BASE].bits()),
+            0.0
+        );
+        assert_eq!(
+            f64::from_bits(parsed.magnitudes[POWERUP_REVEAL].bits()),
+            0.0
+        );
+    }
+
+    /// The percent branch scales by 0.01 and deliberately skips the trim the
+    /// plain branch performs.
+    #[test]
+    fn percent_magnitude_is_scaled_and_plain_magnitude_is_trimmed() {
+        let parsed = table("[Powerups]\nArmor=1, ARMOR , yes , 50%\nSpeed=1,SPEED,yes,  1.25  \n");
+        assert_eq!(f64::from_bits(parsed.magnitudes[POWERUP_ARMOR].bits()), 0.5);
+        assert_eq!(
+            f64::from_bits(parsed.magnitudes[POWERUP_SPEED].bits()),
+            1.25
+        );
+        assert_eq!(parsed.anims[POWERUP_ARMOR].as_deref(), Some("ARMOR"));
+        assert!(parsed.over_water[POWERUP_ARMOR]);
+    }
+
+    /// Token three recognises exactly two literals; anything else is inert.
+    #[test]
+    fn unrecognised_third_token_leaves_the_live_flag_untouched() {
+        let mut accumulator = PowerupsAccumulator::default();
+        accumulator.apply_pass(&IniFile::from_str("[Powerups]\nArmor=1,ARMOR,yes,1\n"));
+        accumulator.apply_pass(&IniFile::from_str("[Powerups]\nArmor=1,ARMOR,true,1\n"));
+        assert!(
+            accumulator.finish().over_water[POWERUP_ARMOR],
+            "`true` is neither literal, so the `yes` from the earlier pass stands"
+        );
+
+        let mut accumulator = PowerupsAccumulator::default();
+        accumulator.apply_pass(&IniFile::from_str("[Powerups]\nArmor=1,ARMOR,yes,1\n"));
+        accumulator.apply_pass(&IniFile::from_str("[Powerups]\nArmor=1,ARMOR,no,1\n"));
+        assert!(!accumulator.finish().over_water[POWERUP_ARMOR]);
+    }
+
+    /// An animation name that no `[AnimTypes]` entry registers behaves exactly
+    /// like native's `Find_Index` returning -1.
+    #[test]
+    fn unregistered_anim_resolves_to_none() {
+        let parsed = table("[Powerups]\nMoney=20,BOGUSANIM,yes,2000\n");
+        let registered = vec!["MONEY".to_owned(), "ARMOR".to_owned()];
+        assert_eq!(parsed.anim_for(POWERUP_MONEY, &registered), None);
+
+        let parsed = table("[Powerups]\nMoney=20,money,yes,2000\n");
+        assert_eq!(
+            parsed.anim_for(POWERUP_MONEY, &registered),
+            Some("MONEY"),
+            "resolution is case-insensitive, like Find_Index"
+        );
+    }
+
+    /// `atoi` stops at the first non-digit rather than failing.
+    #[test]
+    fn native_atoi_matches_crt_prefix_semantics() {
+        assert_eq!(native_atoi("20"), 20);
+        assert_eq!(native_atoi("-7"), -7);
+        assert_eq!(native_atoi("+3"), 3);
+        assert_eq!(native_atoi("12abc"), 12);
+        assert_eq!(native_atoi("abc"), 0);
+        assert_eq!(native_atoi(""), 0);
+    }
+}

--- a/src/rules/powerups.rs
+++ b/src/rules/powerups.rs
@@ -26,7 +26,8 @@
 //! ## Dependency rules
 //! Part of `rules/` — INI parsing and rule data only.
 
-use crate::rules::ini_parser::{IniFile, is_native_none_type_name};
+use crate::rules::ini_parser::IniFile;
+use crate::rules::ini_value::strtrim_ascii;
 use crate::util::native_x87::NativeF64Bits;
 
 /// Slots in the hardcoded name table at `0x007E523C`. The loop bound is
@@ -77,6 +78,14 @@ pub const POWERUP_VETERAN: usize = 14;
 const DEFAULT_WEIGHTS: [i32; POWERUP_COUNT] = [
     50, 20, 1, 3, 5, 5, 20, 1, 1, 10, 10, 10, 1, 3, 1, 1, 1, 1, 1,
 ];
+
+/// `CCINIClass::ReadString` capacity supplied by `ReadPowerups`.
+const READ_STRING_CAPACITY: usize = 0x80;
+
+/// The default handed to every `ReadString` call, verified at `0x0083D4AC`.
+/// Two tokens only: an absent row zeroes the weight and clears the animation
+/// while leaving the flag and magnitude untouched.
+const DEFAULT_ROW: &str = "0,NONE";
 
 /// `Powerup_From_Name @ 0x0048DE70`: case-insensitive walk of the same fixed
 /// name table, returning the slot index. A null or unmatched name yields slot
@@ -155,24 +164,35 @@ impl PowerupsAccumulator {
             // Native always parses, falling back to the literal `"0,NONE"`, so
             // an absent row still zeroes the weight and clears the animation
             // while leaving the flag and magnitude untouched.
-            let raw = section
+            // `CCINIClass__ReadString` copies at most `capacity - 1` bytes and
+            // forces the terminator, so an over-long value truncates at 127.
+            let raw: String = section
                 .get(name)
-                .map(str::to_owned)
-                .unwrap_or_else(|| "0,NONE".to_owned());
-            let mut tokens = raw.split(',');
+                .unwrap_or(DEFAULT_ROW)
+                .chars()
+                .take(READ_STRING_CAPACITY - 1)
+                .collect();
+            // `CRT__strtok` collapses runs of the delimiter and skips leading
+            // ones, so an empty field is not a token at all: `20,,yes,2000`
+            // yields three tokens, not four.
+            let mut tokens = raw.split(',').filter(|token| !token.is_empty());
 
             if let Some(token) = tokens.next() {
-                self.0.weights[slot] = native_atoi(token.trim());
+                self.0.weights[slot] = native_atoi(strtrim_ascii(token));
             }
             if let Some(token) = tokens.next() {
-                let token = token.trim();
+                let token = strtrim_ascii(token);
+                // `AnimTypeClass::Find_Index @ 0x00422B20` special-cases only
+                // the literal `<none>`; every other name falls through to the
+                // array search and yields -1 solely by not matching, which
+                // `anim_for` reproduces against the registered set.
                 self.0.anims[slot] =
-                    (!is_native_none_type_name(token)).then(|| token.to_ascii_uppercase());
+                    (!token.eq_ignore_ascii_case("<none>")).then(|| token.to_ascii_uppercase());
             }
             if let Some(token) = tokens.next() {
                 // Exactly two literals are recognised (`0x00825BF8` "yes" and
                 // `0x00825BF4` "no"); anything else leaves the slot as it was.
-                let token = token.trim();
+                let token = strtrim_ascii(token);
                 if token.eq_ignore_ascii_case("yes") {
                     self.0.over_water[slot] = true;
                 } else if token.eq_ignore_ascii_case("no") {
@@ -185,7 +205,7 @@ impl PowerupsAccumulator {
                 let value = if token.contains('%') {
                     native_atof(token) * 0.01
                 } else {
-                    native_atof(token.trim())
+                    native_atof(strtrim_ascii(token))
                 };
                 self.0.magnitudes[slot] = NativeF64Bits::from_bits(value.to_bits());
             }
@@ -243,6 +263,20 @@ fn native_atof(token: &str) -> f64 {
         end += 1;
         while matches!(bytes.get(end), Some(byte) if byte.is_ascii_digit()) {
             end += 1;
+        }
+    }
+    // CRT `atof` also accepts an exponent, but only when at least one digit
+    // follows it; otherwise the prefix ends before the `e`.
+    if matches!(bytes.get(end), Some(b'e' | b'E')) {
+        let mut exponent = end + 1;
+        if matches!(bytes.get(exponent), Some(b'+' | b'-')) {
+            exponent += 1;
+        }
+        if matches!(bytes.get(exponent), Some(byte) if byte.is_ascii_digit()) {
+            while matches!(bytes.get(exponent), Some(byte) if byte.is_ascii_digit()) {
+                exponent += 1;
+            }
+            end = exponent;
         }
     }
     token[..end].parse::<f64>().unwrap_or(0.0)
@@ -314,7 +348,16 @@ mod tests {
             parsed.weights[POWERUP_MONEY], 0,
             "the default's first token"
         );
-        assert_eq!(parsed.anims[POWERUP_MONEY], None, "NONE clears the anim");
+        // The default row's second token is a bare `NONE`, which is NOT
+        // Find_Index's `<none>` sentinel: it falls through the array search and
+        // yields -1 only by failing to match. `anim_for` is the resolution
+        // point, so that is where the absence becomes observable.
+        assert_eq!(parsed.anims[POWERUP_MONEY].as_deref(), Some("NONE"));
+        assert_eq!(
+            parsed.anim_for(POWERUP_MONEY, &["MONEY".to_owned(), "ARMOR".to_owned()]),
+            None,
+            "no registered AnimType is called NONE, so the slot has no animation"
+        );
         assert!(
             parsed.over_water[POWERUP_MONEY],
             "no third token, so the live flag survives"
@@ -438,6 +481,88 @@ mod tests {
             parsed.anim_for(POWERUP_MONEY, &registered),
             Some("MONEY"),
             "resolution is case-insensitive, like Find_Index"
+        );
+    }
+
+    /// `strtok` skips empty fields, so a doubled or leading comma shifts which
+    /// token feeds which slot.
+    #[test]
+    fn empty_fields_are_not_tokens() {
+        let parsed = table("[Powerups]\nMoney=20,,yes,2000\n");
+        assert_eq!(parsed.weights[POWERUP_MONEY], 20);
+        assert_eq!(
+            parsed.anims[POWERUP_MONEY].as_deref(),
+            Some("YES"),
+            "the third field became the second token"
+        );
+        assert!(
+            !parsed.over_water[POWERUP_MONEY],
+            "`2000` is neither literal, so the flag keeps its default"
+        );
+        assert_eq!(
+            f64::from_bits(parsed.magnitudes[POWERUP_MONEY].bits()),
+            0.0,
+            "there is no fourth token"
+        );
+
+        let parsed = table("[Powerups]\nMoney=,20,MONEY\n");
+        assert_eq!(
+            parsed.weights[POWERUP_MONEY], 20,
+            "a leading delimiter is skipped, not treated as an empty first token"
+        );
+    }
+
+    /// `atof` accepts an exponent, but only with at least one digit after it.
+    #[test]
+    fn magnitude_accepts_exponent_notation() {
+        let parsed = table("[Powerups]\nGas=1,<none>,yes,1e3\nArmor=1,ARMOR,yes,2.5E-2\n");
+        assert_eq!(f64::from_bits(parsed.magnitudes[16].bits()), 1000.0);
+        assert_eq!(
+            f64::from_bits(parsed.magnitudes[POWERUP_ARMOR].bits()),
+            0.025
+        );
+
+        // A trailing `e` with no digits ends the prefix before it.
+        let parsed = table("[Powerups]\nGas=1,<none>,yes,7e\n");
+        assert_eq!(f64::from_bits(parsed.magnitudes[16].bits()), 7.0);
+    }
+
+    /// `strtrim` strips bytes <= 0x20, which is not `str::trim`'s Unicode set.
+    #[test]
+    fn tokens_are_trimmed_with_the_native_ascii_rule() {
+        let parsed = table("[Powerups]\nMoney=\u{1}20\u{1},\u{b}MONEY\u{b},yes,3\n");
+        assert_eq!(parsed.weights[POWERUP_MONEY], 20);
+        assert_eq!(parsed.anims[POWERUP_MONEY].as_deref(), Some("MONEY"));
+        assert_eq!(f64::from_bits(parsed.magnitudes[POWERUP_MONEY].bits()), 3.0);
+    }
+
+    /// Retail lines all carry a trailing `;` comment; the loader strips it
+    /// before the table ever sees the value.
+    #[test]
+    fn trailing_comments_are_stripped_before_tokenizing() {
+        let parsed = table(
+            "[Powerups]\nMoney=20,MONEY,yes,2000             ; a chunk o' cash (maximum cash)\n",
+        );
+        assert_eq!(parsed.weights[POWERUP_MONEY], 20);
+        assert_eq!(parsed.anims[POWERUP_MONEY].as_deref(), Some("MONEY"));
+        assert!(parsed.over_water[POWERUP_MONEY]);
+        assert_eq!(
+            f64::from_bits(parsed.magnitudes[POWERUP_MONEY].bits()),
+            2000.0
+        );
+    }
+
+    /// Only the literal `<none>` is Find_Index's sentinel; a bare `NONE` is an
+    /// ordinary name that simply fails to resolve.
+    #[test]
+    fn only_angle_bracket_none_is_the_anim_sentinel() {
+        let parsed = table("[Powerups]\nMoney=1,<NONE>,yes\nArmor=1,none,yes\n");
+        assert_eq!(parsed.anims[POWERUP_MONEY], None);
+        assert_eq!(parsed.anims[POWERUP_ARMOR].as_deref(), Some("NONE"));
+        assert_eq!(
+            parsed.anim_for(POWERUP_ARMOR, &["MONEY".to_owned()]),
+            None,
+            "an unregistered name still resolves to no animation"
         );
     }
 

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -2336,6 +2336,9 @@ pub struct RuleSet {
     pub bridge_rules: BridgeRules,
     /// Scenario-start crate counts and crate overlay images from `[CrateRules]`.
     pub crate_rules: CrateRules,
+    /// The fixed nineteen-entry `[Powerups]` crate outcome table. Native keeps
+    /// it in four globals outside `RulesClass`; the slot order is what matters.
+    pub powerups: crate::rules::powerups::PowerupTable,
     /// Garrison/bunker/open-topped combat multipliers from [CombatDamage].
     pub garrison_rules: GarrisonRules,
     /// Per-cell radiation-field constants from [Radiation].
@@ -2518,9 +2521,11 @@ impl RuleSet {
         let processed = layers.process()?;
         let content_hash = processed.content_hash();
         let crate_rules = processed.crate_rules().clone();
+        let powerups = processed.powerups().clone();
         let ini = processed.into_projection_discarding_native_receipt();
         let mut rules = Self::from_projected_ini(&ini)?;
         rules.crate_rules = crate_rules;
+        rules.powerups = powerups;
         rules.source_ini_hash = content_hash;
         Ok(rules)
     }
@@ -2530,6 +2535,7 @@ impl RuleSet {
     ) -> Result<Self, RulesError> {
         let mut rules = Self::from_projected_ini(processed.ini())?;
         rules.crate_rules = processed.crate_rules().clone();
+        rules.powerups = processed.powerups().clone();
         rules.source_ini_hash = processed.content_hash();
         Ok(rules)
     }
@@ -2632,6 +2638,9 @@ impl RuleSet {
         let tiberium_types = TiberiumTypeRegistry::from_ini(ini);
         let bridge_rules: BridgeRules = BridgeRules::from_ini(ini);
         let crate_rules = CrateRules::default();
+        // Overwritten from the processed layers by the two callers above; the
+        // projection path has no `[Powerups]` accumulator of its own.
+        let powerups = crate::rules::powerups::PowerupTable::default();
         let garrison_rules: GarrisonRules = GarrisonRules::from_ini(ini);
         let radiation: RadiationRules = RadiationRules::from_ini(ini);
         let radar_event_config: RadarEventConfig = RadarEventConfig::from_ini(ini);
@@ -3103,6 +3112,7 @@ impl RuleSet {
             terrain_object_types,
             bridge_rules,
             crate_rules,
+            powerups,
             garrison_rules,
             radiation,
             radar_event_config,

--- a/src/sim/crates.rs
+++ b/src/sim/crates.rs
@@ -26,7 +26,7 @@ mod runtime;
 mod state;
 
 pub use state::{CrateAuthority, CrateSlot};
-pub(crate) use runtime::{CrateRegeneration, tick_crate_regeneration};
+pub(crate) use runtime::tick_crate_regeneration;
 
 use crate::map::bridge_facts::{
     BRIDGE_FLAG_STRUCTURAL, BridgeFlagStamp, BridgeStampFamily, BridgeStampSlot,


### PR DESCRIPTION
The crate rules authority for GSI-04.23: the fixed nineteen-entry `[Powerups]`
table, every `[CrateRules]` field beyond the scenario-start subset, and the
`CrateTrigger` overlay-type flag.

**This is a verified prerequisite, not a completed mechanism.** Nothing consumes
the table yet; GSI-04.23 stays open until the pickup transaction lands. Landing
it separately keeps the pickup slice reviewable.

## The part that matters most

`[Powerups]` is not read by the section's own key order. `RulesClass__ReadPowerups
@ 0x00673E80` walks a hardcoded nineteen-pointer name table at `0x007E523C` and
asks the INI for each name, so slot order is a property of the binary. Every later
crate behavior — the weighted draw, the `[CrateRules]` solo mappings, and the
pickup jump table — indexes by that order, and a single transposition would be a
silent permanent bug.

All nineteen pointers and their literals were read out of the image rather than
adopted from `RULESCLASS_POWERUPS_TABLE.md`, which turned out to be wrong three
times. Two later reviewers each re-derived the table independently and agree.

## Doc corrections (all binary-verified)

- **Token three is over-water eligibility, not an "enabled" flag.** At `0x00481D52`
  it is read *only* when the crate cell's land type is water, and a cleared flag
  redirects the outcome to Money rather than suppressing the crate. Stock ships
  `Unit=20,<none>,no`; the old reading made it undroppable, when in fact Unit is
  one of the eight positive-weight outcomes.
- The flag global is `u8[19]`, not `int32[19]` — byte stores, byte-indexed read.
- The ReadString default is `"0,NONE"` (`0x0083D4AC`), not `"0,NONE,0"`. Two
  tokens, so an absent row zeroes weight and leaves no animation while flag and
  magnitude survive.
- Money's magnitude is the **minimum**, not the maximum: the branch is
  `RandomRanged(ftol(m), ftol(m)+900)`, so stock pays 2000–2900. The retail INI's
  own `; (maximum cash)` comment is wrong and the doc had inherited it.

## A pre-existing bug found on the way

`IniSection::read_range` has always been missing its lepton conversion.
`CCINIClass__ReadRange @ 0x00474620` does `FMUL double ptr [0x007E1710]` (= 256.0)
at `0x0047464C` before `Math__ftol`; the Ghidra *decompiler* elides that multiply
because it folds into the x87 chain, showing a bare `ftol`, which is what the old
model was written from.

`CrateRadius=3.0` is 768 leptons, not 3. Three independent corroborations: the
stock INI comments the key as cells; the constructor default `0x280` is 2.5 cells;
and decisively, every radius branch in `CrateClass__PickupDispatch` compares a
*lepton* distance directly against `Rules+0x172C` — unscaled, all of them would
have reached nothing. I am currently the only production caller, so the fix is
contained; its own tests had encoded the missing scale.

## Review

Three fresh read-only critics, each rechecking the previous round's fixes. Round
one found five parse gaps (strtok vs split, strtrim vs `str::trim`, missing atof
exponent, dropped ReadString capacity) plus the radius scaling; round two caught
one of my fixes being wrong (I claimed byte truncation but wrote `.chars()`) and a
missed `HealCrateSound` retain branch; round three confirmed those correct and
left only comment accuracy. Every finding is fixed here, none deferred.

Residuals recorded rather than smoothed over: the deferred-vs-parse-time animation
resolution, the undetectable unresolvable-sound case, and a present-but-empty INI
value whose trigger remains genuinely UNCHECKED.

## Validation

`cargo test -p vera20k --lib`: **7987 passed; 0 failed; 76 ignored**, rebased onto
`f0bd95dd`.
