### PR TITLE
fix(rules): read the jumpjet block the way TechnoTypeClass::ReadINI does

### DIFF
--- a/src/rules/jumpjet_params.rs
+++ b/src/rules/jumpjet_params.rs
@@ -1,14 +1,33 @@
-//! Jumpjet-specific parameters parsed from rules.ini.
+//! The ten `Jumpjet*` fields every `TechnoType` carries.
 //!
-//! These fields only apply to units with `JumpJet=yes` in rules.ini.
-//! Stored as `Option<JumpjetParams>` on ObjectType — None for non-jumpjet units.
+//! gamemd-derived: `TechnoTypeClass::ReadINI` reads all ten in one
+//! straight-line run at `0x00715020`-`0x0071520F` with **zero branch
+//! instructions** — `JumpJet=` itself is the last of them, an ordinary sibling
+//! boolean at `+0xD94`, not a gate on the other nine. Every read uses the same
+//! three-instruction idiom: load the field's *current* value, push it as the
+//! reader's default, store the result back. So an absent key leaves the
+//! constructor's value in place, which is why [`JumpjetParams::default`] is the
+//! single source of truth for the defaults and why this struct is unconditional
+//! rather than an `Option`.
 //!
-//! Key behavior notes from the locomotor report:
-//! - `JumpJetAccel` controls acceleration; deceleration = accel * 1.5
-//! - `JumpjetHeight` below 208 is effectively void
-//! - Crash descent speed = `JumpjetClimb + JumpjetCrash` downward
-//! - Infantry with Jumpjet locomotor + JumpJet=yes + no HoverAttack use Walk for
-//!   moves of 3 cells or less (TS-style jumpjet infantry)
+//! ## Key spelling is load-bearing
+//!
+//! gamemd's `INIClass` is case-SENSITIVE: it compares CRC-32s of the raw key
+//! bytes on both the store side (`INIClass::LoadFromStraw @ 0x00525A60`) and
+//! the lookup side (`CCINIClass::ReadInt @ 0x005276D0`), and
+//! `CRCEngine::AddData @ 0x004A1DE0` folds no case. The literals this module
+//! must use are the ones the binary pushes, read out of `.rdata` at
+//! `0x00843640`-`0x008436D0`: `JumpjetTurnRate`, `JumpjetSpeed`,
+//! `JumpjetClimb`, `JumpjetCrash`, `JumpjetHeight`, `JumpjetAccel`,
+//! `JumpjetWobbles`, `JumpjetNoWobbles`, `JumpjetDeviation`, `JumpJet` — a
+//! lowercase `jet` everywhere except the flag itself.
+//!
+//! Stock `rulesmd.ini` spells two of them with a capital mid-word `J`:
+//! `JumpJetTurnRate=` and `JumpJetAccel=`, in all eight jumpjet sections. Those
+//! two lines are therefore **inert in retail** — no stock unit has ever had a
+//! turn rate or acceleration read from the INI, and all eight fly on the
+//! constructor's 4 and 2.0. Reading the INI's spelling instead of gamemd's, as
+//! this module used to, applied an acceleration gamemd ignores.
 //!
 //! ## Dependency rules
 //! - Part of rules/ — no dependencies on sim/, render/, ui/, etc.
@@ -16,62 +35,131 @@
 use crate::rules::ini_parser::IniSection;
 use crate::util::fixed_math::{SimFixed, sim_from_f32};
 
-/// Jumpjet locomotor parameters parsed from rules.ini per-unit keys.
+/// `TechnoTypeClass::Constructor` seed for `+0xD70` (`0x007115AE`).
+const CTOR_TURN_RATE: i32 = 4;
+/// `TechnoTypeClass::Constructor` seed for `+0xD74` (`0x007115B8`, `0xE`).
+const CTOR_SPEED: f32 = 14.0;
+/// `TechnoTypeClass::Constructor` seed for `+0xD78` (`0x007115C7`,
+/// `0x40A00000`). `+0xD7C` takes the same register on the next instruction.
+const CTOR_CLIMB: f32 = 5.0;
+/// `TechnoTypeClass::Constructor` seed for `+0xD7C` (`0x007115CD`).
+const CTOR_CRASH: f32 = 5.0;
+/// `TechnoTypeClass::Constructor` seed for `+0xD80` (`0x007115D3`, `0x1F4`).
+const CTOR_HEIGHT: i32 = 500;
+/// `TechnoTypeClass::Constructor` seed for `+0xD84` (`0x007115DD`,
+/// `0x40000000`).
+const CTOR_ACCEL: f32 = 2.0;
+/// `TechnoTypeClass::Constructor` seed for `+0xD88` (`0x007115E7`,
+/// `0x3E19999A`).
+const CTOR_WOBBLES: f32 = 0.15;
+/// `TechnoTypeClass::Constructor` seed for `+0xD90` (`0x007115F7`, `0x28`).
+const CTOR_DEVIATION: i32 = 40;
+
+/// The Jumpjet block of `TechnoTypeClass`, `+0xD70` through `+0xD90`.
 ///
-/// These control the Jumpjet locomotor's altitude, acceleration, wobble,
-/// and crash behavior. Only populated for units with `JumpJet=yes`.
+/// Present on every type, exactly as in gamemd: the constructor seeds all nine
+/// and `ReadINI` overwrites whichever keys the section authors. `JumpJet=`
+/// (`+0xD94`) is a separate sibling boolean and lives on `ObjectType`, not
+/// here.
+///
+/// Only the Jumpjet locomotor ever reads these — the parameter copy at
+/// `0x0054AD30` pulls `+0xD70`..`+0xD8C` off the type — so a Drive, Fly or
+/// Hover unit carries them and never uses them.
 #[derive(Debug, Clone)]
 pub struct JumpjetParams {
-    /// Turning speed while airborne (`JumpJetTurnRate=`).
+    /// Turning speed while airborne (`JumpjetTurnRate=`, `+0xD70`).
     pub turn_rate: i32,
-    /// Flight speed (JumpjetSpeed=). Separate from ground Speed= value.
+    /// Flight speed (`JumpjetSpeed=`, `+0xD74`). An absolute air speed, not a
+    /// multiplier on `Speed=`: stock `[JUMPJET]` pairs `Speed=9` with
+    /// `JumpjetSpeed=30`, and the constructor seeds 14 — the same value stock
+    /// `[JumpjetControls] Speed=` carries.
     pub speed: SimFixed,
-    /// Climb/ascent rate per tick (JumpjetClimb=).
+    /// Climb/ascent rate per tick (`JumpjetClimb=`, `+0xD78`).
     pub climb: SimFixed,
-    /// Extra descent speed added during crash (JumpjetCrash=).
+    /// Extra descent speed added during crash (`JumpjetCrash=`, `+0xD7C`).
     /// Total crash speed = climb + crash.
     pub crash: SimFixed,
-    /// Target hover altitude in leptons (JumpjetHeight=). Values below 208
-    /// are effectively void in the original engine.
+    /// Target hover altitude in leptons (`JumpjetHeight=`, `+0xD80`).
     pub height: i32,
-    /// Acceleration rate (`JumpJetAccel=`). Deceleration = accel * 1.5.
+    /// Acceleration rate (`JumpjetAccel=`, `+0xD84`). Deceleration = accel *
+    /// 1.5.
     pub accel: SimFixed,
-    /// Wobble amplitude while hovering (JumpjetWobbles=).
+    /// Wobble amplitude while hovering (`JumpjetWobbles=`, `+0xD88`).
     /// KEPT as f32 — only used for render-side visual wobble, not sim state.
     pub wobbles: f32,
-    /// Maximum random XY deviation in leptons (JumpjetDeviation=).
+    /// Maximum random XY deviation in leptons (`JumpjetDeviation=`, `+0xD90`).
     pub deviation: i32,
-    /// When true, disables wobble effect entirely (JumpjetNoWobbles=).
+    /// When true, disables wobble effect entirely (`JumpjetNoWobbles=`,
+    /// `+0xD8C`).
     pub no_wobbles: bool,
 }
 
