### PR TITLE
Phase 6: missiles accelerate, vertical bombs fall, and four projectile keys were dead all along

### DIFF
--- a/src/rules/combat_damage.rs
+++ b/src/rules/combat_damage.rs
@@ -30,6 +30,12 @@ pub struct CombatDamageDefaults {
     /// Signed, unclamped destroyable-cliff chance compared against one
     /// Scenario RandomRanged(0,99) draw. Native constructor default is 100.
     pub collapse_chance: i32,
+    /// `BallisticScatter=` in LEPTONS. `RulesClass::ReadCombatDamage
+    /// @ 0x0066CD5B` reads it through `CCINIClass::ReadRange @ 0x00474620`
+    /// into `RulesClass+0x1734`, so the authored cell count is multiplied by
+    /// 256; the constructor default written at `0x006675C4` is `0x100`, and
+    /// stock `rulesmd.ini:815` authors `1.0` for the same 256.
+    pub ballistic_scatter: i32,
     /// Global `DeathWeapon=` used only when a dying type has neither an
     /// explicit death weapon nor a live current-weapon fallback.
     pub death_weapon: Option<String>,
@@ -59,6 +65,7 @@ impl CombatDamageDefaults {
         Self {
             max_damage: section.get_i32("MaxDamage").unwrap_or(1000),
             collapse_chance: section.get_i32("CollapseChance").unwrap_or(100),
+            ballistic_scatter: section.read_range("BallisticScatter", 0x100),
             death_weapon: read_name(section, "DeathWeapon"),
             default_large_grey_smoke_system: read_name(section, "DefaultLargeGreySmokeSystem"),
             default_small_grey_smoke_system: read_name(section, "DefaultSmallGreySmokeSystem"),
@@ -78,6 +85,7 @@ impl Default for CombatDamageDefaults {
         Self {
             max_damage: 1000,
             collapse_chance: 100,
+            ballistic_scatter: 0x100,
             death_weapon: None,
             default_large_grey_smoke_system: None,
             default_small_grey_smoke_system: None,
@@ -169,8 +177,7 @@ mod tests {
 
     #[test]
     fn whitespace_only_value_treated_as_none() {
-        let ini =
-            IniFile::from_str("[CombatDamage]\nFixtureOnly=1\nDefaultSparkSystem=   \n");
+        let ini = IniFile::from_str("[CombatDamage]\nFixtureOnly=1\nDefaultSparkSystem=   \n");
         let section = ini.section("CombatDamage").unwrap();
         let cd = CombatDamageDefaults::from_ini_section(section);
         assert!(cd.default_spark_system.is_none());

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -1761,6 +1761,36 @@ impl ObjectType {
             fly_back: section.get_bool("FlyBack").unwrap_or(false),
             landable: section.get_bool("Landable").unwrap_or(false),
             jumpjet: section.get_bool("JumpJet").unwrap_or(false),
+            // RESIDUAL — DRIFT, not fixed here (this is not the projectile
+            // flight change's file; recorded so it is not lost).
+            // `TechnoTypeClass::ReadINI` reads the eight `Jumpjet*` keys in one
+            // unconditional straight-line block — `JumpjetClimb` -> `+0xD78`,
+            // `JumpjetCrash` -> `+0xD7C`, `JumpjetHeight` -> `+0xD80`
+            // (`0x00715151`), `JumpjetAccel` -> `+0xD84`, `JumpjetWobbles`,
+            // `JumpjetNoWobbles`, `JumpjetDeviation`, then `JumpJet` itself into
+            // a SEPARATE boolean field at `+0xD94` (`0x007151F8`). `JumpJet=` is
+            // NOT a gate on the others; the per-field defaults come from
+            // `TechnoTypeClass::Constructor` (`+0xD80` = 500 at `0x007115D3`),
+            // and `JumpjetLocomotionClass` reads `+0xD78`/`+0xD7C`/`+0xD80`/
+            // `+0xD84` off the type at `0x0054AD6F`ff.
+            // Gating the whole block on `JumpJet=yes` therefore drops every
+            // jumpjet key authored by a section that takes its Jumpjet locomotor
+            // from the GUID alone. Trigger: stock `[ZEP]` (Kirov) and `[DISK]`
+            // (Floating Disc) both author `JumpjetHeight=750`,
+            // `JumpjetSpeed=`, `JumpjetClimb=`, `JumpJetAccel=`,
+            // `JumpJetTurnRate=` and `JumpjetCrash=` without `JumpJet=`, so all
+            // of them are inert and both units fall back to the hard-coded
+            // defaults in `LocomotorState::air_params_from_object`. Player
+            // effect: a Kirov and a Floating Disc hover 250 leptons (~1 cell)
+            // lower than native and climb, turn and crash at the wrong rates;
+            // the lower hover also shortens the Kirov's bomb fall. Frequency:
+            // every Kirov and every Floating Disc, continuously, in any game
+            // that builds one. Downstream risk: altitude feeds the 3D fire-range
+            // gate and `object_world_z_leptons`, so it moves engagement
+            // distances as well as the picture. The other six stock
+            // `JumpJet=yes` sections ([JUMPJET], [LUNR], [SHAD], [HIND],
+            // [SCHP], [SCHD]) all author `JumpjetHeight=500`, which equals the
+            // fallback, so they are unaffected today.
             jumpjet_params: if section.get_bool("JumpJet").unwrap_or(false) {
                 Some(JumpjetParams::from_ini_section(section))
             } else {

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -8687,21 +8687,34 @@ fn flat_level_zero_terrain(
 /// altitude failed to reach the launch coordinate the bomb would leave level,
 /// never cross `DetonationAltitude=20000`, never drop below the floor, and
 /// drift off the map unexploded. This pins the whole chain instead: the Jumpjet
-/// firer's `JumpjetHeight` reaches `object_world_z_leptons`, the launch pitch
-/// points down, and the flight ends in a detonation.
+/// firer's `JumpjetHeight=` becomes the locomotor's hover target, that hover
+/// altitude reaches `object_world_z_leptons`, the launch pitch points down, and
+/// the flight ends in a detonation.
+///
+/// The fixture authors `JumpJet=yes`, which stock `[ZEP]` does NOT — it takes
+/// its Jumpjet locomotor from the GUID alone. That reproduces gamemd, where
+/// `TechnoTypeClass::ReadINI @ 0x00715151` stores `JumpjetHeight=` into
+/// `TechnoType+0xD80` unconditionally (over the constructor default 500 at
+/// `0x007115D3`), so a native Kirov really does hover at 750. VERA gates the
+/// whole `JumpjetParams` block on `JumpJet=yes` (`rules/object_type.rs`), so a
+/// stock `[ZEP]`/`[DISK]` currently hovers at the 500 default instead — a
+/// recorded DRIFT out of scope here, and the reason this fixture has to author
+/// the key to exercise the chain it claims to pin.
 #[test]
 fn gsi_08_08_kirov_vertical_bomb_falls_and_detonates() {
     use crate::map::resolved_terrain::SharedCellDummy;
     use crate::sim::projectile::{ProjectileStore, ProjectileTrajectory};
 
-    // Stock `[BlimpBombP]`, `[BlimpBomb]` and the Kirov's Jumpjet hover height,
-    // with one deliberate change: `Range=` is widened from the stock 1.5 so the
-    // shot clears the fire-range gate while the firer hovers 750 leptons up.
-    // Nothing on the `Vertical` arm reads `Range=`.
+    // Stock `[BlimpBombP]`, `[BlimpBomb]` and the Kirov's `JumpjetHeight=750`,
+    // with two deliberate changes: `Range=` is widened from the stock 1.5 so the
+    // shot clears the fire-range gate while the firer hovers 750 leptons up
+    // (nothing on the `Vertical` arm reads `Range=`), and `JumpJet=yes` is
+    // authored so VERA's `JumpJet=`-gated parser reaches `JumpjetHeight=` the
+    // way `TechnoTypeClass::ReadINI` does unconditionally. See the doc comment.
     let rules = RuleSet::from_ini(&IniFile::from_str(
         "[VehicleTypes]\n0=ZEP\n1=HTNK\n\
          [ZEP]\nStrength=2000\nArmor=medium\nSpeed=5\nPrimary=BlimpBomb\n\
-         BalloonHover=yes\nJumpjetHeight=750\nConsideredAircraft=yes\n\
+         BalloonHover=yes\nJumpJet=yes\nJumpjetHeight=750\nConsideredAircraft=yes\n\
          MovementZone=Fly\nSpeedType=Hover\n\
          Locomotor={92612C46-F71F-11d1-AC9F-006008055BB5}\n\
          [HTNK]\nStrength=2000\nArmor=heavy\nSpeed=4\n\
@@ -8718,8 +8731,17 @@ fn gsi_08_08_kirov_vertical_bomb_falls_and_detonates() {
     let zep_object = rules.object("ZEP").expect("ZEP object type");
     let mut locomotor =
         crate::sim::movement::locomotor::LocomotorState::from_object_type(zep_object, 0, 0);
-    locomotor.altitude = crate::util::fixed_math::SimFixed::from_num(750);
-    locomotor.target_altitude = locomotor.altitude;
+    // The hover altitude is NOT hand-set: `JumpjetHeight=750` has to arrive
+    // through `LocomotorState::air_params_from_object` as the hover target, and
+    // the airship is then placed at the top of its climb. Assert the rules hop
+    // at its source so a broken parse fails here rather than downstream.
+    assert_eq!(
+        locomotor.target_altitude,
+        crate::util::fixed_math::SimFixed::from_num(750),
+        "`JumpjetHeight=750` must reach the locomotor's hover target; a 500 here \
+         means the rules->locomotor hop is broken, not the flight model"
+    );
+    locomotor.altitude = locomotor.target_altitude;
     kirov.locomotor = Some(locomotor);
     store.insert(kirov);
     let _ = test_intern("HTNK");

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -6592,7 +6592,7 @@ fn persistent_projectile_delays_damage_across_save_load_continuation() {
     let shared_cell_dummy = sim.effective_shared_cell_dummy();
     assert!(
         sim.projectiles
-            .advance(&target_positions, None, &shared_cell_dummy, |_, _| None,)
+            .advance(0, &target_positions, None, &shared_cell_dummy, |_, _| None,)
             .detonations
             .is_empty()
     );
@@ -6607,6 +6607,7 @@ fn persistent_projectile_delays_damage_across_save_load_continuation() {
         detonations = restored
             .projectiles
             .advance(
+                0,
                 &target_positions,
                 None,
                 &restored_shared_cell_dummy,
@@ -8472,5 +8473,124 @@ fn gsi_08_04_projectile_spawns_at_the_muzzle_not_the_hull_centre() {
         (spawn.origin.x - hull_x, spawn.origin.y - hull_y),
         (189, -25),
         "muzzle offset in leptons"
+    );
+}
+
+/// `TechnoClass::FireAt 0x006FEA36`..`0x006FEA4C`: a `ROT > 0` shot leaves the
+/// tube at ONE lepton per frame and the weapon's `Speed=` is stored as
+/// `Bullet+0x110` instead, which `BulletTypeClass::Acceleration` (`+0x2D0`)
+/// then ramps toward. The launch direction is the aim facing, not the bearing
+/// to the target.
+#[test]
+fn gsi_08_06_homing_launch_uses_one_lepton_and_stores_speed_as_the_ceiling() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[VehicleTypes]\n0=LNCHR\n1=HTNK\n\
+         [LNCHR]\nStrength=300\nArmor=heavy\nSpeed=6\nCost=700\nPrimary=Rocket\nTurret=yes\n\
+         [HTNK]\nStrength=2000\nArmor=heavy\nSpeed=4\nCost=900\nPrimary=Rocket\n\
+         [Rocket]\nDamage=65\nROF=50\nRange=6\nSpeed=30\nProjectile=Seeker\nWarhead=AP\n\
+         [Seeker]\nROT=60\nArm=2\nRanged=yes\n\
+         [AP]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("homing launch fixture parses");
+
+    let mut store = EntityStore::new();
+    let mut shooter = make_entity_owned(1, "LNCHR", 5, 5, 300, "Soviet");
+    shooter.facing = 0;
+    shooter.barrel_facing = Some(crate::sim::movement::facing_class::FacingClass::new(
+        0x4000, 0,
+    ));
+    store.insert(shooter);
+    let _ = test_intern("HTNK");
+    store.insert(make_entity_owned(2, "HTNK", 8, 5, 2000, "Americans"));
+    let mut interner = test_interner();
+    issue_attack_command(&mut store, 1, 2, None, &interner);
+
+    let result = tick_combat(
+        &mut store,
+        &mut OccupancyGrid::new(),
+        &rules,
+        &mut interner,
+        &mut BTreeMap::new(),
+        0,
+        100,
+        0,
+        &mut SimRng::new(3),
+    );
+
+    let spawn = result
+        .projectile_spawns
+        .first()
+        .expect("the missile is a tracked projectile");
+    assert_eq!(
+        spawn.speed_leptons_per_frame, 1,
+        "every ROT > 0 launch starts at one lepton per frame"
+    );
+    let guidance = spawn.guidance.expect("a ROT > 0 shot carries guidance");
+    assert_eq!(guidance.max_speed, 30, "weapon Speed= is only the ceiling");
+    assert_eq!(guidance.acceleration, 3, "BulletTypeClass ctor default");
+    assert_eq!(
+        guidance.heading_bam, 0,
+        "the turret faces east (0x4000), which is heading BAM 0"
+    );
+    assert_eq!(
+        guidance.fuse_reference, spawn.initial_target_position,
+        "the ProximityDetector reference is frozen on the launch-time target"
+    );
+    assert_eq!(spawn.velocity, ProjectileVelocity::new(1, 0, 0));
+}
+
+/// `TechnoClass::FireAt 0x006FE9FE`: EVERY launch speed is clamped to half the
+/// straight-line distance to the target before the homing/vertical override.
+#[test]
+fn gsi_08_06_point_blank_shot_clamps_the_launch_speed_to_half_the_distance() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[VehicleTypes]\n0=ARTY\n1=HTNK\n\
+         [ARTY]\nStrength=300\nArmor=heavy\nSpeed=6\nCost=700\nPrimary=Shell\n\
+         [HTNK]\nStrength=2000\nArmor=heavy\nSpeed=4\nCost=900\nPrimary=Shell\n\
+         [Shell]\nDamage=65\nROF=50\nRange=6\nSpeed=200\nProjectile=Lob\nWarhead=AP\n\
+         [Lob]\nArcing=true\n\
+         [AP]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("clamp fixture parses");
+
+    let mut store = EntityStore::new();
+    let mut shooter = make_entity_owned(1, "ARTY", 5, 5, 300, "Soviet");
+    // Turretless: the hull facing is what `GetFireError` gates on, so aim it
+    // east at the target before the shot.
+    shooter.facing = 64;
+    store.insert(shooter);
+    let _ = test_intern("HTNK");
+    store.insert(make_entity_owned(2, "HTNK", 6, 5, 2000, "Americans"));
+    let mut interner = test_interner();
+    issue_attack_command(&mut store, 1, 2, None, &interner);
+
+    let result = tick_combat(
+        &mut store,
+        &mut OccupancyGrid::new(),
+        &rules,
+        &mut interner,
+        &mut BTreeMap::new(),
+        0,
+        100,
+        0,
+        &mut SimRng::new(3),
+    );
+
+    let spawn = result
+        .projectile_spawns
+        .first()
+        .expect("the shell is a tracked projectile");
+    let dx = spawn.initial_target_position.x - spawn.origin.x;
+    let dy = spawn.initial_target_position.y - spawn.origin.y;
+    let dz = spawn.initial_target_position.z - spawn.origin.z;
+    let distance = (f64::from(dx * dx + dy * dy + dz * dz)).sqrt().trunc() as i32;
+    assert!(
+        distance / 2 < 200,
+        "the fixture must be closer than twice the weapon speed"
+    );
+    assert_eq!(
+        i32::from(spawn.speed_leptons_per_frame),
+        distance / 2,
+        "the launch speed is clamped to dist/2"
     );
 }

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -8594,3 +8594,205 @@ fn gsi_08_06_point_blank_shot_clamps_the_launch_speed_to_half_the_distance() {
         "the launch speed is clamped to dist/2"
     );
 }
+
+/// A flat level-0 grid, so the `Vertical` arm's floor probe has a ground
+/// surface to reach.
+fn flat_level_zero_terrain(
+    width: u16,
+    height: u16,
+) -> crate::map::resolved_terrain::ResolvedTerrainGrid {
+    use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid};
+    use crate::rules::terrain_rules::{SpeedCostProfile, TerrainClass};
+
+    let speed_costs = SpeedCostProfile {
+        foot: Some(100),
+        track: Some(100),
+        wheel: Some(100),
+        float: Some(100),
+        amphibious: Some(100),
+        float_beach: Some(100),
+        hover: Some(100),
+    };
+    let mut cells = Vec::with_capacity(usize::from(width) * usize::from(height));
+    for ry in 0..height {
+        for rx in 0..width {
+            cells.push(ResolvedTerrainCell {
+                rx,
+                ry,
+                source_tile_index: 0,
+                source_sub_tile: 0,
+                final_tile_index: 0,
+                final_sub_tile: 0,
+                is_wood_bridge_repair_tile: false,
+                level: 0,
+                filled_clear: true,
+                tileset_index: Some(0),
+                land_type: 0,
+                yr_cell_land_type: 0,
+                slope_type: 0,
+                template_height: 0,
+                render_offset_x: 0,
+                render_offset_y: 0,
+                terrain_class: TerrainClass::Clear,
+                speed_costs,
+                is_water: false,
+                is_cliff_like: false,
+                height_in_pixels: 0,
+                variant: 0,
+                is_rough: false,
+                is_road: false,
+                accepts_smudge: false,
+                allows_tiberium: false,
+                has_ramp: false,
+                canonical_ramp: None,
+                ground_walk_blocked: false,
+                terrain_object_blocks: false,
+                terrain_object_occupation: None,
+                overlay_blocks: false,
+                overlay_zone_type: None,
+                outside_playfield: false,
+                zone_type: 0,
+                base_ground_walk_blocked: false,
+                base_build_blocked: false,
+                base_land_type: 0,
+                base_yr_cell_land_type: 0,
+                base_terrain_class: TerrainClass::Clear,
+                base_speed_costs: speed_costs,
+                build_blocked: false,
+                has_bridge_deck: false,
+                bridge_walkable: false,
+                bridge_transition: false,
+                bridge_deck_level: 0,
+                bridge_layer: None,
+                bridge_facts: crate::map::bridge_facts::BridgeCellFacts::default(),
+                tube_index: None,
+                radar_left: [0, 0, 0],
+                radar_right: [0, 0, 0],
+                has_damaged_data: false,
+                bridgehead_anchor_class_at_load: None,
+            });
+        }
+    }
+    ResolvedTerrainGrid::from_cells(width, height, cells)
+}
+
+/// GSI-08.08 end to end: the Kirov bomb has to FALL and explode.
+///
+/// `[BlimpBombP]` is `Vertical=yes` with `Acceleration=1`, no `ROT=` and no
+/// `Ranged=`, so it carries no fuse and no steering — its only terminations are
+/// the `Vertical` arm's own probes at `BulletClass::AI 0x00467334`ff.
+/// (`DetonationAltitude`, then `GetAltitude() < 0`, then the bridge deck).
+/// `TechnoClass::FireAt` gives a `Vertical` launch a pitch only when the
+/// muzzle-to-target separation exceeds 200 leptons, so if the firer's hover
+/// altitude failed to reach the launch coordinate the bomb would leave level,
+/// never cross `DetonationAltitude=20000`, never drop below the floor, and
+/// drift off the map unexploded. This pins the whole chain instead: the Jumpjet
+/// firer's `JumpjetHeight` reaches `object_world_z_leptons`, the launch pitch
+/// points down, and the flight ends in a detonation.
+#[test]
+fn gsi_08_08_kirov_vertical_bomb_falls_and_detonates() {
+    use crate::map::resolved_terrain::SharedCellDummy;
+    use crate::sim::projectile::{ProjectileStore, ProjectileTrajectory};
+
+    // Stock `[BlimpBombP]`, `[BlimpBomb]` and the Kirov's Jumpjet hover height,
+    // with one deliberate change: `Range=` is widened from the stock 1.5 so the
+    // shot clears the fire-range gate while the firer hovers 750 leptons up.
+    // Nothing on the `Vertical` arm reads `Range=`.
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[VehicleTypes]\n0=ZEP\n1=HTNK\n\
+         [ZEP]\nStrength=2000\nArmor=medium\nSpeed=5\nPrimary=BlimpBomb\n\
+         BalloonHover=yes\nJumpjetHeight=750\nConsideredAircraft=yes\n\
+         MovementZone=Fly\nSpeedType=Hover\n\
+         Locomotor={92612C46-F71F-11d1-AC9F-006008055BB5}\n\
+         [HTNK]\nStrength=2000\nArmor=heavy\nSpeed=4\n\
+         [BlimpBomb]\nDamage=250\nBurst=1\nROF=50\nRange=6\nSpeed=20\n\
+         Projectile=BlimpBombP\nWarhead=BlimpHE\nOmniFire=yes\n\
+         [BlimpBombP]\nArm=10\nAcceleration=1\nVertical=yes\nDetonationAltitude=20000\n\
+         [BlimpHE]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("Kirov bomb fixture parses");
+
+    let mut store = EntityStore::new();
+    let mut kirov = make_entity_owned(1, "ZEP", 5, 5, 2000, "Soviet");
+    kirov.category = EntityCategory::Aircraft;
+    let zep_object = rules.object("ZEP").expect("ZEP object type");
+    let mut locomotor =
+        crate::sim::movement::locomotor::LocomotorState::from_object_type(zep_object, 0, 0);
+    locomotor.altitude = crate::util::fixed_math::SimFixed::from_num(750);
+    locomotor.target_altitude = locomotor.altitude;
+    kirov.locomotor = Some(locomotor);
+    store.insert(kirov);
+    let _ = test_intern("HTNK");
+    // Directly beneath the airship, the way a Kirov bombs.
+    store.insert(make_entity_owned(2, "HTNK", 5, 5, 2000, "Americans"));
+    let mut interner = test_interner();
+    issue_attack_command(&mut store, 1, 2, None, &interner);
+
+    let result = tick_combat(
+        &mut store,
+        &mut OccupancyGrid::new(),
+        &rules,
+        &mut interner,
+        &mut BTreeMap::new(),
+        0,
+        100,
+        0,
+        &mut SimRng::new(7),
+    );
+
+    let spawn = *result
+        .projectile_spawns
+        .first()
+        .expect("the Kirov bomb is a tracked projectile");
+    assert!(
+        matches!(spawn.trajectory, ProjectileTrajectory::Vertical { .. }),
+        "Vertical=yes takes the third arm"
+    );
+    assert!(
+        spawn.origin.z >= 750,
+        "the Jumpjet hover altitude must reach the launch coordinate, else the \
+         bomb leaves level and never terminates; got {}",
+        spawn.origin.z
+    );
+    assert!(
+        spawn.velocity.z < 0,
+        "the launch pitch has to point the bomb DOWN; got {:?}",
+        spawn.velocity
+    );
+
+    let terrain = flat_level_zero_terrain(10, 10);
+    let ground = ProjectileCoord::new(5 * 256, 5 * 256, 0);
+    let mut projectiles = ProjectileStore::new();
+    let id = projectiles.spawn(1, spawn);
+    let dummy = SharedCellDummy::fresh();
+    for frame in 1..600u32 {
+        let step = projectiles
+            .advance_one(
+                id,
+                frame,
+                |_| Some(ground),
+                Some(&terrain),
+                &dummy,
+                |_, _| None,
+            )
+            .expect("the bomb is still in flight");
+        assert!(
+            step.expired.is_empty(),
+            "the bomb must not vanish unexploded at frame {frame}"
+        );
+        if let Some(detonation) = step.detonations.first() {
+            assert_eq!(detonation.projectile_id, id);
+            // The only reachable terminator on this arm: `DetonationAltitude`
+            // is 20000 and the bomb is descending, and there is no bridge and
+            // no fuse — so this is the floor probe, native's `GetAltitude() < 0`
+            // over a level-0 cell.
+            assert!(
+                detonation.impact.z < 0,
+                "the bomb detonates below the level-0 floor, at {}",
+                detonation.impact.z
+            );
+            return;
+        }
+    }
+    panic!("the Kirov bomb never detonated");
+}

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -215,9 +215,9 @@ enum ImmediateProjectileReason {
 /// gamemd-derived: `BulletClass::AI @ 0x004666E0` has exactly two branches,
 /// keyed on `ROT < 1`; the non-homing arm then splits on `Vertical` (`+0x2C0`).
 /// `Arcing`, `SubjectToCliffs`, `SubjectToElevation`, `SubjectToWalls`,
-/// `Proximity`, `FlakScatter`, `Inviso` and `Cluster` are never read by the AI —
-/// they are launch-time or detonation-time keys — so only `ROT` and `Vertical`
-/// select a flight model.
+/// `Proximity`, `FlakScatter`, `Inviso` and `Cluster` never select an arm —
+/// they are launch-time, collision-probe or detonation-time keys — so only
+/// `ROT` and `Vertical` pick a flight model.
 ///
 /// Evidence-backed exclusions (verified 2026-09-03, exhaustive over the direct
 /// `[base + displacement]` operand forms via `search_instructions`) — these keys
@@ -243,18 +243,35 @@ enum ImmediateProjectileReason {
 /// - `Elasticity=` (`+0x2C8`) is live in the ARM B reflection block but has
 ///   zero stock projectile users (the `[PIECE]`/`[TIRE]` hits are VoxelAnims).
 ///
-/// RESIDUAL (GSI-08.07) — the second scatter site is not modelled.
-/// `BulletClass::Fire @ 0x004687B4` scatters an `Inviso && FlakScatter`
-/// bullet's already-resolved target coordinate by
-/// `RandomRanged(0, 2 * BallisticScatter) * ftol(dist) / Range`, so stock
-/// `[FlakProj]` — the Flak Cannon and Flak Track anti-air shell — should miss
-/// by up to two cells at maximum range. VERA resolves an `Inviso` shot on the
-/// immediate path, where the impact coordinate feeds area damage, wall routing,
-/// bridge damage, radiation and animation placement, so offsetting it is its
-/// own change. Trigger: every Flak Cannon / Flak Track shot at an aircraft.
-/// Player effect: flak never misses. Frequency: any skirmish with air units.
-/// Downstream risk: two Scenario RNG draws are missing from that path, so the
-/// draw sequence differs from native for those six weapons.
+/// RESIDUAL (GSI-08.07) — the second scatter site is not modelled, because one
+/// of its operands is unidentified. `BulletClass::Fire @ 0x004687B4` offsets an
+/// `Inviso && FlakScatter` bullet's already-resolved target coordinate, drawing
+/// `Random__RandomRanged(0, RulesClass+0x1734 << 1)` for the magnitude and
+/// `Random__RandomRanged(0, 0x7FFFFFFE)` for the angle. **The blocker is the
+/// divisor.** The magnitude is `(roll * ftol(dist)) / *(*(Bullet+0x130) + 0xB4)`
+/// — `0x004687D9 IMUL ESI,EAX`, `0x004687DC MOV ECX,[EBX+0x130]`,
+/// `0x004687E5 IDIV dword ptr [ECX+0xB4]` — and neither `Bullet+0x130`'s
+/// referent nor its `+0xB4` field has been identified, so the offset cannot be
+/// computed at all today. It is NOT the weapon `Range=`; an earlier note here
+/// said so and was wrong.
+///
+/// Two facts for whoever implements it. First, the site OFFSETS, walked in
+/// assembly this session: `0x00468884 CALL Math__CosFromTable / 0x00468889 FMUL
+/// <mag> / 0x00468890 FIADD dword ptr [ESP+0x44]` and `0x00468864 CALL
+/// Math__SinFromTable / 0x00468869 FMUL <mag> / 0x0046886D FSUBR double ptr
+/// [ESP+0x38]` — `x += cos(theta)*mag`, `y -= sin(theta)*mag`, the same shape as
+/// the verified launch site at `0x006FE7E5`/`0x006FE7C0`. The decompiler renders
+/// it as a plain assignment (the dropped-`FIADD` artifact that made the mapping
+/// ledger wrong at the launch site); do not follow that rendering. Second, VERA
+/// resolves an `Inviso` shot on the immediate path, where the impact coordinate
+/// feeds area damage, wall routing, bridge damage, radiation and animation
+/// placement, so wiring the offset in touches all of those consumers.
+///
+/// Trigger: every Flak Cannon / Flak Track shot at an aircraft (`[FlakProj]`,
+/// 6 weapons). Player effect: flak never misses — the miss distance itself is
+/// not yet derivable. Frequency: any skirmish with air units. Downstream risk:
+/// two Scenario RNG draws are missing from that path, so the draw sequence
+/// differs from native for those six weapons.
 ///
 /// RESIDUAL (GSI-08.06) — the `ROT < 1, Vertical = no` arm subtracts
 /// `Rules.Gravity` from `v.z` on EVERY frame (`0x00467402`..`0x00467429`),
@@ -7756,10 +7773,19 @@ pub(crate) fn resolve_attacker_fire(
         if guidance.is_some() || vertical.is_some() {
             launch_speed = 1;
         }
-        // The aim facing IS the launch direction for a homing or vertical
-        // bullet (`0x006FDD50` takes the turret/body facing whenever
-        // `ROT != 0 || Dropping`); only a `ROT == 0` non-dropping shot points
-        // at the target. `heading_bam` is the math-BAM form of that facing.
+        // The aim facing IS the launch direction for a homing bullet
+        // (`0x006FDD50` takes the turret/body facing whenever
+        // `ROT != 0 || Dropping`); everything else points at the target delta.
+        // `heading_bam` is the math-BAM form of that facing.
+        //
+        // RESIDUAL (VERA-internal, gamemd equivalent UNCHECKED for the two
+        // uncovered shapes): VERA's condition is `rot > 0 && !ballistic &&
+        // !vertical`, native's is `ROT != 0 || Dropping`. The two disagree only
+        // for an `Arcing`+`ROT>0` projectile or a `Dropping`+`ROT==0` one, and
+        // stock `rulesmd.ini` authors neither — every `Vertical` stock
+        // projectile has no `ROT=` and no `Dropping=`, so native takes the
+        // `atan2` delta heading for them exactly as VERA does here. Trigger: a
+        // mod authoring either shape. Frequency: zero in stock.
         let launch_heading_bam = if guidance.is_some() {
             aim_facing16.wrapping_sub(0x4000)
         } else {

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -186,6 +186,15 @@ enum ProjectileDelivery {
         tracks_target: bool,
         collision: ProjectileCollisionPolicy,
         ballistic: bool,
+        /// `Vertical=` (`BulletTypeClass+0x2C0`) selects the third
+        /// `BulletClass::AI` arm. Carries `DetonationAltitude=` (`+0x2BC`).
+        vertical: Option<i32>,
+        /// `BulletTypeClass::Acceleration` (`+0x2D0`), constructor default 3.
+        acceleration: i32,
+        /// `Inaccurate= && Arcing=` — the launch-time scatter gate at
+        /// `TechnoClass::FireAt 0x006FE67D`/`0x006FE68B`. `Some(true)` takes
+        /// the range-scaled flak arm, `Some(false)` the plain arm.
+        launch_scatter_is_flak: Option<bool>,
         guidance: Option<ProjectileGuidance>,
     },
     Immediate(ImmediateProjectileReason),
@@ -199,8 +208,6 @@ enum ImmediateProjectileReason {
     MissingProjectileType,
     Invisible,
     InstantSpeed,
-    Vertical,
-    SpecialTrajectory,
 }
 
 /// Which delivery path a weapon's shot takes.
@@ -212,33 +219,63 @@ enum ImmediateProjectileReason {
 /// they are launch-time or detonation-time keys — so only `ROT` and `Vertical`
 /// select a flight model.
 ///
-/// RESIDUAL (GSI-08.06/08.07/08.08) — four gaps remain, all verified this pass:
-/// - **Launch speed.** `TechnoClassFireAtSpawnsBullet @ 0x006FDD50` sets a
-///   homing or vertical shot's speed to 1 lepton/frame, and
-///   `BulletClassFireRevealArmAndSubmit @ 0x00468670` renormalises the vector to
-///   magnitude 1.0 when `ROT > 0`; the weapon's `Speed=` is only the ceiling
-///   that `Acceleration=` (`+0x2D0`, default 3) ramps toward. VERA launches
-///   every non-ballistic shot at full weapon speed, so missiles leave the tube
-///   at terminal velocity and reach their target early. Frequency: continuous —
-///   every missile in the game. Closing it needs `max_speed_leptons_per_frame`
-///   beside the current speed and a per-frame ramp, and moves the projectile
-///   hash.
-/// - **`Inaccurate=`/`FlakScatter=` are launch-time offsets**, not
-///   disqualifiers: two scenario draws each, at `0x006FDD50` (`Inaccurate &&
-///   Arcing`) and `0x00468670` (`FlakScatter && Inviso`). They still divert a
-///   shot off the tracked path here rather than offsetting its target.
-/// - **`Vertical=`** is the one genuinely missing flight model (the nuke, the
-///   Kirov bomb, the Disc drain).
-/// - **Detonation.** `Arm` gates only the fuse in native, where VERA gates all
-///   four detonation reasons — so an unarmed shot that hits a wall silently
-///   vanishes — and the fuse's reference coordinate is frozen at launch in
-///   native while VERA measures to the live target. `ranged_fuse_distance_step`
-///   itself is bit-exact against `ProximityDetector::Check @ 0x004E11F0`.
+/// Evidence-backed exclusions (verified 2026-09-03, exhaustive over the direct
+/// `[base + displacement]` operand forms via `search_instructions`) — these keys
+/// must NOT divert a shot off authoritative flight, because native never reads
+/// them in the flight loop at all:
+/// - `Bouncy=` (`+0x2A7`) has **no consumer anywhere in the binary**. The
+///   apparent hits at `0x0070D2D2`/`0x0070D2EE` are `TechnoTypeClass+0x2A7`
+///   behind `VeterancyClass::IsVeteran/IsElite`. Stock `[Lobbed]` (the dog
+///   discus) is therefore an ordinary `Arcing` shell.
+/// - `Proximity=` (`+0x29F`) likewise has no consumer; `0x00702BC0`ff. are
+///   `TechnoTypeClass+0x29F` behind the same veterancy pattern.
+/// - `SubjectToCliffs=` (`+0x296`) is consumed only by the AI collision probe
+///   `FUN_00468BB0 @ 0x00468BEC`, and `SubjectToElevation=` (`+0x297`) only by
+///   `TechnoClass::InRange @ 0x006F72EF`/`0x006F7459` — a targeting key, not a
+///   flight key.
+/// - `VeryHigh=` (`+0x299`) is read only as a `HomingTrack` argument on the
+///   `ROT >= 1` arm, so `VeryHigh` with `ROT <= 0` is unreachable; the one
+///   stock user `[ChemMissile]` has `ROT=4`.
+/// - `Degenerates=` (`+0x2A6`) IS live code — `BulletClass::AI 0x00467C86`
+///   decrements the bullet's damage on every non-detonating frame while it
+///   exceeds 5 — but stock `rulesmd.ini` has zero users, so it is recorded and
+///   not implemented.
+/// - `Elasticity=` (`+0x2C8`) is live in the ARM B reflection block but has
+///   zero stock projectile users (the `[PIECE]`/`[TIRE]` hits are VoxelAnims).
 ///
-/// Not gaps: `Floater=` is read on both ballistic launch paths, `ShrapnelWeapon=`
-/// is fully wired, and gravity applies to every `ROT < 1, Vertical=no` bullet —
-/// VERA's gravity-free straight arm is wrong, but only four rare stock
-/// projectiles use it.
+/// RESIDUAL (GSI-08.07) — the second scatter site is not modelled.
+/// `BulletClass::Fire @ 0x004687B4` scatters an `Inviso && FlakScatter`
+/// bullet's already-resolved target coordinate by
+/// `RandomRanged(0, 2 * BallisticScatter) * ftol(dist) / Range`, so stock
+/// `[FlakProj]` — the Flak Cannon and Flak Track anti-air shell — should miss
+/// by up to two cells at maximum range. VERA resolves an `Inviso` shot on the
+/// immediate path, where the impact coordinate feeds area damage, wall routing,
+/// bridge damage, radiation and animation placement, so offsetting it is its
+/// own change. Trigger: every Flak Cannon / Flak Track shot at an aircraft.
+/// Player effect: flak never misses. Frequency: any skirmish with air units.
+/// Downstream risk: two Scenario RNG draws are missing from that path, so the
+/// draw sequence differs from native for those six weapons.
+///
+/// RESIDUAL (GSI-08.06) — the `ROT < 1, Vertical = no` arm subtracts
+/// `Rules.Gravity` from `v.z` on EVERY frame (`0x00467402`..`0x00467429`),
+/// `Arcing=` is not consulted there, and the position integrates as
+/// `pos += ftol(v)`. VERA's `Straight` arm still walks toward the target
+/// coordinate with no gravity. Trigger: a non-`Arcing`, non-`Inviso`, `ROT=0`
+/// projectile. Player effect: those shots fly flat instead of dropping.
+/// Frequency: four stock projectiles across five weapons (`Sonic`, `Cannon2`,
+/// `ASWVirt`, `PulsPr`); every common shell is `Arcing` and every common gun is
+/// `Inviso`. Downstream risk: converting it means giving the arm a real launch
+/// velocity and the native ground clamp, which is the same work as the
+/// `Arcing` solver.
+///
+/// RESIDUAL (GSI-08.07) — `BulletClass::AI 0x00467CDE` refuses the
+/// detonation-coordinate snap onto the target for an `Inaccurate=` bullet, the
+/// same way it does for `Airburst=`. The homing arm's snap here is gated on
+/// `Airburst` only, because no stock `Inaccurate` projectile has `ROT > 0`
+/// (`[FlakProj]` and `[FlakTProj]` are both `ROT=0`), so the gate is
+/// unreachable in stock data. Trigger: a mod authoring `Inaccurate=yes` with
+/// `ROT`. Player effect: the shot would still snap onto its target. Frequency:
+/// zero in stock. Downstream risk: none.
 fn classify_projectile_delivery(
     weapon: &crate::rules::weapon_type::WeaponType,
     rules: &RuleSet,
@@ -255,54 +292,51 @@ fn classify_projectile_delivery(
     if weapon.speed <= 0 {
         return ProjectileDelivery::Immediate(ImmediateProjectileReason::InstantSpeed);
     }
-    if projectile.vertical {
-        return ProjectileDelivery::Immediate(ImmediateProjectileReason::Vertical);
-    }
-    // `BulletClass::AI @ 0x004666E0` reads neither `SubjectToCliffs` (+0x296)
-    // nor `SubjectToElevation` (+0x297) nor `Proximity` (+0x29F) — the flight
-    // loop branches only on `ROT < 1` and then on `Vertical` (+0x2C0). Those
-    // three keys are consumed elsewhere, so they must not disqualify a shot
-    // from authoritative flight; diverting them took essentially the whole
-    // missile family (every `AAHeatSeeker2` carrier, all stock AA missiles, the
-    // six Maverick weapons, the Dreadnought, dog and squid jumps, and Boomer
-    // torpedoes) off the tracked path.
-    //
-    // UNCHECKED: where `+0x296`/`+0x297` ARE consumed. Not in the AI loop; the
-    // collision rung already owns the wall and water predicates.
-    let ballistic = projectile.arcing || weapon.lobber;
-    if projectile.dropping
-        || (projectile.very_high && projectile.rot <= 0)
-        || projectile.flak_scatter
-        || projectile.inaccurate
-        || projectile.degenerates
-        || projectile.bouncy
-    {
-        return ProjectileDelivery::Immediate(ImmediateProjectileReason::SpecialTrajectory);
-    }
+    // `BulletClass::AI @ 0x004666E0` selects an arm exactly twice: `ROT < 1` at
+    // `0x004668D1`, then `Vertical` (`+0x2C0`) at `0x004671D0`. Nothing else
+    // participates.
+    let ballistic = !projectile.vertical && (projectile.arcing || weapon.lobber);
     ProjectileDelivery::Persistent {
         arm_frames: projectile.arm.max(0).min(u16::MAX as i32) as u16,
         tracks_target: projectile.rot > 0,
         collision: ProjectileCollisionPolicy {
             level_non_water: projectile.level,
             subject_to_walls: projectile.subject_to_walls,
-            native_cell_collision: projectile.rot <= 0,
+            native_cell_collision: projectile.rot <= 0 && !projectile.vertical,
         },
         ballistic,
-        guidance: (!ballistic && projectile.rot > 0).then_some(ProjectileGuidance {
-            rot: projectile.rot,
-            missile_rot_var: rules.general.missile_rot_var,
-            course_lock_frames: projectile
-                .course_lock_duration
-                .clamp(0, i32::from(u16::MAX)) as u16,
-            // The RE contract proves this is BulletClass-identity-derived but
-            // not its formula. Keep the raw phase as an explicit live seam.
-            sidewinder_phase: 0,
-            airburst: projectile.airburst,
-            very_high: projectile.very_high,
-            level: projectile.level,
-            pitch_bam: 0x4000,
-            frames_elapsed: 0,
-        }),
+        vertical: projectile.vertical.then_some(projectile.detonation_altitude),
+        acceleration: projectile.acceleration,
+        // `0x006FE67D`/`0x006FE68B`: the outer gate is `Inaccurate && Arcing`.
+        // Inside, `FlakScatter && !Inviso` takes the range-scaled arm at
+        // `0x006FE6AD` and everything else the plain arm at `0x006FE7FE`.
+        launch_scatter_is_flak: (projectile.inaccurate && projectile.arcing)
+            .then_some(projectile.flak_scatter && !projectile.inviso),
+        guidance: (!ballistic && !projectile.vertical && projectile.rot > 0).then_some(
+            ProjectileGuidance {
+                rot: projectile.rot,
+                missile_rot_var: rules.general.missile_rot_var,
+                course_lock_duration: projectile
+                    .course_lock_duration
+                    .clamp(0, i32::from(u16::MAX))
+                    as u16,
+                // The RE contract proves this is BulletClass-identity-derived but
+                // not its formula. Keep the raw phase as an explicit live seam.
+                sidewinder_phase: 0,
+                airburst: projectile.airburst,
+                very_high: projectile.very_high,
+                level: projectile.level,
+                // Replaced at construction with the launch facing.
+                heading_bam: 0,
+                frames_elapsed: 0,
+                max_speed: weapon.speed.clamp(0, i32::from(u16::MAX)) as u16,
+                acceleration: projectile.acceleration,
+                // Replaced at construction with the launch-time target coord.
+                fuse_reference: ProjectileCoord::new(0, 0, 0),
+                closing_frames: 0,
+                closing_accumulator_bits: 0,
+            },
+        ),
     }
 }
 
@@ -365,9 +399,90 @@ mod projectile_delivery_tests {
                     native_cell_collision: true,
                 },
                 ballistic: false,
+                vertical: None,
+                acceleration: 3,
+                launch_scatter_is_flak: None,
                 guidance: None,
             }
         );
+    }
+
+    /// `Bouncy=` (`+0x2A7`), `Proximity=` (`+0x29F`) and `Degenerates=`
+    /// (`+0x2A6`) never divert a shot: the first two have no consumer anywhere
+    /// in `gamemd.exe`, and the third is a damage decay inside
+    /// `BulletClass::AI 0x00467C86`, not a trajectory selector. `Inaccurate=`
+    /// and `FlakScatter=` are launch-time target offsets at
+    /// `TechnoClass::FireAt 0x006FE67D`, and `Dropping=` (`+0x29C`) only
+    /// suppresses the proximity fuse at `0x00467C78`.
+    #[test]
+    fn gsi_08_08_dead_and_launch_time_keys_keep_authoritative_flight() {
+        let ini = IniFile::from_str(
+            "[VehicleTypes]\n0=TA\n1=TB\n\
+             [TA]\nStrength=100\nArmor=heavy\nPrimary=W0\nSecondary=W1\n\
+             [TB]\nStrength=100\nArmor=heavy\nPrimary=W2\nSecondary=W3\n\
+             [W0]\nDamage=10\nROF=20\nRange=5\nSpeed=40\nProjectile=P0\nWarhead=WH\n\
+             [W1]\nDamage=10\nROF=20\nRange=5\nSpeed=40\nProjectile=P1\nWarhead=WH\n\
+             [W2]\nDamage=10\nROF=20\nRange=5\nSpeed=40\nProjectile=P2\nWarhead=WH\n\
+             [W3]\nDamage=10\nROF=20\nRange=5\nSpeed=40\nProjectile=P3\nWarhead=WH\n\
+             [P0]\nBouncy=yes\nArcing=yes\n[P1]\nDegenerates=yes\n\
+             [P2]\nInaccurate=yes\nFlakScatter=yes\nArcing=true\n[P3]\nDropping=yes\nROT=4\n\
+             [WH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+        );
+        let rules = RuleSet::from_ini(&ini).expect("projectile fixture parses");
+        for weapon_name in ["W0", "W1", "W2", "W3"] {
+            let weapon = rules.weapon(weapon_name).expect("weapon");
+            assert!(
+                matches!(
+                    classify_projectile_delivery(weapon, &rules),
+                    ProjectileDelivery::Persistent { .. }
+                ),
+                "{weapon_name} must stay on the tracked path"
+            );
+        }
+        // The flak arm is only selected when `FlakScatter && !Inviso`.
+        let flak = rules.weapon("W2").expect("weapon");
+        assert!(matches!(
+            classify_projectile_delivery(flak, &rules),
+            ProjectileDelivery::Persistent {
+                launch_scatter_is_flak: Some(true),
+                ..
+            }
+        ));
+        // `Bouncy` + `Arcing` is an ordinary ballistic shell, with no scatter.
+        let bouncy = rules.weapon("W0").expect("weapon");
+        assert!(matches!(
+            classify_projectile_delivery(bouncy, &rules),
+            ProjectileDelivery::Persistent {
+                ballistic: true,
+                launch_scatter_is_flak: None,
+                ..
+            }
+        ));
+    }
+
+    /// `Vertical=` selects the third `BulletClass::AI` arm and carries
+    /// `DetonationAltitude=` (`+0x2BC`) and `Acceleration=` (`+0x2D0`).
+    #[test]
+    fn gsi_08_08_vertical_projectile_takes_the_vertical_arm() {
+        let ini = IniFile::from_str(
+            "[VehicleTypes]\n0=T\n[T]\nStrength=100\nArmor=heavy\nPrimary=NUKE\n\
+             [NUKE]\nDamage=10\nROF=20\nRange=5\nSpeed=40\nProjectile=GiantNukeUp\nWarhead=WH\n\
+             [GiantNukeUp]\nArm=2\nAcceleration=1\nVertical=yes\nDetonationAltitude=20000\n\
+             [WH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+        );
+        let rules = RuleSet::from_ini(&ini).expect("projectile fixture parses");
+        let weapon = rules.weapon("NUKE").expect("weapon");
+        assert!(matches!(
+            classify_projectile_delivery(weapon, &rules),
+            ProjectileDelivery::Persistent {
+                vertical: Some(20000),
+                acceleration: 1,
+                arm_frames: 2,
+                guidance: None,
+                ballistic: false,
+                ..
+            }
+        ));
     }
 }
 
@@ -7510,7 +7625,10 @@ pub(crate) fn resolve_attacker_fire(
         tracks_target,
         collision,
         ballistic,
-        guidance,
+        vertical,
+        acceleration,
+        launch_scatter_is_flak,
+        mut guidance,
     } = persistent_delivery
     {
         let impact_world_z_leptons = attack_world_z_leptons(
@@ -7593,11 +7711,119 @@ pub(crate) fn resolve_attacker_fire(
                 }
             })
             .unwrap_or(0);
+        // `TechnoClass::FireAt` step order, `0x006FE663`..`0x006FEA52`:
+        // resolve the target delta, scatter it, recompute the facing from the
+        // scattered delta, clamp the launch speed to half the straight-line
+        // distance, and only then force a homing or vertical shot to one
+        // lepton per frame.
+        let delta = (
+            impact.x - origin.x,
+            impact.y - origin.y,
+            impact.z - origin.z,
+        );
+        let delta = match launch_scatter_is_flak {
+            Some(flak) => crate::sim::projectile::projectile_launch_scatter(
+                delta,
+                rules.combat_damage.ballistic_scatter,
+                (weapon.range * SimFixed::from_num(crate::util::lepton::LEPTONS_PER_CELL_I32))
+                    .to_num::<i32>(),
+                flak,
+                scenario_rng,
+            ),
+            None => delta,
+        };
+        let impact = ProjectileCoord::new(
+            origin.x + delta.0,
+            origin.y + delta.1,
+            origin.z + delta.2,
+        );
+        // `0x006FE9FB`..`0x006FEA00`: `if (dist / 2 < speed) speed = dist / 2`,
+        // applied to EVERY launch before the homing/vertical override.
+        let launch_distance = ((f64::from(delta.0) * f64::from(delta.0)
+            + f64::from(delta.1) * f64::from(delta.1)
+            + f64::from(delta.2) * f64::from(delta.2))
+        .sqrt())
+        .trunc() as i32;
+        let mut launch_speed = weapon.speed.min(launch_distance / 2).max(0);
+        // `0x006FEA36`..`0x006FEA4C`: a `ROT > 0` or `Vertical` bullet from a
+        // firer with `RadialFireSegments == 0` — every stock firer except the
+        // Aegis Cruiser — launches at one lepton per frame, and the weapon's
+        // `Speed=` is stored as `Bullet+0x110` instead. For `ROT > 0` this is
+        // belt-and-braces anyway: `BulletClass::Fire @ 0x00468B2C`
+        // renormalises the vector to magnitude 1.0 whatever the launch speed
+        // was, which is why the Aegis exception has no stock effect and is
+        // deliberately not modelled here.
+        if guidance.is_some() || vertical.is_some() {
+            launch_speed = 1;
+        }
+        // The aim facing IS the launch direction for a homing or vertical
+        // bullet (`0x006FDD50` takes the turret/body facing whenever
+        // `ROT != 0 || Dropping`); only a `ROT == 0` non-dropping shot points
+        // at the target. `heading_bam` is the math-BAM form of that facing.
+        let launch_heading_bam = if guidance.is_some() {
+            aim_facing16.wrapping_sub(0x4000)
+        } else {
+            crate::sim::movement::homing_movement::atan2_bam(
+                SimFixed::from_num(delta.1),
+                SimFixed::from_num(delta.0),
+            )
+        };
+        if let Some(guidance) = guidance.as_mut() {
+            guidance.heading_bam = launch_heading_bam;
+            guidance.fuse_reference = impact;
+        }
+        // `0x006FEB..`: the launch pitch. `Arcing` uses the solver below;
+        // otherwise a level `0x3FFF` unless the vertical separation exceeds
+        // 200 leptons, where native calls `FUN_004CB3D0(dZ - 20, max(dist,
+        // 0.05))`. VERA-internal: that helper's identity is UNCHECKED, so the
+        // pitch is taken as the geometric elevation of the same two arguments.
+        let launch_pitch_bam = if delta.2.abs() > 200 {
+            let horizontal = ((f64::from(delta.0) * f64::from(delta.0)
+                + f64::from(delta.1) * f64::from(delta.1))
+            .sqrt())
+            .max(0.05);
+            crate::sim::movement::homing_movement::atan2_bam(
+                SimFixed::from_num(delta.2 - 20),
+                SimFixed::from_num(horizontal.trunc() as i32),
+            )
+        } else {
+            0
+        };
         // The root-selector argument remains ABI-ambiguous in the closed RE;
         // use the proved ordinary (+root) path rather than inferring Lobber.
         let velocity = if ballistic {
-            ballistic_launch_velocity(origin, impact, weapon.speed, gravity, false)
+            ballistic_launch_velocity(origin, impact, launch_speed, gravity, false)
                 .unwrap_or(ProjectileVelocity::new(0, 0, 0))
+        } else if vertical.is_some() {
+            let horizontal = SimFixed::from_num(launch_speed)
+                * crate::sim::movement::homing_movement::cos_bam(launch_pitch_bam);
+            ProjectileVelocity::new(
+                (horizontal * crate::sim::movement::homing_movement::cos_bam(launch_heading_bam))
+                    .to_num::<i32>(),
+                (horizontal * crate::sim::movement::homing_movement::sin_bam(launch_heading_bam))
+                    .to_num::<i32>(),
+                (SimFixed::from_num(launch_speed)
+                    * crate::sim::movement::homing_movement::sin_bam(launch_pitch_bam))
+                .to_num::<i32>(),
+            )
+        } else if guidance.is_some() {
+            // RESIDUAL (GSI-08.06): the homing arm here is two-dimensional —
+            // `BulletClass::HomingTrack` owns the native pitch control and is
+            // not ported, so the launch pitch is dropped and the bullet keeps
+            // its launch z. Trigger: a homing shot at a target more than 200
+            // leptons above or below the muzzle. Player effect: the missile
+            // flies flat and detonates at the target's horizontal position
+            // instead of climbing to it. Frequency: cliff and building-roof
+            // engagements. Downstream risk: none beyond the impact z.
+            ProjectileVelocity::new(
+                (SimFixed::from_num(launch_speed)
+                    * crate::sim::movement::homing_movement::cos_bam(launch_heading_bam))
+                .to_num::<i32>(),
+                (SimFixed::from_num(launch_speed)
+                    * crate::sim::movement::homing_movement::sin_bam(launch_heading_bam))
+                .to_num::<i32>(),
+                0,
+            )
         } else {
             ProjectileVelocity::new(0, 0, 0)
         };
@@ -7621,19 +7847,30 @@ pub(crate) fn resolve_attacker_fire(
                 weapon: interner.intern(selected.weapon_id),
                 owner: snap.owner,
             },
-            speed_leptons_per_frame: weapon.speed.clamp(1, i32::from(u16::MAX)) as u16,
+            speed_leptons_per_frame: launch_speed.clamp(0, i32::from(u16::MAX)) as u16,
             velocity,
-            trajectory: if ballistic {
-                ProjectileTrajectory::Ballistic { gravity }
-            } else {
-                ProjectileTrajectory::Straight
+            trajectory: match vertical {
+                Some(detonation_altitude) => ProjectileTrajectory::Vertical {
+                    detonation_altitude,
+                    acceleration,
+                    max_speed: weapon.speed,
+                    heading_bam: launch_heading_bam,
+                    pitch_bam: launch_pitch_bam,
+                },
+                None if ballistic => ProjectileTrajectory::Ballistic { gravity },
+                None => ProjectileTrajectory::Straight,
             },
             guidance,
             visual,
             arm_frames,
             fuse_frames: None,
-            ranged_fuse: tracks_target
-                || projectile_type.is_some_and(|projectile| projectile.ranged),
+            // `BulletClass::AI 0x00467C1C`: the fuse runs when `ROT > 0` or
+            // `Ranged=`. `Dropping=` (`0x00467C78`) then discards its result
+            // outright, which is equivalent to never admitting the fuse — the
+            // detector's running minimum feeds nothing else.
+            ranged_fuse: (tracks_target
+                || projectile_type.is_some_and(|projectile| projectile.ranged))
+                && !projectile_type.is_some_and(|projectile| projectile.dropping),
             tracks_target,
             target_expiry: TargetExpiryPolicy::DetonateAtLastKnown,
             collision,

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -7762,6 +7762,24 @@ pub(crate) fn resolve_attacker_fire(
         .sqrt())
         .trunc() as i32;
         let mut launch_speed = weapon.speed.min(launch_distance / 2).max(0);
+        // RESIDUAL (VERA-internal consequence of an otherwise native clamp,
+        // gamemd equivalent UNCHECKED at this separation): the integer `dist/2`
+        // makes `launch_speed` 0 at exactly 1 lepton of muzzle-to-target
+        // separation. Native reaches 0 there too, but its `ROT < 1` non-Vertical
+        // arm then subtracts `Rules.Gravity` every frame at `0x00467402` and the
+        // bullet falls out on the ground probe. VERA's `Straight` arm has no
+        // gravity (recorded separately), so `step_toward(pos, target, 0)`
+        // returns `pos`, `candidate == target_position` is never true, and the
+        // only other removals — target loss and off-grid — cannot fire for a
+        // live on-map target: the projectile never terminates and stays in a
+        // hashed store. Trigger: a `Straight`, non-guided projectile fired at a
+        // target exactly 1 lepton away. Player effect: an invisible immortal
+        // entry in deterministic state, growing one per such shot. Frequency:
+        // effectively zero — 1/256th of a cell of separation, and only for the
+        // four stock projectiles that take the `Straight` arm (`Sonic`,
+        // `Cannon2`, `ASWVirt`, `PulsPr`). Downstream risk: unbounded store
+        // growth and a diverging hash if it ever fires; giving the `Straight`
+        // arm its native gravity closes both this and residual 2 at once.
         // `0x006FEA36`..`0x006FEA4C`: a `ROT > 0` or `Vertical` bullet from a
         // firer with `RadialFireSegments == 0` — every stock firer except the
         // Aegis Cruiser — launches at one lepton per frame, and the weapon's

--- a/src/sim/projectile.rs
+++ b/src/sim/projectile.rs
@@ -1118,6 +1118,19 @@ impl ProjectileStore {
             // Nothing else consults `Arm`: the detonation admission at
             // `BulletClass::AI 0x00467C70` never tests it.
             //
+            // One exception to "only AFTER the live-object pass", noted for
+            // accuracy rather than as a defect: shrapnel children are admitted
+            // from INSIDE the walk — `object_ai_visit_one` calls
+            // `commit_logic_projectile_detonations` (`world/techno_ai.rs`) and
+            // `for_each_live_object` reloads the length each iteration — so
+            // such a child IS visited in its own launch tick, where a
+            // decrement-at-top would arm it one frame early. Inert in stock:
+            // the only `ShrapnelWeapon=` chains are
+            // `SuperCometFragment`/`TeslaFragment`/`CometFragment` ->
+            // `[SuperSmallCometP]`/`[SmallTeslaP]`/`[SmallCometP]`, all
+            // `Inviso=yes` with no `Ranged=` and no `Arm=`, so no shrapnel child
+            // carries a fuse and this counter never runs for one.
+            //
             // RESIDUAL (VERA-internal, gamemd equivalent UNCHECKED): native's
             // `LogicClass::PerTickUpdate @ 0x0055AFB0` object loop reloads its
             // count after every `vtable+0x5C` callback and

--- a/src/sim/projectile.rs
+++ b/src/sim/projectile.rs
@@ -146,10 +146,13 @@ pub struct ProjectileGuidance {
     pub fuse_reference: ProjectileCoord,
     /// `Bullet+0x118`, the warm-up counter of the closing-rate detonation
     /// heuristic on the homing arm. Native runs the plain accumulate while it
-    /// is below 60 and only then admits the decay test.
+    /// is below 60 and only then admits the decay test — `0x00466FB4
+    /// MOV EAX,[EBP+0x118] / CMP EAX,0x3C / JGE`, then `INC EAX /
+    /// MOV [EBP+0x118],EAX` on the warm-up side.
     pub closing_frames: u16,
-    /// `Bullet+0x11C`, the closing-rate accumulator of the same heuristic, held
-    /// as native `double` bits because the native update is
+    /// `Bullet+0x120`, the closing-rate accumulator of the same heuristic
+    /// (`0x00466FD8 FLD double ptr [EBP+0x120]` / `0x00466FEE FST double ptr
+    /// [EBP+0x120]`), held as native `double` bits because the native update is
     /// `accum * 0.9833333333333333 + delta` in x87 doubles.
     pub closing_accumulator_bits: u64,
 }
@@ -419,8 +422,28 @@ pub enum TargetExpiryPolicy {
 
 /// Terrain checks admitted for one `BulletClass` flight.
 ///
-/// The `Vertical` arm owns its own floor and bridge probe inside
-/// `BulletClass::AI 0x00467334`ff., so a vertical bullet takes none of these.
+/// `native_cell_collision` models the ground-height / bridge-deck / building
+/// block at `BulletClass::AI 0x004674AE`..`0x00467778`. That block lives inside
+/// the `ROT < 1, Vertical = no` arm: `0x004671D0 MOV CL,[EAX+0x2C0] /
+/// 0x004671D6 TEST CL,CL / 0x004671D8 JZ 0x00467402` reaches it only when
+/// `Vertical == 0`, and a `Vertical` bullet takes the `0x004671DE`..`0x00467390`
+/// arm instead, which runs its own `DetonationAltitude` / floor / bridge probe.
+/// That is why the flag is narrowed on `!vertical` — not because a `Vertical`
+/// bullet skips every terrain test.
+///
+/// RESIDUAL (GSI-08.08) — the shared post-move probe `FUN_00468BB0` is not
+/// modelled for ANY trajectory. `BulletClass::AI 0x00467BD1` calls it for every
+/// bullet whose impact flag is still clear (`0x00467BA4 MOV AL,[ESP+0x18] /
+/// TEST AL,AL / JNZ 0x00467BF0` — there is no `Vertical` or `ROT` test), and it
+/// detonates on `SubjectToCliffs`/`SubjectToWalls` cliff geometry
+/// (`FUN_004CC360`), on an altitude below `DAT_0089DE70 * -4`, on descending
+/// past an `AA` target, on the `Level` water branch, and on closing within
+/// `0x80` of an air target. Trigger: any bullet crossing a cliff, or an `AA`
+/// shot passing its target. Player effect: those shots keep flying where native
+/// would have detonated them. Frequency: zero for the two `Vertical` stock
+/// projectiles (`[BlimpBombP]`/`[BlimpBombPE]` author none of the gating keys);
+/// otherwise cliff-crossing shots on hilly maps. Downstream risk: none beyond
+/// the impact coordinate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ProjectileCollisionPolicy {
     /// `BulletTypeClass::Level`: detonate after entering a non-water cell.
@@ -588,6 +611,15 @@ fn scatter_angle_radians(scenario_rng: &mut SimRng) -> f64 {
 /// `flak` selects the range-scaled arm taken when
 /// `FlakScatter && !Inviso` (`0x006FE699`/`0x006FE6A7`); stock `[FlakTProj]`
 /// is its only user.
+///
+/// **The axis binding below is deliberate and is NOT the one the mapping ledger
+/// records.** The ledger's §3a has sine and cosine swapped (`dX' = sin`,
+/// `dY' = cos`). Walked in assembly: the `Math__CosFromTable @ 0x004CAD00`
+/// result is the term that reaches the X `FIADD` at `0x006FE7E5`, and the
+/// `Math__SinFromTable @ 0x004CACB0` result is the term that reaches the Y
+/// `FSUBR` at `0x006FE7C0` — so `dX += cos(theta) * mag` and
+/// `dY -= sin(theta) * mag`, as written. Do not "correct" this back to the
+/// ledger.
 pub fn projectile_launch_scatter(
     delta: (i32, i32, i32),
     ballistic_scatter: i32,
@@ -1068,11 +1100,37 @@ impl ProjectileStore {
             // before entering the trajectory portion of BulletClass::AI.
             projectile.visual.advance();
 
-            // `ProximityDetector::Check @ 0x004E11F0` reads
-            // `CurrentFrame - launchFrame` against `Arm=`, so the counter has
-            // already advanced by one when the bullet's first AI frame runs.
-            // Nothing else consults it: the detonation admission at
-            // `BulletClass::AI 0x00467C70` never tests `Arm`.
+            // The arm gate is a WALL-CLOCK frame delta, not a count of AI
+            // visits: `ProximityDetector::Setup @ 0x004E1130` stores
+            // `g_CurrentFrameCounter` into detector `+0x0C` at launch and
+            // `ProximityDetector::Check @ 0x004E11F0` admits the fuse on
+            // `Arm (+0x14) <= g_CurrentFrameCounter - [+0x0C]`. VERA admits a
+            // projectile only AFTER the live-object pass
+            // (`World::advance_tick` -> `tick_combat_with_fatal_lifecycle` ->
+            // `Simulation::admit_projectile`, `world/mod.rs`; the follow-up
+            // tail walk `visit_combat_appended_wave_tail` visits Waves only),
+            // so a projectile's first `advance_one` runs on the tick after
+            // launch, where the native delta is already 1. Decrementing at the
+            // top of the frame therefore reproduces `Arm <= elapsed` on every
+            // frame — and it does so whether or not native's LogicClass pass
+            // also runs a launch-frame `BulletClass::AI`, because that question
+            // changes how many AI visits precede a frame, not the frame delta.
+            // Nothing else consults `Arm`: the detonation admission at
+            // `BulletClass::AI 0x00467C70` never tests it.
+            //
+            // RESIDUAL (VERA-internal, gamemd equivalent UNCHECKED): native's
+            // `LogicClass::PerTickUpdate @ 0x0055AFB0` object loop reloads its
+            // count after every `vtable+0x5C` callback and
+            // `LogicClass::RegisterObject @ 0x0055BAA0` tail-appends, so a
+            // bullet fired from an earlier index MAY take a launch-frame AI
+            // that VERA skips; the Ghidra plate comment on `BulletClass::AI`
+            // records same-pass execution of a concrete appended object as
+            // UNCHECKED. Trigger: every persistent projectile. Player effect:
+            // the shot's whole flight is one frame behind native, so it lands
+            // one frame late — at the new 1-4 leptons/frame launch speed that
+            // is a few leptons of travel. Frequency: every tracked shot.
+            // Downstream risk: deterministic state only; the arm gate above is
+            // unaffected because it is keyed on the frame counter.
             if projectile.arm_frames_remaining > 0 {
                 projectile.arm_frames_remaining -= 1;
             }

--- a/src/sim/projectile.rs
+++ b/src/sim/projectile.rs
@@ -5,6 +5,41 @@
 //! [`ProjectileDetonation`] into damage, warhead effects, and terrain changes.
 //! Keeping that handoff narrow lets the world phase place this system at the
 //! verified native frame rung without duplicating combat arithmetic here.
+//!
+//! ## `BulletClass::AI @ 0x004666E0` — the three flight arms
+//!
+//! Native selects an arm exactly twice, at `0x004668D1` on `ROT < 1` and then
+//! at `0x004671D0` on `Vertical` (`BulletTypeClass+0x2C0`). Nothing else takes
+//! part: `Arcing`, `SubjectToCliffs`, `SubjectToElevation`, `Proximity`,
+//! `FlakScatter`, `Inviso` and `Cluster` are launch-time or detonation-time
+//! keys. [`ProjectileTrajectory`] carries the same three arms.
+//!
+//! Detonation admission at `0x00467C70` is `impact || (!Dropping && fuse != 0)`
+//! and contains NO `Arm=` test — `Arm=` is written once into the bullet's
+//! embedded `ProximityDetector` at `BulletClass::Fire 0x00468A5D` and gates
+//! that one fuse result. A collision, a ground or bridge contact, a
+//! `DetonationAltitude` crossing, or a target reach all detonate an unarmed
+//! bullet.
+//!
+//! RESIDUAL (GSI-08.06) — a guided bullet that overshoots a fast target has
+//! three native termination rules; two of them are here (the reach test and
+//! the closing-rate heuristic) and one is not: the homing arm's own
+//! `GetAltitude() < 1` ground test at the same site. Trigger: a homing shot
+//! whose launch z sits at or below the terrain it crosses. Player effect: the
+//! missile flies over a hill it should hit. Frequency: only on rising terrain,
+//! since the arm holds its launch z. Downstream risk: it is one of the leak
+//! bounds, so the closing-rate heuristic is the only one left for a missile
+//! that never closes — it does terminate, but after up to a few seconds.
+//!
+//! RESIDUAL (GSI-08.06) — the ballistic arm's `reached_target` test is
+//! VERA-internal, gamemd equivalent UNCHECKED: native's `ROT < 1` arms
+//! terminate only on the ground clamp, the wall/building probe and the fuse,
+//! and its `0x00467CEC` "snap onto the target when within `max(128, 2|v|)`" is
+//! a coordinate adjustment applied AFTER detonation is already admitted, not a
+//! reason to detonate. Trigger: every arcing shell. Player effect: a shell can
+//! detonate one frame early, in the air, instead of on the ground at its
+//! landing point. Frequency: continuous for `Arcing` weapons. Downstream risk:
+//! it partly cancels the new launch scatter for `[FlakTProj]`.
 
 use std::collections::BTreeMap;
 
@@ -45,7 +80,28 @@ impl ProjectileVelocity {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ProjectileTrajectory {
     Straight,
-    Ballistic { gravity: i32 },
+    Ballistic {
+        gravity: i32,
+    },
+    /// gamemd-derived: `BulletClass::AI @ 0x004666E0`, the `ROT < 1 &&
+    /// Vertical` arm entered at `0x004671E0`. No gravity is applied there and
+    /// the launch direction is never changed — only the magnitude ramps by
+    /// `Acceleration=` (`BulletTypeClass+0x2D0`) toward `MaxSpeed`
+    /// (`Bullet+0x110`), and flight ends on `z > DetonationAltitude`
+    /// (`+0x2BC`, read at `0x00467334`), a negative altitude, or a bridge-deck
+    /// crossing.
+    ///
+    /// The direction is kept as the launch (yaw, pitch) BAM pair rather than
+    /// as an integer velocity: native renormalises a *double* velocity vector
+    /// every frame, and at the 1-lepton launch magnitude an integer vector
+    /// would quantise the direction away.
+    Vertical {
+        detonation_altitude: i32,
+        acceleration: i32,
+        max_speed: i32,
+        heading_bam: u16,
+        pitch_bam: u16,
+    },
 }
 
 /// Persistent inputs and facing state for the `BulletClass::Update` ROT branch.
@@ -57,13 +113,45 @@ pub enum ProjectileTrajectory {
 pub struct ProjectileGuidance {
     pub rot: i32,
     pub missile_rot_var: SimFixed,
-    pub course_lock_frames: u16,
+    /// `BulletTypeClass::CourseLockDuration` (`+0x2E0`). This is the authored
+    /// duration, not a countdown: `BulletClass::AI @ 0x0046695B` compares its
+    /// own frame counter against it and latches `IsCourseLocked` (`+0x105`,
+    /// constructed to 1 at `0x004663B6`) off exactly once.
+    pub course_lock_duration: u16,
     pub sidewinder_phase: u8,
     pub airburst: bool,
     pub very_high: bool,
     pub level: bool,
-    pub pitch_bam: u16,
+    /// Flight heading as a math BAM (`0` = +X). Native keeps the direction
+    /// implicitly in the double velocity vector it renormalises each frame at
+    /// `0x004669F3`; VERA's velocity is integer leptons, so at the 1-lepton
+    /// launch magnitude the direction has to be carried explicitly.
+    /// `heading_bam == facing16 - 0x4000` for a native launch facing.
+    pub heading_bam: u16,
     pub frames_elapsed: u32,
+    /// `Bullet+0x110`, written from the weapon's `Speed=` (`WeaponTypeClass
+    /// +0xA8`) at `TechnoClass::FireAt 0x006FEA46`. This is the ceiling the
+    /// `Acceleration=` ramp climbs toward, never the launch speed.
+    pub max_speed: u16,
+    /// `BulletTypeClass::Acceleration` (`+0x2D0`, constructor default 3),
+    /// consumed by the homing ramp at `BulletClass::AI 0x00466985`.
+    pub acceleration: i32,
+    /// The proximity fuse's reference coordinate, frozen at launch.
+    /// `ProximityDetector::Setup @ 0x004E1130` (sole caller
+    /// `BulletClass::Fire 0x00468A93`) copies the target's launch-time
+    /// `GetTargetCoords` into detector `+0x18..+0x20` once;
+    /// `ProximityDetector::Check @ 0x004E11F0` (sole caller
+    /// `BulletClass::AI 0x00467C35`) measures the live bullet coordinate
+    /// against that stored copy and never rewrites it.
+    pub fuse_reference: ProjectileCoord,
+    /// `Bullet+0x118`, the warm-up counter of the closing-rate detonation
+    /// heuristic on the homing arm. Native runs the plain accumulate while it
+    /// is below 60 and only then admits the decay test.
+    pub closing_frames: u16,
+    /// `Bullet+0x11C`, the closing-rate accumulator of the same heuristic, held
+    /// as native `double` bits because the native update is
+    /// `accum * 0.9833333333333333 + delta` in x87 doubles.
+    pub closing_accumulator_bits: u64,
 }
 
 /// The independently proved altitude-policy result of
@@ -329,10 +417,10 @@ pub enum TargetExpiryPolicy {
     DetonateAtLastKnown,
 }
 
-/// Terrain checks admitted for one ordinary `BulletClass` flight.
+/// Terrain checks admitted for one `BulletClass` flight.
 ///
-/// The cases intentionally stay narrow: special trajectory kernels retain the
-/// typed immediate path until their native coordinate contracts are ported.
+/// The `Vertical` arm owns its own floor and bridge probe inside
+/// `BulletClass::AI 0x00467334`ff., so a vertical bullet takes none of these.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ProjectileCollisionPolicy {
     /// `BulletTypeClass::Level`: detonate after entering a non-water cell.
@@ -468,6 +556,74 @@ pub fn projectile_burst_plan(airburst: bool, cluster: i32) -> ProjectileBurstPla
         random_radius_rolls: count,
         random_coordinate_calls: count,
     }
+}
+
+/// One uniform BAM angle drawn the way `TechnoClass::FireAt` and
+/// `BulletClass::Fire` draw theirs: a raw `Random__RandomRanged(0, 0x7FFFFFFE)`
+/// mapped to `[0, 2π)`, pushed through the 16-bit facing quantisation, and
+/// converted back to radians.
+///
+/// Named locations: `0x006FE83D`..`0x006FE872` (plain arm),
+/// `0x006FE75B`..`0x006FE790` (flak arm), `0x00468807`..`0x00468840`
+/// (`BulletClass::Fire`). Constants read from the image:
+/// `[0x007E3570] = 1/(2^31 - 1)`, `[0x007E3CC0] = 2π`,
+/// `[0x007E2820] = π/2`, `[0x007E2818] = -10430.06004058427`,
+/// `[0x007E2810] = -9.587672516830327e-05`.
+fn scatter_angle_radians(scenario_rng: &mut SimRng) -> f64 {
+    const INVERSE_RANDOM_SPAN: f64 = 4.656_612_875_245_797e-10;
+    const FACING_SCALE: f64 = -10430.060_040_584_27;
+    const BAM_TO_RADIANS: f64 = -9.587_672_516_830_327e-05;
+    let raw = scenario_rng.next_range_u32_inclusive(0, 0x7fff_fffe);
+    let uniform = f64::from(raw as i32) * INVERSE_RANDOM_SPAN * std::f64::consts::TAU;
+    let bam = ((uniform - std::f64::consts::FRAC_PI_2) * FACING_SCALE).trunc() as i32 as i16;
+    f64::from(i32::from(bam) - 0x3fff) * BAM_TO_RADIANS
+}
+
+/// `TechnoClass::FireAt` launch-time scatter, gated by `Inaccurate && Arcing`
+/// at `0x006FE67D`/`0x006FE68B`. Both arms consume exactly two Scenario RNG
+/// draws — magnitude first, then angle — and both OFFSET the target delta
+/// rather than replacing it (`FIADD` on X at `0x006FE7E5`, `FSUBR` on Y at
+/// `0x006FE7C0`). Z is carried through untouched.
+///
+/// `flak` selects the range-scaled arm taken when
+/// `FlakScatter && !Inviso` (`0x006FE699`/`0x006FE6A7`); stock `[FlakTProj]`
+/// is its only user.
+pub fn projectile_launch_scatter(
+    delta: (i32, i32, i32),
+    ballistic_scatter: i32,
+    weapon_range_leptons: i32,
+    flak: bool,
+    scenario_rng: &mut SimRng,
+) -> (i32, i32, i32) {
+    let magnitude = if flak {
+        // `0x006FE6AD`..`0x006FE6F1` builds the distance from f32 components.
+        let fx = delta.0 as f32;
+        let fy = delta.1 as f32;
+        let fz = delta.2 as f32;
+        let distance = ((f64::from(fx) * f64::from(fx)
+            + f64::from(fy) * f64::from(fy)
+            + f64::from(fz) * f64::from(fz))
+        .sqrt()) as f32;
+        let roll = scenario_rng.next_range_u32_inclusive(0, ballistic_scatter.max(0) as u32) as i32;
+        let scaled = i64::from(roll) * i64::from(distance.trunc() as i32);
+        if weapon_range_leptons == 0 {
+            0
+        } else {
+            (scaled / i64::from(weapon_range_leptons)) as i32
+        }
+    } else {
+        // `0x006FE815`..`0x006FE81C`: `RandomRanged(BallisticScatter / 2,
+        // BallisticScatter)`, the halving being an arithmetic `SAR` by one.
+        let high = ballistic_scatter.max(0);
+        scenario_rng.next_range_u32_inclusive((high / 2) as u32, high as u32) as i32
+    };
+    let theta = scatter_angle_radians(scenario_rng);
+    let magnitude = f64::from(magnitude);
+    (
+        (theta.cos() * magnitude + f64::from(delta.0)).trunc() as i32,
+        (f64::from(delta.1) - theta.sin() * magnitude).trunc() as i32,
+        delta.2,
+    )
 }
 
 /// Produce the next `BulletClass::Explode` cluster coordinate.
@@ -608,7 +764,13 @@ pub struct ProjectileSpawn {
     /// this destination; homing shots replace it from the live target table.
     pub initial_target_position: ProjectileCoord,
     pub payload: ProjectilePayload,
-    /// Native weapon speed expressed by the caller in leptons per logical frame.
+    /// The bullet's CURRENT speed in leptons per frame — native's
+    /// `ftol(|velocity|)`, not the weapon's `Speed=`. `TechnoClass::FireAt
+    /// @ 0x006FEA3A` launches every `ROT > 0` or `Vertical` bullet at 1, and
+    /// `BulletClass::Fire @ 0x00468B2C` renormalises a `ROT > 0` bullet's
+    /// vector to magnitude 1.0 regardless; `Speed=` only becomes the ceiling
+    /// stored at `Bullet+0x110`. Non-homing, non-vertical bullets do keep the
+    /// launch speed here, clamped to `dist/2` at `0x006FE9FE`.
     pub speed_leptons_per_frame: u16,
     pub velocity: ProjectileVelocity,
     pub trajectory: ProjectileTrajectory,
@@ -746,8 +908,11 @@ impl ProjectileStore {
         true
     }
 
-    /// Admit one ordinary projectile. Vertical, airburst, cluster, and other
-    /// special trajectories remain outside this bounded foundation.
+    /// Admit one projectile. All three `BulletClass::AI` flight arms are
+    /// represented — `ROT >= 1` homing, the `ROT < 1` ballistic arm, and the
+    /// `ROT < 1, Vertical` arm; an `Inviso` bullet still resolves on combat's
+    /// immediate path because native's `BulletClass::Fire` scales its velocity
+    /// by `0.0 / |v|` at `0x00468A0E` and resolves the impact in the same call.
     // AbstractClass::AssignUniqueID @ 0x00410230 obtains this identity from
     // ScenarioClass::NextUniqueID @ 0x0068BCB0; the store never owns a second
     // allocator.
@@ -770,7 +935,10 @@ impl ProjectileStore {
                 arm_frames_remaining: spawn.arm_frames,
                 fuse_frames_remaining: spawn.fuse_frames,
                 ranged_fuse: spawn.ranged_fuse,
-                last_distance_half: i32::MAX,
+                // `ProximityDetector::Setup @ 0x004E1130` seeds `+0x24` with
+                // the FULL launch distance from the bullet to its reference
+                // coordinate, not the halved form `Check` writes afterwards.
+                last_distance_half: coord_distance(spawn.origin, spawn.initial_target_position),
                 tracks_target: spawn.tracks_target,
                 target_expiry: spawn.target_expiry,
                 collision: spawn.collision,
@@ -789,6 +957,7 @@ impl ProjectileStore {
     /// candidate next coordinate; object collision remains a later port.
     pub fn advance(
         &mut self,
+        binary_frame: u32,
         target_positions: &BTreeMap<u64, ProjectileCoord>,
         terrain: Option<&ResolvedTerrainGrid>,
         shared_cell_dummy: &SharedCellDummy,
@@ -797,6 +966,7 @@ impl ProjectileStore {
         let ids: Vec<u64> = self.projectiles.keys().copied().collect();
         self.advance_selected(
             &ids,
+            binary_frame,
             |id| target_positions.get(&id).copied(),
             terrain,
             shared_cell_dummy,
@@ -808,6 +978,7 @@ impl ProjectileStore {
     pub(crate) fn advance_one(
         &mut self,
         id: u64,
+        binary_frame: u32,
         target_position: impl FnMut(u64) -> Option<ProjectileCoord>,
         terrain: Option<&ResolvedTerrainGrid>,
         shared_cell_dummy: &SharedCellDummy,
@@ -818,6 +989,7 @@ impl ProjectileStore {
         }
         Some(self.advance_selected(
             &[id],
+            binary_frame,
             target_position,
             terrain,
             shared_cell_dummy,
@@ -826,9 +998,11 @@ impl ProjectileStore {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn advance_selected(
         &mut self,
         ids: &[u64],
+        binary_frame: u32,
         mut target_position: impl FnMut(u64) -> Option<ProjectileCoord>,
         terrain: Option<&ResolvedTerrainGrid>,
         shared_cell_dummy: &SharedCellDummy,
@@ -861,16 +1035,17 @@ impl ProjectileStore {
                             result.expired.push(id);
                             continue;
                         }
+                        // `Arm=` is NOT consulted here. The detonation
+                        // admission at `BulletClass::AI 0x00467C70` tests only
+                        // the impact flag and the proximity-fuse result; the
+                        // Arm counter lives inside `ProximityDetector::Check`
+                        // and gates that one result alone.
                         TargetExpiryPolicy::DetonateAtLastKnown => {
-                            if projectile.arm_frames_remaining == 0 {
-                                result.detonations.push(detonation(
-                                    projectile,
-                                    projectile.last_target_position,
-                                    ProjectileDetonationReason::TargetExpired,
-                                ));
-                            } else {
-                                result.expired.push(id);
-                            }
+                            result.detonations.push(detonation(
+                                projectile,
+                                projectile.last_target_position,
+                                ProjectileDetonationReason::TargetExpired,
+                            ));
                             continue;
                         }
                     },
@@ -893,10 +1068,67 @@ impl ProjectileStore {
             // before entering the trajectory portion of BulletClass::AI.
             projectile.visual.advance();
 
-            let candidate = if let Some(guidance) = projectile.guidance.as_mut() {
-                // `BulletClass::Update` @ 0x00466BD0 enters 0x005B20F0 only
-                // from the ROT-positive branch; ordinary straight flight does
-                // not share this steering decision.
+            // `ProximityDetector::Check @ 0x004E11F0` reads
+            // `CurrentFrame - launchFrame` against `Arm=`, so the counter has
+            // already advanced by one when the bullet's first AI frame runs.
+            // Nothing else consults it: the detonation admission at
+            // `BulletClass::AI 0x00467C70` never tests `Arm`.
+            if projectile.arm_frames_remaining > 0 {
+                projectile.arm_frames_remaining -= 1;
+            }
+
+            let previous_position = projectile.position;
+            // Native `local_198` — set by any arm that hits something. It is
+            // the only value besides the fuse that admits a detonation.
+            let mut impact_flag = false;
+            // Native carries one impact flag; VERA keeps the reason beside it
+            // purely as diagnostic provenance for the combat handoff.
+            let mut impact_reason = ProjectileDetonationReason::Collision;
+            // Native `local_190 == 2`: `FUN_00568350` says the new coordinate
+            // left the map, and `LAB_00467B7A` removes the bullet through
+            // `vtable+0x124(2)` and `ObjectClass::UnInit` with NO detonation.
+            let mut left_the_map = false;
+            let mut snap_impact: Option<ProjectileCoord> = None;
+
+            let candidate = if let Some(mut guidance) = projectile.guidance {
+                // ---- ARM C, `BulletClass::AI 0x004668D9`..`0x00466A33` ----
+                // The speed ramp runs before any steering. `Bullet+0x110` is
+                // MaxSpeed; the current magnitude is `ftol(|v|)`, which native
+                // keeps integral from the 1.0 launch onward.
+                let max_speed = i32::from(guidance.max_speed);
+                let current_speed = i32::from(projectile.speed_leptons_per_frame);
+                // `0x00466925`..`0x00466978`: with `CourseLockDuration == 0`
+                // the lock clears once MaxSpeed reaches 40 (`CMP ...,0x28` /
+                // `JGE`) or the magnitude comes within 0.5 of MaxSpeed;
+                // otherwise a per-bullet counter runs the authored duration
+                // out. Both releases latch, and both are monotone in the
+                // ramping speed, so deriving them per frame is equivalent to
+                // native's stored `IsCourseLocked` byte.
+                let course_locked = if guidance.course_lock_duration == 0 {
+                    max_speed < 40 && max_speed > current_speed
+                } else {
+                    guidance.frames_elapsed.saturating_add(1)
+                        < u32::from(guidance.course_lock_duration)
+                };
+                // `0x0046699D`: a still-locked bullet with no authored
+                // duration ramps at one lepton on even frames and none on odd.
+                let acceleration = if course_locked && guidance.course_lock_duration == 0 {
+                    i32::from(binary_frame.is_multiple_of(2))
+                } else {
+                    guidance.acceleration
+                };
+                let next_speed = if current_speed < max_speed {
+                    (current_speed + acceleration).min(max_speed)
+                } else if current_speed > max_speed {
+                    // `0x00466A33`: overspeed sheds `Acceleration / 2` a frame
+                    // and floors at zero.
+                    (current_speed - acceleration / 2).max(0)
+                } else {
+                    current_speed
+                };
+
+                // `BulletClass::HomingTrack` steering. The turn word is zero
+                // while course-locked (`bVar4 &= ~-(IsCourseLocked != 0)`).
                 let target_distance = horizontal_distance(projectile.position, target_position);
                 let phase = guidance
                     .frames_elapsed
@@ -905,42 +1137,69 @@ impl ProjectileStore {
                     + guidance.missile_rot_var
                     + SimFixed::from_num(1))
                     * SimFixed::from_num(guidance.rot);
-                let turn_word = projectile_rot_turn_word_fixed(
-                    varied_rot,
-                    target_distance,
-                    guidance.course_lock_frames != 0,
-                );
-                let current_yaw = atan2_bam(
-                    SimFixed::from_num(projectile.velocity.y),
-                    SimFixed::from_num(projectile.velocity.x),
-                );
+                let turn_word =
+                    projectile_rot_turn_word_fixed(varied_rot, target_distance, course_locked);
                 let desired_yaw = atan2_bam(
                     SimFixed::from_num(target_position.y - projectile.position.y),
                     SimFixed::from_num(target_position.x - projectile.position.x),
                 );
-                let yaw = step_toward_bam_inclusive(current_yaw, desired_yaw, turn_word);
-                let horizontal_speed = i64::from(projectile.velocity.x)
-                    .pow(2)
-                    .saturating_add(i64::from(projectile.velocity.y).pow(2))
-                    .isqrt() as i32;
-                let horizontal_speed = if horizontal_speed == 0 {
-                    i32::from(projectile.speed_leptons_per_frame)
-                } else {
-                    horizontal_speed
-                };
+                let yaw = step_toward_bam_inclusive(guidance.heading_bam, desired_yaw, turn_word);
+                guidance.heading_bam = yaw;
                 projectile.velocity.x =
-                    (SimFixed::from_num(horizontal_speed) * cos_bam(yaw)).to_num::<i32>();
+                    (SimFixed::from_num(next_speed) * cos_bam(yaw)).to_num::<i32>();
                 projectile.velocity.y =
-                    (SimFixed::from_num(horizontal_speed) * sin_bam(yaw)).to_num::<i32>();
+                    (SimFixed::from_num(next_speed) * sin_bam(yaw)).to_num::<i32>();
+                projectile.speed_leptons_per_frame =
+                    next_speed.clamp(0, i32::from(u16::MAX)) as u16;
                 guidance.frames_elapsed = guidance.frames_elapsed.wrapping_add(1);
-                if guidance.course_lock_frames > 0 {
-                    guidance.course_lock_frames -= 1;
-                }
-                ProjectileCoord::new(
+
+                let candidate = ProjectileCoord::new(
                     projectile.position.x.saturating_add(projectile.velocity.x),
                     projectile.position.y.saturating_add(projectile.velocity.y),
                     projectile.position.z.saturating_add(projectile.velocity.z),
-                )
+                );
+
+                // `HomingTrack` returns the post-step distance to the target
+                // coordinate and the arm detonates on `dist <= |v| * 0.5`,
+                // snapping the impact onto the target coordinate unless the
+                // bullet is `Airburst`.
+                let reached_distance = coord_distance(candidate, target_position);
+                if i64::from(reached_distance) * 2 <= i64::from(next_speed) {
+                    impact_flag = true;
+                    impact_reason = ProjectileDetonationReason::ReachedTarget;
+                    if !guidance.airburst {
+                        snap_impact = Some(target_position);
+                    }
+                }
+
+                // The closing-rate heuristic. `delta` is how much closer this
+                // step got; native accumulates it raw for the first 60 frames
+                // and then decays, detonating inside the `[0, 60)` window when
+                // the bullet is neither `Airburst` nor `VeryHigh`. It runs
+                // only once the course lock has cleared.
+                if !course_locked {
+                    let delta = f64::from(
+                        coord_distance(previous_position, target_position) - reached_distance,
+                    );
+                    let accumulator = f64::from_bits(guidance.closing_accumulator_bits);
+                    if guidance.closing_frames < 60 {
+                        guidance.closing_frames += 1;
+                        guidance.closing_accumulator_bits = (accumulator + delta).to_bits();
+                    } else {
+                        let decayed = accumulator * 0.983_333_333_333_333_3 + delta;
+                        guidance.closing_accumulator_bits = decayed.to_bits();
+                        if (0.0..60.0).contains(&decayed)
+                            && !guidance.airburst
+                            && !guidance.very_high
+                        {
+                            impact_flag = true;
+                            impact_reason = ProjectileDetonationReason::ReachedTarget;
+                        }
+                    }
+                }
+
+                projectile.guidance = Some(guidance);
+                candidate
             } else {
                 match projectile.trajectory {
                     ProjectileTrajectory::Straight => {
@@ -964,67 +1223,140 @@ impl ProjectileStore {
                             projectile.position.z.saturating_add(projectile.velocity.z),
                         )
                     }
+                    // ---- ARM A, `BulletClass::AI 0x004671E0`..`0x00467390` ----
+                    ProjectileTrajectory::Vertical {
+                        detonation_altitude,
+                        acceleration,
+                        max_speed,
+                        heading_bam,
+                        pitch_bam,
+                    } => {
+                        // `0x00467211`: the ramp uses the truncated integer
+                        // magnitude and applies NO clamp on the crossing frame,
+                        // so the magnitude may overshoot MaxSpeed once.
+                        let current_speed = i32::from(projectile.speed_leptons_per_frame);
+                        let next_speed = if current_speed < max_speed {
+                            current_speed + acceleration
+                        } else {
+                            current_speed
+                        };
+                        projectile.speed_leptons_per_frame =
+                            next_speed.clamp(0, i32::from(u16::MAX)) as u16;
+                        let horizontal = SimFixed::from_num(next_speed) * cos_bam(pitch_bam);
+                        projectile.velocity = ProjectileVelocity::new(
+                            (horizontal * cos_bam(heading_bam)).to_num::<i32>(),
+                            (horizontal * sin_bam(heading_bam)).to_num::<i32>(),
+                            (SimFixed::from_num(next_speed) * sin_bam(pitch_bam)).to_num::<i32>(),
+                        );
+                        let candidate = ProjectileCoord::new(
+                            projectile.position.x.saturating_add(projectile.velocity.x),
+                            projectile.position.y.saturating_add(projectile.velocity.y),
+                            projectile.position.z.saturating_add(projectile.velocity.z),
+                        );
+                        // `0x00467334`: `DetonationAltitude` is compared
+                        // against the new WORLD z, not against an altitude
+                        // above ground. Then a negative altitude, then the
+                        // bridge-deck crossing test. No gravity is applied on
+                        // this arm at all.
+                        if candidate.z > detonation_altitude {
+                            impact_flag = true;
+                        } else if terrain_floor_z(terrain, candidate.x, candidate.y)
+                            .is_some_and(|floor| candidate.z < floor)
+                        {
+                            impact_flag = true;
+                        } else if let Some(surface) =
+                            bridge_surface_z(terrain, previous_position, candidate)
+                            && projectile_bridge_crossing(previous_position.z, candidate.z, surface)
+                                != ProjectileBridgeCrossing::None
+                        {
+                            impact_flag = true;
+                        }
+                        candidate
+                    }
                 }
             };
-            if projectile.ranged_fuse && projectile.arm_frames_remaining == 0 {
-                let dx = f64::from(candidate.x - target_position.x);
-                let dy = f64::from(candidate.y - target_position.y);
-                let dz = f64::from(candidate.z - target_position.z);
-                let distance = dx.hypot(dy).hypot(dz).trunc() as i32;
-                let (fuse_mode, next_distance) =
-                    ranged_fuse_distance_step(distance, projectile.last_distance_half);
-                projectile.last_distance_half = next_distance;
-                if fuse_mode != 0 {
-                    result.detonations.push(detonation(
-                        projectile,
-                        candidate,
-                        ProjectileDetonationReason::Fuse,
-                    ));
-                    continue;
-                }
+
+            // `FUN_00568350(newCoord) == 0` -> terminal reason 2. Only the
+            // `ROT < 1` arms run this probe in native, so a homing bullet is
+            // never silently removed for leaving the map.
+            if projectile.guidance.is_none()
+                && let Some(grid) = terrain
+                && !coord_is_on_grid(grid, candidate)
+            {
+                left_the_map = true;
             }
-            if let Some(response) = collides_at(projectile, candidate) {
-                let impact = match response {
+
+            if left_the_map {
+                result.expired.push(id);
+                continue;
+            }
+
+            let collision_impact =
+                collides_at(projectile, candidate).map(|response| match response {
                     ProjectileCollisionResponse::TargetZClamp(impact) => impact,
                     ProjectileCollisionResponse::SlopeMatrixReflect { impact, velocity } => {
                         projectile.velocity = velocity;
                         impact
                     }
-                };
+                });
+            if let Some(impact) = collision_impact {
+                impact_flag = true;
+                impact_reason = ProjectileDetonationReason::Collision;
+                snap_impact = Some(impact);
+            }
+
+            // `ProximityDetector::Check @ 0x004E11F0`. The reference is the
+            // coordinate frozen at launch, the Arm counter gates this result
+            // and nothing else, and `Dropping=` suppresses it entirely at
+            // `0x00467C78` — folded into `ranged_fuse` at construction.
+            let mut fuse_mode = 0;
+            if projectile.ranged_fuse {
+                let reference = projectile
+                    .guidance
+                    .map_or(projectile.last_target_position, |guidance| {
+                        guidance.fuse_reference
+                    });
                 if projectile.arm_frames_remaining == 0 {
+                    let distance = coord_distance(candidate, reference);
+                    let (mode, next_distance) =
+                        ranged_fuse_distance_step(distance, projectile.last_distance_half);
+                    projectile.last_distance_half = next_distance;
+                    fuse_mode = mode;
+                }
+            }
+
+            if !impact_flag && fuse_mode == 0 {
+                projectile.position = candidate;
+                let reached_target = match projectile.trajectory {
+                    ProjectileTrajectory::Ballistic { .. } => {
+                        candidate.z <= target_position.z
+                            && squared_horizontal_distance(candidate, target_position)
+                                <= i64::from(projectile.speed_leptons_per_frame).pow(2)
+                    }
+                    ProjectileTrajectory::Straight if projectile.guidance.is_none() => {
+                        candidate == target_position
+                    }
+                    ProjectileTrajectory::Straight | ProjectileTrajectory::Vertical { .. } => false,
+                };
+                if reached_target {
                     result.detonations.push(detonation(
                         projectile,
-                        impact,
-                        ProjectileDetonationReason::Collision,
+                        candidate,
+                        ProjectileDetonationReason::ReachedTarget,
                     ));
-                } else {
-                    result.expired.push(id);
                 }
                 continue;
             }
 
-            projectile.position = candidate;
-            if projectile.arm_frames_remaining > 0 {
-                projectile.arm_frames_remaining -= 1;
-            }
-            let reached_target = match projectile.trajectory {
-                ProjectileTrajectory::Straight if projectile.guidance.is_none() => {
-                    candidate == target_position
-                }
-                ProjectileTrajectory::Ballistic { .. } => {
-                    candidate.z <= target_position.z
-                        && squared_horizontal_distance(candidate, target_position)
-                            <= i64::from(projectile.speed_leptons_per_frame).pow(2)
-                }
-                ProjectileTrajectory::Straight => false,
+            let impact = snap_impact.unwrap_or(candidate);
+            let reason = if impact_flag {
+                impact_reason
+            } else {
+                ProjectileDetonationReason::Fuse
             };
-            if reached_target && projectile.arm_frames_remaining == 0 {
-                result.detonations.push(detonation(
-                    projectile,
-                    candidate,
-                    ProjectileDetonationReason::ReachedTarget,
-                ));
-            }
+            result
+                .detonations
+                .push(detonation(projectile, impact, reason));
         }
 
         if remove_terminal {
@@ -1052,6 +1384,63 @@ pub fn ranged_fuse_distance_step(distance_fistp: i32, last_distance: i32) -> (i3
     } else {
         (0, distance_half)
     }
+}
+
+/// `Math__ftol(sqrt(dx*dx + dy*dy + dz*dz))` — the truncating straight-line
+/// lepton distance native uses for the proximity fuse, the homing reach test
+/// and the closing-rate accumulator.
+fn coord_distance(a: ProjectileCoord, b: ProjectileCoord) -> i32 {
+    let dx = f64::from(a.x - b.x);
+    let dy = f64::from(a.y - b.y);
+    let dz = f64::from(a.z - b.z);
+    (dx * dx + dy * dy + dz * dz).sqrt().trunc() as i32
+}
+
+/// `CellClass::GetGroundHeight` at a lepton coordinate, or `None` when the
+/// coordinate has no allocated CellClass (headless fixtures and off-map).
+fn terrain_floor_z(terrain: Option<&ResolvedTerrainGrid>, x: i32, y: i32) -> Option<i32> {
+    let rx = u16::try_from(x.div_euclid(256)).ok()?;
+    let ry = u16::try_from(y.div_euclid(256)).ok()?;
+    let cell = terrain?.cell(rx, ry)?;
+    crate::util::lepton::ground_height_leptons(cell.level, cell.slope_type, x, y).ok()
+}
+
+/// The bridge deck height for `BulletClass::AI`'s crossing test: the ground
+/// height plus `DAT_0089DE64`, admitted only when either the previous or the
+/// new cell carries the structural bridge bit (`CellClass+0x140 & 0x100`).
+fn bridge_surface_z(
+    terrain: Option<&ResolvedTerrainGrid>,
+    previous: ProjectileCoord,
+    candidate: ProjectileCoord,
+) -> Option<i32> {
+    let grid = terrain?;
+    let structural = |coord: ProjectileCoord| -> bool {
+        let (Ok(rx), Ok(ry)) = (
+            u16::try_from(coord.x.div_euclid(256)),
+            u16::try_from(coord.y.div_euclid(256)),
+        ) else {
+            return false;
+        };
+        grid.cell(rx, ry).is_some_and(|cell| {
+            cell.bridge_facts.raw_flags & crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL != 0
+        })
+    };
+    if !structural(previous) && !structural(candidate) {
+        return None;
+    }
+    terrain_floor_z(terrain, candidate.x, candidate.y)
+        .map(|floor| floor + crate::util::lepton::BRIDGE_HEIGHT_DELTA_LEPTONS as i32)
+}
+
+/// `FUN_00568350`: whether the coordinate is still inside the playfield.
+fn coord_is_on_grid(grid: &ResolvedTerrainGrid, coord: ProjectileCoord) -> bool {
+    let (Ok(rx), Ok(ry)) = (
+        u16::try_from(coord.x.div_euclid(256)),
+        u16::try_from(coord.y.div_euclid(256)),
+    ) else {
+        return false;
+    };
+    grid.cell(rx, ry).is_some()
 }
 
 fn squared_horizontal_distance(a: ProjectileCoord, b: ProjectileCoord) -> i64 {
@@ -1268,19 +1657,28 @@ mod tests {
         guided.guidance = Some(ProjectileGuidance {
             rot: 4,
             missile_rot_var: SimFixed::from_num(0),
-            course_lock_frames: 0,
+            course_lock_duration: 0,
             sidewinder_phase: 0,
             airburst: false,
             very_high: true,
             level: false,
-            pitch_bam: 0x4000,
+            heading_bam: 0,
+            max_speed: 0,
+            acceleration: 3,
+            fuse_reference: ProjectileCoord::new(0, 0, 0),
+            closing_frames: 0,
+            closing_accumulator_bits: 0,
             frames_elapsed: 0,
         });
         let id = store.spawn(1, guided);
 
-        store.advance(&BTreeMap::new(), None, &SharedCellDummy::fresh(), |_, _| {
-            None
-        });
+        store.advance(
+            0,
+            &BTreeMap::new(),
+            None,
+            &SharedCellDummy::fresh(),
+            |_, _| None,
+        );
 
         let guided = store
             .get(id)
@@ -1350,9 +1748,13 @@ mod tests {
         let first = store.spawn(1, first_spawn);
         let second = store.spawn(2, spawn(ProjectileTarget::Cell { rx: 1, ry: 0 }));
 
-        let result = store.advance(&BTreeMap::new(), None, &SharedCellDummy::fresh(), |_, _| {
-            None
-        });
+        let result = store.advance(
+            0,
+            &BTreeMap::new(),
+            None,
+            &SharedCellDummy::fresh(),
+            |_, _| None,
+        );
 
         assert_eq!(
             result
@@ -1375,7 +1777,7 @@ mod tests {
         let id = store.spawn(1, spawn(ProjectileTarget::Entity(42)));
         let targets = BTreeMap::from([(42, ProjectileCoord::new(128, 128, 0))]);
 
-        store.advance(&targets, None, &SharedCellDummy::fresh(), |_, _| None);
+        store.advance(0, &targets, None, &SharedCellDummy::fresh(), |_, _| None);
 
         assert_eq!(
             store.get(id).unwrap().position,
@@ -1388,11 +1790,15 @@ mod tests {
         let mut store = ProjectileStore::new();
         let id = store.spawn(1, spawn(ProjectileTarget::Entity(42)));
         let targets = BTreeMap::from([(42, ProjectileCoord::new(128, 0, 0))]);
-        store.advance(&targets, None, &SharedCellDummy::fresh(), |_, _| None);
+        store.advance(0, &targets, None, &SharedCellDummy::fresh(), |_, _| None);
 
-        let result = store.advance(&BTreeMap::new(), None, &SharedCellDummy::fresh(), |_, _| {
-            None
-        });
+        let result = store.advance(
+            0,
+            &BTreeMap::new(),
+            None,
+            &SharedCellDummy::fresh(),
+            |_, _| None,
+        );
 
         assert_eq!(result.detonations.len(), 1);
         assert_eq!(result.detonations[0].projectile_id, id);
@@ -1415,6 +1821,7 @@ mod tests {
         let collision_id = store.spawn(2, spawn(ProjectileTarget::Cell { rx: 1, ry: 0 }));
 
         let result = store.advance(
+            0,
             &BTreeMap::new(),
             None,
             &SharedCellDummy::fresh(),
@@ -1595,6 +2002,216 @@ mod tests {
         assert_eq!(
             shrapnel_rng.logical_state(),
             shrapnel_reference.logical_state()
+        );
+    }
+
+    fn guided_spawn(max_speed: u16, acceleration: i32) -> ProjectileSpawn {
+        let mut spawn = spawn(ProjectileTarget::Entity(42));
+        spawn.speed_leptons_per_frame = 1;
+        spawn.velocity = ProjectileVelocity::new(1, 0, 0);
+        spawn.guidance = Some(ProjectileGuidance {
+            rot: 4,
+            missile_rot_var: SimFixed::from_num(0),
+            course_lock_duration: 0,
+            sidewinder_phase: 0,
+            airburst: false,
+            very_high: false,
+            level: false,
+            heading_bam: 0,
+            frames_elapsed: 0,
+            max_speed,
+            acceleration,
+            fuse_reference: ProjectileCoord::new(0, 0, 0),
+            closing_frames: 0,
+            closing_accumulator_bits: 0,
+        });
+        spawn
+    }
+
+    /// `TechnoClass::FireAt 0x006FEA3A` launches at one lepton per frame and
+    /// `BulletClass::AI 0x004669CD` adds `Acceleration=` per frame up to
+    /// `Bullet+0x110`. A `MaxSpeed >= 40` bullet clears the course lock on its
+    /// first AI frame (`CMP [EBP+0x110],0x28` / `JGE` at `0x00466936`), so it
+    /// gets the full acceleration immediately.
+    #[test]
+    fn gsi_08_06_fast_missile_ramps_from_one_by_full_acceleration() {
+        let mut store = ProjectileStore::new();
+        let id = store.spawn(1, guided_spawn(100, 3));
+        let targets = BTreeMap::from([(42, ProjectileCoord::new(10_000, 0, 0))]);
+
+        store.advance(0, &targets, None, &SharedCellDummy::fresh(), |_, _| None);
+        let after_one = store.get(id).expect("missile still flying");
+        assert_eq!(after_one.speed_leptons_per_frame, 4);
+        assert_eq!(after_one.position, ProjectileCoord::new(4, 0, 0));
+
+        store.advance(1, &targets, None, &SharedCellDummy::fresh(), |_, _| None);
+        let after_two = store.get(id).expect("missile still flying");
+        assert_eq!(after_two.speed_leptons_per_frame, 7);
+        assert_eq!(after_two.position, ProjectileCoord::new(11, 0, 0));
+    }
+
+    /// With `CourseLockDuration = 0` and `MaxSpeed < 40` the lock survives, and
+    /// `0x0046699D` replaces `Acceleration=` with one lepton on even global
+    /// frames and none on odd ones. The parity is the GLOBAL frame counter's,
+    /// not the bullet's own age.
+    #[test]
+    fn gsi_08_06_course_locked_missile_ramps_at_half_rate_on_even_frames() {
+        let mut store = ProjectileStore::new();
+        let id = store.spawn(1, guided_spawn(25, 3));
+        let targets = BTreeMap::from([(42, ProjectileCoord::new(10_000, 0, 0))]);
+
+        for (frame, expected) in [(0u32, 2u16), (1, 2), (2, 3), (3, 3), (4, 4)] {
+            store.advance(frame, &targets, None, &SharedCellDummy::fresh(), |_, _| {
+                None
+            });
+            assert_eq!(
+                store
+                    .get(id)
+                    .expect("missile still flying")
+                    .speed_leptons_per_frame,
+                expected,
+                "frame {frame}"
+            );
+        }
+    }
+
+    /// `BulletClass::AI 0x004671E0`: the `Vertical` arm applies no gravity,
+    /// preserves the launch direction, ramps the magnitude by `Acceleration=`
+    /// with no clamp on the crossing frame, and ends when the new world z
+    /// passes `DetonationAltitude` (`0x00467334`).
+    #[test]
+    fn gsi_08_08_vertical_projectile_climbs_and_ends_at_detonation_altitude() {
+        let mut store = ProjectileStore::new();
+        let mut vertical = spawn(ProjectileTarget::Cell { rx: 0, ry: 0 });
+        vertical.speed_leptons_per_frame = 1;
+        vertical.origin = ProjectileCoord::new(0, 0, 0);
+        vertical.trajectory = ProjectileTrajectory::Vertical {
+            detonation_altitude: 10,
+            acceleration: 1,
+            max_speed: 50,
+            heading_bam: 0,
+            pitch_bam: 0x4000,
+        };
+        let id = store.spawn(1, vertical);
+
+        let mut heights = Vec::new();
+        for frame in 0..8u32 {
+            let result = store.advance(
+                frame,
+                &BTreeMap::new(),
+                None,
+                &SharedCellDummy::fresh(),
+                |_, _| None,
+            );
+            if let Some(detonation) = result.detonations.first() {
+                assert_eq!(detonation.projectile_id, id);
+                assert!(
+                    detonation.impact.z > 10,
+                    "the arm ends only once z passes DetonationAltitude"
+                );
+                assert_eq!(detonation.impact.x, 0, "no horizontal drift straight up");
+                assert_eq!(heights, vec![2, 5, 9], "1 + 1, then +3, then +4");
+                return;
+            }
+            heights.push(store.get(id).expect("still climbing").position.z);
+        }
+        panic!("the vertical arm never reached DetonationAltitude");
+    }
+
+    /// `BulletClass::AI 0x00467C70` detonates on ANY impact flag with no `Arm`
+    /// test at all — `Arm=` is written once into the ProximityDetector at
+    /// `BulletClass::Fire 0x00468A5D` and gates only that fuse. An unarmed
+    /// shot that hits a wall must explode, not vanish.
+    #[test]
+    fn gsi_08_07_unarmed_collision_detonates_instead_of_vanishing() {
+        let mut store = ProjectileStore::new();
+        let mut unarmed = spawn(ProjectileTarget::Cell { rx: 4, ry: 0 });
+        unarmed.arm_frames = 5;
+        let id = store.spawn(1, unarmed);
+
+        let result = store.advance(
+            0,
+            &BTreeMap::new(),
+            None,
+            &SharedCellDummy::fresh(),
+            |_, coord| Some(ProjectileCollisionResponse::TargetZClamp(coord)),
+        );
+
+        assert!(result.expired.is_empty(), "an unarmed hit is not a vanish");
+        assert_eq!(result.detonations.len(), 1);
+        assert_eq!(result.detonations[0].projectile_id, id);
+        assert_eq!(
+            result.detonations[0].reason,
+            ProjectileDetonationReason::Collision
+        );
+    }
+
+    /// `ProximityDetector::Check @ 0x004E11F0` measures against the coordinate
+    /// `ProximityDetector::Setup @ 0x004E1130` froze at launch, never against
+    /// the live target.
+    #[test]
+    fn gsi_08_07_proximity_fuse_measures_the_frozen_launch_reference() {
+        let targets = BTreeMap::from([(42, ProjectileCoord::new(10_000, 0, 0))]);
+
+        let mut frozen_near = ProjectileStore::new();
+        let mut spawn_near = guided_spawn(1, 3);
+        spawn_near.ranged_fuse = true;
+        if let Some(guidance) = spawn_near.guidance.as_mut() {
+            guidance.fuse_reference = ProjectileCoord::new(1, 0, 0);
+        }
+        frozen_near.spawn(1, spawn_near);
+        let near = frozen_near.advance(0, &targets, None, &SharedCellDummy::fresh(), |_, _| None);
+        assert_eq!(near.detonations.len(), 1, "the frozen reference is reached");
+        assert_eq!(near.detonations[0].reason, ProjectileDetonationReason::Fuse);
+
+        let mut frozen_far = ProjectileStore::new();
+        let mut spawn_far = guided_spawn(1, 3);
+        spawn_far.ranged_fuse = true;
+        if let Some(guidance) = spawn_far.guidance.as_mut() {
+            guidance.fuse_reference = ProjectileCoord::new(10_000, 0, 0);
+        }
+        frozen_far.spawn(1, spawn_far);
+        let far = frozen_far.advance(0, &targets, None, &SharedCellDummy::fresh(), |_, _| None);
+        assert!(
+            far.detonations.is_empty(),
+            "a distant frozen reference keeps the shot flying even though the \
+             bullet is one lepton from where it started"
+        );
+    }
+
+    /// Both `TechnoClass::FireAt` scatter arms consume exactly two Scenario
+    /// draws — magnitude then angle — and both OFFSET the target delta,
+    /// leaving z untouched.
+    #[test]
+    fn gsi_08_07_launch_scatter_consumes_two_draws_and_offsets_the_delta() {
+        let mut rng = SimRng::new(0x6f_e7fe);
+        let mut reference = rng.clone();
+        let _ = reference.next_range_u32_inclusive(128, 256);
+        let _ = reference.next_range_u32_inclusive(0, 0x7fff_fffe);
+
+        let scattered = projectile_launch_scatter((1024, 0, 77), 256, 1280, false, &mut rng);
+        assert_eq!(rng.logical_state(), reference.logical_state());
+        assert_eq!(scattered.2, 77, "z is carried through unchanged");
+        let offset_x = scattered.0 - 1024;
+        let offset_y = scattered.1;
+        let magnitude = ((offset_x * offset_x + offset_y * offset_y) as f64).sqrt();
+        assert!(
+            (128.0..=257.0).contains(&magnitude),
+            "the plain arm draws its magnitude in [BallisticScatter/2, BallisticScatter], got {magnitude}"
+        );
+
+        // The flak arm scales by distance over weapon range, so a target at
+        // exactly the weapon's range can be displaced by the full scatter.
+        let mut flak_rng = SimRng::new(0x6f_e6ad);
+        let mut flak_reference = flak_rng.clone();
+        let _ = flak_reference.next_range_u32_inclusive(0, 256);
+        let _ = flak_reference.next_range_u32_inclusive(0, 0x7fff_fffe);
+        let flak = projectile_launch_scatter((1280, 0, 0), 256, 1280, true, &mut flak_rng);
+        assert_eq!(flak_rng.logical_state(), flak_reference.logical_state());
+        let flak_magnitude = (((flak.0 - 1280) * (flak.0 - 1280) + flak.1 * flak.1) as f64).sqrt();
+        assert!(
+            flak_magnitude <= 257.0,
+            "at exactly one weapon range the flak arm cannot exceed BallisticScatter, got {flak_magnitude}"
         );
     }
 

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -3075,11 +3075,12 @@ mod tests {
     /// decode from a shorter v117 record; 118 -> 119 gives `ProjectileGuidance`
     /// the native `BulletClass` flight state — `Bullet+0x110` MaxSpeed,
     /// `BulletTypeClass+0x2D0` Acceleration, the launch-frozen
-    /// `ProximityDetector` reference coordinate, and the `Bullet+0x118/+0x11C`
-    /// closing-rate pair — and appends the `Vertical` trajectory variant. The
-    /// three guidance additions sit at the END of the struct, but a v118 record
-    /// still stops short of them, so bincode would run off the end of every
-    /// in-flight projectile.
+    /// `ProximityDetector` reference coordinate, and the `Bullet+0x118/+0x120`
+    /// closing-rate pair — and appends the `Vertical` trajectory variant. All
+    /// five guidance additions (`max_speed`, `acceleration`, `fuse_reference`,
+    /// `closing_frames`, `closing_accumulator_bits`) sit at the END of the
+    /// struct, but a v118 record still stops short of them, so bincode would
+    /// run off the end of every in-flight projectile.
     #[test]
     fn projectile_flight_state_snapshot_version_is_119() {
         assert_eq!(super::SNAPSHOT_VERSION, 119);

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -352,7 +352,7 @@ use crate::sim::world::Simulation;
 // for a short record, so a v117 save would pass the version check and then
 // misread every byte from entity one onward. A mid-struct insertion is exactly
 // the case serde defaults cannot cover, so the version has to move.
-const SNAPSHOT_VERSION: u32 = 118;
+const SNAPSHOT_VERSION: u32 = 119;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -3072,10 +3072,17 @@ mod tests {
     /// deposit radius into the hash schema; 117 -> 118 inserts the
     /// `UnitClass+0x6AF` turret rotation latch and the `TechnoClass+0x120`
     /// last-fire frame mid-`GameEntity`, on every entity, which bincode cannot
-    /// decode from a shorter v117 record.
+    /// decode from a shorter v117 record; 118 -> 119 gives `ProjectileGuidance`
+    /// the native `BulletClass` flight state — `Bullet+0x110` MaxSpeed,
+    /// `BulletTypeClass+0x2D0` Acceleration, the launch-frozen
+    /// `ProximityDetector` reference coordinate, and the `Bullet+0x118/+0x11C`
+    /// closing-rate pair — and appends the `Vertical` trajectory variant. The
+    /// three guidance additions sit at the END of the struct, but a v118 record
+    /// still stops short of them, so bincode would run off the end of every
+    /// in-flight projectile.
     #[test]
-    fn turret_rotation_latch_snapshot_version_is_118() {
-        assert_eq!(super::SNAPSHOT_VERSION, 118);
+    fn projectile_flight_state_snapshot_version_is_119() {
+        assert_eq!(super::SNAPSHOT_VERSION, 119);
     }
 
     #[test]

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -352,6 +352,17 @@ use crate::sim::world::Simulation;
 // for a short record, so a v117 save would pass the version check and then
 // misread every byte from entity one onward. A mid-struct insertion is exactly
 // the case serde defaults cannot cover, so the version has to move.
+// Bumped 118 -> 119: `ProjectileGuidance` gains the five fields the native
+// speed ramp needs — `BulletClass::AI @ 0x00466985` accelerates a homing bullet
+// from one lepton per frame toward the MaxSpeed stored at `+0x110`, so a
+// projectile must carry its current speed, its cap, its acceleration and its
+// flight heading. The heading is stored rather than derived because VERA's
+// velocity is integral: at magnitude 1 the direction would be destroyed by
+// truncation and the missile would leave along an axis instead of the barrel.
+// `ProjectileTrajectory` also gains a `Vertical` variant. All five fields are
+// APPENDED at the end of the struct and the variant is appended to the enum, so
+// unlike the 117 and 118 bumps this one is serde-coverable in principle; the
+// version still moves because the hash schema folds the new state.
 const SNAPSHOT_VERSION: u32 = 119;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -3811,12 +3811,17 @@ fn gsi_05_04_guided_projectile(
     spawn.guidance = Some(ProjectileGuidance {
         rot: 60,
         missile_rot_var: SimFixed::lit("0.25"),
-        course_lock_frames: 0,
+        course_lock_duration: 0,
         sidewinder_phase: 0,
         airburst: false,
         very_high: false,
         level: false,
-        pitch_bam: 0,
+        heading_bam: 0,
+        max_speed: 0,
+        acceleration: 3,
+        fuse_reference: crate::sim::projectile::ProjectileCoord::new(0, 0, 0),
+        closing_frames: 0,
+        closing_accumulator_bits: 0,
         frames_elapsed: 0,
     });
     spawn.tracks_target = true;

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -227,6 +227,10 @@ impl Simulation {
             return true;
         }
         if self.projectiles.get(id).is_some() {
+            // `BulletClass::AI 0x0046699D` reads the GLOBAL frame counter's
+            // parity for the half-rate course-locked acceleration ramp, so the
+            // Logic slot has to hand the flight loop the current frame.
+            let binary_frame = self.session.binary_frame;
             let shared_cell_dummy = self.effective_shared_cell_dummy();
             let terrain = self.resolved_terrain.as_ref();
             let overlay_grid = self.overlay_grid.as_ref();
@@ -238,6 +242,7 @@ impl Simulation {
                 .projectiles
                 .advance_one(
                     id,
+                    binary_frame,
                     |target_id| {
                         let target = entities
                             .get(target_id)


### PR DESCRIPTION
Phase 6, rows 127 (GSI-08.06 launch), 128 (GSI-08.07 flight models) and 129 (GSI-08.08 collision, fuse and detonation).

Every missile in the game left its launcher at full speed and arrived early, because VERA never modelled the acceleration ramp. Six projectile keys diverted their shots off authoritative flight entirely into an instant hit, so an attack dog's discus, a V3's airburst rocket and a Flak Track's anti-ground shell never flew at all. An unarmed shot that hit a wall vanished silently.

## What gamemd does

**Launch.** `TechnoClass::FireAt` clamps every launch speed to half the distance to target, then a homing or vertical shot leaves at **one lepton per frame** with the weapon's `Speed=` kept as the bullet's cap. The direction is the aim facing, not the bearing to the target.

**Flight.** `BulletClass::AI` ramps toward that cap by `Acceleration=`, at half rate while the course is locked, decelerating at half the acceleration when over the cap. The `Vertical=` model, which VERA lacked entirely, carries no gravity and preserves direction until it passes its detonation altitude or reaches the ground — so a Kirov's bomb now falls.

**Detonation.** `Arm=` gates only the proximity fuse. The impact admission has no arm test at all, so an unarmed collision detonates. The fuse's reference coordinate is frozen at launch, and it is the *target's* position rather than the bullet's.

## Exclusions proved rather than implemented

`Bouncy=` and `Proximity=` have no consumer anywhere in the binary; `Degenerates=` and `Elasticity=` are live code with no stock projectile using them; and `VeryHigh` with a zero turn rate is unreachable. Each was scanned independently by a reviewer over the whole image. Four of the six keys that had been diverting shots off flight are simply dead, and the other two are scatter offsets rather than flight models.

## Review history

Three rounds. Each corrected something the mapping research had wrong: the scatter *adds* to the target delta rather than replacing it (replacing would have landed every inaccurate shot a cell from the firer), the ledger had sine and cosine swapped, and the Aegis special case is moot because the native renormalises every homing bullet anyway.

Round one found five comments asserting as fact things the binary does not say, one of them guarding a real one-frame arming shift. That was settled rather than relabelled: the proximity detector gates on a wall-clock frame delta, not an AI-visit count, which makes the question moot and shows the old placement was a frame late either way.

Round two found the Kirov test proving the right thing for the wrong reason, which uncovered a genuine drift now scheduled separately: VERA gates its whole jumpjet parameter block on `JumpJet=yes`, but the native reads those eight keys unconditionally. A Kirov and a Floating Disc therefore hover a cell low with the wrong climb, turn and crash rates. It stayed invisible because every section that *does* author `JumpJet=yes` also authors the fallback height.

## Recorded residuals

The second scatter site is deferred, and the reason is now stated correctly: its magnitude divides by a type field nobody has identified, so the offset cannot be computed. Flak therefore still never misses aircraft.

`cargo test -p vera20k --lib`: `test result: ok. 8189 passed; 0 failed; 75 ignored`. `SNAPSHOT_VERSION` 118 to 119, with the five new guidance fields appended rather than inserted. No golden moved.
