### PR TITLE
Phase 6: damage cues, unit voice feedback, and the capture line engineers never spoke

### DIFF
--- a/src/app/input/context_order.rs
+++ b/src/app/input/context_order.rs
@@ -178,10 +178,25 @@ fn emit_resolved_order_voice(state: &mut AppState, speaker_id: u64, queued: &[Co
 
 /// Resolve one `Voice*` slot on an object type, with the native fallbacks.
 ///
-/// The capture slot is the only one with a fallback in gamemd: `0x00708DCB CMP
-/// [type+0x55C],-1 ; JZ 0x00708DF1` sends an absent `VoiceCapture=` to the
-/// Enter-voice method at `0x00709020`, which reads `VoiceEnter=`
-/// (`TechnoTypeClass+0x558`).
+/// The capture and enter slots are the two with a fallback in gamemd, and they
+/// chain: `0x00708DCB CMP [type+0x55C],-1 ; JZ 0x00708DF1` sends an absent
+/// `VoiceCapture=` to the Enter-voice method at `0x00709020`, which reads
+/// `VoiceEnter=` (`TechnoTypeClass+0x558`) and, when *that* is the `-1`
+/// sentinel too (`0x0070902B CMP [EAX+0x558],-1 ; JZ 0x00709051`), calls
+/// `[vtable+0x368]` — `0x00708FC0` for the BuildingClass-family vtable at
+/// `0x007E3EBC` (`read_memory 0x007E4224` → `0x00708FC0`). That body is **not**
+/// silence: it reads the `VoiceMove=` sound list at `TechnoTypeClass+0x468`
+/// (`0x00712AB6 LEA EDI,[EBP+0x468]` in `TechnoTypeClass::ReadINI` passes key
+/// `"VoiceMove"` at `0x008442C0` to `CCINIClass::ReadSoundList @ 0x00525430`),
+/// skips only when its count at `+0x478` is zero
+/// (`0x00708FD6 TEST ECX,ECX ; JZ 0x00709014`), and otherwise queues
+/// `items[rand % count]` through `[vtable+0x354]`.
+///
+/// VERA models `VoiceMove=` as one id, not a list. No stock type authors a
+/// comma-separated `VoiceMove=` (0 of 148 occurrences in `ini/rulesmd.ini`),
+/// so the pick is observationally identical on retail; the `rand % count` draw
+/// native spends on RNG instance `0x00886B88` (`0x00708FE1 CALL 0x0065C780`)
+/// has no VERA counterpart. Recorded, not landed.
 fn voice_id_for_key<'a>(
     obj: &'a crate::rules::object_type::ObjectType,
     voice_field: &str,
@@ -190,8 +205,12 @@ fn voice_id_for_key<'a>(
         "VoiceMove" => obj.voice_move.as_ref(),
         "VoiceAttack" => obj.voice_attack.as_ref(),
         "VoiceHarvest" => obj.voice_harvest.as_ref(),
-        "VoiceCapture" => obj.voice_capture.as_ref().or(obj.voice_enter.as_ref()),
-        "VoiceEnter" => obj.voice_enter.as_ref(),
+        "VoiceCapture" => obj
+            .voice_capture
+            .as_ref()
+            .or(obj.voice_enter.as_ref())
+            .or(obj.voice_move.as_ref()),
+        "VoiceEnter" => obj.voice_enter.as_ref().or(obj.voice_move.as_ref()),
         "VoiceSpecialAttack" => obj.voice_special_attack.as_ref(),
         _ => None,
     }
@@ -1464,6 +1483,11 @@ mod tests {
     /// `TechnoClass::Queue_Voice @ 0x00708D90`) and only falls through to
     /// `VoiceEnter=` when the key is the `-1` sentinel. Before this, every
     /// stock engineer capture spoke the Enter line.
+    ///
+    /// The chain does not end at `VoiceEnter=`: an absent one sends
+    /// `0x00709020` to `[vtable+0x368]` = `0x00708FC0`, which draws from the
+    /// `VoiceMove=` list at `TechnoTypeClass+0x468` and is silent only when
+    /// that list is empty.
     #[test]
     fn capture_speaks_the_capture_slot_and_falls_back_to_enter() {
         use crate::rules::ini_parser::IniFile;
@@ -1509,9 +1533,25 @@ mod tests {
             Some("EngAllMove")
         );
 
-        // Neither key: silence, not the move line.
+        // Neither key: `0x0070902B` sends the Enter slot to `[vtable+0x368]`
+        // = `0x00708FC0`, which draws from the `VoiceMove=` list at
+        // `TechnoTypeClass+0x468`. Native does NOT go silent here.
         let neither = object("[ENGINEER]\nVoiceMove=EngAllMove\n");
-        assert_eq!(voice_id_for_key(&neither, "VoiceCapture"), None);
+        assert_eq!(
+            voice_id_for_key(&neither, "VoiceCapture").map(String::as_str),
+            Some("EngAllMove")
+        );
+        assert_eq!(
+            voice_id_for_key(&neither, "VoiceEnter").map(String::as_str),
+            Some("EngAllMove"),
+            "the Enter slot itself falls through to the move list"
+        );
+
+        // Silence needs the move list empty too — `0x00708FD6 TEST ECX,ECX ;
+        // JZ 0x00709014` is the only exit that plays nothing.
+        let nothing = object("[ENGINEER]\nStrength=100\n");
+        assert_eq!(voice_id_for_key(&nothing, "VoiceCapture"), None);
+        assert_eq!(voice_id_for_key(&nothing, "VoiceEnter"), None);
     }
 
     fn chord_rules() -> crate::rules::ruleset::RuleSet {

--- a/src/app/input/context_order.rs
+++ b/src/app/input/context_order.rs
@@ -92,17 +92,20 @@ pub(crate) fn resolve_order_modifiers(ctrl: bool, shift: bool, alt: bool) -> Ord
 /// Unload each have their own slot, and every other mission falls to a default
 /// branch that draws a random entry from the type's `VoiceSpecialAttack` list.
 ///
-/// Two retail slots have no VERA counterpart yet:
-/// * Capture has its **own** slot, verified: it reads the type's `VoiceCapture=`
-///   sound and speaks it, and only when the key is absent does it call the Enter
-///   slot instead. VERA now PARSES `VoiceCapture=` (`ObjectType::voice_capture`)
-///   but this router still has no arm for it, so capture keeps routing to the
-///   Enter slot — and every stock engineer ships the key, so every
-///   engineer capture order in ordinary play speaks the wrong line today
-///   (Allied `EngAllMove` instead of `EngAllAttackCommand`, Soviet `EngSovMove`
-///   instead of `EngSovAttackCommand`; Yuri's two keys happen to hold the same
-///   sound, so Yuri is unaffected). Recorded DRIFT, not equivalence: closing it
-///   needs a `VoiceCapture=` field on the object type.
+/// Capture has its **own** slot, and it is wired here now. The dispatcher at
+/// `0x00708DC0` reads the type's `VoiceCapture=` (`TechnoTypeClass+0x55C`) and
+/// queues it (`0x00708DE8 CALL [EDI+0x354]` = `TechnoClass::Queue_Voice @
+/// 0x00708D90`); only when that slot is the `-1` sentinel (`0x00708DCB CMP
+/// [EAX+0x55C],-1`) does it fall through to the Enter-voice method
+/// (`0x00708DF5 CALL [EDX+0x358]` = `0x00709020`, which reads
+/// `VoiceEnter=` at `+0x558` and itself falls through to `[+0x368]` when that
+/// is absent). Every stock engineer ships `VoiceCapture=`, so before this arm
+/// existed every engineer capture spoke the move line (Allied `EngAllMove`
+/// instead of `EngAllAttackCommand`, Soviet `EngSovMove` instead of
+/// `EngSovAttackCommand`; Yuri's two keys hold the same sound, so Yuri was
+/// unaffected).
+///
+/// One retail slot still has no VERA counterpart:
 /// * Deploy/unload plays `VoiceDeploy` / `VoiceUndeploy`, neither of which VERA
 ///   parses — those orders stay silent.
 ///
@@ -115,11 +118,11 @@ fn order_voice_key(command: &Command) -> Option<&'static str> {
             Some("VoiceAttack")
         }
         Command::HarvestCell { .. } => Some("VoiceHarvest"),
+        Command::CaptureBuilding { .. } => Some("VoiceCapture"),
         Command::MinerReturn { .. }
         | Command::EnterTransport { .. }
         | Command::RepairAtDepot { .. }
-        | Command::EnterBunker { .. }
-        | Command::CaptureBuilding { .. } => Some("VoiceEnter"),
+        | Command::EnterBunker { .. } => Some("VoiceEnter"),
         // Sabotage and area guard have no dedicated slot, so retail takes the
         // default branch and speaks a VoiceSpecialAttack line.
         Command::PlantC4 { .. } | Command::Guard { .. } => Some("VoiceSpecialAttack"),
@@ -173,6 +176,27 @@ fn emit_resolved_order_voice(state: &mut AppState, speaker_id: u64, queued: &[Co
     emit_entity_order_voice(state, speaker_id, voice_field);
 }
 
+/// Resolve one `Voice*` slot on an object type, with the native fallbacks.
+///
+/// The capture slot is the only one with a fallback in gamemd: `0x00708DCB CMP
+/// [type+0x55C],-1 ; JZ 0x00708DF1` sends an absent `VoiceCapture=` to the
+/// Enter-voice method at `0x00709020`, which reads `VoiceEnter=`
+/// (`TechnoTypeClass+0x558`).
+fn voice_id_for_key<'a>(
+    obj: &'a crate::rules::object_type::ObjectType,
+    voice_field: &str,
+) -> Option<&'a String> {
+    match voice_field {
+        "VoiceMove" => obj.voice_move.as_ref(),
+        "VoiceAttack" => obj.voice_attack.as_ref(),
+        "VoiceHarvest" => obj.voice_harvest.as_ref(),
+        "VoiceCapture" => obj.voice_capture.as_ref().or(obj.voice_enter.as_ref()),
+        "VoiceEnter" => obj.voice_enter.as_ref(),
+        "VoiceSpecialAttack" => obj.voice_special_attack.as_ref(),
+        _ => None,
+    }
+}
+
 /// Play one entity's voice line for the given `Voice*` INI key.
 ///
 /// The superseded app-layer order-voice helper always spoke the lowest-`stable_id` selected
@@ -196,21 +220,17 @@ fn emit_entity_order_voice(state: &mut AppState, speaker_id: u64, voice_field: &
     let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref)) else {
         return;
     };
-    let voice_id: Option<&String> = match voice_field {
-        "VoiceMove" => obj.voice_move.as_ref(),
-        "VoiceAttack" => obj.voice_attack.as_ref(),
-        "VoiceHarvest" => obj.voice_harvest.as_ref(),
-        "VoiceEnter" => obj.voice_enter.as_ref(),
-        "VoiceSpecialAttack" => obj.voice_special_attack.as_ref(),
-        _ => None,
+    let Some(id) = voice_id_for_key(obj, voice_field) else {
+        return;
     };
-    let Some(id) = voice_id else { return };
     let event = if voice_field == "VoiceAttack" {
         crate::audio::events::GameSoundEvent::UnitAttackOrder {
+            speaker_id,
             sound_id: id.clone(),
         }
     } else {
         crate::audio::events::GameSoundEvent::UnitMoveOrder {
+            speaker_id,
             sound_id: id.clone(),
         }
     };
@@ -1437,6 +1457,61 @@ mod tests {
             }),
             Some("VoiceSpecialAttack")
         );
+    }
+
+    /// A capture order takes the type's own `VoiceCapture=` slot
+    /// (`0x00708DC0` reads `TechnoTypeClass+0x55C` and queues it through
+    /// `TechnoClass::Queue_Voice @ 0x00708D90`) and only falls through to
+    /// `VoiceEnter=` when the key is the `-1` sentinel. Before this, every
+    /// stock engineer capture spoke the Enter line.
+    #[test]
+    fn capture_speaks_the_capture_slot_and_falls_back_to_enter() {
+        use crate::rules::ini_parser::IniFile;
+        use crate::rules::object_type::{ObjectCategory, ObjectType};
+
+        assert_eq!(
+            order_voice_key(&Command::CaptureBuilding {
+                engineer_id: 1,
+                target_building_id: 2,
+            }),
+            Some("VoiceCapture"),
+            "capture has its own slot, it does not share the Enter slot"
+        );
+
+        let object = |body: &str| {
+            let ini = IniFile::from_str(body);
+            ObjectType::from_ini_section(
+                "ENGINEER",
+                ini.section("ENGINEER").unwrap(),
+                ObjectCategory::Infantry,
+            )
+        };
+
+        // Stock Allied engineer: both keys present, capture wins.
+        let stock = object(
+            "[ENGINEER]\nVoiceMove=EngAllMove\nVoiceEnter=EngAllMove\n\
+             VoiceCapture=EngAllAttackCommand\n",
+        );
+        assert_eq!(
+            voice_id_for_key(&stock, "VoiceCapture").map(String::as_str),
+            Some("EngAllAttackCommand")
+        );
+        assert_eq!(
+            voice_id_for_key(&stock, "VoiceEnter").map(String::as_str),
+            Some("EngAllMove"),
+            "an ordinary Enter order is unaffected"
+        );
+
+        // `VoiceCapture=` absent: `0x00708DCB` falls through to the Enter slot.
+        let no_capture = object("[ENGINEER]\nVoiceMove=EngAllMove\nVoiceEnter=EngAllMove\n");
+        assert_eq!(
+            voice_id_for_key(&no_capture, "VoiceCapture").map(String::as_str),
+            Some("EngAllMove")
+        );
+
+        // Neither key: silence, not the move line.
+        let neither = object("[ENGINEER]\nVoiceMove=EngAllMove\n");
+        assert_eq!(voice_id_for_key(&neither, "VoiceCapture"), None);
     }
 
     fn chord_rules() -> crate::rules::ruleset::RuleSet {

--- a/src/app/input/dispatch.rs
+++ b/src/app/input/dispatch.rs
@@ -1310,6 +1310,18 @@ fn dispatch_retail_hotkey(state: &mut AppState, command: HotkeyCommand) {
         | HotkeyCommand::NextObject
         | HotkeyCommand::CombatantSelect
         | HotkeyCommand::VeterancyNav => {}
+        // UNCHECKED residual, all still no-ops. Three of them are audio
+        // triggers whose rules keys VERA already parses or could:
+        // `PlaceBeacon` should place the beacon and play `[AudioVisual]
+        // PlaceBeaconSound` (`Rules+0x1CC`, stock `BeaconPlaced`),
+        // `AllToCheer` should run the cheer animation and play `CheerSound`
+        // (`Rules+0x1C8`, stock `Cheer`), and `Taunt(n)` should broadcast the
+        // multiplayer taunt sample. None of their native command handlers was
+        // read this session, so no mapping is asserted and nothing is wired.
+        // Trigger: pressing the bound key. Player effect: the key does
+        // nothing. Frequency: rare in skirmish — all three are multiplayer
+        // social commands. Downstream risk: beacons and taunts are network
+        // messages, so they belong with `net/`, not with this row.
         HotkeyCommand::ToggleAlliance
         | HotkeyCommand::PlaceBeacon
         | HotkeyCommand::AllToCheer
@@ -2157,7 +2169,7 @@ mod item83_selection_order_tests {
                 .iter()
                 .filter_map(|id| selection_voice_event(&sim, &rules, *id))
                 .map(|event| match event {
-                    GameSoundEvent::UnitSelected { sound_id } => sound_id,
+                    GameSoundEvent::UnitSelected { sound_id, .. } => sound_id,
                     other => panic!("unexpected selection event: {other:?}"),
                 })
                 .collect::<Vec<_>>()
@@ -2543,6 +2555,7 @@ fn selection_voice_event(
     let entity = sim.entities().get(entity_id)?;
     let object = rules.object(sim.interner.resolve(entity.type_ref))?;
     Some(GameSoundEvent::UnitSelected {
+        speaker_id: entity_id,
         sound_id: object.voice_select.clone()?,
     })
 }

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -46,6 +46,34 @@ fn wall_sell_sound_for_local(
     })
 }
 
+/// The `[AudioVisual] BaseUnderAttackSound` siren that follows an accepted
+/// under-attack EVA line.
+///
+/// `HouseClass::NotifyUnderAttack`: the shared tail at
+/// `0x004F95B8..0x004F95CF` loads `Rules+0x184` and plays it through
+/// `VocClass::PlayAtPos @ 0x00750920` with pan `0x2000` and volume `1.0f`,
+/// immediately after the EVA call at `0x004F95B3`. The ore-miner branch at
+/// `0x004F94FB` plays its own EVA and then `goto LAB_004F95D4`, jumping past
+/// the siren — so a harvester under attack is announced but not sirened.
+/// Callers apply the `CreateRadarEvent @ 0x0065FA70` accept gate
+/// (`0x004F95A5`) before reaching here.
+fn base_under_attack_siren(
+    miner: bool,
+    rules: &crate::rules::ruleset::RuleSet,
+) -> Option<GameSoundEvent> {
+    if miner {
+        return None;
+    }
+    let sound_id = rules
+        .general
+        .base_under_attack_sound
+        .as_deref()
+        .filter(|id| !id.is_empty())?;
+    Some(GameSoundEvent::BaseUnderAttackSfx {
+        sound_id: sound_id.to_string(),
+    })
+}
+
 /// Persist and consume the in-memory deterministic diagnostic log.
 ///
 /// The log lives on the app-owned diagnostics owner (F10) and is appended
@@ -1145,8 +1173,22 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         }
                     }
                     SimSoundEvent::DockDeploy { .. } => {
-                        // TODO: resolve building's deploy sound from art.ini
-                        // and select healthy/damaged variant based on health ratio.
+                        // UNCHECKED residual, deliberately silent. This variant
+                        // has no producer: nothing in `sim/` pushes it, and
+                        // `miner_tests::linked_to_pivoting_then_unloading_on_pad_arrival`
+                        // pins that stock unload-start emits none. No native
+                        // counterpart was found either — a refinery has no
+                        // building-side dock cue. `[GAREFN]`'s art carries
+                        // `ActiveAnim`/`SpecialAnim` with no `StartSound=`, and
+                        // stock `DeploySound=` appears on the three MCVs and
+                        // `[SMIN]` only, never on a refinery. What is audible
+                        // in a retail dock cycle is the miner's own
+                        // `MoveSound=` (landed) and the departure cue
+                        // `RefineryExitSfx` (landed).
+                        // Trigger: none today. Player effect: none.
+                        // Frequency: never. Downstream risk: the variant is
+                        // dead sim surface; deleting it needs a `SimSoundEvent`
+                        // change nobody currently depends on.
                         continue;
                     }
                     SimSoundEvent::ChronoTeleport { sound_id, rx, ry } => {
@@ -1233,12 +1275,66 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         GameSoundEvent::BuildingReady { sound_id }
                     }
                     SimSoundEvent::SuperWeaponLaunched { .. } => {
-                        // TODO: play EVA superweapon warning sound.
+                        // UNCHECKED residual, still silent. The producer is
+                        // live (six emitters: force shield, genetic converter,
+                        // iron curtain, lightning storm, paradrop, psychic
+                        // reveal) but the event carries no superweapon
+                        // discriminator, and native's launch cue is
+                        // per-weapon, not global: `[AudioVisual]` holds
+                        // `PsychicDominatorActivateSound` (`Rules+0x24C`),
+                        // `GeneticMutatorActivateSound` (`+0x250`) and
+                        // `PsychicRevealActivateSound` (`+0x254`) from
+                        // `RulesClass::ReadAudioVisual @ 0x006691E0`, and
+                        // `evamd.ini` holds `EVA_IronCurtainActivated`,
+                        // `EVA_ChronosphereActivated`,
+                        // `EVA_LightningStormCreated`,
+                        // `EVA_PsychicDominatorActivated`,
+                        // `EVA_GeneticMutatorActivated` and
+                        // `EVA_ForceShieldActivated`. The reader sites that
+                        // bind each cue to its launch were NOT isolated, so no
+                        // mapping is asserted here.
+                        // Trigger: every superweapon launch. Player effect: the
+                        // launch is silent — no siren, no EVA line. Frequency:
+                        // once per superweapon per recharge (10 min stock),
+                        // i.e. a handful per long game. Downstream risk: the
+                        // fix needs a `kind` field on the sim event, so it
+                        // touches all six emitters.
                         continue;
                     }
