### PR TITLE
feat(sim): combat explosions are real AnimClass instances

### DIFF
--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -1404,6 +1404,14 @@ impl MapLoadInitial {
             &map_data.header.theater,
         )
         .expect("retail scheduler animation closure");
+        // Combat explosions are AnimClass instances; tolerant pass, after the
+        // strict one, which rewrites the scheduler-owned set wholesale.
+        art.bind_combat_explosion_anim_assets(
+            &crate::rules::effect_asset_catalog::combat_explosion_anim_roots(&rules),
+            asset_manager,
+            theater_ext,
+            &map_data.header.theater,
+        );
         rules.art_registry = art.clone();
         rules.bind_effect_assets(asset_manager, theater_ext, &map_data.header.theater);
         rules.bind_terrain_spawner_assets(
@@ -2382,6 +2390,15 @@ pub(crate) fn load_map_from_initial(
             theater_ext,
             &map_data.header.theater,
         )?;
+        // Combat explosions are AnimClass instances, so their art must carry the
+        // same loader-derived End/LoopEnd. Tolerant by design; must follow the
+        // strict pass, which rewrites the scheduler-owned set wholesale.
+        a.bind_combat_explosion_anim_assets(
+            &crate::rules::effect_asset_catalog::combat_explosion_anim_roots(r),
+            &asset_manager,
+            theater_ext,
+            &map_data.header.theater,
+        );
         r.art_registry = a.clone();
         r.bind_effect_assets(&asset_manager, theater_ext, &map_data.header.theater);
         r.bind_terrain_spawner_assets(

--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -1406,11 +1406,14 @@ impl MapLoadInitial {
         .expect("retail scheduler animation closure");
         // Combat explosions are AnimClass instances; tolerant pass, after the
         // strict one, which rewrites the scheduler-owned set wholesale.
-        art.bind_combat_explosion_anim_assets(
+        let unbound_explosion_roots = art.bind_combat_explosion_anim_assets(
             &crate::rules::effect_asset_catalog::combat_explosion_anim_roots(&rules),
             asset_manager,
             theater_ext,
             &map_data.header.theater,
+        );
+        crate::rules::effect_asset_catalog::log_unbound_combat_explosion_roots(
+            unbound_explosion_roots,
         );
         rules.art_registry = art.clone();
         rules.bind_effect_assets(asset_manager, theater_ext, &map_data.header.theater);
@@ -2393,11 +2396,14 @@ pub(crate) fn load_map_from_initial(
         // Combat explosions are AnimClass instances, so their art must carry the
         // same loader-derived End/LoopEnd. Tolerant by design; must follow the
         // strict pass, which rewrites the scheduler-owned set wholesale.
-        a.bind_combat_explosion_anim_assets(
+        let unbound_explosion_roots = a.bind_combat_explosion_anim_assets(
             &crate::rules::effect_asset_catalog::combat_explosion_anim_roots(r),
             &asset_manager,
             theater_ext,
             &map_data.header.theater,
+        );
+        crate::rules::effect_asset_catalog::log_unbound_combat_explosion_roots(
+            unbound_explosion_roots,
         );
         r.art_registry = a.clone();
         r.bind_effect_assets(&asset_manager, theater_ext, &map_data.header.theater);

--- a/src/headless_scenario.rs
+++ b/src/headless_scenario.rs
@@ -344,12 +344,13 @@ pub fn load(retail_dir: &Path, map_file_name: &str, seed: u32) -> Result<Headles
     .map_err(|error| format!("bind authoritative animation assets: {error}"))?;
     // Combat explosions are AnimClass instances; tolerant pass, after the strict
     // one, which rewrites the scheduler-owned set wholesale.
-    art.bind_combat_explosion_anim_assets(
+    let unbound_explosion_roots = art.bind_combat_explosion_anim_assets(
         &crate::rules::effect_asset_catalog::combat_explosion_anim_roots(&rules),
         &assets,
         theater.extension,
         &map.header.theater,
     );
+    crate::rules::effect_asset_catalog::log_unbound_combat_explosion_roots(unbound_explosion_roots);
     let (populated_smudge_dims, fallback_smudge_dims) =
         art.populate_anim_frame_dims(&assets, theater.extension, &map.header.theater);
     log::info!(

--- a/src/headless_scenario.rs
+++ b/src/headless_scenario.rs
@@ -342,6 +342,14 @@ pub fn load(retail_dir: &Path, map_file_name: &str, seed: u32) -> Result<Headles
         &map.header.theater,
     )
     .map_err(|error| format!("bind authoritative animation assets: {error}"))?;
+    // Combat explosions are AnimClass instances; tolerant pass, after the strict
+    // one, which rewrites the scheduler-owned set wholesale.
+    art.bind_combat_explosion_anim_assets(
+        &crate::rules::effect_asset_catalog::combat_explosion_anim_roots(&rules),
+        &assets,
+        theater.extension,
+        &map.header.theater,
+    );
     let (populated_smudge_dims, fallback_smudge_dims) =
         art.populate_anim_frame_dims(&assets, theater.extension, &map.header.theater);
     log::info!(

--- a/src/rules/art_data.rs
+++ b/src/rules/art_data.rs
@@ -16,6 +16,7 @@ use thiserror::Error;
 use crate::rules::flh::{Flh, parse_flh};
 use crate::rules::ini_parser::{IniFile, IniSection};
 use crate::rules::object_type::{BuildingHiddenOccupancyProfile, HIDDEN_OCCUPY_SLOT_COUNT};
+use crate::util::native_x87::NativeF64Bits;
 
 /// Per-object art configuration parsed from an art.ini section.
 #[derive(Debug, Clone)]
@@ -226,6 +227,84 @@ pub struct AnimTypeRuntimeConfig {
     pub spawns: Option<String>,
     pub spawn_count: i32,
     pub running_frames: i32,
+    /// art.ini `Damage=`, `AnimTypeClass+0x2A8`.
+    ///
+    /// gamemd-derived: `AnimTypeClass::ReadINI @ 0x00427D00` reads it through
+    /// `CCINIClass::ReadDouble` into `param_1[0xaa]` (= byte offset `0x2A8`), so
+    /// this is a **double**, not an integer — the stock population is dominated
+    /// by fractional values such as `.003`. The constructor
+    /// (`AnimTypeClass::AnimTypeClass @ 0x00427530`, `param_1[0xaa]/[0xab] = 0`)
+    /// leaves it `0.0` when the key is absent, and the read passes the current
+    /// value back as its own default.
+    ///
+    /// UNCHECKED consumer (M11b): the per-frame damage arm at
+    /// `AnimClass::AI 0x00424507..0x0042464C` accumulates this into
+    /// `AnimClass+0x188`, which the constructor seeds to **`1.0`**
+    /// (`0x00421FA4` zeroes the low dword, `0x00421FC8` writes `0x3FF00000` to
+    /// the high dword), so the first armed frame always emits at least one
+    /// point. Nothing reads this field yet.
+    pub damage: NativeF64Bits,
+    /// art.ini `Warhead=`, `AnimTypeClass+0x330`, resolved by
+    /// `WarheadTypeClass::FindOrAllocate`. Bouncer-landing only — the per-frame
+    /// damage arm hard-selects `[CombatDamage] C4Warhead`/`FlameDamage2`
+    /// instead. Not consumed yet (M11b).
+    pub warhead: Option<String>,
+    /// art.ini `DamageRadius=`, `AnimTypeClass+0x334`. Bouncer-landing only.
+    /// Not consumed yet (M11b).
+    pub damage_radius: i32,
+    /// art.ini `Elasticity=`, `AnimTypeClass+0x310`, a `ReadDouble`.
+    /// Constructor default `0x3FE99999_A0000000` — the single-precision `0.8f`
+    /// widened, **not** the nearest double to 0.8.
+    pub elasticity: NativeF64Bits,
+    /// art.ini `MinZVel=`, `AnimTypeClass+0x318`, a `ReadDouble`.
+    /// Constructor default `0x400C0000_00000000` = **3.5**.
+    pub min_z_vel: NativeF64Bits,
+    /// art.ini `MaxXYVel=`, `AnimTypeClass+0x328`, a `ReadDouble`.
+    /// Constructor default `0x402E0000_00000000` = **15.0**.
+    pub max_xy_vel: NativeF64Bits,
+    /// art.ini `IsMeteor=`, `AnimTypeClass+0x356`. Shares the constructor's
+    /// `BounceClass` fork with `Bouncer=`. Not consumed yet (M11b).
+    pub is_meteor: bool,
+    /// art.ini `IsVeins=`, `AnimTypeClass+0x355`. Zero stock sections author it.
+    pub is_veins: bool,
+    /// art.ini `IsFlamingGuy=`, `AnimTypeClass+0x354`. Gates
+    /// `AnimClass::BounceAI @ 0x00425670` — the flaming-infantry runner — from
+    /// `AnimClass::AI`'s third statement. One stock section (`FLAMEGUY`).
+    pub is_flaming_guy: bool,
+    /// art.ini `Scorch=`, `AnimTypeClass+0x36B`, read by
+    /// `AnimClass::Middle @ 0x00424F00`.
+    pub scorch: bool,
+    /// art.ini `Crater=`, `AnimTypeClass+0x36D`, read by
+    /// `AnimClass::Middle @ 0x00424F00`.
+    pub crater: bool,
+    /// art.ini `ForceBigCraters=`, `AnimTypeClass+0x36E`, read by
+    /// `AnimClass::Middle @ 0x00424F00`.
+    pub force_big_craters: bool,
+    /// art.ini `Sticky=`, `AnimTypeClass+0x36F`.
+    pub sticky: bool,
+    /// art.ini `PsiWarning=`, `AnimTypeClass+0x373`, read by `AnimClass::AI`.
+    pub psi_warning: bool,
+    /// art.ini `DoubleThick=`, `AnimTypeClass+0x368`.
+    pub double_thick: bool,
+    /// art.ini `Flamer=`, `AnimTypeClass+0x36C`. Zero stock sections author it.
+    pub flamer: bool,
+    /// art.ini `SpawnsParticle=`, `AnimTypeClass+0x2CC`, resolved by
+    /// `ParticleTypeClass::FindOrCreate`. Read by
+    /// `AnimClass::Middle @ 0x00424F00`, `NumParticles` times.
+    ///
+    /// Unlike every other key in this parser, `ReadINI` writes the field
+    /// **only when the key is present** (`0x00427D00`: the store sits inside
+    /// the `if (ReadString != 0)` arm), so an absent key keeps the
+    /// constructor's `-1`. `None` here is that `-1`.
+    pub spawns_particle: Option<String>,
+    /// art.ini `NumParticles=`, `AnimTypeClass+0x2D0`.
+    pub num_particles: i32,
+    /// art.ini `ShouldFogRemove=`, `AnimTypeClass+0x374`.
+    /// Constructor default **true**.
+    pub should_fog_remove: bool,
+    /// art.ini `ShouldUseCellDrawer=`, `AnimTypeClass+0x35C`.
+    /// Constructor default **true**.
+    pub should_use_cell_drawer: bool,
     pub detail_level: i32,
     pub next: Option<String>,
     pub bounce_anim: Option<String>,
@@ -248,9 +327,14 @@ pub struct AnimTypeRuntimeConfig {
     /// art.ini `AltPalette=`. gamemd's animation draw path picks the palette in a
     /// cascade: an explicit per-instance palette wins, otherwise the global
     /// ANIM.PAL conversion is used — except when this flag is set, which swaps in
-    /// the first colour scheme's converted unit palette instead. 41 stock sections
-    /// set it, including the Battle Bunker, the `CABUNK0x` bunkers, the Weather
-    /// Storm clouds and the squid grapple.
+    /// the first colour scheme's converted unit palette instead. **31** stock
+    /// art.ini sections set it — every one of them `yes` — including the Battle
+    /// Bunker, the `CABUNK0x` bunkers, the Weather Storm clouds and the squid
+    /// grapple; 23 of the 31 are also declared in `[Animations]`. (Derived by
+    /// section-scanning `artmd.ini` with the exact spelling `AltPalette`;
+    /// gamemd's `CCINIClass` key lookup is case-sensitive, so only that spelling
+    /// counts. The doc previously said 41, which no scan of the retail file
+    /// reproduces.)
     pub alt_palette: bool,
     /// art.ini `UseNormalLight=`. The retail art.ini documents this as "does this
     /// anim always draw at 100% brightness? (def=no)", and gamemd's animation draw
@@ -514,14 +598,27 @@ pub fn anim_translucency_draw_bits(
     anim_fixed_translucency_draw_bits(config.translucency).unwrap_or(ANIM_DRAW_BITS_OPAQUE)
 }
 
+/// Bits of a `CC_Draw_Shape` flag word that name the translucency family.
+///
+/// gamemd-derived: `AnimClass::DrawIt` loads the producer's whole flag word out
+/// of `AnimClass+0x190` (`0x0042304B MOV EBX,[ESI+0x190]`) and then ORs the
+/// selector INTO it — `0x00423075 OR EBX,0x6`, `0x0042307A OR EBX,0x4`, and the
+/// same pattern for the `Translucency=`/`Translucent=` arms further down. So a
+/// flag word carries the producer's bits (`0x600` for a trailer, `0x2600` for a
+/// combat explosion) alongside the family, and the family must be read as a
+/// masked field, never by matching the whole word.
+pub const ANIM_DRAW_BITS_TRANSLUCENCY_MASK: u32 = 0x6;
+
 /// Source-pixel weight implied by a set of translucency draw bits.
 ///
 /// This is the renderer-facing form of the blitter table above: the weight the
-/// native blend gives the incoming sprite pixel. Unknown bit patterns draw opaque.
-/// Float is correct here — it is a colour-target blend factor consumed only by the
-/// render layer, never by simulation math.
+/// native blend gives the incoming sprite pixel. Only
+/// [`ANIM_DRAW_BITS_TRANSLUCENCY_MASK`] is consulted, so a caller may pass the
+/// complete flag word; an unset family draws opaque. Float is correct here — it
+/// is a colour-target blend factor consumed only by the render layer, never by
+/// simulation math.
 pub const fn anim_translucency_source_alpha(draw_bits: u32) -> f32 {
-    match draw_bits {
+    match draw_bits & ANIM_DRAW_BITS_TRANSLUCENCY_MASK {
         ANIM_DRAW_BITS_TRANSLUCENT_25 => 0.75,
         ANIM_DRAW_BITS_TRANSLUCENT_50 => 0.5,
         ANIM_DRAW_BITS_TRANSLUCENT_75 => 0.25,
@@ -575,6 +672,30 @@ fn parse_anim_runtime_config(section: &IniSection) -> AnimTypeRuntimeConfig {
         spawns: parse_anim_ref(section, "Spawns"),
         spawn_count: section.get_i32("SpawnCount").unwrap_or(0),
         running_frames: section.get_i32("RunningFrames").unwrap_or(0),
+        // gamemd-derived: `AnimTypeClass::ReadINI @ 0x00427D00` reads these
+        // through `CCINIClass::ReadDouble` and each defaults to the value the
+        // constructor (`AnimTypeClass::AnimTypeClass @ 0x00427530`) left.
+        damage: read_anim_double(section, "Damage", ANIM_DAMAGE_DEFAULT),
+        warhead: parse_anim_ref(section, "Warhead"),
+        damage_radius: section.get_i32("DamageRadius").unwrap_or(0),
+        elasticity: read_anim_double(section, "Elasticity", ANIM_ELASTICITY_DEFAULT),
+        min_z_vel: read_anim_double(section, "MinZVel", ANIM_MIN_Z_VEL_DEFAULT),
+        max_xy_vel: read_anim_double(section, "MaxXYVel", ANIM_MAX_XY_VEL_DEFAULT),
+        is_meteor: section.get_bool("IsMeteor").unwrap_or(false),
+        is_veins: section.get_bool("IsVeins").unwrap_or(false),
+        is_flaming_guy: section.get_bool("IsFlamingGuy").unwrap_or(false),
+        scorch: section.get_bool("Scorch").unwrap_or(false),
+        crater: section.get_bool("Crater").unwrap_or(false),
+        force_big_craters: section.get_bool("ForceBigCraters").unwrap_or(false),
+        sticky: section.get_bool("Sticky").unwrap_or(false),
+        psi_warning: section.get_bool("PsiWarning").unwrap_or(false),
+        double_thick: section.get_bool("DoubleThick").unwrap_or(false),
+        flamer: section.get_bool("Flamer").unwrap_or(false),
+        spawns_particle: parse_anim_ref(section, "SpawnsParticle"),
+        num_particles: section.get_i32("NumParticles").unwrap_or(0),
+        // Both constructor defaults are 1, not 0.
+        should_fog_remove: section.get_bool("ShouldFogRemove").unwrap_or(true),
+        should_use_cell_drawer: section.get_bool("ShouldUseCellDrawer").unwrap_or(true),
         detail_level: section.get_i32("DetailLevel").unwrap_or(0),
         next: section.get("Next").map(|s| s.trim().to_ascii_uppercase()),
         bounce_anim: parse_anim_ref(section, "BounceAnim"),
@@ -604,6 +725,39 @@ fn parse_anim_runtime_config(section: &IniSection) -> AnimTypeRuntimeConfig {
         start_sound: parse_anim_ref(section, "StartSound"),
         stop_sound: parse_anim_ref(section, "StopSound"),
     }
+}
+
+/// `AnimTypeClass::AnimTypeClass @ 0x00427530` constructor defaults for the four
+/// `ReadDouble` animation keys, taken from the literal dword pairs the
+/// constructor stores.
+///
+/// - `Damage`   `param_1[0xaa] = 0; param_1[0xab] = 0`            -> `0.0`
+/// - `Elasticity` `[0xc4] = 0xA0000000; [0xc5] = 0x3FE99999`      -> `0.8f` as f64
+/// - `MinZVel`  `[0xc6] = 0; [0xc7] = 0x400C0000`                 -> `3.5`
+/// - `MaxXYVel` `[0xca] = 0; [0xcb] = 0x402E0000`                 -> `15.0`
+///
+/// `Elasticity` is worth spelling out: `0x3FE99999_A0000000` is the **single**
+/// precision `0.8f` (`0x3F4CCCCD`) widened, i.e. `0.800000011920929`, not the
+/// nearest double to 0.8 (`0x3FE99999_99999999A`). That is consistent with the
+/// authored path — `CCINIClass::ReadDouble` also parses `%f` and widens — so a
+/// port that writes `0.8_f64` here starts every unauthored bouncer from a
+/// different bit pattern than gamemd.
+const ANIM_DAMAGE_DEFAULT: NativeF64Bits = NativeF64Bits::POSITIVE_ZERO;
+const ANIM_ELASTICITY_DEFAULT: NativeF64Bits = NativeF64Bits::from_bits(0x3fe9_9999_a000_0000);
+const ANIM_MIN_Z_VEL_DEFAULT: NativeF64Bits = NativeF64Bits::from_bits(0x400c_0000_0000_0000);
+const ANIM_MAX_XY_VEL_DEFAULT: NativeF64Bits = NativeF64Bits::from_bits(0x402e_0000_0000_0000);
+
+/// One `CCINIClass::ReadDouble` animation key, retained as native bit pattern.
+///
+/// The bits are kept rather than an `f64` so `AnimTypeRuntimeConfig` stays
+/// `Eq`/`Hash`, and so a consumer that must reproduce a native x87 sequence has
+/// the exact stored value rather than a re-parsed approximation.
+fn read_anim_double(section: &IniSection, key: &str, default: NativeF64Bits) -> NativeF64Bits {
+    NativeF64Bits::from_bits(
+        section
+            .read_double(key, f64::from_bits(default.bits()))
+            .to_bits(),
+    )
 }
 
 fn parse_anim_ref(section: &IniSection, key: &str) -> Option<String> {
@@ -1123,6 +1277,95 @@ impl ArtRegistry {
         self.scheduler_anim_types.insert(key);
     }
 
+    /// Bind the combat-explosion animation family into the scheduler-owned set,
+    /// skipping (rather than failing on) a name retail data cannot resolve.
+    ///
+    /// These roots are the warhead `AnimList=`, `[General] InfDeathAnim*` and
+    /// object `Explosion=`/`DestroyAnim=` names that the combat tick turns into
+    /// `AnimClass` instances. They need the same loader-derived `End`/`LoopEnd`
+    /// as any other scheduler-owned animation, but they must not be able to fail
+    /// a match load: retail `rulesmd.ini` authors at least one unresolvable name
+    /// (`[CRNUKEWH] AnimList=MININUKE - added 11/30`, an editing artefact with no
+    /// art section), and gamemd itself tolerates it — `AnimTypeClass::FindOrCreate`
+    /// mints a type on constructor defaults whose `End` stays `0`, so the anim
+    /// dies on its first `AnimClass::AI` visit and never draws. Skipping the
+    /// binding here reproduces the visible outcome; the residual is that VERA
+    /// also never creates the object.
+    ///
+    /// The strict `bind_scheduler_anim_assets` contract for terrain and
+    /// damage-fire animations is deliberately left alone.
+    ///
+    /// Returns the number of roots that could not be bound.
+    pub fn bind_combat_explosion_anim_assets(
+        &mut self,
+        roots: &[String],
+        asset_manager: &crate::assets::asset_manager::AssetManager,
+        theater_ext: &str,
+        theater_name: &str,
+    ) -> usize {
+        let mut skipped = 0;
+        for root in roots {
+            let name = root.trim().to_ascii_uppercase();
+            if name.is_empty() || self.scheduler_anim_types.contains(&name) {
+                continue;
+            }
+            match self.bind_one_anim_asset(&name, asset_manager, theater_ext, theater_name) {
+                Ok(()) => {
+                    self.scheduler_anim_types.insert(name);
+                }
+                Err(error) => {
+                    skipped += 1;
+                    log::warn!(
+                        "Combat explosion animation [{name}] stays on the legacy effect path: {error}"
+                    );
+                }
+            }
+        }
+        skipped
+    }
+
+    /// Resolve one animation's SHP and write the loader-derived bounds back into
+    /// its runtime config. Shared by the strict and tolerant binders.
+    fn bind_one_anim_asset(
+        &mut self,
+        name: &str,
+        asset_manager: &crate::assets::asset_manager::AssetManager,
+        theater_ext: &str,
+        theater_name: &str,
+    ) -> Result<(), AnimAssetBindError> {
+        let config = self
+            .anim_runtime_configs
+            .get(name)
+            .cloned()
+            .ok_or_else(|| AnimAssetBindError::MissingAnimType(name.to_string()))?;
+        let image_id = self.resolve_effective_image_id(name, name);
+        let candidates =
+            anim_shp_candidates(Some(self), name, &image_id, theater_ext, theater_name);
+        let data = candidates
+            .iter()
+            .find_map(|candidate| asset_manager.get_ref(candidate))
+            .ok_or_else(|| AnimAssetBindError::MissingShp(name.to_string()))?;
+        let raw_count = data
+            .get(6..8)
+            .map(|bytes| i16::from_le_bytes([bytes[0], bytes[1]]) as i32)
+            .unwrap_or(0);
+        let (loaded_end, loaded_loop_end) = resolve_loaded_bounds(
+            name,
+            raw_count,
+            config.shadow,
+            config.explicit_end,
+            config.explicit_loop_end,
+        )?;
+        let bound = self
+            .anim_runtime_configs
+            .get_mut(name)
+            .expect("configuration was resolved above");
+        bound.raw_shp_frame_count = Some(raw_count);
+        bound.end = loaded_end;
+        bound.loop_end = loaded_loop_end;
+        Ok(())
+    }
+
     /// Bind native loader-derived End/LoopEnd values for the transitive
     /// Next/Trailer closure rooted at the supplied animation names.
     pub fn bind_scheduler_anim_assets(
@@ -1147,37 +1390,12 @@ impl ArtRegistry {
             if !resolved.insert(name.clone()) {
                 continue;
             }
+            self.bind_one_anim_asset(&name, asset_manager, theater_ext, theater_name)?;
             let config = self
                 .anim_runtime_configs
                 .get(&name)
                 .cloned()
-                .ok_or_else(|| AnimAssetBindError::MissingAnimType(name.clone()))?;
-            let image_id = self.resolve_effective_image_id(&name, &name);
-            let candidates =
-                anim_shp_candidates(Some(self), &name, &image_id, theater_ext, theater_name);
-            let data = candidates
-                .iter()
-                .find_map(|candidate| asset_manager.get_ref(candidate))
-                .ok_or_else(|| AnimAssetBindError::MissingShp(name.clone()))?;
-            let raw_count = data
-                .get(6..8)
-                .map(|bytes| i16::from_le_bytes([bytes[0], bytes[1]]) as i32)
-                .unwrap_or(0);
-            let (loaded_end, loaded_loop_end) = resolve_loaded_bounds(
-                &name,
-                raw_count,
-                config.shadow,
-                config.explicit_end,
-                config.explicit_loop_end,
-            )?;
-
-            let bound = self
-                .anim_runtime_configs
-                .get_mut(&name)
-                .expect("configuration was resolved above");
-            bound.raw_shp_frame_count = Some(raw_count);
-            bound.end = loaded_end;
-            bound.loop_end = loaded_loop_end;
+                .expect("binding above resolved this configuration");
 
             if let Some(next) = config.next {
                 pending.push_back(next);
@@ -2072,8 +2290,28 @@ mod anim_runtime_metadata_tests {
             0.25
         );
         assert_eq!(anim_translucency_source_alpha(ANIM_DRAW_BITS_OPAQUE), 1.0);
-        // Bits outside the table are not a translucency stage.
+        // Bits outside the family mask are not a translucency stage.
         assert_eq!(anim_translucency_source_alpha(0x800), 1.0);
+
+        // `AnimClass::DrawIt` ORs the family into the producer's own flag word
+        // (`0x0042304B` loads `Anim+0x190`, `0x00423075`/`0x0042307A` OR into
+        // it), so the carried producer bits must not hide the stage. `0x600` is
+        // the trailer/damage-fire word and `0x2600` the combat-explosion word.
+        for carried in [0x0, 0x600, 0x2600] {
+            assert_eq!(
+                anim_translucency_source_alpha(carried | ANIM_DRAW_BITS_TRANSLUCENT_25),
+                0.75
+            );
+            assert_eq!(
+                anim_translucency_source_alpha(carried | ANIM_DRAW_BITS_TRANSLUCENT_50),
+                0.5
+            );
+            assert_eq!(
+                anim_translucency_source_alpha(carried | ANIM_DRAW_BITS_TRANSLUCENT_75),
+                0.25
+            );
+            assert_eq!(anim_translucency_source_alpha(carried), 1.0);
+        }
     }
 
     #[test]
@@ -2251,6 +2489,192 @@ mod anim_runtime_metadata_tests {
                 .expect("stock BIGBLUE declaration")
                 .is_animated_tiberium
         );
+    }
+
+    /// The retail values behind the four `ReadDouble` keys and the
+    /// `AltPalette=`/`UseNormalLight=` counts this module documents.
+    #[test]
+    #[ignore = "requires RA2_DIR with installed retail RA2/YR assets"]
+    fn retail_artmd_anim_damage_cluster_matches_active_yr() {
+        let ra2_dir = std::path::PathBuf::from(
+            std::env::var_os("RA2_DIR")
+                .expect("set RA2_DIR to the installed retail RA2/YR directory"),
+        );
+        let assets = AssetManager::new(&ra2_dir).expect("load retail RA2/YR archive stack");
+        let artmd_bytes = assets.get_ref("ARTMD.INI").expect("load retail ARTMD.INI");
+        let artmd = IniFile::from_bytes(artmd_bytes).expect("parse retail ARTMD.INI");
+        let registry = ArtRegistry::from_ini(&artmd);
+
+        let debris = registry
+            .anim_runtime_config("DBRIS1LG")
+            .expect("stock DBRIS1LG declaration");
+        assert_eq!(f64::from_bits(debris.damage.bits()), 20.0);
+        assert_eq!(debris.warhead.as_deref(), Some("HE"));
+        assert_eq!(debris.damage_radius, 80);
+        assert_eq!(f64::from_bits(debris.elasticity.bits()), 0.0);
+        assert_eq!(f64::from_bits(debris.min_z_vel.bits()), 25.0);
+        assert_eq!(f64::from_bits(debris.max_xy_vel.bits()), 25.0);
+        assert!(debris.bouncer);
+
+        // The one live per-frame-damage producer in stock skirmish: the fire a
+        // destroyed building leaves behind.
+        let fire3 = registry
+            .anim_runtime_config("FIRE3")
+            .expect("stock FIRE3 declaration");
+        let fire3_damage = f64::from_bits(fire3.damage.bits());
+        assert!(
+            fire3_damage > 0.0 && fire3_damage < 0.01,
+            "[FIRE3] Damage= is `.003`, read back as {fire3_damage}"
+        );
+
+        // A section with neither key keeps the constructor's non-zero doubles.
+        let twlt036 = registry
+            .anim_runtime_config("TWLT036")
+            .expect("stock TWLT036 declaration");
+        assert_eq!(f64::from_bits(twlt036.damage.bits()), 0.0);
+        assert_eq!(twlt036.elasticity.bits(), 0x3fe9_9999_a000_0000);
+        assert_eq!(f64::from_bits(twlt036.min_z_vel.bits()), 3.5);
+        assert_eq!(f64::from_bits(twlt036.max_xy_vel.bits()), 15.0);
+
+        // The counts this module's `alt_palette` / `use_normal_light` docs
+        // claim, derived rather than asserted from memory. gamemd's INI key
+        // lookup is case-sensitive, so only the exact spellings count.
+        let alt_palette = registry
+            .anim_runtime_configs
+            .values()
+            .filter(|config| config.alt_palette)
+            .count();
+        let use_normal_light = registry
+            .anim_runtime_configs
+            .values()
+            .filter(|config| config.use_normal_light)
+            .count();
+        assert_eq!(alt_palette, 31, "stock artmd.ini AltPalette= sections");
+        assert_eq!(
+            use_normal_light, 43,
+            "stock artmd.ini UseNormalLight= sections"
+        );
+    }
+
+    /// `AnimTypeClass::ReadINI @ 0x00427D00` reads `Damage=`, `Elasticity=`,
+    /// `MinZVel=` and `MaxXYVel=` through `CCINIClass::ReadDouble`, so each of
+    /// them keeps a fraction. `Damage` in particular is a double at `+0x2A8`,
+    /// never an integer: the stock population is `.003`-scale.
+    #[test]
+    fn anim_double_keys_keep_their_fraction() {
+        let ini = IniFile::from_str(
+            "[DEBRIS]\n\
+             Damage=20\n\
+             Warhead=he\n\
+             DamageRadius=80\n\
+             Elasticity=0.0\n\
+             MinZVel=25.0\n\
+             MaxXYVel=25.0\n\
+             [BURNER]\n\
+             Damage=.003\n",
+        );
+        let reg = ArtRegistry::from_ini(&ini);
+
+        let debris = reg.anim_runtime_config("DEBRIS").unwrap();
+        assert_eq!(f64::from_bits(debris.damage.bits()), 20.0);
+        assert_eq!(debris.warhead.as_deref(), Some("HE"));
+        assert_eq!(debris.damage_radius, 80);
+        assert_eq!(f64::from_bits(debris.elasticity.bits()), 0.0);
+        assert_eq!(f64::from_bits(debris.min_z_vel.bits()), 25.0);
+        assert_eq!(f64::from_bits(debris.max_xy_vel.bits()), 25.0);
+
+        // The fraction survives; an i32 read would have produced 0.
+        let burner = reg.anim_runtime_config("BURNER").unwrap();
+        let damage = f64::from_bits(burner.damage.bits());
+        assert!(
+            damage > 0.0 && damage < 0.01,
+            "{damage} is not `.003`-scale"
+        );
+    }
+
+    /// Constructor defaults from `AnimTypeClass::AnimTypeClass @ 0x00427530`.
+    /// Three of them are NOT the zero/false a naive port would pick:
+    /// `Elasticity` 0.8, `MinZVel` 3.5, `MaxXYVel` 15.0, and both
+    /// `ShouldUseCellDrawer` and `ShouldFogRemove` start true.
+    #[test]
+    fn anim_constructor_defaults_are_not_all_zero() {
+        let ini = IniFile::from_str("[BARE]\nFixtureOnly=1\n");
+        let reg = ArtRegistry::from_ini(&ini);
+        let bare = reg.anim_runtime_config("BARE").unwrap();
+
+        assert_eq!(f64::from_bits(bare.damage.bits()), 0.0);
+        // The literal dword pair the constructor stores is the SINGLE-precision
+        // 0.8f widened, not the nearest double to 0.8.
+        assert_eq!(bare.elasticity.bits(), 0x3fe9_9999_a000_0000);
+        assert_eq!(f64::from_bits(bare.elasticity.bits()), f64::from(0.8_f32));
+        assert_ne!(f64::from_bits(bare.elasticity.bits()), 0.8_f64);
+        assert_eq!(f64::from_bits(bare.min_z_vel.bits()), 3.5);
+        assert_eq!(f64::from_bits(bare.max_xy_vel.bits()), 15.0);
+        assert!(bare.should_use_cell_drawer);
+        assert!(bare.should_fog_remove);
+
+        assert_eq!(bare.warhead, None);
+        assert_eq!(bare.damage_radius, 0);
+        assert_eq!(bare.spawns_particle, None);
+        assert_eq!(bare.num_particles, 0);
+        assert!(!bare.is_meteor);
+        assert!(!bare.is_veins);
+        assert!(!bare.is_flaming_guy);
+        assert!(!bare.scorch);
+        assert!(!bare.crater);
+        assert!(!bare.force_big_craters);
+        assert!(!bare.sticky);
+        assert!(!bare.psi_warning);
+        assert!(!bare.double_thick);
+        assert!(!bare.flamer);
+    }
+
+    /// The two true-by-default flags must be readable back to false, or the
+    /// default would be indistinguishable from an authored `no`.
+    #[test]
+    fn anim_true_by_default_flags_accept_an_authored_no() {
+        let ini = IniFile::from_str(
+            "[HIDDEN]\n\
+             ShouldUseCellDrawer=no\n\
+             ShouldFogRemove=no\n",
+        );
+        let reg = ArtRegistry::from_ini(&ini);
+        let hidden = reg.anim_runtime_config("HIDDEN").unwrap();
+        assert!(!hidden.should_use_cell_drawer);
+        assert!(!hidden.should_fog_remove);
+    }
+
+    #[test]
+    fn anim_middle_effect_flags_and_particle_spawn_parse() {
+        let ini = IniFile::from_str(
+            "[VIRUSD]\n\
+             SpawnsParticle=  gasCloud  \n\
+             NumParticles=8\n\
+             Scorch=yes\n\
+             Crater=yes\n\
+             ForceBigCraters=yes\n\
+             Sticky=yes\n\
+             PsiWarning=yes\n\
+             DoubleThick=yes\n\
+             Flamer=yes\n\
+             IsMeteor=yes\n\
+             IsVeins=yes\n\
+             IsFlamingGuy=yes\n",
+        );
+        let reg = ArtRegistry::from_ini(&ini);
+        let config = reg.anim_runtime_config("VIRUSD").unwrap();
+        assert_eq!(config.spawns_particle.as_deref(), Some("GASCLOUD"));
+        assert_eq!(config.num_particles, 8);
+        assert!(config.scorch);
+        assert!(config.crater);
+        assert!(config.force_big_craters);
+        assert!(config.sticky);
+        assert!(config.psi_warning);
+        assert!(config.double_thick);
+        assert!(config.flamer);
+        assert!(config.is_meteor);
+        assert!(config.is_veins);
+        assert!(config.is_flaming_guy);
     }
 
     #[test]

--- a/src/rules/art_data.rs
+++ b/src/rules/art_data.rs
@@ -1284,18 +1284,57 @@ impl ArtRegistry {
     /// object `Explosion=`/`DestroyAnim=` names that the combat tick turns into
     /// `AnimClass` instances. They need the same loader-derived `End`/`LoopEnd`
     /// as any other scheduler-owned animation, but they must not be able to fail
-    /// a match load: retail `rulesmd.ini` authors at least one unresolvable name
-    /// (`[CRNUKEWH] AnimList=MININUKE - added 11/30`, an editing artefact with no
-    /// art section), and gamemd itself tolerates it — `AnimTypeClass::FindOrCreate`
-    /// mints a type on constructor defaults whose `End` stays `0`, so the anim
-    /// dies on its first `AnimClass::AI` visit and never draws. Skipping the
-    /// binding here reproduces the visible outcome; the residual is that VERA
-    /// also never creates the object.
+    /// a match load, because retail authors names that resolve to no art section
+    /// at all and gamemd tolerates every one of them.
+    ///
+    /// RESIDUAL (M11a) — **retail's three unbindable explosion roots.** Derived
+    /// over the whole of `rulesmd.ini`/`artmd.ini`; neither file carries a
+    /// section for any of them:
+    ///
+    /// | root | authored by | SHP in `conquer.mix`? |
+    /// |---|---|---|
+    /// | `MININUKE - ADDED 11/30` | `[CRNUKEWH] AnimList=` | no |
+    /// | `GTPOWEXP` | `[GAPOWR]`, `[YAPOWR]`, `[YAROCK]` `Explosion=` | yes — 156x126, 29 frames |
+    /// | `TSTLEXP` | `[NAPOWR] Explosion=` | yes — 122x140, 33 frames |
+    ///
+    /// - *Trigger:* `[CRNuke]` for the first; for the other two, the death of a
+    ///   power plant of ANY faction — Allied `GAPOWR`, Soviet `NAPOWR`, Yuri
+    ///   `YAPOWR` — plus `YAROCK`. Each authors a six-entry `Explosion=` list
+    ///   whose last entry is the unbindable name, so one draw in six picks it,
+    ///   and native draws once per foundation cell.
+    /// - *Player effect:* none, and that is verified rather than assumed.
+    ///   `AnimTypeClass::ReadINI @ 0x00427D00` calls `ObjectTypeClass::ReadINI
+    ///   @ 0x005F92D0`, which calls `AbstractTypeClass::ReadINI @ 0x00410A60`;
+    ///   that one does `INIClass::FindSectionByName` and **returns 0 when the
+    ///   section is absent**, so `0x00427D22 JZ 0x004287E9` bails out of
+    ///   `ReadINI` before the vtable `+0xA0` image-loader dispatch at
+    ///   `0x0042894F`. `AnimTypeClass::LoadImageAndResolveFrameBounds @
+    ///   0x00427B50` — the only thing that ever fills `End` (`+0x2C0`) from the
+    ///   SHP header — therefore never runs, `End` keeps its constructor `0`, and
+    ///   the anim dies on its first `AnimClass::AI` visit having drawn nothing.
+    ///   The two SHPs really are in `conquer.mix`, but they are orphaned art:
+    ///   nothing loads them, because the art section that would trigger the load
+    ///   does not exist. **Do not "fix" this by minting a default config from
+    ///   the SHP header** — that would make VERA draw an explosion gamemd does
+    ///   not.
+    /// - *Frequency:* the `[CRNuke]` path is effectively never. The power-plant
+    ///   path is latent for a different reason: the object
+    ///   `Explosion=`/`DestroyAnim=` pick is still gated to
+    ///   `EntityCategory::Unit | Aircraft` under the GSI-08.11 residual in
+    ///   `src/sim/combat/mod.rs`, so no building reaches it yet. Whoever lands
+    ///   GSI-08.11 makes it continuous — every power plant death, every match.
+    /// - *Downstream risk:* the divergence that survives is object identity, not
+    ///   pixels. Native still constructs the `AnimClass`, consuming an ID and a
+    ///   hash slot, then discards it; VERA constructs none. Closing it means
+    ///   minting default-`End` AnimType entries for unresolvable names so the
+    ///   object exists and dies, which belongs with the AnimType registry.
     ///
     /// The strict `bind_scheduler_anim_assets` contract for terrain and
     /// damage-fire animations is deliberately left alone.
     ///
-    /// Returns the number of roots that could not be bound.
+    /// Returns the number of roots that could not be bound. Callers log the
+    /// aggregate: a per-name `warn!` alone would let a future data change that
+    /// breaks ten roots pass unnoticed.
     pub fn bind_combat_explosion_anim_assets(
         &mut self,
         roots: &[String],

--- a/src/rules/art_data.rs
+++ b/src/rules/art_data.rs
@@ -1306,17 +1306,45 @@ impl ArtRegistry {
     ///   `AnimTypeClass::ReadINI @ 0x00427D00` calls `ObjectTypeClass::ReadINI
     ///   @ 0x005F92D0`, which calls `AbstractTypeClass::ReadINI @ 0x00410A60`;
     ///   that one does `INIClass::FindSectionByName` and **returns 0 when the
-    ///   section is absent**, so `0x00427D22 JZ 0x004287E9` bails out of
-    ///   `ReadINI` before the vtable `+0xA0` image-loader dispatch at
-    ///   `0x0042894F`. `AnimTypeClass::LoadImageAndResolveFrameBounds @
-    ///   0x00427B50` — the only thing that ever fills `End` (`+0x2C0`) from the
-    ///   SHP header — therefore never runs, `End` keeps its constructor `0`, and
-    ///   the anim dies on its first `AnimClass::AI` visit having drawn nothing.
-    ///   The two SHPs really are in `conquer.mix`, but they are orphaned art:
-    ///   nothing loads them, because the art section that would trigger the load
-    ///   does not exist. **Do not "fix" this by minting a default config from
-    ///   the SHP header** — that would make VERA draw an explosion gamemd does
-    ///   not.
+    ///   section is absent**, so `0x00427D22 JZ 0x004287E9` bails to the
+    ///   `XOR AL,AL` epilogue before the vtable `+0xA0` image-loader dispatch
+    ///   at `0x00427DDD`, which is itself behind a non-empty art-name test on
+    ///   `+0x1F8`. On an `AnimTypeClass` that `+0xA0` slot *is*
+    ///   `LoadImageAndResolveFrameBounds @ 0x00427B50` (vtable `0x007E3608`,
+    ///   slot `0x007E36A8` holds `0x00427B50`), so the dispatch and the loader
+    ///   are one thing and neither runs.
+    ///
+    ///   `End` (`+0x2C0`) therefore keeps its constructor `0`:
+    ///   `AnimTypeClass::Constructor 0x0042758A` stores `EBX`, and
+    ///   `0x00427542 XOR EBX,EBX` is that function's only write to `EBX`.
+    ///   **Three bodies fill `End` from the SHP header, not one.** Over all 34
+    ///   `+0x2C0` stores in the binary, the writers with an `AnimTypeClass`
+    ///   receiver are exactly: that constructor; `ReadINI` itself
+    ///   (`0x00427D5D`/`0x00427D6D`/`0x00427FE8`, never reached here);
+    ///   `LoadImageAndResolveFrameBounds` (`0x00427C37`/`0x00427C46`); and the
+    ///   lazy fills in `AnimClass::AnimClass @ 0x00422143` and `AnimClass::AI
+    ///   @ 0x00424434` (repeated at `0x00424823`) — the mechanism `anim_class`
+    ///   already models in `effective_bounds`. The lazy fills cannot rescue a
+    ///   sectionless type, and that is *why* they are gated the way they are:
+    ///   the gate wants `End == -1`, the constructor left `0`, and only an
+    ///   `End=` line could put `-1` there — which needs the missing section.
+    ///
+    ///   The other `+0xA0` call sites cannot reach these types either. All five
+    ///   in the binary: `0x00427DDD` above; `0x00427A1E`, `0x00427B3A` and
+    ///   `0x0042894F`, each gated on `NewTheater` (`+0x237`), which defaults
+    ///   false — its only three writers are `ObjectTypeClass::Constructor
+    ///   0x005F71A0` (`BL`, zeroed at `0x005F70A1`) and the two `ReadINI`s that
+    ///   never run; and `0x00428D9C`, inside the lazy art loader at
+    ///   `0x00428C30`, which bails at `0x00428C4F` unless `+0x35E` is set, and
+    ///   `AnimTypeClass::Constructor 0x004276B6` is the *only* instruction in
+    ///   the binary writing `+0x35E`, storing the same zero.
+    ///
+    ///   So the anim dies on its first `AnimClass::AI` visit having drawn
+    ///   nothing. The two SHPs really are in `conquer.mix`, but they are
+    ///   orphaned art: nothing loads them, because the art section that would
+    ///   trigger the load does not exist. **Do not "fix" this by minting a
+    ///   default config from the SHP header** — that would make VERA draw an
+    ///   explosion gamemd does not.
     /// - *Frequency:* the `[CRNuke]` path is effectively never. The power-plant
     ///   path is latent for a different reason: the object
     ///   `Explosion=`/`DestroyAnim=` pick is still gated to
@@ -1324,8 +1352,14 @@ impl ArtRegistry {
     ///   `src/sim/combat/mod.rs`, so no building reaches it yet. Whoever lands
     ///   GSI-08.11 makes it continuous — every power plant death, every match.
     /// - *Downstream risk:* the divergence that survives is object identity, not
-    ///   pixels. Native still constructs the `AnimClass`, consuming an ID and a
-    ///   hash slot, then discards it; VERA constructs none. Closing it means
+    ///   pixels. The unbindable name really does enter native's list:
+    ///   `TechnoTypeClass::ReadINI @ 0x00712170` reads `Explosion`
+    ///   (`0x0081DA00`) at `0x0071399A`, `strtok`s it, and calls
+    ///   `AnimTypeClass::FindOrAllocate @ 0x00428B80` per token at `0x007139E1`,
+    ///   which `operator_new`s a type on a name miss — so the list is six long
+    ///   and the dud is picked one time in six. Native still constructs the
+    ///   `AnimClass`, consuming an ID and a hash slot, then discards it; VERA
+    ///   constructs none. Closing it means
     ///   minting default-`End` AnimType entries for unresolvable names so the
     ///   object exists and dies, which belongs with the AnimType registry.
     ///

--- a/src/rules/effect_asset_catalog.rs
+++ b/src/rules/effect_asset_catalog.rs
@@ -182,6 +182,43 @@ pub fn available_effect_anim_frame_count(
     }
 }
 
+/// Every animation name the combat tick can turn into an `AnimClass` instance.
+///
+/// Exactly the three producers that fill `CombatResult::explosion_effects`:
+/// - the killing warhead's `AnimList=` pick
+///   (`WarheadTypeClass::Detonate` -> `Warhead::SelectExplosionAnim @ 0x0048A4F0`),
+/// - the infantry death animation for the warhead's `InfDeath=`,
+/// - the dying object's own `Explosion=` / `DestroyAnim=` pick
+///   (`UnitClass::Death_Explosion @ 0x00738680`).
+///
+/// The list is derived from loaded rules, never hand-written: over retail
+/// `rulesmd.ini` it resolves to 58 distinct names (34 `AnimList=`, 14
+/// `Explosion=`, 13 `DestroyAnim=`, plus the infantry-death family), which is
+/// why the binder that consumes it must tolerate the handful retail authors
+/// with no art section.
+pub fn combat_explosion_anim_roots(rules: &RuleSet) -> Vec<String> {
+    let mut roots = BTreeSet::new();
+    let mut insert = |name: &str| {
+        if let Some(name) = canonical_asset_id(name) {
+            roots.insert(name);
+        }
+    };
+    for warhead in rules.warheads_iter() {
+        for name in &warhead.anim_list {
+            insert(name);
+        }
+    }
+    for name in rules.general.infantry_death_anims.iter().flatten() {
+        insert(name);
+    }
+    for object in rules.all_objects() {
+        for name in object.explosion_anims.iter().chain(&object.destroy_anims) {
+            insert(name);
+        }
+    }
+    roots.into_iter().collect()
+}
+
 fn authoritative_effect_roots(rules: &RuleSet) -> BTreeSet<String> {
     let mut roots = BTreeSet::new();
     let mut insert = |name: &str| {

--- a/src/rules/effect_asset_catalog.rs
+++ b/src/rules/effect_asset_catalog.rs
@@ -219,6 +219,24 @@ pub fn combat_explosion_anim_roots(rules: &RuleSet) -> Vec<String> {
     roots.into_iter().collect()
 }
 
+/// Report how many combat-explosion roots the tolerant binder could not bind.
+///
+/// The binder already emits a per-name `warn!`, but a per-name line is invisible
+/// in aggregate: a data change that breaks ten roots reads the same as retail's
+/// standing three unless the count is stated once. Retail's own baseline is
+/// three (`MININUKE - ADDED 11/30`, `GTPOWEXP`, `TSTLEXP` — see
+/// `ArtRegistry::bind_combat_explosion_anim_assets`), so anything above that is
+/// new and worth looking at.
+pub fn log_unbound_combat_explosion_roots(unbound: usize) {
+    if unbound == 0 {
+        return;
+    }
+    log::info!(
+        "{unbound} combat explosion animation root(s) have no art section and stay on the \
+         legacy effect path (retail's own baseline is 3)"
+    );
+}
+
 fn authoritative_effect_roots(rules: &RuleSet) -> BTreeSet<String> {
     let mut roots = BTreeSet::new();
     let mut insert = |name: &str| {

--- a/src/sim/anim_class.rs
+++ b/src/sim/anim_class.rs
@@ -1717,6 +1717,25 @@ impl Simulation {
         }
     }
 
+    /// Native `AnimClass::Start @ 0x00424CE0` — the anim's sound emitter.
+    ///
+    /// **The Ghidra labels on this pair are transposed.** `0x00424CE0` is
+    /// labelled `AnimClass__Middle` but its body is `Start`: it Marks, then
+    /// `if (Anim+0x198 /* silent */ == 0 && AnimType+0x2F8 != -1)` takes the
+    /// coordinate through vtable `+0x48` and plays it with `VocClass::PlayAt`,
+    /// then tail-calls `0x00424F00` when `AnimType+0x298 == 0`. `0x00424F00` is
+    /// labelled `AnimClass__Start` but its body is `Middle`: `SpawnsParticle=`
+    /// looped `NumParticles=` times, `Scorch=`, `Crater=`, `ForceBigCraters=`,
+    /// and it plays nothing. This function implements `0x00424CE0`; the Rust
+    /// name follows the (wrong) Ghidra label and is left alone only because
+    /// renaming it is a separate transaction. Read the address, not the name.
+    ///
+    /// `AnimType+0x2F8` is one slot: `AnimTypeClass::ReadINI @ 0x00427D00`
+    /// reads `Report=` into it only when `StartSound=` resolved to `-1`, which
+    /// is what `start_sound.or(report)` reproduces.
+    ///
+    /// The particle/scorch/crater half (`0x00424F00`) is not wired — see the
+    /// module header.
     fn anim_middle(&mut self, id: AnimId, config: &AnimTypeRuntimeConfig) {
         let sound_name = config
             .start_sound
@@ -2115,10 +2134,14 @@ mod tests {
         );
     }
 
-    /// A warhead can name art retail never shipped — `[CRNUKEWH]` authors
-    /// `AnimList=MININUKE - added 11/30`. Native mints a default AnimType whose
-    /// `End` stays 0 and the anim dies unseen; VERA must decline the spawn
-    /// rather than panic or block the shot.
+    /// A producer can name art that resolves to no INI section — retail has
+    /// three (`MININUKE - ADDED 11/30` from `[CRNUKEWH] AnimList=`, plus
+    /// `GTPOWEXP` and `TSTLEXP` from the faction power plants' `Explosion=`).
+    /// Native mints a default AnimType, but `AnimTypeClass::ReadINI @
+    /// 0x00427D00` bails on the absent section before the image loader, so
+    /// `End` stays 0 and the anim dies unseen. VERA must decline the spawn
+    /// rather than panic or block the shot. Full residual on
+    /// `ArtRegistry::bind_combat_explosion_anim_assets`.
     #[test]
     fn combat_explosion_with_unbound_art_declines_instead_of_panicking() {
         let rules = runtime_rules("[TWLT036]\nEnd=8\n", &[("TWLT036", 8)]);

--- a/src/sim/anim_class.rs
+++ b/src/sim/anim_class.rs
@@ -4,7 +4,56 @@
 //! order. This module implements only the verified ordinary non-bouncer
 //! AnimClass lifecycle needed by building damage fire: constructor/reveal,
 //! first-AI guard, logic-frame timing, loops, reverse/ping-pong, Next, trailer,
-//! sound identity, conceal, and deferred deletion.
+//! sound identity, conceal, and deferred deletion — plus the combat-explosion
+//! producer.
+//!
+//! ## Residuals — two `AnimClass::AI` arms are not built
+//!
+//! RESIDUAL (M11b) — **the bouncing-debris landing arm.** `AnimClass::AI
+//! 0x00423E28..0x00423F37` runs when `AnimClass+0x194` (set by the constructor
+//! for `Bouncer=` or `IsMeteor=`) is live and
+//! `AnimClass::ProcessBounceResult @ 0x00423930` reports landed or gone. It
+//! constructs the type's `ExpireAnim=` and calls `Apply_area_damage` with the
+//! type's own `Damage=`/`Warhead=`/`DamageRadius=`, walks the impact cell's
+//! occupant list for `ReceiveDamage`, and spawns `Spawns=` behind two
+//! `RandomRanged` draws. `BounceState` (`src/sim/bounce.rs`) is ported but no
+//! `AnimClass` hosts one.
+//! - Trigger: every building death and every heavy-vehicle death, through
+//!   `[General] MetallicDebris=` (20 stock `DBRIS*` types, all `Bouncer=yes`).
+//! - Player effect: debris chunks neither damage what they land on
+//!   (`Damage=10..20`, warhead `HE`, `DamageRadius=50..80`) nor leave their
+//!   `TWLT026`/`TWLT036` landing explosions.
+//! - Frequency: continuous in ordinary skirmish — the higher-weight of the two
+//!   missing arms by a wide margin.
+//! - Downstream risk: the constructor fork draws two or three RNG values per
+//!   chunk on the scenario stream, so wiring it moves the lockstep stream and
+//!   needs its own `SNAPSHOT_VERSION` move and fixture re-record.
+//!
+//! RESIDUAL (M11b) — **the per-frame damage arm.** `AnimClass::AI
+//! 0x00424507..0x0042464C` accumulates the type's `Damage=` (parsed, see
+//! `AnimTypeRuntimeConfig::damage`) into `AnimClass+0x188`, which the
+//! constructor seeds to `1.0`, and calls `Apply_area_damage` with a
+//! truncating `Math__ftol` whenever the accumulator reaches 1.0, subtracting
+//! the emitted integer back as a double. The warhead is
+//! `[CombatDamage] C4Warhead` when the anim's own section name is `INVISO`
+//! (string at `0x008182F8`, NOT the neighbouring `RING1` at `0x008182F0`) and
+//! `[CombatDamage] FlameDamage2` otherwise; a `TerrainClass` owner
+//! (`What_Am_I` -> `0x24`) multiplies the per-frame value by 5.
+//! - Trigger: the `FIRE3` fires a destroyed building leaves behind
+//!   (`BuildingClass::DestructionEffects` loads the literal name at
+//!   `0x00441AEC`). The `BURN-S/M/L` family is commented out of
+//!   `[Animations]` and `INVISO` has no stock producer, so nothing else in
+//!   stock reaches it.
+//! - Player effect: `[FIRE3] Damage=.003` plus the `1.0` seed means exactly one
+//!   point of `Fire2` area damage on the fire's first ticked frame and then
+//!   none for another ~334 frames. Missing it costs one splash per burning
+//!   building.
+//! - Frequency: once per building death; magnitude 1.
+//! - Downstream risk: low — it applies damage through the existing
+//!   `Apply_area_damage` path and consumes no RNG.
+//!   The `TerrainClass` x5 multiplier has no verified stock producer at all:
+//!   its only source of a terrain-owned anim is `TerrainClass::Catch_Fire @
+//!   0x0071C5B0`, which has no code caller in active YR.
 
 use std::collections::BTreeMap;
 
@@ -65,7 +114,47 @@ impl AnimWorldCoord {
             .clamp(0, i32::from(u8::MAX)) as u8;
         (rx, ry, sub_x, sub_y, z)
     }
+
+    /// Inverse of [`Self::to_cell_sub_z`]: compose the absolute lepton
+    /// coordinate a producer's (cell, sub-cell, height-level) triple names.
+    /// Shares the anim Z scale with the decomposition, so a spawn followed by a
+    /// draw round-trips exactly.
+    pub(crate) fn from_cell_sub_z(
+        rx: u16,
+        ry: u16,
+        sub_x: crate::util::fixed_math::SimFixed,
+        sub_y: crate::util::fixed_math::SimFixed,
+        z: u8,
+    ) -> Self {
+        Self {
+            x: i32::from(rx)
+                .wrapping_mul(LEPTONS_PER_CELL)
+                .wrapping_add(sub_x.to_num::<i32>()),
+            y: i32::from(ry)
+                .wrapping_mul(LEPTONS_PER_CELL)
+                .wrapping_add(sub_y.to_num::<i32>()),
+            z: i32::from(z).wrapping_mul(ANIM_HEIGHT_LEVEL_LEPTONS),
+        }
+    }
 }
+
+/// `AnimClass` constructor `drawFlags` for a combat explosion.
+///
+/// gamemd-derived: `BulletClass::DetonateAtCoord` pushes the literal `0x2600`
+/// at `0x00469C82`, and identically at `0x0046A2E5`. The individual bits are
+/// UNCHECKED — only the `| 0x2000` that `AnimClass::DrawIt @ 0x0042304B` adds
+/// before `CC_Draw_Shape`, and the `AnimClass::SaveExtras` round trip, were
+/// read — so the word is carried verbatim, exactly as every other producer in
+/// this engine carries it.
+pub const COMBAT_EXPLOSION_DRAW_FLAGS: u32 = 0x2600;
+
+/// `AnimClass` constructor `zAdjust` for a combat explosion.
+///
+/// gamemd-derived: the argument at `0x00469C81` is the return of
+/// `0x0048ACE0`, whose whole body is `MOV EAX,0xFFFFFFF1; RET 0xC`
+/// (`disassemble_bytes 0x0048ACE0`) — it takes the impact `CoordStruct` by
+/// value and ignores it, always yielding `-15`.
+pub const COMBAT_EXPLOSION_Z_ADJUST: i32 = -15;
 
 const LEPTONS_PER_CELL: i32 = crate::util::lepton::LEPTONS_PER_CELL_I32;
 const ANIM_HEIGHT_LEVEL_LEPTONS: i32 = 128;
@@ -300,8 +389,15 @@ pub struct AnimDrawRuntime {
     pub translucency_ramp: u8,
     /// AnimClass `+0x119`: force the type-selected 50/75% draw family.
     pub forced_translucent: bool,
-    /// Producer-supplied type `+0x368` interpretation; the art-key mapping is
-    /// not closed, so this is deliberately not inferred from other fields.
+    /// Type `+0x368` = art.ini `DoubleThick=`, consulted only inside the
+    /// `+0x119` forced-translucency arm: `AnimClass::DrawIt` reads
+    /// `0x0042306B MOV CL,[EAX+0x368]` and takes `OR EBX,0x6` when set,
+    /// `OR EBX,0x4` when clear. `AnimTypeClass::ReadINI @ 0x00427D00` stores
+    /// `DoubleThick=` at `param_1[0xda]` (= byte offset `0x368`), which closes
+    /// the art-key mapping this comment previously left open. It stays a
+    /// producer-supplied instance byte rather than a type read because nothing
+    /// in this engine sets `+0x119` yet — the first producer that does should
+    /// feed it from `AnimTypeRuntimeConfig::double_thick`.
     pub forced_uses_75: bool,
 }
 
@@ -516,16 +612,82 @@ impl Simulation {
         rules: &RuleSet,
         descriptor: AnimClassSpawnDescriptor,
     ) -> Result<AnimId, AnimSpawnError> {
-        let world_coord = AnimWorldCoord {
-            x: i32::from(descriptor.rx)
-                .wrapping_mul(LEPTONS_PER_CELL)
-                .wrapping_add(descriptor.sub_x.to_num::<i32>()),
-            y: i32::from(descriptor.ry)
-                .wrapping_mul(LEPTONS_PER_CELL)
-                .wrapping_add(descriptor.sub_y.to_num::<i32>()),
-            z: i32::from(descriptor.z).wrapping_mul(ANIM_HEIGHT_LEVEL_LEPTONS),
-        };
+        let world_coord = AnimWorldCoord::from_cell_sub_z(
+            descriptor.rx,
+            descriptor.ry,
+            descriptor.sub_x,
+            descriptor.sub_y,
+            descriptor.z,
+        );
         self.spawn_anim_at_world(rules, descriptor, world_coord)
+    }
+
+    /// Construct one combat explosion as a real `AnimClass` instance.
+    ///
+    /// gamemd-derived: the warhead's `AnimList=` pick reaches
+    /// `AnimClass::AnimClass @ 0x00421EA0` from `BulletClass::DetonateAtCoord`
+    /// at `0x00469C93` (and identically at `0x0046A2F6`) with the argument row
+    /// `(type, &impactCoord, delay 0, loopCount 1, drawFlags 0x2600,
+    /// zAdjust -15, reverse 0)`. Read as raw pushes over
+    /// `0x00469C40..0x00469CA0`: `PUSH 0x0` (reverse) at `0x00469C65`, then the
+    /// by-value `CoordStruct` the `RET 0xC` helper at `0x0048ACE0` consumes,
+    /// then `PUSH EAX` (-15), `PUSH 0x2600`, `PUSH 0x1`, `PUSH 0x0`,
+    /// `PUSH ECX` (coord), `PUSH EBX` (type).
+    ///
+    /// Because `delay` is zero, `AnimClass::AnimClass` calls `AnimClass::Start
+    /// @ 0x00424CE0` before returning — that is where `Report=`/`StartSound=`
+    /// is played, from the single `AnimTypeClass+0x2F8` slot. So an explosion's
+    /// sound is a constructor-time effect, not a first-tick one.
+    ///
+    /// Returns `None` when the art type never bound (no art section or no SHP,
+    /// see `ArtRegistry::bind_combat_explosion_anim_assets`); native mints a
+    /// default `AnimTypeClass` in that case whose `End` stays 0, so the anim
+    /// dies on its first AI visit and draws nothing.
+    ///
+    /// RESIDUAL — the impact Z arrives as the producer's coarse height-level
+    /// byte, not exact leptons. `ExplosionEffect` carries that byte while its
+    /// paired `SmudgeSpawnRequest::Anim` carries the exact
+    /// `world_z_leptons`; this constructor uses the byte because the whole
+    /// `AnimStore` Z frame is 128 leptons per level (see
+    /// [`AnimWorldCoord::to_cell_sub_z`] and `Simulation::anim_owner_coords`),
+    /// and mixing frames inside one store is worse than the coarseness.
+    /// - Trigger: any detonation whose impact Z is not a multiple of 128
+    ///   leptons — an airburst, or a shot landing on a slope.
+    /// - Player effect: the explosion sprite's height, and therefore its depth
+    ///   sort against nearby objects, can be off by up to one height level.
+    /// - Frequency: common, but the legacy world-effect path had exactly the
+    ///   same byte, so this is inherited, not introduced.
+    /// - Downstream risk: reconciling it means moving the whole anim Z frame to
+    ///   exact leptons, which is a separate transaction.
+    pub(crate) fn spawn_combat_explosion_anim(
+        &mut self,
+        rules: &RuleSet,
+        type_name: InternedId,
+        rx: u16,
+        ry: u16,
+        sub_x: crate::util::fixed_math::SimFixed,
+        sub_y: crate::util::fixed_math::SimFixed,
+        z: u8,
+    ) -> Option<AnimId> {
+        let descriptor = AnimClassSpawnDescriptor {
+            delay: 0,
+            loop_count: 1,
+            draw_flags: COMBAT_EXPLOSION_DRAW_FLAGS,
+            z_adjust: COMBAT_EXPLOSION_Z_ADJUST,
+            reverse: false,
+            ..AnimClassSpawnDescriptor::new(type_name, rx, ry, sub_x, sub_y, z)
+        };
+        let world_coord = AnimWorldCoord::from_cell_sub_z(rx, ry, sub_x, sub_y, z);
+        match self.spawn_anim_at_world(rules, descriptor, world_coord) {
+            Ok(id) => Some(id),
+            Err(error) => {
+                log::debug!(
+                    "combat explosion [{}] did not construct: {error}",
+                    self.interner.resolve(type_name)
+                );
+                None
+            }
+        }
     }
 
     pub(crate) fn spawn_anim_at_world(
@@ -1887,6 +2049,95 @@ mod tests {
                 .make_infantry,
             -2
         );
+    }
+
+    /// The whole point of routing combat explosions through `AnimStore`: the
+    /// verified constructor row from `BulletClass::DetonateAtCoord 0x00469C93`,
+    /// and the `Report=` that only `AnimClass::Start @ 0x00424CE0` can play.
+    #[test]
+    fn combat_explosion_uses_the_verified_constructor_row_and_plays_report() {
+        // TWLT036 is the stock AP-shell explosion: Report=Explosion06,
+        // Translucent=yes, no Rate= (so one logic frame per image frame).
+        let rules = runtime_rules(
+            "[TWLT036]\nTranslucent=yes\nReport=Explosion06\nEnd=8\n",
+            &[("TWLT036", 8)],
+        );
+        let mut sim = Simulation::new();
+        let type_name = sim.interner.intern("TWLT036");
+
+        let id = sim
+            .spawn_combat_explosion_anim(
+                &rules,
+                type_name,
+                7,
+                9,
+                crate::util::fixed_math::SimFixed::from_num(128),
+                crate::util::fixed_math::SimFixed::from_num(64),
+                3,
+            )
+            .expect("bound explosion art constructs an AnimClass");
+
+        let anim = sim.anim(id).expect("explosion is a registered AnimObject");
+        assert_eq!(anim.draw_flags, COMBAT_EXPLOSION_DRAW_FLAGS);
+        assert_eq!(anim.z_adjust, COMBAT_EXPLOSION_Z_ADJUST);
+        assert_eq!(anim.runtime.delay_remaining, 0);
+        assert!(!anim.runtime.constructor_reverse);
+        assert_eq!(anim.runtime.current_frame, 0);
+        assert_eq!(anim.runtime.loop_remaining, 1);
+        assert_eq!(anim.owner_entity, None);
+
+        // `delay == 0` means the constructor itself reached Start, so the
+        // sound is already out before the first AI visit.
+        assert!(anim.start_sound_active);
+        let report = sim.interner.intern("EXPLOSION06");
+        assert!(
+            sim.sound_events.iter().any(|event| matches!(
+                event,
+                SimSoundEvent::AnimationStarted { anim_id, sound_id, .. }
+                    if *anim_id == id && *sound_id == report
+            )),
+            "explosion must emit its art `Report=`, got {:?}",
+            sim.sound_events
+        );
+
+        // The spawn coordinate round-trips through the shared anim Z scale, so
+        // the sprite lands where the legacy world effect did.
+        let coord = sim.anim_absolute_coord(id).expect("absolute coordinate");
+        assert_eq!(
+            coord.to_cell_sub_z(),
+            (
+                7,
+                9,
+                crate::util::fixed_math::SimFixed::from_num(128),
+                crate::util::fixed_math::SimFixed::from_num(64),
+                3
+            )
+        );
+    }
+
+    /// A warhead can name art retail never shipped — `[CRNUKEWH]` authors
+    /// `AnimList=MININUKE - added 11/30`. Native mints a default AnimType whose
+    /// `End` stays 0 and the anim dies unseen; VERA must decline the spawn
+    /// rather than panic or block the shot.
+    #[test]
+    fn combat_explosion_with_unbound_art_declines_instead_of_panicking() {
+        let rules = runtime_rules("[TWLT036]\nEnd=8\n", &[("TWLT036", 8)]);
+        let mut sim = Simulation::new();
+        let missing = sim.interner.intern("MININUKE - ADDED 11/30");
+        assert!(
+            sim.spawn_combat_explosion_anim(
+                &rules,
+                missing,
+                1,
+                1,
+                crate::util::fixed_math::SIM_ZERO,
+                crate::util::fixed_math::SIM_ZERO,
+                0,
+            )
+            .is_none()
+        );
+        assert_eq!(sim.substrate.anims.len(), 0);
+        assert!(sim.sound_events.is_empty());
     }
 
     #[test]

--- a/src/sim/bounce.rs
+++ b/src/sim/bounce.rs
@@ -7,10 +7,19 @@
 //! one at `+0xB0`; `AnimClass` embeds one too, for the SHP debris that uses the
 //! physics path.
 //!
-//! Do not confuse this with `Bouncer=yes` on an `AnimType`. That is a separate
-//! system — `AnimClass::BounceAI @ 0x00425670`, a 2D homing drift toward an
-//! attach target with no gravity and no elasticity — and it does not call
-//! anything here.
+//! `Bouncer=yes` on an `AnimType` really does drive this component. The
+//! constructor takes the `BounceClass::Init` fork on
+//! `!Bouncer(+0x35A) && !IsMeteor(+0x356)` being false
+//! (`AnimClass::AnimClass @ 0x00421EA0`), and
+//! `AnimClass::ProcessBounceResult @ 0x00423930` calls `BounceClass::Update`.
+//!
+//! The separate system to keep apart from this one is
+//! `AnimClass::BounceAI @ 0x00425670` — a 2D homing drift toward an attach
+//! target, with no gravity and no elasticity, which does not call anything
+//! here. `AnimClass::AI @ 0x00423AC0` gates that call on
+//! `IsFlamingGuy=` (`AnimType+0x354`, one stock section: `FLAMEGUY`), NOT on
+//! `Bouncer=`. An earlier revision of this header attributed `BounceAI` to
+//! `Bouncer=`; the mechanism description was right and the key was wrong.
 //!
 //! ## Dependency rules
 //! - Part of sim/ — depends on util/ and the rest of sim/.

--- a/src/sim/combat/combat_force_fire_cell_tests.rs
+++ b/src/sim/combat/combat_force_fire_cell_tests.rs
@@ -110,6 +110,93 @@ fn new_constructor_creates_entity_variant() {
     assert!(matches!(at.target, TargetKind::Entity(123)));
 }
 
+/// Production proof for the combat-explosion animation route: a real shot,
+/// through `Simulation::advance_tick`, must leave an `AnimClass` instance in
+/// `AnimStore` carrying the constructor row
+/// `BulletClass::DetonateAtCoord 0x00469C93` pushes, and must emit the art
+/// type's `Report=`. Before this route existed the same shot pushed a legacy
+/// `WorldEffect` with translucency forced on and no sound at all.
+#[test]
+fn force_fire_detonation_builds_an_anim_instance_and_plays_its_report() {
+    use crate::rules::art_data::ArtRegistry;
+    use crate::sim::anim_class::{COMBAT_EXPLOSION_DRAW_FLAGS, COMBAT_EXPLOSION_Z_ADJUST};
+    use crate::sim::command::{Command, CommandEnvelope};
+    use crate::sim::pathfinding::PathGrid;
+    use crate::sim::world::{SimSoundEvent, Simulation};
+    use std::collections::BTreeMap;
+
+    let mut rules = RuleSet::from_ini(&IniFile::from_str(
+        "[VehicleTypes]\n0=MTNK\n\n\
+         [InfantryTypes]\n\n[BuildingTypes]\n\n[AircraftTypes]\n\n\
+         [MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\nPrimary=105mm\n\n\
+         [105mm]\nDamage=65\nROF=50\nRange=6\nWarhead=AP\n\n\
+         [AP]\nVerses=100%,100%,90%,75%,75%,75%,60%,30%,20%,0%,0%\n\
+         AnimList=TWLT036\n",
+    ))
+    .expect("explosion rules parse");
+    let mut art = ArtRegistry::from_ini(&IniFile::from_str(
+        "[TWLT036]\nTranslucent=yes\nReport=Explosion06\nEnd=8\n",
+    ));
+    art.bind_anim_frame_count_for_test("TWLT036", 8);
+    rules.art_registry = art;
+
+    let mut sim = Simulation::new();
+    sim.input_delay_ticks = 0;
+    sim.substrate
+        .entities
+        .insert(make_unit(1, "MTNK", 5, 5, 300));
+    sim.interner = crate::sim::intern::test_interner();
+    let owner_id = sim.interner.intern("Americans");
+    assert!(matches!(
+        sim.reveal(1),
+        crate::sim::world::RevealOutcome::Revealed { .. }
+    ));
+    let grid = PathGrid::test_all_passable(64, 64);
+    let height_map: BTreeMap<(u16, u16), u8> = BTreeMap::new();
+
+    // In range from the start, so the shot lands without a pursuit walk.
+    sim.queue_command(CommandEnvelope::new(
+        owner_id,
+        sim.session.tick + 1,
+        Command::ForceAttackCell {
+            attacker_id: 1,
+            target_rx: 8,
+            target_ry: 5,
+        },
+    ));
+
+    let explosion_type = sim.interner.intern("TWLT036");
+    let mut explosion = None;
+    for _ in 0..60 {
+        let pending = sim.take_due_commands();
+        sim.advance_tick(&pending, Some(&rules), &height_map, Some(&grid), None, 100);
+        if let Some((&id, _)) = sim.anims().find(|(_, anim)| anim.type_id == explosion_type) {
+            explosion = Some(id);
+            break;
+        }
+    }
+
+    let id = explosion.expect("the detonation must construct a TWLT036 AnimClass");
+    let anim = sim.anim(id).expect("registered explosion anim");
+    assert_eq!(anim.draw_flags, COMBAT_EXPLOSION_DRAW_FLAGS);
+    assert_eq!(anim.z_adjust, COMBAT_EXPLOSION_Z_ADJUST);
+    assert!(anim.start_sound_active);
+    assert!(
+        sim.world_effects.is_empty(),
+        "combat explosions no longer take the legacy world-effect path"
+    );
+
+    let report = sim.interner.intern("EXPLOSION06");
+    assert!(
+        sim.sound_events.iter().any(|event| matches!(
+            event,
+            SimSoundEvent::AnimationStarted { anim_id, sound_id, .. }
+                if *anim_id == id && *sound_id == report
+        )),
+        "the explosion must play its art `Report=`"
+    );
+}
+
 #[test]
 fn force_fire_cell_pursuit_then_fire_integration() {
     // Full pipeline: ctrl-click on a far cell → ForceAttackCell command →

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -2805,6 +2805,17 @@ fn handle_entity_deaths(
             // (forcing the last `Explosion=` entry for a loaded miner) is
             // likewise unread. Trigger: every building death, and every loaded
             // miner death. Frequency: continuous.
+            //
+            // Landing that arm also un-latents a second gap: four of the
+            // buildings it would newly reach — the base power plant of every
+            // faction (`GAPOWR`, `NAPOWR`, `YAPOWR`) plus `YAROCK` — author an
+            // `Explosion=` list whose sixth entry (`gtpowexp`/`tstlexp`) has no
+            // art section, so one draw in six per foundation cell resolves to
+            // nothing VERA can construct. That is correct against gamemd, which
+            // also draws nothing there, but VERA skips the object entirely
+            // where native still constructs and discards one. Read the residual
+            // on `ArtRegistry::bind_combat_explosion_anim_assets` before
+            // treating a missing power-plant explosion as a bug.
             if matches!(category, EntityCategory::Unit | EntityCategory::Aircraft)
                 && let Some(obj) = rules.object(interner.resolve(type_id))
             {

--- a/src/sim/combat/smudge_dispatch.rs
+++ b/src/sim/combat/smudge_dispatch.rs
@@ -27,8 +27,10 @@ use std::collections::BTreeMap;
 /// is within 30 leptons of the ground.
 const SMUDGE_ALTITUDE_GATE_LEPTONS: i32 = 30;
 
-/// Hardcoded ore-reduction amount on `AnimClass::Start @ 0x00424F00`'s
-/// crater branch.
+/// Hardcoded ore-reduction amount on `AnimClass::Middle @ 0x00424F00`'s
+/// crater branch. (Ghidra labels `0x00424F00` `AnimClass__Start`; the label is
+/// transposed with `0x00424CE0` — `0x00424F00` is the particle/scorch/crater
+/// body and plays no sound, so it is `Middle`. The address is right.)
 const CRATER_ORE_REDUCTION: u16 = 6;
 
 /// Damage values passed to `SmudgeGrid::try_place` for building destruction

--- a/src/sim/smudge_grid.rs
+++ b/src/sim/smudge_grid.rs
@@ -306,7 +306,9 @@ impl SmudgeGrid {
     /// building-occupancy gate.
     ///
     /// Returns true if a smudge was placed, false otherwise.
-    /// Ore mutation is caller-specific: `AnimClass::Start @ 0x00424F00`
+    /// Ore mutation is caller-specific: `AnimClass::Middle @ 0x00424F00`
+    /// (Ghidra's `AnimClass__Start` label there is transposed with
+    /// `0x00424CE0`; the address is right)
     /// reduces tiberium before its crater attempt, even on placement failure;
     /// direct `BuildingClass::DestructionEffects @ 0x004415F0` and
     /// `BuildingClass::SpawnSurvivors @ 0x00442D90` callers do not.

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -374,7 +374,7 @@ use crate::sim::world::Simulation;
 // (`TechnoClass::ReceiveDamage @ 0x00701900`, `0x00702281`..`0x0070256C`).
 // Every consumer after a death in the same tick therefore reads a different
 // cursor than it did on v119.
-// Bumped 120 -> 121: combat explosions became `AnimClass` instances. They used
+// Bumped 120 -> 123: combat explosions became `AnimClass` instances. They used
 // to be legacy `WorldEffect` records, which are in neither `AnimStore`'s
 // serialized shape nor the multiplayer checksum; they are now ordinary members
 // of `substrate.anims`, which is in both. So every shot that spawns a warhead
@@ -386,7 +386,18 @@ use crate::sim::world::Simulation;
 // which is exactly what the version guards. `AnimTypeRuntimeConfig` also
 // gained the twenty previously unparsed art keys; that is rules data and is
 // not serialized.
-const SNAPSHOT_VERSION: u32 = 121;
+//
+// 121 and 122 are deliberately skipped because live unmerged branches already
+// stamp them, and two branches stamping different serialized shapes with one
+// number defeats the guard: a snapshot written under one and loaded under the
+// other passes the version check and then mis-decodes. Re-surveyed across
+// every local and `origin` ref when this branch was rebased for merge —
+// 120 `origin/main` (the `VoxelAnimClass` debris store, now landed),
+// 121 `origin/feature/phase3-map-spatial-close`,
+// 122 `origin/feature/phase3-map-spatial-integration`;
+// nothing else claims 123. Whoever resolves a `snapshot.rs` merge conflict
+// here must re-run that survey rather than picking a side.
+const SNAPSHOT_VERSION: u32 = 123;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -3128,13 +3139,17 @@ mod tests {
     /// death-side debris producer, which changes both the hash schema and the
     /// shared RNG cursor at every Techno death whose type authors a POSITIVE
     /// `MaxDebris=` — the 83 stock sections that author `MaxDebris=0` stop at
-    /// `0x00702291` and still cost the stream nothing; 120 -> 121 moves combat
+    /// `0x00702291` and still cost the stream nothing; 120 -> 123 moves combat
     /// explosions off the legacy `WorldEffect` list and into `AnimStore`, so a
     /// warhead `AnimList=` animation is now a serialized, checksum-folded
-    /// object where it used to be neither.
+    /// object where it used to be neither. 121 and 122 are skipped because
+    /// unmerged branches already stamp them — 121
+    /// `origin/feature/phase3-map-spatial-close`, 122
+    /// `origin/feature/phase3-map-spatial-integration` — and two branches
+    /// sharing one version number defeat the mismatch guard entirely.
     #[test]
-    fn combat_explosion_anim_snapshot_version_is_121() {
-        assert_eq!(super::SNAPSHOT_VERSION, 121);
+    fn combat_explosion_anim_snapshot_version_is_123() {
+        assert_eq!(super::SNAPSHOT_VERSION, 123);
     }
 
     #[test]

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -374,7 +374,19 @@ use crate::sim::world::Simulation;
 // (`TechnoClass::ReceiveDamage @ 0x00701900`, `0x00702281`..`0x0070256C`).
 // Every consumer after a death in the same tick therefore reads a different
 // cursor than it did on v119.
-const SNAPSHOT_VERSION: u32 = 120;
+// Bumped 120 -> 121: combat explosions became `AnimClass` instances. They used
+// to be legacy `WorldEffect` records, which are in neither `AnimStore`'s
+// serialized shape nor the multiplayer checksum; they are now ordinary members
+// of `substrate.anims`, which is in both. So every shot that spawns a warhead
+// `AnimList=` animation now adds a hash-participating, serialized object where
+// it previously added none. No committed golden actually moved on this change
+// — the global parity harness authors no `AnimList=`/`Explosion=`/
+// `DestroyAnim=`, so it never reached the new path — but any future fixture
+// that fires a shot with explosion art will hash differently from a v120 one,
+// which is exactly what the version guards. `AnimTypeRuntimeConfig` also
+// gained the twenty previously unparsed art keys; that is rules data and is
+// not serialized.
+const SNAPSHOT_VERSION: u32 = 121;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -3116,10 +3128,13 @@ mod tests {
     /// death-side debris producer, which changes both the hash schema and the
     /// shared RNG cursor at every Techno death whose type authors a POSITIVE
     /// `MaxDebris=` — the 83 stock sections that author `MaxDebris=0` stop at
-    /// `0x00702291` and still cost the stream nothing.
+    /// `0x00702291` and still cost the stream nothing; 120 -> 121 moves combat
+    /// explosions off the legacy `WorldEffect` list and into `AnimStore`, so a
+    /// warhead `AnimList=` animation is now a serialized, checksum-folded
+    /// object where it used to be neither.
     #[test]
-    fn death_debris_store_snapshot_version_is_120() {
-        assert_eq!(super::SNAPSHOT_VERSION, 120);
+    fn combat_explosion_anim_snapshot_version_is_121() {
+        assert_eq!(super::SNAPSHOT_VERSION, 121);
     }
 
     #[test]

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -3107,27 +3107,15 @@ impl Simulation {
         }
 
         self.admit_death_debris(std::mem::take(&mut effects.voxel_debris));
-        for fx in &effects.explosion_effects {
-            let frames = rules
-                .effect_frame_count(self.interner.resolve(fx.shp_name))
-                .unwrap_or(20);
-            self.world_effects.push(WorldEffect {
-                anim_spawn: None,
-                shp_name: fx.shp_name,
-                rx: fx.rx,
-                ry: fx.ry,
-                sub_x: fx.sub_x,
-                sub_y: fx.sub_y,
-                z: fx.z,
-                frame: 0,
-                total_frames: frames,
-                frame_delay: 1,
-                elapsed_frames: 0,
-                translucent: true,
-                delay_frames: 0,
-                start_sound_id: None,
-                start_sound_emitted: false,
-            });
+        // Explosion animations from a non-combat area-damage transaction.
+        // `AnimClass` instances, not legacy world effects: only the real
+        // constructor reaches `AnimClass::Start @ 0x00424CE0`, which is what
+        // plays the art type's `Report=`/`StartSound=`, and only the real
+        // AnimType carries its `Translucent=` and `Rate=`.
+        for fx in std::mem::take(&mut effects.explosion_effects) {
+            self.spawn_combat_explosion_anim(
+                rules, fx.shp_name, fx.rx, fx.ry, fx.sub_x, fx.sub_y, fx.z,
+            );
         }
         self.invulnerability_impact_effects
             .append(&mut effects.invulnerability_impact_effects);
@@ -7705,28 +7693,17 @@ impl Simulation {
                 }
             }
             self.admit_death_debris(std::mem::take(&mut combat_result.voxel_debris));
-            // Spawn explosion animations from combat deaths.
-            for fx in &combat_result.explosion_effects {
-                let frames = rules
-                    .effect_frame_count(self.interner.resolve(fx.shp_name))
-                    .unwrap_or(20);
-                self.world_effects.push(WorldEffect {
-                    anim_spawn: None,
-                    shp_name: fx.shp_name,
-                    rx: fx.rx,
-                    ry: fx.ry,
-                    sub_x: fx.sub_x,
-                    sub_y: fx.sub_y,
-                    z: fx.z,
-                    frame: 0,
-                    total_frames: frames,
-                    frame_delay: 1,
-                    elapsed_frames: 0,
-                    translucent: true,
-                    delay_frames: 0,
-                    start_sound_id: None,
-                    start_sound_emitted: false,
-                });
+            // Spawn explosion animations from combat deaths. `AnimClass`
+            // instances, not legacy world effects: only the real constructor
+            // reaches `AnimClass::Start @ 0x00424CE0`, which is what plays the
+            // art type's `Report=`/`StartSound=`.
+            let explosion_spawns = combat_result
+                .explosion_effects
+                .iter()
+                .map(|fx| (fx.shp_name, fx.rx, fx.ry, fx.sub_x, fx.sub_y, fx.z))
+                .collect::<Vec<_>>();
+            for (shp_name, rx, ry, sub_x, sub_y, z) in explosion_spawns {
+                self.spawn_combat_explosion_anim(rules, shp_name, rx, ry, sub_x, sub_y, z);
             }
             // gamemd-derived: `EBolt::Init @ 0x004C2A60` creates one spark
             // system per electric bolt at `0x004C2B30`, passing


### PR DESCRIPTION
## What a player sees

Combat explosions are now real animation instances instead of a render-side shortcut.
Against retail `rulesmd.ini`/`artmd.ini`, that changes what 33 stock explosion animations
actually do on screen and in the mix:

- **24 explosion animations gain the `Report=` sound the retail art has always declared
  and VERA never played.** Firing a Grizzly at a wall, a Kirov bomb landing, a Prism
  hitting infantry — the art says which sound to play at the moment of detonation, and
  nothing was playing it.
- **9 stop being drawn translucent when they should be opaque.** The old path hardcoded
  `translucent: true` for every explosion regardless of what the art asked for.
- **4 now run at the right speed.** `Rate=400..450` means two ticks per frame; they were
  running at one, so gas clouds, the nuke blast and Yuri's mind-control burst played at
  double speed.

## The rendering bug this uncovered

Routing explosions through the animation draw path passes the producer's whole draw-flags
word into the translucency check, and that check compared the **whole word** against
`0x2`/`0x4`/`0x6` instead of masking. Explosions carry `0x2600`, so `0x2600 | 4` fell
through to "opaque" and all 24 `Translucent=yes` explosion animations would have drawn
solid — a worse regression than the bug being fixed.

`AnimClass::DrawIt` settles it: `0x0042304B MOV EBX,[ESI+0x190]` loads the producer's word
and `0x00423075 OR EBX,0x6` / `0x0042307A OR EBX,0x4` OR the translucency family *into* it.
It is a masked field. The check now masks with `0x6`.

**That defect was already live** for every burning building (damage-fire animations carry
`0x600`) and for trailer animations — both were drawing opaque where their art asks for a
blend. Fixed in this transaction because the explosion route could not land without it.

## Two in-repo errors corrected

- `AltPalette=` was documented as appearing in 41 stock sections. Counted against retail
  `artmd.ini` with case-exact key matching, it is **31** (all `yes`, 23 of them named in
  `rulesmd [Animations]`). An `#[ignore]`d retail test asserts the 31 by counting over the
  registry built from the real mix.
- `src/sim/bounce.rs` said `Bouncer=yes` on an `AnimType` drives `AnimClass::BounceAI`.
  It does not. `Bouncer=` (`AnimType+0x35A`) takes the `BounceClass::Init` fork in
  `AnimClass::AnimClass @ 0x00421EA0` and feeds
  `AnimClass::ProcessBounceResult @ 0x00423930`. `BounceAI @ 0x00425670` is gated on
  `IsFlamingGuy=` (`AnimType+0x354`, one stock section: `FLAMEGUY`). The mechanism
  description was right; the key was wrong.

## Verified gamemd sources

| Native | Address | What it settles |
|---|---|---|
| `BulletClass::DetonateAtCoord` callsite | `0x00469C40..0x00469CA0` | the constructor row: `(type, &impactCoord, delay 0, loopCount 1, drawFlags 0x2600, zAdjust -15, reverse 0)`, read off the raw pushes |
| `AnimClass::AnimClass` | `0x00421EA0` | parameter roles; `delay == 0` calls `Start` before returning |
| `AnimClass::Start` | `0x00424CE0` | plays `Report=`/`StartSound=` from the single `AnimTypeClass+0x2F8` slot. **Ghidra's labels on this and `0x00424F00` are transposed** — read the address, not the name |
| `AnimClass::Middle` | `0x00424F00` | `SpawnsParticle`/`Scorch`/`Crater`; plays no sound |
| `AnimTypeClass::ReadINI` | `0x00427D00` | every art-key offset; `StartSound` at `+0xBE` with `Report` read only when it resolved to `-1` — one slot |
| `AnimTypeClass::AnimTypeClass` | `0x00427530` | the constructor defaults for all twenty newly parsed keys |
| `AnimClass::DrawIt` | `0x0042304B`, `0x00423075`, `0x0042307A` | translucency family is a masked field inside the producer's word |
| explosion `zAdjust` producer | `0x0048ACE0` | `MOV EAX,0xFFFFFFF1; RET 0xC` — takes the impact coord by value and ignores it |

## `SNAPSHOT_VERSION` moves to 123

The animation store is hashed and snapshotted; the legacy `WorldEffect` list was in
neither. Migrating explosions therefore changes the serialized shape and adds
hash-participating objects, so the version has to move.

**121 and 122 are skipped** because they are stamped by another programme's live unmerged
branches (`origin/feature/phase3-map-spatial-close` and `-integration`). 120 is `main`'s,
now landed. Two branches stamping different serialized shapes with one number defeats
exactly the guard the bump exists for. The in-code comment names who holds what and tells
the next merge-resolver to **re-run the survey** rather than pick a side.

Survey re-run at merge time; nothing else claims 123.

## No golden moved, and none could

This route consumes **zero scenario RNG** for any stock explosion. None of the 51 bindable
explosion roots (33 of them `AnimList=` names with an art section) authors `RandomRate=` or
`RandomLoopDelay=`, so `choose_anim_rate`'s only draw sites are unreachable; and
`spawn_anim_at_world` resolves the art config and `effective_bounds` **before**
`choose_anim_rate`, so a name that cannot bind errors out ahead of any draw. The lockstep
stream cannot move in either direction. `GLOBAL_HARNESS_FINAL_HASH` and the per-stream pins
are untouched, and no fixture was re-recorded.

## Row 117 stays OPEN

Two deferred residuals, both M11b, both recorded in-tree with trigger / player effect /
frequency / downstream risk:

1. **The bouncing-debris landing arm** (`AnimClass::AI 0x00423E28..0x00423F37`). Trigger:
   every building death and every heavy-vehicle death, via `[General] MetallicDebris=`
   (20 `DBRIS*` types, all `Bouncer=yes`). Player effect: debris does no damage to what it
   lands on and leaves no `TWLT026`/`TWLT036` landing explosion. Frequency: continuous.
   **Deliberately deferred** — the constructor fork draws 2–3 scenario-stream RNG values
   per chunk, so it would force its own `SNAPSHOT_VERSION` move and a fixture re-record.
   The keys it needs are now parsed and `bounce.rs` is correctly attributed, so it starts
   from data.
2. **The per-frame damage arm** (`AnimClass::AI 0x00424507..0x0042464C`). Trigger: the
   `FIRE3` fire a destroyed building leaves behind. Player effect: exactly one point of
   `Fire2` area damage on the fire's first ticked frame. Frequency: once per building
   death, magnitude 1.

## Validation

One full `cargo test -p vera20k --lib` on the rebased tree:

```
test result: ok. 8259 passed; 0 failed; 78 ignored; 0 measured; 0 filtered out; finished in 25.24s
```

`global_skirmish_replay_is_deterministic_and_baseline_stable` is in that run and passed.

## Rebase

Rebased `ca4cec5f` → `968b24c8`. Two conflicts, both resolved without changing behaviour:

- `src/sim/snapshot.rs` — main took 120 for the `VoxelAnimClass` debris store. Kept both
  version narratives in order, this branch's constant at 123, and one version-pin test
  (`combat_explosion_anim_snapshot_version_is_123`). The survey comment was refreshed to
  the merge-time survey.
- `src/sim/world/mod.rs` — main inserted `admit_death_debris(...)` immediately above the
  `explosion_effects` loop this branch rewrote, at both sites. Kept main's call first, then
  this branch's `spawn_combat_explosion_anim` loop, preserving the ordering both parents had.

`src/sim/bounce.rs` and `src/sim/combat/mod.rs` auto-merged.
