### PR TITLE
Phase 6: turn-to-fire for turretless vehicles, and the full Facing_Update port

### DIFF
--- a/src/sim/combat/combat_cloak_fire_tests.rs
+++ b/src/sim/combat/combat_cloak_fire_tests.rs
@@ -28,6 +28,11 @@ fn boomer_rules() -> RuleSet {
 fn entities(target_type: &str) -> EntityStore {
     let mut store = EntityStore::new();
     let mut bsub = GameEntity::test_default(1, "BSUB", "Soviet", 10, 10);
+    // `BSUB` authors no `Turret=`, so the native body gate
+    // (`UnitClass::GetFireError @ 0x00740FD0` step 17) compares its HULL
+    // `+0x388` against the target. Face it east at the target one cell away so
+    // this fixture exercises the DecloakToFire arm rather than turn-to-fire.
+    bsub.facing = 64;
     bsub.attack_target = Some(AttackTarget::new(2));
     let mut cloak = CloakRuntime::new(0, 9);
     cloak.establish_unlimbo_fully_cloaked();

--- a/src/sim/combat/combat_targeting.rs
+++ b/src/sim/combat/combat_targeting.rs
@@ -98,6 +98,12 @@ pub(crate) struct AttackerSnapshot {
     /// facing gate reads it for `Turret=no` firers so the comparison uses the
     /// full 16-bit animated value rather than the 8-bit mirrored heading.
     pub hull_facing: Option<crate::sim::movement::FacingClass>,
+    /// Turret rotation latch (`UnitClass+0x6AF`) as it stood BEFORE this tick's
+    /// `Facing_Update`, which is the value `UnitClass::GetFireError @
+    /// 0x00741233` reads: `UnitClass::AI` runs `Fire_At_Target @ 0x007365E1`
+    /// before `Facing_Update @ 0x007365E8`, and VERA commits the new latch in
+    /// `apply_unit_facing` after Phase 5.
+    pub turret_rotation_latch: bool,
     pub burst_remaining: u8,
     pub burst_delay_ticks: u8,
     /// Weapon-selection override (Gunner-IFV slot OR open-topped passenger weapon).
@@ -171,6 +177,7 @@ pub fn acquire_best_target_for_entity(
         pending_building_fire: None,
         barrel_facing: entity.barrel_facing,
         hull_facing: entity.body_facing,
+        turret_rotation_latch: entity.turret_rotation_latch,
         burst_remaining: 0,
         burst_delay_ticks: 0,
         weapon_override: entity.weapon_override,

--- a/src/sim/combat/combat_targeting.rs
+++ b/src/sim/combat/combat_targeting.rs
@@ -94,6 +94,10 @@ pub(crate) struct AttackerSnapshot {
     pub pending_infantry_fire: Option<super::PendingInfantryFire>,
     pub pending_building_fire: Option<crate::sim::game_entity::PendingBuildingFire>,
     pub barrel_facing: Option<crate::sim::movement::FacingClass>,
+    /// Hull interpolator (`+0x388`), live only while the body is turning. The
+    /// facing gate reads it for `Turret=no` firers so the comparison uses the
+    /// full 16-bit animated value rather than the 8-bit mirrored heading.
+    pub hull_facing: Option<crate::sim::movement::FacingClass>,
     pub burst_remaining: u8,
     pub burst_delay_ticks: u8,
     /// Weapon-selection override (Gunner-IFV slot OR open-topped passenger weapon).
@@ -166,6 +170,7 @@ pub fn acquire_best_target_for_entity(
         pending_infantry_fire: None,
         pending_building_fire: None,
         barrel_facing: entity.barrel_facing,
+        hull_facing: entity.body_facing,
         burst_remaining: 0,
         burst_delay_ticks: 0,
         weapon_override: entity.weapon_override,
@@ -938,10 +943,14 @@ pub fn tick_retaliation(
                 None => continue,
             };
             if let Some(entity) = entities.get_mut(entity_id) {
-                if entity.barrel_facing.is_none() {
-                    // Body-only retaliator — instantly face the attacker. Turreted
-                    // retaliators get their turret rotation driven by
-                    // tick_turret_rotation in subsequent ticks (matches gamemd).
+                if entity.barrel_facing.is_none() && entity.category != EntityCategory::Unit {
+                    // Body-only retaliator — instantly face the attacker.
+                    // Turreted retaliators get their turret driven by
+                    // `Facing_Update`, and a TURRETLESS VEHICLE turns its hull
+                    // through `UnitClass::Fire_At_Target @ 0x00736DF0` case 2
+                    // once the fire gate refuses it for facing — assignment
+                    // itself writes no facing in gamemd. Infantry keep the snap;
+                    // see the residual on `combat::issue_attack_command`.
                     let dx: i32 = attacker_pos.0 as i32 - entity.position.rx as i32;
                     let dy: i32 = attacker_pos.1 as i32 - entity.position.ry as i32;
                     entity.facing = crate::sim::movement::facing_from_delta(dx, dy);

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -259,6 +259,51 @@ fn guardian_gi_rules() -> RuleSet {
     RuleSet::from_ini(&ini).expect("guardian GI rules should parse")
 }
 
+/// Point every fixture attacker at its own target.
+///
+/// `GameEntity::test_default` spawns facing north (0) with no turret, and the
+/// fixture rules author no `Turret=`, so every fixture attacker is a TURRETLESS
+/// vehicle. Under the native body gate — `UnitClass::GetFireError @ 0x00740FD0`
+/// step 17, which compares the HULL `+0x388` when `Turret=` is unset — such a
+/// unit spends its first ticks turning through `Fire_At_Target @ 0x00736DF0`
+/// case 2 instead of shooting. Tests whose subject is damage, RNG consumption or
+/// resolution ordering pre-align here so they still observe the shot on the
+/// single tick they run; the turn-to-fire behaviour itself is covered by
+/// `combat_turret_facing_tests`.
+fn align_attackers_to_targets(
+    store: &mut EntityStore,
+    rules: &RuleSet,
+    interner: &crate::sim::intern::StringInterner,
+) {
+    for id in store.keys_sorted() {
+        let desired = {
+            let Some(entity) = store.get(id) else {
+                continue;
+            };
+            let Some(attack) = entity.attack_target.as_ref() else {
+                continue;
+            };
+            match crate::sim::movement::turret::facing_toward_target(
+                entity,
+                &attack.target,
+                store,
+                Some(rules),
+                interner,
+            ) {
+                Some(desired) => desired,
+                None => continue,
+            }
+        };
+        if let Some(entity) = store.get_mut(id) {
+            entity.facing = (desired >> 8) as u8;
+            entity.body_facing = None;
+            if let Some(ref mut barrel) = entity.barrel_facing {
+                barrel.snap(desired, 0);
+            }
+        }
+    }
+}
+
 fn make_entity(id: u64, type_ref: &str, rx: u16, ry: u16, hp: u16) -> GameEntity {
     let mut e = GameEntity::test_default(id, type_ref, "Test", rx, ry);
     e.health = Health {
@@ -1247,6 +1292,7 @@ fn considered_aircraft_infantry_is_air_only_while_high_flying() {
             &sim.interner,
         );
         let mut main_rng = SimRng::new(1);
+        align_attackers_to_targets(&mut sim.substrate.entities, &rules, &sim.interner);
         let result = tick_combat(
             &mut sim.substrate.entities,
             &mut sim.substrate.occupancy,
@@ -1311,6 +1357,7 @@ fn ordinary_infantry_remains_ground_for_projectile_legality() {
         &sim.interner,
     );
     let mut main_rng = SimRng::new(1);
+    align_attackers_to_targets(&mut sim.substrate.entities, &rules, &sim.interner);
     let result = tick_combat(
         &mut sim.substrate.entities,
         &mut sim.substrate.occupancy,
@@ -1371,6 +1418,7 @@ fn test_tick_combat_applies_damage() {
     issue_attack_command(&mut store, 1, 2, None, &interner);
     let mut main_rng = SimRng::new(1);
 
+    align_attackers_to_targets(&mut store, &rules, &interner);
     tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -1401,6 +1449,7 @@ fn combat_damage_crossing_condition_yellow_sets_building_damage_state() {
     issue_attack_command(&mut store, 1, 2, None, &interner);
     let mut main_rng = SimRng::new(1);
 
+    align_attackers_to_targets(&mut store, &rules, &interner);
     tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -1461,6 +1510,7 @@ fn aoe_damage_crossing_condition_yellow_sets_building_damage_state() {
     issue_attack_command(&mut store, 1, 2, None, &interner);
     let mut main_rng = SimRng::new(1);
 
+    align_attackers_to_targets(&mut store, &rules, &interner);
     tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -1491,6 +1541,7 @@ fn combat_damage_landed_applies_infantry_fear() {
     issue_attack_command(&mut store, 1, 2, None, &interner);
     let mut main_rng = SimRng::new(1);
 
+    align_attackers_to_targets(&mut store, &rules, &interner);
     tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -1564,6 +1615,7 @@ fn test_tick_combat_only_emits_bridge_damage_for_wall_warheads() {
     let mut interner = test_interner();
     issue_attack_command(&mut store, 1, 2, None, &interner);
     let mut main_rng = SimRng::new(1);
+    align_attackers_to_targets(&mut store, &rules_without_wall, &interner);
     let result = tick_combat_with_fog(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -1610,6 +1662,7 @@ fn test_tick_combat_only_emits_bridge_damage_for_wall_warheads() {
     wall_store.insert(make_entity(3, "MTNK", 5, 5, 300));
     wall_store.insert(make_entity(4, "MTNK", 8, 5, 300));
     issue_attack_command(&mut wall_store, 3, 4, None, &interner);
+    align_attackers_to_targets(&mut wall_store, &bridge_rules, &interner);
     let wall_result = tick_combat_with_fog(
         &mut wall_store,
         &mut OccupancyGrid::new(),
@@ -1675,6 +1728,7 @@ fn gsi_04_07_damage_wad_precedes_wall_and_wood_armor_routing() {
         let mut overlays = OverlayGrid::new(12, 12);
         overlays.place_overlay(8, 5, 0, 0);
         let mut scenario_rng = SimRng::new(1);
+        align_attackers_to_targets(&mut entities, &rules, &interner);
         let result = tick_combat_with_fog(
             &mut entities,
             &mut OccupancyGrid::new(),
@@ -1736,7 +1790,12 @@ fn gsi_04_07_damage_live_order_second_attacker_reads_restored_target() {
     let registry = OverlayTypeRegistry::from_ini(&ini, None);
     let mut entities = EntityStore::new();
     entities.insert(make_entity(10, "MTNK", 5, 5, 300));
-    let mut second = make_entity(20, "MTNK", 6, 5, 300);
+    // The second attacker sits WEST of both the wall cell and the target it
+    // will have restored mid-tick, so one hull heading serves both. Under the
+    // turretless body gate (`UnitClass::GetFireError @ 0x00740FD0` step 17) a
+    // restored target behind the hull would simply be refused for facing, and
+    // the tick would consume one reload jitter instead of two.
+    let mut second = make_entity(20, "MTNK", 4, 5, 300);
     second.mission.apply_test_fixture(MissionTestFixture {
         current: MissionId::from_known(MissionType::Attack),
         suspended: MissionId::from_known(MissionType::Guard),
@@ -1779,6 +1838,7 @@ fn gsi_04_07_damage_live_order_second_attacker_reads_restored_target() {
     expected_rng.next_range_u32_inclusive(0, 2);
     expected_rng.next_range_u32_inclusive(0, 2);
     let before = expected_rng.state();
+    align_attackers_to_targets(&mut entities, &rules, &interner);
     let result = tick_combat_with_fog(
         &mut entities,
         &mut OccupancyGrid::new(),
@@ -1858,7 +1918,11 @@ fn gsi_04_07_damage_prior_projectile_fatal_death_weapon_is_inline() {
 
         let mut entities = EntityStore::new();
         entities.insert(make_entity(10, "BOOMER", 8, 5, victim_hp));
-        let mut later_attacker = make_entity(20, "SHOOTER", 6, 5, 100);
+        // West of both the wall cell and the target restored mid-tick, so one
+        // hull heading serves both — see the note in the sibling live-order
+        // test: a restored target BEHIND a turretless hull is refused for
+        // facing by `UnitClass::GetFireError @ 0x00740FD0` step 17.
+        let mut later_attacker = make_entity(20, "SHOOTER", 4, 5, 100);
         later_attacker
             .mission
             .apply_test_fixture(MissionTestFixture {
@@ -1906,6 +1970,7 @@ fn gsi_04_07_damage_prior_projectile_fatal_death_weapon_is_inline() {
         let mut houses = BTreeMap::new();
         let handles =
             crate::sim::type_handle_table::ResolvedRuleHandles::resolve(&rules, &mut interner);
+        align_attackers_to_targets(&mut entities, &rules, &interner);
         let result = tick_combat_with_fog_and_main_rng(
             &mut entities,
             &mut OccupancyGrid::new(),
@@ -2077,6 +2142,11 @@ fn gsi_04_07_damage_retaliation_is_receiver_synchronous_and_uses_mission_overrid
             ai_counter: 0,
             dispatch_timer: MissionDispatchTimer::at_frame(0),
         });
+        // The victim retaliates WEST at the source; give it that hull heading up
+        // front so the turretless body gate (`UnitClass::GetFireError @
+        // 0x00740FD0` step 17) does not spend this pass turning. The subject
+        // here is the inline mission Override, not turn-to-fire.
+        victim.facing = 192;
         victim.navigation.nav_com = Some(crate::sim::components::NavTargetRef::cell(9, 5));
         victim.movement_target = Some(crate::sim::components::MovementTarget::default());
         entities.insert(victim);
@@ -2127,6 +2197,7 @@ fn gsi_04_07_damage_retaliation_is_receiver_synchronous_and_uses_mission_overrid
         let mut houses = BTreeMap::new();
         let handles =
             crate::sim::type_handle_table::ResolvedRuleHandles::resolve(&rules, &mut interner);
+        align_attackers_to_targets(&mut entities, &rules, &interner);
         let result = tick_combat_with_fog_and_main_rng(
             &mut entities,
             &mut occupancy,
@@ -3931,6 +4002,7 @@ fn gsi_08_05_tick_combat_respects_the_jittered_cooldown() {
 
     let mut fire_once =
         |store: &mut EntityStore, interner: &mut StringInterner, rng: &mut SimRng| {
+            align_attackers_to_targets(store, &rules, interner);
             tick_combat(
                 store,
                 &mut OccupancyGrid::new(),
@@ -4080,6 +4152,7 @@ fn fatal_sound_selection_uses_human_voice_then_die_sound_main_draws() {
     let mut human_rng = SimRng::new(1);
     let handles =
         crate::sim::type_handle_table::ResolvedRuleHandles::resolve(&rules, &mut interner);
+    align_attackers_to_targets(&mut entities, &rules, &interner);
     tick_combat_with_fog_and_main_rng(
         &mut entities,
         &mut OccupancyGrid::new(),
@@ -4356,6 +4429,7 @@ fn test_infantry_vs_heavy_armor() {
     issue_attack_command(&mut store, 1, 2, None, &interner);
     let mut main_rng = SimRng::new(1);
 
+    align_attackers_to_targets(&mut store, &rules, &interner);
     tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -4734,6 +4808,7 @@ fn test_prone_infantry_takes_scaled_direct_damage() {
     issue_attack_command(&mut store, 1, 2, None, &interner);
     let mut main_rng = SimRng::new(1);
 
+    align_attackers_to_targets(&mut store, &rules, &interner);
     tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -4780,6 +4855,7 @@ fn test_prone_infantry_takes_scaled_aoe_damage() {
     issue_attack_command(&mut store, 1, 2, None, &interner);
     let mut main_rng = SimRng::new(1);
 
+    align_attackers_to_targets(&mut store, &rules, &interner);
     tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -5168,6 +5244,7 @@ fn test_weapon_fire_destroys_ore_in_spread() {
     overlays.place_overlay(9, 5, 0, 2);
 
     let mut main_rng = SimRng::new(1);
+    align_attackers_to_targets(&mut store, &rules, &interner);
     let result = tick_combat_with_fog(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -5245,6 +5322,7 @@ fn test_direct_hit_weapon_destroys_center_ore() {
     overlays.place_overlay(9, 5, 0, 5);
 
     let mut main_rng = SimRng::new(1);
+    align_attackers_to_targets(&mut store, &rules, &interner);
     let result = tick_combat_with_fog(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -5313,6 +5391,7 @@ fn test_weak_weapon_partial_ore_reduction() {
     overlays.place_overlay(8, 5, 0, 9);
 
     let mut main_rng = SimRng::new(1);
+    align_attackers_to_targets(&mut store, &rules, &interner);
     let result = tick_combat_with_fog(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -5808,6 +5887,7 @@ fn v3_non_killing_aoe_emits_one_smudge_request() {
     issue_attack_command(&mut store, 1, 2, None, &interner);
     let mut main_rng = SimRng::new(1);
 
+    align_attackers_to_targets(&mut store, &rules, &interner);
     let result = tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -5867,6 +5947,7 @@ fn v3_killing_aoe_emits_exactly_one_smudge_request() {
     issue_attack_command(&mut store, 1, 2, None, &interner);
     let mut main_rng = SimRng::new(1);
 
+    align_attackers_to_targets(&mut store, &rules, &interner);
     let result = tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -5924,6 +6005,7 @@ fn gsi_04_11_death_weapon_anim_precedes_outer_detonation_anim() {
     issue_attack_command(&mut store, 1, 2, None, &interner);
     let mut main_rng = SimRng::new(1);
 
+    align_attackers_to_targets(&mut store, &rules, &interner);
     let result = tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -6021,6 +6103,7 @@ fn gsi_04_11_persistent_projectile_keeps_exact_lepton_z() {
     let mut interner = test_interner();
     issue_attack_command(&mut entities, 1, 2, None, &interner);
 
+    align_attackers_to_targets(&mut entities, &rules, &interner);
     let result = tick_combat(
         &mut entities,
         &mut OccupancyGrid::new(),
@@ -6052,6 +6135,7 @@ fn persistent_projectile_delays_damage_across_save_load_continuation() {
     issue_attack_command(&mut entities, 1, 2, None, &interner);
 
     let mut scenario_rng = SimRng::new(1);
+    align_attackers_to_targets(&mut entities, &rules, &interner);
     let fire = tick_combat(
         &mut entities,
         &mut OccupancyGrid::new(),
@@ -6110,6 +6194,7 @@ fn persistent_projectile_delays_damage_across_save_load_continuation() {
     let mut houses = BTreeMap::new();
     let handles =
         crate::sim::type_handle_table::ResolvedRuleHandles::resolve(&rules, &mut interner);
+    align_attackers_to_targets(&mut entities, &rules, &interner);
     tick_combat_with_fog_and_main_rng(
         &mut entities,
         &mut OccupancyGrid::new(),
@@ -6173,6 +6258,7 @@ fn inviso_scatter_uses_scenario_rng_only_for_effect_and_paired_smudge() {
     // jitter after the shot, on this same instance (`[0x00A8B230] + 0x218` —
     // the one `FootClass::Mission_Attack @ 0x004D4DC0` also uses).
     expected_rng.next_range_u32_inclusive(0, 2);
+    align_attackers_to_targets(&mut store, &rules, &interner);
     let result = tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -6223,6 +6309,7 @@ fn inviso_empty_animlist_still_consumes_one_draw() {
     expected_rng.next_u32();
     // Plus the end-of-burst reload jitter, `GetROF @ 0x006FCFA0`.
     expected_rng.next_range_u32_inclusive(0, 2);
+    align_attackers_to_targets(&mut store, &rules, &interner);
     let result = tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -6261,6 +6348,7 @@ fn gsi_08_05_non_inviso_projectile_advances_scenario_rng_by_the_reload_jitter() 
     // reload unconditionally. Exactly one draw, on the scenario instance.
     let mut expected_rng = scenario_rng.clone();
     expected_rng.next_range_u32_inclusive(0, 2);
+    align_attackers_to_targets(&mut store, &rules, &interner);
     let result = tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -6314,6 +6402,7 @@ fn two_inviso_attackers_consume_consecutive_draws_in_live_order() {
         expected_shot(&mut expected_rng),
         expected_shot(&mut expected_rng),
     ];
+    align_attackers_to_targets(&mut store, &rules, &interner);
     let result = tick_combat_with_fog(
         &mut store,
         &mut OccupancyGrid::new(),
@@ -6520,6 +6609,7 @@ fn combat_resolves_in_live_object_order_not_stable_id() {
     // it fires first and lands the lethal shot.
     {
         let (mut store, rules, mut interner) = build();
+        align_attackers_to_targets(&mut store, &rules, &interner);
         let result = tick_combat_with_fog(
             &mut store,
             &mut OccupancyGrid::new(),
@@ -6554,6 +6644,7 @@ fn combat_resolves_in_live_object_order_not_stable_id() {
     // controls the resolution sequence and that &[] reproduces the prior order.
     {
         let (mut store, rules, mut interner) = build();
+        align_attackers_to_targets(&mut store, &rules, &interner);
         let result = tick_combat_with_fog(
             &mut store,
             &mut OccupancyGrid::new(),
@@ -7308,6 +7399,7 @@ fn projectile_shrapnel_targets_hostile_head_before_random_cell_child() {
 
     let handles =
         crate::sim::type_handle_table::ResolvedRuleHandles::resolve(&rules, &mut interner);
+    align_attackers_to_targets(&mut entities, &rules, &interner);
     let result = tick_combat_with_fog_and_main_rng(
         &mut entities,
         &mut occupancy,
@@ -7709,6 +7801,7 @@ fn gsi_08_12_a_grizzly_promotes_through_the_damage_path() {
                 target.cooldown_ticks = 0;
             }
         }
+        align_attackers_to_targets(&mut store, &rules, &interner);
         tick_combat(
             &mut store,
             &mut OccupancyGrid::new(),
@@ -7762,6 +7855,7 @@ fn gsi_08_05_elite_rof_and_firepower_abilities_reach_the_fire_path() {
         {
             target.cooldown_ticks = 0;
         }
+        align_attackers_to_targets(&mut store, &rules, &interner);
         tick_combat(
             &mut store,
             &mut OccupancyGrid::new(),
@@ -7811,6 +7905,7 @@ fn gsi_08_11_unit_death_plays_type_explosion_then_destroy_anim() {
     let mut interner = test_interner();
     issue_attack_command(&mut store, 1, 2, None, &interner);
 
+    align_attackers_to_targets(&mut store, &rules, &interner);
     let result = tick_combat(
         &mut store,
         &mut OccupancyGrid::new(),

--- a/src/sim/combat/combat_turret_facing_tests.rs
+++ b/src/sim/combat/combat_turret_facing_tests.rs
@@ -1291,3 +1291,109 @@ TurretAnimIsVoxel={}\n\n\
         "and is refused past it, with no snap-and-retry"
     );
 }
+
+#[test]
+fn gsi_08_04_rotation_latch_refuses_the_shot_until_the_arc_finishes() {
+    // `UnitClass::GetFireError @ 0x00740FD0` step 14
+    // (`0x00741229`..`0x00741259`): firing-sequence byte `+0x68D` clear AND
+    // rotation latch `+0x6AF` set AND the projectile's `ROT=`
+    // (`BulletTypeClass+0x2DC`) zero -> `MOV EAX,0x4; RET 0xc`, i.e.
+    // FIRE_ROTATING, returned BEFORE the OmniFire skip at `0x0074125C` and
+    // before the step-17 angle test. A turret that has committed to an arc may
+    // not fire partway through it, even once it is inside 0x0800.
+    fn fires_with_latch(latch: bool, projectile_rot: u32, offset: u16) -> bool {
+        let rules = rules_with_homing_projectile(projectile_rot);
+        let mut sim = Simulation::new();
+        spawn_turreted(&mut sim, 1, 5, 5, 5);
+        spawn_target(&mut sim, 2, 5, 9);
+        use_test_interner(&mut sim);
+        let attacker = sim.substrate.entities.get_mut(1).unwrap();
+        attacker.attack_target = Some(AttackTarget::new(2));
+        attacker.barrel_facing = Some(FacingClass::new(
+            facing_from_5_5_to_5_9().wrapping_add(offset),
+            5,
+        ));
+        attacker.turret_rotation_latch = latch;
+        !run_combat_direct(&mut sim, &rules).fire_events.is_empty()
+    }
+
+    // Exactly on target, so nothing but the latch can be doing the refusing.
+    assert!(
+        fires_with_latch(false, 0, 0),
+        "a finished arc fires: this is the control"
+    );
+    assert!(
+        !fires_with_latch(true, 0, 0),
+        "an armed +0x6AF refuses the shot even when the turret is dead on"
+    );
+    // The refusal precedes the tolerance test, so it also refuses a shot the
+    // angle arm would have passed at the edge of 0x0800.
+    assert!(
+        !fires_with_latch(true, 0, 0x0800),
+        "and it is checked before the angle test, not after it"
+    );
+
+    // `MOV EDX,[EBX+0xA0]; MOV EAX,[EDX+0x2DC]; TEST; JNZ 0x0074125C` at
+    // `0x0074123D`..`0x0074124B` skips the whole refusal when the projectile
+    // homes: a missile turret keeps shooting mid-arc where a cannon may not.
+    // It is the same `+0x2DC` that widens the step-17 tolerance to 0x1000.
+    assert!(
+        fires_with_latch(true, 30, 0),
+        "a homing projectile skips FIRE_ROTATING and fires mid-arc"
+    );
+    assert!(
+        fires_with_latch(true, 30, 0x1000),
+        "with its widened tolerance still applying"
+    );
+}
+
+#[test]
+fn gsi_08_04_no_shot_lands_while_the_turret_is_still_swinging() {
+    // The same step 14 refusal, driven through the production
+    // `Simulation::advance_tick` path rather than the combat entry directly,
+    // so the latch really is committed by `apply_unit_facing` and really is
+    // read back by the gate.
+    //
+    // A half-turn arc at `ROT=1` (0x0100 per frame) takes ~128 frames, and its
+    // last 0x0800 takes 8 of them. Without the FIRE_ROTATING refusal the tank
+    // opens fire for those 8 frames while the turret is visibly still swinging;
+    // with it, no shot lands until the arc is over.
+    let mut sim = Simulation::new();
+    spawn_turreted(&mut sim, 1, 5, 5, 1); // facing north
+    spawn_target(&mut sim, 2, 5, 9); // due south: half a turn away
+    use_test_interner(&mut sim);
+    let rules = rules_with_mtnk_rot(1);
+    sim.substrate.entities.get_mut(1).unwrap().attack_target = Some(AttackTarget::new(2));
+
+    let start_hp = sim.substrate.entities.get(2).unwrap().health.current;
+    let mut fired_on_tick = None;
+    for tick in 0..400u32 {
+        let frame = sim.session.binary_frame;
+        let rotating = sim
+            .substrate
+            .entities
+            .get(1)
+            .unwrap()
+            .barrel_facing
+            .as_ref()
+            .is_some_and(|barrel| barrel.is_rotating(frame));
+        sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
+        let hp = sim
+            .substrate
+            .entities
+            .get(2)
+            .map_or(0, |target| target.health.current);
+        if hp < start_hp {
+            assert!(
+                !rotating,
+                "tick {tick}: a shot landed while the turret was still mid-arc"
+            );
+            fired_on_tick = Some(tick);
+            break;
+        }
+    }
+    assert!(
+        fired_on_tick.is_some(),
+        "the refusal must not deadlock the unit - the arc ends and the shot lands"
+    );
+}

--- a/src/sim/combat/combat_turret_facing_tests.rs
+++ b/src/sim/combat/combat_turret_facing_tests.rs
@@ -1068,9 +1068,10 @@ fn gsi_08_14_rotation_latch_suppresses_the_aim_while_the_arc_runs() {
     let rules = rules_with_mtnk_rot(1);
     sim.substrate.entities.get_mut(1).unwrap().attack_target = Some(AttackTarget::new(2));
 
-    // The first tick's read window sees an untouched barrel and only writes the
-    // destination at the post-batch apply; the latch arms on the next visit,
-    // once `Is_Rotating` is true.
+    // The first tick's read window sees an untouched barrel; the destination
+    // and the latch both land at the post-batch apply, the latch armed by that
+    // same `Set` (`0x00736B16` follows `0x00736A89`). A second tick leaves the
+    // arc running, which is the state under test.
     sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
     sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
     let attacker = sim.substrate.entities.get(1).unwrap();
@@ -1138,6 +1139,23 @@ fn rules_with_homing_projectile(projectile_rot: u32) -> RuleSet {
     );
     let ini: IniFile = IniFile::from_str(&ini_str);
     RuleSet::from_ini(&ini).expect("homing fixture should parse")
+}
+
+/// MTNK with an `OmniFire=` primary and no projectile — a weapon the step-17
+/// angle arm never tests (`WeaponTypeClass+0x12B`, read at `0x0074125C`) but
+/// step 14 still refuses.
+fn rules_with_omni_fire() -> RuleSet {
+    let ini_str: String = "[VehicleTypes]\n0=MTNK\n\n\
+[InfantryTypes]\n\n\
+[BuildingTypes]\n0=GAPILE\n\n\
+[AircraftTypes]\n\n\
+[MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nPrimary=105mm\nROT=5\nTurret=yes\n\n\
+[GAPILE]\nStrength=300\nArmor=heavy\n\n\
+[105mm]\nDamage=65\nROF=50\nRange=6\nWarhead=AP\nOmniFire=yes\n\n\
+[AP]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,0%,0%\n"
+        .to_string();
+    let ini: IniFile = IniFile::from_str(&ini_str);
+    RuleSet::from_ini(&ini).expect("omni-fire fixture should parse")
 }
 
 #[test]
@@ -1326,11 +1344,44 @@ fn gsi_08_04_rotation_latch_refuses_the_shot_until_the_arc_finishes() {
         !fires_with_latch(true, 0, 0),
         "an armed +0x6AF refuses the shot even when the turret is dead on"
     );
-    // The refusal precedes the tolerance test, so it also refuses a shot the
-    // angle arm would have passed at the edge of 0x0800.
+    // A shot the angle arm would have passed at the very edge of 0x0800 is
+    // still refused. (This does not by itself pin WHERE the refusal sits: a
+    // refusal placed after a passing angle test returns the same answer. The
+    // OmniFire pair below is the case that does pin it.)
     assert!(
         !fires_with_latch(true, 0, 0x0800),
-        "and it is checked before the angle test, not after it"
+        "an armed latch refuses even at the edge the angle arm accepts"
+    );
+
+    // The placement pin. `0x0074125C` — the OmniFire test that skips the whole
+    // step-17 angle arm — is the JUMP TARGET of all three step-14 skips, so
+    // step 14 runs BEFORE it: an OmniFire weapon, which never turns its turret
+    // and is never angle-gated, is still refused while `+0x6AF` holds. Put the
+    // refusal inside VERA's `!weapon.omni_fire` block instead and this case
+    // fires. The offset is a quarter turn, far outside any tolerance, to prove
+    // the angle arm really is being skipped.
+    fn fires_with_latch_omni(latch: bool) -> bool {
+        let rules = rules_with_omni_fire();
+        let mut sim = Simulation::new();
+        spawn_turreted(&mut sim, 1, 5, 5, 5);
+        spawn_target(&mut sim, 2, 5, 9);
+        use_test_interner(&mut sim);
+        let attacker = sim.substrate.entities.get_mut(1).unwrap();
+        attacker.attack_target = Some(AttackTarget::new(2));
+        attacker.barrel_facing = Some(FacingClass::new(
+            facing_from_5_5_to_5_9().wrapping_add(0x4000),
+            5,
+        ));
+        attacker.turret_rotation_latch = latch;
+        !run_combat_direct(&mut sim, &rules).fire_events.is_empty()
+    }
+    assert!(
+        fires_with_latch_omni(false),
+        "an OmniFire weapon shoots a quarter turn off-axis: the angle arm is skipped"
+    );
+    assert!(
+        !fires_with_latch_omni(true),
+        "but step 14 precedes that skip, so an armed +0x6AF still refuses it"
     );
 
     // `MOV EDX,[EBX+0xA0]; MOV EAX,[EDX+0x2DC]; TEST; JNZ 0x0074125C` at
@@ -1395,5 +1446,83 @@ fn gsi_08_04_no_shot_lands_while_the_turret_is_still_swinging() {
     assert!(
         fired_on_tick.is_some(),
         "the refusal must not deadlock the unit - the arc ends and the shot lands"
+    );
+}
+
+#[test]
+fn gsi_08_04_a_two_step_re_aim_is_refused_for_the_whole_arc_not_only_its_first_frame() {
+    // Where the `+0x6AF` store SITS, in frames a player can count.
+    //
+    // Native writes the latch at `0x00736B16`, which is AFTER arm A's
+    // `FacingClass::Set @ 0x004C9220` (`CALL` at `0x00736A89`) and after the
+    // `Is_Rotating @ 0x004C9480` call at `0x00736B11` that supplies its value.
+    // `Set` stores `duration = abs(delta)/rate` and `start = frame`, so a `Set`
+    // of one or more `ROT=` steps makes `Is_Rotating` true on that same frame:
+    // the arc is latched from frame one, not from frame two.
+    //
+    // At `[MTNK] ROT=5` the step is 0x0500 and a 0x0A00 re-aim (about 14
+    // degrees, the band a tracked target drifts into between shots) takes two
+    // frames. The whole engagement, per the binary:
+    //
+    //   tick 0  arm A `Set`s; the angle test refuses (0x0A00 > 0x0800);
+    //           latch := Is_Rotating == true
+    //   tick 1  latch refuses, and the animated turret is ALREADY inside
+    //           0x0800 — a latch committed pre-`Set` would fire here
+    //   tick 2  latch still refuses; the turret has arrived
+    //   tick 3  the arc is over, the latch clears, the shot lands
+    //
+    // Committing the latch before the `Set` reads false on tick 0 and fires on
+    // tick 1: two frames early, which moves the damage frame and this shot's
+    // position in the RNG stream.
+    let mut sim = Simulation::new();
+    spawn_turreted(&mut sim, 1, 5, 5, 5);
+    spawn_target(&mut sim, 2, 5, 9);
+    use_test_interner(&mut sim);
+    let rules = rules_with_mtnk_rot(5);
+    let desired = facing_from_5_5_to_5_9();
+    {
+        let attacker = sim.substrate.entities.get_mut(1).unwrap();
+        attacker.attack_target = Some(AttackTarget::new(2));
+        // A finished arc that the target has since drifted two ROT steps away
+        // from: not rotating, so nothing but this tick's own `Set` can arm the
+        // latch.
+        attacker.barrel_facing = Some(FacingClass::new(desired.wrapping_add(0x0A00), 5));
+    }
+
+    let start_hp = sim.substrate.entities.get(2).unwrap().health.current;
+    let mut fired_on_tick = None;
+    let mut aimed_on_tick = None;
+    for tick in 0..16u32 {
+        let frame = sim.session.binary_frame;
+        let attacker = sim.substrate.entities.get(1).unwrap();
+        let animated = attacker.barrel_facing.as_ref().unwrap().current(frame);
+        let off_axis = i32::from(animated.wrapping_sub(desired) as i16).abs();
+        if off_axis <= 0x0800 && aimed_on_tick.is_none() {
+            aimed_on_tick = Some(tick);
+        }
+        sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
+        let hp = sim
+            .substrate
+            .entities
+            .get(2)
+            .map_or(0, |target| target.health.current);
+        if hp < start_hp {
+            fired_on_tick = Some(tick);
+            break;
+        }
+    }
+
+    // The angle arm alone would have let the shot through here, so this is what
+    // separates a latch committed post-`Set` from one committed pre-`Set`.
+    assert_eq!(
+        aimed_on_tick,
+        Some(1),
+        "fixture check: the animated turret must already be inside 0x0800 on tick 1"
+    );
+    assert_eq!(
+        fired_on_tick,
+        Some(3),
+        "gamemd holds fire for the whole two-frame arc; firing on tick 1 means the \
+         latch was committed before arm A's Set instead of after it"
     );
 }

--- a/src/sim/combat/combat_turret_facing_tests.rs
+++ b/src/sim/combat/combat_turret_facing_tests.rs
@@ -256,8 +256,14 @@ fn unit_facing_pass_drives_turret_to_target() {
 
     let want = {
         let e = sim.substrate.entities.get(1).unwrap();
-        desired_turret_facing(e, &sim.substrate.entities)
-            .expect("turreted unit has a desired facing")
+        desired_turret_facing(
+            e,
+            &sim.substrate.entities,
+            Some(&rules),
+            &sim.interner,
+            sim.session.binary_frame,
+        )
+        .expect("turreted unit has a desired facing")
     };
     let result = run_combat_direct(&mut sim, &rules);
     crate::sim::world::unit_post::apply_unit_facing(
@@ -356,8 +362,8 @@ fn unit_facing_of(result: &crate::sim::combat::CombatTickResult, id: u64) -> Opt
     result
         .unit_facing
         .iter()
-        .find(|&&(uid, _)| uid == id)
-        .map(|&(_, d)| d)
+        .find(|u| u.entity_id == id)
+        .and_then(|u| u.turret_destination)
 }
 
 #[test]
@@ -375,7 +381,14 @@ fn s3_unit_facing_emitted_for_attacker_and_idle() {
 
     let want_attacker = {
         let e = sim.substrate.entities.get(1).unwrap();
-        desired_turret_facing(e, &sim.substrate.entities).expect("turreted")
+        desired_turret_facing(
+            e,
+            &sim.substrate.entities,
+            Some(&rules),
+            &sim.interner,
+            sim.session.binary_frame,
+        )
+        .expect("turreted")
     };
     let result = run_combat_direct(&mut sim, &rules);
 
@@ -482,7 +495,14 @@ fn kill_tick_unit_facing_holds_target() {
     // passes on the first resolution — same facing_toward_lepton formula.
     let toward_target = {
         let e = sim.substrate.entities.get(1).unwrap();
-        desired_turret_facing(e, &sim.substrate.entities).expect("turreted")
+        desired_turret_facing(
+            e,
+            &sim.substrate.entities,
+            Some(&rules),
+            &sim.interner,
+            sim.session.binary_frame,
+        )
+        .expect("turreted")
     };
     sim.substrate.entities.get_mut(1).unwrap().barrel_facing =
         Some(FacingClass::new(toward_target, 100));
@@ -531,7 +551,14 @@ fn kill_tick_barrel_holds_target_facing() {
 
     let toward_target = {
         let e = sim.substrate.entities.get(1).unwrap();
-        desired_turret_facing(e, &sim.substrate.entities).expect("turreted")
+        desired_turret_facing(
+            e,
+            &sim.substrate.entities,
+            Some(&rules),
+            &sim.interner,
+            sim.session.binary_frame,
+        )
+        .expect("turreted")
     };
     // Pre-align so the fire gate passes on the first combat tick, and make the
     // first shot lethal.
@@ -556,13 +583,29 @@ fn kill_tick_barrel_holds_target_facing() {
         "kill tick: barrel destination holds the dying target's facing"
     );
 
-    // Next tick: the target is gone from the attacker's machines → idle-return.
+    // Next tick the target is gone, but the idle return does NOT begin. Native
+    // gates it on `frame - LastFireFrame(+0x120) >= GuardAreaTargetingDelay + 5`
+    // (`0x00736B35`..`0x00736B7C`), and `+0x120` was just stamped with this
+    // frame by `TechnoClass::Fire_At @ 0x006FF743` — so the dwell is measured
+    // from the unit's OWN LAST SHOT, not from target loss, and the barrel holds.
     sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
     let attacker = sim.substrate.entities.get(1).unwrap();
     assert_eq!(
         attacker.barrel_facing.as_ref().unwrap().destination(),
+        toward_target,
+        "one tick after the kill: the barrel still holds the dead target's aim"
+    );
+
+    // 36 (`[General] GuardAreaTargetingDelay=`, the RuleSet default) + 5 frames
+    // after that shot, the turret returns to the hull heading.
+    for _ in 0..45 {
+        sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
+    }
+    let attacker = sim.substrate.entities.get(1).unwrap();
+    assert_eq!(
+        attacker.barrel_facing.as_ref().unwrap().destination(),
         body_facing_to_turret(attacker.facing),
-        "post-kill tick: idle-return to body facing begins"
+        "past the dwell: idle-return to the hull heading"
     );
 }
 
@@ -584,6 +627,7 @@ fn facing_apply_point_equivalence_no_kill() {
     let rules = rules_with_mtnk_rot(1);
     sim.substrate.entities.get_mut(1).unwrap().attack_target = Some(AttackTarget::new(2));
 
+    let mut previous_destination: BTreeMap<u64, u16> = BTreeMap::new();
     for tick in 0..12 {
         sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
         // No deaths/retargets in this scenario — assert preconditions hold.
@@ -593,14 +637,34 @@ fn facing_apply_point_equivalence_no_kill() {
         );
         for id in [1u64, 3] {
             let e = sim.substrate.entities.get(id).unwrap();
-            let legacy_read = desired_turret_facing(e, &sim.substrate.entities)
-                .expect("turreted unit has a desired facing");
-            let live = e.barrel_facing.as_ref().unwrap().destination();
-            assert_eq!(
-                live, legacy_read,
-                "tick {tick} unit {id}: P2-window destination must equal the \
-                 legacy post-batch read on no-kill ticks"
+            let legacy_read = desired_turret_facing(
+                e,
+                &sim.substrate.entities,
+                Some(&rules),
+                &sim.interner,
+                sim.session.binary_frame,
             );
+            let live = e.barrel_facing.as_ref().unwrap().destination();
+            match legacy_read {
+                Some(want) => assert_eq!(
+                    live, want,
+                    "tick {tick} unit {id}: P2-window destination must equal the \
+                     legacy post-batch read on no-kill ticks"
+                ),
+                // `None` is the rotation latch (`+0x6AF`) or the idle dwell
+                // suppressing the `Set` entirely — the destination must then be
+                // byte-identical to the previous tick's.
+                None => {
+                    if let Some(&prev) = previous_destination.get(&id) {
+                        assert_eq!(
+                            live, prev,
+                            "tick {tick} unit {id}: a frame where native calls no \
+                             `Set` must leave the destination untouched"
+                        );
+                    }
+                }
+            }
+            previous_destination.insert(id, live);
         }
     }
 }
@@ -623,11 +687,25 @@ fn co_attacker_facing_matches_killer() {
 
     let killer_aim = {
         let e = sim.substrate.entities.get(1).unwrap();
-        desired_turret_facing(e, &sim.substrate.entities).expect("turreted")
+        desired_turret_facing(
+            e,
+            &sim.substrate.entities,
+            Some(&rules),
+            &sim.interner,
+            sim.session.binary_frame,
+        )
+        .expect("turreted")
     };
     let co_aim = {
         let e = sim.substrate.entities.get(3).unwrap();
-        desired_turret_facing(e, &sim.substrate.entities).expect("turreted")
+        desired_turret_facing(
+            e,
+            &sim.substrate.entities,
+            Some(&rules),
+            &sim.interner,
+            sim.session.binary_frame,
+        )
+        .expect("turreted")
     };
     sim.substrate.entities.get_mut(1).unwrap().barrel_facing =
         Some(FacingClass::new(killer_aim, 100));
@@ -671,7 +749,14 @@ fn save_load_round_trip_on_kill_tick() {
     sim.substrate.entities.get_mut(1).unwrap().attack_target = Some(AttackTarget::new(2));
     let toward_target = {
         let e = sim.substrate.entities.get(1).unwrap();
-        desired_turret_facing(e, &sim.substrate.entities).expect("turreted")
+        desired_turret_facing(
+            e,
+            &sim.substrate.entities,
+            Some(&rules),
+            &sim.interner,
+            sim.session.binary_frame,
+        )
+        .expect("turreted")
     };
     sim.substrate.entities.get_mut(1).unwrap().barrel_facing =
         Some(FacingClass::new(toward_target, 100));
@@ -713,7 +798,14 @@ fn non_unit_barrel_still_driven_by_global_sweep() {
 
     let want = {
         let e = sim.substrate.entities.get(1).unwrap();
-        desired_turret_facing(e, &sim.substrate.entities).expect("turreted structure")
+        desired_turret_facing(
+            e,
+            &sim.substrate.entities,
+            Some(&rules),
+            &sim.interner,
+            sim.session.binary_frame,
+        )
+        .expect("turreted structure")
     };
     sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
     assert_eq!(
@@ -765,5 +857,437 @@ fn unit_facing_pass_idles_turret_to_body_without_target() {
         dest,
         body_facing_to_turret(64),
         "idle Unit barrel should return to body facing via the residual pass + apply"
+    );
+}
+
+// --- M4: the turretless body gate, the latch, the dwell and the widened
+//     tolerance (rows 126 GSI-08.14 / 124 GSI-08.04) ---
+
+/// Spawn a `Turret=no` attacker at (rx, ry) facing north. `rules_with_mtnk_rot`
+/// authors no `Turret=` for `[MTNK]`, so leaving `barrel_facing` unset is what
+/// makes this the turretless case the body gate covers.
+fn spawn_turretless(sim: &mut Simulation, stable_id: u64, rx: u16, ry: u16) {
+    let entity = GameEntity::test_default(stable_id, "MTNK", "Americans", rx, ry);
+    sim.substrate.entities.insert(entity);
+    assert!(matches!(
+        sim.reveal(stable_id),
+        crate::sim::world::RevealOutcome::Revealed { .. }
+    ));
+}
+
+#[test]
+fn gsi_08_04_turretless_vehicle_turns_its_hull_before_it_fires() {
+    // The headline scenario: an artillery-shaped vehicle with no turret must
+    // rotate its BODY to face the target before it may shoot, so its first shot
+    // is delayed instead of instant.
+    //
+    // gamemd: `UnitClass::GetFireError @ 0x00740FD0` step 17 compares the HULL
+    // `+0x388` for a `Turret=no` firer (`0x0074129F`..`0x007412AA`) and returns
+    // 2 outside `0x0800`; `UnitClass::Fire_At_Target @ 0x00736DF0` case 2 then
+    // turns the hull at `ROT=` with `FacingClass::Set(+0x388)` at `0x00737004`,
+    // but only while the unit is stationary with no destination.
+    let mut sim = Simulation::new();
+    spawn_turretless(&mut sim, 1, 5, 5); // facing north (0)
+    spawn_target(&mut sim, 2, 5, 9); // due south, inside Range=6
+    use_test_interner(&mut sim);
+    let rules = rules_with_mtnk_rot(5);
+    sim.substrate.entities.get_mut(1).unwrap().attack_target = Some(AttackTarget::new(2));
+
+    // A target assignment writes the pointer and nothing else - no snap.
+    assert_eq!(
+        sim.substrate.entities.get(1).unwrap().facing,
+        0,
+        "assigning a target must not rotate the hull by itself"
+    );
+
+    let start_hp = sim.substrate.entities.get(2).unwrap().health.current;
+    for tick in 0..8 {
+        sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
+        assert_eq!(
+            sim.substrate.entities.get(2).unwrap().health.current,
+            start_hp,
+            "tick {tick}: an off-axis turretless firer must be refused"
+        );
+    }
+    assert_ne!(
+        sim.substrate.entities.get(1).unwrap().facing,
+        0,
+        "the hull must be turning toward the target meanwhile"
+    );
+
+    // And it must eventually line up and shoot - the gate must not deadlock a
+    // unit that has no turret to aim with.
+    let mut fired = false;
+    for _ in 0..80 {
+        sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
+        if sim
+            .substrate
+            .entities
+            .get(2)
+            .is_none_or(|t| t.health.current < start_hp)
+        {
+            fired = true;
+            break;
+        }
+    }
+    assert!(
+        fired,
+        "once the hull is inside 0x0800 the shot must be allowed"
+    );
+}
+
+#[test]
+fn gsi_08_04_moving_turretless_vehicle_does_not_turn_to_fire() {
+    // `Fire_At_Target` case 2 turns the hull only when `NavCom == 0` and the
+    // locomotor reports not-moving (`0x00736FB6`..`0x00736FE6`). A unit under a
+    // move order keeps its travel heading; nothing re-aims it for the shot.
+    let mut sim = Simulation::new();
+    spawn_turretless(&mut sim, 1, 5, 5);
+    spawn_target(&mut sim, 2, 5, 9);
+    use_test_interner(&mut sim);
+    let rules = rules_with_mtnk_rot(5);
+    {
+        let attacker = sim.substrate.entities.get_mut(1).unwrap();
+        attacker.attack_target = Some(AttackTarget::new(2));
+        attacker.passively_acquired_target = true; // pursuit leaves this one alone
+        attacker.movement_target = Some(crate::sim::components::MovementTarget::default());
+    }
+
+    let facing_before = sim.substrate.entities.get(1).unwrap().facing;
+    let result = run_combat_direct(&mut sim, &rules);
+    let slot = result
+        .unit_facing
+        .iter()
+        .find(|u| u.entity_id == 1)
+        .expect("every Unit gets a Facing slot entry");
+    assert_eq!(
+        slot.hull_destination, None,
+        "a moving turretless firer emits no hull turn"
+    );
+    assert_eq!(
+        sim.substrate.entities.get(1).unwrap().facing,
+        facing_before,
+        "and its heading is untouched by the fire decision"
+    );
+}
+
+#[test]
+fn gsi_08_14_idle_turret_dwell_is_measured_from_the_units_own_last_shot() {
+    // `0x00736B2F`..`0x00736B7C`: the idle return needs
+    // `frame - LastFireFrame(+0x120) >= GuardAreaTargetingDelay + 5`. A unit
+    // that has never fired carries the constructor's `-100` (`0x006F2B9C`), so
+    // it is already past the dwell and returns on the first idle frame.
+    let mut sim = Simulation::new();
+    spawn_turreted(&mut sim, 1, 5, 5, 100);
+    sim.substrate.entities.get_mut(1).unwrap().facing = 64;
+    use_test_interner(&mut sim);
+    let rules = rules_with_mtnk_rot(100);
+
+    let never_fired = run_combat_direct(&mut sim, &rules);
+    assert_eq!(
+        never_fired
+            .unit_facing
+            .iter()
+            .find(|u| u.entity_id == 1)
+            .and_then(|u| u.turret_destination),
+        Some(body_facing_to_turret(64)),
+        "a unit that never fired is already past the dwell"
+    );
+
+    // Stamp a shot on this frame and the same idle unit holds instead.
+    sim.substrate.entities.get_mut(1).unwrap().last_fire_frame =
+        i64::from(sim.session.binary_frame);
+    let just_fired = run_combat_direct(&mut sim, &rules);
+    assert_eq!(
+        just_fired
+            .unit_facing
+            .iter()
+            .find(|u| u.entity_id == 1)
+            .and_then(|u| u.turret_destination),
+        None,
+        "inside the dwell native calls no Set at all - the aim is held"
+    );
+}
+
+#[test]
+fn gsi_08_14_idle_turret_leads_toward_the_move_destination() {
+    // `0x00736BA3`..`0x00736BC8`: when the idle return fires and a NavCom is
+    // set, the destination is `DirectionToTarget(this, NavCom)` - the turret
+    // leads toward where the unit is going, not back to the hull.
+    let mut sim = Simulation::new();
+    spawn_turreted(&mut sim, 1, 5, 5, 100);
+    sim.substrate.entities.get_mut(1).unwrap().facing = 0; // hull north
+    use_test_interner(&mut sim);
+    let rules = rules_with_mtnk_rot(100);
+    {
+        let movement = crate::sim::components::MovementTarget {
+            path: vec![(5, 5), (9, 5)], // destination four cells EAST
+            ..Default::default()
+        };
+        sim.substrate.entities.get_mut(1).unwrap().movement_target = Some(movement);
+    }
+
+    let result = run_combat_direct(&mut sim, &rules);
+    let desired = result
+        .unit_facing
+        .iter()
+        .find(|u| u.entity_id == 1)
+        .and_then(|u| u.turret_destination)
+        .expect("an idle turret past its dwell takes a destination");
+    let want = crate::sim::movement::turret::facing_toward_lepton(
+        5,
+        5,
+        crate::util::fixed_math::SimFixed::from_num(128),
+        crate::util::fixed_math::SimFixed::from_num(128),
+        9,
+        5,
+        crate::util::fixed_math::SimFixed::from_num(128),
+        crate::util::fixed_math::SimFixed::from_num(128),
+    );
+    assert_eq!(
+        desired, want,
+        "the idle turret leads toward the move destination, not the hull heading"
+    );
+    assert_ne!(
+        desired,
+        body_facing_to_turret(0),
+        "and specifically not back to the hull heading"
+    );
+}
+
+#[test]
+fn gsi_08_14_rotation_latch_suppresses_the_aim_while_the_arc_runs() {
+    // `0x00736AEA`..`0x00736B16`: while `FacingClass::Is_Rotating` holds, the
+    // latch `+0x6AF` is armed and the WHOLE aim block is skipped on the next
+    // frame, so native commits to each arc instead of re-snapshotting `prev`
+    // against a moving target every frame.
+    let mut sim = Simulation::new();
+    spawn_turreted(&mut sim, 1, 5, 5, 1); // ROT=1 gives a long arc
+    spawn_target(&mut sim, 2, 5, 9);
+    use_test_interner(&mut sim);
+    let rules = rules_with_mtnk_rot(1);
+    sim.substrate.entities.get_mut(1).unwrap().attack_target = Some(AttackTarget::new(2));
+
+    // The first tick's read window sees an untouched barrel and only writes the
+    // destination at the post-batch apply; the latch arms on the next visit,
+    // once `Is_Rotating` is true.
+    sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
+    sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
+    let attacker = sim.substrate.entities.get(1).unwrap();
+    assert!(
+        attacker.turret_rotation_latch,
+        "an arc in progress must arm +0x6AF"
+    );
+    let committed = attacker.barrel_facing.as_ref().unwrap().destination();
+
+    // While it is armed the aim block produces no new destination, even though
+    // the target has not moved and the turret is still short of it.
+    let held = run_combat_direct(&mut sim, &rules);
+    assert_eq!(
+        held.unit_facing
+            .iter()
+            .find(|u| u.entity_id == 1)
+            .and_then(|u| u.turret_destination),
+        None,
+        "the latch suppresses the aim arm"
+    );
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(1)
+            .unwrap()
+            .barrel_facing
+            .as_ref()
+            .unwrap()
+            .destination(),
+        committed,
+        "so the committed arc destination survives the frame"
+    );
+}
+
+/// The exact 16-bit facing from cell (5,5) to cell (5,9) that the fire gate
+/// computes. `atan2`+`ftol` does not land on a round 0x8000, so offsets in the
+/// tolerance tests are taken from this value rather than from a constant.
+fn facing_from_5_5_to_5_9() -> u16 {
+    crate::sim::movement::turret::facing_toward_lepton(
+        5,
+        5,
+        crate::util::fixed_math::SimFixed::from_num(128),
+        crate::util::fixed_math::SimFixed::from_num(128),
+        5,
+        9,
+        crate::util::fixed_math::SimFixed::from_num(128),
+        crate::util::fixed_math::SimFixed::from_num(128),
+    )
+}
+
+/// Rules with an `MTNK` whose 105mm fires a HOMING projectile (`ROT=` non-zero
+/// on the `[Projectile]` section) - the input that widens the fire tolerance.
+fn rules_with_homing_projectile(projectile_rot: u32) -> RuleSet {
+    let ini_str: String = format!(
+        "[VehicleTypes]\n0=MTNK\n\n\
+[InfantryTypes]\n\n\
+[BuildingTypes]\n0=GAPILE\n\n\
+[AircraftTypes]\n\n\
+[Projectiles]\n0=Homer\n\n\
+[MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nPrimary=105mm\nROT=5\nTurret=yes\n\n\
+[GAPILE]\nStrength=300\nArmor=heavy\n\n\
+[Homer]\nROT={projectile_rot}\n\n\
+[105mm]\nDamage=65\nROF=50\nRange=6\nWarhead=AP\nProjectile=Homer\n\n\
+[AP]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,0%,0%\n"
+    );
+    let ini: IniFile = IniFile::from_str(&ini_str);
+    RuleSet::from_ini(&ini).expect("homing fixture should parse")
+}
+
+#[test]
+fn gsi_08_03_homing_projectile_widens_the_fire_tolerance_to_0x1000() {
+    // `0x007412BC`..`0x007412CC`: the tolerance byte is built from the
+    // PROJECTILE's `ROT=` (`WeaponType+0xA0` -> `BulletTypeClass+0x2DC`) with
+    // `NEG`/`SBB`/`AND 8`/`ADD 8` - 8 when that ROT is zero, 0x10 when it is
+    // not - then `MOV CH,BL` shifts it into the high byte. A missile turret
+    // therefore shoots up to 1/16 of a turn off-axis.
+    fn fires_at_offset(rules: &RuleSet, offset: u16) -> bool {
+        let mut sim = Simulation::new();
+        spawn_turreted(&mut sim, 1, 5, 5, 5);
+        spawn_target(&mut sim, 2, 5, 9); // due south -> 0x8000
+        use_test_interner(&mut sim);
+        sim.substrate.entities.get_mut(1).unwrap().attack_target = Some(AttackTarget::new(2));
+        sim.substrate.entities.get_mut(1).unwrap().barrel_facing = Some(FacingClass::new(
+            facing_from_5_5_to_5_9().wrapping_add(offset),
+            5,
+        ));
+        !run_combat_direct(&mut sim, rules).fire_events.is_empty()
+    }
+
+    let straight = rules_with_homing_projectile(0);
+    let homing = rules_with_homing_projectile(30);
+    assert!(
+        fires_at_offset(&straight, 0x0800),
+        "0x0800 itself passes - the native JGE skips the error return"
+    );
+    assert!(
+        !fires_at_offset(&straight, 0x0801),
+        "a straight-flying projectile is refused one unit past 0x0800"
+    );
+    assert!(
+        fires_at_offset(&homing, 0x0801),
+        "a homing projectile widens the slack"
+    );
+    assert!(
+        fires_at_offset(&homing, 0x1000),
+        "all the way to 0x1000 inclusive"
+    );
+    assert!(!fires_at_offset(&homing, 0x1001), "and no further");
+}
+
+#[test]
+fn gsi_08_14_building_turret_holds_its_last_aim() {
+    // A LEA census over `BuildingClass::Update`, `Mission_Guard` and every idle
+    // path finds no `Set`/`UpdateFacing` of `+0x388` outside the attack,
+    // construction and sell paths: a building turret never swings back to a
+    // "body" heading, because a building has no hull.
+    let mut sim = Simulation::new();
+    let mut tower = GameEntity::test_default(1, "MTNK", "Americans", 5, 5);
+    tower.category = crate::map::entities::EntityCategory::Structure;
+    tower.lifecycle.in_limbo = false;
+    tower.barrel_facing = Some(FacingClass::new(body_facing_to_turret(0), 100));
+    tower.attack_target = Some(AttackTarget::new(2));
+    sim.substrate.entities.insert(tower);
+    spawn_target(&mut sim, 2, 5, 9); // due south
+    use_test_interner(&mut sim);
+    let rules = rules_with_mtnk_rot(100);
+
+    sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
+    let aimed = sim
+        .substrate
+        .entities
+        .get(1)
+        .unwrap()
+        .barrel_facing
+        .as_ref()
+        .unwrap()
+        .destination();
+    assert_ne!(aimed, body_facing_to_turret(0), "it aimed at the target");
+
+    // Drop the target and let a long time pass - the aim must not move.
+    sim.substrate.entities.get_mut(1).unwrap().attack_target = None;
+    for _ in 0..60 {
+        sim.advance_tick(&[], Some(&rules), &empty_height_map(), None, None, 67);
+    }
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(1)
+            .unwrap()
+            .barrel_facing
+            .as_ref()
+            .unwrap()
+            .destination(),
+        aimed,
+        "a target-less building turret keeps its last aim forever"
+    );
+}
+
+#[test]
+fn gsi_08_04_voxel_turret_building_needs_an_exact_match_then_snaps_within_one_rot_step() {
+    // `BuildingClass::GetFireError @ 0x00448010`..`0x00448045` narrows the
+    // tolerance to `0x0000` when `BuildingTypeClass+0x16C5` (`TurretAnimIsVoxel=`)
+    // is set, and `BuildingClass::Mission_Attack @ 0x0044B068`..`0x0044B0B3`
+    // gives it a second chance in the SAME visit: within one `ROT=` step it
+    // snaps `+0x388` with `UpdateFacing` and re-runs the error check.
+    fn tower_rules(voxel: bool, rot: u32) -> RuleSet {
+        let ini_str: String = format!(
+            "[VehicleTypes]\n\n\
+[InfantryTypes]\n\n\
+[AircraftTypes]\n\n\
+[BuildingTypes]\n0=GTGCAN\n1=TGT\n\n\
+[GTGCAN]\nStrength=900\nArmor=concrete\nPrimary=105mm\nROT={rot}\nTurret=yes\n\
+TurretAnimIsVoxel={}\n\n\
+[TGT]\nStrength=300\nArmor=heavy\n\n\
+[105mm]\nDamage=65\nROF=50\nRange=6\nWarhead=AP\n\n\
+[AP]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,0%,0%\n",
+            if voxel { "true" } else { "false" }
+        );
+        RuleSet::from_ini(&IniFile::from_str(&ini_str)).expect("tower fixture should parse")
+    }
+    fn fires_at_offset(voxel: bool, rot: u32, offset: u16) -> bool {
+        let rules = tower_rules(voxel, rot);
+        let mut sim = Simulation::new();
+        let mut tower = GameEntity::test_default(1, "GTGCAN", "Americans", 5, 5);
+        tower.category = crate::map::entities::EntityCategory::Structure;
+        tower.lifecycle.in_limbo = false;
+        tower.barrel_facing = Some(FacingClass::new(
+            facing_from_5_5_to_5_9().wrapping_add(offset),
+            rot.clamp(0, 0x7F) as u8,
+        ));
+        tower.attack_target = Some(AttackTarget::new(2));
+        sim.substrate.entities.insert(tower);
+        let target = GameEntity::test_default(2, "TGT", "Soviet", 5, 9); // due south -> 0x8000
+        sim.substrate.entities.insert(target);
+        sim.reveal(1);
+        sim.reveal(2);
+        use_test_interner(&mut sim);
+        !run_combat_direct(&mut sim, &rules).fire_events.is_empty()
+    }
+
+    // ROT=1 means one step is 0x0100.
+    assert!(fires_at_offset(true, 1, 0), "an exact match always passes");
+    assert!(
+        fires_at_offset(true, 1, 0x0100),
+        "within one ROT step the voxel turret snaps and fires the same visit"
+    );
+    assert!(
+        !fires_at_offset(true, 1, 0x0101),
+        "one unit further and it must turn gradually instead"
+    );
+    // An SHP turret keeps the ordinary 0x0800 slack and never snaps.
+    assert!(
+        fires_at_offset(false, 1, 0x0800),
+        "an SHP-turret building keeps the 0x0800 tolerance"
+    );
+    assert!(
+        !fires_at_offset(false, 1, 0x0801),
+        "and is refused past it, with no snap-and-retry"
     );
 }

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -123,7 +123,53 @@ const REVEAL_ON_FIRE_RADIUS: u16 = 3;
 /// `0x007412C9`/`0x007412CC` and compared at `0x007412ED`/`0x007412EF`.
 const NATIVE_FIRE_FACING_TOLERANCE: i32 = 0x0800;
 
+/// The widened slack a HOMING weapon gets — 1/16 of a turn. Native builds the
+/// tolerance byte from the PROJECTILE's `ROT=` (`WeaponType+0xA0` →
+/// `BulletTypeClass+0x2DC`, read at `0x007412BC`) with
+/// `NEG`/`SBB`/`AND 8`/`ADD 8` at `0x007412C3`..`0x007412CC`: 8 when that ROT is
+/// zero, 0x10 when it is not, then `MOV CH,BL` shifts it into the high byte.
+const NATIVE_FIRE_FACING_TOLERANCE_HOMING: i32 = 0x1000;
+
+/// A voxel-turret BUILDING must match its target facing EXACTLY.
+/// `BuildingClass::GetFireError @ 0x00447F10` builds the same tolerance byte
+/// from `BuildingTypeClass+0x16C5` (`TurretAnimIsVoxel=`, read at `0x00448010`)
+/// but with `AND -8`, giving 0 for a voxel turret and 8 for an SHP one.
+const NATIVE_FIRE_FACING_TOLERANCE_VOXEL_TURRET: i32 = 0x0000;
+
 const ANIM_LIST_DAMAGE_STEP: u16 = 25;
+
+/// One Unit's post-Foot Facing slot output for this tick — the write half of
+/// `UnitClass::Facing_Update @ 0x00736990` plus the `Fire_At_Target @
+/// 0x00736DF0` case-2 hull turn, carried from the combat read window to
+/// `unit_post::apply_unit_facing`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UnitFacingUpdate {
+    pub entity_id: u64,
+    /// Turret (`+0x3A0`) destination. `None` means native calls no `Set` on the
+    /// turret this frame — the difference between holding an aim and swinging
+    /// back to the hull.
+    pub turret_destination: Option<u16>,
+    /// Hull (`+0x388`) destination. Set by `Fire_At_Target` case 2 when a
+    /// TURRETLESS vehicle is refused for facing while stationary, and by the
+    /// `Facing_Update` arm-A mid-arc pin.
+    pub hull_destination: Option<u16>,
+    /// New value of the `+0x6AF` rotation latch.
+    pub latch: bool,
+}
+
+impl UnitFacingUpdate {
+    fn from_facing_update(
+        entity_id: u64,
+        update: crate::sim::movement::turret::FacingUpdate,
+    ) -> Self {
+        Self {
+            entity_id,
+            turret_destination: update.turret_destination,
+            hull_destination: update.hull_destination,
+            latch: update.latch,
+        }
+    }
+}
 
 /// Explicitly classified delivery decision at weapon fire.
 ///
@@ -831,10 +877,15 @@ pub fn issue_attack_command(
     };
 
     // Read attacker position before mutable borrow (needed for body-facing delta).
-    let attacker_pos = entities
-        .get(attacker_id)
-        .map(|a| (a.position.rx, a.position.ry, a.barrel_facing.is_some()));
-    let (arx, ary, has_turret) = match attacker_pos {
+    let attacker_pos = entities.get(attacker_id).map(|a| {
+        (
+            a.position.rx,
+            a.position.ry,
+            a.barrel_facing.is_some(),
+            a.category,
+        )
+    });
+    let (arx, ary, has_turret, category) = match attacker_pos {
         Some(p) => p,
         None => return false,
     };
@@ -845,11 +896,24 @@ pub fn issue_attack_command(
         None => return false,
     };
 
-    // Body-only: instantly face the target. For turreted units, the turret
-    // rotates over multiple ticks — driven by tick_turret_rotation reading
-    // attack_target — so we set NO facing here. This matches gamemd: command
-    // handlers set the target; Facing_Update drives the rotation.
-    if !has_turret {
+    // gamemd-derived: a target assignment writes the target pointer and nothing
+    // else — no facing. A TURRETLESS VEHICLE therefore gets no instant snap
+    // here: `UnitClass::Fire_At_Target @ 0x00736DF0` case 2 turns its hull at
+    // `ROT=` (`FacingClass::Set(+0x388)` at `0x00737004`) only once the fire
+    // gate refuses the shot for facing, and only while it is stationary.
+    //
+    // RESIDUAL (GSI-08.04) — infantry (and the aircraft/structure fallthrough)
+    // keep the order-time snap. Native snaps infantry `+0x388` with
+    // `FacingClass::UpdateFacing` at `0x0052091F`, inside
+    // `InfantryClass::Fire_At_Target @ 0x005206B0`, at the moment the FIRE
+    // sequence starts — not at order time, and with no angle gate either way.
+    // - Trigger: ordering any infantryman to attack.
+    // - Player effect: he turns to face while still walking in, instead of
+    //   snapping round as he opens fire.
+    // - Frequency: every infantry attack order.
+    // - Downstream risk: none to the fire decision — infantry are not
+    //   angle-gated at all — but the rendered approach facing differs.
+    if !has_turret && category != EntityCategory::Unit {
         let dx: i32 = trx as i32 - arx as i32;
         let dy: i32 = try_ as i32 - ary as i32;
         attacker.facing = crate::sim::movement::facing_from_delta(dx, dy);
@@ -941,9 +1005,10 @@ pub fn issue_attack_cell_command(
             a.position.ry,
             a.barrel_facing.is_some(),
             has_weapon,
+            a.category,
         )
     });
-    let (arx, ary, has_turret, has_weapon) = match attacker_info {
+    let (arx, ary, has_turret, has_weapon, category) = match attacker_info {
         Some(info) => info,
         None => return false,
     };
@@ -967,7 +1032,9 @@ pub fn issue_attack_cell_command(
         None => return false,
     };
 
-    if !has_turret {
+    // See `issue_attack_command` — a turretless VEHICLE turns through
+    // `Fire_At_Target` case 2, not at order time.
+    if !has_turret && category != EntityCategory::Unit {
         let dx: i32 = trx as i32 - arx as i32;
         let dy: i32 = try_ as i32 - ary as i32;
         attacker.facing = crate::sim::movement::facing_from_delta(dx, dy);
@@ -1312,12 +1379,13 @@ pub struct CombatTickResult {
     /// Hookless-test adapter for smudge requests. Empty on the production world
     /// path because each producer commits before returning.
     pub smudge_spawn_requests: Vec<SmudgeSpawnRequest>,
-    /// (unit_id, desired 16-bit barrel destination) — captured at Phase-2
-    /// entry before current-frame attacker damage; that Unit's own explicit
-    /// retarget/remove may replace it. Applied post-batch by
+    /// Per-Unit post-Foot Facing slot output — captured at Phase-2 entry before
+    /// current-frame attacker damage; that Unit's own explicit retarget/remove
+    /// may replace it, and its `Fire_At_Target` case-2 hull turn is appended
+    /// during the fire pass. Applied post-batch by
     /// `unit_post::apply_unit_facing`. Transient — never stored, serialized, or
     /// hashed.
-    pub unit_facing: Vec<(u64, u16)>,
+    pub unit_facing: Vec<UnitFacingUpdate>,
     /// Base-structure / harvester enemy-damage pings produced at the damage
     /// apply site. Drained by the world into BaseUnderAttack/MinerUnderAttack
     /// radar events + the local player's EVA dispatch.
@@ -4032,11 +4100,10 @@ pub(crate) struct CombatEmit {
     /// Native `CurrentWeaponNumber` writes emitted by live weapon selection.
     /// The per-attacker host commits these before that attack's receivers run.
     pub(crate) current_weapon_updates: Vec<(u64, u8, InternedId)>,
-    /// (unit_id, desired 16-bit barrel destination) — captured at Phase-2
-    /// entry before current-frame attacker damage; that Unit's own explicit
-    /// retarget/remove may replace it. Applied post-batch by
-    /// `unit_post::apply_unit_facing`.
-    pub(crate) unit_facing: Vec<(u64, u16)>,
+    /// Per-Unit post-Foot Facing slot output — captured at Phase-2 entry before
+    /// current-frame attacker damage; that Unit's own explicit retarget/remove
+    /// may replace it. Applied post-batch by `unit_post::apply_unit_facing`.
+    pub(crate) unit_facing: Vec<UnitFacingUpdate>,
     /// (parent_id, target) — a `Spawner=yes` weapon reached its fire point.
     /// gamemd's `Fire_At` hands the target to the parent's `SpawnManager` and
     /// returns NULL, so no bullet, damage or rearm follows.
@@ -5619,16 +5686,22 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
     // but that approximation must not make this frame's barrel destination
     // observe a target loss native Facing_Update cannot yet see.
     for snap in &snapshots {
-        let Some(entity) = entities.get(snap.stable_id).filter(|entity| {
-            entity.category == EntityCategory::Unit && entity.barrel_facing.is_some()
-        }) else {
-            continue;
-        };
-        let Some(desired) = crate::sim::movement::turret::desired_turret_facing(entity, entities)
+        let Some(entity) = entities
+            .get(snap.stable_id)
+            .filter(|entity| entity.category == EntityCategory::Unit)
         else {
             continue;
         };
-        emit.unit_facing.push((snap.stable_id, desired));
+        emit.unit_facing.push(UnitFacingUpdate::from_facing_update(
+            snap.stable_id,
+            crate::sim::movement::turret::facing_update(
+                entity,
+                entities,
+                Some(rules),
+                interner,
+                binary_frame,
+            ),
+        ));
     }
 
     // Phase 2: per-attacker fire decision + emission, in live-LOGIC snapshot
@@ -5791,19 +5864,16 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             .map(|&(_, tid)| tid);
         let own_removed = emit.remove_attack[n_remove..].contains(&snap.stable_id);
         let replacement: Option<u16> = if let Some(tid) = own_retarget {
-            Some(match entities.get(tid) {
-                Some(t) => crate::sim::movement::turret::facing_toward_lepton(
-                    e.position.rx,
-                    e.position.ry,
-                    e.position.sub_x,
-                    e.position.sub_y,
-                    t.position.rx,
-                    t.position.ry,
-                    t.position.sub_x,
-                    t.position.sub_y,
-                ),
-                None => crate::sim::movement::turret::body_facing_to_turret(e.facing),
-            })
+            Some(
+                crate::sim::movement::turret::facing_toward_target(
+                    e,
+                    &TargetKind::Entity(tid),
+                    entities,
+                    Some(rules),
+                    interner,
+                )
+                .unwrap_or_else(|| crate::sim::movement::turret::body_facing_to_turret(e.facing)),
+            )
         } else if own_removed {
             Some(crate::sim::movement::turret::body_facing_to_turret(
                 e.facing,
@@ -5812,12 +5882,12 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             None
         };
         if let Some(replacement) = replacement {
-            let (_, desired) = emit
+            let update = emit
                 .unit_facing
                 .iter_mut()
-                .find(|(id, _)| *id == snap.stable_id)
-                .expect("turreted Unit attacker was seeded before fire");
-            *desired = replacement;
+                .find(|u| u.entity_id == snap.stable_id)
+                .expect("Unit attacker was seeded before fire");
+            update.turret_destination = Some(replacement);
         }
     }
     // S3 residual: every Unit not in the attacker snapshot set (target-less,
@@ -5825,7 +5895,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
     // all attack ReceiveDamage/death-helper calls, so its target read observes
     // the same live state the next native object window would expose.
     {
-        let mut computed: Vec<u64> = emit.unit_facing.iter().map(|&(id, _)| id).collect();
+        let mut computed: Vec<u64> = emit.unit_facing.iter().map(|u| u.entity_id).collect();
         computed.sort_unstable();
         for &id in &keys {
             if fire_suppressed.contains(&id) {
@@ -5838,11 +5908,16 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             if e.category != EntityCategory::Unit {
                 continue;
             }
-            let Some(desired) = crate::sim::movement::turret::desired_turret_facing(e, entities)
-            else {
-                continue;
-            };
-            emit.unit_facing.push((id, desired));
+            emit.unit_facing.push(UnitFacingUpdate::from_facing_update(
+                id,
+                crate::sim::movement::turret::facing_update(
+                    e,
+                    entities,
+                    Some(rules),
+                    interner,
+                    binary_frame,
+                ),
+            ));
         }
     }
     // Every projectile, missile, and live-order attack damage event emitted so
@@ -5918,6 +5993,14 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
     }
     for &(attacker_id, burst_rem, burst_delay, rof_cd) in &burst_updates {
         if let Some(entity) = entities.get_mut(attacker_id) {
+            // gamemd-derived: `TechnoClass::Fire_At @ 0x006FF743` stores
+            // `g_CurrentFrameCounter` into `+0x120` once the shot is committed.
+            // With the constructor at `0x006F2B9C` that is the ONLY writer of
+            // that field on a TechnoClass in the image, which is what makes
+            // `UnitClass::Facing_Update`'s idle dwell a since-my-last-shot
+            // timer rather than a since-target-loss one. `burst_updates` carries
+            // exactly one entry per committed shot, so this is that store.
+            entity.last_fire_frame = i64::from(binary_frame);
             if let Some(ref mut attack) = entity.attack_target {
                 attack.burst_remaining = burst_rem;
                 attack.burst_delay_ticks = burst_delay;
@@ -6182,6 +6265,7 @@ pub(crate) fn build_attacker_snapshot(
         pending_infantry_fire,
         pending_building_fire,
         barrel_facing: entity.barrel_facing,
+        hull_facing: entity.body_facing,
         burst_remaining,
         burst_delay_ticks,
         weapon_override: entity.weapon_override,
@@ -6922,8 +7006,43 @@ pub(crate) fn resolve_attacker_fire(
         }
     }
 
-    // Turret alignment check (FacingClass: destination match + not rotating).
-    if let Some(ref barrel) = snap.barrel_facing {
+    // ---- Facing arm of the fire gate ------------------------------------
+    //
+    // gamemd-derived: `UnitClass::GetFireError @ 0x00740FD0` step 17
+    // (`0x00741288`..`0x007412EF`, read this session by `disassemble_bytes`;
+    // Ghidra has no function boundary there) and its structure twin
+    // `BuildingClass::GetFireError @ 0x00447F10` (`0x00447FE1`..`0x00448045`).
+    //
+    // Native picks the facing to test by `Turret=` (`TechnoType+0xCA1`), NOT by
+    // whether a turret interpolator exists: `Turret=yes` compares the turret
+    // `+0x3A0`, `Turret=no` compares the HULL `+0x388`. Both use the same
+    // tolerance, both take the 16-bit signed difference against
+    // `DirectionToTarget`, and the `JGE` at `0x007412EF` skips the error return
+    // — so `|delta| == tol` passes and `tol + 1` fails. There is no
+    // not-rotating term.
+    //
+    // Infantry are NOT angle-gated: `InfantryClass::Fire_At_Target @
+    // 0x005206B0` snaps `+0x388` with `UpdateFacing` at `0x0052091F` the moment
+    // firing becomes possible and applies no test. A turretless STRUCTURE gets
+    // no gate either (`0x00447FE3` requires `HasTurret`, vtable `+0x3FC`).
+    //
+    // RESIDUAL (GSI-08.04) — an AIRCRAFT is gated only when it carries a turret.
+    // `AircraftClass::GetFireError @ 0x0041A9E0` reads `+0x3A0` unconditionally
+    // at `0x0041AA22`, but behind an embedded-interface predicate
+    // (`AircraftClass+0x6C0`, slot `+0x1C`) whose identity is UNCHECKED and
+    // whose `+0x3A0` writers were not decoded. Trigger: any aircraft attack.
+    // Player effect: unknown; no stock aircraft sets `Turret=`, so no stock
+    // entity has an interpolator to test and the arm is unreachable today.
+    // Frequency: zero in stock. Downstream risk: none until the writers land.
+    let facing_gate_applies = match snap.category {
+        EntityCategory::Unit => true,
+        // `0x00447FE3` requires `HasTurret` (vtable `+0x3FC`) before the
+        // building facing test — a turretless structure is never angle-gated.
+        EntityCategory::Structure | EntityCategory::Aircraft => snap.barrel_facing.is_some(),
+        // Infantry are gated by their FIRE sequence, never by angle.
+        EntityCategory::Infantry => false,
+    };
+    if facing_gate_applies && !weapon.omni_fire {
         let desired: u16 = crate::sim::movement::turret::facing_toward_lepton(
             snap.pos_rx,
             snap.pos_ry,
@@ -6934,53 +7053,56 @@ pub(crate) fn resolve_attacker_fire(
             target_sub_x,
             target_sub_y,
         );
-        // gamemd-derived: the turret alignment arm of the fire gate —
-        // `UnitClass::GetFireError @ 0x00740FD0`, tolerance built at
-        // `0x007412C3`..`0x007412CC` and compared at
-        // `0x007412D4`..`0x007412EF`. Native does NOT require an exact match
-        // and has no not-rotating term: it takes the 16-bit signed difference
-        // between the animated facing and the desired one, and fires whenever
-        // `|delta| <= tolerance`. The `JGE` skips the error return, so `0x0800`
-        // itself passes and `0x0801` fails. `AircraftClass::GetFireError @
-        // 0x0041A9E0` hardcodes the same `0x800`.
-        //
-        // DRIFT (GSI-08.03) — the wider arm is not modelled. Native widens the
-        // tolerance to `0x1000` when `[type+0x2DC]` is set
-        // (`NEG`/`SBB`/`AND 8`/`ADD 8` at `0x007412C3`), and
-        // `BuildingClass::GetFireError @ 0x00447F10` narrows it to `0x0000`
-        // when its own flag is set. Both flags are UNCHECKED, so only the
-        // common `0x0800` constant is implemented.
-        // - Trigger: firing a weapon whose type sets `+0x2DC`.
-        // - Player effect: that weapon holds fire through an arc native would
-        //   already shoot through — at most one extra 1/32-turn of swing.
-        // - Frequency: unknown until `+0x2DC` is identified; bounded by however
-        //   many weapon types set it.
-        // - Downstream risk: none structural; the constant becomes a lookup.
-        // RESIDUAL (GSI-08.04) — this gate exists only for entities that have a
-        // `barrel_facing`, and native gates one more class of firer.
-        // `UnitClass::GetFireError @ 0x00740FD0` tests a TURRETLESS vehicle on
-        // its body facing (`this+0x388`) with the same 0x0800 tolerance, and
-        // `BuildingClass::GetFireError @ 0x00447F10` gates a turreted structure
-        // the same way. Infantry are NOT angle-gated at all — they are gated by
-        // their FIRE animation sequence in `InfantryClass::Fire_At_Target @
-        // 0x005206B0` — so VERA's lack of an angle test for them is correct,
-        // and a turretless STRUCTURE gets no gate in native either.
-        // - Trigger: any turretless vehicle acquiring a target off its heading.
-        // - Player effect: no turn-to-fire delay — an artillery piece fires the
-        //   frame it acquires instead of after swinging round, so first shots
-        //   land early and the unit never visibly lines up.
-        // - Frequency: continuous for the artillery/V3/Dreadnought family; the
-        //   infantry half of pass 1's claim was wrong, which removes most of the
-        //   volume it attributed here.
-        // - Downstream risk: the gate cannot land alone. On failure native
-        //   returns code 2 and `UnitClass::Fire_At_Target @ 0x00736DF0` commands
-        //   the body toward the target without consuming cooldown; VERA emits a
-        //   facing destination only for turreted units, so gating a turretless
-        //   attacker today would freeze it — it would never turn and never fire.
-        //   The emitter comes first, then the gate, and both move engagement
-        //   outcomes and the pinned replay hash.
-        let delta = i32::from(barrel.current(binary_frame).wrapping_sub(desired) as i16);
-        let aligned = delta.abs() <= NATIVE_FIRE_FACING_TOLERANCE;
+        // `Turret=yes` reads the turret, `Turret=no` reads the hull. VERA gives
+        // a turret interpolator to exactly the `Turret=yes` types, so its
+        // presence is the same predicate.
+        let current: u16 = match snap.barrel_facing {
+            Some(ref barrel) => barrel.current(binary_frame),
+            None => match snap.hull_facing {
+                Some(ref hull) => hull.current(binary_frame),
+                None => crate::sim::movement::turret::body_facing_to_turret(snap.facing),
+            },
+        };
+        // A BUILDING narrows to an exact match when its turret art is a voxel
+        // (`BuildingTypeClass+0x16C5`); everything else widens to 1/16 of a turn
+        // when the PROJECTILE homes (`BulletTypeClass+0x2DC != 0`).
+        let is_voxel_turret_building =
+            snap.category == EntityCategory::Structure && obj.turret_anim_is_voxel;
+        let tolerance: i32 = if is_voxel_turret_building {
+            NATIVE_FIRE_FACING_TOLERANCE_VOXEL_TURRET
+        } else if weapon
+            .projectile
+            .as_deref()
+            .and_then(|id| rules.projectile(id))
+            .is_some_and(|projectile| projectile.rot != 0)
+        {
+            NATIVE_FIRE_FACING_TOLERANCE_HOMING
+        } else {
+            NATIVE_FIRE_FACING_TOLERANCE
+        };
+        let delta = i32::from(current.wrapping_sub(desired) as i16);
+        let mut aligned = delta.abs() <= tolerance;
+
+        // `BuildingClass::Mission_Attack @ 0x0044ACF0` gives a voxel turret a
+        // second chance in the SAME visit: when the miss is within one `ROT=`
+        // step (`0x0044B068`..`0x0044B0A4`, or unconditionally when
+        // `BuildingType+0x71C` is zero) it snaps `+0x388` with `UpdateFacing`
+        // at `0x0044B0AC` and re-runs `GetFireError`. That is why a Grand
+        // Cannon at `ROT=1` fires on the tick it comes within one step instead
+        // of waiting a further frame.
+        if !aligned && is_voxel_turret_building {
+            let rot_step: i32 = i32::from(obj.turret_rot.clamp(0, 0x7F) as u8) << 8;
+            if obj.turret_rot == 0 || delta.abs() <= rot_step {
+                if let Some(barrel) = entities
+                    .get_mut(snap.stable_id)
+                    .and_then(|entity| entity.barrel_facing.as_mut())
+                {
+                    barrel.snap(desired, binary_frame);
+                }
+                aligned = true;
+            }
+        }
+
         if !aligned {
             if pending_at_fire_frame {
                 out.pending_infantry_updates.push((snap.stable_id, None));
@@ -6988,6 +7110,24 @@ pub(crate) fn resolve_attacker_fire(
                     snap.stable_id,
                     infantry_idle_sequence(snap.is_prone, snap.is_fully_deployed),
                 ));
+            }
+            // `UnitClass::Fire_At_Target @ 0x00736DF0` case 2
+            // (`0x00736FB6`..`0x0073701C`): a TURRETLESS vehicle that is
+            // stationary with no destination turns its HULL toward the target at
+            // its own `ROT=` — `FacingClass::Set(+0x388)` at `0x00737004`, with
+            // no locomotor involvement — and copies the hull's raw destination
+            // into the turret slot at `0x0073701C`. A moving one does not turn
+            // at all. This is the emitter the gate above depends on: without it
+            // an artillery piece would be refused every frame and never line up.
+            if snap.category == EntityCategory::Unit
+                && snap.barrel_facing.is_none()
+                && !snap.has_movement
+                && let Some(update) = out
+                    .unit_facing
+                    .iter_mut()
+                    .find(|u| u.entity_id == snap.stable_id)
+            {
+                update.hull_destination = Some(desired);
             }
             // FireDecision::Facing — drives gattling spin-up via
             // drives_gattling_spinup() == true.
@@ -7951,7 +8091,13 @@ mod impact_height_tests {
         let mut store = EntityStore::new();
         // `test_interner` snapshots the thread-local, so the entity's type and
         // owner strings must be interned before the snapshot is taken.
-        store.insert(GameEntity::test_default(1, "MTNK", "Americans", 5, 5));
+        let mut firer = GameEntity::test_default(1, "MTNK", "Americans", 5, 5);
+        // The fixture `MTNK` authors no `Turret=`, so its HULL is what the
+        // native body gate compares (`UnitClass::GetFireError @ 0x00740FD0`
+        // step 17). Face it south at the force-fire cell so this test measures
+        // impact height, not turn-to-fire.
+        firer.facing = 128;
+        store.insert(firer);
         let mut interner = test_interner();
         assert!(
             issue_attack_cell_command(&mut store, 1, 5, 6, Some(&rules), &interner),

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -6266,6 +6266,7 @@ pub(crate) fn build_attacker_snapshot(
         pending_building_fire,
         barrel_facing: entity.barrel_facing,
         hull_facing: entity.body_facing,
+        turret_rotation_latch: entity.turret_rotation_latch,
         burst_remaining,
         burst_delay_ticks,
         weapon_override: entity.weapon_override,
@@ -7006,6 +7007,50 @@ pub(crate) fn resolve_attacker_fire(
         }
     }
 
+    // The projectile's `ROT=` (`BulletTypeClass+0x2DC`) is read twice in this
+    // region of `UnitClass::GetFireError`: once by the rotation refusal below
+    // (`0x00741243`) and once to widen the angle tolerance (`0x007412B6`).
+    let projectile_homes = weapon
+        .projectile
+        .as_deref()
+        .and_then(|id| rules.projectile(id))
+        .is_some_and(|projectile| projectile.rot != 0);
+
+    // ---- FIRE_ROTATING (4) ----------------------------------------------
+    //
+    // gamemd-derived: `UnitClass::GetFireError @ 0x00740FD0` step 14,
+    // `0x00741229`..`0x00741259` (disassembled this session):
+    //
+    //   MOV AL,[ESI+0x68D] / TEST AL,AL / JNZ 0x0074125C  ; firing sequence set
+    //   MOV AL,[ESI+0x6AF] / TEST AL,AL / JZ  0x0074125C  ; latch clear
+    //   MOV EDX,[EBX+0xA0] / MOV EAX,[EDX+0x2DC] / TEST / JNZ 0x0074125C ; homing
+    //   MOV EAX,0x4 / RET 0xC                             ; FIRE_ROTATING
+    //
+    // A vehicle whose turret is mid-arc is refused HERE, before the OmniFire
+    // skip at `0x0074125C` and before the step-17 angle test — so it may not
+    // fire until the arc it committed to has actually finished, not merely
+    // once the animated turret wanders inside the tolerance. Without this the
+    // latch would delay the aim but not the shot, and every re-aim wider than
+    // one tolerance step would open fire two to three frames early.
+    //
+    // Unit-and-turret only. `+0x6AF` is read by `UnitClass::GetFireError`
+    // alone (`search_instructions` over `+ 0x6af]` — the other reads on this
+    // layout are Receive_Radio, Mission_Unload, Scatter, PassiveAcquireGate and
+    // the checksum walk; `BuildingClass`/`InfantryClass::GetFireError` have no
+    // such term), and the only writer, `UnitClass::Facing_Update @ 0x00736B16`,
+    // sets it exclusively inside the `Turret=yes` arm.
+    //
+    // The firing-sequence byte needs no VERA analogue: of the 21 references to
+    // `+0x68D`, the only store of 1 is `InfantryClass::Fire_At_Target @
+    // 0x00520912`. On a UnitClass receiver the byte is written 0 by
+    // `FootClass::Constructor @ 0x004D33C6` and by three sites in
+    // `UnitClass::Fire_At_Target` (`0x00736EF9`, `0x0073702D`, `0x0073704B`)
+    // and never set, so for a vehicle the first test always falls through.
+    if snap.category == EntityCategory::Unit && snap.turret_rotation_latch && !projectile_homes {
+        // FireDecision::Rotating — native code 4, also a gattling spin-up code.
+        return;
+    }
+
     // ---- Facing arm of the fire gate ------------------------------------
     //
     // gamemd-derived: `UnitClass::GetFireError @ 0x00740FD0` step 17
@@ -7070,12 +7115,7 @@ pub(crate) fn resolve_attacker_fire(
             snap.category == EntityCategory::Structure && obj.turret_anim_is_voxel;
         let tolerance: i32 = if is_voxel_turret_building {
             NATIVE_FIRE_FACING_TOLERANCE_VOXEL_TURRET
-        } else if weapon
-            .projectile
-            .as_deref()
-            .and_then(|id| rules.projectile(id))
-            .is_some_and(|projectile| projectile.rot != 0)
-        {
+        } else if projectile_homes {
             NATIVE_FIRE_FACING_TOLERANCE_HOMING
         } else {
             NATIVE_FIRE_FACING_TOLERANCE
@@ -7091,6 +7131,13 @@ pub(crate) fn resolve_attacker_fire(
         // Cannon at `ROT=1` fires on the tick it comes within one step instead
         // of waiting a further frame.
         if !aligned && is_voxel_turret_building {
+            // VERA-internal, gamemd equivalent UNCHECKED: native builds the step
+            // as `abs((i16)(ROT << 8))`, which wraps for `ROT >= 0x80`; this
+            // clamps instead. Trigger: a building type authoring `ROT=` at or
+            // above 128. Player effect: none observed — the highest stock
+            // building `ROT=` is `[GTGCAN] ROT=1` — so frequency is zero in
+            // stock. Downstream risk: none; the clamp only bounds the retry
+            // window of a refusal that is re-evaluated next tick anyway.
             let rot_step: i32 = i32::from(obj.turret_rot.clamp(0, 0x7F) as u8) << 8;
             if obj.turret_rot == 0 || delta.abs() <= rot_step {
                 if let Some(barrel) = entities

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -153,8 +153,11 @@ pub struct UnitFacingUpdate {
     /// TURRETLESS vehicle is refused for facing while stationary, and by the
     /// `Facing_Update` arm-A mid-arc pin.
     pub hull_destination: Option<u16>,
-    /// New value of the `+0x6AF` rotation latch.
-    pub latch: bool,
+    /// True when `turret_destination` is arm B's idle return (`Set` at
+    /// `0x00736BDD`), which native runs AFTER the `+0x6AF` store at
+    /// `0x00736B16`; false for arm A's aim `Set` at `0x00736A89`, which runs
+    /// before it. `apply_unit_facing` commits the latch between the two.
+    pub turret_destination_is_idle_return: bool,
 }
 
 impl UnitFacingUpdate {
@@ -166,7 +169,7 @@ impl UnitFacingUpdate {
             entity_id,
             turret_destination: update.turret_destination,
             hull_destination: update.hull_destination,
-            latch: update.latch,
+            turret_destination_is_idle_return: update.turret_destination_is_idle_return,
         }
     }
 }
@@ -5863,6 +5866,16 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             .find(|&&(aid, _)| aid == snap.stable_id)
             .map(|&(_, tid)| tid);
         let own_removed = emit.remove_attack[n_remove..].contains(&snap.stable_id);
+        // Which side of the `+0x6AF` store at `0x00736B16` the replacement
+        // belongs on. A retarget still leaves `Target != 0`, so native reaches
+        // it through arm A's `Set` at `0x00736A89` and the arc arms the latch
+        // on its first frame. A removal leaves `Target == 0`, so native's arm A
+        // does not run at all and the only `Set` left is arm B's idle return at
+        // `0x00736BDD`, which the store precedes — that arc starts with a clear
+        // latch. (VERA swings back on the removal tick rather than after the
+        // dwell; that difference is the pre-existing S3 kill-tick behaviour,
+        // not this flag.)
+        let replacement_is_idle_return = own_retarget.is_none();
         let replacement: Option<u16> = if let Some(tid) = own_retarget {
             Some(
                 crate::sim::movement::turret::facing_toward_target(
@@ -5888,6 +5901,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
                 .find(|u| u.entity_id == snap.stable_id)
                 .expect("Unit attacker was seeded before fire");
             update.turret_destination = Some(replacement);
+            update.turret_destination_is_idle_return = replacement_is_idle_return;
         }
     }
     // S3 residual: every Unit not in the attacker snapshot set (target-less,
@@ -7033,12 +7047,15 @@ pub(crate) fn resolve_attacker_fire(
     // latch would delay the aim but not the shot, and every re-aim wider than
     // one tolerance step would open fire two to three frames early.
     //
-    // Unit-and-turret only. `+0x6AF` is read by `UnitClass::GetFireError`
-    // alone (`search_instructions` over `+ 0x6af]` — the other reads on this
-    // layout are Receive_Radio, Mission_Unload, Scatter, PassiveAcquireGate and
-    // the checksum walk; `BuildingClass`/`InfantryClass::GetFireError` have no
-    // such term), and the only writer, `UnitClass::Facing_Update @ 0x00736B16`,
-    // sets it exclusively inside the `Turret=yes` arm.
+    // Unit-and-turret only. This is the only FIRE gate that reads `+0x6AF`
+    // (`search_instructions` over `+ 0x6af]` — the other readers on this layout
+    // are Receive_Radio, Mission_Unload, Scatter, PassiveAcquireGate, the
+    // not-moving-and-not-rotating sound test in `FUN_00740E80 @ 0x00740EA7`,
+    // and the checksum walk; `BuildingClass`/`InfantryClass::GetFireError` have
+    // no such term). The only writer that ever SETS it is
+    // `UnitClass::Facing_Update @ 0x00736B16`, exclusively inside the
+    // `Turret=yes` arm; the other two writes are the `FootClass::Constructor`
+    // zero-fill at `0x004D3420` and the unconditional clear at `0x00736AD5`.
     //
     // The firing-sequence byte needs no VERA analogue: of the 21 references to
     // `+0x68D`, the only store of 1 is `InfantryClass::Fire_At_Target @
@@ -7047,7 +7064,10 @@ pub(crate) fn resolve_attacker_fire(
     // `UnitClass::Fire_At_Target` (`0x00736EF9`, `0x0073702D`, `0x0073704B`)
     // and never set, so for a vehicle the first test always falls through.
     if snap.category == EntityCategory::Unit && snap.turret_rotation_latch && !projectile_homes {
-        // FireDecision::Rotating — native code 4, also a gattling spin-up code.
+        // Native code 4, which is also one of the {0, 2, 3, 4} codes that drive
+        // gattling spin-up. `FireDecision` has no variant for it and no
+        // producer at all — that gap is the residual recorded on the enum in
+        // `fire_decision.rs`, not something this return introduces.
         return;
     }
 

--- a/src/sim/game_entity.rs
+++ b/src/sim/game_entity.rs
@@ -86,6 +86,14 @@ fn default_foundation() -> String {
     "1x1".to_string()
 }
 
+/// `TechnoClass::Constructor @ 0x006F2B9C` seeds `+0x120` with `-100`, so a
+/// freshly built object is already past the idle-turret dwell on frame 0.
+pub(crate) const NATIVE_LAST_FIRE_FRAME_INIT: i64 = -100;
+
+fn default_last_fire_frame() -> i64 {
+    NATIVE_LAST_FIRE_FRAME_INIT
+}
+
 fn default_base_plan_type_index() -> i32 {
     -1
 }
@@ -575,6 +583,22 @@ pub struct GameEntity {
     /// Independent turret/barrel facing — only on entities with Turret=yes in rules.ini.
     /// Timer-based 16-bit interpolator mirroring gamemd's BarrelFacing primitive.
     pub barrel_facing: Option<crate::sim::movement::FacingClass>,
+    /// Turret rotation latch — `UnitClass+0x6AF`, written only by
+    /// `UnitClass::Facing_Update @ 0x00736990` (cleared at `0x00736AD5`, re-set
+    /// from `FacingClass::Is_Rotating` at `0x00736B16`) and read only by
+    /// `UnitClass::GetFireError @ 0x00741233`. While set, the aim block is
+    /// skipped so the turret finishes the arc it started instead of
+    /// re-snapshotting every frame, and the fire gate answers FIRE_ROTATING(4).
+    #[serde(default)]
+    pub turret_rotation_latch: bool,
+    /// Frame of this object's own last shot — `TechnoClass+0x120`. The
+    /// constructor seeds `-100` (`0x006F2B9C`) and the single other writer in
+    /// the image is `TechnoClass::Fire_At @ 0x006FF743`, which stores
+    /// `g_CurrentFrameCounter`. `UnitClass::Facing_Update` gates the idle turret
+    /// return on `frame - this >= GuardAreaTargetingDelay + 5`, so the dwell is
+    /// measured from the unit's own last shot, NOT from target loss.
+    #[serde(default = "default_last_fire_frame")]
+    pub last_fire_frame: i64,
     /// Building construction animation progress.
     pub building_up: Option<BuildingUp>,
     /// Reverse build-up animation — building is undeploying into a mobile unit.
@@ -1138,6 +1162,8 @@ impl GameEntity {
             last_attacker_id: None,
             was_attacked_by_enemy: false,
             barrel_facing: None,
+            turret_rotation_latch: false,
+            last_fire_frame: NATIVE_LAST_FIRE_FRAME_INIT,
             building_up: None,
             building_down: None,
             building_anim_overlays: None,

--- a/src/sim/game_entity.rs
+++ b/src/sim/game_entity.rs
@@ -588,7 +588,13 @@ pub struct GameEntity {
     /// from `FacingClass::Is_Rotating` at `0x00736B16`) and read only by
     /// `UnitClass::GetFireError @ 0x00741233`. While set, the aim block is
     /// skipped so the turret finishes the arc it started instead of
-    /// re-snapshotting every frame, and the fire gate answers FIRE_ROTATING(4).
+    /// re-snapshotting every frame, and — unless the projectile homes — the
+    /// fire gate answers FIRE_ROTATING(4) at `0x00741250`, refusing the shot
+    /// until the arc completes.
+    ///
+    /// Not folded into `world_hash`: it is last tick's `barrel_facing`
+    /// `Is_Rotating`, which the hash already folds, so a divergence surfaces
+    /// one tick later through the interpolator itself.
     #[serde(default)]
     pub turret_rotation_latch: bool,
     /// Frame of this object's own last shot — `TechnoClass+0x120`. The
@@ -597,6 +603,10 @@ pub struct GameEntity {
     /// `g_CurrentFrameCounter`. `UnitClass::Facing_Update` gates the idle turret
     /// return on `frame - this >= GuardAreaTargetingDelay + 5`, so the dwell is
     /// measured from the unit's own last shot, NOT from target loss.
+    ///
+    /// Not folded into `world_hash`: its only consumer is that idle return, so
+    /// a divergence surfaces one tick later through `barrel_facing`, which the
+    /// hash does fold.
     #[serde(default = "default_last_fire_frame")]
     pub last_fire_frame: i64,
     /// Building construction animation progress.

--- a/src/sim/movement/turret.rs
+++ b/src/sim/movement/turret.rs
@@ -120,8 +120,17 @@ pub(crate) struct FacingUpdate {
     pub turret_destination: Option<u16>,
     /// Hull (`+0x388`) destination from the turretless arm-A commit.
     pub hull_destination: Option<u16>,
-    /// New value of the `+0x6AF` rotation latch.
-    pub latch: bool,
+    /// Which side of the `+0x6AF` store `turret_destination` belongs on.
+    ///
+    /// Native writes the latch mid-arm-B: `MOV [ESI+0x6AF],AL` at
+    /// `0x00736B16` sits BETWEEN arm A's aim `Set` (`0x00736A89`) and arm B's
+    /// idle-return `Set` (`0x00736BDD`), so an aim `Set` arms the latch on the
+    /// same frame while an idle-return `Set` does not. `apply_unit_facing`
+    /// commits the two in that order and reads the latch in between; this flag
+    /// is how it tells them apart. There is no `latch` field: the latch is not
+    /// a decision this pure read can make, it is `Is_Rotating(+0x3A0)`
+    /// evaluated on the barrel as it stands after the aim write.
+    pub turret_destination_is_idle_return: bool,
 }
 
 /// `UnitClass::Facing_Update @ 0x00736990` — verified this session by
@@ -156,7 +165,9 @@ pub(crate) struct FacingUpdate {
 /// `frame - LastFireFrame(+0x120) >= GuardAreaTargetingDelay(Rules+0xE04) + 5`
 /// (41 frames in stock) and suppressed while the unit is bunkered (`+0x2E4`).
 /// The destination is the MOVE DESTINATION when a NavCom is set, else the hull
-/// heading.
+/// heading. The latch VALUE is committed by `apply_unit_facing` rather than
+/// here, because native's store sits between this arm's two `Set` calls — see
+/// [`FacingUpdate::turret_destination_is_idle_return`].
 ///
 /// **C. CACHE** (`0x00736BE2`) writes `+0x4A0 = Is_Rotating()`; that field has
 /// no verified consumer, so it is not modelled.
@@ -198,7 +209,7 @@ pub(crate) fn facing_update(
     let mut out = FacingUpdate {
         turret_destination: None,
         hull_destination: None,
-        latch: entity.turret_rotation_latch,
+        turret_destination_is_idle_return: false,
     };
     let obj = rules.and_then(|r| r.object(interner.resolve(entity.type_ref)));
     let has_turret = entity.barrel_facing.is_some();
@@ -225,33 +236,25 @@ pub(crate) fn facing_update(
     }
 
     // --- B. IDLE --------------------------------------------------------
-    // `0x00736AD5` clears the latch before the `Turret=` test, for every unit.
-    out.latch = false;
+    // The `+0x6AF` write itself is NOT made here — `apply_unit_facing` makes
+    // it, between the two `Set` calls, exactly where `0x00736B16` sits. What
+    // this arm still owns is the BRANCH: native picks between "commit to the
+    // arc" and "idle return" with `Is_Rotating(+0x3A0)` evaluated AFTER arm A's
+    // `Set` (`CALL 0x004C9480` at `0x00736AF2`), while the read below runs
+    // before it. The two agree in every reachable case, which is why the branch
+    // may stay in this pure read: arm A only `Set`s when a target exists, the
+    // idle return only runs when none does, and when native's post-`Set`
+    // `Is_Rotating` is false with a target held it falls into the idle arm and
+    // is thrown straight back out by the `Target != 0` test at `0x00736B21`.
     if has_turret {
         let barrel = entity.barrel_facing.as_ref().expect("has_turret");
-        if barrel.is_rotating(binary_frame) {
-            // `0x00736B11`..`0x00736B16` — commit to the arc; arm A stays shut
-            // until it finishes, so the turret steps in completed turns rather
-            // than re-snapshotting `prev` every frame against a mover.
-            //
-            // DRIFT (GSI-08.14), deferred — this is a PURE READ, so
-            // `is_rotating` is evaluated against the barrel as it stood at the
-            // start of the frame, i.e. BEFORE arm A's own `Set` above (which
-            // `apply_unit_facing` commits post-batch). Native evaluates it
-            // after, because `Facing_Update` mutates `+0x3A0` in place. Effect:
-            // on the FIRST frame of an arc VERA reports `latch = false` where
-            // native reports true, so arm A runs once more on the next frame
-            // and re-snapshots `prev` — one extra re-aim per arc against a
-            // moving target, exactly what the latch exists to prevent. The arc
-            // still ends on the same frame (the destination is unchanged when
-            // the target has not moved), and the fire gate is unaffected,
-            // because it reads the previous tick's committed latch either way.
-            // Trigger: any turreted vehicle starting an arc at a mover.
-            // Frequency: once per arc, so every engagement opening.
-            // Downstream risk: closing it means committing the turret write
-            // before the latch read, i.e. splitting this pure read in two.
-            out.latch = true;
-        } else if entity.attack_target.is_none() {
+        // `0x00736AF9` not taken — the unit has committed to an arc, arm A
+        // stays shut until it finishes, and there is no idle return on that
+        // path (`JMP 0x00736BE2` at `0x00736B1C`). The turret therefore steps
+        // in completed turns instead of re-snapshotting `prev` every frame
+        // against a mover.
+        let committed_to_an_arc = barrel.is_rotating(binary_frame);
+        if !committed_to_an_arc && entity.attack_target.is_none() {
             let dwell = rules.map_or(NATIVE_IDLE_TURRET_DWELL_FALLBACK, |r| {
                 i64::from(r.general.guard_area_targeting_delay)
             }) + NATIVE_IDLE_TURRET_DWELL_BIAS;
@@ -263,6 +266,10 @@ pub(crate) fn facing_update(
                     Some(nav) => nav,
                     None => hull_facing_16(entity, binary_frame),
                 });
+                // `Set` at `0x00736BDD`, which native reaches only AFTER the
+                // `+0x6AF` store — so the arc this starts leaves the latch
+                // clear on its first frame.
+                out.turret_destination_is_idle_return = true;
             }
         }
     }

--- a/src/sim/movement/turret.rs
+++ b/src/sim/movement/turret.rs
@@ -1,9 +1,12 @@
-//! Turret rotation system — rotates turrets toward attack targets or back to body facing.
+//! Turret rotation system — the `UnitClass::Facing_Update @ 0x00736990` port.
 //!
 //! Units with a barrel `FacingClass` have an independently rotating turret.
-//! When attacking, the turret rotates toward the target at the unit's ROT
-//! speed. When idle, it returns to body facing. The weapon-fire alignment
-//! check is performed in combat.rs against the FacingClass animated value.
+//! When attacking, the turret rotates toward the target at the unit's `ROT=`
+//! speed. When the target is gone it holds the aim for
+//! `GuardAreaTargetingDelay + 5` frames measured from the unit's OWN LAST SHOT
+//! (`TechnoClass+0x120`), then returns to the hull — or leads toward the move
+//! destination when one is set. The weapon-fire alignment gate lives in
+//! `sim/combat` and reads the same `FacingClass` animated value.
 //!
 //! ## Dependency rules
 //! - Part of sim/ — depends on sim/components, sim/combat, rules/.
@@ -68,113 +71,309 @@ pub fn body_facing_to_turret(body: u8) -> u16 {
 /// gamemd; the only `TurretRot`-shaped string in the image is
 /// `TurretRotateSound`, so driving turret rotation from `ROT=` is correct.
 ///
-/// RESIDUAL (GSI-08.14) — recoil is not modelled. Native keeps two
-/// `RecoilData` structs at `+0x3D8`/`+0x3F8`, arms them in `Fire_At` and
-/// advances them from `TechnoClass::AI_Update` through `0x0070ED10`; the
-/// displacement is read by four instructions, all in draw code, so it is
-/// render-only and feeds no gameplay path.
-/// - Trigger: firing a type that authors `TurretRecoil=`.
-/// - Player effect: the barrel does not slide back on firing, so heavy guns
-///   read as weightless.
-/// - Frequency: two stock authors, both BUILDINGS (the Grand Cannon and
-///   CAEAST02) — pass 1's "every shot from a turreted unit" was wrong, and no
-///   stock vehicle recoils at all.
-/// - Downstream risk: none to the simulation. It belongs to the render side
-///   and consumes no RNG.
-///
-/// The barrel facing `tick_turret_rotation` drives this entity toward this tick:
-/// toward its attack target (lepton-precise) when it has one, else back to body
-/// facing. `None` when the entity has no turret. PURE READ — mutates neither the
-/// entity nor the store. Shared by the global turret sweep and the per-object
-/// Fire→Facing host so both compute identical barrel destinations (per-entity, so
-/// id-order and live-order walks produce the same result).
-pub(crate) fn desired_turret_facing(entity: &GameEntity, entities: &EntityStore) -> Option<u16> {
-    entity.barrel_facing.as_ref()?;
-    let desired: u16 = if let Some(ref attack) = entity.attack_target {
-        // Look up target position. Entity targets via stable ID, Cell targets via
-        // cell-center leptons (force-fire on ground).
-        let target_pos = match attack.target {
-            crate::sim::combat::TargetKind::Entity(target_id) => entities.get(target_id).map(|t| {
-                (
-                    t.position.rx,
-                    t.position.ry,
-                    t.position.sub_x,
-                    t.position.sub_y,
-                )
-            }),
-            crate::sim::combat::TargetKind::Cell(rx, ry) => {
-                Some((rx, ry, SimFixed::from_num(128), SimFixed::from_num(128)))
-            }
-        };
-        match target_pos {
-            Some((trx, try_, tsx, tsy)) => facing_toward_lepton(
-                entity.position.rx,
-                entity.position.ry,
-                entity.position.sub_x,
-                entity.position.sub_y,
-                trx,
-                try_,
-                tsx,
-                tsy,
-            ),
-            // Target gone — idle-return to body facing.
-            None => body_facing_to_turret(entity.facing),
-        }
-    } else {
-        // No target — return to body facing. See the residual list on
-        // `tick_turret_rotation` for the three native arms this omits.
-        body_facing_to_turret(entity.facing)
-    };
-    Some(desired)
+/// The hull heading as a 16-bit facing — `FacingClass::Current` on the primary
+/// facing `+0x388`. VERA keeps the animated hull in `body_facing` only while a
+/// rotation is live and mirrors its top byte into `entity.facing`, so read the
+/// interpolator when it exists and the byte otherwise.
+pub(crate) fn hull_facing_16(entity: &GameEntity, binary_frame: u32) -> u16 {
+    match entity.body_facing {
+        Some(ref hull) => hull.current(binary_frame),
+        None => body_facing_to_turret(entity.facing),
+    }
 }
 
-/// Per-binary-frame turret rotation — drives barrel_facing toward each
-/// entity's desired facing.
+/// Lepton-precise facing from `entity` toward a resolved attack target, using
+/// the target's own coordinate slot. gamemd reaches the target through
+/// `DirectionToTarget @ 0x005F3DB0`, which calls `GetCoords` (vtable `+0x48`) on
+/// both objects; for a `BuildingClass` that slot returns the FOUNDATION CENTRE,
+/// not the north-west anchor cell. `combat::resolve_target_coords` applies the
+/// same centre shift, so route through it rather than reading `position`.
+pub(crate) fn facing_toward_target(
+    entity: &GameEntity,
+    target: &crate::sim::combat::TargetKind,
+    entities: &EntityStore,
+    rules: Option<&RuleSet>,
+    interner: &crate::sim::intern::StringInterner,
+) -> Option<u16> {
+    let (trx, try_, tsx, tsy) =
+        crate::sim::combat::resolve_target_coords(target, entities, rules, interner)?;
+    Some(facing_toward_lepton(
+        entity.position.rx,
+        entity.position.ry,
+        entity.position.sub_x,
+        entity.position.sub_y,
+        trx,
+        try_,
+        tsx,
+        tsy,
+    ))
+}
+
+/// One frame of `UnitClass::Facing_Update @ 0x00736990`, expressed as data so
+/// the read window can run in the combat Phase-2 pass and the writes land at the
+/// post-batch apply point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct FacingUpdate {
+    /// Turret (`+0x3A0`) destination to hand `FacingClass::set`. `None` when
+    /// native calls no `Set` on the turret this frame — which is the whole
+    /// difference between "hold the aim" and "swing back to the hull".
+    pub turret_destination: Option<u16>,
+    /// Hull (`+0x388`) destination from the turretless arm-A commit.
+    pub hull_destination: Option<u16>,
+    /// New value of the `+0x6AF` rotation latch.
+    pub latch: bool,
+}
+
+/// `UnitClass::Facing_Update @ 0x00736990` — verified this session by
+/// `decompile_function` plus `disassemble_function`, which is where every
+/// receiver binding below comes from (`LEA ECX,[ESI+0x3A0]` = turret at
+/// `0x00736A1A`/`0x00736A26`/`0x00736A9F`/`0x00736AEA`/`0x00736BF3`;
+/// `LEA [ESI+0x388]` = hull at `0x00736A0E`/`0x00736A66`/`0x00736BCF`). It
+/// consumes no RNG and arms no timer other than the `FacingClass` countdown.
 ///
-/// - If entity has AttackTarget: rotate barrel toward target (lepton-precise).
-/// - Otherwise: rotate barrel back to body facing.
+/// PURE READ — mutates neither the entity nor the store. Shared by the global
+/// turret sweep and the per-object Fire→Facing host so both compute identical
+/// destinations (per-entity, so id-order and live-order walks agree).
 ///
-/// Calls FacingClass::set, which is a no-op when the desired facing equals
-/// the current destination — so this function is idempotent.
+/// Native order, and what each arm does here:
 ///
-/// `UnitClass::Facing_Update` @ `0x00736990` owns this natively, on the turret
-/// `FacingClass` at owner `+0x3A0`. Four of its behaviours are **not** modelled,
-/// recorded rather than approximated.
+/// **A. AIM** (`0x00736997`..`0x00736A89`), only when `Target != 0` AND the
+/// latch `+0x6AF` is clear. `tgt = DirectionToTarget(this, Target)`.
+/// - `Turret=yes`: fetch the current weapon slot through vtable `+0x3F4`; skip
+///   the whole aim when its `WeaponType` sets `OmniFire=` (`+0x12B`, checked at
+///   `0x007369F4`) — an omni weapon never turns the turret. Otherwise
+///   `turret.Set(tgt)`.
+/// - `Turret=no`: only when `SpeedType == Track` (`Type+0x67C == 1`), no NavCom
+///   and the locomotor reports not-moving, and then only when the ANIMATED hull
+///   already equals `tgt` exactly (`0x00736A78` compares the low word) — the
+///   mid-arc pass-through pin.
 ///
-/// **These four apply to the live vehicle path too.** This function `continue`s
-/// past every `EntityCategory::Unit` while `L2_UNIT_POST_AUTHORITATIVE` holds,
-/// so the host that actually aims a vehicle turret is `sim::combat`'s
-/// `desired_turret_facing` sweep — the same omissions, one file over.
+/// **B. IDLE** (`0x00736A8E`..`0x00736BDD`). The latch is cleared
+/// unconditionally at `0x00736AD5`, before the `Turret=` test, so a turretless
+/// unit leaves this arm with a clear latch and nothing else. For a turret:
+/// still rotating → re-arm the latch and stop; target still held → stop;
+/// otherwise the idle return, gated on
+/// `frame - LastFireFrame(+0x120) >= GuardAreaTargetingDelay(Rules+0xE04) + 5`
+/// (41 frames in stock) and suppressed while the unit is bunkered (`+0x2E4`).
+/// The destination is the MOVE DESTINATION when a NavCom is set, else the hull
+/// heading.
 ///
-/// - **The idle dwell.** The native idle return is gated on
-///   `frame - owner+0x120 >= Rules+0xE04 + 5` (`0x00736B35`-`0x00736B7C`),
-///   where `Rules+0xE04` is `[General] GuardAreaTargetingDelay` (36 in stock),
-///   so the barrel holds its aim for ~41 frames — nearly three seconds — after
-///   losing a target. VERA returns to the hull on the same tick
-///   `attack_target` becomes `None`. Trigger: every kill and every target loss.
-///   Player effect: turrets whip back to hull-forward where retail holds.
-///   Frequency: dozens of times a minute in any engagement. Downstream risk:
-///   needs a per-entity last-target frame, which is new deterministic state.
-/// - **The NavCom aim.** When the idle return does fire and the unit is under a
-///   move order, native aims the turret at `owner+0x5A4`, the destination
-///   (`0x00736BB1`-`0x00736BC8`), not at the hull. VERA has only the two
-///   outcomes. Trigger: every move order to a turreted vehicle with no target.
-///   Player effect: the barrel tracks the hull through every drive-track curve
-///   instead of leading toward the destination. Frequency: constant.
-/// - **The rotation latch.** `owner+0x6AF` (cleared `0x00736AD5`, re-set from
-///   `Is_Rotating` at `0x00736B11`) suppresses the whole aim block on any frame
-///   after one in which the turret was turning, so native commits to each arc
-///   and steps in completed turns. VERA re-aims every tick, which against a
-///   moving target re-snapshots `prev` and restarts the timer, converging
-///   asymptotically. Trigger: any turreted unit tracking a mover. Frequency:
-///   continuous in combat. Downstream risk: one latch byte on the entity.
-/// - **The building anchor.** Native reaches the target through its `GetCoords`
-///   slot `+0x48`, which for `BuildingClass` returns the foundation centre;
-///   [`desired_turret_facing`] reads the raw NW-anchored position. A 3x3
-///   building aimed at from four cells is off by about 14 degrees. Trigger:
-///   every vehicle attack on a structure. Frequency: constant in any base
-///   assault, and it feeds the fire-alignment gate, so first-shot timing shifts
-///   with it.
+/// **C. CACHE** (`0x00736BE2`) writes `+0x4A0 = Is_Rotating()`; that field has
+/// no verified consumer, so it is not modelled.
+///
+/// RESIDUAL (GSI-08.14) — `TurretSpins=` (`Type+0xD21`) replaces both arms with
+/// the permaspin formula at `0x00736AB1`..`0x00736ACB`. Trigger: a type that
+/// authors the key. Player effect: its turret does not idle-spin. Frequency:
+/// `[DISK]` alone in stock rulesmd, and the key is not parsed here at all.
+/// Downstream risk: none — the arm is self-contained.
+///
+/// RESIDUAL (GSI-08.14) — three idle-hold inputs have no VERA analogue and are
+/// therefore not gated: the per-weapon-slot lock byte `WeaponStruct+0x18`
+/// (`0x00736A02`/`0x00736B96`; identity UNCHECKED, zero stock authors for the
+/// adjacent `WeaponXTurretLocked` art key), the locomotor-piggyback flag
+/// `+0x6AD` (`0x00736BB1`) and the simple-deployer byte `+0x6E0`
+/// (`0x00736B70`, paired with `IsSimpleDeployer=`). Trigger: a piggybacked or
+/// mid-deploy simple deployer losing its target. Player effect: its turret
+/// returns to the hull where retail holds the last aim. Frequency: six stock
+/// `IsSimpleDeployer=` types, and only during the deploy transition.
+/// Downstream risk: none — each is a pure suppression.
+///
+/// RESIDUAL (GSI-08.14) — recoil is not modelled. Native keeps two `RecoilData`
+/// structs at `+0x3D8`/`+0x3F8`, arms them in `Fire_At` and advances them from
+/// `TechnoClass::AI_Update` through `0x0070ED10`; the displacement is read by
+/// four instructions, all in draw code, so it is render-only and feeds no
+/// gameplay path.
+/// - Trigger: firing a type that authors `TurretRecoil=`.
+/// - Player effect: the barrel does not slide back on firing.
+/// - Frequency: two stock authors, both BUILDINGS (the Grand Cannon and
+///   CAEAST02); no stock vehicle recoils at all.
+/// - Downstream risk: none to the simulation. It consumes no RNG.
+pub(crate) fn facing_update(
+    entity: &GameEntity,
+    entities: &EntityStore,
+    rules: Option<&RuleSet>,
+    interner: &crate::sim::intern::StringInterner,
+    binary_frame: u32,
+) -> FacingUpdate {
+    let mut out = FacingUpdate {
+        turret_destination: None,
+        hull_destination: None,
+        latch: entity.turret_rotation_latch,
+    };
+    let obj = rules.and_then(|r| r.object(interner.resolve(entity.type_ref)));
+    let has_turret = entity.barrel_facing.is_some();
+
+    // --- A. AIM ---------------------------------------------------------
+    let target_facing: Option<u16> = entity
+        .attack_target
+        .as_ref()
+        .and_then(|attack| facing_toward_target(entity, &attack.target, entities, rules, interner));
+    if let Some(tgt) = target_facing
+        && !entity.turret_rotation_latch
+    {
+        if has_turret {
+            if !current_weapon_is_omni_fire(entity, rules, interner) {
+                out.turret_destination = Some(tgt);
+            }
+        } else if obj
+            .is_some_and(|o| o.speed_type == crate::rules::locomotor_type::SpeedType::Track)
+            && entity.movement_target.is_none()
+            && hull_facing_16(entity, binary_frame) == tgt
+        {
+            out.hull_destination = Some(tgt);
+        }
+    }
+
+    // --- B. IDLE --------------------------------------------------------
+    // `0x00736AD5` clears the latch before the `Turret=` test, for every unit.
+    out.latch = false;
+    if has_turret {
+        let barrel = entity.barrel_facing.as_ref().expect("has_turret");
+        if barrel.is_rotating(binary_frame) {
+            // `0x00736B11`..`0x00736B16` — commit to the arc; arm A stays shut
+            // until it finishes, so the turret steps in completed turns rather
+            // than re-snapshotting `prev` every frame against a mover.
+            out.latch = true;
+        } else if entity.attack_target.is_none() {
+            let dwell = rules.map_or(NATIVE_IDLE_TURRET_DWELL_FALLBACK, |r| {
+                i64::from(r.general.guard_area_targeting_delay)
+            }) + NATIVE_IDLE_TURRET_DWELL_BIAS;
+            let dwell_elapsed = i64::from(binary_frame) - entity.last_fire_frame >= dwell;
+            // `+0x2E4` — a tank riding a Battle Bunker holds its aim forever.
+            let bunkered = entity.bunker_link.installed_in().is_some();
+            if dwell_elapsed && !bunkered {
+                out.turret_destination = Some(match nav_destination_facing(entity, entities) {
+                    Some(nav) => nav,
+                    None => hull_facing_16(entity, binary_frame),
+                });
+            }
+        }
+    }
+
+    out
+}
+
+/// `[General] GuardAreaTargetingDelay=` fallback for rules-less fixtures. Stock
+/// rulesmd sets 36; `RulesClass` stores it at `+0xE04` (`0x006701B4`).
+const NATIVE_IDLE_TURRET_DWELL_FALLBACK: i64 = 36;
+
+/// The `+5` the idle-return comparison adds to `GuardAreaTargetingDelay`
+/// (`ADD EDX,0x5` at `0x00736B4B`), giving 41 frames in stock.
+const NATIVE_IDLE_TURRET_DWELL_BIAS: i64 = 5;
+
+/// The idle turret's aim when a move order is live — `DirectionToTarget(this,
+/// NavCom)` at `0x00736BC3`. Native reads the destination coordinate at
+/// `+0x5A4`; VERA's equivalent is the last cell of the active path.
+fn nav_destination_facing(entity: &GameEntity, _entities: &EntityStore) -> Option<u16> {
+    let goal = entity.movement_target.as_ref()?.path.last().copied()?;
+    Some(facing_toward_lepton(
+        entity.position.rx,
+        entity.position.ry,
+        entity.position.sub_x,
+        entity.position.sub_y,
+        goal.0,
+        goal.1,
+        SimFixed::from_num(128),
+        SimFixed::from_num(128),
+    ))
+}
+
+/// Whether this object's currently selected weapon sets `OmniFire=`. Native
+/// takes the slot through `TechnoClass` vtable `+0x3F4` (`0x0070E1A0` —
+/// `GetWeapon(TurretCount(+0x808) > 0 ? CurrentWeaponNumber(+0x138) : 0)`) and
+/// reads `WeaponType+0x12B`. An omni weapon is skipped by both the aim arm
+/// (`0x007369F4`) and the fire gate's facing test (`0x0074125C`) — it shoots in
+/// any direction and never turns the turret.
+pub(crate) fn current_weapon_is_omni_fire(
+    entity: &GameEntity,
+    rules: Option<&RuleSet>,
+    interner: &crate::sim::intern::StringInterner,
+) -> bool {
+    let Some(rules) = rules else { return false };
+    let Some(obj) = rules.object(interner.resolve(entity.type_ref)) else {
+        return false;
+    };
+    let index: i32 = if obj.turret_count > 0 {
+        i32::from(entity.current_weapon_index)
+    } else {
+        0
+    };
+    crate::sim::combat::combat_weapon::weapon_for_index(obj, entity.veterancy, index)
+        .and_then(|(weapon_id, _)| rules.weapon(weapon_id))
+        .is_some_and(|weapon| weapon.omni_fire)
+}
+
+/// The turret destination this entity's owning native path drives it toward
+/// this frame, or `None` when that path calls no `Set`.
+///
+/// Dispatches on the class that actually owns the facing in gamemd:
+/// - **Unit** — `UnitClass::Facing_Update @ 0x00736990` ([`facing_update`]).
+/// - **Structure** — `BuildingClass::Mission_Attack @ 0x0044ACF0`, whose only
+///   facing traffic is `turret(+0x388).Set(GetTargetCoords(Target))` on the
+///   non-firing error arms (`0x0044B187`/`0x0044B1DE`/`0x0044B14E`). A LEA
+///   census over `BuildingClass::Update`, `Mission_Guard` and every idle path
+///   finds no other `Set`/`UpdateFacing` of `+0x388`, so **a building turret
+///   keeps its last aim** — it never swings back.
+/// - **Aircraft / Infantry** — unchanged legacy behaviour; how `+0x3A0` is
+///   driven for `AircraftClass` is UNCHECKED (see the residual below).
+///
+/// RESIDUAL (GSI-08.14) — the aircraft turret destination is VERA's own
+/// "target, else body" rule. `AircraftClass::GetFireError @ 0x0041A9E0` proves
+/// the gate reads `+0x3A0` at `0x0800`, but the writers
+/// (`AircraftClass::AI @ 0x0041514C`, `Mission_Attack`, `Fire_At @ 0x00416041`)
+/// were not decoded. Trigger: any aircraft with `Turret=yes`. Player effect:
+/// unknown aim behaviour on those types. Frequency: no stock aircraft sets
+/// `Turret=`, so no stock entity reaches it. Downstream risk: none today.
+pub(crate) fn desired_turret_facing(
+    entity: &GameEntity,
+    entities: &EntityStore,
+    rules: Option<&RuleSet>,
+    interner: &crate::sim::intern::StringInterner,
+    binary_frame: u32,
+) -> Option<u16> {
+    entity.barrel_facing.as_ref()?;
+    match entity.category {
+        crate::map::entities::EntityCategory::Unit => {
+            facing_update(entity, entities, rules, interner, binary_frame).turret_destination
+        }
+        crate::map::entities::EntityCategory::Structure => entity
+            .attack_target
+            .as_ref()
+            .and_then(|attack| {
+                facing_toward_target(entity, &attack.target, entities, rules, interner)
+            })
+            .or_else(|| {
+                // A target that despawned this tick: native re-reads `+0x2B4`,
+                // which the death helper has already cleared, so `Mission_Attack`
+                // takes no facing action at all. Hold.
+                None
+            }),
+        _ => Some(
+            entity
+                .attack_target
+                .as_ref()
+                .and_then(|attack| {
+                    facing_toward_target(entity, &attack.target, entities, rules, interner)
+                })
+                .unwrap_or_else(|| body_facing_to_turret(entity.facing)),
+        ),
+    }
+}
+
+/// Per-binary-frame turret rotation for the classes this sweep still owns —
+/// Aircraft and Buildings. Unit turrets are driven per-object by the combat
+/// Phase-2 read window plus `unit_post::apply_unit_facing` while
+/// `L2_UNIT_POST_AUTHORITATIVE` holds.
+///
+/// Calls `FacingClass::set`, which is a no-op when the desired facing equals the
+/// current destination — so this function is idempotent. `None` from
+/// [`desired_turret_facing`] means "native calls no `Set` this frame", which is
+/// how a building turret holds its last aim.
+///
+/// gamemd-derived: `BuildingClass::Mission_Attack @ 0x0044ACF0` for structures
+/// (all four facing sites are on `+0x388`, `0x0044B14E`/`0x0044B187`/
+/// `0x0044B1DE` plus the voxel snap at `0x0044B0AC`); ROT comes from
+/// `BuildingType+0x71C`, the same `ROT=` key this reads.
 pub fn tick_turret_rotation(
     entities: &mut EntityStore,
     rules: &RuleSet,
@@ -203,7 +402,9 @@ pub fn tick_turret_rotation(
         }
         // Skip non-turreted entities; otherwise take the per-entity desired facing
         // from the shared helper (single source for sweep + per-object host).
-        let Some(desired_facing) = desired_turret_facing(entity, entities) else {
+        let Some(desired_facing) =
+            desired_turret_facing(entity, entities, Some(rules), interner, native_frame)
+        else {
             continue;
         };
 

--- a/src/sim/movement/turret.rs
+++ b/src/sim/movement/turret.rs
@@ -233,6 +233,23 @@ pub(crate) fn facing_update(
             // `0x00736B11`..`0x00736B16` — commit to the arc; arm A stays shut
             // until it finishes, so the turret steps in completed turns rather
             // than re-snapshotting `prev` every frame against a mover.
+            //
+            // DRIFT (GSI-08.14), deferred — this is a PURE READ, so
+            // `is_rotating` is evaluated against the barrel as it stood at the
+            // start of the frame, i.e. BEFORE arm A's own `Set` above (which
+            // `apply_unit_facing` commits post-batch). Native evaluates it
+            // after, because `Facing_Update` mutates `+0x3A0` in place. Effect:
+            // on the FIRST frame of an arc VERA reports `latch = false` where
+            // native reports true, so arm A runs once more on the next frame
+            // and re-snapshots `prev` — one extra re-aim per arc against a
+            // moving target, exactly what the latch exists to prevent. The arc
+            // still ends on the same frame (the destination is unchanged when
+            // the target has not moved), and the fire gate is unaffected,
+            // because it reads the previous tick's committed latch either way.
+            // Trigger: any turreted vehicle starting an arc at a mover.
+            // Frequency: once per arc, so every engagement opening.
+            // Downstream risk: closing it means committing the turret write
+            // before the latch read, i.e. splitting this pure read in two.
             out.latch = true;
         } else if entity.attack_target.is_none() {
             let dwell = rules.map_or(NATIVE_IDLE_TURRET_DWELL_FALLBACK, |r| {

--- a/src/sim/rocking/impulse.rs
+++ b/src/sim/rocking/impulse.rs
@@ -44,10 +44,30 @@ const DEFAULT_WEIGHT: SimFixed = SimFixed::lit("2.0");
 ///   - `dx`, `dy`: target_position − source_position in sim units. Only the
 ///      direction matters; magnitude cancels in the normalization.
 ///
-/// Deferred parity drifts (both documented in the design ledger):
-///   - L31: distance attenuation. Approximated here as constant 0.04
-///      (the maximum).
-///   - L32: rate-timer jitter on impulse direction. Dropped entirely.
+/// **NO PRODUCTION CALLER** — see the module header. Every drift below is
+/// therefore latent: it costs nothing today and must be settled in the slice
+/// that wires a producer and a renderer.
+///
+/// DRIFT (GSI-08.14), verified this session by `decompile_function 0x0070B280`
+/// (`TechnoClass::ApplyRocker`, vtable `+0x3D8`):
+///   - **Assignment, not accumulation.** Native ends with
+///     `this+0x334 = forwards` and `this+0x330 = -sideways` — plain stores. This
+///     function adds into `vel_forwards`/`vel_sideways` and then clamps, so two
+///     impulses in one tick stack here and the second simply replaces the first
+///     natively. Trigger: two `Rocker=` detonations on one vehicle in a frame.
+///     Player effect: a doubled lurch. Frequency: common under artillery fire.
+///   - **The type gate.** Native does nothing at all unless
+///     `TechnoType(vtable+0x84) + 0xB0` is non-null AND the string it points at
+///     is empty (`**(char**)(Type+0xB0) == 0`). Field identity UNCHECKED. Until
+///     it is named, which types can rock at all is unknown.
+///   - **L31 distance attenuation.** Native scales by
+///     `(0.04 - dist * 2.5e-05)` over the 3D source-to-target distance and
+///     additionally refuses the impulse when `|dist| < 2e-05`; this function
+///     uses the constant maximum `0.04`. Player effect: distant hits rock as
+///     hard as point-blank ones.
+///   - **Weight source.** Native divides by `TechnoType+0x370` read as a
+///     `double`; the `Weight=` binding here is DOC, not re-verified.
+///   - **L32:** rate-timer jitter on impulse direction. Dropped entirely.
 pub fn apply_rocker_impulse(
     rocking: &mut RockingState,
     force: SimFixed,

--- a/src/sim/rocking/mod.rs
+++ b/src/sim/rocking/mod.rs
@@ -4,6 +4,39 @@
 //! each tick. Drive/Ship slope interpolation is owned separately by locomotor
 //! runtime payload state.
 //!
+//! # DEAD SUBSYSTEM (GSI-08.14) — no producer and no consumer
+//!
+//! [`tick`] runs every frame from `World::advance_tick` Phase 2.5, but nothing
+//! in the build writes an impulse into it and nothing reads the angles back out:
+//!
+//! - **No producer.** [`apply_rocker_impulse`] has no caller outside this
+//!   module's tests. gamemd reaches `TechnoClass::ApplyRocker` (vtable `+0x3D8`
+//!   → `0x0070B280`) from exactly four places, established this session by a
+//!   `CALL [reg+0x3D8]` census over all 1.16M instructions in the image:
+//!   `BulletClass::DetonateAtCoord @ 0x004699A1` (`DirectRocker=`, zero stock
+//!   authors), `Apply_area_damage @ 0x00489DFF`/`0x00489E3E` (`Rocker=`, 18
+//!   stock warheads), and `WarpAttachClass::UpdateAttack @ 0x0062A21C` (the
+//!   Chrono Legionnaire erase impulse, force `1.5`, one RNG draw for the
+//!   lateral sign). `FootClass::ReceiveEMP @ 0x004DECF0` writes the velocities
+//!   directly instead. **Firing never rocks the body** — there is no
+//!   `ApplyRocker` site in `Fire_At`, and none in any crush or deploy path.
+//! - **No consumer.** `grep` over `render/` and `app/` finds no read of
+//!   `GameEntity::rocking`, so even a correct impulse would tilt nothing, and
+//!   the self-destruct hook the production caller passes is
+//!   [`NoopSelfDestruct`].
+//!
+//! - Trigger: any `Rocker=yes` warhead detonating near a vehicle — that is most
+//!   tank and artillery shells in the game.
+//! - Player effect: vehicles do not lurch when shells land beside them. The
+//!   whole "shot lands next to the Rhino and the Rhino rocks" reading is
+//!   missing.
+//! - Frequency: continuous in any engagement.
+//! - Downstream risk: wiring the producer alone would add per-entity
+//!   deterministic state and move the pinned replay hash while changing nothing
+//!   a player can see, so the producer and the renderer belong in one slice. See
+//!   the verified DRIFT list on [`apply_rocker_impulse`] for what the impulse
+//!   maths must also change when that slice lands.
+//!
 //! ## Dependency rules
 //! - Part of sim/ — depends only on sim/components, sim/entity_store, map,
 //!   rules, util/fixed_math. Never on render/, ui/, audio/, net/.

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -344,7 +344,15 @@ use crate::sim::world::Simulation;
 // `DetectDisguiseRange=` radius on each SensorDeposit. Both fields already
 // round-trip (they are `#[serde(default)]` additive), so this bump exists to
 // keep the hash-schema probes and the serialized version aligned.
-const SNAPSHOT_VERSION: u32 = 117;
+// Bumped 117 -> 118: `GameEntity` gains the `UnitClass+0x6AF` turret rotation
+// latch and the `TechnoClass+0x120` last-fire frame. Both are inserted
+// MID-STRUCT — after `barrel_facing`, before `building_up` — and both are
+// present on EVERY entity. Bincode is not self-describing: the decoder reads
+// the next field's bytes unconditionally and `#[serde(default)]` never fires
+// for a short record, so a v117 save would pass the version check and then
+// misread every byte from entity one onward. A mid-struct insertion is exactly
+// the case serde defaults cannot cover, so the version has to move.
+const SNAPSHOT_VERSION: u32 = 118;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -3061,10 +3069,13 @@ mod tests {
     /// stores (entry array, heap of references, capacity) and adds the
     /// `MapRect` the stores are sized from; 116 -> 117 folds the
     /// disguise-detect counter plane and the cached `DetectDisguiseRange=`
-    /// deposit radius into the hash schema.
+    /// deposit radius into the hash schema; 117 -> 118 inserts the
+    /// `UnitClass+0x6AF` turret rotation latch and the `TechnoClass+0x120`
+    /// last-fire frame mid-`GameEntity`, on every entity, which bincode cannot
+    /// decode from a shorter v117 record.
     #[test]
-    fn disguise_detect_plane_snapshot_version_is_117() {
-        assert_eq!(super::SNAPSHOT_VERSION, 117);
+    fn turret_rotation_latch_snapshot_version_is_118() {
+        assert_eq!(super::SNAPSHOT_VERSION, 118);
     }
 
     #[test]

--- a/src/sim/world/unit_post.rs
+++ b/src/sim/world/unit_post.rs
@@ -53,15 +53,30 @@ pub(crate) const L2_UNIT_POST_AUTHORITATIVE: bool = true;
 /// state. Idempotent — `set` is a no-op when the destination already matches.
 /// ROT byte refreshed from rules each apply, same as the legacy sweep.
 ///
-/// Three writes land here, in native order:
-/// 1. the turret destination from `UnitClass::Facing_Update @ 0x00736990`
-///    (`None` = native calls no `Set`, so the turret holds its aim);
-/// 2. the hull destination from `UnitClass::Fire_At_Target @ 0x00736DF0` case 2
+/// Four writes land here, and their ORDER is native, not incidental:
+/// 1. the hull destination from `UnitClass::Fire_At_Target @ 0x00736DF0` case 2
 ///    (`FacingClass::Set(+0x388)` at `0x00737004`, then the hull's raw
 ///    destination copied into the turret slot at `0x0073701C` — `FUN_004C9470`
-///    returns the DESTINATION dword, not the animated value);
-/// 3. the `+0x6AF` rotation latch (`0x00736AD5`/`0x00736B16`), read next tick by
-///    `UnitClass::GetFireError @ 0x00741233`.
+///    returns the DESTINATION dword, not the animated value). Native runs the
+///    whole of `Fire_At_Target` before `Facing_Update`
+///    (`0x007365E1`/`0x007365E8`), so this precedes everything below;
+/// 2. `Facing_Update` arm A's aim `Set` on the turret, `0x00736A89`
+///    (`None` = native calls no `Set`, so the turret holds its aim);
+/// 3. the `+0x6AF` rotation latch — `MOV [ESI+0x6AF],AL` at `0x00736B16`, the
+///    value being `FacingClass::Is_Rotating(+0x3A0) @ 0x004C9480` called at
+///    `0x00736B11`, with the unconditional clear at `0x00736AD5` covering the
+///    turretless and not-rotating cases. Read next tick by
+///    `UnitClass::GetFireError @ 0x00741233`;
+/// 4. `Facing_Update` arm B's idle-return `Set` on the turret, `0x00736BDD`.
+///
+/// Steps 3 and 4 are in that order in the binary, and it matters:
+/// `FacingClass::Set @ 0x004C9220` writes `duration = abs(delta)/rate` and
+/// `start = g_CurrentFrameCounter`, so any `Set` of one or more `ROT=` steps
+/// makes `Is_Rotating` true immediately. An aim `Set` therefore arms the latch
+/// on the frame it is issued — which is what keeps the fire gate refusing for
+/// the whole arc, including its first one or two frames — while an idle-return
+/// `Set` leaves the latch clear, so a unit that re-acquires a target during an
+/// idle swing-back is free to aim at it on the next frame.
 ///
 /// It then mirrors the animated hull back into `entity.facing`, which is VERA's
 /// authoritative 8-bit heading. gamemd has no such byte — `+0x388` IS the
@@ -85,7 +100,8 @@ pub(crate) fn apply_unit_facing(
         let Some(entity) = entities.get_mut(id) else {
             continue;
         };
-        entity.turret_rotation_latch = update.latch;
+        // 1. `Fire_At_Target` case 2's hull turn, which native completes before
+        //    `Facing_Update` is entered at all (`0x007365E1`/`0x007365E8`).
         if let Some(desired) = update.hull_destination {
             let hull = entity.body_facing.get_or_insert_with(|| {
                 crate::sim::movement::FacingClass::new(u16::from(entity.facing) << 8, rot_byte)
@@ -98,7 +114,28 @@ pub(crate) fn apply_unit_facing(
                 barrel.set(raw_destination, binary_frame);
             }
         }
+        // 2. arm A's aim `Set` (`0x00736A89`) — before the latch store.
         if let Some(desired) = update.turret_destination
+            && !update.turret_destination_is_idle_return
+            && let Some(ref mut barrel) = entity.barrel_facing
+        {
+            barrel.set_rot(rot_byte);
+            barrel.set(desired, binary_frame);
+        }
+        // 3. the `+0x6AF` store (`0x00736B16`), evaluated on the barrel as it
+        //    stands after the writes above. `is_some_and` reproduces the
+        //    `0x00736AD5` clear for a turretless unit, which native leaves at 0
+        //    because the `Type+0xCA1` test at `0x00736ADC` sends it past both
+        //    `Is_Rotating` calls.
+        let latch = entity
+            .barrel_facing
+            .as_ref()
+            .is_some_and(|barrel| barrel.is_rotating(binary_frame));
+        entity.turret_rotation_latch = latch;
+        // 4. arm B's idle-return `Set` (`0x00736BDD`) — after the latch store,
+        //    so the swing-back arc does not arm it.
+        if let Some(desired) = update.turret_destination
+            && update.turret_destination_is_idle_return
             && let Some(ref mut barrel) = entity.barrel_facing
         {
             barrel.set_rot(rot_byte);

--- a/src/sim/world/unit_post.rs
+++ b/src/sim/world/unit_post.rs
@@ -46,29 +46,70 @@ use crate::sim::intern::StringInterner;
 /// skips Units.
 pub(crate) const L2_UNIT_POST_AUTHORITATIVE: bool = true;
 
-/// Apply precomputed Unit barrel destinations (the write half of the post-Foot
+/// Apply the precomputed Unit Facing slot (the write half of the post-Foot
 /// Facing slot). `FacingClass::set` is pure in `(state, binary_frame)` and no
-/// system writes Unit barrels between the combat Phase-2 read window and this
+/// system writes Unit facings between the combat Phase-2 read window and this
 /// site, so the apply point within Phase 5 does not affect the resulting
 /// state. Idempotent — `set` is a no-op when the destination already matches.
 /// ROT byte refreshed from rules each apply, same as the legacy sweep.
+///
+/// Three writes land here, in native order:
+/// 1. the turret destination from `UnitClass::Facing_Update @ 0x00736990`
+///    (`None` = native calls no `Set`, so the turret holds its aim);
+/// 2. the hull destination from `UnitClass::Fire_At_Target @ 0x00736DF0` case 2
+///    (`FacingClass::Set(+0x388)` at `0x00737004`, then the hull's raw
+///    destination copied into the turret slot at `0x0073701C` — `FUN_004C9470`
+///    returns the DESTINATION dword, not the animated value);
+/// 3. the `+0x6AF` rotation latch (`0x00736AD5`/`0x00736B16`), read next tick by
+///    `UnitClass::GetFireError @ 0x00741233`.
+///
+/// It then mirrors the animated hull back into `entity.facing`, which is VERA's
+/// authoritative 8-bit heading. gamemd has no such byte — `+0x388` IS the
+/// heading — so the mirror is what keeps rendering, movement and the fire gate
+/// on the same value. Units the movement tick owns (`movement_target` set) are
+/// skipped: that path already mirrors, and clearing its interpolator here would
+/// fight it.
 pub(crate) fn apply_unit_facing(
     entities: &mut EntityStore,
-    updates: &[(u64, u16)],
+    updates: &[crate::sim::combat::UnitFacingUpdate],
     rules: &RuleSet,
     interner: &StringInterner,
     binary_frame: u32,
 ) {
-    for &(id, desired) in updates {
+    for update in updates {
+        let id = update.entity_id;
         let rot_byte: u8 = rules
             .object(interner.resolve(entities.get(id).map(|e| e.type_ref).unwrap_or_default()))
             .map(|obj| obj.turret_rot.clamp(0, 0xFF) as u8)
             .unwrap_or(5);
-        if let Some(entity) = entities.get_mut(id) {
+        let Some(entity) = entities.get_mut(id) else {
+            continue;
+        };
+        entity.turret_rotation_latch = update.latch;
+        if let Some(desired) = update.hull_destination {
+            let hull = entity.body_facing.get_or_insert_with(|| {
+                crate::sim::movement::FacingClass::new(u16::from(entity.facing) << 8, rot_byte)
+            });
+            hull.set_rot(rot_byte);
+            hull.set(desired, binary_frame);
+            let raw_destination = hull.destination();
             if let Some(ref mut barrel) = entity.barrel_facing {
                 barrel.set_rot(rot_byte);
-                barrel.set(desired, binary_frame);
+                barrel.set(raw_destination, binary_frame);
             }
+        }
+        if let Some(desired) = update.turret_destination
+            && let Some(ref mut barrel) = entity.barrel_facing
+        {
+            barrel.set_rot(rot_byte);
+            barrel.set(desired, binary_frame);
+        }
+        // Mirror the animated hull into the 8-bit heading. The movement tick
+        // owns that mirror while a path is live.
+        if entity.movement_target.is_none()
+            && let Some(ref hull) = entity.body_facing
+        {
+            entity.facing = (hull.current(binary_frame) >> 8) as u8;
         }
     }
 }

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -7527,6 +7527,11 @@ fn combat_death_not_repaired_then_freed_at_end_of_tick() {
     let height_map: BTreeMap<(u16, u16), u8> = BTreeMap::new();
 
     let mut atk = GameEntity::test_default(1, "MTNK", "Americans", 5, 5);
+    // The fixture `MTNK` authors no `Turret=`, so the native body gate
+    // (`UnitClass::GetFireError @ 0x00740FD0` step 17) compares its HULL
+    // `+0x388`. Face it east at the building so the death/drain ordering under
+    // test happens on the first tick instead of after a turn-to-fire.
+    atk.facing = 64;
     atk.health = Health {
         current: 300,
         max: 300,


### PR DESCRIPTION
Phase 6, row 126 (GSI-08.14 body/turret/barrel facing and recoil) and the facing-gate half of row 124 (GSI-08.04).

Before this branch a V3 Launcher, Dreadnought, Tesla Tank or Demo Truck fired the instant it acquired a target, regardless of which way its hull was pointing.

## What gamemd does

`UnitClass::GetFireError @ 0x00740FD0` step 17 chooses the compared facing by `Turret=`: the turret at `+0x3A0` when the type has one, the **hull** at `+0x388` when it does not. So a turretless vehicle must swing its body round before it may shoot, and `Fire_At_Target @ 0x00736DF0` case 2 is the emitter that turns it, only while stationary and without a NavCom. Both landed together here, so the gate cannot strand a unit: a test asserts a turretless attacker turns and then fires.

`Facing_Update @ 0x00736990` is now ported whole, which brings in four arms VERA lacked — the rotation latch at `+0x6AF`, the NavCom aim, the `OmniFire` skip, and the building foundation-centre target anchor — plus the idle dwell. That dwell is measured from the unit's **own last shot**, not from losing its target: `+0x120` has exactly two writers in the whole image, the constructor storing −100 and `Fire_At @ 0x006FF743` storing the frame counter. Two independent reviewers reproduced that census against VERA's previous model.

Tolerance rules follow: `0x0800` widens to `0x1000` when the projectile homes, narrows to `0x0000` for a voxel-turret building with a same-visit snap-and-retry, and a building turret holds its last aim forever.

## Review history

Three critic rounds. The first found the snapshot version had to move, because two new `GameEntity` fields are inserted mid-struct under bincode where `#[serde(default)]` cannot cover a short record — an earlier instruction of mine had wrongly told the builder not to bump it. It also found `FIRE_ROTATING (4)` unimplemented while a comment claimed otherwise, which mattered once the latch committed a turret to a whole arc.

The second found the latch being committed **before** arm A's `Set`, so the new gate fired one to two frames early on every re-aim beyond 11.25 degrees — the band where a tracked target drifts between shots. The builder fixed it but **refused the suggested one-line form**, and was right: arm B's idle-return `Set` sits *after* the store on a mutually exclusive branch, so a blanket post-`Set` read would have pinned a swing-back arc to the idle destination and ignored a new target. The third round verified that refusal from the disassembly and passed with no findings.

## Deliberately not wired

The rocking subsystem is dead at both ends — no producer calls `apply_rocker_impulse`, and nothing in the renderer reads the state. Wiring only the producer would add per-entity deterministic state and move the replay hash while changing nothing a player sees, so producer and renderer are left for one slice. Three drifts verified from `ApplyRocker @ 0x0070B280` are recorded in place, including that it no-ops unless the type points at an empty string.

Row 126 therefore stays open on that residual.

`cargo test -p vera20k --lib`: `test result: ok. 8111 passed; 0 failed; 75 ignored`. `SNAPSHOT_VERSION` 117 to 118; no golden or world-hash constant moved, and main's freshly re-baselined harness constants reproduce unchanged with both mechanisms composed.