-                    SimSoundEvent::SuperWeaponStrike { .. } => {
-                        // TODO: play lightning bolt thunder sound.
-                        continue;
+                    SimSoundEvent::SuperWeaponStrike { rx, ry } => {
+                        // `LightningStorm::GroundStrike @
+                        // 0x0053A45F..0x0053A4A2`: an empty `LightningSounds=`
+                        // list plays nothing (`0x0053A46A TEST ECX,ECX ; JLE`),
+                        // otherwise one entry is drawn and played at the strike
+                        // coordinate through `VocClass::PlayAt @ 0x007509E0`.
+                        let choices = &resources.rules.general.lightning_sounds;
+                        if choices.is_empty() {
+                            continue;
+                        }
+                        // DRIFT, recorded: native's index comes from the
+                        // SCENARIO RNG (`0x0053A46E MOV EDX,[g_ScenarioClass
+                        // @ 0x00A8B230]; LEA ECX,[EDX+0x218]; CALL 0x0065C780`,
+                        // then `0x0053A48D DIV [Rules+0x744]`), so gamemd
+                        // spends one deterministic draw per bolt. VERA draws
+                        // from the presentation RNG instead, the same one
+                        // `audio::sfx` already uses for sample selection.
+                        // Trigger: every lightning bolt. Player effect: none on
+                        // retail — stock `LightningSounds=WeatherStrike` is a
+                        // one-entry list, so `rand % 1` is 0 either way and the
+                        // same cue plays. Frequency: several bolts per storm.
+                        // Downstream risk: VERA's scenario stream sits one draw
+                        // ahead of gamemd's from the first bolt onward, and a
+                        // modded multi-entry list would pick a different entry.
+                        // Closing it means selecting the entry in `sim/` and
+                        // re-baselining whatever goldens the extra draw moves.
+                        let index = match state.audio.sfx_player.as_mut() {
+                            Some(player) => player.pick_index(choices.len()),
+                            None => continue,
+                        };
+                        GameSoundEvent::LightningStrike {
+                            sound_id: choices[index].clone(),
+                            source: Some(sound_source_at_cell(rx, ry)),
+                        }
                     }
                     SimSoundEvent::UnitComplete { owner } => {
                         let owner_str = sim.interner.resolve(owner);
@@ -1526,7 +1622,15 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             .get(cue, faction)
                             .unwrap_or(fallback)
                             .to_string();
-                        GameSoundEvent::UnderAttackEva { eva_sound_id }
+                        state
+                            .match_state
+                            .match_audio
+                            .sound_events
+                            .push(GameSoundEvent::UnderAttackEva { eva_sound_id });
+                        if let Some(siren) = base_under_attack_siren(miner, &resources.rules) {
+                            state.match_state.match_audio.sound_events.push(siren);
+                        }
+                        continue;
                     }
                     SimSoundEvent::WorldEffectStarted {
                         sound_id,
@@ -2225,9 +2329,10 @@ pub(crate) fn rules_hash(rules: &crate::rules::ruleset::RuleSet) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        ExactStepError, ExactStepReceipt, append_fire_effect_batch, begin_fire_effect_batch,
-        cloak_sound_for_app, finish_fire_effect_batch, outcome_eva_entry, upsert_overlay_entries,
-        validate_exact_step_receipt, wall_sell_sound_for_local, world_point_to_cell,
+        ExactStepError, ExactStepReceipt, append_fire_effect_batch, base_under_attack_siren,
+        begin_fire_effect_batch, cloak_sound_for_app, finish_fire_effect_batch, outcome_eva_entry,
+        upsert_overlay_entries, validate_exact_step_receipt, wall_sell_sound_for_local,
+        world_point_to_cell,
     };
     use crate::map::entities::EntityCategory;
     use crate::map::overlay::OverlayEntry;
@@ -2302,6 +2407,36 @@ mod tests {
         assert!(
             wall_sell_sound_for_local(receiver_name, Some("Receiver"), Some(&no_sound)).is_none()
         );
+    }
+
+    /// `HouseClass::NotifyUnderAttack`: the base siren rides the shared tail
+    /// (`0x004F95CF`), and the ore-miner branch at `0x004F94FB` jumps past it.
+    #[test]
+    fn base_under_attack_siren_skips_the_ore_miner_branch() {
+        let rules =
+            crate::rules::ruleset::RuleSet::from_ini(&crate::rules::ini_parser::IniFile::from_str(
+                "[General]\nFixtureOnly=1\n[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n\
+                 [BuildingTypes]\n[AudioVisual]\nBaseUnderAttackSound=BaseUnderAttackSiren\n",
+            ))
+            .unwrap();
+
+        assert!(matches!(
+            base_under_attack_siren(false, &rules),
+            Some(crate::audio::events::GameSoundEvent::BaseUnderAttackSfx { sound_id })
+                if sound_id == "BaseUnderAttackSiren"
+        ));
+        assert!(
+            base_under_attack_siren(true, &rules).is_none(),
+            "0x004F94FB goes straight to LAB_004F95D4, so a harvester gets no siren"
+        );
+
+        let no_key =
+            crate::rules::ruleset::RuleSet::from_ini(&crate::rules::ini_parser::IniFile::from_str(
+                "[General]\nFixtureOnly=1\n[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n\
+                 [BuildingTypes]\n",
+            ))
+            .unwrap();
+        assert!(base_under_attack_siren(false, &no_key).is_none());
     }
 
     #[test]

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -53,7 +53,8 @@ fn wall_sell_sound_for_local(
 /// `0x004F95B8..0x004F95CF` loads `Rules+0x184` and plays it through
 /// `VocClass::PlayAtPos @ 0x00750920` with pan `0x2000` and volume `1.0f`,
 /// immediately after the EVA call at `0x004F95B3`. The ore-miner branch at
-/// `0x004F94FB` plays its own EVA and then `goto LAB_004F95D4`, jumping past
+/// `0x004F94FB` plays its own EVA and then jumps (`0x004F9500 JMP`) to
+/// `LAB_004F95D4`, past
 /// the siren — so a harvester under attack is announced but not sirened.
 /// Callers apply the `CreateRadarEvent @ 0x0065FA70` accept gate
 /// (`0x004F95A5`) before reaching here.
@@ -1178,11 +1179,19 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         // `miner_tests::linked_to_pivoting_then_unloading_on_pad_arrival`
                         // pins that stock unload-start emits none. No native
                         // counterpart was found either — a refinery has no
-                        // building-side dock cue. `[GAREFN]`'s art carries
-                        // `ActiveAnim`/`SpecialAnim` with no `StartSound=`, and
-                        // stock `DeploySound=` appears on the three MCVs and
-                        // `[SMIN]` only, never on a refinery. What is audible
-                        // in a retail dock cycle is the miner's own
+                        // building-side dock cue. None of `[GAREFN]`,
+                        // `[NAREFN]`, `[YAREFN]` carries a `StartSound=` in
+                        // `artmd.ini` (their `ActiveAnim`/`ActiveAnimTwo..Four`
+                        // /`SpecialAnim` entries are silent) or any sound key
+                        // in `rulesmd.ini` except one: `[YAREFN]` — the
+                        // deployed Slave Miner, which *is* a refinery-category
+                        // building — carries
+                        // `DeploySound=SlaveMinerUndeploy` (rulesmd 13298).
+                        // That is an undeploy cue, not a dock cue. The full
+                        // stock `DeploySound=` set is `[E1]`, `[GGI]`,
+                        // `[AMCV]`, `[SMCV]`, `[PCV]`, `[SMIN]`, `[YAREFN]`
+                        // plus the empty `[AudioVisual]` default. What is
+                        // audible in a retail dock cycle is the miner's own
                         // `MoveSound=` (landed) and the departure cue
                         // `RefineryExitSfx` (landed).
                         // Trigger: none today. Player effect: none.
@@ -1275,12 +1284,20 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         GameSoundEvent::BuildingReady { sound_id }
                     }
                     SimSoundEvent::SuperWeaponLaunched { .. } => {
-                        // UNCHECKED residual, still silent. The producer is
-                        // live (six emitters: force shield, genetic converter,
+                        // UNCHECKED residual, still silent, and the NEXT slice
+                        // of this row — not another row's work.
+                        //
+                        // The blocker is evidence, not plumbing: adding a
+                        // `kind` discriminator to the sim event and touching
+                        // the six emitters (force shield, genetic converter,
                         // iron curtain, lightning storm, paradrop, psychic
-                        // reveal) but the event carries no superweapon
-                        // discriminator, and native's launch cue is
-                        // per-weapon, not global: `[AudioVisual]` holds
+                        // reveal) is a small in-scope change and is exactly
+                        // what gameplay-to-audio trigger routing is for. What
+                        // is missing is the native binding: nothing read here
+                        // proves which cue fires on *launch* as opposed to
+                        // ready or impact, and shipping a guessed mapping is
+                        // worse than a recorded silence. Native's launch cue
+                        // is per-weapon, not global: `[AudioVisual]` holds
                         // `PsychicDominatorActivateSound` (`Rules+0x24C`),
                         // `GeneticMutatorActivateSound` (`+0x250`) and
                         // `PsychicRevealActivateSound` (`+0x254`) from
@@ -1296,9 +1313,9 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         // Trigger: every superweapon launch. Player effect: the
                         // launch is silent — no siren, no EVA line. Frequency:
                         // once per superweapon per recharge (10 min stock),
-                        // i.e. a handful per long game. Downstream risk: the
-                        // fix needs a `kind` field on the sim event, so it
-                        // touches all six emitters.
+                        // i.e. a handful per long game. Downstream risk: none
+                        // beyond the six-emitter edit itself; the work is
+                        // isolating each cue's native callsite first.
                         continue;
                     }
                     SimSoundEvent::SuperWeaponStrike { rx, ry } => {
@@ -1322,9 +1339,13 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         // retail — stock `LightningSounds=WeatherStrike` is a
                         // one-entry list, so `rand % 1` is 0 either way and the
                         // same cue plays. Frequency: several bolts per storm.
-                        // Downstream risk: VERA's scenario stream sits one draw
-                        // ahead of gamemd's from the first bolt onward, and a
-                        // modded multi-entry list would pick a different entry.
+                        // Downstream risk: gamemd spends one scenario draw
+                        // per bolt that VERA never spends, so VERA's scenario
+                        // stream runs one draw BEHIND from the first bolt
+                        // onward. On stock data VERA spends no draw at all —
+                        // `pick_index` short-circuits at `count <= 1` — and a
+                        // modded multi-entry list would also pick a different
+                        // entry.
                         // Closing it means selecting the entry in `sim/` and
                         // re-baselining whatever goldens the extra draw moves.
                         let index = match state.audio.sfx_player.as_mut() {
@@ -1499,6 +1520,24 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             _ => continue,
                         };
                         GameSoundEvent::RefineryExitSfx {
+                            sound_id,
+                            source: Some(sound_source_at_cell(rx, ry)),
+                        }
+                    }
+                    SimSoundEvent::BuildingDamagedSfx { rx, ry } => {
+                        // `[AudioVisual] BuildingDamageSound` (`Rules+0x714`),
+                        // played at the building's own coordinate by
+                        // `BuildingClass::ReceiveDamage @ 0x00442700` /
+                        // `0x00442706 CALL VocClass::PlayAtCoord @ 0x00750E20`.
+                        // `RulesClass::ReadAudioVisual` stores only the
+                        // `VocClass::FindByName` result, so an absent or empty
+                        // key is silence rather than a bag lookup.
+                        let sound_id =
+                            match resources.rules.general.building_damage_sound.as_deref() {
+                                Some(s) if !s.is_empty() => s.to_string(),
+                                _ => continue,
+                            };
+                        GameSoundEvent::BuildingDamagedSfx {
                             sound_id,
                             source: Some(sound_source_at_cell(rx, ry)),
                         }
@@ -2410,7 +2449,8 @@ mod tests {
     }
 
     /// `HouseClass::NotifyUnderAttack`: the base siren rides the shared tail
-    /// (`0x004F95CF`), and the ore-miner branch at `0x004F94FB` jumps past it.
+    /// (`0x004F95CF`), and the ore-miner branch (EVA call `0x004F94FB`,
+    /// `JMP` at `0x004F9500`) jumps past it.
     #[test]
     fn base_under_attack_siren_skips_the_ore_miner_branch() {
         let rules =
@@ -2427,7 +2467,7 @@ mod tests {
         ));
         assert!(
             base_under_attack_siren(true, &rules).is_none(),
-            "0x004F94FB goes straight to LAB_004F95D4, so a harvester gets no siren"
+            "0x004F9500 jumps straight to LAB_004F95D4, so a harvester gets no siren"
         );
 
         let no_key =

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -16,6 +16,23 @@ use crate::app::input::commands::{preferred_local_owner, preferred_local_owner_n
 /// Minimum ticks between under-attack EVA voice lines (~30 s at 67 ms/tick).
 /// The native per-house attack-voice repeat delay is UNVERIFIED-pending-trace.
 const EVA_UNDER_ATTACK_COOLDOWN_TICKS: u64 = 450;
+/// Chance in 100 that a techno speaks its `VoiceFeedback=` line on the
+/// half-strength crossing. `TechnoClass::ReceiveDamage @ 0x007026BD
+/// CMP EAX,0x1E ; JGE` against `RandomRanged(0, 99)` — the cue speaks for a
+/// draw of 0..=29. Hardcoded in the binary, not an INI key.
+const VOICE_FEEDBACK_PERCENT: i32 = 0x1E;
+
+/// `TechnoClass::ReceiveDamage @ 0x00702695`'s two post-list gates, in native
+/// order: the roll at `0x007026BD CMP EAX,0x1E ; JGE 0x007027F7` against
+/// `RandomRanged(0, 99)`, then `HouseClass::IsHumanPlayer @ 0x0050B6F0` at
+/// `0x007026C6` — which for `g_GameMode != 0` (skirmish and multiplayer) is
+/// `house == g_PlayerPtr`, the local player alone.
+///
+/// The caller must have drawn `roll` already whatever the owner is: native
+/// spends the draw at `0x007026B3`, before it loads `[ESI+0x21C]`.
+fn voice_feedback_speaks(roll: i32, owner_is_local_human: bool) -> bool {
+    roll < VOICE_FEEDBACK_PERCENT && owner_is_local_human
+}
 use crate::app::types::SIM_TICK_HZ;
 use crate::app::types::SIM_TICK_MS;
 use crate::assets::asset_manager::AssetManager;
@@ -1542,6 +1559,67 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
+                    SimSoundEvent::VoiceFeedback {
+                        owner,
+                        type_ref,
+                        rx,
+                        ry,
+                    } => {
+                        // `TechnoClass::ReceiveDamage @ 0x00701900`, arm
+                        // `0x00702695`. `sim/` has already applied the two
+                        // gates that are deterministic — result 2 (the
+                        // `Strength >> 1` crossing) and a non-empty
+                        // `VoiceFeedback=` list (`0x007026A1`/`0x007026A9`).
+                        // What is left runs in native's exact order.
+                        //
+                        // 1. `0x007026B3` `RandomRanged(0, 99)` on
+                        //    `g_MainRng @ 0x00886B88`, `0x007026BD CMP
+                        //    EAX,0x1E ; JGE` — speaks on 0..=29. Native spends
+                        //    this draw for every house, so it is drawn before
+                        //    the owner gate here too.
+                        let Some(player) = state.audio.sfx_player.as_mut() else {
+                            continue;
+                        };
+                        let roll = player.roll_percent();
+                        // 2. `0x007026C6 MOV ECX,[ESI+0x21C]` / `CALL
+                        //    HouseClass::IsHumanPlayer @ 0x0050B6F0`. With
+                        //    `g_GameMode != 0` (skirmish/multiplayer) that
+                        //    function is `house == g_PlayerPtr`, so only the
+                        //    local player's objects speak.
+                        let owner_str = sim.interner.resolve(owner);
+                        let owner_is_local_human = local_owner_name
+                            .as_deref()
+                            .is_some_and(|local| local.eq_ignore_ascii_case(owner_str));
+                        if !voice_feedback_speaks(roll, owner_is_local_human) {
+                            continue;
+                        }
+                        // 3. `0x007026DE CALL 0x0065C780` / `0x007026E7 DIV
+                        //    [EDI+0x4E8]` picks `items[rand % count]`.
+                        //    RESIDUAL: VERA models `VoiceFeedback=` as one id
+                        //    where native holds a `CCINIClass::ReadSoundList`
+                        //    vector, so no draw is spent here. Trigger: every
+                        //    spoken line. Player effect: none on retail — all
+                        //    133 `VoiceFeedback=` authors in `rulesmd.ini` are
+                        //    single-entry (0 contain a comma), so `rand % 1`
+                        //    is 0 either way. Frequency: every half-health
+                        //    crossing that passes the roll. Downstream risk:
+                        //    none for lockstep — `g_MainRng` is not
+                        //    synchronised — but a modded comma list would pick
+                        //    the wrong entry. Same divergence as the
+                        //    `VoiceMove=` one recorded on `voice_id_for_key`.
+                        let sound_id = match resources
+                            .rules
+                            .object(sim.interner.resolve(type_ref))
+                            .and_then(|object| object.voice_feedback.as_deref())
+                        {
+                            Some(s) if !s.is_empty() => s.to_string(),
+                            _ => continue,
+                        };
+                        GameSoundEvent::VoiceFeedback {
+                            sound_id,
+                            source: Some(sound_source_at_cell(rx, ry)),
+                        }
+                    }
                     SimSoundEvent::BunkerWallsUp { rx, ry } => {
                         // Walls-up cue on install; skip when the rules key is empty.
                         let sound_id = match Some(&resources.rules)
@@ -2368,9 +2446,10 @@ pub(crate) fn rules_hash(rules: &crate::rules::ruleset::RuleSet) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        ExactStepError, ExactStepReceipt, append_fire_effect_batch, base_under_attack_siren,
-        begin_fire_effect_batch, cloak_sound_for_app, finish_fire_effect_batch, outcome_eva_entry,
-        upsert_overlay_entries, validate_exact_step_receipt, wall_sell_sound_for_local,
+        ExactStepError, ExactStepReceipt, VOICE_FEEDBACK_PERCENT, append_fire_effect_batch,
+        base_under_attack_siren, begin_fire_effect_batch, cloak_sound_for_app,
+        finish_fire_effect_batch, outcome_eva_entry, upsert_overlay_entries,
+        validate_exact_step_receipt, voice_feedback_speaks, wall_sell_sound_for_local,
         world_point_to_cell,
     };
     use crate::map::entities::EntityCategory;
@@ -2477,6 +2556,44 @@ mod tests {
             ))
             .unwrap();
         assert!(base_under_attack_siren(false, &no_key).is_none());
+    }
+
+    /// `TechnoClass::ReceiveDamage @ 0x00702695`, the `VoiceFeedback=` arm:
+    /// `0x007026BD CMP EAX,0x1E ; JGE 0x007027F7` against
+    /// `RandomRanged(0, 99)`, then `HouseClass::IsHumanPlayer @ 0x0050B6F0`.
+    #[test]
+    fn the_damage_voice_speaks_on_a_roll_under_thirty_and_only_for_the_local_owner() {
+        // `JGE 0x1E` — 0..=29 speak (30 in 100), 30..=99 fall to the tail.
+        assert!(voice_feedback_speaks(0, true));
+        assert!(voice_feedback_speaks(29, true));
+        assert!(!voice_feedback_speaks(30, true));
+        assert!(!voice_feedback_speaks(99, true));
+
+        // `0x007026C6 MOV ECX,[ESI+0x21C]` / `IsHumanPlayer`: an AI's or an
+        // opponent's object never speaks, however the roll landed.
+        assert!(!voice_feedback_speaks(0, false));
+        assert!(!voice_feedback_speaks(29, false));
+        assert!(!voice_feedback_speaks(30, false));
+    }
+
+    /// The roll itself is `RandomRanged(0, 99)` (`0x007026AF PUSH 0x63 ;
+    /// PUSH 0x0`), and `Random__RandomRanged @ 0x0065C7E0` only skips the draw
+    /// when its two endpoints are equal — so unlike `SfxPlayer::pick_index`
+    /// this one always advances the generator.
+    #[test]
+    fn the_damage_voice_roll_covers_the_native_range_at_the_native_rate() {
+        let mut rng = crate::audio::sfx::SfxRng::seeded(0x5EED);
+        let mut speaks = 0usize;
+        for _ in 0..10_000 {
+            let roll = crate::audio::sfx::SampleRng::ranged(&mut rng, 0, 99);
+            assert!((0..=99).contains(&roll), "roll {roll} left [0, 99]");
+            if roll < VOICE_FEEDBACK_PERCENT {
+                speaks += 1;
+            }
+        }
+        // 30 in 100. The band is wide on purpose: this pins what the 0x1E
+        // threshold means, not the generator behind it.
+        assert!((2_600..3_400).contains(&speaks), "spoke {speaks} of 10000");
     }
 
     #[test]

--- a/src/app/presentation/building_anim.rs
+++ b/src/app/presentation/building_anim.rs
@@ -352,6 +352,32 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
                     );
                 }
             }
