### PR TITLE
fix(research-index): accept decorated INI section headers

### DIFF
--- a/tools/research_index/research_index/chunking.py
+++ b/tools/research_index/research_index/chunking.py
@@ -8,8 +8,12 @@ import re
 
 
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
-INI_SECTION_RE = re.compile(r"^\s*\[([^\]]+)\]\s*$")
 MAX_PLAIN_CHUNK_LINES = 120
+
+# `INIClass__LoadFromStraw @ 0x00525A60` trims the raw line of every character
+# at or below 0x20 (`strtrim @ 0x00727CF0`, called at 0x00525DB8) before any
+# header test. Mirrors `trim_ascii_controls` in `src/rules/ini_parser.rs`.
+_NATIVE_TRIM_CHARS = "".join(chr(code) for code in range(0x21))
 
 
 @dataclass(frozen=True)
@@ -61,20 +65,53 @@ def chunk_markdown(lines: list[str]) -> list[Chunk]:
     return chunks
 
 
+def ini_section_name(line: str) -> str | None:
+    """Return the section name this line opens, or None if it opens none.
+
+    Retail rule, from `INIClass__LoadFromStraw @ 0x00525A60`: after the
+    whole-line trim, a header is a line whose first character is `[` (`CMP
+    byte ptr [ESP + 0x78], 0x5b` @ 0x00525DC1) *and* that contains a `]`
+    anywhere (`strchr(line, ']')` via `PUSH 0x5d` @ 0x00525DCC calling
+    `CRT__strchr @ 0x007CAF30`). The loader then writes a NUL over that first
+    `]` (`MOV byte ptr [EAX],0x0` @ 0x00525DDB), so the name is the text
+    between `[` and the *first* `]` and everything after it is discarded.
+    There is no `;`-comment handling on the header path at all — a trailing
+    comment, or a second `[...]`, is simply thrown away with the rest of the
+    line. All five `[`-detection sites in the function (0x00525B2B,
+    0x00525C0B, 0x00525C95, 0x00525DC1, 0x00525EA5) pair the `[` test with the
+    same `strchr` for `]`, so `[Foo` with no bracket is never a header.
+
+    Retail INIs rely on this: 61 of rulesmd.ini's 1478 headers and 154 of
+    artmd.ini's 1582 carry trailing text (e.g. `[GAFWLL];temp wall for
+    yuri[YAWALL]`). A stricter test drops those headers and misfiles their
+    keys into the preceding section.
+
+    Kept rule-for-rule identical to VERA's own reader,
+    `IniFile::parse_line` in `src/rules/ini_parser.rs`.
+    """
+    trimmed = line.strip(_NATIVE_TRIM_CHARS)
+    if not trimmed.startswith("["):
+        return None
+    end = trimmed.find("]")
+    if end < 0:
+        return None
+    return trimmed[1:end]
+
+
 def chunk_ini(lines: list[str]) -> list[Chunk]:
     chunks: list[Chunk] = []
     start = 1
     heading = "INI"
 
     for idx, line in enumerate(lines, start=1):
-        match = INI_SECTION_RE.match(line)
-        if not match:
+        name = ini_section_name(line)
+        if name is None:
             continue
 
         if idx > start:
             _append_chunk(chunks, heading, start, idx - 1, lines[start - 1 : idx - 1])
 
-        heading = f"INI [{match.group(1).strip()}]"
+        heading = f"INI [{name}]"
         start = idx
 
     if start <= len(lines):

--- a/tools/research_index/tests/test_research_index.py
+++ b/tools/research_index/tests/test_research_index.py
@@ -16,7 +16,7 @@ TOOL_ROOT = Path(__file__).resolve().parents[1]
 if str(TOOL_ROOT) not in sys.path:
     sys.path.insert(0, str(TOOL_ROOT))
 
