### PR TITLE
Phase 6: the native sound channel arbiter, Limit=, looping and pump cadence

### DIFF
--- a/src/app/frame.rs
+++ b/src/app/frame.rs
@@ -114,6 +114,16 @@ impl App {
             }
         }
 
+        // The audio service pass. gamemd drives `AudioSystem::Pump @
+        // 0x00406F70` from `Network_ServiceLoop @ 0x0048D080`, which the main
+        // tick, the frame throttler, the modal dialog pump, the shell dialog
+        // loop and the loading screens all reach — so the sound arbiter, the
+        // EVA queue and `ThemeClass::AI` keep being serviced on the main menu,
+        // behind a pause or an open menu, and while the window is not the
+        // foreground. It therefore sits here, outside every screen and
+        // simulation gate, and carries its own `> 33 ms` rate limit.
+        crate::app::match_runtime::sim_tick::pump_audio_service(state, scenario_now_ms);
+
         Self::sync_in_game_menu_with_options_overlay(state);
 
         // Deactivated windows do not simulate. gamemd parks its main tick in a

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -528,12 +528,26 @@ pub(crate) fn monotonic_frame_pacer_ms(state: &AppState, now: Instant) -> u64 {
 /// `VoxClass::PauseEVA @ 0x007535B0` raises.
 ///
 /// Pause is the explicit `GamePause::Enter @ 0x00406F00` path: suspend every
-/// event, stop the playing channels, and pause the EVA/speech stream. VERA's
-/// separate "in-game menu open" state is deliberately NOT treated as a pause
-/// — gamemd reaches
-/// `GamePause::Enter` only through `ScenarioPause::Enter @ 0x00684060` and
-/// `StateMachine::EnterPause @ 0x00683EB0`, and whether the YR options dialog
-/// routes through either of those is UNCHECKED.
+/// event, stop the playing channels, and pause the EVA/speech stream.
+///
+/// `match_state.paused` **is** VERA's in-game-menu state — `in_game.rs` sets
+/// it from `InGameMenuState::is_open()`, and apart from the `J` debug toggle
+/// VERA has no other pause. That is not a divergence from gamemd; it is
+/// exactly gamemd's pause. `State_Machine @ 0x0048C8B0` brackets its entire
+/// dialog switch — case 5 `OptionsClass::ShowInGameDialog`, case 8
+/// `Show_Diplomacy_Menu`, case 9 `ScenarioClass::ShowMissionRestateBriefing`
+/// — between `StateMachine::EnterPause @ 0x00683EB0`, whose first statement
+/// is `GamePause::Enter`, and `StateMachine::ExitPause @ 0x00683FB0`, whose
+/// last is `GamePause::Exit`. `get_function_callers` on `0x00683EB0` returns
+/// only `State_Machine`, and on `0x00406F00` only that path plus
+/// `ScenarioPause::Enter @ 0x00684060` (the nuke-flash / in-game-movie /
+/// trigger route, not a menu).
+///
+/// So opening the in-game menu in gamemd is a full game pause: the SFX
+/// channels stop and the EVA stream is cut mid-word. Passing `paused`
+/// straight into `set_paused` is the correct behaviour — do **not** add a
+/// "menu open is not really a pause" carve-out here; that would be a
+/// regression against the binary.
 pub(crate) fn pump_audio_service(state: &mut AppState, now_ms: u64) {
     let paused = state.match_state.paused;
     let registry = &state.audio.sound_registry;

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -522,11 +522,15 @@ pub(crate) fn monotonic_frame_pacer_ms(state: &AppState, now: Instant) -> u64 {
 /// the game frame, so `SoundSystem::UpdateTick @ 0x004041D0` keeps reaping
 /// finished events, enforcing `Limit=`, ranking and servicing the EVA queue
 /// during a pause, an open menu, a modal dialog and a loading screen. The
-/// `> 33 ms` gate lives inside `SfxPlayer::pump`, as it does in native.
+/// `> 33 ms` gate lives inside `SfxPlayer::pump`, as it does in native. The
+/// EVA *dequeue* is the one part a pause does stop: `VoxClass::PlayNextQueued
+/// @ 0x00752780` gates its whole body on `DAT_00b1d428 == 0`, which
+/// `VoxClass::PauseEVA @ 0x007535B0` raises.
 ///
 /// Pause is the explicit `GamePause::Enter @ 0x00406F00` path: suspend every
-/// event and stop the playing channels. VERA's separate "in-game menu open"
-/// state is deliberately NOT treated as a pause — gamemd reaches
+/// event, stop the playing channels, and pause the EVA/speech stream. VERA's
+/// separate "in-game menu open" state is deliberately NOT treated as a pause
+/// — gamemd reaches
 /// `GamePause::Enter` only through `ScenarioPause::Enter @ 0x00684060` and
 /// `StateMachine::EnterPause @ 0x00683EB0`, and whether the YR options dialog
 /// routes through either of those is UNCHECKED.

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -515,6 +515,33 @@ pub(crate) fn monotonic_frame_pacer_ms(state: &AppState, now: Instant) -> u64 {
     crate::app::match_runtime::frame_pacer::wall_clock_ms(state.platform.frame_pacer_epoch, now)
 }
 
+/// One `AudioSystem::Pump @ 0x00406F70` service pass, run every frame whether
+/// or not the simulation stepped.
+///
+/// Native reaches the pump from `Network_ServiceLoop @ 0x0048D080`, not from
+/// the game frame, so `SoundSystem::UpdateTick @ 0x004041D0` keeps reaping
+/// finished events, enforcing `Limit=`, ranking and servicing the EVA queue
+/// during a pause, an open menu, a modal dialog and a loading screen. The
+/// `> 33 ms` gate lives inside `SfxPlayer::pump`, as it does in native.
+///
+/// Pause is the explicit `GamePause::Enter @ 0x00406F00` path: suspend every
+/// event and stop the playing channels. VERA's separate "in-game menu open"
+/// state is deliberately NOT treated as a pause — gamemd reaches
+/// `GamePause::Enter` only through `ScenarioPause::Enter @ 0x00684060` and
+/// `StateMachine::EnterPause @ 0x00683EB0`, and whether the YR options dialog
+/// routes through either of those is UNCHECKED.
+pub(crate) fn pump_audio_service(state: &mut AppState, now_ms: u64) {
+    let paused = state.match_state.paused;
+    let registry = &state.audio.sound_registry;
+    let audio_indices = &state.audio.audio_indices;
+    let (Some(sfx), Some(assets)) = (&mut state.audio.sfx_player, state.process_assets.manager())
+    else {
+        return;
+    };
+    sfx.set_paused(paused, now_ms);
+    sfx.pump(now_ms, registry, assets, audio_indices);
+}
+
 /// Front-end session mode, as the modal pump reads it to decide whether the
 /// simulation advances behind an open modal dialog. Mirrors gamemd's `g_GameMode`
 /// discriminator; the values are writer-proofed — the active engine only ever
@@ -853,7 +880,6 @@ fn advance_in_game_runtime_mode(
             .map(|rt| &rt.simulation)
             .map(|sim| sim.session.tick.saturating_sub(garrison_flash_start_tick))
             .unwrap_or(0);
-        crate::app::presentation::building_anim::drain_sound_events(state);
         // Building one-shots, refinery particles, and their logic-frame clocks
         // were finalized inside the authoritative sim transaction. Only the
         // independent wall-clock terrain-overlay timer remains app-owned.
@@ -880,7 +906,16 @@ fn advance_in_game_runtime_mode(
     crate::app::presentation::sidebar_gadgets::update_sidebar_gadget_state(state);
     // Per-frame gadget idle tick (G22 rows 2/3 drag-off/drag-back tracking).
     crate::app::input::gadget_input::idle_tick(state);
+    // The audio service is NOT gated on the simulation. gamemd's
+    // `AudioSystem::Pump @ 0x00406F70` hangs off `Network_ServiceLoop @
+    // 0x0048D080`, whose callers include `Main::ThrottleFrame @ 0x0055E160`,
+    // `ProcessModalServicePump @ 0x00623120` and `ShellDialog::RunUntilResult
+    // @ 0x0060D380`, so the sound arbiter, the EVA queue and `ThemeClass::AI`
+    // keep running behind a pause, an open menu and a loading screen alike.
+    // Pause is expressed separately, by suspending the events and stopping the
+    // playing channels (`GamePause::Enter @ 0x00406F00`).
     let music_now_ms = monotonic_frame_pacer_ms(state, Instant::now());
+    crate::app::presentation::building_anim::drain_sound_events(state);
     if let Some(assets) = state.process_assets.manager() {
         state.audio.update_theme(assets, music_now_ms);
     }

--- a/src/app/presentation/building_anim.rs
+++ b/src/app/presentation/building_anim.rs
@@ -183,12 +183,6 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
     use crate::audio::sfx::{SpatialGain, SpatialListener, SpatialSource, spatial_gain};
 
     let events = state.match_state.match_audio.sound_events.drain();
-    if events.is_empty() {
-        if let Some(sfx) = &mut state.audio.sfx_player {
-            sfx.advance_voice_queue();
-        }
-        return;
-    }
     let (tactical_width, tactical_height) = crate::app::input::camera::tactical_viewport_size_px(
         state.render_width(),
         state.render_height(),
@@ -344,6 +338,49 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
             }
         }
     }
+
+    // `AnimClass::UpdateLoopingSound @ 0x00750D40` from the owner's side.
+    // Native's owner calls it on every one of its own updates with its
+    // current coordinate: a positive volume re-drives `SoundEvent::SetVolume`
+    // and `SetPan` and re-points the handle, and a volume that has fallen to
+    // zero calls `SoundEvent::Stop` and clears the handle — which is what
+    // ends a sustained cue whose object has driven out of earshot.
+    // `SoundEvent::UpdateState @ 0x004057DC` then reaps the event on its next
+    // pass because the owner no longer names it.
+    for owner in sfx.looping_owners() {
+        let Some(sim) = sim else {
+            sfx.update_looping_sound(owner, None);
+            continue;
+        };
+        let Some(world) = sim.looping_sound_owner_coord(owner) else {
+            // The owner object is gone. Native's `ObjectClass` uninit path
+            // releases the handle before the pointer can dangle
+            // (`release_move_sound` / `destroy_anim` push the stop event), so
+            // this is the belt-and-braces arm.
+            sfx.update_looping_sound(owner, None);
+            continue;
+        };
+        let (rx, ry, sub_x, sub_y, z) = world.to_cell_sub_z();
+        let (screen_x, screen_y) = crate::util::lepton::lepton_to_screen(rx, ry, sub_x, sub_y, z);
+        let facts = registry_facts_for_owner(registry, sfx, owner);
+        let gain = facts
+            .and_then(|facts| spatial_gain(facts, screen_x, screen_y, &listener, shrouded(rx, ry)));
+        sfx.update_looping_sound(owner, gain);
+    }
+}
+
+/// The `Range`/`Type`/`MinVolume` a live loop handle's entry carries, for the
+/// per-update `CalcVolumeAndPan` re-drive.
+fn registry_facts_for_owner(
+    registry: &crate::rules::sound_ini::SoundRegistry,
+    sfx: &crate::audio::sfx::SfxPlayer,
+    owner: u64,
+) -> Option<crate::audio::sfx::SpatialSource> {
+    let key = sfx.loop_handle_sound_id(owner)?;
+    Some(registry.get(&key).map_or_else(
+        || crate::audio::sfx::SpatialSource::from_registry_defaults(registry),
+        crate::audio::sfx::SpatialSource::from_entry,
+    ))
 }
 
 /// Spawn new garrison muzzle flash animations from pending fire events and

--- a/src/audio/arbiter.rs
+++ b/src/audio/arbiter.rs
@@ -1,0 +1,1753 @@
+//! The sound channel arbiter: which of the 16 hardware channels a cue gets,
+//! which cue loses one, how many instances an entry may hold, how a looping
+//! cue sustains, and how often the whole thing is serviced.
+//!
+//! Device-free by construction: this module owns the *decisions* and emits
+//! [`ArbiterAction`]s; `audio::sfx` owns the rodio plumbing that applies them.
+//! That split is what makes the mechanism reachable from `cargo test --lib`,
+//! where `SfxPlayer::new` returns `None` because there is no audio device.
+//!
+//! gamemd-derived: `SoundSystem::UpdateTick @ 0x004041D0`, driven by
+//! `AudioSystem::Pump @ 0x00406F70`. The native object is a `SoundEvent`
+//! (0x280 bytes, pool of 300 — `SoundEventPool::Init @ 0x00403ED0`
+//! `MOV EDX,0x280 ; MOV ECX,0x12c`) that competes for one of 16 DirectSound
+//! secondary buffers (`DSoundChannel::CreateAll @ 0x00403530`, requested as
+//! `MOV EDX,0x10` at `0x00406C25` with `CMP EAX,0x10 ; JNZ` disabling output
+//! unless exactly 16 are made).
+//!
+//! ## Dependency rules
+//! - Part of audio/. Depends on nothing but `std` and `rules::sound_ini`
+//!   constants. Does NOT depend on render/, ui/, sidebar/, sim/, or on any
+//!   audio device.
+
+use std::collections::BTreeMap;
+
+use crate::rules::sound_ini::{VOLUME_SCALE, control};
+
+/// DirectSound secondary buffers the mixer owns.
+///
+/// `AudioSystem::Init @ 0x00406B10` calls `DSoundChannel::CreateAll @
+/// 0x00403530` with `MOV EDX,0x10` (`0x00406C25`) and disables audio output
+/// entirely unless the call returns exactly 16 (`CMP EAX,0x10 ; JNZ` at
+/// `0x00406C31`). A `SoundEvent` is the *request*; a channel is the scarce
+/// resource.
+pub const MAX_CHANNELS: usize = 16;
+
+/// `SoundEvent` records in the pool: `SoundEventPool::Init @ 0x00403ED0`
+/// allocates `MemPool(count = 0x12c, elem = 0x280)`. Up to 300 cues can be
+/// alive at once; only [`MAX_CHANNELS`] of them hold a channel.
+pub const MAX_SOUND_EVENTS: usize = 300;
+
+/// The service period. `AudioSystem::Pump @ 0x00406F70` runs a pass only when
+/// more than `0x21` ms have elapsed since the last admitted one
+/// (`0x21 < (uint)now - g_AudioPumpLastTimestamp`), and it is driven from
+/// `Network_ServiceLoop @ 0x0048D080` — the message/service loop, not the
+/// simulation frame. Menus, modal dialogs, loading screens and the frame
+/// pacer's idle all keep the audio service running.
+pub const PUMP_PERIOD_MS: u64 = 0x21;
+
+/// Priority rows in `g_PriorityVolumeBuckets @ 0x0087DE38` (row stride 0x78).
+pub const PRIORITY_ROWS: usize = 7;
+
+/// Volume buckets per priority row (bucket stride 0x0C).
+pub const VOLUME_BUCKETS: usize = 10;
+
+/// Volume-bucket divisor. `SoundSystem::UpdateTick` computes the bucket with
+/// the magic divide at `0x004044AE..0x004044D6`
+/// (`MOV EAX,0x40140141 ; MUL ESI ; SUB ESI,EDX ; SHR ESI,1 ; ADD ESI,EDX ;
+/// SHR ESI,0xa`), which is an unsigned divide of `event+0xBC >> 16` by 1638.
+///
+/// A full-scale instance (`0x4000`) yields **10**, one past the row, so it
+/// spills into `bucket[prio + 1][0]` — harmless with the 7-row array, but it
+/// makes a full-volume entry look one priority tier higher to
+/// [`SoundArbiter::find_lowest_priority`], i.e. harder to preempt.
+pub const BUCKET_DIVISOR: i32 = 1638;
+
+/// Age gap two equal-priority channels need before the older one is taken.
+/// `DSoundChannel::FindAvailable @ 0x004035F0`, `0x0040366B..0x00403675`:
+/// `MOV EBX,ESI ; SUB EBX,EDX ; CMP EBX,0x666 ; JC skip` — the candidate is
+/// only replaced when `bestStamp - stamp >= 0x666`.
+pub const EQUAL_PRIORITY_AGE_GAP: u32 = 0x666;
+
+/// Milliseconds the native ramp takes to cross the whole `0..0x4000` range.
+///
+/// `InterpGroup::Init @ 0x00401000` seeds every group with
+/// `VolumeInterp::SetRate(span = 0x4000, ms = 1000)` for volume and pan
+/// (`PUSH 0x0 ; PUSH 0x3e8 ; CALL 0x004071A0`), and `VolumeInterp::Init @
+/// 0x00407100` writes the same rate literal `0x10624D` = `(0x4000 << 16) /
+/// 1000`. **This is the only fade anywhere in the native audio pipeline** —
+/// there is no per-sample fade-in or fade-out.
+pub const RAMP_SPAN_MS: u32 = 1000;
+
+/// Pre-delay floor and the `Control=ambient` minimum, in milliseconds.
+/// `SoundEvent::UpdateState @ 0x004055C0` draws
+/// `RandomRanged(AMBIENT ? 0x21 : Delay.min, Delay.max)` and discards any
+/// result below `0x21` (`if (iVar5 < 0x21) return;`).
+pub const PREDELAY_FLOOR_MS: i32 = 0x21;
+
+/// Threshold above which the many-sounds limiter engages, and the numerator
+/// it holds the total at. `SoundSystem::UpdateTick @ 0x00404565..0x0040457B`:
+/// `CMP ECX,0x64 ; JLE ; MOV EAX,0x190000 ; XOR EDX,EDX ; DIV ECX`.
+const MANY_SOUNDS_THRESHOLD: i32 = 100;
+const MANY_SOUNDS_NUMERATOR: i32 = 0x0019_0000;
+
+/// `SoundEvent+0x18` flag bits, read from the sites that set them.
+mod event_flags {
+    /// `0x01` — reaped: the event is dead and awaiting pool return.
+    pub const DEAD: u32 = 0x01;
+    /// `0x02` — the DirectSound buffer is running
+    /// (`SoundEvent::StartPlayback @ 0x004054A0`, `flags |= 2`).
+    pub const PLAYING: u32 = 0x02;
+    /// `0x08` — the playout has begun at least once. Set by
+    /// `StartPlayback` and by `SoundEvent::MarkStarted @ 0x004052E0` (the
+    /// only caller of which is `AnimClass::UpdateLoopingSound @ 0x00750D40`).
+    /// `SoundEvent::PreparePlayout @ 0x00404700` reads it to decide whether
+    /// the `Control=attack` sample still heads the playout, so a loop
+    /// restart never replays the attack.
+    pub const STARTED: u32 = 0x08;
+    /// `0x20` — no-replay: suppresses the body and loop branches of
+    /// `SoundEvent::AdvancePlaylist @ 0x004047B0`.
+    pub const NO_REPLAY: u32 = 0x20;
+}
+
+/// `SoundEvent+0x1C`, the switch at `0x004059D0`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventState {
+    /// 0 — needs a channel. `UpdateState` case `0x00405639`.
+    NeedsChannel,
+    /// 1 — has a channel, waiting for the start pass.
+    Ready,
+    /// 2 — counting down a pre-delay. `UpdateState` case `0x004055EB`.
+    PreDelay,
+    /// 3 — playing. `UpdateState` case `0x004057DC`, which is also where the
+    /// looping leash lives.
+    Playing,
+    /// 4 — finished; reaped by the next pass.
+    Dead,
+}
+
+/// One `VolumeInterp` (40 bytes in native): a value that glides toward a
+/// target at a fixed rate, or snaps to it.
+///
+/// gamemd-derived layout, read from `VolumeInterp::Tick @ 0x004071C0` and
+/// `VolumeInterp::Init @ 0x00407100`: `+0x00` flags (bit0 snap, bit1 dirty),
+/// `+0x04` current 16.16, `+0x08` target 16.16, `+0x0C` rate per ms,
+/// `+0x10` 64-bit max `dt`, `+0x18` 64-bit last stamp.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VolumeInterp {
+    snap: bool,
+    /// 16.16 fixed point, as native stores it.
+    current: i64,
+    target: i64,
+    /// `(span << 16) / ms` — `VolumeInterp::SetRate @ 0x004071A0`.
+    rate: i64,
+    max_dt_ms: u64,
+    last_ms: u64,
+}
+
+impl VolumeInterp {
+    /// `VolumeInterp::Init @ 0x00407100`: snap flag set, rate `0x10624D`,
+    /// max `dt` 1000 ms, target `value << 16`, then a tail-jump to `Tick`
+    /// which copies target into current.
+    pub fn new(value: i32, now_ms: u64) -> Self {
+        let scaled = i64::from(value) << 16;
+        Self {
+            snap: true,
+            current: scaled,
+            target: scaled,
+            rate: (i64::from(VOLUME_SCALE) << 16) / i64::from(RAMP_SPAN_MS),
+            max_dt_ms: u64::from(RAMP_SPAN_MS),
+            last_ms: now_ms,
+        }
+    }
+
+    /// `VolumeInterp::SetTargetImmediate @ 0x00407150`:
+    /// `flags |= 1 ; [this+0x8] = value << 16`.
+    pub fn set_target_immediate(&mut self, value: i32) {
+        self.snap = true;
+        self.target = i64::from(value) << 16;
+    }
+
+    /// `VolumeInterp::SetTarget @ 0x00407170`: clears the snap bit so the
+    /// value glides, and re-stamps the clock **only when the interp was at
+    /// rest** (`CMP EAX,ECX ; JNZ` at `0x00407181` compares target against
+    /// current) — a glide already in flight keeps accumulating from its last
+    /// tick.
+    pub fn set_target(&mut self, value: i32, now_ms: u64) {
+        self.snap = false;
+        if self.target == self.current {
+            self.last_ms = now_ms;
+        }
+        self.target = i64::from(value) << 16;
+    }
+
+    /// `VolumeInterp::Tick @ 0x004071C0`. Returns whether anything moved.
+    pub fn tick(&mut self, now_ms: u64) -> bool {
+        let delta = self.target - self.current;
+        if delta == 0 {
+            return false;
+        }
+        if self.snap {
+            self.current = self.target;
+            return true;
+        }
+        let elapsed = now_ms.saturating_sub(self.last_ms);
+        self.last_ms = now_ms;
+        let dt = elapsed.min(self.max_dt_ms);
+        let step = self.rate.saturating_mul(dt as i64);
+        if delta >= 0 {
+            self.current += step.min(delta);
+        } else {
+            self.current -= step.min(-delta);
+        }
+        true
+    }
+
+    /// The integral part native reads everywhere as `>> 0x10`.
+    pub fn value(&self) -> i32 {
+        (self.current >> 16) as i32
+    }
+
+    pub fn target_value(&self) -> i32 {
+        (self.target >> 16) as i32
+    }
+}
+
+/// Identifier of one live `SoundEvent`. VERA-internal: native uses the record
+/// pointer, and pairs it with `+0x138` (the serial) to detect a stale handle.
+/// The slot index plus the same serial carries that contract without pointers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EventId(pub u32);
+
+/// The 16-byte `{ SoundEvent*, serial, VocClass*, &g_AudioIndex }` an owner
+/// holds for a sustained cue (`SoundEvent::SetLoopHandle @ 0x004060F0`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct VocHandle {
+    event: Option<EventId>,
+    serial: u32,
+    entry: u32,
+}
+
+/// The registry facts the arbiter needs, copied at submit time the way native
+/// reads them off the `VocClass` it already points at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EntryFacts {
+    /// `Priority=` (`VocClass+0x40`), `LOWEST 0`..`CRITICAL 4`.
+    pub priority: i32,
+    /// `Limit=` (`+0x48`), 0 = unlimited. `[Defaults] Limit=5` in stock
+    /// `soundmd.ini`, so **every** entry is limited.
+    pub limit: i32,
+    /// `Control=` flag word (`+0x10`).
+    pub control: u32,
+    /// `Loop=` (`+0x4C`). 0 with `Control=loop` means owner-driven sustain.
+    pub loop_count: i32,
+    /// `Delay=` min/max in ms (`+0x58`/`+0x5C`).
+    pub delay_ms: (i32, i32),
+    /// The entry's authored `Volume=` as the native linear value (`+0x1C`
+    /// integral part). Feeds the `Limit=` sort band and the many-sounds sum.
+    pub entry_volume_linear: i32,
+}
+
+impl EntryFacts {
+    /// `AudioEventClass::IsLoopable @ 0x00406650`:
+    /// `(Control & LOOP) && Loop == 0`.
+    pub fn is_loopable(&self) -> bool {
+        self.control & control::LOOP != 0 && self.loop_count == 0
+    }
+}
+
+/// One submitted cue.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlayRequest {
+    /// The `[SoundList]` identity, uppercased. All instances of one identity
+    /// share a `Limit=` counter and one priority-bucket slot.
+    pub key: String,
+    pub facts: EntryFacts,
+    /// The event's starting linear volume (spatial x entry x `VShift=`).
+    pub volume_linear: i32,
+    /// Pan `0..=0x4000`, `0x2000` centred.
+    pub pan: i32,
+    /// The caller's pre-delay draw, in milliseconds.
+    ///
+    /// Native draws it inside `UpdateState` state 0 *after* the channel is
+    /// taken, as the third of three `RandomRanged` calls (FShift, VShift,
+    /// then `RandomRanged(AMBIENT ? 0x21 : Delay.min, Delay.max)`). VERA draws
+    /// all three together in `PlayShifts::draw` so the RNG order is preserved,
+    /// and hands the result here; the arbiter applies it at native's place in
+    /// the state machine, including the `0x21` ms floor.
+    pub predelay_ms: i32,
+}
+
+/// What the device layer must do as a result of one service pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArbiterAction {
+    /// Begin playback. Native `SoundEvent::StartPlayback @ 0x004054A0` snaps
+    /// the volume and pan interps and starts the buffer.
+    Start {
+        event: EventId,
+        volume_linear: i32,
+        pan: i32,
+        /// `Control=loop` with the loop budget still open — the device layer
+        /// must keep the buffer queue topped up.
+        sustaining: bool,
+    },
+    /// Live gain update while playing (the `VolumeInterp` glide).
+    Gain {
+        event: EventId,
+        volume_linear: i32,
+        pan: i32,
+    },
+    /// Release the output. The slot is already free on the arbiter side.
+    Stop { event: EventId },
+}
+
+/// Per-channel state. Native fields: `+0x0C` kind, `+0xA0` priority,
+/// `+0xA4` busy flags (`& 0x15` in use, `& 1` actively playing), `+0xC0` the
+/// event that owns it, `+0xDC` the start stamp.
+#[derive(Debug, Clone, Copy, Default)]
+struct ChannelRec {
+    event: Option<EventId>,
+    priority: i32,
+    /// Native `ch+0xDC`. Its writer was not located; its role as a
+    /// monotonically increasing start stamp is inferred from the
+    /// `(bestStamp - stamp) >= 0x666` comparison in `FindAvailable`, and the
+    /// unit of `0x666` is UNCHECKED. VERA uses a monotonic allocation counter,
+    /// so the gap compares allocation age rather than milliseconds.
+    stamp: u32,
+    /// `ch+0xA4 & 0x15` — holds an event at all.
+    busy: bool,
+    /// `ch+0xA4 & 1` — the buffer is actually running.
+    playing: bool,
+}
+
+/// Per-`[SoundList]`-identity runtime state.
+#[derive(Debug, Clone, Default)]
+struct EntryRuntime {
+    facts: Option<EntryFacts>,
+    /// `VocClass+0x8C/+0x90`: the live instances, sorted by descending
+    /// current volume, rebuilt from scratch every pass.
+    list: Vec<EventId>,
+    /// `+0x44`, the live count for this pass.
+    count: i32,
+    /// `+0x98`, the pass id the counter was reset on.
+    limit_epoch: u32,
+    /// `+0x9C`, the pass id this entry was ranked on.
+    rank_epoch: u32,
+    /// `+0xA0`, the best effective priority seen this ranking pass.
+    best_priority: i32,
+    /// `+0xB0`, the best volume bucket seen this ranking pass.
+    best_bucket: i32,
+    /// Where the entry currently sits in the bucket array, if anywhere.
+    bucket_slot: Option<(usize, usize)>,
+}
+
+#[derive(Debug, Clone)]
+struct EventRec {
+    entry: u32,
+    state: EventState,
+    /// `+0x20`, the state a pre-delay resumes into.
+    resume_state: EventState,
+    flags: u32,
+    channel: Option<usize>,
+    /// The event group's volume interp (`event+0xB8`, current at `+0xBC`).
+    volume: VolumeInterp,
+    /// The group's pan interp (`event+0xB8 + 0x50`).
+    pan: VolumeInterp,
+    /// `+0x138`. Zero means invalidated; a handle holding a different value
+    /// is stale.
+    serial: u32,
+    /// The caller's pre-delay draw, applied in state 0 at native's place.
+    predelay_ms: i32,
+    /// `+0x140`, absolute while running and remaining while suspended.
+    predelay_deadline_ms: u64,
+    predelay_remaining_ms: u64,
+    /// `+0x154`. Written only by `AllocateFromPool` (to 0) anywhere in the
+    /// audio module, so the effective priority in stock play is `0..4`.
+    priority_bonus: i32,
+    /// `+0x158`. Non-zero blocks the start pass, freezes the pre-delay and
+    /// removes the event from the many-sounds volume sum.
+    suspend_depth: i32,
+    /// `+0x1E4`, the completed loop passes.
+    loop_iteration: i32,
+    /// The owner that holds this event's `VocHandle` (`+0x278`).
+    handle_owner: Option<u64>,
+}
+
+impl EventRec {
+    fn is_dead(&self) -> bool {
+        self.flags & event_flags::DEAD != 0
+    }
+}
+
+/// The native sound system's decision half.
+pub struct SoundArbiter {
+    events: Vec<Option<EventRec>>,
+    /// Insertion order of the global `SoundEvent` list (`g_SoundEventList @
+    /// 0x0087E180`). Every pass walks it in this order.
+    order: Vec<EventId>,
+    channels: [ChannelRec; MAX_CHANNELS],
+    entries: Vec<EntryRuntime>,
+    keys: BTreeMap<String, u32>,
+    /// The `[SoundList]` identity of each entry, parallel to `entries`.
+    names: Vec<String>,
+    /// `g_SoundLimitEpoch @ 0x0087E2AC`.
+    limit_epoch: u32,
+    /// `g_SoundRankEpoch @ 0x0087E2B0`.
+    rank_epoch: u32,
+    /// `g_SoundEventSerial @ 0x0081610C`. Starts at 1 so that 0 stays the
+    /// "invalidated" value native writes on a kill.
+    serial: u32,
+    /// `g_PriorityVolumeBuckets @ 0x0087DE38`, cleared every pass.
+    buckets: Vec<Vec<u32>>,
+    /// `g_ManySoundsVolumeGroup @ 0x0087E1B8`, the master scaler chained into
+    /// every channel at `ch+0x98`.
+    many_sounds: VolumeInterp,
+    /// The owner-held loop handles (`SoundEvent::SetLoopHandle @ 0x004060F0`).
+    handles: BTreeMap<u64, VocHandle>,
+    stamp: u32,
+    last_pump_ms: Option<u64>,
+}
+
+impl SoundArbiter {
+    pub fn new(now_ms: u64) -> Self {
+        Self {
+            events: Vec::new(),
+            order: Vec::new(),
+            channels: [ChannelRec::default(); MAX_CHANNELS],
+            entries: Vec::new(),
+            keys: BTreeMap::new(),
+            names: Vec::new(),
+            limit_epoch: 0,
+            rank_epoch: 0,
+            serial: 1,
+            buckets: vec![Vec::new(); PRIORITY_ROWS * VOLUME_BUCKETS],
+            many_sounds: VolumeInterp::new(VOLUME_SCALE, now_ms),
+            handles: BTreeMap::new(),
+            stamp: 0,
+            last_pump_ms: None,
+        }
+    }
+
+    fn entry_index(&mut self, key: &str) -> u32 {
+        if let Some(index) = self.keys.get(key) {
+            return *index;
+        }
+        let index = self.entries.len() as u32;
+        self.entries.push(EntryRuntime::default());
+        self.names.push(key.to_owned());
+        self.keys.insert(key.to_owned(), index);
+        index
+    }
+
+    /// The `[SoundList]` identity an owner's live loop handle names, so the
+    /// caller can look its `Range`/`Type`/`MinVolume` back up for the
+    /// per-update `CalcVolumeAndPan` re-drive.
+    pub fn loop_handle_key(&self, owner: u64) -> Option<&str> {
+        let handle = self.handles.get(&owner)?;
+        handle.event?;
+        self.names.get(handle.entry as usize).map(String::as_str)
+    }
+
+    fn event(&self, id: EventId) -> Option<&EventRec> {
+        self.events.get(id.0 as usize)?.as_ref()
+    }
+
+    fn event_mut(&mut self, id: EventId) -> Option<&mut EventRec> {
+        self.events.get_mut(id.0 as usize)?.as_mut()
+    }
+
+    /// `SoundEvent::AllocateFromPool @ 0x00405190`: take a pooled record,
+    /// zero it, point it at the entry, seed the interp group and hand out the
+    /// next serial. Returns `None` when the pool is exhausted — native reaps
+    /// its dead events and retries once, then gives up and the cue simply
+    /// never plays.
+    pub fn submit(&mut self, request: &PlayRequest, now_ms: u64) -> Option<EventId> {
+        let entry = self.entry_index(&request.key);
+        self.entries[entry as usize].facts = Some(request.facts);
+
+        let slot = match self.events.iter().position(Option::is_none) {
+            Some(slot) => slot,
+            None if self.events.len() < MAX_SOUND_EVENTS => {
+                self.events.push(None);
+                self.events.len() - 1
+            }
+            None => return None,
+        };
+        let id = EventId(slot as u32);
+        let serial = self.serial;
+        self.serial = self.serial.wrapping_add(1).max(1);
+
+        // `InterpGroup::Init @ 0x00401000` seeds volume to 0x4000 and pan to
+        // 0x2000; `SoundEvent::SetVolume/SetPan` then snap them because the
+        // event is not yet in state 3.
+        let mut volume = VolumeInterp::new(VOLUME_SCALE, now_ms);
+        volume.set_target_immediate(request.volume_linear.clamp(0, VOLUME_SCALE));
+        volume.tick(now_ms);
+        let mut pan = VolumeInterp::new(VOLUME_SCALE / 2, now_ms);
+        pan.set_target_immediate(request.pan.clamp(0, VOLUME_SCALE));
+        pan.tick(now_ms);
+
+        self.events[slot] = Some(EventRec {
+            entry,
+            state: EventState::NeedsChannel,
+            resume_state: EventState::Ready,
+            flags: 0,
+            channel: None,
+            volume,
+            pan,
+            serial,
+            predelay_ms: request.predelay_ms,
+            predelay_deadline_ms: 0,
+            predelay_remaining_ms: 0,
+            priority_bonus: 0,
+            suspend_depth: 0,
+            loop_iteration: 0,
+            handle_owner: None,
+        });
+        self.order.push(id);
+        Some(id)
+    }
+
+    /// `VocHandle::ValidateOrClear @ 0x00406130`: the owner-side check. A
+    /// handle whose event has been recycled (different entry) or invalidated
+    /// (serial mismatch) is cleared and reported as empty.
+    pub fn validate_loop_handle(&mut self, owner: u64) -> Option<EventId> {
+        let handle = *self.handles.get(&owner)?;
+        let id = handle.event?;
+        let ok = self
+            .event(id)
+            .is_some_and(|event| event.entry == handle.entry && event.serial == handle.serial);
+        if ok {
+            return Some(id);
+        }
+        if let Some(stored) = self.handles.get_mut(&owner) {
+            stored.event = None;
+        }
+        None
+    }
+
+    /// `SoundEvent::SetLoopHandle @ 0x004060F0`: bind an owner's handle to an
+    /// event, or clear it. Clearing is what stops a sustained cue — the
+    /// leash in `UpdateState` state 3 kills any looping event whose owner no
+    /// longer names it.
+    pub fn set_loop_handle(&mut self, owner: u64, event: Option<EventId>, key: &str) {
+        let entry = self.entry_index(key);
+        let serial = event
+            .and_then(|id| self.event(id))
+            .map_or(0, |event| event.serial);
+        self.handles.insert(
+            owner,
+            VocHandle {
+                event,
+                serial,
+                entry,
+            },
+        );
+        if let Some(id) = event
+            && let Some(record) = self.event_mut(id)
+        {
+            record.handle_owner = Some(owner);
+        }
+    }
+
+    /// Drop an owner's handle entirely (the owner object is gone).
+    pub fn clear_loop_handle(&mut self, owner: u64) {
+        self.handles.remove(&owner);
+    }
+
+    /// Owners that still name a live event. Handles whose event is gone are
+    /// dropped, which is the bookkeeping half of `VocHandle::ValidateOrClear`.
+    pub fn loop_handle_owners(&mut self) -> Vec<u64> {
+        let owners: Vec<u64> = self.handles.keys().copied().collect();
+        let mut live = Vec::new();
+        for owner in owners {
+            if self.validate_loop_handle(owner).is_some() {
+                live.push(owner);
+            } else {
+                self.handles.remove(&owner);
+            }
+        }
+        live
+    }
+
+    /// `SoundEvent::MarkStarted @ 0x004052E0` — `flags |= 8`. The only native
+    /// caller is `AnimClass::UpdateLoopingSound @ 0x00750D40`, right after it
+    /// allocates a loop event, which is why an anim-driven loop never plays
+    /// its `Control=attack` sample.
+    pub fn mark_started(&mut self, id: EventId) {
+        if let Some(event) = self.event_mut(id) {
+            event.flags |= event_flags::STARTED;
+        }
+    }
+
+    /// Whether the first playout of this event still heads with the
+    /// `Control=attack` sample: `SoundEvent::PreparePlayout @ 0x00404700`
+    /// takes the attack path only while `flags & 8` is clear.
+    pub fn plays_attack_sample(&self, id: EventId) -> bool {
+        self.event(id)
+            .is_some_and(|event| event.flags & event_flags::STARTED == 0)
+    }
+
+    /// `SoundEvent::SetVolume @ 0x004061D0`: snap while the event has not
+    /// started, glide once it is playing.
+    pub fn set_volume(&mut self, id: EventId, linear: i32, now_ms: u64) {
+        let linear = linear.clamp(0, VOLUME_SCALE);
+        let Some(event) = self.event_mut(id) else {
+            return;
+        };
+        if event.state == EventState::Playing {
+            event.volume.set_target(linear, now_ms);
+        } else {
+            event.volume.set_target_immediate(linear);
+            event.volume.tick(now_ms);
+        }
+    }
+
+    /// `SoundEvent::SetPan @ 0x00406270`, the same snap/glide rule.
+    pub fn set_pan(&mut self, id: EventId, pan: i32, now_ms: u64) {
+        let pan = pan.clamp(0, VOLUME_SCALE);
+        let Some(event) = self.event_mut(id) else {
+            return;
+        };
+        if event.state == EventState::Playing {
+            event.pan.set_target(pan, now_ms);
+        } else {
+            event.pan.set_target_immediate(pan);
+            event.pan.tick(now_ms);
+        }
+    }
+
+    /// Current glide values, as the device layer must apply them.
+    pub fn live_gain(&self, id: EventId) -> Option<(i32, i32)> {
+        let event = self.event(id)?;
+        Some((event.volume.value(), event.pan.value()))
+    }
+
+    /// `SoundEvent::Stop @ 0x004052F0`: release the channel, drop the loaded
+    /// samples, invalidate the serial and mark the record dead. The reaping
+    /// pass returns it to the pool.
+    pub fn stop(&mut self, id: EventId) {
+        if self.event(id).is_none_or(EventRec::is_dead) {
+            return;
+        }
+        self.release_channel(id);
+        self.kill(id);
+    }
+
+    fn release_channel(&mut self, id: EventId) {
+        let Some(event) = self.event_mut(id) else {
+            return;
+        };
+        let channel = event.channel.take();
+        event.flags &= !event_flags::PLAYING;
+        if let Some(index) = channel
+            && self.channels[index].event == Some(id)
+        {
+            self.channels[index] = ChannelRec::default();
+        }
+    }
+
+    fn kill(&mut self, id: EventId) {
+        if let Some(event) = self.event_mut(id) {
+            event.state = EventState::Dead;
+            event.serial = 0;
+            event.handle_owner = None;
+            event.flags |= event_flags::DEAD;
+        }
+    }
+
+    /// `SoundEvent::ReturnToPool @ 0x00404DD0`: unlink from the global list
+    /// and free the record.
+    fn reap(&mut self, id: EventId) {
+        if let Some(event) = self.event(id)
+            && let Some(owner) = event.handle_owner
+            && let Some(handle) = self.handles.get_mut(&owner)
+            && handle.event == Some(id)
+        {
+            handle.event = None;
+        }
+        self.order.retain(|other| *other != id);
+        self.events[id.0 as usize] = None;
+    }
+
+    /// `SoundSystem::SuspendAll @ 0x00404FD0`, reached from
+    /// `GamePause::Enter @ 0x00406F00`: bump every event's suspend depth and
+    /// convert a running pre-delay deadline into a remaining duration.
+    /// Bookkeeping — reaping, ranking, `Limit=` — keeps running while paused;
+    /// only starting and the pre-delay clock stop.
+    pub fn suspend_all(&mut self, now_ms: u64) {
+        for id in self.order.clone() {
+            let Some(event) = self.event_mut(id) else {
+                continue;
+            };
+            if event.suspend_depth == 0 && event.state == EventState::PreDelay {
+                event.predelay_remaining_ms = event.predelay_deadline_ms.saturating_sub(now_ms);
+            }
+            event.suspend_depth += 1;
+        }
+    }
+
+    /// `SoundSystem::ResumeAll @ 0x00405040` (`GamePause::Exit @ 0x00406F40`):
+    /// decrement, clamped at zero, and re-absolutise the pre-delay.
+    pub fn resume_all(&mut self, now_ms: u64) {
+        for id in self.order.clone() {
+            let Some(event) = self.event_mut(id) else {
+                continue;
+            };
+            if event.suspend_depth == 0 {
+                continue;
+            }
+            event.suspend_depth = (event.suspend_depth - 1).max(0);
+            if event.suspend_depth == 0 && event.state == EventState::PreDelay {
+                event.predelay_deadline_ms = now_ms.saturating_add(event.predelay_remaining_ms);
+            }
+        }
+    }
+
+    /// Whether a service pass is due: `0x21 < now - lastPass`
+    /// (`AudioSystem::Pump @ 0x00406F70`).
+    pub fn pump_due(&self, now_ms: u64) -> bool {
+        match self.last_pump_ms {
+            None => true,
+            Some(last) => now_ms.saturating_sub(last) > PUMP_PERIOD_MS,
+        }
+    }
+
+    /// `AdvancePlaylist @ 0x004047B0` step 2 asked from the device side: may
+    /// this looping event start another pass?
+    ///
+    /// `(Control & LOOP) && !(flags & 0x20) && (Loop == 0 || iteration <
+    /// Loop - 1)`. Consumes one iteration when it answers yes.
+    pub fn advance_loop(&mut self, id: EventId) -> bool {
+        let Some(event) = self.event(id) else {
+            return false;
+        };
+        if event.is_dead() || event.flags & event_flags::NO_REPLAY != 0 {
+            return false;
+        }
+        let Some(facts) = self.entries[event.entry as usize].facts else {
+            return false;
+        };
+        if facts.control & control::LOOP == 0 {
+            return false;
+        }
+        if facts.loop_count != 0 && event.loop_iteration >= facts.loop_count - 1 {
+            return false;
+        }
+        if let Some(event) = self.event_mut(id) {
+            event.loop_iteration += 1;
+        }
+        true
+    }
+
+    /// The device reporting that a buffer chain ran dry with nothing left to
+    /// play — `LAB_00405A00`, the `ch+0xB8` callback, which sets state 4.
+    pub fn notify_playout_ended(&mut self, id: EventId) {
+        if self.event(id).is_none_or(EventRec::is_dead) {
+            return;
+        }
+        self.release_channel(id);
+        self.kill(id);
+    }
+
+    /// Number of live records (native `g_LiveSoundEventCount @ 0x0087E28C`).
+    pub fn live_event_count(&self) -> usize {
+        self.order.len()
+    }
+
+    /// Events currently holding a channel.
+    pub fn busy_channel_count(&self) -> usize {
+        self.channels.iter().filter(|ch| ch.busy).count()
+    }
+
+    /// The many-sounds master scaler (`0x0087E1B8`), chained into every
+    /// channel at `ch+0x98` and multiplied in as `(a * b) >> 14`.
+    pub fn many_sounds_linear(&self) -> i32 {
+        self.many_sounds.value()
+    }
+
+    fn facts_of(&self, event: &EventRec) -> EntryFacts {
+        self.entries[event.entry as usize]
+            .facts
+            .unwrap_or(EntryFacts {
+                priority: 0,
+                limit: 0,
+                control: 0,
+                loop_count: 0,
+                delay_ms: (0, 0),
+                entry_volume_linear: 0,
+            })
+    }
+
+    fn effective_priority(&self, event: &EventRec) -> i32 {
+        self.facts_of(event).priority + event.priority_bonus
+    }
+
+    /// `DSoundChannel::FindAvailable @ 0x004035F0`.
+    ///
+    /// 1. The first fully idle channel is returned immediately, with no
+    ///    further search (`TEST byte ptr [EAX+0xa4],0x15 ; JZ` at
+    ///    `0x00403637`).
+    /// 2. Otherwise two candidates are tracked: the lowest-priority channel
+    ///    that is *not* actively playing, and the lowest-priority one that
+    ///    is. Among actively-playing channels of **equal** priority the older
+    ///    stamp wins, but only when the gap is at least
+    ///    [`EQUAL_PRIORITY_AGE_GAP`].
+    /// 3. The non-playing candidate wins unless the playing candidate has a
+    ///    strictly lower priority (`CMP [ESP+0x10],EDI ; JLE` at
+    ///    `0x004036AA`).
+    fn find_available_channel(&self) -> Option<usize> {
+        let mut best_playing: Option<usize> = None;
+        let mut best_playing_priority = 0x7f;
+        let mut best_playing_stamp = u32::MAX;
+        let mut best_idle: Option<usize> = None;
+        let mut best_idle_priority = 0x7f;
+
+        for (index, channel) in self.channels.iter().enumerate() {
+            if !channel.busy {
+                return Some(index);
+            }
+            if channel.playing {
+                if channel.priority < best_playing_priority {
+                    best_playing_priority = channel.priority;
+                    best_playing_stamp = channel.stamp;
+                    best_playing = Some(index);
+                } else if channel.priority == best_playing_priority
+                    && channel.stamp < best_playing_stamp
+                    && best_playing_stamp - channel.stamp >= EQUAL_PRIORITY_AGE_GAP
+                {
+                    // `0x00403677: MOV EDI,ECX ; MOV EBP,EAX ; MOV ESI,EDX` —
+                    // all three candidate registers move together.
+                    best_playing_priority = channel.priority;
+                    best_playing_stamp = channel.stamp;
+                    best_playing = Some(index);
+                }
+            } else if channel.priority < best_idle_priority {
+                best_idle_priority = channel.priority;
+                best_idle = Some(index);
+            }
+        }
+
+        match best_idle {
+            None => best_playing,
+            Some(idle) if best_idle_priority <= best_playing_priority => Some(idle),
+            Some(_) => best_playing,
+        }
+    }
+
+    /// `StreamBuffer::Allocate @ 0x00405B50`: take the channel
+    /// [`Self::find_available_channel`] picked, **unless** it is busy and the
+    /// newcomer's priority is strictly lower — equal priority still wins the
+    /// channel. A failed allocation drops the cue outright.
+    fn allocate_channel(&mut self, id: EventId, priority: i32) -> Option<usize> {
+        let index = self.find_available_channel()?;
+        if self.channels[index].busy && priority < self.channels[index].priority {
+            return None;
+        }
+        // The dispossessed event is deliberately left pointing at the channel:
+        // native never notifies it, and the reaping pass catches it with
+        // `puVar3 != *(channel + 0xc0)` (`0x004043B7`) — an event whose
+        // channel no longer names it is killed on the spot. That is how a
+        // 17th equal-priority cue in one pass silences one of the sixteen
+        // that took a channel earlier in the same pass.
+        self.stamp = self.stamp.wrapping_add(1);
+        self.channels[index] = ChannelRec {
+            event: Some(id),
+            priority,
+            stamp: self.stamp,
+            busy: true,
+            playing: false,
+        };
+        Some(index)
+    }
+
+    /// `DSoundChannel::FindLowestPriority @ 0x00404E20`: scan
+    /// `g_PriorityVolumeBuckets` rows `[0, priority)` — **strictly lower
+    /// priority only, equal priority is never preempted here** — and inside a
+    /// row take the quietest bucket first. Returns the losing entry.
+    fn find_lowest_priority(&mut self, priority: i32) -> Option<u32> {
+        for row in 0..priority.clamp(0, PRIORITY_ROWS as i32) as usize {
+            for bucket in 0..VOLUME_BUCKETS {
+                let slot = row * VOLUME_BUCKETS + bucket;
+                if let Some(entry) = self.buckets[slot].first().copied() {
+                    // The caller unlinks the winner from its bucket
+                    // (`0x00404605 LEA ECX,[EBX+0xa4] ; CALL 0x00407450`) so
+                    // the retry loop cannot pick the same entry forever.
+                    self.buckets[slot].remove(0);
+                    self.entries[entry as usize].bucket_slot = None;
+                    return Some(entry);
+                }
+            }
+        }
+        None
+    }
+
+    /// One `SoundSystem::UpdateTick @ 0x004041D0` pass, in native phase
+    /// order. The caller is responsible for the `> 33 ms` gate
+    /// ([`Self::pump_due`]); this runs the pass unconditionally so tests can
+    /// step it.
+    pub fn update_tick(&mut self, now_ms: u64) -> Vec<ArbiterAction> {
+        self.last_pump_ms = Some(now_ms);
+        let mut actions = Vec::new();
+
+        self.limit_epoch = self.limit_epoch.wrapping_add(1);
+        self.enforce_limits(now_ms, &mut actions);
+        self.run_state_machine(now_ms, &mut actions);
+        self.reap_and_rank(now_ms, &mut actions);
+        self.start_pass(now_ms, &mut actions);
+        self.emit_live_gains(&mut actions);
+        actions
+    }
+
+    /// Pass 1 (`0x0040421C..0x0040433D`): reset each entry's counter on first
+    /// touch this epoch, tick the event's interp group, re-sort the event
+    /// into the entry's descending-volume list, then enforce `Limit=` by
+    /// killing the **tail** — the quietest instance, or with
+    /// `Control=interrupt` the oldest already-started one.
+    ///
+    /// The new cue is never the victim; the least audible one is.
+    fn enforce_limits(&mut self, now_ms: u64, actions: &mut Vec<ArbiterAction>) {
+        for id in self.order.clone() {
+            let Some(event) = self.event(id) else {
+                continue;
+            };
+            let entry_index = event.entry as usize;
+            if self.entries[entry_index].limit_epoch != self.limit_epoch {
+                self.entries[entry_index].list.clear();
+                self.entries[entry_index].count = 0;
+                self.entries[entry_index].limit_epoch = self.limit_epoch;
+            }
+            // `FUN_00401080` — tick the whole interp group.
+            if let Some(event) = self.event_mut(id) {
+                event.volume.tick(now_ms);
+                event.pan.tick(now_ms);
+            }
+            let Some(event) = self.event(id) else {
+                continue;
+            };
+            if event.state == EventState::Dead {
+                continue;
+            }
+
+            let facts = self.facts_of(event);
+            let volume = event.volume.value();
+            let interrupt = facts.control & control::INTERRUPT != 0;
+            // `iVar2 < (Voc+0x1c / 0xa0000)`: the tie-break band is a tenth
+            // of the entry's own authored volume.
+            let band = facts.entry_volume_linear / 10;
+
+            let slot = self.entries[entry_index]
+                .list
+                .iter()
+                .position(|other| {
+                    let Some(other) = self.event(*other) else {
+                        return true;
+                    };
+                    let other_volume = other.volume.value();
+                    let gap = (other_volume - volume).abs();
+                    if gap < band {
+                        if interrupt {
+                            other.state != EventState::NeedsChannel
+                        } else {
+                            other.state == EventState::NeedsChannel
+                        }
+                    } else {
+                        other_volume < volume
+                    }
+                })
+                .unwrap_or(self.entries[entry_index].list.len());
+            self.entries[entry_index].list.retain(|other| *other != id);
+            let slot = slot.min(self.entries[entry_index].list.len());
+            self.entries[entry_index].list.insert(slot, id);
+            self.entries[entry_index].count += 1;
+
+            let limit = facts.limit;
+            let count = self.entries[entry_index].count;
+            if limit != 0 && count > limit {
+                let Some(victim) = self.entries[entry_index].list.pop() else {
+                    continue;
+                };
+                if self.event(victim).is_some_and(|event| !event.is_dead()) {
+                    self.release_channel(victim);
+                    self.kill(victim);
+                    actions.push(ArbiterAction::Stop { event: victim });
+                }
+                self.entries[entry_index].count -= 1;
+            }
+        }
+    }
+
+    /// Pass 2: `SoundEvent::UpdateState @ 0x004055C0` on every event.
+    fn run_state_machine(&mut self, now_ms: u64, actions: &mut Vec<ArbiterAction>) {
+        for id in self.order.clone() {
+            self.update_state(id, now_ms, actions);
+        }
+    }
+
+    fn update_state(&mut self, id: EventId, now_ms: u64, actions: &mut Vec<ArbiterAction>) {
+        let Some(event) = self.event(id) else {
+            return;
+        };
+        match event.state {
+            // Case `0x00405639`: take a channel, draw the shifts, install the
+            // callbacks, and either go straight to state 1 or park in the
+            // pre-delay.
+            EventState::NeedsChannel => {
+                let priority = self.effective_priority(event);
+                let facts = self.facts_of(event);
+                match self.allocate_channel(id, priority) {
+                    Some(index) => {
+                        let Some(event) = self.event_mut(id) else {
+                            return;
+                        };
+                        event.channel = Some(index);
+                        event.loop_iteration = 0;
+                        event.state = EventState::Ready;
+                        // `if ((Voc.Control & 0x88) == 0) return;` — no
+                        // `Control=predelay` and no `Control=ambient` means no
+                        // pre-delay at all, whatever `Delay=` says.
+                        if facts.control & (control::PREDELAY | control::AMBIENT) == 0 {
+                            return;
+                        }
+                        // `if (iVar5 < 0x21) return;` — a draw under the
+                        // 33 ms floor is discarded and the cue starts at once.
+                        if event.predelay_ms < PREDELAY_FLOOR_MS {
+                            return;
+                        }
+                        event.resume_state = EventState::Ready;
+                        if event.suspend_depth == 0 {
+                            event.predelay_deadline_ms =
+                                now_ms.saturating_add(event.predelay_ms as u64);
+                        } else {
+                            event.predelay_remaining_ms = event.predelay_ms as u64;
+                        }
+                        event.state = EventState::PreDelay;
+                    }
+                    None => {
+                        // Allocation refused: `0x004057A3` — release, mark
+                        // dead, never audible.
+                        if self.event(id).is_some_and(|event| !event.is_dead()) {
+                            self.release_channel(id);
+                            self.kill(id);
+                            actions.push(ArbiterAction::Stop { event: id });
+                        }
+                    }
+                }
+            }
+            // Case `0x004055EB`: the pre-delay wait, serviced by the same
+            // > 33 ms pass, so pre-delays quantise to the pump period.
+            EventState::PreDelay => {
+                if event.suspend_depth != 0 {
+                    return;
+                }
+                if now_ms <= event.predelay_deadline_ms {
+                    return;
+                }
+                let resume = event.resume_state;
+                if let Some(event) = self.event_mut(id) {
+                    event.state = resume;
+                }
+            }
+            // Case `0x004057DC`: the looping leash. A sustained event whose
+            // owner no longer names it dies here, which is what stops a
+            // Rocketeer's engine loop when the unit stops or leaves earshot.
+            EventState::Playing => {
+                let facts = self.facts_of(event);
+                let leashed = facts.control & control::LOOP != 0
+                    && facts.loop_count == 0
+                    && event.flags & event_flags::NO_REPLAY == 0;
+                if !leashed {
+                    return;
+                }
+                let owner = event.handle_owner;
+                let still_ours = owner.is_some_and(|owner| {
+                    self.handles.get(&owner).is_some_and(|handle| {
+                        handle.event == Some(id)
+                            && self.event(id).is_some_and(|event| {
+                                event.entry == handle.entry && event.serial == handle.serial
+                            })
+                    })
+                });
+                if still_ours {
+                    return;
+                }
+                if self.event(id).is_some_and(|event| !event.is_dead()) {
+                    self.release_channel(id);
+                    self.kill(id);
+                    actions.push(ArbiterAction::Stop { event: id });
+                }
+            }
+            EventState::Ready | EventState::Dead => {}
+        }
+    }
+
+    /// Passes 3-5: clear the buckets, bump the ranking epoch, reap every
+    /// event that lost its channel or is already dead, rank the loudest live
+    /// instance of each entry into `bucket[priority][volume / 1638]`, and set
+    /// the many-sounds target.
+    fn reap_and_rank(&mut self, now_ms: u64, actions: &mut Vec<ArbiterAction>) {
+        for bucket in &mut self.buckets {
+            bucket.clear();
+        }
+        for entry in &mut self.entries {
+            entry.bucket_slot = None;
+        }
+        self.rank_epoch = self.rank_epoch.wrapping_add(1);
+
+        let mut volume_sum: i32 = 0;
+        for id in self.order.clone() {
+            let Some(event) = self.event(id) else {
+                continue;
+            };
+            let orphaned = match event.channel {
+                None => true,
+                Some(index) => self.channels[index].event != Some(id),
+            };
+            if orphaned && !event.is_dead() {
+                self.release_channel(id);
+                self.kill(id);
+                actions.push(ArbiterAction::Stop { event: id });
+            }
+            if self.event(id).is_none_or(EventRec::is_dead) {
+                self.reap(id);
+                continue;
+            }
+            let Some(event) = self.event(id) else {
+                continue;
+            };
+
+            // `0x00404474..0x00404496`: each unsuspended live event adds
+            // `(Volume=linear * 5) >> 12` — about `VolumePercent / 5` — to the
+            // budget the limiter holds at 100.
+            let facts = self.facts_of(event);
+            if event.suspend_depth == 0 {
+                volume_sum = volume_sum.saturating_add((facts.entry_volume_linear * 5) >> 12);
+            }
+
+            let priority = self.effective_priority(event);
+            let bucket = event.volume.value() / BUCKET_DIVISOR;
+            let entry_index = event.entry as usize;
+            let entry = &mut self.entries[entry_index];
+            let rank_epoch = self.rank_epoch;
+            let replaces = if entry.rank_epoch == rank_epoch {
+                priority > entry.best_priority
+                    || (priority == entry.best_priority && bucket > entry.best_bucket)
+            } else {
+                entry.rank_epoch = rank_epoch;
+                true
+            };
+            if !replaces {
+                continue;
+            }
+            entry.best_priority = priority;
+            entry.best_bucket = bucket;
+            if let Some((row, column)) = entry.bucket_slot.take() {
+                self.buckets[row * VOLUME_BUCKETS + column]
+                    .retain(|other| *other != entry_index as u32);
+            }
+            let row = (priority.clamp(0, PRIORITY_ROWS as i32 - 1)) as usize;
+            let column = bucket.clamp(0, VOLUME_BUCKETS as i32 - 1) as usize;
+            self.buckets[row * VOLUME_BUCKETS + column].push(entry_index as u32);
+            self.entries[entry_index].bucket_slot = Some((row, column));
+        }
+
+        let target = if volume_sum > MANY_SOUNDS_THRESHOLD {
+            MANY_SOUNDS_NUMERATOR / volume_sum
+        } else {
+            VOLUME_SCALE
+        };
+        self.many_sounds.set_target(target, now_ms);
+        self.many_sounds.tick(now_ms);
+    }
+
+    /// The entry-level preemption layer:
+    /// `DSoundChannel::FindLowestPriority @ 0x00404E20` plus the caller loop
+    /// at `0x004045FA..0x0040466F`, which stops **every** `SoundEvent` of the
+    /// losing entry (`SoundEvent::Stop @ 0x004052F0` + `ReturnToPool @
+    /// 0x00404DD0`) and retries.
+    ///
+    /// **Its native trigger is sample-memory starvation, not channel
+    /// starvation.** The start pass reaches it only when
+    /// `SoundEvent::PreparePlayout @ 0x00404700` returns 0, and the only
+    /// runtime way that happens is `SoundEvent::LoadSamples @ 0x004048B0`
+    /// getting nothing back from `SampleTracker::LoadSample` — i.e. the
+    /// streaming pool (`FUN_004019E0(idx, 0x100000, 200, 0x2000)` at
+    /// `0x00403F29`: 127 blocks of 8 KB inside a 1 MB budget) is full.
+    /// Stopping lower-priority entries frees those blocks.
+    ///
+    /// RESIDUAL (UNCHECKED trigger) — VERA decodes each cue into an owned
+    /// `Vec<f32>` with no fixed budget, so nothing here can starve and this
+    /// layer has no production caller. Trigger in gamemd: more than 1 MB of
+    /// distinct sample data live at once. Player effect of the gap: in the
+    /// rare native case where the stream pool fills, gamemd silences a whole
+    /// low-priority entry to admit a high-priority one, while VERA plays
+    /// both. Frequency: never on this decoder. Downstream risk: none — the
+    /// audible priority arbitration a player hears in a busy fight is the
+    /// *channel* layer ([`Self::find_available_channel`] /
+    /// [`Self::allocate_channel`]), which is live. Reproducing this layer
+    /// needs a fixed decoded-sample budget first; the mechanism is kept and
+    /// tested so that budget is the only thing missing.
+    pub fn preempt_for_sample_memory(&mut self, priority: i32) -> Vec<EventId> {
+        let mut stopped = Vec::new();
+        let Some(victim_entry) = self.find_lowest_priority(priority) else {
+            return stopped;
+        };
+        for other in self.order.clone() {
+            if self
+                .event(other)
+                .is_some_and(|event| event.entry == victim_entry && !event.is_dead())
+            {
+                self.release_channel(other);
+                self.kill(other);
+                stopped.push(other);
+            }
+        }
+        stopped
+    }
+
+    /// Pass 6 (`0x004045A6..0x004046C6`): every event in state 1 that is not
+    /// suspended runs `LoadSamples` -> `PreparePlayout` ->
+    /// (preempt and retry) -> `StartPlayback`.
+    ///
+    /// VERA's payload is decoded before [`Self::submit`], so `LoadSamples`
+    /// and `PreparePlayout` have already succeeded by the time an event
+    /// exists — only `StartPlayback` remains here. See
+    /// [`Self::preempt_for_sample_memory`] for the retry branch and why it
+    /// has no trigger on this decoder.
+    fn start_pass(&mut self, now_ms: u64, actions: &mut Vec<ArbiterAction>) {
+        for id in self.order.clone() {
+            let Some(event) = self.event(id) else {
+                continue;
+            };
+            if event.state != EventState::Ready || event.suspend_depth != 0 {
+                continue;
+            }
+            if event.channel.is_none() {
+                if !event.is_dead() {
+                    self.kill(id);
+                    actions.push(ArbiterAction::Stop { event: id });
+                }
+                continue;
+            }
+
+            // `SoundEvent::StartPlayback @ 0x004054A0`: snap both interps
+            // before the buffer starts, set `flags |= 8 | 2`, state 3.
+            let facts = self.facts_of(event);
+            let sustaining = facts.control & control::LOOP != 0
+                && (facts.loop_count == 0 || facts.loop_count > 1);
+            let Some(event) = self.event_mut(id) else {
+                continue;
+            };
+            event
+                .volume
+                .set_target_immediate(event.volume.target_value());
+            event.volume.tick(now_ms);
+            event.pan.set_target_immediate(event.pan.target_value());
+            event.pan.tick(now_ms);
+            event.flags |= event_flags::STARTED | event_flags::PLAYING;
+            event.state = EventState::Playing;
+            let volume_linear = event.volume.value();
+            let pan = event.pan.value();
+            if let Some(index) = event.channel {
+                self.channels[index].playing = true;
+            }
+            actions.push(ArbiterAction::Start {
+                event: id,
+                volume_linear,
+                pan,
+                sustaining,
+            });
+        }
+    }
+
+    /// Every playing event reports its glided gain so the device layer can
+    /// track the `VolumeInterp` ramp. Native does this implicitly: the
+    /// channel reads `ch+0x90` (the event group) every mix.
+    fn emit_live_gains(&mut self, actions: &mut Vec<ArbiterAction>) {
+        for id in self.order.clone() {
+            let Some(event) = self.event(id) else {
+                continue;
+            };
+            if event.state != EventState::Playing || event.is_dead() {
+                continue;
+            }
+            let started_this_pass = actions
+                .iter()
+                .any(|action| matches!(action, ArbiterAction::Start { event, .. } if *event == id));
+            if started_this_pass {
+                continue;
+            }
+            actions.push(ArbiterAction::Gain {
+                event: id,
+                volume_linear: event.volume.value(),
+                pan: event.pan.value(),
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn facts(priority: i32, limit: i32) -> EntryFacts {
+        EntryFacts {
+            priority,
+            limit,
+            control: 0,
+            loop_count: 0,
+            delay_ms: (0, 0),
+            entry_volume_linear: VOLUME_SCALE,
+        }
+    }
+
+    fn request(key: &str, facts: EntryFacts, volume_linear: i32) -> PlayRequest {
+        PlayRequest {
+            key: key.to_owned(),
+            facts,
+            volume_linear,
+            pan: VOLUME_SCALE / 2,
+            predelay_ms: 0,
+        }
+    }
+
+    fn started(actions: &[ArbiterAction]) -> Vec<EventId> {
+        actions
+            .iter()
+            .filter_map(|action| match action {
+                ArbiterAction::Start { event, .. } => Some(*event),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn stopped(actions: &[ArbiterAction]) -> Vec<EventId> {
+        actions
+            .iter()
+            .filter_map(|action| match action {
+                ArbiterAction::Stop { event } => Some(*event),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// `DSoundChannel::CreateAll @ 0x00403530` makes exactly 16 buffers, so
+    /// only 16 cues can be audible at once. A 17th equal-priority cue in the
+    /// same pass still *takes* a channel — `StreamBuffer::Allocate @
+    /// 0x00405B50` refuses only a strictly lower priority — and the
+    /// dispossessed event is caught by the reaping pass' "my channel no
+    /// longer names me" test.
+    #[test]
+    fn sixteen_channels_cap_the_pool_and_an_equal_priority_seventeenth_displaces_one() {
+        let mut arbiter = SoundArbiter::new(0);
+        let mut ids = Vec::new();
+        for index in 0..17 {
+            let key = format!("CUE{index}");
+            ids.push(
+                arbiter
+                    .submit(&request(&key, facts(2, 0), VOLUME_SCALE), 0)
+                    .expect("pool slot"),
+            );
+        }
+        let actions = arbiter.update_tick(100);
+        assert_eq!(started(&actions).len(), MAX_CHANNELS);
+        assert_eq!(arbiter.busy_channel_count(), MAX_CHANNELS);
+        // `FindAvailable` walks the list in order and keeps the first
+        // lowest-priority candidate, so the newcomer takes channel 0 and the
+        // event that had it is stopped — not the newcomer.
+        assert_eq!(stopped(&actions), vec![ids[0]]);
+        assert!(started(&actions).contains(&ids[16]));
+    }
+
+    /// A `CRITICAL` cue arriving into a full pool of `LOWEST` cues takes a
+    /// channel: `FindLowestPriority` walks rows `[0, 4)`, finds the quietest
+    /// low-priority entry and stops every one of its events.
+    #[test]
+    fn a_higher_priority_cue_preempts_a_full_pool_of_lower_priority_ones() {
+        let mut arbiter = SoundArbiter::new(0);
+        for index in 0..MAX_CHANNELS {
+            let key = format!("QUIET{index}");
+            arbiter
+                .submit(&request(&key, facts(0, 0), VOLUME_SCALE / 4), 0)
+                .expect("pool slot");
+        }
+        assert_eq!(started(&arbiter.update_tick(100)).len(), MAX_CHANNELS);
+
+        let loud = arbiter
+            .submit(&request("LOUD", facts(4, 0), VOLUME_SCALE), 200)
+            .expect("pool slot");
+        let actions = arbiter.update_tick(200);
+        assert!(started(&actions).contains(&loud));
+        assert_eq!(stopped(&actions).len(), 1);
+    }
+
+    /// The reverse: an old `CRITICAL` bed is never displaced by a new
+    /// `LOWEST` cue. `StreamBuffer::Allocate` rejects the newcomer outright.
+    #[test]
+    fn a_lower_priority_cue_never_displaces_a_full_pool_of_higher_priority_ones() {
+        let mut arbiter = SoundArbiter::new(0);
+        for index in 0..MAX_CHANNELS {
+            let key = format!("LOUD{index}");
+            arbiter
+                .submit(&request(&key, facts(4, 0), VOLUME_SCALE), 0)
+                .expect("pool slot");
+        }
+        arbiter.update_tick(100);
+        let quiet = arbiter
+            .submit(&request("QUIET", facts(0, 0), VOLUME_SCALE), 200)
+            .expect("pool slot");
+        let actions = arbiter.update_tick(200);
+        assert!(!started(&actions).contains(&quiet));
+        assert_eq!(stopped(&actions), vec![quiet]);
+        assert_eq!(arbiter.busy_channel_count(), MAX_CHANNELS);
+    }
+
+    /// `[Defaults] Limit=5` applies to all 588 stock entries, and 17 of them
+    /// author `Limit=1`. The victim is the entry's **quietest** live instance
+    /// (the list tail), never the newcomer.
+    #[test]
+    fn limit_one_keeps_the_loudest_instance_and_kills_the_quietest() {
+        let mut arbiter = SoundArbiter::new(0);
+        let quiet = arbiter
+            .submit(&request("CUE", facts(2, 1), VOLUME_SCALE / 8), 0)
+            .expect("pool slot");
+        let loud = arbiter
+            .submit(&request("CUE", facts(2, 1), VOLUME_SCALE), 0)
+            .expect("pool slot");
+        let actions = arbiter.update_tick(100);
+        assert_eq!(stopped(&actions), vec![quiet]);
+        assert!(started(&actions).contains(&loud));
+    }
+
+    /// `Control=interrupt` is a `Limit=` **sort** tie-break, not a "stop the
+    /// previous instance" flag — but at equal volume it does decide which of
+    /// two instances survives the cap.
+    ///
+    /// `0x004042AF..0x004042C6`: inside the volume band, without INTERRUPT the
+    /// newcomer sorts before the first instance still in state 0, and with
+    /// INTERRUPT before the first instance that has *left* state 0. So against
+    /// one already-playing instance the newcomer sorts to the tail without the
+    /// flag (and is culled) and to the head with it (culling the playing one).
+    /// 106 stock entries author it.
+    #[test]
+    fn control_interrupt_only_flips_the_limit_sort_tie_break() {
+        // Two instances at the same volume, `Limit=1`. One is already
+        // playing, one has just been submitted.
+        let run = |interrupt: bool| {
+            let mut arbiter = SoundArbiter::new(0);
+            let mut cue = facts(2, 1);
+            if interrupt {
+                cue.control = control::INTERRUPT;
+            }
+            let first = arbiter
+                .submit(&request("CUE", cue, VOLUME_SCALE), 0)
+                .expect("pool slot");
+            arbiter.update_tick(100);
+            let second = arbiter
+                .submit(&request("CUE", cue, VOLUME_SCALE), 200)
+                .expect("pool slot");
+            let victims = stopped(&arbiter.update_tick(200));
+            (first, second, victims)
+        };
+
+        // Without INTERRUPT the walk never breaks (no list member is still in
+        // state 0), so the newcomer is appended at the tail and the cap kills
+        // it — the already-playing instance keeps the slot.
+        let (_first, second, victims) = run(false);
+        assert_eq!(victims, vec![second]);
+
+        // With INTERRUPT the walk breaks on the first member that has left
+        // state 0, so the newcomer takes the head and the playing instance
+        // becomes the tail that is culled.
+        let (first, _second, victims) = run(true);
+        assert_eq!(victims, vec![first]);
+    }
+
+    /// Two equal-priority channels: the older one only loses its channel when
+    /// the age gap reaches `0x666` (`CMP EBX,0x666 ; JC skip` at
+    /// `0x0040366F`). Below that gap `FindAvailable` keeps the first
+    /// candidate it saw.
+    #[test]
+    fn equal_priority_channels_need_a_1638_stamp_gap_before_the_older_one_loses() {
+        let mut arbiter = SoundArbiter::new(0);
+        // Fill and start all 16 so every channel is `playing`.
+        let mut ids = Vec::new();
+        for index in 0..MAX_CHANNELS {
+            ids.push(
+                arbiter
+                    .submit(&request(&format!("C{index}"), facts(2, 0), VOLUME_SCALE), 0)
+                    .expect("pool slot"),
+            );
+        }
+        arbiter.update_tick(100);
+        // Stamps here are 1..16, so no pair is 0x666 apart: the first
+        // candidate (channel 0, the oldest) is kept and it is the one the
+        // newcomer takes.
+        let newcomer = arbiter
+            .submit(&request("NEW", facts(2, 0), VOLUME_SCALE), 200)
+            .expect("pool slot");
+        let actions = arbiter.update_tick(200);
+        assert!(started(&actions).contains(&newcomer));
+        assert_eq!(stopped(&actions), vec![ids[0]]);
+    }
+
+    /// `Limit=0` is unlimited (`if (Voc+0x48 != 0 && ...)`).
+    #[test]
+    fn limit_zero_is_unlimited() {
+        let mut arbiter = SoundArbiter::new(0);
+        for _ in 0..6 {
+            arbiter
+                .submit(&request("CUE", facts(2, 0), VOLUME_SCALE), 0)
+                .expect("pool slot");
+        }
+        let actions = arbiter.update_tick(100);
+        assert!(stopped(&actions).is_empty());
+        assert_eq!(started(&actions).len(), 6);
+    }
+
+    /// A `Control=loop` cue with `Loop=` absent sustains for as long as its
+    /// owner re-drives the handle, and dies on the first pass after the owner
+    /// clears it (`UpdateState` state 3, `0x004057DC`).
+    #[test]
+    fn an_owner_driven_loop_sustains_until_the_handle_is_cleared() {
+        let mut arbiter = SoundArbiter::new(0);
+        let mut loop_facts = facts(1, 3);
+        loop_facts.control = control::LOOP | control::RANDOM | control::ALL;
+        let event = arbiter
+            .submit(
+                &request("ROCKETEERMOVELOOP", loop_facts, VOLUME_SCALE / 4),
+                0,
+            )
+            .expect("pool slot");
+        arbiter.set_loop_handle(1234, Some(event), "ROCKETEERMOVELOOP");
+
+        let actions = arbiter.update_tick(100);
+        assert!(matches!(
+            actions
+                .iter()
+                .find(|a| matches!(a, ArbiterAction::Start { .. })),
+            Some(ArbiterAction::Start {
+                sustaining: true,
+                ..
+            })
+        ));
+        // Ten more passes with the handle intact: still alive.
+        for pass in 1..=10 {
+            let actions = arbiter.update_tick(100 + pass * 40);
+            assert!(stopped(&actions).is_empty(), "pass {pass} stopped the loop");
+        }
+        assert!(arbiter.advance_loop(event));
+
+        arbiter.set_loop_handle(1234, None, "ROCKETEERMOVELOOP");
+        let actions = arbiter.update_tick(1000);
+        assert_eq!(stopped(&actions), vec![event]);
+    }
+
+    /// A looping event with no owner at all is killed on its first serviced
+    /// pass in state 3: the leash reads `event+0x278` and falls straight to
+    /// the kill when it is null.
+    #[test]
+    fn a_loop_without_an_owner_dies_immediately() {
+        let mut arbiter = SoundArbiter::new(0);
+        let mut loop_facts = facts(1, 0);
+        loop_facts.control = control::LOOP;
+        let event = arbiter
+            .submit(&request("ORPHAN", loop_facts, VOLUME_SCALE), 0)
+            .expect("pool slot");
+        arbiter.update_tick(100);
+        let actions = arbiter.update_tick(200);
+        assert_eq!(stopped(&actions), vec![event]);
+    }
+
+    /// `Loop=N` is a finite budget: `AdvancePlaylist` allows another pass
+    /// only while `iteration < Loop - 1`.
+    #[test]
+    fn a_finite_loop_budget_runs_out() {
+        let mut arbiter = SoundArbiter::new(0);
+        let mut loop_facts = facts(2, 0);
+        loop_facts.control = control::LOOP;
+        loop_facts.loop_count = 3;
+        let event = arbiter
+            .submit(&request("THREE", loop_facts, VOLUME_SCALE), 0)
+            .expect("pool slot");
+        arbiter.update_tick(100);
+        assert!(arbiter.advance_loop(event));
+        assert!(arbiter.advance_loop(event));
+        assert!(!arbiter.advance_loop(event));
+    }
+
+    /// The pre-delay is a real wait, and the `0x21` ms floor discards a
+    /// shorter draw entirely (`if (iVar5 < 0x21) return;`). `[GTNK]
+    /// MoveSound=GrizzlyTankMoveStart` is the stock shape: `Control= random
+    /// predelay`, `Delay=0 400`.
+    #[test]
+    fn a_predelay_holds_the_cue_and_a_sub_floor_draw_is_discarded() {
+        let mut delayed = facts(2, 0);
+        delayed.control = control::PREDELAY;
+        delayed.delay_ms = (0, 400);
+
+        let mut arbiter = SoundArbiter::new(0);
+        let mut held = request("GRIZZLYSTART", delayed, VOLUME_SCALE);
+        held.predelay_ms = 300;
+        let event = arbiter.submit(&held, 0).expect("pool slot");
+        assert!(started(&arbiter.update_tick(40)).is_empty());
+        assert!(started(&arbiter.update_tick(200)).is_empty());
+        assert!(started(&arbiter.update_tick(400)).contains(&event));
+
+        // A draw under the floor never parks the event.
+        let mut arbiter = SoundArbiter::new(0);
+        let mut prompt = request("GRIZZLYSTART", delayed, VOLUME_SCALE);
+        prompt.predelay_ms = PREDELAY_FLOOR_MS - 1;
+        let event = arbiter.submit(&prompt, 0).expect("pool slot");
+        assert!(started(&arbiter.update_tick(40)).contains(&event));
+
+        // Without `Control=predelay`/`ambient` the draw is ignored outright:
+        // `if ((Voc.Control & 0x88) == 0) return;`.
+        let mut arbiter = SoundArbiter::new(0);
+        let mut plain = request("PLAIN", facts(2, 0), VOLUME_SCALE);
+        plain.predelay_ms = 300;
+        let event = arbiter.submit(&plain, 0).expect("pool slot");
+        assert!(started(&arbiter.update_tick(40)).contains(&event));
+    }
+
+    /// Pause suspends events rather than stopping the service: bookkeeping
+    /// keeps running, the pre-delay clock freezes, and nothing starts.
+    #[test]
+    fn suspension_freezes_the_predelay_and_blocks_the_start_pass() {
+        let mut arbiter = SoundArbiter::new(0);
+        let mut delayed = facts(2, 0);
+        delayed.control = control::PREDELAY;
+        delayed.delay_ms = (100, 100);
+        let mut held = request("CUE", delayed, VOLUME_SCALE);
+        held.predelay_ms = 100;
+        let event = arbiter.submit(&held, 0).expect("pool slot");
+        arbiter.update_tick(10);
+        arbiter.suspend_all(50);
+        // 10 seconds of paused passes: nothing starts, and the service keeps
+        // running throughout.
+        for pass in 0..10 {
+            assert!(started(&arbiter.update_tick(100 + pass * 1000)).is_empty());
+        }
+        assert_eq!(arbiter.live_event_count(), 1);
+        arbiter.resume_all(10_100);
+        assert!(started(&arbiter.update_tick(10_140)).is_empty());
+        assert!(started(&arbiter.update_tick(10_200)).contains(&event));
+    }
+
+    /// The entry-level layer takes the whole losing entry, quietest bucket
+    /// first, and never touches an equal tier.
+    #[test]
+    fn sample_memory_preemption_stops_every_event_of_the_lowest_priority_entry() {
+        let mut arbiter = SoundArbiter::new(0);
+        let a = arbiter
+            .submit(&request("QUIET", facts(1, 0), VOLUME_SCALE / 8), 0)
+            .expect("pool slot");
+        let b = arbiter
+            .submit(&request("QUIET", facts(1, 0), VOLUME_SCALE / 8), 0)
+            .expect("pool slot");
+        let peer = arbiter
+            .submit(&request("PEER", facts(3, 0), VOLUME_SCALE), 0)
+            .expect("pool slot");
+        arbiter.update_tick(100);
+
+        // Equal priority is never preempted here (`for p in 0..prio-1`).
+        assert!(arbiter.preempt_for_sample_memory(1).is_empty());
+        // A priority-3 caller takes the whole `QUIET` entry, both instances.
+        let mut victims = arbiter.preempt_for_sample_memory(3);
+        victims.sort();
+        assert_eq!(victims, vec![a, b]);
+        assert!(arbiter.event(peer).is_some_and(|event| !event.is_dead()));
+    }
+
+    /// The many-sounds limiter is a *volume budget*, not a sound count: each
+    /// live event contributes `Volume= / 5`, and the master is scaled to hold
+    /// the total at 100 once the sum passes it. Seven events at the stock
+    /// `[Defaults] Volume=80` (linear 13107, contribution 15) cross it.
+    #[test]
+    fn the_many_sounds_limiter_engages_on_the_summed_volume_budget() {
+        let mut arbiter = SoundArbiter::new(0);
+        let mut quiet = facts(2, 0);
+        quiet.entry_volume_linear = 13107; // Volume=80
+        for index in 0..6 {
+            arbiter
+                .submit(&request(&format!("C{index}"), quiet, VOLUME_SCALE), 0)
+                .expect("pool slot");
+        }
+        arbiter.update_tick(100);
+        assert_eq!(arbiter.many_sounds_linear(), VOLUME_SCALE);
+
+        arbiter
+            .submit(&request("C6", quiet, VOLUME_SCALE), 200)
+            .expect("pool slot");
+        arbiter.update_tick(200);
+        // The scaler glides rather than jumping (`SetTarget`, not
+        // `SetTargetImmediate`), so it has only started to move here.
+        arbiter.update_tick(4000);
+        assert!(
+            arbiter.many_sounds_linear() < VOLUME_SCALE,
+            "limiter never engaged at a 105-unit budget"
+        );
+    }
+
+    /// The ramp is `0x4000` over 1000 ms, and it is the *only* fade native
+    /// applies. A change on a playing event glides; a change before it
+    /// starts snaps.
+    #[test]
+    fn the_volume_ramp_glides_over_one_second_and_snaps_before_playback() {
+        let mut interp = VolumeInterp::new(0, 0);
+        interp.set_target(VOLUME_SCALE, 0);
+        // rate = (0x4000 << 16) / 1000 = 0x10624D, truncated exactly as the
+        // literal `VolumeInterp::Init @ 0x0040712B` writes it, so the ramp
+        // lands one unit short at the nominal half and full marks.
+        interp.tick(500);
+        assert_eq!(interp.value(), VOLUME_SCALE / 2 - 1);
+        interp.tick(1000);
+        assert_eq!(interp.value(), VOLUME_SCALE - 1);
+        interp.tick(1001);
+        assert_eq!(interp.value(), VOLUME_SCALE);
+
+        let mut arbiter = SoundArbiter::new(0);
+        let event = arbiter
+            .submit(&request("CUE", facts(2, 0), VOLUME_SCALE), 0)
+            .expect("pool slot");
+        // Before playback: snap.
+        arbiter.set_volume(event, 0, 0);
+        assert_eq!(arbiter.live_gain(event), Some((0, VOLUME_SCALE / 2)));
+        arbiter.update_tick(40);
+        // Playing: glide.
+        arbiter.set_volume(event, VOLUME_SCALE, 40);
+        assert_eq!(arbiter.live_gain(event).map(|(v, _)| v), Some(0));
+        arbiter.update_tick(540);
+        assert_eq!(
+            arbiter.live_gain(event).map(|(v, _)| v),
+            Some(VOLUME_SCALE / 2 - 1)
+        );
+    }
+
+    /// The pump gate is `> 33 ms`, not `>=`.
+    #[test]
+    fn the_pump_gate_is_strictly_more_than_thirty_three_milliseconds() {
+        let mut arbiter = SoundArbiter::new(0);
+        assert!(arbiter.pump_due(0));
+        arbiter.update_tick(0);
+        assert!(!arbiter.pump_due(PUMP_PERIOD_MS));
+        assert!(arbiter.pump_due(PUMP_PERIOD_MS + 1));
+    }
+
+    /// A stale handle (the event was recycled) is cleared by the owner-side
+    /// check rather than resurrecting a different cue.
+    #[test]
+    fn a_recycled_event_invalidates_its_owner_handle() {
+        let mut arbiter = SoundArbiter::new(0);
+        let mut loop_facts = facts(2, 0);
+        loop_facts.control = control::LOOP;
+        let first = arbiter
+            .submit(&request("CUE", loop_facts, VOLUME_SCALE), 0)
+            .expect("pool slot");
+        arbiter.set_loop_handle(7, Some(first), "CUE");
+        assert_eq!(arbiter.validate_loop_handle(7), Some(first));
+        arbiter.stop(first);
+        arbiter.update_tick(100);
+        assert_eq!(arbiter.validate_loop_handle(7), None);
+    }
+}

--- a/src/audio/arbiter.rs
+++ b/src/audio/arbiter.rs
@@ -123,17 +123,39 @@ pub const RAMP_SPAN_MS: u32 = 1000;
 /// `AdvancePlaylist` restart above the floor while VERA models no substitute,
 /// VERA then *stops*, where gamemd sustains the cue under
 /// `SelectNextSample`'s own `Loop=` budget. So an ambient authored to run
-/// forever would play once and fall silent. Frequency: **zero
-/// today** — exactly 24 `Control=loop` entries in `ini/soundmd.ini` have
-/// `Delay` min >= 33 (23 `ambient`, plus the debug `TestRandomLoopDelayAll`),
-/// none has a producer in `audio/events.rs`, and all 41 distinct
-/// `MoveSound=` values in `ini/rulesmd.ini` resolve to entries with `Delay`
-/// min 0. It goes live the day ambients get a producer. Downstream risk:
+/// forever would play once and fall silent.
+///
+/// Trigger set, stated precisely because the obvious reading is wrong: the
+/// loader split at `0x004048B0` tests `Voc+0x58` alone, with **no `Control=`
+/// term**, so it is not the 24 `Control=loop` entries that qualify but every
+/// entry above the floor — **30** in `ini/soundmd.ini`. Six of those carry no
+/// `Control=loop`, and two of the six, `UpgradeVeteran`/`UpgradeElite`
+/// (`Delay=400`), are produced on **every unit promotion**
+/// (`rules/ruleset.rs` → `sim/world/techno_ai.rs` → `audio/events.rs`). They
+/// are nonetheless inaudibly identical, because a single-sample entry with no
+/// `Control=loop` yields that same one sample from either loader and then
+/// ends.
+///
+/// Frequency: **zero today**, but for the narrower reason. The audible half
+/// needs an above-floor entry with `Control=all`/`attack`/`decay` and more
+/// than one `Sounds=` name — 22 such entries, every one an ambient plus the
+/// debug `TestRandomLoopDelayAll`, and `AmbientSound=` has no producer
+/// anywhere in the crate. All 41 distinct `MoveSound=` values in
+/// `ini/rulesmd.ini` resolve to entries with `Delay` min 0. It goes live the
+/// day ambients get a producer. Downstream risk:
 /// closing it needs the per-buffer playlist that residuals R4 and R9 also
 /// wait on, plus a port of `SelectNextSample`'s separate cursor state — it
 /// is a mechanism port, not a gate on the existing one, which is why the
 /// half-fix (truncating the chain to one sample here) is deliberately not
 /// applied: it would pick the wrong sample and still not loop correctly.
+///
+/// VERA-internal, gamemd equivalent UNCHECKED: native's floor test reads
+/// `*(uint *)(Voc+0x58)` and compares UNSIGNED, so a negative `Delay=` low
+/// bound (which `crt_atoi` will happily parse from a leading `-`) lands above
+/// the floor there and below it here, where the comparison is signed `i32`.
+/// No stock `Delay=` is negative, so this cannot fire on retail data; it is
+/// labelled only because the rest of this module labels its unreachable
+/// divergences.
 pub const PREDELAY_FLOOR_MS: i32 = 0x21;
 
 /// Threshold above which the many-sounds limiter engages, and the numerator

--- a/src/audio/arbiter.rs
+++ b/src/audio/arbiter.rs
@@ -136,13 +136,22 @@ pub const RAMP_SPAN_MS: u32 = 1000;
 /// `Control=loop` yields that same one sample from either loader and then
 /// ends.
 ///
-/// Frequency: **zero today**, but for the narrower reason. The audible half
-/// needs an above-floor entry with `Control=all`/`attack`/`decay` and more
-/// than one `Sounds=` name — 22 such entries, every one an ambient plus the
-/// debug `TestRandomLoopDelayAll`, and `AmbientSound=` has no producer
-/// anywhere in the crate. All 41 distinct `MoveSound=` values in
-/// `ini/rulesmd.ini` resolve to entries with `Delay` min 0. It goes live the
-/// day ambients get a producer. Downstream risk:
+/// Frequency: **zero today**, and the audible set is the union of the two
+/// halves above, not just the chaining one. Chaining diverges for an
+/// above-floor entry with more than one `Sounds=` name — 22 entries.
+/// Sustain diverges for every above-floor `Control=loop` entry, single-sample
+/// ones included: `SelectNextSample` ends a cue only on
+/// `((flags & 1) == 0 && pass == 1)` or
+/// `((flags & 1) != 0 && Voc+0x4C != 0 && Voc+0x4C <= pass)`, and **no**
+/// section in `ini/soundmd.ini` sets `Loop=`, so all 24 sustain forever
+/// natively while [`SoundArbiter::advance_loop`] refuses them. Two of the 24
+/// carry a single `Sounds=` name and so fall outside the chaining set —
+/// `CruiseShipAmbience` (`gship1a`, wired as `AmbientSound=`) and
+/// `_Amb_DesertHawk`. Union: 24 entries, every one an ambient plus the debug
+/// `TestRandomLoopDelayAll`, and `AmbientSound=` has no producer anywhere in
+/// the crate. All 41 distinct `MoveSound=` values in `ini/rulesmd.ini`
+/// resolve to entries with `Delay` min 0. It goes live the day ambients get a
+/// producer. Downstream risk:
 /// closing it needs the per-buffer playlist that residuals R4 and R9 also
 /// wait on, plus a port of `SelectNextSample`'s separate cursor state — it
 /// is a mechanism port, not a gate on the existing one, which is why the

--- a/src/audio/arbiter.rs
+++ b/src/audio/arbiter.rs
@@ -136,22 +136,55 @@ pub const RAMP_SPAN_MS: u32 = 1000;
 /// `Control=loop` yields that same one sample from either loader and then
 /// ends.
 ///
-/// Frequency: **zero today**, and the audible set is the union of the two
-/// halves above, not just the chaining one. Chaining diverges for an
-/// above-floor entry with more than one `Sounds=` name — 22 entries.
-/// Sustain diverges for every above-floor `Control=loop` entry, single-sample
-/// ones included: `SelectNextSample` ends a cue only on
-/// `((flags & 1) == 0 && pass == 1)` or
-/// `((flags & 1) != 0 && Voc+0x4C != 0 && Voc+0x4C <= pass)`, and **no**
-/// section in `ini/soundmd.ini` sets `Loop=`, so all 24 sustain forever
-/// natively while [`SoundArbiter::advance_loop`] refuses them. Two of the 24
-/// carry a single `Sounds=` name and so fall outside the chaining set —
-/// `CruiseShipAmbience` (`gship1a`, wired as `AmbientSound=`) and
-/// `_Amb_DesertHawk`. Union: 24 entries, every one an ambient plus the debug
-/// `TestRandomLoopDelayAll`, and `AmbientSound=` has no producer anywhere in
-/// the crate. All 41 distinct `MoveSound=` values in `ini/rulesmd.ini`
-/// resolve to entries with `Delay` min 0. It goes live the day ambients get a
-/// producer. Downstream risk:
+/// The two halves diverge over **different sets, and neither contains the
+/// other** — state each with its own criterion rather than adding them up.
+/// Both are counted off `ini/soundmd.ini` with the native tokenizer (`strtok`
+/// on `" \t\n"`, the delimiter string at `0x00846570`), so `Delay=` min is the
+/// first token and `Delay=10000 20000` is above the floor.
+///
+/// - **Chaining set — 22 entries**: above the floor, `Control=all`, and more
+///   than one `Sounds=` name. All three terms are load-bearing. Dropping the
+///   `Control=` term would give 24, but wrongly: without `all`,
+///   `select_playout_pass` (`src/audio/sfx.rs`) pushes a single index too, so
+///   `CowAmbient` (`random interrupt ambient`) and `MIGMove`
+///   (`random predelay`) yield one sample from either loader and cannot
+///   chain. `Control=attack`/`decay` would qualify as well, but that arm is
+///   vacuous on stock data — no above-floor entry writes `Attack=` or
+///   `Decay=`.
+/// - **Sustain set — 24 entries**: above the floor and `Control=loop`,
+///   single-sample ones included. `SelectNextSample` ends a cue only on
+///   `((flags & 1) == 0 && pass == 1)` or
+///   `((flags & 1) != 0 && Voc+0x4C != 0 && Voc+0x4C <= pass)`, and `Voc+0x4C`
+///   is `Loop=` read with **default 0**: `VocClass::ReadINI @ 0x00750834`
+///   calls `CCINIClass::ReadInt(section, "Loop", 0)` (key string at
+///   `0x00824238`) into `AudioEventClass::SetLoop @ 0x00406640`
+///   (`MOV [ECX+0x4C],EDX`). The file's one `Loop=` is
+///   `[TestEnvelopeFShift] Loop=3`, which is out of scope twice over — its
+///   `Delay=` is commented out so it sits below the floor, and its
+///   `Control= random` carries no loop bit. So all 24 leave `Voc+0x4C == 0`,
+///   the second disjunct can never fire, and every one sustains forever
+///   natively while [`SoundArbiter::advance_loop`] refuses it.
+///
+/// The two sets share **21** entries, so their union is 22 + 24 − 21 = **25**.
+/// Four entries break a naive reading of one criterion or the other, and they
+/// are why the union is not the larger set: `CruiseShipAmbience` (`gship1a`)
+/// and `_Amb_DesertHawk` sustain but carry a single `Sounds=` name and no
+/// `all`, so they never chain; `ChimpAmbient` (`random all ambient`) chains
+/// but carries no `loop`, so it is the one chaining entry outside the sustain
+/// set; and `PropagandaTruck` is above-floor `Control=loop` carrying **zero**
+/// `Sounds=` names — its list is commented out at `ini/soundmd.ini:2012` — so
+/// it is in the sustain set yet silent under either engine. Audibly
+/// divergent is therefore 25 − 1 = **24**, every one `Control=ambient` except
+/// the debug `TestRandomLoopDelayAll` (`random loop all`, `Priority=HIGH`).
+/// Beware that this 24 and the sustain set's 24 are equal-sized *different*
+/// sets: the sustain set holds `PropagandaTruck` and not `ChimpAmbient`, the
+/// audible union the reverse.
+///
+/// Frequency: **zero today**. `rulesmd.ini` points `AmbientSound=` at six of
+/// the 25, but `AmbientSound=` has no producer anywhere in the crate — the
+/// token appears in `src/` only in this comment. All 41 distinct `MoveSound=`
+/// values in `ini/rulesmd.ini` resolve to entries with `Delay` min 0. It goes
+/// live the day ambients get a producer. Downstream risk:
 /// closing it needs the per-buffer playlist that residuals R4 and R9 also
 /// wait on, plus a port of `SelectNextSample`'s separate cursor state — it
 /// is a mechanism port, not a gate on the existing one, which is why the
@@ -1886,8 +1919,10 @@ mod tests {
     /// whose `Delay=` low bound is 33 ms or more never reaches the LOOP
     /// branch: its sustain is the streaming callback re-drawing
     /// `RandomRanged(Delay.min, Delay.max)` between samples, not a chained
-    /// restart. Every stock entry of that shape is an ambient
-    /// (`_Amb_*`, `PropagandaTruck`, `CruiseShipAmbience`, 24 in all).
+    /// restart. 24 stock entries have that shape — the sustain set of
+    /// [`PREDELAY_FLOOR_MS`] — and every one is `Control=ambient` (`_Amb_*`,
+    /// `PropagandaTruck`, `CruiseShipAmbience`) except the debug
+    /// `TestRandomLoopDelayAll`.
     #[test]
     fn a_loop_entry_with_a_delay_floor_never_reaches_the_loop_branch() {
         let mut spaced = facts(2, 0);

--- a/src/audio/arbiter.rs
+++ b/src/audio/arbiter.rs
@@ -61,6 +61,12 @@ pub const VOLUME_BUCKETS: usize = 10;
 /// spills into `bucket[prio + 1][0]` — harmless with the 7-row array, but it
 /// makes a full-volume entry look one priority tier higher to
 /// [`SoundArbiter::find_lowest_priority`], i.e. harder to preempt.
+///
+/// The spill is reproduced, not clamped away: the ranking insert at
+/// `0x004044CA` (`LEA EBX,[EAX*8 + 0x87de38]`, row stride 120) and
+/// `0x0040454D` (`LEA ECX,[EBX + ECX*4]`, bucket stride 12) applies **no
+/// bound to either index**, so the write is a flat byte offset from the array
+/// base and bucket 10 of row `p` is bucket 0 of row `p + 1`.
 pub const BUCKET_DIVISOR: i32 = 1638;
 
 /// Age gap two equal-priority channels need before the older one is taken.
@@ -337,8 +343,11 @@ struct EntryRuntime {
     best_priority: i32,
     /// `+0xB0`, the best volume bucket seen this ranking pass.
     best_bucket: i32,
-    /// Where the entry currently sits in the bucket array, if anywhere.
-    bucket_slot: Option<(usize, usize)>,
+    /// Where the entry currently sits in the bucket array, if anywhere, as a
+    /// **flat** slot. Native addresses the array as one byte offset
+    /// (`base + 120*row + 12*bucket`) with no per-index bound, so a flat
+    /// index is what reproduces the bucket-10 spill into the next row.
+    bucket_slot: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -716,8 +725,17 @@ impl SoundArbiter {
     /// `AdvancePlaylist @ 0x004047B0` step 2 asked from the device side: may
     /// this looping event start another pass?
     ///
+    /// The whole body is gated on `Voc+0x58 < 0x21 || (flags & 0x20)` (first
+    /// line of the decompiled body), and step 2 itself is
     /// `(Control & LOOP) && !(flags & 0x20) && (Loop == 0 || iteration <
-    /// Loop - 1)`. Consumes one iteration when it answers yes.
+    /// Loop - 1)`. The two combine to `Delay.min < 0x21 && !(flags & 0x20)
+    /// && ...`: an entry whose `Delay=` low bound is 33 ms or more never
+    /// reaches the LOOP branch at all — its sustain is instead the streaming
+    /// callback `FUN_00405AC0` parking the token and re-drawing
+    /// `RandomRanged(Delay.min, Delay.max)` between samples, which is the
+    /// pre-delay path [`EventState::PreDelay`] already models.
+    ///
+    /// Consumes one iteration when it answers yes.
     pub fn advance_loop(&mut self, id: EventId) -> bool {
         let Some(event) = self.event(id) else {
             return false;
@@ -728,6 +746,9 @@ impl SoundArbiter {
         let Some(facts) = self.entries[event.entry as usize].facts else {
             return false;
         };
+        if facts.delay_ms.0 >= PREDELAY_FLOOR_MS {
+            return false;
+        }
         if facts.control & control::LOOP == 0 {
             return false;
         }
@@ -865,6 +886,12 @@ impl SoundArbiter {
     /// `g_PriorityVolumeBuckets` rows `[0, priority)` — **strictly lower
     /// priority only, equal priority is never preempted here** — and inside a
     /// row take the quietest bucket first. Returns the losing entry.
+    ///
+    /// The row bound is `for (p = 0; p < param_1; p++)` with no upper clamp —
+    /// native would walk past the 7-row array for a priority above 7. The
+    /// `PRIORITY_ROWS` ceiling here is VERA-internal, gamemd equivalent
+    /// UNCHECKED; it is unreachable on stock data, where `Priority=` tops out
+    /// at `CRITICAL(4)`.
     fn find_lowest_priority(&mut self, priority: i32) -> Option<u32> {
         for row in 0..priority.clamp(0, PRIORITY_ROWS as i32) as usize {
             for bucket in 0..VOLUME_BUCKETS {
@@ -1141,14 +1168,33 @@ impl SoundArbiter {
             }
             entry.best_priority = priority;
             entry.best_bucket = bucket;
-            if let Some((row, column)) = entry.bucket_slot.take() {
-                self.buckets[row * VOLUME_BUCKETS + column]
-                    .retain(|other| *other != entry_index as u32);
+            if let Some(slot) = entry.bucket_slot.take() {
+                self.buckets[slot].retain(|other| *other != entry_index as u32);
             }
-            let row = (priority.clamp(0, PRIORITY_ROWS as i32 - 1)) as usize;
-            let column = bucket.clamp(0, VOLUME_BUCKETS as i32 - 1) as usize;
-            self.buckets[row * VOLUME_BUCKETS + column].push(entry_index as u32);
-            self.entries[entry_index].bucket_slot = Some((row, column));
+            // `0x004044CA` / `0x0040454D`: the insert address is
+            // `0x0087DE38 + 120*row + 12*bucket` with **no clamp on either
+            // index**, so a full-scale instance's bucket 10 lands in
+            // `bucket[row + 1][0]` — a full-volume entry reads as one
+            // priority tier higher to `find_lowest_priority`, i.e. harder to
+            // preempt. Compute the same flat slot.
+            let slot = priority * VOLUME_BUCKETS as i32 + bucket;
+            // VERA-internal, gamemd equivalent UNCHECKED: native has no bound
+            // here and would write past the 7x10 array. Unreachable on stock
+            // data — `Priority=` parses to `LOWEST(0)..CRITICAL(4)` and the
+            // spill costs one row, so the highest slot a stock cue can reach
+            // is row 5, bucket 0. Trigger: an effective priority of 6 or more,
+            // or a negative one. Player effect if it ever fired: the entry is
+            // simply not rankable, so `preempt_for_sample_memory` cannot pick
+            // it. Frequency: never on stock `soundmd.ini`. Downstream risk:
+            // none — nothing else reads the bucket array.
+            let Ok(slot) = usize::try_from(slot) else {
+                continue;
+            };
+            if slot >= self.buckets.len() {
+                continue;
+            }
+            self.buckets[slot].push(entry_index as u32);
+            self.entries[entry_index].bucket_slot = Some(slot);
         }
 
         let target = if volume_sum > MANY_SOUNDS_THRESHOLD {
@@ -1168,12 +1214,17 @@ impl SoundArbiter {
     ///
     /// **Its native trigger is sample-memory starvation, not channel
     /// starvation.** The start pass reaches it only when
-    /// `SoundEvent::PreparePlayout @ 0x00404700` returns 0, and the only
-    /// runtime way that happens is `SoundEvent::LoadSamples @ 0x004048B0`
-    /// getting nothing back from `SampleTracker::LoadSample` — i.e. the
-    /// streaming pool (`FUN_004019E0(idx, 0x100000, 200, 0x2000)` at
-    /// `0x00403F29`: 127 blocks of 8 KB inside a 1 MB budget) is full.
-    /// Stopping lower-priority entries frees those blocks.
+    /// `SoundEvent::PreparePlayout @ 0x00404700` returns 0. That function has
+    /// three `return 0` paths: a zero loaded-sample count (`+0xA8`, i.e.
+    /// `SoundEvent::LoadSamples @ 0x004048B0` got nothing back from
+    /// `SampleTracker::LoadSample`), `flags & 0x20` (NO_REPLAY), and
+    /// `+0x1E0 < 1` after the attack/decay reservation. **On stock data only
+    /// the first is reachable** — all 33 `Control=attack`/`decay` entries in
+    /// `soundmd.ini` carry at least three `Sounds=`, so the reservation
+    /// cannot empty the list — and it means the streaming pool
+    /// (`FUN_004019E0(idx, 0x100000, 200, 0x2000)` at `0x00403F29`: 127
+    /// blocks of 8 KB inside a 1 MB budget) is full. Stopping lower-priority
+    /// entries frees those blocks.
     ///
     /// RESIDUAL (UNCHECKED trigger) — VERA decodes each cue into an owned
     /// `Vec<f32>` with no fixed budget, so nothing here can starve and this
@@ -1749,5 +1800,77 @@ mod tests {
         arbiter.stop(first);
         arbiter.update_tick(100);
         assert_eq!(arbiter.validate_loop_handle(7), None);
+    }
+
+    /// `AdvancePlaylist @ 0x004047B0` opens with
+    /// `if ((Voc+0x58 < 0x21) || (flags & 0x20))`, so a `Control=loop` entry
+    /// whose `Delay=` low bound is 33 ms or more never reaches the LOOP
+    /// branch: its sustain is the streaming callback re-drawing
+    /// `RandomRanged(Delay.min, Delay.max)` between samples, not a chained
+    /// restart. Every stock entry of that shape is an ambient
+    /// (`_Amb_*`, `PropagandaTruck`, `CruiseShipAmbience`, 24 in all).
+    #[test]
+    fn a_loop_entry_with_a_delay_floor_never_reaches_the_loop_branch() {
+        let mut spaced = facts(2, 0);
+        spaced.control = control::LOOP;
+        spaced.delay_ms = (PREDELAY_FLOOR_MS, 5000);
+        let mut arbiter = SoundArbiter::new(0);
+        let event = arbiter
+            .submit(&request("AMB", spaced, VOLUME_SCALE), 0)
+            .expect("pool slot");
+        arbiter.update_tick(100);
+        assert!(!arbiter.advance_loop(event));
+
+        // One millisecond under the floor and the same entry loops.
+        let mut tight = spaced;
+        tight.delay_ms = (PREDELAY_FLOOR_MS - 1, 5000);
+        let mut arbiter = SoundArbiter::new(0);
+        let event = arbiter
+            .submit(&request("AMB", tight, VOLUME_SCALE), 0)
+            .expect("pool slot");
+        arbiter.update_tick(100);
+        assert!(arbiter.advance_loop(event));
+    }
+
+    /// The ranking insert applies no bound to the volume column
+    /// (`0x004044CA LEA EBX,[EAX*8 + 0x87de38]`, `0x0040454D
+    /// LEA ECX,[EBX + ECX*4]`), so a full-scale instance's bucket
+    /// `0x4000 / 1638 = 10` is written at `base + 120*prio + 120` —
+    /// `bucket[prio + 1][0]`. A full-volume entry therefore reads one
+    /// priority tier higher to `FindLowestPriority` and survives a caller
+    /// that takes its quieter same-priority peer.
+    #[test]
+    fn a_full_volume_entry_spills_into_the_next_priority_row() {
+        let mut arbiter = SoundArbiter::new(0);
+        let loud = arbiter
+            .submit(&request("LOUD", facts(2, 0), VOLUME_SCALE), 0)
+            .expect("pool slot");
+        let quiet = arbiter
+            .submit(&request("QUIET", facts(2, 0), VOLUME_SCALE / 4), 0)
+            .expect("pool slot");
+        arbiter.update_tick(100);
+
+        // `VOLUME_SCALE / 4 = 4096` buckets to 2 and stays in row 2 (slot
+        // 22); `VOLUME_SCALE` buckets to 10 and lands at slot 30, which is
+        // row 3 bucket 0.
+        let loud_entry = arbiter.entry_index("LOUD") as usize;
+        let quiet_entry = arbiter.entry_index("QUIET") as usize;
+        assert_eq!(
+            arbiter.entries[loud_entry].bucket_slot,
+            Some(3 * VOLUME_BUCKETS)
+        );
+        assert_eq!(
+            arbiter.entries[quiet_entry].bucket_slot,
+            Some(2 * VOLUME_BUCKETS + 2)
+        );
+
+        // Rows `[0, 3)` reach row 2, where only the quiet entry sits.
+        assert_eq!(arbiter.preempt_for_sample_memory(3), vec![quiet]);
+        // Asked again, the same caller finds nothing: the loud entry is out
+        // of its reach. Clamping the column to 9 would have put it in row 2
+        // and surrendered it here.
+        assert!(arbiter.preempt_for_sample_memory(3).is_empty());
+        // It takes a caller one tier higher to reach it.
+        assert_eq!(arbiter.preempt_for_sample_memory(4), vec![loud]);
     }
 }

--- a/src/audio/arbiter.rs
+++ b/src/audio/arbiter.rs
@@ -89,6 +89,51 @@ pub const RAMP_SPAN_MS: u32 = 1000;
 /// `SoundEvent::UpdateState @ 0x004055C0` draws
 /// `RandomRanged(AMBIENT ? 0x21 : Delay.min, Delay.max)` and discards any
 /// result below `0x21` (`if (iVar5 < 0x21) return;`).
+///
+/// **Deferred DRIFT — the whole `Delay.min >= 0x21` playout path is a second
+/// native mechanism VERA does not implement (gamemd read, VERA behaviour
+/// UNCHECKED against it).** This value is not only a pre-delay floor: it
+/// selects between two different sample loaders, and VERA implements only
+/// the low side.
+///
+/// - Below the floor (what VERA models): `SoundEvent::PreparePlayout @
+///   0x00404700` builds the whole playlist at `event+0x160` and
+///   `AdvancePlaylist @ 0x004047B0` walks it; all three of that function's
+///   arms — chain, LOOP restart, DECAY tail — sit inside its opening
+///   `if (Voc+0x58 < 0x21 || (flags & 0x20))`.
+/// - At or above it: `SoundEvent::LoadSamples @ 0x004048B0` takes a wholly
+///   separate branch that loads **one** body sample per service pass, chosen
+///   by `SoundEvent::SelectNextSample @ 0x00404BB0` (plus the decay sample
+///   when `Control=decay`). `SelectNextSample` keeps its own playlist at
+///   `event+0x1E8` with its own cursor `+0x270`, remaining count `+0x268`
+///   and pass counter `+0x26C`, and returns `-1` to end the cue: after pass 1
+///   without `Control=loop`, or when `Loop != 0 && Loop <= pass`. So the
+///   `Loop=` budget and the `Control=all` set are honoured there, one sample
+///   per `SoundSystem::UpdateTick @ 0x004041D0` pass, with the pre-delay
+///   between them. `LoadSamples` is called only from `UpdateTick`, and
+///   `SelectNextSample` only from `LoadSamples` (`get_function_callers`).
+///
+/// VERA instead resolves every entry through the low-side path:
+/// `resolve_entry_playback_pass` chains `select_playout_pass`'s whole order
+/// into one payload regardless of `Delay`. Trigger: submitting an entry
+/// whose `Delay=` low bound is >= 33 ms. Player effect, both halves: VERA
+/// plays the full chained set back-to-back as one pass where gamemd plays a
+/// single sample, waits out the re-drawn pre-delay, then plays the next; and
+/// because [`SoundArbiter::advance_loop`] correctly refuses the
+/// `AdvancePlaylist` restart above the floor while VERA models no substitute,
+/// VERA then *stops*, where gamemd sustains the cue under
+/// `SelectNextSample`'s own `Loop=` budget. So an ambient authored to run
+/// forever would play once and fall silent. Frequency: **zero
+/// today** — exactly 24 `Control=loop` entries in `ini/soundmd.ini` have
+/// `Delay` min >= 33 (23 `ambient`, plus the debug `TestRandomLoopDelayAll`),
+/// none has a producer in `audio/events.rs`, and all 41 distinct
+/// `MoveSound=` values in `ini/rulesmd.ini` resolve to entries with `Delay`
+/// min 0. It goes live the day ambients get a producer. Downstream risk:
+/// closing it needs the per-buffer playlist that residuals R4 and R9 also
+/// wait on, plus a port of `SelectNextSample`'s separate cursor state — it
+/// is a mechanism port, not a gate on the existing one, which is why the
+/// half-fix (truncating the chain to one sample here) is deliberately not
+/// applied: it would pick the wrong sample and still not loop correctly.
 pub const PREDELAY_FLOOR_MS: i32 = 0x21;
 
 /// Threshold above which the many-sounds limiter engages, and the numerator
@@ -730,10 +775,13 @@ impl SoundArbiter {
     /// `(Control & LOOP) && !(flags & 0x20) && (Loop == 0 || iteration <
     /// Loop - 1)`. The two combine to `Delay.min < 0x21 && !(flags & 0x20)
     /// && ...`: an entry whose `Delay=` low bound is 33 ms or more never
-    /// reaches the LOOP branch at all — its sustain is instead the streaming
-    /// callback `FUN_00405AC0` parking the token and re-drawing
-    /// `RandomRanged(Delay.min, Delay.max)` between samples, which is the
-    /// pre-delay path [`EventState::PreDelay`] already models.
+    /// reaches *this* LOOP branch.
+    ///
+    /// That is a claim about this path only. Such an entry still loops, and
+    /// still plays its whole `Sounds=` set, through a second mechanism VERA
+    /// does not model — see the `Delay >= 0x21` residual on
+    /// [`PREDELAY_FLOOR_MS`]. Do not read this gate as "the entry does not
+    /// loop".
     ///
     /// Consumes one iteration when it answers yes.
     pub fn advance_loop(&mut self, id: EventId) -> bool {

--- a/src/audio/events.rs
+++ b/src/audio/events.rs
@@ -368,20 +368,26 @@ impl GameSoundEvent {
 /// - Player effect: the line restarts where retail lets it finish.
 /// - Frequency: continuous — it is how players click.
 ///
-/// **Still absent, unchanged.** Nothing emits ambient sound: `WorkingSound=`
-/// (9 stock), `AuxSound1=` (8), `AuxSound2=` (5), `TurretRotateSound=` (2) and
-/// the water enter/leave pair have no producer, and `MoveSound=` is parsed with
-/// per-entity countdown state but no event carries it — and its real trigger is
-/// UNKNOWN, since the site an existing research note names plays
-/// `[AudioVisual] ScoldSound=` instead. `VoiceFeedback=` (133 stock) and
-/// `VoiceCapture=` (3) have no consumers, `VoiceCrashing=` (7) is not parsed,
-/// and taunts reach an empty match arm.
-/// - Player effect: the soundscape is thin — units move silently and bases have
-///   no working hum.
+/// **Partly closed.** `MoveSound=` now has both halves: the sim's
+/// post-locomotor tail (`Simulation::tick_move_sound_after_process`) emits
+/// [`Self::AnimationStarted`]/[`Self::AnimationStopped`] keyed on the object,
+/// and `audio::arbiter` gives that key a real `VocHandle` — so a
+/// `Control=loop` entry such as `RocketeerMoveLoop` sustains for the whole
+/// move and a `Control= random predelay` entry such as
+/// `GrizzlyTankMoveStart` plays one start-up sample, which is what gamemd
+/// does.
+///
+/// **Still absent.** Nothing emits the other ambient families:
+/// `WorkingSound=` (9 stock), `AuxSound1=` (8), `AuxSound2=` (5),
+/// `TurretRotateSound=` (2) and the water enter/leave pair have no producer.
+/// `VoiceFeedback=` (133 stock) and `VoiceCapture=` (3) have no consumers,
+/// `VoiceCrashing=` (7) is not parsed, and taunts reach an empty match arm.
+/// - Player effect: the soundscape is still thin — bases have no working hum.
 /// - Frequency: continuous.
-/// - Downstream risk: every ambient family needs the looping handles recorded on
-///   `audio/sfx.rs`, so they sit behind the same device-free arbiter. The voice
-///   guard does not — it needs only the liveness channel above.
+/// - Downstream risk: none left on the audio side. Each remaining family needs
+///   only a sim-side producer and the same owner-keyed handle `MoveSound=`
+///   already uses; the arbiter behind it is landed. The voice repeat guard
+///   above is separate — it needs only the liveness channel.
 #[derive(Debug, Default)]
 pub struct SoundEventQueue {
     events: Vec<GameSoundEvent>,

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -8,6 +8,7 @@
 //! - audio/ depends on: assets/ (decodes .aud files), sim/ (triggers on game events)
 //! - audio/ does NOT depend on: render/, ui/, sidebar/, net/
 
+pub mod arbiter;
 pub mod events;
 pub mod music;
 pub mod sfx;

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -915,6 +915,17 @@ impl VoiceSuspend {
     fn dequeue_allowed(&self) -> bool {
         self.depth == 0
     }
+
+    /// `VoxClass::ResetAll @ 0x007535F0` zeroes `DAT_00b1d428` outright
+    /// (`DAT_00b1d428 = 0;`, after stopping the stream and calling
+    /// `VoxClass::ClearAllQueues`) rather than unwinding it pause by pause.
+    /// A reset therefore drops any depth a `GamePause::Enter` had raised —
+    /// native does not touch the game's own pause state here, and neither
+    /// does VERA, so a reset taken while paused leaves the dequeue ungated
+    /// in both. Harmless in both, because the queue is empty by then.
+    fn reset(&mut self) {
+        self.depth = 0;
+    }
 }
 
 /// Manages sound effect playback with separate SFX pool and voice slot.
@@ -1358,7 +1369,12 @@ impl SfxPlayer {
     /// `VoxClass::PlayNextQueued @ 0x00752780` wraps its whole body in
     /// `... && (DAT_00b1d428 == 0)` (`0x007527D5`), so while the game is
     /// paused the queue does not advance and the slot is not even recycled.
-    /// The guard is first, as it is there.
+    ///
+    /// VERA tests it first; in native it is the **last** term of the inner
+    /// `if` at `0x007527D5`, after the `StreamPlayer::IsPlaying` poll and the
+    /// end-time comparison. Equivalent, because every term before it is a
+    /// side-effect-free poll and every side effect — the slot recycle
+    /// `DAT_00b1d4c4 + 0x50 = 2` included — sits inside the gate.
     pub fn advance_voice_queue(&mut self) {
         if !self.voice_suspend.dequeue_allowed() {
             return;
@@ -1793,6 +1809,10 @@ impl SfxPlayer {
         }
         self.queued_voice.clear();
         self.current_voice_id = None;
+        // `VoxClass::ResetAll @ 0x007535F0`: stop the stream, clear every
+        // queue, then `DAT_00b1d428 = 0`. The suspend depth is reset here,
+        // not left to unwind on the next pause edge.
+        self.voice_suspend.reset();
     }
 
     /// Get the current SFX master volume.
@@ -2987,6 +3007,28 @@ mod tests {
 
         // `if (d != 0) { d -= 1; if (d < 0) d = 0; }` — an unmatched resume
         // never drives the counter negative, so the next pause still blocks.
+        suspend.set_paused(false);
+        assert!(suspend.dequeue_allowed());
+        suspend.set_paused(true);
+        assert!(!suspend.dequeue_allowed());
+    }
+
+    /// `VoxClass::ResetAll @ 0x007535F0` ends with `DAT_00b1d428 = 0`, so a
+    /// reset drops the whole suspend depth at once instead of unwinding it
+    /// one `GamePause::Exit` at a time. `SfxPlayer::stop_all` is VERA's
+    /// analogue and now does the same.
+    #[test]
+    fn a_reset_clears_the_whole_eva_suspend_depth_at_once() {
+        let mut suspend = VoiceSuspend::default();
+        suspend.set_paused(true);
+        suspend.set_paused(true);
+        assert!(!suspend.dequeue_allowed());
+
+        suspend.reset();
+        assert!(suspend.dequeue_allowed());
+
+        // The depth really is zero, not merely decremented: a single resume
+        // afterwards must not underflow, and a single pause must block again.
         suspend.set_paused(false);
         assert!(suspend.dequeue_allowed());
         suspend.set_paused(true);

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -6,12 +6,21 @@
 //! and plays them through rodio.
 //!
 //! ## Design
-//! - Fire-and-forget: each sound is played via a Player and tracked only to
-//!   cap the max number of concurrent sounds (prevents audio overload).
 //! - Sample selection, pitch/volume shift, positional volume, stereo pan and
 //!   the DirectSound loudness curve are reproduced from `gamemd.exe`
 //!   (`VocClass`, `SoundEvent`, `DSoundBuffer`); see the provenance comments
-//!   on each helper. Everything below `play_decoded` is device plumbing.
+//!   on each helper.
+//! - **Which cue gets one of the 16 channels is not decided here.** A play
+//!   request is decoded, then submitted to [`arbiter::SoundArbiter`], which
+//!   owns the native `SoundSystem::UpdateTick @ 0x004041D0` pass: the channel
+//!   pool, `Priority=` arbitration, `Limit=`, the pre-delay wait, the looping
+//!   leash and the volume ramps. This file applies the arbiter's
+//!   [`arbiter::ArbiterAction`]s to rodio and nothing more, so the decision
+//!   half stays reachable from `cargo test --lib` where there is no device.
+//! - The service pass runs from [`SfxPlayer::pump`], which the app calls every
+//!   frame regardless of whether the simulation stepped — native's
+//!   `AudioSystem::Pump @ 0x00406F70` hangs off `Network_ServiceLoop @
+//!   0x0048D080`, not the sim.
 //!
 //! ## Dependency rules
 //! - Part of audio/ — depends on assets/ (AssetManager for .wav/.aud loading),
@@ -26,41 +35,26 @@ use rodio::{DeviceSinkBuilder, MixerDeviceSink, Player};
 
 use crate::assets::asset_manager::AssetManager;
 use crate::assets::aud_file;
+use crate::audio::arbiter::{self, ArbiterAction, EntryFacts, EventId, PlayRequest, SoundArbiter};
 use crate::rules::sound_ini::{SoundEntry, SoundRegistry, VOLUME_SCALE, control, sound_type};
 
-/// Maximum concurrent SFX sounds — matches original engine's 16 DirectSound buffers.
-/// RESIDUAL (GSI-15.03/15.04) — there is no channel pool, and the parts of
-/// these two rows that matter for parity are entangled with the device.
-/// Eviction is plain FIFO over this queue, so the `Priority=` tier decoded in
-/// `rules/sound_ini.rs` is ignored and a `CRITICAL` cue loses to an older
-/// `LOWEST` one; `Limit=` is parsed but unenforced (17 stock sounds cap at one
-/// instance — native counts live instances per event at `AudioEventClass+0x44`
-/// against `+0x48` in `SoundSystem::UpdateTick @ 0x004041D0` and stops the
-/// oldest); `Control=INTERRUPT` (`0x10`) has no owner; `Control=LOOP`/`Loop=`
-/// (`SoundEvent::SelectNextSample @ 0x00404BB0`, `AdvancePlaylist @
-/// 0x004047B0`) play only their first pass; `Delay=`/`PREDELAY`/`AMBIENT`
-/// pre-delays (`SoundEvent::UpdateState @ 0x004055C0` state 2, threshold
-/// `0x21` ms) are drawn from the RNG but not waited for; and finished handles
-/// are reaped only inside `play_decoded`, so an idle frame never cleans up.
+/// How many passes of a sustaining cue are kept queued on its rodio player:
+/// the one that is sounding plus one waiting behind it.
 ///
-/// Pass 2 established the cadence: `SoundSystem::UpdateTick @ 0x004041D0` is
-/// pumped from `AudioSystem::Pump @ 0x00406F70` off the message/service loop —
-/// NOT the sim tick — so the mixer's update rate is not frame-locked and must
-/// not be modelled as if it were.
-/// - Trigger: any moment more than a handful of sounds compete, and every
-///   ambient, looping or pre-delayed cue.
-/// - Player effect: important cues get dropped for unimportant older ones,
-///   ambient beds never sustain, interruptions click instead of crossing, and
-///   pre-delayed cues start early.
-/// - Frequency: continuous in any busy engagement.
-/// - Downstream risk: **not reachable from `cargo test -p vera20k --lib`.**
-///   `SfxPlayer::new` returns `None` without an audio device, so every path
-///   below `play_decoded` is unverifiable here and none of it may be claimed
-///   verified. The first slice is a device-free arbiter — a slot table,
-///   per-event instance counts and lowest-priority-wins eviction
-///   (`DSoundChannel::FindLowestPriority @ 0x00404E20`) — with all rodio work
-///   left in this file.
-const MAX_CONCURRENT_SFX: usize = 16;
+/// **VERA-internal, gamemd equivalent UNCHECKED.** Native never queues ahead:
+/// `FUN_00405AC0`, installed at `ch+0xB4`, is the DirectSound
+/// buffer-needs-data callback, and it calls
+/// `SoundEvent::AdvancePlaylist @ 0x004047B0` the moment the device asks, so
+/// the chain is gapless by construction. rodio's `Player` exposes no such
+/// callback — only `append` and a queue length — so [`SfxPlayer::pump`] keeps
+/// one pass queued behind the sounding one instead. Trigger for the
+/// divergence: a `Loop=N` cue reads one pass further ahead than native does,
+/// so its final pass is decoded (and its `Control=random` order drawn) one
+/// pass earlier. Player effect: none audible; the same passes play in the
+/// same order. Frequency: every looping cue. Downstream risk: the extra draw
+/// shifts VERA's presentation RNG, which is a clock-seeded non-scenario
+/// generator (`g_MainRng @ 0x00886B88`) and feeds no deterministic state.
+const LOOP_QUEUE_DEPTH: usize = 2;
 
 /// `VocClass::CalcVolumeAndPan @ 0x00750AC0` (`0x00750B0F..0x00750B17`):
 /// `maxRange = Range * 0x3C` pixels.
@@ -500,32 +494,41 @@ impl SampleRng for SfxRng {
 /// (`0x0040567F..0x004056A7`): `fshift = 100 + RandomRanged(FShift.min,
 /// FShift.max)` and `vshift = RandomRanged(0, VShift)`; then, when
 /// `Control & (PREDELAY|AMBIENT)`, `RandomRanged(AMBIENT ? 0x21 : Delay.min,
-/// Delay.max)` for the pre-delay (`0x00405729..0x00405743`). The pre-delay
-/// itself is a channel-arbiter (A2) residual; its draw is kept so the RNG
-/// sequence matches.
+/// Delay.max)` for the pre-delay (`0x00405729..0x00405743`).
+///
+/// Native draws the pre-delay inside `UpdateState` state 0, *after* the
+/// channel has been taken. VERA draws all three here so the RNG sequence
+/// matches, and hands the result to [`arbiter::SoundArbiter`], which applies
+/// it at native's place in the state machine — including the `0x21` ms floor
+/// and the `Control & 0x88` gate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PlayShifts {
     /// Frequency multiplier in percent (`SoundEvent+0x14C`).
     pub frequency_pct: i32,
     /// Volume reduction in percent (`SoundEvent+0x150`).
     pub volume_shift_pct: i32,
+    /// The pre-delay draw in milliseconds; 0 when the entry authors neither
+    /// `Control=predelay` nor `Control=ambient`.
+    pub predelay_ms: i32,
 }
 
 impl PlayShifts {
     pub fn draw(entry: &SoundEntry, rng: &mut impl SampleRng) -> Self {
         let frequency_pct = rng.ranged(entry.fshift.0, entry.fshift.1) + 100;
         let volume_shift_pct = rng.ranged(0, entry.vshift);
+        let mut predelay_ms = 0;
         if entry.control & (control::PREDELAY | control::AMBIENT) != 0 {
             let min = if entry.control & control::AMBIENT != 0 {
-                0x21
+                arbiter::PREDELAY_FLOOR_MS
             } else {
                 entry.delay_ms.0
             };
-            let _predelay_ms = rng.ranged(min, entry.delay_ms.1);
+            predelay_ms = rng.ranged(min, entry.delay_ms.1);
         }
         Self {
             frequency_pct,
             volume_shift_pct,
+            predelay_ms,
         }
     }
 
@@ -587,6 +590,28 @@ impl PlayShifts {
 /// Player effect: VERA plays a valid sample (or nothing) where gamemd would
 /// misbehave. Frequency: never on retail data. Downstream risk: none.
 pub fn select_playout(entry: &SoundEntry, rng: &mut impl SampleRng) -> Vec<usize> {
+    select_playout_pass(entry, rng, true)
+}
+
+/// [`select_playout`] for one pass, with the `Control=attack` head under the
+/// caller's control.
+///
+/// `SoundEvent::PreparePlayout @ 0x00404700` heads the playout with the
+/// attack buffer only while `flags & 8` is clear — the flag
+/// `SoundEvent::StartPlayback @ 0x004054A0` and
+/// `SoundEvent::MarkStarted @ 0x004052E0` both set. So the attack sample is
+/// played on a cue's *first* pass only, never on a loop restart, and never at
+/// all on an owner-driven loop (`AnimClass::UpdateLoopingSound @ 0x00750D40`
+/// marks the event started the instant it allocates it).
+///
+/// The attack **index is still drawn** when it is not played: the draw lives
+/// in `SoundEvent::LoadSamples @ 0x004048B0`, which runs before the decision,
+/// and it still reserves `samples[0]` out of the body range either way.
+pub fn select_playout_pass(
+    entry: &SoundEntry,
+    rng: &mut impl SampleRng,
+    plays_attack: bool,
+) -> Vec<usize> {
     let count = entry.sounds.len() as i32;
     if count == 0 {
         return Vec::new();
@@ -627,7 +652,9 @@ pub fn select_playout(entry: &SoundEntry, rng: &mut impl SampleRng) -> Vec<usize
     // Native keeps the attack buffer first only under the ATTACK control flag,
     // and the decay buffer last only under DECAY; without the flag the count is
     // zero (see `SoundEntry::attack`), so both agree.
-    order.extend(attack);
+    if plays_attack {
+        order.extend(attack);
+    }
     if entry.control & control::RANDOM != 0 {
         while !middle.is_empty() {
             let pick = rng.ranged(0, middle.len() as i32 - 1) as usize;
@@ -641,8 +668,6 @@ pub fn select_playout(entry: &SoundEntry, rng: &mut impl SampleRng) -> Vec<usize
     order.extend(decay);
     order
 }
-
-const FADE_MS: u32 = 3;
 
 /// Decoded audio ready for rodio playback.
 /// Holds interleaved f32 stereo samples, sample rate, and channel count.
@@ -677,6 +702,8 @@ impl DecodedAudio {
 struct ResolvedPlayback {
     decoded: DecodedAudio,
     event_linear: i32,
+    /// The per-play draws, kept so the pre-delay reaches the arbiter.
+    shifts: PlayShifts,
 }
 
 struct QueuedVoice {
@@ -720,6 +747,10 @@ struct SfxOutputScales {
     voice_volume: f32,
     lifecycle_scale: f32,
     focus_output_scale: f32,
+    /// The many-sounds master scaler, `g_ManySoundsVolumeGroup @ 0x0087E1B8`,
+    /// chained into every channel at `ch+0x98` and multiplied in by
+    /// `DSoundBuffer::CombineInterps FUN_004010C0` as `(a * b) >> 14`.
+    many_sounds_linear: i32,
 }
 
 /// Master-independent gain retained beside one live secondary output.
@@ -753,7 +784,11 @@ impl SfxOutputGain {
             SfxChannel::Voice => scales.voice_volume,
         };
         let master_linear = ftol(f64::from(master.clamp(0.0, 1.0)) * f64::from(VOLUME_SCALE));
-        native_volume_amplitude(combine_linear(self.base_linear, master_linear))
+        // The channel multiplies the event group (`ch+0x90`), the many-sounds
+        // scaler (`ch+0x98`) and the user volume group (`ch+0x9C`) together
+        // before `FUN_0040A6D0` converts to decibels.
+        let with_limiter = combine_linear(self.base_linear, scales.many_sounds_linear);
+        native_volume_amplitude(combine_linear(with_limiter, master_linear))
             * scales.lifecycle_scale
             * scales.focus_output_scale
     }
@@ -818,20 +853,68 @@ impl LiveSfxOutput {
     }
 }
 
+/// One submitted cue's payload, waiting for the arbiter's start pass.
+struct PendingPlayback {
+    decoded: DecodedAudio,
+    base_linear: i32,
+    /// The `[SoundList]` identity, so a sustaining cue can re-resolve its
+    /// playout for each loop pass the way `PreparePlayout` does.
+    key: String,
+}
+
+/// Bookkeeping for a cue the arbiter reported as `sustaining`.
+struct LoopQueue {
+    key: String,
+    /// The pan the next queued pass is baked with.
+    ///
+    /// RESIDUAL (device expressiveness) — native re-drives pan continuously
+    /// through the channel's `ch+0x90` interp group, so a unit crossing the
+    /// screen pans smoothly mid-buffer. rodio's `Player::set_volume` is a
+    /// scalar with no per-channel form, so VERA bakes the pan into each
+    /// buffer and a sustaining cue's pan therefore steps at each loop pass.
+    /// Trigger: any moving looping emitter (Rocketeer, Terror Drone, Mig,
+    /// Floating Disc). Player effect: the stereo image updates in steps of
+    /// one loop pass rather than continuously; volume still glides. Frequency:
+    /// whenever such a unit moves. Downstream risk: none. Fixing it needs a
+    /// per-channel gain on a live source, which this sink does not offer.
+    pan: i32,
+    /// The loop budget is exhausted; stop topping up and let the buffer run
+    /// dry so the arbiter is told the playout ended.
+    finished: bool,
+}
+
 /// Manages sound effect playback with separate SFX pool and voice slot.
 ///
 /// Matches the original engine's architecture:
-/// - 16-channel SFX pool for weapons, explosions, ambient
+/// - a 16-channel SFX pool arbitrated by [`arbiter::SoundArbiter`]
 /// - 1 dedicated voice slot for unit responses (cuts off previous)
 pub struct SfxPlayer {
     /// rodio mixer device sink — must be kept alive or all audio stops.
     _device: MixerDeviceSink,
-    /// Active SFX players — oldest first. Capped at MAX_CONCURRENT_SFX.
-    active: VecDeque<LiveSfxOutput>,
-    /// Active sound handle owned by each authoritative animation ID.
-    animation_active: BTreeMap<u64, LiveSfxOutput>,
+    /// The decision half: channel pool, `Priority=`, `Limit=`, pre-delay,
+    /// looping leash, ramps and the many-sounds limiter.
+    arbiter: SoundArbiter,
+    /// Decoded payloads the arbiter has not started yet.
+    pending: BTreeMap<EventId, PendingPlayback>,
+    /// Started outputs, keyed by the arbiter event holding the channel.
+    live: BTreeMap<EventId, LiveSfxOutput>,
+    /// Queue bookkeeping for the sustaining subset of [`Self::live`].
+    loops: BTreeMap<EventId, LoopQueue>,
+    /// Last service-pass timestamp handed in by the app.
+    now_ms: u64,
     /// Dedicated voice player — unit responses cut off the previous voice.
     /// Separate from SFX pool so voices never compete with weapon sounds.
+    ///
+    /// VERA-internal, gamemd equivalent UNCHECKED: native routes voices
+    /// through the same 16 channels via `VocClass::PlayAt @ 0x007509E0`, and
+    /// its "cut the previous line" behaviour is the handle-level interrupt
+    /// (`VocHandle::ValidateOrClear` then `SoundEvent::Stop` when the live
+    /// event names a different entry), not a 17th channel. Trigger: any voice
+    /// line while 16 SFX channels are busy. Player effect: VERA's voice is
+    /// never denied a channel and never displaces an effect. Frequency:
+    /// common in a busy fight. Downstream risk: the EVA queue's own
+    /// semantics (`VoxClass`) are a separate parity surface that owns this
+    /// slot, so folding voices into the pool is deferred to it.
     voice_player: Option<LiveSfxOutput>,
     /// Queued EVA/voice announcements waiting for the dedicated voice slot.
     queued_voice: VecDeque<QueuedVoice>,
@@ -846,6 +929,9 @@ pub struct SfxPlayer {
     /// Foreground-owned primary-output gate. Secondary Players stay running so
     /// their playback cursors continue while global output is suppressed.
     focus_output_scale: f32,
+    /// Whether the game is paused, so [`Self::set_paused`] only acts on the
+    /// edge the way `GamePause::Enter`/`Exit` do.
+    paused: bool,
     /// Presentation-side RNG standing in for `g_MainRng @ 0x00886B88`.
     rng: SfxRng,
 }
@@ -859,8 +945,11 @@ impl SfxPlayer {
 
         Some(Self {
             _device: device,
-            active: VecDeque::new(),
-            animation_active: BTreeMap::new(),
+            arbiter: SoundArbiter::new(0),
+            pending: BTreeMap::new(),
+            live: BTreeMap::new(),
+            loops: BTreeMap::new(),
+            now_ms: 0,
             voice_player: None,
             queued_voice: VecDeque::new(),
             current_voice_id: None,
@@ -868,6 +957,7 @@ impl SfxPlayer {
             voice_volume: 0.7,
             output_scale: 1.0,
             focus_output_scale: 1.0,
+            paused: false,
             rng: SfxRng::from_clock(),
         })
     }
@@ -878,6 +968,7 @@ impl SfxPlayer {
             voice_volume: self.voice_volume as f32,
             lifecycle_scale: self.output_scale,
             focus_output_scale: self.focus_output_scale,
+            many_sounds_linear: self.arbiter.many_sounds_linear(),
         }
     }
 
@@ -909,6 +1000,12 @@ impl SfxPlayer {
         load_sfx(sound_id, assets, audio_indices).map(|decoded| ResolvedPlayback {
             decoded,
             event_linear: VOLUME_SCALE,
+            // A raw bag name has no `VocClass`, so there is nothing to draw.
+            shifts: PlayShifts {
+                frequency_pct: 100,
+                volume_shift_pct: 0,
+                predelay_ms: 0,
+            },
         })
     }
 
@@ -973,8 +1070,10 @@ impl SfxPlayer {
             log::trace!("SFX: could not resolve '{}'", sound_id);
             return false;
         };
+        let facts = entry_facts(sound_id, registry);
         let base_linear = combine_linear(gain.volume_linear(), resolved.event_linear);
-        self.play_decoded(resolved.decoded, base_linear, gain.pan)
+        self.submit_decoded(sound_id, facts, resolved, base_linear, gain.pan)
+            .is_some()
     }
 
     /// Play only a named `sound(md).ini` event and never reinterpret its ID as
@@ -996,11 +1095,26 @@ impl SfxPlayer {
         let Some(resolved) = self.resolve_entry(entry, assets, audio_indices) else {
             return false;
         };
+        let facts = EntryFacts::from(entry);
         let base_linear = combine_linear(gain.volume_linear(), resolved.event_linear);
-        self.play_decoded(resolved.decoded, base_linear, gain.pan)
+        self.submit_decoded(sound_id, facts, resolved, base_linear, gain.pan)
+            .is_some()
     }
 
-    /// Start or replace the sound owned by one animation object.
+    /// Start (or re-point) the cue an owner object holds a loop handle for.
+    ///
+    /// gamemd-derived: `AnimClass::UpdateLoopingSound @ 0x00750D40`, the
+    /// canonical driver of every sustained sound. The owner calls it with its
+    /// current coordinate; when the positional volume is above zero and no
+    /// live event is bound, a loopable entry allocates one and is immediately
+    /// marked started (`SoundEvent::MarkStarted @ 0x004052E0`, which is why an
+    /// owner-driven loop never replays its `Control=attack` sample); the
+    /// volume and pan are then re-driven and the handle re-pointed. When the
+    /// volume drops to zero the event is stopped and the handle cleared —
+    /// that clearing is what ends the loop, through the state-3 leash in
+    /// `SoundEvent::UpdateState @ 0x004057DC`.
+    ///
+    /// `gain: None` is the `CalcVolumeAndPan <= 0` arm.
     pub fn play_animation_sound_spatial(
         &mut self,
         anim_id: u64,
@@ -1010,38 +1124,78 @@ impl SfxPlayer {
         assets: &AssetManager,
         audio_indices: &[crate::assets::audio_bag::AudioIndex],
     ) -> bool {
+        // `VocClass::PlayAt`'s handle-level interrupt: a live event that
+        // belongs to a different entry is stopped before the new one starts.
+        // This — not `Control=interrupt` — is what makes a re-issued cue cut
+        // its predecessor.
         self.stop_animation_sound(anim_id);
-        let Some(resolved) = self.resolve_any(sound_id, registry, assets, audio_indices) else {
+        let facts = entry_facts(sound_id, registry);
+        // An owner-driven loop is marked started at allocation, so its very
+        // first pass already skips the `Control=attack` sample.
+        let plays_attack = !facts.is_loopable();
+        let resolved = match registry.get(sound_id) {
+            Some(entry) => resolve_entry_playback_pass(
+                entry,
+                &mut self.rng,
+                |name| load_sfx(name, assets, audio_indices),
+                plays_attack,
+            ),
+            None => self.resolve_any(sound_id, registry, assets, audio_indices),
+        };
+        let Some(resolved) = resolved else {
             return false;
         };
         let base_linear = combine_linear(gain.volume_linear(), resolved.event_linear);
-        let mut decoded = resolved.decoded;
-        apply_pan(&mut decoded.samples, gain.pan);
-        let prepared = prepare_normal_sfx_output(decoded, base_linear, self.output_scales());
-        let PreparedSfxOutput {
-            decoded,
-            gain,
-            initial_volume,
-        } = prepared;
-        let Some(channels) = NonZero::new(decoded.channels) else {
+        let Some(event) = self.submit_decoded(sound_id, facts, resolved, base_linear, gain.pan)
+        else {
             return false;
         };
-        let Some(sample_rate) = NonZero::new(decoded.sample_rate) else {
-            return false;
-        };
-        let source = SamplesBuffer::new(channels, sample_rate, decoded.samples);
-        let player = Player::connect_new(self._device.mixer());
-        let output = LiveSfxOutput::new(player, gain, initial_volume);
-        output.player.append(source);
-        self.animation_active.insert(anim_id, output);
+        if facts.is_loopable() {
+            self.arbiter.mark_started(event);
+        }
+        // The handle is bound either way: a one-shot still belongs to its
+        // owner so `stop_animation_sound` can find it, it is just not leashed
+        // (`UpdateState` state 3 checks `Control & LOOP` first).
+        self.arbiter
+            .set_loop_handle(anim_id, Some(event), &registry_key(sound_id));
         true
+    }
+
+    /// Re-drive one owner's live loop with its current positional gain, the
+    /// way `AnimClass::UpdateLoopingSound` runs on every owner update.
+    ///
+    /// Returns false when the owner holds no live event.
+    pub fn update_looping_sound(&mut self, anim_id: u64, gain: Option<SpatialGain>) -> bool {
+        let Some(event) = self.arbiter.validate_loop_handle(anim_id) else {
+            return false;
+        };
+        match gain {
+            Some(gain) => {
+                let now = self.now_ms;
+                self.arbiter
+                    .set_volume(event, gain.volume_linear().min(VOLUME_SCALE), now);
+                self.arbiter.set_pan(event, gain.pan, now);
+                if let Some(queue) = self.loops.get_mut(&event) {
+                    queue.pan = gain.pan;
+                }
+                true
+            }
+            None => {
+                // `if (0.0 < fVar3) {...} else { SoundEvent__Stop; }` then
+                // `SetLoopHandle(handle, 0, voc)`.
+                self.stop_animation_sound(anim_id);
+                false
+            }
+        }
     }
 
     /// Release only the handle owned by `anim_id`. Idempotent.
     pub fn stop_animation_sound(&mut self, anim_id: u64) {
-        if let Some(output) = self.animation_active.remove(&anim_id) {
-            output.player.stop();
+        if let Some(event) = self.arbiter.validate_loop_handle(anim_id) {
+            self.arbiter.stop(event);
+            self.release_output(event);
         }
+        self.arbiter.clear_loop_handle(anim_id);
     }
 
     /// Play a sound as a unit voice response (VoiceSelect, VoiceMove, VoiceAttack).
@@ -1204,17 +1358,10 @@ impl SfxPlayer {
         self.current_voice_id = None;
 
         let PreparedSfxOutput {
-            mut decoded,
+            decoded,
             gain,
             initial_volume,
         } = prepared;
-
-        apply_fade(
-            &mut decoded.samples,
-            decoded.sample_rate,
-            decoded.channels,
-            FADE_MS,
-        );
 
         let channels = match NonZero::new(decoded.channels) {
             Some(c) => c,
@@ -1234,56 +1381,280 @@ impl SfxPlayer {
         true
     }
 
-    /// Play already-decoded audio on the SFX pool at the given master-independent
-    /// linear volume and pan.
-    fn play_decoded(&mut self, mut decoded: DecodedAudio, base_linear: i32, pan: i32) -> bool {
-        apply_pan(&mut decoded.samples, pan);
-        let prepared = prepare_normal_sfx_output(decoded, base_linear, self.output_scales());
-        let PreparedSfxOutput {
+    /// Hand a decoded cue to the arbiter. Nothing is audible yet: native's
+    /// `SoundEvent::AllocateFromPool @ 0x00405190` only creates the record in
+    /// state 0, and the channel, pre-delay and playback all happen on the
+    /// next `SoundSystem::UpdateTick` pass (at most `0x21` ms later).
+    fn submit_decoded(
+        &mut self,
+        sound_id: &str,
+        facts: EntryFacts,
+        resolved: ResolvedPlayback,
+        base_linear: i32,
+        pan: i32,
+    ) -> Option<EventId> {
+        let key = registry_key(sound_id);
+        let request = PlayRequest {
+            key: key.clone(),
+            facts,
+            volume_linear: base_linear,
+            pan,
+            predelay_ms: resolved.shifts.predelay_ms,
+        };
+        let event = self.arbiter.submit(&request, self.now_ms)?;
+        self.pending.insert(
+            event,
+            PendingPlayback {
+                decoded: resolved.decoded,
+                base_linear,
+                key,
+            },
+        );
+        Some(event)
+    }
+
+    /// One `AudioSystem::Pump @ 0x00406F70` service pass.
+    ///
+    /// The app calls this every frame, *unconditionally* — native's pump
+    /// hangs off `Network_ServiceLoop @ 0x0048D080`, whose callers include
+    /// `Main::ThrottleFrame @ 0x0055E160`, `ProcessModalServicePump @
+    /// 0x00623120`, `ShellDialog::RunUntilResult @ 0x0060D380` and the
+    /// loading-screen paths, so the audio service keeps running in menus,
+    /// modal dialogs and while the frame pacer idles. Pause is expressed
+    /// separately, by suspending events ([`Self::set_paused`]).
+    ///
+    /// The `> 33 ms` gate lives here, as it does in native.
+    pub fn pump(
+        &mut self,
+        now_ms: u64,
+        registry: &SoundRegistry,
+        assets: &AssetManager,
+        audio_indices: &[crate::assets::audio_bag::AudioIndex],
+    ) {
+        self.now_ms = now_ms;
+        self.advance_voice_queue();
+        self.top_up_loop_queues(now_ms, registry, assets, audio_indices);
+        self.report_finished_outputs();
+        if !self.arbiter.pump_due(now_ms) {
+            return;
+        }
+        let actions = self.arbiter.update_tick(now_ms);
+        let scales = self.output_scales();
+        for action in actions {
+            match action {
+                ArbiterAction::Start {
+                    event,
+                    volume_linear,
+                    pan,
+                    sustaining,
+                } => self.start_output(event, volume_linear, pan, sustaining, now_ms),
+                ArbiterAction::Gain {
+                    event,
+                    volume_linear,
+                    pan,
+                } => {
+                    if let Some(output) = self.live.get_mut(&event) {
+                        output.gain.base_linear = volume_linear;
+                        output.apply_scales(scales);
+                    }
+                    if let Some(queue) = self.loops.get_mut(&event) {
+                        queue.pan = pan;
+                    }
+                }
+                ArbiterAction::Stop { event } => self.release_output(event),
+            }
+        }
+        // The many-sounds scaler moved, so every live output's amplitude has.
+        self.apply_live_output_scales();
+    }
+
+    /// Apply an `ArbiterAction::Start`: build the rodio player, bake the pan
+    /// into the buffer and queue the first pass.
+    fn start_output(
+        &mut self,
+        event: EventId,
+        volume_linear: i32,
+        pan: i32,
+        sustaining: bool,
+        now_ms: u64,
+    ) {
+        let Some(pending) = self.pending.remove(&event) else {
+            return;
+        };
+        let PendingPlayback {
             mut decoded,
+            base_linear,
+            key,
+        } = pending;
+        let _ = base_linear;
+        apply_pan(&mut decoded.samples, pan);
+        let prepared = prepare_normal_sfx_output(decoded, volume_linear, self.output_scales());
+        let PreparedSfxOutput {
+            decoded,
             gain,
             initial_volume,
         } = prepared;
-        apply_fade(
-            &mut decoded.samples,
-            decoded.sample_rate,
-            decoded.channels,
-            FADE_MS,
-        );
-
-        // Evict finished sounds and enforce concurrency limit.
-        self.cleanup_finished();
-        if self.active.len() >= MAX_CONCURRENT_SFX {
-            // Stop and evict oldest sound.
-            if let Some(old) = self.active.pop_front() {
-                old.player.stop();
-            }
-        }
-
-        // NonZero is required by rodio 0.22 SamplesBuffer API.
-        let channels = match NonZero::new(decoded.channels) {
-            Some(c) => c,
-            None => return false,
+        let (Some(channels), Some(sample_rate)) = (
+            NonZero::new(decoded.channels),
+            NonZero::new(decoded.sample_rate),
+        ) else {
+            self.arbiter.stop(event);
+            return;
         };
-        let sample_rate = match NonZero::new(decoded.sample_rate) {
-            Some(r) => r,
-            None => return false,
-        };
-
         let source = SamplesBuffer::new(channels, sample_rate, decoded.samples);
         let player: Player = Player::connect_new(self._device.mixer());
         let output = LiveSfxOutput::new(player, gain, initial_volume);
         output.player.append(source);
-        self.active.push_back(output);
-        true
+        self.live.insert(event, output);
+        let _ = now_ms;
+        if sustaining {
+            self.loops.insert(
+                event,
+                LoopQueue {
+                    key,
+                    pan,
+                    finished: false,
+                },
+            );
+        }
     }
 
-    /// Remove handles for sounds that have finished playing.
-    fn cleanup_finished(&mut self) {
-        self.active.retain(|output| !output.player.empty());
-        self.animation_active
-            .retain(|_, output| !output.player.empty());
-        self.advance_voice_queue();
+    /// Keep every sustaining cue's buffer queue filled at least
+    /// [`LOOP_QUEUE_LOOKAHEAD_MS`] ahead, re-resolving the playout for each
+    /// pass the way `AdvancePlaylist`'s LOOP branch re-enters
+    /// `SoundEvent::PreparePlayout @ 0x00404700` — so a `Control=random`
+    /// entry reshuffles its body order every pass, and the `Control=attack`
+    /// sample is not replayed (`flags & 8` is already set).
+    fn top_up_loop_queues(
+        &mut self,
+        now_ms: u64,
+        registry: &SoundRegistry,
+        assets: &AssetManager,
+        audio_indices: &[crate::assets::audio_bag::AudioIndex],
+    ) {
+        let _ = now_ms;
+        for event in self.loops.keys().copied().collect::<Vec<_>>() {
+            loop {
+                let Some(queue) = self.loops.get(&event) else {
+                    break;
+                };
+                if queue.finished {
+                    break;
+                }
+                let queued = self
+                    .live
+                    .get(&event)
+                    .map_or(0, |output| output.player.len());
+                if queued >= LOOP_QUEUE_DEPTH {
+                    break;
+                }
+                if !self.arbiter.advance_loop(event) {
+                    if let Some(queue) = self.loops.get_mut(&event) {
+                        queue.finished = true;
+                    }
+                    break;
+                }
+                let key = queue.key.clone();
+                let pan = queue.pan;
+                let Some(entry) = registry.get(&key).cloned() else {
+                    if let Some(queue) = self.loops.get_mut(&event) {
+                        queue.finished = true;
+                    }
+                    break;
+                };
+                // `flags & 8` is set by now (`StartPlayback` at the latest), so
+                // `PreparePlayout` takes the `AdvancePlaylist` arm and the
+                // attack sample never heads a restarted pass.
+                let plays_attack = self.arbiter.plays_attack_sample(event);
+                let Some(resolved) = resolve_entry_playback_pass(
+                    &entry,
+                    &mut self.rng,
+                    |name| load_sfx(name, assets, audio_indices),
+                    plays_attack,
+                ) else {
+                    if let Some(queue) = self.loops.get_mut(&event) {
+                        queue.finished = true;
+                    }
+                    break;
+                };
+                let mut decoded = resolved.decoded;
+                apply_pan(&mut decoded.samples, pan);
+                let (Some(channels), Some(sample_rate)) = (
+                    NonZero::new(decoded.channels),
+                    NonZero::new(decoded.sample_rate),
+                ) else {
+                    if let Some(queue) = self.loops.get_mut(&event) {
+                        queue.finished = true;
+                    }
+                    break;
+                };
+                if decoded.samples.is_empty() {
+                    // A zero-length pass would never raise the queue length
+                    // and would spin this loop.
+                    if let Some(queue) = self.loops.get_mut(&event) {
+                        queue.finished = true;
+                    }
+                    break;
+                }
+                let Some(output) = self.live.get(&event) else {
+                    break;
+                };
+                output
+                    .player
+                    .append(SamplesBuffer::new(channels, sample_rate, decoded.samples));
+            }
+        }
+    }
+
+    /// The device telling the arbiter that a playout ran dry with nothing
+    /// left to play — native's `ch+0xB8` callback `LAB_00405A00`, which sets
+    /// state 4 so the next pass reaps the event. This is also the reaping
+    /// cadence native runs every pass and VERA previously only ran inside a
+    /// play call.
+    fn report_finished_outputs(&mut self) {
+        let finished: Vec<EventId> = self
+            .live
+            .iter()
+            .filter(|(_, output)| output.player.empty())
+            .map(|(event, _)| *event)
+            .collect();
+        for event in finished {
+            self.arbiter.notify_playout_ended(event);
+            self.release_output(event);
+        }
+    }
+
+    fn release_output(&mut self, event: EventId) {
+        self.pending.remove(&event);
+        self.loops.remove(&event);
+        if let Some(output) = self.live.remove(&event) {
+            output.player.stop();
+        }
+    }
+
+    /// `GamePause::Enter @ 0x00406F00` / `Exit @ 0x00406F40`: the service
+    /// keeps pumping either way; pause is expressed by suspending every event
+    /// (`SoundSystem::SuspendAll @ 0x00404FD0`) and stopping the actively
+    /// playing channels (`DSoundChannel::PauseAll @ 0x00403770`).
+    ///
+    /// Idempotent — call it with the current pause state every frame.
+    pub fn set_paused(&mut self, paused: bool, now_ms: u64) {
+        self.now_ms = now_ms;
+        if paused == self.paused {
+            return;
+        }
+        self.paused = paused;
+        if paused {
+            self.arbiter.suspend_all(now_ms);
+            for output in self.live.values() {
+                output.player.pause();
+            }
+        } else {
+            self.arbiter.resume_all(now_ms);
+            for output in self.live.values() {
+                output.player.play();
+            }
+        }
     }
 
     /// Compatibility setter: apply one master to both SFX and voice channels.
@@ -1327,10 +1698,7 @@ impl SfxPlayer {
 
     fn apply_live_output_scales(&self) {
         let scales = self.output_scales();
-        for output in &self.active {
-            output.apply_scales(scales);
-        }
-        for output in self.animation_active.values() {
+        for output in self.live.values() {
             output.apply_scales(scales);
         }
         if let Some(output) = self.voice_player.as_ref() {
@@ -1347,12 +1715,17 @@ impl SfxPlayer {
 
     /// Hard-stop every SFX/voice source and discard queued announcements.
     pub fn stop_all(&mut self) {
-        for output in self.active.drain(..) {
+        for event in self.live.keys().copied().collect::<Vec<_>>() {
+            self.arbiter.stop(event);
+        }
+        for (_, output) in std::mem::take(&mut self.live) {
             output.player.stop();
         }
-        for (_, output) in std::mem::take(&mut self.animation_active) {
-            output.player.stop();
+        for event in self.pending.keys().copied().collect::<Vec<_>>() {
+            self.arbiter.stop(event);
         }
+        self.pending.clear();
+        self.loops.clear();
         if let Some(output) = self.voice_player.take() {
             output.player.stop();
         }
@@ -1370,9 +1743,27 @@ impl SfxPlayer {
         self.voice_volume
     }
 
-    /// Number of currently active (playing) sound effects.
+    /// Owners that currently hold a live loop handle, so the app can re-drive
+    /// each one with its object's current coordinate the way native's owner
+    /// calls `AnimClass::UpdateLoopingSound @ 0x00750D40` on every update.
+    pub fn looping_owners(&mut self) -> Vec<u64> {
+        self.arbiter.loop_handle_owners()
+    }
+
+    /// The `[SoundList]` identity one owner's live loop handle names.
+    pub fn loop_handle_sound_id(&self, owner: u64) -> Option<String> {
+        self.arbiter.loop_handle_key(owner).map(str::to_owned)
+    }
+
+    /// Number of live sound events — native `g_LiveSoundEventCount @
+    /// 0x0087E28C`, which counts records in the pool, not busy channels.
     pub fn active_count(&self) -> usize {
-        self.active.len() + self.animation_active.len()
+        self.arbiter.live_event_count()
+    }
+
+    /// Sound events currently holding one of the 16 channels.
+    pub fn busy_channel_count(&self) -> usize {
+        self.arbiter.busy_channel_count()
     }
 
     /// Number of queued EVA/voice announcements waiting on the voice slot.
@@ -1397,19 +1788,80 @@ fn registered_entry<'a>(sound_id: &str, registry: &'a SoundRegistry) -> Option<&
     registry.get(sound_id)
 }
 
+/// The arbiter's identity key for a sound id.
+///
+/// Native compares `VocClass*` pointers, so two plays of the same
+/// `[SoundList]` entry share one `Limit=` counter and one priority-bucket
+/// slot. VERA keys on the uppercased id, which is the same identity because
+/// `VocClass::ReadSoundListINI @ 0x007510D0` dedupes list values
+/// case-insensitively (`FUN_007C8D20`) into one event object.
+fn registry_key(sound_id: &str) -> String {
+    sound_id.to_ascii_uppercase()
+}
+
+impl From<&SoundEntry> for EntryFacts {
+    fn from(entry: &SoundEntry) -> Self {
+        Self {
+            priority: i32::from(entry.priority),
+            limit: entry.limit,
+            control: entry.control,
+            loop_count: entry.loop_count,
+            delay_ms: entry.delay_ms,
+            entry_volume_linear: entry.volume_linear,
+        }
+    }
+}
+
+/// The arbiter facts for a sound id.
+///
+/// A name that is not a `[SoundList]` entry has no `VocClass` in gamemd and
+/// therefore plays nothing at all (`VocClass::PlayAt` bails on an invalid
+/// index). VERA keeps a labelled raw audio-bag fallback for EVA lines and
+/// other bag-only names; those get the `[Defaults]` `Priority=`/`Limit=` and
+/// no `Control=` bits, which is the closest thing to an entry they have.
+/// **VERA-internal, gamemd has no equivalent.** Trigger: a play call naming a
+/// bag sample rather than a `[SoundList]` id. Player effect: VERA plays it
+/// where gamemd is silent — pre-existing, and the EVA path depends on it.
+/// Frequency: every EVA line. Downstream risk: none beyond the extra cue.
+fn entry_facts(sound_id: &str, registry: &SoundRegistry) -> EntryFacts {
+    if let Some(entry) = registry.get(sound_id) {
+        return EntryFacts::from(entry);
+    }
+    let defaults = registry.defaults();
+    EntryFacts {
+        priority: i32::from(defaults.priority),
+        limit: defaults.limit,
+        control: 0,
+        loop_count: 0,
+        delay_ms: (0, 0),
+        entry_volume_linear: VOLUME_SCALE,
+    }
+}
+
 /// Device-free core of one play request: draw the shifts, select the
 /// samples, load and chain them, apply the pitch shift, and combine the entry
 /// volume with the `VShift=` reduction into the event's linear volume.
 fn resolve_entry_playback(
     entry: &SoundEntry,
     rng: &mut impl SampleRng,
+    load: impl FnMut(&str) -> Option<DecodedAudio>,
+) -> Option<ResolvedPlayback> {
+    resolve_entry_playback_pass(entry, rng, load, true)
+}
+
+/// [`resolve_entry_playback`] for one pass; `plays_attack` is
+/// `PreparePlayout`'s `flags & 8` test — see [`select_playout_pass`].
+fn resolve_entry_playback_pass(
+    entry: &SoundEntry,
+    rng: &mut impl SampleRng,
     mut load: impl FnMut(&str) -> Option<DecodedAudio>,
+    plays_attack: bool,
 ) -> Option<ResolvedPlayback> {
     if entry.sounds.is_empty() {
         return None;
     }
     let shifts = PlayShifts::draw(entry, rng);
-    let order = select_playout(entry, rng);
+    let order = select_playout_pass(entry, rng, plays_attack);
     let mut decoded: Option<DecodedAudio> = None;
     for index in order {
         let Some(name) = entry.sounds.get(index) else {
@@ -1428,6 +1880,7 @@ fn resolve_entry_playback(
     Some(ResolvedPlayback {
         decoded,
         event_linear: combine_linear(entry.volume_linear, shifts.volume_linear()),
+        shifts,
     })
 }
 
@@ -1500,42 +1953,6 @@ fn upmix_i16_to_f32_stereo(samples: &[i16], channels: u16) -> Vec<f32> {
                 [f, f]
             })
             .collect()
-    }
-}
-
-/// Apply a short linear fade-in and fade-out to interleaved samples.
-///
-/// Prevents audible click/pop artifacts from abrupt sample transitions.
-/// The fade duration is typically 2-5ms — imperceptible but eliminates clicks.
-fn apply_fade(samples: &mut [f32], sample_rate: u32, channels: u16, fade_ms: u32) {
-    if samples.is_empty() || fade_ms == 0 || sample_rate == 0 {
-        return;
-    }
-    let ch = channels.max(1) as usize;
-    // Number of *frames* to fade (one frame = all channels).
-    let fade_frames = (sample_rate as usize * fade_ms as usize / 1000).max(1);
-    let total_frames = samples.len() / ch;
-    // Don't fade if the sound is shorter than 2× fade duration.
-    if total_frames < fade_frames * 2 {
-        return;
-    }
-
-    // Fade in: ramp from 0.0 to 1.0 over the first fade_frames.
-    for frame in 0..fade_frames {
-        let scale = frame as f32 / fade_frames as f32;
-        for c in 0..ch {
-            samples[frame * ch + c] *= scale;
-        }
-    }
-
-    // Fade out: ramp from 1.0 to 0.0 over the last fade_frames.
-    let fade_out_start = total_frames - fade_frames;
-    for frame in 0..fade_frames {
-        let scale = 1.0 - (frame as f32 / fade_frames as f32);
-        let idx = (fade_out_start + frame) * ch;
-        for c in 0..ch {
-            samples[idx + c] *= scale;
-        }
     }
 }
 
@@ -2107,6 +2524,9 @@ mod tests {
         // 0x4000 - (13 << 14) / 100 = 16384 - 2129.
         assert_eq!(shifts.volume_linear(), 16384 - 2129);
         assert_eq!(shifts.shifted_sample_rate(22050), 22050 * 107 / 100);
+        // The draw is carried, not discarded: the arbiter parks the event in
+        // state 2 for this long.
+        assert_eq!(shifts.predelay_ms, 250);
 
         // AMBIENT pre-delays draw from 0x21 regardless of Delay.min.
         let ambient = entry("[T]\nSounds=a\nControl= loop ambient\nDelay=5000 8000\n");
@@ -2116,12 +2536,58 @@ mod tests {
         assert_eq!(shifts.frequency_pct, 100);
         assert_eq!(shifts.volume_linear(), VOLUME_SCALE);
         assert_eq!(shifts.shifted_sample_rate(22050), 22050);
+        assert_eq!(shifts.predelay_ms, 6000);
 
         // No shifts, no pre-delay control: nothing is drawn.
         let plain = entry("[T]\nSounds=a\nDelay=0 400\n");
         let mut rng = ScriptedRng::new(&[]);
-        PlayShifts::draw(&plain, &mut rng);
+        let shifts = PlayShifts::draw(&plain, &mut rng);
         assert!(rng.requests.is_empty());
+        assert_eq!(shifts.predelay_ms, 0);
+    }
+
+    /// The registry facts the arbiter arbitrates on come straight off the
+    /// `[SoundList]` entry, and a name that is not one falls back to
+    /// `[Defaults]`.
+    #[test]
+    fn entry_facts_carry_the_registry_priority_limit_control_and_loop() {
+        let registry = SoundRegistry::from_ini(&IniFile::from_str(
+            "[Defaults]\nLimit=5\nPriority=NORMAL\n\
+             [SoundList]\n1=RocketeerMoveLoop\n\
+             [RocketeerMoveLoop]\nSounds=a b c d e\n\
+             Control= loop random all decay attack\nPriority=Low\nLimit=3\nVolume=25\n",
+        ));
+        let facts = entry_facts("RocketeerMoveLoop", &registry);
+        assert_eq!(facts.priority, 1);
+        assert_eq!(facts.limit, 3);
+        assert_eq!(facts.loop_count, 0);
+        assert!(facts.control & control::LOOP != 0);
+        // `Loop=` absent with `Control=loop` is the owner-driven sustain that
+        // `AudioEventClass::IsLoopable @ 0x00406650` reports.
+        assert!(facts.is_loopable());
+
+        // `[Defaults] Limit=5` reaches a raw bag name through the fallback.
+        let bag = entry_facts("ImNotAnEntry", &registry);
+        assert_eq!(bag.limit, 5);
+        assert_eq!(bag.priority, 2);
+        assert!(!bag.is_loopable());
+    }
+
+    /// A one-shot `Control= random predelay` entry is not loopable, which is
+    /// what keeps a Grizzly's `MoveSound` a single start-up sample rather
+    /// than an engine hum: `[GTNK] MoveSound=GrizzlyTankMoveStart` and
+    /// `[GrizzlyTankMoveStart] Control= random predelay`, `Delay=0 400`.
+    #[test]
+    fn a_random_predelay_move_sound_is_not_a_sustained_loop() {
+        let registry = SoundRegistry::from_ini(&IniFile::from_str(
+            "[SoundList]\n1=GrizzlyTankMoveStart\n\
+             [GrizzlyTankMoveStart]\nSounds=vgristaa vgristab vgristac\n\
+             Control= random predelay\nDelay=0 400\nPriority=low\nVolume=40\n",
+        ));
+        let facts = entry_facts("GrizzlyTankMoveStart", &registry);
+        assert!(facts.control & control::LOOP == 0);
+        assert!(!facts.is_loopable());
+        assert_eq!(facts.delay_ms, (0, 400));
     }
 
     /// `Control=random` over three samples: one `RandomRanged(0, 2)` draw and
@@ -2264,6 +2730,9 @@ mod tests {
             voice_volume,
             lifecycle_scale,
             focus_output_scale,
+            // The limiter idles at full scale until the summed authored
+            // `Volume=` budget of the live events passes 100.
+            many_sounds_linear: VOLUME_SCALE,
         }
     }
 

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -883,6 +883,40 @@ struct LoopQueue {
     finished: bool,
 }
 
+/// The EVA/speech suspend counter, `g_VoxSuspendDepth (DAT_00b1d428)`.
+///
+/// `GamePause::Enter @ 0x00406F00` calls `VoxClass::PauseEVA @ 0x007535B0`
+/// unconditionally, which raises this counter (`DAT_00b1d428 += 1`) after
+/// pausing the sounding announcement; `GamePause::Exit @ 0x00406F40` calls
+/// `VoxClass::UnpauseEVA @ 0x00753620`, which lowers it with a floor of 0
+/// (`if (d != 0) { d -= 1; if (d < 0) d = 0; }`).
+///
+/// `VoxClass::PlayNextQueued @ 0x00752780` — the dequeue the pump runs every
+/// pass — gates its **entire** body on `DAT_00b1d428 == 0` (read at
+/// `0x007527D5`; `get_xrefs_to 0x00b1d428` shows the only other readers are
+/// `PauseEVA`/`UnpauseEVA`). So a paused game neither finishes the line it is
+/// speaking nor starts the next queued one.
+#[derive(Debug, Clone, Copy, Default)]
+struct VoiceSuspend {
+    depth: i32,
+}
+
+impl VoiceSuspend {
+    /// One `GamePause::Enter`/`Exit` edge.
+    fn set_paused(&mut self, paused: bool) {
+        if paused {
+            self.depth += 1;
+        } else if self.depth != 0 {
+            self.depth = (self.depth - 1).max(0);
+        }
+    }
+
+    /// `VoxClass::PlayNextQueued`'s `DAT_00b1d428 == 0` gate.
+    fn dequeue_allowed(&self) -> bool {
+        self.depth == 0
+    }
+}
+
 /// Manages sound effect playback with separate SFX pool and voice slot.
 ///
 /// Matches the original engine's architecture:
@@ -932,6 +966,8 @@ pub struct SfxPlayer {
     /// Whether the game is paused, so [`Self::set_paused`] only acts on the
     /// edge the way `GamePause::Enter`/`Exit` do.
     paused: bool,
+    /// `g_VoxSuspendDepth (DAT_00b1d428)`: the EVA/speech suspend counter.
+    voice_suspend: VoiceSuspend,
     /// Presentation-side RNG standing in for `g_MainRng @ 0x00886B88`.
     rng: SfxRng,
 }
@@ -958,6 +994,7 @@ impl SfxPlayer {
             output_scale: 1.0,
             focus_output_scale: 1.0,
             paused: false,
+            voice_suspend: VoiceSuspend::default(),
             rng: SfxRng::from_clock(),
         })
     }
@@ -1317,7 +1354,15 @@ impl SfxPlayer {
     }
 
     /// Starts the next queued EVA cue if the dedicated voice slot is idle.
+    ///
+    /// `VoxClass::PlayNextQueued @ 0x00752780` wraps its whole body in
+    /// `... && (DAT_00b1d428 == 0)` (`0x007527D5`), so while the game is
+    /// paused the queue does not advance and the slot is not even recycled.
+    /// The guard is first, as it is there.
     pub fn advance_voice_queue(&mut self) {
+        if !self.voice_suspend.dequeue_allowed() {
+            return;
+        }
         if self
             .voice_player
             .as_ref()
@@ -1637,6 +1682,16 @@ impl SfxPlayer {
     /// (`SoundSystem::SuspendAll @ 0x00404FD0`) and stopping the actively
     /// playing channels (`DSoundChannel::PauseAll @ 0x00403770`).
     ///
+    /// The EVA/speech stream is a **second, unconditional** half of the same
+    /// edge: `Enter` calls `VoxClass::PauseEVA @ 0x007535B0` (which reaches
+    /// `StreamPlayer::Pause` whenever an announcement is sounding, then
+    /// raises [`VoiceSuspend`]) and tail-calls `SpeechSystem::Pause @
+    /// 0x00753500` (`StreamPlayer::Pause` again for the speech stream);
+    /// `Exit` calls `SpeechSystem::Resume @ 0x00753510` then
+    /// `VoxClass::UnpauseEVA @ 0x00753620`. Neither call sits behind the
+    /// `FUN_0053bad0` gate that the SFX half does. VERA serves EVA and unit
+    /// voices from one slot, so both halves land on `voice_player`.
+    ///
     /// Idempotent — call it with the current pause state every frame.
     pub fn set_paused(&mut self, paused: bool, now_ms: u64) {
         self.now_ms = now_ms;
@@ -1644,14 +1699,21 @@ impl SfxPlayer {
             return;
         }
         self.paused = paused;
+        self.voice_suspend.set_paused(paused);
         if paused {
             self.arbiter.suspend_all(now_ms);
             for output in self.live.values() {
                 output.player.pause();
             }
+            if let Some(output) = self.voice_player.as_ref() {
+                output.player.pause();
+            }
         } else {
             self.arbiter.resume_all(now_ms);
             for output in self.live.values() {
+                output.player.play();
+            }
+            if let Some(output) = self.voice_player.as_ref() {
                 output.player.play();
             }
         }
@@ -2895,5 +2957,39 @@ mod tests {
     fn test_decode_pcm_empty() {
         let samples = decode_pcm(&[], 1, 16);
         assert!(samples.is_empty());
+    }
+
+    /// Pausing stops the EVA/speech stream **and** freezes the announcement
+    /// queue. `GamePause::Enter @ 0x00406F00` calls
+    /// `VoxClass::PauseEVA @ 0x007535B0` unconditionally, which raises
+    /// `DAT_00b1d428`, and `VoxClass::PlayNextQueued @ 0x00752780` refuses to
+    /// dequeue anything while that counter is non-zero (`0x007527D5`).
+    /// `VoxClass::UnpauseEVA @ 0x00753620` lowers it with a floor of 0.
+    ///
+    /// This pins the decision half. The matching `Player::pause()` on
+    /// `voice_player` is device-side and shares residual R7 with the rest of
+    /// the rodio plumbing.
+    #[test]
+    fn pausing_suspends_the_eva_queue_until_every_pause_is_lifted() {
+        let mut suspend = VoiceSuspend::default();
+        assert!(suspend.dequeue_allowed());
+
+        suspend.set_paused(true);
+        assert!(!suspend.dequeue_allowed());
+        suspend.set_paused(true);
+        assert!(!suspend.dequeue_allowed());
+
+        // Native's counter is a depth, not a flag: one resume is not enough.
+        suspend.set_paused(false);
+        assert!(!suspend.dequeue_allowed());
+        suspend.set_paused(false);
+        assert!(suspend.dequeue_allowed());
+
+        // `if (d != 0) { d -= 1; if (d < 0) d = 0; }` — an unmatched resume
+        // never drives the counter negative, so the next pause still blocks.
+        suspend.set_paused(false);
+        assert!(suspend.dequeue_allowed());
+        suspend.set_paused(true);
+        assert!(!suspend.dequeue_allowed());
     }
 }

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -3780,6 +3780,29 @@ impl Simulation {
         })
     }
 
+    /// Current world coordinate of whatever object holds one app-side loop
+    /// handle, whether that is an anim or a `MoveSound`-carrying entity.
+    ///
+    /// Read-only, and audio-agnostic: `sim/` never learns that a sound exists.
+    /// It exists because gamemd's owner re-drives its handle every update with
+    /// its own coordinate (`AnimClass::UpdateLoopingSound @ 0x00750D40`, whose
+    /// first argument is the owner's coords), and the app-side owner needs the
+    /// same value. Anim ids and entity stable ids come from one
+    /// `allocate_stable_id` counter — `spawn_anim_at_world` rejects a
+    /// collision against both maps — so one id names at most one object.
+    pub(crate) fn looping_sound_owner_coord(
+        &self,
+        id: crate::sim::anim_class::AnimId,
+    ) -> Option<crate::sim::anim_class::AnimWorldCoord> {
+        if let Some(coord) = self.anim_absolute_coord(id) {
+            return Some(coord);
+        }
+        self.substrate
+            .entities
+            .get(id)
+            .map(Self::movement_sound_world)
+    }
+
     pub(crate) fn movement_sound_world(
         entity: &crate::sim::game_entity::GameEntity,
     ) -> crate::sim::anim_class::AnimWorldCoord {


### PR DESCRIPTION
Phase 6, rows 149 (GSI-15.03 channels, interruption, looping and fades) and 148 (GSI-15.04 audio device, mixer and update cadence).

Before this branch VERA had no channel model at all: a fixed queue with first-in-first-out eviction that ignored `Priority=`, no `Limit=` enforcement, no looping sounds, and a three-millisecond fade constant with no provenance. The service pass also sat inside the simulation's `run_sim` block, so pausing the game froze the EVA queue.

## What gamemd does

Sixteen DirectSound channels (`AudioSystem::Init @ 0x00406B10` requests exactly 0x10 and disables output otherwise), 300 sound-event records, 127 stream blocks. Preemption is two-layer: at the channel level `FindAvailable @ 0x004035F0` takes an idle channel, else the lowest priority, with equal-priority ties needing an age gap of `0x666` and a refusal only when the newcomer is strictly lower; at the entry level `FindLowestPriority @ 0x00404E20` scans the priority-by-volume buckets and stops every event of the victim entry. `Limit=` is a per-entry counter culling the quietest instance, and `Control=interrupt` only flips that tie-break rather than cutting the previous sound. Sustain comes from `AdvancePlaylist @ 0x004047B0` restarting playout from the streaming callback, leashed to a handle the owner re-drives. The service loop runs off the network service loop behind a 33 ms gate, so menus and loading screens all pump it.

## Two corrections to the research this started from

The premise that a Grizzly hums while it drives is wrong: `[GTNK] MoveSound=GrizzlyTankMoveStart` is `Control= random predelay`, a single start-up sample per move order. Only the `*MoveLoop` entries sustain. And `FindLowestPriority`'s real trigger is sample-memory starvation, not channel starvation — driving it from channel starvation would have invented a mechanism gamemd lacks.

## Review history

Five critic rounds. Round one caught a regression this branch introduced: moving the pump out of the simulation block removed an accidental match with native, because gamemd pauses the speech stream and gates the EVA dequeue explicitly. That also overturned my own requirement text — gamemd cuts an EVA announcement mid-word on pause, including on every in-game menu open, and VERA now does the same.

Rounds three through five were documentary, and two of those findings were mine: I twice transcribed a critic's counts into a residual instead of deriving them, and twice got a self-inconsistent paragraph. The final round had a builder derive every number from the retail INI with a tokenizer matching the binary's own delimiter, and print the derivation so the next reader can re-run it.

## Structure

The native decision half lives in a new device-free `arbiter` module that emits actions the sink applies, because the sound player returns nothing without an audio device and would otherwise be untestable. Seventeen named tests cover the decisions; the sink half is covered by compilation only, which is stated plainly rather than implied.

Rows stay open on the recorded residuals, chiefly a second native sample loader (`SelectNextSample @ 0x00404BB0`) that serves entries above the pre-delay floor. It is invisible today because no ambient sound has a producer.

`cargo test -p vera20k --lib`: `test result: ok. 8134 passed; 0 failed; 75 ignored`. No golden moved; `sim/` gains one read-only accessor and no dependency on the audio layer.
