### PR TITLE
feat(combat): refuse the shot when a wall or a cliff blocks the line of fire

### DIFF
--- a/src/app/input/cursor.rs
+++ b/src/app/input/cursor.rs
@@ -210,6 +210,7 @@ pub(crate) fn current_cursor_feedback_kind(state: &AppState) -> Option<CursorFee
             hover,
             state.rules(),
             sim.path_grid(),
+            state.overlay_registry(),
         );
         return Some(kind);
     }
@@ -435,6 +436,7 @@ fn capability_cursor_for_hover(
     hover: &crate::app::input::entity_pick::HoverTargetKindWithId,
     rules: Option<&crate::rules::ruleset::RuleSet>,
     path_grid: Option<&crate::sim::pathfinding::PathGrid>,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
 ) -> CursorFeedbackKind {
     use crate::map::entities::EntityCategory;
 
@@ -590,6 +592,7 @@ fn capability_cursor_for_hover(
                         hover.stable_id,
                         rules,
                         sim.resolved_terrain.as_ref(),
+                        overlay_registry,
                     );
                     return if in_range {
                         if hover.kind == HoverTargetKind::FriendlyUnit {
@@ -654,6 +657,7 @@ fn capability_cursor_for_hover(
                     hover.stable_id,
                     rules,
                     sim.resolved_terrain.as_ref(),
+                    overlay_registry,
                 )
             });
             if in_range {
@@ -689,6 +693,7 @@ fn resolved_unit_in_range(
     target_id: u64,
     rules: Option<&crate::rules::ruleset::RuleSet>,
     terrain: Option<&crate::map::resolved_terrain::ResolvedTerrainGrid>,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
 ) -> bool {
     let rules = match rules {
         Some(r) => r,
@@ -737,6 +742,11 @@ fn resolved_unit_in_range(
                 &sim.interner,
                 sim.entities(),
                 t,
+                &combat::line_of_fire::LineOfFireInputs {
+                    overlay_grid: sim.overlay_grid.as_ref(),
+                    overlay_registry,
+                    alliances: Some(&sim.house_alliances),
+                },
             )
         } else {
             let dist_sq = combat::lepton_distance_sq_raw(
@@ -1241,6 +1251,7 @@ mod tests {
             &hover,
             Some(&rules),
             None,
+            None,
         );
 
         // 7. Dump the gate inputs so we can see which condition fails
@@ -1295,6 +1306,7 @@ mod tests {
             Some(miner_id),
             &hover,
             Some(&rules),
+            None,
             None,
         );
         assert_eq!(

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -2652,15 +2652,18 @@ pub struct RuleSet {
     /// Garrison/bunker/open-topped combat multipliers from [CombatDamage].
     pub garrison_rules: GarrisonRules,
     /// `[WallModel] AlliedWallTransparency` — `RulesClass+0x1850`, read by
-    /// `RulesClass::ReadWallModel` at 0x0066D20E/0x0066D22E, default `false`
-    /// from the constructor store at 0x00667825. Its one consumer is the
+    /// `RulesClass::ReadWallModel` (body 0x0066D1F0-0x0066D262) at
+    /// 0x0066D20E/0x0066D22E with key string 0x0083B39C, default `false` from
+    /// the constructor store at 0x00667825. Its one consumer is the
     /// line-of-fire walk's wall arm (0x004CC458): when set, a wall belonging
     /// to a house allied with the firer stops blocking the shot. Stock rules
     /// set it to `no`.
     ///
-    /// `[WallModel] WallPenetratorThreshold` (`+0x1858`) is deliberately NOT
-    /// parsed here — it belongs to the AI's "fire through walls anyway"
-    /// decision, which is a different mechanism with no consumer in this tree.
+    /// `[WallModel] WallPenetratorThreshold` — a DOUBLE at `+0x1858`, read at
+    /// 0x0066D24A with key string 0x0083B384 and stored by the `FSTP` at
+    /// 0x0066D24F — is deliberately NOT parsed here: it belongs to the AI's
+    /// "fire through walls anyway" decision, a different mechanism with no
+    /// consumer in this tree.
     pub allied_wall_transparency: bool,
     /// Per-cell radiation-field constants from [Radiation].
     pub radiation: RadiationRules,

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -2963,8 +2963,10 @@ impl RuleSet {
         // projection path has no `[Powerups]` accumulator of its own.
         let powerups = crate::rules::powerups::PowerupTable::default();
         let garrison_rules: GarrisonRules = GarrisonRules::from_ini(ini);
-        // `RulesClass::ReadWallModel` 0x0066D1E0 leaves the constructor value
-        // (0, from 0x00667825) in place when `[WallModel]` is absent.
+        // `RulesClass::ReadWallModel` 0x0066D1F0 (body 0x0066D1F0-0x0066D262)
+        // leaves the constructor value (0, from 0x00667825) in place when
+        // `[WallModel]` is absent: 0x0066D20E passes the current
+        // `[ESI+0x1850]` as the default and 0x0066D22E stores the answer back.
         let allied_wall_transparency: bool = ini
             .section("WallModel")
             .and_then(|s| s.get_bool("AlliedWallTransparency"))

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -2651,6 +2651,17 @@ pub struct RuleSet {
     pub powerups: crate::rules::powerups::PowerupTable,
     /// Garrison/bunker/open-topped combat multipliers from [CombatDamage].
     pub garrison_rules: GarrisonRules,
+    /// `[WallModel] AlliedWallTransparency` — `RulesClass+0x1850`, read by
+    /// `RulesClass::ReadWallModel` at 0x0066D20E/0x0066D22E, default `false`
+    /// from the constructor store at 0x00667825. Its one consumer is the
+    /// line-of-fire walk's wall arm (0x004CC458): when set, a wall belonging
+    /// to a house allied with the firer stops blocking the shot. Stock rules
+    /// set it to `no`.
+    ///
+    /// `[WallModel] WallPenetratorThreshold` (`+0x1858`) is deliberately NOT
+    /// parsed here — it belongs to the AI's "fire through walls anyway"
+    /// decision, which is a different mechanism with no consumer in this tree.
+    pub allied_wall_transparency: bool,
     /// Per-cell radiation-field constants from [Radiation].
     pub radiation: RadiationRules,
     /// Radar event visual parameters (ping rectangles on minimap).
@@ -2952,6 +2963,12 @@ impl RuleSet {
         // projection path has no `[Powerups]` accumulator of its own.
         let powerups = crate::rules::powerups::PowerupTable::default();
         let garrison_rules: GarrisonRules = GarrisonRules::from_ini(ini);
+        // `RulesClass::ReadWallModel` 0x0066D1E0 leaves the constructor value
+        // (0, from 0x00667825) in place when `[WallModel]` is absent.
+        let allied_wall_transparency: bool = ini
+            .section("WallModel")
+            .and_then(|s| s.get_bool("AlliedWallTransparency"))
+            .unwrap_or(false);
         let radiation: RadiationRules = RadiationRules::from_ini(ini);
         let radar_event_config: RadarEventConfig = RadarEventConfig::from_ini(ini);
         let country_side_registry = parse_country_side_registry(ini);
@@ -3424,6 +3441,7 @@ impl RuleSet {
             crate_rules,
             powerups,
             garrison_rules,
+            allied_wall_transparency,
             radiation,
             radar_event_config,
             super_weapons,

--- a/src/sim/combat/combat_cloak_legality_tests.rs
+++ b/src/sim/combat/combat_cloak_legality_tests.rs
@@ -88,6 +88,7 @@ fn acquire(
         false,
         crate::sim::combat::ScanMission::Guard,
         None,
+        crate::sim::combat::line_of_fire::LineOfFireInputs::default(),
     )
 }
 

--- a/src/sim/combat/combat_pursuit_tests.rs
+++ b/src/sim/combat/combat_pursuit_tests.rs
@@ -312,3 +312,194 @@ fn guard_still_chases_where_sticky_would_not() {
         "Guard is not short-circuited"
     );
 }
+
+// ---------------------------------------------------------------------------
+// The pursuit predicate is the fire gate's predicate, walk included.
+//
+// `FootClass::Mission_Attack @ 0x004D4DC0` dispatches to the approach search
+// through vtable slot `+0x53C` (`CALL [EAX+0x53c]` at `0x004D4E6A`; the body is
+// `FootClass::Greatest_Threat_Scan @ 0x004D5690`, and InfantryClass's override
+// `0x00522340` chains into it at `0x0052236E`), and that body decides with
+// `TechnoClass::InRange @ 0x006F7220`
+// — called at `0x004D622C` and `0x004D6550` with a candidate coordinate as arg1
+// and TarCom as arg2. `InRange` ends in the wall/cliff walk
+// (`CALL 0x004CC310` at `0x006F7642`). So in gamemd the approach test and the
+// fire test are literally the same call, and VERA's two stages must not use
+// different predicates: if pursuit measured the plain radius while the fire
+// gate ran the walk, a unit ordered to shoot across a wall would halt here and
+// then be refused the shot, freezing under a live order.
+// ---------------------------------------------------------------------------
+
+/// Rules for the wall cases: a `SubjectToWalls=yes` projectile whose warhead
+/// carries no `Wall=`, so `0x004CC342` cannot re-admit the blocked shot.
+///
+/// `[OverlayTypes]` is read by DECLARATION index (`RulesClass::Process`
+/// `XOR EBX,EBX` at `0x00668CF3`, `PUSH EBX` at `0x00668D0A`), so `GAWALL` has
+/// to be the third entry to land on the id `IsWallConnectableInDirection`
+/// 0x00480510 accepts.
+fn wall_pursuit_rules() -> RuleSet {
+    let ini_str: &str = "\
+[OverlayTypes]\n1=GASAND\n2=CYCL\n3=GAWALL\n\n\
+[GASAND]\nWall=yes\n\n[CYCL]\n\n[GAWALL]\nWall=yes\n\n\
+[VehicleTypes]\n0=MTNK\n1=HTNK\n\n\
+[MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nPrimary=105mm\n\n\
+[HTNK]\nStrength=400\nArmor=heavy\nSpeed=5\nPrimary=105mm\n\n\
+[105mm]\nDamage=65\nROF=50\nRange=6\nProjectile=CANNON\nWarhead=AP\n\n\
+[CANNON]\nSubjectToWalls=yes\n\n\
+[AP]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,0%,0%\n";
+    let ini: IniFile = IniFile::from_str(ini_str);
+    RuleSet::from_ini(&ini).expect("wall_pursuit_rules should parse")
+}
+
+fn wall_pursuit_registry() -> crate::map::overlay_types::OverlayTypeRegistry {
+    let ini_str: &str = "\
+[OverlayTypes]\n1=GASAND\n2=CYCL\n3=GAWALL\n\n\
+[GASAND]\nWall=yes\n\n[CYCL]\n\n[GAWALL]\nWall=yes\n";
+    crate::map::overlay_types::OverlayTypeRegistry::from_ini(&IniFile::from_str(ini_str), None)
+}
+
+const WALL_TEST_GRID: u16 = 64;
+/// `GAWALL`'s declaration index in the fixture's `[OverlayTypes]`.
+const WALL_TEST_GAWALL_ID: u8 = 2;
+
+fn wall_test_cell(rx: u16, ry: u16) -> crate::map::resolved_terrain::ResolvedTerrainCell {
+    crate::map::resolved_terrain::ResolvedTerrainCell {
+        rx,
+        ry,
+        source_tile_index: 0,
+        source_sub_tile: 0,
+        final_tile_index: 0,
+        final_sub_tile: 0,
+        is_wood_bridge_repair_tile: false,
+        level: 0,
+        filled_clear: true,
+        tileset_index: Some(0),
+        land_type: 0,
+        yr_cell_land_type: 0,
+        slope_type: 0,
+        template_height: 0,
+        render_offset_x: 0,
+        render_offset_y: 0,
+        terrain_class: Default::default(),
+        speed_costs: Default::default(),
+        is_water: false,
+        is_cliff_like: false,
+        is_rough: false,
+        is_road: false,
+        height_in_pixels: 0,
+        variant: 0,
+        has_ramp: false,
+        canonical_ramp: None,
+        ground_walk_blocked: false,
+        terrain_object_blocks: false,
+        terrain_object_occupation: None,
+        overlay_blocks: false,
+        overlay_zone_type: None,
+        outside_playfield: false,
+        zone_type: 0,
+        base_ground_walk_blocked: false,
+        base_build_blocked: false,
+        base_land_type: 0,
+        base_yr_cell_land_type: 0,
+        base_terrain_class: Default::default(),
+        base_speed_costs: Default::default(),
+        build_blocked: false,
+        has_bridge_deck: false,
+        bridge_walkable: false,
+        bridge_transition: false,
+        bridge_deck_level: 0,
+        bridge_layer: None,
+        bridge_facts: crate::map::bridge_facts::BridgeCellFacts::default(),
+        tube_index: None,
+        radar_left: [0; 3],
+        radar_right: [0; 3],
+        accepts_smudge: true,
+        allows_tiberium: false,
+        has_damaged_data: false,
+        bridgehead_anchor_class_at_load: None,
+    }
+}
+
+/// Flat terrain plus an overlay plane carrying the listed walls, installed on
+/// the sim so `tick_attack_pursuit_with_overlay_registry` can run the 3-D gate.
+fn install_wall_map(sim: &mut Simulation, walls: &[(u16, u16)]) {
+    let cells: Vec<crate::map::resolved_terrain::ResolvedTerrainCell> = (0..WALL_TEST_GRID)
+        .flat_map(|ry| (0..WALL_TEST_GRID).map(move |rx| wall_test_cell(rx, ry)))
+        .collect();
+    sim.resolved_terrain = Some(
+        crate::map::resolved_terrain::ResolvedTerrainGrid::from_cells(
+            WALL_TEST_GRID,
+            WALL_TEST_GRID,
+            cells,
+        ),
+    );
+    let mut overlays = crate::sim::overlay_grid::OverlayGrid::new(WALL_TEST_GRID, WALL_TEST_GRID);
+    for &(rx, ry) in walls {
+        overlays.cell_mut(rx, ry).overlay_id = Some(WALL_TEST_GAWALL_ID);
+    }
+    sim.overlay_grid = Some(overlays);
+}
+
+/// **The deadlock tripwire.** Grizzly at (2,5), Rhino at (6,5): four cells, so
+/// the plain radius says "in range" against `Range=6`. A `GAWALL` sits at (4,5),
+/// and `[CANNON]` is `SubjectToWalls=yes` while `[AP]` has no `Wall=`, so the
+/// fire gate refuses the shot at `0x006F7642`.
+///
+/// If pursuit judged range with the 2-D twin it would produce no pursuit cell,
+/// the fire gate would refuse, and the tank would stand still under a live
+/// attack order forever. Native never gets there: its approach routine measures
+/// with the same `InRange` that runs the walk, so it keeps repositioning.
+#[test]
+fn a_wall_on_the_line_keeps_pursuit_closing_instead_of_freezing() {
+    let mut grizzly = make_unit(1, "MTNK", "Americans", 2, 5, 300);
+    grizzly.attack_target = Some(AttackTarget::new(2));
+    let rhino = make_unit(2, "HTNK", "Soviet", 6, 5, 400);
+    let (mut sim, grid) = make_sim(vec![grizzly, rhino]);
+    install_wall_map(&mut sim, &[(4, 5)]);
+    let rules = wall_pursuit_rules();
+    let registry = wall_pursuit_registry();
+
+    sim.tick_attack_pursuit_with_overlay_registry(
+        &rules,
+        Some(&grid),
+        Some(&registry),
+        &std::collections::BTreeSet::new(),
+    );
+
+    let entity = sim.substrate.entities.get(1).unwrap();
+    assert!(
+        entity.attack_target.is_some(),
+        "the order survives — pursuit never drops a target it is still closing on"
+    );
+    assert!(
+        entity.movement_target.is_some(),
+        "a shot the fire gate refuses must keep pursuit moving, not freeze the unit"
+    );
+}
+
+/// The control: the same fixture with the wall removed still halts, so the
+/// tripwire above is pinning the walk and not merely "pursuit always moves".
+#[test]
+fn without_the_wall_the_same_shot_halts_pursuit() {
+    let mut grizzly = make_unit(1, "MTNK", "Americans", 2, 5, 300);
+    grizzly.attack_target = Some(AttackTarget::new(2));
+    grizzly.movement_target = Some(crate::sim::components::MovementTarget::default());
+    let rhino = make_unit(2, "HTNK", "Soviet", 6, 5, 400);
+    let (mut sim, grid) = make_sim(vec![grizzly, rhino]);
+    install_wall_map(&mut sim, &[]);
+    let rules = wall_pursuit_rules();
+    let registry = wall_pursuit_registry();
+
+    sim.tick_attack_pursuit_with_overlay_registry(
+        &rules,
+        Some(&grid),
+        Some(&registry),
+        &std::collections::BTreeSet::new(),
+    );
+
+    let entity = sim.substrate.entities.get(1).unwrap();
+    assert!(
+        entity.movement_target.is_none(),
+        "with a clear line at four cells the shot is legal, so pursuit halts to fire"
+    );
+}

--- a/src/sim/combat/combat_pursuit_tests.rs
+++ b/src/sim/combat/combat_pursuit_tests.rs
@@ -503,3 +503,50 @@ fn without_the_wall_the_same_shot_halts_pursuit() {
         "with a clear line at four cells the shot is legal, so pursuit halts to fire"
     );
 }
+
+/// A `MinimumRange` refusal must NOT produce a pursuit cell.
+///
+/// Native's approach search 0x004D5690 scans candidate coordinates and takes
+/// one where `InRange` holds, so a V3 that has been closed on backs off. VERA's
+/// pursuit has exactly one candidate — the target's own cell — which for a
+/// too-close refusal is the worst cell in the set. Feeding the fire gate's full
+/// verdict into pursuit without this arm would send the V3 driving AT the tank
+/// it cannot shell, which is a worse symptom than the hold it replaces.
+///
+/// `MinimumRange=` is ordinary stock data: `V3Launcher` 5, `DredLauncher` and
+/// `CruiseLauncher` 8, `MagneticBeam` 3, `HowitzerGun` 2, the
+/// `MissileLauncher`/`HoverMissile` family 1.
+#[test]
+fn inside_minimum_range_pursuit_holds_instead_of_closing() {
+    let ini_str: &str = "\
+[VehicleTypes]\n0=MTNK\n1=HTNK\n\n\
+[MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nPrimary=LOBBER\n\n\
+[HTNK]\nStrength=400\nArmor=heavy\nSpeed=5\nPrimary=LOBBER\n\n\
+[LOBBER]\nDamage=200\nROF=150\nRange=20\nMinimumRange=5\nWarhead=AP\n\n\
+[AP]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,0%,0%\n";
+    let rules = RuleSet::from_ini(&IniFile::from_str(ini_str)).expect("min-range rules parse");
+
+    // Four cells apart: inside MinimumRange=5, well inside Range=20.
+    let mut lobber = make_unit(1, "MTNK", "Americans", 2, 5, 300);
+    lobber.attack_target = Some(AttackTarget::new(2));
+    let rhino = make_unit(2, "HTNK", "Soviet", 6, 5, 400);
+    let (mut sim, grid) = make_sim(vec![lobber, rhino]);
+    install_wall_map(&mut sim, &[]);
+
+    sim.tick_attack_pursuit_with_overlay_registry(
+        &rules,
+        Some(&grid),
+        None,
+        &std::collections::BTreeSet::new(),
+    );
+
+    let entity = sim.substrate.entities.get(1).unwrap();
+    assert!(
+        entity.attack_target.is_some(),
+        "the order survives a too-close refusal"
+    );
+    assert!(
+        entity.movement_target.is_none(),
+        "inside MinimumRange pursuit must hold, never drive at the target"
+    );
+}

--- a/src/sim/combat/combat_targeting.rs
+++ b/src/sim/combat/combat_targeting.rs
@@ -143,7 +143,7 @@ pub(crate) struct AttackerSnapshot {
 /// `zone_grid` is `MapClass`'s per-movement-zone connectivity, which mask 0 uses
 /// to refuse candidates its own movement zone cannot reach.
 #[allow(clippy::too_many_arguments)]
-pub fn acquire_best_target_for_entity(
+pub(crate) fn acquire_best_target_for_entity(
     entities: &EntityStore,
     rules: &RuleSet,
     interner: &StringInterner,
@@ -153,6 +153,7 @@ pub fn acquire_best_target_for_entity(
     require_playfield_membership: bool,
     mask: ScanMission,
     zone_grid: Option<&crate::sim::pathfinding::zone_map::ZoneGrid>,
+    los: super::line_of_fire::LineOfFireInputs<'_>,
 ) -> Option<u64> {
     let entity = entities.get(attacker_id)?;
     // Aircraft with 0 ammo should not acquire new targets — need to reload.
@@ -219,6 +220,7 @@ pub fn acquire_best_target_for_entity(
         terrain,
         require_playfield_membership,
         zone_grid,
+        los,
     )
 }
 
@@ -254,6 +256,7 @@ pub(crate) fn acquire_best_target(
     terrain: Option<&ResolvedTerrainGrid>,
     require_playfield_membership: bool,
     zone_grid: Option<&crate::sim::pathfinding::zone_map::ZoneGrid>,
+    los: super::line_of_fire::LineOfFireInputs<'_>,
 ) -> Option<u64> {
     super::greatest_threat::greatest_threat(
         entities,
@@ -266,6 +269,7 @@ pub(crate) fn acquire_best_target(
         terrain,
         require_playfield_membership,
         zone_grid,
+        los,
     )
 }
 
@@ -705,6 +709,7 @@ mod tests {
                 false,
                 ScanMission::Guard,
                 None,
+                crate::sim::combat::line_of_fire::LineOfFireInputs::default(),
             ),
             Some(2)
         );

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -6226,7 +6226,7 @@ fn wall_damage_deterministic_across_replays() {
 
 #[test]
 fn pursuit_weapon_range_for_entity_target() {
-    use crate::sim::combat::{TargetKind, pursuit_weapon_range};
+    use crate::sim::combat::{TargetKind, pursuit_selected_weapon};
     let rules = test_rules();
     let mut store = EntityStore::new();
     store.insert(make_entity(1, "MTNK", 0, 0, 300));
@@ -6234,7 +6234,7 @@ fn pursuit_weapon_range_for_entity_target() {
     let interner = test_interner();
 
     let attacker = store.get(1).unwrap();
-    let range = pursuit_weapon_range(
+    let range = pursuit_selected_weapon(
         attacker,
         &TargetKind::Entity(2),
         &store,
@@ -6242,21 +6242,22 @@ fn pursuit_weapon_range_for_entity_target() {
         &interner,
         None,
         None,
-    );
+    )
+    .map(|w| w.range);
     // 105mm Range=6.
     assert_eq!(range, Some(crate::util::fixed_math::SimFixed::from_num(6)));
 }
 
 #[test]
 fn pursuit_weapon_range_for_cell_target() {
-    use crate::sim::combat::{TargetKind, pursuit_weapon_range};
+    use crate::sim::combat::{TargetKind, pursuit_selected_weapon};
     let rules = test_rules();
     let mut store = EntityStore::new();
     store.insert(make_entity(1, "MTNK", 0, 0, 300));
     let interner = test_interner();
 
     let attacker = store.get(1).unwrap();
-    let range = pursuit_weapon_range(
+    let range = pursuit_selected_weapon(
         attacker,
         &TargetKind::Cell(50, 50),
         &store,
@@ -6264,7 +6265,8 @@ fn pursuit_weapon_range_for_cell_target() {
         &interner,
         None,
         None,
-    );
+    )
+    .map(|w| w.range);
     // Cell target: the ladder returns slot 0 and the GetFireError cell subset
     // clears it — the 105mm Cannon projectile is AG, and MTNK is not
     // LandTargeting=1. Range = 6.
@@ -6273,7 +6275,7 @@ fn pursuit_weapon_range_for_cell_target() {
 
 #[test]
 fn pursuit_weapon_range_none_for_unarmed_attacker() {
-    use crate::sim::combat::{TargetKind, pursuit_weapon_range};
+    use crate::sim::combat::{TargetKind, pursuit_selected_weapon};
     let rules_str = "[InfantryTypes]\n0=ENGI\n\n\
                      [VehicleTypes]\n\n[BuildingTypes]\n\n[AircraftTypes]\n\n\
                      [ENGI]\nStrength=75\nArmor=none\nSpeed=4\n";
@@ -6284,7 +6286,7 @@ fn pursuit_weapon_range_none_for_unarmed_attacker() {
     let interner = test_interner();
 
     let attacker = store.get(1).unwrap();
-    let range = pursuit_weapon_range(
+    let range = pursuit_selected_weapon(
         attacker,
         &TargetKind::Cell(50, 50),
         &store,
@@ -6292,7 +6294,8 @@ fn pursuit_weapon_range_none_for_unarmed_attacker() {
         &interner,
         None,
         None,
-    );
+    )
+    .map(|w| w.range);
     assert_eq!(range, None);
 }
 

--- a/src/sim/combat/greatest_threat.rs
+++ b/src/sim/combat/greatest_threat.rs
@@ -670,6 +670,11 @@ const STRUCTURE_FOOTPRINT_SLACK_CELLS: i32 = 8;
 /// Everything one scan needs that does not change between candidates.
 struct ScanContext<'a> {
     entities: &'a EntityStore,
+    /// Overlay/alliance state the InRange line-of-fire walk consults
+    /// (0x006F7642). Target selection runs the same `TechnoClass::InRange`
+    /// the fire site does, so it has to see the same walls and cliffs or a
+    /// unit picks a target it can never legally shoot.
+    los: crate::sim::combat::line_of_fire::LineOfFireInputs<'a>,
     rules: &'a RuleSet,
     interner: &'a StringInterner,
     attacker: &'a AttackerSnapshot,
@@ -838,6 +843,7 @@ pub(crate) fn greatest_threat(
     terrain: Option<&ResolvedTerrainGrid>,
     require_playfield_membership: bool,
     zone_grid: Option<&ZoneGrid>,
+    los: crate::sim::combat::line_of_fire::LineOfFireInputs<'_>,
 ) -> Option<u64> {
     let range = match scan_range_override {
         Some(cells) => ScanRange::Hard(cells),
@@ -886,6 +892,7 @@ pub(crate) fn greatest_threat(
 
     let ctx = ScanContext {
         entities,
+        los,
         rules,
         interner,
         attacker,
@@ -1295,6 +1302,7 @@ fn evaluate_candidate(ctx: &ScanContext<'_>, candidate: &GameEntity) -> Option<i
                     ctx.interner,
                     ctx.entities,
                     terrain,
+                    &ctx.los,
                 )
             }
             _ => is_within_range_leptons(dist_sq, selected.weapon.range),
@@ -1589,7 +1597,16 @@ mod tests {
     ) -> Option<u64> {
         let interner = test_interner();
         super::super::acquire_best_target_for_entity(
-            entities, rules, &interner, attacker, None, None, false, mask, zones,
+            entities,
+            rules,
+            &interner,
+            attacker,
+            None,
+            None,
+            false,
+            mask,
+            zones,
+            crate::sim::combat::line_of_fire::LineOfFireInputs::default(),
         )
     }
 

--- a/src/sim/combat/greatest_threat.rs
+++ b/src/sim/combat/greatest_threat.rs
@@ -1281,6 +1281,19 @@ fn evaluate_candidate(ctx: &ScanContext<'_>, candidate: &GameEntity) -> Option<i
         candidate.position.sub_y,
     );
     let in_range = match ctx.range {
+        // RESIDUAL (line of fire) — the hard cutoff is a plain radius, so this
+        // arm never runs the wall/cliff walk `TechnoClass::InRange` 0x006F7220
+        // ends in at 0x006F7642. Its one production author is the garrison
+        // passive scan (`combat::mod`'s `scan_range` override), which is also
+        // the branch whose fire gate skips the walk, so scan and fire agree.
+        // - Trigger: a garrison passive scan with a wall or a ≥4-Level step
+        //   between the building and the candidate.
+        // - Player effect: garrisoned infantry acquire and open fire on a
+        //   target gamemd would refuse.
+        // - Frequency: routine on urban maps.
+        // - Downstream risk: none to deterministic state; it is consistent
+        //   with the garrison fire gate rather than deadlocking against it.
+        //   Cured by the same override-aware range chain.
         ScanRange::Hard(cells) => is_within_range_leptons(dist_sq, cells),
         ScanRange::NoCutoff => true,
         ScanRange::CanFireAt => match (ctx.terrain, ctx.entities.get(ctx.attacker.stable_id)) {

--- a/src/sim/combat/in_range.rs
+++ b/src/sim/combat/in_range.rs
@@ -226,6 +226,45 @@ fn height_fire_bonus_leptons(
     0
 }
 
+/// The `MinimumRange` arm of `TechnoClass::InRange` on its own.
+///
+/// 0x006F737F–0x006F73E8. Native runs it BEFORE the arcing split, always in
+/// 3-D, and gates on `!= 0` rather than `> 0`; the strict `JL` at 0x006F73E8
+/// makes the boundary itself legal.
+fn minimum_range_blocks(weapon: &WeaponType, src: (i64, i64, i64), tgt: (i64, i64, i64)) -> bool {
+    if weapon.minimum_range_leptons == 0 {
+        return false;
+    }
+    let (sx, sy, sz) = src;
+    let (tx, ty, tz) = tgt;
+    let dx = sx - tx;
+    let dy = sy - ty;
+    let dz = sz - tz;
+    isqrt_i64(dx * dx + dy * dy + dz * dz) < i64::from(weapon.minimum_range_leptons)
+}
+
+/// Whether the attacker is standing INSIDE `weapon`'s `MinimumRange` — the one
+/// `InRange` refusal that walking toward the target cannot fix.
+///
+/// Pursuit needs to tell this refusal apart from the others because VERA's
+/// approach produces a single candidate (the target's own cell) where native's
+/// approach search 0x004D5690 scans many: for a too-close refusal the target's
+/// cell is the worst candidate in the set, not the best.
+pub(crate) fn inside_minimum_range(
+    src: (i64, i64, i64),
+    target: &TargetKind,
+    weapon: &WeaponType,
+    rules: &RuleSet,
+    interner: &StringInterner,
+    entities: &EntityStore,
+    terrain: &ResolvedTerrainGrid,
+) -> bool {
+    let Some(tgt) = resolve_target_coords_3d(target, entities, rules, interner, terrain) else {
+        return false;
+    };
+    minimum_range_blocks(weapon, src, tgt)
+}
+
 /// Full 3D range check. Returns true if `attacker` (firing from `src`) can
 /// hit `target` with `weapon`, accounting for all Stage 1 gates.
 ///
@@ -258,16 +297,9 @@ pub(crate) fn compute_in_range(
 
     let (sx, sy, sz) = src;
 
-    // MinimumRange, 0x006F737F–0x006F73E8. Native runs it BEFORE the arcing
-    // split, always in 3-D, and gates on `!= 0` rather than `> 0`; a strict
-    // `JL` at 0x006F73E8 makes the boundary itself legal.
-    if weapon.minimum_range_leptons != 0 {
-        let dx = sx - tx;
-        let dy = sy - ty;
-        let dz = sz - tz;
-        if isqrt_i64(dx * dx + dy * dy + dz * dz) < i64::from(weapon.minimum_range_leptons) {
-            return false;
-        }
+    // MinimumRange, 0x006F737F–0x006F73E8, before the arcing split.
+    if minimum_range_blocks(weapon, src, (tx, ty, tz)) {
+        return false;
     }
 
     // Arcing-weapon 2D fallthrough — preserves V3/Prism/etc. current behavior.

--- a/src/sim/combat/in_range.rs
+++ b/src/sim/combat/in_range.rs
@@ -14,11 +14,17 @@
 //! 0x00474620 scales `Range=` by 256 before truncating, so the fraction on 60
 //! of the 256 stock `Range=` weapons is real reach, not rounding noise.
 //!
+//! The gate's LAST step, on BOTH the arcing and the ground arm, is the
+//! line-of-fire walk at 0x006F7642, which `sim::combat::line_of_fire` owns: a
+//! wall or a cliff on the line refuses the shot outright. That is why this
+//! module takes `LineOfFireInputs` alongside the terrain grid.
+//!
 //! Stages 2-N add the remaining range-VALUE chain (Garrison / Bunker /
 //! OpenTopped / Veteran). Stage Arcing adds the full Branch B slope-arc check.
 //!
 //! Depends on: rules (ObjectType, Weapon, ProjectileType), map (terrain
-//! height + bridge), util/lepton (constants), util/fixed_math (isqrt_i64).
+//! height + bridge), sim/combat/line_of_fire, util/lepton (constants),
+//! util/fixed_math (isqrt_i64).
 //! Does NOT depend on render/ui/sidebar/audio/net.
 
 use crate::map::entities::EntityCategory;
@@ -26,6 +32,7 @@ use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use crate::rules::ruleset::RuleSet;
 use crate::rules::weapon_type::WeaponType;
 use crate::sim::combat::TargetKind;
+use crate::sim::combat::line_of_fire::{self, LineOfFireInputs};
 use crate::sim::entity_store::EntityStore;
 use crate::sim::game_entity::GameEntity;
 use crate::sim::intern::StringInterner;
@@ -224,6 +231,7 @@ fn height_fire_bonus_leptons(
 ///
 /// `src` is caller-supplied as `(attacker_x_lep, attacker_y_lep,
 /// effective_z_leptons(attacker, terrain))`.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn compute_in_range(
     attacker: &GameEntity,
     src: (i64, i64, i64),
@@ -233,6 +241,7 @@ pub(crate) fn compute_in_range(
     interner: &StringInterner,
     entities: &EntityStore,
     terrain: &ResolvedTerrainGrid,
+    los: &LineOfFireInputs<'_>,
 ) -> bool {
     let weapon_range_lep: i64 = i64::from(weapon.range_leptons);
 
@@ -269,7 +278,24 @@ pub(crate) fn compute_in_range(
         .map(|p| p.arcing)
         .unwrap_or(false);
     if arcing {
-        return compute_in_range_arcing_2d(src, (tx, ty), weapon_range_lep);
+        if !compute_in_range_arcing_2d(src, (tx, ty), weapon_range_lep) {
+            return false;
+        }
+        // The arcing arm is NOT exempt from the line-of-fire walk: 0x006F7519
+        // pushes the same two arguments and jumps straight to 0x006F763C, so
+        // both arms share the `CALL 0x004CC310`. This matters on stock data —
+        // `[Cannon]`, the projectile behind every cannon tank, is
+        // `Arcing=true` AND `SubjectToWalls=yes`/`SubjectToCliffs=yes`.
+        return line_of_fire_clear(
+            attacker,
+            src,
+            (tx, ty),
+            weapon,
+            rules,
+            interner,
+            terrain,
+            los,
+        );
     }
 
     let max_range_lep =
@@ -289,7 +315,50 @@ pub(crate) fn compute_in_range(
         return false;
     }
 
-    true
+    // 0x006F7642 — the last thing `InRange` does. `TEST EAX,EAX; SETZ AL`
+    // means a blocking cell is a refusal, not a warning.
+    line_of_fire_clear(
+        attacker,
+        src,
+        (tx, ty),
+        weapon,
+        rules,
+        interner,
+        terrain,
+        los,
+    )
+}
+
+/// `CALL 0x004CC310` at 0x006F7642 with `InRange`'s own source and target
+/// coordinates, the weapon from `[EBP+0x10]`, and the firer's house from
+/// `this->+0x21C` (loaded at 0x006F7631 / 0x006F7511).
+#[allow(clippy::too_many_arguments)]
+fn line_of_fire_clear(
+    attacker: &GameEntity,
+    src: (i64, i64, i64),
+    target_xy: (i64, i64),
+    weapon: &WeaponType,
+    rules: &RuleSet,
+    interner: &StringInterner,
+    terrain: &ResolvedTerrainGrid,
+    los: &LineOfFireInputs<'_>,
+) -> bool {
+    line_of_fire::line_of_fire_blocking_cell(
+        (src.0, src.1),
+        target_xy,
+        weapon,
+        // `try_resolve` rather than `resolve`: the house name is read only by
+        // the `[WallModel] AlliedWallTransparency` arm at 0x004CC458, which
+        // stock rules leave off, and a fixture interner that never saw this
+        // owner must not panic the range gate. An unresolvable owner matches
+        // no alliance, which is the same verdict the stock rule gives.
+        interner.try_resolve(attacker.owner).unwrap_or_default(),
+        rules,
+        terrain,
+        interner,
+        los,
+    )
+    .is_none()
 }
 
 /// Stage 1 arcing-weapon path: 2-D distance against the base weapon range.
@@ -984,6 +1053,7 @@ mod tests {
             &interner,
             &entities,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(in_range, "sentinel range should always be in range");
     }
@@ -1010,6 +1080,7 @@ mod tests {
             &interner,
             &entities,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(at_boundary, "exact-range boundary should be inclusive");
 
@@ -1027,6 +1098,7 @@ mod tests {
             &interner,
             &entities2,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(
             !one_past,
@@ -1060,6 +1132,7 @@ mod tests {
             &interner,
             &entities,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(
             at_min,
@@ -1080,6 +1153,7 @@ mod tests {
             &interner,
             &entities2,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(
             !inside_min,
@@ -1111,6 +1185,7 @@ mod tests {
             &interner,
             &entities,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(!r4, "1273-lepton 3D distance exceeds 1024 leptons");
 
@@ -1126,6 +1201,7 @@ mod tests {
             &interner,
             &entities,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(r5, "1273-lepton 3D distance is within 1280 leptons");
     }
@@ -1152,6 +1228,7 @@ mod tests {
             &interner,
             &entities,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(
             in_range,
@@ -1259,6 +1336,7 @@ mod tests {
             &interner,
             &entities,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(
             !in_range,
@@ -1305,6 +1383,7 @@ mod tests {
             &interner,
             &entities,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(
             in_range,
@@ -1337,6 +1416,7 @@ mod tests {
             &interner,
             &entities,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(in_range, "sentinel should bypass min-range gate");
     }
@@ -1363,6 +1443,7 @@ mod tests {
             &interner,
             &entities,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(
             !in_range,
@@ -1405,6 +1486,7 @@ mod tests {
             &interner,
             &entities,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         );
         assert!(
             in_range,
@@ -1452,7 +1534,15 @@ mod tests {
         let src =
             fire_source_coords(kirov, &target, weapon, &entities, &terrain).expect("source coords");
         compute_in_range(
-            kirov, src, &target, weapon, rules, &interner, &entities, &terrain,
+            kirov,
+            src,
+            &target,
+            weapon,
+            rules,
+            &interner,
+            &entities,
+            &terrain,
+            &LineOfFireInputs::terrain_only(),
         )
     }
 
@@ -1593,7 +1683,15 @@ mod tests {
             "Z becomes the target's own coordinate, not the 520 + 750 it stands at"
         );
         assert!(compute_in_range(
-            &cruising, src, &target, weapon, &rules, &interner, &entities, &terrain,
+            &cruising,
+            src,
+            &target,
+            weapon,
+            &rules,
+            &interner,
+            &entities,
+            &terrain,
+            &LineOfFireInputs::terrain_only(),
         ));
 
         // The same airship one lepton below the split is NOT high-flying, so
@@ -1612,6 +1710,7 @@ mod tests {
                 &interner,
                 &entities,
                 &terrain,
+                &LineOfFireInputs::terrain_only(),
             ),
             "below the split the attacker's own height is still charged"
         );
@@ -1656,6 +1755,7 @@ mod tests {
             &interner,
             &entities,
             &terrain,
+            &LineOfFireInputs::terrain_only(),
         ));
 
         // Two cells out (512 leptons flat) is inside a 599-lepton minimum, but
@@ -1674,6 +1774,7 @@ mod tests {
                 &interner,
                 &close_entities,
                 &close,
+                &LineOfFireInputs::terrain_only(),
             ),
             "a 2-D minimum-range test would have refused this arcing shot"
         );
@@ -1708,7 +1809,15 @@ mod tests {
         let weapon = rules.weapon("GUN").expect("weapon");
         let interner = test_interner();
         compute_in_range(
-            attacker, src, target, weapon, &rules, &interner, entities, terrain,
+            attacker,
+            src,
+            target,
+            weapon,
+            &rules,
+            &interner,
+            entities,
+            terrain,
+            &LineOfFireInputs::terrain_only(),
         )
     }
 
@@ -2056,50 +2165,146 @@ mod tests {
         panic!("unimplemented: InRange 0x006F74D7 arcing bridge height ceiling");
     }
 
-    /// RESIDUAL — gamemd address 0x006F7642, the `CALL 0x004CC310` whose
-    /// result decides `InRange`'s final `return`.
+    /// `InRange`'s final `return`, 0x006F7642: `CALL 0x004CC310` and
+    /// `TEST EAX,EAX; SETZ AL`. A `SubjectToCliffs` projectile with a
+    /// four-Level ridge between attacker and target is refused, and the same
+    /// shot over flat ground is legal — so the walk is reached from
+    /// `compute_in_range` and its verdict decides the gate.
     ///
-    /// Mechanism: after the distance test passes, `InRange` calls
-    /// `FUN_004CC310(weapon, this->+0x21C)` with the source and target
-    /// coordinates and returns `result == 0`. That function delegates to
-    /// `FUN_004CC100`, which — only when the projectile at `WeaponType+0xA0`
-    /// sets `SubjectToCliffs` (`BulletType+0x296`, key string 0x0081B118) or
-    /// `SubjectToWalls` (`+0x298`, key string 0x0081B0F4) — walks the line
-    /// source→target one cell at a time (Chebyshev step count, per-axis
-    /// integer division for the increments) and asks `FUN_004CC360` whether
-    /// each cell blocks. A nonzero answer means blocked, and
-    /// `CellClass::IsWallConnectableInDirection` 0x00480510 combined with the
-    /// warhead byte at `WeaponType+0xAC` `+0x144` re-admits the shot when the
-    /// warhead may break the wall itself.
-    ///
-    /// Trigger: any shot whose projectile is `SubjectToWalls=` or
-    /// `SubjectToCliffs=` and that has a wall or cliff on the line.
-    ///
-    /// Effect: gamemd reports "not in range" and the attacker never fires;
-    /// VERA passes the gate, fires, and leaves the outcome to the projectile's
-    /// own in-flight wall handling in `sim/projectile.rs`. Target selection and
-    /// pursuit also disagree, since both run through this same predicate.
-    ///
-    /// Frequency: 30 stock projectile sections declare either key; 10 set
-    /// `SubjectToWalls=yes` and 9 `SubjectToCliffs=yes`. Both land on
-    /// `InvisibleLow` — the small-arms projectile behind `M60` (`[E1]` GI,
-    /// `[GGI]`), `M1Carbine` (`[E2]` Conscript), `Vulcan` (`[NALASR]` Sentry
-    /// Gun), `AKM` (`[BORIS]`), `Sniper`, `MirageGun` and the rest — and on
-    /// `Cannon`, i.e. every cannon tank. That is most of the units in the game
-    /// shooting past a wall or a cliff.
-    ///
-    /// **This residual is NON-DEFERRABLE by ENGINE.md's own test** — it fires
-    /// in ordinary skirmish and it breaks a loop (pursuit walks a unit toward a
-    /// target it can never legally shoot). It is not ported HERE because the
-    /// per-cell blocking predicate `FUN_004CC360`, the wall-overlay topology,
-    /// `CellClass::IsWallConnectableInDirection` 0x00480510 and the
-    /// warhead wall-breaking re-admission are one coherent mechanism, and
-    /// half-porting it would mean a VERA-only blocking heuristic in `sim/`.
-    /// It is scheduled as its own mechanism, not filed as an accepted gap.
+    /// This is the live wiring of the whole mechanism; the per-cell rules are
+    /// pinned in `sim::combat::line_of_fire`.
     #[test]
-    #[ignore = "gamemd 0x006F7642 refuses the shot when a wall or cliff blocks the line; VERA's range gate has no line walk"]
-    fn inrange_line_of_fire_block_is_unported() {
-        panic!("unimplemented: InRange 0x006F7642 SubjectToWalls/SubjectToCliffs line walk");
+    fn a_cliff_on_the_line_refuses_the_shot() {
+        let rules = rules_with_weapon(
+            "Damage=1\nROF=20\nRange=8\nWarhead=WH\nProjectile=SHELL\n\n\
+             [SHELL]\nSubjectToCliffs=yes",
+            "",
+            "",
+        );
+        let weapon = rules.weapon("GUN").expect("weapon");
+        let attacker = ground_attacker(2, 2, 0, "ATKR");
+        let mut entities = EntityStore::new();
+        entities.insert(ground_target(6, 2, 0, "TGT"));
+        // Snapshot the thread-local interner only after both entities have
+        // interned their owner and type names.
+        let interner = test_interner();
+
+        let flat = flat_terrain(16, 16);
+        assert!(
+            compute_in_range(
+                &attacker,
+                src_at_cell(2, 2, 0),
+                &TargetKind::Entity(200),
+                weapon,
+                &rules,
+                &interner,
+                &entities,
+                &flat,
+                &LineOfFireInputs::terrain_only(),
+            ),
+            "flat ground: nothing blocks, the shot is legal"
+        );
+
+        let mut ridged = flat_terrain(16, 16);
+        for ry in 0..16u16 {
+            ridged.cell_mut(4, ry).expect("ridge cell").level = 4;
+        }
+        assert!(
+            !compute_in_range(
+                &attacker,
+                src_at_cell(2, 2, 0),
+                &TargetKind::Entity(200),
+                weapon,
+                &rules,
+                &interner,
+                &entities,
+                &ridged,
+                &LineOfFireInputs::terrain_only(),
+            ),
+            "a four-Level ridge on the line refuses the shot (0x004CC3F7)"
+        );
+    }
+
+    /// The arcing arm reaches the same call. 0x006F7519 pushes the weapon and
+    /// the firer's house and jumps to 0x006F763C, which is the ground arm's own
+    /// `CALL 0x004CC310`. Stock `[Cannon]` — every cannon tank's projectile —
+    /// is `Arcing=true` with both `SubjectToWalls=yes` and
+    /// `SubjectToCliffs=yes`, so leaving the arcing arm exempt would miss the
+    /// largest population this mechanism governs.
+    #[test]
+    fn the_arcing_arm_runs_the_line_walk_too() {
+        let rules = rules_with_weapon(
+            "Damage=1\nROF=20\nRange=8\nWarhead=WH\nProjectile=SHELL\n\n\
+             [SHELL]\nArcing=yes\nSubjectToCliffs=yes",
+            "",
+            "",
+        );
+        let weapon = rules.weapon("GUN").expect("weapon");
+        assert!(
+            rules.projectile("SHELL").expect("projectile").arcing,
+            "the fixture must actually take the arcing arm"
+        );
+        let attacker = ground_attacker(2, 2, 0, "ATKR");
+        let mut entities = EntityStore::new();
+        entities.insert(ground_target(6, 2, 0, "TGT"));
+        // Snapshot the thread-local interner only after both entities have
+        // interned their owner and type names.
+        let interner = test_interner();
+
+        let mut ridged = flat_terrain(16, 16);
+        for ry in 0..16u16 {
+            ridged.cell_mut(4, ry).expect("ridge cell").level = 4;
+        }
+        assert!(
+            !compute_in_range(
+                &attacker,
+                src_at_cell(2, 2, 0),
+                &TargetKind::Entity(200),
+                weapon,
+                &rules,
+                &interner,
+                &entities,
+                &ridged,
+                &LineOfFireInputs::terrain_only(),
+            ),
+            "the arcing arm must run the walk (0x006F7519 -> 0x006F763C)"
+        );
+    }
+
+    /// The `-512` always-in-range sentinel is tested first (0x006F724E,
+    /// `CMP EDI,0xFFFFFE00`), so it returns before the walk ever runs — a
+    /// `Range=-2` weapon is in range through a cliff.
+    #[test]
+    fn the_always_in_range_sentinel_precedes_the_line_walk() {
+        let rules = rules_with_weapon(
+            "Damage=1\nROF=20\nRange=-2\nWarhead=WH\nProjectile=SHELL\n\n\
+             [SHELL]\nSubjectToCliffs=yes",
+            "",
+            "",
+        );
+        let weapon = rules.weapon("GUN").expect("weapon");
+        let attacker = ground_attacker(2, 2, 0, "ATKR");
+        let mut entities = EntityStore::new();
+        entities.insert(ground_target(6, 2, 0, "TGT"));
+        // Snapshot the thread-local interner only after both entities have
+        // interned their owner and type names.
+        let interner = test_interner();
+
+        let mut ridged = flat_terrain(16, 16);
+        for ry in 0..16u16 {
+            ridged.cell_mut(4, ry).expect("ridge cell").level = 4;
+        }
+        assert!(compute_in_range(
+            &attacker,
+            src_at_cell(2, 2, 0),
+            &TargetKind::Entity(200),
+            weapon,
+            &rules,
+            &interner,
+            &entities,
+            &ridged,
+            &LineOfFireInputs::terrain_only(),
+        ));
     }
 
     /// RESIDUAL — gamemd address 0x006F7314, `CALL dword ptr [EDX + 0x48]` on

--- a/src/sim/combat/line_of_fire.rs
+++ b/src/sim/combat/line_of_fire.rs
@@ -47,12 +47,30 @@ const CLIFF_STEP_LEVELS: i32 = 4;
 /// Overlay array indices that `CellClass::IsWallConnectableInDirection`
 /// 0x00480510 accepts for the "any wall?" query — the form 0x004CC32D uses,
 /// pushing `-1` for both the type and the direction. The three ids are hard
-/// coded in that body; with stock `[OverlayTypes]` (list position IS the id,
-/// so INI key N is id N-1) they are `GAWALL`, `NAWALL` and `CAKRMW`.
+/// coded in that body.
 ///
-/// Deliberately NOT "every `Wall=yes` overlay": `GASAND` (id 0) and `CAFNCP`
-/// also carry `Wall=yes` and are absent from this set, so a wall-breaking
-/// warhead does not get waved through a sandbag line.
+/// **These are `[OverlayTypes]` DECLARATION indices, not the INI key text.**
+/// `RulesClass::Process` reads the section by 0-based entry index — `XOR
+/// EBX,EBX` at 0x00668CF3, `PUSH EBX` as the entry selector at 0x00668D0A,
+/// `INC EBX; CMP EBX,EBP; JL` at 0x00668D2F-0x00668D32 — and never parses the
+/// `N=` on the left of the line. Stock `rulesmd.ini` has 250 entries under keys
+/// 1..253 with keys **40, 41 and 183 missing**, so `id == key - 1` holds only
+/// below key 42. Resolved by declaration index the three ids are `GAWALL`
+/// (key 3), `NAWALL` (key 27) and `GAFWLL` (key 247). `CAKRMW`, the Kremlin
+/// wall, is id **240** and is NOT in this set — a wall-breaking shell is
+/// refused by it exactly as it is by sandbags. VERA shares that numbering:
+/// `rules::overlay_types::is_bridge_overlay_index` pins `BRIDGEB1`/`BRIDGEB2`
+/// at 237/238, their declaration indices, against INI keys 241/242.
+///
+/// Id 243 is inert on stock data anyway: `[GAFWLL]` has no section in
+/// `rulesmd.ini` at all (a Tiberian Sun firestorm-wall leftover left in the
+/// list), so it carries no `Wall=` and the walk never flags it as a wall in
+/// the first place.
+///
+/// Deliberately NOT "every `Wall=yes` overlay": stock authors `Wall=yes` on
+/// seven overlays — `GASAND` (0), `GAWALL` (2), `NAWALL` (26), `CAFNCB`,
+/// `CAFNCW`, `CAKRMW` (240) and `CAFNCP` — of which only two are re-admitted,
+/// so a wall-breaking warhead does not get waved through a sandbag line.
 const WALL_CONNECTABLE_OVERLAY_IDS: [u8; 3] = [2, 26, 243];
 
 /// Map state the walk consults beyond the resolved terrain grid.
@@ -413,8 +431,9 @@ mod tests {
     const SANDBAG_GASAND_ID: u8 = 0;
     const GRID: u16 = 16;
 
-    /// Overlay ids follow `[OverlayTypes]` list position, so the stock
-    /// numbering that puts `GAWALL` at 2 and `NAWALL` at 26 has to be
+    /// Overlay ids follow `[OverlayTypes]` DECLARATION order (0x00668CF3 /
+    /// 0x00668D0A read entries by 0-based index, never by key text), so the
+    /// stock numbering that puts `GAWALL` at 2 and `NAWALL` at 26 has to be
     /// reproduced by the fixture list, not asserted from names.
     fn rules_ini(extra: &str) -> String {
         format!(

--- a/src/sim/combat/line_of_fire.rs
+++ b/src/sim/combat/line_of_fire.rs
@@ -1,0 +1,867 @@
+//! The line-of-fire walk — the last gate in `TechnoClass::InRange`.
+//!
+//! `InRange` 0x006F7220 ends both of its arms in the same call: the arcing arm
+//! at 0x006F7519 pushes its two arguments and jumps to 0x006F763C, the ground
+//! arm falls into 0x006F763B, and both land on `CALL 0x004CC310` at
+//! **0x006F7642**, whose result is inverted into the return
+//! (`TEST EAX,EAX; SETZ AL` at 0x006F7647). A non-null answer is a blocking
+//! cell, and the shot is refused — the attacker reports "not in range" rather
+//! than firing into a wall or a cliff face.
+//!
+//! Three native bodies make up the mechanism:
+//!
+//! | Address | Role |
+//! |---|---|
+//! | 0x004CC310 | wraps the walk and re-admits a breakable wall |
+//! | 0x004CC100 | steps the line source→target one cell at a time |
+//! | 0x004CC360 | decides whether one sampled cell blocks |
+//!
+//! Only projectiles that set `SubjectToCliffs` (`BulletType+0x296`, key string
+//! 0x0081B118, read at 0x0046BFF8) or `SubjectToWalls` (`+0x298`, key string
+//! 0x0081B0F4, read at 0x0046C02C) enter the walk at all — 0x004CC10B tests
+//! both and returns immediately when neither is set.
+//!
+//! Depends on: rules (WeaponType, ProjectileType, WarheadType, RuleSet,
+//! OverlayTypeRegistry), map (resolved terrain, house alliances), sim
+//! (overlay grid, bridge topology). Does NOT depend on render/ui/sidebar/
+//! audio/net.
+
+use crate::map::houses::{HouseAllianceMap, are_houses_friendly};
+use crate::map::overlay_types::OverlayTypeRegistry;
+use crate::map::resolved_terrain::ResolvedTerrainGrid;
+use crate::rules::ruleset::RuleSet;
+use crate::rules::weapon_type::WeaponType;
+use crate::sim::intern::StringInterner;
+use crate::sim::map::bridge_topology::CellBridgeView;
+use crate::sim::overlay_grid::OverlayGrid;
+
+/// Leptons per cell — the divisor in the `CDQ; AND EDX,0xFF; ADD; SAR 8`
+/// idiom the walk uses at 0x004CC12F, 0x004CC28A and 0x004CC371.
+const LEPTONS_PER_CELL: i64 = 256;
+
+/// `CellClass::GetEffectiveHeight` difference at or above which a step counts
+/// as a cliff — `CMP EBX,0x4; JL` at 0x004CC3DE (and the duplicated
+/// `CMP EAX,0x4` at 0x004CC5A7). Units are terrain Levels, not leptons.
+const CLIFF_STEP_LEVELS: i32 = 4;
+
+/// Overlay array indices that `CellClass::IsWallConnectableInDirection`
+/// 0x00480510 accepts for the "any wall?" query — the form 0x004CC32D uses,
+/// pushing `-1` for both the type and the direction. The three ids are hard
+/// coded in that body; with stock `[OverlayTypes]` (list position IS the id,
+/// so INI key N is id N-1) they are `GAWALL`, `NAWALL` and `CAKRMW`.
+///
+/// Deliberately NOT "every `Wall=yes` overlay": `GASAND` (id 0) and `CAFNCP`
+/// also carry `Wall=yes` and are absent from this set, so a wall-breaking
+/// warhead does not get waved through a sandbag line.
+const WALL_CONNECTABLE_OVERLAY_IDS: [u8; 3] = [2, 26, 243];
+
+/// Map state the walk consults beyond the resolved terrain grid.
+///
+/// `overlay_grid`/`overlay_registry` are `Option` because several sim entry
+/// points run against terrain-only fixtures. A `None` there means "this map
+/// carries no overlay plane", which is the same answer as "no wall on the
+/// line" — it is not a VERA-only early-out. Cliffs need only terrain and are
+/// therefore always evaluated.
+///
+/// `alliances` is consulted only under `[WallModel] AlliedWallTransparency`,
+/// which stock rules set to `no`.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct LineOfFireInputs<'a> {
+    pub overlay_grid: Option<&'a OverlayGrid>,
+    pub overlay_registry: Option<&'a OverlayTypeRegistry>,
+    pub alliances: Option<&'a HouseAllianceMap>,
+}
+
+impl<'a> LineOfFireInputs<'a> {
+    /// Terrain-only inputs: cliffs are still evaluated, walls cannot be.
+    pub(crate) const fn terrain_only() -> Self {
+        Self {
+            overlay_grid: None,
+            overlay_registry: None,
+            alliances: None,
+        }
+    }
+}
+
+/// One cell's state as the three native bodies read it.
+#[derive(Clone, Copy)]
+struct WalkCell {
+    rx: u16,
+    ry: u16,
+    /// `CellClass::GetEffectiveHeight` 0x00487D50 —
+    /// `(i8)Level(+0x11B) + ((flags(+0x140) >> 7) & 1) * 4`.
+    effective_height: i32,
+    /// The raw signed `Level` byte at `+0x11B`. The source-vs-target height
+    /// test at 0x004CC444 compares this, NOT the effective height.
+    level: i8,
+    /// `CellClass+0x44` overlay type index, and whether
+    /// `OverlayTypeClass+0x2A8` (`Wall=`, key string 0x0081AC58, read at
+    /// 0x005FE7E0) is set on it.
+    wall_overlay_id: Option<u8>,
+    /// `Houses[CellClass+0x50]` — the wall's owning house, if any.
+    wall_owner: Option<crate::sim::intern::InternedId>,
+}
+
+impl WalkCell {
+    fn has_wall(&self) -> bool {
+        self.wall_overlay_id.is_some()
+    }
+}
+
+/// Fetch one cell's walk-relevant state.
+///
+/// Returns `None` when the coordinate is outside the resolved grid. Native's
+/// `MapClass::Get_CellClass` 0x005657A0 answers a shared dummy `CellClass`
+/// at 0x00ABDC50 instead of failing, and that dummy's persistent `Level` and
+/// overlay index are **UNCHECKED** here. It is unreachable on this path in
+/// ordinary play: the playfield is convex in cell space, so a straight line
+/// between two in-playfield endpoints never leaves it.
+fn walk_cell(
+    terrain: &ResolvedTerrainGrid,
+    los: &LineOfFireInputs<'_>,
+    cx: i32,
+    cy: i32,
+) -> Option<WalkCell> {
+    let rx = u16::try_from(cx).ok()?;
+    let ry = u16::try_from(cy).ok()?;
+    let cell = terrain.cell(rx, ry)?;
+    let view = CellBridgeView::from_resolved(cell);
+
+    let mut wall_overlay_id = None;
+    let mut wall_owner = None;
+    if let (Some(grid), Some(registry)) = (los.overlay_grid, los.overlay_registry) {
+        let overlay_cell = grid.cell(rx, ry);
+        if let Some(id) = overlay_cell.overlay_id {
+            if registry.flags(id).is_some_and(|flags| flags.wall) {
+                wall_overlay_id = Some(id);
+                wall_owner = overlay_cell.wall_owner;
+            }
+        }
+    }
+
+    Some(WalkCell {
+        rx,
+        ry,
+        effective_height: view.effective_height(),
+        level: cell.level as i8,
+        wall_overlay_id,
+        wall_owner,
+    })
+}
+
+/// `FUN_004CC360` 0x004CC360 — does the cell at `(x, y)` block the line?
+///
+/// ```text
+/// ECX = source cell, EDX = target cell
+/// [ESP+4] = the previous sample's cell, +8/+C/+10 = x/y/z leptons,
+/// [ESP+14] = the projectile, [ESP+18] = the firing house
+/// ```
+///
+/// **The tail at 0x004CC489–0x004CC572 is dead and is deliberately not
+/// ported.** Every jump into 0x004CC489 (0x004CC3F7 cliff-blocked,
+/// 0x004CC466 / 0x004CC475 wall-blocked, and the fallthrough from the
+/// not-allied `JNZ` at 0x004CC483) has already concluded "blocked". The tail
+/// then measures the sample point against the cell's own coords and, when the
+/// perpendicular offset dominates, re-fetches a cell from the packed
+/// `CellStruct` at `entry-0x20` — written once at 0x004CC3AD and never
+/// touched again, so it re-reads the *same* cell — and re-runs a byte-for-byte
+/// duplicate of the tests above it. Both duplicated tests read the identical
+/// operands (`CMP EAX,0x4` / `CMP EBX,0x4`; `[ESP+0x1C]` vs `EBP` for the
+/// source cell; `[ESP+0x10]` vs `EBX` for the target; `[ESP+0x50]` for the
+/// house in both), so every path out of it returns the same cell the first
+/// evaluation had already selected. The whole block therefore reduces to
+/// `return stepCell`.
+fn cell_blocks_line_of_fire(
+    src_cell: &WalkCell,
+    tgt_cell: &WalkCell,
+    prev_cell: &WalkCell,
+    x: i64,
+    y: i64,
+    subject_to_cliffs: bool,
+    subject_to_walls: bool,
+    firing_house: &str,
+    allied_wall_transparency: bool,
+    terrain: &ResolvedTerrainGrid,
+    interner: &StringInterner,
+    los: &LineOfFireInputs<'_>,
+) -> Option<(u16, u16)> {
+    let step = walk_cell(
+        terrain,
+        los,
+        (x / LEPTONS_PER_CELL) as i32,
+        (y / LEPTONS_PER_CELL) as i32,
+    )?;
+
+    // Cliff arm, 0x004CC3C0–0x004CC3F7. The step must rise at least four
+    // Levels above the cell we stepped FROM *and* stand above the cell the
+    // shot started in. A climb that only regains ground already lost does not
+    // block.
+    if subject_to_cliffs
+        && step.effective_height - prev_cell.effective_height >= CLIFF_STEP_LEVELS
+        && step.effective_height - src_cell.effective_height > 0
+    {
+        return Some((step.rx, step.ry));
+    }
+
+    // Wall arm, 0x004CC401 onward.
+    if !subject_to_walls {
+        return None;
+    }
+    // 0x004CC434 — the target's own cell never blocks; you are allowed to
+    // shoot the wall you are aiming at.
+    if (step.rx, step.ry) == (tgt_cell.rx, tgt_cell.ry) {
+        return None;
+    }
+    if !step.has_wall() {
+        return None;
+    }
+    // 0x004CC444 — `CMP AL,CL; JG`, a SIGNED byte compare of the raw `Level`
+    // at `+0x11B` (not the effective height the cliff arm uses). Firing from
+    // higher ground than the target clears the wall.
+    if src_cell.level > tgt_cell.level {
+        return None;
+    }
+    // 0x004CC458 — `[WallModel] AlliedWallTransparency`. When it is on, a
+    // wall belonging to a house allied with the firer does not block.
+    if allied_wall_transparency {
+        if let (Some(owner), Some(alliances)) = (step.wall_owner, los.alliances) {
+            if are_houses_friendly(alliances, firing_house, interner.resolve(owner)) {
+                return None;
+            }
+        }
+    }
+
+    Some((step.rx, step.ry))
+}
+
+/// `FUN_004CC100` 0x004CC100 — walk the line and return the first blocking
+/// cell.
+///
+/// Step count is the Chebyshev distance in CELLS between the source and target
+/// cells (0x004CC191–0x004CC1B5); the per-step increments are the lepton
+/// deltas divided by that count with truncating integer division
+/// (`IDIV EBP` at 0x004CC1E7/0x004CC1EE/0x004CC1F9). Sample `i` sits at
+/// `src + i * delta`, so the walk covers the source position and everything up
+/// to but not including the target position.
+///
+/// The "previous cell" argument each step hands to the blocking predicate is
+/// the cell of sample `i-1` — it starts as the source cell (0x004CC22F) and is
+/// re-fetched from the sample just tested at 0x004CC2C2, *before* the
+/// accumulators advance.
+#[allow(clippy::too_many_arguments)]
+fn walk_line_for_blocking_cell(
+    src: (i64, i64),
+    tgt: (i64, i64),
+    subject_to_cliffs: bool,
+    subject_to_walls: bool,
+    firing_house: &str,
+    allied_wall_transparency: bool,
+    terrain: &ResolvedTerrainGrid,
+    interner: &StringInterner,
+    los: &LineOfFireInputs<'_>,
+) -> Option<(u16, u16)> {
+    // 0x004CC10B — neither key set, no walk at all.
+    if !subject_to_cliffs && !subject_to_walls {
+        return None;
+    }
+
+    let src_cx = (src.0 / LEPTONS_PER_CELL) as i32;
+    let src_cy = (src.1 / LEPTONS_PER_CELL) as i32;
+    let tgt_cx = (tgt.0 / LEPTONS_PER_CELL) as i32;
+    let tgt_cy = (tgt.1 / LEPTONS_PER_CELL) as i32;
+
+    let steps = (src_cx - tgt_cx).abs().max((src_cy - tgt_cy).abs());
+    // 0x004CC22D — `CMP EBP,ECX; JLE`, so a same-cell shot never enters the
+    // loop and can never be blocked.
+    if steps <= 0 {
+        return None;
+    }
+
+    // Both endpoint cells are read once, before the loop (0x004CC20D /
+    // 0x004CC222), and reused for every sample.
+    let src_cell = walk_cell(terrain, los, src_cx, src_cy)?;
+    let tgt_cell = walk_cell(terrain, los, tgt_cx, tgt_cy)?;
+
+    let dx = (tgt.0 - src.0) / i64::from(steps);
+    let dy = (tgt.1 - src.1) / i64::from(steps);
+
+    let mut prev_cell = src_cell;
+    for i in 0..i64::from(steps) {
+        let x = src.0 + dx * i;
+        let y = src.1 + dy * i;
+        if let Some(hit) = cell_blocks_line_of_fire(
+            &src_cell,
+            &tgt_cell,
+            &prev_cell,
+            x,
+            y,
+            subject_to_cliffs,
+            subject_to_walls,
+            firing_house,
+            allied_wall_transparency,
+            terrain,
+            interner,
+            los,
+        ) {
+            return Some(hit);
+        }
+        let Some(next) = walk_cell(
+            terrain,
+            los,
+            (x / LEPTONS_PER_CELL) as i32,
+            (y / LEPTONS_PER_CELL) as i32,
+        ) else {
+            return None;
+        };
+        prev_cell = next;
+    }
+    None
+}
+
+/// `FUN_004CC310` 0x004CC310 — the function `InRange` actually calls, and the
+/// one that decides the gate.
+///
+/// ```text
+/// 004cc322  CALL 0x004cc100                    ; the walk
+/// 004cc32b  JZ   ...                           ; nothing blocked -> pass
+/// 004cc333  CALL 0x00480510                    ; IsWallConnectableInDirection(-1, -1)
+/// 004cc342  MOV  CL,[EAX+0x144]                ; weapon->Warhead->Wall
+/// 004cc34d  XOR  EAX,EAX                       ; both true -> report NOT blocked
+/// ```
+///
+/// The re-admission is the reason a Grizzly does not refuse to fire at a
+/// target behind a wall it can knock down: `105mm`'s warhead carries
+/// `Wall=yes`, so the shot is legal and the wall eats it. A warhead without
+/// `Wall=` — small arms, most of `InvisibleLow`'s users — stays refused.
+///
+/// Returns the blocking cell, or `None` when the shot is legal.
+pub(crate) fn line_of_fire_blocking_cell(
+    src: (i64, i64),
+    tgt: (i64, i64),
+    weapon: &WeaponType,
+    firing_house: &str,
+    rules: &RuleSet,
+    terrain: &ResolvedTerrainGrid,
+    interner: &StringInterner,
+    los: &LineOfFireInputs<'_>,
+) -> Option<(u16, u16)> {
+    // `WeaponType+0xA0`, the projectile, written at 0x007729AA.
+    let projectile = weapon
+        .projectile
+        .as_deref()
+        .and_then(|name| rules.projectile(name));
+    let subject_to_cliffs = projectile.is_some_and(|p| p.subject_to_cliffs);
+    let subject_to_walls = projectile.is_some_and(|p| p.subject_to_walls);
+
+    let hit = walk_line_for_blocking_cell(
+        src,
+        tgt,
+        subject_to_cliffs,
+        subject_to_walls,
+        firing_house,
+        rules.allied_wall_transparency,
+        terrain,
+        interner,
+        los,
+    )?;
+
+    // `WeaponType+0xAC`, the warhead, written at 0x00772992; `Wall=` is
+    // `WarheadType+0x144`, key string 0x0081AC58, read at 0x0075D508.
+    let warhead_breaks_walls = weapon
+        .warhead
+        .as_deref()
+        .and_then(|name| rules.warhead(name))
+        .is_some_and(|wh| wh.wall);
+    if warhead_breaks_walls && wall_is_connectable(terrain, los, hit) {
+        return None;
+    }
+
+    Some(hit)
+}
+
+/// `CellClass::IsWallConnectableInDirection(cell, -1, -1)` 0x00480510 as
+/// 0x004CC333 calls it: with the type argument `-1` the body reduces to a
+/// membership test on the cell's own overlay index against three hard-coded
+/// ids, and the direction argument is never read.
+fn wall_is_connectable(
+    terrain: &ResolvedTerrainGrid,
+    los: &LineOfFireInputs<'_>,
+    (rx, ry): (u16, u16),
+) -> bool {
+    let Some(grid) = los.overlay_grid else {
+        return false;
+    };
+    // Bounds are the terrain grid's, matching the walk's own lookups.
+    if terrain.cell(rx, ry).is_none() {
+        return false;
+    }
+    grid.cell(rx, ry)
+        .overlay_id
+        .is_some_and(|id| WALL_CONNECTABLE_OVERLAY_IDS.contains(&id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid};
+    use crate::rules::ini_parser::IniFile;
+    use crate::rules::ruleset::RuleSet;
+    use crate::sim::intern::StringInterner;
+    use crate::sim::overlay_grid::OverlayGrid;
+
+    const WALL_GAWALL_ID: u8 = 2;
+    const SANDBAG_GASAND_ID: u8 = 0;
+    const GRID: u16 = 16;
+
+    /// Overlay ids follow `[OverlayTypes]` list position, so the stock
+    /// numbering that puts `GAWALL` at 2 and `NAWALL` at 26 has to be
+    /// reproduced by the fixture list, not asserted from names.
+    fn rules_ini(extra: &str) -> String {
+        format!(
+            "[OverlayTypes]\n1=GASAND\n2=CYCL\n3=GAWALL\n\n\
+             [GASAND]\nWall=yes\n\n[CYCL]\n\n[GAWALL]\nWall=yes\n\n\
+             [VehicleTypes]\n0=TANK\n\n\
+             [TANK]\nStrength=100\nArmor=heavy\nPrimary=GUN\nSecondary=GUNWALL\n\n\
+             [GUN]\nDamage=20\nROF=10\nRange=8\nSpeed=30\nProjectile=SHELL\nWarhead=WH\n\n\
+             [GUNWALL]\nDamage=20\nROF=10\nRange=8\nSpeed=30\nProjectile=SHELL\nWarhead=WHWALL\n\n\
+             {extra}\n\
+             [WH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\n\
+             [WHWALL]\nWall=yes\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n"
+        )
+    }
+
+    fn rules_with(extra: &str) -> RuleSet {
+        RuleSet::from_ini(&IniFile::from_str(&rules_ini(extra))).expect("rules parse")
+    }
+
+    fn overlay_registry(extra: &str) -> OverlayTypeRegistry {
+        OverlayTypeRegistry::from_ini(&IniFile::from_str(&rules_ini(extra)), None)
+    }
+
+    fn cell_at(rx: u16, ry: u16) -> ResolvedTerrainCell {
+        ResolvedTerrainCell {
+            rx,
+            ry,
+            source_tile_index: 0,
+            source_sub_tile: 0,
+            final_tile_index: 0,
+            final_sub_tile: 0,
+            is_wood_bridge_repair_tile: false,
+            level: 0,
+            filled_clear: true,
+            tileset_index: Some(0),
+            land_type: 0,
+            yr_cell_land_type: 0,
+            slope_type: 0,
+            template_height: 0,
+            render_offset_x: 0,
+            render_offset_y: 0,
+            terrain_class: Default::default(),
+            speed_costs: Default::default(),
+            is_water: false,
+            is_cliff_like: false,
+            is_rough: false,
+            is_road: false,
+            height_in_pixels: 0,
+            variant: 0,
+            has_ramp: false,
+            canonical_ramp: None,
+            ground_walk_blocked: false,
+            terrain_object_blocks: false,
+            terrain_object_occupation: None,
+            overlay_blocks: false,
+            overlay_zone_type: None,
+            outside_playfield: false,
+            zone_type: 0,
+            base_ground_walk_blocked: false,
+            base_build_blocked: false,
+            base_land_type: 0,
+            base_yr_cell_land_type: 0,
+            base_terrain_class: Default::default(),
+            base_speed_costs: Default::default(),
+            build_blocked: false,
+            has_bridge_deck: false,
+            bridge_walkable: false,
+            bridge_transition: false,
+            bridge_deck_level: 0,
+            bridge_layer: None,
+            bridge_facts: crate::map::bridge_facts::BridgeCellFacts::default(),
+            tube_index: None,
+            radar_left: [0; 3],
+            radar_right: [0; 3],
+            accepts_smudge: true,
+            allows_tiberium: false,
+            has_damaged_data: false,
+            bridgehead_anchor_class_at_load: None,
+        }
+    }
+
+    fn flat_terrain() -> ResolvedTerrainGrid {
+        let cells: Vec<ResolvedTerrainCell> = (0..GRID)
+            .flat_map(|ry| (0..GRID).map(move |rx| cell_at(rx, ry)))
+            .collect();
+        ResolvedTerrainGrid::from_cells(GRID, GRID, cells)
+    }
+
+    fn set_level(terrain: &mut ResolvedTerrainGrid, rx: u16, ry: u16, level: u8) {
+        terrain.cell_mut(rx, ry).expect("cell in grid").level = level;
+    }
+
+    fn overlay_grid_with(cells: &[(u16, u16, u8)]) -> OverlayGrid {
+        let mut grid = OverlayGrid::new(GRID, GRID);
+        for &(rx, ry, id) in cells {
+            grid.cell_mut(rx, ry).overlay_id = Some(id);
+        }
+        grid
+    }
+
+    fn centre(cx: i64, cy: i64) -> (i64, i64) {
+        (cx * 256 + 128, cy * 256 + 128)
+    }
+
+    /// The headline case: `[Cannon]` is `SubjectToWalls=yes`, so a tank whose
+    /// warhead cannot break walls is refused a shot through one.
+    #[test]
+    fn a_wall_between_attacker_and_target_blocks_the_shot() {
+        let extra = "[SHELL]\nSubjectToWalls=yes\n";
+        let rules = rules_with(extra);
+        let registry = overlay_registry(extra);
+        let terrain = flat_terrain();
+        let overlays = overlay_grid_with(&[(4, 2, WALL_GAWALL_ID)]);
+        let interner = StringInterner::new();
+        let los = LineOfFireInputs {
+            overlay_grid: Some(&overlays),
+            overlay_registry: Some(&registry),
+            alliances: None,
+        };
+        let weapon = rules.weapon("GUN").expect("GUN");
+
+        assert_eq!(
+            line_of_fire_blocking_cell(
+                centre(2, 2),
+                centre(6, 2),
+                weapon,
+                "Americans",
+                &rules,
+                &terrain,
+                &interner,
+                &los,
+            ),
+            Some((4, 2)),
+        );
+    }
+
+    /// 0x004CC10B — a projectile with neither key never walks, so the same
+    /// wall is invisible to it.
+    #[test]
+    fn a_projectile_with_neither_key_never_walks() {
+        let extra = "[SHELL]\nROT=0\n";
+        let rules = rules_with(extra);
+        let registry = overlay_registry(extra);
+        let terrain = flat_terrain();
+        let overlays = overlay_grid_with(&[(4, 2, WALL_GAWALL_ID)]);
+        let interner = StringInterner::new();
+        let los = LineOfFireInputs {
+            overlay_grid: Some(&overlays),
+            overlay_registry: Some(&registry),
+            alliances: None,
+        };
+        let weapon = rules.weapon("GUN").expect("GUN");
+
+        assert_eq!(
+            line_of_fire_blocking_cell(
+                centre(2, 2),
+                centre(6, 2),
+                weapon,
+                "Americans",
+                &rules,
+                &terrain,
+                &interner,
+                &los,
+            ),
+            None,
+        );
+    }
+
+    /// 0x004CC333 + 0x004CC342 — a `Wall=yes` warhead is waved through a
+    /// GAWALL, which is one of the three ids `IsWallConnectableInDirection`
+    /// accepts.
+    #[test]
+    fn a_wall_breaking_warhead_is_readmitted_through_a_gawall() {
+        let extra = "[SHELL]\nSubjectToWalls=yes\n";
+        let rules = rules_with(extra);
+        let registry = overlay_registry(extra);
+        let terrain = flat_terrain();
+        let overlays = overlay_grid_with(&[(4, 2, WALL_GAWALL_ID)]);
+        let interner = StringInterner::new();
+        let los = LineOfFireInputs {
+            overlay_grid: Some(&overlays),
+            overlay_registry: Some(&registry),
+            alliances: None,
+        };
+        // `GUNWALL` carries `Warhead=WHWALL`, whose `Wall=yes` is the
+        // `WarheadType+0x144` byte 0x004CC342 reads.
+        let weapon = rules.weapon("GUNWALL").expect("GUNWALL");
+
+        assert_eq!(
+            line_of_fire_blocking_cell(
+                centre(2, 2),
+                centre(6, 2),
+                weapon,
+                "Americans",
+                &rules,
+                &terrain,
+                &interner,
+                &los,
+            ),
+            None,
+        );
+    }
+
+    /// The re-admission is narrower than `Wall=yes`: `GASAND` (overlay id 0)
+    /// carries `Wall=yes` and still blocks, because 0x00480510's `-1` arm
+    /// accepts only ids 2, 26 and 243.
+    #[test]
+    fn a_wall_breaking_warhead_is_still_blocked_by_a_sandbag_wall() {
+        let extra = "[SHELL]\nSubjectToWalls=yes\n";
+        let rules = rules_with(extra);
+        let registry = overlay_registry(extra);
+        let terrain = flat_terrain();
+        let overlays = overlay_grid_with(&[(4, 2, SANDBAG_GASAND_ID)]);
+        let interner = StringInterner::new();
+        let los = LineOfFireInputs {
+            overlay_grid: Some(&overlays),
+            overlay_registry: Some(&registry),
+            alliances: None,
+        };
+        // `GUNWALL` carries `Warhead=WHWALL`, whose `Wall=yes` is the
+        // `WarheadType+0x144` byte 0x004CC342 reads.
+        let weapon = rules.weapon("GUNWALL").expect("GUNWALL");
+
+        assert_eq!(
+            line_of_fire_blocking_cell(
+                centre(2, 2),
+                centre(6, 2),
+                weapon,
+                "Americans",
+                &rules,
+                &terrain,
+                &interner,
+                &los,
+            ),
+            Some((4, 2)),
+        );
+    }
+
+    /// 0x004CC434 — the wall standing on the target's own cell is the wall you
+    /// are shooting at, and never blocks.
+    #[test]
+    fn a_wall_on_the_targets_own_cell_does_not_block() {
+        let extra = "[SHELL]\nSubjectToWalls=yes\n";
+        let rules = rules_with(extra);
+        let registry = overlay_registry(extra);
+        let terrain = flat_terrain();
+        let overlays = overlay_grid_with(&[(6, 2, WALL_GAWALL_ID)]);
+        let interner = StringInterner::new();
+        let los = LineOfFireInputs {
+            overlay_grid: Some(&overlays),
+            overlay_registry: Some(&registry),
+            alliances: None,
+        };
+        let weapon = rules.weapon("GUN").expect("GUN");
+
+        assert_eq!(
+            line_of_fire_blocking_cell(
+                centre(2, 2),
+                centre(6, 2),
+                weapon,
+                "Americans",
+                &rules,
+                &terrain,
+                &interner,
+                &los,
+            ),
+            None,
+        );
+    }
+
+    /// 0x004CC444 — firing from higher raw `Level` than the target clears the
+    /// wall. The compare is on `+0x11B`, so a bridge anchor's `+4` effective
+    /// height must NOT enter it.
+    #[test]
+    fn firing_downhill_clears_the_wall() {
+        let extra = "[SHELL]\nSubjectToWalls=yes\n";
+        let rules = rules_with(extra);
+        let registry = overlay_registry(extra);
+        let mut terrain = flat_terrain();
+        set_level(&mut terrain, 2, 2, 3);
+        let overlays = overlay_grid_with(&[(4, 2, WALL_GAWALL_ID)]);
+        let interner = StringInterner::new();
+        let los = LineOfFireInputs {
+            overlay_grid: Some(&overlays),
+            overlay_registry: Some(&registry),
+            alliances: None,
+        };
+        let weapon = rules.weapon("GUN").expect("GUN");
+
+        assert_eq!(
+            line_of_fire_blocking_cell(
+                centre(2, 2),
+                centre(6, 2),
+                weapon,
+                "Americans",
+                &rules,
+                &terrain,
+                &interner,
+                &los,
+            ),
+            None,
+            "source Level 3 > target Level 0 clears the wall (0x004CC444)"
+        );
+    }
+
+    /// 0x004CC3DE / 0x004CC3F7 — a four-Level rise above BOTH the previous
+    /// cell and the source cell blocks a `SubjectToCliffs` shot. Three Levels
+    /// does not: the boundary is `>= 4`.
+    #[test]
+    fn a_four_level_cliff_blocks_and_three_levels_does_not() {
+        let extra = "[SHELL]\nSubjectToCliffs=yes\n";
+        let rules = rules_with(extra);
+        let interner = StringInterner::new();
+        let los = LineOfFireInputs::terrain_only();
+        let weapon = rules.weapon("GUN").expect("GUN");
+
+        for (rise, expect) in [(4u8, Some((4u16, 2u16))), (3u8, None)] {
+            let mut terrain = flat_terrain();
+            for ry in 0..GRID {
+                set_level(&mut terrain, 4, ry, rise);
+            }
+            assert_eq!(
+                line_of_fire_blocking_cell(
+                    centre(2, 2),
+                    centre(6, 2),
+                    weapon,
+                    "Americans",
+                    &rules,
+                    &terrain,
+                    &interner,
+                    &los,
+                ),
+                expect,
+                "a {rise}-Level step verdict"
+            );
+        }
+    }
+
+    /// The second half of 0x004CC3F7: the step must also stand above the
+    /// SOURCE cell. Climbing four Levels out of a pit back to the source's own
+    /// height is not a cliff.
+    #[test]
+    fn a_step_that_only_regains_the_source_height_is_not_a_cliff() {
+        let extra = "[SHELL]\nSubjectToCliffs=yes\n";
+        let rules = rules_with(extra);
+        let mut terrain = flat_terrain();
+        for ry in 0..GRID {
+            set_level(&mut terrain, 2, ry, 4);
+            set_level(&mut terrain, 3, ry, 0);
+            set_level(&mut terrain, 4, ry, 4);
+        }
+        let interner = StringInterner::new();
+        let los = LineOfFireInputs::terrain_only();
+        let weapon = rules.weapon("GUN").expect("GUN");
+
+        assert_eq!(
+            line_of_fire_blocking_cell(
+                centre(2, 2),
+                centre(6, 2),
+                weapon,
+                "Americans",
+                &rules,
+                &terrain,
+                &interner,
+                &los,
+            ),
+            None,
+        );
+    }
+
+    /// 0x004CC22D — a same-cell shot has zero steps and is never blocked, even
+    /// standing on a wall.
+    #[test]
+    fn a_same_cell_shot_is_never_blocked() {
+        let extra = "[SHELL]\nSubjectToWalls=yes\n";
+        let rules = rules_with(extra);
+        let registry = overlay_registry(extra);
+        let terrain = flat_terrain();
+        let overlays = overlay_grid_with(&[(2, 2, WALL_GAWALL_ID)]);
+        let interner = StringInterner::new();
+        let los = LineOfFireInputs {
+            overlay_grid: Some(&overlays),
+            overlay_registry: Some(&registry),
+            alliances: None,
+        };
+        let weapon = rules.weapon("GUN").expect("GUN");
+
+        assert_eq!(
+            line_of_fire_blocking_cell(
+                centre(2, 2),
+                (2 * 256 + 200, 2 * 256 + 40),
+                weapon,
+                "Americans",
+                &rules,
+                &terrain,
+                &interner,
+                &los,
+            ),
+            None,
+        );
+    }
+
+    /// 0x004CC458 — with `[WallModel] AlliedWallTransparency=yes` an allied
+    /// wall stops blocking; with the stock `no` it still blocks.
+    #[test]
+    fn allied_wall_transparency_gates_the_owner_exemption() {
+        use std::collections::{BTreeMap, BTreeSet};
+
+        let terrain = flat_terrain();
+        let mut alliances: HouseAllianceMap = BTreeMap::new();
+        // `normalize_house_name` upper-cases both sides, so the fixture map
+        // has to be keyed the same way.
+        alliances.insert(
+            "AMERICANS".to_string(),
+            BTreeSet::from(["FRENCH".to_string()]),
+        );
+
+        for (transparency, expect) in [("yes", None), ("no", Some((4u16, 2u16)))] {
+            let extra = format!(
+                "[SHELL]\nSubjectToWalls=yes\n\n[WallModel]\nAlliedWallTransparency={transparency}\n"
+            );
+            let rules = rules_with(&extra);
+            let registry = overlay_registry(&extra);
+            let mut interner = StringInterner::new();
+            let mut overlays = overlay_grid_with(&[(4, 2, WALL_GAWALL_ID)]);
+            overlays.cell_mut(4, 2).wall_owner = Some(interner.intern("French"));
+            let los = LineOfFireInputs {
+                overlay_grid: Some(&overlays),
+                overlay_registry: Some(&registry),
+                alliances: Some(&alliances),
+            };
+            let weapon = rules.weapon("GUN").expect("GUN");
+
+            assert_eq!(
+                line_of_fire_blocking_cell(
+                    centre(2, 2),
+                    centre(6, 2),
+                    weapon,
+                    "Americans",
+                    &rules,
+                    &terrain,
+                    &interner,
+                    &los,
+                ),
+                expect,
+                "AlliedWallTransparency={transparency}"
+            );
+        }
+    }
+}

--- a/src/sim/combat/line_of_fire.rs
+++ b/src/sim/combat/line_of_fire.rs
@@ -62,15 +62,31 @@ const CLIFF_STEP_LEVELS: i32 = 4;
 /// `rules::overlay_types::is_bridge_overlay_index` pins `BRIDGEB1`/`BRIDGEB2`
 /// at 237/238, their declaration indices, against INI keys 241/242.
 ///
-/// Id 243 is inert on stock data anyway: `[GAFWLL]` has no section in
-/// `rulesmd.ini` at all (a Tiberian Sun firestorm-wall leftover left in the
-/// list), so it carries no `Wall=` and the walk never flags it as a wall in
-/// the first place.
+/// Id 243 is LIVE, and all three ids fire in ordinary play. `[GAFWLL]` is the
+/// Yuri Citadel Wall: `rulesmd.ini:13561` declares it, `:13571` gives it
+/// `Wall=yes`, and it carries `Name=Yuri Citadel Wall`, `TechLevel=2`,
+/// `Prerequisite=YABRCK`. Its buildable half is `[BuildingTypes] 312`
+/// (`rulesmd.ini:1499`), `artmd.ini:4129`'s `[GAFWLL]` gives it
+/// `Cameo=CITWICON` and `ToOverlay=GAFWLL`, and `[AI] ConcreteWalls`
+/// (`rulesmd.ini:3077`) names exactly `GAWALL,NAWALL,GAFWLL` — this set. Any
+/// Yuri player who walls a base puts overlay 243 on the map.
+///
+/// It is easy to miss because its header carries a trailing comment —
+/// `[GAFWLL];temp wall for yuri[YAWALL]` — which a `^\[NAME\]$` matcher
+/// rejects. Neither real reader does. `INIClass::LoadFromStraw` 0x00525A60
+/// tests `CMP byte ptr [ESP+0x78],0x5B` at 0x00525DC1, calls
+/// `strchr(line, ']')` (`PUSH 0x5D` at 0x00525DCC) and NULs the FIRST `]` at
+/// 0x00525DDB before naming the section from `buffer+1`; VERA's
+/// `rules::ini_parser` takes the same `line.find(']')` prefix. Nor is this a
+/// GAFWLL quirk: 61 stock `rulesmd.ini` sections and 154 in `artmd.ini` have
+/// such headers, `[Controller]`, `[Parasite]`, `[FlakWeapon]` and
+/// `[JumpjetControls]` among them.
 ///
 /// Deliberately NOT "every `Wall=yes` overlay": stock authors `Wall=yes` on
-/// seven overlays — `GASAND` (0), `GAWALL` (2), `NAWALL` (26), `CAFNCB`,
-/// `CAFNCW`, `CAKRMW` (240) and `CAFNCP` — of which only two are re-admitted,
-/// so a wall-breaking warhead does not get waved through a sandbag line.
+/// eight overlays — `GASAND` (0), `GAWALL` (2), `NAWALL` (26), `CAFNCB` (203),
+/// `CAFNCW` (204), `CAKRMW` (240), `CAFNCP` (241) and `GAFWLL` (243) — of
+/// which only three are re-admitted, so a wall-breaking warhead does not get
+/// waved through a sandbag or a fence line.
 const WALL_CONNECTABLE_OVERLAY_IDS: [u8; 3] = [2, 26, 243];
 
 /// Map state the walk consults beyond the resolved terrain grid.

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -998,6 +998,36 @@ pub(crate) fn pursuit_selected_weapon<'a>(
     Some(selected.weapon)
 }
 
+/// What the pursuit stage should do with an attacker that is holding a target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PursuitRangeVerdict {
+    /// The full `InRange` gate passes — halt and let the combat tick fire.
+    CanFire,
+    /// Refused, and closing the distance is what native's approach search does
+    /// about it: too far, or a wall or a cliff on the line.
+    CloseIn,
+    /// Refused because the attacker stands INSIDE the weapon's `MinimumRange`.
+    ///
+    /// **VERA-internal, and a deliberate deferral of a native mechanism.**
+    /// Native's approach search 0x004D5690 scans candidate coordinates and
+    /// takes one where `InRange` holds, so a V3 that has been closed on backs
+    /// off to five cells. VERA's pursuit produces exactly one candidate — the
+    /// target's own cell — which for a too-close refusal is the WORST cell in
+    /// the set. So this verdict holds position instead, which is bit-for-bit
+    /// the behaviour this stage had before the walk landed.
+    /// - Trigger: `MinimumRange=` weapon whose target has come inside it —
+    ///   `V3Launcher` (5), `DredLauncher`/`CruiseLauncher` (8), `MagneticBeam`
+    ///   (3), `HowitzerGun` (2), the `MissileLauncher`/`HoverMissile` family (1).
+    /// - Player effect: the V3 stops rather than backing off, and the fire gate
+    ///   keeps refusing until the target moves away again.
+    /// - Frequency: ordinary — a V3 shelling an advancing column meets it every
+    ///   time the column closes.
+    /// - Downstream risk: none to deterministic state; it is a hold, and the
+    ///   fire gate already refused before this stage ran. Cured by porting the
+    ///   candidate-coordinate scan in 0x004D5690, which is its own mechanism.
+    HoldInsideMinimumRange,
+}
+
 /// Whether a pursuing attacker can already shoot its target from where it
 /// stands — the predicate that decides "halt and fire" against "keep closing".
 ///
@@ -1026,16 +1056,18 @@ pub(crate) fn pursuit_in_range(
     interner: &StringInterner,
     terrain: Option<&ResolvedTerrainGrid>,
     los: &line_of_fire::LineOfFireInputs<'_>,
-) -> bool {
+) -> PursuitRangeVerdict {
     let Some(terrain) = terrain else {
         // No resolved terrain (headless fixtures, pre-map bring-up): the 3-D
         // gate has nothing to measure against, so fall back to the same 2-D
         // twin `resolve_attacker_fire` falls back to in that situation. The
-        // two stages still agree, which is the property that matters.
+        // two stages still agree, which is the property that matters. That twin
+        // has no MinimumRange arm either, so it cannot report the too-close
+        // verdict.
         let Some((trx, try_, tsx, tsy)) =
             resolve_target_coords(target, entities, Some(rules), interner)
         else {
-            return false;
+            return PursuitRangeVerdict::CloseIn;
         };
         let dist_sq = lepton_distance_sq_raw(
             entity.position.rx,
@@ -1047,18 +1079,28 @@ pub(crate) fn pursuit_in_range(
             tsx,
             tsy,
         );
-        return is_within_range_leptons(dist_sq, weapon.range);
+        return if is_within_range_leptons(dist_sq, weapon.range) {
+            PursuitRangeVerdict::CanFire
+        } else {
+            PursuitRangeVerdict::CloseIn
+        };
     };
 
     let Some(src) = in_range::fire_source_coords(entity, target, weapon, entities, terrain) else {
         // The attacker has no resolvable ground height (off-grid). Report
-        // "not in range" so pursuit keeps trying rather than freezing; the
-        // fire gate returns without firing on the same condition.
-        return false;
+        // "keep closing" rather than freezing; the fire gate returns without
+        // firing on the same condition.
+        return PursuitRangeVerdict::CloseIn;
     };
-    in_range::compute_in_range(
+    if in_range::compute_in_range(
         entity, src, target, weapon, rules, interner, entities, terrain, los,
-    )
+    ) {
+        return PursuitRangeVerdict::CanFire;
+    }
+    if in_range::inside_minimum_range(src, target, weapon, rules, interner, entities, terrain) {
+        return PursuitRangeVerdict::HoldInsideMinimumRange;
+    }
+    PursuitRangeVerdict::CloseIn
 }
 
 /// Issue an attack command: make `attacker` fire at `target`.

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -77,6 +77,7 @@ use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use crate::rules::object_type::ObjectType;
 use crate::rules::ruleset::RuleSet;
 use crate::rules::warhead_type::WarheadType;
+use crate::rules::weapon_type::WeaponType;
 use crate::sim::bridge_state::{BridgeDamageEvent, BridgeRuntimeState};
 use crate::sim::entity_store::EntityStore;
 use crate::sim::house_state::HouseState;
@@ -964,7 +965,8 @@ pub(crate) fn can_fire_at_target(
     )
 }
 
-/// Resolve the effective weapon range for an attacker against a `TargetKind`.
+/// Resolve the weapon an attacker would use against a `TargetKind` while
+/// pursuing it.
 ///
 /// Uses the same weapon-select inputs as the combat tick's Phase 2 weapon
 /// selection so pursuit and combat agree on "in range" at the boundary.
@@ -972,15 +974,15 @@ pub(crate) fn can_fire_at_target(
 /// Returns `None` if the selected weapon cannot legally fire at the target
 /// (GetFireError targeting subset). Pursuit treats `None` as "skip — combat
 /// tick will drop the attack on its own weapon-select fail."
-pub(crate) fn pursuit_weapon_range(
+pub(crate) fn pursuit_selected_weapon<'a>(
     entity: &GameEntity,
     target: &TargetKind,
     entities: &EntityStore,
-    rules: &RuleSet,
+    rules: &'a RuleSet,
     interner: &StringInterner,
     terrain: Option<&ResolvedTerrainGrid>,
     alliances: Option<&HouseAllianceMap>,
-) -> Option<SimFixed> {
+) -> Option<&'a WeaponType> {
     let attacker_obj = rules.object(interner.resolve(entity.type_ref))?;
     let selected = select_weapon_against(
         rules,
@@ -993,7 +995,70 @@ pub(crate) fn pursuit_weapon_range(
         terrain,
         alliances,
     )?;
-    Some(selected.weapon.range)
+    Some(selected.weapon)
+}
+
+/// Whether a pursuing attacker can already shoot its target from where it
+/// stands — the predicate that decides "halt and fire" against "keep closing".
+///
+/// gamemd-derived: `FootClass::Mission_Attack @ 0x004D4DC0` dispatches to the
+/// approach search — the "walk to somewhere I can shoot my target from" routine
+/// at vtable slot `+0x53C`, labelled `FootClass::Greatest_Threat_Scan @
+/// 0x004D5690` in the database — through `CALL [EAX+0x53c]` at `0x004D4E6A`,
+/// on the arm where TarCom (`[this+0x2B4]`) is non-null; `InfantryClass`'s
+/// override `0x00522340` chains straight into the same body at `0x0052236E`.
+/// That body decides with `TechnoClass::InRange @ 0x006F7220`, called at
+/// `0x004D622C` and `0x004D6550` with a candidate coordinate as arg1
+/// (`LEA EAX,[ESP+0x30]`) and TarCom as arg2 — and `InRange` ends in the
+/// line-of-fire walk (`CALL 0x004CC310` at `0x006F7642`).
+///
+/// So the approach predicate and the fire gate are the SAME test in gamemd.
+/// Using the 2-D twin here instead would let pursuit believe it had arrived
+/// while `resolve_attacker_fire` refuses the shot, and the unit would stand
+/// still under a standing order forever.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn pursuit_in_range(
+    entity: &GameEntity,
+    target: &TargetKind,
+    weapon: &WeaponType,
+    entities: &EntityStore,
+    rules: &RuleSet,
+    interner: &StringInterner,
+    terrain: Option<&ResolvedTerrainGrid>,
+    los: &line_of_fire::LineOfFireInputs<'_>,
+) -> bool {
+    let Some(terrain) = terrain else {
+        // No resolved terrain (headless fixtures, pre-map bring-up): the 3-D
+        // gate has nothing to measure against, so fall back to the same 2-D
+        // twin `resolve_attacker_fire` falls back to in that situation. The
+        // two stages still agree, which is the property that matters.
+        let Some((trx, try_, tsx, tsy)) =
+            resolve_target_coords(target, entities, Some(rules), interner)
+        else {
+            return false;
+        };
+        let dist_sq = lepton_distance_sq_raw(
+            entity.position.rx,
+            entity.position.ry,
+            entity.position.sub_x,
+            entity.position.sub_y,
+            trx,
+            try_,
+            tsx,
+            tsy,
+        );
+        return is_within_range_leptons(dist_sq, weapon.range);
+    };
+
+    let Some(src) = in_range::fire_source_coords(entity, target, weapon, entities, terrain) else {
+        // The attacker has no resolvable ground height (off-grid). Report
+        // "not in range" so pursuit keeps trying rather than freezing; the
+        // fire gate returns without firing on the same condition.
+        return false;
+    };
+    in_range::compute_in_range(
+        entity, src, target, weapon, rules, interner, entities, terrain, los,
+    )
 }
 
 /// Issue an attack command: make `attacker` fire at `target`.
@@ -7446,6 +7511,22 @@ pub(crate) fn resolve_attacker_fire(
     } else {
         // Garrison override path — preserve 2D until a later stage threads
         // override-aware 3D.
+        //
+        // RESIDUAL (line of fire) — because this arm never calls
+        // `compute_in_range`, it never runs the wall/cliff walk that
+        // `TechnoClass::InRange` 0x006F7220 ends in at 0x006F7642.
+        // - Trigger: any garrisoned occupant firing across a wall or a
+        //   ≥4-Level step; stock `[E1]`'s `M60` is `Projectile=InvisibleLow`
+        //   (`SubjectToWalls=yes`, `SubjectToCliffs=yes`) and its `SA` warhead
+        //   has no `Wall=`, so gamemd refuses that shot.
+        // - Player effect: a garrisoned GI shoots straight through a GAWALL the
+        //   identical GI standing in the open is refused.
+        // - Frequency: routine on urban maps — garrisoning a building next to
+        //   a wall line is an ordinary opening, not an edge case.
+        // - Downstream risk: none to deterministic state. The cure is the
+        //   override-aware range VALUE chain M8 records (Garrison / Bunker /
+        //   OpenTopped), which lets this branch use `compute_in_range` instead
+        //   of a second walk bolted onto the 2-D twin.
         let dist_sq = lepton_distance_sq_raw(
             snap.pos_rx,
             snap.pos_ry,
@@ -8459,23 +8540,35 @@ pub(crate) fn lepton_distance_sq_raw(
 ///
 /// RESIDUAL 2 — this twin also has no line-of-fire walk. `TechnoClass::InRange`
 /// ends in `CALL 0x004CC310` at 0x006F7642 and refuses the shot when a wall or
-/// a cliff sits on the line; `compute_in_range` now runs that walk (see
+/// a cliff sits on the line; `compute_in_range` runs that walk (see
 /// `sim::combat::line_of_fire`) and this function does not.
 ///
-/// - Trigger: pursuit (`World::tick_attack_pursuit`, which calls
-///   `pursuit_weapon_range` + this predicate) closing on a target behind a
-///   wall or a cliff with a `SubjectToWalls=`/`SubjectToCliffs=` projectile.
-/// - Player effect: pursuit stops at the weapon's plain radius and reports
-///   "in range" while the fire gate refuses the shot, so the unit sits still
-///   instead of continuing to reposition. The reverse of the old defect (it
-///   used to walk into range and fire illegally), and narrower: the shot no
-///   longer happens either way.
-/// - Frequency: ordinary — `InvisibleLow` (GI, Conscript, Sentry Gun, Sniper,
-///   Boris) and `Cannon` (every cannon tank) both declare the keys.
-/// - Downstream risk: none to deterministic state; it is a stall, not a
-///   divergent action. The cure is the same migration named above — native's
-///   approach path measures through the same `InRange`, so a second walk
-///   bolted onto this function would be a VERA-only predicate.
+/// Pursuit no longer reaches it: `World::tick_attack_pursuit` measures through
+/// `pursuit_in_range` → `compute_in_range`, matching the approach search
+/// `FootClass::Greatest_Threat_Scan @ 0x004D5690`, which decides with `InRange`
+/// 0x006F7220 itself. Two production readers still take the plain radius, each
+/// recorded on its own call site:
+///
+/// - the fire gate's GARRISON branch (`resolve_attacker_fire`, the
+///   `is_garrison || effective_range != weapon.range` arm);
+/// - `ScanRange::Hard` in `greatest_threat::evaluate_candidate`, the
+///   garrison passive scan's override.
+///
+/// The remaining readers are the no-resolved-terrain fallbacks in the fire
+/// gate, the cursor and pursuit, which cannot run a walk at all and therefore
+/// agree with each other rather than diverging.
+///
+/// - Trigger: a garrisoned occupant firing, or a garrison passive scan
+///   choosing a candidate, across a wall or a ≥4-Level step.
+/// - Player effect: garrisoned infantry shoot through a wall the identical
+///   infantry standing in the open is refused; the passive scan can pick a
+///   candidate behind one.
+/// - Frequency: routine on urban maps, where garrisoning is a normal opening.
+/// - Downstream risk: none to deterministic state; both stages agree with each
+///   other, so it is a uniformly wrong answer, not a stall. The cure is
+///   threading the override-aware range into `compute_in_range` so the garrison
+///   branch can use the 3-D gate — the range VALUE chain M8 already records,
+///   not a second walk bolted onto this function.
 pub(crate) fn is_within_range_leptons(dist_sq_leptons: i64, range_cells: SimFixed) -> bool {
     let range_leptons: i64 = (i64::from(range_cells.to_bits()) * 256) >> 16;
     let range_sq: i64 = range_leptons * range_leptons;

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod fire_decision;
 pub(crate) mod greatest_threat;
 pub(crate) mod in_range;
 mod inviso_scatter;
+pub(crate) mod line_of_fire;
 pub mod smudge_dispatch;
 pub(crate) mod threat_range;
 pub(crate) mod veterancy;
@@ -920,6 +921,7 @@ pub(crate) fn can_fire_at_target(
     target: &TargetKind,
     terrain: &ResolvedTerrainGrid,
     alliances: Option<&HouseAllianceMap>,
+    los: &line_of_fire::LineOfFireInputs<'_>,
 ) -> bool {
     let Some(attacker) = entities.get(attacker_id) else {
         return false;
@@ -958,6 +960,7 @@ pub(crate) fn can_fire_at_target(
         interner,
         entities,
         terrain,
+        los,
     )
 }
 
@@ -7139,6 +7142,11 @@ pub(crate) fn resolve_attacker_fire(
                 // scanner-zone slot native fills at `0x006F8EC4` is read only by
                 // the mask-0 flat walk, which this callsite cannot select.
                 None,
+                line_of_fire::LineOfFireInputs {
+                    overlay_grid: overlay_grid.as_deref(),
+                    overlay_registry,
+                    alliances: fog.map(|fog_state| &fog_state.alliances),
+                },
             ) {
                 out.retarget_events.push((snap.stable_id, new_target));
             } else {
@@ -7265,6 +7273,11 @@ pub(crate) fn resolve_attacker_fire(
                 // scanner-zone slot native fills at `0x006F8EC4` is read only by
                 // the mask-0 flat walk, which this callsite cannot select.
                 None,
+                line_of_fire::LineOfFireInputs {
+                    overlay_grid: overlay_grid.as_deref(),
+                    overlay_registry,
+                    alliances: fog.map(|fog_state| &fog_state.alliances),
+                },
             ) {
                 out.retarget_events.push((snap.stable_id, new_target));
             } else {
@@ -7292,6 +7305,11 @@ pub(crate) fn resolve_attacker_fire(
                 // scanner-zone slot native fills at `0x006F8EC4` is read only by
                 // the mask-0 flat walk, which this callsite cannot select.
                 None,
+                line_of_fire::LineOfFireInputs {
+                    overlay_grid: overlay_grid.as_deref(),
+                    overlay_registry,
+                    alliances: fog.map(|fog_state| &fog_state.alliances),
+                },
             ) {
                 out.retarget_events.push((snap.stable_id, new_target));
             } else {
@@ -7404,6 +7422,11 @@ pub(crate) fn resolve_attacker_fire(
                     interner,
                     entities,
                     t,
+                    &line_of_fire::LineOfFireInputs {
+                        overlay_grid: overlay_grid.as_deref(),
+                        overlay_registry,
+                        alliances: fog.map(|fog_state| &fog_state.alliances),
+                    },
                 )
             }
             _ => {
@@ -8433,6 +8456,26 @@ pub(crate) fn lepton_distance_sq_raw(
 /// The fix belongs with the remaining `is_within_range_leptons` call sites'
 /// migration onto `compute_in_range`, not with a second sentinel test bolted
 /// on here.
+///
+/// RESIDUAL 2 — this twin also has no line-of-fire walk. `TechnoClass::InRange`
+/// ends in `CALL 0x004CC310` at 0x006F7642 and refuses the shot when a wall or
+/// a cliff sits on the line; `compute_in_range` now runs that walk (see
+/// `sim::combat::line_of_fire`) and this function does not.
+///
+/// - Trigger: pursuit (`World::tick_attack_pursuit`, which calls
+///   `pursuit_weapon_range` + this predicate) closing on a target behind a
+///   wall or a cliff with a `SubjectToWalls=`/`SubjectToCliffs=` projectile.
+/// - Player effect: pursuit stops at the weapon's plain radius and reports
+///   "in range" while the fire gate refuses the shot, so the unit sits still
+///   instead of continuing to reposition. The reverse of the old defect (it
+///   used to walk into range and fire illegally), and narrower: the shot no
+///   longer happens either way.
+/// - Frequency: ordinary — `InvisibleLow` (GI, Conscript, Sentry Gun, Sniper,
+///   Boris) and `Cannon` (every cannon tank) both declare the keys.
+/// - Downstream risk: none to deterministic state; it is a stall, not a
+///   divergent action. The cure is the same migration named above — native's
+///   approach path measures through the same `InRange`, so a second walk
+///   bolted onto this function would be a VERA-only predicate.
 pub(crate) fn is_within_range_leptons(dist_sq_leptons: i64, range_cells: SimFixed) -> bool {
     let range_leptons: i64 = (i64::from(range_cells.to_bits()) * 256) >> 16;
     let range_sq: i64 = range_leptons * range_leptons;
@@ -8500,7 +8543,8 @@ fn veteran_rof_frames(
     .clamp(1, i32::from(u16::MAX)) as u16
 }
 
-pub use self::combat_targeting::{acquire_best_target_for_entity, tick_retaliation};
+pub(crate) use self::combat_targeting::acquire_best_target_for_entity;
+pub use self::combat_targeting::tick_retaliation;
 /// The threat mask an acquisition callsite pushes into
 /// `TechnoClass::Greatest_Threat @ 0x006F8DF0`, plus the passive block's own
 /// derivation of it. Re-exported because the mask is chosen by the mission

--- a/src/sim/spawn_manager.rs
+++ b/src/sim/spawn_manager.rs
@@ -313,7 +313,12 @@ pub fn commit_spawn_manager_pool(sim: &mut Simulation, owner_id: u64, rules: &Ru
 /// target through `Spawner=yes` this tick is seen by its own manager in the
 /// same tick — the ordering `TechnoClass::AI_Update` gives natively
 /// (Mission_Dispatch → Fire_At → SetTarget, then the SpawnManager dispatch).
-pub fn tick_spawn_managers(sim: &mut Simulation, rules: &RuleSet, order: &[u64]) {
+pub fn tick_spawn_managers(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    order: &[u64],
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+) {
     let frame = sim.session.binary_frame;
     for &owner_id in order {
         let has_manager = sim
@@ -324,11 +329,17 @@ pub fn tick_spawn_managers(sim: &mut Simulation, rules: &RuleSet, order: &[u64])
         if !has_manager {
             continue;
         }
-        tick_one_manager(sim, rules, owner_id, frame);
+        tick_one_manager(sim, rules, owner_id, frame, overlay_registry);
     }
 }
 
-fn tick_one_manager(sim: &mut Simulation, rules: &RuleSet, owner_id: u64, frame: u32) {
+fn tick_one_manager(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    owner_id: u64,
+    frame: u32,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+) {
     // Update-timer gate. Everything below runs only on a manager frame.
     {
         let Some(entity) = sim.substrate.entities.get_mut(owner_id) else {
@@ -359,7 +370,7 @@ fn tick_one_manager(sim: &mut Simulation, rules: &RuleSet, owner_id: u64, frame:
         step_slot(sim, rules, owner_id, slot_index, frame);
     }
 
-    step_manager_mode(sim, rules, owner_id, frame);
+    step_manager_mode(sim, rules, owner_id, frame, overlay_registry);
 }
 
 /// `SpawnManagerClass::PointerExpired` for the child-death case: a slot whose
@@ -750,7 +761,13 @@ fn regenerate_child(sim: &mut Simulation, rules: &RuleSet, owner_id: u64, slot_i
 }
 
 /// The manager-level machine, run after every slot has been stepped.
-fn step_manager_mode(sim: &mut Simulation, rules: &RuleSet, owner_id: u64, frame: u32) {
+fn step_manager_mode(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    owner_id: u64,
+    frame: u32,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+) {
     let Some(mode) = manager_field(sim, owner_id, |m| m.mode) else {
         return;
     };
@@ -773,6 +790,11 @@ fn step_manager_mode(sim: &mut Simulation, rules: &RuleSet, owner_id: u64, frame
                     &target,
                     terrain,
                     Some(&sim.house_alliances),
+                    &crate::sim::combat::line_of_fire::LineOfFireInputs {
+                        overlay_grid: sim.overlay_grid.as_ref(),
+                        overlay_registry,
+                        alliances: Some(&sim.house_alliances),
+                    },
                 )
             });
             if !target_is_legal {

--- a/src/sim/spawn_manager_tests.rs
+++ b/src/sim/spawn_manager_tests.rs
@@ -440,7 +440,7 @@ fn set_target_queues_and_the_ai_pass_promotes_it() {
         manager.update_timer = SpawnTimer::ready();
     }
 
-    tick_spawn_managers(&mut sim, &rules, &[v3]);
+    tick_spawn_managers(&mut sim, &rules, &[v3], None);
 
     let manager = sim
         .substrate
@@ -478,7 +478,7 @@ fn gsi_05_08_hornet_launcher_maximum_accepts_6400_and_clears_6401() {
         manager.update_timer = SpawnTimer::ready();
 
         move_target_to_x_distance(&mut sim, target, distance);
-        tick_spawn_managers(&mut sim, &rules, &[carrier]);
+        tick_spawn_managers(&mut sim, &rules, &[carrier], None);
 
         let manager = sim
             .substrate
@@ -533,7 +533,7 @@ fn gsi_05_08_idle_legality_uses_effective_3d_distance() {
         .expect("target remains live")
         .position
         .exact_z_leptons = Some(TARGET_Z_LEPTONS);
-    tick_spawn_managers(&mut sim, &rules, &[carrier]);
+    tick_spawn_managers(&mut sim, &rules, &[carrier], None);
 
     let manager = sim
         .substrate
@@ -572,7 +572,7 @@ fn gsi_05_08_v3_minimum_accepts_1280_and_clears_1279() {
         manager.update_timer = SpawnTimer::ready();
 
         move_target_to_x_distance(&mut sim, target, distance);
-        tick_spawn_managers(&mut sim, &rules, &[v3]);
+        tick_spawn_managers(&mut sim, &rules, &[v3], None);
 
         let manager = sim
             .substrate
@@ -617,7 +617,7 @@ fn update_timer_gates_the_whole_ai_pass() {
 
     // Frame 0 with the constructor's 20-frame first delay still pending: no
     // promotion, no launch.
-    tick_spawn_managers(&mut sim, &rules, &[v3]);
+    tick_spawn_managers(&mut sim, &rules, &[v3], None);
     let manager = sim
         .substrate
         .entities
@@ -665,7 +665,7 @@ fn v3_launches_its_rocket_into_the_kamikaze_window() {
     }
     // Pass 1: Idle → Launching (the slot walk runs before the mode block, so
     // nothing launches while the manager is still Idle).
-    tick_spawn_managers(&mut sim, &rules, &[v3]);
+    tick_spawn_managers(&mut sim, &rules, &[v3], None);
     assert_eq!(
         sim.substrate
             .entities
@@ -684,7 +684,7 @@ fn v3_launches_its_rocket_into_the_kamikaze_window() {
     {
         manager.update_timer = SpawnTimer::ready();
     }
-    tick_spawn_managers(&mut sim, &rules, &[v3]);
+    tick_spawn_managers(&mut sim, &rules, &[v3], None);
 
     let child = sim.substrate.entities.get(child_id).expect("child alive");
     assert!(!child.lifecycle.in_limbo, "rocket is out in the world");
@@ -746,7 +746,7 @@ fn a_moving_launcher_holds_its_missile() {
             manager.mode = SpawnManagerMode::Launching;
         }
     }
-    tick_spawn_managers(&mut sim, &rules, &[v3]);
+    tick_spawn_managers(&mut sim, &rules, &[v3], None);
 
     assert!(
         sim.substrate
@@ -999,7 +999,7 @@ fn launcher_death_destroys_a_missile_already_in_flight() {
             manager.set_target(Some(TargetKind::Entity(target)));
             manager.update_timer = SpawnTimer::ready();
         }
-        tick_spawn_managers(&mut sim, &rules, &[v3]);
+        tick_spawn_managers(&mut sim, &rules, &[v3], None);
     }
     assert_eq!(
         sim.substrate
@@ -1114,7 +1114,7 @@ fn missile_flight_speed_uses_the_ra2_conversion() {
             manager.set_target(Some(TargetKind::Entity(target)));
             manager.update_timer = SpawnTimer::ready();
         }
-        tick_spawn_managers(&mut sim, &rules, &[v3]);
+        tick_spawn_managers(&mut sim, &rules, &[v3], None);
     }
 
     let speed = sim
@@ -1205,7 +1205,7 @@ fn hornets_hold_over_the_carrier_until_the_whole_wing_is_up() {
             manager.set_target(Some(TargetKind::Entity(target)));
             manager.update_timer = SpawnTimer::ready();
         }
-        tick_spawn_managers(&mut sim, &rules, &[carrier]);
+        tick_spawn_managers(&mut sim, &rules, &[carrier], None);
     }
 
     let launched: Vec<u64> = sim
@@ -1272,7 +1272,7 @@ fn target_death_clears_the_wing_target() {
         manager.set_target(Some(TargetKind::Entity(target)));
         manager.update_timer = SpawnTimer::ready();
     }
-    tick_spawn_managers(&mut sim, &rules, &[carrier]);
+    tick_spawn_managers(&mut sim, &rules, &[carrier], None);
     assert_eq!(
         sim.substrate
             .entities
@@ -1375,7 +1375,7 @@ fn a_launch_at_a_vanished_target_leaves_no_orphan() {
         manager.mode = SpawnManagerMode::Launching;
         manager.update_timer = SpawnTimer::ready();
     }
-    tick_spawn_managers(&mut sim, &rules, &[v3]);
+    tick_spawn_managers(&mut sim, &rules, &[v3], None);
 
     let child = sim
         .substrate

--- a/src/sim/world/global_parity_harness_tests.rs
+++ b/src/sim/world/global_parity_harness_tests.rs
@@ -587,6 +587,18 @@ fn harness_ini() -> IniFile {
     // Anyone extending this fixture: a fractional `Range=` on `[105mm]` would
     // close the gap, at the cost of one re-baseline of GLOBAL_HARNESS_FINAL_HASH
     // plus the stream pins.
+    //
+    // The same gap covers the line-of-fire walk at `InRange`'s tail
+    // (0x006F7642 -> 0x004CC310). It fires only for a projectile that sets
+    // `SubjectToWalls=` or `SubjectToCliffs=`, and neither `[M60]` nor
+    // `[105mm]` declares a `Projectile=` at all, so no projectile section
+    // exists to carry either key; the only overlay here is `TIB01` ore, so
+    // there is no wall on any line; and the terrain the scenario builds is
+    // flat, so no four-Level cliff step exists either. Stock `[Cannon]` and
+    // `[InvisibleLow]` — every cannon tank and every small-arms infantryman —
+    // DO set both keys. Closing this half needs a projectile section plus a
+    // wall overlay or a level step in the fixture terrain, and the same
+    // re-baseline.
     IniFile::from_str(
         "[InfantryTypes]\n0=E1\n\n\
          [VehicleTypes]\n0=MTNK\n1=HARV\n\n\

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -7510,7 +7510,7 @@ impl Simulation {
             );
             destroyed_structure |= c4_outcome.destroyed_structure;
             bridge_state_changed |= bridge_repaired | c4_outcome.bridge_state_changed;
-            self.tick_order_intents_pre_combat(rules, &tube_turn_owned_ids);
+            self.tick_order_intents_pre_combat(rules, overlay_registry, &tube_turn_owned_ids);
             // Pursuit: walk units with out-of-range attack_target into range,
             // halt movement on range entry. Must run before combat so combat
             // sees the up-to-date movement_target this tick.
@@ -7589,7 +7589,12 @@ impl Simulation {
                 .copied()
                 .filter(|id| !tube_turn_owned_ids.contains(id))
                 .collect::<Vec<_>>();
-            crate::sim::spawn_manager::tick_spawn_managers(self, rules, &ordinary_logic_order);
+            crate::sim::spawn_manager::tick_spawn_managers(
+                self,
+                rules,
+                &ordinary_logic_order,
+                overlay_registry,
+            );
             destroyed_structure |= combat_result.structure_destroyed;
             let combat_dead_infos: Vec<(InternedId, EntityCategory)> = combat_result
                 .despawned_ids

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -486,9 +486,9 @@ fn techno_ai_shell(
             clear_passive_target_off_mission(sim, id);
             mission_common_step(sim, id, rules);
             if let Some(rules) = rules {
-                dispatch_supported_foot_mission_cadence(sim, id, rules);
+                dispatch_supported_foot_mission_cadence(sim, id, rules, ctx);
             }
-            passive_acquire_step(sim, id, rules);
+            passive_acquire_step(sim, id, rules, ctx);
         }
         EntityCategory::Structure => {
             if let Some(rules) = rules {
@@ -521,7 +521,7 @@ fn techno_ai_shell(
             // (`0x0043FE43`/`0x0043FFA3`); with no latch writers live the
             // promotion evaluates to not-ready (recorded residual).
             mission_common_step(sim, id, rules);
-            passive_acquire_step(sim, id, rules);
+            passive_acquire_step(sim, id, rules, ctx);
             // BuildingClass::Update consumes the shared C4/PostMortem latch at
             // its late tail. Keep the forced receiver inline in this object's
             // LogicVector visit so nested death effects precede the next slot.
@@ -1010,11 +1010,11 @@ fn unit_techno_bracket(
         );
     }
     if let Some(rules) = rules {
-        dispatch_supported_foot_mission_cadence(sim, id, rules);
+        dispatch_supported_foot_mission_cadence(sim, id, rules, ctx);
     }
     // Passive / opportunity target acquisition sits between mission dispatch
     // and the second IsAlive guard, before the object's own locomotion.
-    passive_acquire_step(sim, id, rules);
+    passive_acquire_step(sim, id, rules, ctx);
     // Guard E (post-dispatch IsAlive): the dispatched handler may have
     // destroyed the Unit; a dead Unit runs no post-mission block.
     if !sim.substrate.entities.get(id).is_some_and(|e| e.is_alive()) {
@@ -1190,7 +1190,13 @@ fn can_acquire_target(sim: &Simulation, id: u64, rules: &RuleSet) -> bool {
 /// but Area Guard is not one of the three missions that reach here from the AI
 /// body — it becomes live when the Area Guard mission handler (a separate
 /// caller of this scanner) lands.
-fn passive_target_scan(sim: &mut Simulation, id: u64, rules: &RuleSet, mission: MissionType) {
+fn passive_target_scan(
+    sim: &mut Simulation,
+    id: u64,
+    rules: &RuleSet,
+    mission: MissionType,
+    ctx: ObjectAiCtx<'_>,
+) {
     let now = sim.session.binary_frame;
     let base_delay = if mission == MissionType::AreaGuard {
         rules.general.guard_area_targeting_delay
@@ -1286,6 +1292,11 @@ fn passive_target_scan(sim: &mut Simulation, id: u64, rules: &RuleSet, mission: 
         // `scan_mission_for` is that choice, and this is the site that makes it.
         scan_mask,
         sim.zone_grid.as_ref(),
+        crate::sim::combat::line_of_fire::LineOfFireInputs {
+            overlay_grid: sim.overlay_grid.as_ref(),
+            overlay_registry: ctx.overlay_registry,
+            alliances: Some(&sim.fog.alliances),
+        },
     );
     // Install the target only — no mission, no destination, and nothing fires
     // this tick. A unit that acquires while driving keeps driving, and an idle
@@ -1375,7 +1386,12 @@ fn passive_target_scan(sim: &mut Simulation, id: u64, rules: &RuleSet, mission: 
 /// - A deployed Desolator that picks something up on its own suppresses its own
 ///   radiation self-target re-arm, because that path only fires for a structure
 ///   or unit with no target installed.
-fn passive_acquire_step(sim: &mut Simulation, id: u64, rules: Option<&RuleSet>) {
+fn passive_acquire_step(
+    sim: &mut Simulation,
+    id: u64,
+    rules: Option<&RuleSet>,
+    ctx: ObjectAiCtx<'_>,
+) {
     let Some(rules) = rules else {
         return;
     };
@@ -1405,7 +1421,7 @@ fn passive_acquire_step(sim: &mut Simulation, id: u64, rules: Option<&RuleSet>) 
     ) {
         return;
     }
-    passive_target_scan(sim, id, rules, mission);
+    passive_target_scan(sim, id, rules, mission, ctx);
 }
 
 /// The off-mission clear, which runs before the AI counter: a passively
@@ -2155,7 +2171,7 @@ mod tests {
 
         // First scan: no hostile, so nothing is installed but the draw happens.
         let before = sim.scenario_rng.state();
-        passive_acquire_step(&mut sim, 1, Some(&rules));
+        passive_acquire_step(&mut sim, 1, Some(&rules), ObjectAiCtx::default());
         assert_ne!(sim.scenario_rng.state(), before);
 
         // Pretend the scan had found something.
@@ -2176,7 +2192,7 @@ mod tests {
         );
 
         let armed = sim.scenario_rng.state();
-        passive_acquire_step(&mut sim, 1, Some(&rules));
+        passive_acquire_step(&mut sim, 1, Some(&rules), ObjectAiCtx::default());
         assert_ne!(
             sim.scenario_rng.state(),
             armed,
@@ -2221,7 +2237,7 @@ mod tests {
             e.passively_acquired_target = true;
             e.passive_scan_timer.clear();
         }
-        passive_acquire_step(&mut sim, 1, Some(&rules));
+        passive_acquire_step(&mut sim, 1, Some(&rules), ObjectAiCtx::default());
         let attack = sim
             .substrate
             .entities
@@ -2269,7 +2285,7 @@ mod tests {
             e.passively_acquired_target = true;
             e.passive_scan_timer.clear();
         }
-        passive_acquire_step(&mut sim, 1, Some(&rules));
+        passive_acquire_step(&mut sim, 1, Some(&rules), ObjectAiCtx::default());
         let attack = sim
             .substrate
             .entities
@@ -2678,7 +2694,7 @@ mod tests {
         let mut probe = sim.scenario_rng.clone();
         let expected_jitter = probe.next_range_u32_inclusive(0, PASSIVE_SCAN_DELAY_JITTER_MAX);
 
-        passive_acquire_step(&mut sim, 1, Some(&rules));
+        passive_acquire_step(&mut sim, 1, Some(&rules), ObjectAiCtx::default());
 
         let timer = sim.substrate.entities.get(1).unwrap().passive_scan_timer;
         assert_eq!(timer.start_frame, sim.session.binary_frame);
@@ -2711,7 +2727,7 @@ mod tests {
         let main_before = sim.main_rng.state();
         let mapgen_before = sim.mapgen_rng.state();
 
-        passive_acquire_step(&mut sim, 1, Some(&rules));
+        passive_acquire_step(&mut sim, 1, Some(&rules), ObjectAiCtx::default());
 
         assert_eq!(
             sim.scenario_rng.state(),
@@ -2740,7 +2756,7 @@ mod tests {
 
         // A second call before the timer expires draws nothing at all.
         let after_first = sim.scenario_rng.state();
-        passive_acquire_step(&mut sim, 1, Some(&rules));
+        passive_acquire_step(&mut sim, 1, Some(&rules), ObjectAiCtx::default());
         assert_eq!(
             sim.scenario_rng.state(),
             after_first,
@@ -2766,7 +2782,7 @@ mod tests {
         );
 
         let before = sim.scenario_rng.state();
-        passive_acquire_step(&mut sim, 1, Some(&rules));
+        passive_acquire_step(&mut sim, 1, Some(&rules), ObjectAiCtx::default());
         assert_eq!(
             sim.scenario_rng.state(),
             before,
@@ -2784,7 +2800,7 @@ mod tests {
             .unwrap()
             .passive_scan_timer
             .clear();
-        passive_acquire_step(&mut sim, 1, Some(&rules));
+        passive_acquire_step(&mut sim, 1, Some(&rules), ObjectAiCtx::default());
         assert_ne!(
             sim.scenario_rng.state(),
             before,

--- a/src/sim/world/techno_ai/mission_handlers.rs
+++ b/src/sim/world/techno_ai/mission_handlers.rs
@@ -24,6 +24,7 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
     sim: &mut Simulation,
     id: u64,
     rules: &RuleSet,
+    ctx: super::ObjectAiCtx<'_>,
 ) {
     let now = sim.session.binary_frame;
     let input = {
@@ -265,7 +266,7 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
             // The re-acquire can install or clear a target, so running it
             // after the draw would both reorder the state writes and move the
             // scenario-stream position for anything the scan itself consumes.
-            let queue = infantry_deployed_attack_reacquire(sim, id, rules, input);
+            let queue = infantry_deployed_attack_reacquire(sim, id, rules, input, ctx);
             let delay = jittered_mission_cadence(sim, rules, MissionType::Attack);
             MissionHandlerEvaluation {
                 delay,
@@ -365,7 +366,7 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
         ) if input.infantry_deployed_do_type && input.infantry_deploy_fire_stance => {
             // Order is native's: `[vtable+0x428]` runs FIRST, then the shim's
             // tail computes `ftol(Rate * 900)` and draws `RandomRanged(0, 2)`.
-            let queue = infantry_deployed_attack_reacquire(sim, id, rules, input);
+            let queue = infantry_deployed_attack_reacquire(sim, id, rules, input, ctx);
             // `MissionClass::GetMissionTimerEntry @ 0x005B3A00` indexes the
             // control table on `[this+0xAC]`, the object's OWN committed
             // selector — so the shim re-arms a Guard man at `[Guard] Rate` and
@@ -435,10 +436,10 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
         // land. The Foot body's own slave-recall arm is absent for the same
         // reason.
         (EntityCategory::Unit | EntityCategory::Infantry, Some(MissionType::AreaGuard)) => {
-            evaluate_foot_area_guard(sim, id, rules)
+            evaluate_foot_area_guard(sim, id, rules, ctx)
         }
         (EntityCategory::Unit | EntityCategory::Infantry, Some(MissionType::Hunt)) => {
-            evaluate_foot_hunt(sim, id, rules)
+            evaluate_foot_hunt(sim, id, rules, ctx)
         }
         // SKIP/PROVE (GSI-07.09) — Mission 4 Retreat is a dead slot for foot
         // objects, and pass 1's reason was wrong. `FootClass::Mission_Retreat @
@@ -812,6 +813,7 @@ fn retaliate_and_scan(
     rules: &RuleSet,
     mission: MissionType,
     scan_mask: crate::sim::combat::ScanMission,
+    ctx: super::ObjectAiCtx<'_>,
 ) -> bool {
     let now = sim.session.binary_frame;
     let base_delay = if mission == MissionType::AreaGuard {
@@ -873,6 +875,11 @@ fn retaliate_and_scan(
         // Mask 0 asks it for the hunter's own movement-zone component and
         // refuses every candidate outside it.
         sim.zone_grid.as_ref(),
+        crate::sim::combat::line_of_fire::LineOfFireInputs {
+            overlay_grid: sim.overlay_grid.as_ref(),
+            overlay_registry: ctx.overlay_registry,
+            alliances: Some(&sim.fog.alliances),
+        },
     );
     if let Some(sid) = pick {
         let _ = sim
@@ -995,7 +1002,12 @@ fn retaliate_and_scan(
 /// Drone on a miner. Frequency: uncommon, and the visible effect is nil either
 /// way — a `StupidHunt` type does nothing on Hunt in retail either. Downstream
 /// risk: one missing draw per dispatch.
-fn evaluate_foot_hunt(sim: &mut Simulation, id: u64, rules: &RuleSet) -> MissionHandlerEvaluation {
+fn evaluate_foot_hunt(
+    sim: &mut Simulation,
+    id: u64,
+    rules: &RuleSet,
+    ctx: super::ObjectAiCtx<'_>,
+) -> MissionHandlerEvaluation {
     let type_ref = sim.substrate.entities.get(id).map(|entity| entity.type_ref);
     let stupid_hunt = type_ref
         .and_then(|type_ref| sim.interner.try_resolve(type_ref))
@@ -1014,6 +1026,7 @@ fn evaluate_foot_hunt(sim: &mut Simulation, id: u64, rules: &RuleSet) -> Mission
             // `PUSH 0x0` at `0x004D5373` — the literal threat mask Hunt hands
             // the scanner.
             crate::sim::combat::ScanMission::Hunt,
+            ctx,
         );
     }
     MissionHandlerEvaluation::cadence(jittered_mission_cadence(sim, rules, MissionType::Hunt))
@@ -1091,6 +1104,7 @@ fn evaluate_foot_area_guard(
     sim: &mut Simulation,
     id: u64,
     rules: &RuleSet,
+    ctx: super::ObjectAiCtx<'_>,
 ) -> MissionHandlerEvaluation {
     let needs_target = sim
         .substrate
@@ -1098,7 +1112,7 @@ fn evaluate_foot_area_guard(
         .get(id)
         .is_some_and(|entity| entity.attack_target.is_none());
     if needs_target && can_acquire_target(sim, id, rules) {
-        passive_target_scan(sim, id, rules, MissionType::AreaGuard);
+        passive_target_scan(sim, id, rules, MissionType::AreaGuard, ctx);
         let acquired = sim
             .substrate
             .entities
@@ -1520,6 +1534,7 @@ fn infantry_deployed_attack_reacquire(
     id: u64,
     rules: &RuleSet,
     input: MissionHandlerInput,
+    ctx: super::ObjectAiCtx<'_>,
 ) -> Option<MissionType> {
     let had_target = input.has_attack_target;
     if had_target && !attack_target_is_stale(sim, id) {
@@ -1546,6 +1561,11 @@ fn infantry_deployed_attack_reacquire(
         // literal `2`.
         crate::sim::combat::ScanMission::Guard,
         sim.zone_grid.as_ref(),
+        crate::sim::combat::line_of_fire::LineOfFireInputs {
+            overlay_grid: sim.overlay_grid.as_ref(),
+            overlay_registry: ctx.overlay_registry,
+            alliances: Some(&sim.fog.alliances),
+        },
     );
     if had_target || pick.is_some() {
         let current = sim

--- a/src/sim/world/world_orders.rs
+++ b/src/sim/world/world_orders.rs
@@ -53,6 +53,7 @@ impl Simulation {
     pub(crate) fn tick_order_intents_pre_combat(
         &mut self,
         rules: &RuleSet,
+        overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
         turn_suppressed: &BTreeSet<u64>,
     ) {
         // Collect attacker candidates from EntityStore.
@@ -91,6 +92,11 @@ impl Simulation {
                 // "guard this spot" order. gamemd equivalent UNCHECKED.
                 scan_mask,
                 self.zone_grid.as_ref(),
+                combat::line_of_fire::LineOfFireInputs {
+                    overlay_grid: self.overlay_grid.as_ref(),
+                    overlay_registry,
+                    alliances: Some(&self.fog.alliances),
+                },
             ) else {
                 continue;
             };

--- a/src/sim/world/world_orders.rs
+++ b/src/sim/world/world_orders.rs
@@ -1140,7 +1140,14 @@ impl Simulation {
             // gate ran the walk, a unit ordered to shoot across a wall would
             // halt here and then be refused the shot, standing still under a
             // live order.
-            let in_range = combat::pursuit_in_range(
+            //
+            // The one refusal that must NOT produce a pursuit cell is
+            // `MinimumRange`: native's approach search picks a candidate
+            // FARTHER out, and the target's own cell — VERA's only candidate —
+            // is the worst one in that set. `HoldInsideMinimumRange` therefore
+            // takes the halt arm, which is exactly what this stage did for that
+            // case before the walk landed. See `PursuitRangeVerdict`.
+            let verdict = combat::pursuit_in_range(
                 entity,
                 &attack.target,
                 weapon,
@@ -1148,14 +1155,18 @@ impl Simulation {
                 rules,
                 &self.interner,
                 self.resolved_terrain.as_ref(),
+                // Same alliance view the fire gate hands the walk
+                // (`resolve_attacker_fire` passes `fog.alliances`) and the same
+                // one the sibling pre-combat scan uses, so the two stages
+                // cannot disagree on the `AlliedWallTransparency` arm.
                 &combat::line_of_fire::LineOfFireInputs {
                     overlay_grid: self.overlay_grid.as_ref(),
                     overlay_registry,
-                    alliances: Some(&self.house_alliances),
+                    alliances: Some(&self.fog.alliances),
                 },
             );
 
-            if !in_range {
+            if verdict == combat::PursuitRangeVerdict::CloseIn {
                 // **Sticky never chases.** The one place the engine tells
                 // Sticky apart from Guard at all — they share a mission handler
                 // — is the pursuit-cell producer: when the can-fire-at query
@@ -1178,7 +1189,9 @@ impl Simulation {
                 }
                 // else: existing pursuit movement is still running; let it continue.
             } else if entity.movement_target.is_some() {
-                // In range — halt for firing.
+                // `CanFire` — halt for firing. `HoldInsideMinimumRange` halts
+                // here too: closing further cannot help, and this is the arm it
+                // took before the walk landed.
                 actions.push(PursuitAction::ClearMovement { entity_id: id });
             }
         }

--- a/src/sim/world/world_orders.rs
+++ b/src/sim/world/world_orders.rs
@@ -1112,13 +1112,13 @@ impl Simulation {
                 Some(rules),
                 &self.interner,
             );
-            let Some((trx, try_, tsx, tsy)) = target_pos else {
+            let Some((trx, try_, _tsx, _tsy)) = target_pos else {
                 continue;
             };
 
-            // Resolve weapon range using shared helper. None means no weapon
+            // Resolve the weapon using the shared helper. None means no weapon
             // can engage; combat tick will drop on its own weapon-select fail.
-            let Some(weapon_range) = combat::pursuit_weapon_range(
+            let Some(weapon) = combat::pursuit_selected_weapon(
                 entity,
                 &attack.target,
                 &self.substrate.entities,
@@ -1130,18 +1130,30 @@ impl Simulation {
                 continue;
             };
 
-            // Range check — same math as combat tick.
-            let dist_sq = combat::lepton_distance_sq_raw(
-                entity.position.rx,
-                entity.position.ry,
-                entity.position.sub_x,
-                entity.position.sub_y,
-                trx,
-                try_,
-                tsx,
-                tsy,
+            // Range check — the SAME predicate the combat tick's fire gate
+            // uses, line-of-fire walk included. The approach search
+            // (`FootClass::Greatest_Threat_Scan @ 0x004D5690`, vt+0x53C,
+            // reached from `Mission_Attack` 0x004D4DC0 at 0x004D4E6A) decides
+            // with `TechnoClass::InRange` 0x006F7220 at 0x004D622C /
+            // 0x004D6550, and `InRange` ends in the wall/cliff walk at
+            // 0x006F7642. If this stage used the plain radius while the fire
+            // gate ran the walk, a unit ordered to shoot across a wall would
+            // halt here and then be refused the shot, standing still under a
+            // live order.
+            let in_range = combat::pursuit_in_range(
+                entity,
+                &attack.target,
+                weapon,
+                &self.substrate.entities,
+                rules,
+                &self.interner,
+                self.resolved_terrain.as_ref(),
+                &combat::line_of_fire::LineOfFireInputs {
+                    overlay_grid: self.overlay_grid.as_ref(),
+                    overlay_registry,
+                    alliances: Some(&self.house_alliances),
+                },
             );
-            let in_range = combat::is_within_range_leptons(dist_sq, weapon_range);
 
             if !in_range {
                 // **Sticky never chases.** The one place the engine tells

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -2333,7 +2333,7 @@ fn gsi_04_15_active_tube_leaf_preempts_unit_and_infantry_mission_host() {
             // `TechnoClass::Evaluate_Candidate @ 0x006F85AB` refuses an enemy
             // building with no weapon or no posed threat, which is a targeting
             // fact this Tube-ordering test is not about.
-            sim.tick_order_intents_pre_combat(&rules, &std::collections::BTreeSet::new());
+            sim.tick_order_intents_pre_combat(&rules, None, &std::collections::BTreeSet::new());
             assert!(matches!(
                 sim.substrate
                     .entities


### PR DESCRIPTION
## What a player will notice

A unit no longer fires through a wall or a cliff that blocks the line of fire.

`TechnoClass::InRange` (0x006F7220) does not end at the distance test. Both of its arms
converge on one call — the ground arm falls into 0x006F763B, the arcing arm pushes the same
two arguments at 0x006F7519 and jumps to 0x006F763C, and both land on `CALL 0x004CC310` at
0x006F7642, whose result is inverted into the return by `TEST EAX,EAX; SETZ AL`. That call
walks the cells between firer and target and refuses the shot when one blocks. VERA had
never run it: `compute_in_range` returned `true` after the bridge gate, and target selection
agreed with it, so a unit would commit to a target it could never legally engage.

This is not an edge case. The gate lives on the projectile's `SubjectToWalls=` /
`SubjectToCliffs=` keys, and in stock rules those sit on **`[InvisibleLow]`** (GI, Conscript,
Sniper, Mirage Tank, Boris, the Patriot's `Vulcan`) and **`[Cannon]`** (Grizzly, Rhino,
Apocalypse, Lasher, Tank Destroyer, Robot Tank) — i.e. basic infantry and every tank in the
game. `[Cannon]` also sets `Arcing=true`, which is why the arcing arm had to be wired too;
exempting it would have missed every tank.

## Pursuit moved onto the same predicate

gamemd's "can I shoot from here?" and "where do I walk to?" are literally the same call.
`FootClass::Mission_Attack` (0x004D4DC0) dispatches to vtable slot **+0x53C** at 0x004D4E6A
whenever TarCom is non-null; that slot resolves to the approach search at 0x004D5690, and
inside it 0x004D622C and 0x004D6550 are `CALL 0x006F7220` — `InRange` itself, against a
candidate coordinate. The slot is proved from two independently anchored vtables: base
0x007E22A4 (fixed by `[0x007E264C] == 0x006F77B0`, `CanFireAt` at the known slot +0x3A8)
gives `[0x007E27E0] == 0x004D5690`, and `InfantryClass`'s override `[0x007EB594] ==
0x00522340` chains into the same body at 0x0052236E.

Gating fire without gating approach would have frozen a unit under a standing order: pursuit
would stop at the plain radius believing it had arrived while the fire gate refused the shot.
The review caught that, and pursuit now goes through `compute_in_range` with the same
`LineOfFireInputs` — same overlay grid, same registry, same alliance view — so the two stages
cannot disagree. A GI ordered across a `GAWALL` now rounds the wall and fires when the line
clears. There is a regression tripwire for this (`a_wall_on_the_line_keeps_pursuit_closing_
instead_of_freezing`, which fails on the pre-fix commit) plus a control on the identical
fixture with the wall removed.

## Minimum range holds rather than closes — an honest deferral, not parity

Handing pursuit the full fire-gate verdict also hands it the `MinimumRange` refusal
(0x006F737F–0x006F73E8), and for *that* refusal "walk to the target" is exactly backwards.
gamemd does not have the problem because 0x004D5690 scans 25 bearings against a shrinking
radius and picks a candidate coordinate where `InRange` holds — it backs the V3 off. VERA's
pursuit evaluates one candidate, the target's own cell, which for a too-close refusal is the
worst cell in the set; a straight bool would have turned "the V3 sits frozen inside 5 cells"
into "the V3 drives at the tank it cannot shell", which is worse and is ordinary play.

So `pursuit_in_range` returns `CanFire` / `CloseIn` / `HoldInsideMinimumRange`, and the
too-close arm takes the halt path — **bit-for-bit the arm this stage already took**. It is
labelled VERA-internal on the enum with trigger, effect, frequency and downstream risk, and
recorded as a deferral of the candidate-coordinate scan rather than dressed up as an
equivalent of it. `MinimumRange=` is authored on 20 stock weapon sections, 16 of them
non-zero.

## Wall re-admission is narrower than `Wall=yes`

A wall-breaking warhead is re-admitted only when `CellClass::IsWallConnectableInDirection`
(0x00480510) agrees. Called with `-1`/`-1` from 0x004CC333, that body reduces to a
membership test on the cell's overlay index against **{2, 26, 243}** — `GAWALL`, `NAWALL`
and `GAFWLL` (the Yuri Citadel Wall) by `[OverlayTypes]` declaration index, which
`RulesClass::Process` reads by 0-based entry index and never by key text (0x00668CF3 /
0x00668D0A). Sandbags (`GASAND`, id 0) and `CAFNCP` carry `Wall=yes` and are *not* in the
set, so a wall-breaking shell is still refused by a sandbag line. Eight stock overlays set
`Wall=yes`; three of them are re-admitted. Both halves are pinned by tests.

## Row 124 stays OPEN

Two recorded residuals still bypass the walk, both pre-existing structure this change did
not create, and both named at their own call sites:

- **The garrison fire branch** (`combat/mod.rs`) — the `is_garrison || effective_range !=
  weapon.range` arm never calls `compute_in_range`. A garrisoned GI shoots through a `GAWALL`
  the identical GI in the open is refused. Routine on urban maps.
- **`ScanRange::Hard`** (`greatest_threat.rs`) — the garrison passive scan's range override
  is a plain radius. Garrisoned infantry acquire targets gamemd refuses. Routine on urban maps.

Both are cured by the same thing: the override-aware range VALUE chain
(Garrison / Bunker / OpenTopped). Also unchanged: the arcing slope solver, the off-grid
dummy-`CellClass` arm (nil in ordinary play — the playfield is convex in cell space), and
`AlliedWallTransparency` cell ownership (inert on stock, where the key is `no`).

## Verified gamemd sources

| Address | Role |
|---|---|
| 0x006F7220 | `TechnoClass::InRange`; both arms converge on `CALL 0x004CC310` at 0x006F7642, inverted by `SETZ` |
| 0x004CC310 | runs the walk, then the wall re-admission (0x004CC333 + warhead `Wall=` at 0x004CC342) |
| 0x004CC100 | the walk; gated at 0x004CC10B on `SubjectToCliffs`/`SubjectToWalls`, Chebyshev cell step count (0x004CC191–0x004CC1B5), truncating per-axis lepton increments (`IDIV` at 0x004CC1E7/EE/F9) |
| 0x004CC360 | per-cell verdict. Cliff arm 0x004CC3DE/0x004CC3F7 (`>= 4` above prev **and** `> 0` above source); wall arm 0x004CC434 (not the target's own cell) + 0x004CC444 (`CMP AL,CL; JG` on the **raw** signed `Level` `+0x11B`, not the effective height) |
| 0x004CC489–0x004CC572 | dead tail — all four entry edges are "blocks" verdicts, it re-reads the same `CellStruct` at frame−0x20, and duplicates the tests above it on identical operands. Not ported; proved by a complete stack-write trace |
| 0x00480510 | `IsWallConnectableInDirection`; the `-1` arm is overlay id ∈ {2, 26, 243} |
| 0x00487D50 | `CellClass::GetEffectiveHeight` = `(i8)+0x11B + ((+0x140>>7)&1)*4` |
| 0x004D4DC0 / 0x004D5690 / 0x004D622C / 0x004D6550 | the approach search behind vt+0x53C, and its two `InRange` callsites |
| 0x0066D1F0 | `RulesClass::ReadWallModel` → `AlliedWallTransparency` at `Rules+0x1850` (read 0x0066D20E) |
| 0x00668CF3 / 0x00668D0A | `[OverlayTypes]` entries read by 0-based index; declaration order **is** the id |
| 0x0046BFF8 / 0x0046C02C | `BulletTypeClass::ReadINI` — `SubjectToCliffs` `+0x296`, `SubjectToWalls` `+0x298` |
| 0x0075D508 | `WarheadTypeClass::ReadINI_Body` — `Wall=` → `+0x144` |

## Tests

`cargo test -p vera20k --lib`, one run, after rebase onto `38c4adcc`:

```
test result: ok. 8252 passed; 0 failed; 77 ignored; 0 measured; 0 filtered out; finished in 18.63s
```

16 new tests. 10 in `sim::combat::line_of_fire::tests` pin each arm of the walk against its
address — the `>= 4` cliff boundary from both sides, the raw-`Level` downhill case, the
target's-own-cell exemption, the sandbag refusal, the `AlliedWallTransparency` gate, the
`steps <= 0` shortcut. 3 in `sim::combat::in_range::tests` cover the live wiring on both
arms plus the `Range=-2` sentinel. 3 in `sim::combat::combat_pursuit_tests` are the
regression tripwires for the pursuit migration: the deadlock case, its no-wall control, and
the minimum-range hold. The `#[ignore]` residual record
`inrange_line_of_fire_block_is_unported` is removed — this is its subject.

`SNAPSHOT_VERSION` is 120, which is main's value; this branch contributes no version change
of its own. No golden, replay hash or world-hash constant moved. That is coverage rather
than evidence: the global parity harness declares no `Projectile=` on either weapon, no
`MinimumRange=`, and an empty `heights` map, so it cannot exercise either arm — recorded on
`harness_ini()` with what it would take to close.

## One commit message on this branch is wrong

`dfff2248`'s message (`1a9e0a94` after rebase) says "GAFWLL has no section in stock rules at
all, so it carries no `Wall=` and the id is inert on retail data". **That is false and
history was not rewritten.** `[GAFWLL]` is the Yuri Citadel Wall — `rulesmd.ini:13561`,
`Wall=yes` at `:13571`, `[BuildingTypes] 312`, and `[AI] ConcreteWalls=GAWALL,NAWALL,GAFWLL`
names exactly the three ids the hard-coded triple resolves to — so overlay id 243 is live in
ordinary Yuri play. The header was missed because it carries a trailing comment, and
gamemd's `INIClass::LoadFromStraw` (0x00525A60) truncates a section header at the **first**
`]` (`CMP [ESP+0x78],0x5B` 0x00525DC1, `strchr(line,']')` 0x00525DCC, `MOV byte ptr [EAX],0`
0x00525DDB) — as does VERA's parser, checked rule for rule. `aa6ac858` (`49fe8eb3` after
rebase) corrects the code comment and the two knock-on counts, and its own message names and
quotes the wrong sentence — it cites the pre-rebase SHA `dfff2248`, which is the commit that
lands here as `1a9e0a94`. Behaviour never changed: `WALL_CONNECTABLE_OVERLAY_IDS` was and is
`[2, 26, 243]`.
