### PR TITLE
Phase 6: native sound registry, positional volume and stereo pan

### DIFF
--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -20,7 +20,7 @@ use crate::app::types::SIM_TICK_HZ;
 use crate::app::types::SIM_TICK_MS;
 use crate::assets::asset_manager::AssetManager;
 use crate::assets::pal_file::Palette;
-use crate::audio::events::GameSoundEvent;
+use crate::audio::events::{GameSoundEvent, SoundSource};
 use crate::map::terrain;
 use crate::render::sprite_atlas;
 use crate::render::unit_atlas;
@@ -450,9 +450,19 @@ fn build_score_screen_model(
     }
 }
 
-fn anim_world_sound_screen(world: crate::sim::anim_class::AnimWorldCoord) -> (f32, f32) {
+fn anim_world_sound_source(world: crate::sim::anim_class::AnimWorldCoord) -> SoundSource {
     let (rx, ry, sub_x, sub_y, z) = world.to_cell_sub_z();
-    crate::util::lepton::lepton_to_screen(rx, ry, sub_x, sub_y, z)
+    let screen = crate::util::lepton::lepton_to_screen(rx, ry, sub_x, sub_y, z);
+    SoundSource::new(screen, (rx, ry))
+}
+
+/// The sound source of a flat cell event. Native `VocClass::PlayAt`
+/// callers pass an object or cell coordinate — the cell centre `(cell << 8)
+/// + 0x80` — so the projected point is the cell's diamond centre, not the
+/// tile's north-west corner.
+fn sound_source_at_cell(rx: u16, ry: u16) -> SoundSource {
+    let screen = crate::app::input::camera::cell_centre_world_point(rx, ry, 0);
+    SoundSource::new(screen, (rx, ry))
 }
 
 fn cloak_sound_for_app(
@@ -467,7 +477,7 @@ fn cloak_sound_for_app(
         crate::util::lepton::lepton_to_screen_exact_z(rx, ry, sub_x, sub_y, world_z_leptons);
     GameSoundEvent::CloakSound {
         sound_id,
-        screen_pos: Some((sx, sy)),
+        source: Some(SoundSource::new((sx, sy), (rx, ry))),
     }
 }
 
@@ -1013,11 +1023,10 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         sound_id,
                         world,
                     } => {
-                        let (sx, sy) = anim_world_sound_screen(world);
                         GameSoundEvent::AnimationStarted {
                             anim_id,
                             sound_id: sim.interner.resolve(sound_id).to_string(),
-                            screen_pos: Some((sx, sy)),
+                            source: Some(anim_world_sound_source(world)),
                         }
                     }
                     SimSoundEvent::AnimationStopped {
@@ -1025,12 +1034,11 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         stop_sound_id,
                         world,
                     } => {
-                        let (sx, sy) = anim_world_sound_screen(world);
                         GameSoundEvent::AnimationStopped {
                             anim_id,
                             stop_sound_id: stop_sound_id
                                 .map(|id| sim.interner.resolve(id).to_string()),
-                            screen_pos: Some((sx, sy)),
+                            source: Some(anim_world_sound_source(world)),
                         }
                     }
                     SimSoundEvent::WeaponFired {
@@ -1038,10 +1046,9 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         rx,
                         ry,
                     } => {
-                        let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                         GameSoundEvent::WeaponFired {
                             sound_id: sim.interner.resolve(report_sound_id).to_string(),
-                            screen_pos: Some((sx, sy)),
+                            source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
                     SimSoundEvent::EntityDied {
@@ -1049,10 +1056,9 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         rx,
                         ry,
                     } => {
-                        let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                         GameSoundEvent::EntityDestroyed {
                             sound_id: sim.interner.resolve(die_sound_id).to_string(),
-                            screen_pos: Some((sx, sy)),
+                            source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
                     SimSoundEvent::EntityCrushed {
@@ -1060,10 +1066,9 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         rx,
                         ry,
                     } => {
-                        let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                         GameSoundEvent::EntityCrushed {
                             sound_id: sim.interner.resolve(crush_sound_id).to_string(),
-                            screen_pos: Some((sx, sy)),
+                            source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
                     SimSoundEvent::EntityDeployed {
@@ -1071,10 +1076,9 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         rx,
                         ry,
                     } => {
-                        let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                         GameSoundEvent::EntityDeployed {
                             sound_id: sim.interner.resolve(deploy_sound_id).to_string(),
-                            screen_pos: Some((sx, sy)),
+                            source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
                     SimSoundEvent::EntityUndeployed {
@@ -1082,10 +1086,9 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         rx,
                         ry,
                     } => {
-                        let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                         GameSoundEvent::EntityUndeployed {
                             sound_id: sim.interner.resolve(undeploy_sound_id).to_string(),
-                            screen_pos: Some((sx, sy)),
+                            source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
                     SimSoundEvent::DockDeploy { .. } => {
@@ -1094,10 +1097,9 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         continue;
                     }
                     SimSoundEvent::ChronoTeleport { sound_id, rx, ry } => {
-                        let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                         GameSoundEvent::ChronoTeleport {
                             sound_id: sim.interner.resolve(sound_id).to_string(),
-                            screen_pos: Some((sx, sy)),
+                            source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
                     SimSoundEvent::UnitPromoted {
@@ -1123,11 +1125,10 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         // so the arm pushes its own events and never falls
                         // through to the shared push below.
                         if let Some(sound_id) = sound_id {
-                            let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                             state.match_state.match_audio.sound_events.push(
                                 GameSoundEvent::UnitPromoted {
                                     sound_id: sim.interner.resolve(sound_id).to_string(),
-                                    screen_pos: Some((sx, sy)),
+                                    source: Some(sound_source_at_cell(rx, ry)),
                                 },
                             );
                         }
@@ -1315,10 +1316,9 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             Some(s) if !s.is_empty() => s.to_string(),
                             _ => continue,
                         };
-                        let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                         GameSoundEvent::BuildingGarrisonedSfx {
                             sound_id,
-                            screen_pos: Some((sx, sy)),
+                            source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
                     SimSoundEvent::ChuteSound { rx, ry } => {
@@ -1328,17 +1328,15 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             Some(s) if !s.is_empty() => s.to_string(),
                             _ => continue,
                         };
-                        let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                         GameSoundEvent::ChuteSound {
                             sound_id,
-                            screen_pos: Some((sx, sy)),
+                            source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
                     SimSoundEvent::C4Planted { rx, ry } => {
-                        let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                         GameSoundEvent::C4Planted {
                             sound_id: "SealPlaceBomb".to_string(),
-                            screen_pos: Some((sx, sy)),
+                            source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
                     SimSoundEvent::RefineryExitSfx { rx, ry } => {
@@ -1351,10 +1349,9 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             Some(s) if !s.is_empty() => s.to_string(),
                             _ => continue,
                         };
-                        let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                         GameSoundEvent::RefineryExitSfx {
                             sound_id,
-                            screen_pos: Some((sx, sy)),
+                            source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
                     SimSoundEvent::BunkerWallsUp { rx, ry } => {
@@ -1365,10 +1362,9 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             Some(s) if !s.is_empty() => s.to_string(),
                             _ => continue,
                         };
-                        let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                         GameSoundEvent::BunkerWalls {
                             sound_id,
-                            screen_pos: Some((sx, sy)),
+                            source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
                     SimSoundEvent::BunkerWallsDown { rx, ry } => {
@@ -1379,10 +1375,9 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             Some(s) if !s.is_empty() => s.to_string(),
                             _ => continue,
                         };
-                        let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
                         GameSoundEvent::BunkerWalls {
                             sound_id,
-                            screen_pos: Some((sx, sy)),
+                            source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
                     SimSoundEvent::BridgeRepaired {
@@ -1397,11 +1392,10 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         let sound_id = Some(&resources.rules)
                             .and_then(|r| r.bridge_rules.repair_sound.clone())
                             .unwrap_or_default();
-                        let screen_pos = if sound_id.is_empty() {
+                        let source = if sound_id.is_empty() {
                             None
                         } else {
-                            let (sx, sy) = crate::map::terrain::iso_to_screen(rx, ry, 0);
-                            Some((sx, sy))
+                            Some(sound_source_at_cell(rx, ry))
                         };
                         // EVA cue gated on local-human owner. Resolves
                         // `EVA_BridgeRepaired` from the registry (no faction
@@ -1429,7 +1423,7 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         }
                         GameSoundEvent::BridgeRepaired {
                             sound_id,
-                            screen_pos,
+                            source,
                             eva_sound_id,
                         }
                     }
@@ -1493,7 +1487,7 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             crate::util::lepton::lepton_to_screen(rx, ry, sub_x, sub_y, z);
                         GameSoundEvent::WorldEffectStarted {
                             sound_id: sim.interner.resolve(sound_id).to_string(),
-                            screen_pos: Some((sx, sy)),
+                            source: Some(SoundSource::new((sx, sy), (rx, ry))),
                         }
                     }
                 };
@@ -2271,8 +2265,10 @@ mod tests {
             event,
             crate::audio::events::GameSoundEvent::CloakSound {
                 sound_id,
-                screen_pos: Some((-45.0, 315.0)),
+                source: Some(source),
             } if sound_id == "NavalUnitEmerge"
+                && source.screen_pos() == (-45.0, 315.0)
+                && source.cell() == (10, 11)
         ));
     }
 

--- a/src/app/presentation/building_anim.rs
+++ b/src/app/presentation/building_anim.rs
@@ -171,8 +171,13 @@ pub(crate) fn eva_faction_key(
 /// (`audio::sfx::spatial_gain`) against the tactical view rect — the native
 /// listener is the tactical view (`0x00886FA8`/`0x00886FAC`), never the whole
 /// window — with the local player's shroud standing in for the cell flags
-/// `CellClass+0x12C & 0x18`. Zoom is VERA-internal: the listener rect and
-/// positions are the unzoomed native pixels.
+/// `CellClass+0x12C & 0x18`.
+///
+/// Zoom is VERA-internal (gamemd has none). Sound positions are world pixels
+/// and the viewport size is device pixels, so the listener carries the zoom
+/// and `SpatialListener::view_extent` converts the rect into the world frame
+/// the positions already use — see that method for why the world frame is the
+/// side that is scaled.
 pub(crate) fn drain_sound_events(state: &mut AppState) {
     use crate::audio::events::{GameSoundEvent, SoundSource};
     use crate::audio::sfx::{SpatialGain, SpatialListener, SpatialSource, spatial_gain};
@@ -193,6 +198,7 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
         tactical_height: tactical_height as i32,
         origin_x: state.match_state.input.camera_x,
         origin_y: state.match_state.input.camera_y,
+        zoom: state.match_state.input.zoom_level,
     };
     let local_owner = preferred_local_owner_name(state);
     let sim = state

--- a/src/app/presentation/building_anim.rs
+++ b/src/app/presentation/building_anim.rs
@@ -166,9 +166,16 @@ pub(crate) fn eva_faction_key(
 ///
 /// Voice events (VoiceSelect, VoiceMove, VoiceAttack) are routed to the dedicated
 /// voice slot which cuts off the previous voice. All other sounds go to the SFX pool.
+///
+/// Positional cues go through `VocClass::CalcVolumeAndPan @ 0x00750AC0`
+/// (`audio::sfx::spatial_gain`) against the tactical view rect — the native
+/// listener is the tactical view (`0x00886FA8`/`0x00886FAC`), never the whole
+/// window — with the local player's shroud standing in for the cell flags
+/// `CellClass+0x12C & 0x18`. Zoom is VERA-internal: the listener rect and
+/// positions are the unzoomed native pixels.
 pub(crate) fn drain_sound_events(state: &mut AppState) {
-    use crate::audio::events::GameSoundEvent;
-    use crate::audio::sfx::calc_spatial_volume;
+    use crate::audio::events::{GameSoundEvent, SoundSource};
+    use crate::audio::sfx::{SpatialGain, SpatialListener, SpatialSource, spatial_gain};
 
     let events = state.match_state.match_audio.sound_events.drain();
     if events.is_empty() {
@@ -177,14 +184,62 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
         }
         return;
     }
-    let vp_w = state.render_width() as f32;
-    let vp_h = state.render_height() as f32;
+    let (tactical_width, tactical_height) = crate::app::input::camera::tactical_viewport_size_px(
+        state.render_width(),
+        state.render_height(),
+    );
+    let listener = SpatialListener {
+        tactical_width: tactical_width as i32,
+        tactical_height: tactical_height as i32,
+        origin_x: state.match_state.input.camera_x,
+        origin_y: state.match_state.input.camera_y,
+    };
+    let local_owner = preferred_local_owner_name(state);
+    let sim = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation);
+    let local_owner_id = local_owner
+        .as_deref()
+        .and_then(|name| sim.and_then(|sim| sim.interner.get(name)));
     let (Some(sfx), Some(assets)) = (&mut state.audio.sfx_player, state.process_assets.manager()) else {
         return;
     };
-    let cam_x = state.match_state.input.camera_x;
-    let cam_y = state.match_state.input.camera_y;
+    let registry = &state.audio.sound_registry;
+    let audio_indices = &state.audio.audio_indices;
     sfx.advance_voice_queue();
+
+    // `CellClass+0x12C & 0x18 == 0`: neither explored nor visible. The shroud
+    // renderer (`render::shroud_buffer`) blacks out the same cells — never
+    // revealed, or re-shrouded by a hostile gap generator.
+    let shrouded = |rx: u16, ry: u16| -> bool {
+        match (sim, local_owner_id) {
+            (Some(sim), Some(owner)) => {
+                !sim.fog.is_cell_revealed(owner, rx, ry)
+                    || sim.fog.is_cell_gap_covered(owner, rx, ry)
+            }
+            _ => false,
+        }
+    };
+    // `None` is the native "volume below 0.05 -> nothing plays" outcome.
+    let gain_for = |sound_id: &str, source: Option<SoundSource>| -> Option<SpatialGain> {
+        let Some(source) = source else {
+            return Some(SpatialGain::CENTRED_FULL);
+        };
+        let facts = registry.get(sound_id).map_or_else(
+            || SpatialSource::from_registry_defaults(registry),
+            SpatialSource::from_entry,
+        );
+        let (rx, ry) = source.cell();
+        spatial_gain(
+            facts,
+            source.screen_x,
+            source.screen_y,
+            &listener,
+            shrouded(rx, ry),
+        )
+    };
 
     for event in &events {
         match event {
@@ -192,199 +247,93 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
             GameSoundEvent::UnitSelected { .. }
             | GameSoundEvent::UnitMoveOrder { .. }
             | GameSoundEvent::UnitAttackOrder { .. } => {
-                sfx.play_voice_sound(
-                    event.sound_id(),
-                    &state.audio.sound_registry,
-                    assets,
-                    &state.audio.audio_indices,
-                );
+                sfx.play_voice_sound(event.sound_id(), registry, assets, audio_indices);
             }
             // STANDARD EVA cues are fire-and-forget: play only if voice is idle.
             GameSoundEvent::BuildingReady { .. }
             | GameSoundEvent::UnitReady { .. }
             | GameSoundEvent::CannotDeployHere { .. }
             | GameSoundEvent::OutcomeEva { .. } => {
-                sfx.play_standard_eva_sound(
-                    event.sound_id(),
-                    &state.audio.sound_registry,
-                    assets,
-                    &state.audio.audio_indices,
-                );
+                sfx.play_standard_eva_sound(event.sound_id(), registry, assets, audio_indices);
             }
             // Garrison EVA cues are evamd.ini Type=QUEUE.
             GameSoundEvent::StructureGarrisoned { .. }
             | GameSoundEvent::StructureAbandoned { .. } => {
-                sfx.queue_eva_sound(
-                    event.sound_id(),
-                    &state.audio.sound_registry,
-                    assets,
-                    &state.audio.audio_indices,
-                );
+                sfx.queue_eva_sound(event.sound_id(), registry, assets, audio_indices);
             }
             // UI events — always full volume (non-positional).
             GameSoundEvent::UiSound { .. } => {
-                sfx.play_sound(
-                    event.sound_id(),
-                    &state.audio.sound_registry,
-                    assets,
-                    &state.audio.audio_indices,
-                );
+                sfx.play_sound(event.sound_id(), registry, assets, audio_indices);
             }
             GameSoundEvent::AnimationStarted {
                 anim_id,
                 sound_id,
-                screen_pos,
+                source,
             } => {
-                let spatial_vol = if let Some((sx, sy)) = screen_pos {
-                    let (range, min_vol) = state
-                        .audio.sound_registry
-                        .get(sound_id)
-                        .map(|entry| (entry.range, entry.min_volume))
-                        .unwrap_or((crate::audio::sfx::DEFAULT_RANGE_CELLS, 0));
-                    calc_spatial_volume(*sx, *sy, vp_w, vp_h, cam_x, cam_y, range, min_vol)
-                } else {
-                    1.0
-                };
-                if spatial_vol > 0.0 {
-                    sfx.play_animation_sound_with_volume(
+                if let Some(gain) = gain_for(sound_id, *source) {
+                    sfx.play_animation_sound_spatial(
                         *anim_id,
                         sound_id,
-                        spatial_vol,
-                        &state.audio.sound_registry,
+                        gain,
+                        registry,
                         assets,
-                        &state.audio.audio_indices,
+                        audio_indices,
                     );
                 }
             }
             GameSoundEvent::AnimationStopped {
                 anim_id,
                 stop_sound_id,
-                screen_pos,
+                source,
             } => {
                 sfx.stop_animation_sound(*anim_id);
-                if let Some(stop_sound_id) = stop_sound_id.as_deref().filter(|id| !id.is_empty()) {
-                    let spatial_vol = if let Some((sx, sy)) = screen_pos {
-                        let (range, min_vol) = state
-                            .audio.sound_registry
-                            .get(stop_sound_id)
-                            .map(|entry| (entry.range, entry.min_volume))
-                            .unwrap_or((crate::audio::sfx::DEFAULT_RANGE_CELLS, 0));
-                        calc_spatial_volume(*sx, *sy, vp_w, vp_h, cam_x, cam_y, range, min_vol)
-                    } else {
-                        1.0
-                    };
-                    if spatial_vol > 0.0 {
-                        sfx.play_sound_with_volume(
-                            stop_sound_id,
-                            spatial_vol,
-                            &state.audio.sound_registry,
-                            assets,
-                            &state.audio.audio_indices,
-                        );
-                    }
+                if let Some(stop_sound_id) = stop_sound_id.as_deref().filter(|id| !id.is_empty())
+                    && let Some(gain) = gain_for(stop_sound_id, *source)
+                {
+                    sfx.play_sound_spatial(stop_sound_id, gain, registry, assets, audio_indices);
                 }
             }
-            GameSoundEvent::CloakSound {
-                sound_id,
-                screen_pos,
-            } => {
+            GameSoundEvent::CloakSound { sound_id, source } => {
                 // RulesClass::ReadAudioVisual @ 0x006691E0 stores only the
                 // VocClass::FindByName @ 0x007514D0 result. An invalid name is
                 // silent; it must not enter the generic raw audio-bag fallback.
-                let Some(entry) = state.audio.sound_registry.get(sound_id) else {
+                if registry.get(sound_id).is_none() {
                     continue;
-                };
-                let spatial_vol = if let Some((sx, sy)) = screen_pos {
-                    calc_spatial_volume(
-                        *sx,
-                        *sy,
-                        vp_w,
-                        vp_h,
-                        cam_x,
-                        cam_y,
-                        entry.range,
-                        entry.min_volume,
-                    )
-                } else {
-                    1.0
-                };
-                if spatial_vol > 0.0 {
-                    sfx.play_registered_sound_with_volume(
+                }
+                if let Some(gain) = gain_for(sound_id, *source) {
+                    sfx.play_registered_sound_spatial(
                         sound_id,
-                        spatial_vol,
-                        &state.audio.sound_registry,
+                        gain,
+                        registry,
                         assets,
-                        &state.audio.audio_indices,
+                        audio_indices,
                     );
                 }
             }
             GameSoundEvent::BridgeRepaired {
                 sound_id,
-                screen_pos,
+                source,
                 eva_sound_id,
             } => {
-                if !sound_id.is_empty() {
-                    let spatial_vol = if let Some((sx, sy)) = screen_pos {
-                        let (range, min_vol) = state
-                            .audio.sound_registry
-                            .get(sound_id)
-                            .map(|e| (e.range, e.min_volume))
-                            .unwrap_or((crate::audio::sfx::DEFAULT_RANGE_CELLS, 0));
-                        calc_spatial_volume(*sx, *sy, vp_w, vp_h, cam_x, cam_y, range, min_vol)
-                    } else {
-                        1.0
-                    };
-                    if spatial_vol > 0.0 {
-                        sfx.play_sound_with_volume(
-                            sound_id,
-                            spatial_vol,
-                            &state.audio.sound_registry,
-                            assets,
-                            &state.audio.audio_indices,
-                        );
-                    }
+                if !sound_id.is_empty()
+                    && let Some(gain) = gain_for(sound_id, *source)
+                {
+                    sfx.play_sound_spatial(sound_id, gain, registry, assets, audio_indices);
                 }
                 if let Some(eva_sound_id) = eva_sound_id.as_deref().filter(|s| !s.is_empty()) {
-                    sfx.play_standard_eva_sound(
-                        eva_sound_id,
-                        &state.audio.sound_registry,
-                        assets,
-                        &state.audio.audio_indices,
-                    );
+                    sfx.play_standard_eva_sound(eva_sound_id, registry, assets, audio_indices);
                 }
             }
             GameSoundEvent::UnderAttackEva { eva_sound_id } => {
                 // Voice-queued (not immediate): under-attack announcements
                 // wait behind whatever EVA line is currently speaking.
-                let _ = sfx.queue_eva_sound(
-                    eva_sound_id,
-                    &state.audio.sound_registry,
-                    assets,
-                    &state.audio.audio_indices,
-                );
+                let _ = sfx.queue_eva_sound(eva_sound_id, registry, assets, audio_indices);
             }
-            // Spatial events — apply distance-based volume scaling using
-            // per-sound Range and MinVolume from sound.ini.
+            // Spatial events — distance volume and pan from the sound's
+            // Range/Type/MinVolume against the tactical view.
             _ => {
-                let spatial_vol = if let Some((sx, sy)) = event.screen_pos() {
-                    let (range, min_vol) = state
-                        .audio.sound_registry
-                        .get(event.sound_id())
-                        .map(|e| (e.range, e.min_volume))
-                        .unwrap_or((crate::audio::sfx::DEFAULT_RANGE_CELLS, 0));
-                    calc_spatial_volume(sx, sy, vp_w, vp_h, cam_x, cam_y, range, min_vol)
-                } else {
-                    1.0
-                };
-
-                if spatial_vol > 0.0 {
-                    sfx.play_sound_with_volume(
-                        event.sound_id(),
-                        spatial_vol,
-                        &state.audio.sound_registry,
-                        assets,
-                        &state.audio.audio_indices,
-                    );
+                if let Some(gain) = gain_for(event.sound_id(), event.source()) {
+                    sfx.play_sound_spatial(event.sound_id(), gain, registry, assets, audio_indices);
                 }
             }
         }

--- a/src/app/presentation/fire_effects.rs
+++ b/src/app/presentation/fire_effects.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use crate::app::AppState;
-use crate::audio::events::GameSoundEvent;
+use crate::audio::events::{GameSoundEvent, SoundSource};
 use crate::map::entities::EntityCategory;
 use crate::rules::art_data::{ArtEntry, ArtRegistry};
 use crate::rules::ruleset::RuleSet;
@@ -307,7 +307,10 @@ fn build_non_garrison_fire_effects(
         if let Some(report_id) = ev.report_sound_id {
             sounds.push(GameSoundEvent::WeaponFired {
                 sound_id: sim.interner.resolve(report_id).to_string(),
-                screen_pos: Some((origin.screen_x, origin.screen_y)),
+                source: Some(SoundSource::new(
+                    (origin.screen_x, origin.screen_y),
+                    (origin.rx, origin.ry),
+                )),
             });
         }
         if ev.garrison_muzzle_index.is_some() {
@@ -768,14 +771,15 @@ mod tests {
         assert_eq!(flashes[0].screen_x, expected_origin.screen_x);
         assert_eq!(sounds.len(), 1);
         match &sounds[0] {
-            GameSoundEvent::WeaponFired {
-                sound_id,
-                screen_pos,
-            } => {
+            GameSoundEvent::WeaponFired { sound_id, source } => {
                 assert_eq!(sound_id, "GIAttack");
                 assert_eq!(
-                    *screen_pos,
+                    source.map(|s| s.screen_pos()),
                     Some((expected_origin.screen_x, expected_origin.screen_y))
+                );
+                assert_eq!(
+                    source.map(|s| s.cell()),
+                    Some((expected_origin.rx, expected_origin.ry))
                 );
             }
             other => panic!("unexpected sound event: {other:?}"),
@@ -897,8 +901,11 @@ mod tests {
         assert_eq!(sounds.len(), 1);
         let origin = resolve_fire_origin_from_sim(&sim, &rules, &art, &events[0]).unwrap();
         match &sounds[0] {
-            GameSoundEvent::WeaponFired { screen_pos, .. } => {
-                assert_eq!(*screen_pos, Some((origin.screen_x, origin.screen_y)));
+            GameSoundEvent::WeaponFired { source, .. } => {
+                assert_eq!(
+                    source.map(|s| s.screen_pos()),
+                    Some((origin.screen_x, origin.screen_y))
+                );
             }
             other => panic!("unexpected sound event: {other:?}"),
         }

--- a/src/audio/events.rs
+++ b/src/audio/events.rs
@@ -17,6 +17,41 @@
 //! - sim/ may reference this module to push events (acceptable because
 //!   it's pure data with zero audio-library dependencies).
 
+/// Where a positional sound plays: the world-pixel point the presentation
+/// frame draws it at, and the cell it occupies.
+///
+/// gamemd-derived: `VocClass::PlayAt @ 0x007509E0` receives the object's
+/// coordinate; `VocClass::CalcVolumeAndPan @ 0x00750AC0` projects it to the
+/// tactical client point for volume and pan and derives the cell as
+/// `coord >> 8` (`0x00750B32..0x00750B4E`) for the `Type=SHROUD` gate. VERA
+/// carries both halves so the app never has to invert a projection.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SoundSource {
+    pub screen_x: f32,
+    pub screen_y: f32,
+    pub rx: u16,
+    pub ry: u16,
+}
+
+impl SoundSource {
+    pub fn new(screen: (f32, f32), cell: (u16, u16)) -> Self {
+        Self {
+            screen_x: screen.0,
+            screen_y: screen.1,
+            rx: cell.0,
+            ry: cell.1,
+        }
+    }
+
+    pub fn screen_pos(&self) -> (f32, f32) {
+        (self.screen_x, self.screen_y)
+    }
+
+    pub fn cell(&self) -> (u16, u16) {
+        (self.rx, self.ry)
+    }
+}
+
 /// A sound event produced by the game simulation or UI.
 #[derive(Debug, Clone)]
 pub enum GameSoundEvent {
@@ -32,14 +67,14 @@ pub enum GameSoundEvent {
     AnimationStarted {
         anim_id: u64,
         sound_id: String,
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// Release one animation's active handle, then optionally play StopSound.
     AnimationStopped {
         anim_id: u64,
         stop_sound_id: Option<String>,
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
     /// A weapon fired — play the weapon's Report= sound.
     WeaponFired {
@@ -47,7 +82,7 @@ pub enum GameSoundEvent {
         sound_id: String,
         /// Screen position of the sound source (for spatial audio).
         /// If None, plays at full volume (non-positional).
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// A unit was selected by the player — play VoiceSelect.
@@ -73,7 +108,7 @@ pub enum GameSoundEvent {
         /// sound.ini ID from the entity's DieSound= field.
         sound_id: String,
         /// Screen position of the sound source (for spatial audio).
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// An entity was crushed by a vehicle — play CrushSound (the squish).
@@ -81,7 +116,7 @@ pub enum GameSoundEvent {
         /// sound.ini ID from the entity's CrushSound= field.
         sound_id: String,
         /// Screen position of the sound source (for spatial audio).
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// An infantry entity entered the Deploying phase — play DeploySound.
@@ -89,7 +124,7 @@ pub enum GameSoundEvent {
         /// sound.ini ID from the entity's DeploySound= field.
         sound_id: String,
         /// Screen position of the sound source (for spatial audio).
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// An infantry entity entered the Undeploying phase — play UndeploySound.
@@ -97,7 +132,7 @@ pub enum GameSoundEvent {
         /// sound.ini ID from the entity's UndeploySound= field.
         sound_id: String,
         /// Screen position of the sound source (for spatial audio).
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// A chrono teleport happened — play the resolved warp sound at this position.
@@ -106,7 +141,7 @@ pub enum GameSoundEvent {
         /// sound.ini ID — already resolved to the per-unit ChronoIn/OutSound by sim.
         sound_id: String,
         /// Screen position of the sound source (for spatial audio).
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// A local-player object crossed a veterancy rank — the positional
@@ -114,7 +149,7 @@ pub enum GameSoundEvent {
     /// (`VocClass::PlayAt` from `TechnoClass::AI_Update @ 0x006FA0BC`).
     UnitPromoted {
         sound_id: String,
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// The `EVA_UnitPromoted` voice that accompanies `UnitPromoted`.
@@ -124,7 +159,7 @@ pub enum GameSoundEvent {
     /// native StartUncloaking arg-zero transition.
     CloakSound {
         sound_id: String,
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// A building finished construction — play the EVA "Construction complete" or similar.
@@ -163,7 +198,7 @@ pub enum GameSoundEvent {
         /// sound.ini ID for the SFX (resolves "BuildingGarrisoned" → file).
         sound_id: String,
         /// Screen position for spatial audio.
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// Positional SFX from `[SealPlaceBomb]` — plays at the attacker's screen
@@ -172,7 +207,7 @@ pub enum GameSoundEvent {
         /// sound.ini ID for the SFX (resolves "SealPlaceBomb" → file).
         sound_id: String,
         /// Screen position for spatial audio.
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// Positional SFX played when a docked harvester departs after dumping.
@@ -182,7 +217,7 @@ pub enum GameSoundEvent {
         /// sound.ini ID for the SFX.
         sound_id: String,
         /// Screen position for spatial audio.
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// Positional SFX for tank-bunker walls raising (install) or falling
@@ -193,7 +228,7 @@ pub enum GameSoundEvent {
         /// sound.ini ID (BunkerWallsUpSound or BunkerWallsDownSound).
         sound_id: String,
         /// Screen position for spatial audio.
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// Positional SFX played when a paradropped passenger successfully opens
@@ -202,7 +237,7 @@ pub enum GameSoundEvent {
         /// sound.ini ID for the SFX.
         sound_id: String,
         /// Screen position for spatial audio.
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// Positional SFX + EVA cue from a bridge repair triggered by an engineer
@@ -216,7 +251,7 @@ pub enum GameSoundEvent {
         /// `RepairBridgeSound=` is unset in rules.
         sound_id: String,
         /// Screen position for spatial audio.
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
         /// `Some(eva_id)` when the engineer's owner is the local human;
         /// `None` otherwise.
         eva_sound_id: Option<String>,
@@ -227,7 +262,7 @@ pub enum GameSoundEvent {
         /// sound.ini ID for the selected animation's StartSound/Report.
         sound_id: String,
         /// Screen position for spatial audio.
-        screen_pos: Option<(f32, f32)>,
+        source: Option<SoundSource>,
     },
 
     /// Generic UI sound (button click, error beep, etc.).
@@ -273,28 +308,33 @@ impl GameSoundEvent {
         }
     }
 
-    /// Get the screen position for spatial audio, if this event has one.
-    pub fn screen_pos(&self) -> Option<(f32, f32)> {
+    /// Get the positional source for spatial audio, if this event has one.
+    pub fn source(&self) -> Option<SoundSource> {
         match self {
-            Self::WeaponFired { screen_pos, .. } => *screen_pos,
-            Self::AnimationStarted { screen_pos, .. }
-            | Self::AnimationStopped { screen_pos, .. } => *screen_pos,
-            Self::EntityDestroyed { screen_pos, .. } => *screen_pos,
-            Self::EntityCrushed { screen_pos, .. } => *screen_pos,
-            Self::EntityDeployed { screen_pos, .. } => *screen_pos,
-            Self::EntityUndeployed { screen_pos, .. } => *screen_pos,
-            Self::ChronoTeleport { screen_pos, .. } => *screen_pos,
-            Self::UnitPromoted { screen_pos, .. } => *screen_pos,
-            Self::CloakSound { screen_pos, .. } => *screen_pos,
-            Self::BuildingGarrisonedSfx { screen_pos, .. } => *screen_pos,
-            Self::C4Planted { screen_pos, .. } => *screen_pos,
-            Self::RefineryExitSfx { screen_pos, .. } => *screen_pos,
-            Self::BunkerWalls { screen_pos, .. } => *screen_pos,
-            Self::ChuteSound { screen_pos, .. } => *screen_pos,
-            Self::BridgeRepaired { screen_pos, .. } => *screen_pos,
-            Self::WorldEffectStarted { screen_pos, .. } => *screen_pos,
+            Self::WeaponFired { source, .. }
+            | Self::AnimationStarted { source, .. }
+            | Self::AnimationStopped { source, .. }
+            | Self::EntityDestroyed { source, .. }
+            | Self::EntityCrushed { source, .. }
+            | Self::EntityDeployed { source, .. }
+            | Self::EntityUndeployed { source, .. }
+            | Self::ChronoTeleport { source, .. }
+            | Self::UnitPromoted { source, .. }
+            | Self::CloakSound { source, .. }
+            | Self::BuildingGarrisonedSfx { source, .. }
+            | Self::C4Planted { source, .. }
+            | Self::RefineryExitSfx { source, .. }
+            | Self::BunkerWalls { source, .. }
+            | Self::ChuteSound { source, .. }
+            | Self::BridgeRepaired { source, .. }
+            | Self::WorldEffectStarted { source, .. } => *source,
             _ => None,
         }
+    }
+
+    /// Get the screen position for spatial audio, if this event has one.
+    pub fn screen_pos(&self) -> Option<(f32, f32)> {
+        self.source().map(|source| source.screen_pos())
     }
 }
 
@@ -376,7 +416,7 @@ mod tests {
     fn test_sound_id_accessor() {
         let evt: GameSoundEvent = GameSoundEvent::WeaponFired {
             sound_id: "VGCannon1".to_string(),
-            screen_pos: None,
+            source: None,
         };
         assert_eq!(evt.sound_id(), "VGCannon1");
     }
@@ -403,17 +443,18 @@ mod tests {
     fn test_building_garrisoned_sfx_screen_pos_accessor() {
         let evt: GameSoundEvent = GameSoundEvent::BuildingGarrisonedSfx {
             sound_id: "BuildingGarrisoned".to_string(),
-            screen_pos: Some((100.0, 200.0)),
+            source: Some(SoundSource::new((100.0, 200.0), (3, 4))),
         };
         assert_eq!(evt.sound_id(), "BuildingGarrisoned");
         assert_eq!(evt.screen_pos(), Some((100.0, 200.0)));
+        assert_eq!(evt.source().map(|s| s.cell()), Some((3, 4)));
     }
 
     #[test]
     fn test_chute_sound_screen_pos_accessor() {
         let evt = GameSoundEvent::ChuteSound {
             sound_id: "ParachuteDrop".to_string(),
-            screen_pos: Some((128.0, 256.0)),
+            source: Some(SoundSource::new((128.0, 256.0), (5, 6))),
         };
         assert_eq!(evt.sound_id(), "ParachuteDrop");
         assert_eq!(evt.screen_pos(), Some((128.0, 256.0)));
@@ -423,7 +464,7 @@ mod tests {
     fn test_bridge_repaired_carries_spatial_and_eva_sound_ids() {
         let evt = GameSoundEvent::BridgeRepaired {
             sound_id: "BridgeRepaired".to_string(),
-            screen_pos: Some((32.0, 64.0)),
+            source: Some(SoundSource::new((32.0, 64.0), (1, 2))),
             eva_sound_id: Some("EVA_BridgeRepaired".to_string()),
         };
 

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -8,9 +8,10 @@
 //! ## Design
 //! - Fire-and-forget: each sound is played via a Player and tracked only to
 //!   cap the max number of concurrent sounds (prevents audio overload).
-//! - Random selection: when a sound entry has multiple .wav files, one is
-//!   chosen at random for variety.
-//! - Volume scaling: each sound's volume from sound.ini is applied on playback.
+//! - Sample selection, pitch/volume shift, positional volume, stereo pan and
+//!   the DirectSound loudness curve are reproduced from `gamemd.exe`
+//!   (`VocClass`, `SoundEvent`, `DSoundBuffer`); see the provenance comments
+//!   on each helper. Everything below `play_decoded` is device plumbing.
 //!
 //! ## Dependency rules
 //! - Part of audio/ — depends on assets/ (AssetManager for .wav/.aud loading),
@@ -25,128 +26,481 @@ use rodio::{DeviceSinkBuilder, MixerDeviceSink, Player};
 
 use crate::assets::asset_manager::AssetManager;
 use crate::assets::aud_file;
-use crate::rules::sound_ini::SoundRegistry;
+use crate::rules::sound_ini::{SoundEntry, SoundRegistry, VOLUME_SCALE, control, sound_type};
 
 /// Maximum concurrent SFX sounds — matches original engine's 16 DirectSound buffers.
 /// RESIDUAL (GSI-15.03/15.04) — there is no channel pool, and the parts of
 /// these two rows that matter for parity are entangled with the device.
 /// Eviction is plain FIFO over this queue, so the `Priority=` tier decoded in
 /// `rules/sound_ini.rs` is ignored and a `CRITICAL` cue loses to an older
-/// `LOWEST` one; `Limit=` is unenforced (17 stock sounds cap at one instance);
-/// there is no loop-handle mechanism, so `Control=` loop and ambient variants
-/// cannot persist; interruption stops the old player outright with no fade; and
-/// finished handles are reaped only inside `play_decoded`, so an idle frame
-/// never cleans up.
+/// `LOWEST` one; `Limit=` is parsed but unenforced (17 stock sounds cap at one
+/// instance — native counts live instances per event at `AudioEventClass+0x44`
+/// against `+0x48` in `SoundSystem::UpdateTick @ 0x004041D0` and stops the
+/// oldest); `Control=INTERRUPT` (`0x10`) has no owner; `Control=LOOP`/`Loop=`
+/// (`SoundEvent::SelectNextSample @ 0x00404BB0`, `AdvancePlaylist @
+/// 0x004047B0`) play only their first pass; `Delay=`/`PREDELAY`/`AMBIENT`
+/// pre-delays (`SoundEvent::UpdateState @ 0x004055C0` state 2, threshold
+/// `0x21` ms) are drawn from the RNG but not waited for; and finished handles
+/// are reaped only inside `play_decoded`, so an idle frame never cleans up.
 ///
 /// Pass 2 established the cadence: `SoundSystem::UpdateTick @ 0x004041D0` is
 /// pumped from `AudioSystem::Pump @ 0x00406F70` off the message/service loop —
 /// NOT the sim tick — so the mixer's update rate is not frame-locked and must
 /// not be modelled as if it were.
 /// - Trigger: any moment more than a handful of sounds compete, and every
-///   ambient or looping cue.
+///   ambient, looping or pre-delayed cue.
 /// - Player effect: important cues get dropped for unimportant older ones,
-///   ambient beds never sustain, and interruptions click instead of crossing.
+///   ambient beds never sustain, interruptions click instead of crossing, and
+///   pre-delayed cues start early.
 /// - Frequency: continuous in any busy engagement.
 /// - Downstream risk: **not reachable from `cargo test -p vera20k --lib`.**
 ///   `SfxPlayer::new` returns `None` without an audio device, so every path
-///   below it is unverifiable here and none of it may be claimed verified. The
-///   first slice is a device-free arbiter — a slot table, per-`SoundKey`
-///   instance counts and lowest-priority-wins eviction with an age tie-break,
-///   taking a request and returning admit-with-eviction or reject — with all
-///   rodio work left in this file. That arbiter is testable from `--lib`, and it
-///   is what `Limit=` and `Control=INTERRUPT` need before either can land.
+///   below `play_decoded` is unverifiable here and none of it may be claimed
+///   verified. The first slice is a device-free arbiter — a slot table,
+///   per-event instance counts and lowest-priority-wins eviction
+///   (`DSoundChannel::FindLowestPriority @ 0x00404E20`) — with all rodio work
+///   left in this file.
 const MAX_CONCURRENT_SFX: usize = 16;
 
-/// Range multiplier — converts VocClass Range value (cells) to pixels.
-/// In the original engine: `max_distance = Range * 0x3C` where 0x3C = 60.
-const RANGE_MULTIPLIER: f32 = 60.0;
+/// `VocClass::CalcVolumeAndPan @ 0x00750AC0` (`0x00750B0F..0x00750B17`):
+/// `maxRange = Range * 0x3C` pixels.
+const RANGE_MULTIPLIER: i32 = 0x3C;
 
-/// Default audible range in cells when sound has no explicit Range.
-/// The original engine's [Defaults] section uses Range=10.
-pub const DEFAULT_RANGE_CELLS: u16 = 10;
+/// Pan scale: `0..=0x4000` with `0x2000` centre (`0x00750D10..0x00750D24`,
+/// constant `0x007F68E8` = 8192.0f).
+pub const PAN_CENTRE: i32 = 0x2000;
+pub const PAN_SCALE: i32 = 0x4000;
 
-/// Minimum volume cutoff — sounds below this are culled entirely (not played).
-/// Matches original engine behavior (approximately 5%).
-const MIN_VOLUME_CUTOFF: f32 = 0.05;
+/// Audibility cutoff: volumes below the double at `0x007E8AE8` (0.05) are
+/// silent (`0x00750CBD..0x00750CCC`).
+const MIN_VOLUME_CUTOFF: f64 = 0.05;
 
-/// Calculate spatial audio volume based on screen distance from viewport center.
+/// Truncating `Math::ftol @ 0x007C5F00` (control word `0x0E7F`: round toward
+/// zero, 53-bit precision), applied to a double intermediate.
+fn ftol(value: f64) -> i32 {
+    value.trunc() as i32
+}
+
+/// The listener: the tactical view rect in native pixels and its top-left in
+/// the same world-pixel frame the sound positions use.
 ///
-/// Algorithm:
-/// 1. Compute screen-space distance from viewport center
-/// 2. Subtract half viewport (on-screen = full volume)
-/// 3. Double Y for isometric compensation
-/// 4. Linear falloff from 1.0 at viewport edge to 0.0 at max range
+/// gamemd-derived: `CalcVolumeAndPan` reads the width/height globals
+/// `0x00886FA8`/`0x00886FAC` (written by `Set_View_Dimensions`) and projects
+/// the sound through `TacticalClass::CoordsToClient2 @ 0x006D2140`, which
+/// subtracts the view origin (`this+0xB0/+0xB4`).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SpatialListener {
+    pub tactical_width: i32,
+    pub tactical_height: i32,
+    pub origin_x: f32,
+    pub origin_y: f32,
+}
+
+impl SpatialListener {
+    /// Client (view-relative) pixel of a world-pixel position; the native
+    /// client point is integer, so the fractional VERA camera is truncated.
+    pub fn client_point(&self, screen_x: f32, screen_y: f32) -> (i32, i32) {
+        (
+            ftol(f64::from(screen_x) - f64::from(self.origin_x)),
+            ftol(f64::from(screen_y) - f64::from(self.origin_y)),
+        )
+    }
+}
+
+/// The registry facts `CalcVolumeAndPan` reads from the event.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SpatialSource {
+    pub range_cells: i32,
+    pub type_flags: u32,
+    /// `MinVolume` as the stored fraction (`AudioEventClass+0x54`).
+    pub min_volume: f32,
+}
+
+impl SpatialSource {
+    pub fn from_entry(entry: &SoundEntry) -> Self {
+        Self {
+            range_cells: i32::from(entry.range),
+            type_flags: entry.type_flags,
+            min_volume: entry.min_volume,
+        }
+    }
+
+    /// The `[Defaults]` facts, for raw audio-bag names that have no event.
+    /// Native never plays those positionally (an invalid `VocClass` index
+    /// plays nothing); this is the VERA-internal fallback's listener model.
+    pub fn from_registry_defaults(registry: &SoundRegistry) -> Self {
+        let defaults = registry.defaults();
+        Self {
+            range_cells: defaults.range,
+            type_flags: defaults.type_flags,
+            min_volume: defaults.min_volume_fraction(),
+        }
+    }
+}
+
+/// Positional result: the spatial volume `0..=1` and the pan `0..=0x4000`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SpatialGain {
+    pub volume: f32,
+    pub pan: i32,
+}
+
+impl SpatialGain {
+    /// Non-positional playback: full volume, centred. This is what
+    /// `TechnoClass` voices and UI cues use (volume 1.0, pan `0x2000`).
+    pub const CENTRED_FULL: Self = Self {
+        volume: 1.0,
+        pan: PAN_CENTRE,
+    };
+
+    /// Native linear volume `min(ftol(volume * 0x4000), 0x4000)`
+    /// (`VocClass::PlayAt @ 0x007509E0`, `0x00750A55..0x00750A6F`).
+    pub fn volume_linear(&self) -> i32 {
+        ftol(f64::from(self.volume) * f64::from(VOLUME_SCALE)).min(VOLUME_SCALE)
+    }
+}
+
+/// Positional volume and pan for one sound at one client point.
 ///
-/// `range_cells` — audible range from sound.ini Range= key (default 10).
-/// `min_volume_pct` — MinVolume= floor (0-100), volume never drops below this.
-/// RESIDUAL (GSI-15.02) — pass 2 transcribed the native function, so these are
-/// now three DRIFTs against a known target rather than three approximations.
-/// `VocClass::CalcVolumeAndPan @ 0x00750AC0` computes
-/// `volume = (maxRange - max(distX, 2 * distY)) / maxRange` with
-/// `maxRange = Range * 60`, both distances truncated by `ftol` before `abs`,
-/// measured against the TACTICAL VIEW rect (`0x00886FA8`/`0x00886FAC`) — not the
-/// window. The `max(dx, 2 * dy)` metric below is therefore structurally right.
-/// The differences:
-/// - **The `MinVolume=` floor is unconditional here.** Native applies it only
-///   for `Type=GLOBAL` (flag `0x10`, 52 stock entries; `[Defaults]` is not
-///   GLOBAL), and skips the half-viewport subtraction only for `Type=LOCAL`
-///   (flag `0x40`). With stock `[Defaults] MinVolume=50` VERA puts a 50% floor
-///   under every registry-resolved sound, so the audibility cutoff is
-///   unreachable and distant sounds hold at half volume.
-/// - **There is no pan.** Native returns
-///   `ftol(clamp(offsetX, +/-fullW) * 8192 / fullW + 8192)`, i.e. `0..16384`
-///   with 8192 centre, and it is NOT negated — an existing research note reading
-///   an `FCHS` as a pan negation is wrong; that instruction negates the width.
-/// - **The listener rect may be the window rather than the tactical view.**
-/// - Trigger: every positional sound.
-/// - Player effect: no stereo image, and distant sounds that should fade out
-///   hold at half volume.
-/// - Frequency: continuous.
-/// - Downstream risk: the floor and the metric are landable without the
-///   arbiter, once `Type=` is parsed (see `rules/sound_ini.rs`); only wiring pan
-///   into a stereo gain pair needs the device path, which `--lib` cannot reach.
-pub fn calc_spatial_volume(
-    sound_screen_x: f32,
-    sound_screen_y: f32,
-    viewport_w: f32,
-    viewport_h: f32,
-    camera_x: f32,
-    camera_y: f32,
-    range_cells: u16,
-    min_volume_pct: u8,
-) -> f32 {
-    let center_x = camera_x + viewport_w * 0.5;
-    let center_y = camera_y + viewport_h * 0.5;
+/// gamemd-derived: `VocClass::CalcVolumeAndPan @ 0x00750AC0`, transcribed
+/// from `disassemble_function` — every rounding point below names its
+/// instruction range.
+/// - `halfW = W * 0.5f`, `halfH = H * 0.5f`, `fullW = halfW + halfW`
+///   (`0x00750AD6..0x00750B06`), `maxRange = Range * 0x3C` as float.
+/// - `Type=SHROUD` (`0x800`): a sound in a cell whose shroud flags
+///   (`CellClass+0x12C & 0x18`) are both clear returns 0 (`0x00750B2D..
+///   0x00750BAA`). The cell test is the caller's: `shrouded`.
+/// - `offsetX = clientX - halfW` kept as float (`FST [ESP+0x10]`); the
+///   distances are `|ftol(clientX - halfW)|` and `|ftol(clientY - halfH)|`
+///   (`0x00750BBE..0x00750BF6`).
+/// - Unless `Type=LOCAL` (`0x40`): subtract the half view from each and clamp
+///   at 0 (`0x00750BFA..0x00750C37`). Then `distY *= 2` (`0x00750C3D`).
+/// - `volume = (maxRange - max(distX, distY)) / maxRange` only when both are
+///   below `maxRange` and `maxRange > 0`, else 0 (`0x00750C43..0x00750C99`).
+///   The `max` is `distY` when `distX <= distY`.
+/// - `Type=GLOBAL` (`0x10`): `volume = max(volume, MinVolume)`
+///   (`0x00750C9B..0x00750CBD`).
+/// - `volume < 0.05` (double compare) returns 0 with no pan (`0x00750CBD`).
+/// - `pan = ftol(clamp(offsetX, -fullW, fullW) * 8192 / fullW + 8192)`
+///   (`0x00750CDE..0x00750D24`); the `FCHS` builds `-fullW`, it does not
+///   negate the offset.
+pub fn calc_volume_and_pan(
+    client_x: i32,
+    client_y: i32,
+    tactical_width: i32,
+    tactical_height: i32,
+    source: SpatialSource,
+    shrouded: bool,
+) -> Option<SpatialGain> {
+    let half_w: f32 = tactical_width as f32 * 0.5;
+    let half_h: f32 = tactical_height as f32 * 0.5;
+    let full_w: f32 = half_w + half_w;
+    let max_range: f32 = (source.range_cells.wrapping_mul(RANGE_MULTIPLIER)) as f32;
 
-    // Absolute distance from screen center.
-    let mut dx = (sound_screen_x - center_x).abs();
-    let mut dy = (sound_screen_y - center_y).abs();
+    if source.type_flags & sound_type::SHROUD != 0 && shrouded {
+        return None;
+    }
 
-    // Subtract half viewport — sounds on screen have zero distance.
-    dx = (dx - viewport_w * 0.5).max(0.0);
-    dy = (dy - viewport_h * 0.5).max(0.0);
+    let offset_x: f32 = (f64::from(client_x) - f64::from(half_w)) as f32;
+    let mut dist_x: f32 = ftol(f64::from(client_x) - f64::from(half_w)).abs() as f32;
+    let mut dist_y: f32 = ftol(f64::from(client_y) - f64::from(half_h)).abs() as f32;
 
-    // Double Y for isometric compensation (Y axis is visually compressed).
-    dy *= 2.0;
+    if source.type_flags & sound_type::LOCAL == 0 {
+        dist_x -= half_w;
+        dist_y -= half_h;
+        if dist_x < 0.0 {
+            dist_x = 0.0;
+        }
+        if dist_y < 0.0 {
+            dist_y = 0.0;
+        }
+    }
+    dist_y += dist_y;
 
-    // Use the larger axis as effective distance.
-    let dist = dx.max(dy);
+    let mut volume: f32 = 0.0;
+    if dist_x < max_range && dist_y < max_range && 0.0 < max_range {
+        let dist = if dist_x <= dist_y { dist_y } else { dist_x };
+        volume = (max_range - dist) / max_range;
+    }
+    if source.type_flags & sound_type::GLOBAL != 0 && volume < source.min_volume {
+        volume = source.min_volume;
+    }
+    if f64::from(volume) < MIN_VOLUME_CUTOFF {
+        return None;
+    }
 
-    // Max audible distance = Range (cells) * 60 (pixels per cell equivalent).
-    let max_range = range_cells.max(1) as f32 * RANGE_MULTIPLIER;
-    if dist >= max_range {
+    let clamped = if offset_x < -full_w {
+        -full_w
+    } else if offset_x > full_w {
+        full_w
+    } else {
+        offset_x
+    };
+    let pan = ftol(
+        f64::from(clamped) * f64::from(PAN_CENTRE) / f64::from(full_w) + f64::from(PAN_CENTRE),
+    );
+    Some(SpatialGain { volume, pan })
+}
+
+/// [`calc_volume_and_pan`] for a world-pixel position against a listener.
+pub fn spatial_gain(
+    source: SpatialSource,
+    screen_x: f32,
+    screen_y: f32,
+    listener: &SpatialListener,
+    shrouded: bool,
+) -> Option<SpatialGain> {
+    let (client_x, client_y) = listener.client_point(screen_x, screen_y);
+    calc_volume_and_pan(
+        client_x,
+        client_y,
+        listener.tactical_width,
+        listener.tactical_height,
+        source,
+        shrouded,
+    )
+}
+
+/// DirectSound attenuation table, hundredths of a decibel, indexed by the
+/// linear volume in percent. Machine-derived: `read_memory 0x00816380` (101
+/// dwords, `-10000` at 0 through `0` at 100); the entries are
+/// `round(1000 * log2(i / 100))`, i.e. 10 dB per halving, floored at -100 dB.
+/// Applied by the `DSoundBuffer` apply routine `FUN_0040A6D0` as
+/// `SetVolume(table[(volume >> 16) * 25 >> 12])` and as the per-side pan
+/// attenuation.
+const DSOUND_ATTENUATION_TABLE: [i16; 101] = [
+    -10000, -6644, -5644, -5059, -4644, -4322, -4059, -3837, -3644, -3474, -3322, -3184, -3059,
+    -2943, -2837, -2737, -2644, -2556, -2474, -2396, -2322, -2252, -2184, -2120, -2059, -2000,
+    -1943, -1889, -1837, -1786, -1737, -1690, -1644, -1599, -1556, -1515, -1474, -1434, -1396,
+    -1358, -1322, -1286, -1252, -1218, -1184, -1152, -1120, -1089, -1059, -1029, -1000, -971, -943,
+    -916, -889, -862, -837, -811, -786, -761, -737, -713, -690, -667, -644, -621, -599, -578, -556,
+    -535, -515, -494, -474, -454, -434, -415, -396, -377, -358, -340, -322, -304, -286, -269, -252,
+    -234, -218, -201, -184, -168, -152, -136, -120, -105, -89, -74, -59, -44, -29, -14, 0,
+];
+
+/// Amplitude of one DirectSound attenuation (hundredths of a dB).
+/// `DSBVOLUME_MIN` (-10000) is DirectSound's documented silence, so the
+/// table's zero entry maps to exactly 0 rather than the -100 dB it names.
+fn attenuation_amplitude(hundredths_db: i16) -> f32 {
+    if hundredths_db <= DSOUND_ATTENUATION_TABLE[0] {
         return 0.0;
     }
+    10f64.powf(f64::from(hundredths_db) / 2000.0) as f32
+}
 
-    let mut vol = (max_range - dist) / max_range;
+/// Product of two native linear volumes: `DSoundBuffer::CombineInterps
+/// FUN_004010C0` (`0x004010C7..0x004010D6`), `(a * b) >> 14`.
+pub fn combine_linear(a: i32, b: i32) -> i32 {
+    (a.clamp(0, VOLUME_SCALE) * b.clamp(0, VOLUME_SCALE)) >> 14
+}
 
-    // Apply MinVolume floor — volume never drops below this.
-    let min_vol = min_volume_pct as f32 / 100.0;
-    if vol < min_vol {
-        vol = min_vol;
+/// Amplitude the DirectSound layer produces for one combined linear volume:
+/// `FUN_0040A6D0` indexes the table with `volume * 25 >> 12` (0..=100).
+pub fn native_volume_amplitude(linear: i32) -> f32 {
+    let index = (linear.clamp(0, VOLUME_SCALE) * 25) >> 12;
+    attenuation_amplitude(DSOUND_ATTENUATION_TABLE[index as usize])
+}
+
+/// Left/right channel amplitudes for one pan (`0..=0x4000`).
+///
+/// gamemd-derived: `FUN_0040A6D0` (`0x0040A6F4..`) maps the combined pan to
+/// `p = (pan * 25 >> 11) - 100` and calls `SetPan(table[100 - |p|])` for a
+/// left pan (negative DirectSound pan attenuates the right channel) and
+/// `SetPan(-table[100 - p])` for a right pan (attenuates the left channel).
+pub fn pan_channel_gains(pan: i32) -> (f32, f32) {
+    let p = ((pan.clamp(0, PAN_SCALE) * 25) >> 11) - 100;
+    let attenuated = attenuation_amplitude(DSOUND_ATTENUATION_TABLE[(100 - p.abs()) as usize]);
+    if p < 0 {
+        (1.0, attenuated)
+    } else if p > 0 {
+        (attenuated, 1.0)
+    } else {
+        (1.0, 1.0)
+    }
+}
+
+/// Apply per-channel pan gains to interleaved stereo samples.
+fn apply_pan(samples: &mut [f32], pan: i32) {
+    let (left, right) = pan_channel_gains(pan);
+    if left == 1.0 && right == 1.0 {
+        return;
+    }
+    for frame in samples.chunks_exact_mut(2) {
+        frame[0] *= left;
+        frame[1] *= right;
+    }
+}
+
+/// The audio RNG contract: `Random::RandomRanged @ 0x0065C7E0` on the
+/// non-scenario `g_MainRng @ 0x00886B88` (seeded from the system clock in
+/// `Init_Random_Number_System @ 0x0052FC20`, never synchronised). Inclusive
+/// bounds; equal bounds return without drawing.
+pub trait SampleRng {
+    fn ranged(&mut self, low: i32, high: i32) -> i32;
+}
+
+/// Presentation-side RNG for sample choice, pitch and volume shift. The
+/// native generator is clock-seeded, so only its draw contract matters; this
+/// is SplitMix64 with rejection sampling for an unbiased inclusive range.
+#[derive(Debug, Clone)]
+pub struct SfxRng {
+    state: u64,
+}
+
+impl SfxRng {
+    pub fn seeded(seed: u64) -> Self {
+        Self { state: seed }
     }
 
-    if vol < MIN_VOLUME_CUTOFF { 0.0 } else { vol }
+    pub fn from_clock() -> Self {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0x9E37_79B9_7F4A_7C15, |d| d.as_nanos() as u64);
+        Self::seeded(nanos)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+}
+
+impl SampleRng for SfxRng {
+    fn ranged(&mut self, low: i32, high: i32) -> i32 {
+        if low == high {
+            return low;
+        }
+        let (low, high) = if high < low { (high, low) } else { (low, high) };
+        let span = (i64::from(high) - i64::from(low) + 1) as u64;
+        let zone = u64::MAX - (u64::MAX % span);
+        loop {
+            let draw = self.next_u64();
+            if draw < zone {
+                return (i64::from(low) + (draw % span) as i64) as i32;
+            }
+        }
+    }
+}
+
+/// Per-play randomised facts drawn before the samples are chosen.
+///
+/// gamemd-derived: `SoundEvent::UpdateState @ 0x004055C0` state 0
+/// (`0x0040567F..0x004056A7`): `fshift = 100 + RandomRanged(FShift.min,
+/// FShift.max)` and `vshift = RandomRanged(0, VShift)`; then, when
+/// `Control & (PREDELAY|AMBIENT)`, `RandomRanged(AMBIENT ? 0x21 : Delay.min,
+/// Delay.max)` for the pre-delay (`0x00405729..0x00405743`). The pre-delay
+/// itself is a channel-arbiter (A2) residual; its draw is kept so the RNG
+/// sequence matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PlayShifts {
+    /// Frequency multiplier in percent (`SoundEvent+0x14C`).
+    pub frequency_pct: i32,
+    /// Volume reduction in percent (`SoundEvent+0x150`).
+    pub volume_shift_pct: i32,
+}
+
+impl PlayShifts {
+    pub fn draw(entry: &SoundEntry, rng: &mut impl SampleRng) -> Self {
+        let frequency_pct = rng.ranged(entry.fshift.0, entry.fshift.1) + 100;
+        let volume_shift_pct = rng.ranged(0, entry.vshift);
+        if entry.control & (control::PREDELAY | control::AMBIENT) != 0 {
+            let min = if entry.control & control::AMBIENT != 0 {
+                0x21
+            } else {
+                entry.delay_ms.0
+            };
+            let _predelay_ms = rng.ranged(min, entry.delay_ms.1);
+        }
+        Self {
+            frequency_pct,
+            volume_shift_pct,
+        }
+    }
+
+    /// Buffer volume after the shift: `SoundEvent::StartPlayback @
+    /// 0x004054A0` (`0x004054EB..0x00405519`), `0x4000 - ((vshift << 14) /
+    /// 100)` when `vshift > 0`.
+    pub fn volume_linear(&self) -> i32 {
+        if self.volume_shift_pct > 0 {
+            VOLUME_SCALE - ((self.volume_shift_pct << 14) / 100)
+        } else {
+            VOLUME_SCALE
+        }
+    }
+
+    /// Playback rate: `FUN_00401190` returns `(pct * rate) / 100`.
+    pub fn shifted_sample_rate(&self, sample_rate: u32) -> u32 {
+        ((i64::from(self.frequency_pct) * i64::from(sample_rate)) / 100).max(1) as u32
+    }
+}
+
+/// Sample indices, in play order, for one pass of an event.
+///
+/// gamemd-derived: `SoundEvent::LoadSamples @ 0x004048B0` for events whose
+/// `Delay.min < 0x21` (`0x004048FB..0x00404ACD`, all 588 stock `Control=`
+/// entries except the 60 with a longer pre-delay, which reach the same
+/// first-pass result through `SelectNextSample @ 0x00404BB0`):
+/// 1. `Attack > 0`: load `samples[RandomRanged(0, Attack - 1)]`.
+/// 2. Without `ALL`: `RANDOM` loads `samples[RandomRanged(Attack, count -
+///    Decay - 1)]`, otherwise `samples[Attack]` (the first body sample —
+///    never a round-robin). With `ALL`: every body sample in order.
+/// 3. `Decay > 0`: load `samples[RandomRanged(count - Decay, count - 1)]`.
+/// Then `PreparePlayout @ 0x00404700` / `AdvancePlaylist @ 0x004047B0` play
+/// the loaded buffers: the attack buffer first when `Control=ATTACK`, the
+/// decay buffer last when `Control=DECAY`, and the rest in `RandomRanged(0,
+/// remaining - 1)` pick-and-remove order for `RANDOM` or in load order
+/// otherwise.
+pub fn select_playout(entry: &SoundEntry, rng: &mut impl SampleRng) -> Vec<usize> {
+    let count = entry.sounds.len() as i32;
+    if count == 0 {
+        return Vec::new();
+    }
+    let body = entry.body_range();
+    let (body_start, body_end) = (body.start as i32, body.end as i32);
+    let mut attack = None;
+    let mut decay = None;
+    let mut middle: Vec<usize> = Vec::new();
+
+    if entry.attack > 0 {
+        attack = Some(rng.ranged(0, entry.attack - 1).clamp(0, count - 1) as usize);
+    }
+    if entry.control & control::ALL == 0 {
+        let index = if entry.control & control::RANDOM != 0 {
+            rng.ranged(body_start, body_end - 1)
+        } else {
+            body_start
+        };
+        if (0..count).contains(&index) {
+            middle.push(index as usize);
+        }
+    } else {
+        middle.extend(body.clone());
+    }
+    if entry.decay > 0 {
+        decay = Some(
+            rng.ranged(count - entry.decay, count - 1)
+                .clamp(0, count - 1) as usize,
+        );
+    }
+
+    let mut order = Vec::with_capacity(middle.len() + 2);
+    // Native keeps the attack buffer first only under the ATTACK control flag,
+    // and the decay buffer last only under DECAY; without the flag the count is
+    // zero (see `SoundEntry::attack`), so both agree.
+    order.extend(attack);
+    if entry.control & control::RANDOM != 0 {
+        while !middle.is_empty() {
+            let pick = rng.ranged(0, middle.len() as i32 - 1) as usize;
+            order.push(middle.remove(pick.min(middle.len() - 1)));
+        }
+    } else {
+        order.append(&mut middle);
+    }
+    order.extend(decay);
+    order
 }
 
 const FADE_MS: u32 = 3;
@@ -161,25 +515,50 @@ pub(crate) struct DecodedAudio {
     pub(crate) channels: u16,
 }
 
+impl DecodedAudio {
+    /// Append another clip; the native playlist chains buffers back to back.
+    /// A rate mismatch keeps the first clip (RESIDUAL: native streams each
+    /// buffer at its own rate; no stock attack/decay set mixes rates).
+    fn append(&mut self, mut other: DecodedAudio) {
+        if other.sample_rate != self.sample_rate || other.channels != self.channels {
+            log::warn!(
+                "SFX: dropped chained sample with mismatched format ({} Hz vs {} Hz)",
+                other.sample_rate,
+                self.sample_rate
+            );
+            return;
+        }
+        self.samples.append(&mut other.samples);
+    }
+}
+
+/// A resolved playback request: the decoded audio, the event's linear volume
+/// (entry `Volume=` combined with the per-play `VShift=` reduction) and the
+/// spatial gain.
+struct ResolvedPlayback {
+    decoded: DecodedAudio,
+    event_linear: i32,
+}
+
 struct QueuedVoice {
     sound_id: String,
     decoded: DecodedAudio,
-    /// Sound-entry gain only. The current Voice master is applied when this
-    /// cue reaches the dedicated slot, not when it enters the queue.
-    base_gain: f32,
+    /// Sound-entry linear volume only. The current Voice master is applied
+    /// when this cue reaches the dedicated slot, not when it enters the queue.
+    base_linear: i32,
 }
 
 impl QueuedVoice {
-    fn new(sound_id: String, decoded: DecodedAudio, base_gain: f32) -> Self {
+    fn new(sound_id: String, decoded: DecodedAudio, base_linear: i32) -> Self {
         Self {
             sound_id,
             decoded,
-            base_gain,
+            base_linear,
         }
     }
 
     fn prepare_for_dequeue(self, scales: SfxOutputScales) -> (String, PreparedSfxOutput) {
-        let output = prepare_direct_voice_output(self.decoded, self.base_gain, scales);
+        let output = prepare_direct_voice_output(self.decoded, self.base_linear, scales);
         (self.sound_id, output)
     }
 }
@@ -206,19 +585,27 @@ struct SfxOutputScales {
 
 /// Master-independent gain retained beside one live secondary output.
 ///
-/// The base gain includes sound-entry and spatial factors, but not the user
-/// master. User, lifecycle, and foreground factors are recomposed from it so
-/// changing or reopening a gate never has to infer the original value from a
-/// muted Player.
+/// `base_linear` is the native linear volume (`0..=0x4000`) of everything
+/// below the user master: spatial volume, entry volume and the per-play
+/// `VShift=` reduction. The master is chained into the same linear product
+/// before the DirectSound curve — `DSoundBuffer::CombineInterps FUN_004010C0`
+/// multiplies the buffer, event and group interps (`FUN_00402220`; the sound
+/// group at `DAT_0087E758`, `SoundEvent::UpdateState 0x0040571E`) and only
+/// then `FUN_0040A6D0` converts to decibels — so `effective` recomposes the
+/// product each time rather than scaling an amplitude. The VERA-internal
+/// lifecycle and foreground gates multiply the amplitude afterwards.
 #[derive(Debug, Clone, Copy, PartialEq)]
 struct SfxOutputGain {
-    base_gain: f32,
+    base_linear: i32,
     channel: SfxChannel,
 }
 
 impl SfxOutputGain {
-    fn new(base_gain: f32, channel: SfxChannel) -> Self {
-        Self { base_gain, channel }
+    fn new(base_linear: i32, channel: SfxChannel) -> Self {
+        Self {
+            base_linear,
+            channel,
+        }
     }
 
     fn effective(self, scales: SfxOutputScales) -> f32 {
@@ -226,7 +613,10 @@ impl SfxOutputGain {
             SfxChannel::Sound => scales.sound_volume,
             SfxChannel::Voice => scales.voice_volume,
         };
-        self.base_gain * master * scales.lifecycle_scale * scales.focus_output_scale
+        let master_linear = ftol(f64::from(master.clamp(0.0, 1.0)) * f64::from(VOLUME_SCALE));
+        native_volume_amplitude(combine_linear(self.base_linear, master_linear))
+            * scales.lifecycle_scale
+            * scales.focus_output_scale
     }
 }
 
@@ -251,24 +641,24 @@ impl PreparedSfxOutput {
 
 fn prepare_normal_sfx_output(
     decoded: DecodedAudio,
-    base_gain: f32,
+    base_linear: i32,
     scales: SfxOutputScales,
 ) -> PreparedSfxOutput {
     PreparedSfxOutput::new(
         decoded,
-        SfxOutputGain::new(base_gain, SfxChannel::Sound),
+        SfxOutputGain::new(base_linear, SfxChannel::Sound),
         scales,
     )
 }
 
 fn prepare_direct_voice_output(
     decoded: DecodedAudio,
-    base_gain: f32,
+    base_linear: i32,
     scales: SfxOutputScales,
 ) -> PreparedSfxOutput {
     PreparedSfxOutput::new(
         decoded,
-        SfxOutputGain::new(base_gain, SfxChannel::Voice),
+        SfxOutputGain::new(base_linear, SfxChannel::Voice),
         scales,
     )
 }
@@ -317,9 +707,8 @@ pub struct SfxPlayer {
     /// Foreground-owned primary-output gate. Secondary Players stay running so
     /// their playback cursors continue while global output is suppressed.
     focus_output_scale: f32,
-    /// Simple counter used as seed for pseudo-random sound selection.
-    /// Not cryptographic — just needs variety.
-    random_counter: u32,
+    /// Presentation-side RNG standing in for `g_MainRng @ 0x00886B88`.
+    rng: SfxRng,
 }
 
 impl SfxPlayer {
@@ -340,7 +729,7 @@ impl SfxPlayer {
             voice_volume: 0.7,
             output_scale: 1.0,
             focus_output_scale: 1.0,
-            random_counter: 0,
+            rng: SfxRng::from_clock(),
         })
     }
 
@@ -353,11 +742,43 @@ impl SfxPlayer {
         }
     }
 
-    /// Play a sound by its sound.ini ID (e.g., "VGCannon1") or audio.bag name.
+    /// Resolve a registry event to decoded audio: draw the per-play shifts,
+    /// pick the sample sequence, load and chain it, apply the pitch shift.
+    fn resolve_entry(
+        &mut self,
+        entry: &SoundEntry,
+        assets: &AssetManager,
+        audio_indices: &[crate::assets::audio_bag::AudioIndex],
+    ) -> Option<ResolvedPlayback> {
+        resolve_entry_playback(entry, &mut self.rng, |name| {
+            load_sfx(name, assets, audio_indices)
+        })
+    }
+
+    /// Resolve a sound id through the registry, else as a raw audio-bag name
+    /// (EVA lines and other bag-only entries) at full linear volume.
+    fn resolve_any(
+        &mut self,
+        sound_id: &str,
+        registry: &SoundRegistry,
+        assets: &AssetManager,
+        audio_indices: &[crate::assets::audio_bag::AudioIndex],
+    ) -> Option<ResolvedPlayback> {
+        if let Some(entry) = registry.get(sound_id) {
+            return self.resolve_entry(entry, assets, audio_indices);
+        }
+        load_sfx(sound_id, assets, audio_indices).map(|decoded| ResolvedPlayback {
+            decoded,
+            event_linear: VOLUME_SCALE,
+        })
+    }
+
+    /// Play a sound by its sound.ini ID (e.g., "VGCannon1") or audio.bag name,
+    /// non-positionally (full volume, centred).
     ///
     /// Resolution order:
     /// 1. Look up `sound_id` in the SoundRegistry (sound.ini sections)
-    /// 2. If found, pick a filename and load via audio bags then MIX assets
+    /// 2. If found, pick the samples and load via audio bags then MIX assets
     /// 3. If NOT found in registry, try `sound_id` directly as an audio.bag name
     ///    (for EVA sounds and other bag-only entries)
     ///
@@ -369,60 +790,52 @@ impl SfxPlayer {
         assets: &AssetManager,
         audio_indices: &[crate::assets::audio_bag::AudioIndex],
     ) -> bool {
-        // Try SoundRegistry first (sound.ini-based sounds).
-        if let Some(entry) = registry.get(sound_id) {
-            if !entry.sounds.is_empty() {
-                self.random_counter = self.random_counter.wrapping_add(1);
-                let idx: usize = (self.random_counter as usize) % entry.sounds.len();
-                let filename: &str = &entry.sounds[idx];
-
-                if let Some(decoded) = load_sfx(filename, assets, audio_indices) {
-                    let base_gain = entry.volume as f32 / 100.0;
-                    return self.play_decoded(decoded, base_gain);
-                }
-            }
-        }
-
-        // Fallback: try sound_id directly as an audio.bag entry name
-        // (EVA announcements and other sounds not in sound.ini).
-        if let Some(decoded) = load_sfx(sound_id, assets, audio_indices) {
-            return self.play_decoded(decoded, 1.0);
-        }
-
-        log::trace!("SFX: could not resolve '{}'", sound_id);
-        false
+        self.play_sound_spatial(
+            sound_id,
+            SpatialGain::CENTRED_FULL,
+            registry,
+            assets,
+            audio_indices,
+        )
     }
 
-    /// Play a sound with an additional spatial volume multiplier.
-    ///
-    /// Used for positional sounds where volume is scaled by distance from camera.
-    /// The spatial factor (0.0–1.0) is multiplied with the per-sound and master volumes.
+    /// Play a sound with a plain volume multiplier and no pan — the launcher
+    /// beep path, which scales a non-positional cue.
     pub fn play_sound_with_volume(
         &mut self,
         sound_id: &str,
-        spatial_volume: f32,
+        volume: f32,
         registry: &SoundRegistry,
         assets: &AssetManager,
         audio_indices: &[crate::assets::audio_bag::AudioIndex],
     ) -> bool {
-        if let Some(entry) = registry.get(sound_id) {
-            if !entry.sounds.is_empty() {
-                self.random_counter = self.random_counter.wrapping_add(1);
-                let idx = (self.random_counter as usize) % entry.sounds.len();
-                let filename = &entry.sounds[idx];
+        self.play_sound_spatial(
+            sound_id,
+            SpatialGain {
+                volume,
+                pan: PAN_CENTRE,
+            },
+            registry,
+            assets,
+            audio_indices,
+        )
+    }
 
-                if let Some(decoded) = load_sfx(filename, assets, audio_indices) {
-                    let base_gain = entry.volume as f32 / 100.0 * spatial_volume;
-                    return self.play_decoded(decoded, base_gain);
-                }
-            }
-        }
-
-        if let Some(decoded) = load_sfx(sound_id, assets, audio_indices) {
-            return self.play_decoded(decoded, spatial_volume);
-        }
-
-        false
+    /// Play a sound at a positional gain from [`spatial_gain`].
+    pub fn play_sound_spatial(
+        &mut self,
+        sound_id: &str,
+        gain: SpatialGain,
+        registry: &SoundRegistry,
+        assets: &AssetManager,
+        audio_indices: &[crate::assets::audio_bag::AudioIndex],
+    ) -> bool {
+        let Some(resolved) = self.resolve_any(sound_id, registry, assets, audio_indices) else {
+            log::trace!("SFX: could not resolve '{}'", sound_id);
+            return false;
+        };
+        let base_linear = combine_linear(gain.volume_linear(), resolved.event_linear);
+        self.play_decoded(resolved.decoded, base_linear, gain.pan)
     }
 
     /// Play only a named `sound(md).ini` event and never reinterpret its ID as
@@ -430,55 +843,42 @@ impl SfxPlayer {
     /// resolves `[AudioVisual] CloakSound` through `VocClass::FindByName @
     /// 0x007514D0`; a failed lookup preserves the invalid constructor index,
     /// so `StartUncloaking @ 0x007036C0` produces no audible fallback.
-    pub fn play_registered_sound_with_volume(
+    pub fn play_registered_sound_spatial(
         &mut self,
         sound_id: &str,
-        spatial_volume: f32,
+        gain: SpatialGain,
         registry: &SoundRegistry,
         assets: &AssetManager,
         audio_indices: &[crate::assets::audio_bag::AudioIndex],
     ) -> bool {
-        let Some((filename, entry_volume)) =
-            select_registered_sound(sound_id, registry, &mut self.random_counter)
-        else {
+        let Some(entry) = registered_entry(sound_id, registry) else {
             return false;
         };
-        let Some(decoded) = load_sfx(filename, assets, audio_indices) else {
+        let Some(resolved) = self.resolve_entry(entry, assets, audio_indices) else {
             return false;
         };
-        let base_gain = entry_volume as f32 * spatial_volume;
-        self.play_decoded(decoded, base_gain)
+        let base_linear = combine_linear(gain.volume_linear(), resolved.event_linear);
+        self.play_decoded(resolved.decoded, base_linear, gain.pan)
     }
 
     /// Start or replace the sound owned by one animation object.
-    pub fn play_animation_sound_with_volume(
+    pub fn play_animation_sound_spatial(
         &mut self,
         anim_id: u64,
         sound_id: &str,
-        spatial_volume: f32,
+        gain: SpatialGain,
         registry: &SoundRegistry,
         assets: &AssetManager,
         audio_indices: &[crate::assets::audio_bag::AudioIndex],
     ) -> bool {
         self.stop_animation_sound(anim_id);
-        let decoded_and_gain = if let Some(entry) = registry.get(sound_id) {
-            if entry.sounds.is_empty() {
-                None
-            } else {
-                self.random_counter = self.random_counter.wrapping_add(1);
-                let filename = &entry.sounds[(self.random_counter as usize) % entry.sounds.len()];
-                load_sfx(filename, assets, audio_indices).map(|decoded| {
-                    let base_gain = entry.volume as f32 / 100.0 * spatial_volume;
-                    (decoded, base_gain)
-                })
-            }
-        } else {
-            load_sfx(sound_id, assets, audio_indices).map(|decoded| (decoded, spatial_volume))
-        };
-        let Some((decoded, base_gain)) = decoded_and_gain else {
+        let Some(resolved) = self.resolve_any(sound_id, registry, assets, audio_indices) else {
             return false;
         };
-        let prepared = prepare_normal_sfx_output(decoded, base_gain, self.output_scales());
+        let base_linear = combine_linear(gain.volume_linear(), resolved.event_linear);
+        let mut decoded = resolved.decoded;
+        apply_pan(&mut decoded.samples, gain.pan);
+        let prepared = prepare_normal_sfx_output(decoded, base_linear, self.output_scales());
         let PreparedSfxOutput {
             decoded,
             gain,
@@ -508,7 +908,9 @@ impl SfxPlayer {
     /// Play a sound as a unit voice response (VoiceSelect, VoiceMove, VoiceAttack).
     ///
     /// Uses a dedicated voice slot that cuts off the previous voice — unit responses
-    /// don't stack, matching the original engine's behavior.
+    /// don't stack, matching the original engine's behavior. Voices are
+    /// non-positional: `TechnoClass::AI_Update @ 0x006F9EBB` plays them at
+    /// volume 1.0 and pan `0x2000`.
     pub fn play_voice_sound(
         &mut self,
         sound_id: &str,
@@ -517,27 +919,14 @@ impl SfxPlayer {
         audio_indices: &[crate::assets::audio_bag::AudioIndex],
     ) -> bool {
         self.advance_voice_queue();
-
-        // Resolve through registry first, then fallback to bag name.
-        let (decoded, entry_volume) = if let Some(entry) = registry.get(sound_id) {
-            if entry.sounds.is_empty() {
-                return false;
-            }
-            self.random_counter = self.random_counter.wrapping_add(1);
-            let idx = (self.random_counter as usize) % entry.sounds.len();
-            let filename = &entry.sounds[idx];
-            match load_sfx(filename, assets, audio_indices) {
-                Some(d) => (d, entry.volume as f64 / 100.0),
-                None => return false,
-            }
-        } else {
-            match load_sfx(sound_id, assets, audio_indices) {
-                Some(d) => (d, 1.0),
-                None => return false,
-            }
+        let Some(resolved) = self.resolve_any(sound_id, registry, assets, audio_indices) else {
+            return false;
         };
-
-        self.play_voice(decoded, entry_volume as f32, Some(sound_id.to_string()))
+        self.play_voice(
+            resolved.decoded,
+            resolved.event_linear,
+            Some(sound_id.to_string()),
+        )
     }
 
     /// Queue an EVA-style announcement without interrupting the current voice.
@@ -563,15 +952,13 @@ impl SfxPlayer {
             return true;
         }
 
-        let (decoded, entry_volume) =
-            match self.resolve_voice_audio(sound_id, registry, assets, audio_indices) {
-                Some(resolved) => resolved,
-                None => return false,
-            };
+        let Some(resolved) = self.resolve_any(sound_id, registry, assets, audio_indices) else {
+            return false;
+        };
         self.queued_voice.push_back(QueuedVoice::new(
             sound_id.to_string(),
-            decoded,
-            entry_volume as f32,
+            resolved.decoded,
+            resolved.event_linear,
         ));
         self.advance_voice_queue();
         true
@@ -598,12 +985,14 @@ impl SfxPlayer {
             return false;
         }
 
-        let (decoded, entry_volume) =
-            match self.resolve_voice_audio(sound_id, registry, assets, audio_indices) {
-                Some(resolved) => resolved,
-                None => return false,
-            };
-        self.play_voice(decoded, entry_volume as f32, Some(sound_id.to_string()))
+        let Some(resolved) = self.resolve_any(sound_id, registry, assets, audio_indices) else {
+            return false;
+        };
+        self.play_voice(
+            resolved.decoded,
+            resolved.event_linear,
+            Some(sound_id.to_string()),
+        )
     }
 
     /// Replace only the dedicated EVA/voice channel with an INTERRUPT cue.
@@ -624,33 +1013,14 @@ impl SfxPlayer {
         }
         self.current_voice_id = None;
 
-        let (decoded, entry_volume) =
-            match self.resolve_voice_audio(sound_id, registry, assets, audio_indices) {
-                Some(resolved) => resolved,
-                None => return false,
-            };
-        self.play_voice(decoded, entry_volume as f32, Some(sound_id.to_string()))
-    }
-
-    fn resolve_voice_audio(
-        &mut self,
-        sound_id: &str,
-        registry: &SoundRegistry,
-        assets: &AssetManager,
-        audio_indices: &[crate::assets::audio_bag::AudioIndex],
-    ) -> Option<(DecodedAudio, f64)> {
-        if let Some(entry) = registry.get(sound_id) {
-            if entry.sounds.is_empty() {
-                return None;
-            }
-            self.random_counter = self.random_counter.wrapping_add(1);
-            let idx = (self.random_counter as usize) % entry.sounds.len();
-            let filename = &entry.sounds[idx];
-            return load_sfx(filename, assets, audio_indices)
-                .map(|decoded| (decoded, entry.volume as f64 / 100.0));
-        }
-
-        load_sfx(sound_id, assets, audio_indices).map(|decoded| (decoded, 1.0))
+        let Some(resolved) = self.resolve_any(sound_id, registry, assets, audio_indices) else {
+            return false;
+        };
+        self.play_voice(
+            resolved.decoded,
+            resolved.event_linear,
+            Some(sound_id.to_string()),
+        )
     }
 
     /// Starts the next queued EVA cue if the dedicated voice slot is idle.
@@ -676,10 +1046,10 @@ impl SfxPlayer {
     fn play_voice(
         &mut self,
         decoded: DecodedAudio,
-        base_gain: f32,
+        base_linear: i32,
         sound_id: Option<String>,
     ) -> bool {
-        let prepared = prepare_direct_voice_output(decoded, base_gain, self.output_scales());
+        let prepared = prepare_direct_voice_output(decoded, base_linear, self.output_scales());
         self.play_prepared_voice(prepared, sound_id)
     }
 
@@ -725,9 +1095,11 @@ impl SfxPlayer {
         true
     }
 
-    /// Play already-decoded audio on the SFX pool at the given master-independent gain.
-    fn play_decoded(&mut self, decoded: DecodedAudio, base_gain: f32) -> bool {
-        let prepared = prepare_normal_sfx_output(decoded, base_gain, self.output_scales());
+    /// Play already-decoded audio on the SFX pool at the given master-independent
+    /// linear volume and pan.
+    fn play_decoded(&mut self, mut decoded: DecodedAudio, base_linear: i32, pan: i32) -> bool {
+        apply_pan(&mut decoded.samples, pan);
+        let prepared = prepare_normal_sfx_output(decoded, base_linear, self.output_scales());
         let PreparedSfxOutput {
             mut decoded,
             gain,
@@ -880,18 +1252,44 @@ impl SfxPlayer {
     }
 }
 
-fn select_registered_sound<'a>(
-    sound_id: &str,
-    registry: &'a SoundRegistry,
-    random_counter: &mut u32,
-) -> Option<(&'a str, f64)> {
-    let entry = registry.get(sound_id)?;
+/// The registry entry for a Voc identity, or `None` for an unknown name — a
+/// raw sample name is not an event.
+fn registered_entry<'a>(sound_id: &str, registry: &'a SoundRegistry) -> Option<&'a SoundEntry> {
+    registry.get(sound_id)
+}
+
+/// Device-free core of one play request: draw the shifts, select the
+/// samples, load and chain them, apply the pitch shift, and combine the entry
+/// volume with the `VShift=` reduction into the event's linear volume.
+fn resolve_entry_playback(
+    entry: &SoundEntry,
+    rng: &mut impl SampleRng,
+    mut load: impl FnMut(&str) -> Option<DecodedAudio>,
+) -> Option<ResolvedPlayback> {
     if entry.sounds.is_empty() {
         return None;
     }
-    *random_counter = random_counter.wrapping_add(1);
-    let filename = &entry.sounds[(*random_counter as usize) % entry.sounds.len()];
-    Some((filename, entry.volume as f64 / 100.0))
+    let shifts = PlayShifts::draw(entry, rng);
+    let order = select_playout(entry, rng);
+    let mut decoded: Option<DecodedAudio> = None;
+    for index in order {
+        let Some(name) = entry.sounds.get(index) else {
+            continue;
+        };
+        let Some(clip) = load(name) else {
+            continue;
+        };
+        match decoded.as_mut() {
+            Some(chain) => chain.append(clip),
+            None => decoded = Some(clip),
+        }
+    }
+    let mut decoded = decoded?;
+    decoded.sample_rate = shifts.shifted_sample_rate(decoded.sample_rate);
+    Some(ResolvedPlayback {
+        decoded,
+        event_linear: combine_linear(entry.volume_linear, shifts.volume_linear()),
+    })
 }
 
 /// Load a sound effect file and decode it to interleaved f32 stereo samples.
@@ -1248,30 +1646,362 @@ mod tests {
     use super::*;
     use crate::rules::ini_parser::IniFile;
 
+    /// A scripted RNG: hands out the listed draws in order and records every
+    /// request so a test can pin the native draw sequence.
+    struct ScriptedRng {
+        draws: Vec<i32>,
+        requests: Vec<(i32, i32)>,
+    }
+
+    impl ScriptedRng {
+        fn new(draws: &[i32]) -> Self {
+            Self {
+                draws: draws.iter().rev().copied().collect(),
+                requests: Vec::new(),
+            }
+        }
+    }
+
+    impl SampleRng for ScriptedRng {
+        fn ranged(&mut self, low: i32, high: i32) -> i32 {
+            if low == high {
+                return low;
+            }
+            self.requests.push((low, high));
+            self.draws.pop().unwrap_or(low)
+        }
+    }
+
+    fn entry(body: &str) -> SoundEntry {
+        let registry = SoundRegistry::from_ini(&IniFile::from_str(body));
+        registry.get("T").expect("entry").clone()
+    }
+
+    const LISTENER_W: i32 = 1024;
+    const LISTENER_H: i32 = 600;
+
+    fn source(range_cells: i32, type_flags: u32, min_volume: f32) -> SpatialSource {
+        SpatialSource {
+            range_cells,
+            type_flags,
+            min_volume,
+        }
+    }
+
+    fn gain(client_x: i32, client_y: i32, src: SpatialSource) -> Option<SpatialGain> {
+        calc_volume_and_pan(client_x, client_y, LISTENER_W, LISTENER_H, src, false)
+    }
+
+    /// Vectors walked through the `0x00750AC0` transcription: a 1024x600
+    /// tactical view (halfW 512, halfH 300, fullW 1024) and Range 10
+    /// (maxRange 600).
+    #[test]
+    fn calc_volume_and_pan_screen_type_matches_the_native_transcription() {
+        let screen = source(10, sound_type::SCREEN, 0.5);
+        // View centre: on screen is full volume, centred pan.
+        assert_eq!(
+            gain(512, 300, screen),
+            Some(SpatialGain {
+                volume: 1.0,
+                pan: PAN_CENTRE
+            })
+        );
+        // Anywhere on screen is still full volume; pan follows the offset.
+        let edge = gain(1023, 599, screen).unwrap();
+        assert_eq!(edge.volume, 1.0);
+        assert_eq!(edge.pan, ftol(511.0 * 8192.0 / 1024.0 + 8192.0));
+        // 300 px right of the view edge: half volume, pan 8192 + 812 * 8.
+        assert_eq!(
+            gain(1324, 300, screen),
+            Some(SpatialGain {
+                volume: 0.5,
+                pan: 14688
+            })
+        );
+        // Y distances count double: 100 px below the view edge is 200.
+        assert_eq!(gain(512, 700, screen).unwrap().volume, 400.0 / 600.0);
+        // The larger axis wins: 200 px right (200) vs 150 px below (300).
+        assert_eq!(gain(1224, 750, screen).unwrap().volume, 300.0 / 600.0);
+        // Below the 0.05 cutoff is silent; just above is not.
+        assert_eq!(gain(1600, 300, screen), None);
+        assert_eq!(gain(1584, 300, screen).unwrap().volume, 40.0 / 600.0);
+        // At and beyond maxRange the volume is exactly 0 (silent).
+        assert_eq!(gain(1624, 300, screen), None);
+        assert_eq!(gain(-1000, 300, screen), None);
+        // A zero range is never audible.
+        assert_eq!(gain(512, 300, source(0, sound_type::SCREEN, 0.0)), None);
+    }
+
+    #[test]
+    fn calc_volume_and_pan_local_global_and_shroud_gates() {
+        // LOCAL skips the half-view subtraction: 100 px from centre is 100.
+        let local = source(10, sound_type::LOCAL, 0.5);
+        assert_eq!(gain(612, 300, local).unwrap().volume, 500.0 / 600.0);
+        // LOCAL with a large range reaches the pan clamps at both ends.
+        let far = source(100, sound_type::LOCAL, 0.0);
+        assert_eq!(gain(-1500, 300, far).unwrap().pan, 0);
+        assert_eq!(gain(3000, 300, far).unwrap().pan, PAN_SCALE);
+        // GLOBAL raises a 10/600 volume to the MinVolume floor; SCREEN alone
+        // falls below the cutoff instead.
+        let global = source(10, sound_type::SCREEN | sound_type::GLOBAL, 0.5);
+        assert_eq!(gain(1614, 300, global).unwrap().volume, 0.5);
+        assert_eq!(gain(1614, 300, source(10, sound_type::SCREEN, 0.5)), None);
+        // GLOBAL keeps a louder computed volume.
+        assert_eq!(gain(1324, 300, global).unwrap().volume, 0.5);
+        assert_eq!(gain(1224, 300, global).unwrap().volume, 400.0 / 600.0);
+        // SHROUD silences a shrouded cell only when the flag is set.
+        let shroud = source(10, sound_type::SCREEN | sound_type::SHROUD, 0.5);
+        assert_eq!(
+            calc_volume_and_pan(512, 300, LISTENER_W, LISTENER_H, shroud, true),
+            None
+        );
+        assert!(calc_volume_and_pan(512, 300, LISTENER_W, LISTENER_H, shroud, false).is_some());
+        let unshrouded = source(10, sound_type::SCREEN | sound_type::UNSHROUD, 0.5);
+        assert!(calc_volume_and_pan(512, 300, LISTENER_W, LISTENER_H, unshrouded, true).is_some());
+    }
+
+    /// Odd view widths put the centre on a half pixel; the distances are
+    /// `ftol`-truncated before `abs`, the pan offset is not.
+    #[test]
+    fn calc_volume_and_pan_truncates_distances_like_ftol() {
+        let src = source(10, sound_type::LOCAL, 0.0);
+        // clientX - 511.5 = 0.5 -> ftol 0 -> full volume; pan keeps the 0.5.
+        let g = calc_volume_and_pan(512, 300, 1023, LISTENER_H, src, false).unwrap();
+        assert_eq!(g.volume, 1.0);
+        assert_eq!(g.pan, ftol(0.5 * 8192.0 / 1023.0 + 8192.0));
+        // clientX - 511.5 = -0.5 -> ftol 0 as well (truncation toward zero).
+        let g = calc_volume_and_pan(511, 300, 1023, LISTENER_H, src, false).unwrap();
+        assert_eq!(g.volume, 1.0);
+        assert_eq!(g.pan, ftol(-0.5 * 8192.0 / 1023.0 + 8192.0));
+    }
+
+    #[test]
+    fn spatial_listener_projects_world_pixels_to_client_points() {
+        let listener = SpatialListener {
+            tactical_width: LISTENER_W,
+            tactical_height: LISTENER_H,
+            origin_x: 1000.25,
+            origin_y: 2000.0,
+        };
+        assert_eq!(listener.client_point(1512.25, 2300.0), (512, 300));
+        assert_eq!(listener.client_point(999.75, 1999.0), (0, -1));
+        let src = source(10, sound_type::SCREEN, 0.5);
+        assert_eq!(
+            spatial_gain(src, 1512.25, 2300.0, &listener, false),
+            Some(SpatialGain {
+                volume: 1.0,
+                pan: PAN_CENTRE
+            })
+        );
+    }
+
+    #[test]
+    fn spatial_gain_volume_linear_is_ftol_capped_at_the_scale() {
+        assert_eq!(SpatialGain::CENTRED_FULL.volume_linear(), VOLUME_SCALE);
+        let half = SpatialGain {
+            volume: 0.5,
+            pan: PAN_CENTRE,
+        };
+        assert_eq!(half.volume_linear(), 8192);
+        let odd = SpatialGain {
+            volume: 400.0 / 600.0,
+            pan: PAN_CENTRE,
+        };
+        assert_eq!(
+            odd.volume_linear(),
+            ftol(f64::from(400.0f32 / 600.0) * 16384.0)
+        );
+    }
+
+    /// The `0x00816380` table (machine-read) against `round(1000 * log2(i /
+    /// 100))` and the index arithmetic of `FUN_0040A6D0`.
+    #[test]
+    fn dsound_attenuation_table_and_index_follow_the_binary() {
+        for (i, &entry) in DSOUND_ATTENUATION_TABLE.iter().enumerate().skip(1) {
+            let expected = (1000.0 * (i as f64 / 100.0).log2()).round() as i16;
+            assert_eq!(entry, expected, "table[{i}]");
+        }
+        assert_eq!(DSOUND_ATTENUATION_TABLE[0], -10000);
+        assert_eq!(DSOUND_ATTENUATION_TABLE[100], 0);
+        assert_eq!(native_volume_amplitude(VOLUME_SCALE), 1.0);
+        assert!((native_volume_amplitude(8192) - 10f32.powf(-0.5)).abs() < 1e-6);
+        assert_eq!(native_volume_amplitude(0), 0.0);
+        // 16383 * 25 >> 12 = 99, so anything short of full scale loses 0.14 dB.
+        assert!((native_volume_amplitude(16383) - 10f32.powf(-14.0 / 2000.0)).abs() < 1e-6);
+        assert_eq!(combine_linear(13107, VOLUME_SCALE), 13107);
+        assert_eq!(combine_linear(8192, 8192), 4096);
+        assert_eq!(combine_linear(VOLUME_SCALE, VOLUME_SCALE), VOLUME_SCALE);
+    }
+
+    #[test]
+    fn pan_channel_gains_attenuate_the_far_side_through_the_table() {
+        assert_eq!(pan_channel_gains(PAN_CENTRE), (1.0, 1.0));
+        // Full right: p = 100, the left channel takes table[0].
+        assert_eq!(pan_channel_gains(PAN_SCALE), (0.0, 1.0));
+        assert_eq!(pan_channel_gains(0), (1.0, 0.0));
+        // 12288 -> 150 - 100 = 50 -> left attenuated by table[50] = -10 dB.
+        let (left, right) = pan_channel_gains(12288);
+        assert!((left - 10f32.powf(-0.5)).abs() < 1e-6);
+        assert_eq!(right, 1.0);
+        let (left, right) = pan_channel_gains(4096);
+        assert_eq!(left, 1.0);
+        assert!((right - 10f32.powf(-0.5)).abs() < 1e-6);
+        let mut samples = vec![1.0, 1.0, 0.5, 0.5];
+        apply_pan(&mut samples, 12288);
+        assert!((samples[0] - 10f32.powf(-0.5)).abs() < 1e-6);
+        assert_eq!(samples[1], 1.0);
+        assert_eq!(samples[3], 0.5);
+    }
+
+    #[test]
+    fn play_shifts_draw_fshift_vshift_then_predelay_in_native_order() {
+        let e = entry(
+            "[T]\nSounds=a\nFShift= -10 10\nVShift=20\nControl= random predelay\nDelay=0 400\n",
+        );
+        let mut rng = ScriptedRng::new(&[7, 13, 250]);
+        let shifts = PlayShifts::draw(&e, &mut rng);
+        assert_eq!(rng.requests, vec![(-10, 10), (0, 20), (0, 400)]);
+        assert_eq!(shifts.frequency_pct, 107);
+        assert_eq!(shifts.volume_shift_pct, 13);
+        // 0x4000 - (13 << 14) / 100 = 16384 - 2129.
+        assert_eq!(shifts.volume_linear(), 16384 - 2129);
+        assert_eq!(shifts.shifted_sample_rate(22050), 22050 * 107 / 100);
+
+        // AMBIENT pre-delays draw from 0x21 regardless of Delay.min.
+        let ambient = entry("[T]\nSounds=a\nControl= loop ambient\nDelay=5000 8000\n");
+        let mut rng = ScriptedRng::new(&[6000]);
+        let shifts = PlayShifts::draw(&ambient, &mut rng);
+        assert_eq!(rng.requests, vec![(0x21, 8000)]);
+        assert_eq!(shifts.frequency_pct, 100);
+        assert_eq!(shifts.volume_linear(), VOLUME_SCALE);
+        assert_eq!(shifts.shifted_sample_rate(22050), 22050);
+
+        // No shifts, no pre-delay control: nothing is drawn.
+        let plain = entry("[T]\nSounds=a\nDelay=0 400\n");
+        let mut rng = ScriptedRng::new(&[]);
+        PlayShifts::draw(&plain, &mut rng);
+        assert!(rng.requests.is_empty());
+    }
+
+    /// `Control=random` over three samples: one `RandomRanged(0, 2)` draw and
+    /// the equal-bounds pick that follows draws nothing.
+    #[test]
+    fn select_playout_random_picks_one_body_sample() {
+        let e = entry("[T]\nSounds=a b c\nControl=random\n");
+        let mut rng = ScriptedRng::new(&[1]);
+        assert_eq!(select_playout(&e, &mut rng), vec![1]);
+        assert_eq!(rng.requests, vec![(0, 2)]);
+    }
+
+    /// Without `random` the first body sample always plays — there is no
+    /// round-robin — and `all` plays the whole body in order.
+    #[test]
+    fn select_playout_sequential_forms_play_first_or_all() {
+        let first = entry("[T]\nSounds=a b c\n");
+        let mut rng = ScriptedRng::new(&[]);
+        assert_eq!(select_playout(&first, &mut rng), vec![0]);
+        assert_eq!(select_playout(&first, &mut rng), vec![0]);
+        assert!(rng.requests.is_empty());
+
+        let all = entry("[T]\nSounds=a b c\nControl=all\n");
+        assert_eq!(select_playout(&all, &mut rng), vec![0, 1, 2]);
+        assert!(rng.requests.is_empty());
+    }
+
+    /// `random all`: the body is loaded whole and played in pick-and-remove
+    /// order, `RandomRanged(0, remaining - 1)` each step.
+    #[test]
+    fn select_playout_random_all_shuffles_by_pick_and_remove() {
+        let e = entry("[T]\nSounds=a b c\nControl= random all\n");
+        let mut rng = ScriptedRng::new(&[2, 0]);
+        assert_eq!(select_playout(&e, &mut rng), vec![2, 0, 1]);
+        assert_eq!(rng.requests, vec![(0, 2), (0, 1)]);
+    }
+
+    /// Attack/decay envelopes: a random attack sample first, the body, and a
+    /// random decay sample last, with the native draw order.
+    #[test]
+    fn select_playout_attack_body_decay_order_and_draws() {
+        let e = entry(
+            "[T]\nSounds=a1 a2 a3 b1 b2 d1 d2 d3\nControl= random all attack decay\nAttack=3\nDecay=3\n",
+        );
+        let mut rng = ScriptedRng::new(&[1, 6, 1]);
+        assert_eq!(select_playout(&e, &mut rng), vec![1, 4, 3, 6]);
+        assert_eq!(rng.requests, vec![(0, 2), (5, 7), (0, 1)]);
+
+        let single =
+            entry("[T]\nSounds=a b1 b2 d\nControl= random attack decay\nAttack=1\nDecay=1\n");
+        // Attack 1 and Decay 1 are equal-bounds draws: only the body draws.
+        let mut rng = ScriptedRng::new(&[2]);
+        assert_eq!(select_playout(&single, &mut rng), vec![0, 2, 3]);
+        assert_eq!(rng.requests, vec![(1, 2)]);
+    }
+
+    fn clip(value: f32, frames: usize, sample_rate: u32) -> DecodedAudio {
+        DecodedAudio {
+            samples: vec![value; frames * 2],
+            sample_rate,
+            channels: 2,
+        }
+    }
+
+    #[test]
+    fn resolve_entry_playback_chains_samples_and_applies_the_shifts() {
+        let e = entry("[T]\nSounds=a b c\nVolume=80\nControl= all\nFShift=10 10\nVShift=50\n");
+        let mut rng = ScriptedRng::new(&[50]);
+        let resolved = resolve_entry_playback(&e, &mut rng, |name| match name {
+            "a" => Some(clip(0.1, 2, 22050)),
+            "b" => None,
+            "c" => Some(clip(0.3, 1, 22050)),
+            _ => unreachable!(),
+        })
+        .expect("resolved");
+        assert_eq!(resolved.decoded.samples, vec![0.1, 0.1, 0.1, 0.1, 0.3, 0.3]);
+        assert_eq!(resolved.decoded.sample_rate, 22050 * 110 / 100);
+        // Volume=80 -> 13107; VShift draw 50 -> 16384 - 8192; combined >> 14.
+        assert_eq!(resolved.event_linear, combine_linear(13107, 8192));
+        assert_eq!(rng.requests, vec![(0, 50)]);
+
+        // A rate mismatch keeps the first clip only.
+        let mut rng = ScriptedRng::new(&[0]);
+        let resolved = resolve_entry_playback(&e, &mut rng, |name| match name {
+            "a" => Some(clip(0.1, 1, 22050)),
+            _ => Some(clip(0.2, 1, 11025)),
+        })
+        .expect("resolved");
+        assert_eq!(resolved.decoded.samples, vec![0.1, 0.1]);
+
+        // Nothing loadable resolves to nothing.
+        assert!(resolve_entry_playback(&e, &mut rng, |_| None).is_none());
+    }
+
     #[test]
     fn cloak_sound_registered_resolution_rejects_raw_sample_and_invalid_names() {
         let registry = SoundRegistry::from_ini(&IniFile::from_str(
             "[NavalUnitEmerge]\nSounds=vnavupa\nVolume=55\n",
         ));
-        let mut counter = 0;
-
-        assert_eq!(
-            select_registered_sound("NavalUnitEmerge", &registry, &mut counter),
-            Some(("vnavupa", 0.55)),
-            "the retail Voc/event identity resolves to its registered sample"
-        );
-        assert_eq!(counter, 1);
+        let entry = registered_entry("NavalUnitEmerge", &registry)
+            .expect("the retail Voc/event identity resolves to its registered entry");
+        assert_eq!(entry.sounds, vec!["vnavupa"]);
+        assert_eq!(entry.volume_linear, 9011); // ftol(0.55f * 16384)
         for invalid in ["", "MissingCloakEvent", "vnavupa"] {
-            assert_eq!(
-                select_registered_sound(invalid, &registry, &mut counter),
-                None,
+            assert!(
+                registered_entry(invalid, &registry).is_none(),
                 "an invalid Voc identity must not become a raw-bag fallback: {invalid}"
             );
         }
-        assert_eq!(
-            counter, 1,
-            "rejected identities do not advance sound selection"
-        );
+    }
+
+    #[test]
+    fn sfx_rng_honours_inclusive_bounds_and_equal_bounds() {
+        let mut rng = SfxRng::seeded(42);
+        assert_eq!(rng.ranged(5, 5), 5);
+        for _ in 0..1000 {
+            let draw = rng.ranged(0, 2);
+            assert!((0..=2).contains(&draw));
+            let reversed = rng.ranged(3, -3);
+            assert!((-3..=3).contains(&reversed));
+        }
     }
 
     fn test_decoded_audio() -> DecodedAudio {
@@ -1299,14 +2029,20 @@ mod tests {
     #[test]
     fn gsi_01_02_focus_gate_restores_distinct_live_sfx_gains_absolutely() {
         let inactive = test_output_scales(1.0, 0.4, 0.6, 0.0);
-        let quiet = prepare_normal_sfx_output(test_decoded_audio(), 0.2, inactive);
-        let loud = prepare_normal_sfx_output(test_decoded_audio(), 0.75, inactive);
+        let quiet = prepare_normal_sfx_output(test_decoded_audio(), 3277, inactive);
+        let loud = prepare_normal_sfx_output(test_decoded_audio(), 12288, inactive);
 
         assert_eq!(quiet.initial_volume, 0.0);
         assert_eq!(loud.initial_volume, 0.0);
         let active = test_output_scales(1.0, 0.4, 0.6, 1.0);
-        assert!((quiet.gain.effective(active) - 0.12).abs() < f32::EPSILON);
-        assert!((loud.gain.effective(active) - 0.45).abs() < f32::EPSILON);
+        assert!(
+            (quiet.gain.effective(active) - native_volume_amplitude(3277) * 0.6).abs()
+                < f32::EPSILON
+        );
+        assert!(
+            (loud.gain.effective(active) - native_volume_amplitude(12288) * 0.6).abs()
+                < f32::EPSILON
+        );
     }
 
     #[test]
@@ -1315,7 +2051,7 @@ mod tests {
         // production path; only this independently retained output gain is 0.
         let armed_while_inactive = prepare_normal_sfx_output(
             test_decoded_audio(),
-            0.35,
+            5734,
             test_output_scales(1.0, 0.4, 1.0, 0.0),
         );
 
@@ -1324,24 +2060,33 @@ mod tests {
             (armed_while_inactive
                 .gain
                 .effective(test_output_scales(1.0, 0.4, 1.0, 1.0))
-                - 0.35)
-                .abs()
+                - native_volume_amplitude(5734))
+            .abs()
                 < f32::EPSILON
         );
     }
 
+    /// The user master is chained into the linear product before the
+    /// DirectSound curve, so half master is -10 dB, not half amplitude.
     #[test]
     fn options_profile_production_routes_sound_and_direct_voice_independently() {
+        let half = native_volume_amplitude(8192);
         for (sound_volume, voice_volume, expected_sound, expected_voice) in
-            [(0.0, 1.0, 0.0, 0.5), (1.0, 0.0, 0.5, 0.0)]
+            [(0.0, 1.0, 0.0, half), (1.0, 0.0, half, 0.0)]
         {
             let scales = test_output_scales(sound_volume, voice_volume, 1.0, 1.0);
-            let sound = prepare_normal_sfx_output(test_decoded_audio(), 0.5, scales);
-            let direct_voice = prepare_direct_voice_output(test_decoded_audio(), 0.5, scales);
+            let sound = prepare_normal_sfx_output(test_decoded_audio(), 8192, scales);
+            let direct_voice = prepare_direct_voice_output(test_decoded_audio(), 8192, scales);
 
             assert_eq!(sound.initial_volume, expected_sound);
             assert_eq!(direct_voice.initial_volume, expected_voice);
         }
+        let full = prepare_normal_sfx_output(
+            test_decoded_audio(),
+            VOLUME_SCALE,
+            test_output_scales(0.5, 1.0, 1.0, 1.0),
+        );
+        assert_eq!(full.initial_volume, half);
     }
 
     #[test]
@@ -1349,14 +2094,17 @@ mod tests {
         // QueuedVoice retains no master snapshot. The scales supplied by the
         // production dequeue seam alone decide the startup volume.
         let queued_for_voice_enabled_dequeue =
-            QueuedVoice::new("eva-a".to_string(), test_decoded_audio(), 0.8);
+            QueuedVoice::new("eva-a".to_string(), test_decoded_audio(), 13107);
         let (sound_id, started_with_voice_enabled) = queued_for_voice_enabled_dequeue
             .prepare_for_dequeue(test_output_scales(0.0, 1.0, 1.0, 1.0));
         assert_eq!(sound_id, "eva-a");
-        assert!((started_with_voice_enabled.initial_volume - 0.8).abs() < f32::EPSILON);
+        assert!(
+            (started_with_voice_enabled.initial_volume - native_volume_amplitude(13107)).abs()
+                < f32::EPSILON
+        );
 
         let queued_for_voice_muted_dequeue =
-            QueuedVoice::new("eva-b".to_string(), test_decoded_audio(), 0.8);
+            QueuedVoice::new("eva-b".to_string(), test_decoded_audio(), 13107);
         let (sound_id, started_with_voice_muted) = queued_for_voice_muted_dequeue
             .prepare_for_dequeue(test_output_scales(1.0, 0.0, 1.0, 1.0));
         assert_eq!(sound_id, "eva-b");

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -77,23 +77,63 @@ const MIN_VOLUME_CUTOFF: f64 = 0.05;
 
 /// Truncating `Math::ftol @ 0x007C5F00` (control word `0x0E7F`: round toward
 /// zero, 53-bit precision), applied to a double intermediate.
+///
+/// RESIDUAL (UNCHECKED) — out-of-`i32` inputs differ: `FISTP` stores the x87
+/// indefinite `0x80000000` for both signs, while Rust's `as i32` saturates to
+/// `i32::MIN` *or* `i32::MAX`. Trigger: a client point more than 2^31 pixels
+/// from the view centre. Player effect: none — the largest YR map is under
+/// 2^16 pixels across, so only a hand-built [`SpatialListener`] reaches it.
+/// Frequency: never in play. Downstream risk: none.
 fn ftol(value: f64) -> i32 {
     value.trunc() as i32
 }
 
-/// The listener: the tactical view rect in native pixels and its top-left in
-/// the same world-pixel frame the sound positions use.
+/// Native integer absolute value: `CDQ; XOR EAX,EDX; SUB EAX,EDX`
+/// (`0x00750BCF..0x00750BD2` and `0x00750BED..0x00750BF0`). The idiom **wraps**
+/// — `i32::MIN` comes back as `i32::MIN` — where Rust's `i32::abs` panics in a
+/// debug build, so the transcription must use the wrapping form.
+fn native_abs(value: i32) -> i32 {
+    value.wrapping_abs()
+}
+
+/// The listener: the tactical view rect and its top-left in the world-pixel
+/// frame the sound positions use.
 ///
 /// gamemd-derived: `CalcVolumeAndPan` reads the width/height globals
 /// `0x00886FA8`/`0x00886FAC` (written by `Set_View_Dimensions`) and projects
 /// the sound through `TacticalClass::CoordsToClient2 @ 0x006D2140`, which
-/// subtracts the view origin (`this+0xB0/+0xB4`).
+/// scales leptons by the fixed native 60/30-pixel tile (`iVar3 = (x*0x3c)/2 +
+/// (y*-0x3c)/2`, `>> 8`) and subtracts the view origin (`this+0xB0/+0xB4`).
+/// That fixed scale is VERA's world-pixel frame — `map::terrain::TILE_WIDTH`
+/// 60, `TILE_HEIGHT` 30 — so at `zoom == 1.0` `client_point` is the native
+/// client point exactly.
+///
+/// **Zoom is VERA-internal; gamemd has no zoom.** `tactical_width`/`_height`
+/// are the *device* pixels of the tactical viewport, and VERA's projection is
+/// `device = (world - camera) * zoom`, so the viewport spans
+/// `device / zoom` world pixels ([`SpatialListener::view_extent`]). Every
+/// operand handed to [`calc_volume_and_pan`] is therefore expressed in the
+/// world-pixel frame: the client point, the view extent, and `Range * 60`
+/// alike. Scaling the *client point* into device pixels instead would be the
+/// same algebra for the falloff shape and the pan, but it would silently
+/// redefine `Range=` — a cell count in `sound(md).ini` — as a device-pixel
+/// budget, so a `Range=10` cue would carry 2.5 cells at 4x zoom. Keeping the
+/// world frame makes zoom behave like a native resolution change, which is
+/// the only zoom-like thing gamemd actually does: a bigger view rect covers
+/// more world, while `Range` stays a fixed cell distance.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SpatialListener {
+    /// Tactical viewport width in device pixels (native `0x00886FA8`).
     pub tactical_width: i32,
+    /// Tactical viewport height in device pixels (native `0x00886FAC`).
     pub tactical_height: i32,
+    /// World-pixel position of the viewport's top-left corner.
     pub origin_x: f32,
+    /// World-pixel position of the viewport's top-left corner.
     pub origin_y: f32,
+    /// VERA-internal camera zoom (`app::input::camera`, 0.25..=4.0, default
+    /// 1.0). `1.0` reproduces gamemd bit for bit.
+    pub zoom: f32,
 }
 
 impl SpatialListener {
@@ -103,6 +143,24 @@ impl SpatialListener {
         (
             ftol(f64::from(screen_x) - f64::from(self.origin_x)),
             ftol(f64::from(screen_y) - f64::from(self.origin_y)),
+        )
+    }
+
+    /// The tactical view size in the same world-pixel frame as
+    /// [`Self::client_point`]. At `zoom == 1.0` this is the native
+    /// `(float)[0x00886FA8]` / `(float)[0x00886FAC]` cast unchanged (dividing
+    /// by exactly 1.0 is exact in IEEE-754).
+    ///
+    /// VERA-internal, gamemd equivalent UNCHECKED: the `max(EPSILON)` floor.
+    /// `zoom_level` is clamped to `MIN_ZOOM` 0.25 in `app::input::camera`, so
+    /// nothing in the app can reach it; it only stops a hand-built listener
+    /// from dividing by zero. Same guard the visible-bounds code already uses
+    /// (`presentation::instances::helpers`).
+    pub fn view_extent(&self) -> (f32, f32) {
+        let zoom = self.zoom.max(f32::EPSILON);
+        (
+            self.tactical_width as f32 / zoom,
+            self.tactical_height as f32 / zoom,
         )
     }
 }
@@ -170,9 +228,24 @@ impl SpatialGain {
 /// - `Type=SHROUD` (`0x800`): a sound in a cell whose shroud flags
 ///   (`CellClass+0x12C & 0x18`) are both clear returns 0 (`0x00750B2D..
 ///   0x00750BAA`). The cell test is the caller's: `shrouded`.
+///   RESIDUAL — the sentinel-cell early-out ahead of it is not modelled.
+///   `0x00750B51 CMP CX,[0x00b1d310]` / `0x00750B6C CMP AX,[0x00b1d312]`
+///   return 0.0f when the sound's cell equals that `CellStruct` pair, i.e.
+///   *before* the `CellClass` lookup at `0x00750B8F`. `get_xrefs_to` on both
+///   words shows one read (this site) and one write — the three-instruction
+///   setter at `0x007502B0` (`XOR EAX,EAX; MOV [0x00b1d310],AX; MOV
+///   [0x00b1d312],AX`), reached only through the vtable slot at `0x0081562C`
+///   — and the image bytes are already `00 00 00 00`, so the pair is the null
+///   cell `(0,0)` for the whole process lifetime. Trigger: a `Type=SHROUD`
+///   cue whose object sits on map cell `(0,0)`. Player effect: that one cue is
+///   silent. Frequency: never in ordinary play — cell `(0,0)` is outside every
+///   map's playable rectangle, and the 11 stock `SHROUD` cues are super-weapon
+///   ready/open sounds that VERA does not emit yet. Downstream risk: none; it
+///   is an early-out, so modelling it can only add silence.
 /// - `offsetX = clientX - halfW` kept as float (`FST [ESP+0x10]`); the
 ///   distances are `|ftol(clientX - halfW)|` and `|ftol(clientY - halfH)|`
-///   (`0x00750BBE..0x00750BF6`).
+///   (`0x00750BBE..0x00750BF6`), the abs taken by the wrapping `CDQ; XOR; SUB`
+///   idiom ([`native_abs`]).
 /// - Unless `Type=LOCAL` (`0x40`): subtract the half view from each and clamp
 ///   at 0 (`0x00750BFA..0x00750C37`). Then `distY *= 2` (`0x00750C3D`).
 /// - `volume = (maxRange - max(distX, distY)) / maxRange` only when both are
@@ -184,17 +257,27 @@ impl SpatialGain {
 /// - `pan = ftol(clamp(offsetX, -fullW, fullW) * 8192 / fullW + 8192)`
 ///   (`0x00750CDE..0x00750D24`); the `FCHS` builds `-fullW`, it does not
 ///   negate the offset.
+///
+/// `tactical_width`/`tactical_height` and `client_x`/`client_y` must be in the
+/// same pixel frame — see [`SpatialListener::view_extent`], which is what puts
+/// them there under VERA's zoom. Native passes the integer view globals here;
+/// an integral `f32` reproduces the `(float)` cast exactly.
 pub fn calc_volume_and_pan(
     client_x: i32,
     client_y: i32,
-    tactical_width: i32,
-    tactical_height: i32,
+    tactical_width: f32,
+    tactical_height: f32,
     source: SpatialSource,
     shrouded: bool,
 ) -> Option<SpatialGain> {
-    let half_w: f32 = tactical_width as f32 * 0.5;
-    let half_h: f32 = tactical_height as f32 * 0.5;
+    let half_w: f32 = tactical_width * 0.5;
+    let half_h: f32 = tactical_height * 0.5;
     let full_w: f32 = half_w + half_w;
+    // `LEA EAX,[EAX+EAX*2]; LEA EAX,[EAX+EAX*4]; SHL EAX,2` at
+    // `0x00750B0F..0x00750B17` — a 32-bit ×60 that wraps rather than trapping.
+    // `SoundEntry::range` is a `u16`, so the product cannot exceed 3_932_100;
+    // `wrapping_mul` is here to keep a hand-built `SpatialSource` on the
+    // native truncation instead of a debug-build panic.
     let max_range: f32 = (source.range_cells.wrapping_mul(RANGE_MULTIPLIER)) as f32;
 
     if source.type_flags & sound_type::SHROUD != 0 && shrouded {
@@ -202,8 +285,8 @@ pub fn calc_volume_and_pan(
     }
 
     let offset_x: f32 = (f64::from(client_x) - f64::from(half_w)) as f32;
-    let mut dist_x: f32 = ftol(f64::from(client_x) - f64::from(half_w)).abs() as f32;
-    let mut dist_y: f32 = ftol(f64::from(client_y) - f64::from(half_h)).abs() as f32;
+    let mut dist_x: f32 = native_abs(ftol(f64::from(client_x) - f64::from(half_w))) as f32;
+    let mut dist_y: f32 = native_abs(ftol(f64::from(client_y) - f64::from(half_h))) as f32;
 
     if source.type_flags & sound_type::LOCAL == 0 {
         dist_x -= half_w;
@@ -243,6 +326,9 @@ pub fn calc_volume_and_pan(
 }
 
 /// [`calc_volume_and_pan`] for a world-pixel position against a listener.
+///
+/// Both operands come out of the listener in the world-pixel frame, so the
+/// falloff distance and the pan stay in one unit at every zoom.
 pub fn spatial_gain(
     source: SpatialSource,
     screen_x: f32,
@@ -251,14 +337,8 @@ pub fn spatial_gain(
     shrouded: bool,
 ) -> Option<SpatialGain> {
     let (client_x, client_y) = listener.client_point(screen_x, screen_y);
-    calc_volume_and_pan(
-        client_x,
-        client_y,
-        listener.tactical_width,
-        listener.tactical_height,
-        source,
-        shrouded,
-    )
+    let (view_w, view_h) = listener.view_extent();
+    calc_volume_and_pan(client_x, client_y, view_w, view_h, source, shrouded)
 }
 
 /// DirectSound attenuation table, hundredths of a decibel, indexed by the
@@ -453,6 +533,19 @@ impl PlayShifts {
 /// decay buffer last when `Control=DECAY`, and the rest in `RandomRanged(0,
 /// remaining - 1)` pick-and-remove order for `RANDOM` or in load order
 /// otherwise.
+///
+/// **VERA-internal, gamemd equivalent UNCHECKED: every bounds guard below.**
+/// Native indexes the fixed 32-slot sample array at `AudioEventClass+0xB4`
+/// with no check at all, and `AudioEventClass::SetControlFlags @ 0x00406570`
+/// (read this session) normalises the attack/decay counts against the
+/// `Control=` flags *only* — never against how many names `Sounds=` actually
+/// listed. So `Attack=5` on a two-sample entry, or `Sounds=` omitted
+/// entirely, reads past the loaded pointers in gamemd; the observable result
+/// is whatever that garbage pointer does, which VERA cannot reproduce and
+/// must not pretend to. Trigger: only a hand-edited `sound(md).ini` whose
+/// `Attack=`/`Decay=` exceed its own `Sounds=` list — no stock entry does.
+/// Player effect: VERA plays a valid sample (or nothing) where gamemd would
+/// misbehave. Frequency: never on retail data. Downstream risk: none.
 pub fn select_playout(entry: &SoundEntry, rng: &mut impl SampleRng) -> Vec<usize> {
     let count = entry.sounds.len() as i32;
     if count == 0 {
@@ -465,6 +558,7 @@ pub fn select_playout(entry: &SoundEntry, rng: &mut impl SampleRng) -> Vec<usize
     let mut middle: Vec<usize> = Vec::new();
 
     if entry.attack > 0 {
+        // `.clamp`: VERA-internal, see the note above.
         attack = Some(rng.ranged(0, entry.attack - 1).clamp(0, count - 1) as usize);
     }
     if entry.control & control::ALL == 0 {
@@ -473,6 +567,8 @@ pub fn select_playout(entry: &SoundEntry, rng: &mut impl SampleRng) -> Vec<usize
         } else {
             body_start
         };
+        // `.contains`: VERA-internal, see the note above. An empty body range
+        // (`Attack + Decay >= count`) puts `body_start` at `count`.
         if (0..count).contains(&index) {
             middle.push(index as usize);
         }
@@ -480,6 +576,7 @@ pub fn select_playout(entry: &SoundEntry, rng: &mut impl SampleRng) -> Vec<usize
         middle.extend(body.clone());
     }
     if entry.decay > 0 {
+        // `.clamp`: VERA-internal, see the note above.
         decay = Some(
             rng.ranged(count - entry.decay, count - 1)
                 .clamp(0, count - 1) as usize,
@@ -494,6 +591,8 @@ pub fn select_playout(entry: &SoundEntry, rng: &mut impl SampleRng) -> Vec<usize
     if entry.control & control::RANDOM != 0 {
         while !middle.is_empty() {
             let pick = rng.ranged(0, middle.len() as i32 - 1) as usize;
+            // `.min`: VERA-internal, see the note above — `SampleRng` is a
+            // public trait, so an out-of-contract impl must not panic here.
             order.push(middle.remove(pick.min(middle.len() - 1)));
         }
     } else {
@@ -1677,8 +1776,8 @@ mod tests {
         registry.get("T").expect("entry").clone()
     }
 
-    const LISTENER_W: i32 = 1024;
-    const LISTENER_H: i32 = 600;
+    const LISTENER_W: f32 = 1024.0;
+    const LISTENER_H: f32 = 600.0;
 
     fn source(range_cells: i32, type_flags: u32, min_volume: f32) -> SpatialSource {
         SpatialSource {
@@ -1766,22 +1865,120 @@ mod tests {
     fn calc_volume_and_pan_truncates_distances_like_ftol() {
         let src = source(10, sound_type::LOCAL, 0.0);
         // clientX - 511.5 = 0.5 -> ftol 0 -> full volume; pan keeps the 0.5.
-        let g = calc_volume_and_pan(512, 300, 1023, LISTENER_H, src, false).unwrap();
+        let g = calc_volume_and_pan(512, 300, 1023.0, LISTENER_H, src, false).unwrap();
         assert_eq!(g.volume, 1.0);
         assert_eq!(g.pan, ftol(0.5 * 8192.0 / 1023.0 + 8192.0));
         // clientX - 511.5 = -0.5 -> ftol 0 as well (truncation toward zero).
-        let g = calc_volume_and_pan(511, 300, 1023, LISTENER_H, src, false).unwrap();
+        let g = calc_volume_and_pan(511, 300, 1023.0, LISTENER_H, src, false).unwrap();
         assert_eq!(g.volume, 1.0);
         assert_eq!(g.pan, ftol(-0.5 * 8192.0 / 1023.0 + 8192.0));
+    }
+
+    fn zoom_listener(zoom: f32) -> SpatialListener {
+        SpatialListener {
+            tactical_width: LISTENER_W as i32,
+            tactical_height: LISTENER_H as i32,
+            origin_x: 0.0,
+            origin_y: 0.0,
+            zoom,
+        }
+    }
+
+    /// The listener rect and the sound positions must stay in one frame at
+    /// every zoom. VERA projects `device = (world - camera) * zoom`, so a
+    /// 1024x600 device viewport covers `1024/zoom` x `600/zoom` world pixels;
+    /// `SpatialListener::view_extent` is what puts the rect in the world frame
+    /// the positions already use.
+    ///
+    /// gamemd has no zoom, so nothing here is a native golden. What the
+    /// vectors pin is that zoom behaves like the one zoom-shaped thing gamemd
+    /// *does* have — a resolution change, which alters how much world the view
+    /// rect covers while `VocClass::CalcVolumeAndPan @ 0x00750AC0` keeps
+    /// `Range * 0x3C` as a fixed cell distance.
+    #[test]
+    fn spatial_gain_measures_one_frame_at_every_zoom() {
+        let src = source(10, sound_type::SCREEN, 0.5);
+        // At zoom 1.0 the world frame *is* the device frame, so the listener
+        // must reproduce the raw-device-size call bit for bit.
+        for x in [0.0f32, 256.0, 512.0, 1324.0, 1584.0] {
+            assert_eq!(
+                spatial_gain(src, x, 300.0, &zoom_listener(1.0), false),
+                calc_volume_and_pan(x as i32, 300, LISTENER_W, LISTENER_H, src, false),
+                "zoom 1.0 must equal the native device-pixel call at x={x}"
+            );
+        }
+
+        // `Range=10` is 600 world pixels — 10 cells — at every zoom. A sound
+        // exactly 300 world pixels past the right edge of the visible area is
+        // half volume whether the view covers 1024, 512 or 2048 world pixels.
+        for (zoom, view_w, centre_y) in [
+            (1.0f32, 1024.0f32, 300.0f32),
+            (2.0, 512.0, 150.0),
+            (0.5, 2048.0, 600.0),
+        ] {
+            let gain = spatial_gain(src, view_w + 300.0, centre_y, &zoom_listener(zoom), false)
+                .unwrap_or_else(|| panic!("audible at zoom {zoom}"));
+            assert_eq!(gain.volume, 0.5, "zoom {zoom} falloff");
+        }
+
+        // Pan is the position *within* the view, so a sound a quarter of the
+        // way across the visible area sits at the same 6144 at every zoom —
+        // and stays inside the view, hence full volume.
+        for (zoom, view_w, centre_y) in [
+            (1.0f32, 1024.0f32, 300.0f32),
+            (2.0, 512.0, 150.0),
+            (0.5, 2048.0, 600.0),
+        ] {
+            let gain = spatial_gain(src, view_w * 0.25, centre_y, &zoom_listener(zoom), false)
+                .unwrap_or_else(|| panic!("audible at zoom {zoom}"));
+            assert_eq!(
+                (gain.volume, gain.pan),
+                (1.0, 6144),
+                "zoom {zoom} quarter-width pan"
+            );
+        }
+
+        // The regression the frame mismatch hid: one fixed world position must
+        // move with the zoom. Ignoring zoom made all three of these 0.5/14688.
+        let fixed = (1324.0f32, 300.0f32);
+        assert_eq!(
+            spatial_gain(src, fixed.0, fixed.1, &zoom_listener(1.0), false),
+            Some(SpatialGain {
+                volume: 0.5,
+                pan: 14688
+            })
+        );
+        // Zoomed 2x the view covers 512x300 world px, so the same point is
+        // 812 px outside it — past `Range * 60` and silent.
+        assert_eq!(
+            spatial_gain(src, fixed.0, fixed.1, &zoom_listener(2.0), false),
+            None
+        );
+        // Zoomed out to 0.5x the view covers 2048x1200 world px, so the point
+        // is on screen: full volume, panned by its offset from the centre.
+        assert_eq!(
+            spatial_gain(src, fixed.0, fixed.1, &zoom_listener(0.5), false),
+            Some(SpatialGain {
+                volume: 1.0,
+                pan: 9392
+            })
+        );
+
+        // A degenerate zoom must neither divide by zero (the VERA-internal
+        // EPSILON floor) nor panic: the resulting half-view saturates the
+        // `ftol` cast to `i32::MIN`, which `native_abs` wraps the way
+        // `CDQ; XOR; SUB` does instead of trapping like `i32::abs`.
+        assert!(spatial_gain(src, 0.0, 0.0, &zoom_listener(0.0), false).is_some());
     }
 
     #[test]
     fn spatial_listener_projects_world_pixels_to_client_points() {
         let listener = SpatialListener {
-            tactical_width: LISTENER_W,
-            tactical_height: LISTENER_H,
+            tactical_width: LISTENER_W as i32,
+            tactical_height: LISTENER_H as i32,
             origin_x: 1000.25,
             origin_y: 2000.0,
+            zoom: 1.0,
         };
         assert_eq!(listener.client_point(1512.25, 2300.0), (512, 300));
         assert_eq!(listener.client_point(999.75, 1999.0), (0, -1));

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -177,7 +177,7 @@ pub struct SpatialSource {
 impl SpatialSource {
     pub fn from_entry(entry: &SoundEntry) -> Self {
         Self {
-            range_cells: i32::from(entry.range),
+            range_cells: entry.range,
             type_flags: entry.type_flags,
             min_volume: entry.min_volume,
         }
@@ -275,9 +275,10 @@ pub fn calc_volume_and_pan(
     let full_w: f32 = half_w + half_w;
     // `LEA EAX,[EAX+EAX*2]; LEA EAX,[EAX+EAX*4]; SHL EAX,2` at
     // `0x00750B0F..0x00750B17` — a 32-bit ×60 that wraps rather than trapping.
-    // `SoundEntry::range` is a `u16`, so the product cannot exceed 3_932_100;
-    // `wrapping_mul` is here to keep a hand-built `SpatialSource` on the
-    // native truncation instead of a debug-build panic.
+    // `AudioEventClass::SetRange @ 0x004065E0` stores `Range=` as a full int,
+    // so `wrapping_mul` is the transcription of the native overflow, not a
+    // guard: it is what keeps a `Range=` past 35_791_394 on the native
+    // truncation instead of panicking in a debug build.
     let max_range: f32 = (source.range_cells.wrapping_mul(RANGE_MULTIPLIER)) as f32;
 
     if source.type_flags & sound_type::SHROUD != 0 && shrouded {
@@ -370,12 +371,34 @@ fn attenuation_amplitude(hundredths_db: i16) -> f32 {
 
 /// Product of two native linear volumes: `DSoundBuffer::CombineInterps
 /// FUN_004010C0` (`0x004010C7..0x004010D6`), `(a * b) >> 14`.
+///
+/// **VERA-internal, gamemd equivalent UNCHECKED: both `.clamp`s.** The native
+/// volume path is `SHR EDX,0x10; SHR EAX,0x10; IMUL EDX,EAX; SHR EDX,0xe`
+/// (`disassemble_function 0x004010C0`, read this session) — no bound at all;
+/// the two operands are merely the top halves of 32-bit fixed-point fields, so
+/// native accepts anything up to `0xFFFF` on each side and can return well
+/// past `0x4000`. (The *pan* path at `0x00401116..0x0040114C` does clamp to
+/// `0..0x4000`; the volume path does not, so this is not borrowed from there.)
+/// Trigger: an operand outside `0..=0x4000`, which no VERA producer can make —
+/// `SoundEntry::volume_linear` comes out of the native `[0, 1]` clamp times
+/// 16384, and [`PlayShifts::volume_linear`] is `0x4000 - ((vshift << 14)/100)`
+/// with `vshift` already held to `0..=100` by native `SetVShift @ 0x00406620`.
+/// Player effect: none reachable. Frequency: never. Downstream risk: the guard
+/// is what keeps [`native_volume_amplitude`]'s fixed 101-entry table index in
+/// bounds, where Rust would panic and gamemd would read past the table.
 pub fn combine_linear(a: i32, b: i32) -> i32 {
     (a.clamp(0, VOLUME_SCALE) * b.clamp(0, VOLUME_SCALE)) >> 14
 }
 
 /// Amplitude the DirectSound layer produces for one combined linear volume:
 /// `FUN_0040A6D0` indexes the table with `volume * 25 >> 12` (0..=100).
+///
+/// VERA-internal, gamemd equivalent UNCHECKED: the `.clamp`. `FUN_0040A6D0`
+/// computes `(v >> 16) * 25 >> 12` and indexes `DAT_00816380` with it
+/// unchecked, so an out-of-range volume reads past the 101-entry table in
+/// gamemd; in Rust that is a panic, which is not a behaviour worth
+/// reproducing. Trigger and frequency: as [`combine_linear`] — unreachable
+/// from any VERA producer.
 pub fn native_volume_amplitude(linear: i32) -> f32 {
     let index = (linear.clamp(0, VOLUME_SCALE) * 25) >> 12;
     attenuation_amplitude(DSOUND_ATTENUATION_TABLE[index as usize])
@@ -387,6 +410,12 @@ pub fn native_volume_amplitude(linear: i32) -> f32 {
 /// `p = (pan * 25 >> 11) - 100` and calls `SetPan(table[100 - |p|])` for a
 /// left pan (negative DirectSound pan attenuates the right channel) and
 /// `SetPan(-table[100 - p])` for a right pan (attenuates the left channel).
+///
+/// VERA-internal, gamemd equivalent UNCHECKED: the `.clamp`, for the same
+/// reason as [`native_volume_amplitude`] — native indexes the table
+/// unchecked. `CalcVolumeAndPan` produces the pan as
+/// `ftol(clamp(offsetX, -fullW, fullW) * 8192 / fullW + 8192)`, which is
+/// already `0..=0x4000`, so nothing in VERA can reach the guard.
 pub fn pan_channel_gains(pan: i32) -> (f32, f32) {
     let p = ((pan.clamp(0, PAN_SCALE) * 25) >> 11) - 100;
     let attenuated = attenuation_amplitude(DSOUND_ATTENUATION_TABLE[(100 - p.abs()) as usize]);
@@ -511,7 +540,18 @@ impl PlayShifts {
         }
     }
 
-    /// Playback rate: `FUN_00401190` returns `(pct * rate) / 100`.
+    /// Playback rate: `FUN_00401190` returns `(pct * rate) / 100`
+    /// (`SHR ECX,0x10; IMUL ECX,EDX;` then the `0x51EB851F` magic divide by
+    /// 100, truncating toward zero).
+    ///
+    /// VERA-internal, gamemd equivalent UNCHECKED: the `.max(1)`. The native
+    /// body has no floor — it hands the raw quotient to the DirectSound
+    /// buffer's `SetFrequency`, which rejects 0 at the device layer. VERA
+    /// instead feeds the rate to its own resampler, where 0 is not a
+    /// well-defined input. Trigger: `frequency_pct <= 0`, i.e. a `FShift=`
+    /// whose low bound is at or below -100; the widest stock `FShift=` is
+    /// `-15 15`. Player effect: none reachable. Frequency: never on retail
+    /// data. Downstream risk: none.
     pub fn shifted_sample_rate(&self, sample_rate: u32) -> u32 {
         ((i64::from(self.frequency_pct) * i64::from(sample_rate)) / 100).max(1) as u32
     }

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -1811,8 +1811,12 @@ mod tests {
         }
     }
 
+    /// `[SoundList]` is what registers an id (`VocClass::ReadSoundListINI @
+    /// 0x007510D0`), so the fixture names `[T]` there the way the stock file
+    /// names every sound.
     fn entry(body: &str) -> SoundEntry {
-        let registry = SoundRegistry::from_ini(&IniFile::from_str(body));
+        let registry =
+            SoundRegistry::from_ini(&IniFile::from_str(&format!("[SoundList]\n1=T\n{body}")));
         registry.get("T").expect("entry").clone()
     }
 
@@ -2215,7 +2219,7 @@ mod tests {
     #[test]
     fn cloak_sound_registered_resolution_rejects_raw_sample_and_invalid_names() {
         let registry = SoundRegistry::from_ini(&IniFile::from_str(
-            "[NavalUnitEmerge]\nSounds=vnavupa\nVolume=55\n",
+            "[SoundList]\n1=NavalUnitEmerge\n[NavalUnitEmerge]\nSounds=vnavupa\nVolume=55\n",
         ));
         let entry = registered_entry("NavalUnitEmerge", &registry)
             .expect("the retail Voc/event identity resolves to its registered entry");

--- a/src/rules/sound_ini.rs
+++ b/src/rules/sound_ini.rs
@@ -1,4 +1,4 @@
-//! sound.ini / soundmd.ini parser — maps sound IDs to .wav/.aud filenames.
+//! sound.ini / soundmd.ini parser — the `VocClass` registry.
 //!
 //! RA2's sound.ini has sections like:
 //! ```ini
@@ -6,48 +6,235 @@
 //! Sounds=vgcannon.wav
 //! Volume=100
 //! Priority=1
-//! Control=random,all
+//! Control=random
+//! Type=global
 //! ```
 //!
 //! Each section name is a sound ID referenced by weapons (Report=), units
 //! (VoiceSelect=, VoiceMove=, DieSound=), and EVA announcements.
-//! The `Sounds=` key lists one or more sound names separated by whitespace
-//! or commas. Names may have `$` or `#` prefixes (legacy Westwood markers,
-//! stripped at load time). When multiple sounds are listed, the game picks
-//! one at random.
+//!
+//! gamemd-derived: `VocClass::ReadINI @ 0x00750440` reads the fourteen keys
+//! below for every `[SoundList]` entry, in this order, with these defaults —
+//! `Sounds` (""), `Volume` ([Defaults] float, static 80.0), `VShift` (0),
+//! `MinVolume` ([Defaults] float, static 20.0), `Priority` ("NORMAL"),
+//! `Attack` (0), `Decay` (0), `Control` ([Defaults] flags, static 0), `Type`
+//! ([Defaults] flags, static SCREEN), `Limit` ([Defaults], static 5), `Loop`
+//! (0), `Range` ([Defaults], static 10), `Delay` (""), `FShift` (""). The
+//! `[Defaults]` section itself is read once by `VocClass::ReadSoundListINI @
+//! 0x007510D0` (`0x00751126..0x0075128C`). Token lists are split by
+//! `CRT strtok` on the delimiter string at `0x00846570` = `" \t\n"` — commas
+//! are NOT separators.
 //!
 //! ## Dependency rules
 //! - Part of rules/ — depends on rules/ini_parser. No sim/render dependencies.
 
 use std::collections::HashMap;
 
-use crate::rules::ini_parser::IniFile;
+use crate::rules::ini_parser::{IniFile, IniSection};
+
+/// `Control=` flag words. gamemd-derived: the `(char*, u32)` table at
+/// `0x008160C0` walked by `AudioEventClass::ParseControlFlag @ 0x00406820`
+/// (strings read via `inspect_memory_content 0x00816100`). The compare is
+/// `FUN_007C8D20`, a case-insensitive ASCII compare; an unmatched token lands
+/// on the NULL terminator whose value is 0, so it ORs nothing.
+pub mod control {
+    pub const LOOP: u32 = 0x01;
+    pub const RANDOM: u32 = 0x02;
+    pub const ALL: u32 = 0x04;
+    pub const PREDELAY: u32 = 0x08;
+    pub const INTERRUPT: u32 = 0x10;
+    pub const ATTACK: u32 = 0x20;
+    pub const DECAY: u32 = 0x40;
+    pub const AMBIENT: u32 = 0x80;
+}
+
+/// `Type=` flag words. gamemd-derived: the table at `0x00816048` walked by
+/// `AudioEventClass::ParseTypeFlag @ 0x00406870`. `NORMAL` is a real entry
+/// carrying 0. SCREEN/LOCAL (`0x60`) and UNSHROUD/SHROUD (`0xC00`) are
+/// exclusive pairs: matching one clears the other member first.
+pub mod sound_type {
+    pub const NORMAL: u32 = 0x0;
+    pub const VIOLENT: u32 = 0x01;
+    pub const MOVEMENT: u32 = 0x02;
+    pub const QUIET: u32 = 0x04;
+    pub const LOUD: u32 = 0x08;
+    pub const GLOBAL: u32 = 0x10;
+    pub const SCREEN: u32 = 0x20;
+    pub const LOCAL: u32 = 0x40;
+    pub const PLAYER: u32 = 0x80;
+    pub const NOISE_SHY: u32 = 0x100;
+    pub const GUN_SHY: u32 = 0x200;
+    pub const UNSHROUD: u32 = 0x400;
+    pub const SHROUD: u32 = 0x800;
+    pub const AMBIENT: u32 = 0x1000;
+}
+
+const CONTROL_TABLE: [(&str, u32); 8] = [
+    ("ALL", control::ALL),
+    ("LOOP", control::LOOP),
+    ("RANDOM", control::RANDOM),
+    ("PREDELAY", control::PREDELAY),
+    ("INTERRUPT", control::INTERRUPT),
+    ("ATTACK", control::ATTACK),
+    ("DECAY", control::DECAY),
+    ("AMBIENT", control::AMBIENT),
+];
+
+const TYPE_TABLE: [(&str, u32); 14] = [
+    ("AMBIENT", sound_type::AMBIENT),
+    ("VIOLENT", sound_type::VIOLENT),
+    ("MOVEMENT", sound_type::MOVEMENT),
+    ("QUIET", sound_type::QUIET),
+    ("LOUD", sound_type::LOUD),
+    ("GLOBAL", sound_type::GLOBAL),
+    ("SCREEN", sound_type::SCREEN),
+    ("LOCAL", sound_type::LOCAL),
+    ("PLAYER", sound_type::PLAYER),
+    ("NORMAL", sound_type::NORMAL),
+    ("GUN_SHY", sound_type::GUN_SHY),
+    ("NOISE_SHY", sound_type::NOISE_SHY),
+    ("UNSHROUD", sound_type::UNSHROUD),
+    ("SHROUD", sound_type::SHROUD),
+];
+
+/// Native linear volume scale: `VolumeInterp` values are `0..=0x4000`.
+pub const VOLUME_SCALE: i32 = 0x4000;
+
+/// Sample slots per event: `VocClass::AddSample @ 0x004064A0` refuses the
+/// 33rd (`+0x134 == 0x20`).
+pub const MAX_SAMPLES: usize = 0x20;
+
+/// `[Defaults]` values. gamemd-derived: `VocClass::ReadSoundListINI @
+/// 0x007510D0` — Volume -> `0x008464B4` (static 80.0f), MinVolume ->
+/// `0x008464B8` (static 20.0f), Priority -> `0x008464B0` (static 2),
+/// Control -> `0x00B1D3B0` (static 0; reset to 0 before parsing only when a
+/// token exists), Type -> `0x008464BC` (static 0x20; reset to 0x20 before
+/// parsing only when a token exists), Limit -> `0x008464C4` (static 5),
+/// Range -> `0x008464C0` (static 10). Statics read via `read_memory`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SoundDefaults {
+    pub volume: f32,
+    pub min_volume: f32,
+    pub priority: u8,
+    pub control: u32,
+    pub type_flags: u32,
+    pub limit: i32,
+    pub range: i32,
+}
+
+impl Default for SoundDefaults {
+    fn default() -> Self {
+        Self {
+            volume: 80.0,
+            min_volume: 20.0,
+            priority: SOUND_PRIORITY_DEFAULT,
+            control: 0,
+            type_flags: sound_type::SCREEN,
+            limit: 5,
+            range: 10,
+        }
+    }
+}
+
+impl SoundDefaults {
+    fn read(section: Option<&IniSection>) -> Self {
+        let mut defaults = Self::default();
+        let Some(section) = section else {
+            return defaults;
+        };
+        defaults.volume = read_double(section, "Volume", defaults.volume);
+        defaults.min_volume = read_double(section, "MinVolume", defaults.min_volume);
+        defaults.priority = section
+            .get_ignoring_case("Priority")
+            .map_or(defaults.priority, parse_sound_priority);
+        if let Some(control) = parse_control_list(section.get_ignoring_case("Control")) {
+            defaults.control = control;
+        }
+        if let Some(type_flags) = parse_type_list(section.get_ignoring_case("Type")) {
+            defaults.type_flags = type_flags;
+        }
+        defaults.limit = section
+            .get_i32_ignoring_case("Limit")
+            .unwrap_or(defaults.limit);
+        defaults.range = section
+            .get_i32_ignoring_case("Range")
+            .unwrap_or(defaults.range);
+        defaults
+    }
+
+    /// The minimum-volume floor as the stored fraction (see
+    /// [`SoundEntry::min_volume`]).
+    pub fn min_volume_fraction(&self) -> f32 {
+        min_volume_fraction(self.min_volume)
+    }
+}
 
 /// A single sound definition from sound.ini.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SoundEntry {
     /// Section name / sound ID (e.g., "VGCannon1").
     pub id: String,
-    /// List of .wav filenames to choose from (e.g., ["vgcannon.wav"]).
+    /// Sample names in `Sounds=` order, `$`/`#` prefixes stripped, at most
+    /// [`MAX_SAMPLES`]. `Attack=` counts the first N as attack samples and
+    /// `Decay=` the last M as decay samples; the rest is the body.
     pub sounds: Vec<String>,
-    /// Playback volume (0-100, default from [Defaults] or 100).
+    /// Playback volume in percent, `0..=100`.
     pub volume: u8,
+    /// Native linear volume `ftol(clamp(Volume * 0.01, 0, 1) * 0x4000)` as
+    /// stored by `AudioEventClass::SetVolumeRamp @ 0x00406550`
+    /// (`0x007504EE..0x00750548`).
+    pub volume_linear: i32,
     /// Eviction priority, `LOWEST(0)`..`CRITICAL(4)`; higher survives longer.
     ///
     /// `sound(md).ini` writes this as a symbolic token, never a number.
     pub priority: u8,
-    /// Audible range in cells (default 10). Used for spatial audio:
-    /// max audible pixel distance = range * 60 (original engine multiplier).
+    /// Audible range in cells (default 10). `max audible pixel distance =
+    /// Range * 60` in `VocClass::CalcVolumeAndPan @ 0x00750AC0`.
     pub range: u16,
-    /// Minimum volume floor (0-100, default 0). For GLOBAL-type sounds,
-    /// volume never drops below this even at maximum distance.
-    pub min_volume: u8,
+    /// `MinVolume=` as the stored fraction `clamp(MinVolume * 0.01, 0, 1)`
+    /// (`0x00750589..0x007505E3`, `AudioEventClass::SetMinVolume @
+    /// 0x004065F0` at `+0x54`). The floor applies only for `Type=GLOBAL`.
+    pub min_volume: f32,
+    /// `Control=` flag bits ([`control`]), stored by
+    /// `AudioEventClass::SetControlFlags @ 0x00406570` at `+0x10`.
+    pub control: u32,
+    /// `Type=` flag bits ([`sound_type`]), stored at `+0x14`.
+    pub type_flags: u32,
+    /// `Limit=` concurrent-instance cap (`+0x48`).
+    pub limit: i32,
+    /// `Loop=` pass count for looping events (`+0x4C`, 0 = forever).
+    pub loop_count: i32,
+    /// `Delay=` pre-delay range in milliseconds `(min, max)` (`+0x58/+0x5C`);
+    /// a single token sets both, no token sets `(0, 0)`.
+    pub delay_ms: (i32, i32),
+    /// `FShift=` frequency shift range in percent `(min, max)`
+    /// (`+0x60/+0x64`); same one-or-two token rule as `Delay=`.
+    pub fshift: (i32, i32),
+    /// `VShift=` random volume reduction ceiling in percent, clamped
+    /// `0..=100` by `AudioEventClass::SetVShift @ 0x00406620` (`+0x68`).
+    pub vshift: i32,
+    /// Attack sample count (`+0x138`) after `SetControlFlags` normalisation:
+    /// 0 without `Control=ATTACK`, at least 1 with it.
+    pub attack: i32,
+    /// Decay sample count (`+0x13C`), normalised the same way for `DECAY`.
+    pub decay: i32,
+}
+
+impl SoundEntry {
+    /// Body sample index range `attack .. count - decay` (may be empty).
+    pub fn body_range(&self) -> std::ops::Range<usize> {
+        let count = self.sounds.len() as i32;
+        let start = self.attack.clamp(0, count);
+        let end = (count - self.decay).clamp(start, count);
+        start as usize..end as usize
+    }
 }
 
 /// Registry of all sound definitions, keyed by uppercase sound ID.
 #[derive(Debug, Clone, Default)]
 pub struct SoundRegistry {
     entries: HashMap<String, SoundEntry>,
+    defaults: SoundDefaults,
 }
 
 impl SoundRegistry {
@@ -57,23 +244,7 @@ impl SoundRegistry {
     /// Sections from soundmd override sound.ini on conflict.
     pub fn from_ini(ini: &IniFile) -> Self {
         let mut entries: HashMap<String, SoundEntry> = HashMap::new();
-
-        // Read [Defaults] section for fallback values (original engine behavior).
-        let default_volume: u8 = ini
-            .section("Defaults")
-            .and_then(|s| s.get_i32("Volume"))
-            .unwrap_or(100)
-            .clamp(0, 100) as u8;
-        let default_range: u16 = ini
-            .section("Defaults")
-            .and_then(|s| s.get_i32("Range"))
-            .unwrap_or(10)
-            .clamp(1, 1000) as u16;
-        let default_min_volume: u8 = ini
-            .section("Defaults")
-            .and_then(|s| s.get_i32("MinVolume"))
-            .unwrap_or(0)
-            .clamp(0, 100) as u8;
+        let defaults = SoundDefaults::read(ini.section("Defaults"));
 
         for name in ini.section_names() {
             let Some(section) = ini.section(name) else {
@@ -81,52 +252,61 @@ impl SoundRegistry {
             };
             // Skip meta-sections that aren't actual sound definitions.
             if name.eq_ignore_ascii_case("General")
-                || name.eq_ignore_ascii_case("Sounds")
+                || name.eq_ignore_ascii_case("SoundList")
                 || name.eq_ignore_ascii_case("Defaults")
             {
                 continue;
             }
 
-            let sounds_str: &str = match section.get("Sounds") {
+            let sounds_str: &str = match section.get_ignoring_case("Sounds") {
                 Some(s) => s,
                 None => continue,
             };
 
-            // Sounds= can be whitespace-separated (soundmd.ini) or comma-separated
-            // (sound.ini). Names may have $ or # prefixes (legacy, stripped).
-            // Inline comments starting with ; are filtered out.
-            let sounds: Vec<String> = sounds_str
-                .split_whitespace()
-                .flat_map(|token| token.split(','))
-                .map(|s| s.trim())
-                .filter(|s| !s.is_empty() && !s.starts_with(';'))
-                .map(|s| {
-                    s.trim_start_matches('$')
-                        .trim_start_matches('#')
-                        .to_string()
-                })
+            // `VocClass::AddSample @ 0x004064A0` skips every leading `$`/`#`
+            // and stops accepting at 32 samples.
+            let sounds: Vec<String> = split_tokens(sounds_str)
+                .map(|s| s.trim_start_matches(['$', '#']).to_string())
                 .filter(|s| !s.is_empty())
+                .take(MAX_SAMPLES)
                 .collect();
 
             if sounds.is_empty() {
                 continue;
             }
 
-            let volume: u8 = section
-                .get_i32("Volume")
-                .unwrap_or(default_volume as i32)
-                .clamp(0, 100) as u8;
+            let volume_raw = read_double(section, "Volume", defaults.volume);
+            let volume_linear = volume_linear(volume_raw);
+            let volume: u8 = (volume_raw.clamp(0.0, 100.0) as f64).round() as u8;
+            let vshift = section
+                .get_i32_ignoring_case("VShift")
+                .unwrap_or(0)
+                .clamp(0, 100);
+            let min_volume =
+                min_volume_fraction(read_double(section, "MinVolume", defaults.min_volume));
             let priority: u8 = section
-                .get("Priority")
+                .get_ignoring_case("Priority")
                 .map_or(SOUND_PRIORITY_DEFAULT, parse_sound_priority);
+            let attack_raw = section.get_i32_ignoring_case("Attack").unwrap_or(0);
+            let decay_raw = section.get_i32_ignoring_case("Decay").unwrap_or(0);
+            let control = parse_control_list(section.get_ignoring_case("Control"))
+                .unwrap_or(defaults.control);
+            // `AudioEventClass::SetControlFlags @ 0x00406570`: without the
+            // flag the count is zeroed; with it a zero count becomes 1.
+            let attack = normalise_envelope_count(attack_raw, control & control::ATTACK != 0);
+            let decay = normalise_envelope_count(decay_raw, control & control::DECAY != 0);
+            let type_flags =
+                parse_type_list(section.get_ignoring_case("Type")).unwrap_or(defaults.type_flags);
+            let limit = section
+                .get_i32_ignoring_case("Limit")
+                .unwrap_or(defaults.limit);
+            let loop_count = section.get_i32_ignoring_case("Loop").unwrap_or(0);
             let range: u16 = section
-                .get_i32("Range")
-                .unwrap_or(default_range as i32)
-                .clamp(1, 1000) as u16;
-            let min_volume: u8 = section
-                .get_i32("MinVolume")
-                .unwrap_or(default_min_volume as i32)
-                .clamp(0, 100) as u8;
+                .get_i32_ignoring_case("Range")
+                .unwrap_or(defaults.range)
+                .clamp(0, i32::from(u16::MAX)) as u16;
+            let delay_ms = parse_int_pair(section.get_ignoring_case("Delay"));
+            let fshift = parse_int_pair(section.get_ignoring_case("FShift"));
 
             entries.insert(
                 name.to_ascii_uppercase(),
@@ -134,15 +314,25 @@ impl SoundRegistry {
                     id: name.to_string(),
                     sounds,
                     volume,
+                    volume_linear,
                     priority,
                     range,
                     min_volume,
+                    control,
+                    type_flags,
+                    limit,
+                    loop_count,
+                    delay_ms,
+                    fshift,
+                    vshift,
+                    attack,
+                    decay,
                 },
             );
         }
 
         log::info!("SoundRegistry: loaded {} sound definitions", entries.len());
-        Self { entries }
+        Self { entries, defaults }
     }
 
     /// Merge another sound.ini (base RA2) into this registry.
@@ -170,6 +360,11 @@ impl SoundRegistry {
         self.entries.get(&sound_id.to_ascii_uppercase())
     }
 
+    /// The `[Defaults]` values this registry was read with.
+    pub fn defaults(&self) -> &SoundDefaults {
+        &self.defaults
+    }
+
     /// Total number of registered sound definitions.
     pub fn len(&self) -> usize {
         self.entries.len()
@@ -179,6 +374,157 @@ impl SoundRegistry {
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
+}
+
+/// `CCINIClass::ReadDouble @ 0x005283D0`: `sscanf("%f")` into a float, times
+/// 0.01 when the text contains a `%`; absent or unparsable keeps the default.
+fn read_double(section: &IniSection, key: &str, default: f32) -> f32 {
+    let Some(raw) = section.get_ignoring_case(key) else {
+        return default;
+    };
+    let text = raw.trim_start();
+    let end = text
+        .char_indices()
+        .take_while(|(i, c)| {
+            c.is_ascii_digit() || *c == '.' || (*i == 0 && (*c == '-' || *c == '+'))
+        })
+        .map(|(i, c)| i + c.len_utf8())
+        .last()
+        .unwrap_or(0);
+    let Ok(parsed) = text[..end].parse::<f32>() else {
+        return default;
+    };
+    if raw.contains('%') {
+        ((parsed as f64) * 0.01) as f32
+    } else {
+        parsed
+    }
+}
+
+/// `0x007504EE..0x00750548`: `Volume * 0.01f`, clamped to `[0, 1]`, times
+/// 16384, then `Math::ftol` (truncation).
+fn volume_linear(volume: f32) -> i32 {
+    let scaled = ((volume as f64) * (0.01f32 as f64)) as f32;
+    let clamped = if (scaled as f64) > 1.0 {
+        1.0f32
+    } else if scaled < 0.0 {
+        0.0
+    } else {
+        scaled
+    };
+    ((clamped as f64) * (VOLUME_SCALE as f64)).trunc() as i32
+}
+
+/// `0x00750589..0x007505E3`: `MinVolume * 0.01f` clamped to `[0, 1]`, kept
+/// as a float.
+fn min_volume_fraction(min_volume: f32) -> f32 {
+    let scaled = ((min_volume as f64) * (0.01f32 as f64)) as f32;
+    if (scaled as f64) > 1.0 {
+        1.0
+    } else if scaled < 0.0 {
+        0.0
+    } else {
+        scaled
+    }
+}
+
+fn normalise_envelope_count(raw: i32, flagged: bool) -> i32 {
+    match (flagged, raw) {
+        (false, _) => 0,
+        (true, 0) => 1,
+        (true, n) => n,
+    }
+}
+
+/// The native token split: `strtok` on `" \t\n"` (`0x00846570`).
+fn split_tokens(value: &str) -> impl Iterator<Item = &str> {
+    value
+        .split([' ', '\t', '\n'])
+        .filter(|token| !token.is_empty())
+}
+
+/// `Control=` list: `None` when the key is absent or has no token (the
+/// caller keeps the `[Defaults]` flags, `0x007506C9..0x00750700`).
+fn parse_control_list(raw: Option<&str>) -> Option<u32> {
+    let mut tokens = split_tokens(raw?).peekable();
+    tokens.peek()?;
+    Some(tokens.fold(0, |flags, token| flags | parse_control_token(token)))
+}
+
+/// `Type=` list: starts from SCREEN when at least one token exists
+/// (`0x00750759`), otherwise `None` so the caller keeps the `[Defaults]`
+/// flags.
+fn parse_type_list(raw: Option<&str>) -> Option<u32> {
+    let mut tokens = split_tokens(raw?).peekable();
+    tokens.peek()?;
+    let mut flags = sound_type::SCREEN;
+    for token in tokens {
+        apply_type_token(&mut flags, token);
+    }
+    Some(flags)
+}
+
+fn parse_control_token(token: &str) -> u32 {
+    CONTROL_TABLE
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(token))
+        .map_or(0, |&(_, value)| value)
+}
+
+/// `AudioEventClass::ParseTypeFlag @ 0x00406870`.
+fn apply_type_token(flags: &mut u32, token: &str) {
+    let value = TYPE_TABLE
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(token))
+        .map_or(0, |&(_, value)| value);
+    if value & (sound_type::SCREEN | sound_type::LOCAL) != 0 {
+        *flags &= !(sound_type::SCREEN | sound_type::LOCAL);
+    } else if value & (sound_type::UNSHROUD | sound_type::SHROUD) != 0 {
+        *flags &= !(sound_type::UNSHROUD | sound_type::SHROUD);
+    }
+    *flags |= value;
+}
+
+/// `Delay=` / `FShift=` (`0x0075083C..0x00750886`, `0x008B5..0x008FF`): the
+/// first token through `atoi` is the minimum; the second, when present, is
+/// the maximum, otherwise the minimum is reused. No token gives `(0, 0)`.
+fn parse_int_pair(raw: Option<&str>) -> (i32, i32) {
+    let Some(raw) = raw else {
+        return (0, 0);
+    };
+    let mut tokens = split_tokens(raw);
+    let Some(first) = tokens.next() else {
+        return (0, 0);
+    };
+    let min = crt_atoi(first);
+    let max = tokens.next().map_or(min, crt_atoi);
+    (min, max)
+}
+
+/// C `atoi`: leading whitespace, optional sign, decimal digits; anything
+/// else stops the parse (an empty prefix yields 0).
+fn crt_atoi(value: &str) -> i32 {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    while bytes.get(index).is_some_and(u8::is_ascii_whitespace) {
+        index += 1;
+    }
+    let mut negative = false;
+    match bytes.get(index) {
+        Some(b'-') => {
+            negative = true;
+            index += 1;
+        }
+        Some(b'+') => index += 1,
+        _ => {}
+    }
+    let mut magnitude: i64 = 0;
+    while let Some(digit) = bytes.get(index).filter(|b| b.is_ascii_digit()) {
+        magnitude = (magnitude * 10 + i64::from(digit - b'0')).min(i64::from(i32::MAX) + 1);
+        index += 1;
+    }
+    let signed = if negative { -magnitude } else { magnitude };
+    signed.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
 }
 
 /// Per-faction sound IDs for a single EVA event (e.g., EVA_ConstructionComplete).
@@ -288,35 +634,6 @@ const SOUND_PRIORITY_TABLE: [(&str, u8); 5] = [
     ("CRITICAL", 4),
 ];
 
-/// RESIDUAL (GSI-15.01) — the registry reads five keys and stock authors more,
-/// and pass 2 resolved the three that matter. `VocClass::ReadINI @ 0x00750440`
-/// reads fourteen keys in total; two previously unnamed strings are
-/// `0x00824314` = "Type" and `0x00824238` = "Loop".
-/// - `Control=` (594 stock, flag table at `0x008160C0`) selects RANDOM,
-///   INTERRUPT, PREDELAY, LOOP, ALL and AMBIENT. Unparsed, so variant choice is
-///   a plain counter and none of the other modes exist. An existing research doc
-///   has INTERRUPT and PREDELAY swapped — do not use it.
-/// - `Type=` (89 stock, flag table at `0x00816048`) is the one that gates
-///   volume: `CalcVolumeAndPan @ 0x00750AC0` applies the `MinVolume=` floor only
-///   for GLOBAL (`0x10`, 52 stock entries — `[Defaults]` is NOT global), skips
-///   the half-viewport subtraction only for LOCAL (`0x40`), and silences
-///   unrevealed cells for SHROUD (`0x800`). Parsing this is what unblocks the
-///   unconditional floor recorded in `audio/sfx.rs`.
-/// - `Limit=` (77) caps concurrent instances; 17 stock sounds cap at one.
-/// - `Loop=` is NO-DIFF — dead in stock.
-/// - `FShift=` (218), `VShift=` (153), `Attack=`/`Decay=` (12/9) and `Delay=`
-///   (64) remain unparsed pitch and envelope controls.
-/// - Trigger: playing any sound whose entry authors one of them, which is most
-///   of the registry.
-/// - Player effect: sounds do not interrupt or loop as authored, ambient beds
-///   cannot persist, repeated events stack without limit, and no envelope or
-///   pitch shift is applied.
-/// - Frequency: continuous.
-/// - Downstream risk: `Type=` is a pure parse and lands on its own. `Limit=` and
-///   `Control=INTERRUPT` need the channel arbitration that today lives inside
-///   the device-bound player, so they cannot be closed before that device-free
-///   arbiter is extracted (recorded on `audio/sfx.rs`).
-///
 /// The terminator's value in the same table.
 const SOUND_PRIORITY_DEFAULT: u8 = 2;
 
@@ -337,6 +654,13 @@ fn parse_sound_priority(raw: &str) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The stock `[Defaults]` block, verbatim from `soundmd.ini`.
+    const STOCK_DEFAULTS: &str = "[Defaults]\nMinVolume=50\nRange=10\nVolume=80\nLimit=5\nType= NORMAL SCREEN UNSHROUD\nPriority=NORMAL \n";
+
+    fn registry(body: &str) -> SoundRegistry {
+        SoundRegistry::from_ini(&IniFile::from_str(&format!("{STOCK_DEFAULTS}{body}")))
+    }
 
     #[test]
     fn test_parse_single_sound() {
@@ -369,15 +693,17 @@ mod tests {
         assert_eq!(parse_sound_priority("URGENT"), 2);
     }
 
+    /// `strtok` on `" \t\n"` — a comma is part of the sample name, so a
+    /// comma-joined list is one (missing) sample, never three.
     #[test]
-    fn test_parse_multi_sound() {
-        let ini: IniFile = IniFile::from_str(
-            "[E1Voice]\nSounds=e1sel01.wav,e1sel02.wav,e1sel03.wav\nVolume=100\n",
-        );
+    fn sounds_split_on_native_whitespace_only() {
+        let ini: IniFile =
+            IniFile::from_str("[E1Voice]\nSounds=e1sel01 e1sel02\te1sel03\nVolume=100\n");
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         let entry: &SoundEntry = reg.get("E1Voice").expect("should find entry");
-        assert_eq!(entry.sounds.len(), 3);
-        assert_eq!(entry.sounds[0], "e1sel01.wav");
+        assert_eq!(entry.sounds, vec!["e1sel01", "e1sel02", "e1sel03"]);
+        let comma = SoundRegistry::from_ini(&IniFile::from_str("[X]\nSounds=a.wav,b.wav\n"));
+        assert_eq!(comma.get("X").unwrap().sounds, vec!["a.wav,b.wav"]);
     }
 
     #[test]
@@ -410,16 +736,156 @@ mod tests {
         assert!(reg.get("SoundB").is_some());
     }
 
+    /// Without a `[Defaults]` section the static initialisers apply:
+    /// Volume 80, MinVolume 20, Type SCREEN, Limit 5, Range 10, Control 0.
     #[test]
-    fn test_defaults() {
+    fn static_defaults_match_the_binary_initialisers() {
         let ini: IniFile = IniFile::from_str("[MinimalSound]\nSounds=min.wav\n");
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         let entry: &SoundEntry = reg.get("MinimalSound").unwrap();
-        assert_eq!(entry.volume, 100);
+        assert_eq!(entry.volume, 80);
+        assert_eq!(entry.volume_linear, 13107); // ftol(0.8 * 16384)
+        assert!((entry.min_volume - 0.2).abs() < 1e-6);
         // `VocClass::ReadINI @ 0x00750440` passes the literal "NORMAL" as the
         // ReadString default, so an absent key lands on the same 2 the
         // terminator carries.
         assert_eq!(entry.priority, 2);
+        assert_eq!(entry.type_flags, sound_type::SCREEN);
+        assert_eq!(entry.control, 0);
+        assert_eq!(entry.limit, 5);
+        assert_eq!(entry.loop_count, 0);
+        assert_eq!(entry.range, 10);
+        assert_eq!(entry.delay_ms, (0, 0));
+        assert_eq!(entry.fshift, (0, 0));
+        assert_eq!(entry.vshift, 0);
+        assert_eq!((entry.attack, entry.decay), (0, 0));
+    }
+
+    /// The stock `[Defaults]` block: an entry authoring nothing but `Sounds=`
+    /// inherits NORMAL|SCREEN|UNSHROUD, a 0.5 floor, Limit 5 and Range 10.
+    #[test]
+    fn stock_defaults_flow_into_a_bare_entry() {
+        let reg = registry("[Bare]\nSounds=bare\n");
+        let entry = reg.get("Bare").unwrap();
+        assert_eq!(entry.type_flags, sound_type::SCREEN | sound_type::UNSHROUD);
+        assert_eq!(entry.min_volume, 0.5);
+        assert_eq!(entry.volume_linear, 13107);
+        assert_eq!(entry.limit, 5);
+        assert_eq!(entry.range, 10);
+        assert_eq!(reg.defaults().min_volume_fraction(), 0.5);
+        assert_eq!(reg.defaults().control, 0);
+    }
+
+    /// Stock `Type=` spellings. A `Type=` with any token restarts from SCREEN
+    /// (so `[Defaults]`' UNSHROUD is dropped), LOCAL replaces SCREEN, and
+    /// SHROUD replaces UNSHROUD.
+    #[test]
+    fn type_flags_follow_the_native_table_and_exclusive_pairs() {
+        let reg = registry(
+            "[G]\nSounds=g\nType=global\n[L]\nSounds=l\nType= Local\n[GS]\nSounds=gs\nType=global shroud\n[LS]\nSounds=ls\nType= local shroud\n[D]\nSounds=d\nType= NORMAL SCREEN UNSHROUD\n[U]\nSounds=u\nType=bogus\n[E]\nSounds=e\nType=\n",
+        );
+        use sound_type::*;
+        assert_eq!(reg.get("G").unwrap().type_flags, SCREEN | GLOBAL);
+        assert_eq!(reg.get("L").unwrap().type_flags, LOCAL);
+        assert_eq!(reg.get("GS").unwrap().type_flags, SCREEN | GLOBAL | SHROUD);
+        assert_eq!(reg.get("LS").unwrap().type_flags, LOCAL | SHROUD);
+        assert_eq!(reg.get("D").unwrap().type_flags, SCREEN | UNSHROUD);
+        assert_eq!(reg.get("U").unwrap().type_flags, SCREEN);
+        // An empty value has no token: the [Defaults] flags are kept.
+        assert_eq!(reg.get("E").unwrap().type_flags, SCREEN | UNSHROUD);
+        let mut flags = SCREEN | UNSHROUD;
+        apply_type_token(&mut flags, "shroud");
+        apply_type_token(&mut flags, "LOCAL");
+        apply_type_token(&mut flags, "screen");
+        assert_eq!(flags, SCREEN | SHROUD);
+    }
+
+    /// Stock `Control=` spellings through the `0x008160C0` table, plus the
+    /// attack/decay normalisation `SetControlFlags` applies afterwards.
+    #[test]
+    fn control_flags_and_envelope_counts_match_the_native_setters() {
+        let reg = registry(
+            "[R]\nSounds=r\nControl=random\n[RI]\nSounds=ri\nControl= random interrupt \n[RP]\nSounds=rp\nControl=random predelay\n[Amb]\nSounds=a\nControl= random loop all ambient\n[Env]\nSounds=a1 a2 a3 b1 b2 d1 d2 d3\nControl= loop random all decay attack\nAttack=3\nDecay=3\n[EnvNoCount]\nSounds=a b c\nControl= random attack decay\n[NoFlag]\nSounds=a b c\nControl=random\nAttack=2\nDecay=1\n[Empty]\nSounds=x\nControl=\n[Bogus]\nSounds=x\nControl=Random bogus\n",
+        );
+        use control::*;
+        assert_eq!(reg.get("R").unwrap().control, RANDOM);
+        assert_eq!(reg.get("RI").unwrap().control, RANDOM | INTERRUPT);
+        assert_eq!(reg.get("RP").unwrap().control, RANDOM | PREDELAY);
+        assert_eq!(
+            reg.get("Amb").unwrap().control,
+            RANDOM | LOOP | ALL | AMBIENT
+        );
+        let env = reg.get("Env").unwrap();
+        assert_eq!(env.control, LOOP | RANDOM | ALL | DECAY | ATTACK);
+        assert_eq!((env.attack, env.decay), (3, 3));
+        assert_eq!(env.body_range(), 3..5);
+        let env_no_count = reg.get("EnvNoCount").unwrap();
+        assert_eq!((env_no_count.attack, env_no_count.decay), (1, 1));
+        let no_flag = reg.get("NoFlag").unwrap();
+        assert_eq!((no_flag.attack, no_flag.decay), (0, 0));
+        assert_eq!(no_flag.body_range(), 0..3);
+        assert_eq!(reg.get("Empty").unwrap().control, 0);
+        assert_eq!(reg.get("Bogus").unwrap().control, RANDOM);
+        assert_eq!(parse_control_token("INTERRUPT"), 0x10);
+        assert_eq!(parse_control_token("predelay"), 0x08);
+    }
+
+    /// `Delay=`/`FShift=` one-or-two token rule and the `VShift=` clamp, using
+    /// the stock spellings including the lower-case `Fshift`/`Vshift` keys
+    /// (5 and 11 stock occurrences) that gamemd's case-insensitive INI reads.
+    #[test]
+    fn delay_fshift_vshift_follow_native_pairs_and_clamps() {
+        let reg = registry(
+            "[A]\nSounds=a\nDelay=0 400\nFShift= -10 10\nVShift=20\n[B]\nSounds=b\nDelay= 400\nFshift=-5 5\nVshift=15\n[C]\nSounds=c\nVShift=140\nFShift=\nDelay= 5000 8000 9000\n[D]\nSounds=d\nVShift=-3\n",
+        );
+        let a = reg.get("A").unwrap();
+        assert_eq!(a.delay_ms, (0, 400));
+        assert_eq!(a.fshift, (-10, 10));
+        assert_eq!(a.vshift, 20);
+        let b = reg.get("B").unwrap();
+        assert_eq!(b.delay_ms, (400, 400));
+        assert_eq!(b.fshift, (-5, 5));
+        assert_eq!(b.vshift, 15);
+        let c = reg.get("C").unwrap();
+        assert_eq!(c.vshift, 100);
+        assert_eq!(c.fshift, (0, 0));
+        assert_eq!(c.delay_ms, (5000, 8000));
+        assert_eq!(reg.get("D").unwrap().vshift, 0);
+        assert_eq!(crt_atoi(" -12x"), -12);
+        assert_eq!(crt_atoi("abc"), 0);
+    }
+
+    /// `Volume`/`MinVolume` go through `ReadDouble` (float, `%` scaling) and
+    /// the per-entry clamp before the 16384 scale.
+    #[test]
+    fn volume_and_min_volume_follow_read_double_and_the_clamps() {
+        let reg = registry(
+            "[Full]\nSounds=f\nVolume=100\n[Over]\nSounds=o\nVolume=250\nMinVolume=130\n[Neg]\nSounds=n\nVolume=-5\nMinVolume=-1\n[Pct]\nSounds=p\nVolume=5000%\n[Half]\nSounds=h\nVolume=50.5\nMinVolume=25\n[Lower]\nSounds=l\nvolume=60\n",
+        );
+        assert_eq!(reg.get("Full").unwrap().volume_linear, VOLUME_SCALE);
+        let over = reg.get("Over").unwrap();
+        assert_eq!(over.volume_linear, VOLUME_SCALE);
+        assert_eq!(over.min_volume, 1.0);
+        let neg = reg.get("Neg").unwrap();
+        assert_eq!(neg.volume_linear, 0);
+        assert_eq!(neg.min_volume, 0.0);
+        assert_eq!(reg.get("Pct").unwrap().volume_linear, 8192);
+        let half = reg.get("Half").unwrap();
+        assert_eq!(half.volume_linear, volume_linear(50.5));
+        assert_eq!(half.volume_linear, 8273); // ftol(0.505 * 16384)
+        assert_eq!(half.min_volume, 0.25);
+        assert_eq!(reg.get("Lower").unwrap().volume, 60);
+    }
+
+    /// 33 samples: the native slot table holds 32.
+    #[test]
+    fn sample_list_is_capped_at_the_native_slot_count() {
+        let list = (0..40)
+            .map(|i| format!("s{i}"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let reg = SoundRegistry::from_ini(&IniFile::from_str(&format!("[Many]\nSounds={list}\n")));
+        assert_eq!(reg.get("Many").unwrap().sounds.len(), MAX_SAMPLES);
     }
 
     #[test]
@@ -443,7 +909,7 @@ mod tests {
 
     #[test]
     fn test_strip_hash_prefix() {
-        let ini: IniFile = IniFile::from_str("[HashTest]\nSounds= #sound1 #sound2\n");
+        let ini: IniFile = IniFile::from_str("[HashTest]\nSounds= #sound1 #$sound2\n");
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         let entry: &SoundEntry = reg.get("HashTest").expect("should find entry");
         assert_eq!(entry.sounds, vec!["sound1", "sound2"]);

--- a/src/rules/sound_ini.rs
+++ b/src/rules/sound_ini.rs
@@ -142,8 +142,11 @@ impl SoundDefaults {
         let Some(section) = section else {
             return defaults;
         };
-        defaults.volume = read_double(section, "Volume", defaults.volume);
-        defaults.min_volume = read_double(section, "MinVolume", defaults.min_volume);
+        // `VocClass::ReadSoundListINI @ 0x007510D0` narrows both back to the
+        // float32 statics: `_DAT_008464b4 = (float)fVar8`,
+        // `_DAT_008464b8 = (float)fVar8`.
+        defaults.volume = read_double(section, "Volume", defaults.volume) as f32;
+        defaults.min_volume = read_double(section, "MinVolume", defaults.min_volume) as f32;
         defaults.priority = section
             .get_ignoring_case("Priority")
             .map_or(defaults.priority, parse_sound_priority);
@@ -165,7 +168,7 @@ impl SoundDefaults {
     /// The minimum-volume floor as the stored fraction (see
     /// [`SoundEntry::min_volume`]).
     pub fn min_volume_fraction(&self) -> f32 {
-        min_volume_fraction(self.min_volume)
+        min_volume_fraction(f64::from(self.min_volume))
     }
 }
 
@@ -178,11 +181,17 @@ pub struct SoundEntry {
     /// [`MAX_SAMPLES`]. `Attack=` counts the first N as attack samples and
     /// `Decay=` the last M as decay samples; the rest is the body.
     pub sounds: Vec<String>,
-    /// Playback volume in percent, `0..=100`.
+    /// Playback volume in percent, `0..=100`. VERA-internal, gamemd
+    /// equivalent UNCHECKED: native keeps no percentage — `ReadINI` converts
+    /// straight to [`Self::volume_linear`] and throws the percentage away.
+    /// This rounded copy exists for display and tests and feeds no playback
+    /// path.
     pub volume: u8,
-    /// Native linear volume `ftol(clamp(Volume * 0.01, 0, 1) * 0x4000)` as
+    /// Native linear volume `ftol(clamp(Volume * 0.01f, 0, 1) * 16384f)` as
     /// stored by `AudioEventClass::SetVolumeRamp @ 0x00406550`
-    /// (`0x007504EE..0x00750548`).
+    /// (`0x007504EE..0x00750548`). The x87 chain truncates, so `Volume=100`
+    /// yields 16383, not `0x4000` — only the high clamp reaches `0x4000`. See
+    /// [`volume_linear`] for why the whole product must stay in `f64`.
     pub volume_linear: i32,
     /// Eviction priority, `LOWEST(0)`..`CRITICAL(4)`; higher survives longer.
     ///
@@ -190,7 +199,10 @@ pub struct SoundEntry {
     pub priority: u8,
     /// Audible range in cells (default 10). `max audible pixel distance =
     /// Range * 60` in `VocClass::CalcVolumeAndPan @ 0x00750AC0`.
-    pub range: u16,
+    ///
+    /// A full `int`, as `AudioEventClass::SetRange @ 0x004065E0` stores it
+    /// (`MOV [ECX+0x50], EDX; RET` — no clamp of any kind).
+    pub range: i32,
     /// `MinVolume=` as the stored fraction `clamp(MinVolume * 0.01, 0, 1)`
     /// (`0x00750589..0x007505E3`, `AudioEventClass::SetMinVolume @
     /// 0x004065F0` at `+0x54`). The floor applies only for `Type=GLOBAL`.
@@ -258,26 +270,40 @@ impl SoundRegistry {
                 continue;
             }
 
+            // VERA-internal, gamemd equivalent UNCHECKED: using `Sounds=` as
+            // the section filter. Native never scans INI sections — it walks
+            // the `[SoundList]` entries (`VocClass::ReadSoundListINI @
+            // 0x007510D0`, `GetEntryCount`/`GetEntryNameByIndex`) and calls
+            // `VocClass::ReadINI @ 0x00750440` once per name, which reads
+            // `Sounds=` with an empty-string default and simply adds no
+            // samples when it is absent. VERA has no `[SoundList]` pass, so
+            // the key's presence is what separates a sound section from the
+            // rest of the file. Trigger: a `[SoundList]` name whose section
+            // omits `Sounds=`, or writes it empty (`IniFile` drops a key with
+            // an empty value, so the two are indistinguishable at this point).
+            // Player effect: VERA falls through to the audio-bag path for that
+            // id where gamemd would play nothing. Frequency: never on retail
+            // data — every stock `[SoundList]` section writes a non-empty
+            // `Sounds=`. Downstream risk: none.
             let sounds_str: &str = match section.get_ignoring_case("Sounds") {
                 Some(s) => s,
                 None => continue,
             };
 
             // `VocClass::AddSample @ 0x004064A0` skips every leading `$`/`#`
-            // and stops accepting at 32 samples.
+            // and stops accepting at 32 samples. An empty list is registered,
+            // not skipped: native's `VocClass` exists with a zero sample count
+            // and plays nothing, so the id must still resolve here rather than
+            // fall through to the audio-bag path.
             let sounds: Vec<String> = split_tokens(sounds_str)
                 .map(|s| s.trim_start_matches(['$', '#']).to_string())
                 .filter(|s| !s.is_empty())
                 .take(MAX_SAMPLES)
                 .collect();
 
-            if sounds.is_empty() {
-                continue;
-            }
-
             let volume_raw = read_double(section, "Volume", defaults.volume);
             let volume_linear = volume_linear(volume_raw);
-            let volume: u8 = (volume_raw.clamp(0.0, 100.0) as f64).round() as u8;
+            let volume: u8 = volume_raw.clamp(0.0, 100.0).round() as u8;
             let vshift = section
                 .get_i32_ignoring_case("VShift")
                 .unwrap_or(0)
@@ -301,10 +327,9 @@ impl SoundRegistry {
                 .get_i32_ignoring_case("Limit")
                 .unwrap_or(defaults.limit);
             let loop_count = section.get_i32_ignoring_case("Loop").unwrap_or(0);
-            let range: u16 = section
+            let range: i32 = section
                 .get_i32_ignoring_case("Range")
-                .unwrap_or(defaults.range)
-                .clamp(0, i32::from(u16::MAX)) as u16;
+                .unwrap_or(defaults.range);
             let delay_ms = parse_int_pair(section.get_ignoring_case("Delay"));
             let fshift = parse_int_pair(section.get_ignoring_case("FShift"));
 
@@ -376,11 +401,26 @@ impl SoundRegistry {
     }
 }
 
-/// `CCINIClass::ReadDouble @ 0x005283D0`: `sscanf("%f")` into a float, times
-/// 0.01 when the text contains a `%`; absent or unparsable keeps the default.
-fn read_double(section: &IniSection, key: &str, default: f32) -> f32 {
+/// `0.01f` at `0x007EAAE0`, the *float* constant the sound reader multiplies a
+/// percentage by. It is `10737418 / 2^30`, i.e. slightly **below** 0.01, which
+/// is why the whole chain has to stay at x87 precision — see
+/// [`volume_linear`].
+const ONE_PERCENT_F32_AS_F64: f64 = 0.01f32 as f64;
+
+/// `CCINIClass::ReadDouble @ 0x005283D0` — returns a **double**.
+///
+/// `sscanf("%f")` parses into a `float`, which is then widened to double and
+/// kept there (`0x0052855D FLD float [ESP+0x2C]; 0x00528569 FSTP double
+/// [ESP+0x38]`). When `strchr(text, '%')` hits, the double is multiplied by
+/// the *double* 0.01 at `0x007E3808` (`0x0052857E FMUL double`) and stored
+/// back as a double — there is no float narrowing on that path, so the result
+/// this function hands its caller carries 53 significant bits. Absent or
+/// unparsable keeps the caller's default, which reaches the native call as a
+/// `float32` static widened the same way (`0x007504EE FLD float [0x008464B4];
+/// FSTP double [ESP]`).
+fn read_double(section: &IniSection, key: &str, default: f32) -> f64 {
     let Some(raw) = section.get_ignoring_case(key) else {
-        return default;
+        return f64::from(default);
     };
     let text = raw.trim_start();
     let end = text
@@ -392,39 +432,68 @@ fn read_double(section: &IniSection, key: &str, default: f32) -> f32 {
         .last()
         .unwrap_or(0);
     let Ok(parsed) = text[..end].parse::<f32>() else {
-        return default;
+        return f64::from(default);
     };
     if raw.contains('%') {
-        ((parsed as f64) * 0.01) as f32
+        f64::from(parsed) * 0.01
     } else {
-        parsed
+        f64::from(parsed)
     }
 }
 
-/// `0x007504EE..0x00750548`: `Volume * 0.01f`, clamped to `[0, 1]`, times
-/// 16384, then `Math::ftol` (truncation).
-fn volume_linear(volume: f32) -> i32 {
-    let scaled = ((volume as f64) * (0.01f32 as f64)) as f32;
-    let clamped = if (scaled as f64) > 1.0 {
-        1.0f32
-    } else if scaled < 0.0 {
-        0.0
+/// `0x007504EE..0x00750548`: the `ReadDouble` result times the *float* 0.01
+/// at `0x007EAAE0`, clamped to `[0, 1]`, times the float 16384 at `0x007EF38C`,
+/// then `Math::ftol` (truncation) into `AudioEventClass::SetVolumeRamp @
+/// 0x00406550`.
+///
+/// **The product never leaves the x87 stack.** Between `0x00750507 FMUL float
+/// [0x007EAAE0]` and the `ftol` call at `0x0075053F` there is no `FSTP float`
+/// of any kind — only `FCOM`/`FLD` of the clamp constants — and no game code
+/// narrows the x87 precision control (every `FLDCW` site in the image is CRT
+/// or math code saving and restoring its own word), so the chain carries the
+/// MSVC default 53-bit mantissa all the way into the truncation. Reproducing
+/// that in `f64` is load-bearing: with an `f32` intermediate, `Volume=`
+/// 25/50/75/100 (and the `Volume=5000%` form) each round *up* across a linear
+/// step and land one higher than gamemd — 4096/8192/12288/16384 instead of
+/// 4095/8191/12287/16383 — because `0.01f` sits just below 0.01, so the exact
+/// product sits just below the round value. 55 stock `soundmd.ini` sections
+/// write one of those four.
+///
+/// The clamp constants are asymmetric and are transcribed as the binary has
+/// them: the high test compares against the *double* 1.0 at `0x007E1718` and
+/// substitutes the *float* 1.0 at `0x007E2AC8`; the low test compares against
+/// the float 0.0 at `0x007E1748` and takes "less **or** equal"
+/// (`0x0075052C TEST AH,0x41`).
+fn volume_linear(volume: f64) -> i32 {
+    let product = volume * ONE_PERCENT_F32_AS_F64;
+    let clamped = if product > 1.0 {
+        f64::from(1.0f32)
+    } else if product <= 0.0 {
+        f64::from(0.0f32)
     } else {
-        scaled
+        product
     };
-    ((clamped as f64) * (VOLUME_SCALE as f64)).trunc() as i32
+    (clamped * f64::from(VOLUME_SCALE)).trunc() as i32
 }
 
-/// `0x00750589..0x007505E3`: `MinVolume * 0.01f` clamped to `[0, 1]`, kept
-/// as a float.
-fn min_volume_fraction(min_volume: f32) -> f32 {
-    let scaled = ((min_volume as f64) * (0.01f32 as f64)) as f32;
-    if (scaled as f64) > 1.0 {
+/// `0x00750589..0x007505E3`: `MinVolume * 0.01f` clamped to `[0, 1]`, stored
+/// as a float by `AudioEventClass::SetMinVolume @ 0x004065F0` at `+0x54`.
+///
+/// Unlike [`volume_linear`] this chain *does* narrow: `0x007505A8 FST float
+/// [ESP+8]` writes the product to a float32 slot while leaving the
+/// full-precision value in `ST0`, so the `> 1.0` test at `0x007505AC` compares
+/// the **un-narrowed** product against the double 1.0, and the `<= 0.0f` test
+/// at `0x007505C7` reloads the **narrowed** float. Both clamps then write the
+/// literal bit patterns `0x3F800000` / `0x00000000`.
+fn min_volume_fraction(min_volume: f64) -> f32 {
+    let product = min_volume * ONE_PERCENT_F32_AS_F64;
+    let narrowed = product as f32;
+    if product > 1.0 {
         1.0
-    } else if scaled < 0.0 {
+    } else if narrowed <= 0.0 {
         0.0
     } else {
-        scaled
+        narrowed
     }
 }
 
@@ -855,26 +924,76 @@ mod tests {
         assert_eq!(crt_atoi("abc"), 0);
     }
 
-    /// `Volume`/`MinVolume` go through `ReadDouble` (float, `%` scaling) and
-    /// the per-entry clamp before the 16384 scale.
+    /// `Volume`/`MinVolume` go through `ReadDouble` (a double, `%` scaling)
+    /// and the per-entry clamp before the 16384 scale.
+    ///
+    /// The exact values are derived from the native chain, not from VERA: the
+    /// product stays at x87 precision from `0x00750507 FMUL float 0.01f` to
+    /// `0x0075053F CALL Math::ftol`, so `Volume=100` truncates
+    /// `100 * 0.01f * 16384 = 16383.99963...` to **16383**, one below the
+    /// round `0x4000`. `Volume=250` reaches `0x4000` only through the high
+    /// clamp, which substitutes the literal float `1.0` at `0x007E2AC8`.
     #[test]
     fn volume_and_min_volume_follow_read_double_and_the_clamps() {
         let reg = registry(
             "[Full]\nSounds=f\nVolume=100\n[Over]\nSounds=o\nVolume=250\nMinVolume=130\n[Neg]\nSounds=n\nVolume=-5\nMinVolume=-1\n[Pct]\nSounds=p\nVolume=5000%\n[Half]\nSounds=h\nVolume=50.5\nMinVolume=25\n[Lower]\nSounds=l\nvolume=60\n",
         );
-        assert_eq!(reg.get("Full").unwrap().volume_linear, VOLUME_SCALE);
+        // Just under 0x4000: `100 * 0.01f` is `1073741800/2^30`, so the ×16384
+        // product is 16383.9996337890625 and `ftol` truncates.
+        assert_eq!(reg.get("Full").unwrap().volume_linear, VOLUME_SCALE - 1);
         let over = reg.get("Over").unwrap();
+        // Only the clamp reaches exactly 0x4000.
         assert_eq!(over.volume_linear, VOLUME_SCALE);
         assert_eq!(over.min_volume, 1.0);
         let neg = reg.get("Neg").unwrap();
         assert_eq!(neg.volume_linear, 0);
         assert_eq!(neg.min_volume, 0.0);
-        assert_eq!(reg.get("Pct").unwrap().volume_linear, 8192);
+        // `5000%` -> `ReadDouble` returns the double 50.0, then the same chain.
+        assert_eq!(reg.get("Pct").unwrap().volume_linear, 8191);
         let half = reg.get("Half").unwrap();
         assert_eq!(half.volume_linear, volume_linear(50.5));
         assert_eq!(half.volume_linear, 8273); // ftol(0.505 * 16384)
         assert_eq!(half.min_volume, 0.25);
         assert_eq!(reg.get("Lower").unwrap().volume, 60);
+    }
+
+    /// The four stock `Volume=` values whose exact `Volume * 0.01f * 16384`
+    /// product sits just *below* the round linear step. An `f32` intermediate
+    /// anywhere in the chain rounds each of them up and yields
+    /// 4096/8192/12288/16384; the native x87 chain truncates to one less.
+    /// 55 stock `soundmd.ini` sections write one of these four.
+    #[test]
+    fn quarter_volumes_truncate_one_below_the_round_linear_step() {
+        assert_eq!(volume_linear(25.0), 4095);
+        assert_eq!(volume_linear(50.0), 8191);
+        assert_eq!(volume_linear(75.0), 12287);
+        assert_eq!(volume_linear(100.0), 16383);
+        // Values whose product lands above the step are unaffected.
+        assert_eq!(volume_linear(80.0), 13107);
+        assert_eq!(volume_linear(85.0), 13926);
+        assert_eq!(volume_linear(90.0), 14745);
+    }
+
+    /// Native registers a `[SoundList]` name whose `Sounds=` yields no usable
+    /// tokens as a zero-sample `VocClass` (`VocClass::ReadINI @ 0x00750440`
+    /// reads `Sounds=` with an empty default and `AddSample @ 0x004064A0`
+    /// stores nothing for a name that strips to nothing), so the id must still
+    /// resolve here — dropping it would let VERA's audio-bag fallback play a
+    /// file gamemd never would. A bare `Sounds=` cannot reach this: the INI
+    /// parser discards an empty value outright, so `Sounds=$` is the shortest
+    /// live trigger.
+    ///
+    /// `Range=` is stored as a full int by `AudioEventClass::SetRange @
+    /// 0x004065E0` (`MOV [ECX+0x50], EDX`) — no clamp, either end.
+    #[test]
+    fn empty_sample_list_registers_a_zero_sample_entry_and_range_keeps_the_native_int() {
+        let reg = registry("[Silent]\nSounds=$\nRange=100000\n[Named]\nSounds=x\nRange=-4\n");
+        let silent = reg
+            .get("Silent")
+            .expect("a sigil-only Sounds= still registers");
+        assert!(silent.sounds.is_empty());
+        assert_eq!(silent.range, 100_000);
+        assert_eq!(reg.get("Named").unwrap().range, -4);
     }
 
     /// 33 samples: the native slot table holds 32.

--- a/src/rules/sound_ini.rs
+++ b/src/rules/sound_ini.rs
@@ -34,7 +34,7 @@
 use std::collections::HashMap;
 
 use crate::rules::ini_parser::{IniFile, IniSection};
-use crate::rules::ini_value::parse_read_double;
+use crate::rules::ini_value::{parse_read_double, strtrim_ascii, truncate_bytes};
 
 /// `Control=` flag words. gamemd-derived: the `(char*, u32)` table at
 /// `0x008160C0` walked by `AudioEventClass::ParseControlFlag @ 0x00406820`
@@ -107,6 +107,17 @@ pub const VOLUME_SCALE: i32 = 0x4000;
 /// Sample slots per event: `VocClass::AddSample @ 0x004064A0` refuses the
 /// 33rd (`+0x134 == 0x20`).
 pub const MAX_SAMPLES: usize = 0x20;
+
+/// Usable bytes in a sound id. `0x007512CA PUSH 0x20` hands
+/// `CCINIClass::ReadString @ 0x00528A10` a 32-byte stack buffer, and its tail
+/// is `strncpy(dst, value, 0x20); dst[0x1f] = 0; strtrim()`, so a `[SoundList]`
+/// value survives as at most 31 bytes. `AudioEventClass::FindOrCreate @
+/// 0x004063B0` cuts to the same ceiling again — `0x00406460 PUSH 0x1f` into the
+/// zero-filled name field at `+0x6c` — and `VocClass::ReadINI @ 0x00750440`
+/// then looks the section up by that **stored** name (`0x00750462 CALL
+/// 0x00405170` GetName -> `0x0075046A FindSectionByName`), never by the raw
+/// list value.
+const MAX_ID_BYTES: usize = 0x1f;
 
 /// `[Defaults]` values. gamemd-derived: `VocClass::ReadSoundListINI @
 /// 0x007510D0` — Volume -> `0x008464B4` (static 80.0f), MinVolume ->
@@ -245,12 +256,22 @@ impl SoundEntry {
     /// name (`0x0075046A INIClass::FindSectionByName`) and returns at
     /// `0x00750476` without reading a single key when it is missing, so the
     /// object keeps what `AudioEventClass::FindOrCreate @ 0x004063B0` built:
-    /// a zero-filled `0x148` allocation plus `+0xC = 1`, `+0x10 = 0` (Control),
-    /// `+0x14 = 0x20` (Type SCREEN), `+0x40 = 2` (Priority NORMAL),
+    /// a zero-filled `0x148` allocation (`0x00406401..0x00406415` runs
+    /// `REP STOSD` over all `0x52` dwords of it, twice) plus `+0xC = 1`,
+    /// `+0x10 = 0` (Control), `+0x14 = 0x20` (SCREEN), `+0x40 = 2` (NORMAL),
     /// `+0x48 = 3` (Limit), `+0x50 = 10` (Range), `+0x54 = 0.2f` (MinVolume),
     /// and the name `strncpy`d to 31 chars. Those are the **constructor's**
     /// values, not `[Defaults]`' — the `Limit` differs (3 against the static
     /// 5) precisely because `[Defaults]` was never applied here.
+    ///
+    /// The **volume is full, not zero**: `0x0040641F MOV EDX,0x4000;
+    /// 0x00406424 LEA ECX,[ESI+0x18]; 0x00406458 CALL 0x00407100` seeds the
+    /// interpolator at `+0x18` — the same subobject `SetVolumeRamp @
+    /// 0x00406550` writes (`LEA ESI,[ECX+0x18]`) when `Volume=` is read — and
+    /// `0x00407100` is `MOV EDI,EDX; SHL EDI,0x10; MOV [ESI+0x8],EDI`, i.e. the
+    /// 16.16 current value becomes `0x4000 << 16` = [`VOLUME_SCALE`]. The
+    /// zero-fill is overwritten one instruction later, so an unread entry is at
+    /// full volume, not silent-by-volume.
     ///
     /// The sample count `+0x134` stays 0, and `SoundEvent::UpdateState @
     /// 0x004055C0` state 0 abandons the event when it is
@@ -262,8 +283,9 @@ impl SoundEntry {
         Self {
             id: name.to_string(),
             sounds: Vec::new(),
-            volume: 0,
-            volume_linear: 0,
+            // `+0x18` interp seeded to `0x4000` (`0x0040641F`/`0x00406458`).
+            volume: 100,
+            volume_linear: VOLUME_SCALE,
             priority: SOUND_PRIORITY_DEFAULT,
             range: 10,
             min_volume: 0.2,
@@ -314,8 +336,9 @@ impl SoundRegistry {
     /// and no rules/art key references it), and a listed id whose section is
     /// missing still registers — see [`SoundEntry::unread`].
     ///
-    /// `merge_fallback` handles the base-RA2 `sound.ini` layer; native reads
-    /// one file per pass the same way.
+    /// One file per pass; see [`SoundRegistry::merge_fallback`] for the
+    /// base-RA2 `sound.ini` layer VERA stacks under it, which gamemd has no
+    /// equivalent of.
     pub fn from_ini(ini: &IniFile) -> Self {
         let mut entries: HashMap<String, SoundEntry> = HashMap::new();
         let defaults = SoundDefaults::read(ini.section("Defaults"));
@@ -330,7 +353,8 @@ impl SoundRegistry {
         // Values in source order, which is native's entry-index order. The INI
         // parser has already dropped entries with an empty value, matching the
         // `ReadString` length gate.
-        for value in list.get_values() {
+        for raw_value in list.get_values() {
+            let value = cut_list_value(raw_value);
             let key = value.to_ascii_uppercase();
             // `0x007512F4..0x0075133D` compares the id against the names of the
             // events already created (`FUN_007C8D20`, case-insensitive) and,
@@ -354,8 +378,25 @@ impl SoundRegistry {
         Self { entries, defaults }
     }
 
-    /// Merge another sound.ini (base RA2) into this registry.
-    /// Only adds entries that don't already exist (YR-first precedence).
+    /// Merge another sound.ini (base RA2) into this registry, adding only ids
+    /// this registry does not already carry (YR-first precedence).
+    ///
+    /// **VERA-internal, gamemd has no equivalent.** YR registers sounds from
+    /// `SOUNDMD.INI` and nothing else: `get_xrefs_to 0x007510D0` returns the
+    /// single caller `Init_Game @ 0x0052C796`, and the INI it is handed comes
+    /// from the load at `0x0052C763` guarded by
+    /// `"Failed to load SOUNDMD.INI!"` (`0x00825E10`). The base `sound.ini` is
+    /// never opened, so this layer is a VERA convenience for running against a
+    /// base-RA2 asset set.
+    ///
+    /// Retail reachability: it adds exactly one id, `SUBMOVE` — the only
+    /// `[SoundList]` value in `sound.ini` absent from `soundmd.ini`. Only
+    /// `rules.ini` references it (`VoiceMove=SubMove`); YR loads `rulesmd.ini`
+    /// standalone and asks for `TyphoonSubMove`/`SubMoveStart`, both of which
+    /// `soundmd.ini` defines. Trigger: a lookup of an id present only in
+    /// `sound.ini`. Player effect: none observed on retail data (the one extra
+    /// id is unreachable). Frequency: load time only. Downstream risk: an
+    /// id-count difference against a native-side count.
     pub fn merge_fallback(&mut self, ini: &IniFile) {
         let fallback: SoundRegistry = SoundRegistry::from_ini(ini);
         let mut added: usize = 0;
@@ -393,6 +434,25 @@ impl SoundRegistry {
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
+}
+
+/// The sound id a `[SoundList]` value actually becomes.
+///
+/// gamemd-derived: the value never reaches `FindOrCreate` whole. It is read
+/// into a 32-byte buffer ([`MAX_ID_BYTES`] + the forced NUL) by
+/// `CCINIClass::ReadString @ 0x00528A10`, whose tail is `strncpy(dst, value,
+/// capacity); dst[capacity - 1] = 0; strtrim()` — so the cut happens **before**
+/// the trim and is by byte, not by character. Everything downstream (the dedupe
+/// scan at `0x007512F4`, `FindOrCreate`'s own `strncpy` at `0x00406460`, and the
+/// section lookup `ReadINI` does by the stored name at `0x00750462`) sees only
+/// the cut form.
+///
+/// Retail is unaffected: exactly one of the 820 `soundmd.ini` and 500
+/// `sound.ini` list values exceeds 31 bytes — the decorative
+/// `============ Mission Disk sounds ============` — and it has no section at
+/// either length.
+fn cut_list_value(value: &str) -> &str {
+    strtrim_ascii(truncate_bytes(value, MAX_ID_BYTES))
 }
 
 /// One `VocClass::ReadINI @ 0x00750440` pass for `name`: read the fourteen keys
@@ -1157,8 +1217,10 @@ mod tests {
     /// A `[SoundList]` name with no section at all. `ReadINI` returns at
     /// `0x00750476` without reading a key, so the entry keeps what
     /// `AudioEventClass::FindOrCreate @ 0x004063B0` wrote: Priority 2, Limit 3
-    /// (not `[Defaults]`' 5), Range 10, MinVolume 0.2f, Type SCREEN, and no
-    /// samples. Stock hits this through the decorative
+    /// (not `[Defaults]`' 5), Range 10, MinVolume 0.2f, Type SCREEN, volume
+    /// `0x4000` (`0x0040641F MOV EDX,0x4000` -> `0x00406458 CALL 0x00407100`,
+    /// which stores `EDX << 16` into the `+0x18` interp the `Volume=` key
+    /// writes), and no samples. Stock hits this through the decorative
     /// `============ Mission Disk sounds ============` list entry.
     #[test]
     fn listed_name_without_a_section_keeps_the_constructor_state() {
@@ -1173,9 +1235,46 @@ mod tests {
         assert_eq!(ghost.range, 10);
         assert_eq!(ghost.min_volume, 0.2);
         assert_eq!(ghost.type_flags, sound_type::SCREEN);
-        assert_eq!(ghost.volume_linear, 0);
+        // Full, not silent: the zero-fill at `0x00406401` is overwritten by
+        // `0x00406458`'s seed of the `+0x18` volume interp.
+        assert_eq!(ghost.volume_linear, VOLUME_SCALE);
         // `[Defaults]` still applies to entries that do have a section.
         assert_eq!(reg.defaults().limit, 5);
+    }
+
+    /// `[SoundList]` values are cut to 31 bytes on the way in: `0x007512CA
+    /// PUSH 0x20` gives `CCINIClass::ReadString @ 0x00528A10` a 32-byte buffer
+    /// and its tail is `strncpy(dst, value, 0x20); dst[0x1f] = 0; strtrim()`.
+    /// The cut precedes the trim, and the section lookup uses the cut name
+    /// (`0x00750462` GetName -> `0x0075046A FindSectionByName`), so a section
+    /// spelled with the full name is unreachable.
+    #[test]
+    fn a_list_value_is_cut_to_the_native_thirty_one_bytes() {
+        // 31 + 4 characters. Native keeps "AAAA…A" (31) and drops "Tail".
+        let long = format!("{}Tail", "A".repeat(MAX_ID_BYTES));
+        let cut = "A".repeat(MAX_ID_BYTES);
+        let ini = IniFile::from_str(&format!(
+            "[SoundList]\n1={long}\n[{long}]\nSounds=$never\n[{cut}]\nSounds=$cut\n"
+        ));
+        let reg = SoundRegistry::from_ini(&ini);
+        assert_eq!(reg.len(), 1);
+        assert!(
+            reg.get(&long).is_none(),
+            "the full-length id must not exist"
+        );
+        assert_eq!(reg.get(&cut).expect("the cut id registers").sounds, ["cut"]);
+
+        // The cut is by byte and lands before the trim, so a space that ends up
+        // at the boundary is stripped: `strtrim` runs on the copied 31 bytes.
+        let padded = format!("{} Tail", "B".repeat(MAX_ID_BYTES - 1));
+        let ini = IniFile::from_str(&format!("[SoundList]\n1={padded}\n"));
+        let reg = SoundRegistry::from_ini(&ini);
+        assert_eq!(reg.len(), 1);
+        assert!(reg.get(&"B".repeat(MAX_ID_BYTES - 1)).is_some());
+
+        // A value at or under the ceiling is untouched.
+        assert_eq!(cut_list_value("KirovVoiceDie"), "KirovVoiceDie");
+        assert_eq!(cut_list_value(&cut), cut);
     }
 
     /// A twice-listed id: the dedupe scan at `0x007512F4` hands the existing

--- a/src/rules/sound_ini.rs
+++ b/src/rules/sound_ini.rs
@@ -13,8 +13,11 @@
 //! Each section name is a sound ID referenced by weapons (Report=), units
 //! (VoiceSelect=, VoiceMove=, DieSound=), and EVA announcements.
 //!
-//! gamemd-derived: `VocClass::ReadINI @ 0x00750440` reads the fourteen keys
-//! below for every `[SoundList]` entry, in this order, with these defaults —
+//! gamemd-derived: `VocClass::ReadSoundListINI @ 0x007510D0` walks
+//! `[SoundList]` by entry index and registers one sound per entry VALUE; the
+//! INI's sections are never scanned. `VocClass::ReadINI @ 0x00750440` then
+//! reads the fourteen keys below out of the section named by that value, in
+//! this order, with these defaults —
 //! `Sounds` (""), `Volume` ([Defaults] float, static 80.0), `VShift` (0),
 //! `MinVolume` ([Defaults] float, static 20.0), `Priority` ("NORMAL"),
 //! `Attack` (0), `Decay` (0), `Control` ([Defaults] flags, static 0), `Type`
@@ -31,6 +34,7 @@
 use std::collections::HashMap;
 
 use crate::rules::ini_parser::{IniFile, IniSection};
+use crate::rules::ini_value::parse_read_double;
 
 /// `Control=` flag words. gamemd-derived: the `(char*, u32)` table at
 /// `0x008160C0` walked by `AudioEventClass::ParseControlFlag @ 0x00406820`
@@ -217,7 +221,9 @@ pub struct SoundEntry {
     /// `Loop=` pass count for looping events (`+0x4C`, 0 = forever).
     pub loop_count: i32,
     /// `Delay=` pre-delay range in milliseconds `(min, max)` (`+0x58/+0x5C`);
-    /// a single token sets both, no token sets `(0, 0)`.
+    /// a single token sets both, no token sets `(0, 0)`. The pair is real — see
+    /// [`parse_int_pair`] for why the decompiler's single-value rendering of
+    /// this tail is wrong.
     pub delay_ms: (i32, i32),
     /// `FShift=` frequency shift range in percent `(min, max)`
     /// (`+0x60/+0x64`); same one-or-two token rule as `Delay=`.
@@ -233,6 +239,46 @@ pub struct SoundEntry {
 }
 
 impl SoundEntry {
+    /// The state a listed id keeps when its section does not exist.
+    ///
+    /// `VocClass::ReadINI @ 0x00750440` looks the section up by the event's own
+    /// name (`0x0075046A INIClass::FindSectionByName`) and returns at
+    /// `0x00750476` without reading a single key when it is missing, so the
+    /// object keeps what `AudioEventClass::FindOrCreate @ 0x004063B0` built:
+    /// a zero-filled `0x148` allocation plus `+0xC = 1`, `+0x10 = 0` (Control),
+    /// `+0x14 = 0x20` (Type SCREEN), `+0x40 = 2` (Priority NORMAL),
+    /// `+0x48 = 3` (Limit), `+0x50 = 10` (Range), `+0x54 = 0.2f` (MinVolume),
+    /// and the name `strncpy`d to 31 chars. Those are the **constructor's**
+    /// values, not `[Defaults]`' — the `Limit` differs (3 against the static
+    /// 5) precisely because `[Defaults]` was never applied here.
+    ///
+    /// The sample count `+0x134` stays 0, and `SoundEvent::UpdateState @
+    /// 0x004055C0` state 0 abandons the event when it is
+    /// (`0x0040563C CMP [EDI+0x134],EBX; JZ 0x004057A3`), so such an id is
+    /// registered and permanently silent. Stock `[SoundList]` reaches this once,
+    /// through a decorative `============ Mission Disk sounds ============`
+    /// entry.
+    fn unread(name: &str) -> Self {
+        Self {
+            id: name.to_string(),
+            sounds: Vec::new(),
+            volume: 0,
+            volume_linear: 0,
+            priority: SOUND_PRIORITY_DEFAULT,
+            range: 10,
+            min_volume: 0.2,
+            control: 0,
+            type_flags: sound_type::SCREEN,
+            limit: 3,
+            loop_count: 0,
+            delay_ms: (0, 0),
+            fshift: (0, 0),
+            vshift: 0,
+            attack: 0,
+            decay: 0,
+        }
+    }
+
     /// Body sample index range `attack .. count - decay` (may be empty).
     pub fn body_range(&self) -> std::ops::Range<usize> {
         let count = self.sounds.len() as i32;
@@ -252,108 +298,56 @@ pub struct SoundRegistry {
 impl SoundRegistry {
     /// Parse a SoundRegistry from sound.ini / soundmd.ini data.
     ///
-    /// Loads `soundmd.ini` first (YR), then `sound.ini` (base RA2) as fallback.
-    /// Sections from soundmd override sound.ini on conflict.
+    /// gamemd-derived: `VocClass::ReadSoundListINI @ 0x007510D0` reads
+    /// `[Defaults]` once, then finds `[SoundList]` (`0x00751298`) and walks it
+    /// by index — `GetEntryCount @ 0x00526960`, `GetEntryNameByIndex @
+    /// 0x00526CC0`, then `CCINIClass::ReadString @ 0x00528A10` for that
+    /// entry's **value**, which is the sound id (`0x007512C6..0x007512EE`). An
+    /// entry whose value reads back empty is skipped (`0x007512EC TEST EAX,EAX;
+    /// JZ`); every other value becomes an `AudioEventClass` through
+    /// `FindOrCreate @ 0x004063B0` and is filled in by `VocClass::ReadINI @
+    /// 0x00750440`.
+    ///
+    /// The INI's sections are **not** scanned, which is why this walks the list
+    /// rather than the file: a section `[SoundList]` never names is never
+    /// registered (stock `soundmd.ini` has exactly one, `[GuardianGiUnDeploy]`,
+    /// and no rules/art key references it), and a listed id whose section is
+    /// missing still registers — see [`SoundEntry::unread`].
+    ///
+    /// `merge_fallback` handles the base-RA2 `sound.ini` layer; native reads
+    /// one file per pass the same way.
     pub fn from_ini(ini: &IniFile) -> Self {
         let mut entries: HashMap<String, SoundEntry> = HashMap::new();
         let defaults = SoundDefaults::read(ini.section("Defaults"));
 
-        for name in ini.section_names() {
-            let Some(section) = ini.section(name) else {
-                continue;
-            };
-            // Skip meta-sections that aren't actual sound definitions.
-            if name.eq_ignore_ascii_case("General")
-                || name.eq_ignore_ascii_case("SoundList")
-                || name.eq_ignore_ascii_case("Defaults")
-            {
-                continue;
+        // No `[SoundList]` means no sounds: `0x0075129D TEST EAX,EAX; JZ`
+        // leaves the whole registration loop unexecuted.
+        let Some(list) = ini.section("SoundList") else {
+            log::info!("SoundRegistry: no [SoundList] section, 0 sound definitions");
+            return Self { entries, defaults };
+        };
+
+        // Values in source order, which is native's entry-index order. The INI
+        // parser has already dropped entries with an empty value, matching the
+        // `ReadString` length gate.
+        for value in list.get_values() {
+            let key = value.to_ascii_uppercase();
+            // `0x007512F4..0x0075133D` compares the id against the names of the
+            // events already created (`FUN_007C8D20`, case-insensitive) and,
+            // on a hit, hands that same object to `ReadINI` again under its
+            // FIRST spelling. `AddSample` appends rather than replaces, so a
+            // twice-listed id ends up carrying its sample list twice — stock
+            // `[SoundList]` lists `KirovVoiceDie` twice, in both sound files.
+            let previous: Option<SoundEntry> = entries.remove(&key);
+            let name: &str = previous.as_ref().map_or(value, |entry| entry.id.as_str());
+            let mut entry: SoundEntry = read_entry(ini, name, &defaults);
+            if let Some(previous) = previous {
+                let mut sounds: Vec<String> = previous.sounds;
+                sounds.extend(entry.sounds);
+                sounds.truncate(MAX_SAMPLES);
+                entry.sounds = sounds;
             }
-
-            // VERA-internal, gamemd equivalent UNCHECKED: using `Sounds=` as
-            // the section filter. Native never scans INI sections — it walks
-            // the `[SoundList]` entries (`VocClass::ReadSoundListINI @
-            // 0x007510D0`, `GetEntryCount`/`GetEntryNameByIndex`) and calls
-            // `VocClass::ReadINI @ 0x00750440` once per name, which reads
-            // `Sounds=` with an empty-string default and simply adds no
-            // samples when it is absent. VERA has no `[SoundList]` pass, so
-            // the key's presence is what separates a sound section from the
-            // rest of the file. Trigger: a `[SoundList]` name whose section
-            // omits `Sounds=`, or writes it empty (`IniFile` drops a key with
-            // an empty value, so the two are indistinguishable at this point).
-            // Player effect: VERA falls through to the audio-bag path for that
-            // id where gamemd would play nothing. Frequency: never on retail
-            // data — every stock `[SoundList]` section writes a non-empty
-            // `Sounds=`. Downstream risk: none.
-            let sounds_str: &str = match section.get_ignoring_case("Sounds") {
-                Some(s) => s,
-                None => continue,
-            };
-
-            // `VocClass::AddSample @ 0x004064A0` skips every leading `$`/`#`
-            // and stops accepting at 32 samples. An empty list is registered,
-            // not skipped: native's `VocClass` exists with a zero sample count
-            // and plays nothing, so the id must still resolve here rather than
-            // fall through to the audio-bag path.
-            let sounds: Vec<String> = split_tokens(sounds_str)
-                .map(|s| s.trim_start_matches(['$', '#']).to_string())
-                .filter(|s| !s.is_empty())
-                .take(MAX_SAMPLES)
-                .collect();
-
-            let volume_raw = read_double(section, "Volume", defaults.volume);
-            let volume_linear = volume_linear(volume_raw);
-            let volume: u8 = volume_raw.clamp(0.0, 100.0).round() as u8;
-            let vshift = section
-                .get_i32_ignoring_case("VShift")
-                .unwrap_or(0)
-                .clamp(0, 100);
-            let min_volume =
-                min_volume_fraction(read_double(section, "MinVolume", defaults.min_volume));
-            let priority: u8 = section
-                .get_ignoring_case("Priority")
-                .map_or(SOUND_PRIORITY_DEFAULT, parse_sound_priority);
-            let attack_raw = section.get_i32_ignoring_case("Attack").unwrap_or(0);
-            let decay_raw = section.get_i32_ignoring_case("Decay").unwrap_or(0);
-            let control = parse_control_list(section.get_ignoring_case("Control"))
-                .unwrap_or(defaults.control);
-            // `AudioEventClass::SetControlFlags @ 0x00406570`: without the
-            // flag the count is zeroed; with it a zero count becomes 1.
-            let attack = normalise_envelope_count(attack_raw, control & control::ATTACK != 0);
-            let decay = normalise_envelope_count(decay_raw, control & control::DECAY != 0);
-            let type_flags =
-                parse_type_list(section.get_ignoring_case("Type")).unwrap_or(defaults.type_flags);
-            let limit = section
-                .get_i32_ignoring_case("Limit")
-                .unwrap_or(defaults.limit);
-            let loop_count = section.get_i32_ignoring_case("Loop").unwrap_or(0);
-            let range: i32 = section
-                .get_i32_ignoring_case("Range")
-                .unwrap_or(defaults.range);
-            let delay_ms = parse_int_pair(section.get_ignoring_case("Delay"));
-            let fshift = parse_int_pair(section.get_ignoring_case("FShift"));
-
-            entries.insert(
-                name.to_ascii_uppercase(),
-                SoundEntry {
-                    id: name.to_string(),
-                    sounds,
-                    volume,
-                    volume_linear,
-                    priority,
-                    range,
-                    min_volume,
-                    control,
-                    type_flags,
-                    limit,
-                    loop_count,
-                    delay_ms,
-                    fshift,
-                    vshift,
-                    attack,
-                    decay,
-                },
-            );
+            entries.insert(key, entry);
         }
 
         log::info!("SoundRegistry: loaded {} sound definitions", entries.len());
@@ -401,6 +395,87 @@ impl SoundRegistry {
     }
 }
 
+/// One `VocClass::ReadINI @ 0x00750440` pass for `name`: read the fourteen keys
+/// out of `[name]`, or keep the constructor state when there is no such section
+/// (`0x0075046A..0x00750476`).
+///
+/// The section lookup is exact-case where native hashes the name through
+/// `CRCEngine::AddData` (`INIClass::FindSectionByName @ 0x00526810`). Both stock
+/// files spell all 820/500 `[SoundList]` values exactly as their section
+/// headers, so the two agree on retail data; a mod that spelled one differently
+/// would register the id with [`SoundEntry::unread`]'s silent state here.
+fn read_entry(ini: &IniFile, name: &str, defaults: &SoundDefaults) -> SoundEntry {
+    let Some(section) = ini.section(name) else {
+        return SoundEntry::unread(name);
+    };
+
+    // `VocClass::AddSample @ 0x004064A0` skips every leading `$`/`#` and stops
+    // accepting at 32 samples. An absent or token-less `Sounds=` is registered,
+    // not skipped: `ReadINI` reads it with the empty-string default at
+    // `0x0075049D` and simply adds nothing, so the id must still resolve here
+    // rather than fall through to the audio-bag path. Eight stock sections take
+    // that path — `Dummy`, `CampfireLoop`, `PropagandaTruck`, `DolphinFear`,
+    // `OspreyCollision`, `SquidFear`, `SubFear`, `RobotTankPowerDown` — and
+    // `Dummy.wav` is a real 1180-byte file in `audiomd.mix`, so registering the
+    // silent entry is what keeps `[AudioVisual] Construction=`/`GateUp=`/
+    // `GateDown=` from playing a buffer gamemd never starts.
+    let sounds: Vec<String> = split_tokens(section.get_ignoring_case("Sounds").unwrap_or(""))
+        .map(|s| s.trim_start_matches(['$', '#']).to_string())
+        .filter(|s| !s.is_empty())
+        .take(MAX_SAMPLES)
+        .collect();
+
+    let volume_raw = read_double(section, "Volume", defaults.volume);
+    let volume_linear = volume_linear(volume_raw);
+    let volume: u8 = volume_raw.clamp(0.0, 100.0).round() as u8;
+    let vshift = section
+        .get_i32_ignoring_case("VShift")
+        .unwrap_or(0)
+        .clamp(0, 100);
+    let min_volume = min_volume_fraction(read_double(section, "MinVolume", defaults.min_volume));
+    let priority: u8 = section
+        .get_ignoring_case("Priority")
+        .map_or(SOUND_PRIORITY_DEFAULT, parse_sound_priority);
+    let attack_raw = section.get_i32_ignoring_case("Attack").unwrap_or(0);
+    let decay_raw = section.get_i32_ignoring_case("Decay").unwrap_or(0);
+    let control =
+        parse_control_list(section.get_ignoring_case("Control")).unwrap_or(defaults.control);
+    // `AudioEventClass::SetControlFlags @ 0x00406570`: without the flag the
+    // count is zeroed; with it a zero count becomes 1.
+    let attack = normalise_envelope_count(attack_raw, control & control::ATTACK != 0);
+    let decay = normalise_envelope_count(decay_raw, control & control::DECAY != 0);
+    let type_flags =
+        parse_type_list(section.get_ignoring_case("Type")).unwrap_or(defaults.type_flags);
+    let limit = section
+        .get_i32_ignoring_case("Limit")
+        .unwrap_or(defaults.limit);
+    let loop_count = section.get_i32_ignoring_case("Loop").unwrap_or(0);
+    let range: i32 = section
+        .get_i32_ignoring_case("Range")
+        .unwrap_or(defaults.range);
+    let delay_ms = parse_int_pair(section.get_ignoring_case("Delay"));
+    let fshift = parse_int_pair(section.get_ignoring_case("FShift"));
+
+    SoundEntry {
+        id: name.to_string(),
+        sounds,
+        volume,
+        volume_linear,
+        priority,
+        range,
+        min_volume,
+        control,
+        type_flags,
+        limit,
+        loop_count,
+        delay_ms,
+        fshift,
+        vshift,
+        attack,
+        decay,
+    }
+}
+
 /// `0.01f` at `0x007EAAE0`, the *float* constant the sound reader multiplies a
 /// percentage by. It is `10737418 / 2^30`, i.e. slightly **below** 0.01, which
 /// is why the whole chain has to stay at x87 precision — see
@@ -414,31 +489,24 @@ const ONE_PERCENT_F32_AS_F64: f64 = 0.01f32 as f64;
 /// [ESP+0x38]`). When `strchr(text, '%')` hits, the double is multiplied by
 /// the *double* 0.01 at `0x007E3808` (`0x0052857E FMUL double`) and stored
 /// back as a double — there is no float narrowing on that path, so the result
-/// this function hands its caller carries 53 significant bits. Absent or
-/// unparsable keeps the caller's default, which reaches the native call as a
-/// `float32` static widened the same way (`0x007504EE FLD float [0x008464B4];
-/// FSTP double [ESP]`).
+/// this function hands its caller carries 53 significant bits. An absent
+/// section or key keeps the caller's default (`0x00528525`, `0x00528588`),
+/// which reaches the native call as a `float32` static widened the same way
+/// (`0x007504EE FLD float [0x008464B4]; FSTP double [ESP]`).
+///
+/// The value parse itself is [`parse_read_double`], the crate's existing
+/// reproduction of that same `sscanf("%f")` grammar (sign, mantissa, exponent,
+/// `strtrim` at both ends, `%` anywhere scaling by the double 0.01). Only the
+/// case-insensitive key lookup is local: 11 stock sections spell the key
+/// `volume=`/`Vshift=` in lower case, and native's INI lookup is
+/// case-insensitive. Keeping a second parser here diverged from the shared one
+/// on exponents (`1e2` → 1.0 instead of 100.0), on a second `.`, and on
+/// Unicode-vs-byte trimming; no stock `Volume=`/`MinVolume=` value differs
+/// under either, but the duplicate was drift waiting to happen.
 fn read_double(section: &IniSection, key: &str, default: f32) -> f64 {
-    let Some(raw) = section.get_ignoring_case(key) else {
-        return f64::from(default);
-    };
-    let text = raw.trim_start();
-    let end = text
-        .char_indices()
-        .take_while(|(i, c)| {
-            c.is_ascii_digit() || *c == '.' || (*i == 0 && (*c == '-' || *c == '+'))
-        })
-        .map(|(i, c)| i + c.len_utf8())
-        .last()
-        .unwrap_or(0);
-    let Ok(parsed) = text[..end].parse::<f32>() else {
-        return f64::from(default);
-    };
-    if raw.contains('%') {
-        f64::from(parsed) * 0.01
-    } else {
-        f64::from(parsed)
-    }
+    section
+        .get_ignoring_case(key)
+        .map_or(f64::from(default), parse_read_double)
 }
 
 /// `0x007504EE..0x00750548`: the `ReadDouble` result times the *float* 0.01
@@ -554,9 +622,20 @@ fn apply_type_token(flags: &mut u32, token: &str) {
     *flags |= value;
 }
 
-/// `Delay=` / `FShift=` (`0x0075083C..0x00750886`, `0x008B5..0x008FF`): the
-/// first token through `atoi` is the minimum; the second, when present, is
+/// `Delay=` / `FShift=` (`0x0075083C..0x00750886`, `0x0075089E..0x007508FF`):
+/// the first token through `atoi` is the minimum; the second, when present, is
 /// the maximum, otherwise the minimum is reused. No token gives `(0, 0)`.
+///
+/// **Read the disassembly, not the decompiler, for these two tails.** Ghidra's
+/// pseudocode for both shows the first token's value being *overwritten* by the
+/// second — i.e. a single-value read — and it is wrong. The instructions are
+/// unambiguous: `0x00750853 XOR EBX,EBX` seeds the minimum, `0x00750866 MOV
+/// EBX,EAX` takes `atoi(token1)`, `0x00750872 MOV ECX,EBX` pre-loads the
+/// maximum with the minimum, `0x0075087F MOV ECX,EAX` replaces it with
+/// `atoi(token2)` only when a second token exists, and `0x00750881 PUSH ECX;
+/// 0x00750884 MOV EDX,EBX; CALL SetDelay @ 0x00406600` passes the pair to
+/// `+0x58/+0x5C`. `FShift=` is the same shape through `EDI` into `SetFShift @
+/// 0x00406610` (`+0x60/+0x64`). Do not "simplify" this against the decompiler.
 fn parse_int_pair(raw: Option<&str>) -> (i32, i32) {
     let Some(raw) = raw else {
         return (0, 0);
@@ -727,14 +806,38 @@ mod tests {
     /// The stock `[Defaults]` block, verbatim from `soundmd.ini`.
     const STOCK_DEFAULTS: &str = "[Defaults]\nMinVolume=50\nRange=10\nVolume=80\nLimit=5\nType= NORMAL SCREEN UNSHROUD\nPriority=NORMAL \n";
 
+    /// Native registers only what `[SoundList]` names, so every fixture needs
+    /// one. This builds it the way the stock file does — numbered entries whose
+    /// values are the sound ids, in source order — from the section headers in
+    /// `body`, skipping the meta-sections retail never lists.
+    fn with_sound_list(body: &str) -> IniFile {
+        let mut list = String::from("[SoundList]\n");
+        let mut index = 0;
+        for name in body
+            .lines()
+            .filter_map(|line| line.strip_prefix('['))
+            .filter_map(|line| line.split(']').next())
+        {
+            if ["Defaults", "SoundList", "General"]
+                .iter()
+                .any(|meta| meta.eq_ignore_ascii_case(name))
+            {
+                continue;
+            }
+            index += 1;
+            list.push_str(&format!("{index}={name}\n"));
+        }
+        IniFile::from_str(&format!("{list}{body}"))
+    }
+
     fn registry(body: &str) -> SoundRegistry {
-        SoundRegistry::from_ini(&IniFile::from_str(&format!("{STOCK_DEFAULTS}{body}")))
+        SoundRegistry::from_ini(&with_sound_list(&format!("{STOCK_DEFAULTS}{body}")))
     }
 
     #[test]
     fn test_parse_single_sound() {
         let ini: IniFile =
-            IniFile::from_str("[VGCannon1]\nSounds=vgcannon.wav\nVolume=80\nPriority=high\n");
+            with_sound_list("[VGCannon1]\nSounds=vgcannon.wav\nVolume=80\nPriority=high\n");
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         assert_eq!(reg.len(), 1);
         let entry: &SoundEntry = reg.get("VGCannon1").expect("should find entry");
@@ -767,36 +870,43 @@ mod tests {
     #[test]
     fn sounds_split_on_native_whitespace_only() {
         let ini: IniFile =
-            IniFile::from_str("[E1Voice]\nSounds=e1sel01 e1sel02\te1sel03\nVolume=100\n");
+            with_sound_list("[E1Voice]\nSounds=e1sel01 e1sel02\te1sel03\nVolume=100\n");
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         let entry: &SoundEntry = reg.get("E1Voice").expect("should find entry");
         assert_eq!(entry.sounds, vec!["e1sel01", "e1sel02", "e1sel03"]);
-        let comma = SoundRegistry::from_ini(&IniFile::from_str("[X]\nSounds=a.wav,b.wav\n"));
+        let comma = SoundRegistry::from_ini(&with_sound_list("[X]\nSounds=a.wav,b.wav\n"));
         assert_eq!(comma.get("X").unwrap().sounds, vec!["a.wav,b.wav"]);
     }
 
     #[test]
     fn test_case_insensitive_lookup() {
-        let ini: IniFile = IniFile::from_str("[TestSound]\nSounds=test.wav\n");
+        let ini: IniFile = with_sound_list("[TestSound]\nSounds=test.wav\n");
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         assert!(reg.get("testsound").is_some());
         assert!(reg.get("TESTSOUND").is_some());
     }
 
+    /// Registration comes from `[SoundList]`, not from the section headers:
+    /// `VocClass::ReadSoundListINI @ 0x007510D0` only ever visits the ids that
+    /// list names, so a section it does not name stays unregistered however
+    /// complete it looks. Stock `soundmd.ini` has one such section,
+    /// `[GuardianGiUnDeploy]`, and nothing in rules/art references it.
     #[test]
-    fn test_skip_general_section() {
-        let ini: IniFile =
-            IniFile::from_str("[General]\nSounds=nothing.wav\n[Real]\nSounds=real.wav\n");
+    fn only_soundlist_names_register_however_complete_the_section() {
+        let ini: IniFile = IniFile::from_str(
+            "[SoundList]\n1=Real\n[General]\nSounds=nothing.wav\n[Real]\nSounds=real.wav\n[GuardianGiUnDeploy]\nSounds=vgrdund\nVolume=70\n",
+        );
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         assert!(reg.get("General").is_none());
-        assert!(reg.get("Real").is_some());
+        assert!(reg.get("GuardianGiUnDeploy").is_none());
+        assert_eq!(reg.len(), 1);
+        assert_eq!(reg.get("Real").unwrap().sounds, vec!["real.wav"]);
     }
 
     #[test]
     fn test_merge_fallback() {
-        let ini1: IniFile = IniFile::from_str("[SoundA]\nSounds=a.wav\n");
-        let ini2: IniFile =
-            IniFile::from_str("[SoundA]\nSounds=a_old.wav\n[SoundB]\nSounds=b.wav\n");
+        let ini1: IniFile = with_sound_list("[SoundA]\nSounds=a.wav\n");
+        let ini2: IniFile = with_sound_list("[SoundA]\nSounds=a_old.wav\n[SoundB]\nSounds=b.wav\n");
         let mut reg: SoundRegistry = SoundRegistry::from_ini(&ini1);
         reg.merge_fallback(&ini2);
         // SoundA should keep ini1 version (YR precedence)
@@ -809,7 +919,7 @@ mod tests {
     /// Volume 80, MinVolume 20, Type SCREEN, Limit 5, Range 10, Control 0.
     #[test]
     fn static_defaults_match_the_binary_initialisers() {
-        let ini: IniFile = IniFile::from_str("[MinimalSound]\nSounds=min.wav\n");
+        let ini: IniFile = with_sound_list("[MinimalSound]\nSounds=min.wav\n");
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         let entry: &SoundEntry = reg.get("MinimalSound").unwrap();
         assert_eq!(entry.volume, 80);
@@ -955,6 +1065,11 @@ mod tests {
         assert_eq!(half.volume_linear, 8273); // ftol(0.505 * 16384)
         assert_eq!(half.min_volume, 0.25);
         assert_eq!(reg.get("Lower").unwrap().volume, 60);
+        // `sscanf("%f")` accepts an exponent, and the shared
+        // `ini_value::parse_read_double` reproduces it — the private copy this
+        // reader used to carry did not, and read `1e2` as 1.
+        let exponent = registry("[Exp]\nSounds=e\nVolume=1e2\n");
+        assert_eq!(exponent.get("Exp").unwrap().volume_linear, VOLUME_SCALE - 1);
     }
 
     /// The four stock `Volume=` values whose exact `Volume * 0.01f * 16384`
@@ -975,13 +1090,12 @@ mod tests {
     }
 
     /// Native registers a `[SoundList]` name whose `Sounds=` yields no usable
-    /// tokens as a zero-sample `VocClass` (`VocClass::ReadINI @ 0x00750440`
-    /// reads `Sounds=` with an empty default and `AddSample @ 0x004064A0`
-    /// stores nothing for a name that strips to nothing), so the id must still
-    /// resolve here — dropping it would let VERA's audio-bag fallback play a
-    /// file gamemd never would. A bare `Sounds=` cannot reach this: the INI
-    /// parser discards an empty value outright, so `Sounds=$` is the shortest
-    /// live trigger.
+    /// tokens as a zero-sample event (`VocClass::ReadINI @ 0x00750440` reads
+    /// `Sounds=` with the empty-string default at `0x0075049D` and
+    /// `AddSample @ 0x004064A0` stores nothing), so the id must still resolve
+    /// here — dropping it lets VERA's audio-bag fallback play a file gamemd
+    /// never starts, because `SoundEvent::UpdateState @ 0x004055C0` state 0
+    /// abandons an event with a zero sample count at `0x0040563C`.
     ///
     /// `Range=` is stored as a full int by `AudioEventClass::SetRange @
     /// 0x004065E0` (`MOV [ECX+0x50], EDX`) — no clamp, either end.
@@ -996,6 +1110,97 @@ mod tests {
         assert_eq!(reg.get("Named").unwrap().range, -4);
     }
 
+    /// The eight stock `soundmd.ini` sections that write no usable `Sounds=`,
+    /// in their retail shapes: six omit the key outright and two write only a
+    /// comment, which the INI parser truncates away. All eight are named in
+    /// `[SoundList]`, so all eight must register as silent entries.
+    ///
+    /// This is the case that matters in production: `Dummy.wav` really is in
+    /// `audiomd.mix` (1180 bytes, RIFF), and `rulesmd.ini` routes `Dummy`
+    /// through `[AudioVisual] Construction=`, `GateUp=` and `GateDown=`. If the
+    /// id did not resolve here, VERA's bag/MIX fallback would play that buffer
+    /// on every building start and gate cycle while gamemd stays silent.
+    #[test]
+    fn stock_sections_without_a_usable_sample_list_still_register_silently() {
+        let reg = registry(concat!(
+            "[Dummy]\nPriority=lowest\nVolume=0\n",
+            "[DolphinFear]\nVolume=100\nControl=random\n",
+            "[OspreyCollision]\nVolume=100\n",
+            "[SquidFear]\nVolume=100\n",
+            "[SubFear]\nVolume=100\n",
+            "[RobotTankPowerDown]\nVolume=100\n",
+            "[CampfireLoop]\nSounds= ;gcamlo1a gcamlo1b gcamlo1c\nControl=loop\n",
+            "[PropagandaTruck]\nSounds= ;GEF Removed because they won't be in AudioMD ;$aprotr1\nControl=loop\n",
+        ));
+        for id in [
+            "Dummy",
+            "CampfireLoop",
+            "PropagandaTruck",
+            "DolphinFear",
+            "OspreyCollision",
+            "SquidFear",
+            "SubFear",
+            "RobotTankPowerDown",
+        ] {
+            let entry = reg
+                .get(id)
+                .unwrap_or_else(|| panic!("{id} is a [SoundList] name and must register"));
+            assert!(
+                entry.sounds.is_empty(),
+                "{id} must carry no samples, got {:?}",
+                entry.sounds
+            );
+        }
+        assert_eq!(reg.len(), 8);
+    }
+
+    /// A `[SoundList]` name with no section at all. `ReadINI` returns at
+    /// `0x00750476` without reading a key, so the entry keeps what
+    /// `AudioEventClass::FindOrCreate @ 0x004063B0` wrote: Priority 2, Limit 3
+    /// (not `[Defaults]`' 5), Range 10, MinVolume 0.2f, Type SCREEN, and no
+    /// samples. Stock hits this through the decorative
+    /// `============ Mission Disk sounds ============` list entry.
+    #[test]
+    fn listed_name_without_a_section_keeps_the_constructor_state() {
+        let ini = IniFile::from_str(&format!(
+            "{STOCK_DEFAULTS}[SoundList]\n1============= Mission Disk sounds ============\n2=Ghost\n"
+        ));
+        let reg = SoundRegistry::from_ini(&ini);
+        let ghost = reg.get("Ghost").expect("a listed id registers regardless");
+        assert!(ghost.sounds.is_empty());
+        assert_eq!(ghost.priority, 2);
+        assert_eq!(ghost.limit, 3);
+        assert_eq!(ghost.range, 10);
+        assert_eq!(ghost.min_volume, 0.2);
+        assert_eq!(ghost.type_flags, sound_type::SCREEN);
+        assert_eq!(ghost.volume_linear, 0);
+        // `[Defaults]` still applies to entries that do have a section.
+        assert_eq!(reg.defaults().limit, 5);
+    }
+
+    /// A twice-listed id: the dedupe scan at `0x007512F4` hands the existing
+    /// event back to `ReadINI`, and `AddSample` appends, so the sample list
+    /// arrives twice. Stock lists `KirovVoiceDie` twice in both sound files.
+    #[test]
+    fn a_twice_listed_id_reads_its_section_twice_and_appends_samples() {
+        let ini = IniFile::from_str(
+            "[SoundList]\n1=KirovVoiceDie\n2=KirovVoiceDie\n[KirovVoiceDie]\nSounds= $vkirdia $vkirdib $vkirdic $vkirdid\nControl= random\nPriority=low\nVolume=70\n",
+        );
+        let reg = SoundRegistry::from_ini(&ini);
+        assert_eq!(reg.len(), 1);
+        let entry = reg.get("KirovVoiceDie").unwrap();
+        assert_eq!(
+            entry.sounds,
+            vec![
+                "vkirdia", "vkirdib", "vkirdic", "vkirdid", "vkirdia", "vkirdib", "vkirdic",
+                "vkirdid"
+            ]
+        );
+        // The scalars are simply re-read, not accumulated.
+        assert_eq!(entry.priority, 1);
+        assert_eq!(entry.control, control::RANDOM);
+    }
+
     /// 33 samples: the native slot table holds 32.
     #[test]
     fn sample_list_is_capped_at_the_native_slot_count() {
@@ -1003,14 +1208,13 @@ mod tests {
             .map(|i| format!("s{i}"))
             .collect::<Vec<_>>()
             .join(" ");
-        let reg = SoundRegistry::from_ini(&IniFile::from_str(&format!("[Many]\nSounds={list}\n")));
+        let reg = SoundRegistry::from_ini(&with_sound_list(&format!("[Many]\nSounds={list}\n")));
         assert_eq!(reg.get("Many").unwrap().sounds.len(), MAX_SAMPLES);
     }
 
     #[test]
     fn test_whitespace_separated() {
-        let ini: IniFile =
-            IniFile::from_str("[GISelect]\nSounds= igisea igiseb igisec\nVolume=85\n");
+        let ini: IniFile = with_sound_list("[GISelect]\nSounds= igisea igiseb igisec\nVolume=85\n");
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         let entry: &SoundEntry = reg.get("GISelect").expect("should find entry");
         assert_eq!(entry.sounds, vec!["igisea", "igiseb", "igisec"]);
@@ -1020,7 +1224,7 @@ mod tests {
     #[test]
     fn test_strip_dollar_prefix() {
         let ini: IniFile =
-            IniFile::from_str("[VoiceTest]\nSounds= $igisea $igiseb $igisec\nVolume=85\n");
+            with_sound_list("[VoiceTest]\nSounds= $igisea $igiseb $igisec\nVolume=85\n");
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         let entry: &SoundEntry = reg.get("VoiceTest").expect("should find entry");
         assert_eq!(entry.sounds, vec!["igisea", "igiseb", "igisec"]);
@@ -1028,7 +1232,7 @@ mod tests {
 
     #[test]
     fn test_strip_hash_prefix() {
-        let ini: IniFile = IniFile::from_str("[HashTest]\nSounds= #sound1 #$sound2\n");
+        let ini: IniFile = with_sound_list("[HashTest]\nSounds= #sound1 #$sound2\n");
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         let entry: &SoundEntry = reg.get("HashTest").expect("should find entry");
         assert_eq!(entry.sounds, vec!["sound1", "sound2"]);
@@ -1036,8 +1240,7 @@ mod tests {
 
     #[test]
     fn test_inline_comment_filtered() {
-        let ini: IniFile =
-            IniFile::from_str("[CommentTest]\nSounds= irocdiea ;$irocdib $irocdic\n");
+        let ini: IniFile = with_sound_list("[CommentTest]\nSounds= irocdiea ;$irocdib $irocdic\n");
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         let entry: &SoundEntry = reg.get("CommentTest").expect("should find entry");
         assert_eq!(entry.sounds, vec!["irocdiea"]);


### PR DESCRIPTION
Phase 6, rows 147 (GSI-15.01 sound registry) and 150 (GSI-15.02 positional attenuation and stereo pan).

Before this branch every sound in the game played dead centre at a distance-independent volume, and the registry read 5 of the 14 keys `VocClass::ReadINI` reads.

## What gamemd does

`VocClass::ReadINI @ 0x00750440` reads 14 keys, with `[Defaults]` supplied by `ReadSoundListINI @ 0x007510D0` and the `Control=`/`Type=` token tables at `0x008160C0`/`0x00816048`. `VocClass::CalcVolumeAndPan @ 0x00750AC0` measures against the tactical view rect (`0x00886FA8`/`0x00886FAC`), truncates both distances with `ftol` before `abs`, doubles the Y distance, falls off linearly over `Range * 60`, applies the `MinVolume` floor only for `Type=GLOBAL`, silences shrouded cells for `Type=SHROUD`, cuts below 0.05, and returns a pan in 0..16384 with 8192 centre. Volumes chain linearly and then map to DirectSound decibels through the table at `0x00816380`, which this branch reproduces bit-exactly.

Sample choice comes from `LoadSamples @ 0x004048B0`: `Control=random` draws one body sample from the clock-seeded non-scenario RNG at `0x00886B88`, sequential always takes the first body sample, and `all` plays the whole body with the attack and decay envelopes first and last.

## Review history

Five critic rounds, four of which found something real:

1. The listener rect and the sound positions were measured in different units at any zoom other than 1, so at 4x zoom an off-screen fight computed a quarter of its true distance. `TacticalClass::CoordsToClient2 @ 0x006D2140` scales leptons at a fixed 60/30 px per cell, so gamemd's client point is the world-pixel frame; the fix converts the rect to match and labels zoom as VERA-internal.
2. The volume parse narrowed through `f32` where the native x87 chain carries at least 53 bits, and two tests pinned the Rust-derived values as decompile goldens. `CCINIClass::ReadDouble @ 0x005283D0` returns a double as well, so the whole chain is now `f64` and the goldens are re-pinned to the native 16383/8191.
3. Registry construction scanned INI sections; native walks `[SoundList]` by entry index. Eight stock ids have no usable `Sounds=` and must register silently, or VERA's asset fallback plays a file gamemd never plays. The walk also brought in three further native behaviours: a listed id with no section keeps the `FindOrCreate` constructor state, a twice-listed id appends its samples, and a section the list never names is not registered at all.
4. `AudioEventClass::FindOrCreate @ 0x004063B0` seeds the volume interpolator at `+0x18` to full, not zero, and `[SoundList]` values are byte-cut to 31 characters before the trim.

Round 5 passed with no findings, having transcribed `CalcVolumeAndPan` instruction by instruction and verified the attenuation table byte for byte.

## Deferred, with native addresses recorded

The channel arbiter is a separate mechanism: `Limit=`, priority preemption, looping and ambient sounds, interruption, pre-delay and the message-loop pump cadence are parsed and stored here but not yet enforced.

## Player-audible change to expect

Everything is about 3.4 dB quieter than before, from two causes: `[Defaults] Volume=80` now applies to the sections that omit `Volume=`, and the decibel curve replaces a linear multiply. That is the native behaviour, not a regression.

`cargo test -p vera20k --lib`: `test result: ok. 8045 passed; 0 failed; 75 ignored`. No golden moved; `src/sim/` is untouched.
