### PR TITLE
feat(audio): superweapon launch cues and the deferred storm cue

### DIFF
--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -506,6 +506,119 @@ fn anim_world_sound_source(world: crate::sim::anim_class::AnimWorldCoord) -> Sou
 /// callers pass an object or cell coordinate — the cell centre `(cell << 8)
 /// + 0x80` — so the projected point is the cell's diamond centre, not the
 /// tile's north-west corner.
+/// What one superweapon `Type=` case plays when it fires.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct SuperWeaponLaunchCue {
+    /// `[AudioVisual]` (or the type's own `StartSound=`) cue name, if any.
+    pub sound_id: Option<String>,
+    /// `true` when the cue plays at the target coordinate. Only `StormSound`
+    /// is false — `LightningStorm::Start @ 0x0053A044` uses
+    /// `VocClass::PlayAtPos @ 0x00750920` with pan `0x2000`, not
+    /// `PlayAtCoord`.
+    pub positional: bool,
+    /// `evamd.ini` event name, if the case plays one.
+    pub eva_event: Option<&'static str>,
+    /// The `evamd.ini` entry's `Type=QUEUE` (vs the STANDARD default).
+    pub eva_queued: bool,
+}
+
+/// The launch cue table of `SuperClass::Launch @ 0x006CC390`.
+///
+/// Native switches on `*(param_1[10] + 0xB4)` — the launched
+/// `SuperWeaponTypeClass`'s `Type=` index, whose name table is the 12 pointers
+/// at `0x008425C0` (`MultiMissile`, `IronCurtain`, `LightningStorm`,
+/// `ChronoSphere`, `ChronoWarp`, `ParaDrop`, `AmerParaDrop`,
+/// `PsychicDominator`, `SpyPlane`, `GeneticConverter`, `ForceShield`,
+/// `PsychicReveal`), i.e. exactly [`SuperWeaponKind`]'s order. Per case:
+///
+/// | `Type=` | cue | EVA |
+/// |---|---|---|
+/// | `MultiMissile` | `[Rules+0x174]` `DigSound` at target (`0x006CDCAE`, and `0x006CDDE9` on the silo branch) | `EVA_NuclearMissileLaunched` (`0x006CDC98`, `0x006CDE01`) |
+/// | `IronCurtain` | — | `EVA_IronCurtainActivated` (`0x006CCF21`) |
+/// | `LightningStorm` | `[Rules+0x730]` `StormSound`, non-positional, inside `LightningStorm::Start` (`0x0053A032`..`0x0053A044`) | `EVA_LightningStormCreated` (`0x006CCD81`) |
+/// | `ChronoSphere` | — | — |
+/// | `ChronoWarp` | — | `EVA_ChronosphereActivated` (`0x006CCD03`) |
+/// | `ParaDrop`, `AmerParaDrop`, `SpyPlane` | — | — |
+/// | `PsychicDominator` | `[Rules+0x24C]` at target (`0x006CCE28`) | `EVA_PsychicDominatorActivated` (`0x006CCDFA`) |
+/// | `GeneticConverter` | `[Rules+0x250]` at target (`0x006CD8D3`) | `EVA_GeneticMutatorActivated` (`0x006CD8BD`) |
+/// | `ForceShield` | the **type's own** `StartSound=` (`SuperWeaponTypeClass+0xC4`, key at `0x00818418`) at target, skipped when `-1` (`0x006CD16B CMP ECX,-1 ; JZ`), through `VocClass::PlayAt @ 0x007509E0` (`0x006CD176`) | — |
+/// | `PsychicReveal` | `[Rules+0x254]` at target (`0x006CD7BF`) | — |
+///
+/// Every EVA call sits behind `MOV EAX,[0x00A8B538] ; TEST ; JNZ` and nothing
+/// else — not the launching house — so an enemy launch announces itself too.
+/// `0x00A8B538` is the client-side defeated/spectating flag
+/// (`HouseClass::MPlayer_Defeated @ 0x004FC205` sets it to 1); VERA has no
+/// equivalent state, so the gate is unmodelled and always open here.
+pub(crate) fn superweapon_launch_cue(
+    kind: crate::rules::superweapon_type::SuperWeaponKind,
+    general: &crate::rules::ruleset::GeneralRules,
+    start_sound: Option<&str>,
+) -> SuperWeaponLaunchCue {
+    use crate::rules::superweapon_type::SuperWeaponKind as K;
+    let positional = SuperWeaponLaunchCue {
+        positional: true,
+        ..Default::default()
+    };
+    match kind {
+        K::MultiMissile => SuperWeaponLaunchCue {
+            sound_id: general.dig_sound.clone(),
+            eva_event: Some("EVA_NuclearMissileLaunched"),
+            ..positional
+        },
+        K::IronCurtain => SuperWeaponLaunchCue {
+            eva_event: Some("EVA_IronCurtainActivated"),
+            ..Default::default()
+        },
+        K::LightningStorm => SuperWeaponLaunchCue {
+            // `0x0053A014 MOV AL,[Rules+0x17B0]` gates the cue and the storm
+            // message together; the field is `[General] LightningPrintText=`.
+            sound_id: general
+                .lightning_print_text
+                .then(|| general.storm_sound.clone())
+                .flatten(),
+            positional: false,
+            eva_event: Some("EVA_LightningStormCreated"),
+            eva_queued: false,
+        },
+        K::ChronoWarp => SuperWeaponLaunchCue {
+            eva_event: Some("EVA_ChronosphereActivated"),
+            ..Default::default()
+        },
+        K::PsychicDominator => SuperWeaponLaunchCue {
+            sound_id: general.psychic_dominator_activate_sound.clone(),
+            eva_event: Some("EVA_PsychicDominatorActivated"),
+            // `evamd.ini [EVA_PsychicDominatorActivated] Type=QUEUE` — and all
+            // three of its faction values are `Dummy`, so on retail data the
+            // line resolves to a zero-sample entry and is inaudible; only the
+            // `[AudioVisual]` cue is heard.
+            eva_queued: true,
+            ..positional
+        },
+        K::GeneticConverter => SuperWeaponLaunchCue {
+            sound_id: general.genetic_mutator_activate_sound.clone(),
+            eva_event: Some("EVA_GeneticMutatorActivated"),
+            // `evamd.ini [EVA_GeneticMutatorActivated] Type=QUEUE`.
+            eva_queued: true,
+            ..positional
+        },
+        K::ForceShield => SuperWeaponLaunchCue {
+            sound_id: start_sound
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+            ..positional
+        },
+        K::PsychicReveal => SuperWeaponLaunchCue {
+            sound_id: general.psychic_reveal_activate_sound.clone(),
+            ..positional
+        },
+        // Cases 3, 5, 6 and 8 reach neither a `VocClass` nor a `VoxClass` call.
+        K::ChronoSphere | K::ParaDrop | K::AmerParaDrop | K::SpyPlane => {
+            SuperWeaponLaunchCue::default()
+        }
+    }
+}
+
 fn sound_source_at_cell(rx: u16, ry: u16) -> SoundSource {
     let screen = crate::app::input::camera::cell_centre_world_point(rx, ry, 0);
     SoundSource::new(screen, (rx, ry))
@@ -1300,40 +1413,48 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             .to_string();
                         GameSoundEvent::BuildingReady { sound_id }
                     }
