### PR TITLE
Phase 6: cloak and sensor target legality, and the force-cloak drift

### DIFF
--- a/src/app/input/entity_pick.rs
+++ b/src/app/input/entity_pick.rs
@@ -1182,6 +1182,31 @@ pub(crate) fn pick_entity_at_point(
         {
             continue;
         }
+        // `Tactical::PickObjectAtScreenPoint @ 0x006DA380` admits a
+        // render-tracked object only when
+        //   `InLimbo == 0 && (+0x41A != 0 || CloakState != 2
+        //                     || SensorCountForHouse(itsCell, PlayerPtr->ArrayIndex))`.
+        // `+0x41A` is the owned-by-the-local-player byte — `TechnoClass::
+        // PointerExpired @ 0x007077C0` clears it together with `pOwner` — so
+        // being merely allied does NOT exempt a cloaked object. The same filter
+        // guards `DisplayClass::DetermineAction @ 0x00692610` and the
+        // object-name-under-cursor helper, which is why an unsensed submerged
+        // submarine cannot be moused over at all and no explicit attack order
+        // against it can be issued.
+        if let (Some(fog_state), Some(owner_id)) = (fog, local_owner_id)
+            && entity.owner != owner_id
+            && entity
+                .cloak
+                .as_ref()
+                .is_some_and(|cloak| cloak.is_fully_cloaked())
+            && !fog_state.has_sensor_for_house(
+                owner_id,
+                entity.position.rx,
+                entity.position.ry,
+            )
+        {
+            continue;
+        }
         let (sx, sy) = crate::app::presentation::instances::interpolated_screen_position_entity(entity);
         let distance = pick_distance_sq(sx - world_x, sy - world_y) as i32;
         if distance < PICK_DISTANCE_THRESHOLD as i32

--- a/src/render/radar_visibility_lifecycle_tests.rs
+++ b/src/render/radar_visibility_lifecycle_tests.rs
@@ -142,6 +142,12 @@ fn radar_visibility_consumes_live_stock_cloak_and_sensor_lifecycle() {
         detector.position.ry = cell.1;
     }
     sim.move_unit_sensor_after_cell_change(detector, Some(far_cell), Some(cell), &rules);
+    // CORRECTION: this used to require the sensor deposit to force-cloak the
+    // state-zero resident. `TechnoClass+0x420 @ 0x006F4EB0` gates that arm on
+    // `CellClass::IsVisibleToHouse` — the `CloakedByHouses` bit written only by
+    // a `CloakGenerator=yes` building's field, which stock YR does not ship.
+    // The deposit changes what the detector's house can SEE, never the
+    // resident's cloak state.
     assert_eq!(
         sim.substrate
             .entities
@@ -151,27 +157,20 @@ fn radar_visibility_consumes_live_stock_cloak_and_sensor_lifecycle() {
             .as_ref()
             .unwrap()
             .state,
-        1,
-        "the same sensor add accepts StartCloaking(0) for the state-zero resident"
+        0,
+        "a sensor deposit never starts a cloak in stock YR"
     );
-    let cloak_sounds: Vec<_> = sim
-        .sound_events
-        .iter()
-        .filter_map(|event| match event {
-            crate::sim::world::SimSoundEvent::CloakSound { sound_id, .. } => Some(sound_id),
-            _ => None,
-        })
-        .collect();
-    assert_eq!(
-        cloak_sounds.len(),
-        1,
-        "the accepted sensor callback emits exactly one entering-cloak cue"
+    assert!(
+        !sim.sound_events.iter().any(|event| matches!(
+            event,
+            crate::sim::world::SimSoundEvent::CloakSound { .. }
+        )),
+        "and therefore emits no entering-cloak cue"
     );
-    assert_eq!(cloak_sounds[0], "NavalUnitEmerge");
     assert_eq!(
         tracker.update_object(build_update(&sim, entering), false),
         None,
-        "state-one entering cloak remains radar-visible on the callback edge"
+        "an uncloaked resident stays radar-visible across the callback edge"
     );
     assert!(
         tracker.is_registered(entering),

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -1178,6 +1178,23 @@ pub struct ObjectType {
     pub sensors: bool,
     /// `SensorsSight=` — fallback sensor/cloak-generator ring radius.
     pub sensors_sight: u8,
+    /// `DetectDisguise=` — `TechnoTypeClass+0xD31`, written by
+    /// `TechnoTypeClass::ReadINI @ 0x0071444C` (key string `0x00843C78`).
+    /// Two distinct consumers, both verified:
+    /// * as an ATTACKER type it bypasses the disguise rejection in
+    ///   `TechnoClass::Evaluate_Candidate @ 0x006F84D4` — dogs, Yuri and the
+    ///   Psi Corps Trooper auto-acquire Spies and Mirage Tanks;
+    /// * as a BUILDING type it drives the per-cell detect counter through
+    ///   `BuildingClass::OnConstructionComplete @ 0x004467AD` /
+    ///   `BuildingClass::Limbo @ 0x00445A58`.
+    pub detect_disguise: bool,
+    /// `DetectDisguiseRange=` — `TechnoTypeClass+0x5F4`
+    /// (`TechnoTypeClass::ReadINI @ 0x0071430F`, key string `0x00843D3C`),
+    /// the circular radius `BuildingClass::AddDetectDisguiseAt @ 0x00455A80`
+    /// stamps. `TechnoTypeClass::Constructor @ 0x0071100E` seeds it to zero,
+    /// so a `DetectDisguise=yes` building without this key stamps no cells —
+    /// stock YAPSYT and NAPSYB are exactly that case; only NAPSIS (15) deposits.
+    pub detect_disguise_range: u8,
     /// `Cloakable=` — copied into Unit/Infantry runtime cloak ability.
     pub cloakable: bool,
     /// `CloakingSpeed=` — signed frame duration between cloak progress steps.
@@ -1877,6 +1894,11 @@ impl ObjectType {
             sensors: section.get_bool("Sensors").unwrap_or(false),
             sensors_sight: section
                 .get_i32("SensorsSight")
+                .map(|n| n.clamp(0, u8::MAX as i32) as u8)
+                .unwrap_or(0),
+            detect_disguise: section.get_bool("DetectDisguise").unwrap_or(false),
+            detect_disguise_range: section
+                .get_i32("DetectDisguiseRange")
                 .map(|n| n.clamp(0, u8::MAX as i32) as u8)
                 .unwrap_or(0),
             cloakable: section.get_bool("Cloakable").unwrap_or(false),

--- a/src/sim/cloak_disguise.rs
+++ b/src/sim/cloak_disguise.rs
@@ -29,10 +29,21 @@ pub struct CloakRuntime {
     /// Native signed progress delta, +1 cloaking and -1 uncloaking.
     pub step_delta: i32,
     pub step_timer: CloakStepTimer,
-    /// `ReCloakDelayTimer +0x2EC/+0x2F4`.
+    /// **ReCloak delay, native `TechnoClass+0x240/+0x248`.** The offsets on
+    /// this pair and on `secondary_gate_*` used to be written the other way
+    /// round; the writer settles it. `CloakingTick` state 3 → 0 at
+    /// `0x006FB9F8..0x006FBA07` does `LEA EDX,[ESI+0x240]` and stores
+    /// `ftol([Rules+0x1410] * 900.0)` — `[General] CloakDelay` in minutes ×
+    /// 900 frames — into `+0x248`. `CanAutoCloak @ 0x006FBDC0` reads it as its
+    /// LAST timer gate (`param_1[0x90]`/`[0x92]`).
     pub recloak_delay_start: i32,
     pub recloak_delay_frames: i32,
-    /// Independent `CanAutoCloak` gate timer at +0x240/+0x248.
+    /// **Weapon rearm (ROF) countdown, native `TechnoClass+0x2EC/+0x2F4`.**
+    /// Written by `TechnoClass::Fire_At @ 0x006FDD50` after every shot and read
+    /// by `GetFireError` (busy) and by `CanAutoCloak @ 0x006FBDC0` as its FIRST
+    /// timer gate (`param_1[0xbb]`/`[0xbd]`, checked immediately after the
+    /// `CloakState == 2` early-out). A sub that just fired therefore stays
+    /// surfaced for its whole `ROF=` before the CloakDelay above even starts.
     pub secondary_gate_start: i32,
     pub secondary_gate_frames: i32,
 }
@@ -68,6 +79,16 @@ pub struct CloakTickResult {
     /// one positional `[AudioVisual] CloakSound` request. Silent arg-one
     /// transitions and rejected state visits leave this clear.
     pub play_cloak_sound: bool,
+    /// An accepted `StartCloaking @ 0x00703770`, which opens with
+    /// `Detach_All(false)` (vtable +0xDC — Ghidra's `ObjectClass::Destroy`
+    /// label at `0x005F5280` is drift; the body is the LineTrail/Deselect/
+    /// LastRef teardown plus `DispatchPointerExpiredCleanup`). The caller owns
+    /// dispatching that to every registered object.
+    pub began_cloaking: bool,
+    /// The state 1 → 2 completion at `0x006FBA98`, which snapshots the
+    /// still-admitted targeters, runs `Detach_All(false)` again, then
+    /// re-`Assign_Target`s each saved one.
+    pub completed_cloak: bool,
 }
 
 impl CloakRuntime {
@@ -152,6 +173,8 @@ impl CloakRuntime {
             transitioned: false,
             consumed_scenario_rng: false,
             play_cloak_sound: false,
+            began_cloaking: false,
+            completed_cloak: false,
         };
         if self.state == 0 {
             if !facts.state_zero_head_allows || !facts.can_auto_cloak {
@@ -164,13 +187,10 @@ impl CloakRuntime {
                 rng.next_range_u32_inclusive(0, 99) < 4
             };
             if start {
-                let start = self.start_cloaking(
-                    facts.current_frame,
-                    facts.cloaking_speed,
-                    false,
-                );
+                let start = self.start_cloaking(facts.current_frame, facts.cloaking_speed, false);
                 result.transitioned = start.transitioned;
                 result.play_cloak_sound = start.play_sound;
+                result.began_cloaking = start.transitioned;
             }
             return result;
         }
@@ -209,16 +229,13 @@ impl CloakRuntime {
                             duration_frames: 0,
                         };
                         result.transitioned = true;
+                        result.completed_cloak = true;
                     }
                     _ => {}
                 }
             }
             2 if facts.should_uncloak => {
-                let start = self.start_uncloaking(
-                    facts.current_frame,
-                    facts.cloaking_speed,
-                    false,
-                );
+                let start = self.start_uncloaking(facts.current_frame, facts.cloaking_speed, false);
                 result.transitioned = start.transitioned;
                 result.play_cloak_sound = start.play_sound;
             }
@@ -238,13 +255,11 @@ impl CloakRuntime {
                     result.transitioned = true;
                 }
                 1 if facts.can_auto_cloak => {
-                    let start = self.start_cloaking(
-                        facts.current_frame,
-                        facts.cloaking_speed,
-                        true,
-                    );
+                    let start =
+                        self.start_cloaking(facts.current_frame, facts.cloaking_speed, true);
                     result.transitioned = start.transitioned;
                     result.play_cloak_sound = start.play_sound;
+                    result.began_cloaking = start.transitioned;
                 }
                 _ => {}
             },
@@ -258,6 +273,127 @@ impl CloakRuntime {
             && Self::timer_remaining(self.secondary_gate_start, self.secondary_gate_frames, now)
                 == 0
     }
+
+    /// `TechnoClass::Fire_At @ 0x006FDD50` arms the rearm countdown at
+    /// `+0x2EC/+0x2F4` on every shot; `CanAutoCloak @ 0x006FBDC0` refuses to
+    /// begin an auto-cloak while it is running. Called from the fire commit so
+    /// a Typhoon that surfaced to fire cannot dive again inside its own ROF.
+    pub fn arm_rearm_gate(&mut self, now: i32, rearm_frames: i32) {
+        self.secondary_gate_start = now;
+        self.secondary_gate_frames = rearm_frames.max(0);
+    }
+
+    /// `CloakState == 2` — fully cloaked. The only state the native target
+    /// legality gates reject; 1 (cloaking) and 3 (uncloaking) stay legal.
+    pub fn is_fully_cloaked(&self) -> bool {
+        self.state == 2
+    }
+}
+
+/// `TechnoClass::Evaluate_Candidate @ 0x006F7DA9` — the whole cloak arm of the
+/// per-candidate legality test, read from the disassembly:
+///
+/// ```text
+/// if (candidate->CloakState(+0x220) == 2) {
+///     idx  = attacker->pOwner->ArrayIndex(+0x30);
+///     cell = Get_CellClass_At_Coord(candidate->GetCoords());
+///     if (!CellClass::SensorCountForHouse(cell, idx)
+///         && candidate->pOwner != attacker->pOwner) reject;
+/// }
+/// ```
+///
+/// Two things this is NOT: it is not an alliance test (an ALLIED submerged sub
+/// is rejected too — only same-owner is exempt), and it does not look at
+/// cloaking/uncloaking states.
+pub fn cloak_rejects_candidate(
+    candidate_fully_cloaked: bool,
+    attacker_house_senses_candidate_cell: bool,
+    same_owner: bool,
+) -> bool {
+    candidate_fully_cloaked && !attacker_house_senses_candidate_cell && !same_owner
+}
+
+/// `UnitClass::IsDisguisedTo @ 0x00746750` and the byte-identical
+/// `InfantryClass::IsDisguisedTo @ 0x005227F0` (both vtable `+0xC8`).
+///
+/// ```text
+/// if (!IsDisguised(vt+0xC4)) return 0;
+/// if (IsAlliedWith(myOwner, house)) return 0;
+/// if (DisguiseDetectCountForHouse(myCell, house->ArrayIndex)) return 0;
+/// fake = DisguisedAsHouse(+0x51C);
+/// if (fake && fake != house && !IsAlliedWith(house, fake)) return 0;
+/// return 1;
+/// ```
+///
+/// "Disguise revealed" is never a stored state in gamemd — it is this
+/// per-observer predicate, re-evaluated per query. The last clause is why a
+/// Spy wearing a third party's colours is still shot at: only a disguise as
+/// the observer's own house or one of its allies actually hides it.
+pub fn is_disguised_to(
+    raw_disguised: bool,
+    owner_allied_with_observer: bool,
+    observer_detects_disguise_at_cell: bool,
+    disguised_as_is_observer_or_ally: bool,
+    disguised_as_house_present: bool,
+) -> bool {
+    if !raw_disguised || owner_allied_with_observer || observer_detects_disguise_at_cell {
+        return false;
+    }
+    !disguised_as_house_present || disguised_as_is_observer_or_ally
+}
+
+/// The disguise arm of `Evaluate_Candidate`, `0x006F84B1..0x006F854B`.
+///
+/// ```text
+/// if (candidate->vt+0xC8(attacker->pOwner)) {          // IsDisguisedTo
+///   if (attackerType->DetectDisguise(+0xD31) == 0) {
+///     rem = candidate->+0x1F4;
+///     if (candidate->+0x1EC != -1) { el = frame - +0x1EC;
+///                                    if (rem <= el) reject; rem -= el; }
+///     if (rem == 0) reject;                            // blink not running
+///     if (IsControlledByHuman(attacker->pOwner)) reject;
+///     if (RandomRanged(0,99) > Rules.DisabledDisguiseDetectionPercent[..])
+///         reject;                                      // AI houses only
+///   }
+/// }
+/// ```
+///
+/// Everything after the blink window is AI-only, so for a human-owned attacker
+/// the whole gate collapses to: reject unless the attacker type carries
+/// `DetectDisguise=`. `blink_frames_remaining` is the
+/// `DisguiseFakeBlinkTime` window `UnitClass::Fire_At @ 0x00741340` arms after
+/// each Mirage shot; a Spy never arms it, so a Spy is always rejected.
+pub fn disguise_rejects_candidate(
+    is_disguised_to_attacker: bool,
+    attacker_detects_disguise: bool,
+    blink_frames_remaining: i32,
+    attacker_house_is_human: bool,
+) -> DisguiseGateOutcome {
+    if !is_disguised_to_attacker || attacker_detects_disguise {
+        return DisguiseGateOutcome::Accept;
+    }
+    if blink_frames_remaining <= 0 {
+        return DisguiseGateOutcome::Reject;
+    }
+    if attacker_house_is_human {
+        return DisguiseGateOutcome::Reject;
+    }
+    DisguiseGateOutcome::AiDetectionRoll
+}
+
+/// Outcome of [`disguise_rejects_candidate`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisguiseGateOutcome {
+    /// The candidate survives the disguise arm.
+    Accept,
+    /// Native rejects without drawing.
+    Reject,
+    /// Native reaches its one `RandomRanged(0, 99)` on the Scenario stream and
+    /// compares against `[General] DisabledDisguiseDetectionPercent`. Only an
+    /// AI-controlled attacking house gets here, and VERA has no AI opponent, so
+    /// no production caller can produce this variant yet — it is modelled, not
+    /// wired, and wiring it costs one Scenario draw per evaluated candidate.
+    AiDetectionRoll,
 }
 
 #[path = "cloak_transitions.rs"]
@@ -369,12 +505,8 @@ pub fn evaluate_fire_cloak_gates(
 ) -> FireCloakGateResult {
     FireCloakGateResult {
         should_call_reveal_area1: reveal_on_fire && target_house_passes_reveal_check,
-        fire_error_code: fire_requires_uncloaking(
-            decloak_to_fire,
-            current_cloak_state,
-            what_am_i,
-        )
-        .then_some(9),
+        fire_error_code: fire_requires_uncloaking(decloak_to_fire, current_cloak_state, what_am_i)
+            .then_some(9),
     }
 }
 
@@ -383,9 +515,7 @@ pub(crate) fn fire_requires_uncloaking(
     current_cloak_state: i32,
     what_am_i: i32,
 ) -> bool {
-    decloak_to_fire
-        && current_cloak_state != 0
-        && (what_am_i != 2 || current_cloak_state == 2)
+    decloak_to_fire && current_cloak_state != 0 && (what_am_i != 2 || current_cloak_state == 2)
 }
 
 #[cfg(test)]
@@ -495,7 +625,10 @@ mod tests {
         };
         let result = cloak.tick(facts(0), &mut actual);
         assert!(result.consumed_scenario_rng && !result.transitioned);
-        assert_eq!(cloak.state, 1, "the abort branch is inclusive only through 9");
+        assert_eq!(
+            cloak.state, 1,
+            "the abort branch is inclusive only through 9"
+        );
     }
 
     #[test]

--- a/src/sim/cloak_transitions.rs
+++ b/src/sim/cloak_transitions.rs
@@ -86,6 +86,46 @@ impl CloakRuntime {
         self.start_cloaking(now, speed, false)
     }
 
+    /// `TechnoClass::ReceiveDamage @ 0x0070281D` invokes virtual `+0xFC`
+    /// (`0x00703850`, a plain `StartUncloaking(0)` wrapper) for every damage
+    /// result that is not NowDead — the heal case included, because the
+    /// `if (damage < 0) return` early-out sits AFTER this call. Argument zero,
+    /// so the transition owns a `CloakSound`.
+    pub(crate) fn start_uncloaking_from_damage(
+        &mut self,
+        now: i32,
+        speed: i32,
+    ) -> StartUncloakingResult {
+        self.start_uncloaking(now, speed, false)
+    }
+
+    /// `FootClass::PerCellProcess @ 0x004D8829` invokes the same `+0xFC`
+    /// wrapper when a fully cloaked mover enters a cell one of whose eight
+    /// neighbours holds a non-allied `Sensors=yes` object.
+    pub(crate) fn start_uncloaking_from_sensor_neighbour(
+        &mut self,
+        now: i32,
+        speed: i32,
+    ) -> StartUncloakingResult {
+        self.start_uncloaking(now, speed, false)
+    }
+
+    /// `CellClass::Mark_Objects_Redraw @ 0x00483480` — misnamed; the body walks
+    /// the cell's `FirstObject(+0xE4)` chain calling `+0xFC` on every resident.
+    /// Every caller is a locomotor sitting on the branch where
+    /// `Can_Enter_Cell` returned 1 for a cloaked occupant
+    /// (`DriveLocomotionClass::Process_Movement @ 0x004B395E`, `0x004B445B`;
+    /// `ShipLocomotionClass::Process_Movement @ 0x006A2FAD`, `0x006A3A87`;
+    /// `WalkLocomotionClass::ProcessMovement @ 0x0075BBAE`; the two
+    /// `Process_Drive_Track` sites `0x004B1E63` / `0x006A14A6`).
+    pub(crate) fn start_uncloaking_from_mover_bump(
+        &mut self,
+        now: i32,
+        speed: i32,
+    ) -> StartUncloakingResult {
+        self.start_uncloaking(now, speed, false)
+    }
+
     /// `UnitClass::Fire_At_Target @ 0x00736DF0` case 9 invokes virtual
     /// `StartUncloaking +0x45C @ 0x007036C0` after rechecking CanFireAt.
     pub(crate) fn start_uncloaking_to_fire(

--- a/src/sim/cloak_transitions.rs
+++ b/src/sim/cloak_transitions.rs
@@ -110,21 +110,28 @@ impl CloakRuntime {
         self.start_uncloaking(now, speed, false)
     }
 
-    /// `CellClass::Mark_Objects_Redraw @ 0x00483480` — misnamed; the body walks
-    /// the cell's `FirstObject(+0xE4)` chain calling `+0xFC` on every resident.
-    /// Every caller is a locomotor sitting on the branch where
-    /// `Can_Enter_Cell` returned 1 for a cloaked occupant
-    /// (`DriveLocomotionClass::Process_Movement @ 0x004B395E`, `0x004B445B`;
-    /// `ShipLocomotionClass::Process_Movement @ 0x006A2FAD`, `0x006A3A87`;
-    /// `WalkLocomotionClass::ProcessMovement @ 0x0075BBAE`; the two
-    /// `Process_Drive_Track` sites `0x004B1E63` / `0x006A14A6`).
-    pub(crate) fn start_uncloaking_from_mover_bump(
-        &mut self,
-        now: i32,
-        speed: i32,
-    ) -> StartUncloakingResult {
-        self.start_uncloaking(now, speed, false)
-    }
+    // RESIDUAL (UNIMPLEMENTED) — the mover-bump reveal has NO entry point here,
+    // deliberately. Native: `CellClass::Mark_Objects_Redraw @ 0x00483480` is
+    // misnamed; the body walks the cell's `FirstObject(+0xE4)` chain calling
+    // `+0xFC` on every resident, and every caller is a locomotor sitting on the
+    // branch where `Can_Enter_Cell` returned 1 (passable) for a cloaked
+    // occupant (`DriveLocomotionClass::Process_Movement @ 0x004B395E`,
+    // `0x004B445B`; `ShipLocomotionClass::Process_Movement @ 0x006A2FAD`,
+    // `0x006A3A87`; `WalkLocomotionClass::ProcessMovement @ 0x0075BBAE`; the
+    // two `Process_Drive_Track` sites `0x004B1E63` / `0x006A14A6`).
+    //
+    // The prerequisite is missing: VERA's cell-entry classifier
+    // (`sim/movement/movement_occupancy.rs`) has no cloak term, so a fully
+    // cloaked enemy occupant is an ordinary blocker and a mover never enters
+    // its cell. A `start_uncloaking_from_mover_bump` helper alone would be
+    // unreachable, so it is not defined; the passability rule and the reveal
+    // are one coupled change and must land together, in the movement system.
+    // *Trigger:* a mover pathing across a fully cloaked unit's cell.
+    // *Player effect:* in gamemd the cloaked unit surfaces and the mover passes
+    // through; in VERA the mover paths around it and it stays cloaked.
+    // *Frequency:* whenever a ship crosses a submerged submarine — common in
+    // naval play. *Downstream risk:* landing the passability rule alone changes
+    // pathing; landing the reveal alone is inert.
 
     /// `UnitClass::Fire_At_Target @ 0x00736DF0` case 9 invokes virtual
     /// `StartUncloaking +0x45C @ 0x007036C0` after rechecking CanFireAt.

--- a/src/sim/combat/combat_cloak_damage_tests.rs
+++ b/src/sim/combat/combat_cloak_damage_tests.rs
@@ -1,17 +1,24 @@
 //! The `ReceiveDamage` decloak and the damage outcomes that never reach it.
 //!
 //! `TechnoClass::ReceiveDamage @ 0x00701900` calls virtual `+0xFC`
-//! (`StartUncloaking(0) @ 0x00703850`) at `0x0070281D`. The `CMP EDI,4 / JZ`
-//! at `0x007027EE` is the only guard immediately in front of that call, but it
-//! is not the only way native misses it: every defensive gate returns ABOVE the
-//! `uVar7 = ObjectClass__ReceiveDamage(this)` join — the `TypeImmune`
-//! (`type+0xC8C`) same-type/same-owner arm, `vt+0x160` (IronCurtain /
-//! ForceShield), `vt+0x1D4` (warping in), the `AffectsAllies=no`
-//! (`warhead+0x179`) allied arm, and the accepted Psychedelic arm.
+//! (`StartUncloaking(0) @ 0x00703850`) at `0x0070281D`. Two native conditions
+//! keep receivers away from it, and these tests pin both negative halves:
 //!
-//! These pin the negative half. `[DLPH] TypeImmune=yes` in `rulesmd.ini` and
-//! DLPH is one of the four stock `Cloakable=yes` types, so a player's own
-//! Dolphins splashing each other is the ordinary trigger.
+//! 1. Every defensive gate returns ABOVE the `uVar7 =
+//!    ObjectClass__ReceiveDamage(this)` join — the `TypeImmune`
+//!    (`type+0xC8C`) same-type/same-owner arm, `vt+0x160` (IronCurtain /
+//!    ForceShield), `vt+0x1D4` (warping in), the `AffectsAllies=no`
+//!    (`warhead+0x179`) allied arm, and the accepted Psychedelic arm.
+//! 2. After the join, `Health == 0` overwrites the switch selector with 4
+//!    (`0x00702035`) and the jump table at `0x00702D24` sends case 4 to the
+//!    death handler at `0x00702050`, which returns without reaching
+//!    `0x0070281D` — so a corpse never surfaces, whatever ObjectClass
+//!    returned.
+//!
+//! `[DLPH] TypeImmune=yes` in `rulesmd.ini` and DLPH is one of the four stock
+//! `Cloakable=yes` types, so a player's own Dolphins splashing each other is
+//! the ordinary trigger for (1); a multi-record blast on an already-killed
+//! Dolphin is the trigger for (2).
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -82,6 +89,20 @@ fn hit(
     warhead: &str,
     alliances: &HouseAllianceMap,
 ) -> Landed {
+    hit_records(entities, rules, warhead, alliances, &[40])
+}
+
+/// One `commit_damage_events` transaction carrying `damages.len()` ordered
+/// records against entity 2 — the same shape Apply_area_damage produces for a
+/// multi-record blast, and the shape a `DeathWeapon` cascade produces when a
+/// later record lands on a receiver an earlier one already drove to zero.
+fn hit_records(
+    entities: &mut EntityStore,
+    rules: &RuleSet,
+    warhead: &str,
+    alliances: &HouseAllianceMap,
+    damages: &[i32],
+) -> Landed {
     let mut interner = test_interner();
     let soviet = interner.intern("Soviet");
     let allies = interner.intern("Americans");
@@ -102,15 +123,13 @@ fn hit(
     let mut collected: Vec<SimSoundEvent> = Vec::new();
     let mut sound_sink: Option<&mut Vec<SimSoundEvent>> = Some(&mut collected);
 
+    let records: Vec<EntityDamageEvent> = damages
+        .iter()
+        .map(|damage| EntityDamageEvent::area(2, *damage, 0, 1, attacker_owner, warhead_ref))
+        .collect();
+
     let _ = commit_damage_events(
-        &[EntityDamageEvent::area(
-            2,
-            40,
-            0,
-            1,
-            attacker_owner,
-            warhead_ref,
-        )],
+        &records,
         entities,
         &mut occupancy,
         rules,
@@ -254,4 +273,83 @@ fn an_affects_allies_no_warhead_leaves_an_allied_cloaked_dolphin_submerged() {
     );
     assert_eq!(landed.victim_hp, 60, "the warhead resolves and does damage");
     assert_eq!(landed.cloak_state, 3);
+}
+
+fn cloak_sounds(sounds: &[SimSoundEvent]) -> Vec<&SimSoundEvent> {
+    sounds
+        .iter()
+        .filter(|sound| matches!(sound, SimSoundEvent::CloakSound { .. }))
+        .collect()
+}
+
+/// A receiver already at zero health takes native's DEATH branch, not the
+/// surviving tail, so `+0xFC` is never reached for it.
+///
+/// Read from the disassembly — the decompiler's `switch (uVar7)` rendering of
+/// this dispatch is the cross-assignment trap and says the opposite:
+///
+/// ```text
+/// 0070202e MOV  EAX,[ESI+0x6C]   ; this->Health, AFTER the ObjectClass join
+/// 00702031 TEST EAX,EAX
+/// 00702033 JNZ  0x00702040
+/// 00702035 MOV  EDI,0x4          ; overwrites the ObjectClass result code
+/// 00702049 JMP  [EDI*4 + 0x702D24]
+/// ```
+///
+/// The table at `0x00702D24` is `[0x007027F7, 0x00702713, 0x00702695,
+/// 0x007027F7, 0x00702050]`; case 4 (`0x00702050`) returns at `0x00702692`
+/// (`RET 0x1C`) without passing `0x0070281D`. `ObjectClass::ReceiveDamage @
+/// 0x005F5390` does return 0 (case 0) for a corpse, but the health test above
+/// discards that.
+///
+/// The production trigger is an ordinary multi-record blast: a `DeathWeapon`
+/// cascade, a Demo Truck or an Ivan cluster whose earlier record already drove
+/// the receiver to zero inside the SAME `commit_damage_events` transaction.
+#[test]
+fn a_second_record_of_the_same_blast_leaves_a_dead_cloaked_dolphin_submerged() {
+    let rules = dolphin_rules();
+    let mut entities = store("DEST", "Americans");
+    // The 400 kills the 100-HP Dolphin; the 40 then lands on the corpse.
+    let landed = hit_records(
+        &mut entities,
+        &rules,
+        "SonicWH",
+        &HouseAllianceMap::new(),
+        &[400, 40],
+    );
+
+    assert_eq!(landed.victim_hp, 0, "the first record kills the Dolphin");
+    assert_eq!(
+        landed.cloak_state, 2,
+        "Health == 0 forces case 4 at 0x00702035; neither record reaches vt+0xFC"
+    );
+    assert!(
+        cloak_sounds(&landed.sounds).is_empty(),
+        "a corpse emits no CloakSound: {:?}",
+        landed.sounds
+    );
+}
+
+/// The same rule with the death machinery out of the way: a receiver that is
+/// already a corpse when the transaction opens. `receive_damage` returns
+/// `reached_survivor_postlude: true` with `Unaffected` here (native does reach
+/// the join — `ObjectClass::ReceiveDamage` returns 0), so only the post-join
+/// health test at `0x00702031` keeps `+0xFC` away from it.
+#[test]
+fn a_hit_on_an_already_dead_cloaked_dolphin_never_reaches_the_uncloak() {
+    let rules = dolphin_rules();
+    let mut entities = store("DEST", "Americans");
+    entities.get_mut(2).expect("victim present").health.current = 0;
+    let landed = hit(&mut entities, &rules, "SonicWH", &HouseAllianceMap::new());
+
+    assert_eq!(landed.victim_hp, 0, "the kernel is skipped for a corpse");
+    assert_eq!(
+        landed.cloak_state, 2,
+        "native takes the death branch, not the surviving tail"
+    );
+    assert!(
+        cloak_sounds(&landed.sounds).is_empty(),
+        "no CloakSound: {:?}",
+        landed.sounds
+    );
 }

--- a/src/sim/combat/combat_cloak_damage_tests.rs
+++ b/src/sim/combat/combat_cloak_damage_tests.rs
@@ -1,0 +1,257 @@
+//! The `ReceiveDamage` decloak and the damage outcomes that never reach it.
+//!
+//! `TechnoClass::ReceiveDamage @ 0x00701900` calls virtual `+0xFC`
+//! (`StartUncloaking(0) @ 0x00703850`) at `0x0070281D`. The `CMP EDI,4 / JZ`
+//! at `0x007027EE` is the only guard immediately in front of that call, but it
+//! is not the only way native misses it: every defensive gate returns ABOVE the
+//! `uVar7 = ObjectClass__ReceiveDamage(this)` join — the `TypeImmune`
+//! (`type+0xC8C`) same-type/same-owner arm, `vt+0x160` (IronCurtain /
+//! ForceShield), `vt+0x1D4` (warping in), the `AffectsAllies=no`
+//! (`warhead+0x179`) allied arm, and the accepted Psychedelic arm.
+//!
+//! These pin the negative half. `[DLPH] TypeImmune=yes` in `rulesmd.ini` and
+//! DLPH is one of the four stock `Cloakable=yes` types, so a player's own
+//! Dolphins splashing each other is the ordinary trigger.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::*;
+use crate::rules::ini_parser::IniFile;
+use crate::sim::cloak_disguise::CloakRuntime;
+use crate::sim::game_entity::GameEntity;
+use crate::sim::intern::test_interner;
+use crate::sim::superweapon::invulnerability::{InvulnKind, InvulnerabilityState};
+
+const TICK: u64 = 100;
+const CLOAKING_STAGES: i32 = 9;
+
+fn dolphin_rules() -> RuleSet {
+    RuleSet::from_ini(&IniFile::from_str(
+        "[General]\nCloakingStages=9\n\
+         [AudioVisual]\nCloakSound=NavalUnitEmerge\n\
+         [VehicleTypes]\n0=DLPH\n1=DEST\n\
+         [DLPH]\nStrength=600\nArmor=none\nSpeed=4\nCloakable=yes\nCloakingSpeed=1\n\
+         TypeImmune=yes\nPrimary=SonicZap\n\
+         [DEST]\nStrength=600\nArmor=none\nSpeed=6\nPrimary=SonicZap\n\
+         Secondary=AllyBlindZap\n\
+         [SonicZap]\nDamage=40\nROF=20\nRange=8\nWarhead=SonicWH\n\
+         [AllyBlindZap]\nDamage=40\nROF=20\nRange=8\nWarhead=AllyBlindWH\n\
+         [SonicWH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+         [AllyBlindWH]\nAffectsAllies=no\n\
+         Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("dolphin damage fixture")
+}
+
+fn live(mut entity: GameEntity) -> GameEntity {
+    entity.lifecycle.in_limbo = false;
+    entity.in_playfield = true;
+    entity
+}
+
+/// Entity 1 is the attacker (`attacker_type`), entity 2 a fully cloaked DLPH
+/// one cell east. Both belong to `attacker_owner` / `Soviet` respectively.
+fn store(attacker_type: &str, attacker_owner: &str) -> EntityStore {
+    let mut store = EntityStore::new();
+    store.insert(live(GameEntity::test_default(
+        1,
+        attacker_type,
+        attacker_owner,
+        10,
+        10,
+    )));
+    let mut victim = live(GameEntity::test_default(2, "DLPH", "Soviet", 11, 10));
+    let mut cloak = CloakRuntime::new(0, CLOAKING_STAGES);
+    cloak.establish_unlimbo_fully_cloaked();
+    victim.cloak = Some(cloak);
+    store.insert(victim);
+    store
+}
+
+struct Landed {
+    cloak_state: i32,
+    sounds: Vec<SimSoundEvent>,
+    victim_hp: u16,
+}
+
+/// One `commit_damage_events` transaction: entity 1 hits entity 2 for 40 with
+/// `warhead`, at the ordinary area distance zero.
+fn hit(
+    entities: &mut EntityStore,
+    rules: &RuleSet,
+    warhead: &str,
+    alliances: &HouseAllianceMap,
+) -> Landed {
+    let mut interner = test_interner();
+    let soviet = interner.intern("Soviet");
+    let allies = interner.intern("Americans");
+    let warhead_ref = interner.intern(warhead);
+    let attacker_owner = entities.get(1).map(|attacker| attacker.owner);
+
+    let mut houses = BTreeMap::from([
+        (soviet, HouseState::new(soviet, 0, None, false, 0, 10)),
+        (allies, HouseState::new(allies, 1, None, false, 0, 10)),
+    ]);
+    let house_order = [soviet, allies];
+    let mut occupancy = OccupancyGrid::new();
+    let mut main_rng = SimRng::new(11);
+    let mut scenario_rng = SimRng::new(13);
+    let mut handled_deaths = Vec::new();
+    let mut resources = BTreeMap::new();
+    let mut hooks = None;
+    let mut collected: Vec<SimSoundEvent> = Vec::new();
+    let mut sound_sink: Option<&mut Vec<SimSoundEvent>> = Some(&mut collected);
+
+    let _ = commit_damage_events(
+        &[EntityDamageEvent::area(
+            2,
+            40,
+            0,
+            1,
+            attacker_owner,
+            warhead_ref,
+        )],
+        entities,
+        &mut occupancy,
+        rules,
+        &mut interner,
+        &mut houses,
+        &house_order,
+        alliances,
+        &mut main_rng,
+        &mut scenario_rng,
+        &mut handled_deaths,
+        &mut resources,
+        None,
+        None,
+        None,
+        TICK,
+        &mut hooks,
+        &mut sound_sink,
+    );
+
+    let victim = entities.get(2).expect("victim survives the fixture");
+    Landed {
+        cloak_state: victim.cloak.as_ref().map_or(-1, |cloak| cloak.state),
+        sounds: collected,
+        victim_hp: victim.health.current,
+    }
+}
+
+/// Positive control. Without it the three negative tests below would also pass
+/// against a hook that never fires.
+#[test]
+fn an_ordinary_hostile_hit_surfaces_a_fully_cloaked_dolphin() {
+    let rules = dolphin_rules();
+    let mut entities = store("DEST", "Americans");
+    let landed = hit(&mut entities, &rules, "SonicWH", &HouseAllianceMap::new());
+
+    assert_eq!(landed.victim_hp, 60, "the hit lands for its 40");
+    assert_eq!(
+        landed.cloak_state, 3,
+        "0x0070281D reaches vt+0xFC for a surviving receiver"
+    );
+    assert!(
+        matches!(
+            landed.sounds.as_slice(),
+            [SimSoundEvent::CloakSound { sound_id, rx: 11, ry: 10, .. }]
+                if sound_id == "NavalUnitEmerge"
+        ),
+        "StartUncloaking(0) owns one positional CloakSound, got {:?}",
+        landed.sounds
+    );
+}
+
+/// `TypeImmune` returns `0` from `TechnoClass::ReceiveDamage` well above the
+/// `ObjectClass__ReceiveDamage` join, so `+0xFC` is never reached.
+/// `[DLPH] TypeImmune=yes` makes this the routine case for a Dolphin pod.
+#[test]
+fn a_type_immune_sibling_splash_leaves_a_cloaked_dolphin_submerged() {
+    let rules = dolphin_rules();
+    let mut entities = store("DLPH", "Soviet");
+    let landed = hit(&mut entities, &rules, "SonicWH", &HouseAllianceMap::new());
+
+    assert_eq!(landed.victim_hp, 100, "TypeImmune nullifies the damage");
+    assert_eq!(
+        landed.cloak_state, 2,
+        "native returns at type+0xC8C, above the vt+0xFC call"
+    );
+    assert!(
+        landed.sounds.is_empty(),
+        "no CloakSound: {:?}",
+        landed.sounds
+    );
+}
+
+/// `vt+0x160` (IronCurtain / ForceShield) writes `*damage = 0` and returns, so
+/// the protected object never delegates to `ObjectClass::ReceiveDamage`.
+#[test]
+fn an_iron_curtained_cloaked_dolphin_stays_submerged() {
+    let rules = dolphin_rules();
+    let mut entities = store("DEST", "Americans");
+    entities.get_mut(2).unwrap().invulnerability = Some(InvulnerabilityState {
+        start_frame: TICK as u32 - 10,
+        duration_frames: 100,
+        kind: InvulnKind::IronCurtain,
+    });
+    let landed = hit(&mut entities, &rules, "SonicWH", &HouseAllianceMap::new());
+
+    assert_eq!(landed.victim_hp, 100, "IronCurtain nullifies the damage");
+    assert_eq!(landed.cloak_state, 2, "native returns at vt+0x160");
+    assert!(
+        landed.sounds.is_empty(),
+        "no CloakSound: {:?}",
+        landed.sounds
+    );
+}
+
+/// `AffectsAllies=no` (`warhead+0x179`) with a present source and an allied
+/// owner returns above the join too. A house is always allied with itself, and
+/// an explicit two-house alliance behaves the same way.
+#[test]
+fn an_affects_allies_no_warhead_leaves_an_allied_cloaked_dolphin_submerged() {
+    let rules = dolphin_rules();
+
+    let mut own = store("DEST", "Soviet");
+    let landed = hit(&mut own, &rules, "AllyBlindWH", &HouseAllianceMap::new());
+    assert_eq!(landed.victim_hp, 100);
+    assert_eq!(landed.cloak_state, 2, "same house is allied with itself");
+    assert!(
+        landed.sounds.is_empty(),
+        "no CloakSound: {:?}",
+        landed.sounds
+    );
+
+    let alliances: HouseAllianceMap = BTreeMap::from([
+        (
+            "AMERICANS".to_string(),
+            BTreeSet::from(["SOVIET".to_string()]),
+        ),
+        (
+            "SOVIET".to_string(),
+            BTreeSet::from(["AMERICANS".to_string()]),
+        ),
+    ]);
+    let mut allied = store("DEST", "Americans");
+    let landed = hit(&mut allied, &rules, "AllyBlindWH", &alliances);
+    assert_eq!(landed.victim_hp, 100);
+    assert_eq!(landed.cloak_state, 2, "native returns at warhead+0x179");
+    assert!(
+        landed.sounds.is_empty(),
+        "no CloakSound: {:?}",
+        landed.sounds
+    );
+
+    // Control: the SAME warhead against a non-allied owner must still land.
+    // Without this the two assertions above would also hold if `AllyBlindWH`
+    // failed to resolve and the record were dropped before the receiver.
+    let mut hostile = store("DEST", "Americans");
+    let landed = hit(
+        &mut hostile,
+        &rules,
+        "AllyBlindWH",
+        &HouseAllianceMap::new(),
+    );
+    assert_eq!(landed.victim_hp, 60, "the warhead resolves and does damage");
+    assert_eq!(landed.cloak_state, 3);
+}

--- a/src/sim/combat/combat_cloak_legality_tests.rs
+++ b/src/sim/combat/combat_cloak_legality_tests.rs
@@ -1,0 +1,250 @@
+//! Acquisition and fire legality against cloaked and disguised candidates.
+//!
+//! Pins the two arms of `TechnoClass::Evaluate_Candidate @ 0x006F7CA0` that
+//! Phase 6 rows GSI-12.05 / GSI-12.06 own — the cloak gate at `0x006F7DA9` and
+//! the disguise gate at `0x006F84B1` — plus the target-side `GetFireError`
+//! cloak exit at `0x006FC24D`.
+
+use super::*;
+use crate::rules::ini_parser::IniFile;
+use crate::sim::cloak_disguise::{
+    CloakRuntime, DisguiseGateOutcome, cloak_rejects_candidate, disguise_rejects_candidate,
+    is_disguised_to,
+};
+use crate::sim::game_entity::GameEntity;
+use crate::sim::intern::test_interner;
+use crate::sim::vision::FogState;
+
+fn legality_rules() -> RuleSet {
+    RuleSet::from_ini(&IniFile::from_str(
+        "[General]\nCloakingStages=9\n\
+         [VehicleTypes]\n0=DEST\n1=SUB\n2=MGTK\n\
+         [InfantryTypes]\n0=DOG\n1=E1\n\
+         [DEST]\nStrength=600\nArmor=heavy\nSpeed=6\nSensors=yes\nSensorsSight=8\n\
+         Primary=DestroyerGun\nSight=10\n\
+         [SUB]\nStrength=600\nArmor=heavy\nSpeed=4\nCloakable=yes\nCloakingSpeed=1\n\
+         SensorsSight=8\nPrimary=DestroyerGun\nSight=10\n\
+         [MGTK]\nStrength=400\nArmor=light\nSpeed=6\nDisguiseWhenStill=yes\nSight=10\n\
+         [DOG]\nStrength=100\nArmor=none\nSpeed=6\nDetectDisguise=yes\nPrimary=DestroyerGun\n\
+         Sight=10\n\
+         [E1]\nStrength=100\nArmor=none\nSpeed=4\nPrimary=DestroyerGun\nSight=10\n\
+         [DestroyerGun]\nDamage=60\nROF=50\nRange=8\nWarhead=PlainWH\n\
+         [PlainWH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("cloak legality fixture")
+}
+
+fn live(mut entity: GameEntity) -> GameEntity {
+    entity.lifecycle.in_limbo = false;
+    entity.in_playfield = true;
+    entity
+}
+
+fn fog() -> FogState {
+    FogState {
+        width: 64,
+        height: 64,
+        ..FogState::default()
+    }
+}
+
+/// A destroyer at (10,10) and a hostile submarine one cell east.
+fn destroyer_and_sub(sub_cloak_state: i32) -> (EntityStore, StringInterner, FogState) {
+    let mut store = EntityStore::new();
+    store.insert(live(GameEntity::test_default(
+        1,
+        "DEST",
+        "Americans",
+        10,
+        10,
+    )));
+    let mut sub = live(GameEntity::test_default(2, "SUB", "Soviet", 11, 10));
+    let mut cloak = CloakRuntime::new(0, 9);
+    cloak.state = sub_cloak_state;
+    sub.cloak = Some(cloak);
+    store.insert(sub);
+    let mut interner = test_interner();
+    let americans = interner.intern("Americans");
+    interner.intern("Soviet");
+    let mut fog = fog();
+    fog.mark_visible_for_owner(americans, 11, 10);
+    (store, interner, fog)
+}
+
+fn acquire(
+    entities: &EntityStore,
+    rules: &RuleSet,
+    interner: &StringInterner,
+    attacker: u64,
+    fog: &FogState,
+) -> Option<u64> {
+    acquire_best_target_for_entity(entities, rules, interner, attacker, Some(fog), None, false)
+}
+
+#[test]
+fn fully_cloaked_enemy_is_illegal_until_the_attacker_house_senses_its_cell() {
+    let rules = legality_rules();
+    let (entities, interner, mut fog) = destroyer_and_sub(2);
+    let americans = interner.get("Americans").expect("interned attacker house");
+
+    assert_eq!(
+        acquire(&entities, &rules, &interner, 1, &fog),
+        None,
+        "Evaluate_Candidate 0x006F7DA9 rejects CloakState==2 with no sensor count"
+    );
+
+    // The destroyer's own `SensorsSight=` deposit is what makes it legal.
+    fog.increment_sensor_at(americans, 11, 10);
+    assert_eq!(
+        acquire(&entities, &rules, &interner, 1, &fog),
+        Some(2),
+        "a positive sensor count on the candidate's cell restores legality"
+    );
+}
+
+#[test]
+fn cloaking_and_uncloaking_states_stay_legal() {
+    let rules = legality_rules();
+    for state in [0, 1, 3] {
+        let (entities, interner, fog) = destroyer_and_sub(state);
+        assert_eq!(
+            acquire(&entities, &rules, &interner, 1, &fog),
+            Some(2),
+            "only state 2 is filtered; state {state} must stay legal"
+        );
+    }
+}
+
+#[test]
+fn same_owner_is_exempt_but_an_ally_is_not() {
+    let rules = legality_rules();
+
+    // Same owner: native compares `candidate->pOwner != attacker->pOwner`, so a
+    // house's own submerged sub stays a legal candidate. (It is dropped later by
+    // the ordinary friendly filter, so acquisition still returns nothing — the
+    // point is that the cloak arm itself does not reject it.)
+    let mut store = EntityStore::new();
+    store.insert(live(GameEntity::test_default(1, "DEST", "Soviet", 10, 10)));
+    let mut own_sub = live(GameEntity::test_default(2, "SUB", "Soviet", 11, 10));
+    let mut cloak = CloakRuntime::new(0, 9);
+    cloak.state = 2;
+    own_sub.cloak = Some(cloak);
+    store.insert(own_sub);
+    assert!(!cloak_rejects_candidate(true, false, true));
+
+    // Alliance is NOT the test native applies.
+    assert!(cloak_rejects_candidate(true, false, false));
+    assert!(!cloak_rejects_candidate(true, true, false));
+    assert!(!cloak_rejects_candidate(false, false, false));
+    let _ = (&store, &rules);
+}
+
+#[test]
+fn only_a_detect_disguise_attacker_auto_acquires_a_disguised_mirage() {
+    let rules = legality_rules();
+    let mut store = EntityStore::new();
+    store.insert(live(GameEntity::test_default(1, "E1", "Americans", 10, 10)));
+    store.insert(live(GameEntity::test_default(
+        3,
+        "DOG",
+        "Americans",
+        10,
+        11,
+    )));
+    let mut mirage = live(GameEntity::test_default(2, "MGTK", "Soviet", 11, 10));
+    let mut disguise = crate::sim::cloak_disguise::DisguiseRuntime::default();
+    disguise.acquire(0, None, None);
+    mirage.disguise = Some(disguise);
+    store.insert(mirage);
+    let mut interner = test_interner();
+    let americans = interner.intern("Americans");
+    interner.intern("Soviet");
+    let mut fog = fog();
+    fog.mark_visible_for_owner(americans, 11, 10);
+
+    assert_eq!(
+        acquire(&store, &rules, &interner, 1, &fog),
+        None,
+        "Evaluate_Candidate 0x006F84D4: an attacker type without DetectDisguise= is rejected"
+    );
+    assert_eq!(
+        acquire(&store, &rules, &interner, 3, &fog),
+        Some(2),
+        "a DetectDisguise= attacker (dog/Yuri/PTROOP) bypasses the whole arm"
+    );
+}
+
+#[test]
+fn a_detect_disguise_building_covering_the_cell_restores_legality_for_everyone() {
+    let rules = legality_rules();
+    let mut store = EntityStore::new();
+    store.insert(live(GameEntity::test_default(1, "E1", "Americans", 10, 10)));
+    let mut spy = live(GameEntity::test_default(2, "MGTK", "Soviet", 11, 10));
+    let mut disguise = crate::sim::cloak_disguise::DisguiseRuntime::default();
+    disguise.acquire(0, None, None);
+    spy.disguise = Some(disguise);
+    store.insert(spy);
+    let mut interner = test_interner();
+    let americans = interner.intern("Americans");
+    interner.intern("Soviet");
+    let mut fog = fog();
+    fog.mark_visible_for_owner(americans, 11, 10);
+
+    assert_eq!(acquire(&store, &rules, &interner, 1, &fog), None);
+    // `BuildingClass::AddDetectDisguiseAt @ 0x00455A80` stamps
+    // `CellClass+0xAC[house]`; `IsDisguisedTo` reads it through `FUN_004870F0`.
+    fog.disguise_detect_add_at(americans, (11, 10), 3);
+    assert_eq!(
+        acquire(&store, &rules, &interner, 1, &fog),
+        Some(2),
+        "a NAPSIS-shaped detect circle makes the disguise transparent to that house"
+    );
+}
+
+#[test]
+fn is_disguised_to_matches_the_native_clause_order() {
+    // `UnitClass::IsDisguisedTo @ 0x00746750`.
+    assert!(is_disguised_to(true, false, false, false, false));
+    assert!(!is_disguised_to(false, false, false, false, false));
+    assert!(
+        !is_disguised_to(true, true, false, false, false),
+        "an allied owner is never disguised to the observer"
+    );
+    assert!(
+        !is_disguised_to(true, false, true, false, false),
+        "a detect-disguise counter on the cell sees through it"
+    );
+    // The fake-house clause: hidden only when the fake house IS the observer or
+    // one of its allies; a disguise as some third enemy is seen through.
+    assert!(is_disguised_to(true, false, false, true, true));
+    assert!(!is_disguised_to(true, false, false, false, true));
+}
+
+#[test]
+fn the_disguise_gate_collapses_to_a_plain_reject_without_a_blink_window() {
+    // Blink timer not running: native's `if (rem == 0) reject`.
+    assert_eq!(
+        disguise_rejects_candidate(true, false, 0, false),
+        DisguiseGateOutcome::Reject
+    );
+    // Blink running but the attacking house is human: the very next line.
+    assert_eq!(
+        disguise_rejects_candidate(true, false, 5, true),
+        DisguiseGateOutcome::Reject
+    );
+    // Blink running and the house is AI: native reaches its one Scenario draw.
+    // VERA has no AI opponent, so no production caller reaches this variant.
+    assert_eq!(
+        disguise_rejects_candidate(true, false, 5, false),
+        DisguiseGateOutcome::AiDetectionRoll
+    );
+    // Not disguised, or the attacker detects disguises.
+    assert_eq!(
+        disguise_rejects_candidate(false, false, 0, true),
+        DisguiseGateOutcome::Accept
+    );
+    assert_eq!(
+        disguise_rejects_candidate(true, true, 0, true),
+        DisguiseGateOutcome::Accept
+    );
+}

--- a/src/sim/combat/combat_targeting.rs
+++ b/src/sim/combat/combat_targeting.rs
@@ -173,7 +173,14 @@ pub fn acquire_best_target_for_entity(
         scan_mission: scan_mission_for(entity),
     };
     acquire_best_target(
-        entities, rules, interner, &snapshot, obj, fog, None, terrain,
+        entities,
+        rules,
+        interner,
+        &snapshot,
+        obj,
+        fog,
+        None,
+        terrain,
         require_playfield_membership,
     )
 }
@@ -309,6 +316,38 @@ pub(crate) fn acquire_best_target(
         if require_playfield_membership && !candidate.in_playfield {
             continue;
         }
+        // `TechnoClass::Evaluate_Candidate @ 0x006F7DA9` — the cloak arm, in its
+        // native slot: after the `+0x81` InLimbo and `+0x6C` Health rejections
+        // and before the `+0x3D5` playfield byte. A fully cloaked candidate
+        // (`CloakState == 2`) is illegal unless the ATTACKER'S house holds a
+        // positive sensor count on the candidate's own cell, or the two share
+        // an owner. States 1 and 3 are never filtered, and alliance does not
+        // exempt — an allied submerged sub is just as illegal as an enemy one.
+        //
+        // This is what stops every Grizzly, Prism Tower and Aegis in range from
+        // auto-firing at a submerged Typhoon: it is continuous in any naval
+        // game, and until this landed VERA had no cloak term in acquisition at
+        // all.
+        //
+        // With `fog` absent (headless fixtures, sandbox) there is no sensor
+        // plane to consult, so the cell reads as unsensed — the same answer
+        // native gives a house with no deposit there.
+        if crate::sim::cloak_disguise::cloak_rejects_candidate(
+            candidate
+                .cloak
+                .as_ref()
+                .is_some_and(|cloak| cloak.is_fully_cloaked()),
+            fog.is_some_and(|fog_state| {
+                fog_state.has_sensor_for_house(
+                    attacker.owner,
+                    candidate.position.rx,
+                    candidate.position.ry,
+                )
+            }),
+            candidate.owner == attacker.owner,
+        ) {
+            continue;
+        }
         // Skip entities inside a transport — they are hidden from the battlefield.
         if candidate.passenger_role.is_inside_transport() {
             continue;
@@ -413,6 +452,69 @@ pub(crate) fn acquire_best_target(
         };
         if !in_range {
             continue;
+        }
+
+        // `TechnoClass::Evaluate_Candidate @ 0x006F84B1..0x006F854B` — the
+        // disguise arm, in its native slot (after the distance/`CanFireAt`
+        // block, before the flag-driven score extras).
+        //
+        // `IsDisguisedTo` (`UnitClass @ 0x00746750`, `InfantryClass @
+        // 0x005227F0`, vt+0xC8) is evaluated per observer; the allied clause is
+        // already satisfied here because allied candidates were dropped above.
+        // A `DetectDisguise=` attacker TYPE skips the whole arm — that is the
+        // dogs' (ADOG/DOG/YADOG/YDOG), Yuri's and the Psi Corps Trooper's
+        // entire special role against Spies and Mirage Tanks. The building side
+        // of the key reaches this through the per-cell counter instead.
+        //
+        // RESIDUAL — the Mirage fake-blink window and the AI detection roll.
+        // Native, having rejected a DetectDisguise-less attacker, gives it a
+        // second chance while the candidate's `+0x1EC/+0x1F4` blink timer is
+        // running (armed only by `UnitClass::Fire_At @ 0x00741340` with the
+        // firing weapon's `DisguiseFakeBlinkTime=`) AND the attacking house is
+        // computer-controlled, at the cost of one `RandomRanged(0, 99)` on the
+        // Scenario stream compared against `[General]
+        // DisabledDisguiseDetectionPercent=15,5,2`. VERA stores no blink timer,
+        // so `0` is passed and the gate collapses to a plain reject.
+        // - Trigger: an AI-owned attacker evaluating a Mirage Tank within
+        //   `DisguiseFakeBlinkTime` frames of that Mirage's own shot.
+        // - Player effect: none today — every VERA house is human-controlled,
+        //   and native rejects a human attacker on the very next line, so both
+        //   engines reject identically.
+        // - Frequency: zero until an AI opponent ships.
+        // - Downstream risk: wiring it costs one Scenario draw per evaluated
+        //   disguised candidate, which moves RNG order for every later consumer
+        //   in the same tick. It must land together with the AI house, not
+        //   before it.
+        const BLINK_TIMER_NOT_MODELLED: i32 = 0;
+        let candidate_disguised_to_attacker = candidate.disguise.as_ref().is_some_and(|disguise| {
+            crate::sim::cloak_disguise::is_disguised_to(
+                disguise.disguised,
+                false,
+                fog.is_some_and(|fog_state| {
+                    fog_state.detects_disguise_for_house(
+                        attacker.owner,
+                        candidate.position.rx,
+                        candidate.position.ry,
+                    )
+                }),
+                disguise.disguised_as_house.is_some_and(|fake| {
+                    fake == attacker.owner
+                        || fog.is_some_and(|fog_state| {
+                            fog_state.is_friendly(attacker_owner_str, interner.resolve(fake))
+                        })
+                }),
+                disguise.disguised_as_house.is_some(),
+            )
+        });
+        let attacker_detects_disguise = attacker_obj.detect_disguise;
+        match crate::sim::cloak_disguise::disguise_rejects_candidate(
+            candidate_disguised_to_attacker,
+            attacker_detects_disguise,
+            BLINK_TIMER_NOT_MODELLED,
+            true,
+        ) {
+            crate::sim::cloak_disguise::DisguiseGateOutcome::Accept => {}
+            _ => continue,
         }
 
         let class = threat_class(rules, interner, candidate);

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -3466,27 +3466,51 @@ fn commit_damage_events_with_isolation(
                 receive_outcome.is_some_and(|outcome| outcome.reached_survivor_postlude);
             let receive_state = receive_outcome.map(|outcome| outcome.state);
             // `TechnoClass::ReceiveDamage @ 0x0070281D` calls vtable `+0xFC`
-            // (`StartUncloaking(0) @ 0x00703850`) once the `CMP EDI,4 / JZ`
-            // death branch at `0x007027EE` has been passed — so for results
-            // Unaffected/Damaged/Yellow/Red, and NOT for NowDead. It sits
-            // after the ObjectClass HP commit and after the `ToProtect`
-            // response, and before the `if (damage < 0) return` heal
-            // early-out, which is why a HEAL surfaces a diving submarine just
-            // as reliably as a shell does.
+            // (`StartUncloaking(0) @ 0x00703850`). It sits after the
+            // ObjectClass HP commit and after the `ToProtect` response, and
+            // before the `if (damage < 0) return` heal early-out, which is why
+            // a HEAL surfaces a diving submarine just as reliably as a shell
+            // does.
             //
-            // The death branch is the only guard IMMEDIATELY before the call,
-            // but it is not the only way native misses it: every defensive
-            // gate in `TechnoClass::ReceiveDamage @ 0x00701900` returns above
-            // the `uVar7 = ObjectClass__ReceiveDamage(this)` join — the
-            // `TypeImmune` (`type+0xC8C`) same-type/same-owner arm, `vt+0x160`
-            // (IronCurtain/ForceShield), `vt+0x1D4` (warping in), the
-            // `AffectsAllies=no` (`warhead+0x179`) allied arm, and the
-            // accepted Psychedelic arm (`return 1`). None of those reaches
-            // `+0xFC`, so an Iron-Curtained, type-immune or ally-shielded
-            // cloaked object stays submerged. `reached_survivor_postlude` is
-            // exactly "the receiver delegated to ObjectClass and came back
-            // through the surviving-object tail", i.e. that join.
+            // Two native conditions guard it, and BOTH are read from the
+            // disassembly, not the decompiler — the decompiler renders this
+            // dispatch as `switch (uVar7)` after assigning `uStack_a4 = 4`,
+            // which hides the selector overwrite below:
+            //
+            // 1. Every defensive gate in `TechnoClass::ReceiveDamage @
+            //    0x00701900` returns ABOVE the `uVar7 =
+            //    ObjectClass__ReceiveDamage(this)` join — the `TypeImmune`
+            //    (`type+0xC8C`) same-type/same-owner arm, `vt+0x160`
+            //    (IronCurtain/ForceShield), `vt+0x1D4` (warping in), the
+            //    `AffectsAllies=no` (`warhead+0x179`) allied arm, and the
+            //    accepted Psychedelic arm (`return 1`). None of those reaches
+            //    `+0xFC`, so an Iron-Curtained, type-immune or ally-shielded
+            //    cloaked object stays submerged. `reached_survivor_postlude`
+            //    is exactly "the receiver delegated to ObjectClass and came
+            //    back through the surviving-object tail", i.e. that join.
+            // 2. Post-join HEALTH, not the ObjectClass result code:
+            //      0070202e MOV  EAX,[ESI+0x6C]   ; this->Health
+            //      00702031 TEST EAX,EAX
+            //      00702033 JNZ  0x00702040
+            //      00702035 MOV  EDI,0x4          ; overwrites the selector
+            //      00702049 JMP  [EDI*4 + 0x702D24]
+            //    The table at `0x00702D24` is `[0x007027F7, 0x00702713,
+            //    0x00702695, 0x007027F7, 0x00702050]`; case 4 is the death
+            //    handler, which returns at `0x00702692` (`RET 0x1C`) without
+            //    ever reaching `0x0070281D`. So `Health == 0` after the join
+            //    takes the death branch WHATEVER ObjectClass returned — which
+            //    covers both "this record killed it" and "it was already a
+            //    corpse" (`ObjectClass::ReceiveDamage @ 0x005F5390` opens
+            //    `if (Health < 1) return 0`, and 0 is case 0, but the health
+            //    test overrides it). The hostile-hit latch six bytes below at
+            //    `0x00702812` sits in the same basic block and is guarded
+            //    identically.
+            //
+            // `target.health.current` here is still the PRE-record value, so
+            // "post-join health nonzero" is `pre > 0 && state != Dead`:
+            // `classify` returns `Dead` exactly when `prev - delta <= 0`.
             uncloak_after_damage = reached_survivor_postlude
+                && target.health.current > 0
                 && receive_state.is_some_and(|state| state != damage::DamageState::Dead);
             // TechnoClass's persistent hostile-hit byte is written in the
             // shared surviving post-Object tail. The source object must be

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -56,6 +56,10 @@ mod combat_cloak_fire_tests;
 mod combat_cloak_legality_tests;
 
 #[cfg(test)]
+#[path = "combat_cloak_damage_tests.rs"]
+mod combat_cloak_damage_tests;
+
+#[cfg(test)]
 #[path = "delayed_building_fire_tests.rs"]
 mod delayed_building_fire_tests;
 
@@ -3462,16 +3466,28 @@ fn commit_damage_events_with_isolation(
                 receive_outcome.is_some_and(|outcome| outcome.reached_survivor_postlude);
             let receive_state = receive_outcome.map(|outcome| outcome.state);
             // `TechnoClass::ReceiveDamage @ 0x0070281D` calls vtable `+0xFC`
-            // (`StartUncloaking(0) @ 0x00703850`) unconditionally once the
-            // `CMP EDI,4 / JZ` death branch at `0x007027EE` has been passed —
-            // so for results Unaffected/Damaged/Yellow/Red, and NOT for
-            // NowDead. It sits after the ObjectClass HP commit and after the
-            // `ToProtect` response, and before the `if (damage < 0) return`
-            // heal early-out, which is why a HEAL surfaces a diving submarine
-            // just as reliably as a shell does.
-            uncloak_after_damage = receive_state.is_some_and(|state| {
-                state != damage::DamageState::Dead
-            });
+            // (`StartUncloaking(0) @ 0x00703850`) once the `CMP EDI,4 / JZ`
+            // death branch at `0x007027EE` has been passed — so for results
+            // Unaffected/Damaged/Yellow/Red, and NOT for NowDead. It sits
+            // after the ObjectClass HP commit and after the `ToProtect`
+            // response, and before the `if (damage < 0) return` heal
+            // early-out, which is why a HEAL surfaces a diving submarine just
+            // as reliably as a shell does.
+            //
+            // The death branch is the only guard IMMEDIATELY before the call,
+            // but it is not the only way native misses it: every defensive
+            // gate in `TechnoClass::ReceiveDamage @ 0x00701900` returns above
+            // the `uVar7 = ObjectClass__ReceiveDamage(this)` join — the
+            // `TypeImmune` (`type+0xC8C`) same-type/same-owner arm, `vt+0x160`
+            // (IronCurtain/ForceShield), `vt+0x1D4` (warping in), the
+            // `AffectsAllies=no` (`warhead+0x179`) allied arm, and the
+            // accepted Psychedelic arm (`return 1`). None of those reaches
+            // `+0xFC`, so an Iron-Curtained, type-immune or ally-shielded
+            // cloaked object stays submerged. `reached_survivor_postlude` is
+            // exactly "the receiver delegated to ObjectClass and came back
+            // through the surviving-object tail", i.e. that join.
+            uncloak_after_damage = reached_survivor_postlude
+                && receive_state.is_some_and(|state| state != damage::DamageState::Dead);
             // TechnoClass's persistent hostile-hit byte is written in the
             // shared surviving post-Object tail. The source object must be
             // non-null, and alliance direction is target owner -> captured
@@ -5891,8 +5907,20 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             // attack record instead of the object, so the cloak runtime carries
             // its own copy of the same value; without it a Typhoon that
             // surfaced to fire could re-dive on the very next tick.
+            //
+            // The duration native stores is `CALL [EDX+0x318]` at 0x006FE49E
+            // — `TechnoClass::GetROF @ 0x006FCFA0` (vtable slot read at
+            // 0x007F4C78) — whose MID-BURST branch returns the inter-shot gap,
+            // not zero. Native keeps one timer; VERA splits it into
+            // `cooldown_ticks` (armed on the burst's last shot) and
+            // `burst_delay_ticks` (armed between burst shots). The two
+            // decrement together and the fire gate is their union, so the
+            // native `+0x2F4` value is whichever of the two this shot armed.
+            // With `[BoomerTorpedo] Burst=2` on a `Cloakable=yes` BSUB, taking
+            // the union is what stops a re-dive between the two torpedoes.
+            let rearm_gate_frames = i32::from(rof_cd).max(i32::from(burst_delay));
             if let Some(cloak) = entity.cloak.as_mut() {
-                cloak.arm_rearm_gate(binary_frame as i32, i32::from(rof_cd));
+                cloak.arm_rearm_gate(binary_frame as i32, rearm_gate_frames);
             }
         }
     }
@@ -6674,6 +6702,17 @@ pub(crate) fn resolve_attacker_fire(
     //
     // The range-zero/allied fall-through is modelled: a range-0 weapon against
     // an ALLIED invisible target is allowed through, everything else is not.
+    //
+    // RESIDUAL (SUBSTITUTION) — the range term is the SELECTED weapon's range;
+    // native's `GetWeaponRange(this, -1)` at `0x006FC27C` asks the object for
+    // its range across weapons, so the two differ only when the selected weapon
+    // has range 0 while another slot does not.
+    // - Trigger: a zero-range weapon aimed at an allied, fully cloaked,
+    //   unsensed target.
+    // - Player effect: VERA lets the shot through where native returns 6.
+    // - Frequency: none observed in stock — no stock weapon pairs range 0 with
+    //   a second armed slot on a unit that can hold an allied cloaked target.
+    // - Downstream risk: low; it is one range lookup.
     if let TargetKind::Entity(target_sid) = snap.target
         && entities
             .get(target_sid)

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -52,6 +52,10 @@ mod combat_turret_facing_tests;
 mod combat_cloak_fire_tests;
 
 #[cfg(test)]
+#[path = "combat_cloak_legality_tests.rs"]
+mod combat_cloak_legality_tests;
+
+#[cfg(test)]
 #[path = "delayed_building_fire_tests.rs"]
 mod delayed_building_fire_tests;
 
@@ -3418,6 +3422,7 @@ fn commit_damage_events_with_isolation(
         let mut smoke_maintenance: Option<(EntityCategory, damage::DamageState)> = None;
         let mut healing_only = false;
         let mut latch_hostile_hit = false;
+        let mut uncloak_after_damage = false;
         let mut threat_feedback: Option<(InternedId, InternedId, i32, i32, i32)> = None;
         if let Some(target) = entities.get_mut(target_id) {
             if event.distance_leptons.is_none()
@@ -3456,6 +3461,17 @@ fn commit_damage_events_with_isolation(
             let reached_survivor_postlude =
                 receive_outcome.is_some_and(|outcome| outcome.reached_survivor_postlude);
             let receive_state = receive_outcome.map(|outcome| outcome.state);
+            // `TechnoClass::ReceiveDamage @ 0x0070281D` calls vtable `+0xFC`
+            // (`StartUncloaking(0) @ 0x00703850`) unconditionally once the
+            // `CMP EDI,4 / JZ` death branch at `0x007027EE` has been passed —
+            // so for results Unaffected/Damaged/Yellow/Red, and NOT for
+            // NowDead. It sits after the ObjectClass HP commit and after the
+            // `ToProtect` response, and before the `if (damage < 0) return`
+            // heal early-out, which is why a HEAL surfaces a diving submarine
+            // just as reliably as a shell does.
+            uncloak_after_damage = receive_state.is_some_and(|state| {
+                state != damage::DamageState::Dead
+            });
             // TechnoClass's persistent hostile-hit byte is written in the
             // shared surviving post-Object tail. The source object must be
             // non-null, and alliance direction is target owner -> captured
@@ -3573,6 +3589,35 @@ fn commit_damage_events_with_isolation(
                 scenario_rng,
                 terrain.as_deref(),
             );
+        }
+
+        // `0x0070281D`, in its native slot: after the `ToProtect` response
+        // (`0x007027E9`) and before the death branch's kill callbacks. The
+        // `StartUncloaking(0)` argument is zero, so it owns one positional
+        // `[AudioVisual] CloakSound`.
+        if uncloak_after_damage {
+            // Production combat callers derive `current_tick` from
+            // `ScenarioSession::binary_frame`, which is the clock the cloak step
+            // timer is compared against in `CloakingTick`.
+            let now = current_tick as i32;
+            let cloaking_speed = entities
+                .get(target_id)
+                .and_then(|target| rules.object(interner.resolve(target.type_ref)))
+                .map_or(1, |object| object.cloaking_speed);
+            let surfaced = entities
+                .get_mut(target_id)
+                .and_then(|target| target.cloak.as_mut())
+                .map(|cloak| cloak.start_uncloaking_from_damage(now, cloaking_speed));
+            if surfaced.is_some_and(|result| result.play_sound)
+                && let Some(sound_name) = rules.general.cloak_sound.as_deref()
+                && let Some(sink) = sound_sink.as_deref_mut()
+                && let Some(target) = entities.get(target_id)
+            {
+                sink.push(SimSoundEvent::cloak_sound(
+                    sound_name.to_owned(),
+                    &target.position,
+                ));
+            }
         }
 
         if reached_exact_zero && let Some(target) = entities.get_mut(target_id) {
@@ -5838,6 +5883,17 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
                 attack.burst_delay_ticks = burst_delay;
                 attack.cooldown_ticks = rof_cd;
             }
+            // `TechnoClass::Fire_At @ 0x006FDD50` writes the SAME rearm
+            // countdown into `TechnoClass+0x2EC/+0x2F4` (stores at 0x006FE4B0
+            // and 0x006FF2AA), and `CanAutoCloak @ 0x006FBDC0` reads that timer
+            // as its first gate after the `CloakState == 2` early-out
+            // (`param_1[0xbb]`/`[0xbd]`). VERA keeps the rearm counter on the
+            // attack record instead of the object, so the cloak runtime carries
+            // its own copy of the same value; without it a Typhoon that
+            // surfaced to fire could re-dive on the very next tick.
+            if let Some(cloak) = entity.cloak.as_mut() {
+                cloak.arm_rearm_gate(binary_frame as i32, i32::from(rof_cd));
+            }
         }
     }
 
@@ -6593,6 +6649,45 @@ pub(crate) fn resolve_attacker_fire(
             } else {
                 out.remove_attack.push(snap.stable_id);
             }
+            return;
+        }
+    }
+
+    // `TechnoClass::GetFireError @ 0x006FC24D..0x006FC29D` — the target-side
+    // cloak exit, ahead of ammo and the `DecloakToFire` self-check:
+    //
+    //   vs = target->GetVisualState(1, this->pOwner);          // vt+0x68
+    //   if (vs == 5 && !SensorCountForHouse(targetCell, myHouse->ArrayIndex)) {
+    //       if (GetWeaponRange(this, -1) > 0)            return 6;   // 0x006FCD29
+    //       if (!IsAlliedWith(target->pOwner, myOwner))  return 6;
+    //   }
+    //
+    // `GetVisualState(1, house) @ 0x00703860` returns 5 for a `CloakState == 2`
+    // object exactly when that house has no sensor on its cell, so for cloak
+    // this is "fully cloaked and unsensed by me". Error 6 suppresses the shot
+    // only — no retarget and no clear, like the bridge-mismatch arm above.
+    //
+    // Acquisition already refuses such a candidate; this is the case
+    // acquisition cannot cover — a target held from before the dive (the
+    // attacker's house was sensing the cell, so `PointerExpired` let it keep
+    // the pointer) that later falls out of sensor coverage.
+    //
+    // The range-zero/allied fall-through is modelled: a range-0 weapon against
+    // an ALLIED invisible target is allowed through, everything else is not.
+    if let TargetKind::Entity(target_sid) = snap.target
+        && entities
+            .get(target_sid)
+            .and_then(|target| target.cloak.as_ref())
+            .is_some_and(|cloak| cloak.is_fully_cloaked())
+        && fog.is_some_and(|fog_state| {
+            !fog_state.has_sensor_for_house(snap.owner, target_rx, target_ry)
+        })
+    {
+        let attacker_owner_str = interner.resolve(snap.owner);
+        let target_owner_str = interner.resolve(target_owner);
+        let allied = fog
+            .is_some_and(|fog_state| fog_state.is_friendly(attacker_owner_str, target_owner_str));
+        if weapon.range > SimFixed::ZERO || !allied {
             return;
         }
     }

--- a/src/sim/movement/locomotor_tests.rs
+++ b/src/sim/movement/locomotor_tests.rs
@@ -120,6 +120,8 @@ fn make_obj(locomotor: LocomotorKind, category: ObjectCategory) -> ObjectType {
         sensor_array: false,
         sensors: false,
         sensors_sight: 0,
+        detect_disguise: false,
+        detect_disguise_range: 0,
         cloakable: false,
         cloaking_speed: 1,
         cloak_stop: false,

--- a/src/sim/movement/teleport_movement.rs
+++ b/src/sim/movement/teleport_movement.rs
@@ -583,6 +583,8 @@ mod tests {
             sensor_array: false,
             sensors: false,
             sensors_sight: 0,
+            detect_disguise: false,
+            detect_disguise_range: 0,
             cloakable: false,
             cloaking_speed: 1,
             cloak_stop: false,

--- a/src/sim/sensor_lifecycle.rs
+++ b/src/sim/sensor_lifecycle.rs
@@ -14,6 +14,11 @@ use crate::sim::world::Simulation;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct SensorDeposit {
+    /// The house the circle was stamped FOR — native reads
+    /// `this->Owner->ArrayIndex` live at add time and has no such cache. It is
+    /// a record of the add, not the removal's authority: every native remove
+    /// re-reads the live owner (`0x00455980`, `0x004556D0`, `0x004DE940`), so
+    /// `remove_cached_sensor_deposit` must not consult this field.
     pub owner: InternedId,
     pub center: (u16, u16),
     pub add_radius: u16,
@@ -170,16 +175,38 @@ impl Simulation {
         callbacks
     }
 
+    /// Every native remove takes its house index from `this->Owner->ArrayIndex`
+    /// at REMOVAL time, never from anything recorded when the circle was
+    /// stamped. `BuildingClass::RemoveDetectDisguiseAt @ 0x00455980` opens with
+    /// `0045598A MOV EDX,[ECX+0x21C]` / `004559A1 MOV EAX,[EDX+0x30]`;
+    /// `BuildingClass::RemoveSensorArrayAt @ 0x004556D0` and
+    /// `TechnoClass::RemoveSensorsAt @ 0x004DE940` open with the identical
+    /// `*(int *)(param_1[0x87] + 0x30)` read, and so do both adds
+    /// (`0x00455820`, `0x00455A80`). `TechnoClass::ChangeOwner @ 0x007014A0`
+    /// overwrites that pointer (`param_1[0x87] = param_2`), so the live owner
+    /// is whoever holds the object now.
+    ///
+    /// For units the two agree: `FootClass::ChangeOwner @ 0x004DBED0` dispatches
+    /// the remove (`vt+0x4EC`) BEFORE the pointer flip and the add
+    /// (`vt+0x4E8`) after, and VERA calls
+    /// `transfer_sensor_before_owner_change` from the same slot. For BUILDINGS
+    /// they diverge permanently, and that asymmetry is native map state:
+    /// construction credits the builder, `ChangeOwner` dispatches neither add
+    /// nor remove, and Limbo debits the CAPTOR. See the residual on
+    /// `transfer_sensor_before_owner_change_inner`.
     fn remove_cached_sensor_deposit(
         &mut self,
         stable_id: u64,
         rules: Option<&RuleSet>,
     ) -> Option<SensorDeposit> {
-        let deposit = self
-            .substrate
-            .entities
-            .get_mut(stable_id)
-            .and_then(|entity| entity.sensor_deposit.take())?;
+        let (deposit, remove_owner) =
+            self.substrate
+                .entities
+                .get_mut(stable_id)
+                .and_then(|entity| {
+                    let deposit = entity.sensor_deposit.take()?;
+                    Some((deposit, entity.owner))
+                })?;
         if deposit.detect_disguise_radius > 0 {
             // `BuildingClass::RemoveDetectDisguiseAt @ 0x00455980`, reached
             // ONLY from `BuildingClass::Limbo` — `0x00445A58` reads
@@ -190,7 +217,7 @@ impl Simulation {
             // BuildingClass site program-wide, which is why the owner-change
             // path below must not come through here.
             self.fog.disguise_detect_remove_at(
-                deposit.owner,
+                remove_owner,
                 deposit.center,
                 deposit.detect_disguise_radius,
             );
@@ -204,7 +231,7 @@ impl Simulation {
             // stock building reaches this case (NAPSIS carries both keys).
             if deposit.add_radius > 0 {
                 self.apply_building_sensor_remove(
-                    deposit.owner,
+                    remove_owner,
                     deposit.center,
                     deposit.remove_radius.max(0) as u16,
                     rules,
@@ -212,7 +239,7 @@ impl Simulation {
             }
         } else {
             self.apply_unit_sensor_remove(
-                deposit.owner,
+                remove_owner,
                 deposit.center,
                 deposit.remove_radius.max(0) as u16,
                 rules,
@@ -381,8 +408,25 @@ impl Simulation {
     /// `OnConstructionComplete` and `Limbo`. So gamemd leaves BOTH the sensor
     /// array and the disguise-detect circle stamped for the CONSTRUCTING house
     /// until the building is limboed: capturing a Psychic Sensor transfers
-    /// neither, and the eventual sell decrements exactly what construction
-    /// incremented.
+    /// neither.
+    ///
+    /// DRIFT-BY-DESIGN — this reproduces a permanent native counter skew, it
+    /// does not avoid one. Limbo's removes read the LIVE owner
+    /// (`RemoveDetectDisguiseAt @ 0x00455980` opens `0045598A MOV
+    /// EDX,[ECX+0x21C]` / `004559A1 MOV EAX,[EDX+0x30]`; `RemoveSensorArrayAt
+    /// @ 0x004556D0` repeats the read) and
+    /// `CellClass::DecrementDisguiseDetectCount @ 0x00487180` decrements
+    /// unconditionally. So selling or losing a captured Psychic Sensor debits
+    /// the CAPTOR for the circles the BUILDER was credited with.
+    /// *Trigger:* engineer capture of a building carrying `SensorArray=` or
+    /// `DetectDisguise=` (stock: NAPSIS only), then its limbo. *Player effect:*
+    /// the constructing house keeps a phantom detection circle over that ground
+    /// for the rest of the match, and the capturing house's counters go negative
+    /// there, silently cancelling the detection of the next such building it
+    /// puts on the same cells. *Frequency:* uncommon per match, but the state is
+    /// permanent once it happens. *Downstream risk:* none new — the asymmetric
+    /// `CloakRadiusInCells=` remove radius already produces negative sensor
+    /// fringe counts without a capture, so no reader gains an unseen case.
     fn transfer_sensor_before_owner_change_inner(
         &mut self,
         stable_id: u64,
@@ -492,8 +536,13 @@ mod tests {
         assert!(!sim.fog.has_sensor_for_house(americans, 57, 30));
         assert!(sim.fog.has_sensor_for_house(soviet, 57, 30));
 
-        // Drift every live fact after the deposit. Limbo must still remove the
-        // cached Soviet/30,20/radius8 footprint, not current owner/position.
+        // Drift every live fact after the deposit. The cached center still
+        // decides WHICH cells the removal walks, but the HOUSE is re-read live:
+        // `TechnoClass::RemoveSensorsAt @ 0x004DE940` opens with
+        // `*(int *)(param_1[0x87] + 0x30)`, the same read as the BuildingClass
+        // pair. gamemd cannot reach this state for a Foot — only
+        // `FootClass::ChangeOwner @ 0x004DBED0` moves `+0x21C`, and it dispatches
+        // `vt+0x4EC` first — so this pins the read, not a reachable scenario.
         let neutral = sim.interner.intern("Neutral");
         {
             let entity = sim.substrate.entities.get_mut(second).unwrap();
@@ -502,7 +551,15 @@ mod tests {
             entity.position.ry = 5;
         }
         sim.techno_limbo_with_rules(second, &rules);
-        assert!(!sim.fog.has_sensor_for_house(soviet, 57, 30));
+        assert!(
+            sim.fog.has_sensor_for_house(soviet, 57, 30),
+            "the removal debits the live owner, not the deposit's recorded house"
+        );
+        let index = 30 * usize::from(sim.fog.width) + 57;
+        assert_eq!(
+            sim.fog.sensors_by_house[&neutral][index], 0,
+            "and the unit remove's positive pre-count gate leaves no negative residue"
+        );
     }
 
     #[test]
@@ -558,9 +615,11 @@ mod tests {
     /// `+0x4F4`/`+0x4FC` are dispatched only by `OnConstructionComplete`
     /// (`0x004467A1` / `0x004467C3`) and `+0x4F8`/`+0x500` only by `Limbo`
     /// (`0x00445A4C` / `0x00445A6C`). So the counters stay attached to the
-    /// CONSTRUCTING house until the building is limboed, and the eventual sell
-    /// decrements exactly the house that construction incremented — no
-    /// negative residue on the capturing house.
+    /// CONSTRUCTING house until the building is limboed — while the removals
+    /// read the LIVE owner (`0x00455980` / `0x004556D0`), which is what the
+    /// limbo tail below and
+    /// `selling_a_captured_psychic_sensor_debits_the_captor_and_leaves_the_builder_detecting`
+    /// pin.
     #[test]
     fn capturing_a_psychic_sensor_leaves_both_circles_with_the_constructing_house() {
         let rules = rules();
@@ -612,19 +671,93 @@ mod tests {
         assert_eq!(deposit.owner, soviet);
         assert_eq!(deposit.detect_disguise_radius, 15);
 
-        // Selling under the NEW owner still unwinds the OLD owner's counters,
-        // symmetrically for the disguise circle (same `+0x5F4` radius both
-        // ways) and with the asymmetric `CloakRadiusInCells=` fringe for the
-        // sensor array.
+        // Selling under the NEW owner unwinds the NEW owner: both removals read
+        // `this->Owner->ArrayIndex` at removal time, and `ChangeOwner` has
+        // already overwritten that pointer (`0x007014A0 param_1[0x87] =
+        // param_2`). The builder's credit is therefore never returned.
         sim.techno_limbo_with_rules(id, &rules);
         let index = 40 * usize::from(sim.fog.width) + 54;
         assert_eq!(
-            sim.fog.disguise_detect_by_house[&soviet][index], 0,
-            "add and remove walk the same circle"
+            sim.fog.disguise_detect_by_house[&soviet][index], 1,
+            "the builder's increment is permanent: no +0x500 ever names it again"
+        );
+        assert_eq!(
+            sim.fog.disguise_detect_by_house[&americans][index], -1,
+            "0x00455980 debits the LIVE owner and 0x00487180 decrements unconditionally"
+        );
+    }
+
+    /// Capture, then sell, end to end — the permanent counter skew gamemd
+    /// leaves behind, on BOTH planes.
+    ///
+    /// Adds credit `*(int *)(param_1[0x87] + 0x30)` at add time
+    /// (`BuildingClass::AddSensorArrayAt @ 0x00455820`,
+    /// `AddDetectDisguiseAt @ 0x00455A80`); `BuildingClass::ChangeOwner @
+    /// 0x00448260` dispatches neither an add nor a remove but does overwrite
+    /// `+0x21C` through `TechnoClass::ChangeOwner @ 0x007014A0`; and Limbo's
+    /// removes (`0x004556D0`, `0x00455980`) re-read `+0x21C` live. Net: the
+    /// builder keeps `SensorsSight=15` and `DetectDisguiseRange=15`, the captor
+    /// takes `-1` over the `CloakRadiusInCells=20` sensor circle and over the
+    /// 15-cell disguise circle.
+    #[test]
+    fn selling_a_captured_psychic_sensor_debits_the_captor_and_leaves_the_builder_detecting() {
+        let rules = rules();
+        let mut sim = sim_with_map_authority();
+        sim.spawn_object_at_height("NAPOWR", "Soviet", 30, 40, 0, 0, &rules)
+            .unwrap();
+        let id = sim
+            .spawn_object_at_height("NAPSIS", "Soviet", 40, 40, 0, 0, &rules)
+            .unwrap();
+        let soviet = sim.substrate.entities.get(id).unwrap().owner;
+        sim.substrate.entities.get_mut(id).unwrap().building_up = Some(BuildingUp {
+            elapsed_ticks: 0,
+            total_ticks: 1,
+        });
+        sim.advance_tick(
+            &[],
+            Some(&rules),
+            &std::collections::BTreeMap::new(),
+            None,
+            None,
+            67,
+        );
+
+        let americans = sim.interner.intern("Americans");
+        sim.change_owner(id, americans);
+        sim.techno_limbo_with_rules(id, &rules);
+
+        let row = 40 * usize::from(sim.fog.width);
+        let inside = row + 54; // inside both the 15-cell add and the 20-cell remove
+        let fringe = row + 55; // outside the add, inside the sensor remove only
+
+        assert_eq!(
+            sim.fog.sensors_by_house[&soviet][inside], 1,
+            "the builder's SensorsSight credit is never returned"
+        );
+        assert_eq!(
+            sim.fog.sensors_by_house[&americans][inside], -1,
+            "0x004556D0 debits the live owner over CloakRadiusInCells"
+        );
+        assert_eq!(sim.fog.sensors_by_house[&soviet][fringe], 0);
+        assert_eq!(
+            sim.fog.sensors_by_house[&americans][fringe], -1,
+            "the asymmetric remove radius reaches past the add circle too"
         );
         assert!(
-            !sim.fog.disguise_detect_by_house.contains_key(&americans),
-            "the captor's plane was never touched, so no negative residue"
+            sim.fog.has_sensor_for_house(soviet, 54, 40),
+            "the builder keeps submarine detection over ground it no longer owns"
+        );
+        assert!(!sim.fog.has_sensor_for_house(americans, 54, 40));
+
+        assert_eq!(sim.fog.disguise_detect_by_house[&soviet][inside], 1);
+        assert_eq!(
+            sim.fog.disguise_detect_by_house[&americans][inside], -1,
+            "the disguise circle is symmetric in radius but not in house"
+        );
+        assert!(sim.fog.detects_disguise_for_house(soviet, 54, 40));
+        assert!(
+            !sim.fog.detects_disguise_for_house(americans, 54, 40),
+            "a later NAPSIS the captor builds here needs two increments to see again"
         );
     }
 

--- a/src/sim/sensor_lifecycle.rs
+++ b/src/sim/sensor_lifecycle.rs
@@ -181,10 +181,14 @@ impl Simulation {
             .get_mut(stable_id)
             .and_then(|entity| entity.sensor_deposit.take())?;
         if deposit.detect_disguise_radius > 0 {
-            // `BuildingClass::RemoveDetectDisguiseAt @ 0x00455980`, reached from
-            // `BuildingClass::Limbo @ 0x00445A58` through vtable `+0x500`. It
-            // walks the same circle it stamped and decrements
-            // `CellClass+0xAC[house]`; no resident callback is issued.
+            // `BuildingClass::RemoveDetectDisguiseAt @ 0x00455980`, reached
+            // ONLY from `BuildingClass::Limbo` — `0x00445A58` reads
+            // `TechnoTypeClass+0xD31` (`DetectDisguise=`) and `0x00445A6C`
+            // dispatches vtable `+0x500`. It walks the same circle it stamped
+            // and decrements `CellClass+0xAC[house]`; no resident callback is
+            // issued. `search_instructions "call [..+0x500]"` returns that one
+            // BuildingClass site program-wide, which is why the owner-change
+            // path below must not come through here.
             self.fog.disguise_detect_remove_at(
                 deposit.owner,
                 deposit.center,
@@ -248,8 +252,14 @@ impl Simulation {
     /// initialization or construction completion and only while powered — both
     /// open with the same `vt+0x350` powered test, and
     /// `BuildingClass::OnConstructionComplete` dispatches them from adjacent
-    /// slots (`+0x4F8` and `+0x4FC`, the latter reached from `0x004467AD` after
-    /// reading `TechnoTypeClass+0xD31` `DetectDisguise=`).
+    /// slots: `+0x4F4` at `0x004467A1` (sensor array) and `+0x4FC` at
+    /// `0x004467C3` (disguise circle), the latter reached only after
+    /// `0x004467AD` reads `TechnoTypeClass+0xD31` (`DetectDisguise=`). The
+    /// BuildingClass vtable block at `0x007E43B0` is
+    /// `[+0x4F4]=0x00455820` add, `[+0x4F8]=0x004556D0` remove,
+    /// `[+0x4FC]=0x00455A80` disguise add, `[+0x500]=0x00455980` disguise
+    /// remove — `+0x4F8` is the sensor REMOVE, dispatched from
+    /// `BuildingClass::Limbo @ 0x00445A4C`.
     ///
     /// Stock authors: NAPSIS is the only building that stamps a disguise-detect
     /// circle, because `DetectDisguiseRange=` defaults to zero
@@ -357,20 +367,53 @@ impl Simulation {
         self.add_unit_sensor_after_unlimbo(stable_id, rules);
     }
 
-    /// FootClass::ChangeOwner old-remove/new-add pair.
+    /// `FootClass::ChangeOwner @ 0x004DBED0` old-remove/new-add pair — both
+    /// arms gated on `TechnoTypeClass+0x5F0` (`SensorsSight=`), removing for
+    /// the old house through vtable `+0x4EC` at `0x004DBEFB` and adding for the
+    /// new one through `+0x4E8` at `0x004DBF81`.
+    ///
+    /// A BUILDING deposit is deliberately left untouched. Neither
+    /// `BuildingClass::ChangeOwner @ 0x00448260` nor the
+    /// `TechnoClass::ChangeOwner @ 0x007014A0` it calls at `0x00448BE8`
+    /// dispatches any of the four BuildingClass sensor slots, and the
+    /// program-wide `search_instructions` for `call [..+0x4f4/0x4f8/0x4fc/
+    /// 0x500]` finds no BuildingClass dispatcher outside
+    /// `OnConstructionComplete` and `Limbo`. So gamemd leaves BOTH the sensor
+    /// array and the disguise-detect circle stamped for the CONSTRUCTING house
+    /// until the building is limboed: capturing a Psychic Sensor transfers
+    /// neither, and the eventual sell decrements exactly what construction
+    /// incremented.
+    fn transfer_sensor_before_owner_change_inner(
+        &mut self,
+        stable_id: u64,
+        new_owner: InternedId,
+        rules: Option<&RuleSet>,
+    ) {
+        let building_deposit = self
+            .substrate
+            .entities
+            .get(stable_id)
+            .and_then(|entity| entity.sensor_deposit)
+            .is_some_and(|deposit| deposit.building_array);
+        if building_deposit {
+            return;
+        }
+        let Some(mut deposit) = self.remove_cached_sensor_deposit(stable_id, rules) else {
+            return;
+        };
+        deposit.owner = new_owner;
+        self.apply_sensor_add(new_owner, deposit.center, deposit.add_radius, rules);
+        if let Some(entity) = self.substrate.entities.get_mut(stable_id) {
+            entity.sensor_deposit = Some(deposit);
+        }
+    }
+
     pub(crate) fn transfer_sensor_before_owner_change(
         &mut self,
         stable_id: u64,
         new_owner: InternedId,
     ) {
-        let Some(mut deposit) = self.remove_cached_sensor_deposit(stable_id, None) else {
-            return;
-        };
-        deposit.owner = new_owner;
-        self.apply_sensor_add(new_owner, deposit.center, deposit.add_radius, None);
-        if let Some(entity) = self.substrate.entities.get_mut(stable_id) {
-            entity.sensor_deposit = Some(deposit);
-        }
+        self.transfer_sensor_before_owner_change_inner(stable_id, new_owner, None);
     }
 
     pub(crate) fn transfer_sensor_before_owner_change_with_rules(
@@ -379,14 +422,7 @@ impl Simulation {
         new_owner: InternedId,
         rules: &RuleSet,
     ) {
-        let Some(mut deposit) = self.remove_cached_sensor_deposit(stable_id, Some(rules)) else {
-            return;
-        };
-        deposit.owner = new_owner;
-        self.apply_sensor_add(new_owner, deposit.center, deposit.add_radius, Some(rules));
-        if let Some(entity) = self.substrate.entities.get_mut(stable_id) {
-            entity.sensor_deposit = Some(deposit);
-        }
+        self.transfer_sensor_before_owner_change_inner(stable_id, new_owner, Some(rules));
     }
 }
 
@@ -409,6 +445,7 @@ mod tests {
              [SQD]\nStrength=600\nSpeed=4\nCloakable=yes\nCloakingSpeed=5\nSensorsSight=8\n\
              [TGT]\nStrength=600\nSpeed=4\nCloakable=yes\nCloakingSpeed=1\n\
              [NAPSIS]\nStrength=750\nSensorArray=yes\nSensorsSight=15\nPower=-100\nPowered=yes\n\
+             DetectDisguise=yes\nDetectDisguiseRange=15\nCapturable=true\n\
              [NAPOWR]\nStrength=750\nPower=200\n",
         ))
         .expect("cloak/sensor rules")
@@ -511,6 +548,84 @@ mod tests {
         sim.techno_limbo_with_rules(id, &rules);
         let index = 40 * usize::from(sim.fog.width) + 55;
         assert_eq!(sim.fog.sensors_by_house[&owner][index], -1);
+    }
+
+    /// Engineer capture of a Psychic Sensor moves NEITHER stamped circle.
+    ///
+    /// `BuildingClass::ChangeOwner @ 0x00448260` and the
+    /// `TechnoClass::ChangeOwner @ 0x007014A0` it calls at `0x00448BE8`
+    /// dispatch none of the four BuildingClass sensor slots; program-wide,
+    /// `+0x4F4`/`+0x4FC` are dispatched only by `OnConstructionComplete`
+    /// (`0x004467A1` / `0x004467C3`) and `+0x4F8`/`+0x500` only by `Limbo`
+    /// (`0x00445A4C` / `0x00445A6C`). So the counters stay attached to the
+    /// CONSTRUCTING house until the building is limboed, and the eventual sell
+    /// decrements exactly the house that construction incremented — no
+    /// negative residue on the capturing house.
+    #[test]
+    fn capturing_a_psychic_sensor_leaves_both_circles_with_the_constructing_house() {
+        let rules = rules();
+        let mut sim = sim_with_map_authority();
+        sim.spawn_object_at_height("NAPOWR", "Soviet", 30, 40, 0, 0, &rules)
+            .unwrap();
+        let id = sim
+            .spawn_object_at_height("NAPSIS", "Soviet", 40, 40, 0, 0, &rules)
+            .unwrap();
+        let soviet = sim.substrate.entities.get(id).unwrap().owner;
+        sim.substrate.entities.get_mut(id).unwrap().building_up = Some(BuildingUp {
+            elapsed_ticks: 0,
+            total_ticks: 1,
+        });
+        sim.advance_tick(
+            &[],
+            Some(&rules),
+            &std::collections::BTreeMap::new(),
+            None,
+            None,
+            67,
+        );
+        assert!(sim.fog.has_sensor_for_house(soviet, 54, 40));
+        assert!(sim.fog.detects_disguise_for_house(soviet, 54, 40));
+
+        let americans = sim.interner.intern("Americans");
+        sim.change_owner(id, americans);
+
+        assert!(
+            sim.fog.detects_disguise_for_house(soviet, 54, 40),
+            "ChangeOwner dispatches no +0x500, so the builder keeps detection"
+        );
+        assert!(
+            !sim.fog.detects_disguise_for_house(americans, 54, 40),
+            "ChangeOwner dispatches no +0x4FC, so the captor is granted none"
+        );
+        assert!(
+            sim.fog.has_sensor_for_house(soviet, 54, 40),
+            "the sensor array is on the same two slots and moves no more"
+        );
+        assert!(!sim.fog.has_sensor_for_house(americans, 54, 40));
+        let deposit = sim
+            .substrate
+            .entities
+            .get(id)
+            .unwrap()
+            .sensor_deposit
+            .expect("the construction deposit survives the capture");
+        assert_eq!(deposit.owner, soviet);
+        assert_eq!(deposit.detect_disguise_radius, 15);
+
+        // Selling under the NEW owner still unwinds the OLD owner's counters,
+        // symmetrically for the disguise circle (same `+0x5F4` radius both
+        // ways) and with the asymmetric `CloakRadiusInCells=` fringe for the
+        // sensor array.
+        sim.techno_limbo_with_rules(id, &rules);
+        let index = 40 * usize::from(sim.fog.width) + 54;
+        assert_eq!(
+            sim.fog.disguise_detect_by_house[&soviet][index], 0,
+            "add and remove walk the same circle"
+        );
+        assert!(
+            !sim.fog.disguise_detect_by_house.contains_key(&americans),
+            "the captor's plane was never touched, so no negative residue"
+        );
     }
 
     #[test]

--- a/src/sim/sensor_lifecycle.rs
+++ b/src/sim/sensor_lifecycle.rs
@@ -19,6 +19,14 @@ pub struct SensorDeposit {
     pub add_radius: u16,
     pub remove_radius: i16,
     pub building_array: bool,
+    /// `DetectDisguiseRange=` (`TechnoTypeClass+0x5F4`) circle stamped by
+    /// `BuildingClass::AddDetectDisguiseAt @ 0x00455A80` alongside the sensor
+    /// array. Unlike the sensor array, its paired
+    /// `RemoveDetectDisguiseAt @ 0x00455980` reads the SAME field back
+    /// (`0x00455991` loads `+0x5F4`), so add and remove are symmetric and one
+    /// radius suffices.
+    #[serde(default)]
+    pub detect_disguise_radius: u16,
 }
 
 impl SensorDeposit {
@@ -29,16 +37,24 @@ impl SensorDeposit {
             add_radius: radius,
             remove_radius: radius as i16,
             building_array: false,
+            detect_disguise_radius: 0,
         }
     }
 
-    fn building(owner: InternedId, center: (u16, u16), add: u16, remove: i8) -> Self {
+    fn building(
+        owner: InternedId,
+        center: (u16, u16),
+        add: u16,
+        remove: i8,
+        detect_disguise_radius: u16,
+    ) -> Self {
         Self {
             owner,
             center,
             add_radius: add,
             remove_radius: i16::from(remove),
             building_array: true,
+            detect_disguise_radius,
         }
     }
 }
@@ -164,13 +180,32 @@ impl Simulation {
             .entities
             .get_mut(stable_id)
             .and_then(|entity| entity.sensor_deposit.take())?;
-        if deposit.building_array {
-            self.apply_building_sensor_remove(
+        if deposit.detect_disguise_radius > 0 {
+            // `BuildingClass::RemoveDetectDisguiseAt @ 0x00455980`, reached from
+            // `BuildingClass::Limbo @ 0x00445A58` through vtable `+0x500`. It
+            // walks the same circle it stamped and decrements
+            // `CellClass+0xAC[house]`; no resident callback is issued.
+            self.fog.disguise_detect_remove_at(
                 deposit.owner,
                 deposit.center,
-                deposit.remove_radius.max(0) as u16,
-                rules,
+                deposit.detect_disguise_radius,
             );
+        }
+        if deposit.building_array {
+            // A building that stamped only a disguise-detect circle never added
+            // sensor counts, so it must not run the asymmetric
+            // `CloakRadiusInCells=` decrement and manufacture negative fringe
+            // counts. VERA-internal guard; gamemd dispatches the two removals
+            // from separate vtable slots and the pairing is UNCHECKED, but no
+            // stock building reaches this case (NAPSIS carries both keys).
+            if deposit.add_radius > 0 {
+                self.apply_building_sensor_remove(
+                    deposit.owner,
+                    deposit.center,
+                    deposit.remove_radius.max(0) as u16,
+                    rules,
+                );
+            }
         } else {
             self.apply_unit_sensor_remove(
                 deposit.owner,
@@ -208,24 +243,46 @@ impl Simulation {
         }
     }
 
-    /// `BuildingClass::AddSensorArrayAt @ 0x00455820`, used only after map
-    /// initialization or construction completion and only while powered.
+    /// `BuildingClass::AddSensorArrayAt @ 0x00455820` and its sibling
+    /// `BuildingClass::AddDetectDisguiseAt @ 0x00455A80`, used only after map
+    /// initialization or construction completion and only while powered — both
+    /// open with the same `vt+0x350` powered test, and
+    /// `BuildingClass::OnConstructionComplete` dispatches them from adjacent
+    /// slots (`+0x4F8` and `+0x4FC`, the latter reached from `0x004467AD` after
+    /// reading `TechnoTypeClass+0xD31` `DetectDisguise=`).
+    ///
+    /// Stock authors: NAPSIS is the only building that stamps a disguise-detect
+    /// circle, because `DetectDisguiseRange=` defaults to zero
+    /// (`TechnoTypeClass::Constructor @ 0x0071100E`) and YAPSYT / NAPSYB carry
+    /// `DetectDisguise=yes` without a range.
     pub(crate) fn add_building_sensor_array_if_powered(&mut self, stable_id: u64, rules: &RuleSet) {
-        let Some((owner, center, sight, remove_radius, powered, in_limbo)) =
+        let Some((owner, center, sight, remove_radius, detect_radius, powered, in_limbo)) =
             self.substrate.entities.get(stable_id).and_then(|entity| {
                 let object = rules.object(self.interner.resolve(entity.type_ref))?;
                 if entity.category != EntityCategory::Structure
                     || object.category != ObjectCategory::Building
-                    || !object.sensor_array
-                    || object.sensors_sight == 0
                 {
+                    return None;
+                }
+                let sight = if object.sensor_array {
+                    u16::from(object.sensors_sight)
+                } else {
+                    0
+                };
+                let detect_radius = if object.detect_disguise {
+                    u16::from(object.detect_disguise_range)
+                } else {
+                    0
+                };
+                if sight == 0 && detect_radius == 0 {
                     return None;
                 }
                 Some((
                     entity.owner,
                     (entity.position.rx, entity.position.ry),
-                    u16::from(object.sensors_sight),
+                    sight,
                     object.cloak_radius_in_cells,
+                    detect_radius,
                     crate::sim::power_system::is_building_powered(
                         &self.power_states,
                         rules,
@@ -242,10 +299,23 @@ impl Simulation {
             return;
         }
         let _ = self.remove_cached_sensor_deposit(stable_id, Some(rules));
-        self.apply_sensor_add(owner, center, sight, Some(rules));
+        if sight > 0 {
+            self.apply_sensor_add(owner, center, sight, Some(rules));
+        }
+        if detect_radius > 0 {
+            // The disguise-detect walk issues no resident `+0x420` callback —
+            // it only increments `CellClass+0xAC[house]`.
+            self.fog
+                .disguise_detect_add_at(owner, center, detect_radius);
+        }
         if let Some(entity) = self.substrate.entities.get_mut(stable_id) {
-            entity.sensor_deposit =
-                Some(SensorDeposit::building(owner, center, sight, remove_radius));
+            entity.sensor_deposit = Some(SensorDeposit::building(
+                owner,
+                center,
+                sight,
+                remove_radius,
+                detect_radius,
+            ));
         }
     }
 
@@ -455,6 +525,13 @@ mod tests {
             .unwrap();
         let soviet = sim.substrate.entities.get(older).unwrap().owner;
         let detector = sim.interner.intern("Americans");
+        // CORRECTION: this used to reveal the residents' own cell to their own
+        // house, on the reading that `CellClass::IsVisibleToHouse @ 0x004870B0`
+        // meant cell visibility. It is the `CloakedByHouses` bit, whose only
+        // writers sit in `BuildingClass::UpdateGapGenerator_Tick` behind
+        // `CloakGenerator=`, so the vt+0x420 cloak arm is dormant in stock YR.
+        // The FirstObject dispatch ORDER is what this test owns, and it is
+        // observable from the returned resident list alone.
         sim.fog.mark_visible_for_owner(soviet, 40, 30);
         for id in [older, newer] {
             let cloak = sim
@@ -484,20 +561,13 @@ mod tests {
                 .as_ref()
                 .unwrap()
                 .state,
-            1,
-            "+0x420 owner-visible CanAutoCloak calls StartCloaking"
+            0,
+            "no CloakGenerator field means the vt+0x420 cloak arm never fires"
         );
-        assert_eq!(
-            sim.sound_events.len(),
-            2,
-            "each accepted callback emits exactly once"
+        assert!(
+            sim.sound_events.is_empty(),
+            "a dormant cloak arm emits no CloakSound"
         );
-        assert!(sim.sound_events.iter().all(|event| matches!(
-            event,
-            crate::sim::world::SimSoundEvent::CloakSound { sound_id, .. }
-                if sound_id == "NavalUnitEmerge"
-        )));
-        sim.sound_events.clear();
 
         for id in [older, newer] {
             let cloak = sim
@@ -513,12 +583,7 @@ mod tests {
         }
         let removed = sim.apply_unit_sensor_remove(detector, (40, 30), 1, Some(&rules));
         assert_eq!(removed, vec![newer, older]);
-        assert_eq!(
-            sim.sound_events.len(),
-            2,
-            "remove mutation and callbacks synchronously emit one cue per accepted resident"
-        );
-        sim.sound_events.clear();
+        assert!(sim.sound_events.is_empty());
         assert!(
             sim.apply_unit_sensor_remove(detector, (40, 30), 1, Some(&rules))
                 .is_empty(),

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -336,10 +336,15 @@ use crate::sim::world::Simulation;
 // reconstruct counts left behind by a later authored low-body overwrite. The
 // v115 hash schema also folds the live shared-dummy overlay identity/state;
 // that process-global pair is intentionally not Scenario-serialized.
-/// v116: `NativeTiberiumClassState` carries the native queue stores
-/// (`NativeTiberiumQueue`: entry array, heap of references, capacity) and
-/// `OreGrowthState::native_rect`; the serialized queue shape changed.
-const SNAPSHOT_VERSION: u32 = 116;
+// Bumped 115 -> 116: `NativeTiberiumClassState` carries the native queue stores
+// (`NativeTiberiumQueue`: entry array, heap of references, capacity) and
+// `OreGrowthState::native_rect`; the serialized queue shape changed.
+// Bumped 116 -> 117: the v117 hash schema folds the disguise-detect plane —
+// FogState's `CellClass+0xAC[house]` counters and the cached
+// `DetectDisguiseRange=` radius on each SensorDeposit. Both fields already
+// round-trip (they are `#[serde(default)]` additive), so this bump exists to
+// keep the hash-schema probes and the serialized version aligned.
+const SNAPSHOT_VERSION: u32 = 117;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -3054,10 +3059,12 @@ mod tests {
     /// live shared-dummy overlay pair in the current hash schema; 115 -> 116
     /// replaces the per-class tiberium heap vectors with the native queue
     /// stores (entry array, heap of references, capacity) and adds the
-    /// `MapRect` the stores are sized from.
+    /// `MapRect` the stores are sized from; 116 -> 117 folds the
+    /// disguise-detect counter plane and the cached `DetectDisguiseRange=`
+    /// deposit radius into the hash schema.
     #[test]
-    fn native_tiberium_queue_store_snapshot_version_is_116() {
-        assert_eq!(super::SNAPSHOT_VERSION, 116);
+    fn disguise_detect_plane_snapshot_version_is_117() {
+        assert_eq!(super::SNAPSHOT_VERSION, 117);
     }
 
     #[test]

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -4935,6 +4935,7 @@ mod tests {
             add_radius: 2,
             remove_radius: 2,
             building_array: false,
+            detect_disguise_radius: 0,
         });
         sim.substrate.entities.insert(entity);
         // Native in-scenario load restarts Scenario RNG from Seed0; isolate

--- a/src/sim/vision/mod.rs
+++ b/src/sim/vision/mod.rs
@@ -537,6 +537,14 @@ pub struct FogState {
     /// Native signed-word SensorsOfHouses counters, row-major per house.
     #[serde(default)]
     pub sensors_by_house: BTreeMap<InternedId, Vec<i16>>,
+    /// Native `CellClass+0xAC[house]` signed-word disguise-detect counters,
+    /// row-major per house. Only `BuildingClass::AddDetectDisguiseAt @
+    /// 0x00455A80` / `RemoveDetectDisguiseAt @ 0x00455980` write them, and
+    /// `FUN_004870F0` (`+0xAC[house] > 0`) is the only reader — consumed by
+    /// `UnitClass::IsDisguisedTo @ 0x00746750` and
+    /// `InfantryClass::IsDisguisedTo @ 0x005227F0`.
+    #[serde(default)]
+    pub disguise_detect_by_house: BTreeMap<InternedId, Vec<i16>>,
     /// Native CellClass::CloakedByHouses words, row-major by cell. House
     /// selection uses the original x86-masked bit index (`h & 31`).
     #[serde(default)]
@@ -629,6 +637,7 @@ impl FogState {
     /// map-storage recreation edge.
     pub fn reset_sensor_counts(&mut self) {
         self.sensors_by_house.clear();
+        self.disguise_detect_by_house.clear();
     }
 
     /// Recreate the serialized CellClass cloak-owner words for current map
@@ -661,19 +670,28 @@ impl FogState {
         changed
     }
 
-    /// Tests bit `house` of `CellClass+0x78`, the same word
-    /// `CellClass::IsVisibleToHouse` @ `0x004870B0` reads — its body is exactly
-    /// `return (this->dwVisibleToHouses & 1 << (house & 0x1F)) != 0;`. That
-    /// pinned label stands; the earlier claim here that it was stale, and that
-    /// the word means cloak-generator ownership rather than visibility, was
-    /// unfounded. What VERA stores in this plane is its own reading of the bit —
-    /// **VERA-internal, gamemd equivalent UNCHECKED**.
-    /// **Write-dead, and hashed.** `set_cloaked_by_house` and
-    /// `clear_cloaked_by_house` have no production caller, so this can never
-    /// return true — yet `cloaked_by_houses` is folded into the world hash, so
-    /// the first producer to land shifts every golden. Trigger: none today.
-    /// Player effect: none. Frequency: zero. Downstream risk: a guaranteed
-    /// golden re-baseline whenever the plane is wired.
+    /// Tests bit `house` of `CellClass+0x78` — the word
+    /// `CellClass::IsVisibleToHouse @ 0x004870B0` reads, whose body is exactly
+    /// `return (this->dwVisibleToHouses & 1 << (house & 0x1F)) != 0;`.
+    ///
+    /// **The Ghidra label is drift and the field is NOT shroud visibility.**
+    /// `get_xrefs_to 0x00487110 / 0x00487130` (the only OR/AND-NOT writers of
+    /// `+0x78`) returns exactly two callsites, both inside
+    /// `BuildingClass::UpdateGapGenerator_Tick @ 0x004551B9 / 0x004553B3`, and
+    /// that write branch is gated on `BuildingType+0x16C7`
+    /// (`BuildingTypeClass::ReadINI @ 0x00460C06`, key string `0x0081A998` =
+    /// `CloakGenerator`). This is YRpp's `CloakedByHouses` — the cloak-field
+    /// footprint of a `CloakGenerator=yes` building. **No stock YR building
+    /// sets `CloakGenerator=`** (`grep -c '^CloakGenerator' ini/rulesmd.ini`
+    /// is zero), so gamemd itself never sets the bit in an ordinary skirmish.
+    ///
+    /// VERA therefore keeps this plane write-dead ON PURPOSE — that is parity,
+    /// not a gap. Its three consumers (`TechnoClass::ShouldUncloak @
+    /// 0x006FBDA2`, `CanAutoCloak @ 0x006FBE90`, and the vt+0x420 cloak-field
+    /// entry hook at `0x006F4F46`) all read a constantly-false bit in stock,
+    /// and VERA's counterparts must read this and not cell visibility.
+    /// `cloaked_by_houses` is folded into the world hash, so wiring a producer
+    /// (a mod with a cloak generator) would shift every golden.
     pub fn is_cloaked_by_house(&self, house_index: u8, rx: u16, ry: u16) -> bool {
         let Some(word) = self.cloak_word(rx, ry) else {
             return false;
@@ -842,6 +860,69 @@ impl FogState {
         }
         let index = usize::from(ry) * usize::from(self.width) + usize::from(rx);
         self.sensors_by_house
+            .get(&house)
+            .and_then(|counters| counters.get(index))
+            .is_some_and(|count| *count > 0)
+    }
+
+    fn disguise_detect_counter_mut(&mut self, house: InternedId, rx: u16, ry: u16) -> &mut i16 {
+        let cell_count = usize::from(self.width) * usize::from(self.height);
+        let counters = self
+            .disguise_detect_by_house
+            .entry(house)
+            .or_insert_with(|| vec![0; cell_count]);
+        if counters.len() != cell_count {
+            counters.clear();
+            counters.resize(cell_count, 0);
+        }
+        let index = usize::from(ry) * usize::from(self.width) + usize::from(rx);
+        &mut counters[index]
+    }
+
+    /// `BuildingClass::AddDetectDisguiseAt @ 0x00455A80` — the same strict
+    /// outer-Y/inner-X circle the sensor deposit walks, incrementing
+    /// `CellClass+0xAC[house]` (`CellClass::IncrementDisguiseDetectCount`).
+    /// The caller owns the powered gate (native vt+0x350).
+    pub fn disguise_detect_add_at(
+        &mut self,
+        house: InternedId,
+        center: (u16, u16),
+        radius: u16,
+    ) -> Vec<(u16, u16)> {
+        let touched = self.sensor_circle_cells(center, radius);
+        for &(rx, ry) in &touched {
+            let counter = self.disguise_detect_counter_mut(house, rx, ry);
+            *counter = counter.wrapping_add(1);
+        }
+        touched
+    }
+
+    /// `BuildingClass::RemoveDetectDisguiseAt @ 0x00455980`. Unlike the sensor
+    /// array's remove, this one reads the SAME `DetectDisguiseRange=` field
+    /// (`0x00455991` loads `+0x5F4`) that the add used, so the walk is
+    /// symmetric and leaves no fringe residue.
+    pub fn disguise_detect_remove_at(
+        &mut self,
+        house: InternedId,
+        center: (u16, u16),
+        radius: u16,
+    ) -> Vec<(u16, u16)> {
+        let touched = self.sensor_circle_cells(center, radius);
+        for &(rx, ry) in &touched {
+            let counter = self.disguise_detect_counter_mut(house, rx, ry);
+            *counter = counter.wrapping_sub(1);
+        }
+        touched
+    }
+
+    /// `FUN_004870F0` — `CellClass+0xAC[house] > 0`. The observer-side half of
+    /// `IsDisguisedTo`: a house covering the cell sees through the disguise.
+    pub fn detects_disguise_for_house(&self, house: InternedId, rx: u16, ry: u16) -> bool {
+        if rx >= self.width || ry >= self.height {
+            return false;
+        }
+        let index = usize::from(ry) * usize::from(self.width) + usize::from(rx);
+        self.disguise_detect_by_house
             .get(&house)
             .and_then(|counters| counters.get(index))
             .is_some_and(|count| *count > 0)

--- a/src/sim/world/bridge_parity_harness_tests.rs
+++ b/src/sim/world/bridge_parity_harness_tests.rs
@@ -125,13 +125,19 @@ const MIN_DISTINCT_DECK_CELLS: usize = 6;
 // first `AI_Update` promotion sample (-1 -> GetVeterancyLevel code), so every live
 // object's hashed `veterancy_rank_cache` moved. Composition of the hash is unchanged
 // and the RNG stream pins held (FINAL_STREAM_STATES), so no cadence or draw moved.
-// Merge 2026-09-02: main's veterancy re-baseline and this branch's queue-store
-// re-baseline both move the same constants, so the values below are the composed
-// measurement taken on the merged tree, not either side's number.
+// Merge 2026-09-02: main's veterancy re-baseline and its queue-store re-baseline
+// both moved these constants, so the three historical probes below are main's
+// composed measurement, unchanged by this branch.
 const BRIDGE_HARNESS_PRE_BASE_PLAN_V110_HASH: u64 = 0x1880_D391_E620_9834;
 const BRIDGE_HARNESS_PRE_CRATE_AUTHORITY_V114_HASH: u64 = 0x7D9B_C414_D199_21CC;
 const BRIDGE_HARNESS_PRE_WALL_RUNTIME_V115_HASH: u64 = 0xE1C6_54FA_7B7B_9CB3;
-const BRIDGE_HARNESS_FINAL_HASH: u64 = 0x1422_9DF5_DB39_C07B;
+// Re-baselined 2026-09-02 for v117's disguise-detect folds (FogState's
+// `CellClass+0xAC[house]` counter plane and the cached `DetectDisguiseRange=`
+// deposit radius). The dedicated pre-v117 probe reproduces main's committed
+// current baseline exactly; this fixture stamps no disguise circle, so only
+// current-schema composition moved.
+const BRIDGE_HARNESS_PRE_DISGUISE_DETECT_V117_HASH: u64 = 0x1422_9DF5_DB39_C07B;
+const BRIDGE_HARNESS_FINAL_HASH: u64 = 0x7D6C_E7BF_2564_FD19;
 
 fn bridge_ini() -> IniFile {
     // One armed ground vehicle and one distant infantryman on a second house, so
@@ -527,8 +533,9 @@ fn bridge_crossing_replay_is_deterministic_and_baseline_stable() {
     let pre_base_plan_hash = rep.state_hash_without_base_plan_v110();
     let pre_crate_authority_hash = rep.state_hash_without_crate_authority_v114();
     let pre_wall_runtime_hash = rep.state_hash_without_wall_runtime_v115();
+    let pre_disguise_detect_hash = rep.state_hash_without_disguise_detect_v117();
     println!(
-        "[bridge parity] final_hash={final_hash:016X} pre-v110:{pre_base_plan_hash:016X} pre-v114:{pre_crate_authority_hash:016X} pre-v115:{pre_wall_runtime_hash:016X} streams={:016X},{:016X},{:016X}",
+        "[bridge parity] final_hash={final_hash:016X} pre-v110:{pre_base_plan_hash:016X} pre-v114:{pre_crate_authority_hash:016X} pre-v115:{pre_wall_runtime_hash:016X} pre-v117:{pre_disguise_detect_hash:016X} streams={:016X},{:016X},{:016X}",
         rep.scenario_rng.state(),
         rep.main_rng.state(),
         rep.mapgen_rng.state(),
@@ -544,6 +551,10 @@ fn bridge_crossing_replay_is_deterministic_and_baseline_stable() {
     assert_eq!(
         pre_wall_runtime_hash, BRIDGE_HARNESS_PRE_WALL_RUNTIME_V115_HASH,
         "the dedicated pre-v115 probe must reproduce the prior bridge current baseline"
+    );
+    assert_eq!(
+        pre_disguise_detect_hash, BRIDGE_HARNESS_PRE_DISGUISE_DETECT_V117_HASH,
+        "the dedicated pre-v117 probe must reproduce the prior bridge current baseline"
     );
     assert_eq!(
         final_hash, BRIDGE_HARNESS_FINAL_HASH,

--- a/src/sim/world/global_parity_harness_tests.rs
+++ b/src/sim/world/global_parity_harness_tests.rs
@@ -538,13 +538,19 @@ const GLOBAL_HARNESS_PRE_MISSION_V29_HASH: u64 = 0x3F5A_9EED_EC0A_9204;
 // shared-dummy overlay identity/state folds. The dedicated pre-v115 probe reproduces the
 // prior current baseline exactly; this fixture builds a legacy `None`-count grid, so only
 // current-schema composition moved.
-// Merge 2026-09-02: main's veterancy re-baseline and this branch's queue-store
-// re-baseline both move the same constants, so the values below are the composed
-// measurement taken on the merged tree, not either side's number.
+// Merge 2026-09-02: main's veterancy re-baseline and its queue-store re-baseline
+// both moved these constants, so the three historical probes below are main's
+// composed measurement, unchanged by this branch.
 const GLOBAL_HARNESS_PRE_BASE_PLAN_V110_HASH: u64 = 0x8637_8672_B2C7_DC94;
 const GLOBAL_HARNESS_PRE_CRATE_AUTHORITY_V114_HASH: u64 = 0xB534_6D3F_8096_2143;
 const GLOBAL_HARNESS_PRE_WALL_RUNTIME_V115_HASH: u64 = 0x036C_3475_4BE1_F73E;
-const GLOBAL_HARNESS_FINAL_HASH: u64 = 0x743D_0C0C_8931_EF37;
+// Re-baselined 2026-09-02 for v117's disguise-detect folds (FogState's
+// `CellClass+0xAC[house]` counter plane and the cached `DetectDisguiseRange=`
+// deposit radius). The dedicated pre-v117 probe reproduces main's committed
+// current baseline exactly; this fixture stamps no disguise circle, so only
+// current-schema composition moved. The three RNG stream pins are unchanged.
+const GLOBAL_HARNESS_PRE_DISGUISE_DETECT_V117_HASH: u64 = 0x743D_0C0C_8931_EF37;
+const GLOBAL_HARNESS_FINAL_HASH: u64 = 0x8CAB_A20B_EBDA_C994;
 
 fn harness_ini() -> IniFile {
     // Multi-faction vehicles + infantry + buildings (war factory, refinery) plus a
@@ -841,8 +847,9 @@ fn global_skirmish_replay_is_deterministic_and_baseline_stable() {
     let pre_base_plan_hash = rep.state_hash_without_base_plan_v110();
     let pre_crate_authority_hash = rep.state_hash_without_crate_authority_v114();
     let pre_wall_runtime_hash = rep.state_hash_without_wall_runtime_v115();
+    let pre_disguise_detect_hash = rep.state_hash_without_disguise_detect_v117();
     println!(
-        "[global parity] probes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},pre-v110:{pre_base_plan_hash:016X},pre-v114:{pre_crate_authority_hash:016X},pre-v115:{pre_wall_runtime_hash:016X}"
+        "[global parity] probes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},pre-v110:{pre_base_plan_hash:016X},pre-v114:{pre_crate_authority_hash:016X},pre-v115:{pre_wall_runtime_hash:016X},pre-v117:{pre_disguise_detect_hash:016X}"
     );
     assert_eq!(
         pre_lifecycle_hash, GLOBAL_HARNESS_PRE_LIFECYCLE_V28_HASH,
@@ -863,6 +870,10 @@ fn global_skirmish_replay_is_deterministic_and_baseline_stable() {
     assert_eq!(
         pre_wall_runtime_hash, GLOBAL_HARNESS_PRE_WALL_RUNTIME_V115_HASH,
         "the dedicated pre-v115 probe must reproduce the prior global-harness current baseline"
+    );
+    assert_eq!(
+        pre_disguise_detect_hash, GLOBAL_HARNESS_PRE_DISGUISE_DETECT_V117_HASH,
+        "the dedicated pre-v117 probe must reproduce the prior global-harness current baseline"
     );
     assert_eq!(
         final_hash, GLOBAL_HARNESS_FINAL_HASH,

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -2363,8 +2363,25 @@ impl Simulation {
                     .arm(self.session.binary_frame, delay);
             }
 
-            // RadioClass::PointerExpired nulls matching sparse slots in place.
-            listener.clear_live_contact_with(expired_id);
+            // `RadioClass::PointerExpired @ 0x0065AAC0` nulls matching sparse
+            // slots in place, but ONLY on a nonzero control:
+            //
+            // ```
+            // 0065aac1 MOV EBX,[ESP+0xc]      ; EBX = the control argument
+            // 0065aae6 MOV EDX,[EAX + ECX*4]  ; slot
+            // 0065aaec CMP EDX,EDI            ; slot == expired ?
+            // 0065aaee JNZ 0065aafa
+            // 0065aaf0 TEST BL,BL             ; control
+            // 0065aaf2 JZ   0065aafa          ; control 0 skips the clear
+            // 0065aaf4 MOV dword ptr [EAX],0x0
+            // ```
+            //
+            // So `Detach_All(false)` — the dive — leaves radio contacts intact,
+            // and only UnInit breaks them. A diving submarine therefore keeps
+            // its naval-yard repair link and its transport link.
+            if control == PointerExpiryControl::Uninit {
+                listener.clear_live_contact_with(expired_id);
+            }
 
             // TechnoClass removes an expiring passenger from its CargoClass before
             // clearing its target/archive/manager reference family.
@@ -2398,6 +2415,16 @@ impl Simulation {
 
         // FootClass clears SuspendedNavCom first, then its current/aux target,
         // and removes every matching queue entry. Cell targets are unaffected.
+        //
+        // `FootClass::PointerExpired @ 0x004D9960` carries its OWN copy of the
+        // `allowClear` Boolean, computed by a SECOND `SensorCountForHouse`
+        // call — `0x004D9A57 CALL 0x004870D0`, at the expiring object's
+        // `GetCoords` cell (`0x004D9A3D` vslot `+0x48`) for the RECEIVER's house
+        // (`param_1[0x87] + 0x30`) — under the same control-0 / nonnull /
+        // `+0x14` bit-0 guard as the Techno body. It gates the `+0x5A0`/`+0x5A4`
+        // PAIR clear below; the `+0x5A8` clear above it is unguarded. The two
+        // Booleans are equal in value because both read the receiver's house at
+        // the same cell, so the single `allow_clear` local models both.
         if listener
             .navigation
             .suspended_nav_com
@@ -2419,7 +2446,7 @@ impl Simulation {
             && expired_object_alive
             && expired_health > 0
             && !expired_is_selling;
-        if !retain_capture_nav {
+        if !retain_capture_nav && allow_clear {
             if listener
                 .navigation
                 .nav_com_aux
@@ -2539,6 +2566,27 @@ impl Simulation {
     /// runs the same `TechnoClass::PointerExpired` body as the UnInit path over
     /// the same registered-object roster. The detaching object survives, so no
     /// House-side BuildConst removal happens here.
+    ///
+    /// **The non-Techno listeners on that roster are control-INSENSITIVE**, read
+    /// this session and no longer a residual:
+    ///
+    /// * `WaveClass::PointerExpired @ 0x0075F610` (vtable `0x007F6BF4 + 0x28`)
+    ///   and `ParticleSystemClass::PointerExpired @ 0x0062FE90` branch on the
+    ///   control only inside the inherited `ObjectClass` call.
+    /// * `AnimClass`'s `+0x28` override is `0x00425150` (vtable
+    ///   `0x007E3354 + 0x28`; its only xref is that slot). It too forwards the
+    ///   control to `ObjectClass::PointerExpired` and takes no further branch on
+    ///   it.
+    /// * `BulletClass::PointerExpired @ 0x004684E0` branches on the control only
+    ///   for its trailing global-vector erase; the `+0x10C` target repair that
+    ///   substitutes `Get_CellClass` at the expired object's last cell — the arm
+    ///   VERA models in `HomingState::expire_object_target` — is unguarded.
+    /// * `ObjectClass::PointerExpired @ 0x005F5230` itself gates only the
+    ///   `+0x30` chain relink on a nonzero control; VERA models no `+0x30`
+    ///   chain, so it is correct by omission.
+    ///
+    /// So a torpedo already in flight at a diving submarine falling to the sub's
+    /// last cell instead of tracking it is native behavior, not an approximation.
     pub(crate) fn detach_all_pointer_expired(&mut self, expired_id: u64) {
         if !self.substrate.entities.contains(expired_id) {
             return;

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -25,6 +25,32 @@ use crate::util::lepton::{LEPTONS_PER_LEVEL, ground_height_leptons};
 use super::Simulation;
 use super::substrate::ObjectKind;
 
+/// The control value `DispatchPointerExpiredCleanup @ 0x007258D0` forwards to
+/// every listener's `PointerExpired` slot (`vt+0x28`), i.e. the third argument
+/// of `TechnoClass::PointerExpired @ 0x007077C0`.
+///
+/// Two production callers, and they disagree on the value:
+/// * `ObjectClass__UnInit @ 0x005F65F0` dispatches with **1** at `0x005F6616` —
+///   the object is going away, so every reference is dropped unconditionally.
+/// * `ObjectClass::Detach_All(bool)` (vtable `+0xDC`, `0x005F5280`; the
+///   `FootClass` override is `0x004D9720`) forwards its own argument, and both
+///   cloak callers pass **0**: `TechnoClass::StartCloaking @ 0x00703770` and
+///   the `CloakState 1 -> 2` arm of `TechnoClass::CloakingTick @ 0x006FB740`.
+///
+/// A control of 0 changes three things inside the receiver body: it runs the
+/// `allowClear` sensor test (`0x00707994 CALL 0x004870D0`,
+/// `CellClass::SensorCountForHouse`), it exempts a receiver whose own house
+/// owns the expiring object from the Target clear (`0x007079B7..0x007079CB`),
+/// and it skips the `+0x500` / `+0x218` / CaptureManager block opened at
+/// `0x00707AE7`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PointerExpiryControl {
+    /// `Detach_All(false)` — the expiring object survives.
+    DetachAll,
+    /// `ObjectClass::UnInit` — the expiring object is being removed.
+    Uninit,
+}
+
 /// Borrowed map authority carried through one synchronous ObjectClass UnInit
 /// tree. Ordinary entry points use the Simulation-owned terrain; combat uses
 /// this context while that same terrain is staged outside `Simulation`.
@@ -2269,18 +2295,23 @@ impl Simulation {
             })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn notify_entity_pointer_expired(
         &mut self,
         listener_id: u64,
         expired_id: u64,
         // The expiring object's `ObjectClass::GetCoords` cell — the single
         // derivation `BulletClass::PointerExpired @ 0x004684E0` uses for both
-        // the entity-hosted and store-hosted missile arms.
+        // the entity-hosted and store-hosted missile arms. It is also the cell
+        // `TechnoClass::PointerExpired` hands to `SensorCountForHouse` when it
+        // computes `allowClear` on the `Detach_All` control.
         expired_get_coords_cell: Option<(u16, u16)>,
         expired_is_high_flying: bool,
         expired_object_alive: bool,
         expired_health: u16,
         expired_is_selling: bool,
+        expired_owner: Option<InternedId>,
+        control: PointerExpiryControl,
     ) {
         let Some(listener) = self.substrate.entities.get(listener_id) else {
             return;
@@ -2288,13 +2319,42 @@ impl Simulation {
         let current_target_matches = listener.attack_target.as_ref().is_some_and(
             |target| matches!(target.target, TargetKind::Entity(id) if id == expired_id),
         );
+        let listener_owner = listener.owner;
         let passive_scan_remaining = listener
             .passive_scan_timer
             .remaining(self.session.binary_frame);
         let mission_is_suspended =
             listener.mission.suspended() != crate::sim::mission::MissionId::NONE;
 
-        let passive_scan_delay = (current_target_matches && passive_scan_remaining > 10)
+        // `TechnoClass::PointerExpired @ 0x007077C0`, the `allowClear` local
+        // (`[ESP+0x24]`): it starts true and is cancelled only on the
+        // `Detach_All` control, when the expiring object is a Techno and the
+        // RECEIVER's own house already holds a sensor count on that object's
+        // cell — `0x00707994 CALL 0x004870D0`. The Techno half of that guard is
+        // `AbstractFlags +0x14` bit 0, ORed in for every object by
+        // `TechnoClass__Constructor @ 0x006F3228` and therefore true of every
+        // `GameEntity`, so it needs no test here. `allowClear` gates both the
+        // Target (`+0x2B4`) clear at `0x007079AD` and the `+0x2B8` clear at
+        // `0x00707A7A`.
+        let allow_clear = match control {
+            PointerExpiryControl::Uninit => true,
+            PointerExpiryControl::DetachAll => !expired_get_coords_cell
+                .is_some_and(|(rx, ry)| self.fog.has_sensor_for_house(listener_owner, rx, ry)),
+        };
+        // `0x007079B7..0x007079CB`: on the same control the Target clear is
+        // additionally skipped when the expiring object's `GetOwner` (vslot
+        // `+0x3C`) equals the receiver's `+0x21C`, so a diving submarine never
+        // drops its own house's shooters.
+        let same_owner_exempt =
+            control == PointerExpiryControl::DetachAll && expired_owner == Some(listener_owner);
+        let clears_current_target = current_target_matches && allow_clear && !same_owner_exempt;
+
+        // `0x007079D1..0x00707A0D`: the re-arm sits INSIDE the guarded arm,
+        // ahead of `Assign_Target(NULL)`, so a receiver that keeps its target
+        // spends no Scenario draw. An already-expired timer (`elapsed >=
+        // duration`) skips the block entirely, which `remaining()`'s clamp to 0
+        // reproduces.
+        let passive_scan_delay = (clears_current_target && passive_scan_remaining > 10)
             .then(|| self.scenario_rng.next_range_u32_inclusive(4, 8));
         if let Some(listener) = self.substrate.entities.get_mut(listener_id) {
             if let Some(delay) = passive_scan_delay {
@@ -2313,7 +2373,7 @@ impl Simulation {
             }
         }
 
-        if current_target_matches {
+        if clears_current_target {
             self.set_archive_target_represented(listener_id, None)
                 .expect("expiry listener remains present");
             if mission_is_suspended {
@@ -2325,10 +2385,14 @@ impl Simulation {
         let Some(listener) = self.substrate.entities.get_mut(listener_id) else {
             return;
         };
-        if matches!(
-            listener.suspended_attack_target,
-            Some(TargetKind::Entity(id)) if id == expired_id
-        ) {
+        // `+0x2B8` is cleared on an exact match under `allowClear` alone — the
+        // same-owner exemption applies only to `+0x2B4`.
+        if allow_clear
+            && matches!(
+                listener.suspended_attack_target,
+                Some(TargetKind::Entity(id)) if id == expired_id
+            )
+        {
             listener.suspended_attack_target = None;
         }
 
@@ -2454,12 +2518,42 @@ impl Simulation {
     /// listener arms still read the object's liveness, health and mission from
     /// the same destructure.
     fn notify_pointer_expired(&mut self, expired_id: u64, _context: UninitContext<'_>) {
+        if !self.substrate.entities.contains(expired_id) {
+            return;
+        }
+
+        // gamemd-derived: the House pointer-expiry handler reached by this
+        // synchronous broadcast stable-removes a BuildConst Building while it
+        // is still alive, marked, and resolvable. Keeping the House mutation
+        // at this callback boundary also covers direct UnInit/destruction;
+        // Conceal's already-limbo return never reaches it.
+        self.remove_build_const_from_owner(expired_id);
+        self.broadcast_pointer_expired(expired_id, PointerExpiryControl::Uninit);
+    }
+
+    /// `ObjectClass::Detach_All(false)` — the vtable `+0xDC` call
+    /// `TechnoClass::StartCloaking @ 0x00703770` makes before it writes any
+    /// cloak state, and again from the `CloakState 1 -> 2` completion arm of
+    /// `TechnoClass::CloakingTick @ 0x006FB740` (`0x006FBA98`). Both reach
+    /// `DispatchPointerExpiredCleanup @ 0x007258D0` with control **0**, which
+    /// runs the same `TechnoClass::PointerExpired` body as the UnInit path over
+    /// the same registered-object roster. The detaching object survives, so no
+    /// House-side BuildConst removal happens here.
+    pub(crate) fn detach_all_pointer_expired(&mut self, expired_id: u64) {
+        if !self.substrate.entities.contains(expired_id) {
+            return;
+        }
+        self.broadcast_pointer_expired(expired_id, PointerExpiryControl::DetachAll);
+    }
+
+    fn broadcast_pointer_expired(&mut self, expired_id: u64, control: PointerExpiryControl) {
         let Some((
             expired_target_cell,
             expired_is_high_flying,
             expired_object_alive,
             expired_health,
             expired_is_selling,
+            expired_owner,
         )) = self.substrate.entities.get(expired_id).map(|expired| {
             let high_flying = expired.locomotor.as_ref().is_some_and(|locomotor| {
                 // High-flying objects expire to null; lower objects preserve
@@ -2473,18 +2567,12 @@ impl Simulation {
                 expired.health.current,
                 expired.mission.current().known()
                     == Some(crate::sim::mission::MissionType::Selling),
+                Some(expired.owner),
             )
         })
         else {
             return;
         };
-
-        // gamemd-derived: the House pointer-expiry handler reached by this
-        // synchronous broadcast stable-removes a BuildConst Building while it
-        // is still alive, marked, and resolvable. Keeping the House mutation
-        // at this callback boundary also covers direct UnInit/destruction;
-        // Conceal's already-limbo return never reaches it.
-        self.remove_build_const_from_owner(expired_id);
 
         // `BulletClass::PointerExpired @ 0x004684E0` performs the packed
         // `MapClass::Get_CellClass @ 0x005657A0` lookup only for a matching
@@ -2504,7 +2592,7 @@ impl Simulation {
             }
 
             #[cfg(test)]
-            {
+            if control == PointerExpiryControl::Uninit {
                 let (target_alive, target_in_limbo) = self
                     .substrate
                     .entities
@@ -2528,17 +2616,26 @@ impl Simulation {
                     expired_object_alive,
                     expired_health,
                     expired_is_selling,
+                    expired_owner,
+                    control,
                 );
                 // `TechnoClass::PointerExpired` forwards to the listener's
-                // SpawnManager (`0x00707A6F`). This is the only mechanism that
-                // drops a destroyed wing target, so without it a Carrier keeps
-                // sending its Hornets at a corpse.
+                // SpawnManager: `0x00707B24 CALL 0x006B7C60`, gated only on
+                // `+0x2D0 != 0`. This is the only mechanism that drops a
+                // destroyed wing target, so without it a Carrier keeps sending
+                // its Hornets at a corpse. The forward sits OUTSIDE the control
+                // test, so it runs on a cloak dive as well as on UnInit.
                 crate::sim::spawn_manager::notify_pointer_expired(self, listener_id, expired_id);
-                if let Some(manager) = self
-                    .substrate
-                    .entities
-                    .get_mut(listener_id)
-                    .and_then(|entity| entity.capture_manager.as_mut())
+                // The CaptureManager forward — `0x00707B14 CALL 0x00471F90` —
+                // sits inside the `if (control != 0)` block opened at
+                // `0x00707AE7`, so a dive leaves mind-control links alone while
+                // a death drops them.
+                if control == PointerExpiryControl::Uninit
+                    && let Some(manager) = self
+                        .substrate
+                        .entities
+                        .get_mut(listener_id)
+                        .and_then(|entity| entity.capture_manager.as_mut())
                 {
                     manager.pointer_expired(expired_id);
                 }

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -7097,6 +7097,16 @@ impl Simulation {
                 // ordinary promote-only per-cell writer.
                 sim.clear_entity_playfield_membership_after_teleport(stable_id);
             } else if cell_before_movement != cell_after_movement {
+                // `FootClass::PerCellProcess @ 0x004D85D0` runs the `Sensors=`
+                // neighbour scan on its cell-enter arm, after the sensor
+                // deposit has moved (`0x004D8611`/`0x004D8621`, issued just
+                // above) and before its `FUN_006F5090` playfield-membership
+                // tail — which is the promote below.
+                if let Some(rules) = rules {
+                    crate::sim::world::techno_ai_cloak::uncloak_on_sensor_neighbour_after_cell_entry(
+                        sim, stable_id, rules,
+                    );
+                }
                 sim.promote_entity_playfield_membership_after_move(stable_id);
             }
 

--- a/src/sim/world/slice6_retask_tests.rs
+++ b/src/sim/world/slice6_retask_tests.rs
@@ -343,13 +343,19 @@ const SLICE6_PRE_MISSION_V29_HASH: u64 = 0x9694_A52E_B273_078B;
 // shared-dummy overlay identity/state folds. The dedicated pre-v115 probe reproduces the
 // prior current baseline exactly; this fixture builds a legacy `None`-count grid, so only
 // current-schema composition moved.
-// Merge 2026-09-02: main's veterancy re-baseline and this branch's queue-store
-// re-baseline both move the same constants, so the values below are the composed
-// measurement taken on the merged tree, not either side's number.
+// Merge 2026-09-02: main's veterancy re-baseline and its queue-store re-baseline
+// both moved these constants, so the three historical probes below are main's
+// composed measurement, unchanged by this branch.
+// Re-baselined 2026-09-02 for v117's disguise-detect folds: FogState's
+// `CellClass+0xAC[house]` counter plane and the cached `DetectDisguiseRange=`
+// deposit radius. The dedicated pre-v117 probe reproduces main's committed
+// current baseline exactly; this fixture stamps no disguise circle, so only
+// current-schema composition moved.
 const SLICE6_PRE_BASE_PLAN_V110_HASH: u64 = 0x8C10_E3FB_A724_DC45;
 const SLICE6_PRE_CRATE_AUTHORITY_V114_HASH: u64 = 0x85A5_BAF4_8901_5224;
 const SLICE6_PRE_WALL_RUNTIME_V115_HASH: u64 = 0x1A28_C2A9_C8E5_15BC;
-const SLICE6_BASELINE_HASH: u64 = 0x8A0C_1481_C5DC_F2F9;
+const SLICE6_PRE_DISGUISE_DETECT_V117_HASH: u64 = 0x8A0C_1481_C5DC_F2F9;
+const SLICE6_BASELINE_HASH: u64 = 0xF26E_75C0_F0E0_4633;
 
 #[test]
 fn replay_hash_stable_through_slice6() {
@@ -429,9 +435,10 @@ fn replay_hash_stable_through_slice6() {
     let pre_base_plan_hash = sim.state_hash_without_base_plan_v110();
     let pre_crate_authority_hash = sim.state_hash_without_crate_authority_v114();
     let pre_wall_runtime_hash = sim.state_hash_without_wall_runtime_v115();
+    let pre_disguise_detect_hash = sim.state_hash_without_disguise_detect_v117();
     let hash = sim.state_hash();
     println!(
-        "[slice6] hashes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},pre-v110:{pre_base_plan_hash:016X},pre-v114:{pre_crate_authority_hash:016X},pre-v115:{pre_wall_runtime_hash:016X},current:{hash:016X}"
+        "[slice6] hashes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},pre-v110:{pre_base_plan_hash:016X},pre-v114:{pre_crate_authority_hash:016X},pre-v115:{pre_wall_runtime_hash:016X},pre-v117:{pre_disguise_detect_hash:016X},current:{hash:016X}"
     );
     assert_eq!(
         pre_lifecycle_hash, SLICE6_PRE_LIFECYCLE_V28_HASH,
@@ -452,6 +459,10 @@ fn replay_hash_stable_through_slice6() {
     assert_eq!(
         pre_wall_runtime_hash, SLICE6_PRE_WALL_RUNTIME_V115_HASH,
         "the dedicated pre-v115 probe must reproduce the prior Slice 6 current baseline"
+    );
+    assert_eq!(
+        pre_disguise_detect_hash, SLICE6_PRE_DISGUISE_DETECT_V117_HASH,
+        "the dedicated pre-v117 probe must reproduce the prior Slice 6 current baseline"
     );
     assert_eq!(
         hash, SLICE6_BASELINE_HASH,

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -502,6 +502,7 @@ fn techno_ai_shell(
                 veterancy_promotion_step(sim, id, rules);
                 self_heal_step(sim, id, rules);
             }
+            drop_unsensed_cloaked_target_step(sim, id);
             mission_counter_step(sim, id);
         }
     }
@@ -643,6 +644,61 @@ fn self_heal_step(sim: &mut Simulation, id: u64, rules: &RuleSet) {
     }
     if let Some(entity) = sim.substrate.entities.get_mut(id) {
         entity.health.current = entity.health.current.saturating_add(1);
+    }
+}
+
+/// `AircraftClass::AI @ 0x00414D4D..0x00414DA1`, read from the disassembly:
+///
+/// ```text
+/// T = Target(+0x2B4);
+/// if (T && (T->flags & 1) && !IsAlliedWith(myOwner, T)
+///       && T->CloakState(+0x220) == 2
+///       && !T->vt+0x32C(myOwner))                 // IsSensedByHouse
+///     Assign_Target(NULL);
+/// ```
+///
+/// Aircraft alone re-test this every tick, so a Harrier loses its lock the
+/// moment its house's sensor coverage of a submerged target lapses — the ground
+/// units around it keep theirs until their own scan cadence comes round.
+/// (`vt+0x32C` at `0x0070D460` has no function boundary in the database; the
+/// body reads the sensor count for the passed house at the object's own cell,
+/// and returns false for a null house.)
+fn drop_unsensed_cloaked_target_step(sim: &mut Simulation, id: u64) {
+    let Some(entity) = sim.substrate.entities.get(id) else {
+        return;
+    };
+    let Some(crate::sim::combat::TargetKind::Entity(target_id)) =
+        entity.attack_target.as_ref().map(|target| target.target)
+    else {
+        return;
+    };
+    let owner = entity.owner;
+    let owner_str = sim.interner.resolve(owner).to_owned();
+    let Some(target) = sim.substrate.entities.get(target_id) else {
+        return;
+    };
+    if !target
+        .cloak
+        .as_ref()
+        .is_some_and(|cloak| cloak.is_fully_cloaked())
+    {
+        return;
+    }
+    let target_cell = (target.position.rx, target.position.ry);
+    if sim
+        .fog
+        .is_friendly(&owner_str, sim.interner.resolve(target.owner))
+    {
+        return;
+    }
+    if sim
+        .fog
+        .has_sensor_for_house(owner, target_cell.0, target_cell.1)
+    {
+        return;
+    }
+    if let Some(entity) = sim.substrate.entities.get_mut(id) {
+        crate::sim::mission::concrete_effects::represented_assign_target(entity, None);
     }
 }
 

--- a/src/sim/world/techno_ai_cloak.rs
+++ b/src/sim/world/techno_ai_cloak.rs
@@ -330,8 +330,8 @@ pub(crate) fn sensor_reevaluate_stock_cloak(
 /// (`Simulation::detach_all_pointer_expired`) rather than a cloak-local copy.
 /// A miniature copy would have cleared the receiver's Target and nothing else —
 /// no `RandomRanged(4, 8)` re-arm of the `+0x180/+0x188` targeting timer, no
-/// radio-contact null, no cargo/NavCom/manager slot clears, and none of it for
-/// the non-targeters `Detach_All` also visits.
+/// NavCom/cargo/manager slot clears, and none of it for the non-targeters
+/// `Detach_All` also visits.
 ///
 /// The clause that matters most for cloak: the receiver's `Target(+0x2B4)` is
 /// cleared through `Assign_Target(NULL)` unless
@@ -341,10 +341,18 @@ pub(crate) fn sensor_reevaluate_stock_cloak(
 /// * the expiring object has the same owner (`expired->vt+0x3C == my +0x21C`,
 ///   `0x007079B7..0x007079CB`).
 ///
-/// So a destroyer whose house covers the diving submarine keeps firing at it,
-/// and everyone else loses the target the instant the dive begins. Before this
-/// landed, VERA kept every attacker locked on until the next passive-scan
-/// cadence (~28 frames) re-evaluated.
+/// `FootClass::PointerExpired @ 0x004D9960` then recomputes the SAME Boolean
+/// from its own `0x004D9A57 CALL 0x004870D0` and gates the `+0x5A0`/`+0x5A4`
+/// NavCom pair on it, so the sensing house keeps its destination too. Together
+/// those mean a destroyer whose house covers the diving submarine keeps both
+/// firing at it and closing on it, while everyone else loses target and chase
+/// the instant the dive begins. Before this landed, VERA kept every attacker
+/// locked on until the next passive-scan cadence (~28 frames) re-evaluated.
+///
+/// `RadioClass::PointerExpired @ 0x0065AAC0` is the counter-example: its slot
+/// clear is control-1 only (`0065aaf0 TEST BL,BL / JZ`), so a dive breaks no
+/// radio contact — the diving sub keeps its naval-yard repair and transport
+/// links.
 ///
 /// Running this after `CloakRuntime::tick` has written the new state instead of
 /// before it is output-equivalent: the admission test reads only the cloaker's

--- a/src/sim/world/techno_ai_cloak.rs
+++ b/src/sim/world/techno_ai_cloak.rs
@@ -3,6 +3,7 @@
 use crate::map::entities::EntityCategory;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::combat::TargetKind;
+use crate::sim::intern::InternedId;
 use crate::sim::mission::concrete_effects::represented_assign_target;
 
 use super::Simulation;
@@ -28,13 +29,49 @@ fn stock_cloak_tick_facts(
     if !object.cloakable && !rank_cloak {
         return None;
     }
-    let moving = crate::sim::movement::drive_locomotor_is_moving(entity)
-        || entity.movement_target.is_some();
-    let firing = entity.attack_target.is_some();
-    let chrono_active = entity.teleport_state.is_some();
+    let moving =
+        crate::sim::movement::drive_locomotor_is_moving(entity) || entity.movement_target.is_some();
+    let holds_target = entity.attack_target.is_some();
+    // vt+0x1D4 / vt+0x1D8 = `IsWarpingIn` / `IsWarpingOut` (`0x0070C5B0` /
+    // `0x0070C5C0`, reading `TechnoClass+0x270`/`+0x271`). VERA's producers for
+    // the same pair are the teleport phase predicates.
+    let chrono_active = entity
+        .teleport_state
+        .as_ref()
+        .is_some_and(|teleport| teleport.warp_in_active() || teleport.warp_out_active());
+    // `FootClass::IsCloakable @ 0x004DBDA0` (vtable +0x288) =
+    // `HasStealthAbility() && !(CloakStop(+0xC93) && locomotor->IsMoving())`.
     let is_cloakable = object.cloakable && (!object.cloak_stop || !moving);
-    let activity = firing || chrono_active;
-    let state_zero_head_allows = is_cloakable && !activity || rank_cloak;
+
+    // The gate the state-0 head of `CloakingTick @ 0x006FB757..0x006FB7F7`
+    // actually applies, read from the disassembly:
+    //   IsCloakable(+0x288) && !vt+0x37C && !vt+0x380 && !vt+0x1D4 && !vt+0x1D8,
+    //   or, failing that, the current rank's CLOAK ability.
+    //
+    // CORRECTION: VERA used to put "holds an attack target" in this head gate.
+    // Native has no such term here — the target test lives in `CanAutoCloak`
+    // step 4 below, as `Target(+0x2B4) != 0 && CanFireAtTarget(vt+0x3AC)`.
+    // vt+0x37C is `IsUnderEMP` (Techno `0x0070EFD0` reads `+0x504 > 0`; the
+    // Unit override `0x00746C90` ORs in `DeployTarget(+0x6CC) != -1`), and
+    // vt+0x1D4/+0x1D8 are the chrono warp-in/warp-out flags.
+    //
+    // RESIDUAL — no EMP mechanism exists in VERA. `+0x504` has no Rust
+    // counterpart, so the EMP term is hardcoded false here.
+    // - Trigger: any EMP warhead landing on a cloaked object (stock sources:
+    //   the EMPulse Cannon superweapon and the Boomer/Robot EMP warheads).
+    // - Player effect: in gamemd an EMP'd Typhoon or Mirage surfaces for the
+    //   duration; in VERA it stays cloaked. It is also the ONLY live
+    //   `ShouldUncloak` trigger in stock data, so with it missing a fully
+    //   cloaked unit's `ShouldUncloak` arm is effectively dead here.
+    // - Frequency: rare — needs an EMP weapon fired at a cloakable unit.
+    // - Downstream risk: none structurally; the predicate is one boolean and
+    //   drops into `emp_active` below the day an EMP timer lands.
+    // vt+0x380 (`FootClass 0x004DE770`) reads the `+0x6A0/+0x6A8` timer, whose
+    // duration is only ever written zero, so it is dormant and modelled false.
+    let emp_active = false;
+    let deploy_pending = entity.deploy_state.is_some();
+    let state_zero_head_allows =
+        is_cloakable && !emp_active && !deploy_pending && !chrono_active || rank_cloak;
 
     // CloakingTick's pre-CanAuto destination exclusion is Contact_With_Whom(0)
     // resolving to a WeaponsFactory building (naval-yard repair contact), not
@@ -48,30 +85,62 @@ fn stock_cloak_tick_facts(
             .is_some_and(|contact_type| contact_type.weapons_factory)
     });
     let current_frame = sim.session.binary_frame as i32;
+    let cloak_state = entity.cloak.as_ref().map_or(0, |cloak| cloak.state);
+    let cloak_progress = entity.cloak.as_ref().map_or(0, |cloak| cloak.depth);
     let delay_expired = entity
         .cloak
         .as_ref()
         .is_some_and(|cloak| cloak.recloak_delay_expired(current_frame));
-    let can_auto_cloak = !destination_is_weapons_factory
-        && delay_expired
-        && !firing
-        && !entity.mind_controlled
-        && entity.position.z < 1
-        && (is_cloakable
-            || rank_cloak
-            || sim
-                .fog
-                .is_cell_visible(entity.owner, entity.position.rx, entity.position.ry));
 
-    // ShouldUncloak @ 0x006FBC90 returns early while intrinsic cloakability is
-    // idle, and rank CLOAK suppresses the later activity path. The surviving
-    // branch is the current owner-cell visibility test.
-    let should_uncloak = if (is_cloakable || object.cloakable) && !activity || rank_cloak {
+    // `CellClass::IsVisibleToHouse @ 0x004870B0` is the CloakedByHouses bit,
+    // NOT cell visibility — see `FogState::is_cloaked_by_house`. It is only
+    // ever set by a `CloakGenerator=yes` building's field, and stock YR has
+    // none, so this reads false in every ordinary skirmish. VERA previously
+    // substituted `fog.is_cell_visible(owner, ...)` here, which is true for an
+    // owner standing on its own cell — inverting both gates below.
+    let cloaked_by_own_house =
+        owner_cloak_field_bit(sim, entity.owner, entity.position.rx, entity.position.ry);
+
+    // `TechnoClass::CanAutoCloak @ 0x006FBDC0`, in native step order.
+    let can_auto_cloak = (is_cloakable || rank_cloak || cloaked_by_own_house)
+        // 2. already fully cloaked.
+        && cloak_state != 2
+        // 3. the ROF rearm countdown at +0x2EC/+0x2F4, and 6. the CloakDelay
+        //    countdown at +0x240/+0x248. `recloak_delay_expired` requires both.
+        && delay_expired
+        // 4. `Target(+0x2B4) != 0 && CanFireAtTarget(vt+0x3AC)`.
+        //    SUBSTITUTED: VERA has no cheap `CanFireAtTarget` here and uses the
+        //    presence of an attack target instead. The two disagree only for a
+        //    unit holding a target no weapon can engage, which VERA's
+        //    acquisition and retaliation paths do not install.
+        && !holds_target
+        // 5. `WhatAmI != Building && CloakProgress(+0x224) != 0`. This is why
+        //    the state-3 silent re-cloak branch is unreachable for units:
+        //    visual state 1 requires a nonzero progress.
+        && cloak_progress == 0
+        // 7. the mind-control arm (`+0x2B0` plus the FootClass `+0x6AD` byte).
+        && !entity.mind_controlled
+        // 8. `GetHeight() < 1`.
+        && entity.position.z < 1
+        // The pre-CanAutoCloak `Contact_With_Whom(0)` exclusion at
+        // 0x006FB7FD..0x006FB823 (`BuildingType+0x16BD` = `WeaponsFactory=`,
+        // verified from the key string at 0x0081AA4C).
+        && !destination_is_weapons_factory;
+
+    // `TechnoClass::ShouldUncloak @ 0x006FBC90`:
+    //   if ((IsCloakable() || +0x3D2) && !EMP && !vt+0x380 && !WarpIn && !WarpOut)
+    //       return 0;
+    //   if (rank CLOAK) return 0;
+    //   return IsVisibleToHouse(myCell, myOwner) ? 0 : 1;
+    // The tail therefore returns 1 in stock YR, so the predicate reduces to
+    // "the object can no longer sustain its cloak" — EMP, chrono warp, a
+    // pending deploy, `CloakStop=` while moving, or a lost stealth ability.
+    let should_uncloak = if is_cloakable && !emp_active && !deploy_pending && !chrono_active {
+        false
+    } else if rank_cloak {
         false
     } else {
-        !sim
-            .fog
-            .is_cell_visible(entity.owner, entity.position.rx, entity.position.ry)
+        !cloaked_by_own_house
     };
     Some(crate::sim::cloak_disguise::CloakTickFacts {
         current_frame,
@@ -85,6 +154,23 @@ fn stock_cloak_tick_facts(
         cloaking_speed: object.cloaking_speed,
         cloak_delay_frames: rules.general.cloak_delay_frames,
     })
+}
+
+/// `CellClass::IsVisibleToHouse @ 0x004870B0` for the object's own owner — the
+/// `CloakedByHouses` bit read by `ShouldUncloak @ 0x006FBDA2`, `CanAutoCloak @
+/// 0x006FBE90` and the vt+0x420 hook at `0x006F4F46`. Only a
+/// `CloakGenerator=yes` building's field expand/contract writes it
+/// (`BuildingClass::UpdateGapGenerator_Tick @ 0x004551B9 / 0x004553B3`), and no
+/// stock YR building carries the key — so this is constantly false in an
+/// ordinary skirmish, exactly as in gamemd.
+fn owner_cloak_field_bit(sim: &Simulation, owner: InternedId, rx: u16, ry: u16) -> bool {
+    let Some(index) = sim.base_reservation_house_index(owner) else {
+        return false;
+    };
+    let Ok(index) = u8::try_from(index) else {
+        return false;
+    };
+    sim.fog.is_cloaked_by_house(index, rx, ry)
 }
 
 fn sensor_targeters_in_native_dispatch_order(sim: &Simulation, cloaker_id: u64) -> Vec<u64> {
@@ -103,27 +189,43 @@ fn sensor_targeters_in_native_dispatch_order(sim: &Simulation, cloaker_id: u64) 
         .entities
         .iter_sorted()
         .filter_map(|(targeter_id, targeter)| {
-            let targets_cloaker = targeter.attack_target.as_ref().is_some_and(|target| {
-                target.target == TargetKind::Entity(cloaker_id)
-            });
+            let targets_cloaker = targeter
+                .attack_target
+                .as_ref()
+                .is_some_and(|target| target.target == TargetKind::Entity(cloaker_id));
             let admitted = targeter.owner == cloaker_owner
-                || sim.fog.has_sensor_for_house(
-                    targeter.owner,
-                    cloaker_cell.0,
-                    cloaker_cell.1,
-                );
+                || sim
+                    .fog
+                    .has_sensor_for_house(targeter.owner, cloaker_cell.0, cloaker_cell.1);
             (targets_cloaker && admitted).then_some(targeter_id)
         })
         .collect()
 }
 
-/// Active `TechnoClass+0x420 @ 0x006F4EB0` owner-visible/CanAutoCloak arm.
-/// Sensor lifecycle calls this in exact CellClass FirstObject order after the
-/// corresponding signed counter mutation. Under the outer gate, native first
-/// snapshots admitted targeters, then starts cloak/sound, then reassigns the
-/// saved same target through `Assign_Target @ 0x006FCDB0`; that setter clears
-/// passive provenance before its same-target early return. The player-local
-/// redraw arm remains presentation state and is not serialized or world-hashed.
+/// `TechnoClass` vtable `+0x420 @ 0x006F4EB0`, the callback every sensor
+/// deposit runs over the residents of each covered cell (`AddSensorsAt @
+/// 0x004DE7B0` and its three siblings).
+///
+/// The function has two arms, read from the disassembly:
+/// * `0x006F4F05..0x006F4F3A` — if the object is fully cloaked, is not the
+///   local player's, and the local player has no sensor on its cell, call
+///   `ObjectClass::Deselect` (vt+0x150). Local-player UI only; not sim state.
+/// * `0x006F4F3A..0x006F5085` — the **cloak-field entry hook**: if
+///   `CellClass::IsVisibleToHouse(myCell, myOwner)` (the `CloakedByHouses` bit,
+///   `0x004870B0`) AND `CanAutoCloak()`, snapshot the admitted targeters,
+///   `StartCloaking(0)` (vt+0x460), then re-`Assign_Target` each saved one.
+///
+/// Nothing here ever uncloaks, and the second arm is dormant in stock YR
+/// because no building sets `CloakGenerator=`.
+///
+/// **DRIFT corrected here.** VERA gated the second arm on
+/// `fog.is_cell_visible(owner, ...)`, which is true for any owner standing on
+/// its own revealed cell — so every sensor add/remove touching a cell force-
+/// cloaked an eligible unit there and played `CloakSound`. With six stock
+/// `SensorsSight=` types re-depositing on every cell they move through, that
+/// fired continuously in naval play. The gate is now the real
+/// `CloakedByHouses` bit, so the arm is dormant exactly as in gamemd; the
+/// structure stays modelled for a mod that does ship a cloak generator.
 pub(crate) fn sensor_reevaluate_stock_cloak(
     sim: &mut Simulation,
     id: u64,
@@ -132,18 +234,18 @@ pub(crate) fn sensor_reevaluate_stock_cloak(
     let Some(facts) = stock_cloak_tick_facts(sim, id, rules) else {
         return SensorCloakReevaluation::default();
     };
-    let owner_cell_visible = sim.substrate.entities.get(id).is_some_and(|entity| {
-        sim.fog
-            .is_cell_visible(entity.owner, entity.position.rx, entity.position.ry)
+    let inside_friendly_cloak_field = sim.substrate.entities.get(id).is_some_and(|entity| {
+        owner_cloak_field_bit(sim, entity.owner, entity.position.rx, entity.position.ry)
     });
-    if !owner_cell_visible || !facts.can_auto_cloak {
+    if !inside_friendly_cloak_field || !facts.can_auto_cloak {
         return SensorCloakReevaluation::default();
     }
 
     // Snapshot before StartCloaking, its positional sound, or any targeter
     // mutation. This is the DynamicVector transaction in 0x006F4EB0.
     let reassigned_targeters = sensor_targeters_in_native_dispatch_order(sim, id);
-    let start = sim.substrate
+    let start = sim
+        .substrate
         .entities
         .get_mut(id)
         .and_then(|entity| entity.cloak.as_mut())
@@ -165,6 +267,205 @@ pub(crate) fn sensor_reevaluate_stock_cloak(
     }
 }
 
+/// `ObjectClass::Detach_All(false)` (vtable `+0xDC`, `0x005F5280`; the
+/// `FootClass` override is `0x004D9720`) → `DispatchPointerExpiredCleanup @
+/// 0x007258D0` → `TechnoClass::PointerExpired @ 0x007077C0` on every registered
+/// object, which `StartCloaking @ 0x00703770` runs before its own state writes.
+///
+/// The one clause that matters for cloak, verified from the decompile: the
+/// receiver's `Target(+0x2B4)` is cleared through `Assign_Target(NULL)` unless
+///
+/// * `allowClear` was cancelled — the receiver's OWN house holds a sensor count
+///   on the expiring object's cell (`param_1[0x87]->ArrayIndex` at
+///   `0x00707A0D`'s guard); or
+/// * the expiring object has the same owner (`expired->vt+0x3C == my pOwner`).
+///
+/// So a destroyer whose house covers the diving submarine keeps firing at it,
+/// and everyone else loses the target the instant the dive begins. Before this
+/// landed, VERA kept every attacker locked on until the next passive-scan
+/// cadence (~28 frames) re-evaluated.
+///
+/// Running this after `CloakRuntime::tick` has written the new state instead of
+/// before it is output-equivalent: the admission test reads only the cloaker's
+/// cell, its owner and each receiver's house — never the cloak state.
+///
+/// RESIDUAL — the targeting-delay re-arm. Native, on each receiver it does
+/// clear, first re-arms the `+0x180/+0x188` timer with a `RandomRanged(4, 8)`
+/// draw whenever that timer has more than 10 frames left. VERA does not
+/// reproduce it, because the timer's identity is UNCHECKED — `passive_scan_timer`
+/// is only its likely counterpart, and spending a Scenario draw on a guess would
+/// put an unprovable shift into the lockstep stream.
+/// - Trigger: any attacker losing a target to a cloak (or any other pointer
+///   expiry) with more than 10 frames left on that timer.
+/// - Player effect: the attacker's next passive scan happens on VERA's plain
+///   cadence instead of 4-8 frames out, so a re-acquire can be up to ~24 frames
+///   early or late.
+/// - Frequency: once per attacker per dive — common in naval play.
+/// - Downstream risk: adding the draw later moves every Scenario consumer in the
+///   same tick, so it must land with a golden re-baseline.
+fn detach_targeters_on_cloak(sim: &mut Simulation, cloaker_id: u64) -> Vec<u64> {
+    let Some(cloaker) = sim.substrate.entities.get(cloaker_id) else {
+        return Vec::new();
+    };
+    let cloaker_owner = cloaker.owner;
+    let cloaker_cell = (cloaker.position.rx, cloaker.position.ry);
+    let dropped: Vec<u64> = sim
+        .substrate
+        .entities
+        .iter_sorted()
+        .filter_map(|(targeter_id, targeter)| {
+            if targeter_id == cloaker_id {
+                return None;
+            }
+            let targets_cloaker = targeter
+                .attack_target
+                .as_ref()
+                .is_some_and(|target| target.target == TargetKind::Entity(cloaker_id));
+            if !targets_cloaker || targeter.owner == cloaker_owner {
+                return None;
+            }
+            let keeps_through_sensor =
+                sim.fog
+                    .has_sensor_for_house(targeter.owner, cloaker_cell.0, cloaker_cell.1);
+            (!keeps_through_sensor).then_some(targeter_id)
+        })
+        .collect();
+    for &targeter_id in &dropped {
+        if let Some(targeter) = sim.substrate.entities.get_mut(targeter_id) {
+            represented_assign_target(targeter, None);
+        }
+    }
+    dropped
+}
+
+/// Clockwise-from-north neighbour offsets, native `g_DirectionOffsets`
+/// (0x0089F688), indices 0..7 — the exact order `FootClass::PerCellProcess`
+/// walks its eight neighbours.
+const NEIGHBOUR_OFFSETS: [(i32, i32); 8] = [
+    (0, -1),
+    (1, -1),
+    (1, 0),
+    (1, 1),
+    (0, 1),
+    (-1, 1),
+    (-1, 0),
+    (-1, -1),
+];
+
+/// `FootClass::PerCellProcess @ 0x004D85D0`, the cell-enter (`param_2 == 2`)
+/// arm at `0x004D8802..0x004D8829` — the ONLY consumer of `Sensors=`
+/// (`TechnoTypeClass+0xC9D`) that is live in stock YR:
+///
+/// ```text
+/// if (CloakState(+0x220) == 2)
+///   for dir in 0..8 {
+///     n = myCell + g_DirectionOffsets[dir];
+///     if (!Is_Cell_In_Playfield(n, 1)) continue;
+///     o = CellClass::Find_Nearest_Object(n, coord(0,0), 0);
+///     if (o && !Is_Ally_ByObject(this, o)
+///           && (oType->Sensors(+0xC9D) || o->HasWeaponAbility(0xC)))
+///     { vt+0xFC(); break; }
+///   }
+/// ```
+///
+/// This is the "drive a Destroyer next to a moving submarine and it surfaces"
+/// rule. Note what it is NOT: the stationary case is not covered — a Destroyer
+/// parking beside a motionless submerged sub never forces it up; only the sub's
+/// own cell entry can. What the Destroyer's `SensorsSight=` deposit does instead
+/// is make the sub legal to target (the acquisition gate above) without touching
+/// its cloak state.
+///
+/// Substitutions, both recorded rather than hidden:
+/// * `CellClass::Find_Nearest_Object`'s selection rule was NOT read, so which
+///   single object native inspects when a neighbour cell holds several is
+///   UNCHECKED. VERA takes the lowest stable id in the cell, preserving the
+///   one-object-per-cell shape. It can disagree only when a neighbour cell
+///   holds two or more objects and exactly one of them is the detector.
+/// * `HasWeaponAbility(0xC)` is the SENSORS veteran/elite ability. No stock
+///   type lists it (`grep 'Abilities=.*SENSORS' ini/rulesmd.ini` is empty), so
+///   only the `Sensors=` type flag is consulted here.
+pub(crate) fn uncloak_on_sensor_neighbour_after_cell_entry(
+    sim: &mut Simulation,
+    id: u64,
+    rules: &RuleSet,
+) -> bool {
+    let Some(mover) = sim.substrate.entities.get(id) else {
+        return false;
+    };
+    if !mover
+        .cloak
+        .as_ref()
+        .is_some_and(|cloak| cloak.is_fully_cloaked())
+    {
+        return false;
+    }
+    let owner = mover.owner;
+    let owner_str = sim.interner.resolve(owner).to_owned();
+    let (rx, ry) = (i32::from(mover.position.rx), i32::from(mover.position.ry));
+
+    let mut triggered = false;
+    for (dx, dy) in NEIGHBOUR_OFFSETS {
+        let (nx, ny) = (rx + dx, ry + dy);
+        if nx < 0 || ny < 0 {
+            continue;
+        }
+        let (nx, ny) = (nx as u16, ny as u16);
+        // Native passes mode 1 — the height-aware `MapClass::IsCellInPlayfield`
+        // seam.
+        if !crate::sim::cell_rect::cell_is_in_playfield_height_aware(
+            (i32::from(nx), i32::from(ny)),
+            sim.playfield_bounds,
+            sim.resolved_terrain.as_ref(),
+        ) {
+            continue;
+        }
+        let Some(nearest) = sim
+            .substrate
+            .entities
+            .iter_sorted()
+            .find(|(_, other)| other.position.rx == nx && other.position.ry == ny)
+            .map(|(other_id, _)| other_id)
+        else {
+            continue;
+        };
+        let Some(other) = sim.substrate.entities.get(nearest) else {
+            continue;
+        };
+        let other_owner_str = sim.interner.resolve(other.owner);
+        if sim.fog.is_friendly(&owner_str, other_owner_str) || other.owner == owner {
+            continue;
+        }
+        let detects = rules
+            .object(sim.interner.resolve(other.type_ref))
+            .is_some_and(|object| object.sensors);
+        if !detects {
+            continue;
+        }
+        triggered = true;
+        break;
+    }
+    if !triggered {
+        return false;
+    }
+    let cloaking_speed = sim
+        .substrate
+        .entities
+        .get(id)
+        .and_then(|entity| rules.object(sim.interner.resolve(entity.type_ref)))
+        .map_or(1, |object| object.cloaking_speed);
+    let now = sim.session.binary_frame as i32;
+    let surfaced = sim
+        .substrate
+        .entities
+        .get_mut(id)
+        .and_then(|entity| entity.cloak.as_mut())
+        .map(|cloak| cloak.start_uncloaking_from_sensor_neighbour(now, cloaking_speed));
+    if surfaced.is_some_and(|result| result.play_sound) {
+        emit_configured_cloak_sound(sim, id, rules);
+    }
+    surfaced.is_some_and(|result| result.transitioned)
+}
+
 fn emit_configured_cloak_sound(sim: &mut Simulation, id: u64, rules: &RuleSet) {
     let Some(sound_name) = rules.general.cloak_sound.as_deref() else {
         return;
@@ -178,7 +479,10 @@ fn emit_configured_cloak_sound(sim: &mut Simulation, id: u64, rules: &RuleSet) {
         return;
     };
     sim.sound_events
-        .push(crate::sim::world::SimSoundEvent::cloak_sound(sound_name.to_owned(), &position));
+        .push(crate::sim::world::SimSoundEvent::cloak_sound(
+            sound_name.to_owned(),
+            &position,
+        ));
 }
 
 fn health_strictly_above_condition_red(
@@ -207,8 +511,8 @@ pub(super) fn tick_stock_cloak_producer(sim: &mut Simulation, id: u64, rules: &R
     let Some(object) = rules.object(sim.interner.resolve(type_ref)) else {
         return;
     };
-    let rank_cloak = veterancy >= 100 && object.veteran_cloak
-        || veterancy >= 200 && object.elite_cloak;
+    let rank_cloak =
+        veterancy >= 100 && object.veteran_cloak || veterancy >= 200 && object.elite_cloak;
     if !object.cloakable && !rank_cloak {
         return;
     }
@@ -235,6 +539,26 @@ pub(super) fn tick_stock_cloak_producer(sim: &mut Simulation, id: u64, rules: &R
         .get_mut(id)
         .and_then(|entity| entity.cloak.as_mut())
         .map(|cloak| cloak.tick(facts, &mut sim.scenario_rng));
+    if result.is_some_and(|result| result.began_cloaking) {
+        // `StartCloaking @ 0x00703770` opens with `Detach_All(false)`.
+        detach_targeters_on_cloak(sim, id);
+    }
+    if result.is_some_and(|result| result.completed_cloak) {
+        // The 1 → 2 completion at `0x006FBA98` snapshots the still-admitted
+        // targeters (sensed-or-same-owner), runs `Detach_All(false)` again, then
+        // re-`Assign_Target`s each saved one in reverse-of-reverse order. The
+        // re-assign is a no-op for the pointer itself — `Assign_Target @
+        // 0x006FCDB0` returns early on an unchanged target — but it still clears
+        // each receiver's passive-acquire provenance byte `+0x50C` first, which
+        // `represented_assign_target` reproduces.
+        let retained = sensor_targeters_in_native_dispatch_order(sim, id);
+        detach_targeters_on_cloak(sim, id);
+        for targeter_id in retained {
+            if let Some(targeter) = sim.substrate.entities.get_mut(targeter_id) {
+                represented_assign_target(targeter, Some(TargetKind::Entity(id)));
+            }
+        }
+    }
     if result.is_some_and(|result| result.play_cloak_sound) {
         emit_configured_cloak_sound(sim, id, rules);
     }

--- a/src/sim/world/techno_ai_cloak.rs
+++ b/src/sim/world/techno_ai_cloak.rs
@@ -5,6 +5,8 @@ use crate::rules::ruleset::RuleSet;
 use crate::sim::combat::TargetKind;
 use crate::sim::intern::InternedId;
 use crate::sim::mission::concrete_effects::represented_assign_target;
+use crate::sim::movement::locomotor::MovementLayer;
+use crate::util::native_x87::{X87Chop53, sqrt_approx_f32};
 
 use super::Simulation;
 
@@ -55,8 +57,12 @@ fn stock_cloak_tick_facts(
     // Unit override `0x00746C90` ORs in `DeployTarget(+0x6CC) != -1`), and
     // vt+0x1D4/+0x1D8 are the chrono warp-in/warp-out flags.
     //
-    // RESIDUAL — no EMP mechanism exists in VERA. `+0x504` has no Rust
-    // counterpart, so the EMP term is hardcoded false here.
+    // RESIDUAL — **EMP decloak is NOT IMPLEMENTED, and this requirement is
+    // therefore UNMET, not closed.** VERA has no EMP mechanism anywhere: there
+    // is no Rust counterpart to `+0x504`, nothing writes an EMP timer, and the
+    // term is hardcoded false at both of its uses in this file. Closing it is
+    // not a cloak change — it lands with an EMP weapon/warhead system, and this
+    // gate is one of that system's consumers.
     // - Trigger: any EMP warhead landing on a cloaked object (stock sources:
     //   the EMPulse Cannon superweapon and the Boomer/Robot EMP warheads).
     // - Player effect: in gamemd an EMP'd Typhoon or Mirage surfaces for the
@@ -315,16 +321,25 @@ pub(crate) fn sensor_reevaluate_stock_cloak(
 
 /// `ObjectClass::Detach_All(false)` (vtable `+0xDC`, `0x005F5280`; the
 /// `FootClass` override is `0x004D9720`) → `DispatchPointerExpiredCleanup @
-/// 0x007258D0` → `TechnoClass::PointerExpired @ 0x007077C0` on every registered
-/// object, which `StartCloaking @ 0x00703770` runs before its own state writes.
+/// 0x007258D0` with control 0 → `TechnoClass::PointerExpired @ 0x007077C0` on
+/// every registered object, which `StartCloaking @ 0x00703770` runs before its
+/// own state writes.
 ///
-/// The one clause that matters for cloak, verified from the decompile: the
-/// receiver's `Target(+0x2B4)` is cleared through `Assign_Target(NULL)` unless
+/// This is the SAME native body the UnInit broadcast runs, only with a
+/// different control value, so it is routed through the one Rust model of it
+/// (`Simulation::detach_all_pointer_expired`) rather than a cloak-local copy.
+/// A miniature copy would have cleared the receiver's Target and nothing else —
+/// no `RandomRanged(4, 8)` re-arm of the `+0x180/+0x188` targeting timer, no
+/// radio-contact null, no cargo/NavCom/manager slot clears, and none of it for
+/// the non-targeters `Detach_All` also visits.
+///
+/// The clause that matters most for cloak: the receiver's `Target(+0x2B4)` is
+/// cleared through `Assign_Target(NULL)` unless
 ///
 /// * `allowClear` was cancelled — the receiver's OWN house holds a sensor count
-///   on the expiring object's cell (`param_1[0x87]->ArrayIndex` at
-///   `0x00707A0D`'s guard); or
-/// * the expiring object has the same owner (`expired->vt+0x3C == my pOwner`).
+///   on the expiring object's cell (`0x00707994 CALL 0x004870D0`); or
+/// * the expiring object has the same owner (`expired->vt+0x3C == my +0x21C`,
+///   `0x007079B7..0x007079CB`).
 ///
 /// So a destroyer whose house covers the diving submarine keeps firing at it,
 /// and everyone else loses the target the instant the dive begins. Before this
@@ -334,54 +349,8 @@ pub(crate) fn sensor_reevaluate_stock_cloak(
 /// Running this after `CloakRuntime::tick` has written the new state instead of
 /// before it is output-equivalent: the admission test reads only the cloaker's
 /// cell, its owner and each receiver's house — never the cloak state.
-///
-/// RESIDUAL — the targeting-delay re-arm. Native, on each receiver it does
-/// clear, first re-arms the `+0x180/+0x188` timer with a `RandomRanged(4, 8)`
-/// draw whenever that timer has more than 10 frames left. VERA does not
-/// reproduce it, because the timer's identity is UNCHECKED — `passive_scan_timer`
-/// is only its likely counterpart, and spending a Scenario draw on a guess would
-/// put an unprovable shift into the lockstep stream.
-/// - Trigger: any attacker losing a target to a cloak (or any other pointer
-///   expiry) with more than 10 frames left on that timer.
-/// - Player effect: the attacker's next passive scan happens on VERA's plain
-///   cadence instead of 4-8 frames out, so a re-acquire can be up to ~24 frames
-///   early or late.
-/// - Frequency: once per attacker per dive — common in naval play.
-/// - Downstream risk: adding the draw later moves every Scenario consumer in the
-///   same tick, so it must land with a golden re-baseline.
-fn detach_targeters_on_cloak(sim: &mut Simulation, cloaker_id: u64) -> Vec<u64> {
-    let Some(cloaker) = sim.substrate.entities.get(cloaker_id) else {
-        return Vec::new();
-    };
-    let cloaker_owner = cloaker.owner;
-    let cloaker_cell = (cloaker.position.rx, cloaker.position.ry);
-    let dropped: Vec<u64> = sim
-        .substrate
-        .entities
-        .iter_sorted()
-        .filter_map(|(targeter_id, targeter)| {
-            if targeter_id == cloaker_id {
-                return None;
-            }
-            let targets_cloaker = targeter
-                .attack_target
-                .as_ref()
-                .is_some_and(|target| target.target == TargetKind::Entity(cloaker_id));
-            if !targets_cloaker || targeter.owner == cloaker_owner {
-                return None;
-            }
-            let keeps_through_sensor =
-                sim.fog
-                    .has_sensor_for_house(targeter.owner, cloaker_cell.0, cloaker_cell.1);
-            (!keeps_through_sensor).then_some(targeter_id)
-        })
-        .collect();
-    for &targeter_id in &dropped {
-        if let Some(targeter) = sim.substrate.entities.get_mut(targeter_id) {
-            represented_assign_target(targeter, None);
-        }
-    }
-    dropped
+fn detach_targeters_on_cloak(sim: &mut Simulation, cloaker_id: u64) {
+    sim.detach_all_pointer_expired(cloaker_id);
 }
 
 /// Clockwise-from-north neighbour offsets, native `g_DirectionOffsets`
@@ -397,6 +366,75 @@ const NEIGHBOUR_OFFSETS: [(i32, i32); 8] = [
     (-1, 0),
     (-1, -1),
 ];
+
+/// `CellClass::Find_Nearest_Object @ 0x0047C3D0`, read from the disassembly for
+/// the one callsite that matters here (`0x004D87DD`, which passes offset
+/// `{0, 0}`, `alt = 0` and `exclude = NULL`):
+///
+/// ```text
+/// dx7 = offset.X * 7;  dy7 = offset.Y * 7;
+/// for (o = cell->FirstObject(+0xE4); o; o = o->NextObject(+0x30)) {
+///   if (!(o->AbstractFlags(+0x14) & 1)) continue;   // Techno only
+///   if (o == exclude) continue;
+///   c  = o->GetCoords(vt+0x48);
+///   d  = ftol(Sqrt_Approx(sq((c.X & 0xFF) - dx7) + sq((c.Y & 0xFF) - dy7)));
+///   if (best == NULL || d < bestDistance) { best = o; bestDistance = d; }
+/// }
+/// ```
+///
+/// Three things this fixes over the previous "lowest stable id whose
+/// `position` matches" scan:
+///
+/// * **The candidate set is the cell's object list, not every entity parked on
+///   the coordinate.** `techno_limbo` never clears `entity.position`, so a
+///   limboed object keeps a map position for the rest of the match; native
+///   walks `CellClass::FirstObject`, which a limboed object is unlinked from.
+///   `substrate.occupancy` is VERA's model of that list — the same authority
+///   `sensor_lifecycle::sensor_residents_in_native_order` uses — and the
+///   `MovementLayer::Ground` list is the `+0xE4` chain (`+0xE8`, the `alt`
+///   chain, is selected only when `param_3 != 0`, and this callsite passes 0).
+/// * **Selection is nearest-to-the-cell-origin, not lowest id.** With a
+///   `{0, 0}` offset the distance is the object's own sub-cell lepton offset
+///   from the cell's NW corner, through the retail `Sqrt_Approx` LUT and a
+///   truncating `ftol` — so two objects whose distances truncate to the same
+///   integer are decided by list order, and `<` keeps the earlier one.
+/// * **The `+0x14` bit-0 test is the `AbstractFlags` *Techno identity* bit**
+///   (`TechnoClass__Constructor @ 0x006F3228` ORs in 1;
+///   `ObjectClass__Constructor @ 0x005F3B34` ORs in 2), not an on-map flag.
+///   Every `GameEntity` is a Techno, so it needs no counterpart here.
+fn find_nearest_object_in_cell(sim: &Simulation, cell: (u16, u16)) -> Option<u64> {
+    let occupancy = sim.substrate.occupancy.get(cell.0, cell.1)?;
+    let mut best: Option<(u64, i32)> = None;
+    for occupant in occupancy.iter_layer(MovementLayer::Ground) {
+        let Some(other) = sim.substrate.entities.get(occupant.entity_id) else {
+            continue;
+        };
+        let distance = native_subcell_distance_from_cell_origin(
+            other.position.sub_x.to_num::<i32>(),
+            other.position.sub_y.to_num::<i32>(),
+        );
+        if best.is_none_or(|(_, best_distance)| distance < best_distance) {
+            best = Some((occupant.entity_id, distance));
+        }
+    }
+    best.map(|(entity_id, _)| entity_id)
+}
+
+/// The x87 half of `Find_Nearest_Object`: `FILD` both signed deltas, square and
+/// sum them in `(dx*dx) + (dy*dy)` order, run the retail `Sqrt_Approx @
+/// 0x004CAC40` LUT, then `Math__ftol @ 0x007C5F00`.
+fn native_subcell_distance_from_cell_origin(sub_x: i32, sub_y: i32) -> i32 {
+    let dx = X87Chop53::load_i32(sub_x);
+    let dy = X87Chop53::load_i32(sub_y);
+    let squared = X87Chop53::add(X87Chop53::mul(dx, dx), X87Chop53::mul(dy, dy));
+    let Ok(root_bits) = sqrt_approx_f32(squared) else {
+        return i32::MAX;
+    };
+    let Ok(root) = X87Chop53::load_f32(root_bits) else {
+        return i32::MAX;
+    };
+    X87Chop53::ftol_i64(root).map_or(i32::MAX, |distance| distance as i32)
+}
 
 /// `FootClass::PerCellProcess @ 0x004D85D0`, the cell-enter (`param_2 == 2`)
 /// arm at `0x004D8802..0x004D8829` — the ONLY consumer of `Sensors=`
@@ -421,15 +459,10 @@ const NEIGHBOUR_OFFSETS: [(i32, i32); 8] = [
 /// is make the sub legal to target (the acquisition gate above) without touching
 /// its cloak state.
 ///
-/// Substitutions, both recorded rather than hidden:
-/// * `CellClass::Find_Nearest_Object`'s selection rule was NOT read, so which
-///   single object native inspects when a neighbour cell holds several is
-///   UNCHECKED. VERA takes the lowest stable id in the cell, preserving the
-///   one-object-per-cell shape. It can disagree only when a neighbour cell
-///   holds two or more objects and exactly one of them is the detector.
-/// * `HasWeaponAbility(0xC)` is the SENSORS veteran/elite ability. No stock
-///   type lists it (`grep 'Abilities=.*SENSORS' ini/rulesmd.ini` is empty), so
-///   only the `Sensors=` type flag is consulted here.
+/// One substitution, recorded rather than hidden: `HasWeaponAbility(0xC)` is
+/// the SENSORS veteran/elite ability. No stock type lists it
+/// (`grep 'Abilities=.*SENSORS' ini/rulesmd.ini` is empty), so only the
+/// `Sensors=` type flag is consulted here.
 pub(crate) fn uncloak_on_sensor_neighbour_after_cell_entry(
     sim: &mut Simulation,
     id: u64,
@@ -465,13 +498,7 @@ pub(crate) fn uncloak_on_sensor_neighbour_after_cell_entry(
         ) {
             continue;
         }
-        let Some(nearest) = sim
-            .substrate
-            .entities
-            .iter_sorted()
-            .find(|(_, other)| other.position.rx == nx && other.position.ry == ny)
-            .map(|(other_id, _)| other_id)
-        else {
+        let Some(nearest) = find_nearest_object_in_cell(sim, (nx, ny)) else {
             continue;
         };
         let Some(other) = sim.substrate.entities.get(nearest) else {

--- a/src/sim/world/techno_ai_cloak.rs
+++ b/src/sim/world/techno_ai_cloak.rs
@@ -102,6 +102,37 @@ fn stock_cloak_tick_facts(
         owner_cloak_field_bit(sim, entity.owner, entity.position.rx, entity.position.ry);
 
     // `TechnoClass::CanAutoCloak @ 0x006FBDC0`, in native step order.
+    //
+    // Step 1's fall-through is `if (!CloakedByHouses(cell, owner) && +0x3D2 ==
+    // 0) return false`. `+0x3D2` is the raw stealth-ability byte:
+    // `TechnoClass::HasStealthAbility @ 0x0070C5A0` is literally `return
+    // +0x3D2 != 0`, and it is seeded at init from `TechnoTypeClass+0xCD0`
+    // (`Cloakable=`) — `InfantryClass::InitFromType @ 0x00517D80`,
+    // `UnitClass::Constructor @ 0x007355B4`, `TechnoClass::Constructor @
+    // 0x006F2F49`. `object.cloakable` below is that seed, so the term is
+    // modelled. TWO halves of it are not; both are inert in stock YR:
+    //
+    // RESIDUAL 1 — the Cloak CRATE also sets `+0x3D2 = 1` permanently, on every
+    // object within `[CrateRules] CrateRadius` (`Rules+0x172C`, 3.0 cells) of
+    // the picked-up crate: `CrateClass::PickupDispatch @ 0x0048294F`, the arm
+    // whose anim comes from the powerup anim table at `0x0081DAD8` (slot 3 =
+    // `Cloak`, anim `CLOAK`). VERA has no Cloak-crate producer.
+    // - Trigger: a unit picking up a Cloak crate.
+    // - Player effect: in gamemd every unit within three cells is permanently
+    //   cloakable afterwards; in VERA nothing happens.
+    // - Frequency: ZERO in stock. `[Powerups]` in `rulesmd.ini` does not spell
+    //   `Cloak=` at all, and an absent row takes `ReadPowerups`' `"0,NONE"`
+    //   default, so the Cloak crate's selection weight is 0 and it never
+    //   spawns. Only a mod that authors a nonzero `Cloak=` weight reaches it.
+    // - Downstream risk: none; it lands as one extra per-entity flag OR-ed into
+    //   `is_cloakable` here and in `should_uncloak` below.
+    //
+    // RESIDUAL 2 — native ORs the RAW `+0x3D2` here, not vt+0x288, so the two
+    // differ exactly when `FootClass::IsCloakable @ 0x004DBDA0` suppresses a
+    // stealth unit for `CloakStop=` while it is moving: native still passes
+    // step 1, VERA refuses. `grep -c '^CloakStop' ini/rulesmd.ini` is 0, so no
+    // stock type can trigger it. Same asymmetry in `should_uncloak` below.
+    // - Frequency: zero in stock; mod-only.
     let can_auto_cloak = (is_cloakable || rank_cloak || cloaked_by_own_house)
         // 2. already fully cloaked.
         && cloak_state != 2
@@ -114,9 +145,16 @@ fn stock_cloak_tick_facts(
         //    unit holding a target no weapon can engage, which VERA's
         //    acquisition and retaliation paths do not install.
         && !holds_target
-        // 5. `WhatAmI != Building && CloakProgress(+0x224) != 0`. This is why
-        //    the state-3 silent re-cloak branch is unreachable for units:
-        //    visual state 1 requires a nonzero progress.
+        // 5. `iVar3 = vt+0x2C(); if (iVar3 != 6 && CloakProgress(+0x224) != 0)
+        //    return false` — a BUILDING is exempt from the progress test, every
+        //    other category is not. This producer is entered only for
+        //    `EntityCategory::Unit` (see the head of this function), so
+        //    `WhatAmI != 6` holds for every object that reaches here and the
+        //    exemption is structurally unreachable rather than dropped. It is
+        //    also unreachable in gamemd data: no stock section pairs
+        //    `Cloakable=yes` with a building. This is why the state-3 silent
+        //    re-cloak branch is unreachable for units: visual state 1 requires
+        //    a nonzero progress.
         && cloak_progress == 0
         // 7. the mind-control arm (`+0x2B0` plus the FootClass `+0x6AD` byte).
         && !entity.mind_controlled
@@ -135,6 +173,10 @@ fn stock_cloak_tick_facts(
     // The tail therefore returns 1 in stock YR, so the predicate reduces to
     // "the object can no longer sustain its cloak" — EMP, chrono warp, a
     // pending deploy, `CloakStop=` while moving, or a lost stealth ability.
+    // The `|| +0x3D2` disjunct is the raw stealth byte; see the two `+0x3D2`
+    // residuals on `can_auto_cloak` above — `object.cloakable` inside
+    // `is_cloakable` is that byte's stock seed, and the crate-granted and
+    // `CloakStop=`-while-moving halves are both unreachable in stock data.
     let should_uncloak = if is_cloakable && !emp_active && !deploy_pending && !chrono_active {
         false
     } else if rank_cloak {

--- a/src/sim/world/techno_ai_cloak.rs
+++ b/src/sim/world/techno_ai_cloak.rs
@@ -120,10 +120,14 @@ fn stock_cloak_tick_facts(
     // - Trigger: a unit picking up a Cloak crate.
     // - Player effect: in gamemd every unit within three cells is permanently
     //   cloakable afterwards; in VERA nothing happens.
-    // - Frequency: ZERO in stock. `[Powerups]` in `rulesmd.ini` does not spell
-    //   `Cloak=` at all, and an absent row takes `ReadPowerups`' `"0,NONE"`
-    //   default, so the Cloak crate's selection weight is 0 and it never
-    //   spawns. Only a mod that authors a nonzero `Cloak=` weight reaches it.
+    // - Frequency: ZERO in stock, by an AUTHORED zero rather than an absent
+    //   row: `ini/rulesmd.ini` `[Powerups]` spells `Cloak=0,CLOAK,yes`. The
+    //   weights are the selection authority (`CrateClass::PickupDispatch` sums
+    //   the nineteen and draws `RandomRanged(1, total)`), so a 0-weight slot is
+    //   never picked — `src/rules/powerups.rs`
+    //   `stock_section_parses_the_verified_weight_vector` pins that row's 0 in
+    //   the parsed vector (total 110). Only a mod that authors a nonzero
+    //   `Cloak=` weight reaches it.
     // - Downstream risk: none; it lands as one extra per-entity flag OR-ed into
     //   `is_cloakable` here and in `should_uncloak` below.
     //

--- a/src/sim/world/techno_ai_cloak_tests.rs
+++ b/src/sim/world/techno_ai_cloak_tests.rs
@@ -5,6 +5,7 @@ use crate::sim::combat::combat_weapon::WeaponSlot;
 use crate::sim::combat::{AttackTarget, TargetKind};
 use crate::sim::game_entity::PendingBuildingFire;
 use crate::sim::snapshot::GameSnapshot;
+use crate::util::fixed_math::SimFixed;
 
 fn rules() -> RuleSet {
     RuleSet::from_ini(&IniFile::from_str(
@@ -665,6 +666,11 @@ fn start_cloaking_drops_every_targeter_whose_house_cannot_sense_the_cell() {
     let american = sim.substrate.entities.get(sensing).unwrap().owner;
     sim.fog.increment_sensor_at(american, cell.0, cell.1);
 
+    let timers_before: Vec<_> = [sensing, blind, same_owner]
+        .map(|id| sim.substrate.entities.get(id).unwrap().passive_scan_timer)
+        .to_vec();
+    let mut expected_rng = sim.scenario_rng.clone();
+    let rng_before = sim.scenario_rng.logical_state();
     tick_stock_cloak_producer(&mut sim, cloaker, &rules);
     assert_eq!(
         sim.substrate
@@ -704,4 +710,170 @@ fn start_cloaking_drops_every_targeter_whose_house_cannot_sense_the_cell() {
             .is_none(),
         "everyone else loses the pointer at the instant of StartCloaking"
     );
+
+    // `TechnoClass::PointerExpired @ 0x007079D1..0x00707A0D` re-arms the
+    // `+0x180/+0x188` targeting timer with `RandomRanged(4, 8)` — one Scenario
+    // draw — before `Assign_Target(NULL)`, and only on the arm that actually
+    // clears. So exactly one receiver here spends a draw. The healthy cloak
+    // producer itself consumes none (see
+    // `stock_cloak_producer_healthy_trace_uses_type_speed_and_no_rng`), so the
+    // whole delta below belongs to the detach.
+    assert_ne!(
+        sim.scenario_rng.logical_state(),
+        rng_before,
+        "the dive must spend the targeting-delay draw"
+    );
+    let drawn = expected_rng.next_range_u32_inclusive(4, 8);
+    assert_eq!(
+        sim.scenario_rng.logical_state(),
+        expected_rng.logical_state(),
+        "only the receiver that loses its target spends the RandomRanged(4, 8) draw"
+    );
+    let timers_after: Vec<_> = [sensing, blind, same_owner]
+        .map(|id| sim.substrate.entities.get(id).unwrap().passive_scan_timer)
+        .to_vec();
+    assert_eq!(
+        timers_after[0], timers_before[0],
+        "a retained target leaves the sensing receiver's timer untouched"
+    );
+    assert_eq!(
+        timers_after[2], timers_before[2],
+        "the same-owner exemption also skips the re-arm"
+    );
+    assert_ne!(timers_after[1], timers_before[1]);
+    assert_eq!(timers_after[1].start_frame, sim.session.binary_frame);
+    assert_eq!(
+        timers_after[1].duration, drawn,
+        "the re-armed delay is the RandomRanged(4, 8) result"
+    );
+}
+
+#[test]
+fn a_dive_detaches_the_full_pointer_expiry_slot_family_not_just_the_target() {
+    // `Detach_All(false)` runs the SAME `TechnoClass::PointerExpired @
+    // 0x007077C0` body as UnInit over EVERY registered object, so a receiver
+    // that never targeted the diving object still loses its radio contact —
+    // `RadioClass::PointerExpired` nulls matching sparse slots regardless of
+    // the control value. Only the `+0x2B4`/`+0x2B8` pair is behind `allowClear`.
+    let (mut sim, rules, cloaker) = spawned_sub();
+    let cell = sim
+        .substrate
+        .entities
+        .get(cloaker)
+        .map(|entity| (entity.position.rx, entity.position.ry))
+        .unwrap();
+    let bystander = sim
+        .spawn_object_at_height("RANKED", "Neutral", cell.0 + 2, cell.1, 0, 0, &rules)
+        .unwrap();
+    sim.substrate
+        .entities
+        .get_mut(bystander)
+        .unwrap()
+        .mark_live_contact_with(cloaker);
+    // A non-targeter spends no draw: the re-arm is inside the Target arm.
+    let rng_before = sim.scenario_rng.logical_state();
+
+    tick_stock_cloak_producer(&mut sim, cloaker, &rules);
+
+    assert!(
+        !sim.substrate
+            .entities
+            .get(bystander)
+            .unwrap()
+            .has_live_contact_with(cloaker),
+        "the dive nulls the radio contact the old cloak-local sweep never visited"
+    );
+    assert_eq!(sim.scenario_rng.logical_state(), rng_before);
+}
+
+#[test]
+fn a_limboed_entity_on_the_cell_no_longer_shadows_the_sensors_neighbour() {
+    // `CellClass::Find_Nearest_Object @ 0x0047C3D0` walks the cell's own object
+    // chain (`+0xE4`). `techno_limbo` unmarks the entity from the occupancy
+    // grid — VERA's model of that chain — but never clears `entity.position`,
+    // so a raw position scan kept finding the stale object and, taking the
+    // first match, hid the Destroyer behind it.
+    let (mut sim, rules, id) = spawned_sub();
+    let cell = sim
+        .substrate
+        .entities
+        .get(id)
+        .map(|entity| (entity.position.rx, entity.position.ry))
+        .unwrap();
+    sim.substrate
+        .entities
+        .get_mut(id)
+        .unwrap()
+        .cloak
+        .as_mut()
+        .unwrap()
+        .establish_unlimbo_fully_cloaked();
+
+    // Lower stable id than the Destroyer, and it carries no `Sensors=`.
+    let stale = sim
+        .spawn_object_at_height("RANKED", "Neutral", cell.0 + 1, cell.1, 0, 0, &rules)
+        .unwrap();
+    let dest = sim
+        .spawn_object_at_height("DEST", "Americans", cell.0 + 1, cell.1, 0, 0, &rules)
+        .unwrap();
+    assert!(stale < dest);
+    sim.techno_limbo_with_rules(stale, &rules);
+    assert_eq!(
+        sim.substrate.entities.get(stale).unwrap().position.rx,
+        cell.0 + 1,
+        "limbo leaves the stale map position in place, which is why the raw scan was wrong"
+    );
+
+    assert!(
+        uncloak_on_sensor_neighbour_after_cell_entry(&mut sim, id, &rules),
+        "an off-chain limboed object must not shadow the Destroyer"
+    );
+}
+
+#[test]
+fn the_sensors_neighbour_pick_is_nearest_to_the_cell_origin_not_lowest_id() {
+    // With the `{0, 0}` offset the callsite passes, `Find_Nearest_Object`
+    // ranks by `ftol(Sqrt_Approx((X & 0xFF)^2 + (Y & 0xFF)^2))` — the object's
+    // own sub-cell lepton offset from the cell's NW corner — and keeps the
+    // first of equal distances.
+    for dest_wins in [false, true] {
+        let (mut sim, rules, id) = spawned_sub();
+        let cell = sim
+            .substrate
+            .entities
+            .get(id)
+            .map(|entity| (entity.position.rx, entity.position.ry))
+            .unwrap();
+        sim.substrate
+            .entities
+            .get_mut(id)
+            .unwrap()
+            .cloak
+            .as_mut()
+            .unwrap()
+            .establish_unlimbo_fully_cloaked();
+
+        let blocker = sim
+            .spawn_object_at_height("RANKED", "Neutral", cell.0 + 1, cell.1, 0, 0, &rules)
+            .unwrap();
+        let dest = sim
+            .spawn_object_at_height("DEST", "Americans", cell.0 + 1, cell.1, 0, 0, &rules)
+            .unwrap();
+        let (near, far) = if dest_wins {
+            (dest, blocker)
+        } else {
+            (blocker, dest)
+        };
+        for (entity_id, offset) in [(near, 10i32), (far, 200i32)] {
+            let entity = sim.substrate.entities.get_mut(entity_id).unwrap();
+            entity.position.sub_x = SimFixed::from_num(offset);
+            entity.position.sub_y = SimFixed::from_num(offset);
+        }
+
+        assert_eq!(
+            uncloak_on_sensor_neighbour_after_cell_entry(&mut sim, id, &rules),
+            dest_wins,
+            "the single inspected object is the one nearest the cell origin"
+        );
+    }
 }

--- a/src/sim/world/techno_ai_cloak_tests.rs
+++ b/src/sim/world/techno_ai_cloak_tests.rs
@@ -3,6 +3,7 @@ use crate::map::playfield::PlayfieldBounds;
 use crate::rules::ini_parser::IniFile;
 use crate::sim::combat::combat_weapon::WeaponSlot;
 use crate::sim::combat::{AttackTarget, TargetKind};
+use crate::sim::components::NavTargetRef;
 use crate::sim::game_entity::PendingBuildingFire;
 use crate::sim::snapshot::GameSnapshot;
 use crate::util::fixed_math::SimFixed;
@@ -749,12 +750,14 @@ fn start_cloaking_drops_every_targeter_whose_house_cannot_sense_the_cell() {
 }
 
 #[test]
-fn a_dive_detaches_the_full_pointer_expiry_slot_family_not_just_the_target() {
-    // `Detach_All(false)` runs the SAME `TechnoClass::PointerExpired @
-    // 0x007077C0` body as UnInit over EVERY registered object, so a receiver
-    // that never targeted the diving object still loses its radio contact —
-    // `RadioClass::PointerExpired` nulls matching sparse slots regardless of
-    // the control value. Only the `+0x2B4`/`+0x2B8` pair is behind `allowClear`.
+fn a_dive_reaches_every_registered_object_but_leaves_radio_contacts_intact() {
+    // `Detach_All(false)` runs the SAME `TechnoClass -> RadioClass ->
+    // ObjectClass` body as UnInit over EVERY registered object, so a receiver
+    // that never targeted the diving object is still visited. But
+    // `RadioClass::PointerExpired @ 0x0065AAC0` nulls a matching sparse slot
+    // only on a NONZERO control — `0065aaf0 TEST BL,BL / 0065aaf2 JZ` skips the
+    // `0065aaf4 MOV dword ptr [EAX],0x0` on control 0. So a dive leaves the
+    // contact standing and only the UnInit at the end breaks it.
     let (mut sim, rules, cloaker) = spawned_sub();
     let cell = sim
         .substrate
@@ -776,14 +779,95 @@ fn a_dive_detaches_the_full_pointer_expiry_slot_family_not_just_the_target() {
     tick_stock_cloak_producer(&mut sim, cloaker, &rules);
 
     assert!(
+        sim.substrate
+            .entities
+            .get(bystander)
+            .unwrap()
+            .has_live_contact_with(cloaker),
+        "a dive is control 0, so the radio contact survives the broadcast"
+    );
+    assert_eq!(sim.scenario_rng.logical_state(), rng_before);
+
+    // Control 1 — `ObjectClass::UnInit` dispatches the same roster walk with a
+    // nonzero control at `0x005F6616`, and the slot clear then runs.
+    sim.techno_limbo_with_rules(cloaker, &rules);
+    assert!(
         !sim.substrate
             .entities
             .get(bystander)
             .unwrap()
             .has_live_contact_with(cloaker),
-        "the dive nulls the radio contact the old cloak-local sweep never visited"
+        "UnInit is control 1, so the same slot clear does fire"
     );
-    assert_eq!(sim.scenario_rng.logical_state(), rng_before);
+}
+
+#[test]
+fn a_sensing_house_keeps_both_target_and_destination_across_a_dive() {
+    // `FootClass::PointerExpired @ 0x004D9960` computes its own `allowClear`
+    // from a SECOND `SensorCountForHouse` call — `0x004D9A57 CALL 0x004870D0`,
+    // at the diving object's `GetCoords` cell for the RECEIVER's house — and
+    // that Boolean gates the `+0x5A0`/`+0x5A4` NavCom pair clear exactly as the
+    // Techno body's copy gates the `+0x2B4`/`+0x2B8` Target pair. So a
+    // Destroyer whose house senses the sub's cell keeps CHASING it, not just
+    // shooting at it. `+0x5A8` (SuspendedNavCom) is cleared above that guard
+    // and goes on both controls.
+    let (mut sim, rules, cloaker) = spawned_sub();
+    let cell = sim
+        .substrate
+        .entities
+        .get(cloaker)
+        .map(|entity| (entity.position.rx, entity.position.ry))
+        .unwrap();
+    let sensing = sim
+        .spawn_object_at_height("DEST", "Americans", cell.0 + 1, cell.1, 0, 0, &rules)
+        .unwrap();
+    // RANKED carries no `SensorsSight=`, so it deposits nothing and stays blind.
+    let blind = sim
+        .spawn_object_at_height("RANKED", "Neutral", cell.0 + 2, cell.1, 0, 0, &rules)
+        .unwrap();
+    for chaser in [sensing, blind] {
+        let entity = sim.substrate.entities.get_mut(chaser).unwrap();
+        entity.attack_target = Some(AttackTarget::new(cloaker));
+        entity.navigation.nav_com = Some(NavTargetRef::object(cloaker));
+        entity.navigation.nav_com_aux = Some(NavTargetRef::object(cloaker));
+        entity.navigation.suspended_nav_com = Some(NavTargetRef::object(cloaker));
+    }
+    let american = sim.substrate.entities.get(sensing).unwrap().owner;
+    sim.fog.increment_sensor_at(american, cell.0, cell.1);
+
+    tick_stock_cloak_producer(&mut sim, cloaker, &rules);
+
+    let sensing_after = sim.substrate.entities.get(sensing).unwrap();
+    assert!(
+        sensing_after.attack_target.is_some(),
+        "the sensing house keeps its Target (+0x2B4)"
+    );
+    assert_eq!(
+        sensing_after.navigation.nav_com,
+        Some(NavTargetRef::object(cloaker)),
+        "and keeps its destination (+0x5A4) — it must not stop closing"
+    );
+    assert_eq!(
+        sensing_after.navigation.nav_com_aux,
+        Some(NavTargetRef::object(cloaker)),
+        "the +0x5A0 half of the pair is behind the same allowClear"
+    );
+    assert_eq!(
+        sensing_after.navigation.suspended_nav_com, None,
+        "+0x5A8 is cleared above the guard, so it goes even for a sensing house"
+    );
+
+    let blind_after = sim.substrate.entities.get(blind).unwrap();
+    assert!(
+        blind_after.attack_target.is_none(),
+        "a blind house loses the Target"
+    );
+    assert_eq!(
+        blind_after.navigation.nav_com, None,
+        "and loses the destination with it"
+    );
+    assert_eq!(blind_after.navigation.nav_com_aux, None);
+    assert_eq!(blind_after.navigation.suspended_nav_com, None);
 }
 
 #[test]

--- a/src/sim/world/techno_ai_cloak_tests.rs
+++ b/src/sim/world/techno_ai_cloak_tests.rs
@@ -10,9 +10,10 @@ fn rules() -> RuleSet {
     RuleSet::from_ini(&IniFile::from_str(
         "[General]\nCloakingStages=9\nCloakDelay=.02\n\
          [AudioVisual]\nCloakSound=NavalUnitEmerge\n\
-         [VehicleTypes]\n0=SUB\n1=RANKED\n\
+         [VehicleTypes]\n0=SUB\n1=RANKED\n2=DEST\n\
          [BuildingTypes]\n0=NAYARD\n\
          [SUB]\nStrength=600\nSpeed=4\nCloakable=yes\nCloakingSpeed=1\nSensorsSight=7\n\
+         [DEST]\nStrength=600\nSpeed=6\nSensors=yes\nSensorsSight=8\n\
          [RANKED]\nStrength=600\nSpeed=4\nVeteranAbilities=CLOAK\nEliteAbilities=CLOAK\n\
          [NAYARD]\nStrength=1000\nWeaponsFactory=yes\n",
     ))
@@ -159,7 +160,17 @@ fn stock_cloak_producer_current_fire_and_weapons_factory_contact_block_entry() {
 }
 
 #[test]
-fn stock_cloak_producer_should_uncloak_uses_current_activity_and_owner_visibility() {
+fn fully_cloaked_sub_holding_a_target_does_not_surface() {
+    // CORRECTION. This test used to assert the opposite, encoding two VERA
+    // misreadings at once: that `ShouldUncloak @ 0x006FBC90` treats "holds an
+    // attack target" as activity, and that its tail
+    // `CellClass::IsVisibleToHouse @ 0x004870B0` means cell visibility.
+    //
+    // Native: the head is `IsCloakable() && !IsUnderEMP && !vt+0x380 &&
+    // !WarpIn && !WarpOut`, with no target term anywhere, and the tail reads
+    // the `CloakedByHouses` bit — never set in stock YR. So a submerged
+    // Typhoon that acquires a destroyer stays submerged, and only losing the
+    // ability to sustain the cloak surfaces it.
     let (mut sim, rules, id) = spawned_sub();
     sim.substrate
         .entities
@@ -180,50 +191,27 @@ fn stock_cloak_producer_should_uncloak_uses_current_activity_and_owner_visibilit
             .as_ref()
             .unwrap()
             .state,
-        3
+        2,
+        "holding a target is CanAutoCloak step 4, not a ShouldUncloak term"
     );
-    assert!(matches!(
-        sim.sound_events.as_slice(),
-        [crate::sim::world::SimSoundEvent::CloakSound { sound_id, .. }]
-            if sound_id == "NavalUnitEmerge"
-    ));
-    let hash_with_transient_cue = sim.state_hash();
-    let emitted = std::mem::take(&mut sim.sound_events);
-    assert_eq!(
-        sim.state_hash(),
-        hash_with_transient_cue,
-        "the transient positional cue is outside deterministic world hashing"
+    assert!(
+        sim.sound_events.is_empty(),
+        "no transition means no positional cue"
     );
-    sim.sound_events = emitted;
 
-    let (mut visible, rules, id) = spawned_sub();
-    let owner = visible.substrate.entities.get(id).unwrap().owner;
-    let (rx, ry) = visible
+    // Marking the owner's own cell visible must not change the answer either —
+    // that was the substituted predicate.
+    let owner = sim.substrate.entities.get(id).unwrap().owner;
+    let (rx, ry) = sim
         .substrate
         .entities
         .get(id)
         .map(|entity| (entity.position.rx, entity.position.ry))
         .unwrap();
-    visible.fog.mark_visible_for_owner(owner, rx, ry);
-    visible
-        .substrate
-        .entities
-        .get_mut(id)
-        .unwrap()
-        .cloak
-        .as_mut()
-        .unwrap()
-        .establish_unlimbo_fully_cloaked();
-    visible
-        .substrate
-        .entities
-        .get_mut(id)
-        .unwrap()
-        .attack_target = Some(AttackTarget::new(999));
-    tick_stock_cloak_producer(&mut visible, id, &rules);
+    sim.fog.mark_visible_for_owner(owner, rx, ry);
+    tick_stock_cloak_producer(&mut sim, id, &rules);
     assert_eq!(
-        visible
-            .substrate
+        sim.substrate
             .entities
             .get(id)
             .unwrap()
@@ -233,10 +221,45 @@ fn stock_cloak_producer_should_uncloak_uses_current_activity_and_owner_visibilit
             .state,
         2
     );
-    assert!(
-        visible.sound_events.is_empty(),
-        "no transition means no positional cue"
+}
+
+#[test]
+fn chrono_warp_surfaces_a_fully_cloaked_sub() {
+    // The surviving live `ShouldUncloak` arm in stock data once EMP is excluded:
+    // `vt+0x1D4`/`vt+0x1D8` WarpIn/WarpOut. `StartUncloaking(0)` owns the cue.
+    let (mut sim, rules, id) = spawned_sub();
+    sim.substrate
+        .entities
+        .get_mut(id)
+        .unwrap()
+        .cloak
+        .as_mut()
+        .unwrap()
+        .establish_unlimbo_fully_cloaked();
+    sim.substrate.entities.get_mut(id).unwrap().teleport_state =
+        Some(crate::sim::movement::teleport_movement::TeleportState {
+            phase: crate::sim::movement::teleport_movement::TeleportPhase::Relocate,
+            target_rx: 20,
+            target_ry: 20,
+            being_warped_ticks: 0,
+        });
+    tick_stock_cloak_producer(&mut sim, id, &rules);
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(id)
+            .unwrap()
+            .cloak
+            .as_ref()
+            .unwrap()
+            .state,
+        3
     );
+    assert!(matches!(
+        sim.sound_events.as_slice(),
+        [crate::sim::world::SimSoundEvent::CloakSound { sound_id, .. }]
+            if sound_id == "NavalUnitEmerge"
+    ));
 }
 
 #[test]
@@ -267,6 +290,58 @@ fn stock_cloak_producer_honors_rank_selected_cloak_ability() {
     );
 }
 
+/// Set the `CloakedByHouses` bit `CellClass::IsVisibleToHouse @ 0x004870B0`
+/// reads — the outer gate of `TechnoClass+0x420 @ 0x006F4F3A`. Only a
+/// `CloakGenerator=yes` building writes it in gamemd and stock YR ships none,
+/// so this arm is dormant in an ordinary skirmish; the tests below still pin
+/// its collect/dispatch shape for a mod that does ship one.
+fn arm_cloak_field_for(sim: &mut Simulation, owner: InternedId, cell: (u16, u16)) {
+    if !sim.session.house_order.contains(&owner) {
+        sim.session.house_order.push(owner);
+    }
+    sim.fog.reset_cloaked_by_houses();
+    let index = sim
+        .base_reservation_house_index(owner)
+        .expect("registered house index") as u8;
+    assert!(sim.fog.set_cloaked_by_house(index, cell.0, cell.1));
+}
+
+#[test]
+fn sensor_deposit_alone_never_force_cloaks_an_eligible_unit() {
+    // The DRIFT this slice corrects. `TechnoClass+0x420 @ 0x006F4EB0` gates its
+    // cloak arm on `CellClass::IsVisibleToHouse` — the `CloakedByHouses` bit
+    // whose only writers are `BuildingClass::UpdateGapGenerator_Tick @
+    // 0x004551B9 / 0x004553B3`, reached only for a `CloakGenerator=yes`
+    // building. VERA substituted `fog.is_cell_visible(owner, ...)`, which is
+    // true for a unit standing on its own revealed cell, so every sensor
+    // deposit that touched the cell force-cloaked it and played CloakSound.
+    let (mut sim, rules, cloaker) = spawned_sub();
+    let (cell, owner) = sim
+        .substrate
+        .entities
+        .get(cloaker)
+        .map(|entity| ((entity.position.rx, entity.position.ry), entity.owner))
+        .unwrap();
+    sim.fog.mark_visible_for_owner(owner, cell.0, cell.1);
+
+    let outcome = sensor_reevaluate_stock_cloak(&mut sim, cloaker, &rules);
+
+    assert_eq!(outcome, SensorCloakReevaluation::default());
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(cloaker)
+            .unwrap()
+            .cloak
+            .as_ref()
+            .unwrap()
+            .state,
+        0,
+        "no cloak generator field means the vt+0x420 cloak arm never runs"
+    );
+    assert!(sim.sound_events.is_empty());
+}
+
 #[test]
 fn sensor_callback_reassigns_admitted_targeters_in_forward_techno_registration_order() {
     let (mut sim, rules, cloaker) = spawned_sub();
@@ -276,8 +351,7 @@ fn sensor_callback_reassigns_admitted_targeters_in_forward_techno_registration_o
         .get(cloaker)
         .map(|entity| ((entity.position.rx, entity.position.ry), entity.owner))
         .unwrap();
-    sim.fog
-        .mark_visible_for_owner(cloaker_owner, cell.0, cell.1);
+    arm_cloak_field_for(&mut sim, cloaker_owner, cell);
 
     let sensor_admitted = sim
         .spawn_object_at_height("RANKED", "Americans", cell.0 + 1, cell.1, 0, 0, &rules)
@@ -354,7 +428,14 @@ fn sensor_callback_reassigns_admitted_targeters_in_forward_techno_registration_o
 }
 
 #[test]
-fn sensor_callback_rejected_cloak_still_clears_only_same_target_passive_provenance() {
+fn already_cloaked_object_is_refused_by_can_auto_cloak_step_two() {
+    // CORRECTION. This test used to assert that a state-two object still ran
+    // the vt+0x420 collect/reassign transaction and cleared its targeter's
+    // passive provenance. It cannot: `0x006F4F57` calls `CanAutoCloak`
+    // (vt+0x2A0) and jumps past the whole arm on false, and `CanAutoCloak @
+    // 0x006FBDC0` returns false at its second step — `if (param_1[0x88] == 2)
+    // return false;` — for exactly this object. VERA's `can_auto_cloak` was
+    // missing that step, which is what let the collection run.
     let (mut sim, rules, cloaker) = spawned_sub();
     let (cell, cloaker_owner) = sim
         .substrate
@@ -362,8 +443,6 @@ fn sensor_callback_rejected_cloak_still_clears_only_same_target_passive_provenan
         .get(cloaker)
         .map(|entity| ((entity.position.rx, entity.position.ry), entity.owner))
         .unwrap();
-    sim.fog
-        .mark_visible_for_owner(cloaker_owner, cell.0, cell.1);
     sim.substrate
         .entities
         .get_mut(cloaker)
@@ -389,21 +468,17 @@ fn sensor_callback_rejected_cloak_still_clears_only_same_target_passive_provenan
         entity.attack_target = Some(attack);
         entity.passively_acquired_target = true;
     }
+    // Arm even the dormant cloak-field bit, to prove the refusal comes from
+    // CanAutoCloak and not from the outer CloakedByHouses gate.
+    arm_cloak_field_for(&mut sim, cloaker_owner, cell);
     sim.scenario_rng = crate::sim::rng::SimRng::new(0);
     let mission_before = sim.substrate.entities.get(targeter).unwrap().mission;
     let hash_before = sim.state_hash();
 
     let outcome = sensor_reevaluate_stock_cloak(&mut sim, cloaker, &rules);
 
-    assert!(
-        !outcome.cloak_transitioned,
-        "state two rejects StartCloaking"
-    );
-    assert_eq!(outcome.reassigned_targeters, vec![targeter]);
-    assert!(
-        sim.sound_events.is_empty(),
-        "rejected StartCloaking is silent"
-    );
+    assert_eq!(outcome, SensorCloakReevaluation::default());
+    assert!(sim.sound_events.is_empty());
     assert_eq!(
         sim.substrate
             .entities
@@ -416,7 +491,10 @@ fn sensor_callback_rejected_cloak_still_clears_only_same_target_passive_provenan
         2
     );
     let entity = sim.substrate.entities.get(targeter).unwrap();
-    assert!(!entity.passively_acquired_target);
+    assert!(
+        entity.passively_acquired_target,
+        "the transaction never runs, so provenance is untouched"
+    );
     let attack = entity.attack_target.as_ref().unwrap();
     assert_eq!(attack.target, TargetKind::Entity(cloaker));
     assert_eq!(attack.cooldown_ticks, 17);
@@ -430,23 +508,200 @@ fn sensor_callback_rejected_cloak_still_clears_only_same_target_passive_provenan
         })
     );
     assert_eq!(entity.mission, mission_before);
-    let hash_after = sim.state_hash();
-    assert_ne!(
-        hash_after, hash_before,
-        "passive provenance is hashed authority"
+    assert_eq!(
+        sim.state_hash(),
+        hash_before,
+        "a refused callback writes no authoritative state"
     );
 
     let bytes = GameSnapshot::save(&sim, 0, 0, "sensor-targeter", 0);
     let restored = GameSnapshot::load(&bytes)
         .expect("v88 sensor targeter snapshot")
         .sim;
-    assert_eq!(restored.state_hash(), hash_after);
+    assert_eq!(restored.state_hash(), hash_before);
     assert!(
-        !restored
+        restored
             .substrate
             .entities
             .get(targeter)
             .unwrap()
             .passively_acquired_target
+    );
+}
+
+#[test]
+fn the_weapon_rearm_countdown_blocks_the_next_auto_cloak() {
+    // `CanAutoCloak @ 0x006FBDC0` step 3 reads `TechnoClass+0x2EC/+0x2F4`,
+    // written by `TechnoClass::Fire_At @ 0x006FDD50`. VERA documented this pair
+    // as the ReCloak delay and left it unarmed, so a sub that surfaced to fire
+    // could dive again on the very next tick.
+    let (mut sim, rules, id) = spawned_sub();
+    sim.substrate
+        .entities
+        .get_mut(id)
+        .unwrap()
+        .cloak
+        .as_mut()
+        .unwrap()
+        .arm_rearm_gate(0, 20);
+
+    for frame in 0..20 {
+        sim.session.binary_frame = frame;
+        tick_stock_cloak_producer(&mut sim, id, &rules);
+        assert_eq!(
+            sim.substrate
+                .entities
+                .get(id)
+                .unwrap()
+                .cloak
+                .as_ref()
+                .unwrap()
+                .state,
+            0,
+            "frame {frame} is still inside the ROF window"
+        );
+    }
+    sim.session.binary_frame = 20;
+    tick_stock_cloak_producer(&mut sim, id, &rules);
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(id)
+            .unwrap()
+            .cloak
+            .as_ref()
+            .unwrap()
+            .state,
+        1,
+        "the rearm countdown has expired, so the auto-cloak may begin"
+    );
+}
+
+#[test]
+fn a_non_allied_sensors_neighbour_surfaces_a_cloaked_mover_on_cell_entry() {
+    // `FootClass::PerCellProcess @ 0x004D8802..0x004D8829`, the only live
+    // `Sensors=` consumer.
+    let (mut sim, rules, id) = spawned_sub();
+    let cell = sim
+        .substrate
+        .entities
+        .get(id)
+        .map(|entity| (entity.position.rx, entity.position.ry))
+        .unwrap();
+    sim.substrate
+        .entities
+        .get_mut(id)
+        .unwrap()
+        .cloak
+        .as_mut()
+        .unwrap()
+        .establish_unlimbo_fully_cloaked();
+
+    // An own-house neighbour is skipped by the `Is_Ally_ByObject` clause.
+    let friendly = sim
+        .spawn_object_at_height("DEST", "Soviet", cell.0 + 1, cell.1, 0, 0, &rules)
+        .unwrap();
+    assert!(!uncloak_on_sensor_neighbour_after_cell_entry(
+        &mut sim, id, &rules
+    ));
+    assert!(sim.sound_events.is_empty());
+    sim.substrate.entities.remove(friendly);
+
+    // A hostile one with `Sensors=yes` forces the surface, with the cue.
+    sim.spawn_object_at_height("DEST", "Americans", cell.0 + 1, cell.1, 0, 0, &rules)
+        .unwrap();
+    assert!(uncloak_on_sensor_neighbour_after_cell_entry(
+        &mut sim, id, &rules
+    ));
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(id)
+            .unwrap()
+            .cloak
+            .as_ref()
+            .unwrap()
+            .state,
+        3
+    );
+    assert!(matches!(
+        sim.sound_events.as_slice(),
+        [crate::sim::world::SimSoundEvent::CloakSound { sound_id, .. }]
+            if sound_id == "NavalUnitEmerge"
+    ));
+}
+
+#[test]
+fn start_cloaking_drops_every_targeter_whose_house_cannot_sense_the_cell() {
+    // `StartCloaking @ 0x00703770` opens with `Detach_All(false)`; each
+    // receiver's `TechnoClass::PointerExpired @ 0x007077C0` keeps the pointer
+    // only when its OWN house senses the expiring object's cell, or when it
+    // shares the owner.
+    let (mut sim, rules, cloaker) = spawned_sub();
+    let cell = sim
+        .substrate
+        .entities
+        .get(cloaker)
+        .map(|entity| (entity.position.rx, entity.position.ry))
+        .unwrap();
+    let sensing = sim
+        .spawn_object_at_height("DEST", "Americans", cell.0 + 1, cell.1, 0, 0, &rules)
+        .unwrap();
+    // RANKED carries no `SensorsSight=`, so these two deposit nothing of their
+    // own and stay genuinely blind to the cell.
+    let blind = sim
+        .spawn_object_at_height("RANKED", "Neutral", cell.0 + 2, cell.1, 0, 0, &rules)
+        .unwrap();
+    let same_owner = sim
+        .spawn_object_at_height("RANKED", "Soviet", cell.0 + 3, cell.1, 0, 0, &rules)
+        .unwrap();
+    for targeter in [sensing, blind, same_owner] {
+        sim.substrate
+            .entities
+            .get_mut(targeter)
+            .unwrap()
+            .attack_target = Some(AttackTarget::new(cloaker));
+    }
+    let american = sim.substrate.entities.get(sensing).unwrap().owner;
+    sim.fog.increment_sensor_at(american, cell.0, cell.1);
+
+    tick_stock_cloak_producer(&mut sim, cloaker, &rules);
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(cloaker)
+            .unwrap()
+            .cloak
+            .as_ref()
+            .unwrap()
+            .state,
+        1
+    );
+    assert!(
+        sim.substrate
+            .entities
+            .get(sensing)
+            .unwrap()
+            .attack_target
+            .is_some(),
+        "a house that senses the cell keeps firing through the dive"
+    );
+    assert!(
+        sim.substrate
+            .entities
+            .get(same_owner)
+            .unwrap()
+            .attack_target
+            .is_some(),
+        "same owner is exempt"
+    );
+    assert!(
+        sim.substrate
+            .entities
+            .get(blind)
+            .unwrap()
+            .attack_target
+            .is_none(),
+        "everyone else loses the pointer at the instant of StartCloaking"
     );
 }

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -439,7 +439,7 @@ impl Simulation {
     pub fn state_hash(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, true,
         )
     }
 
@@ -451,7 +451,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             true, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -463,7 +463,7 @@ impl Simulation {
     pub(crate) fn state_hash_before_lifecycle_v28_and_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             false, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -473,7 +473,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_spark_dummy_level_slope_v107(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, false, false,
-            false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
         )
     }
 
@@ -484,7 +484,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_naval_build_const_v109(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
         )
     }
 
@@ -495,7 +495,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_base_plan_v110(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, false, false, false, false, false, false,
+            true, false, false, false, false, false, false, false,
         )
     }
 
@@ -504,7 +504,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_base_plan_center_v111(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, false, false, false, false, false,
+            true, true, false, false, false, false, false, false,
         )
     }
 
@@ -513,7 +513,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_house_deploy_latches_v112(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, false, false, false, false,
+            true, true, true, false, false, false, false, false,
         )
     }
 
@@ -523,7 +523,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_house_update_activation_v113(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, false, false, false,
+            true, true, true, true, false, false, false, false,
         )
     }
 
@@ -532,7 +532,19 @@ impl Simulation {
     pub(crate) fn state_hash_without_crate_authority_v114(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, false, false,
+            true, true, true, true, true, false, false, false,
+        )
+    }
+
+    /// Test-only provenance probe for the schema-v117 disguise-detect folds:
+    /// the `CellClass+0xAC[house]` counter plane and the cached
+    /// `DetectDisguiseRange=` deposit radius. It reconstructs the committed
+    /// v115 hash layout.
+    #[cfg(test)]
+    pub(crate) fn state_hash_without_disguise_detect_v117(&self) -> u64 {
+        self.state_hash_with_schema(
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, false,
         )
     }
 
@@ -542,7 +554,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_wall_runtime_v115(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, false,
+            true, true, true, true, true, true, false, false,
         )
     }
 
@@ -569,6 +581,7 @@ impl Simulation {
         include_house_update_activation_v113: bool,
         include_crate_authority_v114: bool,
         include_wall_runtime_v115: bool,
+        include_disguise_detect_v117: bool,
     ) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
 
@@ -627,7 +640,7 @@ impl Simulation {
         }
         self.hash_production(&mut hasher);
         self.hash_power_states(&mut hasher);
-        self.hash_fog_and_alliances(&mut hasher);
+        self.hash_fog_and_alliances(&mut hasher, include_disguise_detect_v117);
         self.hash_bridge_state(&mut hasher);
         if include_real_cell_bridge_flags_v90 {
             // `resolved_terrain` is derived/skipped. Fold the exact saved real
@@ -701,6 +714,7 @@ impl Simulation {
             include_techno_constructor_v104,
             include_naval_build_const_v109,
             include_base_plan_v110,
+            include_disguise_detect_v117,
         );
         self.hash_anims(&mut hasher);
         self.hash_particle_systems(&mut hasher);
@@ -1094,7 +1108,7 @@ impl Simulation {
     }
 
     /// Hash fog-of-war visibility and house alliance data.
-    fn hash_fog_and_alliances(&self, hasher: &mut impl Hasher) {
+    fn hash_fog_and_alliances(&self, hasher: &mut impl Hasher, include_disguise_detect_v117: bool) {
         self.fog.width.hash(hasher);
         self.fog.height.hash(hasher);
         for (owner, fog) in &self.fog.by_owner {
@@ -1117,6 +1131,14 @@ impl Simulation {
         self.fog.fogged_object_cells.hash(hasher);
         self.fog.fogged_objects.hash(hasher);
         self.fog.sensors_by_house.hash(hasher);
+        if include_disguise_detect_v117 {
+            // `CellClass+0xAC[house]` disguise-detect counters.
+            // Behaviour-affecting like their `SensorsOfHouses` sibling above:
+            // `FUN_004870F0` reads them inside `IsDisguisedTo`, which decides
+            // target acquisition and so changes issued commands, not just
+            // presentation.
+            self.fog.disguise_detect_by_house.hash(hasher);
+        }
         self.fog.cloaked_by_houses.hash(hasher);
         for (owner, allies) in &self.house_alliances {
             owner.hash(hasher);
@@ -1298,6 +1320,7 @@ impl Simulation {
         include_techno_constructor_v104: bool,
         include_naval_build_const_v109: bool,
         include_base_plan_v110: bool,
+        include_disguise_detect_v117: bool,
     ) {
         for entity in self.substrate.entities.values() {
             entity.stable_id.hash(hasher);
@@ -1564,6 +1587,12 @@ impl Simulation {
                     deposit.add_radius.hash(hasher);
                     deposit.remove_radius.hash(hasher);
                     deposit.building_array.hash(hasher);
+                    if include_disguise_detect_v117 {
+                        // The cached `DetectDisguiseRange=` circle. It is the
+                        // radius Limbo will decrement, so it selects which
+                        // cells leave the disguise-detect plane.
+                        deposit.detect_disguise_radius.hash(hasher);
+                    }
                 } else {
                     0u8.hash(hasher);
                 }


### PR DESCRIPTION
Phase 6, rows 137 (GSI-12.05 cloak state and decloak triggers) and 138 (GSI-12.06 sensors, detection and stealth legality).

Before this branch a fully cloaked submarine was a legal target for anything in range, and every sensor deposit force-cloaked eligible units on the cell it touched.

## The drift that had been in the tree the longest

VERA read `CellClass+0x78` through `fog.is_cell_visible(owner, ...)`. That field is not shroud visibility: it is the `CloakedByHouses` bit, written only by `BuildingClass::UpdateGapGenerator_Tick` behind `BuildingType+0x16C7`, which `BuildingTypeClass::ReadINI @ 0x00460C06` fills from `CloakGenerator` — a key no stock YR building authors. Because the substituted predicate was true for any unit standing on its own revealed cell, every sensor add and remove force-cloaked an eligible unit there and played its cloak sound. Six stock types re-deposit `SensorsSight=` on every cell they cross, so in naval play this fired continuously. The same misreading had inverted `CanAutoCloak`'s first step and disabled `ShouldUncloak` entirely.

## What gamemd does

`Evaluate_Candidate @ 0x006F7CA0` rejects a `CloakState == 2` candidate when the attacker's house has no sensor count on its cell and the owner differs; states 1 and 3 stay legal. `GetFireError @ 0x006FC0B0` returns 6 for the same condition on the target side. Decloak triggers are firing, any non-lethal damage including heals, EMP, warp, deploy, a `Sensors=` neighbour on cell entry, and being bumped by a mover. Disguise is `IsDisguisedTo` per observer, bypassed by a `DetectDisguise=` attacker — the dogs', Yuri's and the Psi Corps Trooper's whole role against spies and Mirage Tanks.

## Review history

Six critic rounds. The first three found the decloak firing where `ReceiveDamage` returns from its defensive gates (so a player's own Dolphin surfaced another with splash), a removal that unwound the cached rather than the live owner, and an unhashed detection plane. Rounds four and five came from routing the dive through the crate's existing pointer-expiry model, which turned out to be the same native body `UnInit` runs with a different control value: that exposed `FootClass::PointerExpired`'s own `allowClear` gate, without which a Destroyer that senses a diving submarine kept its target but lost its destination and abandoned the chase.

Twice a builder overruled a critic from the binary and was right, including a vtable slot the critic had mis-derived.

## Deliberately reproduced, not tidied

Native reads the live owner when it unwinds a sensor circle, and `ChangeOwner` re-stamps nothing. So after a captured Psychic Sensor is sold, the constructing house keeps a phantom detection circle forever and the capturing house's counters go to minus one. That is what gamemd does, and this branch reproduces it rather than cleaning it up.

## Rows stay open

EMP decloak is unmet: VERA has no EMP mechanism anywhere, so `emp_active` is pinned false. It lands with an EMP weapon system. The mover-bump reveal is likewise deferred, because VERA's cell-entry classifier has no cloak term and the reveal alone would be dead code.

`cargo test -p vera20k --lib`: `test result: ok. 8100 passed; 0 failed; 75 ignored`. `SNAPSHOT_VERSION` 116 to 117 with all three world-hash constants re-derived on current main; every pre-117 probe reproduces its committed value.