-from research_index.chunking import chunk_file
+from research_index.chunking import chunk_file, ini_section_name
 from research_index.database import rebuild_database, search
 from research_index.brief import research_brief
 from research_index.formatting import (
@@ -69,6 +69,60 @@ class ExtractionTests(unittest.TestCase):
 
         self.assertEqual(extract_terms(text, ".ini").ini_keys, ("BridgeRepairHut", "RepairBridge"))
         self.assertEqual(extract_terms(text, ".md").ini_keys, ())
+
+
+class IniSectionHeaderTests(unittest.TestCase):
+    """Header detection must match `INIClass__LoadFromStraw @ 0x00525A60`.
+
+    The name is the text between `[` and the *first* `]`; the rest of the line
+    is discarded (`MOV byte ptr [EAX],0x0` @ 0x00525DDB). A `]` somewhere on
+    the line is required (`strchr` via `PUSH 0x5d` @ 0x00525DCC), so `[Foo`
+    alone opens nothing.
+    """
+
+    def test_plain_header(self) -> None:
+        self.assertEqual(ini_section_name("[NACLON]"), "NACLON")
+
+    def test_leading_whitespace_is_trimmed_before_the_bracket_test(self) -> None:
+        self.assertEqual(ini_section_name("\t  [NACLON]  \r"), "NACLON")
+
+    def test_trailing_semicolon_comment_is_discarded(self) -> None:
+        self.assertEqual(ini_section_name("[CAHOSP];copypasted the good one on top of it"), "CAHOSP")
+        self.assertEqual(ini_section_name("[ROCK] ; Rocketeer"), "ROCK")
+
+    def test_trailing_second_bracket_group_is_discarded(self) -> None:
+        # Retail rulesmd.ini:13561.
+        self.assertEqual(ini_section_name("[GAFWLL];temp wall for yuri[YAWALL]"), "GAFWLL")
+
+    def test_closing_bracket_inside_a_trailing_comment_does_not_extend_the_name(self) -> None:
+        self.assertEqual(ini_section_name("[DISK];gs changed to K [see the Master Name Doc]"), "DISK")
+
+    def test_open_bracket_without_a_closing_bracket_is_not_a_header(self) -> None:
+        self.assertIsNone(ini_section_name("[Foo"))
+        self.assertIsNone(ini_section_name("  [JumpjetControls ;gs no bracket"))
+
+    def test_non_header_lines_are_not_headers(self) -> None:
+        self.assertIsNone(ini_section_name(""))
+        self.assertIsNone(ini_section_name("Wall=yes"))
+        self.assertIsNone(ini_section_name(";[NotASection]"))
+        self.assertIsNone(ini_section_name("Prerequisite=YABRCK ; [not a section]"))
+
+    def test_decorated_headers_start_their_own_chunk_instead_of_merging_upward(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "rules.ini"
+            path.write_text(
+                "[NACLON]\nStrength=1000\n"
+                "[GAFWLL];temp wall for yuri[YAWALL]\nWall=yes\n"
+                "[Parasite] ; special warhead\nVersus=100%%\n",
+                encoding="utf-8",
+            )
+
+            chunks = chunk_file(path)
+
+            self.assertEqual(
+                [(chunk.heading_path, chunk.start_line, chunk.end_line) for chunk in chunks],
+                [("INI [NACLON]", 1, 2), ("INI [GAFWLL]", 3, 4), ("INI [Parasite]", 5, 6)],
+            )
 
 
 class RankingTests(unittest.TestCase):


### PR DESCRIPTION
## Effect

The research index was silently dropping **61 section headers in `rulesmd.ini`** and **154
in `artmd.ini`**, and misfiling every key of those sections into the *preceding* section.
Searches did not merely miss content — they returned the wrong content, attributed to the
wrong game object, for material this programme is actively working on.

Concretely: `Wall=yes` at `rulesmd.ini:13571` belongs to `[GAFWLL]` (Yuri's Citadel Wall).
It was served to every agent under `INI [NACLON]` — the Cloning Vats. Among the sections
with no chunk of their own: the nine special warheads `Crush`, `Controller`,
`ControllerBuilding`, `Parasite`, `ParasiteDog`, `ParasitePlus`, `V3HE`, `IvanBomb`,
`IvanWH`, plus `DeathWH`, and a large animation group (`NUKEANIM`, `MINDANIM`, `APOCEXP`,
`CRIVEXP`, `VTEXPLOD`, `NATSLA_*`, `GAPRIS_*`, `GADEPT_*`).

The cause was one strict regex in the chunker, `^\s*\[([^\]]+)\]\s*$`, which requires a
header line to end at the closing bracket. Retail INIs routinely decorate headers:
`[GAFWLL];temp wall for yuri[YAWALL]`.

## The gamemd rule

Verified live in `gamemd.exe`, `INIClass__LoadFromStraw @ 0x00525A60`:

- `0x00525DB8` `LEA ECX,[ESP+0x78]` / `CALL 0x00727CF0` — the line is passed through
  `strtrim @ 0x00727CF0` (strips both ends of bytes `<= 0x20`) before any header test.
- `0x00525DC1` `CMP byte ptr [ESP + 0x78], 0x5b` — the first character must be `[`.
- `0x00525DCC` `PUSH 0x5d` / `0x00525DCF` `CALL 0x007CAF30` — `strchr(line, ']')`
  (`CRT__strchr`); `TEST EAX,EAX; JZ` means no `]` opens no section, so `[Foo` is not a
  header.
- `0x00525DDB` `MOV byte ptr [EAX],0x0` — a NUL is written over the **first** `]`.

**The section name is the text between `[` and the first `]`; the rest of the line is
discarded. There is no `;`-comment handling on the header path at all.** All five
`[`-detection sites in the function (`0x00525B2B`, `0x00525C0B`, `0x00525C95`,
`0x00525DC1`, `0x00525EA5`) pair the `[` test with the same `strchr` for `]`.

The name is **not** trimmed inside the brackets — the loader copies from `local_400 + 1`
verbatim after the NUL. The old code's `.strip()` was dropped for that reason. This is
rule-for-rule identical to VERA's own reader, `IniFile::parse_line` in
`src/rules/ini_parser.rs`: trim `<= 0x20`, `starts_with('[')`, first-`]` scan, untrimmed
`[1..end]`.

## Before / after

Rebuilt against the main-checkout workspace:

| file | before | after |
|---|---|---|
| `ini/rulesmd.ini` | 1418 chunks | **1479** |
| `ini/artmd.ini` | 1429 chunks | **1583** |

1479 = 1478 native headers + 1 pre-header preamble; 1583 = 1582 + 1. Both exact, no
off-by-one. Across all 27 indexed `.ini` documents, **7 gain chunks** (`art.ini` +101,
`artmd.ini` +154, `rules.ini` +51, `rulesmd.ini` +61, `evamd`/`sound`/`soundmd` +1 each),
20 are unchanged, and **none loses a chunk** — the change is monotone and cannot un-file
anything previously filed correctly.

`INI [GAFWLL]` now exists at `ini/rulesmd.ini` 13561-13589 and carries its own `Wall=yes`;
`INI [NACLON]` correctly ends at 13560.

## Tests

New `IniSectionHeaderTests` (8 tests) in `tools/research_index/tests/test_research_index.py`,
covering trailing `;` comments, a trailing second `[...]` group, a `]` inside a trailing
comment (pinning *first*-`]` rather than last), `[Foo` with no closing bracket, non-header
lines, and an end-to-end `chunk_file` assertion on exact `(heading_path, start_line,
end_line)` triples.

`python -m unittest tests.test_research_index` → `Ran 42 tests in 11.736s` → `OK (skipped=1)`.

The skip is `MCPServerSmokeTests` (13 tests, class-level): the worktree has no gitignored
`.cache/research.db`. The main checkout runs the same suite at `Ran 47 tests ... OK` with
no skip. None of the 13 asserts on INI content.

Python-only change; no cargo involved. No database artefact is committed —
`tools/research_index/.cache/` is gitignored (`.gitignore:53`) and the commit touches
exactly two source files.

## Note: the fix only takes effect once this is on `main`

Every read tool on the `research-index` MCP server calls `ensure_fresh()`, which rebuilds
whenever `_builder_signature()` — a hash over `BUILDER_INPUTS`, which includes
`chunking.py` — differs. The server imports `research_index` from the **main checkout**, so
a database published from a worktree is rejected and rebuilt with the old chunker within
seconds. No manual rebuild step is needed after merge: the first read auto-rebuilds
correctly.

## Follow-ups (not in this PR)

**Markdown headings inside fenced code blocks.** `HEADING_RE` has no fence tracking, so a
`#` line inside a ``` block (a shell or C comment) is read as a document heading:
**116 false headings across 27 files** in `docs/research` + `docs/plans` (3145 files
scanned). It splits a code block across two chunks and corrupts the `heading_path`
breadcrumb until the next real heading. No content is lost and every file/line citation
stays exact, so it misleads a reader rather than misattributing evidence to the wrong game
object — strictly less severe than this bug. Deferred deliberately: fence tracking is a
behavioral change to markdown chunking that deserves its own commit, and bundling it would
widen the review surface of an urgent merge. It will force its own full rebuild, so it is
worth landing soon after this one rather than letting it drift.

**Known benign instance of the same shortcut in Rust.** `src/util/ini_writer.rs:265`:

```rust
let inner = t.strip_prefix('[')?.strip_suffix(']')?;
```

`strip_suffix(']')` is the same strict rule, plus an inner trim gamemd does not do. It
targets `RA2MD.INI`, a settings file the game writes itself and never decorates, so it is
not a defect today and does not affect retail data. Recording it rather than leaving it
silent; the claim that `chunking.py` was the only strict-header parser is scoped to
`tools/`, and that scoped claim holds — no other INI section reader exists there.