-                    SimSoundEvent::SuperWeaponLaunched { .. } => {
-                        // UNCHECKED residual, still silent, and the NEXT slice
-                        // of this row — not another row's work.
-                        //
-                        // The blocker is evidence, not plumbing: adding a
-                        // `kind` discriminator to the sim event and touching
-                        // the six emitters (force shield, genetic converter,
-                        // iron curtain, lightning storm, paradrop, psychic
-                        // reveal) is a small in-scope change and is exactly
-                        // what gameplay-to-audio trigger routing is for. What
-                        // is missing is the native binding: nothing read here
-                        // proves which cue fires on *launch* as opposed to
-                        // ready or impact, and shipping a guessed mapping is
-                        // worse than a recorded silence. Native's launch cue
-                        // is per-weapon, not global: `[AudioVisual]` holds
-                        // `PsychicDominatorActivateSound` (`Rules+0x24C`),
-                        // `GeneticMutatorActivateSound` (`+0x250`) and
-                        // `PsychicRevealActivateSound` (`+0x254`) from
-                        // `RulesClass::ReadAudioVisual @ 0x006691E0`, and
-                        // `evamd.ini` holds `EVA_IronCurtainActivated`,
-                        // `EVA_ChronosphereActivated`,
-                        // `EVA_LightningStormCreated`,
-                        // `EVA_PsychicDominatorActivated`,
-                        // `EVA_GeneticMutatorActivated` and
-                        // `EVA_ForceShieldActivated`. The reader sites that
-                        // bind each cue to its launch were NOT isolated, so no
-                        // mapping is asserted here.
-                        // Trigger: every superweapon launch. Player effect: the
-                        // launch is silent — no siren, no EVA line. Frequency:
-                        // once per superweapon per recharge (10 min stock),
-                        // i.e. a handful per long game. Downstream risk: none
-                        // beyond the six-emitter edit itself; the work is
-                        // isolating each cue's native callsite first.
-                        continue;
+                    SimSoundEvent::SuperWeaponLaunched {
+                        sw_type, rx, ry, ..
+                    } => {
+                        // `SuperClass::Launch @ 0x006CC390` switches on the
+                        // launched type's `Type=` index and plays that case's
+                        // cue and/or EVA line. `superweapon_launch_cue` is that
+                        // table; both halves come off the one type object, as
+                        // native's `param_1[10]` does.
+                        let type_name = sim.interner.resolve(sw_type);
+                        let Some(sw) = resources.rules.super_weapon(type_name) else {
+                            continue;
+                        };
+                        let cue = superweapon_launch_cue(
+                            sw.kind,
+                            &resources.rules.general,
+                            sw.start_sound.as_deref(),
+                        );
+                        // The EVA sample is picked for the *listening* client's
+                        // side, not the launcher's: `VoxClass::PlayEVA` takes
+                        // only the event name and resolves the faction row
+                        // locally.
+                        let eva_sound_id = cue.eva_event.and_then(|event| {
+                            let local = local_owner_name.as_deref()?;
+                            let faction = crate::app::presentation::building_anim::eva_faction_key(
+                                local,
+                                &state.match_state.match_presentation.house_roster,
+                            );
+                            state
+                                .audio
+                                .eva_registry
+                                .get(event, faction)
+                                .map(str::to_string)
+                        });
+                        if cue.sound_id.is_none() && eva_sound_id.is_none() {
+                            continue;
+                        }
+                        GameSoundEvent::SuperWeaponActivated {
+                            sound_id: cue.sound_id.unwrap_or_default(),
+                            source: cue.positional.then(|| sound_source_at_cell(rx, ry)),
+                            eva_sound_id,
+                            eva_queued: cue.eva_queued,
+                        }
                     }
                     SimSoundEvent::SuperWeaponStrike { rx, ry } => {
                         // `LightningStorm::GroundStrike @
@@ -2445,12 +2566,13 @@ pub(crate) fn rules_hash(rules: &crate::rules::ruleset::RuleSet) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use super::SuperWeaponLaunchCue;
     use super::{
         ExactStepError, ExactStepReceipt, VOICE_FEEDBACK_PERCENT, append_fire_effect_batch,
         base_under_attack_siren, begin_fire_effect_batch, cloak_sound_for_app,
-        finish_fire_effect_batch, outcome_eva_entry, upsert_overlay_entries,
-        validate_exact_step_receipt, voice_feedback_speaks, wall_sell_sound_for_local,
-        world_point_to_cell,
+        finish_fire_effect_batch, outcome_eva_entry, superweapon_launch_cue,
+        upsert_overlay_entries, validate_exact_step_receipt, voice_feedback_speaks,
+        wall_sell_sound_for_local, world_point_to_cell,
     };
     use crate::map::entities::EntityCategory;
     use crate::map::overlay::OverlayEntry;
@@ -2594,6 +2716,114 @@ mod tests {
         // 30 in 100. The band is wide on purpose: this pins what the 0x1E
         // threshold means, not the generator behind it.
         assert!((2_600..3_400).contains(&speaks), "spoke {speaks} of 10000");
+    }
+
+    /// Stock `[AudioVisual]` values, so the table below is what a retail
+    /// skirmish actually plays.
+    fn stock_audio_visual() -> crate::rules::ruleset::GeneralRules {
+        // The parse of each key from stock `[AudioVisual]` text is pinned in
+        // `rules::ruleset::tests::superweapon_activate_sounds_parse_their_stock_values`.
+        let mut general = crate::rules::ruleset::GeneralRules::default();
+        general.psychic_dominator_activate_sound = Some("PsychicDominatorActivate".to_string());
+        general.genetic_mutator_activate_sound = Some("GeneticMutatorActivate".to_string());
+        general.psychic_reveal_activate_sound = Some("PsychicRevealActivate".to_string());
+        general.dig_sound = Some("NukeSiren".to_string());
+        general.storm_sound = Some("WeatherIntro".to_string());
+        general
+    }
+
+    /// The whole `SuperClass::Launch @ 0x006CC390` cue table, one row per
+    /// `Type=` case. Addresses are on `superweapon_launch_cue`.
+    #[test]
+    fn every_superweapon_case_plays_the_cue_its_native_arm_plays() {
+        use crate::rules::superweapon_type::SuperWeaponKind as K;
+        let g = stock_audio_visual();
+        let cue = |kind, start: Option<&str>| superweapon_launch_cue(kind, &g, start);
+
+        // Case 0: DigSound at the target plus the nuke EVA.
+        let nuke = cue(K::MultiMissile, None);
+        assert_eq!(nuke.sound_id.as_deref(), Some("NukeSiren"));
+        assert!(nuke.positional);
+        assert_eq!(nuke.eva_event, Some("EVA_NuclearMissileLaunched"));
+        assert!(!nuke.eva_queued);
+
+        // Case 1: EVA only — the arm reaches no VocClass call.
+        let ic = cue(K::IronCurtain, None);
+        assert_eq!(ic.sound_id, None);
+        assert_eq!(ic.eva_event, Some("EVA_IronCurtainActivated"));
+
+        // Case 2: StormSound is NON-positional (PlayAtPos, pan 0x2000).
+        let storm = cue(K::LightningStorm, None);
+        assert_eq!(storm.sound_id.as_deref(), Some("WeatherIntro"));
+        assert!(!storm.positional);
+        assert_eq!(storm.eva_event, Some("EVA_LightningStormCreated"));
+
+        // Case 4 speaks; case 3 is entirely silent.
+        assert_eq!(
+            cue(K::ChronoWarp, None).eva_event,
+            Some("EVA_ChronosphereActivated")
+        );
+        assert_eq!(cue(K::ChronoSphere, None), SuperWeaponLaunchCue::default());
+
+        // Cases 5, 6 and 8 are silent: no VocClass and no VoxClass call.
+        for kind in [K::ParaDrop, K::AmerParaDrop, K::SpyPlane] {
+            assert_eq!(
+                cue(kind, None),
+                SuperWeaponLaunchCue::default(),
+                "{kind:?} plays nothing in gamemd"
+            );
+        }
+
+        // Cases 7 and 9: positional cue plus a Type=QUEUE EVA line.
+        let dominator = cue(K::PsychicDominator, None);
+        assert_eq!(
+            dominator.sound_id.as_deref(),
+            Some("PsychicDominatorActivate")
+        );
+        assert!(dominator.positional && dominator.eva_queued);
+        let mutator = cue(K::GeneticConverter, None);
+        assert_eq!(mutator.sound_id.as_deref(), Some("GeneticMutatorActivate"));
+        assert!(mutator.positional && mutator.eva_queued);
+
+        // Case 11: cue only, no EVA.
+        let reveal = cue(K::PsychicReveal, None);
+        assert_eq!(reveal.sound_id.as_deref(), Some("PsychicRevealActivate"));
+        assert_eq!(reveal.eva_event, None);
+    }
+
+    /// Case 10 is the only one whose cue comes off the *type* object
+    /// (`SuperWeaponTypeClass+0xC4`, `StartSound=`), and `0x006CD16B CMP
+    /// ECX,-1 ; JZ 0x006CD17B` skips it when the type authors none. Stock
+    /// `[ForceShieldSpecial]` is the only `[SuperWeaponTypes]` section that
+    /// does author it.
+    #[test]
+    fn force_shield_takes_its_cue_from_the_launched_type_not_from_audiovisual() {
+        use crate::rules::superweapon_type::SuperWeaponKind as K;
+        let g = stock_audio_visual();
+
+        let stock = superweapon_launch_cue(K::ForceShield, &g, Some("ForceShieldStarting"));
+        assert_eq!(stock.sound_id.as_deref(), Some("ForceShieldStarting"));
+        assert!(stock.positional);
+        assert_eq!(stock.eva_event, None, "case 10 reaches no VoxClass call");
+
+        let unset = superweapon_launch_cue(K::ForceShield, &g, None);
+        assert_eq!(unset.sound_id, None);
+        let empty = superweapon_launch_cue(K::ForceShield, &g, Some("  "));
+        assert_eq!(empty.sound_id, None);
+    }
+
+    /// `LightningStorm::Start @ 0x0053A014` reads `[Rules+0x17B0]`
+    /// (`[General] LightningPrintText=`) and skips both the storm message and
+    /// `StormSound` when it is false. The EVA line is outside that gate — it
+    /// is played by `SuperClass::Launch` case 2 at `0x006CCD81`.
+    #[test]
+    fn the_storm_cue_but_not_its_eva_rides_lightning_print_text() {
+        use crate::rules::superweapon_type::SuperWeaponKind as K;
+        let mut off = stock_audio_visual();
+        off.lightning_print_text = false;
+        let cue = superweapon_launch_cue(K::LightningStorm, &off, None);
+        assert_eq!(cue.sound_id, None);
+        assert_eq!(cue.eva_event, Some("EVA_LightningStormCreated"));
     }
 
     #[test]

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -502,19 +502,15 @@ fn anim_world_sound_source(world: crate::sim::anim_class::AnimWorldCoord) -> Sou
     SoundSource::new(screen, (rx, ry))
 }
 
-/// The sound source of a flat cell event. Native `VocClass::PlayAt`
-/// callers pass an object or cell coordinate — the cell centre `(cell << 8)
-/// + 0x80` — so the projected point is the cell's diamond centre, not the
-/// tile's north-west corner.
 /// What one superweapon `Type=` case plays when it fires.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct SuperWeaponLaunchCue {
     /// `[AudioVisual]` (or the type's own `StartSound=`) cue name, if any.
     pub sound_id: Option<String>,
-    /// `true` when the cue plays at the target coordinate. Only `StormSound`
-    /// is false — `LightningStorm::Start @ 0x0053A044` uses
-    /// `VocClass::PlayAtPos @ 0x00750920` with pan `0x2000`, not
-    /// `PlayAtCoord`.
+    /// `true` when the cue plays at the target coordinate. Every launch cue
+    /// this table still carries is positional; the one non-positional cue in
+    /// the system, `StormSound`, is not a launch cue at all — see
+    /// [`lightning_storm_begin_cue`].
     pub positional: bool,
     /// `evamd.ini` event name, if the case plays one.
     pub eva_event: Option<&'static str>,
@@ -535,7 +531,7 @@ pub(crate) struct SuperWeaponLaunchCue {
 /// |---|---|---|
 /// | `MultiMissile` | `[Rules+0x174]` `DigSound` at target (`0x006CDCAE`, and `0x006CDDE9` on the silo branch) | `EVA_NuclearMissileLaunched` (`0x006CDC98`, `0x006CDE01`) |
 /// | `IronCurtain` | — | `EVA_IronCurtainActivated` (`0x006CCF21`) |
-/// | `LightningStorm` | `[Rules+0x730]` `StormSound`, non-positional, inside `LightningStorm::Start` (`0x0053A032`..`0x0053A044`) | `EVA_LightningStormCreated` (`0x006CCD81`) |
+/// | `LightningStorm` | — (the `StormSound` cue is deferred, see [`lightning_storm_begin_cue`]) | `EVA_LightningStormCreated` (`0x006CCD81`) |
 /// | `ChronoSphere` | — | — |
 /// | `ChronoWarp` | — | `EVA_ChronosphereActivated` (`0x006CCD03`) |
 /// | `ParaDrop`, `AmerParaDrop`, `SpyPlane` | — | — |
@@ -569,16 +565,15 @@ pub(crate) fn superweapon_launch_cue(
             eva_event: Some("EVA_IronCurtainActivated"),
             ..Default::default()
         },
+        // Case 2 plays the EVA line and nothing else at launch. It hands
+        // `[Rules+0x1794]` (`LightningDeferment`, stock 250) to
+        // `LightningStorm::Start @ 0x00539EB0`, whose `if (param_2 != 0)`
+        // early return fires before the `StormSound` call at `0x0053A044` —
+        // so the cue belongs to the deferment expiry, not to the launch.
+        // [`lightning_storm_begin_cue`] carries it.
         K::LightningStorm => SuperWeaponLaunchCue {
-            // `0x0053A014 MOV AL,[Rules+0x17B0]` gates the cue and the storm
-            // message together; the field is `[General] LightningPrintText=`.
-            sound_id: general
-                .lightning_print_text
-                .then(|| general.storm_sound.clone())
-                .flatten(),
-            positional: false,
             eva_event: Some("EVA_LightningStormCreated"),
-            eva_queued: false,
+            ..Default::default()
         },
         K::ChronoWarp => SuperWeaponLaunchCue {
             eva_event: Some("EVA_ChronosphereActivated"),
@@ -619,6 +614,38 @@ pub(crate) fn superweapon_launch_cue(
     }
 }
 
+/// The cue the storm plays when it *begins* — `[Rules+0x730]`, i.e.
+/// `[AudioVisual] StormSound=` (key `"StormSound"` at `0x0083A400`, bound at
+/// `0x0066AEAE`/`0x0066AEE6`), behind the `0x0053A014 MOV AL,[Rules+0x17B0]`
+/// gate. `Rules+0x17B0` is `[General] LightningPrintText=` and the
+/// `0x0053A01C JZ` skips the cue and the on-screen storm message together.
+///
+/// **Not a launch cue.** `SuperClass::Launch @ 0x006CC390` case 2 passes
+/// `[Rules+0x1794]` (`LightningDeferment`) as `LightningStorm::Start @
+/// 0x00539EB0`'s `param_2`, and `Start` opens `if (param_2 != 0) { arm the
+/// countdown; return; }` — returning before `0x0053A044`. `LightningStorm::
+/// Process @ 0x0053A6C0` decrements that countdown (`0x0053AAAD`) and at zero
+/// re-enters `Start` with `param_2` cleared (`0x0053AAC8 XOR EDX,EDX`), which
+/// is the entry that reaches the cue. Stock `rulesmd.ini:130` sets
+/// `LightningDeferment=250`, so on retail the cue always trails the launch
+/// EVA line by the full deferment.
+///
+/// Non-positional: `0x0053A044 CALL VocClass::PlayAtPos @ 0x00750920` with pan
+/// `0x2000` (`0x0053A03A`) and volume `1.0f` (`0x0053A03F`), so it is played
+/// centred rather than at the storm cell.
+pub(crate) fn lightning_storm_begin_cue(
+    general: &crate::rules::ruleset::GeneralRules,
+) -> Option<String> {
+    general
+        .lightning_print_text
+        .then(|| general.storm_sound.clone())
+        .flatten()
+}
+
+/// The sound source of a flat cell event. Native `VocClass::PlayAt`
+/// callers pass an object or cell coordinate — the cell centre `(cell << 8)
+/// + 0x80` — so the projected point is the cell's diamond centre, not the
+/// tile's north-west corner.
 fn sound_source_at_cell(rx: u16, ry: u16) -> SoundSource {
     let screen = crate::app::input::camera::cell_centre_world_point(rx, ry, 0);
     SoundSource::new(screen, (rx, ry))
@@ -1454,6 +1481,24 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             source: cue.positional.then(|| sound_source_at_cell(rx, ry)),
                             eva_sound_id,
                             eva_queued: cue.eva_queued,
+                        }
+                    }
+                    SimSoundEvent::LightningStormBegan => {
+                        // The deferred half of case 2: the sky flips to Ion and
+                        // `LightningStorm::Start` plays `StormSound`
+                        // (`0x0053A044`). Nothing else — the EVA line was
+                        // already spoken at launch, ~250 frames earlier.
+                        let Some(sound_id) = lightning_storm_begin_cue(&resources.rules.general)
+                        else {
+                            continue;
+                        };
+                        GameSoundEvent::SuperWeaponActivated {
+                            sound_id,
+                            // `PlayAtPos` with pan `0x2000`: centred, not at
+                            // the storm cell.
+                            source: None,
+                            eva_sound_id: None,
+                            eva_queued: false,
                         }
                     }
                     SimSoundEvent::SuperWeaponStrike { rx, ry } => {
@@ -2570,9 +2615,9 @@ mod tests {
     use super::{
         ExactStepError, ExactStepReceipt, VOICE_FEEDBACK_PERCENT, append_fire_effect_batch,
         base_under_attack_siren, begin_fire_effect_batch, cloak_sound_for_app,
-        finish_fire_effect_batch, outcome_eva_entry, superweapon_launch_cue,
-        upsert_overlay_entries, validate_exact_step_receipt, voice_feedback_speaks,
-        wall_sell_sound_for_local, world_point_to_cell,
+        finish_fire_effect_batch, lightning_storm_begin_cue, outcome_eva_entry,
+        superweapon_launch_cue, upsert_overlay_entries, validate_exact_step_receipt,
+        voice_feedback_speaks, wall_sell_sound_for_local, world_point_to_cell,
     };
     use crate::map::entities::EntityCategory;
     use crate::map::overlay::OverlayEntry;
@@ -2752,10 +2797,15 @@ mod tests {
         assert_eq!(ic.sound_id, None);
         assert_eq!(ic.eva_event, Some("EVA_IronCurtainActivated"));
 
-        // Case 2: StormSound is NON-positional (PlayAtPos, pan 0x2000).
+        // Case 2: EVA only at launch. `Start` gets `LightningDeferment` as
+        // `param_2` and returns before the cue, so `StormSound` is not a
+        // launch cue — `the_storm_cue_is_deferred_and_rides_lightning_print_text`
+        // owns it.
         let storm = cue(K::LightningStorm, None);
-        assert_eq!(storm.sound_id.as_deref(), Some("WeatherIntro"));
-        assert!(!storm.positional);
+        assert_eq!(
+            storm.sound_id, None,
+            "case 2 reaches no VocClass call of its own"
+        );
         assert_eq!(storm.eva_event, Some("EVA_LightningStormCreated"));
 
         // Case 4 speaks; case 3 is entirely silent.
@@ -2812,18 +2862,43 @@ mod tests {
         assert_eq!(empty.sound_id, None);
     }
 
-    /// `LightningStorm::Start @ 0x0053A014` reads `[Rules+0x17B0]`
-    /// (`[General] LightningPrintText=`) and skips both the storm message and
-    /// `StormSound` when it is false. The EVA line is outside that gate — it
-    /// is played by `SuperClass::Launch` case 2 at `0x006CCD81`.
+    /// `StormSound` belongs to the storm *beginning*, not to the launch.
+    /// `SuperClass::Launch` case 2 hands `[Rules+0x1794]`
+    /// (`LightningDeferment`, stock 250) to `LightningStorm::Start @
+    /// 0x00539EB0`, whose `if (param_2 != 0) { arm the countdown; return; }`
+    /// returns before the cue at `0x0053A044`;
+    /// `LightningStorm::Process @ 0x0053A6C0` re-enters with `param_2` cleared
+    /// (`0x0053AAC8 XOR EDX,EDX`) at countdown zero and that entry plays it.
+    ///
+    /// `0x0053A014 MOV AL,[Rules+0x17B0]` (`[General] LightningPrintText=`)
+    /// gates the cue and the on-screen storm message together. The EVA line is
+    /// outside that gate — `SuperClass::Launch` plays it at `0x006CCD81`,
+    /// after `Start` has returned, deferred or not.
     #[test]
-    fn the_storm_cue_but_not_its_eva_rides_lightning_print_text() {
+    fn the_storm_cue_is_deferred_and_rides_lightning_print_text() {
         use crate::rules::superweapon_type::SuperWeaponKind as K;
+        let on = stock_audio_visual();
+        assert!(on.lightning_print_text, "the constructor default is true");
+
+        // The launch moment: EVA only, no cue.
+        let launch = superweapon_launch_cue(K::LightningStorm, &on, None);
+        assert_eq!(launch.sound_id, None);
+        assert_eq!(launch.eva_event, Some("EVA_LightningStormCreated"));
+
+        // The beginning: the cue, and nothing else.
+        assert_eq!(
+            lightning_storm_begin_cue(&on).as_deref(),
+            Some("WeatherIntro")
+        );
+
         let mut off = stock_audio_visual();
         off.lightning_print_text = false;
-        let cue = superweapon_launch_cue(K::LightningStorm, &off, None);
-        assert_eq!(cue.sound_id, None);
-        assert_eq!(cue.eva_event, Some("EVA_LightningStormCreated"));
+        assert_eq!(lightning_storm_begin_cue(&off), None);
+        assert_eq!(
+            superweapon_launch_cue(K::LightningStorm, &off, None).eva_event,
+            Some("EVA_LightningStormCreated"),
+            "the EVA line is outside the LightningPrintText gate"
+        );
     }
 
     #[test]

--- a/src/app/presentation/building_anim.rs
+++ b/src/app/presentation/building_anim.rs
@@ -396,6 +396,54 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
                     );
                 }
             }
+            GameSoundEvent::SuperWeaponActivated {
+                sound_id,
+                source,
+                eva_sound_id,
+                eva_queued,
+            } => {
+                // `RulesClass::ReadAudioVisual @ 0x006691E0` and
+                // `SuperWeaponTypeClass::ReadINI @ 0x006CEBE5` both store only
+                // the `VocClass::FindByName @ 0x007514D0` result, so a name
+                // that is not a registered Voc is silence in gamemd and must
+                // not reach the raw audio-bag fallback.
+                if !sound_id.is_empty() && registry.get(sound_id).is_some() {
+                    match source {
+                        // `VocClass::PlayAtCoord @ 0x00750E20` /
+                        // `PlayAt @ 0x007509E0` at the target coordinate.
+                        Some(source) => {
+                            if let Some(gain) = gain_for(sound_id, Some(*source)) {
+                                let _ = sfx.play_registered_sound_spatial(
+                                    sound_id,
+                                    gain,
+                                    registry,
+                                    assets,
+                                    audio_indices,
+                                );
+                            }
+                        }
+                        // `StormSound` only: `LightningStorm::Start` calls
+                        // `VocClass::PlayAtPos @ 0x00750920` with pan `0x2000`
+                        // and volume `1.0f` (`0x0053A03A`/`0x0053A03F`).
+                        None => {
+                            let _ = sfx.play_registered_sound_spatial(
+                                sound_id,
+                                SpatialGain::CENTRED_FULL,
+                                registry,
+                                assets,
+                                audio_indices,
+                            );
+                        }
+                    }
+                }
+                if let Some(eva_sound_id) = eva_sound_id.as_deref().filter(|s| !s.is_empty()) {
+                    if *eva_queued {
+                        let _ = sfx.queue_eva_sound(eva_sound_id, registry, assets, audio_indices);
+                    } else {
+                        sfx.play_standard_eva_sound(eva_sound_id, registry, assets, audio_indices);
+                    }
+                }
+            }
             GameSoundEvent::BridgeRepaired {
                 sound_id,
                 source,

--- a/src/audio/events.rs
+++ b/src/audio/events.rs
@@ -342,10 +342,14 @@ pub enum GameSoundEvent {
     /// [`crate::app::match_runtime::sim_tick::superweapon_launch_cue`] for the
     /// case-by-case table and its addresses. Every cue in that table is played
     /// by `VocClass::PlayAtCoord @ 0x00750E20` (or `PlayAt @ 0x007509E0` for
-    /// `ForceShield`) at the target coordinate, hence `source`; the one
-    /// exception is `StormSound`, which `LightningStorm::Start @ 0x0053A044`
-    /// plays through `VocClass::PlayAtPos @ 0x00750920` with pan `0x2000` and
-    /// volume `1.0f`, hence `source: None` and a centred full-volume play.
+    /// `ForceShield`) at the target coordinate, hence `source`.
+    ///
+    /// The one `source: None` producer is `StormSound`, and it is not a launch
+    /// cue: `LightningStorm::Start @ 0x00539EB0` returns early on a deferred
+    /// launch, so the cue is played only when the deferment expires
+    /// (`0x0053A044`, `VocClass::PlayAtPos @ 0x00750920`, pan `0x2000`, volume
+    /// `1.0f` — centred and full-volume). See
+    /// [`crate::app::match_runtime::sim_tick::lightning_storm_begin_cue`].
     ///
     /// The EVA line is not gated on the launching house: native calls
     /// `VoxClass::PlayEVA` behind `[0x00A8B538]` only, a client-side flag that

--- a/src/audio/events.rs
+++ b/src/audio/events.rs
@@ -336,6 +336,33 @@ pub enum GameSoundEvent {
         source: Option<SoundSource>,
     },
 
+    /// A superweapon fired: its `[AudioVisual]` cue and/or its EVA warning.
+    ///
+    /// `SuperClass::Launch @ 0x006CC390` decides both per `Type=` case; see
+    /// [`crate::app::match_runtime::sim_tick::superweapon_launch_cue`] for the
+    /// case-by-case table and its addresses. Every cue in that table is played
+    /// by `VocClass::PlayAtCoord @ 0x00750E20` (or `PlayAt @ 0x007509E0` for
+    /// `ForceShield`) at the target coordinate, hence `source`; the one
+    /// exception is `StormSound`, which `LightningStorm::Start @ 0x0053A044`
+    /// plays through `VocClass::PlayAtPos @ 0x00750920` with pan `0x2000` and
+    /// volume `1.0f`, hence `source: None` and a centred full-volume play.
+    ///
+    /// The EVA line is not gated on the launching house: native calls
+    /// `VoxClass::PlayEVA` behind `[0x00A8B538]` only, a client-side flag that
+    /// `HouseClass::MPlayer_Defeated @ 0x004FC205` sets to 1 — i.e. an
+    /// enemy's launch announces itself on your client until you are defeated.
+    SuperWeaponActivated {
+        /// `[AudioVisual]`/`StartSound=` cue; empty when the case plays none.
+        sound_id: String,
+        /// Target-cell position, or `None` for a non-positional cue.
+        source: Option<SoundSource>,
+        /// Resolved per-faction `evamd.ini` sample, or `None` when the case
+        /// plays no EVA line.
+        eva_sound_id: Option<String>,
+        /// The EVA entry's `Type=QUEUE` (true) vs STANDARD (false).
+        eva_queued: bool,
+    },
+
     /// Generic UI sound (button click, error beep, etc.).
     UiSound {
         /// sound.ini ID for the UI sound.
@@ -375,6 +402,7 @@ impl GameSoundEvent {
             | Self::BuildingDamagedSfx { sound_id, .. }
             | Self::VoiceFeedback { sound_id, .. }
             | Self::LightningStrike { sound_id, .. }
+            | Self::SuperWeaponActivated { sound_id, .. }
             | Self::WorldEffectStarted { sound_id, .. } => sound_id,
             Self::AnimationStopped { stop_sound_id, .. } => stop_sound_id.as_deref().unwrap_or(""),
             Self::UnderAttackEva { eva_sound_id }
@@ -405,6 +433,7 @@ impl GameSoundEvent {
             | Self::BuildingDamagedSfx { source, .. }
             | Self::VoiceFeedback { source, .. }
             | Self::LightningStrike { source, .. }
+            | Self::SuperWeaponActivated { source, .. }
             | Self::WorldEffectStarted { source, .. } => *source,
             _ => None,
         }
@@ -542,18 +571,35 @@ impl GameSoundEvent {
 /// - `EnterGrinderSound`/`LeaveGrinderSound` (`+0x268`/`+0x26C`),
 ///   `EnterBioReactorSound`/`LeaveBioReactorSound` (`+0x270`/`+0x274`): no
 ///   grinder or bio-reactor consumer exists in `sim/` at all.
-/// - The seven `Crate*Sound` keys (`+0x1E4`..`+0x1FC`): no crate-pickup
-///   producer exists.
-/// - `PlaceBeaconSound` (`+0x1CC`), `MindClearedSound` (`+0x264`),
-///   `MasterMindOverloadDeathSound` (`+0x258`), `ImpactLandSound`/
-///   `ImpactWaterSound` (`+0x204`/`+0x200`), `CreditTicks` (`+0x6DC`),
-///   `IceCrackSounds` (`+0x644`): no producer.
-/// - **No player-visible gap on retail data:** `GateUp`/`GateDown`
-///   (`+0x404`/`+0x408`) are both `Dummy`, `Construction` (`+0x6C8`) is
-///   `Dummy`, and `CreateUnitSound`/`CreateInfantrySound`/`CreateAircraftSound`
-///   (`+0x178`..`+0x180`) and `LeaveGrinderSound` are empty in stock
-///   `rulesmd.ini`. `Dummy` is one of the eight `[SoundList]` ids with no
-///   usable `Sounds=`, so it registers silently.
+/// - The seven `Crate*Sound` keys (`+0x1E4`..`+0x1FC`): `sim/crates` places
+///   and regenerates crates but nothing picks one up, so there is no VERA
+///   producer to hang them on. The gap is a crate-pickup gap, not an audio one.
+/// - `MindClearedSound` (`+0x264`) — native consumer
+///   `CaptureManagerClass::FreeUnit @ 0x004720C5`; `MasterMindOverloadDeath`‑
+///   `Sound` (`+0x258`) — `CaptureManagerClass::Update @ 0x00471B39`;
+///   `PlaceBeaconSound` (`+0x1CC`) — `RadarClass::PlaceBeacon @ 0x00430D8E`
+///   (each found by an operand sweep for that `RulesClass` offset, which is
+///   capped and therefore not an exhaustive enumeration of readers). VERA has
+///   no mind-control release path, no MasterMind overload and no beacons, so
+///   none of the three has a producer to wire.
+/// - `ImpactWaterSound` (`+0x200`), `CreditTicks` (`+0x6DC`): no producer; the
+///   native readers were not isolated.
+/// - **Dead on retail data, so not parsed:** `ImpactLandSound` (`+0x204`) and
+///   `IceCrackSounds` (`+0x644`) are both **empty** in stock `rulesmd.ini`;
+///   `GateUp`/`GateDown` (`+0x404`/`+0x408`) and `Construction` (`+0x6C8`) are
+///   `Dummy`; `CreateUnitSound`/`CreateInfantrySound`/`CreateAircraftSound`
+///   (`+0x178`..`+0x180`) and `LeaveGrinderSound` are empty. `Dummy` is one of
+///   the eight `[SoundList]` ids with no usable `Sounds=`, so it registers
+///   silently. Parsing any of these would add a field with no player effect.
+///
+/// **Superweapon launch cues are landed** — see
+/// [`GameSoundEvent::SuperWeaponActivated`] and
+/// [`crate::app::match_runtime::sim_tick::superweapon_launch_cue`]. Two
+/// residuals remain there: the EVA suppression flag `[0x00A8B538]` has no VERA
+/// equivalent (VERA has no defeated-spectator state), and the `MultiMissile`,
+/// `ChronoSphere`, `ChronoWarp`, `PsychicDominator` and `SpyPlane` cases have
+/// no sim launch handler yet, so their rows in the table are mapped but never
+/// reached.
 #[derive(Debug, Default)]
 pub struct SoundEventQueue {
     events: Vec<GameSoundEvent>,

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -627,6 +627,63 @@ pub struct GeneralRules {
     /// entirely when the count is zero and otherwise plays
     /// `items[rand % count]` at the strike coordinate.
     pub lightning_sounds: Vec<String>,
+    /// Weather-storm start cue from `[AudioVisual] StormSound=` (stock
+    /// `WeatherIntro`), stored at `Rules+0x730`.
+    ///
+    /// gamemd: `RulesClass::ReadAudioVisual @ 0x0066AEAE..0x0066AEE6` reads
+    /// the key at `0x0083A400` and keeps the `VocClass::FindByName` result.
+    /// `LightningStorm::Start @ 0x0053A032..0x0053A044` plays it
+    /// **non-positionally** — `MOV ECX,[Rules+0x730]`, `MOV EDX,0x2000`
+    /// (centred pan), `PUSH 0x3F800000` (volume `1.0f`), no handle, through
+    /// `VocClass::PlayAtPos @ 0x00750920` — and only inside the
+    /// `0x0053A014 MOV AL,[Rules+0x17B0]` gate it shares with the on-screen
+    /// storm message. See [`GeneralRules::lightning_print_text`].
+    pub storm_sound: Option<String>,
+    /// `[General] LightningPrintText=` (`Rules+0x17B0`), the gate on both the
+    /// storm message and [`GeneralRules::storm_sound`].
+    ///
+    /// gamemd: `RulesClass::ReadGeneral @ 0x0067107F..0x0067108C` reads the
+    /// key at `0x0083BC74`. Stock `rulesmd.ini` does **not** author it, so the
+    /// constructor default decides: `RulesClass::Constructor @ 0x006676BC MOV
+    /// byte ptr [ESI+0x17B0],AL`, where the last definition of `EAX` before it
+    /// is `0x00667202 MOV EAX,0x1` and the function's last `CALL` is at
+    /// `0x0066715D` — so the default is **true** and the storm cue does play
+    /// on retail data.
+    pub lightning_print_text: bool,
+    /// Nuclear-missile launch cue from `[AudioVisual] DigSound=` (stock
+    /// `NukeSiren`), stored at `Rules+0x174`.
+    ///
+    /// gamemd: `RulesClass::ReadAudioVisual @ 0x00669331..0x00669367` reads
+    /// the key at `0x0083AB70` (`"DigSound"`). Despite the name it is the
+    /// nuke siren — stock `rulesmd.ini` says so in a comment — and
+    /// `SuperClass::Launch @ 0x006CC390` case 0 (`Type=MultiMissile`) is its
+    /// only reader, playing it at the target coordinate through
+    /// `VocClass::PlayAtCoord @ 0x00750E20` on both branches
+    /// (`0x006CDCA8`/`0x006CDCAE` when the silo animates the launch,
+    /// `0x006CDDE3`/`0x006CDDE9` when it does not).
+    pub dig_sound: Option<String>,
+    /// `[AudioVisual] PsychicDominatorActivateSound=` (stock
+    /// `PsychicDominatorActivate`), stored at `Rules+0x24C`.
+    ///
+    /// gamemd: `SuperClass::Launch @ 0x006CC390` case 7 plays it at the target
+    /// coordinate — `0x006CCE22 MOV ECX,[Rules+0x24C]`,
+    /// `0x006CCE28 CALL VocClass::PlayAtCoord @ 0x00750E20`.
+    pub psychic_dominator_activate_sound: Option<String>,
+    /// `[AudioVisual] GeneticMutatorActivateSound=` (stock
+    /// `GeneticMutatorActivate`), stored at `Rules+0x250`.
+    ///
+    /// gamemd: `SuperClass::Launch @ 0x006CC390` case 9 plays it at the target
+    /// coordinate — `0x006CD8CD MOV ECX,[Rules+0x250]`,
+    /// `0x006CD8D3 CALL VocClass::PlayAtCoord @ 0x00750E20`.
+    pub genetic_mutator_activate_sound: Option<String>,
+    /// `[AudioVisual] PsychicRevealActivateSound=` (stock
+    /// `PsychicRevealActivate`), stored at `Rules+0x254`.
+    ///
+    /// gamemd: `SuperClass::Launch @ 0x006CC390` case 11 plays it at the
+    /// target coordinate — `0x006CD7B9 MOV ECX,[Rules+0x254]`,
+    /// `0x006CD7BF CALL VocClass::PlayAtCoord @ 0x00750E20`. This case plays
+    /// no EVA line.
+    pub psychic_reveal_activate_sound: Option<String>,
     /// SFX played when a paradropped passenger successfully deploys a parachute.
     /// Parsed from [AudioVisual] ChuteSound (stock "ParachuteDrop").
     /// None = no sound configured. Resolved at app layer to a sound.ini entry.
@@ -1185,6 +1242,14 @@ impl Default for GeneralRules {
             building_die_sound: None,
             building_damage_sound: None,
             lightning_sounds: Vec::new(),
+            storm_sound: None,
+            // `RulesClass::Constructor @ 0x006676BC` writes AL, and the last
+            // definition of EAX before it is `0x00667202 MOV EAX,0x1`.
+            lightning_print_text: true,
+            dig_sound: None,
+            psychic_dominator_activate_sound: None,
+            genetic_mutator_activate_sound: None,
+            psychic_reveal_activate_sound: None,
             chute_sound: None,
             gui_main_button_sound: None,
             gui_move_in_sound: None,
@@ -1933,6 +1998,35 @@ impl GeneralRules {
                         .collect()
                 })
                 .unwrap_or_default(),
+            storm_sound: audio_visual
+                .and_then(|s| s.get("StormSound"))
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+            // `RulesClass::ReadGeneral @ 0x0067107F` passes the field's own
+            // current value as the default, so an absent key keeps the
+            // constructor's `true` (see the field doc).
+            lightning_print_text: general.get_bool("LightningPrintText").unwrap_or(true),
+            dig_sound: audio_visual
+                .and_then(|s| s.get("DigSound"))
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+            psychic_dominator_activate_sound: audio_visual
+                .and_then(|s| s.get("PsychicDominatorActivateSound"))
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+            genetic_mutator_activate_sound: audio_visual
+                .and_then(|s| s.get("GeneticMutatorActivateSound"))
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
+            psychic_reveal_activate_sound: audio_visual
+                .and_then(|s| s.get("PsychicRevealActivateSound"))
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
             chute_sound: audio_visual
                 .and_then(|s| s.get("ChuteSound"))
                 .map(str::trim)
@@ -5484,6 +5578,81 @@ BuildingGarrisonedSound=BuildingGarrisoned
             empty.lightning_sounds.is_empty(),
             "stock ships an empty IceCrackSounds= in the same shape"
         );
+    }
+
+    /// `SuperClass::Launch @ 0x006CC390` reads three `[AudioVisual]` cues
+    /// straight off `RulesClass` — `+0x24C` at `0x006CCE22`, `+0x250` at
+    /// `0x006CD8CD`, `+0x254` at `0x006CD7B9` — plus `DigSound` (`+0x174`,
+    /// `0x006CDCA8`), the nuke siren despite the name.
+    #[test]
+    fn superweapon_activate_sounds_parse_their_stock_values() {
+        let stock = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]
+FlightLevel=500
+[AudioVisual]
+             PsychicDominatorActivateSound=PsychicDominatorActivate
+             GeneticMutatorActivateSound=GeneticMutatorActivate
+             PsychicRevealActivateSound=PsychicRevealActivate
+             DigSound=NukeSiren		; HACK: Nuke siren here
+             StormSound=WeatherIntro
+",
+        ));
+        assert_eq!(
+            stock.psychic_dominator_activate_sound.as_deref(),
+            Some("PsychicDominatorActivate")
+        );
+        assert_eq!(
+            stock.genetic_mutator_activate_sound.as_deref(),
+            Some("GeneticMutatorActivate")
+        );
+        assert_eq!(
+            stock.psychic_reveal_activate_sound.as_deref(),
+            Some("PsychicRevealActivate")
+        );
+        assert_eq!(
+            stock.dig_sound.as_deref(),
+            Some("NukeSiren"),
+            "the inline comment is cut before the value is trimmed"
+        );
+        assert_eq!(stock.storm_sound.as_deref(), Some("WeatherIntro"));
+
+        let absent = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]
+FlightLevel=500
+[AudioVisual]
+DigSound=
+StormSound=
+",
+        ));
+        assert_eq!(absent.psychic_dominator_activate_sound, None);
+        assert_eq!(absent.genetic_mutator_activate_sound, None);
+        assert_eq!(absent.psychic_reveal_activate_sound, None);
+        assert_eq!(absent.dig_sound, None, "an empty value is silence");
+        assert_eq!(absent.storm_sound, None);
+    }
+
+    /// `LightningPrintText` is absent from stock `rulesmd.ini`, so the gate on
+    /// `StormSound` is decided by `RulesClass::Constructor @ 0x006676BC`, which
+    /// stores `AL` after `0x00667202 MOV EAX,0x1` with no intervening `CALL`
+    /// (the function's last is `0x0066715D`).
+    #[test]
+    fn lightning_print_text_defaults_true_and_reads_the_general_key() {
+        let stock = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]
+FlightLevel=500
+",
+        ));
+        assert!(
+            stock.lightning_print_text,
+            "the storm cue is audible on stock data"
+        );
+        let off = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]
+FlightLevel=500
+LightningPrintText=no
+",
+        ));
+        assert!(!off.lightning_print_text);
     }
 
     #[test]

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -638,6 +638,13 @@ pub struct GeneralRules {
     /// `VocClass::PlayAtPos @ 0x00750920` — and only inside the
     /// `0x0053A014 MOV AL,[Rules+0x17B0]` gate it shares with the on-screen
     /// storm message. See [`GeneralRules::lightning_print_text`].
+    ///
+    /// It is **not** a launch cue. `SuperClass::Launch @ 0x006CC390` case 2
+    /// passes `[Rules+0x1794]` (`LightningDeferment`, stock 250) as `Start`'s
+    /// `param_2`, and `Start` returns at `if (param_2 != 0)` before reaching
+    /// `0x0053A044`; `LightningStorm::Process @ 0x0053A6C0` re-enters with
+    /// `param_2` cleared (`0x0053AAC8 XOR EDX,EDX`) once the countdown expires
+    /// and that entry plays it.
     pub storm_sound: Option<String>,
     /// `[General] LightningPrintText=` (`Rules+0x17B0`), the gate on both the
     /// storm message and [`GeneralRules::storm_sound`].

--- a/src/sim/superweapon/force_shield.rs
+++ b/src/sim/superweapon/force_shield.rs
@@ -28,6 +28,7 @@ pub fn launch(
     owner: InternedId,
     target_rx: u16,
     target_ry: u16,
+    sw_type: InternedId,
 ) -> bool {
     let duration = rules.general.force_shield_duration;
     let radius_cells = rules.general.force_shield_radius as i64;
@@ -92,6 +93,7 @@ pub fn launch(
     // 5. Sound event.
     sim.sound_events.push(SimSoundEvent::SuperWeaponLaunched {
         owner,
+        sw_type,
         rx: target_rx,
         ry: target_ry,
     });

--- a/src/sim/superweapon/genetic_converter.rs
+++ b/src/sim/superweapon/genetic_converter.rs
@@ -37,6 +37,7 @@ pub fn launch(
     owner: InternedId,
     target_rx: u16,
     target_ry: u16,
+    sw_type: InternedId,
     overlay_registry: Option<&OverlayTypeRegistry>,
 ) -> bool {
     // 1. Spawn invoke anim (IonBlast equivalent).
@@ -58,6 +59,7 @@ pub fn launch(
     // 4. Sound event.
     sim.sound_events.push(SimSoundEvent::SuperWeaponLaunched {
         owner,
+        sw_type,
         rx: target_rx,
         ry: target_ry,
     });

--- a/src/sim/superweapon/iron_curtain.rs
+++ b/src/sim/superweapon/iron_curtain.rs
@@ -25,6 +25,7 @@ pub fn launch(
     owner: InternedId,
     target_rx: u16,
     target_ry: u16,
+    sw_type: InternedId,
 ) -> bool {
     let duration = rules.general.iron_curtain_duration;
     let anim_name = rules.general.iron_curtain_invoke_anim.clone();
@@ -64,6 +65,7 @@ pub fn launch(
     // 4. Sound event.
     sim.sound_events.push(SimSoundEvent::SuperWeaponLaunched {
         owner,
+        sw_type,
         rx: target_rx,
         ry: target_ry,
     });
@@ -126,7 +128,8 @@ mod tests {
         let mut sim = Simulation::new();
         let owner = sim.interner.intern("Americans");
         spawn(&mut sim, 1, "MTNK", 10, 10, EntityCategory::Unit);
-        assert!(launch(&mut sim, &rules, owner, 10, 10));
+        let sw_test = sim.interner.intern("SWTEST");
+        assert!(launch(&mut sim, &rules, owner, 10, 10, sw_test));
         let e = sim.substrate.entities.get(1).expect("tank exists");
         assert!(e.invulnerability.is_some());
         assert!(is_invulnerable(
@@ -141,7 +144,8 @@ mod tests {
         let mut sim = Simulation::new();
         let owner = sim.interner.intern("Americans");
         spawn(&mut sim, 1, "E1", 10, 10, EntityCategory::Infantry);
-        assert!(launch(&mut sim, &rules, owner, 10, 10));
+        let sw_test = sim.interner.intern("SWTEST");
+        assert!(launch(&mut sim, &rules, owner, 10, 10, sw_test));
         let e = sim.substrate.entities.get(1).expect("infantry exists");
         assert_eq!(e.health.current, 0);
         assert!(e.dying);
@@ -156,7 +160,8 @@ mod tests {
         spawn(&mut sim, 1, "MTNK", 9, 9, EntityCategory::Unit);
         spawn(&mut sim, 2, "MTNK", 10, 10, EntityCategory::Unit);
         spawn(&mut sim, 3, "MTNK", 11, 11, EntityCategory::Unit);
-        launch(&mut sim, &rules, owner, 10, 10);
+        let sw_test = sim.interner.intern("SWTEST");
+        launch(&mut sim, &rules, owner, 10, 10, sw_test);
         assert!(
             sim.substrate
                 .entities
@@ -189,7 +194,8 @@ mod tests {
         let mut sim = Simulation::new();
         let owner = sim.interner.intern("Americans");
         spawn(&mut sim, 1, "MTNK", 15, 15, EntityCategory::Unit);
-        launch(&mut sim, &rules, owner, 10, 10);
+        let sw_test = sim.interner.intern("SWTEST");
+        launch(&mut sim, &rules, owner, 10, 10, sw_test);
         assert!(
             sim.substrate
                 .entities

--- a/src/sim/superweapon/lightning_storm.rs
+++ b/src/sim/superweapon/lightning_storm.rs
@@ -54,6 +54,17 @@ pub struct LightningStormState {
     pub last_bolt_ry: u16,
 }
 
+/// The storm actually begins — the non-deferred half of
+/// `LightningStorm::Start @ 0x00539EB0`, which flips the sky and plays the
+/// `StormSound` cue at `0x0053A044` in that order. Every path that reaches the
+/// beginning goes through here so the lighting and the cue cannot separate:
+/// in gamemd they are two statements of one straight-line block, reached only
+/// once the deferment countdown is zero.
+fn begin(sim: &mut Simulation) {
+    sim.session.lighting.select_ion();
+    sim.sound_events.push(SimSoundEvent::LightningStormBegan);
+}
+
 /// Start a new lightning storm. An overlapping invocation retargets the one
 /// global storm without creating a second queued lifetime.
 pub fn start(
@@ -68,18 +79,20 @@ pub fn start(
         storm.owner = owner;
         storm.target_rx = target_rx;
         storm.target_ry = target_ry;
-        if storm.deferment_remaining > 0 {
+        let begins_now = if storm.deferment_remaining > 0 {
             let requested_deferment = rules.general.lightning_deferment;
             if requested_deferment <= storm.deferment_remaining {
                 storm.deferment_remaining = requested_deferment;
             }
             storm.duration_remaining = rules.general.lightning_storm_duration;
-            if storm.deferment_remaining <= 0 {
-                sim.session.lighting.select_ion();
-            }
             log::info!("Deferred Lightning Storm retargeted to ({target_rx}, {target_ry})");
+            storm.deferment_remaining <= 0
         } else {
             log::info!("Active Lightning Storm retargeted to ({target_rx}, {target_ry})");
+            false
+        };
+        if begins_now {
+            begin(sim);
         }
         return true;
     }
@@ -99,10 +112,15 @@ pub fn start(
     let starts_active = state.deferment_remaining <= 0;
     sim.lightning_storm = Some(state);
     if starts_active {
-        sim.session.lighting.select_ion();
+        // `LightningDeferment=0` is the only way the launch call reaches the
+        // cue: `Start`'s `if (param_2 != 0)` early return is skipped and the
+        // whole block runs inside `SuperClass::Launch` itself. Native plays it
+        // before the case-2 EVA line at `0x006CCD81`, hence this order.
+        begin(sim);
     }
 
-    // Sound event for EVA warning.
+    // `EVA_LightningStormCreated` — `0x006CCD81`, played by case 2 after
+    // `LightningStorm::Start` returns, deferred or not.
     sim.sound_events.push(SimSoundEvent::SuperWeaponLaunched {
         owner,
         sw_type,
@@ -142,7 +160,12 @@ pub fn process(
         Some(_) => false,
     };
     if activates_now {
-        sim.session.lighting.select_ion();
+        // `LightningStorm::Process @ 0x0053AAAD` decrements the countdown and
+        // at zero re-enters `Start` with `param_2` cleared (`0x0053AAC8 XOR
+        // EDX,EDX`), so this is the frame that runs the non-deferred block —
+        // Ion lighting and `StormSound`. On stock data (`LightningDeferment=
+        // 250`) this is the only frame the cue is ever heard on.
+        begin(sim);
         // Native Process calls Start and returns on the countdown-zero frame;
         // expiry and bolt cadence begin on the next object tick.
         return;
@@ -546,6 +569,109 @@ mod tests {
         sim.advance_tick(&[], Some(&rules), &heights, None, None, 67);
         assert_eq!(sim.session.lighting.current_ambient, 100);
         assert_eq!(sim.scenario_rng.state(), rng_before);
+    }
+
+    fn storm_began_count(sim: &Simulation) -> usize {
+        sim.sound_events
+            .iter()
+            .filter(|event| matches!(event, SimSoundEvent::LightningStormBegan))
+            .count()
+    }
+
+    fn launch_announced_count(sim: &Simulation) -> usize {
+        sim.sound_events
+            .iter()
+            .filter(|event| matches!(event, SimSoundEvent::SuperWeaponLaunched { .. }))
+            .count()
+    }
+
+    /// `StormSound` is deferred. `SuperClass::Launch @ 0x006CC390` case 2
+    /// hands `LightningStorm::Start @ 0x00539EB0` the `[Rules+0x1794]`
+    /// `LightningDeferment` value as `param_2`, and `Start` returns at
+    /// `if (param_2 != 0) { arm the countdown; return; }` — before the cue at
+    /// `0x0053A044`. `LightningStorm::Process @ 0x0053A6C0` decrements the
+    /// countdown (`0x0053AAAD`) and at zero re-enters `Start` with `param_2`
+    /// cleared (`0x0053AAC8 XOR EDX,EDX ; 0x0053AACA CALL 0x00539EB0`); that
+    /// second entry is what plays it. Stock `rulesmd.ini:130` is
+    /// `LightningDeferment=250`, so on retail data the cue never lands on the
+    /// launch frame — only the EVA line does.
+    #[test]
+    fn the_storm_cue_lands_on_the_deferment_expiry_not_on_the_launch() {
+        let rules = lighting_timing_rules(3, 2, ".2");
+        let mut sim = Simulation::with_seed(0x422);
+        let owner = sim.interner.intern("Americans");
+        let sw_test = sim.interner.intern("LightningStormSpecial");
+
+        assert!(start(&mut sim, &rules, owner, 8, 9, sw_test));
+        assert_eq!(
+            storm_began_count(&sim),
+            0,
+            "a deferred launch returns before the cue"
+        );
+        assert_eq!(
+            launch_announced_count(&sim),
+            1,
+            "the EVA line is still spoken at launch (0x006CCD81)"
+        );
+        assert_eq!(
+            sim.session.lighting.selected_profile,
+            ScenarioLightingProfile::Normal
+        );
+
+        for frame in 1..=2 {
+            process(&mut sim, &rules, None);
+            assert_eq!(
+                storm_began_count(&sim),
+                0,
+                "countdown frame {frame} has not reached zero"
+            );
+        }
+
+        process(&mut sim, &rules, None);
+        assert_eq!(
+            storm_began_count(&sim),
+            1,
+            "the countdown-zero frame re-enters Start and plays the cue"
+        );
+        assert_eq!(
+            sim.session.lighting.selected_profile,
+            ScenarioLightingProfile::Ion,
+            "the cue and the Ion flip are one block in Start"
+        );
+
+        process(&mut sim, &rules, None);
+        assert_eq!(
+            storm_began_count(&sim),
+            1,
+            "the non-deferred block runs once per storm"
+        );
+    }
+
+    /// The one launch that does reach the cue: `LightningDeferment=0` skips
+    /// `Start`'s early return, so the whole non-deferred block runs inside
+    /// `SuperClass::Launch` itself, before the case-2 EVA line.
+    #[test]
+    fn a_zero_deferment_storm_plays_its_cue_on_the_launch_frame() {
+        let rules = lighting_timing_rules(0, 2, ".2");
+        let mut sim = Simulation::with_seed(0x423);
+        let owner = sim.interner.intern("Americans");
+        let sw_test = sim.interner.intern("LightningStormSpecial");
+
+        assert!(start(&mut sim, &rules, owner, 8, 9, sw_test));
+        assert_eq!(storm_began_count(&sim), 1);
+        assert_eq!(launch_announced_count(&sim), 1);
+        let cue_first = sim
+            .sound_events
+            .iter()
+            .position(|event| matches!(event, SimSoundEvent::LightningStormBegan))
+            < sim
+                .sound_events
+                .iter()
+                .position(|event| matches!(event, SimSoundEvent::SuperWeaponLaunched { .. }));
+        assert!(
+            cue_first,
+            "native calls Start before the EVA line at 0x006CCD81"
+        );
     }
 
     #[test]

--- a/src/sim/superweapon/lightning_storm.rs
+++ b/src/sim/superweapon/lightning_storm.rs
@@ -62,6 +62,7 @@ pub fn start(
     owner: InternedId,
     target_rx: u16,
     target_ry: u16,
+    sw_type: InternedId,
 ) -> bool {
     if let Some(storm) = sim.lightning_storm.as_mut() {
         storm.owner = owner;
@@ -104,6 +105,7 @@ pub fn start(
     // Sound event for EVA warning.
     sim.sound_events.push(SimSoundEvent::SuperWeaponLaunched {
         owner,
+        sw_type,
         rx: target_rx,
         ry: target_ry,
     });
@@ -470,7 +472,8 @@ mod tests {
         let heights = std::collections::BTreeMap::new();
         let rng_before = sim.scenario_rng.state();
 
-        assert!(start(&mut sim, &rules, owner, 8, 9));
+        let sw_test = sim.interner.intern("SWTEST");
+        assert!(start(&mut sim, &rules, owner, 8, 9, sw_test));
         assert_eq!(
             sim.session.lighting.selected_profile,
             ScenarioLightingProfile::Normal,
@@ -551,7 +554,8 @@ mod tests {
         let mut sim = Simulation::with_seed(0x421);
         let owner = sim.interner.intern("Americans");
 
-        assert!(start(&mut sim, &rules, owner, 8, 9));
+        let sw_test = sim.interner.intern("SWTEST");
+        assert!(start(&mut sim, &rules, owner, 8, 9, sw_test));
         for _ in 0..4 {
             process(&mut sim, &rules, None);
             assert_eq!(
@@ -576,12 +580,21 @@ mod tests {
         let first_owner = sim.interner.intern("Americans");
         let second_owner = sim.interner.intern("Soviet");
 
-        assert!(start(&mut sim, &first_rules, first_owner, 4, 5));
+        let sw_test = sim.interner.intern("SWTEST");
+        assert!(start(&mut sim, &first_rules, first_owner, 4, 5, sw_test));
         sim.lightning_storm
             .as_mut()
             .expect("deferred storm")
             .deferment_remaining = 3;
-        assert!(start(&mut sim, &second_rules, second_owner, 17, 19));
+        let sw_test = sim.interner.intern("SWTEST");
+        assert!(start(
+            &mut sim,
+            &second_rules,
+            second_owner,
+            17,
+            19,
+            sw_test
+        ));
 
         let storm = sim.lightning_storm.as_ref().expect("one deferred storm");
         assert_eq!(storm.owner, second_owner);
@@ -601,14 +614,16 @@ mod tests {
         let first_owner = sim.interner.intern("Americans");
         let second_owner = sim.interner.intern("Soviet");
 
-        assert!(start(&mut sim, &rules, first_owner, 4, 5));
+        let sw_test = sim.interner.intern("SWTEST");
+        assert!(start(&mut sim, &rules, first_owner, 4, 5, sw_test));
         assert_eq!(
             sim.session.lighting.selected_profile,
             ScenarioLightingProfile::Ion
         );
         let duration = sim.lightning_storm.as_ref().unwrap().duration_remaining;
 
-        assert!(start(&mut sim, &rules, second_owner, 17, 19));
+        let sw_test = sim.interner.intern("SWTEST");
+        assert!(start(&mut sim, &rules, second_owner, 17, 19, sw_test));
         let storm = sim
             .lightning_storm
             .as_ref()

--- a/src/sim/superweapon/lightning_storm.rs
+++ b/src/sim/superweapon/lightning_storm.rs
@@ -141,7 +141,9 @@ pub fn start(
 }
 
 /// Process the active lightning storm for one tick.
-/// Called from `tick_superweapons()` each tick.
+/// Called from `tick_active_superweapon_effects()` each tick, which is what
+/// `World::advance_tick` reaches in production; `tick_superweapons()` is a
+/// test-only compatibility wrapper and is not on the production path.
 pub fn process(
     sim: &mut Simulation,
     rules: &RuleSet,

--- a/src/sim/superweapon/paradrop.rs
+++ b/src/sim/superweapon/paradrop.rs
@@ -40,6 +40,7 @@ pub fn launch(
     target_rx: u16,
     target_ry: u16,
     kind: ParaDropKind,
+    sw_type: InternedId,
     _path_grid: Option<&PathGrid>,
 ) -> bool {
     // Bridge rejection deferred — map system does not yet expose is_bridge_cell.
@@ -79,9 +80,14 @@ pub fn launch(
         }
     };
 
-    // EVA "superweapon launched" voice — same convention as IronCurtain etc.
+    // Launch notification for the app layer. `SuperClass::Launch @ 0x006CC390`
+    // cases 5 (`ParaDrop`) and 6 (`AmerParaDrop`) play **no** cue and **no**
+    // EVA line — neither case body reaches a `VocClass` or `VoxClass` call —
+    // so the app resolves this to silence. The event is still emitted so every
+    // launch reaches one mapping site.
     sim.sound_events.push(SimSoundEvent::SuperWeaponLaunched {
         owner,
+        sw_type,
         rx: target_rx,
         ry: target_ry,
     });

--- a/src/sim/superweapon/paradrop_tests.rs
+++ b/src/sim/superweapon/paradrop_tests.rs
@@ -237,6 +237,7 @@ fn paradrop_launch_spawns_carrier_with_loaded_cargo() {
     let owner = sim.interner.intern("Americans");
 
     // Target near the north edge of the map.
+    let sw_test = sim.interner.intern("SWTEST");
     let ok = launch(
         &mut sim,
         &rules,
@@ -244,6 +245,7 @@ fn paradrop_launch_spawns_carrier_with_loaded_cargo() {
         50,
         20,
         ParaDropKind::American,
+        sw_test,
         Some(&path_grid),
     );
     assert!(ok, "launch should succeed with valid waypoint edge + cargo");
@@ -304,6 +306,7 @@ fn paradrop_multi_entry_resolves_each_edge_after_its_carrier_constructor() {
         let _passenger_constructor_word = expected_rng.next_u32();
     }
 
+    let sw_test = sim.interner.intern("SWTEST");
     assert!(launch(
         &mut sim,
         &rules,
@@ -311,6 +314,7 @@ fn paradrop_multi_entry_resolves_each_edge_after_its_carrier_constructor() {
         50,
         20,
         ParaDropKind::American,
+        sw_test,
         Some(&path_grid),
     ));
     let mut actual_cells = sim
@@ -342,6 +346,7 @@ fn paradrop_launch_ignores_blocked_ground_spawn_edge() {
     let owner = sim.interner.intern("Americans");
     let blocked_grid = PathGrid::test_all_blocked(200, 200);
 
+    let sw_test = sim.interner.intern("SWTEST");
     let ok = launch(
         &mut sim,
         &rules,
@@ -349,6 +354,7 @@ fn paradrop_launch_ignores_blocked_ground_spawn_edge() {
         50,
         20,
         ParaDropKind::American,
+        sw_test,
         Some(&blocked_grid),
     );
 
@@ -374,6 +380,7 @@ fn paradrop_launch_invalid_waypoint_edge_falls_back_to_north() {
     let owner = sim.interner.intern("Americans");
     sim.houses.get_mut(&owner).unwrap().waypoint_edge = 255;
 
+    let sw_test = sim.interner.intern("SWTEST");
     let ok = launch(
         &mut sim,
         &rules,
@@ -381,6 +388,7 @@ fn paradrop_launch_invalid_waypoint_edge_falls_back_to_north() {
         40,
         20,
         ParaDropKind::American,
+        sw_test,
         Some(&path_grid),
     );
 
@@ -405,6 +413,7 @@ fn paradrop_cargo_load_bypasses_pdplane_capacity_and_passenger_occupancy() {
     let (mut sim, path_grid) = build_sim(&rules);
     let owner = sim.interner.intern("Americans");
 
+    let sw_test = sim.interner.intern("SWTEST");
     let ok = launch(
         &mut sim,
         &rules,
@@ -412,6 +421,7 @@ fn paradrop_cargo_load_bypasses_pdplane_capacity_and_passenger_occupancy() {
         50,
         20,
         ParaDropKind::American,
+        sw_test,
         Some(&path_grid),
     );
 
@@ -454,6 +464,7 @@ fn paradrop_full_pipeline_drops_infantry_until_cargo_empty() {
     let pre_e1_count = count_alive_infantry(&sim, "E1");
     assert_eq!(pre_e1_count, 0, "no E1 should exist pre-launch");
 
+    let sw_test = sim.interner.intern("SWTEST");
     let ok = launch(
         &mut sim,
         &rules,
@@ -461,6 +472,7 @@ fn paradrop_full_pipeline_drops_infantry_until_cargo_empty() {
         50,
         20,
         ParaDropKind::American,
+        sw_test,
         Some(&path_grid),
     );
     assert!(ok, "launch should succeed");
@@ -518,6 +530,7 @@ fn paradrop_descent_ends_with_landed_infantry_and_carrier_despawned() {
     let (mut sim, path_grid) = build_sim(&rules);
     let owner = sim.interner.intern("Americans");
 
+    let sw_test = sim.interner.intern("SWTEST");
     launch(
         &mut sim,
         &rules,
@@ -525,6 +538,7 @@ fn paradrop_descent_ends_with_landed_infantry_and_carrier_despawned() {
         50,
         20,
         ParaDropKind::American,
+        sw_test,
         Some(&path_grid),
     );
 
@@ -653,6 +667,7 @@ CellSpread=0
         sim.houses.insert(owner_id, house);
         let path_grid = PathGrid::test_all_passable(200, 200);
 
+        let sw_test = sim.interner.intern("SWTEST");
         launch(
             &mut sim,
             &rules,
@@ -660,6 +675,7 @@ CellSpread=0
             50,
             20,
             ParaDropKind::Generic,
+            sw_test,
             Some(&path_grid),
         );
 
@@ -709,6 +725,7 @@ CellSpread=0
         sim.houses.insert(owner_id, house);
         let path_grid = PathGrid::test_all_passable(200, 200);
 
+        let sw_test = sim.interner.intern("SWTEST");
         launch(
             &mut sim,
             &rules,
@@ -716,6 +733,7 @@ CellSpread=0
             50,
             20,
             ParaDropKind::Generic,
+            sw_test,
             Some(&path_grid),
         );
 
@@ -743,6 +761,7 @@ CellSpread=0
         sim.houses.insert(owner_id, house);
         let path_grid = PathGrid::test_all_passable(200, 200);
 
+        let sw_test = sim.interner.intern("SWTEST");
         launch(
             &mut sim,
             &rules,
@@ -750,6 +769,7 @@ CellSpread=0
             50,
             20,
             ParaDropKind::Generic,
+            sw_test,
             Some(&path_grid),
         );
 

--- a/src/sim/superweapon/psychic_reveal.rs
+++ b/src/sim/superweapon/psychic_reveal.rs
@@ -19,6 +19,7 @@ pub fn launch(
     owner: InternedId,
     target_rx: u16,
     target_ry: u16,
+    sw_type: InternedId,
 ) -> bool {
     let radius = rules.general.psychic_reveal_radius as u16;
 
@@ -28,6 +29,7 @@ pub fn launch(
 
     sim.sound_events.push(SimSoundEvent::SuperWeaponLaunched {
         owner,
+        sw_type,
         rx: target_rx,
         ry: target_ry,
     });
@@ -63,7 +65,8 @@ mod tests {
         sim.fog.width = 30;
         sim.fog.height = 30;
         let owner = sim.interner.intern("Americans");
-        assert!(launch(&mut sim, &rules, owner, 10, 10));
+        let sw_test = sim.interner.intern("SWTEST");
+        assert!(launch(&mut sim, &rules, owner, 10, 10, sw_test));
         let vis = sim.fog.by_owner.get(&owner).expect("owner fog exists");
         assert!(vis.is_visible(10, 10));
     }
@@ -75,9 +78,40 @@ mod tests {
         sim.fog.width = 30;
         sim.fog.height = 30;
         let owner = sim.interner.intern("Americans");
-        launch(&mut sim, &rules, owner, 10, 10);
+        let sw_test = sim.interner.intern("SWTEST");
+        launch(&mut sim, &rules, owner, 10, 10, sw_test);
         let vis = sim.fog.by_owner.get(&owner).expect("owner fog exists");
         // Radius=5, so (25, 25) is well outside.
         assert!(!vis.is_visible(25, 25));
+    }
+
+    /// The launch event carries the launched `[SuperWeaponTypes]` section, the
+    /// same object `SuperClass::Launch @ 0x006CC390` reads its `Type=` case
+    /// and (for `ForceShield`) its `StartSound=` from. Without it the app
+    /// layer cannot tell one superweapon's cue from another's.
+    #[test]
+    fn the_launch_event_names_the_superweapon_type_that_fired() {
+        let rules = minimal_rules();
+        let mut sim = Simulation::new();
+        sim.fog.width = 30;
+        sim.fog.height = 30;
+        let owner = sim.interner.intern("Americans");
+        let sw_test = sim.interner.intern("PsychicRevealSpecial");
+        assert!(launch(&mut sim, &rules, owner, 10, 11, sw_test));
+        let launched = sim
+            .sound_events
+            .iter()
+            .find_map(|event| match event {
+                SimSoundEvent::SuperWeaponLaunched {
+                    owner,
+                    sw_type,
+                    rx,
+                    ry,
+                } => Some((*owner, *sw_type, *rx, *ry)),
+                _ => None,
+            })
+            .expect("a launch emits exactly one SuperWeaponLaunched event");
+        assert_eq!(launched, (owner, sw_test, 10, 11));
+        assert_eq!(sim.interner.resolve(launched.1), "PsychicRevealSpecial");
     }
 }

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -493,8 +493,27 @@ pub enum SimSoundEvent {
         miner: bool,
         eva_allowed: bool,
     },
-    /// A superweapon was launched — play EVA warning.
-    SuperWeaponLaunched { owner: InternedId, rx: u16, ry: u16 },
+    /// A superweapon fired. `sw_type` is the interned `[SuperWeaponTypes]`
+    /// section name of the launched weapon — the discriminator the app layer
+    /// needs to pick the cue, and the same object gamemd switches on.
+    ///
+    /// `SuperClass::Launch @ 0x006CC390` switches on `*(param_1[10] + 0xB4)`,
+    /// the launched `SuperWeaponTypeClass`'s `Type=` index, and each case
+    /// plays its own cue: nothing at all for `ChronoSphere`, `ParaDrop`,
+    /// `AmerParaDrop` and `SpyPlane`; an EVA line only for `IronCurtain`
+    /// (`0x006CCF21`), `LightningStorm` (`0x006CCD81`) and `ChronoWarp`
+    /// (`0x006CCD03`); a positional `[AudioVisual]` cue only for `ForceShield`
+    /// (`0x006CD176`, from the *type's* own `StartSound=`) and `PsychicReveal`
+    /// (`0x006CD7BF`); and both for `MultiMissile`, `PsychicDominator` and
+    /// `GeneticConverter`. Carrying the type rather than a per-case flag is
+    /// what lets the app read both the case index and `StartSound=` off one
+    /// object, as `param_1[10]` does.
+    SuperWeaponLaunched {
+        owner: InternedId,
+        sw_type: InternedId,
+        rx: u16,
+        ry: u16,
+    },
     /// A lightning bolt struck — play thunder sound.
     SuperWeaponStrike { rx: u16, ry: u16 },
     /// First occupant entered a CanBeOccupied building (cargo 0→1).

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -514,6 +514,25 @@ pub enum SimSoundEvent {
         rx: u16,
         ry: u16,
     },
+    /// The lightning storm actually began — the moment the sky flips to Ion,
+    /// which on retail data is ~250 frames *after* the Weather Controller
+    /// fired. This is where `StormSound` belongs, not on the launch.
+    ///
+    /// `SuperClass::Launch @ 0x006CC390` case 2 calls `LightningStorm::Start
+    /// @ 0x00539EB0` with `param_2 = [Rules+0x1794]` — `[General]
+    /// LightningDeferment`, whose key string `"LightningDeferment"` sits at
+    /// `0x0083BD18` and is pushed at `0x00670F82` in `RulesClass::ReadGeneral`
+    /// (read `0x00670F75`, stored `0x00670F8F`). `Start`'s body opens with
+    /// `if (param_2 != 0) { arm the countdown; store the duration; return; }`,
+    /// and that early return is *before* the cue at `0x0053A044`
+    /// (`VocClass::PlayAtPos @ 0x00750920`). `LightningStorm::Process @
+    /// 0x0053A6C0` decrements the countdown and, at zero, re-enters `Start`
+    /// with `param_2` zeroed (`0x0053AAC8 XOR EDX,EDX ; 0x0053AACA CALL
+    /// 0x00539EB0`); that second entry is the one that plays it.
+    ///
+    /// Stock `rulesmd.ini:130` is `LightningDeferment=250`, so the launch call
+    /// *always* takes the early return and the cue is always deferred.
+    LightningStormBegan,
     /// A lightning bolt struck — play thunder sound.
     SuperWeaponStrike { rx: u16, ry: u16 },
     /// First occupant entered a CanBeOccupied building (cargo 0→1).

--- a/src/sim/world/world_commands.rs
+++ b/src/sim/world/world_commands.rs
@@ -2126,19 +2126,34 @@ impl Simulation {
                     crate::rules::superweapon_type::SuperWeaponKind::LightningStorm => {
                         let rules = rules.unwrap();
                         crate::sim::superweapon::lightning_storm::start(
-                            self, rules, owner_iid, *target_rx, *target_ry,
+                            self,
+                            rules,
+                            owner_iid,
+                            *target_rx,
+                            *target_ry,
+                            *sw_type_id,
                         )
                     }
                     crate::rules::superweapon_type::SuperWeaponKind::IronCurtain => {
                         let rules = rules.unwrap();
                         crate::sim::superweapon::iron_curtain::launch(
-                            self, rules, owner_iid, *target_rx, *target_ry,
+                            self,
+                            rules,
+                            owner_iid,
+                            *target_rx,
+                            *target_ry,
+                            *sw_type_id,
                         )
                     }
                     crate::rules::superweapon_type::SuperWeaponKind::ForceShield => {
                         let rules = rules.unwrap();
                         crate::sim::superweapon::force_shield::launch(
-                            self, rules, owner_iid, *target_rx, *target_ry,
+                            self,
+                            rules,
+                            owner_iid,
+                            *target_rx,
+                            *target_ry,
+                            *sw_type_id,
                         )
                     }
                     crate::rules::superweapon_type::SuperWeaponKind::GeneticConverter => {
@@ -2149,13 +2164,19 @@ impl Simulation {
                             owner_iid,
                             *target_rx,
                             *target_ry,
+                            *sw_type_id,
                             overlay_registry,
                         )
                     }
                     crate::rules::superweapon_type::SuperWeaponKind::PsychicReveal => {
                         let rules = rules.unwrap();
                         crate::sim::superweapon::psychic_reveal::launch(
-                            self, rules, owner_iid, *target_rx, *target_ry,
+                            self,
+                            rules,
+                            owner_iid,
+                            *target_rx,
+                            *target_ry,
+                            *sw_type_id,
                         )
                     }
                     crate::rules::superweapon_type::SuperWeaponKind::ParaDrop => {
@@ -2167,6 +2188,7 @@ impl Simulation {
                             *target_rx,
                             *target_ry,
                             crate::sim::superweapon::paradrop::ParaDropKind::Generic,
+                            *sw_type_id,
                             path_grid,
                         )
                     }
@@ -2179,6 +2201,7 @@ impl Simulation {
                             *target_rx,
                             *target_ry,
                             crate::sim::superweapon::paradrop::ParaDropKind::American,
+                            *sw_type_id,
                             path_grid,
                         )
                     }


### PR DESCRIPTION
## What this changes for the player

Superweapons used to fire in total silence. Now they sound like retail:

- **Lightning Storm** plays its weather intro — and plays it at the moment the storm actually
  arrives, not at the button press. Retail defers the storm by `LightningDeferment=250` frames
  (~8 seconds), and the cue belongs to the expiry, not the launch.
- **Iron Curtain** and **Chronosphere** announce themselves over EVA.
- **Psychic Dominator**, **Genetic Mutator** and **Psychic Reveal** play their activation sound
  at the target cell.
- **Force Shield** plays the launched type's own `StartSound=`, not a shared `[AudioVisual]` key.
- **Nuclear missile** gets the siren and its EVA warning.
- **ChronoSphere, ParaDrop, AmerParaDrop and SpyPlane stay silent** — that is what gamemd does,
  and it is now pinned by a test rather than being an accident.

An enemy's launch announces itself on your client, matching native: the EVA line is gated only on
the local defeated/spectating flag, never on the launching house.

## Verified gamemd sources

- `SuperClass::Launch @ 0x006CC390` — a 12-arm switch on the launched type's `Type=` index
  (`SuperWeaponTypeClass+0xB4`). Every arm disassembled; the cue table is the switch.
- `0x008425C0` — the 12 `char*` `Type=` name table that fixes the enum order, walked by
  `SuperWeaponTypeClass::ReadINI @ 0x006CEA20` (`0x006CEC46`..`0x006CEC7E`, 48 bytes = 12 entries).
- `LightningStorm::Start @ 0x00539EB0` — `StormSound` (`Rules+0x730`) is played here, not in
  `Launch`, non-positional (pan `0x2000`, volume `1.0f`, `VocClass::PlayAtPos @ 0x00750920`), behind
  the `Rules+0x17B0` `LightningPrintText` gate at `0x0053A014`.
- **The deferral**: case 2 passes `EDX = [Rules+0x1794]` (`LightningDeferment`, key at `0x0083BD18`)
  as `Start`'s `param_2` at `0x006CCD5D`. Non-zero takes an early return that only arms the
  countdown. `LightningStorm::Process` re-enters at `0x0053AACA` with `0x0053AAC8 XOR EDX,EDX` —
  `param_2 = 0` — and *that* call plays the cue. The decompiler renders this call with two
  arguments and hides the zeroed register argument; only the disassembly shows it.
- `LightningPrintText` (`Rules+0x17B0`) is absent from stock `rulesmd.ini`, so the constructor
  default decides it. `RulesClass::Constructor @ 0x006676BC` stores `AL` = 1: the function contains
  **no jump instructions at all** (0 over 1621), its last `CALL` is `0x0066715D`, and the last
  EAX write before the store is `0x00667202 MOV EAX,0x1`. The cue is audible on retail data.
- `DigSound` (`Rules+0x174`, key `0x0083AB70`) is the nuke siren — stock `rulesmd.ini` says so:
  `DigSound=NukeSiren ; HACK: Nuke siren here since I believe this is unused`.
- `StartSound` (`SuperWeaponTypeClass+0xC4`, key `0x00818418`), skipped when `-1`
  (`0x006CD16B CMP ECX,-1 ; JZ`), via `VocClass::PlayAt @ 0x007509E0`.
- `0x00A8B538` — the EVA suppression flag, written by `HouseClass::MPlayer_Defeated @ 0x004FC205`.

Ghidra was read-only throughout: decompile, disassemble, read_memory and search_instructions only.
Nothing was renamed, labelled, commented or saved. Annotation candidates are recorded in the
session reports, not applied.

## Residuals left open

**R2 — five cue rows are mapped and tested but not yet reachable.** `MultiMissile`, `ChronoSphere`,
`ChronoWarp`, `PsychicDominator` and `SpyPlane` have no sim launch handler; they fall to the
`not yet implemented` arm in `world_commands.rs`, return `success == false`, and emit no sound event
at all. So the nuke siren, the Chronosphere announcement and the Dominator cue cannot fire yet. This
is a superweapon-mechanics gap, not an audio one — each row lights up the moment its handler lands.
Recorded in the `SoundEventQueue` doc block.

**R8 — the deferment countdown's repeat EVA is not modelled.** `LightningStorm::Process` re-issues
a line every 225 (`0xE1`) countdown frames behind the same `Rules+0x17B0` gate
(`0x0053AB11 CALL VoxClass::PlayEVA`, `ECX = 0x00828080` = `EVA_LightningStormCreated` — the *same*
line as the launch, not a distinct one). With stock `LightningDeferment=250` the countdown passes
225 exactly once, ~25 frames after the launch line. **Whether this is audible at all is UNCHECKED**:
`VoxClass::QueueVoice @ 0x00752480` skips its whole body when the requested VoxClass is the one
currently playing, and there is a second de-dup below it, so on stock data gamemd most likely says
it once. The unambiguous gap on that path is the second on-screen
`TXT_LIGHTNING_STORM_APPROACHING` message (`0x0053AB27`), which is a UI gap, not an audio one.
Deferred as its own slice: it needs a new sim event, a new translation arm, the `0xE1` cadence and
a test.

Also standing: R1 (the `0x00A8B538` defeated/spectating gate is unmodelled — VERA has no spectator
state), R3 (cue-vs-EVA order within a case; they land on independent mixer paths), R4
(`EVA_PsychicDominatorActivated` is `Dummy` on all three sides in retail `evamd.ini`, so the
Dominator announces itself only through its `[AudioVisual]` cue), R5/R6 (`MindClearedSound`,
`MasterMindOverloadDeathSound`, `PlaceBeaconSound` and the seven `Crate*Sound` keys have verified
native consumers but no VERA producer yet), R7 (`ImpactLandSound` and `IceCrackSounds` are empty and
`GateUp`/`GateDown`/`Construction` are `Dummy` in stock data — an evidence-backed exclusion).

## Tests

```
cargo test -p vera20k --lib
test result: ok. 8212 passed; 0 failed; 75 ignored; 0 measured; 0 filtered out
```

Eight tests added over the branch, covering all 12 switch rows, the storm's deferred cue timing
(zero cue events at launch, exactly one on the expiry frame), the `LightningDeferment=0` path where
the cue does land on the launch frame, the `ForceShield` type-scoped `StartSound=` and its `-1`
skip, and the discriminator reaching the sim event.

`SNAPSHOT_VERSION` is unchanged at 119. No golden or world-hash constant moved.
`grep -rn "crate::audio" src/sim/` is empty — no new layering edge.
