### PR TITLE
fix(combat): special detonations keep the shared explosion tail

### DIFF
--- a/src/rules/warhead_type.rs
+++ b/src/rules/warhead_type.rs
@@ -97,14 +97,27 @@ pub struct WarheadType {
     /// Conventional warhead — no special effects. Offset +0x14B.
     pub conventional: bool,
     /// Area-damage rocker: detonation pushes a rocker impulse into every
-    /// vehicle in a 3×3 cell radius (Rocker= in [Warhead]). Default `no`.
+    /// vehicle in a 3×3 cell radius (`Rocker=` in `[Warhead]`). Default `no`.
+    /// `WarheadTypeClass+0x14E`, written by `WarheadTypeClass::ReadINI`
+    /// @ `0x0075d5be` from the key string at `0x00847de8`.
     pub rocker: bool,
-    /// Direct-hit rocker: fires an impulse on the bullet's target if the
-    /// target is a vehicle (DirectRocker= in [Warhead]). Default `no`.
+    /// Direct-hit rocker: fires an impulse on the bullet's target if that
+    /// target is a vehicle (`DirectRocker=` in `[Warhead]`). Default `no`.
+    /// `WarheadTypeClass+0x14F`, written by `WarheadTypeClass::ReadINI`
+    /// @ `0x0075d5d8` from the key string at `0x00847dd8`.
+    ///
+    /// This is the eighth arm of the detonation chain — tested at
+    /// `BulletClass::DetonateAtCoord @ 0x0046978e`, the only arm there whose
+    /// predicate also inspects the target. Dead in stock YR: `rulesmd.ini`
+    /// has no live `DirectRocker=` line (its one textual occurrence sits
+    /// inside a `;` comment at line 27314), so the arm never fires in stock
+    /// play. Kept correct anyway.
     pub direct_rocker: bool,
-    /// Spawns tiberium/ore on impact. Offset +0x14E.
+    /// Spawns tiberium/ore on impact.
     pub tiberium: bool,
-    /// Bright flash on detonation. Offset +0x14F.
+    /// Bright flash on detonation. `WarheadTypeClass+0x150`, written by
+    /// `WarheadTypeClass::ReadINI` @ `0x0075d60c` from the key string at
+    /// `0x00847dd0`.
     pub bright: bool,
     /// Positive values override the damage-derived transient combat-light size.
     /// Parsed through native `ReadDouble`, whose input is f32-first and whose
@@ -119,21 +132,31 @@ pub struct WarheadType {
     pub prone_damage_basis_points: u32,
     /// Instantly destroys any wall. Offset +0x151.
     pub wall_absolute_destroyer: bool,
-    /// Chrono legionnaire erase effect. Offset +0x152.
+    /// Chrono legionnaire erase effect. `WarheadTypeClass+0x15A` (ReadINI
+    /// `0x0075D871`, key string `0x00817168`), tested by the detonation chain
+    /// at `BulletClass::DetonateAtCoord @ 0x00469423`.
     pub temporal: bool,
     /// Changes target's locomotor (magnetron). `WarheadTypeClass+0x15B`
     /// (ReadINI `0x0075D87C`), read by
     /// `TechnoClass::What_Weapon_Should_I_Use @ 0x006F352E`.
     pub is_locomotor: bool,
-    /// Terror drone attach. Offset +0x154.
+    /// Terror drone / attack dog / squid attach. `WarheadTypeClass+0x159`
+    /// (ReadINI `0x0075D84E`, key string `0x0081717C`), tested by the
+    /// detonation chain at `BulletClass::DetonateAtCoord @ 0x004693d3`.
     pub parasite: bool,
-    /// Mind control visual effect. Offset +0x155.
+    /// Psychedelic (berserk) effect. `WarheadTypeClass+0x16D` (ReadINI
+    /// `0x0075D8FB`, key string `0x00847D30`). Not a detonation-chain arm.
     pub psychedelic: bool,
-    /// Crazy ivan bomb attach. Offset +0x174.
+    /// Crazy ivan bomb attach. `WarheadTypeClass+0x157` (ReadINI
+    /// `0x0075D823`, key string `0x0081BD60`), tested by the detonation chain
+    /// at `BulletClass::DetonateAtCoord @ 0x00469343`.
     pub ivan_bomb: bool,
-    /// Yuri mind control. Offset +0x175.
+    /// Yuri mind control. `WarheadTypeClass+0x155` (ReadINI `0x0075D7E0`, key
+    /// string `0x0081BBC8`), tested first in the detonation chain at
+    /// `BulletClass::DetonateAtCoord @ 0x00469211`.
     pub mind_control: bool,
-    /// Poison damage. Offset +0x176.
+    /// Poison damage. `WarheadTypeClass+0x156` (ReadINI `0x0075D800`, key
+    /// string `0x00847D58`).
     pub poison: bool,
     /// Calls in airstrike. `WarheadTypeClass+0x16C` (ReadINI `0x0075D8F0`),
     /// read by `TechnoClass::What_Weapon_Should_I_Use @ 0x006F3481`.
@@ -142,21 +165,29 @@ pub struct WarheadType {
     pub electric: bool,
     /// Radiation contamination. Offset +0x179.
     pub radiation: bool,
-    /// Kills infantry outright below threshold. Offset +0x17A.
+    /// Squid finishing move — kills a weakened victim outright instead of
+    /// dealing the parasite's per-cycle damage. `WarheadTypeClass+0x174`
+    /// (ReadINI `0x0075D949`, key string `0x00847D10`); consumed by
+    /// `ParasiteClass::AI @ 0x006297F0`, not by the detonation chain.
     pub culling: bool,
-    /// Spy disguise warhead. Offset +0x17B.
+    /// Spy disguise warhead. `WarheadTypeClass+0x175` (ReadINI `0x0075D969`,
+    /// key string `0x00847D00`), tested by the detonation chain at
+    /// `BulletClass::DetonateAtCoord @ 0x00469a03`.
     pub makes_disguise: bool,
-    /// Ordered BulletClass detonation predicates whose effect bodies remain
-    /// explicit unsupported runtime branches.
-    ///
-    /// `electric_assault` is `WarheadTypeClass+0x158` (ReadINI
-    /// `0x0075D82E`), read by
-    /// `TechnoClass::What_Weapon_Should_I_Use @ 0x006F361F`.
+    /// Tesla Trooper charging a Tesla Coil. `WarheadTypeClass+0x158` (ReadINI
+    /// `0x0075D82E`, key string `0x00847D48`), read by
+    /// `TechnoClass::What_Weapon_Should_I_Use @ 0x006F361F` and tested by the
+    /// detonation chain at `BulletClass::DetonateAtCoord @ 0x0046937a`.
     pub electric_assault: bool,
+    /// Engineer defuse kit. `WarheadTypeClass+0x16E` (ReadINI `0x0075D91B`,
+    /// key string `0x00847D24`), tested by the detonation chain at
+    /// `BulletClass::DetonateAtCoord @ 0x004699ca`.
     pub bomb_disarm: bool,
+    /// Spawns the descending half of a nuke at the target cell.
+    /// `WarheadTypeClass+0x176` (ReadINI `0x0075D983`, key string
+    /// `0x00847CF4`), tested last in the detonation chain at
+    /// `BulletClass::DetonateAtCoord @ 0x00469a2c`.
     pub nuke_maker: bool,
-    /// Native WarheadType byte `+0x14f`; parser-key identity remains unproven.
-    pub raw_335: bool,
 
     // --- Int fields ---
     /// EMP duration in frames. Offset +0x170.
@@ -327,7 +358,6 @@ impl WarheadType {
             electric_assault: section.get_bool("ElectricAssault").unwrap_or(false),
             bomb_disarm: section.get_bool("BombDisarm").unwrap_or(false),
             nuke_maker: section.get_bool("NukeMaker").unwrap_or(false),
-            raw_335: false,
 
             // Int fields — all default 0
             em_effect: section.get_i32("EMEffect").unwrap_or(0),

--- a/src/rules/warhead_type.rs
+++ b/src/rules/warhead_type.rs
@@ -44,10 +44,16 @@ pub struct WarheadType {
     /// the authoritative cutover retires it.
     pub verses_f64: [f64; 11],
     /// Splash damage radius in cells (SIM_ZERO = direct hit only).
+    /// Native `CellSpread=` is a **float** at `WarheadTypeClass+0x124`
+    /// (ReadDouble `0x005283d0` called at `0x0075d3e6`, `FSTP float ptr` at
+    /// `0x0075d3eb`, key string `0x00847ea0`).
     pub cell_spread: SimFixed,
     /// Native `CellSpread` float widened to f64 for ApplyWarheadDamage.
     pub cell_spread_f64: f64,
     /// Damage percentage at maximum spread distance (0–100).
+    /// Native `PercentAtMax=` is a **float** at `WarheadTypeClass+0x12C`
+    /// (ReadDouble at `0x0075d424`, `FSTP float ptr` at `0x0075d429`, key
+    /// string `0x00847e84`).
     pub percent_at_max: u8,
     /// Native `PercentAtMax` float widened to f64 for the receiver damage
     /// kernel. The byte percentage above remains for legacy presentation and
@@ -59,6 +65,8 @@ pub struct WarheadType {
     /// Native signed PostMortem base duration (`+0x134`); default 5.
     pub delay_kill_frames: i32,
     /// Native binary32 `DelayKillAtMax` widened exactly to f64; default 1.0f.
+    /// `WarheadTypeClass+0x138` (ReadDouble at `0x0075d477`, `FSTP float ptr`
+    /// at `0x0075d47c`, key string `0x00847e54`).
     pub delay_kill_at_max_f64: f64,
     /// Whether this warhead can damage walls/bridges (Wall=yes).
     /// NO-DIFF (GSI-08.33) — pass 1's three "unparsed effect flags" have no
@@ -74,16 +82,27 @@ pub struct WarheadType {
     /// with its consumer deleted. And all 28 stock `Sparky=` entries are `no`,
     /// including `[Fire]` and `[Fire2]` — the opposite of "most fire weapons are
     /// Sparky". Parsing them here would add fields nothing can read.
+    ///
+    /// The field itself is `WarheadTypeClass+0x144` (ReadINI `0x0075d508`,
+    /// key string `0x0081ac58`).
     pub wall: bool,
     /// Whether this warhead can damage terrain objects with Wood armor gate.
     /// TerrainClass::Take_Damage requires this before applying damage.
+    /// `WarheadTypeClass+0x147` (ReadINI `0x0075d556`, key string
+    /// `0x00847e00`).
     pub wood: bool,
     /// Whether this warhead reaches a target installed in a bunker. The active
     /// receiver has category-specific linked-building/occupant semantics.
+    /// `WarheadTypeClass+0x146` (ReadINI `0x0075d53c`, key string
+    /// `0x00847e08`).
     pub penetrates_bunker: bool,
     /// Whether this warhead can affect allied targets. Native default is true.
+    /// `WarheadTypeClass+0x179` (ReadINI `0x0075d9f2`, key string
+    /// `0x00847cc8`).
     pub affects_allies: bool,
     /// Psychic-damage immunity selector (distinct from Psychedelic).
+    /// `WarheadTypeClass+0x178` (ReadINI `0x0075d9d2`, key string
+    /// `0x00847cd8`).
     pub psychic_damage: bool,
     /// Explosion animation names indexed by damage magnitude (AnimList= in rules.ini).
     /// The original engine selects by `damage / 25`, clamped to list length.
@@ -94,7 +113,9 @@ pub struct WarheadType {
     pub inf_death: u8,
 
     // --- Bool fields (verified offsets from WarheadTypeClass::ReadINI) ---
-    /// Conventional warhead — no special effects. Offset +0x14B.
+    /// Conventional warhead — no special effects. `WarheadTypeClass+0x14D`,
+    /// written by `WarheadTypeClass::ReadINI` @ `0x0075d4ee` from the key
+    /// string at `0x00847e34`. (`+0x14B` is `Sonic=`, not this.)
     pub conventional: bool,
     /// Area-damage rocker: detonation pushes a rocker impulse into every
     /// vehicle in a 3×3 cell radius (`Rocker=` in `[Warhead]`). Default `no`.
@@ -113,7 +134,9 @@ pub struct WarheadType {
     /// inside a `;` comment at line 27314), so the arm never fires in stock
     /// play. Kept correct anyway.
     pub direct_rocker: bool,
-    /// Spawns tiberium/ore on impact.
+    /// Spawns tiberium/ore on impact. `WarheadTypeClass+0x148`, written by
+    /// `WarheadTypeClass::ReadINI` @ `0x0075d570` from the key string at
+    /// `0x00817278`.
     pub tiberium: bool,
     /// Bright flash on detonation. `WarheadTypeClass+0x150`, written by
     /// `WarheadTypeClass::ReadINI` @ `0x0075d60c` from the key string at
@@ -122,6 +145,8 @@ pub struct WarheadType {
     /// Positive values override the damage-derived transient combat-light size.
     /// Parsed through native `ReadDouble`, whose input is f32-first and whose
     /// percent form therefore stores a fraction (`40%` -> widened f32 `0.4`).
+    /// `WarheadTypeClass+0x13C` (ReadDouble at `0x0075d496`, `FSTP float ptr`
+    /// at `0x0075d49b`, key string `0x00847e44`).
     pub combat_light_size_f64: f64,
     /// Native `double` damage multiplier read by InfantryClass before it enters
     /// the shared Foot/Techno/Object receiver. `50%` is stored as `0.5`.
@@ -130,7 +155,9 @@ pub struct WarheadType {
     /// concrete Infantry receiver. The authoritative receiver uses the double
     /// above.
     pub prone_damage_basis_points: u32,
-    /// Instantly destroys any wall. Offset +0x151.
+    /// Instantly destroys any wall. `WarheadTypeClass+0x145`, written by
+    /// `WarheadTypeClass::ReadINI` @ `0x0075d522` from the key string at
+    /// `0x00847e1c`. (`+0x151` is `CLDisableRed=`, not this.)
     pub wall_absolute_destroyer: bool,
     /// Chrono legionnaire erase effect. `WarheadTypeClass+0x15A` (ReadINI
     /// `0x0075D871`, key string `0x00817168`), tested by the detonation chain
@@ -161,9 +188,18 @@ pub struct WarheadType {
     /// Calls in airstrike. `WarheadTypeClass+0x16C` (ReadINI `0x0075D8F0`),
     /// read by `TechnoClass::What_Weapon_Should_I_Use @ 0x006F3481`.
     pub airstrike: bool,
-    /// Tesla weapon. Offset +0x178.
+    /// Tesla weapon. Native offset **UNKNOWN** — VERA-internal, gamemd
+    /// equivalent UNCHECKED. `WarheadTypeClass::ReadINI_Body @ 0x0075D3A0`
+    /// (body `0x0075D3A0`-`0x0075DEBD`) pushes 61 distinct key strings and
+    /// none of them is `Electric`; `search_strings ^Electric$` over the image
+    /// returns nothing. So there is no native `Electric=` warhead key to bind
+    /// to, and `+0x178` — the offset previously claimed here — is
+    /// `PsychicDamage=`. Stock `rulesmd.ini` authors no `Electric=` line, so
+    /// this field is always `false` in stock play.
     pub electric: bool,
-    /// Radiation contamination. Offset +0x179.
+    /// Radiation contamination. `WarheadTypeClass+0x177`, written by
+    /// `WarheadTypeClass::ReadINI` @ `0x0075d9c7` from the key string at
+    /// `0x00839e80`. (`+0x179` is `AffectsAllies=`, not this.)
     pub radiation: bool,
     /// Squid finishing move — kills a weakened victim outright instead of
     /// dealing the parasite's per-cycle damage. `WarheadTypeClass+0x174`
@@ -190,11 +226,36 @@ pub struct WarheadType {
     pub nuke_maker: bool,
 
     // --- Int fields ---
-    /// EMP duration in frames. Offset +0x170.
+    /// EMP flag. RESIDUAL — native type mismatch, pre-existing, NOT fixed here
+    /// (M15a is documentation-only). `EMEffect=` is a **bool** in gamemd, at
+    /// `WarheadTypeClass+0x154`: `ReadBool` at `0x0075d7c1`, stored
+    /// `0x0075d7d5`, key string `0x00847d60`. VERA reads it as an `i32`.
+    /// `+0x170` — the offset previously claimed here — is a *different* key,
+    /// `Paralyzes=`, which is genuinely an int (`ReadInt` at `0x0075d92a`,
+    /// stored `0x0075d93e`, key string `0x00847d18`) and which VERA does not
+    /// parse at all.
+    /// - Trigger: a warhead authoring `EMEffect=` or `Paralyzes=`.
+    /// - Player effect: none in stock. The one stock `EMEffect=yes` is
+    ///   `[EMPuls]`, which retail itself annotates `;gs disabled in code` and
+    ///   which no stock weapon mounts; `get_i32("yes")` yields 0 where native
+    ///   would read `true`. The one stock `Paralyzes=32767` is `[ParasitePlus]`
+    ///   (SquidGrab) and belongs to the unported parasite effect (M15b).
+    /// - Frequency: zero observable occurrences in stock skirmish.
+    /// - Downstream risk: fixing the type is a rules-parse change, so it lands
+    ///   with whichever port first reads either field.
     pub em_effect: i32,
-    /// Money transfer on hit. Offset +0x17C.
+    /// Money transfer on hit. Native offset **UNKNOWN** — VERA-internal,
+    /// gamemd equivalent UNCHECKED. `WarheadTypeClass::ReadINI_Body` reads no
+    /// `TransactMoney=` key (and no such string exists in the image);
+    /// `+0x17C` — the offset previously claimed here — is `ShakeXlo=`, an int.
+    /// Stock `rulesmd.ini` authors no `TransactMoney=` line, so this field is
+    /// always 0 in stock play.
     pub transact_money: i32,
-    /// Infantry death type for cell-level kills. Offset +0x114.
+    /// Infantry death type for cell-level kills. Native offset **UNKNOWN** —
+    /// VERA-internal, gamemd equivalent UNCHECKED. `WarheadTypeClass::ReadINI_Body`
+    /// writes nothing at `+0x114` and reads no `CellInfDeath=` key (no such
+    /// string exists in the image). Stock `rulesmd.ini` authors no
+    /// `CellInfDeath=` line, so this field is always 0 in stock play.
     pub cell_inf_death: i32,
 
     // --- List fields ---

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -9059,3 +9059,219 @@ fn gsi_05_14_a_type_without_maxdebris_takes_no_draw() {
         "no MaxDebris= means no debris at all: {names:?}"
     );
 }
+
+/// GSI-08.08 — a special detonation arm suppresses shrapnel and area damage,
+/// but NOT the shared tail.
+///
+/// `BulletClass::DetonateAtCoord @ 0x004690b0`: only the final else at
+/// `0x00469a3f` runs `BulletClass::SpawnShrapnel @ 0x0046a310` and
+/// `Apply_area_damage @ 0x00489280`, so any arm shadows both. Every arm then
+/// leaves through `JMP LAB_00469AA4`, which is the explosion-anim /
+/// scorch-crater / debris / `Airburst` tail — `Warhead::SelectExplosionAnim`
+/// is called from inside it at `0x00469bcf`. Stock `[Controller]` carries
+/// `AnimList=YURICNTL`, so a Yuri beam impact must still draw.
+#[test]
+fn gsi_08_08_special_arm_suppresses_damage_but_keeps_the_detonation_tail() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n\
+         [VehicleTypes]\n0=TARGET\n\
+         [AircraftTypes]\n\
+         [BuildingTypes]\n\
+         [TARGET]\nStrength=200\nArmor=heavy\n\
+         [Warheads]\n0=Controller\n1=Plain\n\
+         [Controller]\nMindControl=yes\nAnimList=YURICNTL\n\
+         Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+         [Plain]\nAnimList=YURICNTL\n\
+         Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("Controller/Plain warhead rules");
+
+    struct TailOutcome {
+        damage_events: usize,
+        anims: Vec<(String, u16, u16, u8)>,
+        smudges: usize,
+    }
+
+    fn run(rules: &RuleSet, warhead_name: &str) -> TailOutcome {
+        let mut interner = test_interner();
+        let mut entities = EntityStore::new();
+        entities.insert(make_entity(10, "TARGET", 8, 5, 200));
+        let occupancy = OccupancyGrid::new();
+        let warhead_ref = interner.intern(warhead_name);
+        let detonation = ProjectileDetonation {
+            projectile_id: 1,
+            source_id: 77,
+            target: ProjectileTarget::Entity(10),
+            impact: ProjectileCoord::new(8 * 256 + 128, 5 * 256 + 128, 0),
+            payload: ProjectilePayload {
+                base_damage: 50,
+                warhead: warhead_ref,
+                weapon: interner.intern("MissingWeapon"),
+                owner: interner.intern("Test"),
+            },
+            reason: ProjectileDetonationReason::ReachedTarget,
+        };
+        let mut scenario_rng = SimRng::new(9);
+        let mut emitted = CombatEmit::default();
+        let mut resources = BTreeMap::new();
+        let mut inline_hooks = None;
+        let handles =
+            crate::sim::type_handle_table::ResolvedRuleHandles::resolve(rules, &mut interner);
+        emit_projectile_detonations(
+            &[detonation],
+            &mut entities,
+            &occupancy,
+            rules,
+            &mut interner,
+            Some(handles),
+            &mut resources,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            &HouseAllianceMap::new(),
+            &mut scenario_rng,
+            &mut inline_hooks,
+            &mut emitted,
+        );
+        let anims: Vec<(String, u16, u16, u8)> = emitted
+            .explosion_effects
+            .iter()
+            .map(|effect| {
+                (
+                    interner.resolve(effect.shp_name).to_string(),
+                    effect.rx,
+                    effect.ry,
+                    effect.z,
+                )
+            })
+            .collect();
+        TailOutcome {
+            damage_events: emitted.damage_events.len(),
+            anims,
+            smudges: emitted.smudge_spawn_requests.len(),
+        }
+    }
+
+    let mind_control = run(&rules, "Controller");
+    assert_eq!(
+        mind_control.damage_events, 0,
+        "the MindControl arm at 0x00469211 shadows Apply_area_damage"
+    );
+    assert_eq!(
+        mind_control.anims,
+        vec![("YURICNTL".to_string(), 8, 5, 0)],
+        "LAB_00469AA4 still selects and starts the AnimList explosion"
+    );
+    assert_eq!(
+        mind_control.smudges, 1,
+        "the anim's smudge/scorch half runs from the same tail"
+    );
+
+    let plain = run(&rules, "Plain");
+    assert_eq!(
+        plain.damage_events, 1,
+        "the ordinary arm at 0x00469a3f is unchanged"
+    );
+    assert_eq!(
+        plain.anims, mind_control.anims,
+        "the tail selects the same anim at the same place whichever arm reached it"
+    );
+    assert_eq!(plain.smudges, mind_control.smudges);
+}
+
+/// GSI-08.33 — `DirectRocker` is the chain's only conditional arm.
+///
+/// `BulletClass::DetonateAtCoord @ 0x0046978e` tests the flag, then
+/// `Target != 0` (`0x004697a4`) and `Target->What_Am_I() == 1`
+/// (`0x004697b2`, `UnitClass`). All three failures jump to `0x004699c4`, the
+/// *next* test, so a `DirectRocker=yes` warhead that hits infantry still runs
+/// ordinary damage. Dead in stock — `rulesmd.ini` carries no live
+/// `DirectRocker=` line — but kept correct.
+#[test]
+fn gsi_08_33_direct_rocker_only_claims_a_vehicle_target() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=FOOT\n\
+         [VehicleTypes]\n0=TARGET\n\
+         [AircraftTypes]\n\
+         [BuildingTypes]\n\
+         [TARGET]\nStrength=200\nArmor=heavy\n\
+         [FOOT]\nStrength=200\nArmor=none\n\
+         [Warheads]\n0=Rocker\n\
+         [Rocker]\nDirectRocker=yes\nAnimList=YURICNTL\n\
+         Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("DirectRocker warhead rules");
+    assert!(
+        rules.warhead("Rocker").expect("Rocker").direct_rocker,
+        "DirectRocker= must reach the parsed field, not a dead raw byte"
+    );
+
+    fn run(rules: &RuleSet, category: EntityCategory, type_ref: &str) -> usize {
+        let mut interner = test_interner();
+        let mut entities = EntityStore::new();
+        let mut target = make_entity(10, type_ref, 8, 5, 200);
+        target.category = category;
+        entities.insert(target);
+        let occupancy = OccupancyGrid::new();
+        let detonation = ProjectileDetonation {
+            projectile_id: 1,
+            source_id: 77,
+            target: ProjectileTarget::Entity(10),
+            impact: ProjectileCoord::new(8 * 256 + 128, 5 * 256 + 128, 0),
+            payload: ProjectilePayload {
+                base_damage: 50,
+                warhead: interner.intern("Rocker"),
+                weapon: interner.intern("MissingWeapon"),
+                owner: interner.intern("Test"),
+            },
+            reason: ProjectileDetonationReason::ReachedTarget,
+        };
+        let mut scenario_rng = SimRng::new(9);
+        let mut emitted = CombatEmit::default();
+        let mut resources = BTreeMap::new();
+        let mut inline_hooks = None;
+        let handles =
+            crate::sim::type_handle_table::ResolvedRuleHandles::resolve(rules, &mut interner);
+        emit_projectile_detonations(
+            &[detonation],
+            &mut entities,
+            &occupancy,
+            rules,
+            &mut interner,
+            Some(handles),
+            &mut resources,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            &HouseAllianceMap::new(),
+            &mut scenario_rng,
+            &mut inline_hooks,
+            &mut emitted,
+        );
+        assert_eq!(
+            emitted.explosion_effects.len(),
+            1,
+            "both branches reach LAB_00469AA4"
+        );
+        emitted.damage_events.len()
+    }
+
+    assert_eq!(
+        run(&rules, EntityCategory::Unit, "TARGET"),
+        0,
+        "a vehicle target enters the arm and shadows Apply_area_damage"
+    );
+    assert_eq!(
+        run(&rules, EntityCategory::Infantry, "FOOT"),
+        1,
+        "infantry falls through 0x004697b2 to the next test, so damage runs"
+    );
+}

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -95,9 +95,10 @@ use crate::sim::power_system::PowerState;
 use crate::sim::projectile::{
     ProjectileCollisionPolicy, ProjectileCoord, ProjectileDetonation, ProjectileGuidance,
     ProjectilePayload, ProjectileSpawn, ProjectileTarget, ProjectileTrajectory, ProjectileVelocity,
-    ProjectileVisualState, SpecialDetonationAction, SpecialDetonationFlags, TargetExpiryPolicy,
-    ballistic_launch_velocity, projectile_next_cluster_coord, projectile_random_shrapnel_cell,
-    projectile_shrapnel_count, projectile_special_detonation_action,
+    ProjectileVisualState, SpecialDetonationAction, SpecialDetonationFlags, SpecialDetonationTarget,
+    TargetExpiryPolicy, ballistic_launch_velocity, projectile_next_cluster_coord,
+    projectile_random_shrapnel_cell, projectile_shrapnel_count,
+    projectile_special_detonation_action,
 };
 use crate::sim::rng::SimRng;
 use crate::sim::terrain_object::{TerrainAreaReceiveResult, TerrainAreaState};
@@ -4881,114 +4882,142 @@ fn emit_one_projectile_detonation(
             });
     }
 
-    let special_action = projectile_special_detonation_action(SpecialDetonationFlags {
-        mind_control: warhead.mind_control,
-        ivan_bomb: warhead.ivan_bomb,
-        electric_assault: warhead.electric_assault,
-        parasite: warhead.parasite,
-        temporal: warhead.temporal,
-        is_locomotor: warhead.is_locomotor,
-        airstrike: warhead.airstrike,
-        raw_335: warhead.raw_335,
-        bomb_disarm: warhead.bomb_disarm,
-        makes_disguise: warhead.makes_disguise,
-        nuke_maker: warhead.nuke_maker,
-    });
-    if special_action != SpecialDetonationAction::OrdinaryDamage {
-        // Effect bodies remain explicit residuals. Native else-if ownership is
-        // authoritative, so an earlier unsupported predicate still shadows
-        // Shrapnel and ordinary DamageArea.
-        log::debug!(
-            "Projectile {} selected unsupported special detonation {:?}",
-            detonation.projectile_id,
-            special_action
-        );
-        return;
-    }
-
-    emit_projectile_shrapnel(
-        detonation,
-        entities,
-        occupancy,
-        rules,
-        interner,
-        terrain.as_deref(),
-        house_alliances,
-        scenario_rng,
-        out,
+    // `BulletClass::DetonateAtCoord @ 0x0046978e` is the chain's only
+    // conditional arm and the only one that consults the target: it reads the
+    // bullet's raw `+0x10c` and calls `What_Am_I` through vtable `+0x2c`,
+    // claiming the impact only for RTTI 1 (`UnitClass::What_Am_I
+    // @ 0x00746e20`). A cell, dummy-cell or null target is never a UnitClass.
+    let special_target = SpecialDetonationTarget {
+        is_unit: match detonation.target {
+            ProjectileTarget::Entity(id) => entities
+                .get(id)
+                .is_some_and(|entity| entity.category == EntityCategory::Unit),
+            ProjectileTarget::Cell { .. }
+            | ProjectileTarget::None
+            | ProjectileTarget::DummyCell => false,
+        },
+    };
+    let special_action = projectile_special_detonation_action(
+        SpecialDetonationFlags {
+            mind_control: warhead.mind_control,
+            ivan_bomb: warhead.ivan_bomb,
+            electric_assault: warhead.electric_assault,
+            parasite: warhead.parasite,
+            temporal: warhead.temporal,
+            is_locomotor: warhead.is_locomotor,
+            airstrike: warhead.airstrike,
+            direct_rocker: warhead.direct_rocker,
+            bomb_disarm: warhead.bomb_disarm,
+            makes_disguise: warhead.makes_disguise,
+            nuke_maker: warhead.nuke_maker,
+        },
+        special_target,
     );
 
-    let routed_wall = wall_overlay_flags_at(
-        overlay_grid.as_deref(),
-        overlay_registry,
-        impact_rx,
-        impact_ry,
-    )
-    .is_some_and(|flags| warhead_damages_wall(warhead, flags));
-    let ore_amount = if scenario_no_damage {
-        None
-    } else {
-        tiberium_reduction_amount(detonation.payload.base_damage, true, warhead)
-    };
-    let aoe = {
-        let mut cell_prelude = CombatTiberiumCellPrelude {
-            amount: ore_amount,
-            deferred: &mut out.tiberium_reduction_requests,
-            inline_hooks,
-            rules,
-            resource_nodes,
-            terrain_area_state,
-        };
-        self::combat_aoe::apply_aoe_damage_with_terrain_and_scenario(
-            entities,
-            impact_rx,
-            impact_ry,
-            detonation.payload.base_damage,
-            warhead,
-            rules,
-            interner,
-            handles,
-            (
-                detonation.source_id,
-                Some(detonation.payload.owner),
-                detonation.payload.warhead,
-            ),
-            self::combat_aoe::AoELayerContext {
-                occupancy: Some(occupancy),
-                terrain: terrain.as_deref_mut(),
-                overlay_grid: overlay_grid.as_deref_mut(),
-                overlay_registry,
-                scenario_rng: Some(&mut *scenario_rng),
-                air_impact,
-                impact_z,
-            },
-            terrain_objects,
-            scenario_no_damage,
-            Some(&mut cell_prelude),
-        )
-    };
-    out.wall_mutations.extend(aoe.wall_mutations);
-    out.wall_radar_dirty_cells
-        .extend(aoe.wall_radar_dirty_cells);
-    out.cell_target_detaches.extend(aoe.cell_target_detaches);
-    out.damage_events.extend(aoe.receivers);
+    // Native ownership: only the final else at `0x00469a3f` runs
+    // `BulletClass::SpawnShrapnel @ 0x0046a310` and
+    // `Apply_area_damage @ 0x00489280`, so an arm that claims the impact
+    // shadows both — including an arm whose effect body VERA has not ported,
+    // because native's own bail-outs (e.g. `0x00469235`) shadow them too.
+    // What an arm never shadows is the shared tail below `LAB_00469AA4`: every
+    // arm reaches the explosion anim and its smudge. The RESIDUAL list for the
+    // unported effect bodies lives on `SpecialDetonationAction`.
+    match special_action {
+        SpecialDetonationAction::OrdinaryDamage => {
+            emit_projectile_shrapnel(
+                detonation,
+                entities,
+                occupancy,
+                rules,
+                interner,
+                terrain.as_deref(),
+                house_alliances,
+                scenario_rng,
+                out,
+            );
 
-    if !scenario_no_damage && detonation.payload.base_damage > 0 {
-        let damage = detonation.payload.base_damage.min(i32::from(u16::MAX)) as u16;
-        if !routed_wall && warhead.wall {
-            out.bridge_damage_events.push(BridgeDamageEvent {
-                rx: impact_rx,
-                ry: impact_ry,
-                damage,
-                warhead_ref: detonation.payload.warhead,
-                is_ion_cannon: detonation.payload.warhead
-                    == handles
-                        .expect("Simulation::resolve_type_handles must run before combat")
-                        .ion_cannon,
-                impact_z,
-            });
+            let routed_wall = wall_overlay_flags_at(
+                overlay_grid.as_deref(),
+                overlay_registry,
+                impact_rx,
+                impact_ry,
+            )
+            .is_some_and(|flags| warhead_damages_wall(warhead, flags));
+            let ore_amount = if scenario_no_damage {
+                None
+            } else {
+                tiberium_reduction_amount(detonation.payload.base_damage, true, warhead)
+            };
+            let aoe = {
+                let mut cell_prelude = CombatTiberiumCellPrelude {
+                    amount: ore_amount,
+                    deferred: &mut out.tiberium_reduction_requests,
+                    inline_hooks,
+                    rules,
+                    resource_nodes,
+                    terrain_area_state,
+                };
+                self::combat_aoe::apply_aoe_damage_with_terrain_and_scenario(
+                    entities,
+                    impact_rx,
+                    impact_ry,
+                    detonation.payload.base_damage,
+                    warhead,
+                    rules,
+                    interner,
+                    handles,
+                    (
+                        detonation.source_id,
+                        Some(detonation.payload.owner),
+                        detonation.payload.warhead,
+                    ),
+                    self::combat_aoe::AoELayerContext {
+                        occupancy: Some(occupancy),
+                        terrain: terrain.as_deref_mut(),
+                        overlay_grid: overlay_grid.as_deref_mut(),
+                        overlay_registry,
+                        scenario_rng: Some(&mut *scenario_rng),
+                        air_impact,
+                        impact_z,
+                    },
+                    terrain_objects,
+                    scenario_no_damage,
+                    Some(&mut cell_prelude),
+                )
+            };
+            out.wall_mutations.extend(aoe.wall_mutations);
+            out.wall_radar_dirty_cells.extend(aoe.wall_radar_dirty_cells);
+            out.cell_target_detaches.extend(aoe.cell_target_detaches);
+            out.damage_events.extend(aoe.receivers);
+
+            if !scenario_no_damage && detonation.payload.base_damage > 0 {
+                let damage = detonation.payload.base_damage.min(i32::from(u16::MAX)) as u16;
+                if !routed_wall && warhead.wall {
+                    out.bridge_damage_events.push(BridgeDamageEvent {
+                        rx: impact_rx,
+                        ry: impact_ry,
+                        damage,
+                        warhead_ref: detonation.payload.warhead,
+                        is_ion_cannon: detonation.payload.warhead
+                            == handles
+                                .expect("Simulation::resolve_type_handles must run before combat")
+                                .ion_cannon,
+                        impact_z,
+                    });
+                }
+            }
+        }
+        claimed => {
+            log::debug!(
+                "Projectile {} claimed by unimplemented special detonation {:?}; \
+                 shrapnel and area damage suppressed, shared tail still runs",
+                detonation.projectile_id,
+                claimed
+            );
         }
     }
+
+    // `LAB_00469AA4` — reached by the ordinary arm and by every special arm.
     emit_warhead_detonation_effects(
         warhead,
         detonation.payload.base_damage,

--- a/src/sim/projectile.rs
+++ b/src/sim/projectile.rs
@@ -713,22 +713,124 @@ pub fn projectile_shrapnel_count(
         .max(0) as u32
 }
 
+/// Which arm of the native special-detonation chain claims one impact.
+///
+/// gamemd-derived: `BulletClass::DetonateAtCoord @ 0x004690b0` is a strict
+/// twelve-arm `else if` chain over `WarheadTypeClass` flag bytes. Each test's
+/// fall-through `JZ` targets the *next* test, so the arms are mutually
+/// exclusive and the order below is the native order, read from the flag tests
+/// at `0x00469211`, `0x00469343`, `0x0046937a`, `0x004693d3`, `0x00469423`,
+/// `0x004694cb`, `0x00469705`, `0x0046978e`, `0x004699ca`, `0x00469a03` and
+/// `0x00469a2c`.
+///
+/// Only the final else at `0x00469a3f` reaches
+/// `BulletClass::SpawnShrapnel @ 0x0046a310` and
+/// `Apply_area_damage @ 0x00489280`, so any special arm suppresses both. What a
+/// special arm does **not** suppress is the shared tail: every arm, including
+/// its internal bail-outs (e.g. MindControl with no CaptureManager at
+/// `0x00469235`), leaves through `JMP LAB_00469AA4`, and `LAB_00469AA4` is not
+/// the epilogue — it is the `Inviso` visual re-scatter (`0x00469ad7`), the
+/// `AnimList=` explosion (`Warhead::SelectExplosionAnim` called at
+/// `0x00469bcf`), the scorch/crater/combat-light spawn (`0x00469c41`), the
+/// debris loop and the `Airburst=` sub-munition fan (`BulletClass::Init` at
+/// `0x00469f7f` / `0x0046a150`). The ordinary arm reaches that same tail only
+/// behind the `bullet+0x90` gate at `0x00469a94`; special arms bypass the gate.
+///
+/// RESIDUAL — **no special effect body is implemented in VERA.** Every variant
+/// except `OrdinaryDamage` currently claims the detonation, suppresses damage
+/// and shrapnel exactly as native does, and then runs the shared tail without
+/// performing its effect. Per-variant native callees are named below; the
+/// unimplemented effect families are ports M15b (Parasite), M15c (MindControl)
+/// and M15d (the rest).
+/// - Trigger: any impact whose warhead carries one of the eleven flags. In
+///   stock `rulesmd.ini` that is 14 warhead sections across 20 weapons —
+///   Yuri/Yuri Prime/Psychic Tower/Mastermind, attack dogs, Terror Drones,
+///   Giant Squids, Chrono Legionnaires, Crazy Ivan, Engineers, Spies,
+///   Magnetrons, Tesla Troopers, Boris and the Weed Guy.
+/// - Player effect: the shot lands, plays its animation and leaves its crater,
+///   but nobody is controlled, attached to, erased, bombed, defused, disguised
+///   or lifted, and the target takes no damage from that shot.
+/// - Frequency: continuous in ordinary skirmish — an attack dog appears in
+///   almost every game and a Yuri beam fires every few seconds in any Yuri
+///   game.
+/// - Downstream risk: the ports add snapshotted, hashed entity state
+///   (`ParasiteClass`, the victim-side mind-control link, `TemporalClass`,
+///   `BombClass`), so each carries its own `SNAPSHOT_VERSION` bump.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SpecialDetonationAction {
+    /// `MindControl=` (`WarheadTypeClass+0x155`), test `0x00469211` ->
+    /// `CaptureManagerClass::CaptureUnit @ 0x00471d40`. UNIMPLEMENTED (M15c).
     MindControl,
+    /// `IvanBomb=` (`+0x157`), test `0x00469343` ->
+    /// `BombClass::Attach @ 0x00438e70`. UNIMPLEMENTED (M15d).
     IvanBomb,
+    /// `ElectricAssault=` (`+0x158`), test `0x0046937a` -> the Tesla-Coil
+    /// charger-vector append at `0x00452820`. UNIMPLEMENTED (M15d).
     ElectricAssault,
+    /// `Parasite=` (`+0x159`), test `0x004693d3` ->
+    /// `ParasiteClass::AttachTo @ 0x0062a980`. UNIMPLEMENTED (M15b).
     Parasite,
+    /// `Temporal=` (`+0x15a`), test `0x00469423` ->
+    /// `TemporalClass::InitiateWarp @ 0x0071af20`. UNIMPLEMENTED (M15d).
     Temporal,
+    /// `IsLocomotor=` (`+0x15b`), test `0x004694cb` -> the Magnetron
+    /// deploy / chrono-warp arm. UNIMPLEMENTED (M15d).
     Locomotor,
+    /// `Airstrike=` (`+0x16c`), test `0x00469705` ->
+    /// `AirstrikeClass::SetTarget @ 0x0041d830`. UNIMPLEMENTED (M15d).
+    ///
+    /// The decompile shows this arm as conditional; the disassembly does not.
+    /// `0x0046970d JZ 0x0046978e` is its only fall-through and fires on the
+    /// flag alone — every sub-condition failure (`0x00469717`, `0x00469725`,
+    /// `0x0046972f`, `0x0046973d`, `0x0046975b`) jumps to `0x00469aa4`
+    /// instead. So Airstrike is flag-gated like the other ten.
     Airstrike,
-    Raw335,
+    /// `DirectRocker=` (`+0x14f`), test `0x0046978e` ->
+    /// `TechnoClass::ApplyRocker` through vtable `+0x3d8` at `0x004699a1`,
+    /// plus the mutual `+0x2a8` link.
+    ///
+    /// The **only** conditional arm in the chain: `0x00469796` (flag),
+    /// `0x004697a4` (`Target != 0`) and `0x004697b2`
+    /// (`Target->What_Am_I() == 1`, `UnitClass`) all fall through to
+    /// `0x004699c4`, the *next* test, so a `DirectRocker=yes` warhead that hits
+    /// infantry, a building or a bare cell still takes ordinary damage.
+    /// Failures *after* those three (`0x004697dc`, `0x004697e4`, `0x004697f6`)
+    /// jump to the tail like every other arm.
+    ///
+    /// Dead in stock YR: `rulesmd.ini` carries no live `DirectRocker=` line
+    /// (its one textual occurrence is inside a `;` comment), so the arm never
+    /// fires in stock play. Kept correct anyway; the impulse body is
+    /// deliberately NOT implemented.
+    DirectRocker,
+    /// `BombDisarm=` (`+0x16e`), test `0x004699ca` ->
+    /// `BombClass::Defuse @ 0x004389b0`. UNIMPLEMENTED (M15d).
     BombDisarm,
+    /// `MakesDisguise=` (`+0x175`), test `0x00469a03` -> the firer disguises as
+    /// the target through owner vtable `+0x46c` at `0x00469a24`.
+    /// UNIMPLEMENTED (M15d).
     MakesDisguise,
+    /// `NukeMaker=` (`+0x176`), test `0x00469a2c` ->
+    /// `BulletClass::SpawnDownwardNuke @ 0x0046b310`. UNIMPLEMENTED (M15d).
     NukeMaker,
+    /// The final else at `0x00469a3f`: shrapnel plus `Apply_area_damage`.
     OrdinaryDamage,
 }
 
+impl SpecialDetonationAction {
+    /// True for every arm that claims the detonation away from
+    /// `Apply_area_damage @ 0x00489280` and
+    /// `BulletClass::SpawnShrapnel @ 0x0046a310`.
+    pub fn suppresses_ordinary_damage(self) -> bool {
+        self != SpecialDetonationAction::OrdinaryDamage
+    }
+}
+
+/// The eleven `WarheadTypeClass` flag bytes the native chain tests, in native
+/// order. Offsets verified from `WarheadTypeClass::ReadINI` string->offset
+/// writes (`0x0075d5d8`, `0x0075d7e0`, `0x0075d823`, `0x0075d82e`,
+/// `0x0075d84e`, `0x0075d871`, `0x0075d87c`, `0x0075d8f0`, `0x0075d91b`,
+/// `0x0075d969`, `0x0075d983`) and cross-checked against the reads in
+/// `BulletClass::DetonateAtCoord @ 0x004690b0`.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SpecialDetonationFlags {
     pub mind_control: bool,
@@ -738,14 +840,29 @@ pub struct SpecialDetonationFlags {
     pub temporal: bool,
     pub is_locomotor: bool,
     pub airstrike: bool,
-    pub raw_335: bool,
+    pub direct_rocker: bool,
     pub bomb_disarm: bool,
     pub makes_disguise: bool,
     pub nuke_maker: bool,
 }
 
+/// Target-side context the native chain consults *inside* an arm predicate.
+///
+/// Only `DirectRocker` reads it. `0x0046979c`/`0x004697aa` load the bullet's
+/// raw `+0x10c` target and call `What_Am_I` through vtable `+0x2c`; a null
+/// target or any RTTI id other than 1 (`UnitClass::What_Am_I @ 0x00746e20`)
+/// falls through to the BombDisarm test instead of claiming the detonation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SpecialDetonationTarget {
+    /// `Target != 0 && Target->What_Am_I() == 1`.
+    pub is_unit: bool,
+}
+
+/// Resolve the one arm of `BulletClass::DetonateAtCoord @ 0x004690b0` that owns
+/// this impact. The `else if` order is native; see [`SpecialDetonationAction`].
 pub fn projectile_special_detonation_action(
     flags: SpecialDetonationFlags,
+    target: SpecialDetonationTarget,
 ) -> SpecialDetonationAction {
     if flags.mind_control {
         SpecialDetonationAction::MindControl
@@ -760,9 +877,12 @@ pub fn projectile_special_detonation_action(
     } else if flags.is_locomotor {
         SpecialDetonationAction::Locomotor
     } else if flags.airstrike {
+        // Flag-gated, not conditional — see the `Airstrike` variant doc.
         SpecialDetonationAction::Airstrike
-    } else if flags.raw_335 {
-        SpecialDetonationAction::Raw335
+    } else if flags.direct_rocker && target.is_unit {
+        // The chain's only conditional arm: `0x004697a4` / `0x004697b2` fall
+        // through to the BombDisarm test at `0x004699c4`, not to the tail.
+        SpecialDetonationAction::DirectRocker
     } else if flags.bomb_disarm {
         SpecialDetonationAction::BombDisarm
     } else if flags.makes_disguise {
@@ -2037,13 +2157,70 @@ mod tests {
         assert_eq!(projectile_shrapnel_count(-8, true, 3), 5);
         assert_eq!(projectile_shrapnel_count(-8, false, 99), 3);
         assert_eq!(
-            projectile_special_detonation_action(SpecialDetonationFlags {
-                mind_control: true,
-                nuke_maker: true,
-                ..SpecialDetonationFlags::default()
-            }),
+            projectile_special_detonation_action(
+                SpecialDetonationFlags {
+                    mind_control: true,
+                    nuke_maker: true,
+                    ..SpecialDetonationFlags::default()
+                },
+                SpecialDetonationTarget::default()
+            ),
             SpecialDetonationAction::MindControl
         );
+    }
+
+    /// `BulletClass::DetonateAtCoord @ 0x0046978e` is the chain's only
+    /// conditional arm: `0x00469796` (flag), `0x004697a4` (`Target != 0`) and
+    /// `0x004697b2` (`Target->What_Am_I() == 1`) all fall through to the
+    /// BombDisarm test at `0x004699c4`, so a `DirectRocker=yes` warhead that
+    /// misses a vehicle still runs ordinary damage. Airstrike only *looks*
+    /// conditional in the decompile — `0x0046970d` is its sole fall-through
+    /// and fires on the flag alone.
+    #[test]
+    fn direct_rocker_is_the_only_conditional_arm() {
+        let rocker = SpecialDetonationFlags {
+            direct_rocker: true,
+            ..SpecialDetonationFlags::default()
+        };
+        assert_eq!(
+            projectile_special_detonation_action(rocker, SpecialDetonationTarget { is_unit: true }),
+            SpecialDetonationAction::DirectRocker
+        );
+        assert_eq!(
+            projectile_special_detonation_action(
+                rocker,
+                SpecialDetonationTarget { is_unit: false }
+            ),
+            SpecialDetonationAction::OrdinaryDamage
+        );
+
+        // A non-vehicle target falls through to the NEXT test, not to the
+        // tail: BombDisarm still claims the impact.
+        assert_eq!(
+            projectile_special_detonation_action(
+                SpecialDetonationFlags {
+                    direct_rocker: true,
+                    bomb_disarm: true,
+                    ..SpecialDetonationFlags::default()
+                },
+                SpecialDetonationTarget { is_unit: false }
+            ),
+            SpecialDetonationAction::BombDisarm
+        );
+
+        // Airstrike is entered on the flag alone, whatever the target is.
+        for is_unit in [false, true] {
+            assert_eq!(
+                projectile_special_detonation_action(
+                    SpecialDetonationFlags {
+                        airstrike: true,
+                        ..SpecialDetonationFlags::default()
+                    },
+                    SpecialDetonationTarget { is_unit }
+                ),
+                SpecialDetonationAction::Airstrike
+            );
+        }
     }
 
     #[test]

--- a/src/sim/projectile.rs
+++ b/src/sim/projectile.rs
@@ -728,13 +728,33 @@ pub fn projectile_shrapnel_count(
 /// `Apply_area_damage @ 0x00489280`, so any special arm suppresses both. What a
 /// special arm does **not** suppress is the shared tail: every arm, including
 /// its internal bail-outs (e.g. MindControl with no CaptureManager at
-/// `0x00469235`), leaves through `JMP LAB_00469AA4`, and `LAB_00469AA4` is not
-/// the epilogue — it is the `Inviso` visual re-scatter (`0x00469ad7`), the
-/// `AnimList=` explosion (`Warhead::SelectExplosionAnim` called at
-/// `0x00469bcf`), the scorch/crater/combat-light spawn (`0x00469c41`), the
-/// debris loop and the `Airburst=` sub-munition fan (`BulletClass::Init` at
-/// `0x00469f7f` / `0x0046a150`). The ordinary arm reaches that same tail only
-/// behind the `bullet+0x90` gate at `0x00469a94`; special arms bypass the gate.
+/// `0x00469235`), leaves through `JMP LAB_00469AA4`, and `LAB_00469AA4`
+/// (`0x00469aa4 MOV EAX,[EBP+0x8]`) is not the epilogue — the epilogue is
+/// `0x0046a290`. Unconditionally the tail is the `Inviso` visual re-scatter
+/// (`0x00469ad7`), the explosion-anim *selection*
+/// (`Warhead::SelectExplosionAnim` called at `0x00469bcf`), the `AnimList=`
+/// `AnimClass` itself (built from `0x00469c46`), the debris loop and the
+/// `Airburst=` sub-munition fan (`BulletClass::Init` at `0x00469f7f` /
+/// `0x0046a150`). The ordinary arm reaches that same tail only behind the
+/// `bullet+0x90` gate at `0x00469a94`; special arms bypass the gate.
+///
+/// **The combat-light / `CLDisable*` block is NOT part of that unconditional
+/// tail.** `0x00469bf0..0x00469c45`, ending in the light spawn
+/// `0x00469c41 CALL 0x0048a620`, runs only when `bullet+0xe0 != 0` **and**
+/// `[ESP+0xf] == 0` — `0x00469bdc TEST AL,AL` / `0x00469be2 JZ 0x0046a299`
+/// then `0x00469be8 TEST AL,AL` / `0x00469bea JNZ 0x0046a2a1` — and
+/// `0x0046a29b JZ 0x00469c46` rejoins *past* it, so the `AnimList=` anim is
+/// reached either way. `bullet+0xe0` is the per-**weapon** `Bright=` flag, not
+/// a warhead key: `BulletClass::Init` stores its last stack argument there
+/// (`0x004664e6 MOV byte ptr [ECX+0xe0], DL` from `[ESP+0x1c]`), fed from
+/// `TechnoClass::FireAt` (`0x006fe53f MOV CL, byte ptr [EBX+0x12f]`) =
+/// `WeaponTypeClass+0x12f`, written by `WeaponTypeClass::ReadINI` at
+/// `0x00772817` from the key string at `0x00847dd0` = `"Bright"`. Whoever
+/// ports `0x0048a620` must carry that gate, or every non-`Bright=` impact
+/// flashes. The block itself folds warhead `+0x151`/`+0x152`/`+0x153`
+/// (`CLDisableRed=`/`Green=`/`Blue=`, read at `0x00469bf8`/`0x00469c07`/
+/// `0x00469c13`) into a 2/4/8 bit mask and passes it with the impact coord and
+/// `bullet+0x6c`; the exact visual `0x0048a620` produces is UNCHECKED here.
 ///
 /// RESIDUAL — **no special effect body is implemented in VERA.** Every variant
 /// except `OrdinaryDamage` currently claims the detonation, suppresses damage
@@ -743,10 +763,15 @@ pub fn projectile_shrapnel_count(
 /// unimplemented effect families are ports M15b (Parasite), M15c (MindControl)
 /// and M15d (the rest).
 /// - Trigger: any impact whose warhead carries one of the eleven flags. In
-///   stock `rulesmd.ini` that is 14 warhead sections across 20 weapons —
-///   Yuri/Yuri Prime/Psychic Tower/Mastermind, attack dogs, Terror Drones,
+///   stock `rulesmd.ini` that is 14 warhead sections, named by 24 weapon
+///   sections through an exact-case `Warhead=`, of which 22 are actually
+///   mounted (`TankMakeupKit` and `CRMakeupKit` are named by no mount key;
+///   gamemd's INI lookup is case-sensitive, and there is no near-miss
+///   spelling of any of the eleven keys or of `Warhead=` in stock) — carried
+///   by Yuri/Yuri Prime/Psychic Tower/Mastermind, attack dogs, Terror Drones,
 ///   Giant Squids, Chrono Legionnaires, Crazy Ivan, Engineers, Spies,
-///   Magnetrons, Tesla Troopers, Boris and the Weed Guy.
+///   Magnetrons, Tesla Troopers, the IFV's chrono weapon, Boris and the Weed
+///   Guy.
 /// - Player effect: the shot lands, plays its animation and leaves its crater,
 ///   but nobody is controlled, attached to, erased, bombed, defused, disguised
 ///   or lifted, and the target takes no damage from that shot.
@@ -756,6 +781,33 @@ pub fn projectile_shrapnel_count(
 /// - Downstream risk: the ports add snapshotted, hashed entity state
 ///   (`ParasiteClass`, the victim-side mind-control link, `TemporalClass`,
 ///   `BombClass`), so each carries its own `SNAPSHOT_VERSION` bump.
+///
+/// RESIDUAL — **the `[ESP+0xf]` ordinary-arm visual bypass is not modelled.**
+/// `0x004690c9` zeroes `[ESP+0xf]` on entry and `0x00469a9f` is its only
+/// writer: it sets 1 when `Apply_area_damage` (called at `0x00469a83`) returns
+/// exactly 2 and the `bullet+0x90` gate at `0x00469a94` passed
+/// (`0x00469a9a CMP EAX,0x2` / `0x00469a9d JNZ 0x00469aa4`). When set, the tail
+/// diverts at `0x00469bea` / `0x0046a299` to `0x0046a2a1`, which builds a
+/// different `0x1c8`-byte object from global `[0x008871e0] + 0x350` and falls
+/// straight into the epilogue — skipping the `AnimList=` anim, the combat
+/// light, the debris loop and the `Airburst=` fan entirely. It is the same
+/// `Apply_area_damage` return-value handling as the `bullet+0x90` gate above,
+/// and it suppresses far more than that gate does.
+/// - Trigger: an ordinary-arm impact where `Apply_area_damage` returns 2. What
+///   that return value means is **UNCHECKED** — settled by reading
+///   `Apply_area_damage @ 0x00489280`'s return contract.
+/// - Player effect: on native such an impact draws the alternate object
+///   instead of its explosion, crater, debris and `Airburst=` children; VERA
+///   always draws the ordinary set.
+/// - Frequency: UNCHECKED on the ordinary arm, and provably **zero on every
+///   arm in this enum** — `0x00469a9f` is the flag's only writer and it sits
+///   inside the final else at `0x00469a3f`, which `get_xrefs_to 0x00469a3f`
+///   shows is entered by exactly one jump, the `NukeMaker` test's `JZ` at
+///   `0x00469a34`. No special arm can reach it, so the flag is 0 for all of
+///   them.
+/// - Downstream risk: none for M15a. It belongs with the rest of the tail
+///   (`Inviso`, debris, `Airburst=`) and with the `bullet+0x90` gate, i.e. to
+///   whoever ports `Apply_area_damage`'s return contract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SpecialDetonationAction {
     /// `MindControl=` (`WarheadTypeClass+0x155`), test `0x00469211` ->


### PR DESCRIPTION
## What a player sees

Special warheads produced **no visible impact at all**. Yuri's mind-control beam, the
parasite family (attack dogs, Terror Drone, Giant Squid), the Chrono Legionnaire's erase
beam and seven other live effects all landed in total silence — no explosion, no scorch,
no debris. A Yuri beam drew nothing even though retail `rulesmd.ini` declares
`[Controller] AnimList=YURICNTL` for exactly that impact.

The cause: VERA returned early from `emit_one_projectile_detonation` for any special
warhead, which correctly skipped damage but also skipped the shared detonation tail that
every native arm runs. The explosion, crater, debris and sub-munition tail now run for
special warheads, exactly as gamemd does.

## The suppression is correct, and it is kept

Special warheads still deal no ordinary damage and throw no shrapnel. That is not a
shortcut — it is what the binary does.

`BulletClass::DetonateAtCoord @ 0x004690b0` is a strict **twelve-arm `else if` chain**
over `WarheadTypeClass` flag bytes, and only the final arm at `0x00469a3f` reaches
`BulletClass::SpawnShrapnel @ 0x0046a310` and `Apply_area_damage @ 0x00489280`. Entering
any special arm shadows both.

This was settled by cross-reference, not inferred from reading the chain:
`get_xrefs_to 0x00469a3f` returns **exactly one** xref — the NukeMaker test's `JZ` at
`0x00469a34`. No special arm can reach ordinary damage by any path.

Every arm, and every bail-out inside an arm, then leaves through `JMP 0x00469aa4`. That
address is not the epilogue (`0x0046a290`); it is the shared tail — the `Inviso` visual
re-scatter, `SelectExplosionAnim @ 0x0048a4f0`, the `AnimList=` `AnimClass` built from
`0x00469c46`, the debris loop, and the `Airburst=` sub-munition fan.

## Two dispatch-shape corrections

- **`DirectRocker` is the chain's only conditional arm.** Its predicate inspects the
  target as well as the flag: flag (`0x00469796`), `Target != 0` (`0x004697a4`), and
  `Target->What_Am_I() == 1` (`0x004697b2`) each fall through to `0x004699c4`, which is
  the *next test* (BombDisarm) — so a non-vehicle target still takes ordinary damage.
- **`Airstrike` merely looks conditional in decompiled output, and is not.** The
  disassembly shows `0x0046970d` as its only fall-through; every sub-condition failure
  (`0x00469717`, `0x00469725`, `0x0046972f`, `0x0046973d`, `0x0046975b`) jumps to the
  tail instead. It is flag-gated like the other ten.

## An unnamed flag identified

VERA carried a `raw_335` field bound only by raw offset, hardcoded `false`, feeding an
arm that was therefore unreachable — while a fully parsed `direct_rocker` sat unused
beside it. `WarheadTypeClass::ReadINI` writes `+0x14f` (= 335) at `0x0075d5d8` from the
key string at `0x00847dd8`, which reads back as `"DirectRocker"`. The duplicate dead
field is deleted and the arm now reads the parsed one.

## Warhead struct doc sweep

The whole struct was swept against a full disassembly of
`WarheadTypeClass::ReadINI_Body @ 0x0075d3a0` (body `0x0075d3a0`–`0x0075debd`), pairing
every store receiver to its pushed key string and reading each string back.

- **34 offset claims checked, 7 were wrong** and are corrected — including
  `conventional` (`+0x14B` -> `+0x14D`), `wall_absolute_destroyer` (`+0x151` -> `+0x145`)
  and `radiation` (`+0x179` -> `+0x177`).
- **10 previously unannotated fields** gained a verified offset.
- 3 fields (`electric`, `transact_money`, `cell_inf_death`) have no native INI key at all
  and are marked `UNKNOWN` / VERA-internal rather than guessed.

## The effect bodies remain unimplemented — rows 129/133 stay OPEN

**This transaction fixes dispatch, not effects.** All eleven special effect bodies are
still unimplemented: nothing is mind-controlled, attached to, erased, bombed, defused,
disguised or lifted, and the target takes no damage from the shot. What changed is that
the impact is now *visible* and the suppression is now *provably* the native one.

Each variant of `SpecialDetonationAction` records its native callee, trigger, player
effect and frequency in code. Frequency is continuous — an attack dog is in almost every
skirmish, and a Yuri beam fires every few seconds in a Yuri game. Plan rows 129
(GSI-08.08) and 133 (GSI-08.33) remain **OPEN** pending M15b (Parasite), M15c
(MindControl) and M15d.

Two further residuals are recorded in code: the ordinary arm's `bullet+0x90` tail gate at
`0x00469a94`, and the `[ESP+0xf]` visual bypass set at `0x00469a9f` (provably `0` on
every special arm; its trigger on the ordinary arm is UNCHECKED pending
`Apply_area_damage`'s return contract).

## Verified gamemd sources

`BulletClass::DetonateAtCoord @ 0x004690b0` (the twelve-arm chain and its shared tail at
`0x00469aa4`), `BulletClass::SpawnShrapnel @ 0x0046a310`,
`Apply_area_damage @ 0x00489280`, `UnitClass::What_Am_I @ 0x00746e20` (returns 1),
`WarheadTypeClass::ReadINI_Body @ 0x0075d3a0`, `WeaponTypeClass::ReadINI @ 0x00772817`
(the `Bright=` gate on `bullet+0xe0`), and
`INIClass::LoadFromStraw @ 0x00525a60` (the section-header rule used to derive the stock
counts: 14 special warhead sections, named by 24 weapon sections, of which 22 are
mounted).

Ghidra was read-only throughout; annotation candidates stay queued, not applied.

## Tests

Three new decompile-derived tests enter through the production path
(`emit_projectile_detonations`), not the helper:
`direct_rocker_is_the_only_conditional_arm`,
`gsi_08_08_special_arm_suppresses_damage_but_keeps_the_detonation_tail`, and
`gsi_08_33_direct_rocker_only_claims_a_vehicle_target`.

Full suite on the rebased branch:

```
test result: ok. 8236 passed; 0 failed; 78 ignored; 0 measured; 0 filtered out; finished in 20.00s
```

No `SNAPSHOT_VERSION` change (stays at 120), no golden or world-hash constant moved, no
`PENDING_REBASELINES.md` entry needed. `emit_warhead_detonation_effects` consumes no RNG,
so the restored tail is RNG-neutral by construction.