-impl JumpjetParams {
-    /// Parse jumpjet parameters from a rules.ini section.
+impl Default for JumpjetParams {
+    /// The `TechnoTypeClass::Constructor` seeds, `0x007115AE`-`0x007115F7`.
     ///
-    /// Uses RA2/YR defaults for missing keys.
-    pub fn from_ini_section(section: &IniSection) -> Self {
+    /// These are what a type keeps for any key its section does not author,
+    /// because `ReadINI` passes the current field value as the reader default.
+    fn default() -> Self {
         Self {
-            turn_rate: section.get_i32("JumpJetTurnRate").unwrap_or(4),
+            turn_rate: CTOR_TURN_RATE,
+            speed: sim_from_f32(CTOR_SPEED),
+            climb: sim_from_f32(CTOR_CLIMB),
+            crash: sim_from_f32(CTOR_CRASH),
+            height: CTOR_HEIGHT,
+            accel: sim_from_f32(CTOR_ACCEL),
+            wobbles: CTOR_WOBBLES,
+            deviation: CTOR_DEVIATION,
+            no_wobbles: false,
+        }
+    }
+}
+
+impl JumpjetParams {
+    /// Parse the nine jumpjet parameters from a rules.ini section.
+    ///
+    /// gamemd-derived: `TechnoTypeClass::ReadINI` @ `0x00715020`-`0x007151DF`,
+    /// one unconditional read per key over the constructor seed. Called for
+    /// every section, jumpjet or not, exactly as the native run is.
+    pub fn from_ini_section(section: &IniSection) -> Self {
+        let ctor = Self::default();
+        Self {
+            // `0x007150AF PUSH 0x8436D0` -> `0x007150C3 MOV [EBP+0xD70],EAX`.
+            // Stock spells this `JumpJetTurnRate=`, which gamemd cannot see, so
+            // all eight stock jumpjet sections keep the constructor's 4.
+            turn_rate: section.get_i32("JumpjetTurnRate").unwrap_or(ctor.turn_rate),
+            // `0x007150D0 PUSH 0x8436C0` -> `0x007150E4 MOV [EBP+0xD74],EAX`.
             speed: section
                 .get_f32("JumpjetSpeed")
                 .map(sim_from_f32)
-                .unwrap_or(sim_from_f32(14.0)),
+                .unwrap_or(ctor.speed),
+            // `0x007150F8 PUSH 0x8436B0` -> `0x0071510A FSTP [EBP+0xD78]`.
             climb: section
                 .get_f32("JumpjetClimb")
                 .map(sim_from_f32)
-                .unwrap_or(sim_from_f32(5.0)),
+                .unwrap_or(ctor.climb),
+            // `0x0071511E PUSH 0x8436A0` -> `0x00715130 FSTP [EBP+0xD7C]`.
             crash: section
                 .get_f32("JumpjetCrash")
                 .map(sim_from_f32)
-                .unwrap_or(sim_from_f32(5.0)),
-            height: section.get_i32("JumpjetHeight").unwrap_or(500),
+                .unwrap_or(ctor.crash),
+            // `0x0071513F PUSH 0x843690` -> `0x00715151 MOV [EBP+0xD80],EAX`.
+            height: section.get_i32("JumpjetHeight").unwrap_or(ctor.height),
+            // `0x00715165 PUSH 0x843680` -> `0x00715177 FSTP [EBP+0xD84]`.
+            // Stock spells this `JumpJetAccel=`; same story as the turn rate.
             accel: section
-                .get_f32("JumpJetAccel")
+                .get_f32("JumpjetAccel")
                 .map(sim_from_f32)
-                .unwrap_or(sim_from_f32(2.0)),
-            wobbles: section.get_f32("JumpjetWobbles").unwrap_or(0.15),
-            deviation: section.get_i32("JumpjetDeviation").unwrap_or(40),
-            no_wobbles: section.get_bool("JumpjetNoWobbles").unwrap_or(false),
+                .unwrap_or(ctor.accel),
+            // `0x0071518B PUSH 0x843670` -> `0x0071519D FSTP [EBP+0xD88]`.
+            wobbles: section.get_f32("JumpjetWobbles").unwrap_or(ctor.wobbles),
+            // `0x007151CB PUSH 0x843648` -> `0x007151DF MOV [EBP+0xD90],EAX`.
+            deviation: section
+                .get_i32("JumpjetDeviation")
+                .unwrap_or(ctor.deviation),
+            // `0x007151AC PUSH 0x84365C` -> `0x007151BE MOV [EBP+0xD8C],AL`.
+            no_wobbles: section
+                .get_bool("JumpjetNoWobbles")
+                .unwrap_or(ctor.no_wobbles),
         }
     }
 }
@@ -101,9 +189,9 @@ mod tests {
     #[test]
     fn test_parse_jumpjet_custom_values() {
         let ini = IniFile::from_str(
-            "[JUMPJET]\nJumpJetTurnRate=8\nJumpjetSpeed=20.0\n\
+            "[JUMPJET]\nJumpjetTurnRate=8\nJumpjetSpeed=20.0\n\
              JumpjetClimb=3.0\nJumpjetCrash=10.0\nJumpjetHeight=750\n\
-             JumpJetAccel=4.0\nJumpjetWobbles=0.0\nJumpjetDeviation=0\n\
+             JumpjetAccel=4.0\nJumpjetWobbles=0.0\nJumpjetDeviation=0\n\
              JumpjetNoWobbles=yes\n",
         );
         let section = ini.section("JUMPJET").unwrap();
@@ -118,5 +206,50 @@ mod tests {
         assert!((params.wobbles).abs() < 0.01);
         assert_eq!(params.deviation, 0);
         assert!(params.no_wobbles);
+    }
+
+    /// gamemd looks up `JumpjetTurnRate` and `JumpjetAccel` (`0x008436D0` and
+    /// `0x00843680`), and its `INIClass` compares CRC-32s of the raw key bytes
+    /// with no case folding (`CRCEngine::AddData @ 0x004A1DE0`). Stock spells
+    /// both with a capital mid-word `J`, so retail never reads either one.
+    #[test]
+    fn miscased_turn_rate_and_accel_are_not_read() {
+        let ini =
+            IniFile::from_str("[ZEP]\nJumpJetTurnRate=2\nJumpJetAccel=10\nJumpjetHeight=750\n");
+        let section = ini.section("ZEP").unwrap();
+        let params = JumpjetParams::from_ini_section(section);
+
+        assert_eq!(
+            params.turn_rate, 4,
+            "`JumpJetTurnRate=` is invisible to gamemd; the constructor's 4 stands"
+        );
+        assert_eq!(
+            params.accel,
+            sim_from_f32(2.0),
+            "`JumpJetAccel=` is invisible to gamemd; the constructor's 2.0 stands"
+        );
+        // The correctly-cased sibling on the same fixture still lands, which is
+        // what makes this a case test rather than a "nothing parses" test.
+        assert_eq!(params.height, 750);
+    }
+
+    /// The constructor seeds are the defaults, so an empty section and a
+    /// `Default::default()` must agree field for field.
+    #[test]
+    fn empty_section_yields_the_constructor_seeds() {
+        let ini = IniFile::from_str("[E1]\nStrength=100\n");
+        let section = ini.section("E1").unwrap();
+        let params = JumpjetParams::from_ini_section(section);
+        let ctor = JumpjetParams::default();
+
+        assert_eq!(params.turn_rate, ctor.turn_rate);
+        assert_eq!(params.speed, ctor.speed);
+        assert_eq!(params.climb, ctor.climb);
+        assert_eq!(params.crash, ctor.crash);
+        assert_eq!(params.height, ctor.height);
+        assert_eq!(params.accel, ctor.accel);
+        assert_eq!(params.wobbles, ctor.wobbles);
+        assert_eq!(params.deviation, ctor.deviation);
+        assert_eq!(params.no_wobbles, ctor.no_wobbles);
     }
 }

--- a/src/rules/jumpjet_params.rs
+++ b/src/rules/jumpjet_params.rs
@@ -29,6 +29,13 @@
 //! constructor's 4 and 2.0. Reading the INI's spelling instead of gamemd's, as
 //! this module used to, applied an acceleration gamemd ignores.
 //!
+//! ## Recorded DRIFTs
+//!
+//! Two native behaviours this module does not reproduce, both harmless on stock
+//! data and both written out where the field lives: the 208-lepton hover floor
+//! the Jumpjet locomotor applies to [`JumpjetParams::height`], and the integer
+//! reader type of [`JumpjetParams::speed`].
+//!
 //! ## Dependency rules
 //! - Part of rules/ — no dependencies on sim/, render/, ui/, etc.
 
@@ -73,6 +80,10 @@ pub struct JumpjetParams {
     /// multiplier on `Speed=`: stock `[JUMPJET]` pairs `Speed=9` with
     /// `JumpjetSpeed=30`, and the constructor seeds 14 — the same value stock
     /// `[JumpjetControls] Speed=` carries.
+    ///
+    /// This is the one field whose Rust type does not match its native one —
+    /// `+0xD74` is an `int`. See the residual at the read site in
+    /// [`JumpjetParams::from_ini_section`].
     pub speed: SimFixed,
     /// Climb/ascent rate per tick (`JumpjetClimb=`, `+0xD78`).
     pub climb: SimFixed,
@@ -80,6 +91,29 @@ pub struct JumpjetParams {
     /// Total crash speed = climb + crash.
     pub crash: SimFixed,
     /// Target hover altitude in leptons (`JumpjetHeight=`, `+0xD80`).
+    ///
+    /// RESIDUAL — DRIFT, not implemented in VERA. gamemd never hovers at this
+    /// value raw: the `JumpjetLocomotionClass` parameter copy at `0x0054AD30`
+    /// clamps it **up** on the way into the locomotor (`0x0054AD9B`:
+    /// `ECX = 2 * [0x00ABC5E8]`, `CMP EAX,ECX`, `JG` keeps the type's value,
+    /// else `EAX = ECX`), giving an effective floor of **208 leptons**.
+    /// `[0x00ABC5E8]` has exactly one writer, `0x0054AB2B`, and every input is
+    /// a static `.rdata` constant: `[0x007ECD38] = pi/180`, times
+    /// `[0x007E1730] = 90` gives `[0x00ABC570] = pi/2` (`0x0054AAE0`); times
+    /// `[0x007E1728] = 60` gives `[0x00ABC598] = pi/3` (`0x0054AAC0`);
+    /// `sqrt(2 * 256^2)` gives `[0x00ABC590] = 256*sqrt(2) = 362.0387`
+    /// (`0x0054AA30`); then `0x0054AB00` computes
+    /// `ftol(tan_table(pi/2 - pi/3) * 362.0387 * 0.5)`, the 0.5 being
+    /// `[0x007E1738]`. The table entry the index lands on, `0x0085D5F8`, holds
+    /// `0x3F13A08F = 0.5766687`, so `104.3878 -> 104` and the floor is
+    /// `2 * 104`. Every constant in that chain was read out of the binary.
+    ///
+    /// Trigger: a section authoring `JumpjetHeight` below 208. Player effect:
+    /// that unit hovers lower in VERA than in gamemd, permanently. Frequency:
+    /// **zero on stock data** — the lowest authored height in retail
+    /// `rulesmd.ini` is 500, and `[ZEP]`/`[DISK]` author 750, so every stock
+    /// jumpjet clears the floor. Only a mod or map INI can reach it.
+    /// Downstream risk: none — nothing else reads the clamped value.
     pub height: i32,
     /// Acceleration rate (`JumpjetAccel=`, `+0xD84`). Deceleration = accel *
     /// 1.5.
@@ -128,6 +162,21 @@ impl JumpjetParams {
             // all eight stock jumpjet sections keep the constructor's 4.
             turn_rate: section.get_i32("JumpjetTurnRate").unwrap_or(ctor.turn_rate),
             // `0x007150D0 PUSH 0x8436C0` -> `0x007150E4 MOV [EBP+0xD74],EAX`.
+            //
+            // RESIDUAL — DRIFT, pre-existing and not fixed here. The native
+            // reader is `CCINIClass::ReadInt @ 0x005276D0` into the *integer*
+            // field `+0xD74`, which `0x0054AD5C` copies out as a plain int;
+            // VERA reads a double and keeps the fraction in `SimFixed`. Every
+            // other key in this block matches its native reader type (ints via
+            // `get_i32`, `ReadDouble` keys via `get_f32`, the flag via
+            // `get_bool`) — this one does not. Trigger: a section authoring a
+            // fractional `JumpjetSpeed=`, e.g. 16.5, where the native integer
+            // read yields 16 and VERA keeps 16.5 — that unit cruises ~3% fast
+            // for the life of the mod. Frequency: **zero on stock** — all eight
+            // jumpjet sections author integers (5, 16, 30x5, 40) and the
+            // constructor seeds 14. Downstream risk: low; only a mod or map INI
+            // reaches it. The fix is `get_i32` here; left recorded rather than
+            // changed to keep this slice documentation-only.
             speed: section
                 .get_f32("JumpjetSpeed")
                 .map(sim_from_f32)

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -737,10 +737,12 @@ pub struct ObjectType {
     pub fly_back: bool,
     /// Landable=yes — aircraft can land on the ground.
     pub landable: bool,
-    /// Whether this unit uses jumpjet controls (JumpJet= in rules.ini).
+    /// `JumpJet=` in rules.ini — `TechnoTypeClass+0xD94`, a sibling of the
+    /// nine parameters below rather than a gate on them.
     pub jumpjet: bool,
-    /// Jumpjet-specific tuning parameters. Only populated when `jumpjet` is true.
-    pub jumpjet_params: Option<JumpjetParams>,
+    /// The `TechnoTypeClass+0xD70..+0xD90` jumpjet block. Present on every
+    /// type, as in gamemd; only the Jumpjet locomotor ever reads it.
+    pub jumpjet_params: JumpjetParams,
 
     // -- Deploy / undeploy fields --
     /// What this unit deploys into (e.g., AMCV DeploysInto=GACNST).
@@ -1790,42 +1792,25 @@ impl ObjectType {
             fly_by: section.get_bool("FlyBy").unwrap_or(false),
             fly_back: section.get_bool("FlyBack").unwrap_or(false),
             landable: section.get_bool("Landable").unwrap_or(false),
+            // gamemd-derived: `TechnoTypeClass::ReadINI` reads `JumpJet` into
+            // its own boolean at `+0xD94` (`0x007151EC PUSH 0x843640` ->
+            // `0x00715200 MOV [EBP+0xD94],AL`), the last member of the same
+            // straight-line run that reads the nine parameters below. It is a
+            // sibling of theirs, not a gate on them.
             jumpjet: section.get_bool("JumpJet").unwrap_or(false),
-            // RESIDUAL — DRIFT, not fixed here (this is not the projectile
-            // flight change's file; recorded so it is not lost).
-            // `TechnoTypeClass::ReadINI` reads the eight `Jumpjet*` keys in one
-            // unconditional straight-line block — `JumpjetClimb` -> `+0xD78`,
-            // `JumpjetCrash` -> `+0xD7C`, `JumpjetHeight` -> `+0xD80`
-            // (`0x00715151`), `JumpjetAccel` -> `+0xD84`, `JumpjetWobbles`,
-            // `JumpjetNoWobbles`, `JumpjetDeviation`, then `JumpJet` itself into
-            // a SEPARATE boolean field at `+0xD94` (`0x007151F8`). `JumpJet=` is
-            // NOT a gate on the others; the per-field defaults come from
-            // `TechnoTypeClass::Constructor` (`+0xD80` = 500 at `0x007115D3`),
-            // and `JumpjetLocomotionClass` reads `+0xD78`/`+0xD7C`/`+0xD80`/
-            // `+0xD84` off the type at `0x0054AD6F`ff.
-            // Gating the whole block on `JumpJet=yes` therefore drops every
-            // jumpjet key authored by a section that takes its Jumpjet locomotor
-            // from the GUID alone. Trigger: stock `[ZEP]` (Kirov) and `[DISK]`
-            // (Floating Disc) both author `JumpjetHeight=750`,
-            // `JumpjetSpeed=`, `JumpjetClimb=`, `JumpJetAccel=`,
-            // `JumpJetTurnRate=` and `JumpjetCrash=` without `JumpJet=`, so all
-            // of them are inert and both units fall back to the hard-coded
-            // defaults in `LocomotorState::air_params_from_object`. Player
-            // effect: a Kirov and a Floating Disc hover 250 leptons (~1 cell)
-            // lower than native and climb, turn and crash at the wrong rates;
-            // the lower hover also shortens the Kirov's bomb fall. Frequency:
-            // every Kirov and every Floating Disc, continuously, in any game
-            // that builds one. Downstream risk: altitude feeds the 3D fire-range
-            // gate and `object_world_z_leptons`, so it moves engagement
-            // distances as well as the picture. The other six stock
-            // `JumpJet=yes` sections ([JUMPJET], [LUNR], [SHAD], [HIND],
-            // [SCHP], [SCHD]) all author `JumpjetHeight=500`, which equals the
-            // fallback, so they are unaffected today.
-            jumpjet_params: if section.get_bool("JumpJet").unwrap_or(false) {
-                Some(JumpjetParams::from_ini_section(section))
-            } else {
-                None
-            },
+            // gamemd-derived: the nine `Jumpjet*` parameters are read
+            // unconditionally for every section — `TechnoTypeClass::ReadINI`
+            // `0x00715020`-`0x0071520F` contains no branch instruction at all,
+            // so `JumpJet=` cannot gate them. Both stock sections that take
+            // their Jumpjet locomotor from the GUID alone, `[ZEP]` (Kirov,
+            // `JumpjetHeight=750`) and `[DISK]` (Floating Disc, likewise 750),
+            // omit `JumpJet=`; gating the block on it threw away all nine of
+            // their authored keys and dropped both units to the constructor's
+            // 500-lepton hover. Only the Jumpjet locomotor consults these —
+            // the parameter copy at `0x0054AD30` reads `+0xD70`..`+0xD8C` off
+            // the type — so carrying them on every `ObjectType`, as
+            // `TechnoTypeClass` does, changes nothing for other locomotors.
+            jumpjet_params: JumpjetParams::from_ini_section(section),
 
             // Crush properties. `Crushable=` is the one key whose default is
             // category-dependent: the ObjectTypeClass constructor clears the
@@ -3978,5 +3963,191 @@ mod tests {
             ObjectCategory::Vehicle,
         );
         assert_eq!(mtnk.weight, SimFixed::lit("2.0"));
+    }
+
+    /// Retail `rulesmd.ini`, read from the gitignored `ini/` corpus.
+    ///
+    /// The golden is retail INI bytes, not a hand-written fixture, so these are
+    /// parity checks on the authored data rather than Rust-vs-Rust.
+    #[cfg(test)]
+    fn retail_rules_ini() -> IniFile {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("ini")
+            .join("rulesmd.ini");
+        let bytes = std::fs::read(&path).unwrap_or_else(|e| {
+            panic!(
+                "cannot read {}: {e}. The gitignored ini/ directory is required; \
+                 a fresh worktree needs it copied in from the main checkout.",
+                path.display()
+            )
+        });
+        IniFile::from_bytes(&bytes).expect("retail rulesmd.ini parses")
+    }
+
+    /// The two stock sections that take their Jumpjet locomotor from the
+    /// `Locomotor=` GUID alone and never author `JumpJet=`.
+    ///
+    /// gamemd reads all nine parameters for them anyway —
+    /// `TechnoTypeClass::ReadINI` `0x00715020`-`0x0071520F` has no branch — so
+    /// a retail Kirov and Floating Disc hover at their authored 750, not at the
+    /// constructor's 500 (`0x007115D3`). Gating the block on `JumpJet=yes`
+    /// dropped every one of these values.
+    #[test]
+    fn retail_kirov_and_disc_keep_their_jumpjet_block_without_the_flag() {
+        let ini = retail_rules_ini();
+
+        for id in ["ZEP", "DISK"] {
+            let section = ini.section(id).unwrap_or_else(|| panic!("[{id}] section"));
+            assert!(
+                section.get("JumpJet").is_none(),
+                "[{id}] is only interesting because stock omits JumpJet="
+            );
+            let obj = ObjectType::from_ini_section(id, section, ObjectCategory::Vehicle);
+            assert!(
+                !obj.jumpjet,
+                "[{id}] JumpJet= is absent, so the flag is false"
+            );
+            assert_eq!(
+                obj.locomotor,
+                LocomotorKind::Jumpjet,
+                "[{id}] takes the Jumpjet locomotor from its CLSID"
+            );
+            assert_eq!(
+                obj.jumpjet_params.height, 750,
+                "[{id}] authors JumpjetHeight=750 and gamemd reads it"
+            );
+        }
+
+        let zep = ObjectType::from_ini_section(
+            "ZEP",
+            ini.section("ZEP").expect("[ZEP]"),
+            ObjectCategory::Vehicle,
+        );
+        assert_eq!(
+            zep.jumpjet_params.speed,
+            crate::util::fixed_math::sim_from_f32(5.0)
+        );
+        assert_eq!(
+            zep.jumpjet_params.climb,
+            crate::util::fixed_math::sim_from_f32(6.0)
+        );
+        assert_eq!(
+            zep.jumpjet_params.crash,
+            crate::util::fixed_math::sim_from_f32(12.0)
+        );
+        assert!(zep.jumpjet_params.no_wobbles, "[ZEP] JumpjetNoWobbles=yes");
+        // `[ZEP]` authors no deviation, so the constructor's 40 stands.
+        assert_eq!(zep.jumpjet_params.deviation, 40);
+
+        let disk = ObjectType::from_ini_section(
+            "DISK",
+            ini.section("DISK").expect("[DISK]"),
+            ObjectCategory::Vehicle,
+        );
+        assert_eq!(
+            disk.jumpjet_params.speed,
+            crate::util::fixed_math::sim_from_f32(16.0)
+        );
+        assert_eq!(
+            disk.jumpjet_params.climb,
+            crate::util::fixed_math::sim_from_f32(8.0)
+        );
+        assert_eq!(
+            disk.jumpjet_params.crash,
+            crate::util::fixed_math::sim_from_f32(15.0)
+        );
+        assert_eq!(disk.jumpjet_params.deviation, 15);
+    }
+
+    /// The six stock sections that do author `JumpJet=yes` must be untouched by
+    /// removing the gate: they all author `JumpjetHeight=500`, which is also the
+    /// constructor seed.
+    #[test]
+    fn retail_jumpjet_yes_sections_are_unchanged_by_dropping_the_gate() {
+        let ini = retail_rules_ini();
+        // Categories as the stock registries list them: the two jumpjet
+        // infantry under `[InfantryTypes]`, the four choppers/transports under
+        // `[VehicleTypes]`. Category does not reach the jumpjet block, but
+        // parsing a section under the wrong one invites a later reader to
+        // misread the fixture.
+        for (id, category) in [
+            ("JUMPJET", ObjectCategory::Infantry),
+            ("LUNR", ObjectCategory::Infantry),
+            ("SHAD", ObjectCategory::Vehicle),
+            ("HIND", ObjectCategory::Vehicle),
+            ("SCHP", ObjectCategory::Vehicle),
+            ("SCHD", ObjectCategory::Vehicle),
+        ] {
+            let section = ini.section(id).unwrap_or_else(|| panic!("[{id}] section"));
+            let obj = ObjectType::from_ini_section(id, section, category);
+            assert!(obj.jumpjet, "[{id}] authors JumpJet=yes");
+            assert_eq!(obj.jumpjet_params.height, 500, "[{id}] authors 500");
+        }
+    }
+
+    /// gamemd looks up `JumpjetTurnRate` (`0x008436D0`) and `JumpjetAccel`
+    /// (`0x00843680`) — lowercase `jet` — and `INIClass` compares CRC-32s of
+    /// the raw key bytes (`CRCEngine::AddData @ 0x004A1DE0`), so the capital-J
+    /// spelling stock uses is invisible to it. Every stock jumpjet section
+    /// therefore flies on the constructor's turn rate 4 (`0x007115AE`) and
+    /// acceleration 2.0 (`0x007115DD`).
+    ///
+    /// Derived over the retail file rather than asserted from a list: the
+    /// section set is whatever authors a `Jumpjet*` key, and the two counts are
+    /// counted here.
+    #[test]
+    fn retail_never_authors_the_spelling_gamemd_reads_for_turn_rate_or_accel() {
+        let ini = retail_rules_ini();
+
+        let mut native_spelling = 0usize;
+        let mut ini_spelling = 0usize;
+        let mut jumpjet_sections = 0usize;
+        let mut seen: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+        for name in ini.section_names() {
+            if !seen.insert(name) {
+                continue;
+            }
+            let Some(section) = ini.section(name) else {
+                continue;
+            };
+            let authors_any = section
+                .keys()
+                .any(|k| k.to_ascii_lowercase().starts_with("jumpjet"));
+            if !authors_any {
+                continue;
+            }
+            jumpjet_sections += 1;
+            for key in ["JumpjetTurnRate", "JumpjetAccel"] {
+                if section.get(key).is_some() {
+                    native_spelling += 1;
+                }
+            }
+            for key in ["JumpJetTurnRate", "JumpJetAccel"] {
+                if section.get(key).is_some() {
+                    ini_spelling += 1;
+                }
+            }
+
+            let obj = ObjectType::from_ini_section(name, section, ObjectCategory::Vehicle);
+            assert_eq!(
+                obj.jumpjet_params.turn_rate, 4,
+                "[{name}] must keep the constructor turn rate"
+            );
+            assert_eq!(
+                obj.jumpjet_params.accel,
+                crate::util::fixed_math::sim_from_f32(2.0),
+                "[{name}] must keep the constructor acceleration"
+            );
+        }
+
+        assert_eq!(
+            native_spelling, 0,
+            "no stock section spells the keys the way gamemd looks them up"
+        );
+        assert_eq!(
+            (jumpjet_sections, ini_spelling),
+            (8, 16),
+            "8 stock sections author Jumpjet* keys and all 8 carry both mis-cased keys"
+        );
     }
 }

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -8694,30 +8694,26 @@ fn flat_level_zero_terrain(
 /// altitude reaches `object_world_z_leptons`, the launch pitch points down, and
 /// the flight ends in a detonation.
 ///
-/// The fixture authors `JumpJet=yes`, which stock `[ZEP]` does NOT — it takes
-/// its Jumpjet locomotor from the GUID alone. That reproduces gamemd, where
-/// `TechnoTypeClass::ReadINI @ 0x00715151` stores `JumpjetHeight=` into
-/// `TechnoType+0xD80` unconditionally (over the constructor default 500 at
-/// `0x007115D3`), so a native Kirov really does hover at 750. VERA gates the
-/// whole `JumpjetParams` block on `JumpJet=yes` (`rules/object_type.rs`), so a
-/// stock `[ZEP]`/`[DISK]` currently hovers at the 500 default instead — a
-/// recorded DRIFT out of scope here, and the reason this fixture has to author
-/// the key to exercise the chain it claims to pin.
+/// The fixture is stock-faithful on the jumpjet keys: like retail `[ZEP]` it
+/// omits `JumpJet=` and takes its Jumpjet locomotor from the GUID alone, and
+/// `JumpjetHeight=750` still lands, because `TechnoTypeClass::ReadINI @
+/// 0x00715151` stores it into `TechnoType+0xD80` unconditionally (over the
+/// constructor default 500 at `0x007115D3`). A native Kirov really does hover
+/// at 750.
 #[test]
 fn gsi_08_08_kirov_vertical_bomb_falls_and_detonates() {
     use crate::map::resolved_terrain::SharedCellDummy;
     use crate::sim::projectile::{ProjectileStore, ProjectileTrajectory};
 
     // Stock `[BlimpBombP]`, `[BlimpBomb]` and the Kirov's `JumpjetHeight=750`,
-    // with two deliberate changes: `Range=` is widened from the stock 1.5 so the
+    // with one deliberate change: `Range=` is widened from the stock 1.5 so the
     // shot clears the fire-range gate while the firer hovers 750 leptons up
-    // (nothing on the `Vertical` arm reads `Range=`), and `JumpJet=yes` is
-    // authored so VERA's `JumpJet=`-gated parser reaches `JumpjetHeight=` the
-    // way `TechnoTypeClass::ReadINI` does unconditionally. See the doc comment.
+    // (nothing on the `Vertical` arm reads `Range=`). `JumpJet=` stays absent,
+    // as in stock. See the doc comment.
     let rules = RuleSet::from_ini(&IniFile::from_str(
         "[VehicleTypes]\n0=ZEP\n1=HTNK\n\
          [ZEP]\nStrength=2000\nArmor=medium\nSpeed=5\nPrimary=BlimpBomb\n\
-         BalloonHover=yes\nJumpJet=yes\nJumpjetHeight=750\nConsideredAircraft=yes\n\
+         BalloonHover=yes\nJumpjetHeight=750\nConsideredAircraft=yes\n\
          MovementZone=Fly\nSpeedType=Hover\n\
          Locomotor={92612C46-F71F-11d1-AC9F-006008055BB5}\n\
          [HTNK]\nStrength=2000\nArmor=heavy\nSpeed=4\n\
@@ -8944,7 +8940,10 @@ fn gsi_05_14_a_dying_building_uses_its_own_debris_anims() {
         .collect();
     let own: usize = names.iter().filter(|n| n.starts_with("DBRI-WM")).count();
     // `MinDebris=3`, `MaxDebris=4` pins the budget at 3 with no draw.
-    assert_eq!(own, 3, "the whole budget comes from DebrisAnims=: {names:?}");
+    assert_eq!(
+        own, 3,
+        "the whole budget comes from DebrisAnims=: {names:?}"
+    );
     assert!(
         !names.iter().any(|n| n.starts_with("DBRIS")),
         "the Rules MetallicDebris arm must not also fire: {names:?}"

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -8940,10 +8940,7 @@ fn gsi_05_14_a_dying_building_uses_its_own_debris_anims() {
         .collect();
     let own: usize = names.iter().filter(|n| n.starts_with("DBRI-WM")).count();
     // `MinDebris=3`, `MaxDebris=4` pins the budget at 3 with no draw.
-    assert_eq!(
-        own, 3,
-        "the whole budget comes from DebrisAnims=: {names:?}"
-    );
+    assert_eq!(own, 3, "the whole budget comes from DebrisAnims=: {names:?}");
     assert!(
         !names.iter().any(|n| n.starts_with("DBRIS")),
         "the Rules MetallicDebris arm must not also fire: {names:?}"

--- a/src/sim/movement/locomotor.rs
+++ b/src/sim/movement/locomotor.rs
@@ -30,7 +30,7 @@ use crate::sim::movement::locomotion::piggyback::{
     self, EndGateContext, LocomotorRuntimePayload, StashedLocomotor,
 };
 use crate::sim::movement::slope_transition::SlopeTransitionState;
-use crate::util::fixed_math::{SIM_ZERO, SimFixed, sim_from_f32};
+use crate::util::fixed_math::{SIM_ZERO, SimFixed};
 
 /// Which spatial layer the unit currently occupies.
 ///
@@ -292,8 +292,21 @@ impl LocomotorState {
         let (target_alt, climb, jj_speed) =
             Self::air_params_from_object(kind, &obj.jumpjet_params, flight_level);
 
-        // Extract extended jumpjet fields (accel, deviation, crash, turn rate).
-        let jj = obj.jumpjet_params.as_ref();
+        // gamemd-derived: every `TechnoType` carries the `+0xD70`..`+0xD90`
+        // jumpjet block, but only the Jumpjet locomotor ever copies it out —
+        // the parameter copy at `0x0054AD30` pulls `+0xD70` (turn rate),
+        // `+0xD74` (speed), `+0xD78` (climb), `+0xD7C` (crash), `+0xD80`
+        // (height), `+0xD84` (accel), `+0xD88` (wobbles), `+0xD90`
+        // (deviation) and `+0xD8C` (no-wobbles) off the type in one run. A
+        // Drive/Fly/Hover locomotor has no such fields in gamemd and never
+        // reads the type's, so they stay inert here for every other kind.
+        // VERA-internal: this one struct serves every locomotor kind, so the
+        // non-jumpjet arms still need *a* value. Zero for the three that mean
+        // "off", and 4 for the turn rate — the `TechnoTypeClass::Constructor`
+        // seed at `0x007115AE`, which is also what this line produced before
+        // the block became unconditional.
+        let jj: Option<&JumpjetParams> =
+            (kind == LocomotorKind::Jumpjet).then_some(&obj.jumpjet_params);
         let jj_accel: SimFixed = jj.map_or(SIM_ZERO, |p| p.accel);
         let jj_deviation: i32 = jj.map_or(0, |p| p.deviation);
         let jj_crash_speed: SimFixed =
@@ -335,11 +348,16 @@ impl LocomotorState {
         }
     }
 
-    /// Compute altitude parameters from locomotor kind and optional jumpjet params.
-    /// Returns (target_altitude, climb_rate, jumpjet_speed).
+    /// Compute altitude parameters from locomotor kind and the type's jumpjet
+    /// block. Returns (target_altitude, climb_rate, jumpjet_speed).
+    ///
+    /// The Jumpjet arm has no fallback literals: `JumpjetParams` already
+    /// carries the `TechnoTypeClass::Constructor` seeds (`0x007115AE`ff) for
+    /// every key the section leaves out, so duplicating them here would be a
+    /// second, drift-prone source of truth.
     fn air_params_from_object(
         kind: LocomotorKind,
-        jumpjet_params: &Option<JumpjetParams>,
+        jumpjet_params: &JumpjetParams,
         flight_level: i32,
     ) -> (SimFixed, SimFixed, SimFixed) {
         match kind {
@@ -348,13 +366,13 @@ impl LocomotorState {
                 (alt, FLY_CLIMB_RATE, SIM_ZERO)
             }
             LocomotorKind::Jumpjet => {
-                let jj = jumpjet_params.as_ref();
-                let height: SimFixed =
-                    jj.map_or(SimFixed::from_num(500), |p| SimFixed::from_num(p.height));
-                let climb: SimFixed = jj.map_or(sim_from_f32(5.0), |p| p.climb);
-                let speed: SimFixed = jj.map_or(sim_from_f32(14.0), |p| p.speed);
+                let height: SimFixed = SimFixed::from_num(jumpjet_params.height);
                 // Jumpjet climb rate scaled to leptons/second (original is per-tick at 15Hz).
-                (height, climb * SimFixed::from_num(15), speed)
+                (
+                    height,
+                    jumpjet_params.climb * SimFixed::from_num(15),
+                    jumpjet_params.speed,
+                )
             }
             _ => (SIM_ZERO, SIM_ZERO, SIM_ZERO),
         }

--- a/src/sim/movement/locomotor_tests.rs
+++ b/src/sim/movement/locomotor_tests.rs
@@ -194,7 +194,7 @@ fn make_obj(locomotor: LocomotorKind, category: ObjectCategory) -> ObjectType {
         fly_back: false,
         landable: false,
         jumpjet: false,
-        jumpjet_params: None,
+        jumpjet_params: JumpjetParams::default(),
         deploys_into: None,
         undeploys_into: None,
         deploy_facing: 0x80,
@@ -375,7 +375,7 @@ fn test_jumpjet_air_layer() {
 fn test_jumpjet_with_custom_params() {
     let mut obj = make_obj(LocomotorKind::Jumpjet, ObjectCategory::Infantry);
     obj.jumpjet = true;
-    obj.jumpjet_params = Some(JumpjetParams {
+    obj.jumpjet_params = JumpjetParams {
         turn_rate: 4,
         speed: sim_from_f32(20.0),
         climb: sim_from_f32(8.0),
@@ -385,7 +385,7 @@ fn test_jumpjet_with_custom_params() {
         wobbles: 0.2,
         deviation: 40,
         no_wobbles: false,
-    });
+    };
     let state = LocomotorState::from_object_type(&obj, 1500, 0);
     assert_eq!(state.target_altitude, SimFixed::from_num(750));
     assert_eq!(state.jumpjet_speed, sim_from_f32(20.0));
@@ -502,4 +502,111 @@ fn drive_piggyback_refuses_an_unstashed_active_drive() {
     assert!(!state.begin_drive_piggyback_for_teleporter(0));
     assert_eq!(state.kind, LocomotorKind::Drive);
     assert!(state.piggyback.is_none());
+}
+
+/// End of the production chain for the two units the `JumpJet=` gate broke:
+/// retail INI bytes -> `ObjectType::from_ini_section` -> `LocomotorState`.
+///
+/// gamemd copies the type's jumpjet block into the locomotor unconditionally
+/// once the Jumpjet locomotor is installed (parameter copy at `0x0054AD30`,
+/// reading `TechnoType+0xD70`..`+0xD8C`), and `TechnoTypeClass::ReadINI`
+/// `0x00715020`-`0x0071520F` filled that block with no reference to
+/// `JumpJet=`. So a stock Kirov hovers at its authored 750, not at the
+/// constructor's 500.
+#[test]
+fn retail_kirov_and_disc_reach_their_authored_hover_altitude() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("ini")
+        .join("rulesmd.ini");
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| {
+        panic!(
+            "cannot read {}: {e}. The gitignored ini/ directory is required; \
+             a fresh worktree needs it copied in from the main checkout.",
+            path.display()
+        )
+    });
+    let ini =
+        crate::rules::ini_parser::IniFile::from_bytes(&bytes).expect("retail rulesmd.ini parses");
+
+    // (section, JumpjetSpeed, JumpjetClimb, JumpjetCrash) as authored.
+    for (id, speed, climb, crash) in [("ZEP", 5.0, 6.0, 12.0), ("DISK", 16.0, 8.0, 15.0)] {
+        let obj = ObjectType::from_ini_section(
+            id,
+            ini.section(id).unwrap_or_else(|| panic!("[{id}] section")),
+            ObjectCategory::Vehicle,
+        );
+        let state = LocomotorState::from_object_type(&obj, 1500, 0);
+
+        assert_eq!(state.kind, LocomotorKind::Jumpjet, "[{id}]");
+        assert_eq!(
+            state.target_altitude,
+            SimFixed::from_num(750),
+            "[{id}] hovers at its authored JumpjetHeight"
+        );
+        assert_eq!(state.jumpjet_speed, sim_from_f32(speed), "[{id}]");
+        assert_eq!(
+            state.climb_rate,
+            sim_from_f32(climb) * SimFixed::from_num(15),
+            "[{id}]"
+        );
+        assert_eq!(
+            state.jumpjet_crash_speed,
+            (sim_from_f32(climb) + sim_from_f32(crash)) * SimFixed::from_num(15),
+            "[{id}] crash descent is (climb + crash)"
+        );
+        // The constructor's acceleration, because stock spells the key
+        // `JumpJetAccel=` and gamemd looks up `JumpjetAccel`.
+        assert_eq!(state.jumpjet_accel, sim_from_f32(2.0), "[{id}]");
+        assert_eq!(state.jumpjet_turn_rate, 4, "[{id}]");
+    }
+}
+
+/// Non-Jumpjet locomotors must not pick up the block. Every `TechnoType`
+/// carries it, but only the copy at `0x0054AD30` reads it, and that lives in
+/// the Jumpjet locomotor.
+#[test]
+fn non_jumpjet_locomotors_ignore_the_types_jumpjet_block() {
+    for kind in [
+        LocomotorKind::Drive,
+        LocomotorKind::Walk,
+        LocomotorKind::Hover,
+        LocomotorKind::Fly,
+        LocomotorKind::Ship,
+    ] {
+        let mut obj = make_obj(kind, ObjectCategory::Vehicle);
+        // A section that authored every jumpjet key would still not reach a
+        // Drive or Fly locomotor.
+        obj.jumpjet_params = JumpjetParams {
+            turn_rate: 100,
+            speed: sim_from_f32(99.0),
+            climb: sim_from_f32(9.0),
+            crash: sim_from_f32(9.0),
+            height: 750,
+            accel: sim_from_f32(10.0),
+            wobbles: 0.5,
+            deviation: 15,
+            no_wobbles: true,
+        };
+        let state = LocomotorState::from_object_type(&obj, 1500, 0);
+
+        assert_eq!(
+            state.jumpjet_accel,
+            crate::util::fixed_math::SIM_ZERO,
+            "{kind:?}"
+        );
+        assert_eq!(state.jumpjet_deviation, 0, "{kind:?}");
+        assert_eq!(
+            state.jumpjet_crash_speed,
+            crate::util::fixed_math::SIM_ZERO,
+            "{kind:?}"
+        );
+        assert_eq!(state.jumpjet_turn_rate, 4, "{kind:?}");
+        if kind != LocomotorKind::Fly {
+            assert_eq!(
+                state.target_altitude,
+                crate::util::fixed_math::SIM_ZERO,
+                "{kind:?}"
+            );
+        }
+    }
 }

--- a/src/sim/movement/teleport_movement.rs
+++ b/src/sim/movement/teleport_movement.rs
@@ -657,7 +657,7 @@ mod tests {
             fly_back: false,
             landable: false,
             jumpjet: false,
-            jumpjet_params: None,
+            jumpjet_params: crate::rules::jumpjet_params::JumpjetParams::default(),
             deploys_into: None,
             undeploys_into: None,
             deploy_facing: 0x80,

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -1963,6 +1963,17 @@ fn hash_locomotor_runtime(
     common.speed_fraction.to_bits().hash(hasher);
     common.fly_current_speed.to_bits().hash(hasher);
     common.altitude.to_bits().hash(hasher);
+    // On a Jumpjet locomotor, the fields from `target_altitude` down to
+    // `jumpjet_turn_rate` are seeded from the type's `+0xD70`..`+0xD90` block —
+    // the run gamemd copies into the locomotor at `0x0054AD30` —
+    // `jumpjet_current_speed` excepted, which is runtime state. All of them are
+    // hash-visible, so any correction to how `rules::jumpjet_params` reads
+    // those keys changes this hash for every jumpjet type. No committed golden
+    // or parity fixture currently flies a Rocketeer, Kirov, Floating Disc,
+    // BlackHawk, Hind or Siege Chopper, so such a correction can land with a
+    // green suite — that is a gap in harness coverage, not evidence that
+    // nothing moved. A harness that adds one will need a re-baseline
+    // attributable to the rules read, not to a harness bug.
     common.target_altitude.to_bits().hash(hasher);
     common.climb_rate.to_bits().hash(hasher);
     common.jumpjet_speed.to_bits().hash(hasher);


### PR DESCRIPTION
## The Kirov and the Floating Disc were flying on fallback values

Both units author nine jumpjet keys, and neither authors a `JumpJet=` flag — they take the
jumpjet locomotor from the CLSID alone. VERA gated the whole nine-key parse block on that
flag, so it threw all nine away and fell back to hardcoded locomotor literals.

gamemd does not gate them. `TechnoTypeClass::ReadINI` reads all ten jumpjet keys in one
branch-free run (`0x00715020`-`0x0071520F`, disassembled: 133 instructions, no `J*` branch
anywhere) and reads `JumpJet` **last**, into its own boolean at `+0xD94`. A key read tenth
cannot gate the nine that precede it.

Both units now get their authored hover height, jumpjet speed, climb, crash descent, wobble
and deviation:

| | authored | VERA before |
|---|---|---|
| `[ZEP]` Kirov | height 750, speed 5, climb 6, crash 12 | 500 / 14 / 5 / none |
| `[DISK]` Floating Disc | height 750, speed 16, climb 8, crash 15, deviation 15 | 500 / 14 / 5 / none |

The hover error was **250 leptons out of 256 — nearly a full cell**, not a fraction of one.
Frequency: continuous, from the moment either unit exists.

## Separately: two keys are now read the way gamemd reads them

Stock `rulesmd.ini` spells `JumpJetAccel` and `JumpJetTurnRate` with a capital middle J. The
binary looks up `JumpjetAccel` and `JumpjetTurnRate` (literals at `0x00843680` and
`0x008436D0`), and `INIClass` compares CRC-32s of the raw key bytes with no case folding.

So **gamemd has never read those two keys for any unit.** All eight jumpjet sections fly on
the constructor's acceleration 2.0f and turn rate 4 (`0x007115AE`-`0x007115F7`). VERA was
reading the INI's spelling and applying authored values — 10 or 12 acceleration, turn rates
up to 100 — that gamemd ignores.

The fix corrects the lookup literal rather than deleting the read, so a mod that spells the
key the way gamemd looks it up still works.

**The acceleration change is real and player-visible** — `jumpjet_accel` feeds
`tick_jumpjet_acceleration`, which runs every tick a jumpjet moves.

**The turn-rate change is latent.** VERA stores `jumpjet_turn_rate`, carries it through the
piggyback payload and hashes it, but no code turns by it. This corrects the stored value and
stops a wrong one entering the hash; it does **not** mean Floating Discs now turn correctly.
Native does consume it (`0x0054AD30` feeds it to the facing helper at `0x004C91E0`); VERA's
consumer is a separate, pre-existing gap.

## Coverage, not evidence

The suite is green, but that is a fact about the harness, not proof nothing moved. **No
committed golden or parity fixture flies a jumpjet** — not a Rocketeer, Kirov, Floating Disc,
BlackHawk, Hind or Siege Chopper. The type's jumpjet block is hash-visible through
`hash_locomotor_runtime`, so had one been in the global replay harness its constant would
have had to be re-baselined here.

Values that would have moved:

- **turn rate** 10 / 10 / 6 / 12 / 6 / 6 → **4** for the six `JumpJet=yes` sections
- **acceleration** → **2.0** for all eight jumpjet sections
- **deviation** 0 → **40** (`[ZEP]`, the constructor seed — its key is commented out) and
  0 → **15** (`[DISK]`) for the two unflagged sections
- plus **target altitude, climb rate, jumpjet speed and crash descent** for those same two,
  whose whole block had been discarded

That blind spot is recorded in a durable comment beside the hashed fields, so the next
engineer who adds a jumpjet to the harness and sees the hash move looks at the rules read
rather than hunting a harness bug.

## Verified gamemd sources

| address | what it establishes |
|---|---|
| `0x00715020`-`0x0071520F` | `TechnoTypeClass::ReadINI` — ten reads, branch-free, `JumpJet` read last |
| `0x00843640`-`0x008436D0` | the ten key literals; only `JumpJet` carries a capital mid-word J |
| `0x007115AE`-`0x007115F7` | `TechnoTypeClass::Constructor` seeds `+0xD70`..`+0xD94` (4, 14, 5.0f, 5.0f, 500, 2.0f, 0.15f, false, 40) |
| `0x0054AD30` | the sole consumer — ILocomotion slot `+0x0C`, copies `+0xD70`..`+0xD8C`, never consults `+0xD94` |
| `0x006743D0` | `RulesClass::ReadJumpjetControls` writes `RulesClass+0x40C`..`+0x438`, not the TechnoType block |

`[JumpjetControls]`'s stock values happen to equal the per-type constructor seeds, which is
why the capital-J typo went unnoticed for twenty-five years.

## New residual

**The 208-lepton hover floor is not implemented.** `0x0054AD9B` clamps the copied height *up*
to `2 x [0x00ABC5E8]`, and that global is derived entirely from static `.rdata` constants:
`ftol(tan_table(pi/2 - pi/3) x 256*sqrt(2) x 0.5)` = `104.3878` → 104, so the floor is 208
leptons. **It cannot fire on stock data** — the lowest authored `JumpjetHeight` in retail is
500, and both units here author 750. Recorded with its full derivation on
`JumpjetParams::height`.

Also recorded: `JumpjetSpeed` is read natively by `ReadInt` into an int, while VERA reads a
double into `SimFixed` — the only key in the block whose type diverges. Zero stock impact;
all eight sections author integers.

## Validation

Full suite after rebasing onto `main`:

```
test result: ok. 8266 passed; 0 failed; 78 ignored; 0 measured; 0 filtered out; finished in 30.21s
```

`SNAPSHOT_VERSION` unchanged by this branch — it inherits 123 from `main`. No golden or
world-hash constant moved. Ghidra stayed read-only; the six annotation candidates remain
queued and unapplied.
