### PR TITLE
Phase 6: one ADPCM decoder, and the tail gamemd actually plays

### DIFF
--- a/docs/research/ADPCM_NIBBLE_VALUE_CERTIFICATION_GHIDRA_REPORT.md
+++ b/docs/research/ADPCM_NIBBLE_VALUE_CERTIFICATION_GHIDRA_REPORT.md
@@ -18,8 +18,8 @@ is value-identical to the original's (`IMA_ADPCM__DecodeBlock @ 0x0040AA70`) on
 all retail data.** Evidence:
 algorithm identity from decompiles, table identity from raw memory reads,
 15 machine-derived emulation vectors (including both saturation clamps), and
-corpus proofs that the two behavioral divergence classes (invalid-preamble
-handling; unaligned mono payloads) never occur in retail data.
+corpus proofs that the divergence classes in §2 never occur in retail data —
+with one residual, a sound shorter than one stride, recorded in §2.1.
 
 ## 1. Nibble decoder identity
 
@@ -79,25 +79,26 @@ table identity above — the vectors guard the restatement.
 `FUN_00409C40` (format tag 1). Grammar: per block, one 4-byte preamble per
 channel `{i16 predictor, u8 step_index, u8 reserved}`, predictor emitted as
 the first sample, then nibble payload (mono: 4-byte groups; stereo: 8-byte
-L/R groups, remainder truncated). Matches src/assets/audio_bag.rs
-`decode_ima_adpcm_blocks` with two behavioral differences:
+L/R groups). The pump hands it exactly `block_align` bytes every time — see
+§2.1 — so the block grammar is stride-determined. Matches
+src/assets/ima_adpcm.rs `decode_blocks` with these behavioral differences:
 
 | Divergence class | Native | Ours | Corpus status |
 |---|---|---|---|
 | Preamble step_index > 0x58 or reserved ≠ 0 | rejects the block, stopping the sound | rejects the block, stopping the sound | **never occurs** (0 of 3,325 IMA entries, all blocks) |
-| Mono payload not a multiple of 4 | rounds the group count UP, reads past the block end, then reports failure | drops the block | **never occurs** (all mono blocks 4-aligned) |
-| Stereo payload not a multiple of 8 | runs one group past the end, then reports failure | drops the block | AUDIOMD `grexselb` only (§2.1) |
+| Stride payload not a multiple of `4*channels` | rounds the group count UP (mono) / runs one group long (stereo), reads past the block end, then reports failure | drops the block | **unreachable**: the pump always presents exactly `block_align` bytes, and `(512-4)%4 == 0`, `(1024-8)%8 == 0` (§2.1) |
+| Last block shorter than the stride | decodes a full stride; the bytes past the tail are the previous block's, still in the input buffer | reproduces that buffer, except for a sound shorter than one stride (§2.1) | 2,049 of 2,197 AUDIOMD IMA entries |
 
 Proven by `certify_bag_adpcm_block_invariants`
 (tests/retail_goldens/certify_audio.rs): 3,325 IMA entries across
 AUDIOMD/AUDIO.MIX.
 
-### 2.1 CORRECTION (2026-09-03) — the stereo remainder row was wrong
+### 2.1 CORRECTION (2026-09-03) — the remainder rows were wrong twice
 
-An earlier revision of this table claimed the native "truncates" a short stereo
-remainder and was therefore "identical by construction". The disassembly says
-otherwise. `0x0040ACB3: TEST ECX,ECX / JG 0x0040abf5` continues the group loop
-while any bytes remain, so a remainder of 1..7 bytes runs one **more** full
+**First error (the original table).** It claimed the native "truncates" a short
+stereo remainder and was therefore "identical by construction". The disassembly
+says otherwise. `0x0040ACB3: TEST ECX,ECX / JG 0x0040abf5` continues the group
+loop while any bytes remain, so a remainder of 1..7 bytes runs one **more** full
 8-byte group — over-reading the block — and the closing `SETZ AL` then returns
 false. `Audio__DecodeCompressedBlock` case 2 turns that false into a `return 0`
 (`0x00409F4E`) and the buffer pump abandons the sound, so the block's samples
@@ -105,22 +106,69 @@ never reach the mixer. Mono is the same shape: `0x0040AB4E: LEA EAX,[ECX+3] /
 SHR EAX,0x2` rounds the group count up, and `0x0040ABD4` reports failure unless
 the payload was an exact multiple of 4.
 
-The corpus claim was also incomplete. The check only tested mono alignment, so a
-stereo violation could not be seen, and the entry count was understated: AUDIOMD
-alone holds **9** stereo entries (5 IMA with `chunk_size` 1024, 4 raw PCM), not 7
-across both bags. Sweeping the shipped AUDIOMD `audio.idx` (2,285 entries) finds
-exactly one misaligned block in the whole file:
+**Second error (the first correction, same day).** All of the above is true of
+the *function*, and none of it applies to the *pipeline*. An earlier revision of
+this section then claimed "native drops that tail block … VERA now does the
+same" and that the over-read values "are discarded with the block". Both are
+false, because the block decoder never sees a short payload.
 
-- `grexselb` — offset 7,063,684, size 41,212, stereo IMA, `chunk_size` 1024.
-  40 whole blocks plus a 252-byte tail whose 244-byte payload is 30 whole groups
-  plus 4 bytes. Native drops that tail block (241 frames, ~11 ms at 22,050 Hz)
-  and stops the sound there; VERA now does the same.
+The decoder's available-byte count is `+0x80 - +0x84`, read in the `0x0040AA70`
+prologue. Between them those fields have exactly four writes, all in
+`Audio__DecodeCompressedBlock @ 0x00409DE0`; `FUN_00409880 @ 0x00409880` writes
+neither (`search_instructions` over both functions, 2026-09-03):
 
-Since 2026-09-03 VERA's `assets::ima_adpcm::decode_blocks` drops a block whose
-payload is not a whole number of `4 * channels`-byte groups, and drops a block
-with an invalid preamble, instead of clamping and truncating. The residual
-difference is only the *values* the native computes from bytes past the block
-end, which are stale decoder-buffer contents and are discarded with the block.
+| Address | Write |
+|---|---|
+| `0x00409F8A` | case 3: `+0x80 = +0xAC` = `block_align` |
+| `0x00409F90` | case 3: `+0x84 = +0xAC` = `block_align` |
+| `0x00409EBE` | case 0: `+0x84 -= bytes copied into the input buffer` |
+| `0x00409EA4` | case 0: `+0x84 = 0`, forced when the source is exhausted or NULL |
+
+Case 0 leaves the fill state only with `+0x84 == 0`, so **`avail` is always
+exactly `block_align`**. Every retail block therefore has a whole payload
+(`(512-4) % 4 == 0`, `(1024-8) % 8 == 0`) and the two failure branches above are
+unreachable on retail data — they are reachable only through a stride that is
+itself ragged.
+
+**What actually happens at end of stream.** `FUN_00409880` calls the decode
+callback with a NULL source pointer and a NULL count at `0x00409B41` (the
+`PUSH EDI/PUSH EDI` pair with `EDI == 0`), taken while the stream's
+"decoder still holds data" flag `+0xA8` is set. `+0x84` is forced to 0 and the
+block decoder runs over a full stride. The input buffer at `+0x7C` is
+`malloc(block_align)` (`FUN_00409C40`) and every fill cycle writes it from
+offset 0 (`puVar6 = (+0x80 - +0x84) + +0x7C`), so the bytes past a short tail
+are **the previous block's bytes at those same offsets** — real audio from
+one block earlier, not decay or silence. `Audio__DecodeCompressedBlock` case 1
+then copies the whole `+0x94` decoded byte count out to the DirectSound buffer;
+there is no length cap. So the native emits `ceil(size / block_align)` blocks
+for every sound, each `1 + (block_align - 4*ch)/(4*ch) * 8` frames.
+
+Measured consequences of the two retail shapes:
+
+- `ABIRJ01A` — 14,388 bytes, mono, stride 512 → 29 × 1017 = **29,493 samples**.
+  VERA emitted 28,573 before 2026-09-03 (~41.7 ms short).
+- `grexselb` — offset 7,063,684, size 41,212, stereo IMA, stride 1024 → 41 ×
+  1017 frames = **83,394 samples**. Its 252-byte tail is the corpus's only block
+  whose *real* payload is ragged (30 whole groups plus 4 bytes), which is why
+  the earlier "native drops it" reading picked this entry — but padded to the
+  stride it is not ragged and the native decodes it in full.
+
+Since 2026-09-03 `assets::ima_adpcm::decode_blocks` reproduces that feed: it
+rebuilds the flush buffer as `tail ++ previous_block[tail.len()..]`, keeps the
+preamble rejection, and gates the ragged-payload rejection on the stride rather
+than on where the data ends. Pinned by
+`retail_sound_shapes_decode_the_native_block_count` and
+`end_of_stream_flush_pads_from_the_previous_block_like_the_native`.
+
+**Residual.** A sound shorter than one stride is flushed against a buffer this
+sound never filled — `malloc`ed on first use, otherwise the previous sound's
+bytes, since `FUN_00409C40` reallocates only when the stride grows. Not
+reproducible from the file; VERA decodes the whole groups such a sound carries.
+
+The corpus claim in the original table was also incomplete: the check only
+tested mono alignment, so a stereo violation could not be seen, and the entry
+count was understated — AUDIOMD alone holds **9** stereo entries (5 IMA with
+`chunk_size` 1024, 4 raw PCM), not 7 across both bags.
 
 ## 3. The .aud chunk path
 

--- a/docs/research/ADPCM_NIBBLE_VALUE_CERTIFICATION_GHIDRA_REPORT.md
+++ b/docs/research/ADPCM_NIBBLE_VALUE_CERTIFICATION_GHIDRA_REPORT.md
@@ -9,11 +9,13 @@ instrument (first use in this repo that produced committed goldens).
 
 ## Verdict
 