+            GameSoundEvent::VoiceFeedback { sound_id, source } => {
+                // `CCINIClass::ReadSoundList @ 0x00525430` only stores tokens
+                // `VocClass::FindPtrByName` resolves, so a `VoiceFeedback=`
+                // name that is not a registered Voc never enters the vector at
+                // `TechnoTypeClass+0x4D8` and must not reach the raw audio-bag
+                // fallback here.
+                //
+                // Played as a positional one-shot, not through the
+                // `VoiceQueue`: native's arm calls `VocClass::PlayAt @
+                // 0x007509E0` (`0x00702709`) directly, with no
+                // `TechnoClass::Queue_Voice @ 0x00708D90` latch and no
+                // `+0x4DC` handle, so it neither cuts nor is cut by a
+                // selection or order line.
+                if registry.get(sound_id).is_none() {
+                    continue;
+                }
+                if let Some(gain) = gain_for(sound_id, *source) {
+                    sfx.play_registered_sound_spatial(
+                        sound_id,
+                        gain,
+                        registry,
+                        assets,
+                        audio_indices,
+                    );
+                }
+            }
             GameSoundEvent::LightningStrike { sound_id, source } => {
                 // `CCINIClass::ReadSoundList @ 0x00525430` only stores tokens
                 // `VocClass::FindPtrByName` resolves, so a `LightningSounds=`

--- a/src/app/presentation/building_anim.rs
+++ b/src/app/presentation/building_anim.rs
@@ -164,8 +164,11 @@ pub(crate) fn eva_faction_key(
 
 /// Drain pending sound events from the queue and play them through the SFX player.
 ///
-/// Voice events (VoiceSelect, VoiceMove, VoiceAttack) are routed to the dedicated
-/// voice slot which cuts off the previous voice. All other sounds go to the SFX pool.
+/// Voice events (VoiceSelect, VoiceMove, VoiceAttack, VoiceCapture, ...) are
+/// latched per speaking object and drained at the end of the pass — see
+/// [`crate::audio::voice_queue`] — so a repeated click drops the second line
+/// instead of restarting the first mid-word. All other sounds go to the SFX
+/// pool.
 ///
 /// Positional cues go through `VocClass::CalcVolumeAndPan @ 0x00750AC0`
 /// (`audio::sfx::spatial_gain`) against the tactical view rect — the native
@@ -243,11 +246,15 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
 
     for event in &events {
         match event {
-            // Voice events — always full volume (non-positional), use dedicated voice slot.
-            GameSoundEvent::UnitSelected { .. }
-            | GameSoundEvent::UnitMoveOrder { .. }
-            | GameSoundEvent::UnitAttackOrder { .. } => {
-                sfx.play_voice_sound(event.sound_id(), registry, assets, audio_indices);
+            // Unit acknowledgement lines — always full volume (non-positional).
+            // `TechnoClass::Queue_Voice @ 0x00708D90` only latches the line on
+            // the speaking object; `drain_unit_voices` below is the
+            // `TechnoClass::AI_Update @ 0x006F9EBB` drain that decides whether
+            // it plays, is dropped as a repeat, or waits for the live line.
+            GameSoundEvent::UnitSelected { speaker_id, .. }
+            | GameSoundEvent::UnitMoveOrder { speaker_id, .. }
+            | GameSoundEvent::UnitAttackOrder { speaker_id, .. } => {
+                sfx.queue_unit_voice(*speaker_id, event.sound_id());
             }
             // STANDARD EVA cues are fire-and-forget: play only if voice is idle.
             GameSoundEvent::BuildingReady { .. }
@@ -297,6 +304,41 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
                 // RulesClass::ReadAudioVisual @ 0x006691E0 stores only the
                 // VocClass::FindByName @ 0x007514D0 result. An invalid name is
                 // silent; it must not enter the generic raw audio-bag fallback.
+                if registry.get(sound_id).is_none() {
+                    continue;
+                }
+                if let Some(gain) = gain_for(sound_id, *source) {
+                    sfx.play_registered_sound_spatial(
+                        sound_id,
+                        gain,
+                        registry,
+                        assets,
+                        audio_indices,
+                    );
+                }
+            }
+            GameSoundEvent::BaseUnderAttackSfx { sound_id } => {
+                // `0x004F95BF MOV EDX,0x2000` / `0x004F95C4 PUSH 0x3F800000`:
+                // pan centred, volume 1.0f, no handle — an ordinary pooled
+                // event, not a voice. `RulesClass::ReadAudioVisual` keeps only
+                // the `VocClass::FindByName` result, so an unregistered name
+                // must not reach the raw audio-bag path.
+                if registry.get(sound_id).is_none() {
+                    continue;
+                }
+                sfx.play_registered_sound_spatial(
+                    sound_id,
+                    SpatialGain::CENTRED_FULL,
+                    registry,
+                    assets,
+                    audio_indices,
+                );
+            }
+            GameSoundEvent::LightningStrike { sound_id, source } => {
+                // `CCINIClass::ReadSoundList @ 0x00525430` only stores tokens
+                // `VocClass::FindPtrByName` resolves, so a `LightningSounds=`
+                // name that is not a registered Voc never reaches the list and
+                // must not fall through to the raw audio-bag path here.
                 if registry.get(sound_id).is_none() {
                     continue;
                 }
@@ -367,6 +409,12 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
             .and_then(|facts| spatial_gain(facts, screen_x, screen_y, &listener, shrouded(rx, ry)));
         sfx.update_looping_sound(owner, gain);
     }
+
+    // `TechnoClass::AI_Update @ 0x006F9EBB` drains the per-object voice latch
+    // immediately after its `AnimClass::UpdateLoopingSound` call at
+    // `0x006F9EA8`, so the drain runs last here too. This is where a repeated
+    // click is dropped instead of restarting the line mid-word.
+    sfx.drain_unit_voices(registry, assets, audio_indices);
 }
 
 /// The `Range`/`Type`/`MinVolume` a live loop handle's entry carries, for the

--- a/src/app/presentation/building_anim.rs
+++ b/src/app/presentation/building_anim.rs
@@ -334,6 +334,24 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
                     audio_indices,
                 );
             }
+            GameSoundEvent::BuildingDamagedSfx { sound_id, source } => {
+                // `RulesClass::ReadAudioVisual @ 0x006691E0` keeps only the
+                // `VocClass::FindByName` result in `Rules+0x714`, so a name
+                // that is not a registered Voc is silence in gamemd and must
+                // not reach the raw audio-bag fallback here.
+                if registry.get(sound_id).is_none() {
+                    continue;
+                }
+                if let Some(gain) = gain_for(sound_id, *source) {
+                    sfx.play_registered_sound_spatial(
+                        sound_id,
+                        gain,
+                        registry,
+                        assets,
+                        audio_indices,
+                    );
+                }
+            }
             GameSoundEvent::LightningStrike { sound_id, source } => {
                 // `CCINIClass::ReadSoundList @ 0x00525430` only stores tokens
                 // `VocClass::FindPtrByName` resolves, so a `LightningSounds=`

--- a/src/audio/events.rs
+++ b/src/audio/events.rs
@@ -289,6 +289,23 @@ pub enum GameSoundEvent {
         sound_id: String,
     },
 
+    /// The global `[AudioVisual] BuildingDamageSound` cue for a struck
+    /// building whose type carries no `DamageSound=` of its own.
+    ///
+    /// `BuildingClass::ReceiveDamage @ 0x00442230` plays it at the building's
+    /// own coordinate (`0x004426DB LEA ECX,[ESI+0x9C]`,
+    /// `0x00442700 MOV ECX,[Rules+0x714]`,
+    /// `0x00442706 CALL VocClass::PlayAtCoord @ 0x00750E20`). The gate is
+    /// `0x004426D2 CMP [type+0x538],-1` and the arm is only reached for the
+    /// damage-state crossings 2 and 3 (`0x00442476 JMP [EAX*4 + 0x00442C18]`),
+    /// both decided sim-side.
+    BuildingDamagedSfx {
+        /// sound.ini ID from `[AudioVisual] BuildingDamageSound=`.
+        sound_id: String,
+        /// Screen position for spatial audio.
+        source: Option<SoundSource>,
+    },
+
     /// A lightning-storm bolt reached the ground — the thunder crack.
     ///
     /// `LightningStorm::GroundStrike @ 0x0053A45F..0x0053A4A2` plays
@@ -339,6 +356,7 @@ impl GameSoundEvent {
             | Self::BunkerWalls { sound_id, .. }
             | Self::ChuteSound { sound_id, .. }
             | Self::BridgeRepaired { sound_id, .. }
+            | Self::BuildingDamagedSfx { sound_id, .. }
             | Self::LightningStrike { sound_id, .. }
             | Self::WorldEffectStarted { sound_id, .. } => sound_id,
             Self::AnimationStopped { stop_sound_id, .. } => stop_sound_id.as_deref().unwrap_or(""),
@@ -367,6 +385,7 @@ impl GameSoundEvent {
             | Self::BunkerWalls { source, .. }
             | Self::ChuteSound { source, .. }
             | Self::BridgeRepaired { source, .. }
+            | Self::BuildingDamagedSfx { source, .. }
             | Self::LightningStrike { source, .. }
             | Self::WorldEffectStarted { source, .. } => *source,
             _ => None,
@@ -436,6 +455,33 @@ impl GameSoundEvent {
 /// line (`HouseClass::NotifyUnderAttack @ 0x004F95B8..0x004F95CF`), on the
 /// building branch only.
 ///
+/// `[AudioVisual] BuildingDamageSound=` (`Rules+0x714`) is landed too. It is a
+/// **damage-state** cue, not a per-hit one: `BuildingClass::ReceiveDamage @
+/// 0x00442230` only enters the arm through
+/// `0x00442476 JMP [EAX*4 + 0x00442C18]` with `EAX = result - 2`, so results 2
+/// (the hit crossed HP from `>= Strength >> 1` to below it) and 3 (it crossed
+/// below `Strength * Rules+0x1708`, ConditionRed) reach
+/// `0x004426D2 CMP [type+0x538],-1` while an ordinary non-crossing hit
+/// (result 1) plays nothing. A dead building is skipped earlier still by
+/// `0x0044242C MOV AL,[ESI+0x90]` (`ObjectClass::IsAlive`). Frequency: twice
+/// per building on the way down in a sustained base attack, plus every
+/// repair-and-re-damage cycle across a threshold — not the every-shot cadence
+/// an earlier pass assumed. Stock `BuildingDamageSound=BuildingDamaged` is a
+/// five-sample `[SoundList]`, and only 34 of all stock types author a
+/// `DamageSound=` of their own (30 `BuildingMetalDamaged`, 4 `Dummy`), so the
+/// global covers nearly every structure.
+///
+/// **Still absent on the damage side.** The per-type `DamageSound=`
+/// (`TechnoTypeClass+0x538`) is parsed but only *read as a gate*; native also
+/// plays it, from a TechnoClass-level path (`0x00702717` inside
+/// `TechnoClass::ReceiveDamage`, reached for results the switch at
+/// `0x00702049` sends there). That callsite was not walked, so nothing is
+/// asserted. Trigger: a damaged type that authors the key. Player effect: the
+/// 30 `BuildingMetalDamaged` structures and 4 `Dummy` ones are silent where
+/// native has a cue. Frequency: those 34 types only. Downstream risk: it is a
+/// Techno-level cue, so landing it means reading that switch arm, not
+/// extending the BuildingClass arm.
+///
 /// **Still absent.** Nothing emits the other ambient families:
 /// `WorkingSound=` (9 stock), `AuxSound1=` (8), `AuxSound2=` (5),
 /// `TurretRotateSound=` (2) and the water enter/leave pair have no producer.
@@ -448,13 +494,6 @@ impl GameSoundEvent {
 /// **`[AudioVisual]` keys with a verified native consumer but no VERA producer
 /// yet**, all read by `RulesClass::ReadAudioVisual @ 0x006691E0` and all
 /// UNCHECKED against their own callers unless noted:
-/// - `BuildingDamageSound=BuildingDamaged` (`Rules+0x714`).
-///   `BuildingClass::ReceiveDamage @ 0x00442700` plays it at the building's
-///   coordinate, but only when the type has no `DamageSound=` of its own
-///   (`0x004426D2 CMP [type+0x538],-1`); the jump-table arm that reaches
-///   `0x004426AC` was not mapped, and VERA parses neither the global nor the
-///   per-type key. Trigger: a non-fatal hit on a building. Player effect: a
-///   struck building is silent. Frequency: continuous in any base attack.
 /// - `EnterGrinderSound`/`LeaveGrinderSound` (`+0x268`/`+0x26C`),
 ///   `EnterBioReactorSound`/`LeaveBioReactorSound` (`+0x270`/`+0x274`): no
 ///   grinder or bio-reactor consumer exists in `sim/` at all.

--- a/src/audio/events.rs
+++ b/src/audio/events.rs
@@ -306,6 +306,22 @@ pub enum GameSoundEvent {
         source: Option<SoundSource>,
     },
 
+    /// A techno crossed the half-strength threshold and speaks its
+    /// `VoiceFeedback=` line.
+    ///
+    /// `TechnoClass::ReceiveDamage @ 0x00701900`, arm `0x00702695` (index 2 of
+    /// the switch table at `0x00702D24`, i.e. damage result 2). The 30% roll,
+    /// the `HouseClass::IsHumanPlayer @ 0x0050B6F0` gate and the
+    /// `rand % count` pick are resolved before this event is built; it plays
+    /// positionally through `VocClass::PlayAt @ 0x007509E0` at the object's
+    /// own coordinate.
+    VoiceFeedback {
+        /// sound.ini ID for the chosen `VoiceFeedback=` entry.
+        sound_id: String,
+        /// Screen position for spatial audio.
+        source: Option<SoundSource>,
+    },
+
     /// A lightning-storm bolt reached the ground — the thunder crack.
     ///
     /// `LightningStorm::GroundStrike @ 0x0053A45F..0x0053A4A2` plays
@@ -357,6 +373,7 @@ impl GameSoundEvent {
             | Self::ChuteSound { sound_id, .. }
             | Self::BridgeRepaired { sound_id, .. }
             | Self::BuildingDamagedSfx { sound_id, .. }
+            | Self::VoiceFeedback { sound_id, .. }
             | Self::LightningStrike { sound_id, .. }
             | Self::WorldEffectStarted { sound_id, .. } => sound_id,
             Self::AnimationStopped { stop_sound_id, .. } => stop_sound_id.as_deref().unwrap_or(""),
@@ -386,6 +403,7 @@ impl GameSoundEvent {
             | Self::ChuteSound { source, .. }
             | Self::BridgeRepaired { source, .. }
             | Self::BuildingDamagedSfx { source, .. }
+            | Self::VoiceFeedback { source, .. }
             | Self::LightningStrike { source, .. }
             | Self::WorldEffectStarted { source, .. } => *source,
             _ => None,
@@ -425,14 +443,17 @@ impl GameSoundEvent {
 /// from `sim/`, so the whole guard lives in [`crate::audio::voice_queue`] as a
 /// device-free decision module and `sim/` never learns about audio.
 ///
-/// **Still absent on the voice side.** `VoiceFeedback=` (133 stock authors)
-/// has no consumer, `VoiceDeploy=`/`VoiceUndeploy=` (deploy/unload orders),
-/// `VoiceCrashing=` (7) and `VoiceSinking=`/`VoiceFalling=` are not parsed,
-/// and taunts reach an empty match arm. The native consumers of those slots
-/// were not isolated, so no mapping is asserted.
+/// **Still absent on the voice side.** `VoiceDeploy=`/`VoiceUndeploy=`
+/// (deploy/unload orders), `VoiceCrashing=` (7) and
+/// `VoiceSinking=`/`VoiceFalling=` are not parsed, and taunts reach an empty
+/// match arm. The native consumers of those slots were not isolated, so no
+/// mapping is asserted.
 /// - Player effect: those orders and states stay silent.
 /// - Frequency: deploy orders are common; crashing/sinking lines need an
 ///   aircraft or ship kill.
+///
+/// `VoiceFeedback=` (133 stock authors) is **no longer among them** — see
+/// [`Self::VoiceFeedback`].
 ///
 /// **Partly closed.** `MoveSound=` now has both halves: the sim's
 /// post-locomotor tail (`Simulation::tick_move_sound_after_process`) emits
@@ -471,16 +492,40 @@ impl GameSoundEvent {
 /// `DamageSound=` of their own (30 `BuildingMetalDamaged`, 4 `Dummy`), so the
 /// global covers nearly every structure.
 ///
-/// **Still absent on the damage side.** The per-type `DamageSound=`
-/// (`TechnoTypeClass+0x538`) is parsed but only *read as a gate*; native also
-/// plays it, from a TechnoClass-level path (`0x00702717` inside
-/// `TechnoClass::ReceiveDamage`, reached for results the switch at
-/// `0x00702049` sends there). That callsite was not walked, so nothing is
-/// asserted. Trigger: a damaged type that authors the key. Player effect: the
-/// 30 `BuildingMetalDamaged` structures and 4 `Dummy` ones are silent where
-/// native has a cue. Frequency: those 34 types only. Downstream risk: it is a
-/// Techno-level cue, so landing it means reading that switch arm, not
-/// extending the BuildingClass arm.
+/// `[AudioVisual]`'s companion damage voice is landed as well — see
+/// [`GameSoundEvent::VoiceFeedback`] for `TechnoClass::ReceiveDamage @
+/// 0x00701900`'s result-2 arm at `0x00702695`.
+///
+/// **Still absent on the damage side: the per-type `DamageSound=` cue.**
+/// `TechnoTypeClass+0x538` is parsed but only *read as a gate*. Native plays
+/// it from arm `0x00702713`/`0x00702717` of the same switch — **index 1 of the
+/// table at `0x00702D24`, the ordinary NON-crossing hit** (damage result 1),
+/// not the crossings the global rides. So the per-type and the global cue are
+/// mutually exclusive by *result*, not merely by the `-1` gate: a type with
+/// its own `DamageSound=` gets a clang on every ordinary hit and **nothing**
+/// on a crossing, while a type without one is silent on ordinary hits and
+/// sounds the global on crossings. The arm also plays the sound **twice** —
+/// two identical blocks at `0x00702760` and `0x007027A9`, each re-reading
+/// `[type+0x538]` and the same coordinate `[ESI+0x9C]`.
+/// Trigger: any non-crossing hit on a type that authors the key. Player
+/// effect: those types are silent under ordinary fire where native double-taps
+/// a clang. Frequency: all 34 stock authors are civilian/neutral props (30
+/// `CA*` structures plus `AMMOCRAT` on `BuildingMetalDamaged`, 4 `CAARMY0*` on
+/// `Dummy`) — no player-built structure and no unit authors it, so this is
+/// "whenever you shoot civilian scenery", common on urban maps and absent from
+/// a pure base fight. Downstream risk: landing it needs a distinct
+/// `DamageState::Damaged` (result 1) emission, which VERA classifies but does
+/// not currently route.
+///
+/// **Also unrecorded until now: an unresolvable per-type `DamageSound=`.**
+/// `TechnoTypeClass+0x538` is `-1` both when the key is absent *and* when the
+/// name resolves to no Voc, so native falls back to the global in both cases;
+/// VERA's `damage_sound: Option<String>` is `Some` for any non-empty string
+/// and suppresses the global. Trigger: a type naming a sound that is not in
+/// `soundmd.ini`. Player effect: that structure is silent where native plays
+/// the global cue. Frequency: never on retail — `BuildingMetalDamaged` and
+/// `Dummy` both register. Downstream risk: none; closing it means resolving
+/// the name against the sound registry, which lives above `rules/`.
 ///
 /// **Still absent.** Nothing emits the other ambient families:
 /// `WorkingSound=` (9 stock), `AuxSound1=` (8), `AuxSound2=` (5),

--- a/src/audio/events.rs
+++ b/src/audio/events.rs
@@ -86,19 +86,30 @@ pub enum GameSoundEvent {
     },
 
     /// A unit was selected by the player — play VoiceSelect.
+    ///
+    /// `speaker_id` is the object that speaks: `TechnoClass::Queue_Voice @
+    /// 0x00708D90` latches the line on the techno itself (`+0x4F0`), so the
+    /// repeat guard in [`crate::audio::voice_queue`] needs to know whose line
+    /// this is.
     UnitSelected {
+        /// Stable id of the speaking object.
+        speaker_id: u64,
         /// sound.ini ID from the unit's VoiceSelect= field.
         sound_id: String,
     },
 
     /// A unit was ordered to move — play VoiceMove.
     UnitMoveOrder {
+        /// Stable id of the speaking object.
+        speaker_id: u64,
         /// sound.ini ID from the unit's VoiceMove= field.
         sound_id: String,
     },
 
     /// A unit was ordered to attack — play VoiceAttack.
     UnitAttackOrder {
+        /// Stable id of the speaking object.
+        speaker_id: u64,
         /// sound.ini ID from the unit's VoiceAttack= field.
         sound_id: String,
     },
@@ -265,6 +276,33 @@ pub enum GameSoundEvent {
         source: Option<SoundSource>,
     },
 
+    /// The `[AudioVisual] BaseUnderAttackSound` siren that rides with the
+    /// under-attack EVA line.
+    ///
+    /// `HouseClass::NotifyUnderAttack @ 0x004F95B8..0x004F95CF` plays
+    /// `Rules+0x184` through `VocClass::PlayAtPos @ 0x00750920` with pan
+    /// `0x2000` and volume `1.0f` — non-positional — immediately after the EVA
+    /// call at `0x004F95B3`, and only when `CreateRadarEvent @ 0x0065FA70`
+    /// accepted the ping (`0x004F95A5 TEST AL,AL ; JZ`).
+    BaseUnderAttackSfx {
+        /// sound.ini ID from `[AudioVisual] BaseUnderAttackSound=`.
+        sound_id: String,
+    },
+
+    /// A lightning-storm bolt reached the ground — the thunder crack.
+    ///
+    /// `LightningStorm::GroundStrike @ 0x0053A45F..0x0053A4A2` plays
+    /// `[AudioVisual] LightningSounds[n]` positionally at the strike cell
+    /// through `VocClass::PlayAt @ 0x007509E0`; the entry is chosen when the
+    /// event is built. Skipped upstream when the list is empty
+    /// (`0x0053A46A TEST ECX,ECX ; JLE`).
+    LightningStrike {
+        /// sound.ini ID for the chosen `LightningSounds=` entry.
+        sound_id: String,
+        /// Screen position for spatial audio.
+        source: Option<SoundSource>,
+    },
+
     /// Generic UI sound (button click, error beep, etc.).
     UiSound {
         /// sound.ini ID for the UI sound.
@@ -278,9 +316,9 @@ impl GameSoundEvent {
         match self {
             Self::WeaponFired { sound_id, .. }
             | Self::AnimationStarted { sound_id, .. }
-            | Self::UnitSelected { sound_id }
-            | Self::UnitMoveOrder { sound_id }
-            | Self::UnitAttackOrder { sound_id }
+            | Self::UnitSelected { sound_id, .. }
+            | Self::UnitMoveOrder { sound_id, .. }
+            | Self::UnitAttackOrder { sound_id, .. }
             | Self::EntityDestroyed { sound_id, .. }
             | Self::EntityCrushed { sound_id, .. }
             | Self::EntityDeployed { sound_id, .. }
@@ -292,6 +330,7 @@ impl GameSoundEvent {
             | Self::UnitReady { sound_id }
             | Self::CannotDeployHere { sound_id }
             | Self::UiSound { sound_id }
+            | Self::BaseUnderAttackSfx { sound_id }
             | Self::StructureGarrisoned { sound_id }
             | Self::StructureAbandoned { sound_id }
             | Self::BuildingGarrisonedSfx { sound_id, .. }
@@ -300,6 +339,7 @@ impl GameSoundEvent {
             | Self::BunkerWalls { sound_id, .. }
             | Self::ChuteSound { sound_id, .. }
             | Self::BridgeRepaired { sound_id, .. }
+            | Self::LightningStrike { sound_id, .. }
             | Self::WorldEffectStarted { sound_id, .. } => sound_id,
             Self::AnimationStopped { stop_sound_id, .. } => stop_sound_id.as_deref().unwrap_or(""),
             Self::UnderAttackEva { eva_sound_id }
@@ -327,6 +367,7 @@ impl GameSoundEvent {
             | Self::BunkerWalls { source, .. }
             | Self::ChuteSound { source, .. }
             | Self::BridgeRepaired { source, .. }
+            | Self::LightningStrike { source, .. }
             | Self::WorldEffectStarted { source, .. } => *source,
             _ => None,
         }
@@ -354,19 +395,25 @@ impl GameSoundEvent {
 /// nothing (`ObjectClass::Select @ 0x005F4520` returns false), and the
 /// one-voice-per-batch latch matches `g_SelectionVoice_Enable @ 0x00822CF2`.
 ///
-/// **The repeat guard proper is NOT a timer, and it is what is missing.** Each
-/// techno owns a pending-voice index (`+0x4F0`, sentinel -1), a live handle
-/// (`+0x4DC`) and the playing index (`+0x4F4`). `TechnoClass::Queue_Voice @
-/// 0x00708D90` only latches; `TechnoClass::AI_Update @ 0x006F9EBB` drains it —
-/// handle free plays, handle live with the SAME index drops, handle live with a
-/// different index holds and retries next tick. Voices are non-positional
-/// (volume 1.0, pan 0x2000). VERA cannot model this yet because the drain needs
-/// a liveness fact that only the audio layer knows, and `sim/` must not depend
-/// on `audio/`: it wants a read-only per-tick liveness view passed INTO the
-/// tick, or an inbound event queue — never an import.
-/// - Trigger: ordering the same unit twice in quick succession.
-/// - Player effect: the line restarts where retail lets it finish.
-/// - Frequency: continuous — it is how players click.
+/// **The repeat guard is landed.** It is not a timer: each techno owns a
+/// pending-voice index (`+0x4F0`, sentinel -1), a live handle (`+0x4DC`) and
+/// the playing index (`+0x4F4`); `TechnoClass::Queue_Voice @ 0x00708D90` only
+/// latches and `TechnoClass::AI_Update @ 0x006F9EBB` drains — handle free
+/// plays, handle live with the SAME index drops, handle live with a different
+/// index holds and retries next pass. Voices are non-positional (volume 1.0f,
+/// pan 0x2000, `0x006F9EE0`/`0x006F9EE5`). The layering worry turned out not to
+/// bind: VERA emits acknowledgement lines from the **app** input layer, never
+/// from `sim/`, so the whole guard lives in [`crate::audio::voice_queue`] as a
+/// device-free decision module and `sim/` never learns about audio.
+///
+/// **Still absent on the voice side.** `VoiceFeedback=` (133 stock authors)
+/// has no consumer, `VoiceDeploy=`/`VoiceUndeploy=` (deploy/unload orders),
+/// `VoiceCrashing=` (7) and `VoiceSinking=`/`VoiceFalling=` are not parsed,
+/// and taunts reach an empty match arm. The native consumers of those slots
+/// were not isolated, so no mapping is asserted.
+/// - Player effect: those orders and states stay silent.
+/// - Frequency: deploy orders are common; crashing/sinking lines need an
+///   aircraft or ship kill.
 ///
 /// **Partly closed.** `MoveSound=` now has both halves: the sim's
 /// post-locomotor tail (`Simulation::tick_move_sound_after_process`) emits
@@ -377,17 +424,52 @@ impl GameSoundEvent {
 /// `GrizzlyTankMoveStart` plays one start-up sample, which is what gamemd
 /// does.
 ///
+/// **Also landed.** `VoiceCapture=` is routed (`0x00708DC0` reads
+/// `TechnoTypeClass+0x55C` and only falls through to the Enter slot at
+/// `0x00709020` when it is absent), so an engineer capture speaks the capture
+/// line instead of the move line. `[AudioVisual] BuildingDieSound=` is emitted
+/// when a dying building's type carries no `DieSound=` of its own
+/// (`BuildingClass::DestructionEffects`, `0x0044173F`..`0x00441779`),
+/// `[AudioVisual] LightningSounds=` is played at each bolt strike
+/// (`LightningStorm::GroundStrike @ 0x0053A45F..0x0053A4A2`), and
+/// `[AudioVisual] BaseUnderAttackSound=` now rides with the under-attack EVA
+/// line (`HouseClass::NotifyUnderAttack @ 0x004F95B8..0x004F95CF`), on the
+/// building branch only.
+///
 /// **Still absent.** Nothing emits the other ambient families:
 /// `WorkingSound=` (9 stock), `AuxSound1=` (8), `AuxSound2=` (5),
 /// `TurretRotateSound=` (2) and the water enter/leave pair have no producer.
-/// `VoiceFeedback=` (133 stock) and `VoiceCapture=` (3) have no consumers,
-/// `VoiceCrashing=` (7) is not parsed, and taunts reach an empty match arm.
 /// - Player effect: the soundscape is still thin — bases have no working hum.
 /// - Frequency: continuous.
 /// - Downstream risk: none left on the audio side. Each remaining family needs
 ///   only a sim-side producer and the same owner-keyed handle `MoveSound=`
-///   already uses; the arbiter behind it is landed. The voice repeat guard
-///   above is separate — it needs only the liveness channel.
+///   already uses; the arbiter behind it is landed.
+///
+/// **`[AudioVisual]` keys with a verified native consumer but no VERA producer
+/// yet**, all read by `RulesClass::ReadAudioVisual @ 0x006691E0` and all
+/// UNCHECKED against their own callers unless noted:
+/// - `BuildingDamageSound=BuildingDamaged` (`Rules+0x714`).
+///   `BuildingClass::ReceiveDamage @ 0x00442700` plays it at the building's
+///   coordinate, but only when the type has no `DamageSound=` of its own
+///   (`0x004426D2 CMP [type+0x538],-1`); the jump-table arm that reaches
+///   `0x004426AC` was not mapped, and VERA parses neither the global nor the
+///   per-type key. Trigger: a non-fatal hit on a building. Player effect: a
+///   struck building is silent. Frequency: continuous in any base attack.
+/// - `EnterGrinderSound`/`LeaveGrinderSound` (`+0x268`/`+0x26C`),
+///   `EnterBioReactorSound`/`LeaveBioReactorSound` (`+0x270`/`+0x274`): no
+///   grinder or bio-reactor consumer exists in `sim/` at all.
+/// - The seven `Crate*Sound` keys (`+0x1E4`..`+0x1FC`): no crate-pickup
+///   producer exists.
+/// - `PlaceBeaconSound` (`+0x1CC`), `MindClearedSound` (`+0x264`),
+///   `MasterMindOverloadDeathSound` (`+0x258`), `ImpactLandSound`/
+///   `ImpactWaterSound` (`+0x204`/`+0x200`), `CreditTicks` (`+0x6DC`),
+///   `IceCrackSounds` (`+0x644`): no producer.
+/// - **No player-visible gap on retail data:** `GateUp`/`GateDown`
+///   (`+0x404`/`+0x408`) are both `Dummy`, `Construction` (`+0x6C8`) is
+///   `Dummy`, and `CreateUnitSound`/`CreateInfantrySound`/`CreateAircraftSound`
+///   (`+0x178`..`+0x180`) and `LeaveGrinderSound` are empty in stock
+///   `rulesmd.ini`. `Dummy` is one of the eight `[SoundList]` ids with no
+///   usable `Sounds=`, so it registers silently.
 #[derive(Debug, Default)]
 pub struct SoundEventQueue {
     events: Vec<GameSoundEvent>,

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -13,3 +13,4 @@ pub mod events;
 pub mod music;
 pub mod sfx;
 pub(crate) mod theme;
+pub mod voice_queue;

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -1342,6 +1342,20 @@ impl SfxPlayer {
         self.rng.ranged(0, count as i32 - 1) as usize
     }
 
+    /// Draw `RandomRanged(0, 99)` from the presentation RNG.
+    ///
+    /// The stand-in for gamemd's percentage gates on `g_MainRng @ 0x00886B88`.
+    /// `TechnoClass::ReceiveDamage @ 0x007026AF..0x007026C0` is the one caller:
+    /// `PUSH 0x63 ; PUSH 0x0 ; MOV ECX,0x886B88 ; CALL 0x0065C7E0`, then
+    /// `CMP EAX,0x1E ; JGE` — so the cue speaks for a draw of 0..=29.
+    ///
+    /// Unlike [`Self::pick_index`] this always draws, matching native: the
+    /// `RandomRanged` body at `0x0065C7E0` only skips the draw when its two
+    /// endpoints are equal, and `0` and `99` are not.
+    pub fn roll_percent(&mut self) -> i32 {
+        self.rng.ranged(0, 99)
+    }
+
     /// Forget one object's latch and playing index — object removal.
     ///
     /// RESIDUAL: **nothing calls this today.** The app layer has no

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -1303,12 +1303,25 @@ impl SfxPlayer {
     /// VERA-internal shape, gamemd equivalent read: native stores the handle
     /// on the techno (`+0x4DC`) so any number of objects can be speaking at
     /// once; VERA has one voice slot, so at most the slot's current owner can
-    /// answer `true`. Trigger: two objects with a latched line in the same
-    /// pass. Player effect: the second line cuts the first where native lets
-    /// them overlap. Frequency: never from player input — the one-voice-per-
-    /// batch latch (`g_SelectionVoice_Enable @ 0x00822CF2`) already lets only
-    /// one object speak per dispatch. Downstream risk: none; folding voices
-    /// into the 16-channel pool is the `voice_player` residual's job.
+    /// answer `true`.
+    ///
+    /// Two consequences, both recorded:
+    /// 1. An EVA line taking the slot kills a unit's handle mid-word.
+    /// 2. [`Self::drain_unit_voices`] resolves this **once** before its loop,
+    ///    so if two objects both have a line latched in the same pass, both
+    ///    play and the second cuts the first — native would let them overlap,
+    ///    because each object probes its own handle. Re-resolving inside the
+    ///    loop would not fix it either; one slot cannot hold two lines.
+    ///
+    /// Trigger: two objects with a latched line in the same
+    /// `drain_sound_events` pass, or an EVA line landing on a unit line.
+    /// Player effect: the second line cuts the first. Frequency: not reachable
+    /// from ordinary player input while A1's one-voice-per-batch latch
+    /// (`g_SelectionVoice_Enable @ 0x00822CF2`) holds — it lets only one
+    /// object speak per dispatch — but a selection voice and an order voice
+    /// from *different* objects arriving in the same pass would hit it.
+    /// Downstream risk: none; folding voices into the 16-channel pool is the
+    /// `voice_player` residual's job, and that is what closes both cases.
     fn live_voice_owner(&self) -> Option<u64> {
         let owner = self.current_voice_owner?;
         self.voice_player
@@ -1330,6 +1343,16 @@ impl SfxPlayer {
     }
 
     /// Forget one object's latch and playing index — object removal.
+    ///
+    /// RESIDUAL: **nothing calls this today.** The app layer has no
+    /// entity-removal hook that reaches `SfxPlayer`, so the intended
+    /// "object died, drop its voice state" edge is unwired. It is inert
+    /// rather than a leak: [`VoiceQueue::drain`] prunes `playing` at the top
+    /// of every pass, and `pending` can only ever hold the single live owner,
+    /// so no state survives a removed object. Trigger: none. Player effect:
+    /// none. Frequency: never. Downstream risk: the moment voices move into
+    /// the 16-channel pool, per-object state can outlive its object and this
+    /// must be wired to removal or deleted with the single-slot design.
     pub fn forget_unit_voice(&mut self, owner: u64) {
         self.voice_queue.forget(owner);
         if self.current_voice_owner == Some(owner) {

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -36,6 +36,7 @@ use rodio::{DeviceSinkBuilder, MixerDeviceSink, Player};
 use crate::assets::asset_manager::AssetManager;
 use crate::assets::aud_file;
 use crate::audio::arbiter::{self, ArbiterAction, EntryFacts, EventId, PlayRequest, SoundArbiter};
+use crate::audio::voice_queue::VoiceQueue;
 use crate::rules::sound_ini::{SoundEntry, SoundRegistry, VOLUME_SCALE, control, sound_type};
 
 /// How many passes of a sustaining cue are kept queued on its rodio player:
@@ -965,6 +966,13 @@ pub struct SfxPlayer {
     queued_voice: VecDeque<QueuedVoice>,
     /// Sound id currently occupying the dedicated voice slot, when known.
     current_voice_id: Option<String>,
+    /// Stable id of the object whose acknowledgement line owns the voice slot,
+    /// i.e. the object whose `TechnoClass+0x4DC` handle is live. `None` for an
+    /// EVA cue or an ownerless voice.
+    current_voice_owner: Option<u64>,
+    /// The per-object voice latch: `TechnoClass::Queue_Voice @ 0x00708D90`
+    /// writes it, `TechnoClass::AI_Update @ 0x006F9EBB` drains it.
+    voice_queue: VoiceQueue,
     /// Ordinary and animation SFX master volume (0.0 to 1.0).
     sound_volume: f64,
     /// Unit and EVA voice master volume (0.0 to 1.0).
@@ -1000,6 +1008,8 @@ impl SfxPlayer {
             voice_player: None,
             queued_voice: VecDeque::new(),
             current_voice_id: None,
+            current_voice_owner: None,
+            voice_queue: VoiceQueue::new(),
             sound_volume: 0.7,
             voice_volume: 0.7,
             output_scale: 1.0,
@@ -1246,28 +1256,85 @@ impl SfxPlayer {
         self.arbiter.clear_loop_handle(anim_id);
     }
 
-    /// Play a sound as a unit voice response (VoiceSelect, VoiceMove, VoiceAttack).
+    /// `TechnoClass::Queue_Voice @ 0x00708D90` — latch one object's
+    /// acknowledgement line (VoiceSelect, VoiceMove, VoiceAttack, ...).
     ///
-    /// Uses a dedicated voice slot that cuts off the previous voice — unit responses
-    /// don't stack, matching the original engine's behavior. Voices are
-    /// non-positional: `TechnoClass::AI_Update @ 0x006F9EBB` plays them at
-    /// volume 1.0 and pan `0x2000`.
-    pub fn play_voice_sound(
+    /// Nothing plays here. [`Self::drain_unit_voices`] is the drain half, and
+    /// it is what decides whether a second click restarts the line, drops it,
+    /// or waits — see [`crate::audio::voice_queue`] for the three outcomes.
+    pub fn queue_unit_voice(&mut self, owner: u64, sound_id: &str) {
+        self.voice_queue.queue(owner, sound_id);
+    }
+
+    /// `TechnoClass::AI_Update @ 0x006F9EBB` — drain every latched line.
+    ///
+    /// Voices are non-positional: `0x006F9EE0`/`0x006F9EE5` pass pan `0x2000`
+    /// and volume `1.0f` to `VocClass::PlayAtPos @ 0x00750920`, which is what
+    /// the dedicated voice slot already does.
+    pub fn drain_unit_voices(
         &mut self,
-        sound_id: &str,
         registry: &SoundRegistry,
         assets: &AssetManager,
         audio_indices: &[crate::assets::audio_bag::AudioIndex],
-    ) -> bool {
-        self.advance_voice_queue();
-        let Some(resolved) = self.resolve_any(sound_id, registry, assets, audio_indices) else {
-            return false;
-        };
-        self.play_voice(
-            resolved.decoded,
-            resolved.event_linear,
-            Some(sound_id.to_string()),
-        )
+    ) {
+        // `VocHandle::ValidateOrClear @ 0x00406130` for each object, resolved
+        // once for the pass: VERA's single voice slot means at most one
+        // object's handle can be live at a time.
+        let live_owner = self.live_voice_owner();
+        let decisions = self.voice_queue.drain(|owner| live_owner == Some(owner));
+        for decision in decisions {
+            let Some(resolved) =
+                self.resolve_any(&decision.sound_id, registry, assets, audio_indices)
+            else {
+                continue;
+            };
+            if self.play_voice(
+                resolved.decoded,
+                resolved.event_linear,
+                Some(decision.sound_id),
+            ) {
+                self.current_voice_owner = Some(decision.owner);
+            }
+        }
+    }
+
+    /// The object whose voice handle is still live, if any.
+    ///
+    /// VERA-internal shape, gamemd equivalent read: native stores the handle
+    /// on the techno (`+0x4DC`) so any number of objects can be speaking at
+    /// once; VERA has one voice slot, so at most the slot's current owner can
+    /// answer `true`. Trigger: two objects with a latched line in the same
+    /// pass. Player effect: the second line cuts the first where native lets
+    /// them overlap. Frequency: never from player input — the one-voice-per-
+    /// batch latch (`g_SelectionVoice_Enable @ 0x00822CF2`) already lets only
+    /// one object speak per dispatch. Downstream risk: none; folding voices
+    /// into the 16-channel pool is the `voice_player` residual's job.
+    fn live_voice_owner(&self) -> Option<u64> {
+        let owner = self.current_voice_owner?;
+        self.voice_player
+            .as_ref()
+            .filter(|output| !output.player.empty())
+            .map(|_| owner)
+    }
+
+    /// Draw an index in `0..count` from the presentation RNG.
+    ///
+    /// The app layer's stand-in for a native `rand % count` list pick — the
+    /// `LightningSounds=` choice at `0x0053A48D DIV [Rules+0x744]` is the one
+    /// caller. `count == 0` yields 0 and the caller must not index with it.
+    pub fn pick_index(&mut self, count: usize) -> usize {
+        if count <= 1 {
+            return 0;
+        }
+        self.rng.ranged(0, count as i32 - 1) as usize
+    }
+
+    /// Forget one object's latch and playing index — object removal.
+    pub fn forget_unit_voice(&mut self, owner: u64) {
+        self.voice_queue.forget(owner);
+        if self.current_voice_owner == Some(owner) {
+            self.current_voice_owner = None;
+        }
     }
 
     /// Queue an EVA-style announcement without interrupting the current voice.
@@ -1439,6 +1506,12 @@ impl SfxPlayer {
         output.player.append(source);
         self.voice_player = Some(output);
         self.current_voice_id = sound_id;
+        // Every other route into the slot (EVA queue, STANDARD cue, interrupt)
+        // is ownerless; `drain_unit_voices` re-stamps the owner right after it
+        // starts an object's line. An EVA cue taking the slot therefore kills
+        // the live techno handle — VERA-internal, and the same single-slot
+        // limitation the `voice_player` field records.
+        self.current_voice_owner = None;
         true
     }
 

--- a/src/audio/voice_queue.rs
+++ b/src/audio/voice_queue.rs
@@ -1,0 +1,281 @@
+//! Per-object unit-voice latch and drain — the repeat guard.
+//!
+//! gamemd keeps three fields on every techno for its acknowledgement line:
+//! a **pending** voice index at `TechnoClass+0x4F0` (sentinel `-1`), a live
+//! **handle** at `+0x4DC`, and the index the handle is **playing** at `+0x4F4`.
+//!
+//! `TechnoClass::Queue_Voice @ 0x00708D90` only *latches*:
+//!
+//! ```text
+//! 00708d90  MOV  AL,[0x00822cf2]        ; g_SelectionVoice_Enable
+//! 00708d96  TEST AL,AL ; JZ  -> return  ; voice disabled
+//! 00708da1  CMP  EDI,-1 ; JZ  -> return ; no voice for this slot
+//! 00708da6  MOV  ECX,[ESI+0x21c]        ; owner house
+//! 00708dac  CALL 0x0050b6f0             ; HouseClass::IsHumanPlayer
+//! 00708db3  JZ   -> return              ; not the human player
+//! 00708db5  MOV  [ESI+0x4f0],EDI        ; latch, overwriting any prior pending
+//! ```
+//!
+//! `TechnoClass::AI_Update @ 0x006F9EBB` drains it once per object AI pass:
+//!
+//! ```text
+//! 006f9ebb  MOV  EAX,[ESI+0x4f0] ; CMP EAX,-1 ; JZ  -> nothing pending
+//! 006f9ec8  LEA  EDI,[ESI+0x4dc] ; CALL 0x00406130   ; VocHandle::ValidateOrClear
+//! 006f9ed7  JNZ  0x006f9ef7                          ; handle still live
+//!           ; handle free:
+//! 006f9eea  MOV  [ESI+0x4f4],ECX ; CALL 0x00750920   ; VocClass::PlayAtPos,
+//!                                                    ; volume 1.0f, pan 0x2000
+//! 006f9ef5  JMP  0x006f9f07                          ; then clear pending
+//! 006f9ef7  MOV  EDX,[ESI+0x4f4] ; MOV EAX,[ESI+0x4f0] ; CMP EDX,EAX
+//! 006f9f05  JNZ  0x006f9f0d                          ; DIFFERENT -> keep pending
+//! 006f9f07  MOV  [ESI+0x4f0],-1                      ; SAME -> drop the repeat
+//! ```
+//!
+//! So it is **not a timer**. Three outcomes, and only the middle one is what
+//! players hear when they click the same unit twice:
+//!
+//! | handle | pending vs playing | outcome |
+//! |---|---|---|
+//! | free | — | play, remember the index, clear pending |
+//! | live | same | **drop** — the line keeps going, it does not restart |
+//! | live | different | **hold** — retry on the next pass, do not cut the line |
+//!
+//! This module is the decision half only: it owns no audio device and no
+//! decoded samples, so the whole guard is testable without one. The caller
+//! supplies the single audio fact it needs — whether an owner's handle is
+//! still live — and applies the returned [`VoiceDecision`]s.
+
+use std::collections::BTreeMap;
+
+/// One object's voice work for this pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoiceDecision {
+    /// Stable id of the object whose line this is (native: the `TechnoClass`).
+    pub owner: u64,
+    /// The `sound(md).ini` id to start. gamemd stores the Voc index; VERA
+    /// carries the id string and compares it the same way.
+    pub sound_id: String,
+}
+
+/// The per-object pending / playing pair, without the audio device.
+#[derive(Debug, Default)]
+pub struct VoiceQueue {
+    /// `TechnoClass+0x4F0`. Absent == the native `-1` sentinel.
+    pending: BTreeMap<u64, String>,
+    /// `TechnoClass+0x4F4`, the index the object's live handle is playing.
+    playing: BTreeMap<u64, String>,
+}
+
+impl VoiceQueue {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `TechnoClass::Queue_Voice @ 0x00708D90` — latch, do not play.
+    ///
+    /// An empty id stands in for the native `-1` slot (`0x00708DA1`) and is
+    /// ignored. A second latch before the drain overwrites the first, exactly
+    /// as `MOV [ESI+0x4F0],EDI` does.
+    ///
+    /// The two gates ahead of the latch — `g_SelectionVoice_Enable @
+    /// 0x00822CF2` and `HouseClass::IsHumanPlayer @ 0x0050B6F0` — are already
+    /// upstream in VERA: the app input layer issues selection and order voices
+    /// only for the local player's own objects, and only one object per
+    /// dispatch batch speaks.
+    pub fn queue(&mut self, owner: u64, sound_id: &str) {
+        if sound_id.is_empty() {
+            return;
+        }
+        self.pending.insert(owner, sound_id.to_string());
+    }
+
+    /// `TechnoClass::AI_Update @ 0x006F9EBB` — drain every latched voice.
+    ///
+    /// `handle_live(owner)` is `VocHandle::ValidateOrClear @ 0x00406130` for
+    /// that object: true while the event the handle names is still the same
+    /// event playing the same entry.
+    ///
+    /// Native visits objects in the active-object scheduler's order; VERA
+    /// walks the map in ascending stable-id order so the pass is deterministic.
+    /// The two only differ when two objects both have a voice latched in the
+    /// same pass, which the one-voice-per-batch latch above already prevents
+    /// for player input.
+    pub fn drain(&mut self, mut handle_live: impl FnMut(u64) -> bool) -> Vec<VoiceDecision> {
+        // VERA-internal, gamemd has no counterpart: native stores the playing
+        // index inside the techno (`+0x4F4`), so it dies with the object and a
+        // stale value is harmless — `0x006F9F03` only reads it while the
+        // handle is live. VERA's map would otherwise keep one entry per object
+        // that ever spoke, so entries whose handle has gone are dropped at the
+        // top of the pass, before any of them can be compared.
+        self.playing.retain(|&owner, _| handle_live(owner));
+
+        let mut decisions = Vec::new();
+        let mut settled = Vec::new();
+
+        for (&owner, sound_id) in &self.pending {
+            if handle_live(owner) {
+                // `0x006F9EF7`: same index -> clear pending and let the line
+                // finish; different index -> leave it latched for next pass.
+                if self
+                    .playing
+                    .get(&owner)
+                    .is_some_and(|live| live == sound_id)
+                {
+                    settled.push(owner);
+                }
+            } else {
+                // `0x006F9ED9`: the handle is free, so this one starts now.
+                self.playing.insert(owner, sound_id.clone());
+                decisions.push(VoiceDecision {
+                    owner,
+                    sound_id: sound_id.clone(),
+                });
+                settled.push(owner);
+            }
+        }
+
+        for owner in settled {
+            self.pending.remove(&owner);
+        }
+
+        decisions
+    }
+
+    /// Forget one object entirely (removal, or a hard voice-slot reset).
+    pub fn forget(&mut self, owner: u64) {
+        self.pending.remove(&owner);
+        self.playing.remove(&owner);
+    }
+
+    /// The id latched for `owner`, if any — `TechnoClass+0x4F0`.
+    pub fn pending_for(&self, owner: u64) -> Option<&str> {
+        self.pending.get(&owner).map(String::as_str)
+    }
+
+    /// The id this object's handle is playing — `TechnoClass+0x4F4`.
+    pub fn playing_for(&self, owner: u64) -> Option<&str> {
+        self.playing.get(&owner).map(String::as_str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_free_handle_plays_and_clears_the_pending_slot() {
+        let mut queue = VoiceQueue::new();
+        queue.queue(7, "GIMove");
+        assert_eq!(queue.pending_for(7), Some("GIMove"));
+
+        let decisions = queue.drain(|_| false);
+        assert_eq!(
+            decisions,
+            vec![VoiceDecision {
+                owner: 7,
+                sound_id: "GIMove".to_string()
+            }]
+        );
+        assert_eq!(queue.pending_for(7), None, "0x006F9F07 clears the latch");
+    }
+
+    #[test]
+    fn the_same_line_while_it_is_still_playing_is_dropped_not_restarted() {
+        let mut queue = VoiceQueue::new();
+        queue.queue(7, "GIMove");
+        assert_eq!(queue.drain(|_| false).len(), 1);
+
+        // Second click on the same unit while its line is mid-word.
+        queue.queue(7, "GIMove");
+        let decisions = queue.drain(|owner| owner == 7);
+        assert!(
+            decisions.is_empty(),
+            "0x006F9F03 same-index path must not start the line again"
+        );
+        assert_eq!(queue.pending_for(7), None, "and it clears the latch");
+        assert_eq!(queue.playing_for(7), Some("GIMove"));
+    }
+
+    #[test]
+    fn a_different_line_waits_for_the_live_one_instead_of_cutting_it() {
+        let mut queue = VoiceQueue::new();
+        queue.queue(7, "GISelect");
+        assert_eq!(queue.drain(|_| false).len(), 1);
+
+        queue.queue(7, "GIMove");
+        // Handle still live with a different index: hold, do not play.
+        assert!(queue.drain(|owner| owner == 7).is_empty());
+        assert_eq!(
+            queue.pending_for(7),
+            Some("GIMove"),
+            "0x006F9F05 leaves the latch set so the next pass retries"
+        );
+
+        // The line finishes; the retry starts the held one.
+        let decisions = queue.drain(|_| false);
+        assert_eq!(
+            decisions,
+            vec![VoiceDecision {
+                owner: 7,
+                sound_id: "GIMove".to_string()
+            }]
+        );
+        assert_eq!(queue.playing_for(7), Some("GIMove"));
+    }
+
+    #[test]
+    fn a_second_latch_before_the_drain_replaces_the_first() {
+        let mut queue = VoiceQueue::new();
+        queue.queue(7, "GISelect");
+        queue.queue(7, "GIMove");
+        assert_eq!(queue.pending_for(7), Some("GIMove"));
+        let decisions = queue.drain(|_| false);
+        assert_eq!(decisions.len(), 1);
+        assert_eq!(decisions[0].sound_id, "GIMove");
+    }
+
+    #[test]
+    fn an_empty_id_is_the_native_minus_one_slot_and_latches_nothing() {
+        let mut queue = VoiceQueue::new();
+        queue.queue(7, "");
+        assert_eq!(queue.pending_for(7), None);
+        assert!(queue.drain(|_| false).is_empty());
+    }
+
+    #[test]
+    fn two_objects_drain_in_ascending_stable_id_order() {
+        let mut queue = VoiceQueue::new();
+        queue.queue(9, "DogMove");
+        queue.queue(3, "GIMove");
+        let decisions = queue.drain(|_| false);
+        assert_eq!(
+            decisions.iter().map(|d| d.owner).collect::<Vec<_>>(),
+            vec![3, 9]
+        );
+    }
+
+    #[test]
+    fn the_playing_map_does_not_grow_past_the_live_handles() {
+        let mut queue = VoiceQueue::new();
+        for owner in 0..8u64 {
+            queue.queue(owner, "GIMove");
+        }
+        queue.drain(|_| false);
+        // Nothing is live afterwards, so the bookkeeping empties out.
+        queue.drain(|_| false);
+        for owner in 0..8u64 {
+            assert_eq!(queue.playing_for(owner), None);
+        }
+    }
+
+    #[test]
+    fn forget_drops_both_halves() {
+        let mut queue = VoiceQueue::new();
+        queue.queue(7, "GIMove");
+        queue.drain(|_| false);
+        queue.queue(7, "GISelect");
+        queue.forget(7);
+        assert_eq!(queue.pending_for(7), None);
+        assert_eq!(queue.playing_for(7), None);
+    }
+}

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -406,6 +406,15 @@ pub struct ObjectType {
     pub voice_die: Vec<String>,
     /// Ordered sound choices played when this entity dies or is destroyed.
     pub die_sounds: Vec<String>,
+    /// `DamageSound=` — `TechnoTypeClass+0x538`, the type's own struck cue.
+    ///
+    /// Only its presence is consumed here: `BuildingClass::ReceiveDamage`
+    /// gates the global `[AudioVisual] BuildingDamageSound=` on
+    /// `0x004426D2 CMP [type+0x538],-1`, so a type that names any resolvable
+    /// sound suppresses the global. Playing this per-type cue itself is a
+    /// TechnoClass-level path (`0x00702717` in `TechnoClass::ReceiveDamage`)
+    /// that VERA does not route yet — recorded, not landed.
+    pub damage_sound: Option<String>,
     /// Sound ID played while this entity moves (looping engine/footstep).
     pub move_sound: Option<String>,
     /// Sound ID played when this unit reacts to taking fire (fear cry).
@@ -1527,6 +1536,11 @@ impl ObjectType {
             prevent_attack_move: section.get_bool("PreventAttackMove").unwrap_or(false),
             voice_die: parse_csv_string_list(section.get("VoiceDie")),
             die_sounds: parse_csv_string_list(section.get("DieSound")),
+            damage_sound: section
+                .get("DamageSound")
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
             move_sound: section.get("MoveSound").map(|s| s.to_string()),
             voice_feedback: section.get("VoiceFeedback").map(|s| s.to_string()),
             voice_special_attack: section.get("VoiceSpecialAttack").map(|s| s.to_string()),

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -411,13 +411,34 @@ pub struct ObjectType {
     /// Only its presence is consumed here: `BuildingClass::ReceiveDamage`
     /// gates the global `[AudioVisual] BuildingDamageSound=` on
     /// `0x004426D2 CMP [type+0x538],-1`, so a type that names any resolvable
-    /// sound suppresses the global. Playing this per-type cue itself is a
-    /// TechnoClass-level path (`0x00702717` in `TechnoClass::ReceiveDamage`)
-    /// that VERA does not route yet — recorded, not landed.
+    /// sound suppresses the global.
+    ///
+    /// RESIDUAL: the per-type cue itself is not routed. Native plays it from
+    /// `TechnoClass::ReceiveDamage @ 0x00701900` arm `0x00702713`/`0x00702717`
+    /// — index **1** of the switch table at `0x00702D24`, i.e. the ordinary
+    /// **non-crossing** hit (damage result 1), not the result-2/3 crossings
+    /// the global rides — and plays it **twice** (`0x00702760`, `0x007027A9`).
+    /// The two cues are therefore mutually exclusive by result, not just by
+    /// the `-1` gate. Trigger / player effect / frequency are recorded in full
+    /// on `crate::audio::events::SoundEventQueue`.
     pub damage_sound: Option<String>,
     /// Sound ID played while this entity moves (looping engine/footstep).
     pub move_sound: Option<String>,
-    /// Sound ID played when this unit reacts to taking fire (fear cry).
+    /// `VoiceFeedback=` — `TechnoTypeClass+0x4D8`, the line spoken when this
+    /// techno's HP crosses below half strength.
+    ///
+    /// Identity: `0x00712D9C LEA EDI,[EBP+0x4D8]` in
+    /// `TechnoTypeClass::ReadINI` pushes the key string at `0x0084424C`
+    /// (`"VoiceFeedback"`) into `CCINIClass::ReadSoundList @ 0x00525430`
+    /// (`0x00712DCB`), so the vector is at `+0x4D8` with items `+0x4DC` and
+    /// count `+0x4E8` — the exact fields
+    /// `TechnoClass::ReceiveDamage @ 0x00702695` reads. Consumed through
+    /// `SimSoundEvent::VoiceFeedback`.
+    ///
+    /// RESIDUAL: native holds a comma list, VERA one id. All 133 stock authors
+    /// are single-entry (0 contain a comma), so the `rand % count` pick at
+    /// `0x007026E7` is 0 either way; a modded list would diverge. Same
+    /// divergence as the `VoiceMove=` one on `voice_id_for_key`.
     pub voice_feedback: Option<String>,
     /// Sound ID played when this unit performs a special attack.
     pub voice_special_attack: Option<String>,

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -570,6 +570,43 @@ pub struct GeneralRules {
     pub building_garrisoned_sound: Option<String>,
     /// Global wall/building sale cue from `[AudioVisual] SellSound=`.
     pub sell_sound: Option<String>,
+    /// Base-alert siren from `[AudioVisual] BaseUnderAttackSound=` (stock
+    /// `BaseUnderAttackSiren`), stored at `Rules+0x184`.
+    ///
+    /// gamemd: `HouseClass::NotifyUnderAttack @ 0x004F95B8..0x004F95CF` plays
+    /// it non-positionally (pan `0x2000`, volume `1.0f`, no handle) through
+    /// `VocClass::PlayAtPos @ 0x00750920`, right after the EVA line at
+    /// `0x004F95B3` and only when `CreateRadarEvent @ 0x0065FA70` accepted the
+    /// ping. The ore-miner branch at `0x004F94FB` jumps straight to
+    /// `LAB_004F95D4`, so a harvester under attack gets the EVA and **no**
+    /// siren.
+    pub base_under_attack_sound: Option<String>,
+    /// Building crumble cue from `[AudioVisual] BuildingDieSound=` (stock
+    /// `BuildingGenericDie`).
+    ///
+    /// gamemd: `RulesClass::ReadAudioVisual @ 0x0066AA49..0x0066AA88` stores
+    /// the `VocClass::FindByName` result in `Rules+0x6E8`.
+    /// `BuildingClass::DestructionEffects` plays it at the building's own
+    /// coordinate (`0x0044174E LEA EAX,[ESI+0x9C]`, then
+    /// `0x00441773 MOV ECX,[Rules+0x6E8]`, `0x00441779 CALL
+    /// VocClass::PlayAtCoord @ 0x00750E20`) — but **only when the building
+    /// type's own `DieSound=` list is empty**: `0x0044173F MOV
+    /// ECX,[type+0x520]` is that `DynamicVectorClass`'s count
+    /// (`TechnoTypeClass+0x510..0x528`) and `0x0044174A CMP ECX,EBX ; JNZ`
+    /// skips the global when it is non-zero (`EBX` is zeroed for the whole
+    /// function at `0x00441606`).
+    pub building_die_sound: Option<String>,
+    /// Thunder cues from `[AudioVisual] LightningSounds=` (stock a single
+    /// `WeatherStrike`), in source order.
+    ///
+    /// gamemd: `CCINIClass::ReadSoundList @ 0x00525430` reads the value with
+    /// `ReadString(..., "", buf, 0x80)`, tokenises it with `strtok` on `","`
+    /// (`0x00817F70`) and keeps only names `VocClass::FindPtrByName` resolves,
+    /// leaving the vector at `Rules+0x734` (items `+0x738`, count `+0x744`).
+    /// `LightningStorm::GroundStrike @ 0x0053A45F..0x0053A4A2` skips the cue
+    /// entirely when the count is zero and otherwise plays
+    /// `items[rand % count]` at the strike coordinate.
+    pub lightning_sounds: Vec<String>,
     /// SFX played when a paradropped passenger successfully deploys a parachute.
     /// Parsed from [AudioVisual] ChuteSound (stock "ParachuteDrop").
     /// None = no sound configured. Resolved at app layer to a sound.ini entry.
@@ -1124,6 +1161,9 @@ impl Default for GeneralRules {
             guard_area_targeting_delay: 36,
             building_garrisoned_sound: None,
             sell_sound: None,
+            base_under_attack_sound: None,
+            building_die_sound: None,
+            lightning_sounds: Vec::new(),
             chute_sound: None,
             gui_main_button_sound: None,
             gui_move_in_sound: None,
@@ -1841,6 +1881,32 @@ impl GeneralRules {
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .map(str::to_string),
+            base_under_attack_sound: audio_visual
+                .and_then(|s| s.get("BaseUnderAttackSound"))
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+            building_die_sound: audio_visual
+                .and_then(|s| s.get("BuildingDieSound"))
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+            // `CCINIClass::ReadSoundList @ 0x00525430`: `ReadString(..., "",
+            // buf, 0x80)` first (so the whole value is byte-cut and trimmed
+            // once), then `strtok` on `","` (`0x00817F70`) with the tokens
+            // left untrimmed. Resolution against the Voc registry
+            // (`VocClass::FindPtrByName`, which drops unresolvable names) is
+            // deferred to the app layer, where the registry lives.
+            lightning_sounds: audio_visual
+                .map(|section| section.read_string("LightningSounds", "", 0x80))
+                .map(|value| {
+                    value
+                        .split(',')
+                        .filter(|token| !token.is_empty())
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default(),
             chute_sound: audio_visual
                 .and_then(|s| s.get("ChuteSound"))
                 .map(str::trim)
@@ -5293,6 +5359,80 @@ BuildingGarrisonedSound=BuildingGarrisoned
         assert_eq!(
             general.building_garrisoned_sound.as_deref(),
             Some("BuildingGarrisoned")
+        );
+    }
+
+    /// `[AudioVisual] BaseUnderAttackSound=` — the siren
+    /// `HouseClass::NotifyUnderAttack` plays at `0x004F95CF` next to the EVA
+    /// line.
+    #[test]
+    fn base_under_attack_sound_parses_and_an_absent_key_is_silence() {
+        let stock = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\nBaseUnderAttackSound=BaseUnderAttackSiren\n",
+        ));
+        assert_eq!(
+            stock.base_under_attack_sound.as_deref(),
+            Some("BaseUnderAttackSiren")
+        );
+
+        let absent =
+            GeneralRules::from_ini(&IniFile::from_str("[General]\nFlightLevel=500\n[AudioVisual]\n"));
+        assert_eq!(absent.base_under_attack_sound, None);
+    }
+
+    /// `[AudioVisual] BuildingDieSound=` — the global building crumble cue
+    /// `BuildingClass::DestructionEffects` plays at `0x00441779` when the
+    /// dying building's type has no `DieSound=` of its own.
+    #[test]
+    fn building_die_sound_parses_and_an_absent_key_is_silence() {
+        let stock = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\nBuildingDieSound=BuildingGenericDie\n",
+        ));
+        assert_eq!(
+            stock.building_die_sound.as_deref(),
+            Some("BuildingGenericDie")
+        );
+
+        let absent =
+            GeneralRules::from_ini(&IniFile::from_str("[General]\nFlightLevel=500\n[AudioVisual]\n"));
+        assert_eq!(absent.building_die_sound, None);
+
+        let empty = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\nBuildingDieSound=\n",
+        ));
+        assert_eq!(empty.building_die_sound, None);
+    }
+
+    /// `[AudioVisual] LightningSounds=` goes through `CCINIClass::ReadSoundList
+    /// @ 0x00525430`, which tokenises on `","` (`0x00817F70`) after one
+    /// `ReadString` trim; empty fields collapse and an absent key leaves the
+    /// vector empty, which is the `0x0053A46A JLE` "play nothing" branch.
+    #[test]
+    fn lightning_sounds_reads_the_native_comma_list() {
+        let stock = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\nLightningSounds=WeatherStrike\n",
+        ));
+        assert_eq!(stock.lightning_sounds, vec!["WeatherStrike".to_string()]);
+
+        let multi = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\nLightningSounds=A,,B\n",
+        ));
+        assert_eq!(
+            multi.lightning_sounds,
+            vec!["A".to_string(), "B".to_string()],
+            "strtok collapses the empty field between the two commas"
+        );
+
+        let absent =
+            GeneralRules::from_ini(&IniFile::from_str("[General]\nFlightLevel=500\n[AudioVisual]\n"));
+        assert!(absent.lightning_sounds.is_empty());
+
+        let empty = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\nLightningSounds=\n",
+        ));
+        assert!(
+            empty.lightning_sounds.is_empty(),
+            "stock ships an empty IceCrackSounds= in the same shape"
         );
     }
 

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -577,9 +577,11 @@ pub struct GeneralRules {
     /// it non-positionally (pan `0x2000`, volume `1.0f`, no handle) through
     /// `VocClass::PlayAtPos @ 0x00750920`, right after the EVA line at
     /// `0x004F95B3` and only when `CreateRadarEvent @ 0x0065FA70` accepted the
-    /// ping. The ore-miner branch at `0x004F94FB` jumps straight to
-    /// `LAB_004F95D4`, so a harvester under attack gets the EVA and **no**
-    /// siren.
+    /// ping. The ore-miner branch plays `EVA_OreMinerUnderAttack` at
+    /// `0x004F94FB` and then jumps (`0x004F9500 JMP`) to `LAB_004F95D4`, so a
+    /// harvester under attack gets the EVA and **no** siren. The
+    /// `EVA_OurAllyIsUnderAttack` branch does NOT jump past — native sirens
+    /// for an ally's base too, which VERA does not (pre-existing residual).
     pub base_under_attack_sound: Option<String>,
     /// Building crumble cue from `[AudioVisual] BuildingDieSound=` (stock
     /// `BuildingGenericDie`).
@@ -596,6 +598,24 @@ pub struct GeneralRules {
     /// skips the global when it is non-zero (`EBX` is zeroed for the whole
     /// function at `0x00441606`).
     pub building_die_sound: Option<String>,
+    /// Struck-building cue from `[AudioVisual] BuildingDamageSound=` (stock
+    /// `BuildingDamaged`), stored at `Rules+0x714`.
+    ///
+    /// gamemd: `BuildingClass::ReceiveDamage @ 0x00442230` plays it at the
+    /// building's own coordinate (`0x004426DB LEA ECX,[ESI+0x9C]`,
+    /// `0x00442700 MOV ECX,[Rules+0x714]`, `0x00442706 CALL
+    /// VocClass::PlayAtCoord @ 0x00750E20`). It is **not** a per-hit cue: the
+    /// shared Techno receiver's result selects the arm. `0x0044242C MOV
+    /// AL,[ESI+0x90]` (`ObjectClass::IsAlive`) skips the whole dispatch for a
+    /// dead building; otherwise `0x00442476 JMP [EAX*4 + 0x00442C18]` with
+    /// `EAX = result - 2` enters the four-entry table
+    /// `{0x004426AC, 0x004426C8, 0x004424A2, 0x0044247D}`, and only entries 0
+    /// and 1 — result 2 (the hit crossed HP from `>= Strength >> 1` to below
+    /// it) and result 3 (it crossed below `Strength * Rules+0x1708`,
+    /// ConditionRed) — reach the gate at `0x004426D2 CMP [type+0x538],-1`.
+    /// A type with its own `DamageSound=` takes `JNZ 0x0044270B` and the
+    /// global is skipped.
+    pub building_damage_sound: Option<String>,
     /// Thunder cues from `[AudioVisual] LightningSounds=` (stock a single
     /// `WeatherStrike`), in source order.
     ///
@@ -1163,6 +1183,7 @@ impl Default for GeneralRules {
             sell_sound: None,
             base_under_attack_sound: None,
             building_die_sound: None,
+            building_damage_sound: None,
             lightning_sounds: Vec::new(),
             chute_sound: None,
             gui_main_button_sound: None,
@@ -1888,6 +1909,11 @@ impl GeneralRules {
                 .map(str::to_string),
             building_die_sound: audio_visual
                 .and_then(|s| s.get("BuildingDieSound"))
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+            building_damage_sound: audio_visual
+                .and_then(|s| s.get("BuildingDamageSound"))
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .map(str::to_string),
@@ -5401,6 +5427,30 @@ BuildingGarrisonedSound=BuildingGarrisoned
             "[General]\nFlightLevel=500\n[AudioVisual]\nBuildingDieSound=\n",
         ));
         assert_eq!(empty.building_die_sound, None);
+    }
+
+    /// `[AudioVisual] BuildingDamageSound=` — the global struck-building cue
+    /// `BuildingClass::ReceiveDamage` plays at `0x00442706` when the damaged
+    /// building's type has no `DamageSound=` of its own
+    /// (`0x004426D2 CMP [type+0x538],-1`).
+    #[test]
+    fn building_damage_sound_parses_and_an_absent_key_is_silence() {
+        let stock = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\nBuildingDamageSound=BuildingDamaged\n",
+        ));
+        assert_eq!(
+            stock.building_damage_sound.as_deref(),
+            Some("BuildingDamaged")
+        );
+
+        let absent =
+            GeneralRules::from_ini(&IniFile::from_str("[General]\nFlightLevel=500\n[AudioVisual]\n"));
+        assert_eq!(absent.building_damage_sound, None);
+
+        let empty = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\nBuildingDamageSound=\n",
+        ));
+        assert_eq!(empty.building_damage_sound, None);
     }
 
     /// `[AudioVisual] LightningSounds=` goes through `CCINIClass::ReadSoundList

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -4362,6 +4362,171 @@ fn a_struck_building_sounds_the_global_damage_cue_only_on_a_state_crossing() {
     assert!(damage_cues(&sounds).is_empty());
 }
 
+/// `TechnoClass::ReceiveDamage @ 0x00701900` arm `0x00702695` — index 2 of the
+/// switch table at `0x00702D24`, i.e. damage result 2 only. Unlike the
+/// BuildingClass cue this is a Techno-level arm, so every category reaches it;
+/// and unlike it, result 3 does NOT (index 3 is `0x007027F7`, the tail).
+#[test]
+fn a_techno_speaks_its_voice_feedback_only_on_the_half_strength_crossing() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "\
+[General]\nFlightLevel=500\n\n\
+[AudioVisual]\nBuildingDamageSound=BuildingDamaged\nConditionRed=25%\n\n\
+[InfantryTypes]\n0=E1\n1=E2\n\n\
+[VehicleTypes]\n0=MTNK\n\n\
+[AircraftTypes]\n\n\
+[BuildingTypes]\n0=GAPOWR\n\n\
+[E1]\nStrength=100\nArmor=none\nVoiceFeedback=GIFear\n\n\
+[E2]\nStrength=100\nArmor=none\n\n\
+[MTNK]\nStrength=300\nArmor=none\nSpeed=6\nPrimary=Plain\n\n\
+[GAPOWR]\nStrength=100\nArmor=none\nVoiceFeedback=StructureFear\n\n\
+[Plain]\nDamage=10\nROF=20\nRange=6\nWarhead=PlainWH\n\n\
+[PlainWH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("voice-feedback rules parse");
+
+    let hit = |victim_type: &str,
+               victim_category: EntityCategory,
+               damage: i32|
+     -> (Vec<SimSoundEvent>, u16) {
+        let mut entities = EntityStore::new();
+        let mut attacker = GameEntity::test_default(1, "MTNK", "Americans", 10, 10);
+        attacker.lifecycle.in_limbo = false;
+        attacker.in_playfield = true;
+        entities.insert(attacker);
+        let mut victim = GameEntity::test_default(2, victim_type, "Soviet", 4, 7);
+        victim.category = victim_category;
+        victim.health = Health {
+            current: 100,
+            max: 100,
+        };
+        victim.lifecycle.in_limbo = false;
+        victim.in_playfield = true;
+        entities.insert(victim);
+
+        let mut interner = test_interner();
+        let allies = interner.intern("Americans");
+        let soviet = interner.intern("Soviet");
+        let warhead_ref = interner.intern("PlainWH");
+
+        let mut houses = BTreeMap::from([
+            (soviet, HouseState::new(soviet, 0, None, false, 0, 10)),
+            (allies, HouseState::new(allies, 1, None, false, 0, 10)),
+        ]);
+        let house_order = [soviet, allies];
+        let mut occupancy = OccupancyGrid::new();
+        let mut main_rng = SimRng::new(11);
+        let mut scenario_rng = SimRng::new(13);
+        let mut handled_deaths = Vec::new();
+        let mut resources = BTreeMap::new();
+        let mut hooks = None;
+        let mut collected: Vec<SimSoundEvent> = Vec::new();
+        let mut sound_sink: Option<&mut Vec<SimSoundEvent>> = Some(&mut collected);
+
+        let records = [EntityDamageEvent::area(
+            2,
+            damage,
+            0,
+            1,
+            Some(allies),
+            warhead_ref,
+        )];
+        let scenario_before = scenario_rng.state();
+        let main_before = main_rng.state();
+        let _ = commit_damage_events(
+            &records,
+            &mut entities,
+            &mut occupancy,
+            &rules,
+            &mut interner,
+            &mut houses,
+            &house_order,
+            &HouseAllianceMap::new(),
+            &mut main_rng,
+            &mut scenario_rng,
+            &mut handled_deaths,
+            &mut resources,
+            None,
+            None,
+            None,
+            100,
+            &mut hooks,
+            &mut sound_sink,
+        );
+        // Both native draws are on `g_MainRng @ 0x00886B88`, which per-frame
+        // draw paths also consume, so the cue must cost `sim/` nothing.
+        assert_eq!(
+            scenario_rng.state(),
+            scenario_before,
+            "the damage voice must not spend a scenario draw"
+        );
+        assert_eq!(
+            main_rng.state(),
+            main_before,
+            "the damage voice must not spend a sim main draw"
+        );
+        let hp = entities.get(2).map_or(0, |victim| victim.health.current);
+        (collected, hp)
+    };
+
+    let voices = |sounds: &[SimSoundEvent]| -> Vec<(u16, u16)> {
+        sounds
+            .iter()
+            .filter_map(|sound| match sound {
+                SimSoundEvent::VoiceFeedback { rx, ry, .. } => Some((*rx, *ry)),
+                _ => None,
+            })
+            .collect()
+    };
+
+    // 100 -> 40 crosses `Strength >> 1` = 50 without reaching ConditionRed
+    // (25): result 2, index 2 of `0x00702D24`, spoken at the object's own cell
+    // (`0x00702702 CALL [EDX+0x48]`).
+    let (sounds, hp) = hit("E1", EntityCategory::Infantry, 60);
+    assert_eq!(hp, 40);
+    assert_eq!(voices(&sounds), [(4, 7)]);
+
+    // 100 -> 80 crosses nothing: result 1, index 1 — the per-type
+    // `DamageSound=` arm, never the voice.
+    let (sounds, hp) = hit("E1", EntityCategory::Infantry, 20);
+    assert_eq!(hp, 80);
+    assert!(voices(&sounds).is_empty());
+
+    // 100 -> 20 crosses BOTH thresholds, and `ObjectClass::ReceiveDamage @
+    // 0x005F5390` lets 3 override 2. Index 3 is `0x007027F7`, the shared tail,
+    // so a hit that drops a unit straight into the red says nothing.
+    let (sounds, hp) = hit("E1", EntityCategory::Infantry, 80);
+    assert_eq!(hp, 20);
+    assert!(voices(&sounds).is_empty());
+
+    // 100 -> 0 is forced to index 4 by `0x00702035 MOV EDI,0x4`.
+    let (sounds, _) = hit("E1", EntityCategory::Infantry, 100);
+    assert!(voices(&sounds).is_empty());
+
+    // `0x007026A1 MOV EAX,[EDI+0x4E8]` / `0x007026A9 JLE`: an empty list
+    // returns before the roll, so a type with no `VoiceFeedback=` is silent.
+    let (sounds, hp) = hit("E2", EntityCategory::Infantry, 60);
+    assert_eq!(hp, 40);
+    assert!(voices(&sounds).is_empty());
+
+    // The arm is TechnoClass-level, so a building speaks too — and the voice
+    // is emitted first, because native runs it inside
+    // `TechnoClass::ReceiveDamage`, which `BuildingClass::ReceiveDamage` only
+    // resumes after at `0x00442425`.
+    let (sounds, hp) = hit("GAPOWR", EntityCategory::Structure, 60);
+    assert_eq!(hp, 40);
+    assert_eq!(voices(&sounds), [(4, 7)]);
+    let order: Vec<&str> = sounds
+        .iter()
+        .filter_map(|sound| match sound {
+            SimSoundEvent::VoiceFeedback { .. } => Some("voice"),
+            SimSoundEvent::BuildingDamagedSfx { .. } => Some("building"),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(order, ["voice", "building"]);
+}
+
 #[test]
 fn fatal_sound_selection_uses_human_voice_then_die_sound_main_draws() {
     let rules = RuleSet::from_ini(&IniFile::from_str(

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -4214,6 +4214,154 @@ fn a_building_with_no_die_sound_falls_back_to_the_global_building_die_sound() {
     assert!(sounds.is_empty());
 }
 
+/// `BuildingClass::ReceiveDamage @ 0x00442230`: the global
+/// `[AudioVisual] BuildingDamageSound` (`Rules+0x714`) is a **damage-state**
+/// cue, not a per-hit one.
+///
+/// `0x00442476 JMP [EAX*4 + 0x00442C18]` indexes the four-entry table
+/// `{0x004426AC, 0x004426C8, 0x004424A2, 0x0044247D}` with `result - 2`;
+/// entry 0 (result 2, the `Strength >> 1` crossing) falls through into entry 1
+/// (result 3, the `Strength * Rules+0x1708` crossing) and both reach
+/// `0x004426D2 CMP [type+0x538],-1`, so a type with its own `DamageSound=`
+/// takes `JNZ 0x0044270B` and the global never plays. Results 1 (no crossing)
+/// and 4 (dead) leave the arm unvisited, and `0x0044242C MOV AL,[ESI+0x90]`
+/// (`ObjectClass::IsAlive`) skips the whole dispatch for a corpse.
+#[test]
+fn a_struck_building_sounds_the_global_damage_cue_only_on_a_state_crossing() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "\
+[General]\nFlightLevel=500\n\n\
+[AudioVisual]\nBuildingDamageSound=BuildingDamaged\nConditionRed=25%\n\n\
+[InfantryTypes]\n0=E1\n\n\
+[VehicleTypes]\n0=MTNK\n\n\
+[AircraftTypes]\n\n\
+[BuildingTypes]\n0=GAPOWR\n1=GAWEAP\n\n\
+[E1]\nStrength=100\nArmor=none\n\n\
+[MTNK]\nStrength=300\nArmor=none\nSpeed=6\nPrimary=Plain\n\n\
+[GAPOWR]\nStrength=100\nArmor=none\n\n\
+[GAWEAP]\nStrength=100\nArmor=none\nDamageSound=BuildingMetalDamaged\n\n\
+[Plain]\nDamage=10\nROF=20\nRange=6\nWarhead=PlainWH\n\n\
+[PlainWH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("building damage-sound rules parse");
+
+    // One `commit_damage_events` transaction: entity 1 (MTNK) hits entity 2
+    // for `damage`. `victim_type`/`victim_category` shape the receiver.
+    let hit = |victim_type: &str,
+               victim_category: EntityCategory,
+               damage: i32|
+     -> (Vec<SimSoundEvent>, u16) {
+        // `GameEntity::test_default` interns through the thread-local test
+        // interner, and `test_interner()` snapshots it — so the entities must
+        // exist before the snapshot or their type ids resolve to whatever the
+        // clone happens to hold at that index.
+        let mut entities = EntityStore::new();
+        let mut attacker = GameEntity::test_default(1, "MTNK", "Americans", 10, 10);
+        attacker.lifecycle.in_limbo = false;
+        attacker.in_playfield = true;
+        entities.insert(attacker);
+        let mut victim = GameEntity::test_default(2, victim_type, "Soviet", 4, 7);
+        victim.category = victim_category;
+        victim.health = Health {
+            current: 100,
+            max: 100,
+        };
+        victim.lifecycle.in_limbo = false;
+        victim.in_playfield = true;
+        entities.insert(victim);
+
+        let mut interner = test_interner();
+        let allies = interner.intern("Americans");
+        let soviet = interner.intern("Soviet");
+        let warhead_ref = interner.intern("PlainWH");
+
+        let mut houses = BTreeMap::from([
+            (soviet, HouseState::new(soviet, 0, None, false, 0, 10)),
+            (allies, HouseState::new(allies, 1, None, false, 0, 10)),
+        ]);
+        let house_order = [soviet, allies];
+        let mut occupancy = OccupancyGrid::new();
+        let mut main_rng = SimRng::new(11);
+        let mut scenario_rng = SimRng::new(13);
+        let mut handled_deaths = Vec::new();
+        let mut resources = BTreeMap::new();
+        let mut hooks = None;
+        let mut collected: Vec<SimSoundEvent> = Vec::new();
+        let mut sound_sink: Option<&mut Vec<SimSoundEvent>> = Some(&mut collected);
+
+        let records = [EntityDamageEvent::area(
+            2,
+            damage,
+            0,
+            1,
+            Some(allies),
+            warhead_ref,
+        )];
+        let _ = commit_damage_events(
+            &records,
+            &mut entities,
+            &mut occupancy,
+            &rules,
+            &mut interner,
+            &mut houses,
+            &house_order,
+            &HouseAllianceMap::new(),
+            &mut main_rng,
+            &mut scenario_rng,
+            &mut handled_deaths,
+            &mut resources,
+            None,
+            None,
+            None,
+            100,
+            &mut hooks,
+            &mut sound_sink,
+        );
+        let hp = entities.get(2).map_or(0, |victim| victim.health.current);
+        (collected, hp)
+    };
+
+    let damage_cues = |sounds: &[SimSoundEvent]| -> Vec<(u16, u16)> {
+        sounds
+            .iter()
+            .filter_map(|sound| match sound {
+                SimSoundEvent::BuildingDamagedSfx { rx, ry } => Some((*rx, *ry)),
+                _ => None,
+            })
+            .collect()
+    };
+
+    // 100 -> 40 crosses `Strength >> 1` = 50: result 2, entry 0 of the table,
+    // and the cue plays at the building's own cell.
+    let (sounds, hp) = hit("GAPOWR", EntityCategory::Structure, 60);
+    assert_eq!(hp, 40);
+    assert_eq!(damage_cues(&sounds), [(4, 7)]);
+
+    // 100 -> 80 crosses nothing: result 1, which the `CMP EAX,3 ; JA` bound at
+    // `0x0044246D` rejects, so the damage-sound arm is never entered.
+    let (sounds, hp) = hit("GAPOWR", EntityCategory::Structure, 20);
+    assert_eq!(hp, 80);
+    assert!(damage_cues(&sounds).is_empty());
+
+    // 100 -> 0 is result 4: entry 2 of the table (`0x004424A2`), which never
+    // reaches `0x004426D2`. A dying building gets its crumble cue instead.
+    let (sounds, _) = hit("GAPOWR", EntityCategory::Structure, 100);
+    assert!(damage_cues(&sounds).is_empty());
+
+    // `[GAWEAP] DamageSound=` is the `0x004426D2` gate: the type's own cue
+    // wins and the global is skipped.
+    let (sounds, hp) = hit("GAWEAP", EntityCategory::Structure, 60);
+    assert_eq!(hp, 40);
+    assert!(damage_cues(&sounds).is_empty());
+
+    // The arm is BuildingClass-only — an infantryman crossing the same
+    // threshold returns through `TechnoClass::ReceiveDamage`, never
+    // `0x00442476`.
+    let (sounds, hp) = hit("E1", EntityCategory::Infantry, 60);
+    assert_eq!(hp, 40);
+    assert!(damage_cues(&sounds).is_empty());
+}
+
 #[test]
 fn fatal_sound_selection_uses_human_voice_then_die_sound_main_draws() {
     let rules = RuleSet::from_ini(&IniFile::from_str(

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -4120,6 +4120,100 @@ fn selected_death_sounds_for(
         .collect()
 }
 
+/// `BuildingClass::DestructionEffects`: a dying building whose type has no
+/// `DieSound=` of its own falls back to `[AudioVisual] BuildingDieSound`
+/// (`0x0044173F` reads the type's `DieSound` vector count at `+0x520`,
+/// `0x0044174A CMP ECX,EBX ; JNZ` skips the global when it is non-zero, and
+/// `0x00441773`/`0x00441779` play `Rules+0x6E8` at the building's coordinate).
+/// The fallback is not owner-gated and draws no RNG.
+#[test]
+fn a_building_with_no_die_sound_falls_back_to_the_global_building_die_sound() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "\
+[General]\nFlightLevel=500\n\n\
+[AudioVisual]\nBuildingDieSound=BuildingGenericDie\n\n\
+[InfantryTypes]\n0=E1\n\n\
+[VehicleTypes]\n\n\
+[AircraftTypes]\n\n\
+[BuildingTypes]\n0=GAPOWR\n1=GATECH\n\n\
+[E1]\nStrength=1\nArmor=none\nDieSound=DieA\n\n\
+[GAPOWR]\nStrength=750\nArmor=wood\n\n\
+[GATECH]\nStrength=750\nArmor=wood\nDieSound=OwnCrumble\n",
+    ))
+    .expect("building die-sound rules parse");
+
+    let selected = |type_name: &str, category: EntityCategory| -> Vec<String> {
+        let mut interner = test_interner();
+        let mut rng = SimRng::new(11);
+        let rng_before = rng.state();
+        let mut sounds = Vec::new();
+        super::append_selected_death_sounds(
+            rules.object(type_name).expect("type"),
+            category,
+            rules.general.building_die_sound.as_deref(),
+            true,
+            &mut rng,
+            &mut interner,
+            4,
+            7,
+            &mut sounds,
+        );
+        assert_eq!(
+            rng.state() == rng_before,
+            rules.object(type_name).expect("type").die_sounds.is_empty(),
+            "the global cue must not draw; only a non-empty DieSound= list does",
+        );
+        sounds
+            .into_iter()
+            .map(|(id, rx, ry)| {
+                assert_eq!((rx, ry), (4, 7), "played at the building's own cell");
+                interner.resolve(id).to_string()
+            })
+            .collect()
+    };
+
+    assert_eq!(
+        selected("GAPOWR", EntityCategory::Structure),
+        ["BuildingGenericDie"],
+        "no DieSound= on the type, so the global crumble cue plays"
+    );
+    assert_eq!(
+        selected("GATECH", EntityCategory::Structure),
+        ["OwnCrumble"],
+        "0x0044174A skips the global when the type has its own list"
+    );
+    assert_eq!(
+        selected("E1", EntityCategory::Infantry),
+        ["DieA"],
+        "the fallback is BuildingClass-only"
+    );
+
+    // A rules file with no BuildingDieSound= leaves the building silent
+    // rather than inventing a cue.
+    let bare = RuleSet::from_ini(&IniFile::from_str(
+        "\
+[General]\nFlightLevel=500\n\n\
+[InfantryTypes]\n\n[VehicleTypes]\n\n[AircraftTypes]\n\n\
+[BuildingTypes]\n0=GAPOWR\n\n[GAPOWR]\nStrength=750\nArmor=wood\n",
+    ))
+    .expect("bare rules parse");
+    let mut interner = test_interner();
+    let mut rng = SimRng::new(11);
+    let mut sounds = Vec::new();
+    super::append_selected_death_sounds(
+        bare.object("GAPOWR").expect("type"),
+        EntityCategory::Structure,
+        bare.general.building_die_sound.as_deref(),
+        true,
+        &mut rng,
+        &mut interner,
+        4,
+        7,
+        &mut sounds,
+    );
+    assert!(sounds.is_empty());
+}
+
 #[test]
 fn fatal_sound_selection_uses_human_voice_then_die_sound_main_draws() {
     let rules = RuleSet::from_ini(&IniFile::from_str(

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -3527,6 +3527,9 @@ fn commit_damage_events_with_isolation(
         let mut healing_only = false;
         let mut latch_hostile_hit = false;
         let mut uncloak_after_damage = false;
+        // `BuildingClass::ReceiveDamage`'s damage-state dispatch result: the
+        // building coordinate to sound the global struck cue at, or `None`.
+        let mut building_damage_cue: Option<(u16, u16)> = None;
         let mut threat_feedback: Option<(InternedId, InternedId, i32, i32, i32)> = None;
         if let Some(target) = entities.get_mut(target_id) {
             if event.distance_leptons.is_none()
@@ -3697,6 +3700,43 @@ fn commit_damage_events_with_isolation(
                     smoke_maintenance = None;
                     latch_hostile_hit = false;
                 }
+            }
+
+            // gamemd-derived: `BuildingClass::ReceiveDamage @ 0x00442230`'s
+            // damage-state dispatch, latched here and emitted below so it
+            // lands after the shared Techno receiver's own consequences —
+            // native only reaches it once `TechnoClass::ReceiveDamage`
+            // (`0x00442425`) has returned.
+            //
+            // `0x0044242C MOV AL,[ESI+0x90]` is `ObjectClass::IsAlive`: a dead
+            // building skips the dispatch and the function returns. Otherwise
+            // `0x00442476 JMP [EAX*4 + 0x00442C18]` with `EAX = result - 2`
+            // enters `{0x004426AC, 0x004426C8, 0x004424A2, 0x0044247D}`.
+            // Entry 0 (result 2) scales the docked unit's `+0xE8` and falls
+            // through into entry 1 (result 3); both reach
+            // `0x004426D2 CMP [type+0x538],-1`, so only a type with **no**
+            // `DamageSound=` of its own continues to
+            // `0x00442700 MOV ECX,[Rules+0x714]` and `0x00442706 CALL
+            // VocClass::PlayAtCoord @ 0x00750E20` at the building's own
+            // coordinate (`0x004426DB LEA ECX,[ESI+0x9C]`). Not owner-gated,
+            // draws no RNG.
+            //
+            // Results 2/3 are `DamageState::Yellow`/`Red` — the threshold
+            // crossings `ObjectClass::ReceiveDamage @ 0x005F5390` computes
+            // (2: HP went from `>= Strength >> 1` to below it; 3: from above
+            // `Strength * Rules+0x1708` to below it). A hit that crosses
+            // nothing returns 1 and is silent, so this is a per-crossing cue,
+            // not a per-hit one.
+            if matches!(
+                receive_state,
+                Some(damage::DamageState::Yellow | damage::DamageState::Red)
+            ) && target.category == EntityCategory::Structure
+                && target.lifecycle.object_alive
+                && rules
+                    .object(interner.resolve(target.type_ref))
+                    .is_some_and(|object| object.damage_sound.is_none())
+            {
+                building_damage_cue = Some((target.position.rx, target.position.ry));
             }
         }
 
@@ -3976,6 +4016,12 @@ fn commit_damage_events_with_isolation(
             if attacker_id != RAD_NO_ATTACKER && event.distance_leptons.is_none() {
                 target.last_attacker_id = Some(attacker_id);
             }
+        }
+
+        if let Some((rx, ry)) = building_damage_cue
+            && let Some(sink) = sound_sink.as_deref_mut()
+        {
+            sink.push(SimSoundEvent::BuildingDamagedSfx { rx, ry });
         }
 
         if synchronous_retaliation && attacker_id != RAD_NO_ATTACKER {

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -2069,8 +2069,28 @@ impl DeathEffects {
     }
 }
 
+/// Select the death cues one dying object contributes.
+///
+/// The building tail is `BuildingClass::DestructionEffects`: when the dying
+/// object is a structure whose type carries **no** `DieSound=` entries,
+/// gamemd plays the global `[AudioVisual] BuildingDieSound` at the building's
+/// own coordinate — `0x0044173F MOV ECX,[type+0x520]` reads the `DieSound`
+/// vector's count (`TechnoTypeClass+0x510..0x528`), `0x0044174A CMP ECX,EBX ;
+/// JNZ` skips the global when it is non-zero (`EBX` is zeroed at
+/// `0x00441606` and stays zero), and `0x00441773 MOV ECX,[Rules+0x6E8]` +
+/// `0x00441779 CALL VocClass::PlayAtCoord @ 0x00750E20` is the play. It is
+/// not owner-gated and draws no RNG — there is one id, not a list.
+///
+/// Where the global sits relative to the per-type `VoiceDie=`/`DieSound=`
+/// draws is UNCHECKED: native emits it from the building-specific destruction
+/// path, not from the shared Techno death transaction. It cannot matter on
+/// retail data, because the branch that reaches it requires an empty
+/// `DieSound=` list and no stock building pairs `VoiceDie=` with an empty
+/// `DieSound=`.
 fn append_selected_death_sounds(
     object_type: &ObjectType,
+    category: EntityCategory,
+    building_die_sound: Option<&str>,
     owner_is_human: bool,
     main_rng: &mut SimRng,
     interner: &mut StringInterner,
@@ -2090,6 +2110,12 @@ fn append_selected_death_sounds(
         append_choice(&object_type.voice_die);
     }
     append_choice(&object_type.die_sounds);
+
+    if category == EntityCategory::Structure && object_type.die_sounds.is_empty() {
+        if let Some(sound_id) = building_die_sound.filter(|id| !id.is_empty()) {
+            death_sounds.push((interner.intern(sound_id), rx, ry));
+        }
+    }
 }
 
 /// Concrete-class death work that native runs only after the shared Techno
@@ -2234,6 +2260,8 @@ fn handle_entity_deaths(
             if let Some(obj) = rules.object(type_id_str) {
                 append_selected_death_sounds(
                     obj,
+                    category,
+                    rules.general.building_die_sound.as_deref(),
                     houses.get(&owner).is_some_and(|house| house.is_human),
                     main_rng,
                     interner,

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -3530,6 +3530,9 @@ fn commit_damage_events_with_isolation(
         // `BuildingClass::ReceiveDamage`'s damage-state dispatch result: the
         // building coordinate to sound the global struck cue at, or `None`.
         let mut building_damage_cue: Option<(u16, u16)> = None;
+        // `TechnoClass::ReceiveDamage`'s result-2 damage-voice arm: the owner,
+        // type and coordinate to sound the `VoiceFeedback=` line at, or `None`.
+        let mut voice_feedback_cue: Option<(InternedId, InternedId, u16, u16)> = None;
         let mut threat_feedback: Option<(InternedId, InternedId, i32, i32, i32)> = None;
         if let Some(target) = entities.get_mut(target_id) {
             if event.distance_leptons.is_none()
@@ -3712,8 +3715,15 @@ fn commit_damage_events_with_isolation(
             // building skips the dispatch and the function returns. Otherwise
             // `0x00442476 JMP [EAX*4 + 0x00442C18]` with `EAX = result - 2`
             // enters `{0x004426AC, 0x004426C8, 0x004424A2, 0x0044247D}`.
-            // Entry 0 (result 2) scales the docked unit's `+0xE8` and falls
-            // through into entry 1 (result 3); both reach
+            // Entry 0 (result 2) multiplies the `float` at `+0xE8` of the
+            // object pointed to by `BuildingClass+0x30C` by `1.5f`
+            // (`0x007E4460`) when that pointer is non-null, then falls
+            // through into entry 1 (result 3). That object's identity is
+            // UNCHECKED — it is written once by `BuildingClass::Unlimbo @
+            // 0x00440F5B` from `CALL 0x0062DC50` on `[BuildingTypeClass
+            // +0x764]`, and read and rewritten by
+            // `BuildingClass::UpdateGapGenerator_Tick` (`0x00454E7F`,
+            // `0x0045500C`). Both entries reach
             // `0x004426D2 CMP [type+0x538],-1`, so only a type with **no**
             // `DamageSound=` of its own continues to
             // `0x00442700 MOV ECX,[Rules+0x714]` and `0x00442706 CALL
@@ -3737,6 +3747,47 @@ fn commit_damage_events_with_isolation(
                     .is_some_and(|object| object.damage_sound.is_none())
             {
                 building_damage_cue = Some((target.position.rx, target.position.ry));
+            }
+
+            // gamemd-derived: `TechnoClass::ReceiveDamage @ 0x00701900`, the
+            // damage-voice arm. `0x00702049 JMP [EDI*4 + 0x00702D24]` selects
+            // on the damage result (`EDI` forced to 4 at `0x00702035` when
+            // `[ESI+0x6C]` Health is zero); index 2 — result 2, the
+            // `Strength >> 1` crossing, i.e. `DamageState::Yellow` — is
+            // `0x00702695`, which reads the type's `VoiceFeedback=` count at
+            // `+0x4E8` and returns without drawing when it is empty
+            // (`0x007026A9 JLE`).
+            //
+            // This is TechnoClass, not BuildingClass: every category reaches
+            // it, and result 3 (`Red`) does not — index 3 is `0x007027F7`, the
+            // shared tail. Native runs it *inside* `TechnoClass::ReceiveDamage`,
+            // so it precedes the BuildingClass cue latched above; the push
+            // below preserves that order.
+            //
+            // Only the "would native draw?" test lives here. The 30% roll
+            // (`0x007026B3` `RandomRanged(0, 99)` vs `0x007026BD CMP EAX,0x1E`),
+            // the `HouseClass::IsHumanPlayer @ 0x0050B6F0` gate at `0x007026C6`
+            // and the `rand % count` pick at `0x007026DE`/`0x007026E7` are all
+            // app-side: both draws are on `g_MainRng @ 0x00886B88`, which
+            // per-frame draw paths also consume, so they are not lockstep state
+            // and must not touch a `sim/` stream. Native spends the roll before
+            // the owner gate, so the event is emitted for every house.
+            if receive_state == Some(damage::DamageState::Yellow)
+                && rules
+                    .object(interner.resolve(target.type_ref))
+                    .is_some_and(|object| {
+                        object
+                            .voice_feedback
+                            .as_deref()
+                            .is_some_and(|voice| !voice.is_empty())
+                    })
+            {
+                voice_feedback_cue = Some((
+                    target.owner,
+                    target.type_ref,
+                    target.position.rx,
+                    target.position.ry,
+                ));
             }
         }
 
@@ -4016,6 +4067,21 @@ fn commit_damage_events_with_isolation(
             if attacker_id != RAD_NO_ATTACKER && event.distance_leptons.is_none() {
                 target.last_attacker_id = Some(attacker_id);
             }
+        }
+
+        // Native order: the TechnoClass arm runs inside
+        // `TechnoClass::ReceiveDamage @ 0x00701900`, which `BuildingClass::
+        // ReceiveDamage` only resumes after at `0x00442425`, so the voice
+        // precedes the building cue.
+        if let Some((owner, type_ref, rx, ry)) = voice_feedback_cue
+            && let Some(sink) = sound_sink.as_deref_mut()
+        {
+            sink.push(SimSoundEvent::VoiceFeedback {
+                owner,
+                type_ref,
+                rx,
+                ry,
+            });
         }
 
         if let Some((rx, ry)) = building_damage_cue

--- a/src/sim/movement/locomotor_tests.rs
+++ b/src/sim/movement/locomotor_tests.rs
@@ -81,6 +81,7 @@ fn make_obj(locomotor: LocomotorKind, category: ObjectCategory) -> ObjectType {
         prevent_attack_move: false,
         voice_die: Vec::new(),
         die_sounds: Vec::new(),
+        damage_sound: None,
         move_sound: None,
         voice_feedback: None,
         voice_special_attack: None,

--- a/src/sim/movement/teleport_movement.rs
+++ b/src/sim/movement/teleport_movement.rs
@@ -544,6 +544,7 @@ mod tests {
             prevent_attack_move: false,
             voice_die: Vec::new(),
             die_sounds: Vec::new(),
+            damage_sound: None,
             move_sound: None,
             voice_feedback: None,
             voice_special_attack: None,

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -516,6 +516,27 @@ pub enum SimSoundEvent {
     /// "TankBunkerDown"). Stock zero-link refinery unload completion does
     /// not emit this event.
     RefineryExitSfx { rx: u16, ry: u16 },
+    /// A struck building crossed a damage-state threshold and its type carries
+    /// no `DamageSound=` of its own — the global `[AudioVisual]
+    /// BuildingDamageSound=` cue, played at the building's own coordinate.
+    ///
+    /// gamemd: `BuildingClass::ReceiveDamage @ 0x00442230`. After the shared
+    /// Techno receiver returns at `0x00442425`, `0x0044242C MOV AL,[ESI+0x90]`
+    /// (`ObjectClass::IsAlive`) skips the whole dispatch for a dead building;
+    /// otherwise `0x00442476 JMP [EAX*4 + 0x00442C18]` with `EAX = result - 2`
+    /// enters `{0x004426AC, 0x004426C8, 0x004424A2, 0x0044247D}`. Entry 0
+    /// (result 2) scales the docked unit's `+0xE8` and falls through into
+    /// entry 1 (result 3); both reach `0x004426D2 CMP [type+0x538],-1`, and
+    /// only an absent per-type `DamageSound=` continues to
+    /// `0x00442700 MOV ECX,[Rules+0x714]` / `0x00442706 CALL
+    /// VocClass::PlayAtCoord @ 0x00750E20` at `[ESI+0x9C]`.
+    ///
+    /// Results 2 and 3 are the threshold crossings computed by
+    /// `ObjectClass::ReceiveDamage @ 0x005F5390`: 2 when the hit took HP from
+    /// `>= Strength >> 1` to below it, 3 when it took HP from above
+    /// `Strength * Rules+0x1708` (ConditionRed) to below it. Ordinary hits
+    /// that cross nothing return 1 and are silent.
+    BuildingDamagedSfx { rx: u16, ry: u16 },
     /// Tank-bunker walls-up cue — emitted on install. App resolves to
     /// [AudioVisual] BunkerWallsUpSound (retail "TankBunkerUp").
     BunkerWallsUp { rx: u16, ry: u16 },

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -525,9 +525,15 @@ pub enum SimSoundEvent {
     /// (`ObjectClass::IsAlive`) skips the whole dispatch for a dead building;
     /// otherwise `0x00442476 JMP [EAX*4 + 0x00442C18]` with `EAX = result - 2`
     /// enters `{0x004426AC, 0x004426C8, 0x004424A2, 0x0044247D}`. Entry 0
-    /// (result 2) scales the docked unit's `+0xE8` and falls through into
-    /// entry 1 (result 3); both reach `0x004426D2 CMP [type+0x538],-1`, and
-    /// only an absent per-type `DamageSound=` continues to
+    /// (result 2) multiplies the `float` at `+0xE8` of the object pointed to
+    /// by `BuildingClass+0x30C` by `1.5f` (`0x007E4460`) when that pointer is
+    /// non-null, then falls through into entry 1 (result 3). The identity of
+    /// that object is UNCHECKED: it is written once by
+    /// `BuildingClass::Unlimbo @ 0x00440F5B` from `CALL 0x0062DC50` on
+    /// `[BuildingTypeClass+0x764]` and is read and rewritten by
+    /// `BuildingClass::UpdateGapGenerator_Tick` (`0x00454E7F`, `0x0045500C`).
+    /// Both entries reach `0x004426D2 CMP [type+0x538],-1`, and only an absent
+    /// per-type `DamageSound=` continues to
     /// `0x00442700 MOV ECX,[Rules+0x714]` / `0x00442706 CALL
     /// VocClass::PlayAtCoord @ 0x00750E20` at `[ESI+0x9C]`.
     ///
@@ -537,6 +543,50 @@ pub enum SimSoundEvent {
     /// `Strength * Rules+0x1708` (ConditionRed) to below it. Ordinary hits
     /// that cross nothing return 1 and are silent.
     BuildingDamagedSfx { rx: u16, ry: u16 },
+    /// A techno of any category crossed the half-strength threshold and its
+    /// type authors a non-empty `VoiceFeedback=` — the damage voice line.
+    ///
+    /// gamemd: `TechnoClass::ReceiveDamage @ 0x00701900`. The damage result
+    /// selects an arm through `0x00702049 JMP [EDI*4 + 0x00702D24]`
+    /// (`{0x007027F7, 0x00702713, 0x00702695, 0x007027F7, 0x00702050}`, with
+    /// `EDI` forced to 4 when `[ESI+0x6C]` Health is zero at `0x00702035`).
+    /// Index 2 — result 2, the `Strength >> 1` crossing — is `0x00702695`:
+    ///
+    /// - `0x007026A1 MOV EAX,[EDI+0x4E8]` / `0x007026A9 JLE` — an empty
+    ///   `VoiceFeedback=` list returns without drawing anything.
+    /// - `0x007026B3 MOV ECX,0x886B88` / `CALL 0x0065C7E0` with `(0, 0x63)` —
+    ///   `RandomRanged(0, 99)`; `0x007026BD CMP EAX,0x1E ; JGE` drops the cue,
+    ///   so it speaks 30 times in 100. **The draw is spent before the owner
+    ///   gate**, so this event is emitted for every qualifying crossing on any
+    ///   house and the roll happens app-side.
+    /// - `0x007026C6 MOV ECX,[ESI+0x21C]` / `CALL HouseClass::IsHumanPlayer @
+    ///   0x0050B6F0` — in a skirmish or multiplayer game (`g_GameMode != 0`)
+    ///   that is `house == g_PlayerPtr`, i.e. the local player only.
+    /// - `0x007026DE CALL 0x0065C780` then `0x007026E7 DIV [EDI+0x4E8]` picks
+    ///   `items[rand % count]` from `[EDI+0x4DC]`, and `0x00702709 CALL
+    ///   VocClass::PlayAt @ 0x007509E0` plays it at the object's own coords
+    ///   (`0x00702702 CALL [EDX+0x48]`).
+    ///
+    /// `TechnoTypeClass+0x4D8` is the `VoiceFeedback=` vector (items `+0x4DC`,
+    /// count `+0x4E8`): `0x00712D9C LEA EDI,[EBP+0x4D8]` in
+    /// `TechnoTypeClass::ReadINI` pushes the key string at `0x0084424C`
+    /// (`"VoiceFeedback"`) into `CCINIClass::ReadSoundList @ 0x00525430` at
+    /// `0x00712DCB`.
+    ///
+    /// Both draws are on `g_MainRng @ 0x00886B88`, which
+    /// `Init_Random_Number_System @ 0x0052FC20` seeds from `g_RngSeed`
+    /// alongside the scenario stream but which per-frame draw paths
+    /// (`EBolt::DrawRecursiveBolt`, `LaserDrawClass::Draw`,
+    /// `RadBeam::DrawAndTickAll`) also consume, so it is not lockstep state.
+    /// They therefore belong to the presentation RNG here, not to `sim/`.
+    VoiceFeedback {
+        /// Owning house — `[ESI+0x21C]`, resolved against the local player.
+        owner: InternedId,
+        /// The techno's type, for the `VoiceFeedback=` list lookup.
+        type_ref: InternedId,
+        rx: u16,
+        ry: u16,
+    },
     /// Tank-bunker walls-up cue — emitted on install. App resolves to
     /// [AudioVisual] BunkerWallsUpSound (retail "TankBunkerUp").
     BunkerWallsUp { rx: u16, ry: u16 },


### PR DESCRIPTION
Phase 6, rows 151 (GSI-15.05 gameplay-to-audio trigger routing) and 152 (GSI-15.08 unit voices and acknowledgements).

Four things a player hears constantly were missing: a struck building made no sound, a unit dropping below half health said nothing, an engineer capturing a building spoke its *move* line, and clicking the same unit twice restarted its acknowledgement mid-word.

## What gamemd does

**The repeat guard is not a timer.** `TechnoClass::Queue_Voice @ 0x00708D90` latches a pending voice index on the object, and `AI_Update @ 0x006F9EBB` drains it: a free handle plays, a live handle with the *same* index drops, and a live handle with a *different* index holds and retries next tick. That is reproduced in a device-free module, so the simulation gained no dependency on the audio layer.

**Damage cues come off one jump table.** `TechnoClass::ReceiveDamage @ 0x00701900` dispatches through `0x00702D24` on the damage result, forced to the death arm when health reaches zero. Index 1, the ordinary non-crossing hit, plays the type's own `DamageSound=`. Index 2, the crossing below half strength, plays `VoiceFeedback=` behind a 30% roll and a local-player check. A separate table in `BuildingClass::ReceiveDamage` reaches the global `BuildingDamageSound=` on the half-strength and ConditionRed crossings, which covers all but the 34 stock types authoring their own.

**Capture speaks a chain**, not a single key: `VoiceCapture=`, falling back to `VoiceEnter=`, falling back to `VoiceMove=` at `0x00708FC0`. VERA had only the last, so every stock engineer said the wrong line.

## Review history

Three rounds, and the first two each found a mechanism deferred on a false blocker. Round one proved `BuildingDamageSound` was reachable: the "unmapped" computed jump was a four-entry table whose address sat in the instruction itself. Round two then found `VoiceFeedback`'s consumer *inside a function the builder had decompiled that same round*.

Working through them corrected several claims. The damage cue fires on threshold crossings, not on every hit. A hit that crosses ConditionRed in one blow is silent, because that result overrides the half-strength one. And the 30% roll is spent *before* the owner check, so the simulation must emit for every house and let the app decide.

**One determinism question settled properly.** The roll uses gamemd's main RNG, not the scenario stream. The conclusive proof came from the reviewer: the arm's second draw sits *below* the local-player gate, so gamemd advances that stream a different number of times on each peer of the same match. It cannot be lockstep state, so the draw belongs on VERA's presentation RNG, and a test pins both simulation streams byte-identical.

## Not done, and honestly recorded

Superweapon launch cues stay silent: the sim event carries no discriminator, and the native binding of each cue to its launch was not isolated, so guessing was refused. That is this row's next slice.

`cargo test -p vera20k --lib`: `test result: ok. 8168 passed; 0 failed; 75 ignored`. No golden moved, `SNAPSHOT_VERSION` untouched, and `sim/` still has no dependency on `audio/`.
