### PR TITLE
feat(debris): death debris on gamemd's draining budget, and the case-exact MaxDebris read

### DIFF
--- a/src/rules/ini_parser.rs
+++ b/src/rules/ini_parser.rs
@@ -200,13 +200,14 @@ impl IniSection {
     /// equivalent, and no new caller should be added.**
     ///
     /// gamemd's `INIClass` is case-SENSITIVE on both section names and entry
-    /// names. It hashes the raw bytes on the store side (`INIClass::
-    /// LoadFromStraw @ 0x005260C9`, whose only text transform is `strtrim @
-    /// 0x00727CF0` — bytes `<= 0x20` off both ends) and on the lookup side
-    /// (`CCINIClass::ReadInt @ 0x00527715`), through the standard reflected
-    /// CRC-32 in `CRCEngine::AddData @ 0x004A1DE0` (table at `0x0081F7B4`,
-    /// poly `0xEDB88320`), and then compares 32-bit integers only —
-    /// `INIClass::FindEntry_BinarySearch @ 0x0052B4F0` and
+    /// names. It hashes the raw bytes on the store side
+    /// (`INIClass::LoadFromStraw @ 0x00525A60`, raw-pointer CRC call at
+    /// `0x005260D4`, whose only text transform is `strtrim @ 0x00727CF0` —
+    /// bytes `<= 0x20` off both ends) and on the lookup side
+    /// (`CCINIClass::ReadInt @ 0x005276D0`, CRC call at `0x00527727`), through
+    /// the standard reflected CRC-32 in `CRCEngine::AddData @ 0x004A1DE0`
+    /// (table at `0x0081F7B4`, poly `0xEDB88320`), and then compares 32-bit
+    /// integers only — `INIClass::FindEntry_BinarySearch @ 0x0052B4F0` and
     /// `FindSection_BinarySearch @ 0x0052B620` never call `strcmp`. There is
     /// no folding instruction anywhere on the path and no string fallback.
     ///
@@ -217,12 +218,14 @@ impl IniSection {
     /// divergence. Those call sites are now case-exact.
     ///
     /// Across the whole stock INI corpus exactly 6 authored key spellings
-    /// disagree in case with gamemd's own literal, touching 44 (section, key)
-    /// pairs; 0 section names disagree. The survivors here are
-    /// `sound_ini.rs`'s 18 call sites — the mis-spellings that reach them are
-    /// `Vshift` (9 soundmd sections), `Fshift` (3) and `volume` (2), 12
-    /// distinct sound events in all — and they belong to the audio lane. This
-    /// helper is deleted once those are converted.
+    /// disagree in case with gamemd's own literal: `Maxdebris` (17 sections),
+    /// `JumpJetAccel` (8), `JumpJetTurnRate` (8), `Vshift` (9), `Fshift` (3)
+    /// and `volume` (2) — 47 (section, key) pairs over 38 distinct sections.
+    /// 0 section names disagree. The survivors here are `sound_ini.rs`'s 18
+    /// call sites, reached by the three soundmd mis-spellings above: 14 of
+    /// those 47 pairs, over 13 distinct sound events, because
+    /// `[GrinderGrinding]` carries both `Fshift` and `Vshift`. They belong to
+    /// the audio lane; this helper is deleted once those are converted.
     pub fn get_ignoring_case(&self, key: &str) -> Option<&str> {
         self.key_ignore_ascii_case(key)
             .and_then(|exact| self.entries.get(exact))

--- a/src/rules/ini_parser.rs
+++ b/src/rules/ini_parser.rs
@@ -196,15 +196,33 @@ impl IniSection {
         self.set(&next.to_string(), value);
     }
 
-    /// Value lookup that ignores key case.
+    /// Value lookup that ignores key case. **VERA-internal — gamemd has no
+    /// equivalent, and no new caller should be added.**
     ///
-    /// The ordinary readers match keys exactly, which is right for almost
-    /// everything because retail spells keys consistently. `MaxDebris=` is the
-    /// exception this exists for: 17 of the 456 stock sections that author it
-    /// spell it `Maxdebris=`, and gamemd's `INIClass` compares keys
-    /// case-insensitively, so those 17 do take effect in retail. Reach for this
-    /// only where a retail spelling inconsistency is known and counted — making
-    /// every reader case-insensitive is an INI-layer change with its own row.
+    /// gamemd's `INIClass` is case-SENSITIVE on both section names and entry
+    /// names. It hashes the raw bytes on the store side (`INIClass::
+    /// LoadFromStraw @ 0x005260C9`, whose only text transform is `strtrim @
+    /// 0x00727CF0` — bytes `<= 0x20` off both ends) and on the lookup side
+    /// (`CCINIClass::ReadInt @ 0x00527715`), through the standard reflected
+    /// CRC-32 in `CRCEngine::AddData @ 0x004A1DE0` (table at `0x0081F7B4`,
+    /// poly `0xEDB88320`), and then compares 32-bit integers only —
+    /// `INIClass::FindEntry_BinarySearch @ 0x0052B4F0` and
+    /// `FindSection_BinarySearch @ 0x0052B620` never call `strcmp`. There is
+    /// no folding instruction anywhere on the path and no string fallback.
+    ///
+    /// An earlier version of this comment claimed the opposite and cited
+    /// `MaxDebris=` as the reason this helper exists. That was backwards: the
+    /// 17 stock `[VehicleTypes]` spelling `Maxdebris=3` are invisible to
+    /// gamemd and keep the constructor default of 0, so reading them was the
+    /// divergence. Those call sites are now case-exact.
+    ///
+    /// Across the whole stock INI corpus exactly 6 authored key spellings
+    /// disagree in case with gamemd's own literal, touching 44 (section, key)
+    /// pairs; 0 section names disagree. The survivors here are
+    /// `sound_ini.rs`'s 18 call sites — the mis-spellings that reach them are
+    /// `Vshift` (9 soundmd sections), `Fshift` (3) and `volume` (2), 12
+    /// distinct sound events in all — and they belong to the audio lane. This
+    /// helper is deleted once those are converted.
     pub fn get_ignoring_case(&self, key: &str) -> Option<&str> {
         self.key_ignore_ascii_case(key)
             .and_then(|exact| self.entries.get(exact))

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -1199,21 +1199,27 @@ pub struct ObjectType {
     /// from `[MinDebris, MaxDebris]` and spends it on `DebrisTypes` VoxelAnims
     /// and `DebrisAnims` SHP anims.
     ///
-    /// 456 stock sections author it, 17 of them spelled `Maxdebris=`; gamemd
-    /// matches keys case-insensitively, so this is read that way and all 456
-    /// count.
+    /// 456 stock sections author some spelling of it, but gamemd reads the key
+    /// case-exactly, so only the **439** spelled `MaxDebris=` count. The other
+    /// 17 spell it `Maxdebris=3` and keep the constructor default of 0
+    /// (`TechnoTypeClass::Constructor 0x00710FB7`), which is why the Rhino, the
+    /// Apocalypse and 12 more buildable vehicles throw no death debris at all.
     pub max_debris: i32,
-    /// `MinDebris=` — the floor of the same range. 272 stock sections, every
-    /// one of them a `[BuildingTypes]` member.
+    /// `MinDebris=` — the floor of the same range, read at `0x007125A8` into
+    /// `TechnoType+0x5C0` and floored to 0 at `0x007125BD`. 272 stock sections
+    /// author it, every one of them a `[BuildingTypes]` member.
     pub min_debris: i32,
     /// `DebrisTypes=` CSV of `[VoxelAnims]` ids. 36 stock sections author it
-    /// and every one of them names exactly `TIRE`.
+    /// and every one of them names exactly `TIRE`; 32 of the 36 also reach the
+    /// block, the other 4 (`CMON`, `FV`, `HORV`, `HTK`) being among the 17 that
+    /// mis-spell `MaxDebris=` and so throw nothing.
     pub debris_types: Vec<String>,
     /// `DebrisMaximums=` CSV, positionally paired with `debris_types`: the cap
     /// on how many of each type may be thrown. 36 stock sections.
     pub debris_maximums: Vec<i32>,
     /// `DebrisAnims=` CSV of `[Animations]` ids — the SHP half of the debris a
-    /// death throws, as distinct from the VXL half above. 166 stock sections.
+    /// death throws, as distinct from the VXL half above. 166 stock sections,
+    /// all of them `[BuildingTypes]`.
     pub debris_anims: Vec<String>,
     /// `CloseRange=` bool — `TechnoTypeClass+0x695`, read at `0x0071497A`
     /// (key string `0x008439C4`) and stored at `0x00714987`.
@@ -1476,6 +1482,30 @@ impl ObjectType {
         // `Primary`/`Secondary` are slots 0/1 of these arrays in gamemd — the
         // same storage, filled by whichever ReadINI branch this type takes.
         let (weapon_list, elite_weapon_list) = Self::read_weapon_arrays(section);
+
+        // `TechnoTypeClass::ReadINI @ 0x00712587..0x007125DF` reads the debris
+        // span in a fixed order and then clamps it twice:
+        //   `0x0071258E PUSH 0x84439C` ("MaxDebris") -> `0x0071259B` +0x5BC
+        //   `0x007125A8 PUSH 0x844390` ("MinDebris") -> `0x007125B7` +0x5C0
+        //   `0x007125BD JGE`  -> `0x007125BF` MinDebris = 0 when it read below 0
+        //   `0x007125D7 JGE`  -> `0x007125D9` MaxDebris = MinDebris when it is lower
+        // The order is load-bearing and matches the warhead sibling at
+        // `WarheadTypeClass::ReadINI 0x0075DAC4`/`0x0075DAE0`: MinDebris is
+        // floored first, so a negative MinDebris cannot drag MaxDebris below
+        // zero and re-open the block that `MaxDebris <= 0` closes. No stock
+        // section authors a negative MinDebris or an inverted span, so this is
+        // reachable only from modded rules — but it is what makes
+        // `throw_death_debris`'s inverted-span branch well-defined.
+        //
+        // Both keys are read case-exactly. `0x0084439C` is the C string
+        // `MaxDebris` and `0x00844390` is `MinDebris`, and `CCINIClass::ReadInt
+        // @ 0x005276D0` CRCs the raw key bytes (`0x00527715..0x00527750`) with
+        // no folding step, so the 17 `[VehicleTypes]` that spell it
+        // `Maxdebris=3` are invisible to gamemd and keep the constructor
+        // default of 0 (`TechnoTypeClass::Constructor 0x00710FB7`).
+        let max_debris = section.get_i32("MaxDebris").unwrap_or(0);
+        let min_debris = section.get_i32("MinDebris").unwrap_or(0).max(0);
+        let max_debris = max_debris.max(min_debris);
 
         Self {
             id: id.to_string(),
@@ -1981,14 +2011,14 @@ impl ObjectType {
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty()),
             damage_particle_systems: parse_csv_string_list(section.get("DamageParticleSystems")),
-            max_debris: section.get_i32_ignoring_case("MaxDebris").unwrap_or(0),
-            min_debris: section.get_i32_ignoring_case("MinDebris").unwrap_or(0),
-            debris_types: parse_csv_string_list(section.get_ignoring_case("DebrisTypes")),
-            debris_maximums: parse_csv_string_list(section.get_ignoring_case("DebrisMaximums"))
+            max_debris,
+            min_debris,
+            debris_types: parse_csv_string_list(section.get("DebrisTypes")),
+            debris_maximums: parse_csv_string_list(section.get("DebrisMaximums"))
                 .iter()
                 .filter_map(|value| value.parse::<i32>().ok())
                 .collect(),
-            debris_anims: parse_csv_string_list(section.get_ignoring_case("DebrisAnims")),
+            debris_anims: parse_csv_string_list(section.get("DebrisAnims")),
             close_range: section.get_bool("CloseRange").unwrap_or(false),
             stupid_hunt: section.get_bool("StupidHunt").unwrap_or(false),
             cyborg: section.get_bool("Cyborg").unwrap_or(false),
@@ -3438,7 +3468,7 @@ mod tests {
     }
 
     #[test]
-    fn gsi_05_14_debris_keys_parse_including_the_retail_lowercase_spelling() {
+    fn gsi_05_14_debris_keys_are_case_exact_so_the_retail_lowercase_spelling_is_unread() {
         // A death spends a count drawn from [MinDebris, MaxDebris] on
         // DebrisTypes VoxelAnims and DebrisAnims SHP anims.
         let ini: IniFile = IniFile::from_str(
@@ -3457,16 +3487,83 @@ mod tests {
         assert_eq!(obj.debris_maximums, vec![3]);
         assert_eq!(obj.debris_anims.len(), 3);
 
-        // 17 of the 456 stock sections spell it `Maxdebris=`, and gamemd's
-        // INIClass compares keys case-insensitively, so those 17 do throw
-        // debris in retail. An exact-cased read would silently give them 0.
+        // The lowercase spelling must NOT be read. gamemd's `INIClass` hashes
+        // the raw bytes of the key on both the store side
+        // (`INIClass::LoadFromStraw @ 0x005260C9`) and the lookup side
+        // (`CCINIClass::ReadInt @ 0x00527715`), and both binary searches
+        // compare 32-bit CRCs only — there is no folding instruction anywhere
+        // on the path, and `strtrim @ 0x00727CF0` strips whitespace and
+        // nothing else. `0x0084439C` is the literal `MaxDebris`, so the 17
+        // stock `[VehicleTypes]` that spell it `Maxdebris=3` are invisible to
+        // the read and keep the `TechnoTypeClass::Constructor 0x00710FB7`
+        // default of 0. That zero closes the whole debris block at
+        // `TechnoClass::ReceiveDamage 0x00702293 JLE`, so the Rhino, the
+        // Apocalypse, the Prism Tank, the Battle Fortress, the IFV and 9 more
+        // buildable vehicles throw nothing on death in retail and take no RNG
+        // draw for it. Reading them would be the divergence, not the fix.
         let ini: IniFile = IniFile::from_str("[NAPOWR]\nMaxdebris=7\nMindebris=2\n");
         let obj = ObjectType::from_ini_section(
             "NAPOWR",
             ini.section("NAPOWR").unwrap(),
             ObjectCategory::Building,
         );
-        assert_eq!((obj.min_debris, obj.max_debris), (2, 7));
+        assert_eq!((obj.min_debris, obj.max_debris), (0, 0));
+
+        // The same rule on the CSV siblings: no stock section mis-spells any
+        // of these three, so this arm is wrong-in-principle only today, but it
+        // goes live the moment a mod mis-spells one.
+        let ini: IniFile = IniFile::from_str(
+            "[NAPOWR]\nMaxDebris=5\n\
+             debristypes=TIRE\nDEBRISMAXIMUMS=3\nDebrisanims=DBRIS1LG\n",
+        );
+        let obj = ObjectType::from_ini_section(
+            "NAPOWR",
+            ini.section("NAPOWR").unwrap(),
+            ObjectCategory::Building,
+        );
+        assert_eq!(obj.max_debris, 5);
+        assert!(obj.debris_types.is_empty());
+        assert!(obj.debris_maximums.is_empty());
+        assert!(obj.debris_anims.is_empty());
+    }
+
+    /// `TechnoTypeClass::ReadINI @ 0x007125BD` floors `MinDebris` at 0, then
+    /// `0x007125D9` raises `MaxDebris` to meet it. The order matters: flooring
+    /// first is what stops a negative `MinDebris` from dragging `MaxDebris`
+    /// below zero and re-opening the block that `MaxDebris <= 0` closes.
+    ///
+    /// Stock-unreachable — 0 sections author a negative `MinDebris` and 0
+    /// author an inverted span — so this is modded-rules territory, but it is
+    /// what makes `throw_death_debris`'s inverted-span branch well-defined.
+    #[test]
+    fn gsi_05_14_mindebris_floors_at_zero_then_raises_maxdebris() {
+        let ini: IniFile = IniFile::from_str("[NAPOWR]\nMaxDebris=2\nMinDebris=-9\n");
+        let obj = ObjectType::from_ini_section(
+            "NAPOWR",
+            ini.section("NAPOWR").unwrap(),
+            ObjectCategory::Building,
+        );
+        // MinDebris floored to 0 first, so MaxDebris is left where it was.
+        assert_eq!((obj.min_debris, obj.max_debris), (0, 2));
+
+        let ini: IniFile = IniFile::from_str("[NAPOWR]\nMaxDebris=2\nMinDebris=7\n");
+        let obj = ObjectType::from_ini_section(
+            "NAPOWR",
+            ini.section("NAPOWR").unwrap(),
+            ObjectCategory::Building,
+        );
+        // Inverted span: MaxDebris rises to meet MinDebris.
+        assert_eq!((obj.min_debris, obj.max_debris), (7, 7));
+
+        let ini: IniFile = IniFile::from_str("[NAPOWR]\nMaxDebris=-4\nMinDebris=-9\n");
+        let obj = ObjectType::from_ini_section(
+            "NAPOWR",
+            ini.section("NAPOWR").unwrap(),
+            ObjectCategory::Building,
+        );
+        // A negative MinDebris must not drag MaxDebris up out of its own
+        // negative: the floor lands on 0, and MaxDebris rises only to 0.
+        assert_eq!((obj.min_debris, obj.max_debris), (0, 0));
     }
     #[test]
     fn techno_type_parses_damage_particle_systems_csv() {

--- a/src/rules/warhead_type.rs
+++ b/src/rules/warhead_type.rs
@@ -266,14 +266,21 @@ impl WarheadType {
             .collect();
 
         // `WarheadTypeClass::ReadINI @ 0x0075DA95..0x0075DAE6`: MaxDebris is
-        // read first, MinDebris is clamped up to zero, and only then is
-        // MaxDebris raised to meet MinDebris. The order is load-bearing — a
-        // negative MinDebris must not drag MaxDebris below zero.
-        let max_debris = section.get_i32_ignoring_case("MaxDebris").unwrap_or(0);
-        let min_debris = section
-            .get_i32_ignoring_case("MinDebris")
-            .unwrap_or(0)
-            .max(0);
+        // read first (`0x0075DA95 PUSH 0x84439C` -> `0x0075DAB1` +0x1C4),
+        // MinDebris second (`0x0075DAAB PUSH 0x844390` -> `0x0075DABE` +0x1C8),
+        // MinDebris is clamped up to zero (`0x0075DAC4 JGE`), and only then is
+        // MaxDebris raised to meet MinDebris (`0x0075DAE0`). The order is
+        // load-bearing — a negative MinDebris must not drag MaxDebris below
+        // zero.
+        //
+        // Both keys are read case-exactly, the same as their TechnoType
+        // siblings: `CCINIClass::ReadInt @ 0x005276D0` CRCs the raw key bytes
+        // and folds no case, and the pushed literals are `MaxDebris`
+        // (`0x0084439C`) and `MinDebris` (`0x00844390`). No stock `[Warheads]`
+        // section mis-spells either — only `Smashing` and `TRexWH` author them
+        // at all — so this changes nothing in retail and is right in principle.
+        let max_debris = section.get_i32("MaxDebris").unwrap_or(0);
+        let min_debris = section.get_i32("MinDebris").unwrap_or(0).max(0);
         let max_debris = max_debris.max(min_debris);
 
         Self {

--- a/src/sim/bounce.rs
+++ b/src/sim/bounce.rs
@@ -82,12 +82,13 @@ pub struct BounceState {
     ///   `0x00439E7F`..`0x00439E87` and before the integrate.
     /// - Trigger: drawing any live piece of debris.
     /// - Player effect: debris would fly the right arc but not tumble.
-    /// - Frequency: zero today — no producer creates a `VoxelAnimObject` at
-    ///   all, so nothing bounces. Continuous the moment the producer lands,
-    ///   since stock `Duration=` runs 70-150 ticks per piece.
+    /// - Frequency: continuous while debris is airborne. The death-side
+    ///   producer now throws pieces on every vehicle death that authors
+    ///   `DebrisTypes=` (36 stock sections, all naming `[TIRE]`), and `[TIRE]`
+    ///   lives 150 ticks.
     /// - Downstream risk: none to the simulation. The spin is display-only and
-    ///   consumes no RNG beyond the axis draws already taken here, so it lands
-    ///   with the producer/draw slice and moves no hash.
+    ///   consumes no RNG beyond the axis draws already taken here, so it moves
+    ///   no hash.
     pub spin_axis: [NativeF32Bits; 3],
     /// The per-tick rotation angle — `Init`'s trailing argument, the one
     /// Ghidra's recovered signature omits.
@@ -299,6 +300,81 @@ impl BounceState {
 /// see [`reflect_off_ground`].
 const FLAT_RAMP: u8 = 0;
 
+/// `DAT_0089C76C`, the offset added to the ground height to get the bridge deck
+/// plane `BounceClass::Update` snaps to (`0x00439BF8`) and the stop test
+/// subtracts (`0x00439A7A`).
+///
+/// RESIDUAL (GSI-05.14) — the image bytes at `0x0089C76C` are zero, and the
+/// only writer, `FUN_00439610 @ 0x00439610`, has no direct caller: its single
+/// xref is a data reference from `0x00812738`, a vtable slot, so it is reached
+/// (if at all) only through a virtual dispatch this session did not resolve.
+/// The load-image value is therefore what is modelled.
+/// - Trigger: debris crossing a bridge deck plane.
+/// - Player effect: with a non-zero runtime offset the deck snap would land the
+///   debris that many leptons above or below the bridge surface.
+/// - Frequency: bounded by bridge cells only; a vehicle has to die on or
+///   directly under a bridge and throw voxel debris (36 stock types).
+/// - Downstream risk: none to the stream — the offset is arithmetic on the
+///   position, it consumes no draws and gates no branch count.
+const DECK_PLANE_OFFSET_LEPTONS: i32 = 0;
+
+/// The drop applied when the body rises back through the deck plane
+/// (`0x00439D5D`, `local_118 + -0x14`).
+const DECK_RISE_DROP_LEPTONS: i32 = 20;
+
+/// The window below the ground height inside which the non-deck arm clamps the
+/// position up to the surface (`0x00439D71`, `local_114 + -100`).
+const GROUND_CLAMP_WINDOW_LEPTONS: i32 = 100;
+
+/// The proximity gate on the building/wall lookup alone (`0x007E3DA8`).
+const BUILDING_LOOKUP_PROXIMITY_LEPTONS: f32 = 150.0;
+
+/// The stop threshold. `FCOMP double [0x007E3D80]` at `0x0043A08C` compares the
+/// magnitude against the double at that address, whose bytes are `2.5`, and the
+/// `TEST AH,1 / JNZ` pair below it returns 2 (`Stopped`) only when the compare
+/// set C0 — i.e. strictly BELOW the threshold. `FUN_00439A10` returns an
+/// `ftol`-truncated integer, so that is `< 3`.
+const STOP_MAGNITUDE_THRESHOLD: f32 = 2.5;
+
+/// The map facts one `BounceClass::Update` reads.
+///
+/// `BounceClass` itself calls `CellClass::GetGroundHeight`,
+/// `MapClass::Get_CellClass_At_Coord`, `Look_up_building_in_cell` and
+/// `CellClass::IsWallConnectableInDirection` directly. Those live in the world,
+/// so the integrator takes them through this port rather than reaching for a
+/// map grid — `sim/` keeps the physics pure and the caller supplies terrain.
+pub trait BounceTerrain {
+    /// `CellClass::GetGroundHeight` at the given world coordinate, in leptons.
+    fn ground_height_leptons(&self, coord: IVec3) -> i32;
+    /// `CellClass+0x140 & 0x100` — the cell carries a bridge deck.
+    fn is_bridge_cell(&self, coord: IVec3) -> bool;
+    /// `CellClass+0x11B`, the cell's height level. Only the difference between
+    /// the pre- and post-move cells is read.
+    fn cell_height_level(&self, coord: IVec3) -> i32;
+    /// The cell's ramp index, which selects the reflection matrix.
+    fn ramp(&self, coord: IVec3) -> u8;
+    /// `Look_up_building_in_cell` non-null, or
+    /// `CellClass::IsWallConnectableInDirection(-1, -1)`.
+    fn has_bounce_surface(&self, coord: IVec3) -> bool;
+    /// `CellClass+0xEC == 2` — LandType WATER. `BounceClass::Update` itself
+    /// never reads it; the hosts do, both at the death gate and on a landing.
+    fn is_water(&self, coord: IVec3) -> bool;
+}
+
+/// `ftol` each float position component into the `CoordStruct` native builds
+/// with `FUN_00437090` before and after the move.
+fn ftol_coord(position: [NativeF32Bits; 3]) -> Result<IVec3, NativeX87Error> {
+    Ok(IVec3::new(
+        X87Chop53::ftol_i64(X87Chop53::load_f32(position[0])?)? as i32,
+        X87Chop53::ftol_i64(X87Chop53::load_f32(position[1])?)? as i32,
+        X87Chop53::ftol_i64(X87Chop53::load_f32(position[2])?)? as i32,
+    ))
+}
+
+fn f32_of(bits: NativeF32Bits) -> f32 {
+    f32::from_bits(bits.bits())
+}
+
 impl BounceState {
     /// `BounceClass::Update`'s reflection block, `0x00439D91`..`0x00439E89`.
     ///
@@ -331,13 +407,12 @@ impl BounceState {
     /// - Player effect: it would rebound along the slope's normal in retail and
     ///   rebounds vertically here, so a chunk landing on a hillside runs
     ///   downhill in retail and hops in place here.
-    /// - Frequency: corrected upward. `[TIRE]` is indeed the only stock
-    ///   `[VoxelAnims]` entry with a non-zero `Elasticity` (0.8), and
-    ///   `Elasticity = 0` zeroes the velocity whatever the matrix — but all 36
-    ///   stock `DebrisTypes=` lines name `TIRE`, so every debris-throwing stock
-    ///   vehicle throws exactly the bouncing type. The remaining bound is
-    ///   terrain alone: debris lands on flat ground far more often than on a
-    ///   ramp. Zero today, because no producer creates debris at all.
+    /// - Frequency: `[TIRE]` is the only stock `[VoxelAnims]` entry with a
+    ///   non-zero `Elasticity` (0.8), and `Elasticity = 0` zeroes the velocity
+    ///   whatever the matrix — but all 36 stock `DebrisTypes=` lines name
+    ///   `TIRE`, so every debris-throwing stock vehicle throws exactly the
+    ///   bouncing type. The remaining bound is terrain alone: debris lands on
+    ///   flat ground far more often than on a ramp.
     /// - Downstream risk: closing it needs the runtime contents of
     ///   `MATRIX_TABLE_0x00B45188`, which `VXL_MasterLighting_Init` builds from
     ///   `Matrix3x4_BuildFromRotateXAndFacing` — the eight facings and two
@@ -372,6 +447,229 @@ impl BounceState {
             })?;
         }
         Ok(Some(out))
+    }
+
+    /// [`Self::reflect_off_ground`] with the flat collapse standing in for the
+    /// ramps whose matrices are unread.
+    ///
+    /// RESIDUAL (GSI-05.14) — see [`Self::reflect_off_ground`] for why the
+    /// sloped entries of `MATRIX_TABLE_0x00B45188` cannot be derived here: the
+    /// table is built at runtime by `VXL_MasterLighting_Init @ 0x00755400`, its
+    /// image bytes are zero, and `emulate_function` reports registers only, so
+    /// a matrix a helper writes to memory is not observable through the
+    /// instrument. This wrapper exists because the alternative — refusing the
+    /// reflection inside `update` — would leave the body's downward velocity
+    /// intact on a hillside and drive it through the terrain, which is a larger
+    /// divergence than reflecting vertically.
+    /// - Trigger: debris contacting a sloped cell.
+    /// - Player effect: the piece rebounds straight up instead of along the
+    ///   slope normal, so it hops in place where retail sends it downhill.
+    /// - Frequency: every bounce that lands on a ramp cell. Only `[TIRE]`
+    ///   (`Elasticity=0.8`) bounces at all in stock — but all 36 stock
+    ///   `DebrisTypes=` lines name `TIRE`, so it is every voxel-debris death
+    ///   whose scatter reaches a ramp.
+    /// - Downstream risk: none to the stream. The reflection consumes no draws;
+    ///   it only changes where a display object travels. The `Stopped` decision
+    ///   reads the reflected velocity, so a piece can rest one tick earlier or
+    ///   later than retail on a slope.
+    fn reflect_off_ground_or_flat(
+        velocity: [NativeF32Bits; 3],
+        elasticity: NativeF64Bits,
+        ramp: u8,
+    ) -> Result<[NativeF32Bits; 3], NativeX87Error> {
+        if let Some(reflected) = Self::reflect_off_ground(velocity, elasticity, ramp)? {
+            return Ok(reflected);
+        }
+        Ok(Self::reflect_off_ground(velocity, elasticity, FLAT_RAMP)?
+            .expect("the flat ramp is always modelled"))
+    }
+
+    /// `FUN_00439A10 @ 0x00439A10` — the magnitude the stop test compares
+    /// against `2.5`.
+    ///
+    /// Every term is `ftol`-truncated to an integer before the sum, so the
+    /// result is an integer and the threshold is effectively `>= 3`. The Z term
+    /// is PREDICTIVE: `heightAboveGround * Gravity + Velocity.Z`
+    /// (`0x00439A9D`..`0x00439AAB`), not the stored Z velocity, so a body still
+    /// high above the ground reads far from rest whatever it is doing. The sum
+    /// associates `(vz*vz + vx*vx) + vy*vy` — read from the `FLD ST(n)/FMUL
+    /// ST(n)/FADDP` ladder at `0x00439AC3`..`0x00439AD1`, because the
+    /// decompiler canonicalises the commutative sum.
+    fn stop_magnitude(&self, terrain: &dyn BounceTerrain) -> Result<i32, NativeX87Error> {
+        let coord = ftol_coord(self.position)?;
+        let ground = terrain.ground_height_leptons(coord);
+        // `FILD ground` then `FSUBR float [pos.Z]` — the reverse subtract makes
+        // this `pos.Z - ground`, not `ground - pos.Z`.
+        let mut height_above = X87Chop53::ftol_i64(X87Chop53::sub(
+            X87Chop53::load_f32(self.position[2])?,
+            X87Chop53::load_i32(ground),
+        ))? as i32;
+        if terrain.is_bridge_cell(coord) && height_above >= DECK_PLANE_OFFSET_LEPTONS {
+            height_above -= DECK_PLANE_OFFSET_LEPTONS;
+        }
+        let vx = X87Chop53::ftol_i64(X87Chop53::load_f32(self.velocity[0])?)? as i32;
+        let vy = X87Chop53::ftol_i64(X87Chop53::load_f32(self.velocity[1])?)? as i32;
+        let predictive_z = X87Chop53::ftol_i64(X87Chop53::add(
+            X87Chop53::mul(
+                X87Chop53::load_i32(height_above),
+                X87Chop53::load_f64(self.gravity)?,
+            ),
+            X87Chop53::load_f32(self.velocity[2])?,
+        ))? as i32;
+
+        let pz = X87Chop53::load_i32(predictive_z);
+        let fx = X87Chop53::load_i32(vx);
+        let fy = X87Chop53::load_i32(vy);
+        let root = sqrt_approx_f32(X87Chop53::add(
+            X87Chop53::add(X87Chop53::mul(pz, pz), X87Chop53::mul(fx, fx)),
+            X87Chop53::mul(fy, fy),
+        ))?;
+        Ok(X87Chop53::ftol_i64(X87Chop53::load_f32(root)?)? as i32)
+    }
+
+    /// `BounceClass::Update @ 0x00439B00` — one tick of the physics body.
+    ///
+    /// The verified order, from the body and the disassembly cited per step:
+    /// 1. `Velocity.Z -= Gravity` (`0x00439B4A`).
+    /// 2. The angular clamp at `0x00439B7A` is DEAD and is deliberately not
+    ///    ported: the raw bytes show `FLD ST(0)` / `FDIVRP` on an empty-above
+    ///    stack, so the scale is `|V| / |V|` = 1.0, and every `Init` caller
+    ///    passes `angVelMagnitude` as two literal zeros anyway, which makes the
+    ///    `0.0 < AVM` gate false everywhere in the image.
+    /// 3. `Position += Velocity` (`FUN_0043A100`), between the pre- and
+    ///    post-move `ftol` coordinate captures.
+    /// 4. Ground height at the POST-move coordinate, then the deck plane
+    ///    `ground + DAT_0089C76C`.
+    /// 5. Deck crossing, gated on either cell carrying the bridge flag: `fell`
+    ///    = new below the deck and old at or above it; `rose` = the reverse.
+    /// 6. Building/wall lookup, gated by the `150.0` proximity window ALONE —
+    ///    that gate does not apply to ordinary ground contact.
+    /// 7. Snap ladder. Below the ground surface the body always reflects; at or
+    ///    above it, only a deck crossing or a building/wall surface does, and
+    ///    otherwise the tick returns `Falling` with no reflection at all.
+    /// 8. The reflection round trip, then the stop test.
+    ///
+    /// Two arms are NOT modelled, each recorded where it is skipped: the slope
+    /// re-bounce (step 8 of the module spec) and the quaternion integration.
+    pub fn update(&mut self, terrain: &dyn BounceTerrain) -> Result<BounceOutcome, NativeX87Error> {
+        self.velocity[2] = X87Chop53::store_f32(X87Chop53::sub(
+            X87Chop53::load_f32(self.velocity[2])?,
+            X87Chop53::load_f64(self.gravity)?,
+        ))?;
+
+        let old_coord = ftol_coord(self.position)?;
+        for axis in 0..3 {
+            self.position[axis] = X87Chop53::store_f32(X87Chop53::add(
+                X87Chop53::load_f32(self.position[axis])?,
+                X87Chop53::load_f32(self.velocity[axis])?,
+            ))?;
+        }
+        let new_coord = ftol_coord(self.position)?;
+
+        let ground = terrain.ground_height_leptons(new_coord);
+        let deck = ground + DECK_PLANE_OFFSET_LEPTONS;
+
+        let mut fell_through_deck = false;
+        let mut rose_through_deck = false;
+        if terrain.is_bridge_cell(new_coord) || terrain.is_bridge_cell(old_coord) {
+            if new_coord.z < deck {
+                fell_through_deck = deck <= old_coord.z;
+            } else {
+                rose_through_deck = old_coord.z < deck;
+            }
+        }
+
+        let position_z = f32_of(self.position[2]);
+        let ground_f = ground as f32;
+        // The `150.0` window gates the building/wall LOOKUP only.
+        let building_surface = !fell_through_deck
+            && !rose_through_deck
+            && ground_f <= position_z
+            && position_z - BUILDING_LOOKUP_PROXIMITY_LEPTONS < ground_f
+            && terrain.has_bounce_surface(new_coord);
+
+        // The `LaserFence=` rejection inside native's building arm
+        // (`type+0x16BF` with `building+0x618 >= 8`) is Tiberian Sun legacy —
+        // no stock RA2/YR building authors the key — and is not ported.
+        let clamp_to_surface = |state: &mut Self| {
+            let clamp_floor = (ground - GROUND_CLAMP_WINDOW_LEPTONS) as f32;
+            if clamp_floor < f32_of(state.position[2]) {
+                state.position[2] = NativeF32Bits::from_bits(ground_f.to_bits());
+            }
+        };
+        if position_z < ground_f {
+            if fell_through_deck {
+                self.position[2] = NativeF32Bits::from_bits((deck as f32).to_bits());
+            } else if rose_through_deck {
+                self.position[2] =
+                    NativeF32Bits::from_bits(((deck - DECK_RISE_DROP_LEPTONS) as f32).to_bits());
+            } else {
+                clamp_to_surface(self);
+            }
+        } else if fell_through_deck {
+            self.position[2] = NativeF32Bits::from_bits((deck as f32).to_bits());
+        } else if rose_through_deck {
+            self.position[2] =
+                NativeF32Bits::from_bits(((deck - DECK_RISE_DROP_LEPTONS) as f32).to_bits());
+        } else if !building_surface {
+            // `uVar8 = 0; goto LAB_0043A066` — no reflection this tick, but the
+            // stop test still runs.
+            return self.finish_tick(terrain, BounceOutcome::Falling);
+        } else {
+            clamp_to_surface(self);
+        }
+
+        self.velocity = Self::reflect_off_ground_or_flat(
+            self.velocity,
+            self.elasticity,
+            terrain.ramp(new_coord),
+        )?;
+
+        // RESIDUAL (GSI-05.14) — the slope re-bounce at `0x00439F2C` is not
+        // modelled. When `cell(new).level - cell(old).level >= 2` and the
+        // entry-tick velocity conditions against `-0.0002` / `-0.0003` hold,
+        // native rolls the body back to the pre-tick snapshot and REPLACES the
+        // reflection above with one of four planar mirror matrices from
+        // `FUN_00755C60 @ 0x00755C60`, scaling by `Elasticity` as a double
+        // rather than the f32 narrowing. Those matrices are built at runtime
+        // and are unreadable through this instrument for the same reason as the
+        // ramp table.
+        // - Trigger: a piece crossing two or more height levels in one tick and
+        //   still rising at the cell boundary — a cliff face, not a ramp.
+        // - Player effect: the piece reflects off the flat plane and can end up
+        //   on top of the cliff where retail bounces it off the face.
+        // - Frequency: rare. It needs a two-level step inside one tick's travel.
+        // - Downstream risk: none to the stream; no draws are involved.
+        let _ = (
+            terrain.cell_height_level(new_coord),
+            terrain.cell_height_level(old_coord),
+        );
+
+        self.finish_tick(terrain, BounceOutcome::Bounced)
+    }
+
+    /// `LAB_0043A066` — the tail both the contact and the no-contact arms reach.
+    ///
+    /// RESIDUAL (GSI-05.14) — the unconditional quaternion integration
+    /// (`orientation = product(orientation, rotation)` at `0x0043A066`, and the
+    /// bounce arm's negation of the rotation quaternion's components 0..=2) is
+    /// not built: `Quaternion_FromAxisAngle @ 0x00646480` needs
+    /// `Math__SinFromTable`/`Math__CosFromTable`, whose table contents are
+    /// UNCHECKED. Trigger: drawing any live piece of debris. Player effect: the
+    /// piece flies the right arc but does not tumble. Frequency: continuous
+    /// while debris is airborne. Downstream risk: none — the spin is
+    /// display-only, consumes no draws beyond the axis draws `Init` already
+    /// takes, and nothing in the physics reads the orientation.
+    fn finish_tick(
+        &self,
+        terrain: &dyn BounceTerrain,
+        contact: BounceOutcome,
+    ) -> Result<BounceOutcome, NativeX87Error> {
+        let magnitude = self.stop_magnitude(terrain)?;
+        if (magnitude as f32) < STOP_MAGNITUDE_THRESHOLD {
+            return Ok(BounceOutcome::Stopped);
+        }
+        Ok(contact)
     }
 }
 

--- a/src/sim/bounce.rs
+++ b/src/sim/bounce.rs
@@ -89,8 +89,9 @@ pub struct BounceState {
     /// - Player effect: debris would fly the right arc but not tumble.
     /// - Frequency: continuous while debris is airborne. The death-side
     ///   producer now throws pieces on every vehicle death that authors
-    ///   `DebrisTypes=` (36 stock sections, all naming `[TIRE]`), and `[TIRE]`
-    ///   lives 150 ticks.
+    ///   `DebrisTypes=` (36 stock sections, all naming `[TIRE]`, of which 32
+    ///   reach the block in gamemd — `CMON`, `FV`, `HORV` and `HTK` spell
+    ///   `Maxdebris=` and take the default 0), and `[TIRE]` lives 150 ticks.
     /// - Downstream risk: none to the simulation. The spin is display-only and
     ///   consumes no RNG beyond the axis draws already taken here, so it moves
     ///   no hash.
@@ -281,12 +282,16 @@ impl BounceState {
 /// - `Elasticity = 0` stops on FIRST ground contact and exits via `Stopped`,
 ///   not `Bounced`, so it never plays its `BounceAnim`. Every stock
 ///   `[VoxelAnims]` type is `Elasticity=0` except `[TIRE]` at `0.8` — so the
-///   reflection produces real motion for exactly one stock type, and the
-///   scrap a dying vehicle throws (`PIECE`, `GASTANK`) lands dead.
+///   reflection produces real motion for exactly one stock type, and `PIECE`,
+///   `GASTANK` and the other seven land dead. The death-debris producer never
+///   reaches them: all 36 stock `DebrisTypes=` lines name `TIRE`, so no stock
+///   section throws `PIECE` or `GASTANK` on death.
 /// - The building/wall arm's first rejection — `type+0x16BF` (`LaserFence=`)
 ///   with `building+0x618 >= 8` — is Tiberian Sun legacy. No stock RA2/YR
-///   building authors `LaserFence=`; `rulesmd.ini:3652` mentions it only in a
-///   comment. Do not port it as a default.
+///   building authors `LaserFence=`, and the string occurs exactly once in
+///   `rulesmd.ini` — line 3652, a comment describing the neighbouring
+///   `LaserFencePost=` key, which nothing authors either. Do not port it as a
+///   default.
 ///
 /// Still UNCHECKED, and each blocks a piece of the implementation:
 /// - `DAT_0089C76C`'s runtime value. The image bytes are zero and its only
@@ -318,7 +323,8 @@ const FLAT_RAMP: u8 = 0;
 /// - Player effect: with a non-zero runtime offset the deck snap would land the
 ///   debris that many leptons above or below the bridge surface.
 /// - Frequency: bounded by bridge cells only; a vehicle has to die on or
-///   directly under a bridge and throw voxel debris (36 stock types).
+///   directly under a bridge and throw voxel debris (32 stock types in gamemd,
+///   36 in VERA until the INI case fix lands).
 /// - Downstream risk: none to the stream — the offset is arithmetic on the
 ///   position, it consumes no draws and gates no branch count.
 const DECK_PLANE_OFFSET_LEPTONS: i32 = 0;
@@ -415,9 +421,10 @@ impl BounceState {
     /// - Frequency: `[TIRE]` is the only stock `[VoxelAnims]` entry with a
     ///   non-zero `Elasticity` (0.8), and `Elasticity = 0` zeroes the velocity
     ///   whatever the matrix — but all 36 stock `DebrisTypes=` lines name
-    ///   `TIRE`, so every debris-throwing stock vehicle throws exactly the
-    ///   bouncing type. The remaining bound is terrain alone: debris lands on
-    ///   flat ground far more often than on a ramp.
+    ///   `TIRE`, so every stock section that throws VOXEL debris throws exactly
+    ///   the bouncing type. (Most stock vehicles throw SHP debris instead and
+    ///   never reach this code.) The remaining bound is terrain alone: debris
+    ///   lands on flat ground far more often than on a ramp.
     /// - Downstream risk: closing it needs the runtime contents of
     ///   `MATRIX_TABLE_0x00B45188`, which `VXL_MasterLighting_Init` builds from
     ///   `Matrix3x4_BuildFromRotateXAndFacing` — the eight facings and two
@@ -472,7 +479,8 @@ impl BounceState {
     /// - Frequency: every bounce that lands on a ramp cell. Only `[TIRE]`
     ///   (`Elasticity=0.8`) bounces at all in stock — but all 36 stock
     ///   `DebrisTypes=` lines name `TIRE`, so it is every voxel-debris death
-    ///   whose scatter reaches a ramp.
+    ///   whose scatter reaches a ramp. (32 of those 36 sections reach the
+    ///   producer in gamemd; the other four spell `Maxdebris=`.)
     /// - Downstream risk: none to the stream. The reflection consumes no draws;
     ///   it only changes where a display object travels. The `Stopped` decision
     ///   reads the reflected velocity, so a piece can rest one tick earlier or
@@ -742,11 +750,13 @@ mod tests {
 
     #[test]
     fn gsi_05_14_zero_elasticity_kills_the_bounce() {
-        // Every stock `[VoxelAnims]` type except `[TIRE]` is `Elasticity=0`, so
-        // this is the path the scrap a dying vehicle throws actually takes: the
-        // reflection runs in full and produces no motion, which is why that
-        // debris stops on first contact and exits through the STOP test rather
-        // than the bounce one — and so never plays its `BounceAnim`.
+        // Nine of the ten stock `[VoxelAnims]` types are `Elasticity=0`, so
+        // this is the path every one of them takes: the reflection runs in full
+        // and produces no motion, which is why such a piece stops on first
+        // contact and exits through the STOP test rather than the bounce one —
+        // and so never plays its `BounceAnim`. The death-debris producer is not
+        // one of their callers: all 36 stock `DebrisTypes=` lines name `TIRE`,
+        // the one type with `Elasticity=0.8`.
         let v = [f32bits(3.0), f32bits(-4.0), f32bits(12.0)];
         let out = BounceState::reflect_off_ground(v, NativeF64Bits::POSITIVE_ZERO, 0)
             .expect("zero elasticity is in domain")

--- a/src/sim/bounce.rs
+++ b/src/sim/bounce.rs
@@ -323,8 +323,9 @@ const FLAT_RAMP: u8 = 0;
 /// - Player effect: with a non-zero runtime offset the deck snap would land the
 ///   debris that many leptons above or below the bridge surface.
 /// - Frequency: bounded by bridge cells only; a vehicle has to die on or
-///   directly under a bridge and throw voxel debris (32 stock types in gamemd,
-///   36 in VERA until the INI case fix lands).
+///   directly under a bridge and throw voxel debris (32 stock types; the other
+///   4 of the 36 authoring `DebrisTypes=` mis-spell `MaxDebris=` and throw
+///   nothing).
 /// - Downstream risk: none to the stream — the offset is arithmetic on the
 ///   position, it consumes no draws and gates no branch count.
 const DECK_PLANE_OFFSET_LEPTONS: i32 = 0;

--- a/src/sim/bounce.rs
+++ b/src/sim/bounce.rs
@@ -58,18 +58,23 @@ pub struct BounceState {
     /// quaternion is to negate its components on a bounce.
     ///
     /// RESIDUAL (GSI-05.14) — the quaternion integration itself is not built,
-    /// but it is now fully specified. Everything below was read this session;
-    /// only the sine/cosine table remains unknown, so the next slice builds it
-    /// rather than re-deriving it.
+    /// but it is now fully specified, table included, so the next slice builds
+    /// it rather than re-deriving it. Nothing about it is instrument-blocked:
+    /// it is unstarted work behind a renderer that has no VoxelAnim draw path.
     /// - Units are RADIANS. `VoxelAnimTypeClass::ReadINI @ 0x0074B128`/
     ///   `0x0074B159` multiplies `MinAngularVelocity=`/`MaxAngularVelocity=` by
     ///   the double at `0x007F65E8`, whose bytes are pi/180. A degrees reading
     ///   spins debris ~57x too slowly.
     /// - `Quaternion_FromAxisAngle @ 0x00646480` re-normalises the axis a
     ///   SECOND time through `Sqrt_Approx` and then stores
-    ///   `(axis * sin(a/2), cos(a/2))` — `Math__SinFromTable`/
-    ///   `Math__CosFromTable`, whose table contents are UNCHECKED and are the
-    ///   one thing still needed.
+    ///   `(axis * sin(a/2), cos(a/2))` via `Math__SinFromTable @ 0x004CACB0`
+    ///   and `Math__CosFromTable`. That table is READABLE, not unknown:
+    ///   `SinFromTable` multiplies the radian argument by the exact f32
+    ///   2607.594482421875, `Math__ftol`s it, then half-step-indexes
+    ///   `&DAT_0084F084`, whose image bytes read
+    ///   `0.0, 7.6699e-4, 1.53398e-3, 2.30097e-3, …` = `sin(n * 2/2607.5945)`.
+    ///   An earlier note here called the contents UNCHECKED; they were simply
+    ///   not read, which is not the same thing and does not defer the port.
     /// - The product `FUN_00645ED0 @ 0x00645ED0` is a Hamilton product divided
     ///   by the SQUARED norm, not the norm, guarded by a `!= 0.0` test. Port
     ///   the quirk literally; a "corrected" normalise changes every frame of
@@ -656,9 +661,12 @@ impl BounceState {
     /// RESIDUAL (GSI-05.14) — the unconditional quaternion integration
     /// (`orientation = product(orientation, rotation)` at `0x0043A066`, and the
     /// bounce arm's negation of the rotation quaternion's components 0..=2) is
-    /// not built: `Quaternion_FromAxisAngle @ 0x00646480` needs
-    /// `Math__SinFromTable`/`Math__CosFromTable`, whose table contents are
-    /// UNCHECKED. Trigger: drawing any live piece of debris. Player effect: the
+    /// not built. It is unstarted, not blocked — the
+    /// `Math__SinFromTable @ 0x004CACB0` table at `&DAT_0084F084` that
+    /// `Quaternion_FromAxisAngle @ 0x00646480` needs is readable and its values
+    /// are recorded on [`BounceState::spin_axis`]; what is missing is a
+    /// renderer that can draw a `VoxelAnimClass` at an arbitrary orientation.
+    /// Trigger: drawing any live piece of debris. Player effect: the
     /// piece flies the right arc but does not tumble. Frequency: continuous
     /// while debris is airborne. Downstream risk: none — the spin is
     /// display-only, consumes no draws beyond the axis draws `Init` already

--- a/src/sim/bounce.rs
+++ b/src/sim/bounce.rs
@@ -530,7 +530,8 @@ impl BounceState {
     /// `BounceClass::Update @ 0x00439B00` — one tick of the physics body.
     ///
     /// The verified order, from the body and the disassembly cited per step:
-    /// 1. `Velocity.Z -= Gravity` (`0x00439B4A`).
+    /// 1. `Velocity.Z -= Gravity`, stored back by `FSTP float [EBX+0x8]` at
+    ///    `0x00439B5F` — `EBX` is the velocity base `+0x24`, so `+0x8` is Z.
     /// 2. The angular clamp at `0x00439B7A` is DEAD and is deliberately not
     ///    ported: the raw bytes show `FLD ST(0)` / `FDIVRP` on an empty-above
     ///    stack, so the scale is `|V| / |V|` = 1.0, and every `Init` caller
@@ -625,8 +626,10 @@ impl BounceState {
             terrain.ramp(new_coord),
         )?;
 
-        // RESIDUAL (GSI-05.14) — the slope re-bounce at `0x00439F2C` is not
-        // modelled. When `cell(new).level - cell(old).level >= 2` and the
+        // RESIDUAL (GSI-05.14) — the slope re-bounce is not modelled. Its
+        // decisive test is `SUB EDX,ESI / CMP EDX,0x2` at `0x00439F5C`, over the
+        // two cells' `+0x11B` height levels read at `0x00439F3F` and
+        // `0x00439F55`. When `cell(new).level - cell(old).level >= 2` and the
         // entry-tick velocity conditions against `-0.0002` / `-0.0003` hold,
         // native rolls the body back to the pre-tick snapshot and REPLACES the
         // reflection above with one of four planar mirror matrices from

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -8825,10 +8825,25 @@ fn gsi_08_08_kirov_vertical_bomb_falls_and_detonates() {
 /// gamemd-derived: `TechnoClass::ReceiveDamage @ 0x00701900`. With
 /// `DebrisAnims.Count == 0` (`0x007023FC`) and `DebrisTypes.Count == 0`
 /// (`0x007024D2`) the whole budget goes to the arm at `0x007024E0`, one
-/// `RandomRanged(0, RulesClass+0x14C - 1)` per chunk at `0x0070253A`. 168 stock
-/// TechnoTypes take exactly this path — MTNK, Rhino, the Battle Fortress, every
-/// aircraft — so before this landed, most vehicle deaths in the game threw
-/// nothing at all.
+/// `RandomRanged(0, RulesClass+0x14C - 1)` per chunk at `0x0070253A`. 155 stock
+/// TechnoTypes take exactly this path in gamemd — `MTNK` (Grizzly), `ZEP` (Kirov
+/// Airship), `NAPSYA` (Psychic Amplifier), and 11 of the 12 `[AircraftTypes]`;
+/// the twelfth, `APACHE`, has no `[APACHE]` section in `rulesmd.ini` at all, so
+/// it keeps the `TechnoTypeClass` constructor default of 0 (`0x00710B00` ->
+/// `0x00710FB7`) and takes no draw. Before this landed, none of them threw
+/// anything.
+///
+/// PENDING the INI case fix: VERA reaches **168** here rather than 155, because
+/// `ObjectType::from_ini` still reads `MaxDebris=` case-insensitively while
+/// gamemd's `INIClass` CRCs the raw key bytes and folds no case anywhere on the
+/// path. 17 stock `[VehicleTypes]` spell the key `Maxdebris=` — 14 buildable
+/// (Rhino, Apocalypse, Lasher, Tesla, Gattling, Prism, V3, Magnetron, Master
+/// Mind, Battle Fortress, IFV, Flak Track, Landing Craft, Armored Transport)
+/// and 3 at `TechLevel=-1` (`CMON`, `HORV`, `UTNK`) — and gamemd gives every one
+/// of them the default 0 and no debris at all. 13 of the 17 sit on this metallic
+/// arm, which is exactly the 168 - 155 gap; the other 4 (`CMON`, `FV`, `HORV`,
+/// `HTK`) sit on the voxel arm. All three exemplars named above spell
+/// `MaxDebris` exactly, so they hold on either basis.
 #[test]
 fn gsi_05_14_a_dying_vehicle_scatters_metallic_debris() {
     let rules = RuleSet::from_ini(&IniFile::from_str(
@@ -8880,8 +8895,12 @@ fn gsi_05_14_a_dying_vehicle_scatters_metallic_debris() {
 ///
 /// gamemd-derived: `0x007023EF` reads `TechnoType+0x5D4` first and only a zero
 /// count falls through to the Rules list at `0x007024BB`. All 166 stock
-/// `DebrisAnims=` lines sit on `[BuildingTypes]` sections, so this is the arm
-/// every structure death takes.
+/// `DebrisAnims=` lines sit on `[BuildingTypes]` sections, so only a structure
+/// ever takes this arm — but not every structure does: of the 292 registered
+/// `[BuildingTypes]` that throw, 126 carry `MaxDebris=` alone and fall through
+/// to `[General] MetallicDebris=`. All three figures are basis-independent: the
+/// 17 sections that spell the key `Maxdebris=` are every one of them a
+/// `[VehicleTypes]`, so the INI case fix moves no building count.
 #[test]
 fn gsi_05_14_a_dying_building_uses_its_own_debris_anims() {
     let rules = RuleSet::from_ini(&IniFile::from_str(
@@ -8935,8 +8954,9 @@ fn gsi_05_14_a_dying_building_uses_its_own_debris_anims() {
 /// gamemd-derived: with `DebrisTypes.Count > 0` the loop at `0x007022FE`
 /// drains the budget to zero before either SHP arm is tested, so a type that
 /// names `DebrisTypes=` throws VXL debris and nothing else. All 36 stock
-/// `DebrisTypes=` lines name `TIRE`; `[HARV]` is `MaxDebris=6`,
-/// `DebrisMaximums=4`.
+/// `DebrisTypes=` lines name `TIRE`, and 32 of the 36 reach the block in gamemd
+/// — `CMON`, `FV`, `HORV` and `HTK` spell `Maxdebris=` and so get the default 0.
+/// `[HARV]` spells `MaxDebris=6` exactly, with `DebrisMaximums=4`.
 #[test]
 fn gsi_05_14_a_dying_harvester_throws_voxel_tires_and_no_shp_debris() {
     let rules = RuleSet::from_ini(&IniFile::from_str(
@@ -8995,9 +9015,9 @@ fn gsi_05_14_a_dying_harvester_throws_voxel_tires_and_no_shp_debris() {
 /// A type with `MaxDebris=0` costs the shared stream nothing.
 ///
 /// `TEST ECX,ECX / JLE 0x00702572` at `0x00702291` skips the whole block above
-/// the budget draw. Most `[InfantryTypes]` sections author no `MaxDebris=` at
-/// all, so this is the common case, and consuming a draw here would shift the
-/// cursor for every later consumer in the tick.
+/// the budget draw. No `[InfantryTypes]` section authors `MaxDebris=` at all —
+/// 0 of the 65 — so this is the common case, and consuming a draw here would
+/// shift the cursor for every later consumer in the tick.
 #[test]
 fn gsi_05_14_a_type_without_maxdebris_takes_no_draw() {
     let ini = "[General]\nMetallicDebris=DBRIS1LG,DBRIS2LG,DBRIS3LG\n\

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -8833,17 +8833,17 @@ fn gsi_08_08_kirov_vertical_bomb_falls_and_detonates() {
 /// `0x00710FB7`) and takes no draw. Before this landed, none of them threw
 /// anything.
 ///
-/// PENDING the INI case fix: VERA reaches **168** here rather than 155, because
-/// `ObjectType::from_ini` still reads `MaxDebris=` case-insensitively while
-/// gamemd's `INIClass` CRCs the raw key bytes and folds no case anywhere on the
-/// path. 17 stock `[VehicleTypes]` spell the key `Maxdebris=` — 14 buildable
-/// (Rhino, Apocalypse, Lasher, Tesla, Gattling, Prism, V3, Magnetron, Master
-/// Mind, Battle Fortress, IFV, Flak Track, Landing Craft, Armored Transport)
-/// and 3 at `TechLevel=-1` (`CMON`, `HORV`, `UTNK`) — and gamemd gives every one
-/// of them the default 0 and no debris at all. 13 of the 17 sit on this metallic
-/// arm, which is exactly the 168 - 155 gap; the other 4 (`CMON`, `FV`, `HORV`,
-/// `HTK`) sit on the voxel arm. All three exemplars named above spell
-/// `MaxDebris` exactly, so they hold on either basis.
+/// 155, not 168: `ObjectType::from_ini_section` reads `MaxDebris=` case-exactly,
+/// the way gamemd's `INIClass` does — it CRCs the raw key bytes and folds no
+/// case anywhere on the path. 17 stock `[VehicleTypes]` spell the key
+/// `Maxdebris=` — 14 buildable (Rhino, Apocalypse, Lasher, Tesla, Gattling,
+/// Prism, V3, Magnetron, Master Mind, Battle Fortress, IFV, Flak Track, Landing
+/// Craft, Armored Transport) and 3 at `TechLevel=-1` (`CMON`, `HORV`, `UTNK`) —
+/// and every one of them takes the constructor default 0 and throws no debris
+/// at all. 13 of the 17 would have sat on this metallic arm, which is exactly
+/// the 168 - 155 gap; the other 4 (`CMON`, `FV`, `HORV`, `HTK`) author
+/// `DebrisTypes=TIRE` and would have sat on the voxel arm. All three exemplars
+/// named above spell `MaxDebris` exactly, so they are unaffected either way.
 #[test]
 fn gsi_05_14_a_dying_vehicle_scatters_metallic_debris() {
     let rules = RuleSet::from_ini(&IniFile::from_str(
@@ -8900,7 +8900,7 @@ fn gsi_05_14_a_dying_vehicle_scatters_metallic_debris() {
 /// `[BuildingTypes]` that throw, 126 carry `MaxDebris=` alone and fall through
 /// to `[General] MetallicDebris=`. All three figures are basis-independent: the
 /// 17 sections that spell the key `Maxdebris=` are every one of them a
-/// `[VehicleTypes]`, so the INI case fix moves no building count.
+/// `[VehicleTypes]`, so the case-exact read moves no building count.
 #[test]
 fn gsi_05_14_a_dying_building_uses_its_own_debris_anims() {
     let rules = RuleSet::from_ini(&IniFile::from_str(

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -8818,3 +8818,224 @@ fn gsi_08_08_kirov_vertical_bomb_falls_and_detonates() {
     }
     panic!("the Kirov bomb never detonated");
 }
+
+/// A destroyed vehicle with `MaxDebris=` alone scatters SHP chunks from
+/// `[General] MetallicDebris=`.
+///
+/// gamemd-derived: `TechnoClass::ReceiveDamage @ 0x00701900`. With
+/// `DebrisAnims.Count == 0` (`0x007023FC`) and `DebrisTypes.Count == 0`
+/// (`0x007024D2`) the whole budget goes to the arm at `0x007024E0`, one
+/// `RandomRanged(0, RulesClass+0x14C - 1)` per chunk at `0x0070253A`. 254 stock
+/// sections take exactly this path — MTNK, Rhino, the Battle Fortress, every
+/// aircraft — so before this landed, most vehicle deaths in the game threw
+/// nothing at all.
+#[test]
+fn gsi_05_14_a_dying_vehicle_scatters_metallic_debris() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[General]\nMetallicDebris=DBRIS1LG,DBRIS2LG,DBRIS3LG\n\
+         [VehicleTypes]\n0=MTNK\n1=HTNK\n\
+         [MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nCost=700\nPrimary=105mm\n\
+         [HTNK]\nStrength=1\nArmor=heavy\nSpeed=4\nCost=900\nPrimary=105mm\nMaxDebris=4\n\
+         [105mm]\nDamage=65\nROF=50\nRange=6\nWarhead=AP\n\
+         [AP]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("metallic-debris fixture parses");
+
+    let mut store = EntityStore::new();
+    store.insert(make_entity_owned(1, "MTNK", 5, 5, 300, "Soviet"));
+    let _ = test_intern("HTNK");
+    store.insert(make_entity_owned(2, "HTNK", 8, 5, 1, "Americans"));
+    let mut interner = test_interner();
+    issue_attack_command(&mut store, 1, 2, None, &interner);
+    align_attackers_to_targets(&mut store, &rules, &interner);
+
+    let result = tick_combat(
+        &mut store,
+        &mut OccupancyGrid::new(),
+        &rules,
+        &mut interner,
+        &mut BTreeMap::new(),
+        0,
+        100,
+        0,
+        &mut SimRng::new(9),
+    );
+
+    let names: Vec<&str> = result
+        .explosion_effects
+        .iter()
+        .map(|effect| interner.resolve(effect.shp_name))
+        .collect();
+    assert!(
+        names.iter().any(|name| name.starts_with("DBRIS")),
+        "the death should scatter MetallicDebris chunks, got {names:?}"
+    );
+    assert!(
+        result.voxel_debris.is_empty(),
+        "a type with no DebrisTypes= throws no VoxelAnims"
+    );
+}
+
+/// `DebrisAnims=` on the section wins over `[General] MetallicDebris=`.
+///
+/// gamemd-derived: `0x007023EF` reads `TechnoType+0x5D4` first and only a zero
+/// count falls through to the Rules list at `0x007024BB`. All 166 stock
+/// `DebrisAnims=` lines sit on `[BuildingTypes]` sections, so this is the arm
+/// every structure death takes.
+#[test]
+fn gsi_05_14_a_dying_building_uses_its_own_debris_anims() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[General]\nMetallicDebris=DBRIS1LG,DBRIS2LG,DBRIS3LG\n\
+         [VehicleTypes]\n0=MTNK\n1=HTNK\n\
+         [MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nCost=700\nPrimary=105mm\n\
+         [HTNK]\nStrength=1\nArmor=heavy\nSpeed=4\nCost=900\nPrimary=105mm\n\
+         MinDebris=3\nMaxDebris=4\nDebrisAnims=DBRI-WM1,DBRI-WM2\n\
+         [105mm]\nDamage=65\nROF=50\nRange=6\nWarhead=AP\n\
+         [AP]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("debris-anims fixture parses");
+
+    let mut store = EntityStore::new();
+    store.insert(make_entity_owned(1, "MTNK", 5, 5, 300, "Soviet"));
+    let _ = test_intern("HTNK");
+    store.insert(make_entity_owned(2, "HTNK", 8, 5, 1, "Americans"));
+    let mut interner = test_interner();
+    issue_attack_command(&mut store, 1, 2, None, &interner);
+    align_attackers_to_targets(&mut store, &rules, &interner);
+
+    let result = tick_combat(
+        &mut store,
+        &mut OccupancyGrid::new(),
+        &rules,
+        &mut interner,
+        &mut BTreeMap::new(),
+        0,
+        100,
+        0,
+        &mut SimRng::new(21),
+    );
+
+    let names: Vec<&str> = result
+        .explosion_effects
+        .iter()
+        .map(|effect| interner.resolve(effect.shp_name))
+        .collect();
+    let own: usize = names.iter().filter(|n| n.starts_with("DBRI-WM")).count();
+    // `MinDebris=3`, `MaxDebris=4` pins the budget at 3 with no draw.
+    assert_eq!(own, 3, "the whole budget comes from DebrisAnims=: {names:?}");
+    assert!(
+        !names.iter().any(|n| n.starts_with("DBRIS")),
+        "the Rules MetallicDebris arm must not also fire: {names:?}"
+    );
+}
+
+/// A destroyed harvester throws `[VoxelAnims]` tyres, and its budget never
+/// reaches the SHP arms.
+///
+/// gamemd-derived: with `DebrisTypes.Count > 0` the loop at `0x007022FE`
+/// drains the budget to zero before either SHP arm is tested, so a type that
+/// names `DebrisTypes=` throws VXL debris and nothing else. All 36 stock
+/// `DebrisTypes=` lines name `TIRE`; `[HARV]` is `MaxDebris=6`,
+/// `DebrisMaximums=4`.
+#[test]
+fn gsi_05_14_a_dying_harvester_throws_voxel_tires_and_no_shp_debris() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[General]\nMetallicDebris=DBRIS1LG,DBRIS2LG,DBRIS3LG\n\
+         [VoxelAnims]\n1=TIRE\n\
+         [TIRE]\nElasticity=0.8\nMinAngularVelocity=12.0\nMaxAngularVelocity=24.0\n\
+         MinZVel=28.0\nMaxZVel=32.0\nMaxXYVel=10.0\nDuration=150\n\
+         [VehicleTypes]\n0=MTNK\n1=HTNK\n\
+         [MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nCost=700\nPrimary=105mm\n\
+         [HTNK]\nStrength=1\nArmor=heavy\nSpeed=4\nCost=900\nPrimary=105mm\n\
+         MinDebris=5\nMaxDebris=6\nDebrisTypes=TIRE\nDebrisMaximums=4\n\
+         [105mm]\nDamage=65\nROF=50\nRange=6\nWarhead=AP\n\
+         [AP]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("voxel-debris fixture parses");
+
+    let mut store = EntityStore::new();
+    store.insert(make_entity_owned(1, "MTNK", 5, 5, 300, "Soviet"));
+    let _ = test_intern("HTNK");
+    store.insert(make_entity_owned(2, "HTNK", 8, 5, 1, "Americans"));
+    let mut interner = test_interner();
+    issue_attack_command(&mut store, 1, 2, None, &interner);
+    align_attackers_to_targets(&mut store, &rules, &interner);
+
+    let result = tick_combat(
+        &mut store,
+        &mut OccupancyGrid::new(),
+        &rules,
+        &mut interner,
+        &mut BTreeMap::new(),
+        0,
+        100,
+        0,
+        &mut SimRng::new(5),
+    );
+
+    // MinDebris == MaxDebris - 1 pins the budget at 5 with no draw, and the
+    // loop drains exactly that many.
+    assert_eq!(result.voxel_debris.len(), 5);
+    let names: Vec<&str> = result
+        .explosion_effects
+        .iter()
+        .map(|effect| interner.resolve(effect.shp_name))
+        .collect();
+    assert!(
+        !names.iter().any(|n| n.starts_with("DBRI")),
+        "the voxel loop spends the whole budget: {names:?}"
+    );
+    // Every piece launches from the wreck's own coordinate, lifted 10 leptons.
+    for piece in &result.voxel_debris {
+        assert_eq!(piece.object.duration, 150);
+        assert_eq!(piece.object.world_coord().z, 10);
+    }
+}
+
+/// A type with `MaxDebris=0` costs the shared stream nothing.
+///
+/// `TEST ECX,ECX / JLE 0x00702572` at `0x00702291` skips the whole block above
+/// the budget draw. Most `[InfantryTypes]` sections author no `MaxDebris=` at
+/// all, so this is the common case, and consuming a draw here would shift the
+/// cursor for every later consumer in the tick.
+#[test]
+fn gsi_05_14_a_type_without_maxdebris_takes_no_draw() {
+    let ini = "[General]\nMetallicDebris=DBRIS1LG,DBRIS2LG,DBRIS3LG\n\
+         [VehicleTypes]\n0=MTNK\n1=HTNK\n\
+         [MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nCost=700\nPrimary=105mm\n\
+         [HTNK]\nStrength=1\nArmor=heavy\nSpeed=4\nCost=900\nPrimary=105mm\n\
+         [105mm]\nDamage=65\nROF=50\nRange=6\nWarhead=AP\n\
+         [AP]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n";
+    let rules = RuleSet::from_ini(&IniFile::from_str(ini)).expect("no-debris fixture parses");
+
+    let mut store = EntityStore::new();
+    store.insert(make_entity_owned(1, "MTNK", 5, 5, 300, "Soviet"));
+    let _ = test_intern("HTNK");
+    store.insert(make_entity_owned(2, "HTNK", 8, 5, 1, "Americans"));
+    let mut interner = test_interner();
+    issue_attack_command(&mut store, 1, 2, None, &interner);
+    align_attackers_to_targets(&mut store, &rules, &interner);
+
+    let mut rng = SimRng::new(64);
+    let result = tick_combat(
+        &mut store,
+        &mut OccupancyGrid::new(),
+        &rules,
+        &mut interner,
+        &mut BTreeMap::new(),
+        0,
+        100,
+        0,
+        &mut rng,
+    );
+    assert!(result.voxel_debris.is_empty());
+    let names: Vec<&str> = result
+        .explosion_effects
+        .iter()
+        .map(|effect| interner.resolve(effect.shp_name))
+        .collect();
+    assert!(
+        !names.iter().any(|n| n.starts_with("DBRI")),
+        "no MaxDebris= means no debris at all: {names:?}"
+    );
+}

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -8825,8 +8825,8 @@ fn gsi_08_08_kirov_vertical_bomb_falls_and_detonates() {
 /// gamemd-derived: `TechnoClass::ReceiveDamage @ 0x00701900`. With
 /// `DebrisAnims.Count == 0` (`0x007023FC`) and `DebrisTypes.Count == 0`
 /// (`0x007024D2`) the whole budget goes to the arm at `0x007024E0`, one
-/// `RandomRanged(0, RulesClass+0x14C - 1)` per chunk at `0x0070253A`. 254 stock
-/// sections take exactly this path — MTNK, Rhino, the Battle Fortress, every
+/// `RandomRanged(0, RulesClass+0x14C - 1)` per chunk at `0x0070253A`. 168 stock
+/// TechnoTypes take exactly this path — MTNK, Rhino, the Battle Fortress, every
 /// aircraft — so before this landed, most vehicle deaths in the game threw
 /// nothing at all.
 #[test]

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -1511,6 +1511,10 @@ pub struct CombatTickResult {
     pub destroyed_garrison_buildings: Vec<DestroyedGarrisonBuilding>,
     /// Explosion animations to spawn at death/impact locations.
     pub explosion_effects: Vec<ExplosionEffect>,
+    /// `VoxelAnimClass` debris a death threw. Built inside the combat
+    /// transaction, which does not hold the shared object-id allocator, so the
+    /// world stamps ids and reveals in this order.
+    pub voxel_debris: Vec<crate::sim::voxel_anim::VoxelDebrisSpawn>,
     /// Receiver-ordered IC/ForceShield transient combat-light requests.
     pub invulnerability_impact_effects: Vec<InvulnerabilityImpactEffect>,
     /// Hookless-test adapter for smudge requests. Empty on the production world
@@ -1834,6 +1838,11 @@ pub(crate) struct DeathEffects {
     pub(crate) destroyed_crewed_buildings: Vec<DestroyedCrewedBuilding>,
     pub(crate) destroyed_garrison_buildings: Vec<DestroyedGarrisonBuilding>,
     pub(crate) explosion_effects: Vec<ExplosionEffect>,
+    /// `VoxelAnimClass` debris the death block built but could not admit: the
+    /// combat transaction borrows the entity store out of the world, so it does
+    /// not hold the shared object-id allocator. The world stamps ids and
+    /// reveals in this order.
+    pub(crate) voxel_debris: Vec<crate::sim::voxel_anim::VoxelDebrisSpawn>,
     pub(crate) invulnerability_impact_effects: Vec<InvulnerabilityImpactEffect>,
     pub(crate) bridge_damage_events: Vec<BridgeDamageEvent>,
     pub(crate) wall_mutations: Vec<WallMutation>,
@@ -2179,6 +2188,7 @@ impl DeathEffects {
         self.destroyed_garrison_buildings
             .append(&mut other.destroyed_garrison_buildings);
         self.explosion_effects.append(&mut other.explosion_effects);
+        self.voxel_debris.append(&mut other.voxel_debris);
         self.invulnerability_impact_effects
             .append(&mut other.invulnerability_impact_effects);
         self.bridge_damage_events
@@ -2220,6 +2230,152 @@ impl DeathEffects {
 /// retail data, because the branch that reaches it requires an empty
 /// `DieSound=` list and no stock building pairs `VoiceDie=` with an empty
 /// `DieSound=`.
+/// `CellClass+0xEC` LandType WATER, the value the death-side debris gate
+/// compares against at `0x00702274`.
+const WATER_YR_CELL_LAND_TYPE: u8 = 2;
+
+/// The height above ground below which the water gate applies, from
+/// `CMP EAX, 0xa / JG 0x00702281` at `0x00702238`.
+const DEBRIS_WATER_GATE_MAX_HEIGHT_LEPTONS: i32 = 10;
+
+/// The debris block of `TechnoClass::ReceiveDamage @ 0x00701900`, wired to the
+/// dying object.
+///
+/// The entry gate is `0x00702232`..`0x0070227B`: the object's height virtual
+/// (`vtable+0x1C8`) must be at most 10 AND its `+0x8F` byte must be set before
+/// the cell is even looked up; only then does `LandType == Water` skip the
+/// whole block, RNG included. A high-flying object dying over water therefore
+/// still throws debris.
+///
+/// RESIDUAL (GSI-05.14) — `ObjectClass+0x8F` is read as one byte at
+/// `0x0070223D` and this session did not identify it; Ghidra's imported struct
+/// name for the slot is YRpp-derived and not evidence. It is modelled as always
+/// set, which is the suppressing direction: if the flag is ever clear on a
+/// ground-level object, VERA withholds debris where retail throws it and the
+/// shared stream diverges by the whole block's draws.
+/// - Trigger: any Techno death at height <= 10 on a water cell.
+/// - Player effect: a wreck sinking at a shoreline scatters nothing.
+/// - Frequency: naval deaths and shoreline vehicle deaths only; the same
+///   `+0x8F`-and-height pair guards the water-splash arm of
+///   `UnitClass::ReceiveDamage @ 0x00737C90`, which does fire in ordinary play,
+///   so the flag is at least commonly set.
+/// - Downstream risk: it gates draws, so a wrong reading shifts the cursor for
+///   every consumer after that death in the same tick.
+///
+/// RESIDUAL (GSI-05.14) — the SHP half spawns through the existing
+/// `ExplosionEffect` -> `WorldEffect` path, which plays the sprite at a fixed
+/// point. Native builds a real `AnimClass` (`0x00421EA0`), and every stock
+/// debris AnimType is `Bouncer=yes` (`AnimTypeClass+0x35A`, read at
+/// `0x004286A7`), so native's constructor enters its own `BounceClass::Init`
+/// arm and the chunk flies an arc before landing.
+/// - Trigger: every death that reaches either SHP arm — 420 of the 456 stock
+///   sections that author `MaxDebris=`.
+/// - Player effect: the debris sprite plays where the wreck stood instead of
+///   tumbling outward, and its `Damage=`/`Warhead=` on landing is not applied.
+/// - Frequency: continuous — every building death and most vehicle deaths.
+/// - Downstream risk: the constructor's own draws are not consumed either —
+///   one `RandomRanged` for `RandomRate=`, three `Random__Next()` for the
+///   launch velocity and three `RandomRanged(-0xFFFF, 0xFFFF)` inside
+///   `BounceClass::Init`, so seven per anim. Every `WorldEffect` anim in the
+///   engine shares that gap today; closing it belongs with the AnimClass
+///   bouncer owner, not here, because the same seven draws are missing from
+///   the `Explosion=`/`DestroyAnim=` producer beside this one.
+#[allow(clippy::too_many_arguments)]
+fn throw_debris_for_death(
+    object_type: &ObjectType,
+    rules: &RuleSet,
+    terrain: Option<&crate::map::resolved_terrain::ResolvedTerrainGrid>,
+    interner: &mut StringInterner,
+    owner: InternedId,
+    rx: u16,
+    ry: u16,
+    sub_x: SimFixed,
+    sub_y: SimFixed,
+    z: u8,
+    world_z_leptons: i32,
+    main_rng: &mut SimRng,
+    voxel_debris: &mut Vec<crate::sim::voxel_anim::VoxelDebrisSpawn>,
+    explosion_effects: &mut Vec<ExplosionEffect>,
+) {
+    use crate::sim::voxel_anim::{DebrisTypeData, ShpDebrisSource, throw_death_debris};
+
+    if object_type.max_debris <= 0 {
+        return;
+    }
+    let world_x = i32::from(rx)
+        .wrapping_mul(256)
+        .wrapping_add(sub_x.to_num::<i32>());
+    let world_y = i32::from(ry)
+        .wrapping_mul(256)
+        .wrapping_add(sub_y.to_num::<i32>());
+    if let Some(cell) = terrain.and_then(|grid| grid.cell(rx, ry))
+        && cell.yr_cell_land_type == WATER_YR_CELL_LAND_TYPE
+    {
+        let ground = crate::util::lepton::ground_height_leptons(
+            cell.level,
+            cell.slope_type,
+            world_x,
+            world_y,
+        )
+        .unwrap_or(0);
+        if world_z_leptons - ground <= DEBRIS_WATER_GATE_MAX_HEIGHT_LEPTONS {
+            return;
+        }
+    }
+
+    let debris_types: Vec<Option<(crate::rules::voxel_anim_type::VoxelAnimTypeId, _)>> =
+        object_type
+            .debris_types
+            .iter()
+            .map(|name| {
+                rules
+                    .voxel_anim_type_id_by_name(name)
+                    .map(|id| (id, rules.voxel_anim_type(id)))
+            })
+            .collect();
+    let data = DebrisTypeData {
+        max_debris: object_type.max_debris,
+        min_debris: object_type.min_debris,
+        debris_types: &debris_types,
+        debris_maximums: &object_type.debris_maximums,
+        debris_anim_count: object_type.debris_anims.len(),
+        metallic_debris_count: rules.general.metallic_debris.len(),
+    };
+    let Ok(thrown) = throw_death_debris(
+        &data,
+        Some(owner),
+        glam::IVec3::new(world_x, world_y, world_z_leptons),
+        main_rng,
+    ) else {
+        // A launch velocity outside the verified x87 domain needs a modded
+        // `[VoxelAnims]` value far past any stock one; the draws are already
+        // consumed, so the death simply throws nothing.
+        return;
+    };
+    voxel_debris.extend(thrown.voxels);
+    for row in thrown.anims {
+        let name = match row.source {
+            ShpDebrisSource::TypeDebrisAnims => object_type.debris_anims.get(row.index),
+            ShpDebrisSource::RulesMetallicDebris => rules.general.metallic_debris.get(row.index),
+        };
+        // Native lifts the anim coordinate by 20 leptons (`ADD EAX, 0x14` at
+        // `0x00702443`). `ExplosionEffect` carries Z as a height LEVEL, and 20
+        // leptons is under a sixth of one, so the lift is below this row's
+        // resolution and is not represented.
+        if let Some(name) = name {
+            let shp_name = interner.intern(name);
+            explosion_effects.push(ExplosionEffect {
+                shp_name,
+                rx,
+                ry,
+                sub_x,
+                sub_y,
+                z,
+            });
+        }
+    }
+}
+
 fn append_selected_death_sounds(
     object_type: &ObjectType,
     category: EntityCategory,
@@ -2330,6 +2486,7 @@ fn handle_entity_deaths(
     let mut destroyed_crewed_buildings: Vec<DestroyedCrewedBuilding> = Vec::new();
     let mut destroyed_garrison_buildings: Vec<DestroyedGarrisonBuilding> = Vec::new();
     let mut explosion_effects: Vec<ExplosionEffect> = Vec::new();
+    let mut voxel_debris: Vec<crate::sim::voxel_anim::VoxelDebrisSpawn> = Vec::new();
     let mut invulnerability_impact_effects: Vec<InvulnerabilityImpactEffect> = Vec::new();
     let mut bridge_damage_events: Vec<BridgeDamageEvent> = Vec::new();
     let mut wall_mutations: Vec<WallMutation> = Vec::new();
@@ -2401,6 +2558,30 @@ fn handle_entity_deaths(
                     rx,
                     ry,
                     &mut death_sounds,
+                );
+                // gamemd-derived: the debris block of
+                // `TechnoClass::ReceiveDamage @ 0x00701900`
+                // (`0x00702281`..`0x0070256C`). It sits BELOW the two death
+                // sound draws in the same destruction arm and ABOVE
+                // `UnitClass::Death_Explosion`, which `UnitClass::ReceiveDamage
+                // @ 0x00737C90` only calls after this function has returned 4 —
+                // so it lands here, between the sounds and the `Explosion=` /
+                // `DestroyAnim=` draws below.
+                throw_debris_for_death(
+                    obj,
+                    rules,
+                    terrain.as_deref(),
+                    interner,
+                    owner,
+                    rx,
+                    ry,
+                    sub_x,
+                    sub_y,
+                    z,
+                    world_z_leptons,
+                    main_rng,
+                    &mut voxel_debris,
+                    &mut explosion_effects,
                 );
                 if let Some((dmg, wh_id, weapon_id)) = death_weapon_aoe(
                     rules,
@@ -2728,6 +2909,7 @@ fn handle_entity_deaths(
             destroyed_crewed_buildings.append(&mut nested.destroyed_crewed_buildings);
             destroyed_garrison_buildings.append(&mut nested.destroyed_garrison_buildings);
             explosion_effects.append(&mut nested.explosion_effects);
+            voxel_debris.append(&mut nested.voxel_debris);
             invulnerability_impact_effects.append(&mut nested.invulnerability_impact_effects);
             bridge_damage_events.append(&mut nested.bridge_damage_events);
             wall_mutations.append(&mut nested.wall_mutations);
@@ -2829,6 +3011,7 @@ fn handle_entity_deaths(
         destroyed_crewed_buildings,
         destroyed_garrison_buildings,
         explosion_effects,
+        voxel_debris,
         invulnerability_impact_effects,
         bridge_damage_events,
         wall_mutations,
@@ -4334,6 +4517,7 @@ fn absorb_inline_death_effects(
     out.tiberium_reduction_requests
         .append(&mut death.tiberium_reduction_requests);
     out.explosion_effects.append(&mut death.explosion_effects);
+    out.voxel_debris.append(&mut death.voxel_debris);
     out.smudge_spawn_requests
         .append(&mut death.smudge_spawn_requests);
     out.rad_detonations.append(&mut death.rad_detonations);
@@ -4365,6 +4549,8 @@ pub(crate) struct CombatEmit {
     pub(crate) cell_target_detaches: Vec<combat_aoe::CellTargetDetach>,
     pub(crate) tiberium_reduction_requests: Vec<TiberiumReductionRequest>,
     pub(crate) explosion_effects: Vec<ExplosionEffect>,
+    /// Death-thrown `VoxelAnimClass` debris awaiting an object id.
+    pub(crate) voxel_debris: Vec<crate::sim::voxel_anim::VoxelDebrisSpawn>,
     pub(crate) smudge_spawn_requests: Vec<SmudgeSpawnRequest>,
     /// (id, burst_rem, burst_delay, rof_cd)
     pub(crate) burst_updates: Vec<(u64, u8, u8, u16)>,
@@ -5289,6 +5475,7 @@ pub(crate) fn commit_logic_projectile_detonations(
     effects
         .explosion_effects
         .append(&mut emit.explosion_effects);
+    effects.voxel_debris.append(&mut emit.voxel_debris);
     effects
         .smudge_spawn_requests
         .append(&mut emit.smudge_spawn_requests);
@@ -5471,6 +5658,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             destroyed_crewed_buildings: Vec::new(),
             destroyed_garrison_buildings: Vec::new(),
             explosion_effects: Vec::new(),
+            voxel_debris: Vec::new(),
             invulnerability_impact_effects: Vec::new(),
             smudge_spawn_requests: Vec::new(),
             unit_facing: Vec::new(),
@@ -6234,6 +6422,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
         mut cell_target_detaches,
         mut tiberium_reduction_requests,
         mut explosion_effects,
+        mut voxel_debris,
         mut smudge_spawn_requests,
         burst_updates,
         ammo_deduct,
@@ -6451,6 +6640,8 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
     cell_target_detaches.append(&mut late_death.cell_target_detaches);
     tiberium_reduction_requests.append(&mut late_death.tiberium_reduction_requests);
     explosion_effects.append(&mut late_death.explosion_effects);
+    voxel_debris.append(&mut late_death.voxel_debris);
+    voxel_debris.append(&mut death.voxel_debris);
     smudge_spawn_requests.append(&mut late_death.smudge_spawn_requests);
     death.append(late_death);
     under_attack_events.append(&mut late_pings);
@@ -6505,6 +6696,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
         destroyed_crewed_buildings: death.destroyed_crewed_buildings,
         destroyed_garrison_buildings: death.destroyed_garrison_buildings,
         explosion_effects,
+        voxel_debris,
         invulnerability_impact_effects: death.invulnerability_impact_effects,
         smudge_spawn_requests,
         unit_facing,

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -2232,14 +2232,24 @@ impl DeathEffects {
 /// RESIDUAL (GSI-05.14) — the SHP half spawns through the existing
 /// `ExplosionEffect` -> `WorldEffect` path, which plays the sprite at a fixed
 /// point. Native builds a real `AnimClass` (`0x00421EA0`), and every stock
-/// debris AnimType is `Bouncer=yes` (`AnimTypeClass+0x35A`, read at
-/// `0x004286A7`), so native's constructor enters its own `BounceClass::Init`
+/// debris AnimType is `Bouncer=yes` — all 26 named by `[General]
+/// MetallicDebris=` or by any `DebrisAnims=` line carry it, authored in
+/// `artmd.ini` rather than `rulesmd.ini` (`AnimTypeClass+0x35A`, read at
+/// `0x004286A7`) — so native's constructor enters its own `BounceClass::Init`
 /// arm and the chunk flies an arc before landing.
-/// - Trigger: every death that reaches either SHP arm — 337 of the 373 stock
-///   sections that throw (of 456 authoring `MaxDebris=`, 83 author 0).
+/// - Trigger: every death that reaches either SHP arm — in gamemd, 324 of the
+///   356 stock sections that throw (of 439 authoring `MaxDebris=` in gamemd's
+///   own spelling, 83 author 0).
 /// - Player effect: the debris sprite plays where the wreck stood instead of
 ///   tumbling outward, and its `Damage=`/`Warhead=` on landing is not applied.
-/// - Frequency: continuous — every building death and most vehicle deaths.
+/// - Frequency: continuous — every building death (no `[BuildingTypes]` section
+///   authors `DebrisTypes=`, so all 292 that throw land here) plus 18 of the 50
+///   registered `[VehicleTypes]` that throw and 11 of the 12 `[AircraftTypes]`.
+///   The other 32 vehicle types take the voxel arm instead.
+/// - PENDING the INI case fix: VERA currently counts 337 of 373 (456 authoring)
+///   and 31 of 67 vehicles, because `ObjectType::from_ini` still folds case on
+///   `MaxDebris=` and gamemd does not — 17 `[VehicleTypes]` spell it
+///   `Maxdebris=` and take the constructor default 0 in retail.
 /// - Downstream risk: the constructor's own draws are not consumed either —
 ///   one `RandomRanged` for `RandomRate=`, three `Random__Next()` for the
 ///   launch velocity and three `RandomRanged(-0xFFFF, 0xFFFF)` inside

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -2212,55 +2212,22 @@ impl DeathEffects {
     }
 }
 
-/// Select the death cues one dying object contributes.
-///
-/// The building tail is `BuildingClass::DestructionEffects`: when the dying
-/// object is a structure whose type carries **no** `DieSound=` entries,
-/// gamemd plays the global `[AudioVisual] BuildingDieSound` at the building's
-/// own coordinate — `0x0044173F MOV ECX,[type+0x520]` reads the `DieSound`
-/// vector's count (`TechnoTypeClass+0x510..0x528`), `0x0044174A CMP ECX,EBX ;
-/// JNZ` skips the global when it is non-zero (`EBX` is zeroed at
-/// `0x00441606` and stays zero), and `0x00441773 MOV ECX,[Rules+0x6E8]` +
-/// `0x00441779 CALL VocClass::PlayAtCoord @ 0x00750E20` is the play. It is
-/// not owner-gated and draws no RNG — there is one id, not a list.
-///
-/// Where the global sits relative to the per-type `VoiceDie=`/`DieSound=`
-/// draws is UNCHECKED: native emits it from the building-specific destruction
-/// path, not from the shared Techno death transaction. It cannot matter on
-/// retail data, because the branch that reaches it requires an empty
-/// `DieSound=` list and no stock building pairs `VoiceDie=` with an empty
-/// `DieSound=`.
-/// `CellClass+0xEC` LandType WATER, the value the death-side debris gate
-/// compares against at `0x00702274`.
-const WATER_YR_CELL_LAND_TYPE: u8 = 2;
-
-/// The height above ground below which the water gate applies, from
-/// `CMP EAX, 0xa / JG 0x00702281` at `0x00702238`.
-const DEBRIS_WATER_GATE_MAX_HEIGHT_LEPTONS: i32 = 10;
-
 /// The debris block of `TechnoClass::ReceiveDamage @ 0x00701900`, wired to the
 /// dying object.
 ///
-/// The entry gate is `0x00702232`..`0x0070227B`: the object's height virtual
-/// (`vtable+0x1C8`) must be at most 10 AND its `+0x8F` byte must be set before
-/// the cell is even looked up; only then does `LandType == Water` skip the
-/// whole block, RNG included. A high-flying object dying over water therefore
-/// still throws debris.
-///
-/// RESIDUAL (GSI-05.14) — `ObjectClass+0x8F` is read as one byte at
-/// `0x0070223D` and this session did not identify it; Ghidra's imported struct
-/// name for the slot is YRpp-derived and not evidence. It is modelled as always
-/// set, which is the suppressing direction: if the flag is ever clear on a
-/// ground-level object, VERA withholds debris where retail throws it and the
-/// shared stream diverges by the whole block's draws.
-/// - Trigger: any Techno death at height <= 10 on a water cell.
-/// - Player effect: a wreck sinking at a shoreline scatters nothing.
-/// - Frequency: naval deaths and shoreline vehicle deaths only; the same
-///   `+0x8F`-and-height pair guards the water-splash arm of
-///   `UnitClass::ReceiveDamage @ 0x00737C90`, which does fire in ordinary play,
-///   so the flag is at least commonly set.
-/// - Downstream risk: it gates draws, so a wrong reading shifts the cursor for
-///   every consumer after that death in the same tick.
+/// The entry gate is `0x00702232`..`0x0070227B` and it is a *drop-in* gate, not
+/// a water gate. `0x0070223D MOV AL,[ESI+0x8F] / TEST AL,AL / JZ 0x00702281`
+/// jumps **past** the cell lookup and into the `MaxDebris` test whenever the
+/// byte is CLEAR, so the `CMP [cell+0xEC],2` water skip at `0x00702274` is
+/// reached only while the byte is set. `ObjectClass+0x8F` is written 0 by
+/// `ObjectClass::Constructor @ 0x005F3981` (`MOV [ESI+0x8F],BL` after
+/// `XOR EBX,EBX` at `0x005F3909`) and set to 1 only by
+/// `ObjectClass::DropIn @ 0x005F4171` — the paradrop / free-fall entry, which
+/// sets `+0x8D` in the same breath — and `ObjectClass::AI @ 0x005F4021` reads
+/// it as the gate on its fall arm. A program-wide `search_instructions` for
+/// `+ 0x8f]` finds no third writer. An object that is not currently falling
+/// from a drop-in therefore has the byte clear, so an ordinary death over water
+/// DOES throw debris and consumes the block's draws.
 ///
 /// RESIDUAL (GSI-05.14) — the SHP half spawns through the existing
 /// `ExplosionEffect` -> `WorldEffect` path, which plays the sprite at a fixed
@@ -2268,8 +2235,8 @@ const DEBRIS_WATER_GATE_MAX_HEIGHT_LEPTONS: i32 = 10;
 /// debris AnimType is `Bouncer=yes` (`AnimTypeClass+0x35A`, read at
 /// `0x004286A7`), so native's constructor enters its own `BounceClass::Init`
 /// arm and the chunk flies an arc before landing.
-/// - Trigger: every death that reaches either SHP arm — 420 of the 456 stock
-///   sections that author `MaxDebris=`.
+/// - Trigger: every death that reaches either SHP arm — 337 of the 373 stock
+///   sections that throw (of 456 authoring `MaxDebris=`, 83 author 0).
 /// - Player effect: the debris sprite plays where the wreck stood instead of
 ///   tumbling outward, and its `Damage=`/`Warhead=` on landing is not applied.
 /// - Frequency: continuous — every building death and most vehicle deaths.
@@ -2284,7 +2251,6 @@ const DEBRIS_WATER_GATE_MAX_HEIGHT_LEPTONS: i32 = 10;
 fn throw_debris_for_death(
     object_type: &ObjectType,
     rules: &RuleSet,
-    terrain: Option<&crate::map::resolved_terrain::ResolvedTerrainGrid>,
     interner: &mut StringInterner,
     owner: InternedId,
     rx: u16,
@@ -2308,20 +2274,6 @@ fn throw_debris_for_death(
     let world_y = i32::from(ry)
         .wrapping_mul(256)
         .wrapping_add(sub_y.to_num::<i32>());
-    if let Some(cell) = terrain.and_then(|grid| grid.cell(rx, ry))
-        && cell.yr_cell_land_type == WATER_YR_CELL_LAND_TYPE
-    {
-        let ground = crate::util::lepton::ground_height_leptons(
-            cell.level,
-            cell.slope_type,
-            world_x,
-            world_y,
-        )
-        .unwrap_or(0);
-        if world_z_leptons - ground <= DEBRIS_WATER_GATE_MAX_HEIGHT_LEPTONS {
-            return;
-        }
-    }
 
     let debris_types: Vec<Option<(crate::rules::voxel_anim_type::VoxelAnimTypeId, _)>> =
         object_type
@@ -2376,6 +2328,24 @@ fn throw_debris_for_death(
     }
 }
 
+/// Select the death cues one dying object contributes.
+///
+/// The building tail is `BuildingClass::DestructionEffects`: when the dying
+/// object is a structure whose type carries **no** `DieSound=` entries,
+/// gamemd plays the global `[AudioVisual] BuildingDieSound` at the building's
+/// own coordinate — `0x0044173F MOV ECX,[type+0x520]` reads the `DieSound`
+/// vector's count (`TechnoTypeClass+0x510..0x528`), `0x0044174A CMP ECX,EBX ;
+/// JNZ` skips the global when it is non-zero (`EBX` is zeroed at
+/// `0x00441606` and stays zero), and `0x00441773 MOV ECX,[Rules+0x6E8]` +
+/// `0x00441779 CALL VocClass::PlayAtCoord @ 0x00750E20` is the play. It is
+/// not owner-gated and draws no RNG — there is one id, not a list.
+///
+/// Where the global sits relative to the per-type `VoiceDie=`/`DieSound=`
+/// draws is UNCHECKED: native emits it from the building-specific destruction
+/// path, not from the shared Techno death transaction. It cannot matter on
+/// retail data, because the branch that reaches it requires an empty
+/// `DieSound=` list and no stock building pairs `VoiceDie=` with an empty
+/// `DieSound=`.
 fn append_selected_death_sounds(
     object_type: &ObjectType,
     category: EntityCategory,
@@ -2570,7 +2540,6 @@ fn handle_entity_deaths(
                 throw_debris_for_death(
                     obj,
                     rules,
-                    terrain.as_deref(),
                     interner,
                     owner,
                     rx,
@@ -6640,8 +6609,13 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
     cell_target_detaches.append(&mut late_death.cell_target_detaches);
     tiberium_reduction_requests.append(&mut late_death.tiberium_reduction_requests);
     explosion_effects.append(&mut late_death.explosion_effects);
-    voxel_debris.append(&mut late_death.voxel_debris);
+    // `death` collects the deaths committed before the late radiation pass, so
+    // its debris is stamped first. It is empty in every path today —
+    // `absorb_inline_death_effects` drains `death.voxel_debris` into
+    // `CombatEmit` before the lifecycle append — but taking it in the wrong
+    // order here would invert the spawn ids the moment it stopped being empty.
     voxel_debris.append(&mut death.voxel_debris);
+    voxel_debris.append(&mut late_death.voxel_debris);
     smudge_spawn_requests.append(&mut late_death.smudge_spawn_requests);
     death.append(late_death);
     under_attack_events.append(&mut late_pings);

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -2245,11 +2245,11 @@ impl DeathEffects {
 /// - Frequency: continuous — every building death (no `[BuildingTypes]` section
 ///   authors `DebrisTypes=`, so all 292 that throw land here) plus 18 of the 50
 ///   registered `[VehicleTypes]` that throw and 11 of the 12 `[AircraftTypes]`.
-///   The other 32 vehicle types take the voxel arm instead.
-/// - PENDING the INI case fix: VERA currently counts 337 of 373 (456 authoring)
-///   and 31 of 67 vehicles, because `ObjectType::from_ini` still folds case on
-///   `MaxDebris=` and gamemd does not — 17 `[VehicleTypes]` spell it
-///   `Maxdebris=` and take the constructor default 0 in retail.
+///   The other 32 vehicle types take the voxel arm instead. Those counts are on
+///   gamemd's case-exact key read, which `ObjectType::from_ini_section` matches
+///   (`CCINIClass::ReadInt @ 0x005276D0` CRCs the raw key bytes): the 17
+///   `[VehicleTypes]` spelling `Maxdebris=` take the constructor default 0 here
+///   as they do in retail and never reach this arm.
 /// - Downstream risk: the constructor's own draws are not consumed either —
 ///   one `RandomRanged` for `RandomRate=`, three `Random__Next()` for the
 ///   launch velocity and three `RandomRanged(-0xFFFF, 0xFFFF)` inside

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -363,7 +363,18 @@ use crate::sim::world::Simulation;
 // APPENDED at the end of the struct and the variant is appended to the enum, so
 // unlike the 117 and 118 bumps this one is serde-coverable in principle; the
 // version still moves because the hash schema folds the new state.
-const SNAPSHOT_VERSION: u32 = 119;
+// Bumped 119 -> 120: `ObjectSubstrate` gains the `VoxelAnimClass` registry —
+// the flying VXL debris a vehicle or building death throws. The field is
+// `#[serde(default)]` and appended, so bincode can read a v119 record, but the
+// version still moves because the hash schema folds the new store AND because
+// the death path now consumes draws it did not before: one
+// `RandomRanged(MinDebris, MaxDebris - 1)` per destroyed Techno with
+// `MaxDebris > 0`, then per debris entry one `Random__Next()` and seven draws
+// per voxel piece, then one `RandomRanged` per SHP debris anim
+// (`TechnoClass::ReceiveDamage @ 0x00701900`, `0x00702281`..`0x0070256C`).
+// Every consumer after a death in the same tick therefore reads a different
+// cursor than it did on v119.
+const SNAPSHOT_VERSION: u32 = 120;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -776,6 +787,15 @@ impl RestoredObjectIndex {
         }
         for (&registry_id, anim) in sim.substrate.anims.iter() {
             Self::register(&mut identities, "AnimStore", registry_id, anim.stable_id)?;
+            highest_id = highest_id.max(registry_id);
+        }
+        for (&registry_id, debris) in sim.substrate.voxel_anims.iter() {
+            Self::register(
+                &mut identities,
+                "VoxelAnimStore",
+                registry_id,
+                debris.stable_id,
+            )?;
             highest_id = highest_id.max(registry_id);
         }
         for (&registry_id, system) in sim.substrate.particle_systems.iter() {
@@ -3091,10 +3111,13 @@ mod tests {
     /// five guidance additions (`max_speed`, `acceleration`, `fuse_reference`,
     /// `closing_frames`, `closing_accumulator_bits`) sit at the END of the
     /// struct, but a v118 record still stops short of them, so bincode would
-    /// run off the end of every in-flight projectile.
+    /// run off the end of every in-flight projectile; 119 -> 120 adds the
+    /// `VoxelAnimClass` debris registry to `ObjectSubstrate` and wires the
+    /// death-side debris producer, which changes both the hash schema and the
+    /// shared RNG cursor at every Techno death that authors `MaxDebris=`.
     #[test]
-    fn projectile_flight_state_snapshot_version_is_119() {
-        assert_eq!(super::SNAPSHOT_VERSION, 119);
+    fn death_debris_store_snapshot_version_is_120() {
+        assert_eq!(super::SNAPSHOT_VERSION, 120);
     }
 
     #[test]

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -3114,7 +3114,9 @@ mod tests {
     /// run off the end of every in-flight projectile; 119 -> 120 adds the
     /// `VoxelAnimClass` debris registry to `ObjectSubstrate` and wires the
     /// death-side debris producer, which changes both the hash schema and the
-    /// shared RNG cursor at every Techno death that authors `MaxDebris=`.
+    /// shared RNG cursor at every Techno death whose type authors a POSITIVE
+    /// `MaxDebris=` — the 83 stock sections that author `MaxDebris=0` stop at
+    /// `0x00702291` and still cost the stream nothing.
     #[test]
     fn death_debris_store_snapshot_version_is_120() {
         assert_eq!(super::SNAPSHOT_VERSION, 120);

--- a/src/sim/voxel_anim.rs
+++ b/src/sim/voxel_anim.rs
@@ -24,12 +24,17 @@
 //! - Trigger: a death whose type authors `DebrisTypes=`.
 //! - Player effect: the tyres a dying harvester throws are invisible; the SHP
 //!   half of the same block does draw, so the death is not silent.
-//! - Frequency: 36 stock sections author `DebrisTypes=` — the Allied and Soviet
-//!   miners, the IFV, the Flak Track, the demo truck. Against them, 337
-//!   sections take a visible SHP arm: of the 456 that author `MaxDebris=`,
-//!   83 author `MaxDebris=0` and throw nothing at all, leaving 373 that throw —
-//!   166 with their own `DebrisAnims=`, 171 falling back to `[General]
-//!   MetallicDebris=`, and the 36 voxel ones.
+//! - Frequency: 36 stock sections author `DebrisTypes=`, of which 32 reach the
+//!   block in gamemd — the Chrono Miner, the War Miner, the Slave Miner, the
+//!   demolitions truck, the fire truck and the civilian traffic. Against them,
+//!   324 sections take a visible SHP arm: of the 439 that author `MaxDebris=`
+//!   in gamemd's own spelling, 83 author `MaxDebris=0` and throw nothing at
+//!   all, leaving 356 that throw — 166 with their own `DebrisAnims=`, 158
+//!   falling back to `[General] MetallicDebris=`, and the 32 voxel ones.
+//!   PENDING the INI case fix, VERA counts 36 / 337 / 456 / 373 / 171 instead,
+//!   because it still folds case on `MaxDebris=` where gamemd does not; see
+//!   [`throw_death_debris`] for the reconciliation and the 17 sections it
+//!   turns on.
 //! - Downstream risk: none to the stream — the pieces already consume their
 //!   draws, hash, and expire on schedule, so adding the draw later moves no
 //!   state.
@@ -171,8 +176,14 @@ const DEBRIS_GRAVITY: NativeF64Bits = NativeF64Bits::from_bits(0x3ff6_6666_6000_
 ///
 /// VERA-internal, gamemd equivalent UNCHECKED: a zero divisor returns 0 where
 /// native's `IDIV` raises a divide error. It needs `MaxXYVel` under 0.5, or a
-/// `MaxZVel` below `MinZVel - 1`; every stock `[VoxelAnims]` section authors
-/// `MaxXYVel` at 10 or above, so this is unreachable in stock.
+/// `MaxZVel` below `MinZVel - 1`. Neither occurs in stock, and the two facts are
+/// independent of each other: the lowest `MaxXYVel` in the ten `[VoxelAnims]`
+/// sections is 8.0 (`GASTANK`, `SONICTURRET`, `4TNKTURRET` — the rest run
+/// 10.0..100.0), so the smallest XY divisor is `ftol(2 * 8.0)` = 16; and no
+/// section has `MaxZVel < MinZVel` at all — `METEOR01`/`METEOR02` sit at
+/// `MaxZVel == MinZVel == -100.0`, which the `+ 1.0` bias turns into a Z divisor
+/// of 1. The death-debris path is narrower still: all 36 stock `DebrisTypes=`
+/// lines name `[TIRE]`, at `MaxXYVel=10.0`.
 ///
 /// VERA-internal, gamemd equivalent UNCHECKED: the sign flips at exactly
 /// `draw == 0x8000_0000`. Native's `CDQ/XOR/SUB` two's-complement negate
@@ -443,9 +454,13 @@ const DEBRIS_LOOP_ITERATION_CEILING: u32 = 4096;
 ///    that the block is skipped whole and the shared stream is untouched.
 /// 3. `budget = RandomRanged(MinDebris, MaxDebris - 1)` at `0x007022C8`. The
 ///    `DEC EDI` at `0x007022AD` is why the top is one BELOW `MaxDebris`, so
-///    `MaxDebris=1` can only ever yield the `MinDebris` end. Most stock
-///    sections author `MaxDebris=` with no `MinDebris=`, so their budget is
-///    `RandomRanged(0, MaxDebris - 1)` and can come out zero.
+///    `MaxDebris=1` can only ever yield the `MinDebris` end. 167 of the 439
+///    stock sections gamemd sees authoring `MaxDebris=` author no `MinDebris=`
+///    (84 of the 356 that throw), so their budget is
+///    `RandomRanged(0, MaxDebris - 1)` and can come out zero. Every stock
+///    `MinDebris=` is spelled exactly, so only the `MaxDebris=` half of these
+///    two figures moves with the INI case fix (VERA reads 184 of 456, 101 of
+///    373 today).
 /// 4. The voxel loop, entered only when `DebrisTypes.Count > 0` (`+0x324`,
 ///    `0x007022EA`) AND `budget > 0` (`0x007022F8`). Per iteration:
 ///    - one `Random__Next()` at `0x0070232B`, then
@@ -470,23 +485,42 @@ const DEBRIS_LOOP_ITERATION_CEILING: u32 = 4096;
 ///      `budget` anims from `[General] MetallicDebris=`, each taking one
 ///      `RandomRanged(0, RulesClass+0x14C - 1)` at `0x0070253A`.
 ///
-/// That last arm is the one players see most. Of the 456 stock sections that
-/// author `MaxDebris=`, 83 author `MaxDebris=0` and stop at step 2; of the 373
-/// that throw, 171 carry `MaxDebris=` alone and land on `[General]
-/// MetallicDebris=`, 166 carry their own `DebrisAnims=`, and 36 name
+/// That last arm is the one players see most. Of the 439 stock sections gamemd
+/// sees authoring `MaxDebris=`, 83 author `MaxDebris=0` and stop at step 2; of
+/// the 356 that throw, 158 carry `MaxDebris=` alone and land on `[General]
+/// MetallicDebris=`, 166 carry their own `DebrisAnims=`, and 32 name
 /// `DebrisTypes=` (all `TIRE`). The three sets do not overlap.
 ///
-/// Those are section counts. Only 168 of the 171 are registered TechnoTypes
+/// Those are section counts. Only 155 of the 158 are registered TechnoTypes
 /// that can reach this function: `[TRexWH]` and `[Smashing]` are warheads
 /// (`[Warheads] 101=`/`86=`), whose `MaxDebris=` is read into the warhead by
 /// `WarheadTypeClass::ReadINI @ 0x0075D590` (the key at `0x0075DA95`) rather
 /// than into `TechnoType+0x5BC` by `TechnoTypeClass::ReadINI @ 0x00712170`
 /// (the key at `0x0071258E`), and `[UFO]` is a building-shaped section in no
 /// type registry, as is `[CAIRFGL]` among the 83 zeros. `[BuildingTypes]` also
-/// names `NAPSYA` twice, so a registry walk counts 169 where find-or-allocate
-/// yields 168. Every figure here is taken with a case-insensitive
-/// `MaxDebris=` read — 17 stock sections spell it `Maxdebris=`; see
-/// [`crate::rules::ini_parser::IniSection::get_ignoring_case`].
+/// names `NAPSYA` twice, so a registry walk counts 156 where find-or-allocate
+/// yields 155. The 155 break down as 18 `[VehicleTypes]`, 11 `[AircraftTypes]`
+/// and 126 `[BuildingTypes]`.
+///
+/// PENDING the INI case fix — the counting basis, stated because every figure
+/// above depends on it. gamemd's `INIClass` CRCs the raw bytes of the key on
+/// both the store and the lookup side and compares 32-bit integers only, with
+/// no folding instruction anywhere on the path, so `MaxDebris=` and
+/// `Maxdebris=` are different entries in retail. 17 stock `[VehicleTypes]`
+/// spell it `Maxdebris=3` — `APOC BFRT CMON FV HORV HTK HTNK LCRF LTNK MIND
+/// SAPC SREF TELE TTNK UTNK V3 YTNK` — and gamemd gives all 17 the
+/// `TechnoTypeClass` constructor default of 0, so the Rhino, the Apocalypse,
+/// the Prism Tank, the Battle Fortress and the IFV throw NO death debris in
+/// retail. 14 of the 17 are buildable; `CMON`, `HORV` and `UTNK` are
+/// `TechLevel=-1`. The three miners a player actually builds — `[HARV]`,
+/// `[CMIN]`, `[SMIN]` — spell `MaxDebris` exactly and keep their tyres on
+/// either basis; it is `HORV` and `CMON`, the unbuildable duplicates that
+/// share their `Name=`, that lose them. VERA still reads the key through
+/// [`crate::rules::ini_parser::IniSection::get_ignoring_case`] and therefore
+/// runs this block for all 17, on the counts 456 / 373 / 171 / 168 / 36. That
+/// is an RNG-cursor divergence, not a cosmetic one, and it is owned by this
+/// branch as a separate behavioural round; the numbers above are the ones the
+/// fix lands on.
 pub fn throw_death_debris(
     data: &DebrisTypeData<'_>,
     owner_house: Option<InternedId>,
@@ -499,10 +533,13 @@ pub fn throw_death_debris(
     }
     // `Random__RandomRanged` sorts reversed bounds and consumes no draw when
     // they coincide; `next_range_i32_inclusive` models that helper directly.
-    // The signed form is the right one because a `MinDebris=` above
-    // `MaxDebris - 1` is authored by stock buildings (`MinDebris=4`,
-    // `MaxDebris=6` gives 4..5, but `MinDebris=7`/`MaxDebris=15` gives 7..14)
-    // and an unsigned read of a negative top would invent a huge span.
+    // The signed form is what native computes: `DEC EDI` at `0x007022AD` puts
+    // the top at `MaxDebris - 1`, which `MinDebris` can sit on or above, and an
+    // unsigned read of an inverted span would invent a huge one instead of
+    // letting the helper sort it. No stock section goes above the top — 5 pin
+    // `MinDebris == MaxDebris - 1` (`(0,1)`, `(1,2)`, three at `(2,3)`), which
+    // is a coincident span costing no draw, and none is higher — so only a
+    // modded rules file inverts it.
     let mut budget = rng.next_range_i32_inclusive(data.min_debris, data.max_debris - 1);
 
     if !data.debris_types.is_empty() && budget > 0 {
@@ -762,8 +799,9 @@ mod tests {
     fn gsi_05_14_debris_anims_win_over_the_rules_metallic_list() {
         // `0x007023FC` tests `DebrisAnims.Count` first; only a type with an
         // EMPTY list AND no `DebrisTypes=` falls through to `RulesClass+0x140`
-        // at `0x0070252D`. 166 stock sections take the first arm and 171 the
-        // second.
+        // at `0x0070252D`. 166 stock sections take the first arm and 158 the
+        // second (171 until the INI case fix lands — 13 of the 17 sections
+        // spelling `Maxdebris=` sit on the second arm).
         let input = data(9, 7, &[], &[], 6, 20);
         let mut rng = SimRng::new(31);
         let thrown = throw(&input, &mut rng);

--- a/src/sim/voxel_anim.rs
+++ b/src/sim/voxel_anim.rs
@@ -16,15 +16,20 @@
 //! RESIDUAL (GSI-05.14) — the pieces are simulated but not DRAWN. The unit
 //! voxel renderer is keyed by entity type, house remap and facing, and a
 //! `VoxelAnimClass` has none of those; its draw orientation is the quaternion
-//! tumble, which is itself blocked on the unread `Math__SinFromTable` /
-//! `Math__CosFromTable` contents (see [`crate::sim::bounce::BounceState`]), so
-//! a renderer added now would have to invent a facing.
+//! tumble ([`crate::sim::bounce::BounceState`]), which is not ported, so a
+//! renderer added now would have to invent a facing. That missing draw path is
+//! the whole blocker — the sine table it needs is readable, see the tumble
+//! residual on `BounceState` — and no harness or replay fixture exercises this
+//! module at all, so nothing red catches a regression here.
 //! - Trigger: a death whose type authors `DebrisTypes=`.
 //! - Player effect: the tyres a dying harvester throws are invisible; the SHP
 //!   half of the same block does draw, so the death is not silent.
 //! - Frequency: 36 stock sections author `DebrisTypes=` — the Allied and Soviet
-//!   miners, the Battle Fortress, the Flak Track, the demo truck. The other 420
-//!   sections that author `MaxDebris=` take the SHP arms and are visible.
+//!   miners, the Battle Fortress, the Flak Track, the demo truck. Against them,
+//!   337 sections take a visible SHP arm: of the 456 that author `MaxDebris=`,
+//!   83 author `MaxDebris=0` and throw nothing at all, leaving 373 that throw —
+//!   166 with their own `DebrisAnims=`, 171 falling back to `[General]
+//!   MetallicDebris=`, and the 36 voxel ones.
 //! - Downstream risk: none to the stream — the pieces already consume their
 //!   draws, hash, and expire on schedule, so adding the draw later moves no
 //!   state.
@@ -168,6 +173,13 @@ const DEBRIS_GRAVITY: NativeF64Bits = NativeF64Bits::from_bits(0x3ff6_6666_6000_
 /// native's `IDIV` raises a divide error. It needs `MaxXYVel` under 0.5, or a
 /// `MaxZVel` below `MinZVel - 1`; every stock `[VoxelAnims]` section authors
 /// `MaxXYVel` at 10 or above, so this is unreachable in stock.
+///
+/// VERA-internal, gamemd equivalent UNCHECKED: the sign flips at exactly
+/// `draw == 0x8000_0000`. Native's `CDQ/XOR/SUB` two's-complement negate
+/// saturates there — `abs(i32::MIN)` is still `i32::MIN` — so its `IDIV`
+/// divides a NEGATIVE dividend and yields a negative remainder, while
+/// `(draw as i32) % divisor` followed by `.abs()` here yields the positive one.
+/// `|x| % d == |x % d|` for every other draw. One draw in 2^32.
 fn raw_abs_modulo(draw: u32, divisor: i32) -> i32 {
     if divisor == 0 {
         return 0;
@@ -415,17 +427,21 @@ const DEBRIS_LOOP_ITERATION_CEILING: u32 = 4096;
 /// from the disassembly at `0x00702281`..`0x0070256C`.
 ///
 /// The gates and the draws, in native order:
-/// 1. `MapClass::Get_CellClass_At_Coord` on the death cell, then
-///    `CMP [cell+0xEC], 2 / JZ 0x00702672` at `0x00702274` — a unit dying on
-///    WATER throws no debris at all and takes no draw. That gate is the
-///    caller's: it is itself guarded by `vtable+0x1C8 < 0xB` and the object's
-///    `+0x8F`, which this function does not model.
+/// 1. A water skip that ordinary deaths never reach. `CMP [cell+0xEC], 2 /
+///    JZ 0x00702672` at `0x00702274` does suppress the whole block, RNG
+///    included, but reaching it needs BOTH `vtable+0x1C8 <= 0xA` and the
+///    object's `+0x8F` byte SET (`0x0070223D`, whose `JZ` on a clear byte
+///    jumps forward into the block). `+0x8F` is 0 from
+///    `ObjectClass::Constructor @ 0x005F3981` and is set only by
+///    `ObjectClass::DropIn @ 0x005F4171`, so only an object still falling from
+///    a drop-in can take the skip. VERA does not model drop-in free fall, so
+///    this function correctly models the byte as clear and never suppresses.
 /// 2. `TechnoType+0x5BC` (`MaxDebris`) must be positive (`0x00702291`). Below
 ///    that the block is skipped whole and the shared stream is untouched.
 /// 3. `budget = RandomRanged(MinDebris, MaxDebris - 1)` at `0x007022C8`. The
 ///    `DEC EDI` at `0x007022AD` is why the top is one BELOW `MaxDebris`, so
-///    `MaxDebris=1` can only ever yield the `MinDebris` end. 254 stock sections
-///    author `MaxDebris=` with no `MinDebris=`, so their budget is
+///    `MaxDebris=1` can only ever yield the `MinDebris` end. Most stock
+///    sections author `MaxDebris=` with no `MinDebris=`, so their budget is
 ///    `RandomRanged(0, MaxDebris - 1)` and can come out zero.
 /// 4. The voxel loop, entered only when `DebrisTypes.Count > 0` (`+0x324`,
 ///    `0x007022EA`) AND `budget > 0` (`0x007022F8`). Per iteration:
@@ -451,9 +467,11 @@ const DEBRIS_LOOP_ITERATION_CEILING: u32 = 4096;
 ///      `budget` anims from `[General] MetallicDebris=`, each taking one
 ///      `RandomRanged(0, RulesClass+0x14C - 1)` at `0x0070253A`.
 ///
-/// That last arm is the one players see most: 254 stock sections carry
-/// `MaxDebris=` alone, 166 carry it with `DebrisAnims=`, and only 36 name
-/// `DebrisTypes=`.
+/// That last arm is the one players see most. Of the 456 stock sections that
+/// author `MaxDebris=`, 83 author `MaxDebris=0` and stop at step 2; of the 373
+/// that throw, 171 carry `MaxDebris=` alone and land on `[General]
+/// MetallicDebris=`, 166 carry their own `DebrisAnims=`, and 36 name
+/// `DebrisTypes=` (all `TIRE`). The three sets do not overlap.
 pub fn throw_death_debris(
     data: &DebrisTypeData<'_>,
     owner_house: Option<InternedId>,
@@ -482,6 +500,11 @@ pub fn throw_death_debris(
             // length — 36 sections, each `DebrisTypes=TIRE` with one maximum —
             // so this is unreachable in stock.
             let maximum = data.debris_maximums.get(index).copied().unwrap_or(0);
+            // VERA-internal, gamemd equivalent UNCHECKED: the `.max(1)` floor.
+            // Native computes the divisor as `INC ECX` over the raw entry and
+            // divides with `IDIV ECX` at `0x00702339`, so a `DebrisMaximums=-1`
+            // entry faults there. Every stock `DebrisMaximums=` line is 4 or 6,
+            // so only a modded rules file reaches the floor.
             let divisor = maximum.saturating_add(1).max(1) as u32;
             let mut count = rng.next_raw_abs_modulo(divisor) as i32;
             if count >= budget {
@@ -524,7 +547,16 @@ pub fn throw_death_debris(
                 source: ShpDebrisSource::TypeDebrisAnims,
             });
         }
-    } else if data.debris_types.is_empty() && data.metallic_debris_count > 0 {
+    } else if data.debris_types.is_empty() {
+        // No count gate here, unlike the arm above: `0x007024D2` tests only
+        // `DebrisTypes.Count` and `0x007024DA` only the budget, then
+        // `0x00702525 MOV EAX,[Rules+0x14C] / DEC EAX` feeds the list length
+        // straight to `RandomRanged(0, len - 1)` at `0x0070253A`. An empty
+        // `[General] MetallicDebris=` therefore still costs `budget` draws in
+        // gamemd — the resulting -1 lands in the out-of-bounds index at
+        // `0x00702560 MOV EDX,[ECX + EAX*4]`, which is why the caller resolves
+        // the name with `.get()` and drops the row rather than inventing one.
+        // Stock authors 20 entries, so only a modded rules file reaches it.
         for _ in 0..budget.max(0) {
             let index =
                 rng.next_range_i32_inclusive(0, data.metallic_debris_count as i32 - 1) as usize;
@@ -611,6 +643,44 @@ mod tests {
     }
 
     #[test]
+    fn gsi_05_14_an_empty_metallic_debris_list_still_spends_the_budget_in_draws() {
+        // `0x007024D2` gates the arm on `DebrisTypes.Count` and `0x007024DA` on
+        // the budget — there is NO test of `[Rules+0x14C]`. `0x00702525
+        // MOV EAX,[EDX+0x14C] / DEC EAX` hands the length straight to
+        // `RandomRanged(0, len - 1)` at `0x0070253A`, so an empty list costs
+        // `budget` draws in gamemd and lands on an out-of-bounds index the
+        // caller resolves away. Skipping the draws instead would shift the
+        // shared cursor for every later consumer in the tick.
+        let input = data(5, 4, &[], &[], 0, 0);
+        let mut rng = SimRng::new(5);
+        let thrown = throw(&input, &mut rng);
+        assert!(
+            thrown.voxels.is_empty(),
+            "no DebrisTypes= means no voxel pieces"
+        );
+
+        // The budget is exactly 4 (MinDebris == MaxDebris - 1 takes no draw),
+        // and each unit spends one RandomRanged draw over the reversed span
+        // (0, -1) that native's `DEC EAX` produces on an empty list.
+        let mut expected = SimRng::new(5);
+        for _ in 0..4 {
+            let _ = expected.next_range_i32_inclusive(0, -1);
+        }
+        assert_eq!(
+            rng.logical_view(),
+            expected.logical_view(),
+            "an empty MetallicDebris list must still spend the budget in draws"
+        );
+        assert_eq!(thrown.anims.len(), 4);
+        assert!(
+            thrown
+                .anims
+                .iter()
+                .all(|row| row.source == ShpDebrisSource::RulesMetallicDebris)
+        );
+    }
+
+    #[test]
     fn gsi_05_14_the_voxel_budget_drains_and_the_type_index_wraps() {
         // The load-bearing correction to the earlier reading of this block.
         // `SUB EBX,EAX` at `0x007023B5` subtracts the spent count from the
@@ -677,8 +747,8 @@ mod tests {
     fn gsi_05_14_debris_anims_win_over_the_rules_metallic_list() {
         // `0x007023FC` tests `DebrisAnims.Count` first; only a type with an
         // EMPTY list AND no `DebrisTypes=` falls through to `RulesClass+0x140`
-        // at `0x0070252D`. 166 stock building sections take the first arm and
-        // 254 vehicle sections the second.
+        // at `0x0070252D`. 166 stock sections take the first arm and 171 the
+        // second.
         let input = data(9, 7, &[], &[], 6, 20);
         let mut rng = SimRng::new(31);
         let thrown = throw(&input, &mut rng);

--- a/src/sim/voxel_anim.rs
+++ b/src/sim/voxel_anim.rs
@@ -25,8 +25,8 @@
 //! - Player effect: the tyres a dying harvester throws are invisible; the SHP
 //!   half of the same block does draw, so the death is not silent.
 //! - Frequency: 36 stock sections author `DebrisTypes=` — the Allied and Soviet
-//!   miners, the Battle Fortress, the Flak Track, the demo truck. Against them,
-//!   337 sections take a visible SHP arm: of the 456 that author `MaxDebris=`,
+//!   miners, the IFV, the Flak Track, the demo truck. Against them, 337
+//!   sections take a visible SHP arm: of the 456 that author `MaxDebris=`,
 //!   83 author `MaxDebris=0` and throw nothing at all, leaving 373 that throw —
 //!   166 with their own `DebrisAnims=`, 171 falling back to `[General]
 //!   MetallicDebris=`, and the 36 voxel ones.
@@ -434,8 +434,11 @@ const DEBRIS_LOOP_ITERATION_CEILING: u32 = 4096;
 ///    jumps forward into the block). `+0x8F` is 0 from
 ///    `ObjectClass::Constructor @ 0x005F3981` and is set only by
 ///    `ObjectClass::DropIn @ 0x005F4171`, so only an object still falling from
-///    a drop-in can take the skip. VERA does not model drop-in free fall, so
-///    this function correctly models the byte as clear and never suppresses.
+///    a drop-in can take the skip. This function models the byte as clear and
+///    never suppresses. VERA does have a paradrop descent, but it carries
+///    infantry only ([`crate::sim::superweapon::paradrop`]) and no stock
+///    `[InfantryTypes]` section authors a positive `MaxDebris=` — 0 of the 65 —
+///    so nothing VERA drops in survives step 2 even with the byte set.
 /// 2. `TechnoType+0x5BC` (`MaxDebris`) must be positive (`0x00702291`). Below
 ///    that the block is skipped whole and the shared stream is untouched.
 /// 3. `budget = RandomRanged(MinDebris, MaxDebris - 1)` at `0x007022C8`. The
@@ -472,6 +475,18 @@ const DEBRIS_LOOP_ITERATION_CEILING: u32 = 4096;
 /// that throw, 171 carry `MaxDebris=` alone and land on `[General]
 /// MetallicDebris=`, 166 carry their own `DebrisAnims=`, and 36 name
 /// `DebrisTypes=` (all `TIRE`). The three sets do not overlap.
+///
+/// Those are section counts. Only 168 of the 171 are registered TechnoTypes
+/// that can reach this function: `[TRexWH]` and `[Smashing]` are warheads
+/// (`[Warheads] 101=`/`86=`), whose `MaxDebris=` is read into the warhead by
+/// `WarheadTypeClass::ReadINI @ 0x0075D590` (the key at `0x0075DA95`) rather
+/// than into `TechnoType+0x5BC` by `TechnoTypeClass::ReadINI @ 0x00712170`
+/// (the key at `0x0071258E`), and `[UFO]` is a building-shaped section in no
+/// type registry, as is `[CAIRFGL]` among the 83 zeros. `[BuildingTypes]` also
+/// names `NAPSYA` twice, so a registry walk counts 169 where find-or-allocate
+/// yields 168. Every figure here is taken with a case-insensitive
+/// `MaxDebris=` read — 17 stock sections spell it `Maxdebris=`; see
+/// [`crate::rules::ini_parser::IniSection::get_ignoring_case`].
 pub fn throw_death_debris(
     data: &DebrisTypeData<'_>,
     owner_house: Option<InternedId>,

--- a/src/sim/voxel_anim.rs
+++ b/src/sim/voxel_anim.rs
@@ -31,10 +31,9 @@
 //!   in gamemd's own spelling, 83 author `MaxDebris=0` and throw nothing at
 //!   all, leaving 356 that throw — 166 with their own `DebrisAnims=`, 158
 //!   falling back to `[General] MetallicDebris=`, and the 32 voxel ones.
-//!   PENDING the INI case fix, VERA counts 36 / 337 / 456 / 373 / 171 instead,
-//!   because it still folds case on `MaxDebris=` where gamemd does not; see
-//!   [`throw_death_debris`] for the reconciliation and the 17 sections it
-//!   turns on.
+//!   VERA reads the key case-exactly and lands on these same figures; see
+//!   [`throw_death_debris`] for the 17 sections that mis-spell it and
+//!   therefore throw nothing.
 //! - Downstream risk: none to the stream — the pieces already consume their
 //!   draws, hash, and expire on schedule, so adding the draw later moves no
 //!   state.
@@ -459,8 +458,8 @@ const DEBRIS_LOOP_ITERATION_CEILING: u32 = 4096;
 ///    (84 of the 356 that throw), so their budget is
 ///    `RandomRanged(0, MaxDebris - 1)` and can come out zero. Every stock
 ///    `MinDebris=` is spelled exactly, so only the `MaxDebris=` half of these
-///    two figures moves with the INI case fix (VERA reads 184 of 456, 101 of
-///    373 today).
+///    two figures ever depended on the case basis; a folding read would have
+///    counted 184 of 456 and 101 of 373 instead.
 /// 4. The voxel loop, entered only when `DebrisTypes.Count > 0` (`+0x324`,
 ///    `0x007022EA`) AND `budget > 0` (`0x007022F8`). Per iteration:
 ///    - one `Random__Next()` at `0x0070232B`, then
@@ -502,25 +501,29 @@ const DEBRIS_LOOP_ITERATION_CEILING: u32 = 4096;
 /// yields 155. The 155 break down as 18 `[VehicleTypes]`, 11 `[AircraftTypes]`
 /// and 126 `[BuildingTypes]`.
 ///
-/// PENDING the INI case fix — the counting basis, stated because every figure
-/// above depends on it. gamemd's `INIClass` CRCs the raw bytes of the key on
-/// both the store and the lookup side and compares 32-bit integers only, with
-/// no folding instruction anywhere on the path, so `MaxDebris=` and
-/// `Maxdebris=` are different entries in retail. 17 stock `[VehicleTypes]`
-/// spell it `Maxdebris=3` — `APOC BFRT CMON FV HORV HTK HTNK LCRF LTNK MIND
-/// SAPC SREF TELE TTNK UTNK V3 YTNK` — and gamemd gives all 17 the
-/// `TechnoTypeClass` constructor default of 0, so the Rhino, the Apocalypse,
-/// the Prism Tank, the Battle Fortress and the IFV throw NO death debris in
-/// retail. 14 of the 17 are buildable; `CMON`, `HORV` and `UTNK` are
-/// `TechLevel=-1`. The three miners a player actually builds — `[HARV]`,
-/// `[CMIN]`, `[SMIN]` — spell `MaxDebris` exactly and keep their tyres on
-/// either basis; it is `HORV` and `CMON`, the unbuildable duplicates that
-/// share their `Name=`, that lose them. VERA still reads the key through
-/// [`crate::rules::ini_parser::IniSection::get_ignoring_case`] and therefore
-/// runs this block for all 17, on the counts 456 / 373 / 171 / 168 / 36. That
-/// is an RNG-cursor divergence, not a cosmetic one, and it is owned by this
-/// branch as a separate behavioural round; the numbers above are the ones the
-/// fix lands on.
+/// The counting basis, stated because every figure above depends on it.
+/// gamemd's `INIClass` CRCs the raw bytes of the key on both the store and the
+/// lookup side and compares 32-bit integers only, with no folding instruction
+/// anywhere on the path, so `MaxDebris=` and `Maxdebris=` are different
+/// entries in retail. 17 stock `[VehicleTypes]` spell it `Maxdebris=3` —
+/// `APOC BFRT CMON FV HORV HTK HTNK LCRF LTNK MIND SAPC SREF TELE TTNK UTNK V3
+/// YTNK` — and gamemd gives all 17 the `TechnoTypeClass` constructor default
+/// of 0, so the Rhino, the Apocalypse, the Prism Tank, the Battle Fortress and
+/// the IFV throw NO death debris in retail. 14 of the 17 are buildable;
+/// `CMON`, `HORV` and `UTNK` are `TechLevel=-1`. The three miners a player
+/// actually builds — `[HARV]`, `[CMIN]`, `[SMIN]` — spell `MaxDebris` exactly
+/// and keep their tyres; it is `HORV` and `CMON`, the unbuildable duplicates
+/// that share their `Name=`, that lose them. 13 of the 17 sit on the metallic
+/// arm and 4 (`CMON`, `FV`, `HORV`, `HTK`) author `DebrisTypes=TIRE` and would
+/// have sat on the voxel one.
+///
+/// `ObjectType::from_ini_section` reads the key case-exactly, so VERA lands on
+/// the counts above and takes no draw for those 17. The gate is the only one:
+/// `MaxDebris <= 0` at `0x00702293` jumps clear of both arms and the metallic
+/// fallback to `0x00702572`, so there is no other path a mis-spelled type
+/// falls back to. The warhead-side producer is separate and unaffected —
+/// `BulletClass::DetonateAtCoord @ 0x00469D0C` gates on the WARHEAD's
+/// `+0x1C4`, and only `[Smashing]` and `[TRexWH]` author it in stock.
 pub fn throw_death_debris(
     data: &DebrisTypeData<'_>,
     owner_house: Option<InternedId>,
@@ -800,8 +803,8 @@ mod tests {
         // `0x007023FC` tests `DebrisAnims.Count` first; only a type with an
         // EMPTY list AND no `DebrisTypes=` falls through to `RulesClass+0x140`
         // at `0x0070252D`. 166 stock sections take the first arm and 158 the
-        // second (171 until the INI case fix lands — 13 of the 17 sections
-        // spelling `Maxdebris=` sit on the second arm).
+        // second; 13 of the 17 sections spelling `Maxdebris=` would have
+        // joined the second arm had the read folded case, which it does not.
         let input = data(9, 7, &[], &[], 6, 20);
         let mut rng = SimRng::new(31);
         let thrown = throw(&input, &mut rng);

--- a/src/sim/voxel_anim.rs
+++ b/src/sim/voxel_anim.rs
@@ -9,15 +9,25 @@
 //! sharing only `ObjectClass`. It is also not `sim::components::VoxelAnimation`,
 //! which is a per-entity HVA frame cursor.
 //!
-//! ## Not yet wired, deliberately
+//! The store IS wired: `world::substrate.voxel_anims` owns it, the LogicVector
+//! owns AI order through `ObjectKind::VoxelAnim`, and it folds into the state
+//! hash and the snapshot (`SNAPSHOT_VERSION` 120).
 //!
-//! The store is not in `world::substrate`, the state hash or the snapshot yet.
-//! That wiring lands in the SAME slice as the debris producer, not before:
-//! folding an always-empty store into the hash would move
-//! `GLOBAL_HARNESS_FINAL_HASH` and spend a re-baseline entry on plumbing, with
-//! no behaviour to cite for it. When the producer lands, the fold and the
-//! re-baseline go in together — and nothing may spawn a `VoxelAnimObject`
-//! before then, or it would be live and unhashed.
+//! RESIDUAL (GSI-05.14) — the pieces are simulated but not DRAWN. The unit
+//! voxel renderer is keyed by entity type, house remap and facing, and a
+//! `VoxelAnimClass` has none of those; its draw orientation is the quaternion
+//! tumble, which is itself blocked on the unread `Math__SinFromTable` /
+//! `Math__CosFromTable` contents (see [`crate::sim::bounce::BounceState`]), so
+//! a renderer added now would have to invent a facing.
+//! - Trigger: a death whose type authors `DebrisTypes=`.
+//! - Player effect: the tyres a dying harvester throws are invisible; the SHP
+//!   half of the same block does draw, so the death is not silent.
+//! - Frequency: 36 stock sections author `DebrisTypes=` — the Allied and Soviet
+//!   miners, the Battle Fortress, the Flak Track, the demo truck. The other 420
+//!   sections that author `MaxDebris=` take the SHP arms and are visible.
+//! - Downstream risk: none to the stream — the pieces already consume their
+//!   draws, hash, and expire on schedule, so adding the draw later moves no
+//!   state.
 //!
 //! ## Dependency rules
 //! - Part of sim/ — depends on rules/, map/, util/ and the rest of sim/.
@@ -28,17 +38,21 @@ use std::collections::BTreeMap;
 use glam::IVec3;
 use serde::{Deserialize, Serialize};
 
-use crate::rules::voxel_anim_type::VoxelAnimTypeId;
-use crate::sim::bounce::BounceState;
+use crate::rules::voxel_anim_type::{VoxelAnimType, VoxelAnimTypeId};
+use crate::sim::bounce::{BounceOutcome, BounceState, BounceTerrain};
 use crate::sim::intern::InternedId;
+use crate::sim::rng::SimRng;
+use crate::util::native_x87::{NativeF64Bits, NativeX87Error, X87Chop53};
 
 /// One live `VoxelAnimClass` instance.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VoxelAnimObject {
     pub stable_id: u64,
     pub type_id: VoxelAnimTypeId,
-    /// `+0x10C`. Ticks remaining. The AI decrements it while positive and runs
-    /// the expiry arm at zero.
+    /// `+0x140`, seeded from the type's `Duration=` (`+0x29C`) by the
+    /// constructor. Ticks remaining. `VoxelAnimClass::AI @ 0x00749F30`
+    /// decrements it while non-zero and runs the expiry arm once it is not
+    /// positive.
     pub duration: i32,
     /// `+0x110`. Queued for removal; the AI deletes on its next visit.
     pub marked_for_deletion: bool,
@@ -79,6 +93,10 @@ impl VoxelAnimStore {
         self.0.get(&id)
     }
 
+    pub(crate) fn values_mut(&mut self) -> impl Iterator<Item = &mut VoxelAnimObject> + '_ {
+        self.0.values_mut()
+    }
+
     pub(crate) fn get_mut(&mut self, id: u64) -> Option<&mut VoxelAnimObject> {
         self.0.get_mut(&id)
     }
@@ -113,153 +131,777 @@ impl VoxelAnimStore {
     }
 }
 
-/// How many debris objects of each `DebrisTypes=` entry a death throws.
+/// The Z the constructor launches from: `GetCoords().Z + 10` (`0x0074950C`,
+/// `ADD EAX, 0xa`).
+const LAUNCH_Z_OFFSET_LEPTONS: i32 = 10;
+
+/// Placeholder identity for a piece built inside the combat transaction.
 ///
-/// gamemd-derived: the debris block of `TechnoClass::ReceiveDamage @
-/// 0x00701900`, read from disassembly at `0x0070226F`..`0x007023B3`. The
-/// arithmetic is small and the RNG order is the whole parity contract, so it is
-/// pinned here as a pure function rather than buried in the spawn walk.
+/// Native's `AbstractClass::AssignUniqueID` runs inside
+/// `VoxelAnimClass::Constructor`, interleaved with the death's other object
+/// allocations. Combat here does not hold the shared allocator — it borrows the
+/// entity store out of the world — so the id is stamped when the world admits
+/// the piece, preserving spawn ORDER but not the interleaving with any other
+/// allocation the same tick makes between the two points. The stores are keyed
+/// by that id, so order is what the hash and the AI walk read.
+const UNASSIGNED_STABLE_ID: u64 = 0;
+
+/// The `1.0` at `0x007E1718` that both inclusive-range divisors add before the
+/// `ftol` (`0x007495A8`, `0x0074960B`). It makes `MaxZVel`/`MaxAngularVelocity`
+/// reachable, and it is what collapses `[TIRE]`'s 12deg..24deg spin band to a
+/// divisor of 1 — the band is stored in RADIANS, so its width is 0.21.
+const INCLUSIVE_RANGE_BIAS: NativeF64Bits = NativeF64Bits::from_bits(0x3ff0_0000_0000_0000);
+
+/// The gravity `VoxelAnimClass::Constructor` hands `BounceClass::Init` as two
+/// literal pushes: `0x60000000` / `0x3ff66666` (`0x00749651`, `0x0074964C`) —
+/// the double `1.4`. It is NOT read from the type.
+const DEBRIS_GRAVITY: NativeF64Bits = NativeF64Bits::from_bits(0x3ff6_6666_6000_0000);
+
+/// One raw `Random__Next()` draw taken through native's `CDQ/XOR/SUB` absolute
+/// value and then `CDQ/IDIV`.
 ///
-/// The gates, in native order:
-/// 1. `MapClass::Get_CellClass_At_Coord` on the death cell, then
-///    `CMP [cell+0xEC], 2 / JZ 0x00702672` at `0x00702274` — a unit dying on
-///    WATER throws no debris at all, and takes no draw. That is the caller's
-///    gate, not this function's.
-/// 2. `TechnoType+0x5BC` (`MaxDebris`) must be positive (`0x00702291`).
-/// 3. `RandomRanged(MinDebris, MaxDebris - 1)` at `0x007022C8`. Note the `DEC
-///    EDI` at `0x007022AD`: the range's top is one BELOW `MaxDebris`, not equal
-///    to it, so `MaxDebris=1` can only ever yield the `MinDebris` end.
-/// 4. The `DebrisTypes` vector count (`TechnoType+0x324`) must be positive, and
-///    the budget must be positive (`0x007022EA`, `0x007022F8`).
-/// 5. For each entry, in list order: one `Random__Next()`, then
-///    `count = min(|next| % (DebrisMaximums[i] + 1), budget)`.
+/// Mirrors [`SimRng::next_raw_abs_modulo`] exactly; it is spelled out here
+/// because the constructor takes all four draws BEFORE any divisor exists, so
+/// the draw and its remainder cannot be one call.
 ///
-/// The budget is a PER-ENTRY CAP, not a pool that drains. `CMP EDX,EBX` at
-/// `0x0070233B` compares against the same `EBX` every iteration, and the
-/// `[ESP+0x14]` save/restore around the loop exists only because
-/// `MOV EBX,EAX` at `0x0070235B` clobbers the register with the freshly
-/// allocated object — nothing ever subtracts from it. A type listing two
-/// debris entries can therefore throw up to twice the budget.
-///
-/// `debris_maximums` is positionally paired with `debris_types`.
-pub fn debris_spawn_counts(
-    debris_type_count: usize,
-    debris_maximums: &[i32],
-    min_debris: i32,
-    max_debris: i32,
-    rng: &mut crate::sim::rng::SimRng,
-) -> Vec<i32> {
-    if max_debris <= 0 || debris_type_count == 0 {
-        return Vec::new();
+/// VERA-internal, gamemd equivalent UNCHECKED: a zero divisor returns 0 where
+/// native's `IDIV` raises a divide error. It needs `MaxXYVel` under 0.5, or a
+/// `MaxZVel` below `MinZVel - 1`; every stock `[VoxelAnims]` section authors
+/// `MaxXYVel` at 10 or above, so this is unreachable in stock.
+fn raw_abs_modulo(draw: u32, divisor: i32) -> i32 {
+    if divisor == 0 {
+        return 0;
     }
-    // `RandomRanged(MinDebris, MaxDebris - 1)`. The helper sorts reversed
-    // bounds and consumes no draw when they are equal, matching native's own
-    // `RandomRanged`.
-    let low = min_debris.max(0) as u32;
-    let high = (max_debris - 1).max(0) as u32;
-    let budget = rng.next_range_u32_inclusive(low, high) as i32;
-    if budget <= 0 {
-        return Vec::new();
+    ((draw as i32) % divisor).abs()
+}
+
+/// `VoxelAnimClass::Constructor @ 0x007493B0`, the ordinary (non-`IsMeteor`)
+/// arm at `0x007494F0`..`0x00749663` — the one a death's `DebrisTypes=` takes.
+///
+/// Seven draws, in this exact order, all on the shared scenario stream
+/// (`[0x00A8B230] + 0x218`):
+/// - four `Random__Next()` at `0x0074951D`, `0x00749531`, `0x00749544`,
+///   `0x00749559`, then
+/// - three `RandomRanged(-0xFFFF, 0xFFFF)` inside [`BounceState::init`].
+///
+/// The four raw draws are taken up front and only then divided, so the divisors
+/// are computed between the draws and the remainders. Reading the decompile's
+/// variable order instead would pair the wrong draw with the wrong axis; the
+/// pairing below is from the `FILD`/`FSUB`/`FSTP` ladder at
+/// `0x0074958D`..`0x007495FA`:
+/// - draw 1 -> the spin angle: `|d| % ftol(MaxAngularVelocity - MinAngularVelocity + 1.0) + MinAngularVelocity`
+/// - draw 2 -> `Velocity.Z`: `|d| % ftol(MaxZVel - MinZVel + 1.0) + MinZVel`
+/// - draw 3 -> `Velocity.Y`: `|d| % ftol(MaxXYVel + MaxXYVel) - MaxXYVel`
+/// - draw 4 -> `Velocity.X`, same form as Y and the SAME divisor, which the
+///   function saves in `[ESP+0x14]` rather than recomputing.
+///
+/// The velocity triple is written to the stack as `[X, Y, Z]` at `[ESP+0x1C]`,
+/// `[ESP+0x20]`, `[ESP+0x24]` and that address is what `Init` receives, so the
+/// Y component is the one from the THIRD draw even though its store comes last.
+pub fn spawn_debris_piece(
+    stable_id: u64,
+    type_id: VoxelAnimTypeId,
+    voxel_anim_type: &VoxelAnimType,
+    owner_house: Option<InternedId>,
+    origin: IVec3,
+    rng: &mut SimRng,
+) -> Result<VoxelAnimObject, NativeX87Error> {
+    let start = IVec3::new(
+        origin.x,
+        origin.y,
+        origin.z.saturating_add(LAUNCH_Z_OFFSET_LEPTONS),
+    );
+
+    let angular_draw = rng.next_u32();
+    let z_draw = rng.next_u32();
+    let y_draw = rng.next_u32();
+    let x_draw = rng.next_u32();
+
+    let max_xy = X87Chop53::load_f64(voxel_anim_type.max_xy_vel)?;
+    let xy_divisor = X87Chop53::ftol_i64(X87Chop53::add(max_xy, max_xy))? as i32;
+    let bias = X87Chop53::load_f64(INCLUSIVE_RANGE_BIAS)?;
+
+    let velocity_y = X87Chop53::store_f32(X87Chop53::sub(
+        X87Chop53::load_i32(raw_abs_modulo(y_draw, xy_divisor)),
+        X87Chop53::load_f64(voxel_anim_type.max_xy_vel)?,
+    ))?;
+    let z_divisor = X87Chop53::ftol_i64(X87Chop53::add(
+        X87Chop53::sub(
+            X87Chop53::load_f64(voxel_anim_type.max_z_vel)?,
+            X87Chop53::load_f64(voxel_anim_type.min_z_vel)?,
+        ),
+        bias,
+    ))? as i32;
+    let velocity_z = X87Chop53::store_f32(X87Chop53::add(
+        X87Chop53::load_i32(raw_abs_modulo(z_draw, z_divisor)),
+        X87Chop53::load_f64(voxel_anim_type.min_z_vel)?,
+    ))?;
+    let velocity_x = X87Chop53::store_f32(X87Chop53::sub(
+        X87Chop53::load_i32(raw_abs_modulo(x_draw, xy_divisor)),
+        X87Chop53::load_f64(voxel_anim_type.max_xy_vel)?,
+    ))?;
+    let angular_divisor = X87Chop53::ftol_i64(X87Chop53::add(
+        X87Chop53::sub(
+            X87Chop53::load_f64(voxel_anim_type.max_angular_velocity)?,
+            X87Chop53::load_f64(voxel_anim_type.min_angular_velocity)?,
+        ),
+        bias,
+    ))? as i32;
+    let rotation_angle_per_tick = X87Chop53::store_f64(X87Chop53::add(
+        X87Chop53::load_i32(raw_abs_modulo(angular_draw, angular_divisor)),
+        X87Chop53::load_f64(voxel_anim_type.min_angular_velocity)?,
+    ))?;
+
+    let bounce = BounceState::init(
+        start,
+        voxel_anim_type.elasticity,
+        DEBRIS_GRAVITY,
+        NativeF64Bits::POSITIVE_ZERO,
+        [velocity_x, velocity_y, velocity_z],
+        rotation_angle_per_tick,
+        rng,
+    )?;
+
+    Ok(VoxelAnimObject {
+        stable_id,
+        type_id,
+        duration: voxel_anim_type.duration,
+        marked_for_deletion: false,
+        owner_house,
+        bounce,
+        in_logic_vector: false,
+    })
+}
+
+/// What one `VoxelAnimClass::AI` visit asks the world to do after it returns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VoxelAnimAiOutcome {
+    /// Still flying. The object stays in the store and in the LogicVector.
+    Alive,
+    /// The AI reached `vtable+0xF8` (`Delete`). The world retires the object.
+    Delete,
+}
+
+/// One `VoxelAnimClass::AI @ 0x00749F30` visit for the debris arm.
+///
+/// The verified order:
+/// 1. `StopSound` (`+0x2DC`) looping-sound maintenance.
+/// 2. `marked_for_deletion` (`+0x110`) -> `Delete`, return.
+/// 3. `if (duration != 0) duration -= 1` — the decrement is unconditional on
+///    the sign, so a negative duration walks further negative.
+/// 4. `duration > 0`: the `TrailerAnim=` arm on even frames, then
+///    `BounceClass::Update`, then the `IsMeteor` extra gravity, then the
+///    contact arms; a `Bounced` on WATER sets `duration = 0` instead of playing
+///    the `BounceAnim=`, and a `Stopped` sets `duration = 0` outright.
+/// 5. Otherwise the expiry arm, ending in `Delete`.
+///
+/// RESIDUAL (GSI-05.14) — three arms of the native AI are not built here:
+/// - The `BounceAnim=`/`ExpireAnim=`/`TrailerAnim=` `AnimClass` spawns and the
+///   expiry `Apply_area_damage` (`+0x2F0`/`+0x2F4`/`+0x2F8`). Every stock
+///   `DebrisTypes=` line names `[TIRE]`, which authors none of the four keys,
+///   so the death-debris path never reaches any of them in stock; `[PIECE]` and
+///   `[GASTANK]` carry `Damage=`/`ExpireAnim=` but no stock section throws
+///   them. Trigger: a mod pointing `DebrisTypes=` at a damaging type. Player
+///   effect: that debris would leave no puff and do no splash damage.
+///   Frequency: zero in stock skirmish. Downstream risk: the damage arm would
+///   need the combat AoE transaction, so wiring it belongs with that owner.
+/// - The `IsMeteor` arms — the extra per-tick gravity add at `+0xDC`, the
+///   `Spawns=`/`SpawnCount=` child burst (two `RandomRanged(0, SpawnCount)`
+///   draws, summed), and the `IsTiberium` ore-laying ring. `IsMeteor` types
+///   reach the field through scenario meteor storms, never through a death.
+///   Frequency: zero on this path.
+/// - The water splash pair at expiry (`Rules+0x94`, `Rules+0xBC4`). Trigger:
+///   debris expiring over water while below the deck. Player effect: no splash
+///   ring. Frequency: only when a piece scatters off a shoreline.
+pub fn voxel_anim_ai(
+    object: &mut VoxelAnimObject,
+    terrain: &dyn BounceTerrain,
+) -> Result<VoxelAnimAiOutcome, NativeX87Error> {
+    if object.marked_for_deletion {
+        return Ok(VoxelAnimAiOutcome::Delete);
+    }
+    if object.duration != 0 {
+        object.duration -= 1;
+    }
+    if object.duration <= 0 {
+        return Ok(VoxelAnimAiOutcome::Delete);
     }
 
-    (0..debris_type_count)
-        .map(|index| {
+    match object.bounce.update(terrain)? {
+        BounceOutcome::Falling => {}
+        BounceOutcome::Bounced => {
+            // Native distinguishes a water landing here and kills the piece
+            // instead of playing its `BounceAnim=`; the anim itself is the
+            // residual above, the `duration = 0` is not.
+            if terrain.is_water(object.world_coord()) {
+                object.duration = 0;
+            }
+        }
+        BounceOutcome::Stopped => object.duration = 0,
+    }
+    Ok(VoxelAnimAiOutcome::Alive)
+}
+
+//// Which list the SHP half of the death block draws its anim from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShpDebrisSource {
+    /// `TechnoType+0x5C4` — the section's own `DebrisAnims=`.
+    TypeDebrisAnims,
+    /// `RulesClass+0x140` / `+0x14C` — `[General] MetallicDebris=`.
+    RulesMetallicDebris,
+}
+
+/// One `VoxelAnimClass` the death block asks the world to construct.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VoxelDebrisSpawn {
+    pub type_id: VoxelAnimTypeId,
+    /// Everything the constructor and `BounceClass::Init` already decided; the
+    /// world only assigns the shared object id.
+    pub object: VoxelAnimObject,
+}
+
+/// One SHP debris anim the death block asks the world to construct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ShpDebrisSpawn {
+    /// Index into the source list the row names.
+    pub index: usize,
+    pub source: ShpDebrisSource,
+}
+
+/// Everything one death throws, in native emission order.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct DeathDebris {
+    pub voxels: Vec<VoxelDebrisSpawn>,
+    pub anims: Vec<ShpDebrisSpawn>,
+}
+
+impl DeathDebris {
+    pub fn is_empty(&self) -> bool {
+        self.voxels.is_empty() && self.anims.is_empty()
+    }
+}
+
+/// The inputs the debris block reads off the dying object's `TechnoTypeClass`.
+pub struct DebrisTypeData<'a> {
+    /// `+0x5BC`.
+    pub max_debris: i32,
+    /// `+0x5C0`.
+    pub min_debris: i32,
+    /// `+0x314` vector, count at `+0x324`. Resolved entries in list order; an
+    /// entry naming a `[VoxelAnims]` section that does not exist is `None`.
+    /// Native resolves the names once at rules-load time and stores pointers,
+    /// so an unresolvable name would be a null slot there too.
+    pub debris_types: &'a [Option<(VoxelAnimTypeId, &'a VoxelAnimType)>],
+    /// `+0x330` vector, positionally paired with `debris_types`.
+    pub debris_maximums: &'a [i32],
+    /// `+0x5C4` vector, count at `+0x5D4`.
+    pub debris_anim_count: usize,
+    /// `RulesClass+0x14C`.
+    pub metallic_debris_count: usize,
+}
+
+/// VERA-internal, gamemd equivalent UNCHECKED: the ceiling on the drain loop.
+///
+/// Native's loop is `while (0 < budget)` and only the per-entry count drains
+/// it, so a `DebrisMaximums=` list of all zeros gives a divisor of 1, a
+/// remainder that is always 0, and an infinite loop — gamemd hangs. Every stock
+/// `DebrisMaximums=` line is 4 or 6, so the divisor is never 1 and the loop is
+/// geometric; this bound only stops a mod from freezing the tick. It sits far
+/// above any reachable iteration count for a stock budget (`MaxDebris` tops out
+/// at 15 in stock rules).
+const DEBRIS_LOOP_ITERATION_CEILING: u32 = 4096;
+
+/// The whole debris block of `TechnoClass::ReceiveDamage @ 0x00701900`, read
+/// from the disassembly at `0x00702281`..`0x0070256C`.
+///
+/// The gates and the draws, in native order:
+/// 1. `MapClass::Get_CellClass_At_Coord` on the death cell, then
+///    `CMP [cell+0xEC], 2 / JZ 0x00702672` at `0x00702274` — a unit dying on
+///    WATER throws no debris at all and takes no draw. That gate is the
+///    caller's: it is itself guarded by `vtable+0x1C8 < 0xB` and the object's
+///    `+0x8F`, which this function does not model.
+/// 2. `TechnoType+0x5BC` (`MaxDebris`) must be positive (`0x00702291`). Below
+///    that the block is skipped whole and the shared stream is untouched.
+/// 3. `budget = RandomRanged(MinDebris, MaxDebris - 1)` at `0x007022C8`. The
+///    `DEC EDI` at `0x007022AD` is why the top is one BELOW `MaxDebris`, so
+///    `MaxDebris=1` can only ever yield the `MinDebris` end. 254 stock sections
+///    author `MaxDebris=` with no `MinDebris=`, so their budget is
+///    `RandomRanged(0, MaxDebris - 1)` and can come out zero.
+/// 4. The voxel loop, entered only when `DebrisTypes.Count > 0` (`+0x324`,
+///    `0x007022EA`) AND `budget > 0` (`0x007022F8`). Per iteration:
+///    - one `Random__Next()` at `0x0070232B`, then
+///      `count = |next| % (DebrisMaximums[index] + 1)` (`0x00702339`);
+///    - `if (count >= budget) count = budget` (`0x0070233B`);
+///    - `count` constructions of `DebrisTypes[index]`, each taking the seven
+///      draws in [`spawn_debris_piece`];
+///    - **`budget -= count`** — `SUB EBX,EAX` at `0x007023B5`, with `EBX`
+///      reloaded from `[ESP+0x14]` at `0x007023A7` because the spawn loop's
+///      `MOV EBX,EAX` at `0x0070235B` clobbers it. The budget is a POOL THAT
+///      DRAINS, not a per-entry cap;
+///    - `index += 1`, wrapping to 0 once it reaches `DebrisTypes.Count`
+///      (`0x007023D3`), and the loop repeats while `budget > 0`
+///      (`0x007023DF`). So a type with two debris entries cycles the list until
+///      the pool is spent, and the total thrown is exactly the budget.
+/// 5. The SHP arms, on whatever budget survives. Since step 4 exits only at
+///    `budget <= 0`, a type that lists `DebrisTypes=` never reaches them:
+///    - `DebrisAnims.Count > 0` (`+0x5D4`, `0x007023FC`) and `budget > 0`:
+///      `budget` anims, each taking one `RandomRanged(0, count - 1)` at
+///      `0x00702473`;
+///    - otherwise `DebrisTypes.Count == 0` (`0x007024D2`) and `budget > 0`:
+///      `budget` anims from `[General] MetallicDebris=`, each taking one
+///      `RandomRanged(0, RulesClass+0x14C - 1)` at `0x0070253A`.
+///
+/// That last arm is the one players see most: 254 stock sections carry
+/// `MaxDebris=` alone, 166 carry it with `DebrisAnims=`, and only 36 name
+/// `DebrisTypes=`.
+pub fn throw_death_debris(
+    data: &DebrisTypeData<'_>,
+    owner_house: Option<InternedId>,
+    origin: IVec3,
+    rng: &mut SimRng,
+) -> Result<DeathDebris, NativeX87Error> {
+    let mut out = DeathDebris::default();
+    if data.max_debris <= 0 {
+        return Ok(out);
+    }
+    // `Random__RandomRanged` sorts reversed bounds and consumes no draw when
+    // they coincide; `next_range_i32_inclusive` models that helper directly.
+    // The signed form is the right one because a `MinDebris=` above
+    // `MaxDebris - 1` is authored by stock buildings (`MinDebris=4`,
+    // `MaxDebris=6` gives 4..5, but `MinDebris=7`/`MaxDebris=15` gives 7..14)
+    // and an unsigned read of a negative top would invent a huge span.
+    let mut budget = rng.next_range_i32_inclusive(data.min_debris, data.max_debris - 1);
+
+    if !data.debris_types.is_empty() && budget > 0 {
+        let mut index = 0usize;
+        let mut iterations = 0u32;
+        loop {
             // VERA-internal, gamemd equivalent UNCHECKED: a `DebrisMaximums`
             // entry this list does not have is treated as 0, where native reads
             // past the vector's end. Stock authors the two lists at equal
             // length — 36 sections, each `DebrisTypes=TIRE` with one maximum —
             // so this is unreachable in stock.
-            let maximum = debris_maximums.get(index).copied().unwrap_or(0);
+            let maximum = data.debris_maximums.get(index).copied().unwrap_or(0);
             let divisor = maximum.saturating_add(1).max(1) as u32;
-            let drawn = rng.next_raw_abs_modulo(divisor) as i32;
-            drawn.min(budget)
-        })
-        .collect()
+            let mut count = rng.next_raw_abs_modulo(divisor) as i32;
+            if count >= budget {
+                count = budget;
+            }
+            if count > 0
+                && let Some((type_id, voxel_type)) = data.debris_types[index]
+            {
+                for _ in 0..count {
+                    out.voxels.push(VoxelDebrisSpawn {
+                        type_id,
+                        object: spawn_debris_piece(
+                            UNASSIGNED_STABLE_ID,
+                            type_id,
+                            voxel_type,
+                            owner_house,
+                            origin,
+                            rng,
+                        )?,
+                    });
+                }
+            }
+            budget -= count;
+            index += 1;
+            if index >= data.debris_types.len() {
+                index = 0;
+            }
+            iterations += 1;
+            if budget <= 0 || iterations >= DEBRIS_LOOP_ITERATION_CEILING {
+                break;
+            }
+        }
+    }
+
+    if data.debris_anim_count > 0 {
+        for _ in 0..budget.max(0) {
+            let index = rng.next_range_i32_inclusive(0, data.debris_anim_count as i32 - 1) as usize;
+            out.anims.push(ShpDebrisSpawn {
+                index,
+                source: ShpDebrisSource::TypeDebrisAnims,
+            });
+        }
+    } else if data.debris_types.is_empty() && data.metallic_debris_count > 0 {
+        for _ in 0..budget.max(0) {
+            let index =
+                rng.next_range_i32_inclusive(0, data.metallic_debris_count as i32 - 1) as usize;
+            out.anims.push(ShpDebrisSpawn {
+                index,
+                source: ShpDebrisSource::RulesMetallicDebris,
+            });
+        }
+    }
+
+    Ok(out)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rules::voxel_anim_type::VoxelAnimType;
     use crate::sim::rng::SimRng;
+
+    /// A `[VoxelAnims]` section with the stock `[TIRE]` numbers, which is the
+    /// only type any stock `DebrisTypes=` line names.
+    fn tire() -> VoxelAnimType {
+        let ini = crate::rules::ini_parser::IniFile::from_str(
+            "[TIRE]\nElasticity=0.8\nMinAngularVelocity=12.0\nMaxAngularVelocity=24.0\n\
+             MinZVel=28.0\nMaxZVel=32.0\nMaxXYVel=10.0\nDuration=150\n",
+        );
+        VoxelAnimType::from_ini_section("TIRE", ini.section("TIRE").unwrap())
+    }
+
+    fn data<'a>(
+        max_debris: i32,
+        min_debris: i32,
+        debris_types: &'a [Option<(VoxelAnimTypeId, &'a VoxelAnimType)>],
+        debris_maximums: &'a [i32],
+        debris_anim_count: usize,
+        metallic_debris_count: usize,
+    ) -> DebrisTypeData<'a> {
+        DebrisTypeData {
+            max_debris,
+            min_debris,
+            debris_types,
+            debris_maximums,
+            debris_anim_count,
+            metallic_debris_count,
+        }
+    }
+
+    fn throw(input: &DebrisTypeData<'_>, rng: &mut SimRng) -> DeathDebris {
+        throw_death_debris(input, None, IVec3::new(1280, 2560, 0), rng)
+            .expect("the debris block stays inside the verified x87 domain")
+    }
 
     #[test]
     fn gsi_05_14_no_debris_without_a_positive_maxdebris_and_no_draw_taken() {
         // `TEST ECX,ECX / JLE` at `0x00702291` sits BEFORE the budget draw, so
         // a type with no `MaxDebris=` costs the shared stream nothing.
+        let voxel_type = tire();
+        let types = [Some((VoxelAnimTypeId(0), &voxel_type))];
+        let input = data(0, 0, &types, &[3], 6, 20);
         let mut rng = SimRng::new(11);
-        let counts = debris_spawn_counts(1, &[3], 0, 0, &mut rng);
-        assert!(counts.is_empty());
-        assert_eq!(rng.logical_view(), SimRng::new(11).logical_view());
-
-        // Same for a type that authors debris counts but lists no types.
-        let mut rng = SimRng::new(11);
-        let counts = debris_spawn_counts(0, &[], 2, 9, &mut rng);
-        assert!(counts.is_empty());
+        assert!(throw(&input, &mut rng).is_empty());
         assert_eq!(rng.logical_view(), SimRng::new(11).logical_view());
     }
 
     #[test]
     fn gsi_05_14_budget_range_stops_one_below_maxdebris() {
         // `DEC EDI` at `0x007022AD` — the range is [MinDebris, MaxDebris - 1].
-        // With MinDebris == MaxDebris - 1 the two bounds coincide, and the
-        // helper (like native's RandomRanged) then consumes no draw at all, so
-        // the budget is exactly that value and every later draw is the entry's.
+        // With MinDebris == MaxDebris - 1 the two bounds coincide and the
+        // helper (like native's RandomRanged) consumes no draw, so the budget
+        // is exactly that value and every later draw belongs to an entry.
+        let input = data(5, 4, &[], &[], 0, 20);
         let mut rng = SimRng::new(5);
-        let counts = debris_spawn_counts(1, &[0], 4, 5, &mut rng);
-        // DebrisMaximums[0] = 0 gives a divisor of 1, so the entry draw is
-        // taken and always yields 0.
-        assert_eq!(counts, vec![0]);
-        let mut expected = SimRng::new(5);
-        expected.next_raw_abs_modulo(1);
-        assert_eq!(rng.logical_view(), expected.logical_view());
-    }
-
-    #[test]
-    fn gsi_05_14_budget_caps_each_entry_independently_rather_than_draining() {
-        // The load-bearing correction: `CMP EDX,EBX` at `0x0070233B` compares
-        // against the same budget every iteration. Two entries can therefore
-        // each reach the cap, for twice the budget in total — a pool that
-        // drained would give at most the budget across both.
-        //
-        // MinDebris == MaxDebris - 1 == 1 pins the budget at 1 with no draw;
-        // each entry then draws `|next| % 6` and clamps to 1.
-        let mut rng = SimRng::new(2024);
-        let counts = debris_spawn_counts(2, &[5, 5], 1, 2, &mut rng);
-        assert_eq!(counts.len(), 2);
-        assert!(counts.iter().all(|&n| (0..=1).contains(&n)));
-
-        // Exactly two draws, one per entry — the second is taken even if the
-        // first already consumed the whole budget.
-        let mut expected = SimRng::new(2024);
-        expected.next_raw_abs_modulo(6);
-        expected.next_raw_abs_modulo(6);
-        assert_eq!(rng.logical_view(), expected.logical_view());
-
-        // And the pool reading would be observably different: search seeds for
-        // a case where both entries want the cap. With the pool reading the
-        // second would be forced to 0.
-        let both_at_cap = (0..500u64).any(|seed| {
-            let mut rng = SimRng::new(seed);
-            debris_spawn_counts(2, &[5, 5], 1, 2, &mut rng) == vec![1, 1]
-        });
+        let thrown = throw(&input, &mut rng);
+        // No DebrisTypes and no DebrisAnims: the whole budget goes to the
+        // `[General] MetallicDebris=` arm, one RandomRanged draw each.
+        assert_eq!(thrown.anims.len(), 4);
+        assert!(thrown.voxels.is_empty());
         assert!(
-            both_at_cap,
-            "a per-entry cap must be able to produce [1, 1]; a draining pool never could"
+            thrown
+                .anims
+                .iter()
+                .all(|row| row.source == ShpDebrisSource::RulesMetallicDebris)
         );
     }
 
     #[test]
-    fn gsi_05_14_entry_count_is_bounded_by_its_own_debris_maximum() {
-        // `|next| % (DebrisMaximums[i] + 1)` — inclusive of the maximum.
-        for seed in 0..200u64 {
+    fn gsi_05_14_the_voxel_budget_drains_and_the_type_index_wraps() {
+        // The load-bearing correction to the earlier reading of this block.
+        // `SUB EBX,EAX` at `0x007023B5` subtracts the spent count from the
+        // budget, and `CMP EDI,ECX / JL` at `0x007023D3` wraps the type index,
+        // so the loop cycles the list until the pool is empty and the TOTAL
+        // thrown is exactly the budget. The rejected reading — a per-entry cap
+        // that never drains — would let two entries each reach the cap and
+        // throw up to twice the budget.
+        let voxel_type = tire();
+        let types = [
+            Some((VoxelAnimTypeId(0), &voxel_type)),
+            Some((VoxelAnimTypeId(0), &voxel_type)),
+        ];
+        for seed in 0..64u64 {
+            let input = data(7, 6, &types, &[5, 5], 0, 20);
             let mut rng = SimRng::new(seed);
-            let counts = debris_spawn_counts(1, &[3], 9, 10, &mut rng);
-            assert_eq!(counts.len(), 1);
+            let thrown = throw(&input, &mut rng);
+            assert_eq!(
+                thrown.voxels.len(),
+                6,
+                "seed {seed}: the pool drains to exactly the budget"
+            );
             assert!(
-                (0..=3).contains(&counts[0]),
-                "seed {seed} produced {} for DebrisMaximums=3",
-                counts[0]
+                thrown.anims.is_empty(),
+                "a type that lists DebrisTypes= spends the whole budget and never reaches the SHP arms"
             );
         }
+    }
+
+    #[test]
+    fn gsi_05_14_each_voxel_piece_costs_exactly_seven_draws() {
+        // Four `Random__Next()` in `VoxelAnimClass::Constructor` plus three
+        // `RandomRanged(-0xFFFF, 0xFFFF)` in `BounceClass::Init`. The count is
+        // the lockstep contract: a miscount desyncs every later consumer in the
+        // same tick.
+        let voxel_type = tire();
+        let types = [Some((VoxelAnimTypeId(0), &voxel_type))];
+        let input = data(4, 3, &types, &[9], 0, 20);
+        let mut rng = SimRng::new(2024);
+        let thrown = throw(&input, &mut rng);
+        assert_eq!(thrown.voxels.len(), 3);
+
+        // The budget bounds coincide, so it costs no draw. The loop then takes
+        // one count draw per iteration; with DebrisMaximums=9 and a budget of
+        // 3 the first iteration can already spend the pool.
+        let mut expected = SimRng::new(2024);
+        let mut spawned = 0;
+        while spawned < 3 {
+            let count = (expected.next_raw_abs_modulo(10) as i32).min(3 - spawned);
+            for _ in 0..count {
+                for _ in 0..4 {
+                    expected.next_u32();
+                }
+                for _ in 0..3 {
+                    expected.next_range_u32_inclusive(0, (0xFFFF - -0xFFFF) as u32);
+                }
+            }
+            spawned += count;
+        }
+        assert_eq!(rng.logical_view(), expected.logical_view());
+    }
+
+    #[test]
+    fn gsi_05_14_debris_anims_win_over_the_rules_metallic_list() {
+        // `0x007023FC` tests `DebrisAnims.Count` first; only a type with an
+        // EMPTY list AND no `DebrisTypes=` falls through to `RulesClass+0x140`
+        // at `0x0070252D`. 166 stock building sections take the first arm and
+        // 254 vehicle sections the second.
+        let input = data(9, 7, &[], &[], 6, 20);
+        let mut rng = SimRng::new(31);
+        let thrown = throw(&input, &mut rng);
+        assert!(!thrown.anims.is_empty());
+        assert!(
+            thrown
+                .anims
+                .iter()
+                .all(|row| row.source == ShpDebrisSource::TypeDebrisAnims && row.index < 6)
+        );
+    }
+
+    #[test]
+    fn gsi_05_14_a_type_with_debris_anims_but_debris_types_throws_no_shp() {
+        // The voxel loop exits only at `budget <= 0`, so both SHP arms see a
+        // spent pool. `[HARV]` is the stock case: `MaxDebris=6`,
+        // `DebrisTypes=TIRE`, no `DebrisAnims=`.
+        let voxel_type = tire();
+        let types = [Some((VoxelAnimTypeId(0), &voxel_type))];
+        let input = data(6, 5, &types, &[4], 6, 20);
+        let mut rng = SimRng::new(77);
+        let thrown = throw(&input, &mut rng);
+        assert_eq!(thrown.voxels.len(), 5);
+        assert!(thrown.anims.is_empty());
+    }
+
+    #[test]
+    fn gsi_05_14_launch_velocity_pairs_each_draw_with_the_axis_native_pairs() {
+        // Draw 3 feeds Y and draw 4 feeds X, both through
+        // `|d| % ftol(2 * MaxXYVel) - MaxXYVel`; draw 2 feeds Z through
+        // `|d| % ftol(MaxZVel - MinZVel + 1) + MinZVel`. Swapping X and Y (the
+        // natural mistake, because native stores Y last) would mirror every
+        // piece's scatter across the diagonal.
+        let voxel_type = tire();
+        let mut rng = SimRng::new(9);
+        let mut expected = SimRng::new(9);
+        let (d1, d2, d3, d4) = (
+            expected.next_u32(),
+            expected.next_u32(),
+            expected.next_u32(),
+            expected.next_u32(),
+        );
+        let piece = spawn_debris_piece(
+            7,
+            VoxelAnimTypeId(0),
+            &voxel_type,
+            None,
+            IVec3::new(0, 0, 0),
+            &mut rng,
+        )
+        .expect("in domain");
+        let velocity = piece.bounce.velocity_f32();
+        // MaxXYVel = 10.0 -> divisor 20, offset -10. MaxZVel - MinZVel + 1 = 5.
+        assert_eq!(velocity[0], ((d4 as i32) % 20).abs() as f32 - 10.0);
+        assert_eq!(velocity[1], ((d3 as i32) % 20).abs() as f32 - 10.0);
+        assert_eq!(velocity[2], ((d2 as i32) % 5).abs() as f32 + 28.0);
+        // MaxAngularVelocity - MinAngularVelocity is 24deg - 12deg = 0.209 rad,
+        // so the +1.0 bias leaves a divisor of 1 and the spin is always the
+        // MinAngularVelocity end whatever the draw. Reading the keys as degrees
+        // would give a divisor of 13 and a spin band that actually varies.
+        let _ = d1;
+        assert_eq!(
+            f64::from_bits(piece.bounce.spin_angle.bits()),
+            f64::from_bits(voxel_type.min_angular_velocity.bits())
+        );
+        assert_eq!(piece.duration, 150);
+        assert_eq!(piece.stable_id, 7);
+    }
+
+    #[test]
+    fn gsi_05_14_the_launch_point_is_ten_leptons_above_the_wreck() {
+        // `ADD EAX, 0xa` at `0x0074950C` — the constructor lifts the coordinate
+        // it got from `ObjectClass::GetCoords` before handing it to
+        // `BounceClass::Init`.
+        let mut rng = SimRng::new(4);
+        let piece = spawn_debris_piece(
+            1,
+            VoxelAnimTypeId(0),
+            &tire(),
+            None,
+            IVec3::new(1280, 2560, 96),
+            &mut rng,
+        )
+        .expect("in domain");
+        assert_eq!(piece.world_coord(), IVec3::new(1280, 2560, 106));
+    }
+
+    /// Flat ground at Z = 0 with no bridges, buildings or ramps — the terrain
+    /// the overwhelming majority of debris lands on.
+    struct FlatGround;
+
+    impl BounceTerrain for FlatGround {
+        fn ground_height_leptons(&self, _coord: IVec3) -> i32 {
+            0
+        }
+        fn is_bridge_cell(&self, _coord: IVec3) -> bool {
+            false
+        }
+        fn cell_height_level(&self, _coord: IVec3) -> i32 {
+            0
+        }
+        fn ramp(&self, _coord: IVec3) -> u8 {
+            0
+        }
+        fn has_bounce_surface(&self, _coord: IVec3) -> bool {
+            false
+        }
+        fn is_water(&self, _coord: IVec3) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn gsi_05_14_a_tire_flies_bounces_and_comes_to_rest_inside_its_duration() {
+        // The end-to-end physics check: `[TIRE]` launches at 28..32 leptons per
+        // tick upward with 1.4 gravity and `Elasticity=0.8`, so it must leave
+        // the ground, come back, bounce at least once, and stop through the
+        // `FUN_00439A10` magnitude test well inside its 150-tick `Duration=`.
+        let mut rng = SimRng::new(1234);
+        let mut piece = spawn_debris_piece(
+            1,
+            VoxelAnimTypeId(0),
+            &tire(),
+            None,
+            IVec3::new(1280, 2560, 0),
+            &mut rng,
+        )
+        .expect("in domain");
+        let ground = FlatGround;
+        let mut peak = piece.world_coord().z;
+        let mut bounces = 0;
+        let mut ticks_alive = 0;
+        for _ in 0..150 {
+            match voxel_anim_ai(&mut piece, &ground).expect("in domain") {
+                VoxelAnimAiOutcome::Alive => {}
+                VoxelAnimAiOutcome::Delete => break,
+            }
+            ticks_alive += 1;
+            peak = peak.max(piece.world_coord().z);
+            if piece.duration == 0 {
+                bounces += 1;
+                break;
+            }
+        }
+        assert!(peak > 100, "the tire should climb, peaked at {peak}");
+        assert!(
+            bounces > 0,
+            "the tire should settle rather than fly forever"
+        );
+        assert!(
+            ticks_alive < 150,
+            "it settled after {ticks_alive} ticks, inside its Duration"
+        );
+        // The AI zeroes the duration on a stop; the next visit deletes.
+        assert_eq!(
+            voxel_anim_ai(&mut piece, &ground).expect("in domain"),
+            VoxelAnimAiOutcome::Delete
+        );
+    }
+
+    #[test]
+    fn gsi_05_14_a_marked_piece_deletes_before_the_duration_decrement() {
+        // `+0x110` is tested at the top of the AI, above the decrement, so a
+        // marked object never spends another tick of its duration.
+        let mut rng = SimRng::new(3);
+        let mut piece =
+            spawn_debris_piece(1, VoxelAnimTypeId(0), &tire(), None, IVec3::ZERO, &mut rng)
+                .expect("in domain");
+        piece.marked_for_deletion = true;
+        assert_eq!(
+            voxel_anim_ai(&mut piece, &FlatGround).expect("in domain"),
+            VoxelAnimAiOutcome::Delete
+        );
+        assert_eq!(piece.duration, 150, "the decrement sits below the gate");
+    }
+
+    #[test]
+    fn gsi_05_14_debris_landing_in_water_dies_on_contact() {
+        // `CMP [cell+0xEC], 2` inside the AI's bounce arm sets `duration = 0`
+        // instead of playing the BounceAnim, so a piece that scatters off a
+        // shoreline sinks rather than skipping.
+        struct Water;
+        impl BounceTerrain for Water {
+            fn ground_height_leptons(&self, _coord: IVec3) -> i32 {
+                0
+            }
+            fn is_bridge_cell(&self, _coord: IVec3) -> bool {
+                false
+            }
+            fn cell_height_level(&self, _coord: IVec3) -> i32 {
+                0
+            }
+            fn ramp(&self, _coord: IVec3) -> u8 {
+                0
+            }
+            fn has_bounce_surface(&self, _coord: IVec3) -> bool {
+                false
+            }
+            fn is_water(&self, _coord: IVec3) -> bool {
+                true
+            }
+        }
+        let mut rng = SimRng::new(88);
+        let mut piece = spawn_debris_piece(
+            1,
+            VoxelAnimTypeId(0),
+            &tire(),
+            None,
+            IVec3::new(1280, 2560, 0),
+            &mut rng,
+        )
+        .expect("in domain");
+        let water = Water;
+        let mut outcome = VoxelAnimAiOutcome::Alive;
+        for _ in 0..150 {
+            outcome = voxel_anim_ai(&mut piece, &water).expect("in domain");
+            if outcome == VoxelAnimAiOutcome::Delete || piece.duration == 0 {
+                break;
+            }
+        }
+        assert!(
+            piece.duration == 0 || outcome == VoxelAnimAiOutcome::Delete,
+            "a water landing must end the piece"
+        );
     }
 }

--- a/src/sim/voxel_anim.rs
+++ b/src/sim/voxel_anim.rs
@@ -342,7 +342,7 @@ pub fn voxel_anim_ai(
     Ok(VoxelAnimAiOutcome::Alive)
 }
 
-//// Which list the SHP half of the death block draws its anim from.
+/// Which list the SHP half of the death block draws its anim from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ShpDebrisSource {
     /// `TechnoType+0x5C4` — the section's own `DebrisAnims=`.

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -1528,6 +1528,8 @@ impl Simulation {
     pub(crate) fn classify_object(&self, stable_id: u64) -> Option<ObjectKind> {
         if self.substrate.anims.contains_key(stable_id) {
             Some(ObjectKind::Anim)
+        } else if self.substrate.voxel_anims.contains_key(stable_id) {
+            Some(ObjectKind::VoxelAnim)
         } else if self.substrate.particle_systems.contains_key(stable_id) {
             Some(ObjectKind::ParticleSystem)
         } else if self.production.terrain_objects.contains_key(&stable_id) {
@@ -1553,6 +1555,11 @@ impl Simulation {
                 .anims
                 .get(stable_id)
                 .is_some_and(|anim| anim.in_logic_vector),
+            ObjectKind::VoxelAnim => self
+                .substrate
+                .voxel_anims
+                .get(stable_id)
+                .is_some_and(|debris| debris.in_logic_vector),
             ObjectKind::ParticleSystem => self
                 .substrate
                 .particle_systems
@@ -1587,6 +1594,11 @@ impl Simulation {
             ObjectKind::Anim => {
                 if let Some(anim) = self.substrate.anims.get_mut(stable_id) {
                     anim.in_logic_vector = member;
+                }
+            }
+            ObjectKind::VoxelAnim => {
+                if let Some(debris) = self.substrate.voxel_anims.get_mut(stable_id) {
+                    debris.in_logic_vector = member;
                 }
             }
             ObjectKind::ParticleSystem => {
@@ -1684,6 +1696,15 @@ impl Simulation {
 
     pub(crate) fn conceal_anim(&mut self, stable_id: u64) -> bool {
         self.unregister_logic_object(stable_id)
+    }
+
+    /// `ObjectClass::Unlimbo` inside `VoxelAnimClass::Constructor @ 0x007493B0`
+    /// reveals the piece, which is what puts it in the LogicClass vector.
+    pub(crate) fn reveal_voxel_anim(&mut self, stable_id: u64) -> bool {
+        if !self.substrate.voxel_anims.contains_key(stable_id) {
+            return false;
+        }
+        self.register_logic_object(stable_id)
     }
 
     pub(crate) fn reveal_particle_system(&mut self, stable_id: u64) -> bool {

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -3106,6 +3106,7 @@ impl Simulation {
             }
         }
 
+        self.admit_death_debris(std::mem::take(&mut effects.voxel_debris));
         for fx in &effects.explosion_effects {
             let frames = rules
                 .effect_frame_count(self.interner.resolve(fx.shp_name))
@@ -4529,6 +4530,11 @@ impl Simulation {
                         .is_some_and(|anim| anim.in_logic_vector)
                     || self
                         .substrate
+                        .voxel_anims
+                        .get(id)
+                        .is_some_and(|debris| debris.in_logic_vector)
+                    || self
+                        .substrate
                         .particle_systems
                         .get(id)
                         .is_some_and(|system| system.in_logic_vector)
@@ -4560,6 +4566,12 @@ impl Simulation {
             .iter()
             .filter(|(_, anim)| anim.in_logic_vector)
             .count();
+        let flagged_voxel_anims = self
+            .substrate
+            .voxel_anims
+            .iter()
+            .filter(|(_, debris)| debris.in_logic_vector)
+            .count();
         let flagged_particle_systems = self
             .substrate
             .particle_systems
@@ -4584,6 +4596,7 @@ impl Simulation {
             .count();
         let flagged = flagged_entities
             + flagged_anims
+            + flagged_voxel_anims
             + flagged_particle_systems
             + flagged_terrain
             + flagged_projectiles
@@ -4880,6 +4893,9 @@ impl Simulation {
         for anim in self.substrate.anims.values_mut() {
             anim.in_logic_vector = false;
         }
+        for debris in self.substrate.voxel_anims.values_mut() {
+            debris.in_logic_vector = false;
+        }
         for (_, system) in self.substrate.particle_systems.iter_mut() {
             system.in_logic_vector = false;
         }
@@ -4897,6 +4913,8 @@ impl Simulation {
                 e.in_logic_vector = true;
             } else if let Some(anim) = self.substrate.anims.get_mut(id) {
                 anim.in_logic_vector = true;
+            } else if let Some(debris) = self.substrate.voxel_anims.get_mut(id) {
+                debris.in_logic_vector = true;
             } else if let Some(system) = self.substrate.particle_systems.get_mut(id) {
                 system.in_logic_vector = true;
             } else if let Some(terrain) = self.production.terrain_objects.get_mut(&id) {
@@ -4908,6 +4926,28 @@ impl Simulation {
             }
         }
         self.substrate.logic.set_order_for_test(order);
+    }
+
+
+    /// Admit the `VoxelAnimClass` debris a death threw.
+    ///
+    /// gamemd-derived: `VoxelAnimClass::Constructor @ 0x007493B0` assigns the
+    /// shared unique id (`AbstractClass::AssignUniqueID`), appends to the
+    /// VoxelAnim registry, then `ObjectClass::Unlimbo` reveals the piece into
+    /// the LogicClass vector. The launch velocity and the physics body were
+    /// already built inside the combat transaction, which consumed the draws in
+    /// native order; only the identity and the registration happen here.
+    pub(crate) fn admit_death_debris(
+        &mut self,
+        spawns: Vec<crate::sim::voxel_anim::VoxelDebrisSpawn>,
+    ) {
+        for spawn in spawns {
+            let stable_id = self.allocate_stable_id();
+            let mut object = spawn.object;
+            object.stable_id = stable_id;
+            self.substrate.voxel_anims.insert(object);
+            self.reveal_voxel_anim(stable_id);
+        }
     }
 
     /// Increment owned count for the given owner when an entity spawns.
@@ -5302,6 +5342,9 @@ impl Simulation {
         for anim in self.substrate.anims.values_mut() {
             anim.in_logic_vector = false;
         }
+        for debris in self.substrate.voxel_anims.values_mut() {
+            debris.in_logic_vector = false;
+        }
         for (_, system) in self.substrate.particle_systems.iter_mut() {
             system.in_logic_vector = false;
         }
@@ -5319,6 +5362,8 @@ impl Simulation {
                 entity.in_logic_vector = true;
             } else if let Some(anim) = self.substrate.anims.get_mut(id) {
                 anim.in_logic_vector = true;
+            } else if let Some(debris) = self.substrate.voxel_anims.get_mut(id) {
+                debris.in_logic_vector = true;
             } else if let Some(system) = self.substrate.particle_systems.get_mut(id) {
                 system.in_logic_vector = true;
             } else if let Some(terrain) = self.production.terrain_objects.get_mut(&id) {
@@ -7497,7 +7542,7 @@ impl Simulation {
                 .map(|(&stable_id, _)| stable_id)
                 .collect::<BTreeSet<_>>();
             let fire_suppressed = tube_turn_owned_ids.clone();
-            let combat_result = self.tick_combat_with_fatal_lifecycle(
+            let mut combat_result = self.tick_combat_with_fatal_lifecycle(
                 rules,
                 overlay_registry,
                 tick_ms,
@@ -7654,6 +7699,7 @@ impl Simulation {
                     crate::sim::superweapon::refresh_super_weapons_for_owner(self, rules, owner_id);
                 }
             }
+            self.admit_death_debris(std::mem::take(&mut combat_result.voxel_debris));
             // Spawn explosion animations from combat deaths.
             for fx in &combat_result.explosion_effects {
                 let frames = rules

--- a/src/sim/world/substrate.rs
+++ b/src/sim/world/substrate.rs
@@ -22,6 +22,7 @@ use crate::sim::occupancy::{
     CellOccupationGrid, HiddenOccupationGrid, OccupancyGrid, RawCellOccupationGrid,
 };
 use crate::sim::particles::ParticleSystemStore;
+use crate::sim::voxel_anim::VoxelAnimStore;
 
 const FIRST_MULTIPLAYER_FEEDBACK_ANIM_ID: u64 = 1 << 63;
 
@@ -62,13 +63,15 @@ impl EnterOrderCounter {
 
 /// The object kinds the LogicVector registration/removal dispatch
 /// distinguishes (F13). Classification probes the stores in this fixed order:
-/// anims → particle systems → terrain objects → projectiles → waves →
-/// entities — the exact probe order the pre-consolidation dispatch used at
-/// every site. Object IDs are unique across stores (one monotonic
+/// anims → voxel anims → particle systems → terrain objects → projectiles →
+/// waves → entities — the pre-consolidation dispatch order with the
+/// `VoxelAnimClass` registry inserted next to the other ObjectClass registry it
+/// shares a death with. Object IDs are unique across stores (one monotonic
 /// `next_stable_object_id` namespace), so at most one store can match.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ObjectKind {
     Anim,
+    VoxelAnim,
     ParticleSystem,
     Terrain,
     Projectile,
@@ -122,6 +125,12 @@ pub(crate) struct ObjectSubstrate {
     /// LogicVector with entities.
     #[serde(default)]
     pub(crate) anims: AnimStore,
+    /// `VoxelAnimClass` registry — the flying VXL debris a death throws. Shares
+    /// the global object-ID namespace and the LogicVector with entities and
+    /// anims, exactly as native's `VoxelAnimClass::Constructor` does through
+    /// `AbstractClass::AssignUniqueID` and `ObjectClass::Unlimbo`.
+    #[serde(default)]
+    pub(crate) voxel_anims: VoxelAnimStore,
     /// Multiplayer click-feedback animations use a separate, sync-exempt
     /// registry and never enter the ordinary LogicVector.
     #[serde(skip)]
@@ -160,6 +169,7 @@ impl ObjectSubstrate {
             base_reservations: CellReservationGrid::new(),
             entities: EntityStore::new(),
             anims: AnimStore::default(),
+            voxel_anims: VoxelAnimStore::default(),
             multiplayer_feedback_anims: AnimStore::default(),
             next_multiplayer_feedback_anim_id: FIRST_MULTIPLAYER_FEEDBACK_ANIM_ID,
             multiplayer_feedback_pending_delete: Vec::new(),

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -194,6 +194,44 @@ impl Simulation {
         self.mission_host_promote(id, self.session.binary_frame, rules);
     }
 
+
+    /// One `VoxelAnimClass::AI @ 0x00749F30` LogicVector slot.
+    ///
+    /// The piece is taken out of the store for the visit so the integrator can
+    /// read the live terrain grid through `&self` while it mutates the body,
+    /// then reinserted at the same key — `BTreeMap` order is unchanged.
+    ///
+    /// A `Delete` verdict is native's `vtable+0xF8`. Native queues the free on
+    /// the deferred finalization list; here the object leaves the LogicVector
+    /// and the store in the same step, because nothing resolves debris by id
+    /// between the two points.
+    pub(crate) fn visit_voxel_anim(&mut self, id: u64) {
+        let Some(mut debris) = self.substrate.voxel_anims.remove(id) else {
+            return;
+        };
+        let outcome = {
+            let terrain = ResolvedBounceTerrain {
+                terrain: self.resolved_terrain.as_ref(),
+            };
+            crate::sim::voxel_anim::voxel_anim_ai(&mut debris, &terrain)
+        };
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                log::warn!("voxel debris {id} left the verified x87 domain: {error}");
+                crate::sim::voxel_anim::VoxelAnimAiOutcome::Delete
+            }
+        };
+        // Reinsert before the verdict is acted on: the LogicVector dispatch
+        // classifies by store membership, and native's object is likewise still
+        // registered when `vtable+0xF8` runs.
+        self.substrate.voxel_anims.insert(debris);
+        if outcome == crate::sim::voxel_anim::VoxelAnimAiOutcome::Delete {
+            self.unregister_non_entity_object(id);
+            self.substrate.voxel_anims.remove(id);
+        }
+    }
+
     /// Dispatch one current LogicVector slot. A finishing death sequence calls
     /// UnInit synchronously here, so compacting removal is visible before the
     /// scheduler increments its cursor.
@@ -207,6 +245,10 @@ impl Simulation {
             if let Some(rules) = rules {
                 self.visit_anim(id, rules, ctx.overlay_registry);
             }
+            return true;
+        }
+        if self.substrate.voxel_anims.contains_key(id) {
+            self.visit_voxel_anim(id);
             return true;
         }
         if self.substrate.particle_systems.contains_key(id) {
@@ -6413,3 +6455,83 @@ ConditionRedSparkingProbability=1.0\nConditionYellowSparkingProbability=1.0\n\n\
 #[cfg(test)]
 #[path = "techno_ai_veterancy_tests.rs"]
 mod veterancy_tests;
+
+/// `CellClass+0xEC` LandType WATER.
+const BOUNCE_WATER_LAND_TYPE: u8 = 2;
+/// `RecalcZoneType` classes the bounce surface lookup accepts: 2 = Wall,
+/// 5 = Building / TerrainObject.
+const BOUNCE_SURFACE_ZONE_WALL: u8 = 2;
+const BOUNCE_SURFACE_ZONE_BUILDING: u8 = 5;
+
+/// The map facts `BounceClass::Update @ 0x00439B00` looks up, bound to the
+/// live `ResolvedTerrainGrid`.
+///
+/// `sim/bounce.rs` stays a pure integrator; this is the world-side port.
+struct ResolvedBounceTerrain<'a> {
+    terrain: Option<&'a crate::map::resolved_terrain::ResolvedTerrainGrid>,
+}
+
+impl ResolvedBounceTerrain<'_> {
+    fn cell(
+        &self,
+        coord: glam::IVec3,
+    ) -> Option<&crate::map::resolved_terrain::ResolvedTerrainCell> {
+        let rx = u16::try_from(coord.x.div_euclid(256)).ok()?;
+        let ry = u16::try_from(coord.y.div_euclid(256)).ok()?;
+        self.terrain?.cell(rx, ry)
+    }
+}
+
+impl crate::sim::bounce::BounceTerrain for ResolvedBounceTerrain<'_> {
+    fn ground_height_leptons(&self, coord: glam::IVec3) -> i32 {
+        self.cell(coord)
+            .and_then(|cell| {
+                crate::util::lepton::ground_height_leptons(
+                    cell.level,
+                    cell.slope_type,
+                    coord.x,
+                    coord.y,
+                )
+                .ok()
+            })
+            .unwrap_or(0)
+    }
+
+    fn is_bridge_cell(&self, coord: glam::IVec3) -> bool {
+        self.cell(coord).is_some_and(|cell| cell.has_bridge_deck)
+    }
+
+    fn cell_height_level(&self, coord: glam::IVec3) -> i32 {
+        self.cell(coord).map_or(0, |cell| i32::from(cell.level))
+    }
+
+    fn ramp(&self, coord: glam::IVec3) -> u8 {
+        self.cell(coord).map_or(0, |cell| cell.slope_type)
+    }
+
+    fn has_bounce_surface(&self, coord: glam::IVec3) -> bool {
+        // Native does `Look_up_building_in_cell` and, failing that,
+        // `CellClass::IsWallConnectableInDirection(-1, -1)`. `RecalcZoneType`
+        // already classifies exactly those two occupants, and the occupancy
+        // lifecycle keeps a dynamic building footprint's byte current, so this
+        // reads the same two facts through the cached class.
+        //
+        // RESIDUAL (GSI-05.14) — native then rejects the surface when the
+        // building's `+0x80` virtual returns non-zero. That virtual was
+        // verified only to return a `char` whose non-zero value suppresses the
+        // bounce; which buildings set it is UNCHECKED, so debris bounces off
+        // every building roof here. Trigger: debris landing on a structure.
+        // Player effect: a chunk that should pass through rests on the roof.
+        // Frequency: bounded by `[TIRE]`'s scatter reaching a building cell.
+        // Downstream risk: none to the stream.
+        self.cell(coord).is_some_and(|cell| {
+            cell.zone_type == BOUNCE_SURFACE_ZONE_WALL
+                || cell.zone_type == BOUNCE_SURFACE_ZONE_BUILDING
+        })
+    }
+
+    fn is_water(&self, coord: glam::IVec3) -> bool {
+        self.cell(coord)
+            .is_some_and(|cell| cell.yr_cell_land_type == BOUNCE_WATER_LAND_TYPE)
+    }
+}

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -717,6 +717,7 @@ impl Simulation {
             include_disguise_detect_v117,
         );
         self.hash_anims(&mut hasher);
+        self.hash_voxel_anims(&mut hasher);
         self.hash_particle_systems(&mut hasher);
         self.session.fold_identity(&mut hasher);
 
@@ -1889,6 +1890,46 @@ impl Simulation {
         for (id, anim) in self.substrate.anims.iter() {
             id.hash(hasher);
             anim.hash(hasher);
+        }
+    }
+
+    /// `VoxelAnimClass` debris in stable-ID order.
+    ///
+    /// The physics body is authoritative simulation state, not a render cache:
+    /// `VoxelAnimClass::AI @ 0x00749F30` refreshes the object coordinate from it
+    /// every tick and reads its `Bounced`/`Stopped` verdict to decide when the
+    /// piece dies. The spin axis and angle fold too — they are drawn from the
+    /// shared stream by `BounceClass::Init`, so a divergence there is a
+    /// divergence in the stream itself, even though nothing in the physics
+    /// reads them back.
+    fn hash_voxel_anims(&self, hasher: &mut impl Hasher) {
+        // An empty store contributes NO bytes, the same convention
+        // `fold_raw_cell_occupation` uses. Debris exists only between a death
+        // and the moment the last piece expires, so hashing a length of zero on
+        // every other frame would move every established golden and every
+        // historical schema probe for a plumbing reason rather than a
+        // behavioural one — and would keep doing so at each future store.
+        if self.substrate.voxel_anims.is_empty() {
+            return;
+        }
+        b"voxel-anim-debris-v1".hash(hasher);
+        self.substrate.voxel_anims.len().hash(hasher);
+        for (id, debris) in self.substrate.voxel_anims.iter() {
+            id.hash(hasher);
+            debris.type_id.0.hash(hasher);
+            debris.duration.hash(hasher);
+            debris.marked_for_deletion.hash(hasher);
+            debris.owner_house.hash(hasher);
+            let bounce = &debris.bounce;
+            bounce.elasticity.bits().hash(hasher);
+            bounce.gravity.bits().hash(hasher);
+            bounce.angular_velocity_magnitude.bits().hash(hasher);
+            for axis in 0..3 {
+                bounce.position[axis].bits().hash(hasher);
+                bounce.velocity[axis].bits().hash(hasher);
+                bounce.spin_axis[axis].bits().hash(hasher);
+            }
+            bounce.spin_angle.bits().hash(hasher);
         }
     }
 }

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -1903,12 +1903,27 @@ impl Simulation {
     /// divergence in the stream itself, even though nothing in the physics
     /// reads them back.
     fn hash_voxel_anims(&self, hasher: &mut impl Hasher) {
-        // An empty store contributes NO bytes, the same convention
-        // `fold_raw_cell_occupation` uses. Debris exists only between a death
-        // and the moment the last piece expires, so hashing a length of zero on
-        // every other frame would move every established golden and every
-        // historical schema probe for a plumbing reason rather than a
-        // behavioural one — and would keep doing so at each future store.
+        // An empty store contributes NO bytes. Debris exists only between a
+        // death and the moment the last piece expires, so hashing a length of
+        // zero on every other frame would move every established golden and
+        // every historical schema probe for a plumbing reason rather than a
+        // behavioural one — and would keep doing so at each future store. It
+        // masks nothing: the fold is domain-separated by
+        // `b"voxel-anim-debris-v1"`, so an empty store carries no information a
+        // `0usize` would add.
+        //
+        // Be aware when reading this that it does NOT match its neighbours.
+        // `fold_raw_cell_occupation` is the precedent, but that is a sparse
+        // GRID fold; the two STORE folds this one sits between — `hash_anims`
+        // and `hash_particle_systems` — both write their length
+        // unconditionally. The skip was chosen to avoid a re-baseline, and it
+        // is load-bearing for that reason alone.
+        //
+        // Coverage gap: no parity harness and no replay fixture authors a
+        // positive `MaxDebris=`, so nothing red today exercises either this
+        // fold's populated arm or the producer that fills it. The first fixture
+        // that kills a `MaxDebris>0` type moves the goldens through the RNG
+        // cursor even before a single piece survives to be folded.
         if self.substrate.voxel_anims.is_empty() {
             return;
         }

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -9626,3 +9626,111 @@ fn debug_toggle_updates_existing_and_future_entities() {
         "disabling clears every entity's log"
     );
 }
+
+/// The `VoxelAnimClass` store is a live scheduler citizen, not a side table.
+///
+/// gamemd-derived: `VoxelAnimClass::Constructor @ 0x007493B0` assigns the
+/// shared unique id, appends to the VoxelAnim registry, and `ObjectClass::
+/// Unlimbo` reveals the piece into the LogicClass vector; `LogicClass::AI`
+/// then visits it in that order every frame until `VoxelAnimClass::AI @
+/// 0x00749F30` reaches `vtable+0xF8`. This pins the four wiring facts a
+/// desync would ride in on: the id comes from the shared allocator, the piece
+/// enters the live order, the state hash folds it, and a snapshot restores
+/// both the store and its logic membership.
+#[test]
+fn gsi_05_14_death_debris_joins_the_live_order_the_hash_and_the_snapshot() {
+    let voxel_type = crate::rules::voxel_anim_type::VoxelAnimType::from_ini_section(
+        "TIRE",
+        IniFile::from_str(
+            "[TIRE]\nElasticity=0.8\nMinAngularVelocity=12.0\nMaxAngularVelocity=24.0\n\
+             MinZVel=28.0\nMaxZVel=32.0\nMaxXYVel=10.0\nDuration=150\n",
+        )
+        .section("TIRE")
+        .unwrap(),
+    );
+
+    let mut sim = Simulation::new();
+    let empty_hash = sim.state_hash();
+    let mut rng = crate::sim::rng::SimRng::new(17);
+    let pieces: Vec<_> = (0..3)
+        .map(|_| crate::sim::voxel_anim::VoxelDebrisSpawn {
+            type_id: crate::rules::voxel_anim_type::VoxelAnimTypeId(0),
+            object: crate::sim::voxel_anim::spawn_debris_piece(
+                0,
+                crate::rules::voxel_anim_type::VoxelAnimTypeId(0),
+                &voxel_type,
+                None,
+                glam::IVec3::new(1280, 2560, 0),
+                &mut rng,
+            )
+            .expect("in domain"),
+        })
+        .collect();
+    sim.admit_death_debris(pieces);
+
+    assert_eq!(sim.substrate.voxel_anims.len(), 3);
+    let ids: Vec<u64> = sim.substrate.voxel_anims.ids();
+    assert_eq!(
+        sim.live_object_order_snapshot(),
+        ids,
+        "each piece is revealed into the live order in spawn order"
+    );
+    assert_ne!(
+        sim.state_hash(),
+        empty_hash,
+        "the store folds into the state hash"
+    );
+
+    // The fold reads the physics body, not just the identity: a single tick of
+    // the duration has to move the hash.
+    let before_tick = sim.state_hash();
+    let first_id = ids[0];
+    sim.substrate
+        .voxel_anims
+        .get_mut(first_id)
+        .unwrap()
+        .duration -= 1;
+    assert_ne!(sim.state_hash(), before_tick);
+    sim.substrate
+        .voxel_anims
+        .get_mut(first_id)
+        .unwrap()
+        .duration += 1;
+    assert_eq!(sim.state_hash(), before_tick);
+
+    let expected_order = sim.live_object_order_snapshot();
+    let expected_store = sim.substrate.voxel_anims.clone();
+    let bytes = bincode::serialize(&sim).expect("serialize sim with VoxelAnimStore");
+    let mut restored: Simulation =
+        bincode::deserialize(&bytes).expect("deserialize VoxelAnimStore");
+    restored.rebuild_logic_membership();
+    assert_eq!(restored.live_object_order_snapshot(), expected_order);
+    assert_eq!(
+        restored.substrate.voxel_anims, expected_store,
+        "every piece and its physics body survive the snapshot"
+    );
+    restored.debug_assert_logic_membership_consistent();
+
+    // The scheduler slot advances the physics body, and a piece leaves the live
+    // order once its AI reaches Delete.
+    let first = first_id;
+    let before = sim.substrate.voxel_anims.get(first).unwrap().world_coord();
+    sim.visit_voxel_anim(first);
+    let after = sim.substrate.voxel_anims.get(first).unwrap().world_coord();
+    assert_ne!(before, after, "one AI visit moves the body");
+    for _ in 0..200 {
+        if !sim.substrate.voxel_anims.contains_key(first) {
+            break;
+        }
+        sim.visit_voxel_anim(first);
+    }
+    assert!(
+        !sim.substrate.voxel_anims.contains_key(first),
+        "the piece expires inside its Duration"
+    );
+    assert!(
+        !sim.live_object_order_snapshot().contains(&first),
+        "Delete leaves the LogicVector"
+    );
+    sim.debug_assert_logic_membership_consistent();
+}


### PR DESCRIPTION
## What a player sees

**Deaths throw debris now.** A destroyed vehicle, building or aircraft scatters wreckage:
live voxel pieces that fly, bounce off the ground and come to rest; sprite debris animations
authored by the type itself; and the generic metallic chunks from `[General] MetallicDebris=`
for everything that authors neither. How much is thrown comes from a per-type budget drawn
once at death — and the budget **drains as it spends**, so two debris entries share one pool
instead of each filling it.

**And it removes debris VERA was wrongly throwing.** gamemd's INI key lookup is
case-sensitive: both the store side and the lookup side CRC the raw key bytes with no folding
step anywhere on the path, and the entry table is searched by that integer alone. 17
`[VehicleTypes]` sections in retail `rulesmd.ini` spell the key `Maxdebris=3`, not
`MaxDebris`, so gamemd never finds it and those types throw **nothing**. VERA's
case-insensitive read was giving 3 pieces each to 14 buildable units — Rhino, Apocalypse,
Prism Tank, Battle Fortress, IFV, Flak Track, Lasher, Tesla Tank, Gattling Tank, Magnetron,
Master Mind, V3 Launcher, Landing Craft, Armored Transport — **and consuming lockstep RNG
draws that feed the world hash** at every one of those deaths. That is the
determinism-relevant half of this change, and the Rhino and the Apocalypse are ordinary
skirmish deaths, not an edge case.

The three miners a player builds are *not* affected: `[HARV]`, `[CMIN]` and `[SMIN]` all spell
`MaxDebris` exactly and keep their tyres. The two mis-spelled miner rows (`[CMON]`, `[HORV]`)
are `TechLevel=-1` duplicates nobody can build, so the harvest loop is untouched.

Counts on the gamemd (exact-case) basis: 439 sections author `MaxDebris=`, 83 of them author
0, so **356 throw** — 166 on their own `DebrisAnims=`, 158 on the metallic fallback, 32 on the
voxel arm. 155 of those are registered TechnoTypes on the metallic arm (18 vehicle, 11
aircraft, 126 building).

## Verified gamemd sources

The whole producer is the destruction arm of `TechnoClass::ReceiveDamage @ 0x00701900`, at
`0x00702281`..`0x0070256C`:

- `MaxDebris` (`TechnoType+0x5BC`) must be positive at `0x00702291`, or the block — RNG
  included — is skipped to `0x00702572`.
- `budget = RandomRanged(MinDebris, MaxDebris - 1)` at `0x007022C8`; the top is one below
  `MaxDebris` because of `DEC EDI` at `0x007022AD`.
- The voxel loop at `0x007022FE` takes one `Random__Next()` per iteration (`0x0070232B`),
  computes `count = |next| % (DebrisMaximums[i] + 1)` (`0x00702339`), clamps to the budget,
  and **`SUB EBX,EAX` at `0x007023B5` subtracts the spent count from the budget**; the type
  index wraps at `0x007023D3` and the loop repeats while the budget survives (`0x007023DF`).
- Whatever budget is left goes to `DebrisAnims` (`+0x5C4`/`+0x5D4`, gated at `0x007023FC`,
  one `RandomRanged` per chunk at `0x00702473`), else — only if `DebrisTypes` is also empty
  (`0x007024D2`) — to `[General] MetallicDebris=` (`RulesClass+0x140`/`+0x14C`, one
  `RandomRanged` per chunk at `0x0070253A`). The metallic arm has no count gate, so an empty
  list still spends the budget in draws.
- Each voxel piece costs **seven** draws: four `Random__Next()` in
  `VoxelAnimClass::Constructor @ 0x007493B0` (`0x0074951D`, `0x00749531`, `0x00749544`,
  `0x00749559`) plus three `RandomRanged(-0xFFFF, 0xFFFF)` in `BounceClass::Init`. The
  draw-to-axis pairing was read off the `FILD`/`FSUB`/`FSTP` ladder at
  `0x0074958D`..`0x007495FA`, not off the decompiler's variable order.
- Flight and rest: `VoxelAnimClass::AI @ 0x00749F30` over `BounceClass::Update @ 0x00439B00`,
  whose stop test compares the magnitude helper at `0x00439A10` against the `2.5` at
  `0x007E3D80` (`FCOMP` at `0x0043A08C`).
- `ObjectClass+0x8F`, read at `0x0070223D`, is a **drop-in** flag, not a water flag: written 0
  by `ObjectClass::Constructor @ 0x005F3981` and set only by `ObjectClass::DropIn @
  0x005F4171`. A clear byte jumps past the water check and into the block, so an ordinary
  death over water throws.
- Draw ordering: `UnitClass::ReceiveDamage @ 0x00737C90` runs `FootClass::ReceiveDamage` to
  completion before `UnitClass::Death_Explosion`, which is why the debris draws sit between
  the death-sound draws and the `Explosion=`/`DestroyAnim=` draws.

For the case-sensitive read:

- `TechnoTypeClass::ReadINI @ 0x00712170` pushes the literal `MaxDebris` (`0x0084439C`) into
  `CCINIClass::ReadInt @ 0x005276D0` and stores to `+0x5BC`; `MinDebris` (`0x00844390`) into
  `+0x5C0`.
- `CCINIClass::ReadInt` strlen's the caller's key and CRCs it raw (CRC call at `0x00527727`);
  `INIClass::LoadFromStraw @ 0x00525A60` CRCs the stored entry name the same way (CRC call at
  `0x005260D4`). `CRCEngine::AddData @ 0x004A1DE0` indexes the table at `0x0081F7B4` — verified
  bit-identical to reflected CRC-32, poly `0xEDB88320`, all 256 entries — with the raw byte:
  no `AND 0xDF`, no `OR 0x20`, no toupper. `FindEntry_BinarySearch @ 0x0052B4F0` then compares
  nothing but those integers, with no string fallback.
- The two clamps `ObjectType` was missing are now in, in native order:
  `TechnoTypeClass::ReadINI` floors `MinDebris` at 0 (`0x007125BD`) and then raises
  `MaxDebris` to it (`0x007125D9`); the warhead sibling does the same at `0x0075DAC4` /
  `0x0075DAE0`.

## Residuals — row 119 stays open on these

1. **The voxel debris is simulated but not drawn.** There is no `VoxelAnimClass` draw path
   (the unit voxel renderer keys on entity type, house remap and facing; a debris piece has
   none). Trigger: any death on the voxel arm. Frequency: 32 sections against 324 whose SHP
   debris does draw. The pieces already consume their draws, hash and expire, so adding the
   draw later moves no state.
2. **The quaternion tumble** is unstarted, not instrument-blocked — the sin/cos tables are
   readable and `Quaternion_FromAxisAngle @ 0x00646480` is decompiled. It is blocked by
   residual 1, since orientation with no draw path lands nowhere.
3. **Sloped-ramp reflection** and **the slope re-bounce arm**: the mirror matrices are built at
   runtime by `VXL_MasterLighting_Init` and the image bytes are zero, and `emulate_function`
   returns registers only, so a matrix written to memory is unobservable through this
   instrument. A bounce onto a ramp hops in place instead of running downhill.
4. **The SHP half spawns as a `WorldEffect`, not an `AnimClass`.** Every stock debris AnimType
   is `Bouncer=yes` (`AnimTypeClass+0x35A`, written at `0x004286B8`), so native's chunk flies
   an arc, applies its landing `Damage=`/`Warhead=`, and consumes seven draws of its own. VERA
   plays the sprite at the wreck. Frequency: continuous — 324 sections. The same seven draws
   are already missing from the `Explosion=`/`DestroyAnim=` producer beside it and from every
   `WorldEffect` anim in the engine, so closing it belongs to the AnimClass bouncer owner in
   one pass, not here.
5. **The warhead-side debris producer** (`BulletClass::DetonateAtCoord`, warhead `+0x1C4`) is
   parsed but not consumed. Only `[Smashing]` and `[TRexWH]` of the 105 registered warheads
   author it and neither is reachable from a skirmish weapon, so frequency is effectively zero;
   pre-existing, and it belongs to whoever owns detonation.
6. **`DAT_0089C76C`** (bridge deck-plane offset) is modelled as the image value 0; its sole
   writer has no direct caller. Bridge cells only.
7. **The building `+0x80` bounce-surface virtual** is UNCHECKED, so debris bounces off every
   building roof here.
8. **`VoxelAnimClass::AI`'s anim/damage/meteor arms** (`BounceAnim=`, `ExpireAnim=`,
   `TrailerAnim=`, expiry area damage, the `IsMeteor` ore ring) are unimplemented. All 32
   voxel-arm sections name `[TIRE]`, which authors none of them, so frequency in stock is zero.
9. **Object-id interleaving.** Native stamps the piece's id inside the constructor; VERA stamps
   at admission. Spawn order is preserved, interleaving with another allocation in the same
   tick is not.
10. **Four VERA-internal guards, gamemd equivalent UNCHECKED**, all labelled at the code: a
    4096-iteration ceiling on the drain loop (gamemd hangs on an all-zero `DebrisMaximums=`), a
    short `DebrisMaximums` entry read as 0 (native reads past the vector), a zero-divisor guard
    in the launch arithmetic, and a `.max(1)` divisor floor. All need modded rules — every
    stock `DebrisMaximums=` is 4 or 6. Noted separately: `raw_abs_modulo` differs in sign from
    native's saturating negate at exactly `0x8000_0000` (1 in 2^32), in the shared RNG
    primitive rather than here.
11. **Coverage.** No parity harness or replay fixture authors a positive `MaxDebris=`, so
    nothing red exercises this producer or the populated hash-fold arm. The first fixture that
    kills a `MaxDebris>0` type will move the goldens through the RNG cursor and close the gap.
12. **`get_ignoring_case` survives** for `sound_ini.rs`'s 18 call sites — 13 registered sound
    events over 14 mis-spelled keys (`Vshift`, `Fshift`, `volume`). Audio-only; `PlayShifts`
    draws unconditionally, so the drawn value changes and the draw count does not. Audio lane's.
13. **The jumpjet key mis-spelling is untouched.** `jumpjet_params.rs` reads `JumpJetAccel` /
    `JumpJetTurnRate` where gamemd's literals are `JumpjetAccel` (`0x00843680`) /
    `JumpjetTurnRate` (`0x008436D0`), so gamemd reads neither and VERA reads both. Continuous
    position error on 8 flying units, hashed from tick one — a separate mechanism, deliberately
    not bundled.

## Validation

One full run on the rebased tip, nothing else building:

```
test result: ok. 8233 passed; 0 failed; 78 ignored; 0 measured; 0 filtered out; finished in 14.96s
```

`SNAPSHOT_VERSION` is **120** (main carries 119). No golden, replay fixture or world-hash
constant moved; `tests/` is untouched across the whole branch, and no `PENDING_REBASELINES`
entry is needed. Rebased onto `ca4cec5f` with no conflict — the branch contributes the same
2202 added / 184 removed lines against the new base as against the old one, verified by
comparing the added- and removed-line sets in all four directions.

## A note on this branch's history

The early commits here state debris counts that later rounds corrected — the metallic-arm
figure moved twice (254, then 171 sections), and every count moved again when the key-case
question was settled and the basis changed from folded to exact. **The figures in the final
code are the ones to trust**; the commit messages and intermediate comments are not. Two
earlier addresses cited in `bounce.rs` were also wrong and were repinned to the instructions
actually read. The mechanism itself was certified unchanged across the last two review rounds.