-**Our IMA-ADPCM nibble decoder (src/assets/aud_file.rs
-`ImaAdpcmState::decode_nibble`) is value-identical to the original engine's
-(`IMA_ADPCM__DecodeSample @ 0x0040ACD0`), and our bag block decoder
-(src/assets/audio_bag.rs) is value-identical to the original's
-(`IMA_ADPCM__DecodeBlock @ 0x0040AA70`) on all retail data.** Evidence:
+**Our IMA-ADPCM nibble decoder (src/assets/ima_adpcm.rs
+`ImaAdpcmState::decode_nibble`, moved there from `aud_file.rs` on 2026-09-03
+when the crate's three copies were unified) is value-identical to the original
+engine's (`IMA_ADPCM__DecodeSample @ 0x0040ACD0`), and our block decoder
+(`ima_adpcm::decode_blocks`, shared by the bag and WAV paths as it is natively)
+is value-identical to the original's (`IMA_ADPCM__DecodeBlock @ 0x0040AA70`) on
+all retail data.** Evidence:
 algorithm identity from decompiles, table identity from raw memory reads,
 15 machine-derived emulation vectors (including both saturation clamps), and
 corpus proofs that the two behavioral divergence classes (invalid-preamble
@@ -52,7 +54,8 @@ Tables (verified via `read_memory`):
 15 vectors captured by emulating `0x0040ACD0` with ECX = nibble and EDX
 pointing at (predictor, index) pairs; committed as the unit test
 `adpcm_nibble_matches_original_engine_emulation_vectors` in
-src/assets/aud_file.rs — all 15 match our decoder:
+src/assets/ima_adpcm.rs (moved there 2026-09-03 with the decoder itself, so the
+vectors now guard the WAV path too) — all 15 match our decoder:
 
 | state (pred, idx) | state source | nibbles → samples |
 |---|---|---|
@@ -81,13 +84,43 @@ L/R groups, remainder truncated). Matches src/assets/audio_bag.rs
 
 | Divergence class | Native | Ours | Corpus status |
 |---|---|---|---|
-| Preamble step_index > 0x58 or reserved ≠ 0 | rejects the whole load | clamps / ignores | **never occurs** (0 of 3,325 IMA entries, all blocks) |
-| Mono payload not 4-byte aligned | rounds UP, reads past block end | decodes exact bytes | **never occurs** (all mono blocks 4-aligned) |
-| Stereo payload remainder < 8 bytes | truncates | truncates | identical by construction (7 stereo entries) |
+| Preamble step_index > 0x58 or reserved ≠ 0 | rejects the block, stopping the sound | rejects the block, stopping the sound | **never occurs** (0 of 3,325 IMA entries, all blocks) |
+| Mono payload not a multiple of 4 | rounds the group count UP, reads past the block end, then reports failure | drops the block | **never occurs** (all mono blocks 4-aligned) |
+| Stereo payload not a multiple of 8 | runs one group past the end, then reports failure | drops the block | AUDIOMD `grexselb` only (§2.1) |
 
 Proven by `certify_bag_adpcm_block_invariants`
 (tests/retail_goldens/certify_audio.rs): 3,325 IMA entries across
-AUDIOMD/AUDIO.MIX, zero violations (2026-07-19 run).
+AUDIOMD/AUDIO.MIX.
+
+### 2.1 CORRECTION (2026-09-03) — the stereo remainder row was wrong
+
+An earlier revision of this table claimed the native "truncates" a short stereo
+remainder and was therefore "identical by construction". The disassembly says
+otherwise. `0x0040ACB3: TEST ECX,ECX / JG 0x0040abf5` continues the group loop
+while any bytes remain, so a remainder of 1..7 bytes runs one **more** full
+8-byte group — over-reading the block — and the closing `SETZ AL` then returns
+false. `Audio__DecodeCompressedBlock` case 2 turns that false into a `return 0`
+(`0x00409F4E`) and the buffer pump abandons the sound, so the block's samples
+never reach the mixer. Mono is the same shape: `0x0040AB4E: LEA EAX,[ECX+3] /
+SHR EAX,0x2` rounds the group count up, and `0x0040ABD4` reports failure unless
+the payload was an exact multiple of 4.
+
+The corpus claim was also incomplete. The check only tested mono alignment, so a
+stereo violation could not be seen, and the entry count was understated: AUDIOMD
+alone holds **9** stereo entries (5 IMA with `chunk_size` 1024, 4 raw PCM), not 7
+across both bags. Sweeping the shipped AUDIOMD `audio.idx` (2,285 entries) finds
+exactly one misaligned block in the whole file:
+
+- `grexselb` — offset 7,063,684, size 41,212, stereo IMA, `chunk_size` 1024.
+  40 whole blocks plus a 252-byte tail whose 244-byte payload is 30 whole groups
+  plus 4 bytes. Native drops that tail block (241 frames, ~11 ms at 22,050 Hz)
+  and stops the sound there; VERA now does the same.
+
+Since 2026-09-03 VERA's `assets::ima_adpcm::decode_blocks` drops a block whose
+payload is not a whole number of `4 * channels`-byte groups, and drops a block
+with an invalid preamble, instead of clamping and truncating. The residual
+difference is only the *values* the native computes from bytes past the block
+end, which are stale decoder-buffer contents and are discarded with the block.
 
 ## 3. The .aud chunk path
 

--- a/docs/research/ADPCM_NIBBLE_VALUE_CERTIFICATION_GHIDRA_REPORT.md
+++ b/docs/research/ADPCM_NIBBLE_VALUE_CERTIFICATION_GHIDRA_REPORT.md
@@ -113,16 +113,31 @@ same" and that the over-read values "are discarded with the block". Both are
 false, because the block decoder never sees a short payload.
 
 The decoder's available-byte count is `+0x80 - +0x84`, read in the `0x0040AA70`
-prologue. Between them those fields have exactly four writes, all in
-`Audio__DecodeCompressedBlock @ 0x00409DE0`; `FUN_00409880 @ 0x00409880` writes
-neither (`search_instructions` over both functions, 2026-09-03):
+prologue. Between them those fields have exactly six writes in the whole image —
+a program-wide `search_instructions` for `MOV [reg + 0x84],` / `MOV [reg +
+0x80],`, 2026-09-03, re-read against the disassembly rather than the decompile.
+`FUN_00409880 @ 0x00409880` writes neither:
 
-| Address | Write |
-|---|---|
-| `0x00409F8A` | case 3: `+0x80 = +0xAC` = `block_align` |
-| `0x00409F90` | case 3: `+0x84 = +0xAC` = `block_align` |
-| `0x00409EBE` | case 0: `+0x84 -= bytes copied into the input buffer` |
-| `0x00409EA4` | case 0: `+0x84 = 0`, forced when the source is exhausted or NULL |
+| Address | Function | Write |
+|---|---|---|
+| `0x00409F8A` | `Audio__DecodeCompressedBlock` | case 3: `+0x80 = +0xAC` = `block_align` |
+| `0x00409F90` | `Audio__DecodeCompressedBlock` | case 3: `+0x84 = +0xAC` = `block_align` |
+| `0x00409EA4` | `Audio__DecodeCompressedBlock` | case 0: `+0x84 -= bytes copied into the input buffer` (`0x00409E92 MOV ECX,[EBX+0x84]` / `0x00409E9A SUB ECX,EAX` / `0x00409EA4 MOV [EBX+0x84],ECX`, then `+0xA8 = 1` at `0x00409EAA`) |
+| `0x00409EBE` | `Audio__DecodeCompressedBlock` | case 0: `+0x84 = 0`, forced when the source is exhausted or NULL (`MOV [EBX+0x84],ESI` with `ESI == 0`, paired with the state transition `0x00409EC4 MOV [EBX+0x74],EAX`) |
+| `0x00409C6C` | `FUN_00409C40` | configure: `+0x84 = 0` (`MOV [ESI+0x84],EDI`, `EDI == 0`) |
+| `0x00409C72` | `FUN_00409C40` | configure: `+0x80 = 0` (`MOV [ESI+0x80],EDI`) |
+
+> **The last two rows do not disturb the conclusion.** `FUN_00409C40` forces the
+> state back to 3 two instructions later (`0x00409C78 MOV [ESI+0x74],0x3`) in the
+> same straight-line block, so case 3 reloads both fields from `+0xAC` before any
+> `IMA_ADPCM__DecodeBlock` call — the decoder is never reached with the zeros.
+> `FUN_00409880` also calls `FUN_00409C40` only while `+0xA8 == 0`
+> (`0x00409A83 CMP [ESI+0xa8],EDI / JNZ 0x00409AA2`), so it cannot reallocate or
+> re-format the input buffer while a partial block is pending.
+>
+> The `0x00409EA4` / `0x00409EBE` rows were **swapped in two earlier revisions of
+> this table** (and in the code comments that cite it). The disassembly above is
+> the authority: `0x00409EA4` is the subtraction, `0x00409EBE` is the forced zero.
 
 Case 0 leaves the fill state only with `+0x84 == 0`, so **`avail` is always
 exactly `block_align`**. Every retail block therefore has a whole payload
@@ -142,6 +157,16 @@ one block earlier, not decay or silence. `Audio__DecodeCompressedBlock` case 1
 then copies the whole `+0x94` decoded byte count out to the DirectSound buffer;
 there is no length cap. So the native emits `ceil(size / block_align)` blocks
 for every sound, each `1 + (block_align - 4*ch)/(4*ch) * 8` frames.
+
+A source delivered in several segments still yields **exactly one** flush. The
+flush branch needs the remaining-source count `+0x2C` to be `<= 0`
+(`0x00409AE3 JG 0x00409B2B`, then `0x00409B34 JG 0x00409B53`); a new segment
+sets `+0x2C` from `+0x174` at `0x00409ACD`, which routes the pump to the
+with-source call at `0x00409B65` instead, so the flush is unreachable until true
+EOF. And it produces one extra block, not a run of them: case 1 clears `+0xA8`
+once it has drained the flushed block (`0x00409ED9`), after which
+`0x00409AEB JNZ` falls through to the silence fill at `0x00409AED` rather than
+calling the decoder again.
 
 Measured consequences of the two retail shapes:
 

--- a/docs/research/AUDIO_IDX_BAG_GHIDRA_REPORT.md
+++ b/docs/research/AUDIO_IDX_BAG_GHIDRA_REPORT.md
@@ -179,12 +179,31 @@ In version 1 idx files, this field does not exist on disk and is zeroed in memor
 In version 2 idx files, it is read from disk.
 
 In `FUN_00401640`, it is stored into the audio format struct at offset +0x18
-(`param_3[6]`). In the WAV file parser (`FUN_00408610` at `0x00408610`), the equivalent
-field is `wSamplesPerBlock` from the WAV fmt chunk header (bytes 12-13 of the fmt chunk
-data, for IMA ADPCM format 0x11). This is the number of decoded PCM samples per ADPCM
-block.
+(`param_3[6]`). In the WAV file parser (`WAV__ParseHeader` at `0x00408610`), the same
+descriptor field is filled for IMA ADPCM (`wFormatTag == 0x11`) from `psVar6[6]` — fmt
+chunk bytes 12-13, which is **`nBlockAlign`**, not `wSamplesPerBlock`.
 
-When this field is 0 (version 1 or uncompressed PCM), the engine does not use it.
+**CORRECTION (2026-09-03):** an earlier revision of this section named the field
+`wSamplesPerBlock` and called it "the number of decoded PCM samples per ADPCM block".
+That is wrong. It is a **byte** stride — the compressed bytes per block. Verified from
+`FUN_00409C40` at `0x00409C40`, which reads descriptor `+0x18` and uses it as
+- `param_1[0x23]` / `param_1[0x2b]` (stream `+0x8C` / `+0xAC`): the number of bytes read
+  into the decoder's input buffer per block (`Audio__DecodeCompressedBlock` case 3 sets
+  `+0x80 = +0x84 = +0xAC`), and
+- `param_1[0x28] = chunk_size * 4 + 0x80` (stream `+0xA0`): the output buffer size, i.e.
+  4 output bytes (2 samples x 2 bytes) per input byte plus 128 bytes of slack.
+
+A samples-per-block reading is also arithmetically impossible for the retail data: the
+2,192 mono IMA entries in AUDIOMD carry 512, and mono IMA samples-per-block is always
+odd (`2*(blockAlign-4)+1`).
+
+Retail values (machine-read from the shipped `audio.idx` in `langmd.mix -> audiomd.mix`,
+2,285 entries): 512 for the 2,192 mono IMA entries, 1,024 for the 5 stereo IMA entries,
+and 0 for the 88 raw-PCM entries (84 mono flags 6, 4 stereo flags 7).
+
+When this field is 0 the engine has no block stride to fill its input buffer with, so a
+compressed entry with `chunk_size == 0` decodes to nothing. No retail entry hits that:
+both shipped `audio.idx` files are version 2.
 
 
 ## 5. Sorting and Binary Search
@@ -331,12 +350,17 @@ The .bag file contains raw audio sample data at the offsets specified by the .id
   at the given offset for the given size.
 
 - **IMA ADPCM compressed (flags bit 3 = 1):** Standard IMA ADPCM encoded data. The engine
-  contains a standard IMA ADPCM decoder at `FUN_0040acd0` (`0x0040acd0`) with:
+  contains **exactly one** IMA ADPCM nibble decoder, `IMA_ADPCM__DecodeSample` at
+  `0x0040acd0` — verified 2026-09-03 by `get_xrefs_to` on both coefficient tables (one
+  DATA reference each, both from `0x0040acd0`) plus a `search_byte_patterns` sweep for the
+  step table's head, which found no second copy in the image:
   - Step size table at `0x00816558` (89 entries: 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19,
     21, 23, 25, 28, 31, ... 32767)
   - Index adjustment table at `0x00816518` (16 entries: -1,-1,-1,-1, 2,4,6,8 repeated)
   - Decodes 4-bit nibbles to 16-bit signed PCM samples
-  - `chunk_size` field (entry +0x20) specifies samples per ADPCM block
+  - Reached only from the single block decoder `IMA_ADPCM__DecodeBlock @ 0x0040aa70`,
+    installed as the stream's `+0xB0` callback by `FUN_00409C40` for compression id 1
+  - `chunk_size` field (entry +0x20) is the block stride in **bytes** (see §4)
 
 
 ## 8. VocClass::ReadINI — Sound Tokenizer (FUN_00750440)

--- a/src/assets/aud_file.rs
+++ b/src/assets/aud_file.rs
@@ -12,7 +12,9 @@
 //!
 //! The DEAF-chunk container this file walks has **no decoder in `gamemd.exe`**:
 //! the only `.aud` filenames the binary references are TEXT1–3.AUD (score-screen
-//! narration), no code compares the `0x0000DEAF` chunk magic, and the image's
+//! narration), no code in the audio path compares the `0x0000DEAF` chunk magic
+//! (the image's one `CMP word ptr [...+0x4],0xDEAF` is at `0x005F1D2F`, inside
+//! the serial/null-modem packet framer `FUN_005F1C60`), and the image's
 //! single IMA decoder (`IMA_ADPCM__DecodeSample @ 0x0040ACD0`, reached only via
 //! the block decoder `IMA_ADPCM__DecodeBlock @ 0x0040AA70`) is block-framed, not
 //! chunk-framed. See `docs/research/AUD_TRAILING_SAMPLE_UNREACHABLE_GHIDRA_REPORT.md`.

--- a/src/assets/aud_file.rs
+++ b/src/assets/aud_file.rs
@@ -8,24 +8,27 @@
 //! The file is divided into chunks, each with a small header and compressed payload.
 //! Decoding produces 16-bit signed PCM samples.
 //!
+//! ## Reachability in gamemd
+//!
+//! The DEAF-chunk container this file walks has **no decoder in `gamemd.exe`**:
+//! the only `.aud` filenames the binary references are TEXT1–3.AUD (score-screen
+//! narration), no code compares the `0x0000DEAF` chunk magic, and the image's
+//! single IMA decoder (`IMA_ADPCM__DecodeSample @ 0x0040ACD0`, reached only via
+//! the block decoder `IMA_ADPCM__DecodeBlock @ 0x0040AA70`) is block-framed, not
+//! chunk-framed. See `docs/research/AUD_TRAILING_SAMPLE_UNREACHABLE_GHIDRA_REPORT.md`.
+//! The chunk walk below is therefore VERA-internal — a reader for files the
+//! original never decodes — while the nibble math it borrows from
+//! `ima_adpcm` is the certified native one.
+//!
 //! ## Dependency rules
 //! - Part of assets/ — standalone parser, no game dependencies.
+//! - IMA ADPCM sample math comes from `assets::ima_adpcm`, the crate's single
+//!   implementation.
+
+use super::ima_adpcm::{ImaAdpcmState, decode_nibbles};
 
 /// Magic value at the start of each audio chunk.
 const CHUNK_MAGIC: u32 = 0x0000DEAF;
-
-/// IMA ADPCM step index adjustment table.
-/// Indexed by the lower 3 bits of each encoded nibble.
-const INDEX_ADJUST: [i32; 8] = [-1, -1, -1, -1, 2, 4, 6, 8];
-
-/// IMA ADPCM step size table (89 entries).
-const STEP_TABLE: [i32; 89] = [
-    7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41, 45, 50, 55, 60, 66,
-    73, 80, 88, 97, 107, 118, 130, 143, 157, 173, 190, 209, 230, 253, 279, 307, 337, 371, 408, 449,
-    494, 544, 598, 658, 724, 796, 876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066, 2272,
-    2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484, 7132, 7845, 8630, 9493,
-    10442, 11487, 12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767,
-];
 
 /// Parsed .aud file header.
 #[derive(Debug, Clone)]
