### PR TITLE
Phase 6: Hunt gets a body, and the two differences hiding in its scan

### DIFF
--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -911,6 +911,25 @@ pub struct ObjectType {
     /// Stock YR sets this on GI (E1), GuardianGI (GGI), and a handful of others.
     pub deploy_fire: bool,
 
+    /// `UndeployDelay=` int — `TechnoTypeClass+0x6C4`, read by
+    /// `TechnoTypeClass::ReadINI` (key string `0x008438F4` =
+    /// `"UndeployDelay"`, `ReadInt @ 0x005276D0`, store `0x00714BBA`).
+    /// Constructor default **-1** (`TechnoTypeClass::Constructor` loads
+    /// `EBP = -1` at `0x00710CED` and stores it at `0x00711187`).
+    ///
+    /// The infantry deploy shim `FUN_00521320` — the body behind
+    /// `InfantryClass::Mission_Guard @ 0x0051F620` and
+    /// `InfantryClass::Mission_AreaGuard @ 0x0051F640` — tests `-1 < this`
+    /// FIRST for an already-deployed man and makes him undeploy when it holds,
+    /// ahead of every `DeployFire=` arm. Stock: only `YURI` (150) and `YURIPR`
+    /// (75) set it, which is why a deployed Yuri leaves his stance on its own
+    /// and a deployed GI does not.
+    ///
+    /// **Frame trap:** this is the TYPE field. The `InfantryClass` *instance*
+    /// carries its DoType at the same `+0x6C4`, and a `UnitClass` instance
+    /// carries a `UnitTypeClass*` there.
+    pub undeploy_delay: i32,
+
     /// Index of the weapon (0=primary, 1=secondary) that the AI auto-deploy planner
     /// considers when deciding "should I deploy here?". Parsed from `DeployFireWeapon=N`
     /// in rules.ini. Default `None`. Not consulted in B1 (no AI auto-deploy);
@@ -928,6 +947,18 @@ pub struct ObjectType {
     /// Whether this infantry can assault enemy buildings (hostile garrison entry).
     /// Parsed from `Assaulter=yes` in rules.ini.
     pub assaulter: bool,
+
+    /// `VehicleThief=` bool — `InfantryTypeClass+0xEC6`, read by
+    /// `InfantryTypeClass::ReadINI` (key string `0x0082593C` = `"VehicleThief"`,
+    /// default loaded from the field itself at `0x005245CC`, `ReadBool @
+    /// 0x005295F0` called at `0x005245E1`).
+    ///
+    /// The last of the three type arms in `FootClass::Mission_Hunt @
+    /// 0x004D5350` (`0x004D546C`): a hunting thief walks onto its target and
+    /// queues Capture(8) instead of shooting. **No stock section sets it**, so
+    /// the arm is dead on retail data; it is parsed because the Hunt body
+    /// branches on it and a map or mod INI can set it.
+    pub vehicle_thief: bool,
 
     /// Weapon used when this infantry fires from inside a garrisoned building.
     /// Parsed from `OccupyWeapon=WeaponName` in rules.ini. Falls back to
@@ -1197,6 +1228,18 @@ pub struct ObjectType {
     /// `+0xD39` (`DefaultToGuardArea`); the research corpus has all three
     /// crossed.
     pub close_range: bool,
+    /// `StupidHunt=` bool — `TechnoTypeClass+0x6D4`, read by
+    /// `TechnoTypeClass::ReadINI` (key string `0x008438A4` = `"StupidHunt"`,
+    /// `ReadBool @ 0x005295F0`, store `0x00714C80`); constructor default
+    /// `false` (`0x007111A4` writes the zeroed `BL`).
+    ///
+    /// It is the very first test in `FootClass::Mission_Hunt @ 0x004D5350`
+    /// (`0x004D535F`): a type carrying it **never scans for a target on Hunt**
+    /// and drops straight through to the idle / return-to-base arm. The INI's
+    /// own trailing comment says it plainly — "this guy can't handle a hunt
+    /// command, so he should just run towards the player". Six stock sections:
+    /// `SPY`, `LCRF`, `CMIN`, `SAPC`, `YHVR`, `SMIN`.
+    pub stupid_hunt: bool,
     /// `Cyborg=` bool — gamemd's TechnoTypeClass `+0xC8F` "emits damage sparks"
     /// flag that `AI_Update` gates the per-tick damage-Spark prob-roll on.
     /// Verified: only `InfantryTypeClass::ReadINI` writes `+0xC8F` (from `Cyborg=`);
@@ -1417,7 +1460,6 @@ impl ObjectType {
             .collect();
 
         let btm_f32: f32 = section.get_f32("BuildTimeMultiplier").unwrap_or(1.0);
-
 
         // `TechnoTypeClass::ReadINI` reads `VeteranAbilities=` into `+0x29C`
         // (`0x007154A3`) and `EliteAbilities=` into `+0x2AE` (`0x007154E8`).
@@ -1798,10 +1840,14 @@ impl ObjectType {
             ifv_mode: section.get_i32("IFVMode").unwrap_or(0).max(0) as u32,
             open_transport_weapon: section.get_i32("OpenTransportWeapon").unwrap_or(-1),
             deploy_fire: section.get_bool("DeployFire").unwrap_or(false),
+            // `TechnoTypeClass::Constructor @ 0x00711187` seeds -1, and
+            // `ReadINI @ 0x00714BBA` only overwrites it when the key is present.
+            undeploy_delay: section.get_i32("UndeployDelay").unwrap_or(-1),
             deploy_fire_weapon: section.get_i32("DeployFireWeapon"),
             max_number_occupants: section.get_i32("MaxNumberOccupants").unwrap_or(0).max(0) as u32,
             occupier: section.get_bool("Occupier").unwrap_or(false),
             assaulter: section.get_bool("Assaulter").unwrap_or(false),
+            vehicle_thief: section.get_bool("VehicleThief").unwrap_or(false),
             occupy_weapon: section.get("OccupyWeapon").map(|s| s.to_string()),
             elite_occupy_weapon: section.get("EliteOccupyWeapon").map(|s| s.to_string()),
             occupy_pip: section
@@ -1914,6 +1960,7 @@ impl ObjectType {
                 .collect(),
             debris_anims: parse_csv_string_list(section.get_ignoring_case("DebrisAnims")),
             close_range: section.get_bool("CloseRange").unwrap_or(false),
+            stupid_hunt: section.get_bool("StupidHunt").unwrap_or(false),
             cyborg: section.get_bool("Cyborg").unwrap_or(false),
             destroy_particle_systems: parse_csv_string_list(section.get("DestroyParticleSystems")),
             damage_smoke_offset: section

--- a/src/sim/combat/combat_cloak_legality_tests.rs
+++ b/src/sim/combat/combat_cloak_legality_tests.rs
@@ -78,7 +78,17 @@ fn acquire(
     attacker: u64,
     fog: &FogState,
 ) -> Option<u64> {
-    acquire_best_target_for_entity(entities, rules, interner, attacker, Some(fog), None, false)
+    acquire_best_target_for_entity(
+        entities,
+        rules,
+        interner,
+        attacker,
+        Some(fog),
+        None,
+        false,
+        crate::sim::combat::ScanMission::Guard,
+        None,
+    )
 }
 
 #[test]

--- a/src/sim/combat/combat_targeting.rs
+++ b/src/sim/combat/combat_targeting.rs
@@ -13,9 +13,10 @@
 //! and the retaliation pass.
 //!
 //! ## Scan radius
-//! How far the scan reaches is a property of the attacker and the mission it is
-//! on, not of the candidate — see [`super::threat_range`]. A unit on Area Guard
-//! acquires roughly twice as far out as the same unit on plain Guard.
+//! How far the scan reaches is a property of the attacker and of the threat
+//! mask its CALLER pushed, not of the candidate — see [`super::threat_range`].
+//! A unit on Area Guard acquires roughly twice as far out as the same unit on
+//! plain Guard, and a unit on Hunt is not walking cell rings at all.
 //!
 //! ## Auto-deploy on target acquisition
 //! Targeting NEVER initiates a deploy transition. A walking GGI that acquires
@@ -35,7 +36,7 @@ use super::combat_weapon::{
     VersesGate, attacker_facts, is_ally_by_object, select_weapon_for_target, techno_target_facts,
     verses_gate,
 };
-use super::threat_range::{ScanMission, scan_mission_for};
+use super::threat_range::ScanMission;
 use crate::map::entities::EntityCategory;
 use crate::map::houses::{HouseAllianceMap, is_allied_with};
 use crate::map::resolved_terrain::ResolvedTerrainGrid;
@@ -109,8 +110,10 @@ pub(crate) struct AttackerSnapshot {
     pub weapon_override: Option<super::combat_weapon::WeaponOverride>,
     /// Garrison state — present only for garrisoned buildings (IsOccupied).
     pub garrison: Option<GarrisonSnapshot>,
-    /// Which acquisition mission the attacker is on. Selects the scan radius
-    /// formula — Area Guard reaches roughly twice as far as plain Guard.
+    /// The threat mask this scan's CALLER pushed — `Greatest_Threat`'s second
+    /// argument, always a literal in retail. It selects the radius formula
+    /// (Area Guard reaches roughly twice as far as plain Guard) and, for mask
+    /// 0, the scan topology itself.
     pub scan_mission: ScanMission,
 }
 
@@ -120,6 +123,26 @@ pub(crate) struct AttackerSnapshot {
 /// `terrain` is threaded through for the 3D InRange check; when `None`
 /// (headless tests, no map loaded), the range check falls back to the
 /// existing 2D behavior.
+///
+/// `mask` is `Greatest_Threat`'s second argument. Every caller pushes a literal
+/// — `0` from `FootClass::Mission_Hunt @ 0x004D5373`, `1` from the common Techno
+/// AI body and from `FUN_0051F330`'s in-place re-acquire (`vt+0x3C4(1, ...)`),
+/// `2` from `FootClass::Mission_AreaGuard` — and mask 0 selects a different scan
+/// topology entirely, not a wider radius. So it is a parameter here rather than
+/// something read off the entity. [`super::threat_range::scan_mission_for`]
+/// remains, for the passive callsites whose literal genuinely depends on which
+/// mission dispatched them.
+///
+/// What the literal is NOT is what `TechnoClass::Greatest_Threat` finally sees:
+/// a `FootClass` dispatch goes through the `+0x3C4` overrides first, which OR
+/// the attacker's projectile class bits in (`0x00743190`, `0x0051E39F`) and,
+/// while `FootClass+0x688` is set, coerce it to `(mask & ~2) | 1`
+/// (`0x004D9931`). Both are recorded as residuals on
+/// [`super::greatest_threat::greatest_threat`]; neither is modelled here.
+///
+/// `zone_grid` is `MapClass`'s per-movement-zone connectivity, which mask 0 uses
+/// to refuse candidates its own movement zone cannot reach.
+#[allow(clippy::too_many_arguments)]
 pub fn acquire_best_target_for_entity(
     entities: &EntityStore,
     rules: &RuleSet,
@@ -128,6 +151,8 @@ pub fn acquire_best_target_for_entity(
     fog: Option<&FogState>,
     terrain: Option<&ResolvedTerrainGrid>,
     require_playfield_membership: bool,
+    mask: ScanMission,
+    zone_grid: Option<&crate::sim::pathfinding::zone_map::ZoneGrid>,
 ) -> Option<u64> {
     let entity = entities.get(attacker_id)?;
     // Aircraft with 0 ammo should not acquire new targets — need to reload.
@@ -181,7 +206,7 @@ pub fn acquire_best_target_for_entity(
         burst_delay_ticks: 0,
         weapon_override: entity.weapon_override,
         garrison: None,
-        scan_mission: scan_mission_for(entity),
+        scan_mission: mask,
     };
     acquire_best_target(
         entities,
@@ -193,6 +218,7 @@ pub fn acquire_best_target_for_entity(
         None,
         terrain,
         require_playfield_membership,
+        zone_grid,
     )
 }
 
@@ -216,6 +242,7 @@ pub fn acquire_best_target_for_entity(
 /// engineer scores highest — and that a base defence with several attackers in
 /// reach commits to the one in the innermost band rather than the nearest by
 /// Euclidean distance.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn acquire_best_target(
     entities: &EntityStore,
     rules: &RuleSet,
@@ -226,6 +253,7 @@ pub(crate) fn acquire_best_target(
     scan_range_override: Option<SimFixed>,
     terrain: Option<&ResolvedTerrainGrid>,
     require_playfield_membership: bool,
+    zone_grid: Option<&crate::sim::pathfinding::zone_map::ZoneGrid>,
 ) -> Option<u64> {
     super::greatest_threat::greatest_threat(
         entities,
@@ -237,6 +265,7 @@ pub(crate) fn acquire_best_target(
         scan_range_override,
         terrain,
         require_playfield_membership,
+        zone_grid,
     )
 }
 
@@ -273,7 +302,12 @@ fn can_retaliate(
 }
 
 /// `TechnoClass::Calculate_Threat_Score @ 0x0070CD10` as `ShouldRetaliate`
-/// consumes it, on the native `&NullCoord` branch.
+/// consumes it, on the native `&NullCoord` branch — verified, not assumed:
+/// both `ShouldRetaliate` callsites push the sentinel literally
+/// (`PUSH 0xb0ea90 @ 0x00708A81` and `@ 0x00708A92` before the calls at
+/// `0x00708A89` / `0x00708A9A`), so this comparison is on the CELL scale. The
+/// lepton-scale branch is reachable only from `Evaluate_Candidate`'s mask-0
+/// flat walk; see [`super::greatest_threat::ThreatReference`].
 ///
 /// The five coefficients are the ones the scorer's own house selects — see
 /// [`super::greatest_threat::ThreatCoefficients`] and
@@ -308,6 +342,7 @@ pub(crate) fn calculate_ai_threat_score(
         terrain,
         alliances,
         coefficients,
+        super::greatest_threat::ThreatReference::NullCoord,
     )
 }
 
@@ -660,7 +695,17 @@ mod tests {
         let interner = test_interner();
 
         assert_eq!(
-            acquire_best_target_for_entity(&entities, &rules, &interner, 1, None, None, false),
+            acquire_best_target_for_entity(
+                &entities,
+                &rules,
+                &interner,
+                1,
+                None,
+                None,
+                false,
+                ScanMission::Guard,
+                None,
+            ),
             Some(2)
         );
     }

--- a/src/sim/combat/greatest_threat.rs
+++ b/src/sim/combat/greatest_threat.rs
@@ -295,7 +295,26 @@ pub(crate) enum ThreatReference {
     /// Because `Mission_Hunt`'s copy and `GetCoords` read the same three
     /// fields, the reference *point* is identical to the `NullCoord` branch's;
     /// only the scale differs. Modelled as the scorer's own coordinate here for
-    /// that reason, and no other caller can reach this branch.
+    /// that reason.
+    ///
+    /// **The name is narrower than the native branch, deliberately.** The
+    /// coordinate is chosen a level up, at `Greatest_Threat`, whose gate
+    /// `TEST AL,0x3 ; JZ 0x006F9B6E @ 0x006F8FE0` sends *any* mask with the low
+    /// two bits clear down the flat walk — and `search_instructions
+    /// CALL "+ 0x3c4]"` finds fourteen callsites, not one.
+    /// `FootClass::Mission_Rescue @ 0x004DE056` passes mask 0 with
+    /// `param_1[0x86]`'s coords, i.e. the **ArchiveTarget**
+    /// (`TechnoClass+0x218`) rather than the scanner's own position, and two
+    /// further flat-walk sites (`0x00414B24` mask `0x40`, `0x00414B64` mask 0)
+    /// sit in an undefined body with three more passing a register mask,
+    /// unsettled.
+    ///
+    /// So this variant is exact for every path VERA runs today — Hunt is the
+    /// only production caller that reaches the flat walk — but it is NOT a
+    /// general "supplied coordinate" model, and a second caller cannot simply
+    /// reuse it. Wiring Rescue (VERA already has a paradrop analogue in
+    /// `sim::aircraft::paradrop_mission`) needs an arbitrary-point sibling
+    /// carrying the ArchiveTarget, not this one.
     ScannerCoords,
 }
 

--- a/src/sim/combat/greatest_threat.rs
+++ b/src/sim/combat/greatest_threat.rs
@@ -119,6 +119,7 @@ use crate::sim::game_entity::GameEntity;
 use crate::sim::intern::StringInterner;
 use crate::sim::movement::locomotor::MovementLayer;
 use crate::sim::occupancy::{CellListInsertion, OccupancyGrid, cell_list_layer_for_entity};
+use crate::sim::pathfinding::zone_map::{ZoneGrid, ZoneId};
 use crate::sim::vision::FogState;
 use crate::util::fixed_math::SimFixed;
 use crate::util::native_x87::{NativeF64Bits, X87Chop53, X87Value, sqrt_approx_f32};
@@ -134,7 +135,6 @@ const THREAT_SCORE_BASE: f64 = 100_000.0;
 /// `0.019999999552965164` and an authored `Verses=2%` (exactly `0.02` as a
 /// double) is *above* it and passes.
 const VERSES_FLOOR: f64 = 0.02f32 as f64;
-
 /// The five weights of `TechnoClass::Calculate_Threat_Score @ 0x0070CD10`, in
 /// the order the native body loads them.
 #[derive(Debug, Clone, Copy)]
@@ -148,7 +148,9 @@ pub(crate) struct ThreatCoefficients {
     pub target_special_threat: f64,
     /// `D` — the candidate's live health ratio.
     pub target_strength: f64,
-    /// `E` — whole cells beyond the scorer's weapon range.
+    /// `E` — distance beyond the scorer's weapon range, in whole cells on the
+    /// `NullCoord` branch and in LEPTONS on the supplied-coordinate one; see
+    /// [`ThreatReference`].
     pub target_distance: f64,
 }
 
@@ -250,10 +252,55 @@ fn threat_coord(entity: &GameEntity, terrain: Option<&ResolvedTerrainGrid>) -> (
     (x, y, z)
 }
 
-/// `TechnoClass::Calculate_Threat_Score @ 0x0070CD10`, on the `&NullCoord`
-/// branch every acquisition caller takes (`0x0070D023`) — the distance term is
-/// therefore whole CELLS, `ftol(Sqrt_Approx(3-D lepton delta)) >> 8`, not
-/// leptons.
+/// `TechnoClass::Calculate_Threat_Score`'s third parameter, in the only two
+/// shapes its three callsites pass (`get_xrefs_to 0x0070CD10`).
+///
+/// The parameter is a `CoordStruct*`, and the first thing the distance term
+/// does with it is compare all three words against the `NullCoord` globals
+/// `0x00B0EA90/94/98` (`CMP EAX,ECX` / `CMP ECX,[0x00b0ea94] @ 0x0070CFA9` /
+/// `CMP EDX,[0x00b0ea98] @ 0x0070CFB5`, then `JZ 0x0070D023 @ 0x0070CFBC`).
+/// **The two branches are not the same computation at a different starting
+/// point — they are the same geometry at a 256x different SCALE**, so which one
+/// runs decides whether distance barely matters or dominates the whole score.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ThreatReference {
+    /// `PUSH 0xb0ea90` — the sentinel, taken by `TechnoClass::ShouldRetaliate`
+    /// at both its callsites (`0x00708A81`, `0x00708A92`) and by every
+    /// `Evaluate_Candidate` callsite except the mask-0 flat walk
+    /// (`PUSH 0xb0ea90 @ 0x006F929A` on the ring walk, `@ 0x006F9C18` on the
+    /// aircraft pre-walk).
+    ///
+    /// Native then measures scorer-to-candidate through both objects' own
+    /// `vt+0x48` (`ObjectClass::GetCoords @ 0x005F65A0`, a verbatim copy of
+    /// `ObjectClass+0x9C/+0xA0/+0xA4`) and converts to **whole CELLS**:
+    /// `CDQ ; AND EDX,0xff ; ADD EAX,EDX ; SAR EAX,0x8` at
+    /// `0x0070D094`-`0x0070D09D`.
+    NullCoord,
+    /// A real coordinate supplied by the caller, which in the whole reachable
+    /// set is the **scanner's own `ObjectClass+0x9C` Coords**:
+    /// `FootClass::Mission_Hunt` copies its three words to a local and passes
+    /// the pointer (`LEA ECX,[ESI+0x9c] @ 0x004D536D`, three dwords to
+    /// `[ESP+0x14..0x1C]`, `LEA EAX,[ESP+0x14]` / `PUSH EAX @ 0x004D538B`),
+    /// `Retaliate_And_Scan` forwards it as `Greatest_Threat`'s arg2, and the
+    /// flat walk alone pushes it as `Evaluate_Candidate`'s arg7
+    /// (`MOV EBP,[ESP+0x74] @ 0x006F9C76`, `PUSH EBP @ 0x006F9D64`), which
+    /// becomes this parameter at `0x006F86FE`-`0x006F8706`.
+    ///
+    /// This branch measures the supplied point to the candidate's `vt+0x48`
+    /// and then **jumps straight to the join** — `JMP 0x0070D0A0 @ 0x0070D021`,
+    /// with no `SAR EAX,0x8` anywhere on the path — so its distance stays in
+    /// **LEPTONS** while the range it is compared against was shifted to cells
+    /// at `0x0070CF99`.
+    ///
+    /// Because `Mission_Hunt`'s copy and `GetCoords` read the same three
+    /// fields, the reference *point* is identical to the `NullCoord` branch's;
+    /// only the scale differs. Modelled as the scorer's own coordinate here for
+    /// that reason, and no other caller can reach this branch.
+    ScannerCoords,
+}
+
+/// `TechnoClass::Calculate_Threat_Score @ 0x0070CD10`. The distance term's
+/// scale is chosen by `reference`; see [`ThreatReference`].
 ///
 /// Term order and the per-term 64-bit store are the native ones: every
 /// intermediate is written back to the `[ESP+0x10]` double between terms, and
@@ -274,6 +321,7 @@ pub(crate) fn calculate_threat_score(
     terrain: Option<&ResolvedTerrainGrid>,
     alliances: Option<&HouseAllianceMap>,
     coefficients: ThreatCoefficients,
+    reference: ThreatReference,
 ) -> Option<X87Value> {
     let scorer = entities.get(scorer_id)?;
     let candidate = entities.get(candidate_id)?;
@@ -355,9 +403,19 @@ pub(crate) fn calculate_threat_score(
     };
     score = X87Chop53::add(score, X87Chop53::mul(coeff_d, health_ratio));
 
-    // E: whole cells beyond the scorer's selected weapon range. With no weapon
+    // E: distance beyond the scorer's selected weapon range. With no weapon
     // selected native falls back to the scorer type's `GuardRange`
     // (`TechnoTypeClass+0x5B8`, `0x0070CF81`) — NOT `Sight`.
+    //
+    // The RANGE is always shifted to whole cells (`SAR EAX,0x8 @ 0x0070CF99`,
+    // stored to `[ESP+0xC]` and reloaded as EDI at `0x0070D0A0`). The DISTANCE
+    // is shifted only on the `NullCoord` branch, so the subtraction at
+    // `SUB EAX,EDI @ 0x0070D0A9` mixes leptons with cells whenever a caller
+    // supplies a coordinate. That is not a bug being reproduced blind: it is
+    // what makes a hunting unit overwhelmingly nearest-first, because with
+    // stock `[General] TargetDistanceCoefficientDefault=-10` against the
+    // `100000` base at `0x0070D0C4`, anything past roughly 39 cells drives the
+    // score negative and `Evaluate_Candidate`'s tail clamps it to 1.
     let scorer_coord = threat_coord(scorer, terrain);
     let candidate_coord = threat_coord(candidate, terrain);
     let dx = X87Chop53::load_i32(scorer_coord.0.wrapping_sub(candidate_coord.0));
@@ -369,7 +427,14 @@ pub(crate) fn calculate_threat_score(
     );
     let distance_root = X87Chop53::load_f32(sqrt_approx_f32(distance_sq).ok()?).ok()?;
     let distance_leptons = i32::try_from(X87Chop53::ftol_i64(distance_root).ok()?).ok()?;
-    let distance_cells = crate::util::direction_tables::lepton_to_cell(distance_leptons);
+    let distance = match reference {
+        // `CDQ ; AND EDX,0xff ; ADD EAX,EDX ; SAR EAX,0x8` at `0x0070D094`.
+        ThreatReference::NullCoord => {
+            crate::util::direction_tables::lepton_to_cell(distance_leptons)
+        }
+        // `JMP 0x0070D0A0 @ 0x0070D021` — the shift is on the other branch.
+        ThreatReference::ScannerCoords => distance_leptons,
+    };
     let range_cells = selected_scorer_weapon.as_ref().map_or_else(
         || {
             scorer_type
@@ -378,7 +443,7 @@ pub(crate) fn calculate_threat_score(
         },
         |selected| selected.weapon.range.to_num::<i32>(),
     );
-    let beyond_range = distance_cells.wrapping_sub(range_cells).max(0);
+    let beyond_range = distance.wrapping_sub(range_cells).max(0);
     score = X87Chop53::add(
         X87Chop53::mul(X87Chop53::load_i32(beyond_range), coeff_e),
         score,
@@ -457,6 +522,12 @@ fn scan_radius_cells(rules: &RuleSet, obj: &ObjectType, veterancy: u16, range: S
             let air_bonus_cells = obj.air_range_bonus.map_or(0, |bonus| bonus.to_num::<i32>());
             weapon_cells + 1 + air_bonus_cells
         }
+        // Mask 0 computes no walk bound because it runs no walk — the jump at
+        // `0x006F8FE2` skips `iStack_34` along with the rings.
+        // [`greatest_threat`] takes the flat-list branch before it reaches
+        // here; zero is returned so that any future caller which does ask
+        // walks nothing rather than walking the map.
+        ScanRange::NoCutoff => 0,
     }
 }
 
@@ -589,6 +660,36 @@ struct ScanContext<'a> {
     require_playfield_membership: bool,
     range: ScanRange,
     coefficients: ThreatCoefficients,
+    zone_grid: Option<&'a ZoneGrid>,
+    /// `[ESP+0x3C]` in `Greatest_Threat` — the scanner's own movement-zone
+    /// component id, or `None` for native's `-1` "gate off".
+    ///
+    /// Native seeds the slot with `-1` (`OR EBP,0xffffffff @ 0x006F8DFF`,
+    /// `MOV [ESP+0x3c],EBP @ 0x006F8E15`) and overwrites it at `0x006F8EC4`
+    /// with `MapClass::GetZoneID(my cell, myType->MovementZone, 1)` when the
+    /// mask has bit0 CLEAR (`TEST BL,0x1 ; JNZ 0x006F8EC8` at
+    /// `0x006F8E48`) and `What_Am_I()` is neither `6` (Building) nor `2`
+    /// (Aircraft) — the two classes with no movement zone (`CMP EAX,0x6 ; JZ`
+    /// at `0x006F8E54`, `CMP EAX,0x2 ; JZ` at `0x006F8E60`).
+    ///
+    /// It reaches [`evaluate_candidate`] as `Evaluate_Candidate`'s **arg6**
+    /// only on the mask-0 flat walk (`PUSH ECX @ 0x006F9D69`); every ring-walk
+    /// callsite fills the same slot with the literal `-1`
+    /// (`PUSH -0x1 @ 0x006F92A3`, `@ 0x006F9C21`), so the gate is a property of
+    /// the flat walk, not of the shared candidate ladder.
+    scanner_zone: Option<ZoneId>,
+    /// `Evaluate_Candidate`'s **arg7**, the coordinate
+    /// `Calculate_Threat_Score` measures its distance term from — and, through
+    /// the sentinel test at `0x0070CFA0`-`0x0070CFBC`, the term's SCALE.
+    ///
+    /// Like [`Self::scanner_zone`] this is a property of the walk and not of
+    /// the shared candidate ladder, and the two walks disagree in the same
+    /// direction: the flat walk forwards `Greatest_Threat`'s own arg2
+    /// (`PUSH EBP @ 0x006F9D64`, loaded `MOV EBP,[ESP+0x74] @ 0x006F9C76`),
+    /// which for `Mission_Hunt` is a copy of the hunter's Coords, while the
+    /// ring walk and the aircraft pre-walk push the `NullCoord` sentinel
+    /// (`PUSH 0xb0ea90` at `0x006F929A` and `0x006F9C18`).
+    threat_reference: ThreatReference,
 }
 
 impl ScanContext<'_> {
@@ -615,6 +716,97 @@ impl ScanContext<'_> {
 ///
 /// `scan_range_override` replaces the mission-derived radius with a hard cutoff;
 /// it exists for garrisoned buildings, whose reach is foundation-derived.
+///
+/// ## Two topologies, selected by the caller's threat mask
+///
+/// The mask is `Greatest_Threat`'s own second argument, a literal at every
+/// callsite (see [`super::threat_range::ScanMission`]), and the first thing the
+/// body does with it is
+/// `MOV AL,[ESP+0x70] ; TEST AL,0x3 ; JZ 0x006F9B6E` at `0x006F8FDC`-
+/// `0x006F8FE2`. With bit0 or bit1 set the function runs the radius block, the
+/// airborne pre-pass (`0x006F9169`) and the expanding-ring cell walk. With
+/// **neither** set — mask 0, which only `FootClass::Mission_Hunt @ 0x004D5373`
+/// pushes — the jump lands past all three, and the scan that actually runs is
+/// the flat walk over the global object array; see [`global_list_scan`].
+///
+/// Modelling that as a wider *radius* would be wrong twice over: the ring walk
+/// does not enumerate every object (one candidate per cell, and it stops at the
+/// `radius/4` and `radius/2` bands), and mask 0 does not reach the ring walk at
+/// all.
+///
+/// ## The mask is a callsite literal that two overrides may still rewrite
+///
+/// Every callsite pushes a constant, but a `FootClass` dispatch does not land
+/// here directly — it lands in the per-class `+0x3C4` overrides first, and both
+/// of them can change what arrives:
+///
+/// - `UnitClass::Greatest_Threat @ 0x00743190` ORs the attacker's own
+///   projectile class bits into the mask (`FUN_00772A90`, AA → `4`,
+///   AG → `0xB8`) whenever `mask & 0x1B978 == 0`, which mask 0 satisfies. The
+///   topology is untouched — neither `4` nor `0xB8` carries `TEST AL,0x3` — but
+///   the derived flags word `[ESP+0x14]` that becomes `Evaluate_Candidate`'s
+///   arg2 does change, and an AA-capable hunter additionally runs the aircraft
+///   list pre-walk at `0x006F9B7E`. See the class-bit residual in this module's
+///   header; it now reaches the flat walk too.
+/// - `FootClass::Greatest_Threat @ 0x004D9920` rewrites the mask to
+///   `(mask & ~2) | 1` — mask 0 becomes mask 1, so the RING walk runs — while
+///   `FootClass+0x688` is set, and clears that byte at `0x004D9955` only when
+///   the coerced scan **returned 0** (`TEST EAX,EAX ; JNZ 0x004D995B` at
+///   `0x004D9951` jumps past the store otherwise). Not modelled; residual
+///   below.
+///
+/// RESIDUAL — the `FootClass+0x688` "arrived but cannot fire" retarget latch.
+///
+/// `MOV AL,[ESI+0x688] ; TEST AL,AL ; MOV EAX,[ESP+0x8] ; JZ 0x004D9935 ;
+/// AND AL,0xfd ; OR AL,0x1` at `0x004D9923`-`0x004D9933`, then the base call at
+/// `0x004D9942` and `MOV [ESI+0x688],AL @ 0x004D9955` clearing the byte when
+/// the base returned 0. `UnitClass @ 0x00743190` (`CALL @ 0x0074325C`) and the
+/// Infantry override (`CALL @ 0x0051E39F`) both chain through it, so it covers
+/// every ground attacker.
+///
+/// The byte is written `1` in the locomotor "movement finished" tail under
+/// three conditions, read this session at
+/// `DriveLocomotionClass::Process_Movement @ 0x004B2E7B`-`0x004B2EA2` and
+/// instruction-for-instruction at the infantry twin `FUN_005164D0 @
+/// 0x00516828`-`0x0051684D`: the locomotor's `vt+0x10` says not moving,
+/// `TechnoClass+0x2B4` — the Target, written by `TechnoClass::Assign_Target @
+/// 0x006FCF3E` — is non-null, and `vt+0x3AC` = `TechnoClass::CanFireAtTarget @
+/// 0x006F7780` says the attacker cannot fire at it.
+/// `ShipLocomotionClass::Process_Movement @ 0x006A24F2`, `FUN_0069B170 @
+/// 0x0069B4D4` and `TechnoClass::Clear_Convoy_Chain @ 0x006EC3BD` write the
+/// same `1`; `FootClass::Mission_Rescue @ 0x004DE03E` clears it.
+/// - Trigger: a ground attacker finishes a move still holding a target it
+///   cannot fire on, and then scans after that target goes away.
+/// - Player effect: for one scan cadence a hunting unit looks only as far as
+///   plain Guard reaches instead of over the whole map, and an Area Guard unit
+///   uses the plain-Guard radius instead of the doubled one — so it takes a
+///   nearer target, or none, one cadence sooner than VERA does.
+/// - Frequency: the *set* is common — any unit that drives up to something it
+///   cannot shoot. The clear is narrower than "the next scan", though: it is
+///   conditional on that scan returning **nothing**. `TEST EAX,EAX ;
+///   JNZ 0x004D995B` at `0x004D9951` jumps past the store when the coerced
+///   scan found a target, so the byte survives, and nothing clears it on a
+///   mission change — the only other clears in the image are
+///   `FootClass::Mission_Rescue @ 0x004DE03E` and `FUN_0069B170 @ 0x0069B17D`,
+///   while `FootClass::ComputeChecksum @ 0x004DBCE2` reads it, so it is
+///   durable sim state. So the honest ceiling is "until the first coerced scan
+///   comes back empty", not one cadence: a latched hunter that keeps finding
+///   targets inside the coerced ring walk stays coerced for as long as it keeps
+///   finding them.
+///
+///   The load-bearing conclusion is unchanged, because the case where the flat
+///   walk matters is the case that clears the latch: with nothing inside plain
+///   Guard reach the coerced ring scan returns nothing, the byte is cleared,
+///   and the next cadence runs the flat walk. The mask-0 flat walk stays the
+///   ordinary Hunt scan, so the zone gate and the lepton-scale distance term
+///   above are both on the common path.
+/// - Downstream risk: closing it needs a persistent per-entity latch written by
+///   the locomotor arrival path, i.e. a new snapshot field plus a
+///   `SNAPSHOT_VERSION` bump and a movement-side write. Target choice only — no
+///   RNG is drawn on either path.
+///
+/// `zone_grid` supplies `MapClass`'s per-movement-zone connectivity for the
+/// mask-0 gate; see [`ScanContext::scanner_zone`].
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn greatest_threat(
     entities: &EntityStore,
@@ -626,6 +818,7 @@ pub(crate) fn greatest_threat(
     scan_range_override: Option<SimFixed>,
     terrain: Option<&ResolvedTerrainGrid>,
     require_playfield_membership: bool,
+    zone_grid: Option<&ZoneGrid>,
 ) -> Option<u64> {
     let range = match scan_range_override {
         Some(cells) => ScanRange::Hard(cells),
@@ -636,11 +829,41 @@ pub(crate) fn greatest_threat(
             attacker.scan_mission,
         ),
     };
-    let radius = scan_radius_cells(rules, attacker_obj, attacker.veterancy, range);
-    if radius <= 0 {
-        // `for (r = 0; r < radius; r++)` never executes.
-        return None;
-    }
+
+    // `MOV [ESP+0x3c],EAX @ 0x006F8EC4`, guarded by `TEST BL,0x1 ; JNZ` at
+    // `0x006F8E48` and the two `What_Am_I()` skips at `0x006F8E54` /
+    // `0x006F8E60`.
+    //
+    // RESIDUAL — the ring walk's own use of the same slot. Native computes it
+    // for every mask with bit0 clear, which includes Area Guard's mask 2, and
+    // the ring path threads it into `Scan_Cell_For_Target @ 0x006F8960`
+    // (`MOV ECX,[ESP+0x3c] @ 0x006F941B`, `PUSH ECX @ 0x006F9427` — arg7 of the
+    // seven pushes before `CALL @ 0x006F9440`), which is a different argument
+    // from the `Evaluate_Candidate` arg6 the flat walk fills, and one
+    // `scan_cell_for_target` below does not take. Trigger: any Guard or Area
+    // Guard ring scan whose cells span more than one movement-zone component —
+    // a defender beside water, a cliff edge, a bridge. Player effect: at most
+    // which occupant of a cell that cell offers. Frequency: UNCHECKED — the
+    // argument's role inside `0x006F8960` was not decompiled. Downstream risk:
+    // none here; it belongs with the ring walk's own port. So the slot is
+    // filled only on the branch that reads it in this module.
+    let scanner_zone = if matches!(range, ScanRange::NoCutoff)
+        && !matches!(
+            attacker.category,
+            EntityCategory::Structure | EntityCategory::Aircraft
+        ) {
+        zone_grid.and_then(|zones| {
+            zones.get_zone_id_native(
+                (i32::from(attacker.pos_rx), i32::from(attacker.pos_ry)),
+                attacker_obj.movement_zone,
+                // `PUSH 0x1 @ 0x006F8E73` — the scanner's own cell is always
+                // asked with bridge resolution on, whatever layer it stands on.
+                true,
+            )
+        })
+    } else {
+        None
+    };
 
     let ctx = ScanContext {
         entities,
@@ -657,7 +880,28 @@ pub(crate) fn greatest_threat(
             attacker_obj,
             HOUSE_SELECTS_OWN_COEFFICIENTS,
         ),
+        zone_grid,
+        scanner_zone,
+        // `PUSH EBP @ 0x006F9D64` on the flat walk against `PUSH 0xb0ea90` at
+        // `0x006F929A` / `0x006F9C18` on the two ring-shaped walks.
+        threat_reference: if matches!(range, ScanRange::NoCutoff) {
+            ThreatReference::ScannerCoords
+        } else {
+            ThreatReference::NullCoord
+        },
     };
+
+    // `TEST AL,0x3 ; JZ 0x006F9B6E`. Mask 0 takes the flat topology; every
+    // other mask falls through into the radius block below.
+    if matches!(range, ScanRange::NoCutoff) {
+        return global_list_scan(&ctx);
+    }
+
+    let radius = scan_radius_cells(rules, attacker_obj, attacker.veterancy, range);
+    if radius <= 0 {
+        // `for (r = 0; r < radius; r++)` never executes.
+        return None;
+    }
 
     let cx = i32::from(attacker.pos_rx);
     let cy = i32::from(attacker.pos_ry);
@@ -736,6 +980,104 @@ pub(crate) fn greatest_threat(
         }
         if best.is_some() && is_early_return_ring(ring, radius) {
             return best;
+        }
+    }
+    best
+}
+
+/// The mask-0 scan: `Greatest_Threat`'s flat walk over the global object array,
+/// `0x006F9C67`-`0x006F9D9B`.
+///
+/// This is where a hunting object's mask lands. Verified from the disassembly
+/// this session:
+///
+/// - `0x006F9B6E` `MOV AL,[ESP+0x14] ; TEST AL,0x4 ; JZ 0x006F9C56` — the
+///   derived flags word is built from the mask alone
+///   (`0x006F8F29`-`0x006F8F72`, seeded `XOR EDI,EDI`), so for mask 0 it is
+///   zero and the FIRST global walk (the `0x00A8E394` list) is skipped.
+/// - `0x006F9C56` `TEST byte ptr [ESP+0x70],0x10 ; JZ 0x006F9C67` — mask 0
+///   falls into the **unconditional** second walk.
+/// - `0x006F9C67` `MOV EAX,[0x00A8EC88]` (the element count),
+///   `XOR EBX,EBX ; TEST EAX,EAX ; JLE 0x006F9DA1`, then
+///   `MOV EDX,[0x00A8EC7C] ; MOV EDI,[EDX + EBX*0x4]` — a plain indexed walk of
+///   the global techno array, closed by `INC EBX ; CMP EBX,EAX ; JL 0x006F9C7A`
+///   at `0x006F9D98`. **The loop is bounded by the object count**, exactly like
+///   this one; nothing here is bounded by a radius because nothing here uses
+///   one.
+/// - `0x006F9D70` `PUSH -0x1` sits in the arg3 range slot (counting the seven
+///   pushes back from `CALL 0x006F7CA0`), the same slot the ring path fills
+///   with its computed radius (`MOV ECX,[ESP+0x2C] @ 0x006F9292`,
+///   `PUSH ECX @ 0x006F92A7`). `Evaluate_Candidate @ 0x006F7CA0` rejects on
+///   distance only under `0 < range` and falls back to `TechnoType+0x5B8` /
+///   `vt+0x3A8` only under `range == 0`, so `-1` trips neither gate.
+///
+/// Every candidate goes through the same [`evaluate_candidate`] ladder the ring
+/// walk uses, because native calls the same `Evaluate_Candidate` — the self,
+/// ally, limbo, dead and in-transport rejects all live inside that function.
+///
+/// **The two walks do not pass that function the same arguments.** The flat
+/// walk pushes the scanner's movement-zone id in arg6
+/// (`MOV ECX,[ESP+0x3c] @ 0x006F9D5C`, `PUSH ECX @ 0x006F9D69`) where every
+/// ring callsite pushes `-1` (`0x006F92A3`, `0x006F9C21`), and a non-`-1` arg6
+/// switches on a hard reject inside `Evaluate_Candidate`: the candidate's cell
+/// must resolve to the same movement-zone component
+/// (`MOV EBP,[ESP+0x54] ; CMP EBP,-0x1 ; JZ 0x006F7EA2` at
+/// `0x006F7E32`-`0x006F7E45`, then
+/// `GetZoneID(candidate cell, ATTACKER type +0x5B4, candidate +0x8C)` and
+/// `CMP EAX,EBP ; JNZ 0x006F894F` at `0x006F7E7E`-`0x006F7E9C`). So a hunting
+/// object considers only what its own movement zone can reach from where it
+/// stands — it does not walk at something across water or up a cliff. That
+/// gate is carried here by [`ScanContext::scanner_zone`].
+///
+/// arg6 is not the only argument the two walks disagree on. **arg7 differs
+/// too, and it decides the SCALE of the score's distance term.** The flat walk
+/// forwards `Greatest_Threat`'s own arg2 — for `Mission_Hunt` a copy of the
+/// hunter's Coords (`0x004D536D`-`0x004D538B`) — with
+/// `MOV EBP,[ESP+0x74] @ 0x006F9C76` and `PUSH EBP @ 0x006F9D64`, where both
+/// ring-shaped walks push the `NullCoord` sentinel (`PUSH 0xb0ea90` at
+/// `0x006F929A` and `0x006F9C18`). That argument reaches
+/// `Calculate_Threat_Score` at `0x006F86FE`-`0x006F8706`, and a non-sentinel
+/// value takes the branch that never shifts its distance to cells
+/// (`JMP 0x0070D0A0 @ 0x0070D021` against `SAR EAX,0x8 @ 0x0070D09D`). With
+/// stock `TargetDistanceCoefficientDefault=-10` that makes a hunting object
+/// overwhelmingly nearest-first where a ring scanner barely weighs distance at
+/// all. Carried here by [`ScanContext::threat_reference`].
+///
+/// There is no airborne pre-pass and no band early return on this path: both
+/// sit at `0x006F9169` and `0x006F94D0`, below the mask-0 jump target, so a
+/// hunting object simply sees every object once. Aircraft are reached here like
+/// anything else, because the global array holds them too.
+///
+/// DRIFT — enumeration order. Native walks the array in registration order;
+/// [`EntityStore`] is a `BTreeMap`, so this walks in `stable_id` order. The
+/// keep is strictly-greater in both, so the order is observable only when two
+/// candidates score *exactly* equal, where the winner can differ.
+/// - Trigger: a hunting object with two equally-scored enemies in view.
+/// - Player effect: which of two interchangeable targets it walks to.
+/// - Frequency: rare — the score folds health, distance and armour
+///   effectiveness, so exact ties need near-identical candidates.
+/// - Downstream risk: none beyond target choice; no RNG is drawn here.
+///
+/// COST — this walks every live entity once per Hunt scan, which is the shape
+/// native has (`[0x00A8EC88]` is the global object count) and is bounded by the
+/// object count rather than by the map. It is strictly cheaper than the ring
+/// path, which makes the same full pass inside [`ScanIndex::build`] and then
+/// sorts and allocates on top of it. A hunting object scans only when it holds
+/// no target and its `NormalTargetingDelay` timer has expired, so at charter
+/// scale the cost is one N-pass per hunting object per cadence — not per tick,
+/// and not per ring.
+fn global_list_scan(ctx: &ScanContext<'_>) -> Option<u64> {
+    let mut best: Option<u64> = None;
+    // `local_50 = -1` on the ring path; the same strictly-greater keep, so a
+    // score of 0 (itself a rejection) can never displace nothing.
+    let mut best_score: i32 = -1;
+    for candidate in ctx.entities.values() {
+        let Some(score) = evaluate_candidate(ctx, candidate) else {
+            continue;
+        };
+        if score > best_score {
+            best_score = score;
+            best = Some(candidate.stable_id);
         }
     }
     best
@@ -855,9 +1197,53 @@ fn evaluate_candidate(ctx: &ScanContext<'_>, candidate: &GameEntity) -> Option<i
         return None;
     }
 
+    // G12 — the movement-zone gate, `0x006F7E32`-`0x006F7E9C`, in its native
+    // slot (between the in-transport reject and the distance test).
+    //
+    // `MOV EBP,[ESP+0x54]` reads arg6; `CMP EBP,-0x1 ; JZ 0x006F7EA2` skips the
+    // whole block when the caller passed `-1`, which every ring-walk callsite
+    // does. Otherwise the candidate's coords are converted to a cell
+    // (`CALL [vt+0x48] @ 0x006F7E2D`, `SAR EAX,0x8` twice) and
+    // `MapClass::GetZoneID(that cell, ATTACKER type +0x5B4, candidate +0x8C)`
+    // at `0x006F7E7E`-`0x006F7E95` must equal arg6, or `JNZ 0x006F894F` rejects.
+    // Note both zone lookups use the ATTACKER's `MovementZone=`; only the
+    // bridge-resolution flag differs — a literal `1` for the scanner's own cell
+    // (`PUSH 0x1 @ 0x006F8E73`), the candidate's own on-bridge byte here
+    // (`MOV CL,[ESI+0x8c] @ 0x006F7E5B`, `PUSH ECX @ 0x006F7E77`).
+    //
+    // The player-visible effect is that a hunting unit will not commit to a
+    // victim across water, up a cliff, or in a disconnected pocket: it picks
+    // something it can actually walk to, or nothing.
+    //
+    // VERA-internal, gamemd has no equivalent: a `None` from either lookup
+    // leaves the gate off rather than rejecting. `ZoneGrid`'s exact GetZoneID
+    // surface refuses a non-square or topology-less grid instead of performing
+    // native's unchecked read, and `zone_grid` is `None` in headless fixtures
+    // with no map. Trigger: unit tests and any map whose resolved terrain is
+    // not square. Player effect in production: none — `rebuild_zone_grid_full`
+    // always builds from resolved terrain. Frequency: nil in a real match.
+    if let Some(scanner_zone) = ctx.scanner_zone {
+        let candidate_zone = ctx.zone_grid.and_then(|zones| {
+            zones.get_zone_id_native(
+                (
+                    i32::from(candidate.position.rx),
+                    i32::from(candidate.position.ry),
+                ),
+                ctx.attacker_obj.movement_zone,
+                candidate.on_bridge,
+            )
+        });
+        if candidate_zone.is_some_and(|zone| zone != scanner_zone) {
+            return None;
+        }
+    }
+
     // G13 — distance. A non-zero `Threat_Range` is a hard cutoff; a zero one
     // defers to the attacker's own can-fire-at query, which is the range of the
-    // weapon picked against this very candidate.
+    // weapon picked against this very candidate; a NEGATIVE one — the literal
+    // `-1` the mask-0 walk pushes at `0x006F9D70` — satisfies neither
+    // `0 < range` nor `range == 0`, so both gates are skipped and the candidate
+    // is admitted at any separation.
     let dist_sq = lepton_distance_sq_raw(
         ctx.attacker.pos_rx,
         ctx.attacker.pos_ry,
@@ -870,6 +1256,7 @@ fn evaluate_candidate(ctx: &ScanContext<'_>, candidate: &GameEntity) -> Option<i
     );
     let in_range = match ctx.range {
         ScanRange::Hard(cells) => is_within_range_leptons(dist_sq, cells),
+        ScanRange::NoCutoff => true,
         ScanRange::CanFireAt => match (ctx.terrain, ctx.entities.get(ctx.attacker.stable_id)) {
             (Some(terrain), Some(attacker_entity)) => {
                 let source_z = super::in_range::effective_z_leptons(attacker_entity, terrain)?;
@@ -1057,6 +1444,7 @@ fn evaluate_candidate(ctx: &ScanContext<'_>, candidate: &GameEntity) -> Option<i
         ctx.terrain,
         ctx.alliances(),
         ctx.coefficients,
+        ctx.threat_reference,
     )?;
     finish_score(score)
 }
@@ -1094,7 +1482,11 @@ fn live_threat_posed(rules: &RuleSet, candidate: &GameEntity, obj: &ObjectType) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::map::bridge_facts::BridgeCellFacts;
+    use crate::map::resolved_terrain::{ResolvedTerrainCell, zone_class};
     use crate::rules::ini_parser::IniFile;
+    use crate::rules::locomotor_type::MovementZone;
+    use crate::rules::terrain_rules::{SpeedCostProfile, TerrainClass};
     use crate::sim::intern::test_interner;
 
     /// A skirmish-shaped fixture: one gun tank, the two civilian object classes
@@ -1117,7 +1509,7 @@ mod tests {
              [InfantryTypes]\n0=ENGINEER\n\
              [BuildingTypes]\n0=WALL\n1=PILLBOX\n2=POWER\n3=CHRONO\n4=GATTLING\n\
              [WeaponTypes]\n0=105mm\n1=Vulcan\n\
-             [GRIZZLY]\nStrength=300\nArmor=heavy\nPrimary=105mm\n\
+             [GRIZZLY]\nStrength=300\nArmor=heavy\nPrimary=105mm\nMovementZone=Normal\n\
              [SCOUT]\nStrength=300\nArmor=heavy\n\
              [PRIZE]\nStrength=300\nArmor=heavy\nSpecialThreatValue=10\n\
              [CAR]\nStrength=100\nArmor=light\nInsignificant=yes\n\
@@ -1154,10 +1546,483 @@ mod tests {
     }
 
     fn pick(entities: &EntityStore, rules: &RuleSet, attacker: u64) -> Option<u64> {
+        pick_with_mask(entities, rules, attacker, super::super::ScanMission::Guard)
+    }
+
+    /// The same acquisition entry, with the threat mask the caller would push.
+    fn pick_with_mask(
+        entities: &EntityStore,
+        rules: &RuleSet,
+        attacker: u64,
+        mask: super::super::ScanMission,
+    ) -> Option<u64> {
+        pick_with_mask_and_zones(entities, rules, attacker, mask, None)
+    }
+
+    /// The acquisition entry with `MapClass`'s zone topology supplied, which is
+    /// what the mask-0 walk needs to run its movement-zone gate.
+    fn pick_with_mask_and_zones(
+        entities: &EntityStore,
+        rules: &RuleSet,
+        attacker: u64,
+        mask: super::super::ScanMission,
+        zones: Option<&ZoneGrid>,
+    ) -> Option<u64> {
         let interner = test_interner();
         super::super::acquire_best_target_for_entity(
-            entities, rules, &interner, attacker, None, None, false,
+            entities, rules, &interner, attacker, None, None, false, mask, zones,
         )
+    }
+
+    /// One clear ground cell.
+    fn zone_test_cell(rx: u16, ry: u16, impassable: bool) -> ResolvedTerrainCell {
+        ResolvedTerrainCell {
+            rx,
+            ry,
+            source_tile_index: 0,
+            source_sub_tile: 0,
+            final_tile_index: 0,
+            final_sub_tile: 0,
+            is_wood_bridge_repair_tile: false,
+            level: 0,
+            filled_clear: false,
+            tileset_index: Some(0),
+            land_type: 0,
+            yr_cell_land_type: 0,
+            slope_type: 0,
+            template_height: 0,
+            render_offset_x: 0,
+            render_offset_y: 0,
+            terrain_class: TerrainClass::Clear,
+            speed_costs: SpeedCostProfile::default(),
+            is_water: false,
+            is_cliff_like: impassable,
+            is_rough: false,
+            is_road: false,
+            accepts_smudge: false,
+            allows_tiberium: false,
+            height_in_pixels: 0,
+            variant: 0,
+            has_ramp: false,
+            canonical_ramp: None,
+            ground_walk_blocked: impassable,
+            terrain_object_blocks: false,
+            terrain_object_occupation: None,
+            overlay_blocks: false,
+            overlay_zone_type: None,
+            outside_playfield: false,
+            zone_type: if impassable {
+                zone_class::IMPASSABLE
+            } else {
+                zone_class::GROUND
+            },
+            base_ground_walk_blocked: impassable,
+            base_build_blocked: impassable,
+            base_land_type: 0,
+            base_yr_cell_land_type: 0,
+            base_terrain_class: TerrainClass::Clear,
+            base_speed_costs: SpeedCostProfile::default(),
+            build_blocked: impassable,
+            has_bridge_deck: false,
+            bridge_walkable: false,
+            bridge_transition: false,
+            bridge_deck_level: 0,
+            bridge_layer: None,
+            bridge_facts: BridgeCellFacts::default(),
+            tube_index: None,
+            radar_left: [0, 0, 0],
+            radar_right: [0, 0, 0],
+            has_damaged_data: false,
+            bridgehead_anchor_class_at_load: None,
+        }
+    }
+
+    /// A square map cut in two by one impassable column, so that
+    /// `MovementZone::Normal` has two disconnected components.
+    fn split_zone_grid(side: u16, barrier_rx: u16) -> ZoneGrid {
+        let cells = (0..side)
+            .flat_map(|ry| (0..side).map(move |rx| zone_test_cell(rx, ry, rx == barrier_rx)))
+            .collect();
+        let terrain = ResolvedTerrainGrid::from_cells(side, side, cells);
+        let path_grid = crate::sim::pathfinding::PathGrid::from_resolved_terrain(&terrain);
+        ZoneGrid::build_with_terrain(
+            &path_grid,
+            &BTreeMap::new(),
+            Some(&terrain),
+            &[],
+            side,
+            side,
+        )
+    }
+
+    /// The mask-0 walk is movement-zone filtered, and the ring walk is not.
+    ///
+    /// `Greatest_Threat` computes the scanner's own zone id at `0x006F8EC4`
+    /// whenever the mask has bit0 clear, and the flat walk pushes it into
+    /// `Evaluate_Candidate`'s arg6 (`PUSH ECX @ 0x006F9D69`) where every ring
+    /// callsite pushes `-1` (`0x006F92A3`). A non-`-1` arg6 turns on the reject
+    /// at `0x006F7E7E`-`0x006F7E9C`: the candidate's cell must resolve to the
+    /// same component under the ATTACKER's `MovementZone=`.
+    ///
+    /// Fixture: an impassable column at `rx = 5` splits an 12x12 map. The
+    /// attacker sits at `(2, 2)`; the nearer enemy at `(8, 2)` is on the far
+    /// side and unreachable, the further one at `(1, 10)` is on its own side.
+    /// Distance carries a negative coefficient, so without the gate the nearer
+    /// one wins — which is exactly what the same fixture returns when no zone
+    /// topology is supplied.
+    #[test]
+    fn gsi_07_20_mask_zero_refuses_a_target_its_movement_zone_cannot_reach() {
+        let rules = scan_rules();
+        let zones = split_zone_grid(12, 5);
+        let near_side = zones
+            .get_zone_id_nonbridge_native((2, 2), MovementZone::Normal)
+            .expect("attacker cell resolves a Normal zone id");
+        let far_side = zones
+            .get_zone_id_nonbridge_native((8, 2), MovementZone::Normal)
+            .expect("across-the-barrier cell resolves a Normal zone id");
+        assert_ne!(
+            near_side, far_side,
+            "the fixture must actually split MovementZone=Normal into two components"
+        );
+
+        let mut entities = EntityStore::new();
+        place(
+            &mut entities,
+            1,
+            "GRIZZLY",
+            "Americans",
+            2,
+            2,
+            EntityCategory::Unit,
+        );
+        place(
+            &mut entities,
+            2,
+            "SCOUT",
+            "Soviets",
+            8,
+            2,
+            EntityCategory::Unit,
+        );
+        place(
+            &mut entities,
+            3,
+            "SCOUT",
+            "Soviets",
+            1,
+            10,
+            EntityCategory::Unit,
+        );
+
+        assert_eq!(
+            pick_with_mask_and_zones(&entities, &rules, 1, super::super::ScanMission::Hunt, None),
+            Some(2),
+            "with no zone topology the gate is off and the nearer target wins on score"
+        );
+        assert_eq!(
+            pick_with_mask_and_zones(
+                &entities,
+                &rules,
+                1,
+                super::super::ScanMission::Hunt,
+                Some(&zones)
+            ),
+            Some(3),
+            "the zone gate refuses the nearer target across the barrier and takes the reachable one"
+        );
+    }
+
+    /// The gate belongs to the flat walk alone. Same fixture, one enemy, and it
+    /// is on the far side of the barrier and inside plain Guard's ring bound:
+    /// mask 1 still takes it, because the ring callsite pushes `-1` into arg6
+    /// (`PUSH -0x1 @ 0x006F92A3`) and the reject at `0x006F7E45` is skipped.
+    #[test]
+    fn gsi_07_20_the_ring_walk_ignores_the_zone_gate_the_flat_walk_applies() {
+        let rules = scan_rules();
+        let zones = split_zone_grid(12, 5);
+
+        let mut entities = EntityStore::new();
+        place(
+            &mut entities,
+            1,
+            "GRIZZLY",
+            "Americans",
+            4,
+            2,
+            EntityCategory::Unit,
+        );
+        place(
+            &mut entities,
+            2,
+            "SCOUT",
+            "Soviets",
+            6,
+            2,
+            EntityCategory::Unit,
+        );
+
+        assert_eq!(
+            pick_with_mask_and_zones(
+                &entities,
+                &rules,
+                1,
+                super::super::ScanMission::Guard,
+                Some(&zones)
+            ),
+            Some(2),
+            "mask 1 pushes -1 in the arg6 slot, so the zone reject never runs"
+        );
+        assert_eq!(
+            pick_with_mask_and_zones(
+                &entities,
+                &rules,
+                1,
+                super::super::ScanMission::Hunt,
+                Some(&zones)
+            ),
+            None,
+            "mask 0 supplies the zone and refuses the same candidate"
+        );
+    }
+
+    /// A 20-cell-range attacker with one long weapon, a plain enemy and an
+    /// otherwise identical enemy worth `SpecialThreatValue=10`. Nothing else
+    /// separates the two candidates, so the score ordering is decided by the
+    /// special-threat term against the distance term alone.
+    fn lepton_scale_rules() -> RuleSet {
+        RuleSet::from_ini(&IniFile::from_str(
+            "[General]\n\
+             MyEffectivenessCoefficientDefault=200\n\
+             TargetEffectivenessCoefficientDefault=-200\n\
+             TargetSpecialThreatCoefficientDefault=200\n\
+             TargetStrengthCoefficientDefault=-200\n\
+             TargetDistanceCoefficientDefault=-10\n\
+             [VehicleTypes]\n0=LONGTANK\n1=PLAIN\n2=JUICY\n\
+             [WeaponTypes]\n0=LongGun\n\
+             [LONGTANK]\nStrength=300\nArmor=heavy\nPrimary=LongGun\nMovementZone=Normal\n\
+             [PLAIN]\nStrength=300\nArmor=heavy\n\
+             [JUICY]\nStrength=300\nArmor=heavy\nSpecialThreatValue=10\n\
+             [LongGun]\nDamage=100\nROF=110\nRange=20\nWarhead=AP\n\
+             [AP]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+        ))
+        .expect("lepton-scale fixture")
+    }
+
+    /// The flat walk scores distance in LEPTONS where every ring-shaped walk
+    /// scores it in CELLS — the same geometry at 256x the scale, in the one
+    /// term that separates two candidates.
+    ///
+    /// `Mission_Hunt` copies its own `ObjectClass+0x9C` Coords to a local and
+    /// passes the pointer (`LEA ECX,[ESI+0x9c] @ 0x004D536D` … `LEA EAX,
+    /// [ESP+0x14]` / `PUSH EAX @ 0x004D538B`); `Retaliate_And_Scan` forwards it
+    /// as `Greatest_Threat`'s arg2, and the flat walk alone pushes it as
+    /// `Evaluate_Candidate`'s arg7 (`MOV EBP,[ESP+0x74] @ 0x006F9C76`,
+    /// `PUSH EBP @ 0x006F9D64`), which becomes `Calculate_Threat_Score`'s third
+    /// parameter at `0x006F86FE`-`0x006F8706`. The ring walk and the aircraft
+    /// pre-walk push the `NullCoord` sentinel instead (`PUSH 0xb0ea90` at
+    /// `0x006F929A` and `0x006F9C18`), and a sentinel takes the branch that
+    /// ends `SAR EAX,0x8 @ 0x0070D09D`; the supplied-coordinate branch has no
+    /// shift at all (`JMP 0x0070D0A0 @ 0x0070D021`).
+    ///
+    /// Fixture: the attacker at `(10, 10)`, the plain enemy 2 cells east, the
+    /// juicier one 4 cells east. Both sit well inside `Range=20`, so on the
+    /// CELL scale `max(0, dist − range)` is zero for both and the
+    /// special-threat term (`200 x 10 = 2000`) decides; on the LEPTON scale the
+    /// same pair is ~492 and ~1004 beyond range, i.e. about `-4920` against
+    /// `-8040 = -10040 + 2000`, and the nearer, cheaper target wins.
+    ///
+    /// Both bands of the ring walk's early return (`radius/4 = 5`,
+    /// `radius/2 = 10` with `radius = 21`) sit outside ring 4, so the ring walk
+    /// really does score both candidates before it can return.
+    #[test]
+    fn gsi_07_20_the_flat_walk_scores_distance_in_leptons_where_the_ring_walk_scores_cells() {
+        let rules = lepton_scale_rules();
+
+        let mut entities = EntityStore::new();
+        place(
+            &mut entities,
+            1,
+            "LONGTANK",
+            "Americans",
+            10,
+            10,
+            EntityCategory::Unit,
+        );
+        place(
+            &mut entities,
+            2,
+            "PLAIN",
+            "Soviets",
+            12,
+            10,
+            EntityCategory::Unit,
+        );
+        place(
+            &mut entities,
+            3,
+            "JUICY",
+            "Soviets",
+            14,
+            10,
+            EntityCategory::Unit,
+        );
+
+        assert_eq!(
+            pick_with_mask(&entities, &rules, 1, super::super::ScanMission::Guard),
+            Some(3),
+            "the ring walk pushes the NullCoord sentinel, so its distance term \
+             is in cells, both candidates are inside the weapon range, and \
+             SpecialThreatValue alone decides"
+        );
+        assert_eq!(
+            pick_with_mask(&entities, &rules, 1, super::super::ScanMission::Hunt),
+            Some(2),
+            "the flat walk forwards the hunter's own Coords, so its distance \
+             term is in leptons and the nearer candidate wins despite being \
+             worth 2000 less"
+        );
+
+        // The same pair through the scorer directly, so the walk-level result
+        // above cannot be explained by anything but the reference coordinate.
+        let interner = test_interner();
+        let attacker_obj = rules.object("LONGTANK").expect("attacker type");
+        let coefficients =
+            ThreatCoefficients::resolve(&rules, attacker_obj, HOUSE_SELECTS_OWN_COEFFICIENTS);
+        let score = |candidate: u64, reference: ThreatReference| {
+            finish_score(
+                calculate_threat_score(
+                    &entities,
+                    1,
+                    candidate,
+                    &rules,
+                    &interner,
+                    None,
+                    None,
+                    coefficients,
+                    reference,
+                )
+                .expect("scored"),
+            )
+            .expect("accepted")
+        };
+        assert!(
+            score(3, ThreatReference::NullCoord) > score(2, ThreatReference::NullCoord),
+            "on the cell scale the juicier candidate outscores the nearer one: {} vs {}",
+            score(3, ThreatReference::NullCoord),
+            score(2, ThreatReference::NullCoord)
+        );
+        assert!(
+            score(2, ThreatReference::ScannerCoords) > score(3, ThreatReference::ScannerCoords),
+            "on the lepton scale the ordering flips: {} vs {}",
+            score(2, ThreatReference::ScannerCoords),
+            score(3, ThreatReference::ScannerCoords)
+        );
+    }
+
+    /// Mask 0 is a different scan TOPOLOGY, not a wider radius: `TEST AL,0x3 ;
+    /// JZ 0x006F9B6E` at `0x006F8FE0` skips the radius block and the ring walk
+    /// outright, and the walk that runs instead enumerates the global object
+    /// array with a literal `-1` in the range slot (`PUSH -0x1 @ 0x006F9D70`).
+    ///
+    /// 30 cells is far outside anything the ring walk could reach for this
+    /// type: `105mm Range=5` with no `GuardRange=` bounds the Guard walk at
+    /// `5 + 1 + 0 = 6` rings, and even the Area Guard formula caps at
+    /// [`AREA_GUARD_MAX_SCAN_CELLS`] = 16. Both are asserted, so the Hunt result
+    /// cannot be explained by a radius the walk happened to compute.
+    #[test]
+    fn gsi_07_20_mask_zero_reaches_past_every_ring_the_walk_could_compute() {
+        let rules = scan_rules();
+        let mut entities = EntityStore::new();
+        place(
+            &mut entities,
+            1,
+            "GRIZZLY",
+            "Americans",
+            10,
+            10,
+            EntityCategory::Unit,
+        );
+        place(
+            &mut entities,
+            2,
+            "SCOUT",
+            "Soviets",
+            10,
+            40,
+            EntityCategory::Unit,
+        );
+
+        assert_eq!(
+            pick_with_mask(&entities, &rules, 1, super::super::ScanMission::Guard),
+            None,
+            "the mask-1 ring walk bounds at weapon range + 1 = 6 cells"
+        );
+        assert_eq!(
+            pick_with_mask(&entities, &rules, 1, super::super::ScanMission::AreaGuard),
+            None,
+            "even the doubled-and-capped mask-2 radius stops at 16 cells"
+        );
+        assert_eq!(
+            pick_with_mask(&entities, &rules, 1, super::super::ScanMission::Hunt),
+            Some(2),
+            "mask 0 enumerates the global list with range -1, so 30 cells is not a cutoff"
+        );
+    }
+
+    /// The other half of the topology difference, and the one a radius cannot
+    /// imitate at any width: the ring walk asks each cell for a single
+    /// candidate (`Scan_Cell_For_Target @ 0x006F8960` stops at the list head),
+    /// so a cell whose head the gate refuses contributes nothing at all. The
+    /// mask-0 walk has no cells — it runs `Evaluate_Candidate` on every array
+    /// element — so the second occupant of that cell is still seen.
+    ///
+    /// Fixture: a hostile `CAR` (`Insignificant=yes`, refused by G19) sharing a
+    /// cell with a hostile `SCOUT`, one cell from the attacker and well inside
+    /// every radius. Guard finds nothing; Hunt finds the scout.
+    #[test]
+    fn gsi_07_20_mask_zero_sees_past_a_refused_cell_list_head() {
+        let rules = scan_rules();
+        let mut entities = EntityStore::new();
+        place(
+            &mut entities,
+            1,
+            "GRIZZLY",
+            "Americans",
+            10,
+            10,
+            EntityCategory::Unit,
+        );
+        // The cell list prepends non-buildings, so the later-ordered entry ends
+        // up at the head; the CAR must be the one the walk stops on.
+        place(
+            &mut entities,
+            2,
+            "SCOUT",
+            "Soviets",
+            11,
+            10,
+            EntityCategory::Unit,
+        );
+        place(
+            &mut entities,
+            3,
+            "CAR",
+            "Soviets",
+            11,
+            10,
+            EntityCategory::Unit,
+        );
+
+        assert_eq!(
+            pick_with_mask(&entities, &rules, 1, super::super::ScanMission::Guard),
+            None,
+            "the ring walk takes the cell's list head, and an Insignificant civilian is refused"
+        );
+        assert_eq!(
+            pick_with_mask(&entities, &rules, 1, super::super::ScanMission::Hunt),
+            Some(2),
+            "the mask-0 walk evaluates every object, so the scout behind the car is still seen"
+        );
     }
 
     /// The headline scenario for row 121: a gun tank sitting on Guard with an

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -6795,6 +6795,12 @@ pub(crate) fn resolve_attacker_fire(
                 garrison_retarget_range,
                 terrain.as_deref(),
                 require_playfield_membership,
+                // No zone grid on the retarget path, and none is needed: this
+                // snapshot's mask comes from `build_attacker_snapshot`, i.e.
+                // `scan_mission_for`, which only ever returns `1` or `2`. The
+                // scanner-zone slot native fills at `0x006F8EC4` is read only by
+                // the mask-0 flat walk, which this callsite cannot select.
+                None,
             ) {
                 out.retarget_events.push((snap.stable_id, new_target));
             } else {
@@ -6915,6 +6921,12 @@ pub(crate) fn resolve_attacker_fire(
                 garrison_retarget_range,
                 terrain.as_deref(),
                 require_playfield_membership,
+                // No zone grid on the retarget path, and none is needed: this
+                // snapshot's mask comes from `build_attacker_snapshot`, i.e.
+                // `scan_mission_for`, which only ever returns `1` or `2`. The
+                // scanner-zone slot native fills at `0x006F8EC4` is read only by
+                // the mask-0 flat walk, which this callsite cannot select.
+                None,
             ) {
                 out.retarget_events.push((snap.stable_id, new_target));
             } else {
@@ -6936,6 +6948,12 @@ pub(crate) fn resolve_attacker_fire(
                 garrison_retarget_range,
                 terrain.as_deref(),
                 require_playfield_membership,
+                // No zone grid on the retarget path, and none is needed: this
+                // snapshot's mask comes from `build_attacker_snapshot`, i.e.
+                // `scan_mission_for`, which only ever returns `1` or `2`. The
+                // scanner-zone slot native fills at `0x006F8EC4` is read only by
+                // the mask-0 flat walk, which this callsite cannot select.
+                None,
             ) {
                 out.retarget_events.push((snap.stable_id, new_target));
             } else {
@@ -7966,6 +7984,12 @@ fn veteran_rof_frames(
 }
 
 pub use self::combat_targeting::{acquire_best_target_for_entity, tick_retaliation};
+/// The threat mask an acquisition callsite pushes into
+/// `TechnoClass::Greatest_Threat @ 0x006F8DF0`, plus the passive block's own
+/// derivation of it. Re-exported because the mask is chosen by the mission
+/// handlers in `sim/world/`, not inside `combat/`.
+pub use self::threat_range::ScanMission;
+pub(crate) use self::threat_range::scan_mission_for;
 
 /// Impact-height tests: a shot that lands on a ground cell must take that
 /// cell's terrain floor height, not a constant. Kept inline because they pin

--- a/src/sim/combat/threat_range.rs
+++ b/src/sim/combat/threat_range.rs
@@ -24,6 +24,16 @@
 //! The doubling applies to `GuardRange=` too, not just to the weapon-range
 //! fallback.
 //!
+//! ## The third mask: Hunt asks for no filter and no ring walk
+//!
+//! `FootClass::Mission_Hunt @ 0x004D5373` pushes the literal `0`, and mask 0
+//! does not select a third radius formula — it skips the radius block, the
+//! airborne pre-pass and the ring walk outright and enumerates the global
+//! object array instead, passing a literal `-1` where the ring path passes its
+//! computed radius. That is a scan *topology*, so it lives in
+//! [`super::greatest_threat`]; [`ScanRange::NoCutoff`] is only the
+//! per-candidate half of it. See [`ScanMission::Hunt`].
+//!
 //! ## Why plain Guard really is `CanFireAt` — the mask literals
 //!
 //! This has now been challenged twice, so the chain is written down here.
@@ -59,12 +69,16 @@
 //! scan's mask is forced down to the plain-Guard one, so a unit that has just
 //! moved takes the narrow radius even on Area Guard; the first scan that finds
 //! nothing lowers the flag, and the wide radius applies from the next scan on.
-//! Its whole observable effect is to delay the widening by one scan cadence
-//! after each movement — a parked guard reaches its doubled radius on its
-//! second scan instead of its first. VERA has no such field, and adding one
+//! Its observable effect is to delay the widening until the first scan that
+//! finds nothing — usually one cadence after each movement, so a parked guard
+//! reaches its doubled radius on its second scan; but the clear is conditional
+//! on the *result*, not on the scan happening (`TEST EAX,EAX ; JNZ 0x004D995B`
+//! at `0x004D9951` skips the store), so a unit that keeps finding targets at
+//! the narrow radius keeps the narrow radius. VERA has no such field, and
+//! adding one
 //! means writes from the locomotors plus a snapshot field, so it is recorded
-//! here rather than modelled: units acquire at the wide radius one cadence
-//! sooner than retail after they stop moving.
+//! here rather than modelled: units acquire at the wide radius at least one
+//! cadence sooner than retail after they stop moving.
 //!
 //! **The unarmed-Guard override.** When the scanning object has no usable
 //! weapon at all *and* its mission is exactly Guard, retail forces the radius
@@ -108,15 +122,83 @@ const AREA_GUARD_RANGE_MULTIPLIER: i32 = 2;
 /// lepton value to 0x1000; at 256 leptons per cell that is 16 cells.
 const AREA_GUARD_MAX_SCAN_CELLS: i32 = 16;
 
-/// Which acquisition mission the scanning object is on. Selects the threat
-/// mask retail forwards into the scan, and through it the radius formula.
+/// The threat mask a callsite pushes into the scan — retail's `Greatest_Threat`
+/// argument 2, a literal at every callsite, named here after the mission that
+/// pushes it. It selects the radius formula and, for [`ScanMission::Hunt`], the
+/// scan topology. It is NOT a property of the object being scanned for, nor
+/// read off the scanner's mission field: two callers can hand the same object
+/// different masks, and `FUN_0051F330` does exactly that when it re-acquires in
+/// place for a deployed infantryman that is sitting on Area Guard.
+///
+/// **The literal is not always what `TechnoClass::Greatest_Threat` receives.**
+/// A `FootClass` dispatch goes through a `+0x3C4` override first, and two of
+/// them rewrite it on the way:
+/// - `UnitClass @ 0x00743190` and the Infantry override (`CALL @ 0x0051E39F`)
+///   OR the attacker's own projectile class bits in (`FUN_00772A90`, AA → `4`,
+///   AG → `0xB8`) when `mask & 0x1B978 == 0`, which mask 0 satisfies. The
+///   topology survives — neither value carries `TEST AL,0x3` — but the derived
+///   flags word changes.
+/// - `FootClass::Greatest_Threat @ 0x004D9931` coerces the mask to
+///   `(mask & ~2) | 1` while `FootClass+0x688` is set, turning mask 0 into mask
+///   1 and so the flat walk into the ring walk, and clears that byte at
+///   `0x004D9955` when the scan returns nothing.
+///
+/// Neither rewrite is modelled; both are recorded as residuals on
+/// [`super::greatest_threat::greatest_threat`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ScanMission {
+pub enum ScanMission {
     /// Guard, Move, Harvest — the plain passive-acquire missions. All of them
     /// take the same mask, so they share one variant.
     Guard,
     /// Area Guard — "hold this spot and cover it".
     AreaGuard,
+    /// Hunt — mask **0**, which is not a third radius formula but the absence
+    /// of one.
+    ///
+    /// `FootClass::Mission_Hunt @ 0x004D5373` pushes the literal `0` as the
+    /// threat mask (`disassemble_function 0x004D5350`), and
+    /// `TechnoClass::Greatest_Threat @ 0x006F8FE0` opens its radius block with
+    /// `TEST AL,0x3 ; JZ 0x006F9B6E` — with neither bit set it jumps **past**
+    /// both the `Threat_Range` selection (`vt+0x31C` at `0x006F900A` /
+    /// `0x006F9018`, result stored into the range slot `[ESP+0x2C]` at
+    /// `0x006F9020`) and the cell walk that consumes it.
+    ///
+    /// Where mask 0 actually lands: at `0x006F9B6E` the **first** global walk
+    /// (the `0x00A8E394` list) is gated on `TEST AL,0x4` against the derived
+    /// flags word `[ESP+0x14]` — zeroed at entry (`XOR EDI,EDI @ 0x006F8DFD`,
+    /// stored at `0x006F8F2C`) and thereafter built from the mask alone
+    /// (`0x006F8F29`-`0x006F8F72`). For mask 0 it is 0, the bit is clear, and
+    /// that walk is **skipped** (`JZ 0x006F9C56`). Execution falls through
+    /// `0x006F9C56` (`TEST byte ptr [ESP+0x70],0x10 ; JZ 0x006F9C67`) into the
+    /// **unconditional** second walk over the `0x00A8EC7C` list at `0x006F9C67`.
+    ///
+    /// What removes the cutoff is that walk's range argument, not the absence
+    /// of a distance test: it passes the literal `PUSH -0x1` (`0x006F9D70`) in
+    /// the argument slot where the radius path passes its computed range
+    /// (`MOV ECX,[ESP+0x2C] @ 0x006F9292`, `PUSH ECX @ 0x006F92A7`).
+    /// `TechnoClass::Evaluate_Candidate @ 0x006F7CA0` rejects on distance only
+    /// when that argument is `> 0`, and falls back to the
+    /// `TechnoType+0x5B8` / `vt+0x3A8` (Sight / can-fire-at) test only when it
+    /// is `== 0`; `-1` trips neither. So a hunting object has no *distance*
+    /// cutoff at all — that is the mechanism that sends a berserked unit across
+    /// the map.
+    ///
+    /// It is not unfiltered, though. The same walk that removes the distance
+    /// cutoff switches a **movement-zone** gate on: it passes the scanner's own
+    /// zone id (`MapClass::GetZoneID @ 0x006F8EBF`, stored at `0x006F8EC4`) in
+    /// `Evaluate_Candidate`'s arg6 (`PUSH ECX @ 0x006F9D69`) where every ring
+    /// callsite passes `-1`, and a non-`-1` arg6 rejects any candidate whose
+    /// cell is in a different component under the attacker's own
+    /// `MovementZone=` (`0x006F7E7E`-`0x006F7E9C`). A hunter reaches the far
+    /// side of the map but not the far side of a river.
+    ///
+    /// **Mask 0 is a scan TOPOLOGY, not a radius.** The jump at `0x006F8FE2`
+    /// lands past the airborne pre-pass *and* past the expanding-ring cell walk
+    /// (`0x006F9169` and `0x006F94D0` both sit below `0x006F9B6E`), so a
+    /// hunting object never walks a single cell ring — it walks the global
+    /// object array. [`super::greatest_threat`] owns that branch; this variant
+    /// only names which mask the caller pushed.
+    Hunt,
 }
 
 /// The distance filter the candidate acceptance test applies.
@@ -128,9 +210,30 @@ pub(crate) enum ScanRange {
     CanFireAt,
     /// A hard Euclidean cutoff, in cells. The can-fire-at query is skipped.
     Hard(SimFixed),
+    /// Native's literal `-1` range argument (`PUSH -0x1 @ 0x006F9D70`), which
+    /// `Evaluate_Candidate` treats as neither `> 0` (no distance reject) nor
+    /// `== 0` (no Sight / can-fire-at fallback). Weapon legality still decides;
+    /// distance does not. Only mask 0 produces it, and it selects the flat
+    /// global-list topology in [`super::greatest_threat`] as well as the
+    /// per-candidate predicate.
+    NoCutoff,
 }
 
-/// Read the acquisition mission off an entity.
+/// The mask the *passive* acquisition callsites push.
+///
+/// In retail no callsite derives the mask from the object it is scanning for —
+/// it is a literal at the caller (what the `+0x3C4` overrides then do to that
+/// literal is documented on [`ScanMission`]), and the
+/// three literals are `1` (the common Techno AI body, the only route to the
+/// scan for missions Move/Guard/Harvest, and `FUN_0051F330`'s in-place
+/// re-acquire), `2` (`FootClass::Mission_AreaGuard`) and `0`
+/// (`FootClass::Mission_Hunt @ 0x004D5373`). This function is therefore not a
+/// general "what mask is this object on" reader: it is the *passive* block's
+/// own choice between its literal `1` and the Area Guard handler's literal `2`,
+/// and it is called BY those callsites. Hunt and the deploy shim pass their own
+/// literals and never come through here — reading [`ScanMission::Hunt`] off an
+/// entity's mission field would make the mask a property of the mission, which
+/// it is not.
 ///
 /// Area Guard has two representations here and both mean the same retail
 /// mission: the committed mission substrate value, and the `OrderIntent::Guard`
@@ -167,6 +270,15 @@ pub(crate) fn scan_range(
             Some(gr) => ScanRange::Hard(gr),
             None => ScanRange::CanFireAt,
         },
+        // Mask 0 never reaches the radius block at all: `TEST AL,0x3 ; JZ
+        // 0x006F9B6E` at `0x006F8FE0` jumps past `Threat_Range` *and* past the
+        // ring walk, so no radius is computed for Hunt and `GuardRange=` is not
+        // consulted — a `GuardRange=9` V3 on Hunt is no more limited than a
+        // Grizzly is. `greatest_threat` branches on the mask before it asks for
+        // a radius, so this arm is not on the live path; it carries native's
+        // literal `PUSH -0x1` (`0x006F9D70`) so that a caller which does ask
+        // gets the same answer the flat walk hardcodes.
+        ScanMission::Hunt => ScanRange::NoCutoff,
         ScanMission::AreaGuard => {
             let base = guard_range.unwrap_or_else(|| max_weapon_range(rules, obj, veterancy));
             let doubled = base.saturating_mul(SimFixed::from_num(AREA_GUARD_RANGE_MULTIPLIER));

--- a/src/sim/movement/locomotor_tests.rs
+++ b/src/sim/movement/locomotor_tests.rs
@@ -308,6 +308,9 @@ fn make_obj(locomotor: LocomotorKind, category: ObjectCategory) -> ObjectType {
         refinery_smoke_frames: 0,
         gap_radius_in_cells: 0,
         super_gap_radius_in_cells: 0,
+        stupid_hunt: false,
+        vehicle_thief: false,
+        undeploy_delay: -1,
     }
 }
 

--- a/src/sim/movement/teleport_movement.rs
+++ b/src/sim/movement/teleport_movement.rs
@@ -771,6 +771,9 @@ mod tests {
             refinery_smoke_frames: 0,
             gap_radius_in_cells: 0,
             super_gap_radius_in_cells: 0,
+            stupid_hunt: false,
+            vehicle_thief: false,
+            undeploy_delay: -1,
         }
     }
 

--- a/src/sim/pathfinding/zone_map.rs
+++ b/src/sim/pathfinding/zone_map.rs
@@ -349,7 +349,8 @@ impl ZoneGrid {
         raw_row.get(cluster as usize).copied()
     }
 
-    /// Exact response-owned `MapClass::Can_Reach_Zone @ 0x0056D100` surface.
+    /// Exact `MapClass::Can_Reach_Zone @ 0x0056D100` surface as the
+    /// base-defence response consumes it.
     ///
     /// `None` is native MovementZone `-1`. The response passes the candidate
     /// destination as source A, the protected victim destination as B, the
@@ -380,17 +381,29 @@ impl ZoneGrid {
             return true;
         }
 
-        let source_zone = self.get_zone_id_response_native(
-            source,
-            movement_zone,
-            source_should_be_on_bridge,
-        );
-        let destination_zone =
-            self.get_zone_id_response_native(destination, movement_zone, false);
+        let source_zone =
+            self.get_zone_id_native(source, movement_zone, source_should_be_on_bridge);
+        let destination_zone = self.get_zone_id_native(destination, movement_zone, false);
         source_zone.is_some() && source_zone == destination_zone
     }
 
-    fn get_zone_id_response_native(
+    /// `MapClass::GetZoneID @ 0x0056D230` with its third argument, the
+    /// bridge-resolution flag, honoured.
+    ///
+    /// Native takes `(CellStruct *cell, int movementZone, char checkBridge)`.
+    /// With `checkBridge` set and the cell carrying the bridge flag `0x100`, it
+    /// resolves the matching `BridgeRecord` and answers with the ground
+    /// endpoint's zone; otherwise it projects the cell's own base cluster
+    /// through the requested movement row. `checkBridge` clear skips the
+    /// record lookup entirely.
+    ///
+    /// Two consumers so far, both passing exactly what native passes:
+    /// - `Can_Reach_Zone @ 0x0056D100` (base-defence response), the candidate's
+    ///   `ShouldBeOnBridge` for source A and `false` for B;
+    /// - `TechnoClass::Greatest_Threat @ 0x006F8EBF`, a literal `1` for the
+    ///   scanner's own cell, and `TechnoClass::Evaluate_Candidate @
+    ///   0x006F7E95`, the candidate's `Object+0x8C` on-bridge byte.
+    pub(crate) fn get_zone_id_native(
         &self,
         coord: (i32, i32),
         movement_zone: MovementZone,

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -1218,6 +1218,14 @@ fn passive_target_scan(sim: &mut Simulation, id: u64, rules: &RuleSet, mission: 
     // per-scan RNG cost is therefore 1 in both engines. The residual is only
     // that an instruction search cannot exclude a computed-pointer writer of
     // those two fields.
+    let Some(scan_mask) = sim
+        .substrate
+        .entities
+        .get(id)
+        .map(crate::sim::combat::scan_mission_for)
+    else {
+        return;
+    };
     let pick = crate::sim::combat::acquire_best_target_for_entity(
         &sim.substrate.entities,
         rules,
@@ -1226,6 +1234,11 @@ fn passive_target_scan(sim: &mut Simulation, id: u64, rules: &RuleSet, mission: 
         Some(&sim.fog),
         sim.resolved_terrain.as_ref(),
         sim.playfield_bounds.is_some(),
+        // The passive callsite's own literal: `1` from the common Techno AI
+        // body for Move/Guard/Harvest, `2` from `FootClass::Mission_AreaGuard`.
+        // `scan_mission_for` is that choice, and this is the site that makes it.
+        scan_mask,
+        sim.zone_grid.as_ref(),
     );
     // Install the target only — no mission, no destination, and nothing fires
     // this tick. A unit that acquires while driving keeps driving, and an idle
@@ -3360,6 +3373,7 @@ mod tests {
             unit_deploy_begin_active: false,
             unit_deploy_reverse_active: false,
             infantry_deployed_do_type: false,
+            infantry_deploy_fire_stance: false,
         };
 
         assert_eq!(
@@ -3458,6 +3472,7 @@ mod tests {
             unit_deploy_begin_active: false,
             unit_deploy_reverse_active: false,
             infantry_deployed_do_type: false,
+            infantry_deploy_fire_stance: false,
         };
 
         for frozen in [MissionType::Hunt, MissionType::Sticky] {
@@ -3579,12 +3594,22 @@ mod tests {
         let mut sim = Simulation::with_seed(0x487A);
         let rules = representative_foot_handler_rules();
         let mut infantry = entity_of(1, EntityCategory::Infantry);
+        // The Hunt body resolves the object type (for `StupidHunt=`) and runs
+        // the scanner, so the fixture has to be interned in THIS sim.
+        infantry.owner = sim.interner.intern("Americans");
+        infantry.type_ref = sim.interner.intern("TEST");
         update_mission_test_fixture(&mut infantry.mission, |fixture| {
             fixture.current = MissionId::from_known(MissionType::Hunt);
             fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
         });
         sim.substrate.entities.insert(infantry);
         let mut expected_rng = sim.clone_scenario_rng();
+        // Two draws, in this order. `TechnoClass::Retaliate_And_Scan @
+        // 0x00709820` takes the first one unconditionally, before any branch
+        // (`PUSH 0x2` / `PUSH 0x0` at `0x0070982C`/`0x0070983D`), for the scan
+        // timer's re-arm; the handler tail at `0x004D55A9` takes the second for
+        // the cadence jitter.
+        let _scan_jitter = expected_rng.next_range_u32_inclusive(0, 2);
         let expected_delay = 14 + expected_rng.next_range_u32_inclusive(0, 2) as i32;
 
         sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
@@ -3665,6 +3690,240 @@ mod tests {
         let delay = unit.mission.dispatch_timer().delay();
         assert!((14..=16).contains(&delay), "Rate + RandomRanged(0, 2)");
         assert_ne!(sim.scenario_rng.logical_state(), before_rng);
+    }
+
+    /// Rules for the Hunt body and the infantry deploy shim.
+    ///
+    /// `HUNTVEH` is an ordinary armed vehicle; `DUMBVEH` carries
+    /// `StupidHunt=yes`; `DEPINF` carries `DeployFire=yes` with neither
+    /// `ImmuneToRadiation=` nor `UndeployDelay=`, which is the GI / Guardian GI
+    /// shape the shim's live arm selects.
+    fn hunt_body_rules() -> RuleSet {
+        RuleSet::from_ini(&IniFile::from_str(
+            "[General]\nNormalTargetingDelay=27\nGuardAreaTargetingDelay=36\n\n\
+             [Attack]\nRate=.016\n\n[Guard]\nRate=.016\n\n[AreaGuard]\nRate=.016\n\n\
+             [Hunt]\nRate=.016\n\n[Move]\nRate=.016\n\n\
+             [VehicleTypes]\n0=HUNTVEH\n1=DUMBVEH\n\n[InfantryTypes]\n0=DEPINF\n\n\
+             [HUNTVEH]\nLocomotor={4A582741-9839-11d1-B709-00A024DDAFD1}\n\
+             Strength=300\nArmor=heavy\nSpeed=6\nSight=10\nPrimary=SHORTGUN\n\n\
+             [DUMBVEH]\nLocomotor={4A582741-9839-11d1-B709-00A024DDAFD1}\n\
+             Strength=300\nArmor=heavy\nSpeed=6\nSight=10\nPrimary=SHORTGUN\nStupidHunt=yes\n\n\
+             [DEPINF]\nLocomotor={4A582744-9839-11d1-B709-00A024DDAFD1}\n\
+             Strength=125\nArmor=none\nSpeed=4\nSight=10\nPrimary=SHORTGUN\nDeployFire=yes\n\n\
+             [SHORTGUN]\nDamage=10\nROF=20\nRange=4\nWarhead=WH\n\n\
+             [WH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+        ))
+        .expect("Hunt body rules parse")
+    }
+
+    /// One armed hunter of `hunter_type` at (20, 20) and one hostile at
+    /// (20 + gap, 20), both spawned through the map path so ownership, fog and
+    /// playfield membership are the production ones.
+    fn hunt_pair(seed: u64, hunter_type: &str, gap: u16, mission: MissionType) -> Simulation {
+        let rules = hunt_body_rules();
+        let heights: std::collections::BTreeMap<(u16, u16), u8> = std::collections::BTreeMap::new();
+        let mut sim = Simulation::with_seed(seed);
+        sim.spawn_from_map(
+            &[
+                passive_map_entity("Americans", hunter_type, 20, 20, EntityCategory::Unit),
+                passive_map_entity("Soviet", "HUNTVEH", 20 + gap, 20, EntityCategory::Unit),
+            ],
+            Some(&rules),
+            &heights,
+        );
+        let hunter = sim
+            .substrate
+            .entities
+            .get_mut(1)
+            .expect("hunter spawned first");
+        update_mission_test_fixture(&mut hunter.mission, |fixture| {
+            fixture.current = MissionId::from_known(mission);
+            fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
+        });
+        sim
+    }
+
+    /// The headline of GSI-07.20: a hunting object acquires past its own weapon
+    /// reach, and the target it installs is NOT flagged passively-acquired — so
+    /// the pursuit pass will close on it instead of skipping it. Native:
+    /// `FootClass::Mission_Hunt @ 0x004D5373` scans with threat mask `0`, and
+    /// `TechnoClass::Greatest_Threat @ 0x006F8FE0` (`TEST AL,0x3 ; JZ`) jumps
+    /// past the whole radius block for that mask; `Retaliate_And_Scan @
+    /// 0x00709820` installs the result through `Assign_Target` at `0x00709960`
+    /// and never writes the passively-acquired byte `+0x50C`.
+    #[test]
+    fn gsi_07_20_hunt_acquires_past_weapon_range_and_leaves_the_target_pursuable() {
+        let rules = hunt_body_rules();
+        // 8 cells apart against `SHORTGUN` Range=4 — comfortably outside the
+        // weapon reach that bounds a Guard-mission scan, comfortably inside
+        // Sight=10 so the candidate is not shrouded.
+        let mut sim = hunt_pair(0x40_0720, "HUNTVEH", 8, MissionType::Hunt);
+        let heights: std::collections::BTreeMap<(u16, u16), u8> = std::collections::BTreeMap::new();
+        let grid = crate::sim::pathfinding::PathGrid::new(64, 64);
+        // Record the state at the moment of acquisition: the hunter starts
+        // closing as soon as it has a target, and the point of the test is how
+        // far away it was when it found one.
+        let mut acquired = None;
+        for _ in 0..40 {
+            let _ = sim.advance_tick(&[], Some(&rules), &heights, Some(&grid), None, 67);
+            let hunter = sim.substrate.entities.get(1).expect("hunter present");
+            if hunter.attack_target.is_some() {
+                acquired = Some((
+                    28u16.saturating_sub(hunter.position.rx),
+                    hunter.passively_acquired_target,
+                ));
+                break;
+            }
+        }
+        let (gap_cells, passive) = acquired.expect(
+            "a hunting object scans with no radius cutoff and must find the hostile 8 cells away",
+        );
+        assert!(
+            gap_cells > 4,
+            "acquisition must happen outside SHORTGUN's 4-cell reach: {gap_cells}"
+        );
+        assert!(
+            !passive,
+            "Retaliate_And_Scan never writes +0x50C, so the Hunt target must stay pursuable"
+        );
+    }
+
+    /// The control for the test above: the very same pair, at the very same
+    /// range, acquires nothing on Guard. Without this the Hunt result could be
+    /// explained by an over-wide scan rather than by the mask-0 arm.
+    #[test]
+    fn gsi_07_20_guard_at_the_same_range_acquires_nothing() {
+        let rules = hunt_body_rules();
+        let mut sim = hunt_pair(0x40_0721, "HUNTVEH", 8, MissionType::Guard);
+        let heights: std::collections::BTreeMap<(u16, u16), u8> = std::collections::BTreeMap::new();
+        let grid = crate::sim::pathfinding::PathGrid::new(64, 64);
+        for _ in 0..40 {
+            let _ = sim.advance_tick(&[], Some(&rules), &heights, Some(&grid), None, 67);
+        }
+
+        assert!(
+            sim.substrate
+                .entities
+                .get(1)
+                .expect("guard present")
+                .attack_target
+                .is_none(),
+            "a Guard-mission scan defers to the weapon's own reach (4 cells), so 8 is out"
+        );
+    }
+
+    /// `StupidHunt=` (`TechnoTypeClass+0x6D4`, store `0x00714C80`, key
+    /// `0x008438A4`) is the FIRST test in `FootClass::Mission_Hunt`
+    /// (`0x004D535F`): such a type never reaches the scanner at all. It
+    /// therefore acquires nothing AND takes only the tail's single draw.
+    #[test]
+    fn gsi_07_20_stupid_hunt_type_never_scans_and_draws_once() {
+        let rules = hunt_body_rules();
+        let mut sim = hunt_pair(0x40_0722, "DUMBVEH", 8, MissionType::Hunt);
+        let mut expected_rng = sim.clone_scenario_rng();
+        let expected_delay = 14 + expected_rng.next_range_u32_inclusive(0, 2) as i32;
+
+        sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
+
+        let hunter = sim.substrate.entities.get(1).expect("hunter present");
+        assert!(
+            hunter.attack_target.is_none(),
+            "StupidHunt skips the scan entirely"
+        );
+        assert_eq!(hunter.mission.dispatch_timer().delay(), expected_delay);
+        assert_eq!(
+            sim.scenario_rng.logical_state(),
+            expected_rng.logical_state(),
+            "the StupidHunt path draws only the tail jitter"
+        );
+    }
+
+    /// The cadence band is `[282, 768]` on the **approximated** distance
+    /// `ftol(Sqrt_Approx(dx*dx + dy*dy))`, not on the squared one:
+    /// `disassemble_bytes 0x004D4EF0..0x004D4FB1` — `CMP EAX,0x300 ; JG skip`
+    /// after the `Sqrt_Approx`/`ftol` pair.
+    ///
+    /// This fixture sits at dx = 768, dy = 30, i.e. `d² = 590724`. The old
+    /// squared predicate `d² <= 768² = 589824` rejected it; native truncates
+    /// the root to 768 and admits it, halving the cadence.
+    #[test]
+    fn gsi_07_06_cadence_band_admits_a_distance_above_the_squared_bound() {
+        let rules = representative_foot_handler_rules();
+        let mut sim = Simulation::with_seed(0x40_0706);
+        let mut attacker = entity_of(1, EntityCategory::Unit);
+        attacker.attack_target = Some(AttackTarget::new(2));
+        update_mission_test_fixture(&mut attacker.mission, |fixture| {
+            fixture.current = MissionId::from_known(MissionType::Attack);
+            fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
+        });
+        // Target sits at (5, 5); 3 cells east is exactly 768 leptons, and the
+        // 30-lepton north/south offset pushes d² past 768² without pushing the
+        // truncated root past 768.
+        attacker.position.rx = 8;
+        attacker.position.sub_y += crate::util::fixed_math::SimFixed::from_num(30);
+        attacker.owner = sim.interner.intern("Americans");
+        attacker.type_ref = sim.interner.intern("SHORTVEH");
+        sim.substrate.entities.insert(attacker);
+        register_entity(&mut sim, entity_of(2, EntityCategory::Unit));
+
+        let mut expected_rng = sim.clone_scenario_rng();
+        let jitter = expected_rng.next_range_u32_inclusive(0, 2) as i32;
+        sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
+
+        assert_eq!(
+            sim.substrate
+                .entities
+                .get(1)
+                .unwrap()
+                .mission
+                .dispatch_timer()
+                .delay(),
+            (14 + jitter) / 2,
+            "trunc(Sqrt_Approx(590724)) is 768, which the band admits"
+        );
+    }
+
+    /// GSI-07.16 — a deployed `DeployFire=` infantryman on Area Guard runs the
+    /// leaf shim `FUN_00521320`, not `FootClass::Mission_AreaGuard`. The shim
+    /// re-acquires in place and returns `Rate + RandomRanged(0, 2)`; the Foot
+    /// body would run `Retaliate_And_Scan` (one draw) and then return
+    /// `Rate + RandomRanged(1, 5)` (a second). One draw versus two is the
+    /// discriminator.
+    #[test]
+    fn gsi_07_16_deployed_deploy_fire_infantry_takes_the_shim_on_area_guard() {
+        let rules = hunt_body_rules();
+        let mut sim = Simulation::with_seed(0x40_0716);
+        let mut man = entity_of(1, EntityCategory::Infantry);
+        man.owner = sim.interner.intern("Americans");
+        man.type_ref = sim.interner.intern("DEPINF");
+        man.deploy_state = Some(crate::sim::deploy::DeployPhase::Deployed);
+        update_mission_test_fixture(&mut man.mission, |fixture| {
+            fixture.current = MissionId::from_known(MissionType::AreaGuard);
+            fixture.dispatch_timer = MissionDispatchTimer::at_frame(0);
+        });
+        sim.substrate.entities.insert(man);
+
+        let mut expected_rng = sim.clone_scenario_rng();
+        let expected_delay = 14 + expected_rng.next_range_u32_inclusive(0, 2) as i32;
+
+        sim.object_ai_visit_one(1, Some(&rules), ObjectAiCtx::default());
+
+        assert_eq!(
+            sim.substrate
+                .entities
+                .get(1)
+                .unwrap()
+                .mission
+                .dispatch_timer()
+                .delay(),
+            expected_delay,
+            "the shim returns [AreaGuard] Rate + RandomRanged(0, 2)"
+        );
+        assert_eq!(
+            sim.scenario_rng.logical_state(),
+            expected_rng.logical_state(),
+            "the shim never reaches the Foot body's scan or its (1, 5) jitter"
+        );
     }
 
     // ===== The base (un-overridden) mission handler =====

--- a/src/sim/world/techno_ai/mission_handlers.rs
+++ b/src/sim/world/techno_ai/mission_handlers.rs
@@ -3,11 +3,12 @@
 //! The object-AI host and its ordering remain in the parent module; this module
 //! owns only handler inputs, results, and the single timer epilogue.
 
-use super::{Simulation, can_acquire_target, passive_target_scan};
+use super::{PASSIVE_SCAN_DELAY_JITTER_MAX, Simulation, can_acquire_target, passive_target_scan};
 use crate::map::entities::EntityCategory;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::mission::authority::EntityReadyInputProvider;
 use crate::sim::mission::{MissionId, MissionType};
+use crate::util::native_x87::{X87Chop53, sqrt_approx_f32};
 
 /// Re-arm the evidence-backed Foot/Unit handler subset without duplicating the
 /// legacy movement, combat, or target-selection systems.
@@ -96,6 +97,18 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
                     Some(crate::sim::deploy::DeployPhase::Deploying { .. })
                         | Some(crate::sim::deploy::DeployPhase::Deployed)
                 ),
+            // Only resolved for an already-deployed infantryman: that is the
+            // only branch of `FUN_00521320` these three flags gate, and the
+            // type lookup is not free.
+            infantry_deploy_fire_stance: category == EntityCategory::Infantry
+                && entity.deploy_state.is_some()
+                && sim
+                    .interner
+                    .try_resolve(entity.type_ref)
+                    .and_then(|name| rules.object(name))
+                    .is_some_and(|obj| {
+                        obj.deploy_fire && !obj.immune_to_radiation && obj.undeploy_delay < 0
+                    }),
         }
     };
     if !input.timer_due {
@@ -195,15 +208,32 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
         //   `0x0051F6A4` — loading `[ESI+0x6C0]` first — to decide whether an
         //   AI-owned deployed unit undeploys immediately, so a port that reads
         //   the instance field there gets Yuri Clone undeploy wrong.
-        // - A spy/engineer-class infantryman (`InfType+0xEC2`, or
-        //   `HasWeaponAbility(0xE)`) holding a BuildingClass target whose type
-        //   has `+0x1577` set and `+0x1701` clear takes
-        //   `Set_Destination(target, 1)` then `Assign_Mission(0x11 Sabotage)`
-        //   and returns 1. Frequency: low-to-moderate — the ordinary
-        //   right-click resolver usually issues the enter action directly, so
-        //   this is the force-fire / retarget path.
-        // - An AI-owned engineer or medic converts to Capture. Frequency: zero
-        //   today, because this project has no AI opponent.
+        // - **This arm is FIRST in the override and is NOT AI-gated.** A
+        //   demolition infantryman — `InfantryType->C4` (`+0xEC2`, key `"C4"`
+        //   at `0x00825978`, store `0x00524559`) or `HasWeaponAbility(0xE)` —
+        //   holding a BuildingClass target takes
+        //   `Set_Destination(target, 1); Queue_Mission(0x11 Sabotage, 0);
+        //   return 1` with **no RNG draw** (`decompile_function 0x0051F3E0`,
+        //   `0x0051F400`-`0x0051F44A`). The two building-type gates are now
+        //   named: `+0x1577` is **`CanC4=`** (key `"CanC4"` at `0x0081ADFC`,
+        //   `BuildingTypeClass::ReadINI` store `0x0046005D`, constructor
+        //   default **1** at `0x0045E063`) and `+0x1701` is
+        //   **`InvisibleInGame=`** (key at `0x0081A8CC`, store `0x00460E01`) —
+        //   both already parsed here as `can_c4` and `invisible_in_game`, and
+        //   both already used by the player Sabotage order in
+        //   `world_commands.rs`. What is still missing is the *handler* arm:
+        //   VERA drives Sabotage from that order path's `c4_plant` goal state
+        //   and its own movement issue, and the Sabotage selector has no
+        //   dispatch arm, so queueing it from here would park the object on a
+        //   selector whose timer nothing re-arms. Trigger: a force-fire or
+        //   retarget onto a building by Tanya, a Navy SEAL, a Crazy Ivan or a
+        //   Psi-Corps Trooper. Player effect: VERA shoots the building where
+        //   retail walks in and plants. Frequency: low-to-moderate — the
+        //   ordinary right-click resolver issues the enter action directly.
+        // - An AI-owned `Infiltrate=`(`+0xEBE`) / `Occupier=`(`+0xEB4`) /
+        //   `Assaulter=`(`+0xEB5`) infantryman converts to
+        //   `Assign_Mission(Capture)` and returns 1. Frequency: zero today,
+        //   because this project has no AI opponent.
         //
         // RESIDUAL (GSI-07.06) — two further Foot-body steps are absent:
         // - Step 1, the `HoverAttack` re-anchor. When `TechnoType+0x390`
@@ -247,7 +277,7 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
         }
         (EntityCategory::Unit | EntityCategory::Infantry, Some(MissionType::Attack)) => {
             let cadence = jittered_mission_cadence(sim, rules, MissionType::Attack);
-            let delay = if foot_attack_in_half_cadence_band(sim, rules, id) {
+            let delay = if foot_dispatch_in_cadence_band(sim, rules, id) {
                 cadence / 2
             } else {
                 cadence
@@ -283,6 +313,71 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
                     && attack_target_is_stale(sim, id),
                 clear_attack_target: false,
                 queue: idle_queue,
+            }
+        }
+        // `FUN_00521320`, the deploy shim both infantry Guard-family slots run
+        // BEFORE the Foot body. `InfantryClass::Mission_Guard @ 0x0051F620`
+        // (slot `+0x21C`, shared by Guard(5) and Sticky(6)) and
+        // `InfantryClass::Mission_AreaGuard @ 0x0051F640` (slot `+0x220`) are
+        // both nine instructions: call it, return its value unless it is `-1`,
+        // and only `-1` falls through.
+        //
+        // `decompile_function 0x00521320`, deployed branch (DoType in
+        // `{0x1B..0x1E}`), in order:
+        // 1. `if (-1 < Type->UndeployDelay) { Do_Action(Undeploy 0x1F); return
+        //    the sequence duration }` — the Yuri arm, see the residual below;
+        // 2. `if (Type->DeployFire)`:
+        //    - `!Type->ImmuneToRadiation` → `[vtable+0x428]()` (the in-place
+        //      re-acquire) then `ftol(Rate * 900) + RandomRanged(0, 2)`;
+        //    - otherwise the Desolator radiation arm, see the residual below;
+        // 3. `return -1` → the Foot body.
+        //
+        // So a deployed GI or Guardian GI holding ground **never reaches
+        // `FootClass::Mission_AreaGuard`**: it re-acquires where it stands and
+        // re-dispatches on `Rate + (0, 2)`, not on the Foot body's scan plus
+        // `Rate + (1, 5)`. That is both a cadence and an RNG-stream difference,
+        // and it is why this arm sits ahead of the three below.
+        //
+        // RESIDUAL — the two arms this predicate excludes:
+        // - **`UndeployDelay >= 0`** (`YURI` 150, `YURIPR` 75): retail makes a
+        //   deployed Yuri undeploy on his own next Guard dispatch and returns
+        //   an animation duration read through `Type[+0xE3C] -> [+0x460]`.
+        //   VERA parses no sequence-duration table, so the return value cannot
+        //   be produced. Trigger: a deployed Yuri or Yuri Prime on Guard,
+        //   Sticky or Area Guard. Player effect: retail's stands back up,
+        //   VERA's stays deployed. Frequency: every use of Yuri's mind
+        //   control in a Yuri-faction match. Downstream risk: none for RNG —
+        //   the arm draws nothing.
+        // - **`ImmuneToRadiation`** (`DESO`): the Desolator arm re-targets its
+        //   own cell, checks the rad level under it against
+        //   `GetWeapon(1)->Warhead[+0x158] / 3`, and returns either an
+        //   animation duration (`Type[+0xE3C] -> [+0x418]`, after
+        //   `Do_Action(DeployedFire 0x1D)`) or `Rate + RandomRanged(10, 20)`.
+        //   The `(10, 20)` draw is a scenario-RNG consumption VERA never
+        //   makes, but it sits behind a rad-site query and a warhead field
+        //   (`+0x158`) that are not modelled, and only one of the two exits
+        //   takes it — committing the draw alone would be wrong on the other.
+        //   Trigger: a deployed Desolator. Player effect: cadence and stream.
+        //   Frequency: continuous wherever a Soviet player deploys one.
+        (
+            EntityCategory::Infantry,
+            Some(MissionType::Guard | MissionType::Sticky | MissionType::AreaGuard),
+        ) if input.infantry_deployed_do_type && input.infantry_deploy_fire_stance => {
+            // Order is native's: `[vtable+0x428]` runs FIRST, then the shim's
+            // tail computes `ftol(Rate * 900)` and draws `RandomRanged(0, 2)`.
+            let queue = infantry_deployed_attack_reacquire(sim, id, rules, input);
+            // `MissionClass::GetMissionTimerEntry @ 0x005B3A00` indexes the
+            // control table on `[this+0xAC]`, the object's OWN committed
+            // selector — so the shim re-arms a Guard man at `[Guard] Rate` and
+            // an Area Guard man at `[Area Guard] Rate`.
+            let delay =
+                jittered_mission_cadence(sim, rules, input.mission.unwrap_or(MissionType::Guard));
+            MissionHandlerEvaluation {
+                delay,
+                clear_stale_attack_target: input.has_attack_target
+                    && attack_target_is_stale(sim, id),
+                clear_attack_target: false,
+                queue,
             }
         }
         (EntityCategory::Unit, Some(MissionType::Guard)) => {
@@ -328,37 +423,23 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
         // and nothing else, so an Area Guard object is deliberately never
         // scanned there; this arm is its single acquisition route.
         //
-        // RESIDUAL (GSI-07.16) — pass 1 left this row unmarked, and a leaf-level
-        // read finds the Foot body matches while BOTH categories are routed past
-        // a real override.
-        // - `InfantryClass::Mission_AreaGuard @ 0x0051F640` carries the same
-        //   deployed-DoType shim as its Guard slot, including a
-        //   `RandomRanged(10, 20)` draw VERA never makes. Trigger: a deployed GI
-        //   or Desolator on Area Guard — ordinary micro. Frequency: routine, and
-        //   the missing draw diverges the scenario stream on every dispatch.
-        // - `UnitClass::Mission_AreaGuard @ 0x00744100` is the slave-miner
-        //   recall and returns `RandomRanged(0, 2)` where the Foot body returns
-        //   `RandomRanged(1, 5)` — an RNG fork, not just a different delay.
-        //   Frequency: zero today (no slave miners), continuous once they land.
-        // The Foot body's own slave-recall arm is absent for the same reason.
+        // GSI-07.16 — the infantry leaf override
+        // `InfantryClass::Mission_AreaGuard @ 0x0051F640` is now taken by the
+        // deploy-shim arm above; only the arms it excludes remain recorded
+        // there.
+        //
+        // RESIDUAL (GSI-07.16) — `UnitClass::Mission_AreaGuard @ 0x00744100` is
+        // the slave-miner recall and returns `RandomRanged(0, 2)` where the Foot
+        // body returns `RandomRanged(1, 5)` — an RNG fork, not just a different
+        // delay. Frequency: zero today (no slave miners), continuous once they
+        // land. The Foot body's own slave-recall arm is absent for the same
+        // reason.
         (EntityCategory::Unit | EntityCategory::Infantry, Some(MissionType::AreaGuard)) => {
             evaluate_foot_area_guard(sim, id, rules)
         }
-        // `FootClass::Mission_Hunt`: the observed Capture/Sabotage/Move routes
-        // need an authoritative selector. Until one exists, retain its cadence
-        // and do not manufacture a target or queued mission.
-        // RESIDUAL (GSI-07.20) — Hunt has a cadence and no body. Native
-        // `FootClass::Mission_Hunt @ 0x004D5350` selects among Sabotage,
-        // Capture and a Move return-to-base; the two arms here only re-arm the
-        // dispatch timer, so an object on Hunt is assigned and then does
-        // nothing. Trigger: anything queued onto Hunt — the crate and trigger
-        // paths assign it today. Player effect: hunting units stand still.
-        // Frequency: NOT AI-only, contrary to pass 1 — VERA's own berserk path
-        // queues Hunt, so every Chaos Drone use reaches this arm. Downstream
-        // risk: the selector needs the Capture/Sabotage target scan, so it
-        // lands with the engineer and terrorist mission work, not before. The
-        // cadence half of the row is closed below.
-        //
+        (EntityCategory::Unit | EntityCategory::Infantry, Some(MissionType::Hunt)) => {
+            evaluate_foot_hunt(sim, id, rules)
+        }
         // SKIP/PROVE (GSI-07.09) — Mission 4 Retreat is a dead slot for foot
         // objects, and pass 1's reason was wrong. `FootClass::Mission_Retreat @
         // 0x004DA2C0` (slot `+0x230`, proven from the dispatch jump table at
@@ -373,18 +454,6 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
         // project lacks an AI. Keep the enum slot; the only cost of the missing
         // arm is that a Retreat-committed foot object would leave its timer
         // untouched, which nothing can produce today.
-        (EntityCategory::Infantry, Some(MissionType::Hunt)) => MissionHandlerEvaluation::cadence(
-            jittered_mission_cadence(sim, rules, MissionType::Hunt),
-        ),
-        // The `UnitClass` Hunt override retries the strict target probe, then
-        // queues Enter only if its separate approach virtual returns one.
-        // Neither producer exists here, so the body stays absent — but the
-        // cadence is jittered: pass 1 preserved a "no-jitter fallback" that does
-        // not exist. BOTH exits of `UnitClass::Mission_Hunt @ 0x0073EFC0` and
-        // `FootClass::Mission_Hunt @ 0x004D5350` draw `RandomRanged(0, 2)`.
-        (EntityCategory::Unit, Some(MissionType::Hunt)) => MissionHandlerEvaluation::cadence(
-            jittered_mission_cadence(sim, rules, MissionType::Hunt),
-        ),
         // Everything else: the object still reaches a handler and still re-arms
         // its timer. Where that handler is the un-overridden base one, the
         // return value is a verified constant and no RNG is drawn; where the
@@ -445,6 +514,19 @@ pub(super) struct MissionHandlerInput {
     /// its Attack slot takes `InfantryClass::Mission_Attack`'s own override
     /// instead of the Foot body.
     pub(super) infantry_deployed_do_type: bool,
+    /// The type half of the deploy shim `FUN_00521320`'s live arm:
+    /// `DeployFire=` set (`TechnoTypeClass+0x6AC`, key `"DeployFire"` at
+    /// `0x00843AA0`, store `0x007147FC`), `ImmuneToRadiation=` clear
+    /// (`+0xD37`, key `0x00843854`, store `0x00714D67`) and `UndeployDelay=`
+    /// negative (`+0x6C4`, key `0x008438F4`, store `0x00714BBA`, ctor default
+    /// `-1` from `0x00710CED`/`0x00711187`).
+    ///
+    /// Stock `DeployFire=yes`: `E1`, `GGI`, `DESO`, `YURI`, `YURIPR`, `CAOS`.
+    /// `DESO` is radiation-immune and `YURI`/`YURIPR` carry an
+    /// `UndeployDelay`, so this predicate selects the GI and the Guardian GI —
+    /// and `CAOS`, which is a voxel `UnitClass` and never reaches an infantry
+    /// arm.
+    pub(super) infantry_deploy_fire_stance: bool,
 }
 
 /// The handler result is evaluated before the one common MissionClass timer
@@ -640,6 +722,303 @@ pub(super) fn foot_enter_idle_mode_queue(
     Some(MissionType::Guard)
 }
 
+/// `TechnoClass::Retaliate_And_Scan @ 0x00709820`, vtable `+0x39C` — the
+/// scanner the mission handlers call directly, as opposed to the passive block
+/// in the common Techno AI body.
+///
+/// `disassemble_function 0x00709820`. Entry order, all of it load-bearing:
+/// 1. `[this+0x4FC] = frame` (`0x0070982E`);
+/// 2. **one unconditional `RandomRanged(0, 2)`** on the scenario RNG at
+///    `*(0x00A8B230)+0x218` — the `PUSH 0x2` / `PUSH 0x0` pair at `0x0070982C`
+///    and `0x0070983D` is set up before the very first branch, so the draw
+///    happens on every call whatever the routine goes on to do;
+/// 3. the scan timer re-arms to `Rules->GuardAreaTargetingDelay` (`+0xE04`)
+///    when the object's committed mission is Area Guard (`CMP EAX,0xB` at
+///    `0x0070983A`) and `Rules->NormalTargetingDelay` (`+0xE08`) otherwise,
+///    **plus that same draw**;
+/// 4. a target the object's own scanner installed may be dropped;
+/// 5. `if (Target == 0)` the threat scan runs and its result is committed
+///    through `Assign_Target` (`vt+0x3C8`, called at `0x00709960`).
+///
+/// **The one thing that separates this from [`super::passive_target_scan`]:
+/// step 5 does NOT set the passively-acquired byte `[this+0x50C]`.** The whole
+/// body only ever *reads* it (`0x007098C3`); the write lives in the passive
+/// block's caller inside `TechnoClass::AI_Update`. So a target a mission
+/// handler acquires through this routine is an ordinary target — VERA's
+/// pursuit pass will close on it, which is exactly how a hunting object gets
+/// to what it found. Installing through the shared target setter reproduces
+/// that: `RepresentedConcreteMissionEffects::apply_target` clears the byte.
+///
+/// Returns the native return value: `this->Target != 0` (`SETNZ` at
+/// `0x007099C4`).
+///
+/// RESIDUAL — step 4's drop is not modelled, exactly as
+/// [`super::passive_target_scan`] records for the same three action codes
+/// (`vt+0x3C0` returning 5, 6 or 8) whose meanings are UNCHECKED. Here it can
+/// only matter for an object that walked onto Hunt still holding a target its
+/// own scanner picked up on Guard: retail may re-evaluate it, VERA keeps it.
+/// Trigger: a passive target surviving a mission change into Hunt — Hunt is not
+/// one of the twelve missions that strip one. Frequency: uncommon; the berserk
+/// path that produces most Hunt assignments hits idle and engaged units alike.
+/// Downstream risk: none beyond target choice.
+///
+/// RESIDUAL — the post-install debit at `0x00709966`-`0x007099B5` is not
+/// modelled. After `Assign_Target` native calls
+/// `vt+0x2E4` (`0x00709971`) and `vt+0x3F8` (`0x0070998C`), then — gated on the
+/// newly acquired target's `[+0x14] & 1` (`0x0070997B`-`0x00709985`; EDI is the
+/// scan result, `MOV EDI,EAX @ 0x0070993C`) and on the selected weapon's
+/// `[[weapon+0xA0]+0x2A2] == 0` (`0x0070999C`-`0x007099AA`) — calls
+/// `0x006FDB80` and does `SUB dword ptr [EDI+0x70], EAX` (`0x007099B5`) — a
+/// **write into another object**. `TechnoClass+0x70` is the same field
+/// `Evaluate_Candidate` scores candidates on (`[ESI+0x70] < 1` at `0x006F872A`
+/// and `[ESI+0x70]` against `TechnoType->[0xA0] / 2` at `0x006F874B`-
+/// `0x006F8755`), so acquisition debits a running claim on the target that
+/// later scanners then read. What `0x006FDB80` returns is UNCHECKED — not
+/// decompiled — so the amount cannot be reproduced and none of this is
+/// implemented. Trigger: every scan through this routine that installs a
+/// target, i.e. every Hunt or Area Guard acquisition. Player effect: with the
+/// claim never debited, VERA's scanners keep seeing the full value and can
+/// over-commit several attackers onto one target instead of spreading. Player-
+/// visible only where three or more units acquire freely at once. Frequency:
+/// common once several hunting units share a battlefield; nil in a duel.
+/// Downstream risk: target distribution only — VERA has no `+0x70` analogue,
+/// so nothing else reads or writes it, and neither lifecycle nor determinism
+/// is touched.
+///
+/// RESIDUAL — ordering, inert today. Native runs the scan (`vt+0x3C4` at
+/// `0x00709932`) and only then reads `TechnoType+0x6B0` (`DistributedFire`,
+/// `0x00709944`) to decide between the spread-fire assignment and
+/// `Assign_Target`; the early return below tests the type first and so skips
+/// the scan. No stream divergence: `Evaluate_Candidate`'s only draw is the
+/// disguise-blink `RandomRanged(0,99)`, which short-circuits on
+/// `IsControlledByHuman` for every VERA house. Trigger: a `DistributedFire=`
+/// type dispatching Hunt or Area Guard with no target. Frequency: rare on stock
+/// data. Downstream risk: it would surface the moment a non-human-controlled
+/// house exists. This mirrors the shape [`super::passive_target_scan`] already
+/// has rather than introducing a new one.
+///
+/// `scan_mask` is `Greatest_Threat`'s argument 2, forwarded from whoever
+/// dispatched this routine. No callsite derives it from the object it is
+/// scanning for: `FootClass::Mission_Hunt` pushes the literal `0` at
+/// `0x004D5373`, and mask 0 is not a wider radius — it is a different scan
+/// topology (see [`crate::sim::combat::ScanMission::Hunt`]). What the `+0x3C4`
+/// overrides then do to that literal before `TechnoClass::Greatest_Threat` sees
+/// it is documented there and on
+/// [`crate::sim::combat::greatest_threat::greatest_threat`]; VERA forwards the
+/// literal unchanged.
+fn retaliate_and_scan(
+    sim: &mut Simulation,
+    id: u64,
+    rules: &RuleSet,
+    mission: MissionType,
+    scan_mask: crate::sim::combat::ScanMission,
+) -> bool {
+    let now = sim.session.binary_frame;
+    let base_delay = if mission == MissionType::AreaGuard {
+        rules.general.guard_area_targeting_delay
+    } else {
+        rules.general.normal_targeting_delay
+    };
+    let jitter = sim
+        .scenario_rng
+        .next_range_u32_inclusive(0, PASSIVE_SCAN_DELAY_JITTER_MAX);
+    if let Some(entity) = sim.substrate.entities.get_mut(id) {
+        entity.last_target_scan_frame = now;
+        entity
+            .passive_scan_timer
+            .arm(now, base_delay.saturating_add(jitter));
+    }
+
+    let Some(has_target) = sim
+        .substrate
+        .entities
+        .get(id)
+        .map(|entity| entity.attack_target.is_some())
+    else {
+        return false;
+    };
+    // Step 5 is `if (Target == 0)`: a live target ends the routine and is
+    // reported back as success.
+    if has_target {
+        return true;
+    }
+    // `if (GetTechnoType()[0x6B0]) FUN_00709550(this)` at `0x00709944` — a
+    // `DistributedFire` type takes the spread-fire assignment instead of the
+    // single-target one, which VERA does not implement (recorded on
+    // `passive_target_scan`). It installs nothing here, as there.
+    let spreads_fire = sim
+        .substrate
+        .entities
+        .get(id)
+        .and_then(|entity| sim.interner.try_resolve(entity.type_ref))
+        .and_then(|name| rules.object(name))
+        .is_some_and(|obj| obj.distributed_fire);
+    if spreads_fire {
+        return false;
+    }
+    let pick = crate::sim::combat::acquire_best_target_for_entity(
+        &sim.substrate.entities,
+        rules,
+        &sim.interner,
+        id,
+        Some(&sim.fog),
+        sim.resolved_terrain.as_ref(),
+        sim.playfield_bounds.is_some(),
+        // The mask the CALLER pushes. `FootClass::Mission_Hunt` pushes the
+        // literal `0` at `0x004D5373` and this routine forwards whatever it was
+        // handed; mask 0 is what makes the scan enumerate the global object list
+        // with no distance cutoff instead of walking cell rings.
+        scan_mask,
+        // `MapClass` itself in native — `MOV ECX,0x87f7e8` at `0x006F8EBA`.
+        // Mask 0 asks it for the hunter's own movement-zone component and
+        // refuses every candidate outside it.
+        sim.zone_grid.as_ref(),
+    );
+    if let Some(sid) = pick {
+        let _ = sim
+            .set_archive_target_represented(id, Some(crate::sim::combat::TargetKind::Entity(sid)));
+    }
+    sim.substrate
+        .entities
+        .get(id)
+        .is_some_and(|entity| entity.attack_target.is_some())
+}
+
+/// `FootClass::Mission_Hunt @ 0x004D5350` — "go find something and kill it".
+///
+/// Verified by `decompile_function 0x004D5350` + `disassemble_function
+/// 0x004D5350`. Boundary `0x004D5350`-`0x004D55B5`, returns the next dispatch
+/// delay in EAX.
+///
+/// Native order, and what VERA commits for each step:
+///
+/// 1. **`GetTechnoType()->StupidHunt` (`+0x6D4`, `0x004D535F`).** Set → the
+///    handler never scans and falls straight through to step 4. Six stock
+///    types carry it and the INI says why: "this guy can't handle a hunt
+///    command, so he should just run towards the player".
+/// 2. **`Retaliate_And_Scan(&this->Coords, 0)`** (`0x004D5373` pushes the
+///    literal mask `0`, `0x004D5392` makes the call). Mask 0 is the whole
+///    mechanism of the mission: `TechnoClass::Greatest_Threat @ 0x006F8FE0`
+///    opens with `TEST AL,0x3 ; JZ 0x006F9B6E` and jumps past the radius block,
+///    the airborne pre-pass and the expanding-ring cell walk alike, landing in
+///    a flat walk of the global object array that passes a literal `-1` where
+///    the ring path passes its computed radius. So **a hunting object has no
+///    distance cutoff** and can pick up an enemy anywhere on the map. It is
+///    a scan topology, not a radius, and is modelled as such — the mask travels
+///    as [`crate::sim::combat::ScanMission::Hunt`] and
+///    `combat::greatest_threat` branches on it. That same walk switches a
+///    movement-zone gate ON (`0x006F8EC4` computes the hunter's zone id and
+///    `0x006F9D69` hands it to `Evaluate_Candidate`, which rejects any
+///    candidate outside it at `0x006F7E9C`), so the hunter reaches the far side
+///    of the map but not the far side of a river.
+/// 3. **The type arms**, taken only when the scan came back with a target —
+///    recorded below rather than committed.
+/// 4. **No target**: a human-owned object runs the idle-action virtual
+///    (`vt+0x478`, `0x004D557C`); an AI-owned one walks home to its base cell.
+/// 5. **The tail** at `0x004D5582`, reached from every arm:
+///    `ftol(MissionControl[Hunt].Rate * 900.0) + RandomRanged(0, 2)`.
+///
+/// So the normal path draws the scenario RNG **twice** — once inside the
+/// scanner, once in the tail — and the `StupidHunt` path draws once. An earlier
+/// note on this arm said "BOTH exits draw `RandomRanged(0, 2)`", counting one
+/// draw; that was the tail only.
+///
+/// The approach itself is `vt+0x53C` (`FootClass::Greatest_Threat_Scan @
+/// 0x004D5690`), which the handler calls for a non-infantry object at
+/// `0x004D54E3` and for an infantryman with none of the three type flags at
+/// `0x004D54D2`. That routine is the "walk to somewhere I can shoot my target
+/// from" search and ends in `Set_Destination` (`vt+0x480`); VERA's equivalent
+/// is the pursuit pass, which runs for any object holding a target that is not
+/// flagged passively-acquired — and the scanner above deliberately leaves the
+/// flag clear, as native does.
+///
+/// RESIDUAL — **the three type arms are not committed.** All three end in a
+/// `Set_Destination(Target, 1)` plus a `Queue_Mission` that VERA cannot yet
+/// execute: `Capture` and `Sabotage` are driven here by the order path's
+/// `capture_target` / `c4_plant` goal state and its own movement issue, not by
+/// a mission handler, and neither mission has a dispatch arm — queueing one
+/// from here would park the object on a selector whose timer nothing re-arms.
+/// - `Engineer` and not `C4` and no weapon ability 14 (`0x004D53C0`) →
+///   `Queue_Mission(Capture)`. Trigger: a berserked or Hunt-ordered engineer
+///   that acquires a target. Stock carriers: `ENGINEER`, `SENGINEER`,
+///   `YENGINEER`. Frequency: rare — engineers are rarely in a Chaos Drone's
+///   splash and are never given a Hunt order by a player.
+/// - `C4` or weapon ability 14, with a **BuildingClass** target
+///   (`0x004D5416`) → `Set_Destination(target)`, `Queue_Mission(Sabotage)`.
+///   Trigger: a berserked demolition infantryman holding a building.
+///   Frequency: rare, same reason.
+/// - `VehicleThief` (`+0xEC6`, `0x004D546C`) → `Queue_Mission(Capture)`.
+///   Frequency: **zero on stock data** — no retail section sets the key.
+/// Player effect while they are absent: such a unit shoots what it found
+/// instead of walking in to capture or plant. Downstream risk: closing them
+/// means giving Capture and Sabotage real handler arms, which is the engineer /
+/// terrorist mission work, not this row.
+///
+/// RESIDUAL — **the infantry no-flags arm's `Set_Destination(NULL, 1)`**
+/// (`0x004D54C6`) is not committed: it is a movement-owned write, and the
+/// pursuit pass re-derives a destination on the next tick anyway. Effect: a
+/// berserked infantryman already walking somewhere keeps that destination for
+/// one dispatch where retail drops it first. Frequency: only while such a unit
+/// is mid-move.
+///
+/// RESIDUAL — **the AI return-to-base arm** (`0x004D54EE`-`0x004D5576`) is
+/// dead: it is gated on `!HouseClass::IsControlledByHuman(this->Owner)` and
+/// `g_GameMode (0x00A8B238) == 0`, and every house in VERA is human. The human
+/// arm's `UpdateIdleAction` is already covered — `sim::infantry::tick_idle_actions`
+/// admits Hunt and gates on "no target", the same condition — from a different
+/// position in the tick, which is that function's own recorded residual.
+///
+/// RESIDUAL — **the two leaf overrides above this body**, neither of which
+/// changes anything today:
+/// - `InfantryClass::Mission_Hunt @ 0x0051F540` (slot `+0x228`, single DATA
+///   xref `0x007EB280`; `0x007EB280 - 0x007EB058 = 0x228`). Both of its arms
+///   open with `HouseClass::IsControlledByHuman(...) == 0`, so both are dead
+///   without an AI opponent. They matter when one lands: an AI-owned
+///   `Infiltrate`/`Occupier`/`Assaulter` infantryman holding a building
+///   `Assign_Mission(Capture)`s and returns 1, and an AI-owned deployed man
+///   with no target plays `Do_Action(0x1F)` and returns 1 — **both consume no
+///   RNG at all**, so the stream forks the day an AI house ships.
+/// - `UnitClass::Mission_Hunt @ 0x0073EFC0` (verified plate comment on the
+///   function). A type with `DeploysInto` set (`UnitTypeClass+0x404`) deploys
+///   in place instead of hunting and returns `ftol(Rate*900) + RandomRanged(0, 2)`
+///   with **no scan**; a type without it tail-calls this body. Trigger: a
+///   berserked or Hunt-ordered MCV or deployable vehicle. Player effect: retail
+///   unpacks it, VERA sends it hunting. Frequency: low — it needs a Chaos Drone
+///   on an MCV. Downstream risk: the arm also consults a `RulesClass` list at
+///   `+0x8B0`/`+0x8BC` whose identity is UNCHECKED, so it cannot be closed by
+///   guessing.
+/// RESIDUAL — **a miner never reaches this body at all**, because the miner
+/// exclusion at the head of [`dispatch_supported_foot_mission_cadence`] admits
+/// only Guard. Retail's four `StupidHunt=yes` miners (`CMIN`, `SMIN`, `YHVR`,
+/// and the `SAPC` transport) would take the idle arm and re-arm on
+/// `Rate + RandomRanged(0, 2)`; VERA leaves their timer alone. Trigger: a Chaos
+/// Drone on a miner. Frequency: uncommon, and the visible effect is nil either
+/// way — a `StupidHunt` type does nothing on Hunt in retail either. Downstream
+/// risk: one missing draw per dispatch.
+fn evaluate_foot_hunt(sim: &mut Simulation, id: u64, rules: &RuleSet) -> MissionHandlerEvaluation {
+    let type_ref = sim.substrate.entities.get(id).map(|entity| entity.type_ref);
+    let stupid_hunt = type_ref
+        .and_then(|type_ref| sim.interner.try_resolve(type_ref))
+        .and_then(|name| rules.object(name))
+        .is_some_and(|obj| obj.stupid_hunt);
+    if !stupid_hunt {
+        // The return value selects between the type arms (all recorded above)
+        // and the idle / return-to-base arm (already covered elsewhere), so
+        // nothing branches on it here — but the call itself is the mission:
+        // it is what installs the target the pursuit pass then closes on.
+        let _acquired = retaliate_and_scan(
+            sim,
+            id,
+            rules,
+            MissionType::Hunt,
+            // `PUSH 0x0` at `0x004D5373` — the literal threat mask Hunt hands
+            // the scanner.
+            crate::sim::combat::ScanMission::Hunt,
+        );
+    }
+    MissionHandlerEvaluation::cadence(jittered_mission_cadence(sim, rules, MissionType::Hunt))
+}
+
 /// Smallest value of the Area Guard cadence jitter draw (`RandomRanged(1, 5)`).
 /// Every other absorbed handler draws `(0, 2)`; this one does not.
 const AREA_GUARD_CADENCE_JITTER_MIN: u32 = 1;
@@ -682,17 +1061,18 @@ const AREA_GUARD_CADENCE_JITTER_MAX: u32 = 5;
 ///   that lands the moment either of those two closes. `+0xE0E` is UNCHECKED.
 /// - **the tank-bunker adjacency scan** at 0x004D6F44, byte-for-byte the block
 ///   recorded on [`evaluate_foot_guard_cadence`].
-/// - **the infantry idle action.** With still no target the handler calls
-///   `[vtable+0x478]` at 0x004D6F25 = `InfantryClass::UpdateIdleAction`
+/// - **the infantry idle action's call POSITION.** With still no target the
+///   handler calls `[vtable+0x478]` at 0x004D6F25 = `InfantryClass::UpdateIdleAction`
 ///   0x0051CDB0, which fidgets the facing, can play an idle `VocClass` line, and
-///   draws `RandomRanged(0, 0x7FFFFFFE)` plus up to three more values. `Mission_Guard`
-///   calls it from the same no-target position. VERA has no infantry idle-action
-///   system. Trigger: any idle infantryman on Guard, Sticky or Area Guard.
-///   Player effect: retail infantry look around and shuffle while standing
-///   guard; VERA's stand still. Frequency: continuous, every idle infantryman
-///   in every match. Downstream risk: those draws are scenario-RNG consumption
-///   VERA does not make, so the streams cannot be compared frame-for-frame
-///   until an idle-action system lands.
+///   draws its wait re-arm plus up to two more values. `Mission_Guard` calls it
+///   from the same no-target position. **VERA does have that system** —
+///   `sim::infantry::tick_idle_actions`, which admits Guard, Area Guard and
+///   Hunt and gates on "no target", the same condition — but it runs as its own
+///   per-tick pass rather than from inside the handler. Trigger: any idle
+///   infantryman on Guard, Sticky or Area Guard. Player effect: none visible;
+///   the wait timer is the real gate in both. Frequency: continuous.
+///   Downstream risk: the draws land a few ticks earlier than the handler's own
+///   cadence would take them, which that function already records.
 /// - **the guard post.** The original anchors the scan on a stored guard-post
 ///   target, defaulting it to the object's own cell the first time the handler
 ///   runs with none. VERA has no such field, so the scan is always anchored on
@@ -701,10 +1081,10 @@ const AREA_GUARD_CADENCE_JITTER_MAX: u32 = 5;
 /// - **the post leash.** When the object drifts further from its post than its
 ///   own area-guard range, the original drops the target and sends it home.
 ///   Nothing in VERA moves an Area Guard object off its post today.
-/// - **the aircraft cadence doubling** (the original doubles the rate for
-///   aircraft only, and aircraft never reach this arm) and the extra
-///   short-range close-band divisor, whose second gate is an unresolved
-///   infantry type flag.
+/// - **the `What_Am_I() == 2` cadence doubling** at 0x004D7048. The RTTI id is
+///   UNCHECKED and no object of that kind reaches this arm; the doubling sits
+///   between the `ftol` and the `(1, 5)` draw, so adding it later moves the
+///   delay without moving the stream.
 /// - one further per-object predicate the original checks between can-acquire
 ///   and the scan, whose identity is UNKNOWN.
 fn evaluate_foot_area_guard(
@@ -736,25 +1116,43 @@ fn evaluate_foot_area_guard(
         .scenario_rng
         .next_range_u32_inclusive(AREA_GUARD_CADENCE_JITTER_MIN, AREA_GUARD_CADENCE_JITTER_MAX)
         as i32;
-    MissionHandlerEvaluation::cadence(base.saturating_add(jitter))
+    let jittered = base.saturating_add(jitter);
+    // The `/6` twin of `FootClass::Mission_Attack`'s `/2` band, at
+    // `0x004D70D3`-`0x004D7158`: the same type gate, the same
+    // `Sqrt_Approx`+`ftol` distance and the same `[282, 768]` window, dividing
+    // the ALREADY-JITTERED value (`IMUL 0x2AAAAAAB` plus the sign fixup at
+    // `0x004D714A` is a signed divide by 6). The draw is never skipped — the
+    // band only scales what it produced.
+    //
+    // The `if (What_Am_I() == 2) EBP += EBP` doubling at `0x004D7048` sits
+    // between the ftol and the draw and is deliberately absent: RTTI 2 is an
+    // object kind that does not reach this arm in VERA, and its identity is
+    // UNCHECKED.
+    let delay = if foot_dispatch_in_cadence_band(sim, rules, id) {
+        jittered / 6
+    } else {
+        jittered
+    };
+    MissionHandlerEvaluation::cadence(delay)
 }
 
 /// `FootClass::Mission_Guard` 0x004D5070, the body Guard(5) and Sticky(6) share.
 ///
-/// **Shared for units. Infantry reach it only through a leaf override VERA does
-/// not model, recorded here.** `InfantryClass`'s slot `+0x21C` is `0x0051F620`,
-/// nine instructions: `CALL 0x00521320; CMP EAX,-1; JNZ` returns that value
-/// directly, and only `-1` falls through to the Foot body. `0x00521320` owns
-/// infantry deploy and undeploy on Guard; its arms return an animation-table
-/// duration (`Type+0xE3C` plus `+0x460`/`+0x3D0`/`+0x418`), or `Rate +
-/// RandomRanged(0, 2)`, or — on the radiation arm gated by `Type+0xD37`,
-/// Desolator-shaped — `Rate + RandomRanged(10, 0x14)`, a draw VERA never makes.
-/// Trigger: any infantryman on Guard or Sticky whose type can deploy.
-/// Player effect: a deploying GI, Guardian GI or Desolator re-dispatches on the
-/// Foot cadence instead of its animation's own length. Frequency: continuous
-/// wherever deployed infantry hold ground, which is ordinary play for both
-/// Allied and Soviet. Downstream risk: it consumes scenario RNG on the
-/// radiation arm, so the stream diverges as well as the cadence.
+/// **Shared for units. Infantry reach it only through a leaf override.**
+/// `InfantryClass`'s slot `+0x21C` is `0x0051F620`, nine instructions:
+/// `CALL 0x00521320; CMP EAX,-1; JNZ` returns that value directly, and only
+/// `-1` falls through to the Foot body. `0x00521320` owns infantry deploy and
+/// undeploy on Guard; its live GI / Guardian GI arm is now taken by the
+/// deploy-shim arm in [`dispatch_supported_foot_mission_cadence`], and the two
+/// arms that one excludes (`UndeployDelay >= 0`, `ImmuneToRadiation`) are
+/// recorded there.
+///
+/// RESIDUAL — the shim's own **undeployed** branch is still absent. It is
+/// gated on `HouseClass::IsControlledByHuman(...) == 0` plus `Deployer=`
+/// (`InfantryTypeClass+0xEC8`), `DeployFire=`, a negative `UndeployDelay` and a
+/// `Rules[+0xE30]`-indexed frame gate, and makes an AI-owned deployer sit down
+/// on its own. Frequency: **zero today** — this project has no AI opponent.
+/// Everything else in that branch returns `-1`, which is the Foot body below.
 ///
 /// The Sticky half of the shared-slot claim is confirmed:
 /// `MissionClass::GetMissionTimerEntry` @ `0x005B3A00` is
@@ -933,14 +1331,19 @@ fn jittered_mission_cadence(sim: &mut Simulation, rules: &RuleSet, mission: Miss
     base.saturating_add(jitter)
 }
 
-/// Whether this dispatch takes `FootClass::Mission_Attack`'s halved cadence.
+/// Whether this dispatch takes the shortened cadence — `FootClass::Mission_Attack`'s
+/// `/2` or `FootClass::Mission_AreaGuard`'s `/6`.
 ///
-/// gamemd-derived: `FootClass::Mission_Attack @ 0x004D4DC0` halves its return
-/// only when a target is installed AND the attacker qualifies by TYPE AND the
-/// 2D distance falls in the close band. The type half is
-/// `(What_Am_I() == 0xF && InfantryType->CloseRange) || primaryWeapon.Range <
-/// 0x201` — an infantry type carrying `CloseRange=`, or any type whose primary
-/// reaches under 513 leptons.
+/// gamemd-derived: `FootClass::Mission_Attack @ 0x004D4DC0` and
+/// `FootClass::Mission_AreaGuard @ 0x004D6AA0` carry the **same** gate,
+/// instruction for instruction, and differ only in the divisor. Each shortens
+/// its return only when a target is installed AND the attacker qualifies by
+/// TYPE AND the 2D distance falls in the close band. The type half is
+/// `(What_Am_I() == 0xF && InfantryType->CloseRange) || primaryWeapon.Range <=
+/// 0x200` — an infantry type carrying `CloseRange=`, or any type whose primary
+/// reaches at most 512 leptons. The binary spells the second half
+/// `CMP dword ptr [ECX+0xB4], 0x200 ; JG` (`0x004D4F12`, `0x004D70C3`): it
+/// takes the shortened cadence when the range is NOT greater than `0x200`.
 ///
 /// That gate was missing, which is the whole point of this function's rewrite:
 /// without it every tank, rifle infantryman and artillery piece ran the halved
@@ -951,21 +1354,52 @@ fn jittered_mission_cadence(sim: &mut Simulation, rules: &RuleSet, mission: Miss
 /// consumes, ran at roughly double the native rate through every close-quarters
 /// engagement.
 ///
-/// UNCHECKED: the band's exact boundaries. The `282..=768` pair below is
-/// inherited from the earlier survey that wrote this function; a later reading
-/// put it at `[281.6, 769)`, which disagrees at both ends, and neither reading
-/// carries an address. Left as found rather than moved on prose.
-fn foot_attack_in_half_cadence_band(sim: &Simulation, rules: &RuleSet, id: u64) -> bool {
-    const MIN_LEPTONS: i64 = 282;
-    const MAX_LEPTONS: i64 = 768;
-    /// `CMP ..., 0x201` — the primary-weapon reach below which any type
-    /// qualifies, in leptons.
+/// The band boundaries are SETTLED, and they are integer tests on the
+/// *approximated* distance, not on the squared one. `disassemble_bytes
+/// 0x004D4EF0..0x004D4FB1`:
+///
+/// ```text
+/// FILD dy ; FILD dx ; dx*dx ; dy*dy ; FADDP        ; exact in f64
+/// CALL 0x004CAC40                                  ; Sqrt_Approx -> f32
+/// CALL 0x007C5F00                                  ; Math__ftol  -> EAX, truncating
+/// CMP  EAX,0x300 ; JG  skip                        ; require len <= 768
+/// FILD len ; FCOMP double [0x007E9228]             ; K
+/// FNSTSW AX ; TEST AH,0x1 ; JNZ skip               ; C0 set means len < K
+/// ```
+///
+/// `read_memory 0x007E9228` is `9A 99 99 99 99 99 71 40` = **281.6** exactly
+/// (1.1 cells), so with `len` integral the lower bound is `len >= 282` and the
+/// band is `282 ..= 768`.
+///
+/// The previous implementation applied those two numbers to the **squared**
+/// distance. That is wrong at the top, but only just: native admits every `len`
+/// that truncates to 768, i.e. `d2 < 769² = 591361`, where `d2 <= 768² =
+/// 589824` stopped one lepton early. The two predicates therefore disagree on
+/// exactly one shell — separations strictly between 768 and 769 leptons, under
+/// 1/256 of a cell wide — and agree everywhere else including at 768 itself.
+/// *Frequency:* an attacker inside the band re-tests this every Attack or Area
+/// Guard dispatch while closing, so a unit crossing 3 cells passes through the
+/// shell often; but it occupies the shell for at most one dispatch, and the
+/// only consequence of landing in it is which of two cadences that single
+/// dispatch returns. Player-visible effect: none observed, one dispatch of
+/// re-aim latency at most.
+///
+/// The bigger reason to reproduce the lookup rather than compare squares is
+/// that no squared predicate can be exact at all: `Sqrt_Approx @ 0x004CAC40`
+/// is a 16384-entry f32 mantissa lookup, not an IEEE root, so its truncated
+/// result is not a function of `d2` that squaring can invert.
+fn foot_dispatch_in_cadence_band(sim: &Simulation, rules: &RuleSet, id: u64) -> bool {
+    /// The primary-weapon reach below which any type qualifies, in leptons.
+    /// Native is `CMP dword ptr [ECX+0xB4], 0x200 ; JG` (`0x004D4F12`,
+    /// `0x004D70C3`) — qualify when `range <= 0x200`. Held here as the
+    /// exclusive bound `0x201` because the comparison below is `<`; the two
+    /// forms are equivalent on integers.
     const CLOSE_PRIMARY_RANGE_LEPTONS: i64 = 0x201;
 
     let Some(attacker) = sim.substrate.entities.get(id) else {
         return false;
     };
-    if !foot_attack_type_takes_half_cadence(sim, rules, attacker, CLOSE_PRIMARY_RANGE_LEPTONS) {
+    if !foot_type_takes_cadence_band(sim, rules, attacker, CLOSE_PRIMARY_RANGE_LEPTONS) {
         return false;
     };
     let Some(crate::sim::combat::AttackTarget {
@@ -978,8 +1412,55 @@ fn foot_attack_in_half_cadence_band(sim: &Simulation, rules: &RuleSet, id: u64) 
     let Some(target) = sim.substrate.entities.get(*target_id) else {
         return false;
     };
-    let distance_sq = crate::sim::combat::lepton_distance_sq(&attacker.position, &target.position);
-    distance_sq >= MIN_LEPTONS * MIN_LEPTONS && distance_sq <= MAX_LEPTONS * MAX_LEPTONS
+    native_distance_is_in_cadence_band(&attacker.position, &target.position)
+}
+
+/// Lower bound of the shared cadence band, in leptons.
+///
+/// `FCOMP double ptr [0x007E9228]` against **281.6** with an integral `len`,
+/// so the first admitted value is 282. Both consumers — Attack's `/2` at
+/// `0x004D4F8A` and Area Guard's `/6` at `0x004D7139` — read the same constant.
+const CADENCE_BAND_MIN_LEPTONS: i64 = 282;
+/// Upper bound of the shared cadence band, in leptons: `CMP EAX,0x300 ; JG`.
+const CADENCE_BAND_MAX_LEPTONS: i64 = 768;
+
+/// `len in [282, 768]` on the native approximated 2D distance.
+///
+/// gamemd-derived: the identical block in `FootClass::Mission_Attack @
+/// 0x004D4F22`-`0x004D4F9B` and `FootClass::Mission_AreaGuard @
+/// 0x004D70D3`-`0x004D7148`. The two `FILD`s take the **integer lepton**
+/// component differences, the products and their sum are exact in f64, and the
+/// only inexact step is `Sqrt_Approx`, which is reproduced bit-for-bit by
+/// [`sqrt_approx_f32`].
+fn native_distance_is_in_cadence_band(
+    from: &crate::sim::components::Position,
+    to: &crate::sim::components::Position,
+) -> bool {
+    let lepton = |cell: u16, sub: crate::util::fixed_math::SimFixed| -> i64 {
+        cell as i64 * 256 + sub.to_num::<i64>()
+    };
+    let dx = lepton(from.rx, from.sub_x) - lepton(to.rx, to.sub_x);
+    let dy = lepton(from.ry, from.sub_y) - lepton(to.ry, to.sub_y);
+    let (Ok(dx), Ok(dy)) = (i32::try_from(dx), i32::try_from(dy)) else {
+        // Native holds both differences in 32-bit registers; a map large
+        // enough to overflow one cannot exist.
+        return false;
+    };
+    let dx = X87Chop53::load_i32(dx);
+    let dy = X87Chop53::load_i32(dy);
+    // `FADDP` adds dy*dy (ST0) into dx*dx (ST1); both products are exact, so
+    // the order is immaterial, but it is written the native way.
+    let sum = X87Chop53::add(X87Chop53::mul(dx, dx), X87Chop53::mul(dy, dy));
+    let Ok(root) = sqrt_approx_f32(sum) else {
+        return false;
+    };
+    let Ok(loaded) = X87Chop53::load_f32(root) else {
+        return false;
+    };
+    let Ok(len) = X87Chop53::ftol_i64(loaded) else {
+        return false;
+    };
+    (CADENCE_BAND_MIN_LEPTONS..=CADENCE_BAND_MAX_LEPTONS).contains(&len)
 }
 
 /// The type half of the halved-cadence gate.
@@ -987,7 +1468,7 @@ fn foot_attack_in_half_cadence_band(sim: &Simulation, rules: &RuleSet, id: u64) 
 /// `What_Am_I() == 0xF` is InfantryClass, so `CloseRange=` only qualifies an
 /// infantry type — a vehicle carrying the key would NOT take the short path in
 /// native, and does not here.
-fn foot_attack_type_takes_half_cadence(
+fn foot_type_takes_cadence_band(
     sim: &Simulation,
     rules: &RuleSet,
     attacker: &crate::sim::game_entity::GameEntity,
@@ -1056,6 +1537,15 @@ fn infantry_deployed_attack_reacquire(
         Some(&sim.fog),
         sim.resolved_terrain.as_ref(),
         sim.playfield_bounds.is_some(),
+        // `vt+0x3C4(1, ...)` — `0x0051F330` pushes the literal `1`, the narrow
+        // (plain-Guard) mask, EVEN WHEN the infantryman it is re-acquiring for
+        // is committed to Area Guard. This is the callsite-vs-mission
+        // distinction in its most visible form: reading the mask off the
+        // entity's mission would hand a deployed Guardian GI on Area Guard the
+        // doubled radius that native reserves for the Area Guard handler's own
+        // literal `2`.
+        crate::sim::combat::ScanMission::Guard,
+        sim.zone_grid.as_ref(),
     );
     if had_target || pick.is_some() {
         let current = sim
@@ -1087,8 +1577,14 @@ fn infantry_deployed_attack_reacquire(
     if pick.is_some() {
         return None;
     }
-    // `0x0051F3C0`: the idle exit is skipped when the committed mission is
-    // Guard (`5`). This arm only runs on Attack, so the test passes.
+    // `decompile_function 0x0051F330`: the idle exit is `if (this->[0xAC] != 5
+    // && GetTechnoType()[0xD94] == 0) Enter_Idle_Mode(0, 1)` — skipped when the
+    // COMMITTED mission is Guard. That was vacuous while the Attack handler was
+    // the only caller; the deploy shim `FUN_00521320` also reaches this virtual
+    // from Guard, Sticky and Area Guard, so the gate is now live.
+    if input.mission == Some(MissionType::Guard) {
+        return None;
+    }
     foot_enter_idle_mode_queue(rules, input)
 }
 

--- a/src/sim/world/world_orders.rs
+++ b/src/sim/world/world_orders.rs
@@ -70,6 +70,14 @@ impl Simulation {
         }
 
         for attacker_id in attacker_ids {
+            let Some(scan_mask) = self
+                .substrate
+                .entities
+                .get(attacker_id)
+                .map(combat::scan_mission_for)
+            else {
+                continue;
+            };
             let Some(target_sid) = combat::acquire_best_target_for_entity(
                 &self.substrate.entities,
                 rules,
@@ -78,6 +86,11 @@ impl Simulation {
                 Some(&self.fog),
                 self.resolved_terrain.as_ref(),
                 self.playfield_bounds.is_some(),
+                // VERA-internal entry with no single native counterpart, so it
+                // keeps the passive block's mask — `1`, or `2` for a player
+                // "guard this spot" order. gamemd equivalent UNCHECKED.
+                scan_mask,
+                self.zone_grid.as_ref(),
             ) else {
                 continue;
             };


### PR DESCRIPTION
Phase 6, rows 141 (GSI-07.20 Hunt), 140 (GSI-07.16 Area Guard) and the Attack leaf overrides of row 120 (GSI-07.06).

The Hunt handler had a cadence and no body. It re-armed its timer and did nothing else — and VERA's own berserk path is what puts units on Hunt, so every Chaos Drone victim simply stood still.

## What gamemd does

`FootClass::Mission_Hunt @ 0x004D5350` checks `StupidHunt=`, then calls the retaliate-and-scan entry with **mask 0**. That mask is the whole mechanism: `Greatest_Threat`'s opening `TEST AL,0x3` jumps past the ring walk, the airborne pre-pass and the radius block entirely, into a flat pass over the global object array that passes a literal `-1` where the ring path passes its computed threat range. `Evaluate_Candidate` rejects on distance only for a positive range and falls back to sight only for zero, so `-1` trips neither: **a hunting object has no acquisition cutoff at all.**

Two further differences hang off that same flat walk, and both were found by review rather than by the first pass:

**It is movement-zone filtered.** The flat walk passes the scanner's zone id where the ring walk passes `-1`, and `Evaluate_Candidate` then rejects any candidate whose zone differs. So a hunting unit only considers targets its own movement zone can reach. Without that, a berserked unit picks a victim across water and walks at something it can never touch.

**It scores distance in leptons, not cells.** The ring walk takes a sentinel that ends in a shift to whole cells; the flat walk's supplied-coordinate branch jumps straight to the join with no shift. With the stock distance coefficient against a 100000 base, that makes gamemd's hunter overwhelmingly nearest-first — anything past roughly 39 cells clamps to the floor. Reusing the cell-scale scorer made distance nearly irrelevant, so a hunter would march past a near enemy at a distant, juicier one.

## A live bug in the half-cadence band

The mission dispatcher halves its cadence for targets inside a distance band. VERA compared *squared* distance against a squared bound; native runs an approximate square root through an f32 lookup and then truncates, comparing `282..=768` on the result. The two predicates differ on exactly one shell, under a 256th of a cell wide, but the native lookup is now reproduced rather than approximated. The same gate exists with a divide-by-six divisor in Area Guard and had never been wired at all.

## Also

A deployed GI on Area Guard was running the Foot body's scan *and* its random draw — two draws where native takes one, which is a determinism defect as well as a cadence one.

## Review history

Four rounds. Two findings were regressions introduced while fixing an earlier one, and the last three were caught only because each critic re-derived the native rather than reading the builder's account. The final round is documentation: the scoring fix is exact for every path VERA runs, but the enum modelling it is narrower than the native branch, and a second caller such as Rescue would need its own variant carrying the ArchiveTarget.

## Rows stay open

The Area Guard guard post is deliberately not done: it needs a new snapshot field, and native's Area Guard target is both un-flagged *and* leashed, so landing the un-flagging without the leash would send Area Guard units wandering.

`cargo test -p vera20k --lib`: `test result: ok. 8178 passed; 0 failed; 75 ignored`. No golden moved and `SNAPSHOT_VERSION` is untouched.