@@ -103,7 +106,7 @@ pub fn decode_aud(data: &[u8]) -> Option<(AudHeader, Vec<i16>)> {
 
     while offset + CHUNK_HEADER_SIZE <= data.len() {
         let compressed_size: u16 = u16::from_le_bytes([data[offset], data[offset + 1]]);
-        let _chunk_output_size: u16 = u16::from_le_bytes([data[offset + 2], data[offset + 3]]);
+        let chunk_output_size: u16 = u16::from_le_bytes([data[offset + 2], data[offset + 3]]);
         let magic: u32 = u32::from_le_bytes([
             data[offset + 4],
             data[offset + 5],
@@ -125,82 +128,33 @@ pub fn decode_aud(data: &[u8]) -> Option<(AudHeader, Vec<i16>)> {
         let chunk_end: usize = (offset + compressed_size as usize).min(data.len());
         let chunk_data: &[u8] = &data[offset..chunk_end];
 
+        let before: usize = samples.len();
         if header.format == 99 {
-            decode_ima_adpcm_chunk(chunk_data, &mut state, &mut samples);
+            decode_nibbles(chunk_data, &mut state, &mut samples);
         } else {
             decode_ws_compressed_chunk(chunk_data, &mut samples);
+        }
+
+        // The chunk header also declares how many OUTPUT bytes the chunk should
+        // produce. Decoding stays input-driven — every nibble present is
+        // decoded and nothing is padded to the declaration — because gamemd has
+        // no AUD chunk decoder to match (see the module header), and because the
+        // only retail files where the two disagree declare exactly one 16-bit
+        // sample more than their nibbles can produce: intro.aud, wipe.aud,
+        // efficien.aud and mouseon.aud, none of which the original ever loads.
+        // A disagreement is still worth seeing when it happens.
+        let produced: usize = (samples.len() - before) * 2;
+        if produced != chunk_output_size as usize {
+            log::debug!(
+                "AUD chunk at {offset}: declared {chunk_output_size} output bytes, \
+                 {produced} produced from {compressed_size} compressed bytes"
+            );
         }
 
         offset = chunk_end;
     }
 
     Some((header, samples))
-}
-
-/// IMA ADPCM decoder state (persists across chunks for continuous decoding).
-pub(crate) struct ImaAdpcmState {
-    index: i32,
-    predicted: i32,
-}
-
-impl ImaAdpcmState {
-    pub(crate) fn new() -> Self {
-        Self {
-            index: 0,
-            predicted: 0,
-        }
-    }
-
-    /// Initialize state from a block preamble (predictor + step_index).
-    pub(crate) fn set_state(&mut self, predicted: i32, index: i32) {
-        self.predicted = predicted;
-        self.index = index.clamp(0, 88);
-    }
-
-    /// Decode a single 4-bit IMA ADPCM nibble into a 16-bit sample.
-    pub(crate) fn decode_nibble(&mut self, nibble: u8) -> i16 {
-        let step: i32 = STEP_TABLE[self.index as usize];
-        let code: u8 = nibble & 0x07;
-
-        // Delta = step * code / 4 + step / 8  (integer arithmetic).
-        let mut diff: i32 = step >> 3;
-        if code & 0x04 != 0 {
-            diff += step;
-        }
-        if code & 0x02 != 0 {
-            diff += step >> 1;
-        }
-        if code & 0x01 != 0 {
-            diff += step >> 2;
-        }
-
-        // Sign bit (bit 3 of nibble).
-        if nibble & 0x08 != 0 {
-            self.predicted -= diff;
-        } else {
-            self.predicted += diff;
-        }
-
-        // Clamp to 16-bit range.
-        self.predicted = self.predicted.clamp(-32768, 32767);
-
-        // Update step index.
-        self.index += INDEX_ADJUST[code as usize];
-        self.index = self.index.clamp(0, 88);
-
-        self.predicted as i16
-    }
-}
-
-/// Decode a chunk of IMA ADPCM data into PCM samples.
-pub(crate) fn decode_ima_adpcm_chunk(data: &[u8], state: &mut ImaAdpcmState, out: &mut Vec<i16>) {
-    for &byte in data {
-        // Each byte contains two 4-bit samples: low nibble first, then high nibble.
-        let lo: u8 = byte & 0x0F;
-        let hi: u8 = (byte >> 4) & 0x0F;
-        out.push(state.decode_nibble(lo));
-        out.push(state.decode_nibble(hi));
-    }
 }
 
 /// Decode a Westwood Compressed (format 1) chunk.
@@ -274,42 +228,6 @@ fn decode_ws_compressed_chunk(data: &[u8], out: &mut Vec<i16>) {
 mod tests {
     use super::*;
 
-    /// Golden vectors captured by emulating the original engine's IMA nibble
-    /// decoder (machine-derived; see docs/research/
-    /// ADPCM_NIBBLE_VALUE_CERTIFICATION_GHIDRA_REPORT.md for the capture
-    /// log). Each row: (predictor, step_index) state, input nibble, expected
-    /// 16-bit sample. Covers zero state, mid states, and both saturation
-    /// clamps.
-    #[test]
-    fn adpcm_nibble_matches_original_engine_emulation_vectors() {
-        const VECTORS: &[(i32, i32, u8, i16)] = &[
-            (0, 0, 0x0, 0),
-            (0, 0, 0x3, 4),
-            (0, 0, 0x5, 8),
-            (0, 0, 0x7, 11),
-            (0, 0, 0x8, 0),
-            (0, 0, 0xB, -4),
-            (0, 0, 0xF, -11),
-            (0, 4, 0x7, 19),
-            (0, 4, 0xF, -19),
-            (24, 40, 0x7, 655),
-            (24, 40, 0xA, -186),
-            (36, 64, 0x5, 4609),
-            (36, 64, 0xD, -4537),
-            (60, 84, 0x7, 32767),  // positive clamp
-            (60, 84, 0xF, -32768), // negative clamp
-        ];
-        for &(pred, idx, nibble, expected) in VECTORS {
-            let mut state = ImaAdpcmState::new();
-            state.set_state(pred, idx);
-            assert_eq!(
-                state.decode_nibble(nibble),
-                expected,
-                "state ({pred},{idx}) nibble {nibble:#x}"
-            );
-        }
-    }
-
     #[test]
     fn test_parse_header_too_short() {
         assert!(parse_header(&[0u8; 5]).is_none());
@@ -336,51 +254,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ima_adpcm_decode_nibble_zero_is_small_step() {
-        let mut state = ImaAdpcmState::new();
-        // Nibble 0 with initial state: predicted=0, index=0, step=7.
-        // diff = 7/8 = 0 (integer), predicted += 0 = 0.
-        let sample: i16 = state.decode_nibble(0);
-        assert_eq!(sample, 0);
-        // Index should decrease by 1 but clamp to 0.
-        assert_eq!(state.index, 0);
-    }
-
-    #[test]
-    fn test_ima_adpcm_decode_produces_nonzero() {
-        let mut state = ImaAdpcmState::new();
-        // Nibble 0x07 (code=7, sign=0): diff = 7/8 + 7/2 + 7/4 = 0+3+1 = 4+0 = 4.
-        // Actually: diff = step>>3 = 0, +step>>1=3, +step>>2=1 => diff=0+3+1=4?
-        // Wait: step=7, diff starts at 7>>3=0.
-        // code&4=4 => diff += 7 => diff=7
-        // code&2=2 => diff += 3 => diff=10
-        // code&1=1 => diff += 1 => diff=11
-        // sign=0 => predicted = 0+11 = 11
-        let sample: i16 = state.decode_nibble(0x07);
-        assert_eq!(sample, 11);
-        // Index += INDEX_ADJUST[7] = 8, clamped to 8.
-        assert_eq!(state.index, 8);
-    }
-
-    #[test]
-    fn test_ima_adpcm_negative_nibble() {
-        let mut state = ImaAdpcmState::new();
-        // Nibble 0x0F (code=7, sign=1): diff=11, predicted = 0-11 = -11.
-        let sample: i16 = state.decode_nibble(0x0F);
-        assert_eq!(sample, -11);
-    }
-
-    #[test]
-    fn test_decode_chunk_pairs_nibbles() {
-        let mut state = ImaAdpcmState::new();
-        let mut out: Vec<i16> = Vec::new();
-        // Single byte 0x10: lo=0, hi=1.
-        decode_ima_adpcm_chunk(&[0x10], &mut state, &mut out);
-        assert_eq!(out.len(), 2);
-        // First sample from nibble 0, second from nibble 1.
-    }
-
-    #[test]
     fn test_decode_aud_invalid_format() {
         let mut data: Vec<u8> = Vec::new();
         data.extend_from_slice(&22050u16.to_le_bytes());
@@ -402,6 +275,65 @@ mod tests {
         let (hdr, samples) = decode_aud(&data).expect("should decode");
         assert_eq!(hdr.sample_rate, 22050);
         assert!(samples.is_empty());
+    }
+
+    /// The four retail AUDs whose final chunk declares `4*compressed + 2` —
+    /// intro.aud, wipe.aud, efficien.aud, mouseon.aud — declare one 16-bit
+    /// sample more than their nibbles can produce. Decoding stays input-driven,
+    /// so we end one sample short of the declaration rather than padding.
+    /// gamemd never loads any of them (it has no AUD chunk decoder at all), so
+    /// there is no native behavior to match here; this pins the choice.
+    #[test]
+    fn decode_aud_is_input_driven_when_a_chunk_overdeclares_its_output() {
+        let mut data: Vec<u8> = Vec::new();
+        data.extend_from_slice(&22050u16.to_le_bytes());
+        data.extend_from_slice(&4u32.to_le_bytes()); // data_size
+        data.extend_from_slice(&18u32.to_le_bytes()); // output_size (declared)
+        data.push(0x02);
+        data.push(99);
+        // One chunk: 4 compressed bytes but 4*4 + 2 = 18 declared output bytes.
+        data.extend_from_slice(&4u16.to_le_bytes());
+        data.extend_from_slice(&18u16.to_le_bytes());
+        data.extend_from_slice(&CHUNK_MAGIC.to_le_bytes());
+        data.extend_from_slice(&[0x00, 0x11, 0x22, 0x33]);
+
+        let (hdr, samples) = decode_aud(&data).expect("should decode");
+        assert_eq!(hdr.output_size, 18);
+        // 4 bytes x 2 nibbles = 8 samples = 16 bytes: one sample short of 18.
+        assert_eq!(samples.len(), 8);
+    }
+
+    #[test]
+    fn decode_aud_carries_adpcm_state_across_chunks() {
+        // The decoder state is created once per file, so splitting the same
+        // nibbles across two chunks must give the same samples as one chunk.
+        let payload: [u8; 8] = [0x37, 0x59, 0x2b, 0xc4, 0x16, 0x8a, 0x71, 0x03];
+        let mut header: Vec<u8> = Vec::new();
+        header.extend_from_slice(&22050u16.to_le_bytes());
+        header.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        header.extend_from_slice(&((payload.len() as u32) * 4).to_le_bytes());
+        header.push(0x02);
+        header.push(99);
+
+        let chunk = |bytes: &[u8]| {
+            let mut c: Vec<u8> = Vec::new();
+            c.extend_from_slice(&(bytes.len() as u16).to_le_bytes());
+            c.extend_from_slice(&((bytes.len() as u16) * 4).to_le_bytes());
+            c.extend_from_slice(&CHUNK_MAGIC.to_le_bytes());
+            c.extend_from_slice(bytes);
+            c
+        };
+
+        let mut one = header.clone();
+        one.extend_from_slice(&chunk(&payload));
+        let mut two = header.clone();
+        two.extend_from_slice(&chunk(&payload[..4]));
+        two.extend_from_slice(&chunk(&payload[4..]));
+
+        let (_, a) = decode_aud(&one).expect("single chunk");
+        let (_, b) = decode_aud(&two).expect("split chunks");
+        assert_eq!(a.len(), 16);
+        assert_eq!(a, b);
     }
 
     #[test]

--- a/src/assets/audio_bag.rs
+++ b/src/assets/audio_bag.rs
@@ -28,7 +28,8 @@
 //!
 //! ## Dependency rules
 //! - Part of assets/ — standalone parser, no game dependencies.
-//! - Uses IMA ADPCM decoder from `aud_file.rs`.
+//! - Compressed entries decode through `assets::ima_adpcm`, the crate's single
+//!   IMA ADPCM implementation, mirroring the single decoder in `gamemd.exe`.
 
 const IDX_HEADER_SIZE: usize = 12;
 /// V1 entries are 32 bytes, V2 entries are 36 bytes (extra chunk_size field).
@@ -258,7 +259,11 @@ pub fn decode_bag_audio(entry: &AudioBagEntry, data: &[u8]) -> Option<BagAudio> 
     }
 
     let samples_i16 = if entry.is_ima_adpcm() {
-        decode_ima_adpcm_blocks(data, entry.channels(), entry.chunk_size)
+        // `AudioIndex__GetFormat @ 0x00401640` turns flags bit 3 into compression
+        // id 1 and passes `chunk_size` (entry +0x20) through as the block stride;
+        // `FUN_00409C40 @ 0x00409C40` then wires the one block decoder,
+        // `IMA_ADPCM__DecodeBlock @ 0x0040AA70`.
+        super::ima_adpcm::decode_blocks(data, entry.channels(), entry.chunk_size)
     } else if entry.is_16bit() {
         // Raw 16-bit signed PCM (little-endian).
         data.chunks_exact(2)
@@ -274,124 +279,6 @@ pub fn decode_bag_audio(entry: &AudioBagEntry, data: &[u8]) -> Option<BagAudio> 
         sample_rate: entry.sample_rate,
         channels: entry.channels(),
     })
-}
-
-/// Decode IMA ADPCM data with per-block preambles.
-///
-/// Each block starts with a 4-byte preamble per channel:
-///   int16 predictor (LE), u8 step_index (0-88), u8 reserved (must be 0)
-/// Followed by nibble data for the remaining block bytes.
-///
-/// If `block_size` is 0 (v1 IDX or unknown), treats the entire data as one block.
-/// RESIDUAL (GSI-02.15) — the multi-block preamble is unexercised, and pass 2
-/// established that it is the LIVE path, not a hypothetical one. Retail
-/// `audio(md).idx` is v2 and every one of its 2292 entries carries
-/// `chunk_size = 512`, so the 36-byte stride runs for every retail sound.
-/// `chunk_size` is a BYTE stride, proved by 8 of 8 sampled entries satisfying
-/// `(size mod 512) - 4 == 0 (mod 4)`, which `IMA_ADPCM::DecodeBlock @
-/// 0x0040AA70` requires. The preamble, the predictor-as-first-sample and the
-/// left/right interleave all match; only coverage is missing. `ABIRJ01A` is a
-/// concrete retail fixture — 28 full blocks plus a 52-byte tail.
-/// - Trigger: decoding any retail sound.
-/// - Player effect: none observed; the risk is a silent decode regression.
-/// - Frequency: continuous.
-/// - Downstream risk: none — this is test coverage over a path that already
-///   matches, so it is a cheap slice whenever assets are in reach.
-fn decode_ima_adpcm_blocks(data: &[u8], channels: u16, block_size: u32) -> Vec<i16> {
-    use super::aud_file::ImaAdpcmState;
-
-    let ch = channels.max(1) as usize;
-    let preamble_size = ch * 4; // 4 bytes per channel preamble
-
-    // If no block size specified, try treating entire data as one block.
-    let bs = if block_size > 0 {
-        block_size as usize
-    } else {
-        data.len()
-    };
-
-    if bs < preamble_size {
-        // Block too small for even the preamble — fall back to raw nibble decode.
-        let mut state = ImaAdpcmState::new();
-        let mut out = Vec::with_capacity(data.len() * 2);
-        super::aud_file::decode_ima_adpcm_chunk(data, &mut state, &mut out);
-        return out;
-    }
-
-    let mut out = Vec::with_capacity(data.len() * 4);
-    let mut pos = 0;
-
-    while pos + preamble_size <= data.len() {
-        let block_end = (pos + bs).min(data.len());
-        let block = &data[pos..block_end];
-
-        if block.len() < preamble_size {
-            break;
-        }
-
-        if ch == 1 {
-            // Mono: single preamble + nibble data.
-            let predictor = i16::from_le_bytes([block[0], block[1]]) as i32;
-            let step_index = block[2] as i32;
-            let _reserved = block[3];
-
-            let mut state = ImaAdpcmState::new();
-            state.set_state(predictor, step_index.clamp(0, 88));
-
-            // First output sample is the predictor value itself.
-            out.push(predictor as i16);
-
-            // Decode remaining nibble data.
-            let nibble_data = &block[preamble_size..];
-            super::aud_file::decode_ima_adpcm_chunk(nibble_data, &mut state, &mut out);
-        } else {
-            // Stereo: two preambles, then interleaved nibble groups.
-            let pred_l = i16::from_le_bytes([block[0], block[1]]) as i32;
-            let idx_l = block[2] as i32;
-            let pred_r = i16::from_le_bytes([block[4], block[5]]) as i32;
-            let idx_r = block[6] as i32;
-
-            let mut state_l = ImaAdpcmState::new();
-            let mut state_r = ImaAdpcmState::new();
-            state_l.set_state(pred_l, idx_l.clamp(0, 88));
-            state_r.set_state(pred_r, idx_r.clamp(0, 88));
-
-            // First output frame is the predictor values.
-            out.push(pred_l as i16);
-            out.push(pred_r as i16);
-
-            // Stereo IMA ADPCM: nibbles are in 4-byte groups per channel,
-            // alternating: 4 bytes L, 4 bytes R, 4 bytes L, 4 bytes R...
-            let nibble_data = &block[preamble_size..];
-            let mut i = 0;
-            while i + 8 <= nibble_data.len() {
-                // 4 bytes for left channel (8 nibbles = 8 samples).
-                let mut l_samples = Vec::with_capacity(8);
-                super::aud_file::decode_ima_adpcm_chunk(
-                    &nibble_data[i..i + 4],
-                    &mut state_l,
-                    &mut l_samples,
-                );
-                // 4 bytes for right channel (8 nibbles = 8 samples).
-                let mut r_samples = Vec::with_capacity(8);
-                super::aud_file::decode_ima_adpcm_chunk(
-                    &nibble_data[i + 4..i + 8],
-                    &mut state_r,
-                    &mut r_samples,
-                );
-                // Interleave L/R output.
-                for j in 0..l_samples.len().min(r_samples.len()) {
-                    out.push(l_samples[j]);
-                    out.push(r_samples[j]);
-                }
-                i += 8;
-            }
-        }
-
-        pos += bs;
-    }
-
-    out
 }
 
 /// Read a little-endian u32 from a byte slice at the given offset.
@@ -524,6 +411,139 @@ mod tests {
             chunk_size: 0,
         };
         assert!(decode_bag_audio(&entry, &[]).is_none());
+    }
+
+    // ---------------------------------------------------------------------
+    // Retail v2 index bytes.
+    //
+    // Every retail sound is looked up through a version-2 `audio.idx` with the
+    // 36-byte stride, yet nothing here exercised that stride: the builder above
+    // emits version 1. The bytes below are copied verbatim from the retail
+    // `audio.idx` inside `langmd.mix -> audiomd.mix` (2,285 entries), so the
+    // stride, field offsets, flag bits and `chunk_size` are pinned against the
+    // shipped file rather than against our own writer.
+    // ---------------------------------------------------------------------
+
+    /// The retail 12-byte header: magic `GABA`, version 2, 2,285 entries.
+    const RETAIL_IDX_HEADER: [u8; 12] = [
+        0x47, 0x41, 0x42, 0x41, 0x02, 0x00, 0x00, 0x00, 0xed, 0x08, 0x00, 0x00,
+    ];
+
+    /// Four retail entries, one per (flags, chunk_size) shape that occurs in
+    /// AUDIOMD: mono IMA (2,192 entries), stereo IMA (5), mono raw PCM (84),
+    /// stereo raw PCM (4).
+    const RETAIL_ENTRIES: [[u8; 36]; 4] = [
+        // "abirj01a": off 11770646, size 14388, 22050 Hz, flags 12, chunk 512
+        [
+            0x61, 0x62, 0x69, 0x72, 0x6a, 0x30, 0x31, 0x61, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x16, 0x9b, 0xb3, 0x00, 0x34, 0x38, 0x00, 0x00, 0x22, 0x56, 0x00, 0x00,
+            0x0c, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
+        ],
+        // "grexselb": off 7063684, size 41212, flags 13 (stereo IMA), chunk 1024
+        [
+            0x67, 0x72, 0x65, 0x78, 0x73, 0x65, 0x6c, 0x62, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x84, 0xc8, 0x6b, 0x00, 0xfc, 0xa0, 0x00, 0x00, 0x22, 0x56, 0x00, 0x00,
+            0x0d, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00,
+        ],
+        // "icraloop": off 285960, size 16606, flags 6 (mono raw 16-bit), chunk 0
+        [
+            0x69, 0x63, 0x72, 0x61, 0x6c, 0x6f, 0x6f, 0x70, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x08, 0x5d, 0x04, 0x00, 0xde, 0x40, 0x00, 0x00, 0x22, 0x56, 0x00, 0x00,
+            0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ],
+        // "uscolo1": off 8107566, size 309980, flags 7 (stereo raw 16-bit), chunk 0
+        [
+            0x75, 0x73, 0x63, 0x6f, 0x6c, 0x6f, 0x31, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x2e, 0xb6, 0x7b, 0x00, 0xdc, 0xba, 0x04, 0x00, 0x22, 0x56, 0x00, 0x00,
+            0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ],
+    ];
+
+    /// Retail header + entries, with only the entry count rewritten to the
+    /// number of entries actually embedded.
+    fn retail_idx_slice() -> Vec<u8> {
+        let mut idx = RETAIL_IDX_HEADER.to_vec();
+        idx[8..12].copy_from_slice(&(RETAIL_ENTRIES.len() as u32).to_le_bytes());
+        for entry in &RETAIL_ENTRIES {
+            idx.extend_from_slice(entry);
+        }
+        idx
+    }
+
+    #[test]
+    fn retail_v2_index_parses_with_the_36_byte_stride() {
+        let index = AudioIndex::from_idx_bag(&retail_idx_slice(), Vec::new())
+            .expect("retail v2 header must parse");
+        assert_eq!(index.len(), RETAIL_ENTRIES.len());
+
+        let by_name = |n: &str| {
+            index
+                .entries()
+                .iter()
+                .find(|e| e.name == n)
+                .unwrap_or_else(|| panic!("missing {n}"))
+        };
+
+        // Names are uppercased on load; the shipped index stores them lowercase.
+        let abirj = by_name("ABIRJ01A");
+        assert_eq!((abirj.offset, abirj.size), (11_770_646, 14_388));
+        assert_eq!(abirj.sample_rate, 22_050);
+        assert_eq!(abirj.chunk_size, 512);
+        assert!(abirj.is_ima_adpcm() && abirj.is_16bit() && !abirj.is_stereo());
+        // 28 whole 512-byte blocks and a 52-byte tail — the shape the block
+        // decoder actually sees.
+        assert_eq!(abirj.size % abirj.chunk_size, 52);
+
+        let grex = by_name("GREXSELB");
+        assert_eq!(grex.chunk_size, 1024, "stereo IMA doubles the stride");
+        assert!(grex.is_ima_adpcm() && grex.is_stereo());
+        assert_eq!(grex.channels(), 2);
+
+        let icra = by_name("ICRALOOP");
+        assert!(!icra.is_ima_adpcm() && icra.is_16bit() && !icra.is_stereo());
+        assert_eq!(icra.chunk_size, 0, "raw PCM carries no block stride");
+
+        let usc = by_name("USCOLO1");
+        assert!(!usc.is_ima_adpcm() && usc.is_16bit() && usc.is_stereo());
+        assert_eq!(usc.chunk_size, 0);
+
+        // Sorted for the native's bsearch over `_stricmp` (0x004013AB / 0x007c8d20).
+        let names: Vec<&str> = index.entries().iter().map(|e| e.name.as_str()).collect();
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        assert_eq!(names, sorted);
+    }
+
+    /// The retail final block of AUDIOMD `ABIRJ01A` (bag offset 11,770,646 +
+    /// 28 x 512): 4-byte preamble + 48-byte payload.
+    const ABIRJ01A_TAIL_BLOCK: &[u8] = &[
+        0xf8, 0xff, 0x01, 0x00, 0x17, 0xbc, 0x33, 0xa1, 0x1b, 0x00, 0x90, 0x3a, 0xb5, 0x2c, 0x92,
+        0x10, 0xb2, 0x9c, 0x32, 0xb3, 0x2d, 0x21, 0xcb, 0x79, 0xa1, 0x0a, 0x31, 0xc0, 0x1a, 0x23,
+        0xbb, 0x4b, 0xb2, 0x1b, 0x13, 0x11, 0xd9, 0x39, 0x92, 0xa9, 0x30, 0x90, 0x0a, 0x11, 0x11,
+        0x1a, 0x91, 0x09, 0x11, 0x09, 0x00, 0x00,
+    ];
+
+    #[test]
+    fn retail_ima_entry_decodes_through_the_shared_block_decoder() {
+        // Entry metadata is the shipped ABIRJ01A row; the data is its real final
+        // block, so this walks idx flags -> channels/chunk_size -> block decoder.
+        let entry = AudioBagEntry {
+            name: "ABIRJ01A".into(),
+            offset: 0,
+            size: ABIRJ01A_TAIL_BLOCK.len() as u32,
+            sample_rate: 22_050,
+            flags: 12,
+            chunk_size: 512,
+        };
+        let audio = decode_bag_audio(&entry, ABIRJ01A_TAIL_BLOCK).expect("should decode");
+        assert_eq!(audio.channels, 1);
+        assert_eq!(audio.sample_rate, 22_050);
+        assert_eq!(audio.samples_i16.len(), 97);
+        assert_eq!(audio.samples_i16[0], -8, "preamble predictor is sample 0");
+        assert_eq!(
+            audio.samples_i16,
+            crate::assets::ima_adpcm::decode_blocks(ABIRJ01A_TAIL_BLOCK, 1, 512)
+        );
     }
 
     #[test]

--- a/src/assets/ima_adpcm.rs
+++ b/src/assets/ima_adpcm.rs
@@ -143,9 +143,9 @@ const GROUP_BYTES_PER_CHANNEL: usize = 4;
 
 /// Decode block-framed IMA ADPCM into interleaved 16-bit PCM.
 ///
-/// This is `IMA_ADPCM__DecodeBlock @ 0x0040AA70` driven by the streaming pump
-/// `Audio__DecodeCompressedBlock @ 0x00409DE0`, which hands it one
-/// `block_align`-byte buffer at a time.
+/// This is `IMA_ADPCM__DecodeBlock @ 0x0040AA70` driven the way the native
+/// streaming pump drives it, because the pump — not the file — decides how many
+/// bytes each block decode sees.
 ///
 /// Per block the native:
 /// 1. requires at least `4 * channels` bytes, else fails (`0x0040AAAD`);
@@ -164,13 +164,41 @@ const GROUP_BYTES_PER_CHANNEL: usize = 4;
 /// abandon the sound, so the block's samples never reach the mixer. We stop and
 /// return what earlier blocks produced, which is what the player hears.
 ///
-/// The same "return false" happens when a block's payload is not a whole number
-/// of groups: mono rounds the group count up and reads past the block
-/// (`0x0040AB4E: LEA EAX,[ECX+3] / SHR EAX,2`), stereo runs one group too many
-/// (`0x0040ACB3: TEST ECX,ECX / JG`), and both then report failure. We do not
-/// reproduce the over-read — its inputs are stale buffer bytes — so we drop the
-/// block, which is the audible outcome either way.
+/// ## The native feed: every block is exactly `block_align` bytes
+///
+/// The decoder's available-byte count is `+0x80 - +0x84`
+/// (`0x0040AA70` prologue), and in `Audio__DecodeCompressedBlock @ 0x00409DE0`
+/// those two fields have exactly four writes between them:
+/// - case 3 sets both to `+0xAC` = `block_align` (`0x00409F8A`, `0x00409F90`);
+/// - case 0 fills the `malloc(block_align)` input buffer at `+0x7C`, writing at
+///   offset `+0x80 - +0x84` and subtracting what it copied (`0x00409EBE`);
+/// - case 0 forces `+0x84 = 0` (`0x00409EA4`) when the source is exhausted or
+///   the source pointer is NULL, then hands over to the block decoder.
+///
+/// `FUN_00409880 @ 0x00409880` writes neither field. Case 0 only ever leaves the
+/// fill state with `+0x84 == 0`, so **`avail` is always exactly `block_align`**.
+/// Two consequences, both of which this function reproduces:
+///
+/// - At end of stream the pump calls the decode callback with a NULL source and
+///   a NULL count (`0x00409B41`, taken while the stream's "decoder still holds
+///   data" flag `+0xA8` is set), so a final short tail is still decoded as a
+///   **full `block_align` block**. The bytes past the tail are whatever the
+///   previous cycle left in the input buffer at those same offsets — i.e. the
+///   previous block's bytes — because every cycle refills the buffer from
+///   offset 0. We rebuild exactly that buffer.
+/// - The "payload is not a whole number of groups" failure (mono
+///   `0x0040AB4E: LEA EAX,[ECX+3] / SHR EAX,2` then `0x0040ABD4 SETZ`; stereo
+///   `0x0040ACB3: TEST ECX,ECX / JG`) is therefore decided by `block_align`
+///   alone, never by where the data ends. Both retail strides are whole
+///   (`(512-4) % 4 == 0`, `(1024-8) % 8 == 0`), so it is unreachable on retail
+///   data; we keep the rule gated on the stride so a synthetic stride behaves
+///   natively. We do not reproduce the over-read values, which the rejected
+///   block discards anyway.
 pub fn decode_blocks(data: &[u8], channels: u16, block_align: u32) -> Vec<i16> {
+    // VERA-internal, gamemd equivalent UNCHECKED: with `+0xA4 == 0` the native's
+    // stereo loop at `0x0040ABED` subtracts 0 per pass and spins forever, so
+    // there is no native behavior to match. No retail entry declares 0 channels
+    // (`AudioIndex__GetFormat @ 0x00401640` derives it from a flag bit).
     let channels = channels.max(1) as usize;
     let preamble = PREAMBLE_BYTES_PER_CHANNEL * channels;
     let group = GROUP_BYTES_PER_CHANNEL * channels;
@@ -189,15 +217,38 @@ pub fn decode_blocks(data: &[u8], channels: u16, block_align: u32) -> Vec<i16> {
     let mut states: Vec<ImaAdpcmState> = (0..channels).map(|_| ImaAdpcmState::new()).collect();
     let mut pos = 0usize;
 
-    while pos + preamble <= data.len() {
-        let block_end = (pos + block_align).min(data.len());
-        let block = &data[pos..block_end];
+    while pos < data.len() {
+        let real = &data[pos..(pos + block_align).min(data.len())];
+        let stale_padded;
+        let block: &[u8] = if real.len() == block_align {
+            real
+        } else if pos >= block_align {
+            // End-of-stream flush: the input buffer still holds the previous
+            // block's bytes past the short tail (see the module comment above).
+            let mut buffer = Vec::with_capacity(block_align);
+            buffer.extend_from_slice(real);
+            buffer.extend_from_slice(&data[pos - block_align + real.len()..pos]);
+            stale_padded = buffer;
+            &stale_padded
+        } else {
+            // VERA-internal, gamemd equivalent UNCHECKED: a sound shorter than
+            // one stride is flushed against a buffer that was never filled by
+            // this sound — `malloc`ed on first use, otherwise the previous
+            // sound's bytes, since `FUN_00409C40` only reallocates when the
+            // stride grows. Neither is reproducible from the file, so we decode
+            // the whole groups this sound actually carries.
+            if real.len() < preamble {
+                break;
+            }
+            &real[..preamble + (real.len() - preamble) / group * group]
+        };
+
         // A rejected block is discarded whole by the caller, so everything this
         // iteration appends has to go with it.
         let block_out_start = out.len();
 
         // Preambles: predictor, step index, reserved — per channel, in order.
-        let mut rejected = block[preamble..].len() % group != 0;
+        let mut rejected = (block.len() - preamble) % group != 0;
         for (ch, state) in states.iter_mut().enumerate() {
             if rejected {
                 break;
@@ -402,6 +453,9 @@ mod tests {
 
     #[test]
     fn retail_mono_tail_block_matches_native_block_decode() {
+        // Fed alone these are the 52 bytes the native's flush block starts
+        // with, so these 97 samples are the leading 97 the native emits for it
+        // (the rest come from the stale buffer tail, covered separately).
         let out = decode_blocks(ABIRJ01A_TAIL_BLOCK, 1, 512);
         // 1 preamble sample + 48 payload bytes x 2 nibbles.
         assert_eq!(out.len(), 97);
@@ -430,15 +484,83 @@ mod tests {
     }
 
     #[test]
-    fn unaligned_payload_drops_the_block_like_the_native() {
-        // 44 bytes: 8 preamble + 36 payload, and 36 is not a whole number of
-        // 8-byte groups. `0x0040ACB3` runs one group past the end and then
-        // `SETZ AL` reports failure, so the block never reaches the mixer.
+    fn ragged_stride_drops_the_block_like_the_native() {
+        // The over-read failure is decided by the STRIDE, not by where the data
+        // ends: the pump always presents exactly `block_align` bytes, so
+        // `0x0040AB4E`'s rounded-up group count only overshoots when
+        // `(block_align - 4*channels) % (4*channels) != 0`. Stride 13 mono
+        // leaves a 9-byte payload — two whole groups plus one byte — so the
+        // native reads a third group past the block and `0x0040ABD4 SETZ`
+        // reports failure, dropping it.
+        let ragged = vec![0u8; 26];
+        assert!(decode_blocks(&ragged, 1, 13).is_empty());
+        // Neither retail stride is ragged, so this is unreachable on retail
+        // data: (512-4) % 4 == 0 and (1024-8) % 8 == 0.
+        assert_eq!((512 - 4) % 4, 0);
+        assert_eq!((1024 - 8) % 8, 0);
+    }
+
+    #[test]
+    fn end_of_stream_flush_pads_from_the_previous_block_like_the_native() {
+        // `FUN_00409880`'s NULL-source call at `0x00409B41` makes
+        // `Audio__DecodeCompressedBlock` force `+0x84 = 0` (`0x00409EA4`), so
+        // the block decoder still sees a full stride. Every fill cycle writes
+        // the input buffer from offset 0, so the bytes past a short tail are
+        // the previous block's bytes at those same offsets.
+        let block0: Vec<u8> = vec![
+            0x64, 0x00, 0x05, 0x00, 0x3c, 0x91, 0x27, 0x08, 0xa5, 0x1f, 0x60, 0xd3,
+        ];
+        let tail: Vec<u8> = vec![0x10, 0x00, 0x02, 0x00, 0x8f, 0x41];
+
+        let mut data = block0.clone();
+        data.extend_from_slice(&tail);
+        let out = decode_blocks(&data, 1, 12);
+
+        // Two whole blocks' worth of output, not one and a fragment.
+        assert_eq!(out.len(), 34, "the short tail still decodes a full stride");
+
+        // The flush block is byte-for-byte `tail ++ block0[6..12]`.
+        let mut expected_buffer = tail.clone();
+        expected_buffer.extend_from_slice(&block0[6..]);
+        assert_eq!(expected_buffer.len(), 12);
+        assert_eq!(
+            &out[17..],
+            decode_blocks(&expected_buffer, 1, 12).as_slice()
+        );
+    }
+
+    #[test]
+    fn retail_sound_shapes_decode_the_native_block_count() {
+        // Sample counts measured against gamemd's pipeline: every sound decodes
+        // ceil(size / stride) blocks of 1 + (stride - 4*ch)/(4*ch) * 8 frames,
+        // because the end-of-stream flush presents a full stride.
+        //
+        // ABIRJ01A: 14,388 bytes, mono, stride 512 -> 29 blocks x 1017 samples.
+        let mut mono = vec![0x11u8; 14_388];
+        for start in (0..mono.len()).step_by(512) {
+            mono[start..start + 4].fill(0);
+        }
+        assert_eq!(decode_blocks(&mono, 1, 512).len(), 29 * 1017);
+
+        // GREXSELB: 41,212 bytes, stereo, stride 1024 -> 41 blocks x 1017
+        // frames = 83,394 samples. Its 252-byte tail is the corpus's only block
+        // whose *real* payload is ragged; padded to the stride it is not.
+        let mut stereo = vec![0x11u8; 41_212];
+        for start in (0..stereo.len()).step_by(1024) {
+            stereo[start..start + 8].fill(0);
+        }
+        assert_eq!(decode_blocks(&stereo, 2, 1024).len(), 41 * 1017 * 2);
+    }
+
+    #[test]
+    fn lone_short_block_decodes_whole_groups_only() {
+        // VERA-internal: a sound shorter than one stride is flushed against a
+        // buffer this sound never filled, so there is nothing to reproduce. We
+        // decode the whole groups it carries. 44 bytes stereo = 8 preamble + 36
+        // payload -> 4 whole 8-byte groups, the spare 4 bytes dropped.
         let out = decode_blocks(GTIMESHI_STEREO_BYTES, 2, 1024);
-        assert!(out.is_empty(), "a rejected first block yields nothing");
-        // Retail hits this exactly once: AUDIOMD `grexselb` (offset 7,063,684,
-        // size 41,212, chunk 1024) ends in a 252-byte block whose 244-byte
-        // payload is 30 whole groups plus 4 bytes.
+        assert_eq!(out.len(), 66);
+        assert_eq!(out.as_slice(), GTIMESHI_STEREO_SAMPLES);
     }
 
     #[test]

--- a/src/assets/ima_adpcm.rs
+++ b/src/assets/ima_adpcm.rs
@@ -166,18 +166,26 @@ const GROUP_BYTES_PER_CHANNEL: usize = 4;
 ///
 /// ## The native feed: every block is exactly `block_align` bytes
 ///
-/// The decoder's available-byte count is `+0x80 - +0x84`
-/// (`0x0040AA70` prologue), and in `Audio__DecodeCompressedBlock @ 0x00409DE0`
-/// those two fields have exactly four writes between them:
+/// The decoder's available-byte count is `+0x80 - +0x84` (`0x0040AA70`
+/// prologue). Those two fields have exactly six writes in the whole image, four
+/// of them in `Audio__DecodeCompressedBlock @ 0x00409DE0`:
 /// - case 3 sets both to `+0xAC` = `block_align` (`0x00409F8A`, `0x00409F90`);
 /// - case 0 fills the `malloc(block_align)` input buffer at `+0x7C`, writing at
-///   offset `+0x80 - +0x84` and subtracting what it copied (`0x00409EBE`);
-/// - case 0 forces `+0x84 = 0` (`0x00409EA4`) when the source is exhausted or
-///   the source pointer is NULL, then hands over to the block decoder.
+///   offset `+0x80 - +0x84` and subtracting what it copied (`0x00409EA4`,
+///   preceded by `0x00409E92 MOV ECX,[EBX+0x84]` / `0x00409E9A SUB ECX,EAX`);
+/// - case 0 forces `+0x84 = 0` (`0x00409EBE MOV [EBX+0x84],ESI`, `ESI == 0`)
+///   when the source is exhausted or the source pointer is NULL, paired with
+///   the state transition at `0x00409EC4` that hands over to the block decoder.
 ///
-/// `FUN_00409880 @ 0x00409880` writes neither field. Case 0 only ever leaves the
-/// fill state with `+0x84 == 0`, so **`avail` is always exactly `block_align`**.
-/// Two consequences, both of which this function reproduces:
+/// The other two are `FUN_00409C40 @ 0x00409C40` zeroing both fields at
+/// configure time (`0x00409C6C`, `0x00409C72`). They never reach the block
+/// decoder: the same straight-line block forces the state back to 3
+/// (`0x00409C78`), so case 3 reloads both from `+0xAC` first. `FUN_00409880 @
+/// 0x00409880` writes neither field, and it calls `FUN_00409C40` only while
+/// `+0xA8 == 0` (`0x00409A83 CMP [ESI+0xa8],EDI / JNZ`), so the buffer cannot be
+/// reallocated or re-formatted while a partial block is pending. Case 0 only
+/// ever leaves the fill state with `+0x84 == 0`, so **`avail` is always exactly
+/// `block_align`**. Two consequences, both of which this function reproduces:
 ///
 /// - At end of stream the pump calls the decode callback with a NULL source and
 ///   a NULL count (`0x00409B41`, taken while the stream's "decoder still holds
@@ -185,7 +193,13 @@ const GROUP_BYTES_PER_CHANNEL: usize = 4;
 ///   **full `block_align` block**. The bytes past the tail are whatever the
 ///   previous cycle left in the input buffer at those same offsets — i.e. the
 ///   previous block's bytes — because every cycle refills the buffer from
-///   offset 0. We rebuild exactly that buffer.
+///   offset 0. We rebuild exactly that buffer. A source delivered in several
+///   segments still flushes exactly once: a new segment sets the remaining
+///   source count `+0x2C` (`0x00409ACD`) and `0x00409AE3 JG` then routes to the
+///   with-source call at `0x00409B65`, so the flush branch is unreachable until
+///   true EOF; and once case 1 has drained the flushed block it clears `+0xA8`
+///   (`0x00409ED9`), after which the pump fills silence (`0x00409AED`) rather
+///   than calling the decoder again.
 /// - The "payload is not a whole number of groups" failure (mono
 ///   `0x0040AB4E: LEA EAX,[ECX+3] / SHR EAX,2` then `0x0040ABD4 SETZ`; stereo
 ///   `0x0040ACB3: TEST ECX,ECX / JG`) is therefore decided by `block_align`
@@ -435,7 +449,8 @@ mod tests {
     /// `GTIMESHI`, AUDIOMD bag offset 33,758,996, stereo IMA, `chunk_size` 1024:
     /// the first 44 bytes of its block 10 (8-byte preamble pair + 36 payload
     /// bytes). The first 40 bytes are a whole number of 8-byte L/R groups; the
-    /// spare 4 make the same bytes usable as the unaligned-payload case.
+    /// spare 4 let the same bytes serve the sub-stride case, where VERA decodes
+    /// the whole groups only (`lone_short_block_decodes_whole_groups_only`).
     const GTIMESHI_STEREO_BYTES: &[u8] = &[
         0x3d, 0xda, 0x45, 0x00, 0x40, 0x18, 0x4a, 0x00, 0x07, 0x90, 0x09, 0x4a, 0x8d, 0x10, 0xa1,
         0xc6, 0x1c, 0x90, 0xa0, 0x5a, 0xa2, 0x90, 0x00, 0x98, 0x8f, 0xa8, 0x42, 0x90, 0xb8, 0xd3,
@@ -503,7 +518,7 @@ mod tests {
     #[test]
     fn end_of_stream_flush_pads_from_the_previous_block_like_the_native() {
         // `FUN_00409880`'s NULL-source call at `0x00409B41` makes
-        // `Audio__DecodeCompressedBlock` force `+0x84 = 0` (`0x00409EA4`), so
+        // `Audio__DecodeCompressedBlock` force `+0x84 = 0` (`0x00409EBE`), so
         // the block decoder still sees a full stride. Every fill cycle writes
         // the input buffer from offset 0, so the bytes past a short tail are
         // the previous block's bytes at those same offsets.

--- a/src/assets/ima_adpcm.rs
+++ b/src/assets/ima_adpcm.rs
@@ -1,0 +1,511 @@
+//! IMA ADPCM decoding — the single decoder every compressed retail sound flows through.
+//!
+//! `gamemd.exe` contains exactly **one** IMA-ADPCM nibble decoder,
+//! `IMA_ADPCM__DecodeSample @ 0x0040ACD0`, and exactly **one** block decoder,
+//! `IMA_ADPCM__DecodeBlock @ 0x0040AA70`. Verified by `get_xrefs_to` on both
+//! coefficient tables (`0x00816558` step, `0x00816518` index adjust): each has a
+//! single DATA reference, both from `0x0040ACD0`; a `search_byte_patterns` sweep
+//! for the step table's head found no second copy in the image. The block decoder
+//! is reached only as the `+0xB0` callback installed by the audio pipeline setup
+//! `FUN_00409C40 @ 0x00409C40` when the format descriptor's compression id
+//! (`+0x04`) is 1.
+//!
+//! Both retail sound sources feed that one pipeline through the *same* format
+//! descriptor, so one Rust implementation is the gamemd-native structure rather
+//! than a Rust convenience:
+//! - bag entries: `AudioIndex__GetFormat @ 0x00401640` fills the descriptor from
+//!   an `audio.idx` entry (compression 1 when flags bit 3 is set, `chunk_size`
+//!   from entry `+0x20` into descriptor `+0x18`).
+//! - WAV files: `WAV__ParseHeader @ 0x00408610` fills the same descriptor for
+//!   `wFormatTag == 0x11`, taking descriptor `+0x18` from the fmt chunk's
+//!   **`nBlockAlign`** (`psVar6[6]`, fmt bytes 12..14).
+//!
+//! `FUN_00409C40` then reads descriptor `+0x18` into the stream's input-buffer
+//! size (`+0x8C`/`+0xAC`) and sizes the output buffer as `chunk*4 + 0x80`, so the
+//! field is a **byte** stride — the number of compressed bytes per block — not a
+//! sample count. (`docs/research/AUDIO_IDX_BAG_GHIDRA_REPORT.md` §4 called it
+//! `wSamplesPerBlock`; that name is wrong, the offset it cites is `nBlockAlign`.)
+//!
+//! ## No VOC decoder, and none is needed
+//!
+//! `gamemd.exe` has no Creative VOC support: `search_strings "(?i)\.voc"` and
+//! `search_strings "(?i)creative voice"` both return zero matches, no retail
+//! `ini/` file references a `.voc`, and the retail install carries no `.voc`
+//! file. The format is excluded, not unimplemented.
+//!
+//! ## Dependency rules
+//! - Part of `assets/` — standalone decoder, no game dependencies.
+
+/// IMA ADPCM step size table (89 entries).
+///
+/// Machine-read from `gamemd.exe` at `0x00816558` (89 x i32) — see
+/// `ima_step_table_matches_image_bytes`.
+pub(crate) const STEP_TABLE: [i32; 89] = [
+    7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41, 45, 50, 55, 60, 66,
+    73, 80, 88, 97, 107, 118, 130, 143, 157, 173, 190, 209, 230, 253, 279, 307, 337, 371, 408, 449,
+    494, 544, 598, 658, 724, 796, 876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066, 2272,
+    2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484, 7132, 7845, 8630, 9493,
+    10442, 11487, 12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767,
+];
+
+/// IMA ADPCM step index adjustment, indexed by the low 3 bits of the nibble.
+///
+/// The native table at `0x00816518` is 16 x i32 and mirrors entries 0..7 into
+/// 8..15 (`[-1,-1,-1,-1,2,4,6,8]` twice), so indexing it by the full nibble is
+/// identical to indexing these 8 entries by `nibble & 7` — see
+/// `ima_index_table_matches_image_bytes`.
+pub(crate) const INDEX_ADJUST: [i32; 8] = [-1, -1, -1, -1, 2, 4, 6, 8];
+
+/// Highest legal step index; the native clamps to this and rejects any block
+/// preamble declaring more (`0x0040AAE8: CMP EDX,0x58 / JG reject`).
+pub(crate) const MAX_STEP_INDEX: i32 = 0x58;
+
+/// IMA ADPCM decoder state: the running predictor and step index.
+///
+/// `IMA_ADPCM__DecodeSample @ 0x0040ACD0` keeps this as two `i32` at
+/// `[EDX]` (predictor) and `[EDX+4]` (step index).
+pub(crate) struct ImaAdpcmState {
+    index: i32,
+    predicted: i32,
+}
+
+impl ImaAdpcmState {
+    pub(crate) fn new() -> Self {
+        Self {
+            index: 0,
+            predicted: 0,
+        }
+    }
+
+    /// Initialize state from a block preamble (predictor + step_index).
+    pub(crate) fn set_state(&mut self, predicted: i32, index: i32) {
+        self.predicted = predicted;
+        self.index = index.clamp(0, MAX_STEP_INDEX);
+    }
+
+    /// Decode a single 4-bit IMA ADPCM nibble into a 16-bit sample.
+    ///
+    /// `IMA_ADPCM__DecodeSample @ 0x0040ACD0`, instruction for instruction:
+    /// the predictor clamps (`0x0040AD0F`/`0x0040AD1F`) *before* the index
+    /// update (`0x0040AD2C`), and the returned sample is the clamped predictor
+    /// re-read as a 16-bit word (`0x0040AD5A: MOV AX, word ptr [EDX]`).
+    pub(crate) fn decode_nibble(&mut self, nibble: u8) -> i16 {
+        let step: i32 = STEP_TABLE[self.index as usize];
+        let code: u8 = nibble & 0x07;
+
+        // 0x0040ACDE..0x0040ACFD: step/8, plus step/4, step/2, step per set bit.
+        let mut diff: i32 = step >> 3;
+        if code & 0x04 != 0 {
+            diff += step;
+        }
+        if code & 0x02 != 0 {
+            diff += step >> 1;
+        }
+        if code & 0x01 != 0 {
+            diff += step >> 2;
+        }
+
+        // 0x0040ACFF: sign bit 3 negates the delta.
+        if nibble & 0x08 != 0 {
+            self.predicted -= diff;
+        } else {
+            self.predicted += diff;
+        }
+
+        self.predicted = self.predicted.clamp(-32768, 32767);
+
+        self.index += INDEX_ADJUST[code as usize];
+        self.index = self.index.clamp(0, MAX_STEP_INDEX);
+
+        self.predicted as i16
+    }
+}
+
+/// Decode a run of packed nibbles, low nibble of each byte first.
+///
+/// The native's inner loops fetch `BL = [EBP]`, decode `BL & 0xF` then
+/// `BL >> 4` (`0x0040AB83`/`0x0040AB99` mono, `0x0040AC36`/`0x0040AC50`
+/// stereo), so the low nibble is always the earlier sample.
+pub(crate) fn decode_nibbles(data: &[u8], state: &mut ImaAdpcmState, out: &mut Vec<i16>) {
+    for &byte in data {
+        out.push(state.decode_nibble(byte & 0x0F));
+        out.push(state.decode_nibble((byte >> 4) & 0x0F));
+    }
+}
+
+/// Bytes of preamble the native consumes per channel: `i16` predictor,
+/// `u8` step index, `u8` reserved.
+const PREAMBLE_BYTES_PER_CHANNEL: usize = 4;
+
+/// Compressed bytes each channel contributes to one interleave group; each
+/// group yields 8 sample frames.
+const GROUP_BYTES_PER_CHANNEL: usize = 4;
+
+/// Decode block-framed IMA ADPCM into interleaved 16-bit PCM.
+///
+/// This is `IMA_ADPCM__DecodeBlock @ 0x0040AA70` driven by the streaming pump
+/// `Audio__DecodeCompressedBlock @ 0x00409DE0`, which hands it one
+/// `block_align`-byte buffer at a time.
+///
+/// Per block the native:
+/// 1. requires at least `4 * channels` bytes, else fails (`0x0040AAAD`);
+/// 2. reads one `{i16 predictor, u8 step_index, u8 reserved}` preamble per
+///    channel and **rejects the block** if `step_index > 0x58` or
+///    `reserved != 0` (`0x0040AAEE`, `0x0040AAF9`);
+/// 3. emits each channel's predictor as the block's first sample frame
+///    (`0x0040AB0C`);
+/// 4. consumes the payload in groups of `4 * channels` bytes — 4 bytes per
+///    channel, channel 0 first, the input pointer advancing monotonically —
+///    each group producing 8 interleaved frames (`0x0040AB77` mono,
+///    `0x0040AC2C` stereo).
+///
+/// A rejected block makes the decoder return false, which makes
+/// `Audio__DecodeCompressedBlock` return 0 (`0x00409F4E`) and the buffer pump
+/// abandon the sound, so the block's samples never reach the mixer. We stop and
+/// return what earlier blocks produced, which is what the player hears.
+///
+/// The same "return false" happens when a block's payload is not a whole number
+/// of groups: mono rounds the group count up and reads past the block
+/// (`0x0040AB4E: LEA EAX,[ECX+3] / SHR EAX,2`), stereo runs one group too many
+/// (`0x0040ACB3: TEST ECX,ECX / JG`), and both then report failure. We do not
+/// reproduce the over-read — its inputs are stale buffer bytes — so we drop the
+/// block, which is the audible outcome either way.
+pub fn decode_blocks(data: &[u8], channels: u16, block_align: u32) -> Vec<i16> {
+    let channels = channels.max(1) as usize;
+    let preamble = PREAMBLE_BYTES_PER_CHANNEL * channels;
+    let group = GROUP_BYTES_PER_CHANNEL * channels;
+
+    // `FUN_00409C40` copies the format descriptor's `+0x18` straight into the
+    // stream's input-buffer size, so a zero stride leaves the block decoder with
+    // zero available bytes and it fails on its first call: the sound is silent.
+    // (No retail entry reaches this — both retail `audio.idx` files are v2 and
+    // every IMA entry carries 512 (mono) or 1024 (stereo).)
+    let block_align = block_align as usize;
+    if block_align < preamble {
+        return Vec::new();
+    }
+
+    let mut out: Vec<i16> = Vec::with_capacity(data.len() * 2 + channels);
+    let mut states: Vec<ImaAdpcmState> = (0..channels).map(|_| ImaAdpcmState::new()).collect();
+    let mut pos = 0usize;
+
+    while pos + preamble <= data.len() {
+        let block_end = (pos + block_align).min(data.len());
+        let block = &data[pos..block_end];
+        // A rejected block is discarded whole by the caller, so everything this
+        // iteration appends has to go with it.
+        let block_out_start = out.len();
+
+        // Preambles: predictor, step index, reserved — per channel, in order.
+        let mut rejected = block[preamble..].len() % group != 0;
+        for (ch, state) in states.iter_mut().enumerate() {
+            if rejected {
+                break;
+            }
+            let base = ch * PREAMBLE_BYTES_PER_CHANNEL;
+            let predictor = i16::from_le_bytes([block[base], block[base + 1]]) as i32;
+            let step_index = block[base + 2] as i32;
+            let reserved = block[base + 3];
+            if step_index > MAX_STEP_INDEX || reserved != 0 {
+                rejected = true;
+                break;
+            }
+            state.set_state(predictor, step_index);
+            out.push(predictor as i16);
+        }
+        if rejected {
+            out.truncate(block_out_start);
+            return out;
+        }
+
+        let payload = &block[preamble..];
+        if channels == 1 {
+            decode_nibbles(payload, &mut states[0], &mut out);
+        } else {
+            let mut group_start = out.len();
+            for chunk in payload.chunks_exact(group) {
+                out.resize(group_start + 8 * channels, 0);
+                for (ch, state) in states.iter_mut().enumerate() {
+                    let bytes = &chunk[ch * GROUP_BYTES_PER_CHANNEL..][..GROUP_BYTES_PER_CHANNEL];
+                    let mut frame = 0usize;
+                    for &byte in bytes {
+                        out[group_start + frame * channels + ch] = state.decode_nibble(byte & 0x0F);
+                        frame += 1;
+                        out[group_start + frame * channels + ch] =
+                            state.decode_nibble((byte >> 4) & 0x0F);
+                        frame += 1;
+                    }
+                }
+                group_start += 8 * channels;
+            }
+        }
+
+        pos += block_align;
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The native step table, machine-read out of `gamemd.exe` at `0x00816558`
+    /// with `read_memory` (356 bytes = 89 x i32 little-endian). This is the
+    /// binary's own data, not a restatement of ours.
+    const IMAGE_STEP_TABLE_BYTES: &[u8] = &[
+        0x07, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00,
+        0x00, 0x0b, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x0e, 0x00,
+        0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x13, 0x00, 0x00, 0x00, 0x15,
+        0x00, 0x00, 0x00, 0x17, 0x00, 0x00, 0x00, 0x19, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00,
+        0x1f, 0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00, 0x25, 0x00, 0x00, 0x00, 0x29, 0x00, 0x00,
+        0x00, 0x2d, 0x00, 0x00, 0x00, 0x32, 0x00, 0x00, 0x00, 0x37, 0x00, 0x00, 0x00, 0x3c, 0x00,
+        0x00, 0x00, 0x42, 0x00, 0x00, 0x00, 0x49, 0x00, 0x00, 0x00, 0x50, 0x00, 0x00, 0x00, 0x58,
+        0x00, 0x00, 0x00, 0x61, 0x00, 0x00, 0x00, 0x6b, 0x00, 0x00, 0x00, 0x76, 0x00, 0x00, 0x00,
+        0x82, 0x00, 0x00, 0x00, 0x8f, 0x00, 0x00, 0x00, 0x9d, 0x00, 0x00, 0x00, 0xad, 0x00, 0x00,
+        0x00, 0xbe, 0x00, 0x00, 0x00, 0xd1, 0x00, 0x00, 0x00, 0xe6, 0x00, 0x00, 0x00, 0xfd, 0x00,
+        0x00, 0x00, 0x17, 0x01, 0x00, 0x00, 0x33, 0x01, 0x00, 0x00, 0x51, 0x01, 0x00, 0x00, 0x73,
+        0x01, 0x00, 0x00, 0x98, 0x01, 0x00, 0x00, 0xc1, 0x01, 0x00, 0x00, 0xee, 0x01, 0x00, 0x00,
+        0x20, 0x02, 0x00, 0x00, 0x56, 0x02, 0x00, 0x00, 0x92, 0x02, 0x00, 0x00, 0xd4, 0x02, 0x00,
+        0x00, 0x1c, 0x03, 0x00, 0x00, 0x6c, 0x03, 0x00, 0x00, 0xc3, 0x03, 0x00, 0x00, 0x24, 0x04,
+        0x00, 0x00, 0x8e, 0x04, 0x00, 0x00, 0x02, 0x05, 0x00, 0x00, 0x83, 0x05, 0x00, 0x00, 0x10,
+        0x06, 0x00, 0x00, 0xab, 0x06, 0x00, 0x00, 0x56, 0x07, 0x00, 0x00, 0x12, 0x08, 0x00, 0x00,
+        0xe0, 0x08, 0x00, 0x00, 0xc3, 0x09, 0x00, 0x00, 0xbd, 0x0a, 0x00, 0x00, 0xd0, 0x0b, 0x00,
+        0x00, 0xff, 0x0c, 0x00, 0x00, 0x4c, 0x0e, 0x00, 0x00, 0xba, 0x0f, 0x00, 0x00, 0x4c, 0x11,
+        0x00, 0x00, 0x07, 0x13, 0x00, 0x00, 0xee, 0x14, 0x00, 0x00, 0x06, 0x17, 0x00, 0x00, 0x54,
+        0x19, 0x00, 0x00, 0xdc, 0x1b, 0x00, 0x00, 0xa5, 0x1e, 0x00, 0x00, 0xb6, 0x21, 0x00, 0x00,
+        0x15, 0x25, 0x00, 0x00, 0xca, 0x28, 0x00, 0x00, 0xdf, 0x2c, 0x00, 0x00, 0x5b, 0x31, 0x00,
+        0x00, 0x4b, 0x36, 0x00, 0x00, 0xb9, 0x3b, 0x00, 0x00, 0xb2, 0x41, 0x00, 0x00, 0x44, 0x48,
+        0x00, 0x00, 0x7e, 0x4f, 0x00, 0x00, 0x71, 0x57, 0x00, 0x00, 0x2f, 0x60, 0x00, 0x00, 0xce,
+        0x69, 0x00, 0x00, 0x62, 0x74, 0x00, 0x00, 0xff, 0x7f, 0x00, 0x00,
+    ];
+
+    /// The native index-adjust table, machine-read at `0x00816518`
+    /// (64 bytes = 16 x i32 little-endian).
+    const IMAGE_INDEX_TABLE_BYTES: &[u8] = &[
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0x02, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x08, 0x00,
+        0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0x02, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00,
+        0x08, 0x00, 0x00, 0x00,
+    ];
+
+    fn as_i32_le(bytes: &[u8]) -> Vec<i32> {
+        bytes
+            .chunks_exact(4)
+            .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    }
+
+    #[test]
+    fn ima_step_table_matches_image_bytes() {
+        let image = as_i32_le(IMAGE_STEP_TABLE_BYTES);
+        assert_eq!(image.len(), STEP_TABLE.len(), "step table length");
+        assert_eq!(image.as_slice(), STEP_TABLE.as_slice());
+    }
+
+    #[test]
+    fn ima_index_table_matches_image_bytes() {
+        let image = as_i32_le(IMAGE_INDEX_TABLE_BYTES);
+        assert_eq!(image.len(), 16, "native table is 16 x i32");
+        // Entries 8..15 mirror 0..7, which is why indexing our 8-entry table by
+        // `nibble & 7` equals the native's full-nibble indexing.
+        assert_eq!(&image[0..8], &image[8..16], "native halves must mirror");
+        for (i, &want) in image[0..8].iter().enumerate() {
+            assert_eq!(INDEX_ADJUST[i], want, "index adjust entry {i}");
+        }
+    }
+
+    /// Golden vectors captured by emulating the original engine's IMA nibble
+    /// decoder (`emulate_function` on `IMA_ADPCM__DecodeSample @ 0x0040ACD0`;
+    /// capture log in docs/research/
+    /// ADPCM_NIBBLE_VALUE_CERTIFICATION_GHIDRA_REPORT.md). Each row:
+    /// (predictor, step_index) state, input nibble, expected 16-bit sample.
+    /// Covers zero state, mid states, and both saturation clamps.
+    #[test]
+    fn adpcm_nibble_matches_original_engine_emulation_vectors() {
+        const VECTORS: &[(i32, i32, u8, i16)] = &[
+            (0, 0, 0x0, 0),
+            (0, 0, 0x3, 4),
+            (0, 0, 0x5, 8),
+            (0, 0, 0x7, 11),
+            (0, 0, 0x8, 0),
+            (0, 0, 0xB, -4),
+            (0, 0, 0xF, -11),
+            (0, 4, 0x7, 19),
+            (0, 4, 0xF, -19),
+            (24, 40, 0x7, 655),
+            (24, 40, 0xA, -186),
+            (36, 64, 0x5, 4609),
+            (36, 64, 0xD, -4537),
+            (60, 84, 0x7, 32767),  // positive clamp
+            (60, 84, 0xF, -32768), // negative clamp
+        ];
+        for &(pred, idx, nibble, expected) in VECTORS {
+            let mut state = ImaAdpcmState::new();
+            state.set_state(pred, idx);
+            assert_eq!(
+                state.decode_nibble(nibble),
+                expected,
+                "state ({pred},{idx}) nibble {nibble:#x}"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Retail-byte block fixtures.
+    //
+    // The compressed bytes below are copied verbatim out of the retail
+    // `audio.bag` inside `langmd.mix -> audiomd.mix`; the expected samples come
+    // from a decoder transcribed from the `0x0040AA70` / `0x0040ACD0`
+    // disassembly using the tables read out of the image above, cross-checked
+    // against all 15 emulation vectors before the goldens were emitted. They are
+    // certification references, not Rust-vs-Rust ratchets, and they run in the
+    // default `cargo test` with no retail install present.
+    // ---------------------------------------------------------------------
+
+    /// `ABIRJ01A`, AUDIOMD bag offset 11,770,646, size 14,388, mono IMA,
+    /// `chunk_size` 512: this is its final block — 28 x 512 bytes precede it,
+    /// leaving a 52-byte tail (4-byte preamble + 48-byte payload).
+    const ABIRJ01A_TAIL_BLOCK: &[u8] = &[
+        0xf8, 0xff, 0x01, 0x00, 0x17, 0xbc, 0x33, 0xa1, 0x1b, 0x00, 0x90, 0x3a, 0xb5, 0x2c, 0x92,
+        0x10, 0xb2, 0x9c, 0x32, 0xb3, 0x2d, 0x21, 0xcb, 0x79, 0xa1, 0x0a, 0x31, 0xc0, 0x1a, 0x23,
+        0xbb, 0x4b, 0xb2, 0x1b, 0x13, 0x11, 0xd9, 0x39, 0x92, 0xa9, 0x30, 0x90, 0x0a, 0x11, 0x11,
+        0x1a, 0x91, 0x09, 0x11, 0x09, 0x00, 0x00,
+    ];
+
+    const ABIRJ01A_TAIL_SAMPLES: &[i16] = &[
+        -8, 7, 13, -5, -20, -6, 8, 12, 5, -5, -2, -1, 0, 1, 0, -3, 1, 9, 1, -10, -3, 3, 0, 1, 4, 7,
+        3, -4, -7, -2, 2, 6, 2, -6, 0, 3, 8, 1, -6, -9, 6, 12, 2, -6, -5, -1, 7, 8, -2, -8, -5, 2,
+        7, 3, -1, -5, 2, 7, 0, -4, -3, 1, 2, 3, 4, 3, -5, -8, 0, 5, 2, 1, -2, -2, 2, 2, 1, -2, -2,
+        -1, 0, 1, 2, -1, 0, 1, 0, -1, -1, 0, 1, 0, 0, 0, 0, 0, 0,
+    ];
+
+    /// `GTIMESHI`, AUDIOMD bag offset 33,758,996, stereo IMA, `chunk_size` 1024:
+    /// the first 44 bytes of its block 10 (8-byte preamble pair + 36 payload
+    /// bytes). The first 40 bytes are a whole number of 8-byte L/R groups; the
+    /// spare 4 make the same bytes usable as the unaligned-payload case.
+    const GTIMESHI_STEREO_BYTES: &[u8] = &[
+        0x3d, 0xda, 0x45, 0x00, 0x40, 0x18, 0x4a, 0x00, 0x07, 0x90, 0x09, 0x4a, 0x8d, 0x10, 0xa1,
+        0xc6, 0x1c, 0x90, 0xa0, 0x5a, 0xa2, 0x90, 0x00, 0x98, 0x8f, 0xa8, 0x42, 0x90, 0xb8, 0xd3,
+        0x97, 0x82, 0x19, 0x1a, 0x01, 0x0d, 0xa8, 0x48, 0x29, 0x8d, 0x81, 0x2b, 0xb4, 0x99,
+    ];
+
+    const GTIMESHI_STEREO_SAMPLES: &[i16] = &[
+        -9667, 6208, 378, -5657, 1813, -7236, 3118, -5801, -441, -1886, -3676, 1673, -2696, -3720,
+        -7153, 9027, 141, -6609, -8684, 3902, -5125, -5653, -4047, -3916, -6988, -8653, -6097,
+        -7218, -10149, -5913, -13832, -7099, -6466, -10334, -21174, -11314, -23276, -17554, -25187,
+        -11881, -32768, -19984, -24872, -3804, -11950, -10741, -10213, -230, -14950, -2141, -19256,
+        -3878, -15341, -11774, -21273, -13209, -18038, -1462, -15097, -6199, -14206, 979, -23121,
+        -13378, -21935, -15289,
+    ];
+
+    #[test]
+    fn retail_mono_tail_block_matches_native_block_decode() {
+        let out = decode_blocks(ABIRJ01A_TAIL_BLOCK, 1, 512);
+        // 1 preamble sample + 48 payload bytes x 2 nibbles.
+        assert_eq!(out.len(), 97);
+        // 0x0040AB0C emits the preamble predictor as the block's first sample.
+        assert_eq!(
+            out[0],
+            i16::from_le_bytes([ABIRJ01A_TAIL_BLOCK[0], ABIRJ01A_TAIL_BLOCK[1]])
+        );
+        assert_eq!(out.as_slice(), ABIRJ01A_TAIL_SAMPLES);
+    }
+
+    #[test]
+    fn retail_stereo_block_matches_native_interleave() {
+        let aligned = &GTIMESHI_STEREO_BYTES[..40];
+        let out = decode_blocks(aligned, 2, 1024);
+        // 1 preamble frame + 4 groups x 8 frames = 33 frames = 66 samples.
+        assert_eq!(out.len(), 66);
+        assert_eq!(out[0], i16::from_le_bytes([aligned[0], aligned[1]]));
+        assert_eq!(out[1], i16::from_le_bytes([aligned[4], aligned[5]]));
+        // Left and right differ in every frame here, so a swapped or collapsed
+        // interleave cannot pass.
+        assert!(out.chunks_exact(2).all(|f| f[0] != f[1]));
+        assert_eq!(out.as_slice(), GTIMESHI_STEREO_SAMPLES);
+        // The negative saturation clamp is exercised by these retail bytes.
+        assert!(out.contains(&-32768));
+    }
+
+    #[test]
+    fn unaligned_payload_drops_the_block_like_the_native() {
+        // 44 bytes: 8 preamble + 36 payload, and 36 is not a whole number of
+        // 8-byte groups. `0x0040ACB3` runs one group past the end and then
+        // `SETZ AL` reports failure, so the block never reaches the mixer.
+        let out = decode_blocks(GTIMESHI_STEREO_BYTES, 2, 1024);
+        assert!(out.is_empty(), "a rejected first block yields nothing");
+        // Retail hits this exactly once: AUDIOMD `grexselb` (offset 7,063,684,
+        // size 41,212, chunk 1024) ends in a 252-byte block whose 244-byte
+        // payload is 30 whole groups plus 4 bytes.
+    }
+
+    #[test]
+    fn invalid_preamble_stops_the_stream_like_the_native() {
+        // Two 12-byte mono blocks; the second declares step_index 0x59, one past
+        // the native's `CMP EDX,0x58 / JG` limit at 0x0040AAEE.
+        let mut data = vec![0x00, 0x00, 0x00, 0x00];
+        data.extend_from_slice(&[0x11; 8]);
+        data.extend_from_slice(&[0x00, 0x00, 0x59, 0x00]);
+        data.extend_from_slice(&[0x11; 8]);
+        let out = decode_blocks(&data, 1, 12);
+        assert_eq!(out.len(), 17, "first block only: 1 + 8 bytes x 2 nibbles");
+
+        // A nonzero reserved byte rejects just the same (0x0040AAF9).
+        let mut data = vec![0x00, 0x00, 0x00, 0x00];
+        data.extend_from_slice(&[0x11; 8]);
+        data.extend_from_slice(&[0x00, 0x00, 0x00, 0x01]);
+        data.extend_from_slice(&[0x11; 8]);
+        assert_eq!(decode_blocks(&data, 1, 12).len(), 17);
+    }
+
+    #[test]
+    fn zero_block_align_decodes_nothing() {
+        // `FUN_00409C40` copies the stride into the input-buffer size, so a zero
+        // stride leaves `0x0040AAAD` with no bytes and the sound stays silent.
+        assert!(decode_blocks(ABIRJ01A_TAIL_BLOCK, 1, 0).is_empty());
+        assert!(decode_blocks(ABIRJ01A_TAIL_BLOCK, 1, 3).is_empty());
+    }
+
+    #[test]
+    fn multi_block_state_restarts_from_each_preamble() {
+        // Two identical 12-byte blocks must decode to two identical halves: the
+        // native reloads predictor and step index from every preamble
+        // (0x0040AAC9..0x0040AAEB) rather than carrying state across blocks.
+        let mut block = vec![0x64, 0x00, 0x05, 0x00];
+        block.extend_from_slice(&[0x3c, 0x91, 0x27, 0x08, 0xa5, 0x1f, 0x60, 0xd3]);
+        let mut data = block.clone();
+        data.extend_from_slice(&block);
+        let out = decode_blocks(&data, 1, 12);
+        assert_eq!(out.len(), 34);
+        assert_eq!(&out[..17], &out[17..]);
+        assert_eq!(out[0], 100);
+    }
+
+    #[test]
+    fn step_index_walks_and_clamps_at_both_ends() {
+        // The index moves by INDEX_ADJUST[nibble & 7] and clamps to 0..=0x58
+        // (0x0040AD41 `JNS` and 0x0040AD4E `CMP EAX,0x58`).
+        let mut state = ImaAdpcmState::new();
+        state.decode_nibble(0x0); // adjust -1 from 0 -> clamps to 0
+        assert_eq!(state.index, 0);
+        state.decode_nibble(0x7); // +8
+        assert_eq!(state.index, 8);
+        state.decode_nibble(0xF); // sign bit ignored by the adjust lookup: +8
+        assert_eq!(state.index, 16);
+        state.set_state(0, MAX_STEP_INDEX);
+        state.decode_nibble(0x7);
+        assert_eq!(state.index, MAX_STEP_INDEX, "upper clamp");
+        assert_eq!(STEP_TABLE[MAX_STEP_INDEX as usize], 32767);
+    }
+
+    #[test]
+    fn nibble_run_decodes_low_nibble_first() {
+        let mut state = ImaAdpcmState::new();
+        let mut out: Vec<i16> = Vec::new();
+        // 0x70: low nibble 0 (delta 0), high nibble 7 (delta +11 at step 7).
+        decode_nibbles(&[0x70], &mut state, &mut out);
+        assert_eq!(out, vec![0, 11]);
+    }
+}

--- a/src/assets/mod.rs
+++ b/src/assets/mod.rs
@@ -33,6 +33,7 @@ pub mod error;
 pub mod fnt_file;
 pub mod format_sniff;
 pub mod hva_file;
+pub mod ima_adpcm;
 pub mod mix_archive;
 pub mod mix_crypto;
 #[cfg(test)]

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -2235,143 +2235,19 @@ pub(crate) fn decode_wav(data: &[u8], filename: &str) -> Option<DecodedAudio> {
     None
 }
 
-/// IMA ADPCM step size table — standard IMA/DVI specification.
-const IMA_STEP_TABLE: [i32; 89] = [
-    7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41, 45, 50, 55, 60, 66,
-    73, 80, 88, 97, 107, 118, 130, 143, 157, 173, 190, 209, 230, 253, 279, 307, 337, 371, 408, 449,
-    494, 544, 598, 658, 724, 796, 876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066, 2272,
-    2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358, 5894, 6484, 7132, 7845, 8630, 9493,
-    10442, 11487, 12635, 13899, 15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767,
-];
-
-/// IMA ADPCM index adjustment table for each nibble value.
-const IMA_INDEX_TABLE: [i32; 16] = [-1, -1, -1, -1, 2, 4, 6, 8, -1, -1, -1, -1, 2, 4, 6, 8];
-
 /// Decode IMA ADPCM WAV data into interleaved f32 samples.
 ///
-/// Each block starts with a 4-byte header per channel: i16 predictor + u8 step index + u8 pad.
-/// Remaining bytes contain packed 4-bit nibbles decoded with the standard IMA algorithm.
+/// `WAV__ParseHeader @ 0x00408610` maps `wFormatTag == 0x11` onto the same audio
+/// format descriptor the bag index fills, taking the block stride from the fmt
+/// chunk's `nBlockAlign` (`psVar6[6]`). `FUN_00409C40 @ 0x00409C40` then installs
+/// the one block decoder in the image, `IMA_ADPCM__DecodeBlock @ 0x0040AA70`, so
+/// WAV and bag IMA share a decoder natively and share `ima_adpcm::decode_blocks`
+/// here.
 fn decode_ima_adpcm(data: &[u8], channels: u16, block_align: u16) -> Vec<f32> {
-    let ch = channels as usize;
-    let block_size = block_align as usize;
-    if block_size == 0 || ch == 0 {
-        return Vec::new();
-    }
-    let header_size = 4 * ch;
-    if block_size < header_size {
-        return Vec::new();
-    }
-
-    // Samples per block: header gives 1 sample per channel, then 2 nibbles per byte.
-    let data_bytes_per_block = block_size - header_size;
-    let samples_per_block = 1 + data_bytes_per_block * 2 / ch;
-    let num_blocks = (data.len() + block_size - 1) / block_size;
-    let mut output: Vec<f32> = Vec::with_capacity(num_blocks * samples_per_block * ch);
-
-    for block in data.chunks(block_size) {
-        if block.len() < header_size {
-            break;
-        }
-
-        // Read per-channel header: initial predictor and step index.
-        let mut predictor = [0i32; 2];
-        let mut step_index = [0i32; 2];
-        for c in 0..ch {
-            let base = c * 4;
-            predictor[c] = i16::from_le_bytes([block[base], block[base + 1]]) as i32;
-            step_index[c] = block[base + 2] as i32;
-            step_index[c] = step_index[c].clamp(0, 88);
-            // First sample from header.
-            if ch == 1 {
-                output.push(predictor[c] as f32 / 32768.0);
-            }
-        }
-        // For stereo, interleave the initial samples.
-        if ch == 2 {
-            output.push(predictor[0] as f32 / 32768.0);
-            output.push(predictor[1] as f32 / 32768.0);
-        }
-
-        // Decode nibbles from the data portion.
-        let payload = &block[header_size..];
-        if ch == 1 {
-            // Mono: straightforward sequential nibbles.
-            for &byte in payload {
-                for shift in [0u8, 4] {
-                    let nibble = ((byte >> shift) & 0x0F) as usize;
-                    let step = IMA_STEP_TABLE[step_index[0] as usize];
-                    let mut diff = step >> 3;
-                    if nibble & 4 != 0 {
-                        diff += step;
-                    }
-                    if nibble & 2 != 0 {
-                        diff += step >> 1;
-                    }
-                    if nibble & 1 != 0 {
-                        diff += step >> 2;
-                    }
-                    if nibble & 8 != 0 {
-                        predictor[0] -= diff;
-                    } else {
-                        predictor[0] += diff;
-                    }
-                    predictor[0] = predictor[0].clamp(-32768, 32767);
-                    step_index[0] += IMA_INDEX_TABLE[nibble];
-                    step_index[0] = step_index[0].clamp(0, 88);
-                    output.push(predictor[0] as f32 / 32768.0);
-                }
-            }
-        } else {
-            // Stereo: nibbles are interleaved in 8-nibble (4-byte) chunks per channel.
-            // Layout: 4 bytes for ch0 (8 nibbles), 4 bytes for ch1 (8 nibbles), repeat.
-            let mut samples_buf: Vec<[f32; 2]> = Vec::new();
-            let mut pos = 0;
-            while pos + 8 <= payload.len() {
-                for c in 0..2 {
-                    for b in 0..4 {
-                        let byte = payload[pos + c * 4 + b];
-                        for shift in [0u8, 4] {
-                            let nibble = ((byte >> shift) & 0x0F) as usize;
-                            let step = IMA_STEP_TABLE[step_index[c] as usize];
-                            let mut diff = step >> 3;
-                            if nibble & 4 != 0 {
-                                diff += step;
-                            }
-                            if nibble & 2 != 0 {
-                                diff += step >> 1;
-                            }
-                            if nibble & 1 != 0 {
-                                diff += step >> 2;
-                            }
-                            if nibble & 8 != 0 {
-                                predictor[c] -= diff;
-                            } else {
-                                predictor[c] += diff;
-                            }
-                            predictor[c] = predictor[c].clamp(-32768, 32767);
-                            step_index[c] += IMA_INDEX_TABLE[nibble];
-                            step_index[c] = step_index[c].clamp(0, 88);
-                            let sample = predictor[c] as f32 / 32768.0;
-                            let sample_idx = b * 2 + shift as usize / 4;
-                            if c == 0 {
-                                samples_buf.push([sample, 0.0]);
-                            } else if sample_idx < samples_buf.len() {
-                                let last = samples_buf.len();
-                                samples_buf[last - 8 + sample_idx][1] = sample;
-                            }
-                        }
-                    }
-                }
-                pos += 8;
-                for pair in samples_buf.drain(..) {
-                    output.push(pair[0]);
-                    output.push(pair[1]);
-                }
-            }
-        }
-    }
-
-    output
+    crate::assets::ima_adpcm::decode_blocks(data, channels, block_align as u32)
+        .into_iter()
+        .map(|s| s as f32 / 32768.0)
+        .collect()
 }
 
 /// Convert raw PCM bytes to f32 samples. Output channel count matches input.
@@ -3076,6 +2952,85 @@ mod tests {
         let wav = build_test_wav(44100, 16, 2, &pcm);
         let decoded = decode_wav(&wav, "test.wav").expect("should decode");
         assert_eq!(decoded.samples.len(), 4); // 2 stereo frames, already 2ch
+    }
+
+    /// Build a `wFormatTag == 0x11` (IMA ADPCM) WAV around a raw block payload.
+    fn build_test_ima_wav(
+        sample_rate: u32,
+        channels: u16,
+        block_align: u16,
+        blocks: &[u8],
+    ) -> Vec<u8> {
+        let data_size: u32 = blocks.len() as u32;
+        let fmt_size: u32 = 20; // WAVEFORMATEX + cbSize(2) + wSamplesPerBlock(2)
+        let riff_size: u32 = 4 + (8 + fmt_size) + (8 + data_size);
+        let samples_per_block: u16 = 1 + (block_align - 4 * channels) * 2 / channels;
+
+        let mut wav: Vec<u8> = Vec::new();
+        wav.extend_from_slice(b"RIFF");
+        wav.extend_from_slice(&riff_size.to_le_bytes());
+        wav.extend_from_slice(b"WAVE");
+        wav.extend_from_slice(b"fmt ");
+        wav.extend_from_slice(&fmt_size.to_le_bytes());
+        wav.extend_from_slice(&0x0011u16.to_le_bytes()); // wFormatTag
+        wav.extend_from_slice(&channels.to_le_bytes());
+        wav.extend_from_slice(&sample_rate.to_le_bytes());
+        wav.extend_from_slice(&(sample_rate / 2).to_le_bytes()); // nAvgBytesPerSec
+        wav.extend_from_slice(&block_align.to_le_bytes()); // psVar6[6] @ 0x00408610
+        wav.extend_from_slice(&4u16.to_le_bytes()); // wBitsPerSample
+        wav.extend_from_slice(&2u16.to_le_bytes()); // cbSize
+        wav.extend_from_slice(&samples_per_block.to_le_bytes());
+        wav.extend_from_slice(b"data");
+        wav.extend_from_slice(&data_size.to_le_bytes());
+        wav.extend_from_slice(blocks);
+        wav
+    }
+
+    /// The retail final block of AUDIOMD `ABIRJ01A` (bag offset 11,770,646 +
+    /// 28 x 512): the same bytes the bag path decodes, run through the WAV path.
+    const ABIRJ01A_TAIL_BLOCK: &[u8] = &[
+        0xf8, 0xff, 0x01, 0x00, 0x17, 0xbc, 0x33, 0xa1, 0x1b, 0x00, 0x90, 0x3a, 0xb5, 0x2c, 0x92,
+        0x10, 0xb2, 0x9c, 0x32, 0xb3, 0x2d, 0x21, 0xcb, 0x79, 0xa1, 0x0a, 0x31, 0xc0, 0x1a, 0x23,
+        0xbb, 0x4b, 0xb2, 0x1b, 0x13, 0x11, 0xd9, 0x39, 0x92, 0xa9, 0x30, 0x90, 0x0a, 0x11, 0x11,
+        0x1a, 0x91, 0x09, 0x11, 0x09, 0x00, 0x00,
+    ];
+
+    #[test]
+    fn decode_wav_ima_adpcm_mono_matches_the_shared_block_decoder() {
+        let wav = build_test_ima_wav(22050, 1, 52, ABIRJ01A_TAIL_BLOCK);
+        let decoded = decode_wav(&wav, "ima.wav").expect("format tag 0x11 must decode");
+        assert_eq!(decoded.sample_rate, 22050);
+        assert_eq!(decoded.channels, 2, "mono is upmixed for playback");
+        // 97 mono samples duplicated into stereo pairs.
+        assert_eq!(decoded.samples.len(), 97 * 2);
+        let want = crate::assets::ima_adpcm::decode_blocks(ABIRJ01A_TAIL_BLOCK, 1, 52);
+        for (i, &s) in want.iter().enumerate() {
+            let f = s as f32 / 32768.0;
+            assert_eq!(decoded.samples[i * 2], f, "left at {i}");
+            assert_eq!(decoded.samples[i * 2 + 1], f, "right at {i}");
+        }
+    }
+
+    #[test]
+    fn decode_wav_ima_adpcm_stereo_keeps_the_channels_apart() {
+        // Two channels whose preambles differ, so a collapsed or swapped
+        // interleave cannot pass. 8-byte preamble pair + one 8-byte L/R group.
+        let mut block: Vec<u8> = vec![0x00, 0x10, 0x00, 0x00, 0x00, 0xF0, 0x00, 0x00];
+        block.extend_from_slice(&[0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x00]);
+        let wav = build_test_ima_wav(22050, 2, 16, &block);
+        let decoded = decode_wav(&wav, "ima2.wav").expect("stereo IMA must decode");
+        assert_eq!(decoded.channels, 2);
+        // 1 preamble frame + 8 group frames = 9 frames.
+        assert_eq!(decoded.samples.len(), 18);
+        assert_eq!(decoded.samples[0], 0x1000 as f32 / 32768.0);
+        assert_eq!(decoded.samples[1], -4096.0 / 32768.0);
+        let want = crate::assets::ima_adpcm::decode_blocks(&block, 2, 16);
+        let got: Vec<i16> = decoded
+            .samples
+            .iter()
+            .map(|&f| (f * 32768.0) as i16)
+            .collect();
+        assert_eq!(got, want);
     }
 
     #[test]

--- a/tests/retail_goldens/certify_audio.rs
+++ b/tests/retail_goldens/certify_audio.rs
@@ -137,20 +137,23 @@ fn certify_bag_adpcm_block_invariants() {
     // Value-parity certification for bag IMA-ADPCM decode, block level.
     // The original engine's block decoder (see docs/research/
     // ADPCM_NIBBLE_VALUE_CERTIFICATION_GHIDRA_REPORT.md):
-    // - REJECTS a block whose per-channel preamble has step_index > 88 or a
-    //   nonzero reserved byte (our decoder clamps/continues instead) — so
-    //   equivalence needs: no retail preamble is invalid;
-    // - for MONO blocks rounds the nibble payload up to 4-byte groups,
-    //   reading past an unaligned block end (ours decodes exact bytes) — so
-    //   equivalence needs: every mono block payload is 4-byte aligned;
-    // - for STEREO blocks truncates the payload to whole 8-byte L/R groups —
-    //   identical to ours by construction.
+    // - REJECTS a block whose per-channel preamble has step_index > 0x58 or a
+    //   nonzero reserved byte (0x0040AAEE / 0x0040AAF9) — so equivalence needs:
+    //   no retail preamble is invalid;
+    // - REJECTS a block whose payload is not a whole number of 4*channels-byte
+    //   groups: mono rounds the group count up and reads past the block end
+    //   (0x0040AB4E), stereo runs one group too many (0x0040ACB3), and both then
+    //   return false, which makes the buffer pump drop the block. We drop it
+    //   without the over-read, so equivalence on VALUES needs: no retail block
+    //   has a ragged payload — with one known, recorded exception below.
+    const KNOWN_RAGGED: &[&str] = &["GREXSELB"];
     let Some(root) = ra2_dir() else {
         println!("SKIP: set RA2_DIR to the retail install");
         return;
     };
     let am = load_corpus(&root);
     let mut failures: Vec<String> = Vec::new();
+    let mut ragged_known: Vec<String> = Vec::new();
     let mut ima_entries = 0usize;
     let mut stereo_entries = 0usize;
     for mix_name in ["AUDIOMD.MIX", "AUDIO.MIX"] {
@@ -203,11 +206,18 @@ fn certify_bag_adpcm_block_invariants() {
                     }
                 }
                 let payload = block_end - pos - preamble;
-                if channels == 1 && payload % 4 != 0 {
-                    failures.push(format!(
-                        "{mix_name} '{name}': mono block at {pos} payload {payload} \
-                         not 4-aligned — native reads past block end"
-                    ));
+                let group = 4 * channels;
+                if payload % group != 0 {
+                    let line = format!(
+                        "{mix_name} '{name}': {channels}ch block at {pos} payload \
+                         {payload} not a multiple of {group} — native over-reads \
+                         and drops the block"
+                    );
+                    if KNOWN_RAGGED.contains(&name.as_str()) {
+                        ragged_known.push(line);
+                    } else {
+                        failures.push(line);
+                    }
                 }
                 if block_size == 0 {
                     break;
@@ -217,6 +227,14 @@ fn certify_bag_adpcm_block_invariants() {
         }
     }
     println!("RECORD: IMA-ADPCM bag entries: {ima_entries} ({stereo_entries} stereo)");
+    for line in &ragged_known {
+        println!("RECORD: known ragged tail (native drops it, so do we): {line}");
+    }
+    assert!(
+        !ragged_known.is_empty(),
+        "GREXSELB's ragged tail block is the recorded exception; if it is gone the \
+         corpus changed and the exception list should shrink"
+    );
     assert!(
         failures.is_empty(),
         "bag ADPCM block invariants: {} violations:\n{}",

--- a/tests/retail_goldens/certify_audio.rs
+++ b/tests/retail_goldens/certify_audio.rs
@@ -140,12 +140,18 @@ fn certify_bag_adpcm_block_invariants() {
     // - REJECTS a block whose per-channel preamble has step_index > 0x58 or a
     //   nonzero reserved byte (0x0040AAEE / 0x0040AAF9) — so equivalence needs:
     //   no retail preamble is invalid;
-    // - REJECTS a block whose payload is not a whole number of 4*channels-byte
-    //   groups: mono rounds the group count up and reads past the block end
-    //   (0x0040AB4E), stereo runs one group too many (0x0040ACB3), and both then
-    //   return false, which makes the buffer pump drop the block. We drop it
-    //   without the over-read, so equivalence on VALUES needs: no retail block
-    //   has a ragged payload — with one known, recorded exception below.
+    // - would REJECT a block whose payload is not a whole number of
+    //   4*channels-byte groups (mono 0x0040AB4E, stereo 0x0040ACB3, both then
+    //   SETZ) — but never sees one: Audio__DecodeCompressedBlock hands the
+    //   decoder exactly block_align bytes on every call (only four writes touch
+    //   +0x80/+0x84, and case 0 always leaves +0x84 at 0 — see
+    //   ADPCM_NIBBLE_VALUE_CERTIFICATION_GHIDRA_REPORT.md §2.1), and both retail
+    //   strides are whole. A short final tail is padded from the previous
+    //   block's bytes still in the input buffer, which decode_blocks now
+    //   reproduces.
+    // The ragged-tail sweep below is therefore a corpus fact, not a divergence:
+    // it records which entries carry a *real* tail that is not group-aligned,
+    // which is what the pre-2026-09-03 reading mistook for a dropped block.
     const KNOWN_RAGGED: &[&str] = &["GREXSELB"];
     let Some(root) = ra2_dir() else {
         println!("SKIP: set RA2_DIR to the retail install");
@@ -156,6 +162,8 @@ fn certify_bag_adpcm_block_invariants() {
     let mut ragged_known: Vec<String> = Vec::new();
     let mut ima_entries = 0usize;
     let mut stereo_entries = 0usize;
+    let mut short_tail_entries = 0usize;
+    let mut shorter_than_stride_entries = 0usize;
     for mix_name in ["AUDIOMD.MIX", "AUDIO.MIX"] {
         let Some(mix) = am.archive(mix_name) else {
             continue;
@@ -186,6 +194,19 @@ fn certify_bag_adpcm_block_invariants() {
             if channels == 2 {
                 stereo_entries += 1;
             }
+            // Frequency evidence for the two end-of-stream classes: a short
+            // final block (reproduced from the previous block's bytes) and a
+            // sound shorter than one whole stride (not reproducible — the
+            // native flushes it against a buffer this sound never filled).
+            if entry.chunk_size > 0 {
+                let stride = entry.chunk_size as usize;
+                if data.len() % stride != 0 {
+                    short_tail_entries += 1;
+                }
+                if data.len() < stride {
+                    shorter_than_stride_entries += 1;
+                }
+            }
             let preamble = channels * 4;
             let block_size = if entry.chunk_size > 0 {
                 entry.chunk_size as usize
@@ -209,9 +230,9 @@ fn certify_bag_adpcm_block_invariants() {
                 let group = 4 * channels;
                 if payload % group != 0 {
                     let line = format!(
-                        "{mix_name} '{name}': {channels}ch block at {pos} payload \
-                         {payload} not a multiple of {group} — native over-reads \
-                         and drops the block"
+                        "{mix_name} '{name}': {channels}ch block at {pos} real payload \
+                         {payload} not a multiple of {group} — the native pads it \
+                         to the stride from the input buffer"
                     );
                     if KNOWN_RAGGED.contains(&name.as_str()) {
                         ragged_known.push(line);
@@ -227,13 +248,21 @@ fn certify_bag_adpcm_block_invariants() {
         }
     }
     println!("RECORD: IMA-ADPCM bag entries: {ima_entries} ({stereo_entries} stereo)");
+    println!(
+        "RECORD: entries with a short final block (native pads from the previous \
+         block, we reproduce it): {short_tail_entries}"
+    );
+    println!(
+        "RECORD: entries shorter than one whole stride (native pads from a buffer \
+         this sound never filled — VERA-internal residual): {shorter_than_stride_entries}"
+    );
     for line in &ragged_known {
-        println!("RECORD: known ragged tail (native drops it, so do we): {line}");
+        println!("RECORD: known non-group-aligned real tail: {line}");
     }
     assert!(
         !ragged_known.is_empty(),
-        "GREXSELB's ragged tail block is the recorded exception; if it is gone the \
-         corpus changed and the exception list should shrink"
+        "GREXSELB's non-group-aligned real tail is the recorded corpus fact; if it \
+         is gone the corpus changed and the exception list should shrink"
     );
     assert!(
         failures.is_empty(),

--- a/tests/retail_goldens/main.rs
+++ b/tests/retail_goldens/main.rs
@@ -26,7 +26,7 @@
 //! | `certify_pcx_structural` | PCX dims match raw header bounds; pixel buffer matches plane count (271 files) |
 //! | `certify_aud_chunk_walk` | AUD chunk walk lands exactly on EOF; chunk outputs sum to header output_size; decode consumes every input nibble |
 //! | `certify_audio_bag_total` | Every audio.idx entry (3,438 across AUDIOMD/AUDIO.MIX) resolves and decodes |
-//! | `certify_bag_adpcm_block_invariants` | ADPCM decoded SAMPLE VALUES: no retail block has an invalid preamble or unaligned mono payload — the only classes where our decoder and the original's diverge (nibble math certified by emulation vectors in src/assets/aud_file.rs) |
+//! | `certify_bag_adpcm_block_invariants` | ADPCM decoded SAMPLE VALUES: no retail block has an invalid preamble, and exactly one (AUDIOMD `grexselb`) has a ragged payload the native over-reads and drops — the only classes where our decoder and the original's diverge (nibble math certified by emulation vectors in src/assets/ima_adpcm.rs) |
 //! | `certify_pal_roundtrip_bytes` | Both palette scale formulas recomputed from raw bytes match parsed output channel-for-channel; all retail bytes in 6-bit domain |
 //! | `certify_hva_roundtrip_bytes` | Section names and every transform f32 are bit-identical to the raw bytes |
 //! | `certify_vpl_roundtrip_bytes` | Header fields and every lighting page byte-equal the raw file |

--- a/tests/retail_goldens/main.rs
+++ b/tests/retail_goldens/main.rs
@@ -26,7 +26,7 @@
 //! | `certify_pcx_structural` | PCX dims match raw header bounds; pixel buffer matches plane count (271 files) |
 //! | `certify_aud_chunk_walk` | AUD chunk walk lands exactly on EOF; chunk outputs sum to header output_size; decode consumes every input nibble |
 //! | `certify_audio_bag_total` | Every audio.idx entry (3,438 across AUDIOMD/AUDIO.MIX) resolves and decodes |
-//! | `certify_bag_adpcm_block_invariants` | ADPCM decoded SAMPLE VALUES: no retail block has an invalid preamble, and exactly one (AUDIOMD `grexselb`) has a ragged payload the native over-reads and drops — the only classes where our decoder and the original's diverge (nibble math certified by emulation vectors in src/assets/ima_adpcm.rs) |
+//! | `certify_bag_adpcm_block_invariants` | ADPCM decoded SAMPLE VALUES: no retail block has an invalid preamble; records how many entries end in a short block (the native pads it from the previous block's bytes, which we reproduce) and how many are shorter than one whole stride (the one residual). Exactly one entry (AUDIOMD `grexselb`) has a real tail that is not group-aligned — a corpus fact, not a divergence, since the native never sees a short payload. Nibble math certified by emulation vectors in src/assets/ima_adpcm.rs |
 //! | `certify_pal_roundtrip_bytes` | Both palette scale formulas recomputed from raw bytes match parsed output channel-for-channel; all retail bytes in 6-bit domain |
 //! | `certify_hva_roundtrip_bytes` | Section names and every transform f32 are bit-identical to the raw bytes |
 //! | `certify_vpl_roundtrip_bytes` | Header fields and every lighting page byte-equal the raw file |


### PR DESCRIPTION
Phase 6, row 146 (GSI-02.15 audio indexes and AUD/VOC/WAV decoding).

Every retail sound in the game flows through this decoder, and nothing in a default `cargo test` protected any of it — the only value-parity coverage sat behind an `#[ignore]` and a `RA2_DIR` environment variable. There were also three separate IMA-ADPCM implementations that could drift apart, one of them with its own copies of the coefficient tables and an untested hand-rolled stereo interleave. That third copy decoded every retail music track.

## What gamemd does

It has exactly **one** IMA-ADPCM decoder. Both coefficient tables have a single data reference each, and bag entries and WAV files fill the same format descriptor that gets wired to that one callback. VERA's three copies are now one module.

The interesting part is what happens at the end of a sound. The decoder is fed fixed strides from a buffer that is allocated once and never cleared between blocks, and at end of file the pump calls it with a null source — so a short final block is decoded as a **full stride whose trailing bytes are the previous block's**. gamemd genuinely emits that extra audio.

## The review turned this branch around twice

The first pass concluded a ragged final block should be dropped. A reviewer proved that modelled a branch gamemd cannot execute, and measured the consequence: gamemd decodes the full tail, old VERA kept part of it, and the new rule discarded it entirely. The branch had moved *away* from native.

The fix reproduces the stale-buffer flush instead. That matters more than it sounds: **3,064 of 3,325 retail bag entries end in a short block**, so the alternative would have cut roughly 40 ms from 92% of every unit voice in ordinary play. A second reviewer re-derived the whole feed independently — the null-source flush, the buffer's lifetime, and the fact that a multi-segment source still yields exactly one flush — and confirmed the reconstruction is exact.

## Research corrections

Two tracked claims were wrong and are fixed with evidence: the chunk size is a byte count rather than a sample count, and the native does not truncate a short stereo remainder. The corpus check that had "proved" zero violations only tested mono, so it missed the one real retail case.

One passage needed correcting twice, because a builder and a reviewer independently swapped the same pair of addresses. It now quotes the instruction text beside each address and records that history, so the next reader can falsify it without re-deriving the state machine.

`VOC` is a proven exclusion, not a gap: no such strings in the binary, none in the INIs, no files in the install.

## Coverage

Seventeen new tests that run by default, with fixtures lifted verbatim from the shipped archives, including the v2 index stride that every retail sound uses and previously had no default-run test at all.

`cargo test -p vera20k --lib`: `test result: ok. 8204 passed; 0 failed; 75 ignored`. Four `retail_goldens` failures are pre-existing and unrelated, measured on the base branch by a reviewer. No golden moved and `SNAPSHOT_VERSION` is untouched.
