### PR TITLE
Match homing ground impact and final coordinate handoff

### DIFF
--- a/docs/research/BULLETCLASS_TRAJECTORY_AND_HOMING.md
+++ b/docs/research/BULLETCLASS_TRAJECTORY_AND_HOMING.md
@@ -503,9 +503,67 @@ if (BulletTypeClass.ROT < 1 && !BulletTypeClass.Ranged):
 else:
     prox_result = ProximityDetector::Check(&this->ProxDetector, &new_pos)
 
-// Special case: if firer has specific flag (offset 0xD94) and prox_result == 2:
+// Special case: if the LIVE firer's type has JumpJet (+0xD94) and prox_result == 2:
 //   Override to prox_result = 1 (treat overshoot as close-hit)
 ```
+
+### 3.5 Homing ground admission and final coordinate (2026-09-05)
+
+Fresh retail body inspection corrects the ground-contact interpretation. At
+`0x00466DB1..0x00466E6B`, AI admits an impact when the returned homing distance
+is at most half the **double velocity vector's magnitude**, or the **old**
+ObjectClass height is nonpositive. Bullet vtable `0x007E46E4 + 0x1C8` binds
+`ObjectClass::GetHeight @ 0x005F5F40`; it reads the object's still-uncommitted
+location, ground from `0x00578080`, and the object's own OnBridge byte.
+The arm copies its cached target coordinate into the candidate only when height
+is positive, Airburst is false, and that target coordinate is nonzero.
+Inaccurate does not gate this first snap.
+
+At `0x00467BF0..0x00467C06`, an admitted impact whose **committed** height is
+negative invokes `+0x1CC(0)` (`0x005F5FA0`). The setter performs another ground
+lookup and changes ObjectClass location; the stack coordinate passed to the
+proximity detector remains unchanged. At `0x00467C3C..0x00467C66`, a live firer
+at Bullet `+0xB0` supplies type `+0x84`; its JumpJet byte `+0xD94` changes
+detector mode 2 to mode 1. ReadINI `0x007151EC..0x00715200` binds that byte to
+the string `JumpJet` at `0x00843640`. This is the firer, not the target.
+
+The mode-1 tail at `0x00467CA9..0x00467E4D` requires a non-null target and
+neither Airburst nor Inaccurate; it finally copies target `+0x48` through
+Bullet's setter `+0x1B4 @ 0x005F6940`. A CellClass aim point (`+0x58 @ 0x00486890`)
+includes a structural bridge offset, but its location (`+0x48 @ 0x00486840`)
+is the cell center at ground height. A retained shared dummy must be read again
+after the intervening ground lookups, which may stamp its coordinate.
+
+Active path: LogicClass `0x0055AFB0` calls object vtable `+0x5C`, which binds
+Bullet AI at `0x007E4740`. Retail `[HoverMissile]` uses `[AAHeatSeeker2]`
+(`ROT=60`, `Arm=2`, `Ranged=yes`, non-Inviso). Non-Inviso fresh bullets retain
+the base constructor's OnBridge=false: the observed FireAt `+0x8C` propagation
+at `0x006FF08B..0x006FF0B7` is gated on Inviso. Raw native save-image mutations
+are outside this fresh-object proof. Stock JumpJet firers examined use either
+Inviso projectiles or non-Ranged, ROT=0 Ballistic projectiles; generic source
+mode conversion is implemented, but stock homing reachability of that combination
+is not claimed.
+
+Rust production delivery is `SimRuntime::advance_frame -> advance_app_frame ->
+advance_master_frame -> object_ai_visit_one -> ProjectileStore::advance_one ->
+commit_logic_projectile_detonations`. The runtime regression
+`homing_ground_impact_reaches_damage_and_cleanup_through_runtime_frame` checks
+old-height timing, impact-cell wall damage, removal, and live firer cleanup.
+`homing_mode_one_fuse_snaps_to_cell_location_below_bridge_aim_point` checks the
+CellClass receiver distinction. These are Rust regression tests, not native
+whole-frame comparisons.
+
+[The executable oracle](../../tools/projectile_oracle/homing_impact.py) emits
+[retail-derived vectors](../../tools/projectile_oracle/homing_impact_vectors.json)
+for admission, common clamp/final snap, and live-source mode conversion. It runs
+the original instruction ranges and ObjectClass getter/setter bodies with
+controlled external floor and target-coordinate inputs. Its comparison is bounded
+to the recorded inputs; it does not prove the upstream HomingTrack velocity,
+target-coordinate production, bridge-flight trajectory, null-target altitude
+termination, or downstream warhead implementation. Rust still quantizes velocity
+to integer components and lacks native homing pitch integration. GSI-08.07 and
+GSI-08.08 remain open; the extra ballistic target-nearness admission and ordinary
+ground/source collision discrepancies also remain open.
 
 ---
 
@@ -587,17 +645,24 @@ From BulletClass::AI, detonation is triggered when ANY of:
 | Object within 127 leptons | Proximity fuse (non-homing) | 0x004679xx |
 | Out of map bounds | FUN_00568350 returns false | 0x00467Axx |
 | speed < 10.0 AND height <= 9 | Stalled near ground | 0x00467Bxx |
-| speed * 90.0 >= distance | Close enough (homing) | 0x00466Exx |
-| height < 1 | At/below ground (homing) | 0x00466Exx |
+| vector magnitude * 0.5 >= distance | Close enough (homing); see §3.5 | 0x00466DB1..0x00466E05 |
+| old ObjectClass height <= 0 | At/below ground (homing); see §3.5 | 0x00466DF6..0x00466E20 |
 | Target lost + height >= FlightLevel | Lost target, too high | 0x00466Fxx |
 | ApproachSum in [0, 60) for 60+ ticks | No longer closing (homing) | 0x004670xx |
 | Bridge crossing (homing) | Altitude crosses bridge | 0x004671xx |
 | ProximityDetector returns 1 or 2 | Embedded proximity check | 0x00467Cxx |
 | Dropping=yes + HasDropped | Drop bomb behavior | 0x004668xx |
 
-### 4.3 Bounce vs Detonate
+### 4.3 Collision probe and detonation admission
 
-Before detonation, BulletClass::AI calls BounceCheck (0x00468BB0):
+At `0x00467BD1`, AI calls `0x00468BB0` only while its impact flag is clear.
+It commits the returned coordinate buffer through `+0x1B4` and copies the
+boolean result into the impact flag. A true result proceeds through the
+negative committed-height clamp (`+0x1C8 < 0 -> +0x1CC(0)`) and admits the
+detonation tail at `0x00467C70`, independently of the proximity fuse. A false
+result does not itself admit detonation; the fuse can still do so when
+Dropping is false.
+
 ```c
 bool BounceCheck(BulletClass* this, CoordStruct* impact_pos) {
     *impact_pos = this->Location;
@@ -610,7 +675,7 @@ bool BounceCheck(BulletClass* this, CoordStruct* impact_pos) {
         cur_cell = MapClass::Get_CellClass(LastCell)
         firer_house = (this->Owner != 0) ? Owner->HouseClass : 0
         if FUN_004CC360(cur_cell, pos, BulletType, firer_house):
-            return true  // deflect off cliff/wall
+            return true  // admit impact
 
     // 2. Deeply underground
     if GetHeight() <= -4 * cell_size:
@@ -632,12 +697,10 @@ bool BounceCheck(BulletClass* this, CoordStruct* impact_pos) {
         if distance(bullet, target) < 128:
             return true
 
-    return false  // no bounce, proceed to detonate
+    return false  // no impact admitted by this probe
 }
 ```
 
-When BounceCheck returns true, the bullet adjusts position and continues flying
-rather than detonating. The height is clamped to 0 if below ground.
 
 ---
 

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -8794,6 +8794,7 @@ fn gsi_08_08_kirov_vertical_bomb_falls_and_detonates() {
                 |_| Some(ground),
                 Some(&terrain),
                 &dummy,
+                false,
                 |_, _| None,
             )
             .expect("the bomb is still in flight");

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -288,14 +288,6 @@ enum ImmediateProjectileReason {
 /// velocity and the native ground clamp, which is the same work as the
 /// `Arcing` solver.
 ///
-/// RESIDUAL (GSI-08.07) — `BulletClass::AI 0x00467CDE` refuses the
-/// detonation-coordinate snap onto the target for an `Inaccurate=` bullet, the
-/// same way it does for `Airburst=`. The homing arm's snap here is gated on
-/// `Airburst` only, because no stock `Inaccurate` projectile has `ROT > 0`
-/// (`[FlakProj]` and `[FlakTProj]` are both `ROT=0`), so the gate is
-/// unreachable in stock data. Trigger: a mod authoring `Inaccurate=yes` with
-/// `ROT`. Player effect: the shot would still snap onto its target. Frequency:
-/// zero in stock. Downstream risk: none.
 fn classify_projectile_delivery(
     weapon: &crate::rules::weapon_type::WeaponType,
     rules: &RuleSet,
@@ -344,6 +336,7 @@ fn classify_projectile_delivery(
                 // not its formula. Keep the raw phase as an explicit live seam.
                 sidewinder_phase: 0,
                 airburst: projectile.airburst,
+                inaccurate: projectile.inaccurate,
                 very_high: projectile.very_high,
                 level: projectile.level,
                 // Replaced at construction with the launch facing.

--- a/src/sim/projectile.rs
+++ b/src/sim/projectile.rs
@@ -21,15 +21,10 @@
 //! `DetonationAltitude` crossing, or a target reach all detonate an unarmed
 //! bullet.
 //!
-//! RESIDUAL (GSI-08.06) — a guided bullet that overshoots a fast target has
-//! three native termination rules; two of them are here (the reach test and
-//! the closing-rate heuristic) and one is not: the homing arm's own
-//! `GetAltitude() < 1` ground test at the same site. Trigger: a homing shot
-//! whose launch z sits at or below the terrain it crosses. Player effect: the
-//! missile flies over a hill it should hit. Frequency: only on rising terrain,
-//! since the arm holds its launch z. Downstream risk: it is one of the leak
-//! bounds, so the closing-rate heuristic is the only one left for a missile
-//! that never closes — it does terminate, but after up to a few seconds.
+//! Homing termination reads the OLD ObjectClass height, before committing the
+//! new coordinate (`0x00466DF6`). Ground admission suppresses the arm's target
+//! snap; the common tail then clamps a negative committed height and may snap
+//! a mode-1 fuse to the target's location (`+0x48`, not its aim point `+0x58`).
 //!
 //! RESIDUAL (GSI-08.06) — the ballistic arm's `reached_target` test is
 //! VERA-internal, gamemd equivalent UNCHECKED: native's `ROT < 1` arms
@@ -120,6 +115,9 @@ pub struct ProjectileGuidance {
     pub course_lock_duration: u16,
     pub sidewinder_phase: u8,
     pub airburst: bool,
+    /// `BulletTypeClass+0x2A2`, the common final-snap exclusion at `0x00467CDE`.
+    /// The earlier homing reach snap at `0x00466E22` does not test this flag.
+    pub inaccurate: bool,
     pub very_high: bool,
     pub level: bool,
     /// Flight heading as a math BAM (`0` = +X). Native keeps the direction
@@ -1174,6 +1172,7 @@ impl ProjectileStore {
             |id| target_positions.get(&id).copied(),
             terrain,
             shared_cell_dummy,
+            false,
             collides_at,
             true,
         )
@@ -1186,6 +1185,7 @@ impl ProjectileStore {
         target_position: impl FnMut(u64) -> Option<ProjectileCoord>,
         terrain: Option<&ResolvedTerrainGrid>,
         shared_cell_dummy: &SharedCellDummy,
+        source_is_jumpjet: bool,
         collides_at: impl FnMut(&Projectile, ProjectileCoord) -> Option<ProjectileCollisionResponse>,
     ) -> Option<ProjectileAdvanceResult> {
         if !self.projectiles.contains_key(&id) {
@@ -1197,6 +1197,7 @@ impl ProjectileStore {
             target_position,
             terrain,
             shared_cell_dummy,
+            source_is_jumpjet,
             collides_at,
             false,
         ))
@@ -1207,9 +1208,10 @@ impl ProjectileStore {
         &mut self,
         ids: &[u64],
         binary_frame: u32,
-        mut target_position: impl FnMut(u64) -> Option<ProjectileCoord>,
+        mut resolve_target_position: impl FnMut(u64) -> Option<ProjectileCoord>,
         terrain: Option<&ResolvedTerrainGrid>,
         shared_cell_dummy: &SharedCellDummy,
+        source_is_jumpjet: bool,
         mut collides_at: impl FnMut(&Projectile, ProjectileCoord) -> Option<ProjectileCollisionResponse>,
         remove_terminal: bool,
     ) -> ProjectileAdvanceResult {
@@ -1227,7 +1229,7 @@ impl ProjectileStore {
                 // collision, and reached-target decisions.
                 ProjectileTarget::None => ProjectileCoord::new(0, 0, 0),
                 ProjectileTarget::DummyCell => dummy_cell_target_coord(shared_cell_dummy),
-                ProjectileTarget::Entity(target_id) => match target_position(target_id) {
+                ProjectileTarget::Entity(target_id) => match resolve_target_position(target_id) {
                     Some(position) => {
                         if projectile.tracks_target {
                             projectile.last_target_position = position;
@@ -1402,15 +1404,33 @@ impl ProjectileStore {
                     projectile.position.z.saturating_add(projectile.velocity.z),
                 );
 
-                // `HomingTrack` returns the post-step distance to the target
-                // coordinate and the arm detonates on `dist <= |v| * 0.5`,
-                // snapping the impact onto the target coordinate unless the
-                // bullet is `Airburst`.
+                // gamemd-derived: `BulletClass::AI 0x00466DB1..0x00466E6B`.
+                // The +0x1C8 receiver is ObjectClass::GetHeight @ 0x005F5F40
+                // on the OLD object coordinate; HomingTrack has only updated
+                // the stack candidate. Stock persistent (non-Inviso) bullets
+                // retain the constructor's OnBridge=false, so this height is
+                // above terrain, even when the cell contains a bridge.
                 let reached_distance = coord_distance(candidate, target_position);
-                if i64::from(reached_distance) * 2 <= i64::from(next_speed) {
+                let old_height = previous_position.z.wrapping_sub(projectile_ground_z(
+                    terrain,
+                    shared_cell_dummy,
+                    previous_position,
+                ));
+                let (admit_impact, snap_to_target) = homing_impact_admission(
+                    reached_distance,
+                    projectile.velocity,
+                    old_height,
+                    guidance.airburst,
+                    target_position != ProjectileCoord::new(0, 0, 0),
+                );
+                if admit_impact {
                     impact_flag = true;
-                    impact_reason = ProjectileDetonationReason::ReachedTarget;
-                    if !guidance.airburst {
+                    impact_reason = if old_height <= 0 {
+                        ProjectileDetonationReason::Collision
+                    } else {
+                        ProjectileDetonationReason::ReachedTarget
+                    };
+                    if snap_to_target {
                         snap_impact = Some(target_position);
                     }
                 }
@@ -1534,8 +1554,13 @@ impl ProjectileStore {
                 continue;
             }
 
-            let collision_impact =
-                collides_at(projectile, candidate).map(|response| match response {
+            // The homing arm's admitted impact bypasses the post-move probe
+            // (`0x00467BA4..0x00467BD1`). ROT<1 collision has its own earlier
+            // block and retains its existing callback order.
+            let collision_impact = (!(projectile.guidance.is_some() && impact_flag))
+                .then(|| collides_at(projectile, candidate))
+                .flatten()
+                .map(|response| match response {
                     ProjectileCollisionResponse::TargetZClamp(impact) => impact,
                     ProjectileCollisionResponse::SlopeMatrixReflect { impact, velocity } => {
                         projectile.velocity = velocity;
@@ -1546,6 +1571,17 @@ impl ProjectileStore {
                 impact_flag = true;
                 impact_reason = ProjectileDetonationReason::Collision;
                 snap_impact = Some(impact);
+            }
+
+            let mut impact = snap_impact.unwrap_or(candidate);
+            if projectile.guidance.is_some() && impact_flag {
+                // `0x00467BF0..0x00467C06`: the getter and, when negative,
+                // setter both query the committed coordinate before the fuse.
+                // The setter does not rewrite the stack coordinate used below.
+                let floor = projectile_ground_z(terrain, shared_cell_dummy, impact);
+                if impact.z.wrapping_sub(floor) < 0 {
+                    impact.z = projectile_ground_z(terrain, shared_cell_dummy, impact);
+                }
             }
 
             // `ProximityDetector::Check @ 0x004E11F0`. The reference is the
@@ -1560,13 +1596,17 @@ impl ProjectileStore {
                         guidance.fuse_reference
                     });
                 if projectile.arm_frames_remaining == 0 {
-                    let distance = coord_distance(candidate, reference);
+                    let distance = coord_distance(snap_impact.unwrap_or(candidate), reference);
                     let (mode, next_distance) =
                         ranged_fuse_distance_step(distance, projectile.last_distance_half);
                     projectile.last_distance_half = next_distance;
                     fuse_mode = mode;
                 }
             }
+            // `0x00467C3C..0x00467C66`: Bullet+0xB0 is the live firer,
+            // whose type +0xD94 (JumpJet) changes overshoot mode 2 into 1.
+            // Pointer cleanup can clear the source between flight visits.
+            fuse_mode = projectile_fuse_mode(fuse_mode, source_is_jumpjet);
 
             if !impact_flag && fuse_mode == 0 {
                 projectile.position = candidate;
@@ -1591,7 +1631,38 @@ impl ProjectileStore {
                 continue;
             }
 
-            let impact = snap_impact.unwrap_or(candidate);
+            if let Some(guidance) = projectile.guidance {
+                // `0x00467CA9..0x00467E4D`: a mode-1 fuse unconditionally
+                // selects target +0x48 after the Airburst/Inaccurate gates.
+                // Re-read a shared dummy here: earlier ground lookups may
+                // have stamped a different coordinate into that same target.
+                if fuse_mode == 1 && !guidance.airburst && !guidance.inaccurate {
+                    let location = match projectile.target {
+                        ProjectileTarget::Entity(id) => resolve_target_position(id),
+                        ProjectileTarget::Cell { rx, ry } => {
+                            let mut location = cell_target_coord(terrain, rx, ry);
+                            location.z = projectile_ground_z(terrain, shared_cell_dummy, location);
+                            Some(location)
+                        }
+                        ProjectileTarget::DummyCell => {
+                            let mut location = dummy_cell_target_coord(shared_cell_dummy);
+                            let snapshot = shared_cell_dummy.snapshot();
+                            location.z = crate::util::lepton::ground_height_leptons(
+                                snapshot.level as u8,
+                                snapshot.slope_type,
+                                location.x,
+                                location.y,
+                            )
+                            .expect("shared CellClass target must have a supported slope");
+                            Some(location)
+                        }
+                        ProjectileTarget::None => None,
+                    };
+                    if let Some(location) = location {
+                        impact = location;
+                    }
+                }
+            }
             let reason = if impact_flag {
                 impact_reason
             } else {
@@ -1637,6 +1708,63 @@ fn coord_distance(a: ProjectileCoord, b: ProjectileCoord) -> i32 {
     let dy = f64::from(a.y - b.y);
     let dz = f64::from(a.z - b.z);
     (dx * dx + dy * dy + dz * dz).sqrt().trunc() as i32
+}
+
+/// `CellClass::GetGroundHeight @ 0x00578080`: signed /256, fixed-512
+/// allocation lookup, and live shared-dummy fallback, evaluated at the original
+/// lepton XY. The fallback stamp is observable by a retained DummyCell target.
+fn projectile_ground_z(
+    terrain: Option<&ResolvedTerrainGrid>,
+    shared_cell_dummy: &SharedCellDummy,
+    coord: ProjectileCoord,
+) -> i32 {
+    use crate::sim::cell_rect::{CellRef, get_cellclass_fallback_leptons};
+    let (level, slope) = if let Some(terrain) = terrain {
+        match get_cellclass_fallback_leptons(Some(terrain), coord.x, coord.y) {
+            CellRef::Real(cell) => (cell.level, cell.slope_type),
+            CellRef::Dummy { cell } => {
+                let snapshot = cell.snapshot();
+                (snapshot.level as u8, snapshot.slope_type)
+            }
+        }
+    } else {
+        shared_cell_dummy.stamp_coord(coord.x / 256, coord.y / 256);
+        let snapshot = shared_cell_dummy.snapshot();
+        (snapshot.level as u8, snapshot.slope_type)
+    };
+    crate::util::lepton::ground_height_leptons(level, slope, coord.x, coord.y)
+        .expect("projectile ground probe requires a supported CellClass slope")
+}
+
+/// `BulletClass::AI 0x00466DB1..0x00466E6B`, with its already-computed
+/// distance, represented velocity and OLD ObjectClass height as inputs.
+/// Native retains a double vector; upstream VERA flight still quantizes its
+/// components, an open trajectory discrepancy rather than a scalar-speed
+/// substitute at this predicate.
+fn homing_impact_admission(
+    distance: i32,
+    velocity: ProjectileVelocity,
+    old_height: i32,
+    airburst: bool,
+    nonzero_target: bool,
+) -> (bool, bool) {
+    let x = f64::from(velocity.x);
+    let y = f64::from(velocity.y);
+    let z = f64::from(velocity.z);
+    let half_speed = (x * x + y * y + z * z).sqrt() * 0.5;
+    let impact = f64::from(distance) <= half_speed || old_height <= 0;
+    (
+        impact,
+        impact && old_height > 0 && !airburst && nonzero_target,
+    )
+}
+
+fn projectile_fuse_mode(detector_mode: i32, source_is_jumpjet: bool) -> i32 {
+    if source_is_jumpjet && detector_mode == 2 {
+        1
+    } else {
+        detector_mode
+    }
 }
 
 /// `CellClass::GetGroundHeight` at a lepton coordinate, or `None` when the
@@ -1806,6 +1934,104 @@ fn detonation(
 mod tests {
     use super::*;
 
+    #[test]
+    fn homing_impact_admission_matches_executed_retail_vectors() {
+        let vectors: serde_json::Value = serde_json::from_str(include_str!(
+            "../../tools/projectile_oracle/homing_impact_vectors.json"
+        ))
+        .unwrap();
+        for row in vectors["admissions"].as_array().unwrap() {
+            let (admit, snap) = homing_impact_admission(
+                row["distance"].as_i64().unwrap() as i32,
+                ProjectileVelocity::new(
+                    row["velocity"][0].as_i64().unwrap() as i32,
+                    row["velocity"][1].as_i64().unwrap() as i32,
+                    row["velocity"][2].as_i64().unwrap() as i32,
+                ),
+                row["height"].as_i64().unwrap() as i32,
+                row["airburst"].as_bool().unwrap(),
+                !row["empty_target"].as_bool().unwrap(),
+            );
+            assert_eq!(admit, row["impact"].as_bool().unwrap(), "{row}");
+            let candidate = if snap {
+                [640, 128, 624]
+            } else {
+                [504, 128, 207]
+            };
+            assert_eq!(serde_json::json!(candidate), row["candidate"], "{row}");
+        }
+    }
+
+    #[test]
+    fn homing_impact_handoff_matches_executed_retail_vectors() {
+        let vectors: serde_json::Value = serde_json::from_str(include_str!(
+            "../../tools/projectile_oracle/homing_impact_vectors.json"
+        ))
+        .unwrap();
+        for row in vectors["handoffs"].as_array().unwrap() {
+            let height = row["height"].as_i64().unwrap() as i32;
+            let mode = row["fuse_mode"].as_i64().unwrap();
+            let mut shot = guided_spawn(4, 0);
+            shot.origin = ProjectileCoord::new(500, 128, 208 + height);
+            shot.speed_leptons_per_frame = 4;
+            shot.initial_target_position = ProjectileCoord::new(640, 128, 208);
+            shot.target = if row["target_present"].as_bool().unwrap() {
+                ProjectileTarget::Entity(42)
+            } else {
+                ProjectileTarget::None
+            };
+            shot.ranged_fuse = true;
+            let guidance = shot.guidance.as_mut().unwrap();
+            guidance.rot = 0; // Keep the externally supplied candidate fixed.
+            guidance.airburst = row["airburst"].as_bool().unwrap();
+            guidance.inaccurate = row["inaccurate"].as_bool().unwrap();
+            guidance.fuse_reference = ProjectileCoord::new(
+                match mode {
+                    1 => 504,
+                    2 => 604,
+                    _ => 4000,
+                },
+                128,
+                208 + height,
+            );
+            let dummy = SharedCellDummy::fresh();
+            dummy.set_level_slope(2, 0);
+            let mut store = ProjectileStore::new();
+            let id = store.spawn(1, shot);
+            store.projectiles.get_mut(&id).unwrap().last_distance_half = 0;
+            let targets = BTreeMap::from([(42, ProjectileCoord::new(640, 128, 208))]);
+            let result = store.advance(0, &targets, None, &dummy, |_, candidate| {
+                Some(ProjectileCollisionResponse::TargetZClamp(candidate))
+            });
+            let impact = result.detonations[0].impact;
+            assert_eq!(
+                serde_json::json!([impact.x, impact.y, impact.z]),
+                row["impact"],
+                "{row}"
+            );
+        }
+    }
+
+    #[test]
+    fn homing_source_fuse_mode_matches_executed_retail_vectors() {
+        let vectors: serde_json::Value = serde_json::from_str(include_str!(
+            "../../tools/projectile_oracle/homing_impact_vectors.json"
+        ))
+        .unwrap();
+        for row in vectors["source_modes"].as_array().unwrap() {
+            let mode = projectile_fuse_mode(
+                row["detector_mode"].as_i64().unwrap() as i32,
+                row["source_present"].as_bool().unwrap()
+                    && row["source_jumpjet"].as_bool().unwrap(),
+            );
+            assert_eq!(
+                i64::from(mode),
+                row["admitted_mode"].as_i64().unwrap(),
+                "{row}"
+            );
+        }
+    }
+
     fn spawn(target: ProjectileTarget) -> ProjectileSpawn {
         ProjectileSpawn {
             source_id: 7,
@@ -1897,12 +2123,14 @@ mod tests {
     fn guided_projectile_turns_with_persisted_rot_state() {
         let mut store = ProjectileStore::new();
         let mut guided = spawn(ProjectileTarget::Cell { rx: 0, ry: 4 });
+        guided.origin.z = 1; // Steering fixture: above the native ground-impact plane.
         guided.guidance = Some(ProjectileGuidance {
             rot: 4,
             missile_rot_var: SimFixed::from_num(0),
             course_lock_duration: 0,
             sidewinder_phase: 0,
             airburst: false,
+            inaccurate: false,
             very_high: true,
             level: false,
             heading_bam: 0,
@@ -2307,6 +2535,7 @@ mod tests {
 
     fn guided_spawn(max_speed: u16, acceleration: i32) -> ProjectileSpawn {
         let mut spawn = spawn(ProjectileTarget::Entity(42));
+        spawn.origin.z = 1; // Flight/fuse fixtures must not start in ground contact.
         spawn.speed_leptons_per_frame = 1;
         spawn.velocity = ProjectileVelocity::new(1, 0, 0);
         spawn.guidance = Some(ProjectileGuidance {
@@ -2315,6 +2544,7 @@ mod tests {
             course_lock_duration: 0,
             sidewinder_phase: 0,
             airburst: false,
+            inaccurate: false,
             very_high: false,
             level: false,
             heading_bam: 0,
@@ -2342,12 +2572,12 @@ mod tests {
         store.advance(0, &targets, None, &SharedCellDummy::fresh(), |_, _| None);
         let after_one = store.get(id).expect("missile still flying");
         assert_eq!(after_one.speed_leptons_per_frame, 4);
-        assert_eq!(after_one.position, ProjectileCoord::new(4, 0, 0));
+        assert_eq!(after_one.position, ProjectileCoord::new(4, 0, 1));
 
         store.advance(1, &targets, None, &SharedCellDummy::fresh(), |_, _| None);
         let after_two = store.get(id).expect("missile still flying");
         assert_eq!(after_two.speed_leptons_per_frame, 7);
-        assert_eq!(after_two.position, ProjectileCoord::new(11, 0, 0));
+        assert_eq!(after_two.position, ProjectileCoord::new(11, 0, 1));
     }
 
     /// With `CourseLockDuration = 0` and `MaxSpeed < 40` the lock survives, and

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -397,7 +397,11 @@ use crate::sim::world::Simulation;
 // 122 `origin/feature/phase3-map-spatial-integration`;
 // nothing else claims 123. Whoever resolves a `snapshot.rs` merge conflict
 // here must re-run that survey rather than picking a side.
-const SNAPSHOT_VERSION: u32 = 123;
+// v126 adds the retained homing Inaccurate flag, consumed by BulletClass's
+// final impact-coordinate snap. v123 cannot decode the new guidance shape.
+// Versions 124 and 125 are reserved by the concurrent parasite and audio-lane
+// changes, respectively; this format must not share either version.
+const SNAPSHOT_VERSION: u32 = 126;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -3147,9 +3151,11 @@ mod tests {
     /// `origin/feature/phase3-map-spatial-close`, 122
     /// `origin/feature/phase3-map-spatial-integration` — and two branches
     /// sharing one version number defeat the mismatch guard entirely.
+    /// 123 -> 126 adds the retained homing Inaccurate flag; 124 and 125 are
+    /// reserved by the concurrent parasite and audio-lane changes.
     #[test]
-    fn combat_explosion_anim_snapshot_version_is_123() {
-        assert_eq!(super::SNAPSHOT_VERSION, 123);
+    fn projectile_homing_impact_snapshot_version_is_126() {
+        assert_eq!(super::SNAPSHOT_VERSION, 126);
     }
 
     #[test]

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -3806,6 +3806,9 @@ fn gsi_05_04_guided_projectile(
     initial_target_position: ProjectileCoord,
 ) -> ProjectileSpawn {
     let mut spawn = gsi_05_02_projectile(source_id, None);
+    // These fixtures test pointer lifetime/steering, above the native ground
+    // impact plane (including their level-2 terrain). Impact tests override it.
+    spawn.origin.z = 1000;
     spawn.target = target;
     spawn.initial_target_position = initial_target_position;
     spawn.guidance = Some(ProjectileGuidance {
@@ -3814,6 +3817,7 @@ fn gsi_05_04_guided_projectile(
         course_lock_duration: 0,
         sidewinder_phase: 0,
         airburst: false,
+        inaccurate: false,
         very_high: false,
         level: false,
         heading_bam: 0,
@@ -3827,6 +3831,160 @@ fn gsi_05_04_guided_projectile(
     spawn.tracks_target = true;
     spawn.target_expiry = TargetExpiryPolicy::DetonateAtLastKnown;
     spawn
+}
+
+#[test]
+fn homing_ground_impact_reaches_damage_and_cleanup_through_runtime_frame() {
+    use crate::rules::ini_parser::IniFile;
+    use crate::rules::ruleset::RuleSet;
+    use crate::sim::runtime::SimRuntime;
+
+    // Retail AAHeatSeeker2's active ROT/Arm/collision policy, with a one-point
+    // wall receiver to expose the final impact cell and ground-layer handoff.
+    let ini = IniFile::from_str(
+        "[VehicleTypes]\n0=MTNK\n[MTNK]\nJumpJet=yes\nStrength=100\n\
+         [Warheads]\n0=WALLWH\n[OverlayTypes]\n0=GAWALL\n\
+         [WALLWH]\nWall=yes\nCellSpread=0\nPercentAtMax=1\n\
+         Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+         [GAWALL]\nWall=yes\nStrength=1\n",
+    );
+    let art = IniFile::from_str("[GAWALL]\nDamageLevels=4\n");
+    for (old_height, with_source, expire_source) in [
+        (0, false, false),
+        (1, false, false),
+        (0, true, false),
+        (0, true, true),
+    ] {
+        let mut sim = Simulation::new();
+        install_common_raw_terrain(&mut sim, 16, 16, 2, None);
+        let mut overlays = crate::sim::overlay_grid::OverlayGrid::new(16, 16);
+        overlays.place_overlay(5, 5, 0, 0);
+        overlays.place_overlay(12, 5, 0, 0);
+        let _ = overlays.take_dirty_cells();
+        sim.overlay_grid = Some(overlays);
+        let origin = ProjectileCoord::new(5 * 256 + 128, 5 * 256 + 128, 208 + old_height);
+        let mut shot = gsi_05_04_guided_projectile(
+            crate::sim::combat::RAD_NO_ATTACKER,
+            ProjectileTarget::Cell { rx: 12, ry: 5 },
+            ProjectileCoord::new(12 * 256 + 128, 5 * 256 + 128, 208),
+        );
+        shot.origin = origin;
+        shot.speed_leptons_per_frame = 4;
+        shot.velocity = ProjectileVelocity::new(4, 0, -2);
+        shot.arm_frames = 2;
+        shot.ranged_fuse = true;
+        let guidance = shot.guidance.as_mut().unwrap();
+        guidance.max_speed = 4;
+        guidance.fuse_reference = shot.initial_target_position;
+        let source_id = if with_source {
+            let source_id = sim.allocate_stable_id();
+            insert_entity(&mut sim, source_id, EntityCategory::Unit);
+            let type_ref = sim.interner.intern("MTNK");
+            sim.substrate.entities.get_mut(source_id).unwrap().type_ref = type_ref;
+            shot.source_id = source_id;
+            shot.arm_frames = 0;
+            guidance.fuse_reference = ProjectileCoord::new(origin.x + 104, origin.y, origin.z - 2);
+            Some(source_id)
+        } else {
+            None
+        };
+        shot.payload = ProjectilePayload {
+            base_damage: 1,
+            warhead: sim.interner.intern("WALLWH"),
+            weapon: sim.interner.intern("MISSINGWEAPON"),
+            owner: sim.interner.intern("Americans"),
+        };
+        let id = sim.allocate_stable_id();
+        sim.admit_projectile(id, shot);
+        if with_source {
+            sim.projectiles.get_mut(id).unwrap().last_distance_half = 0;
+        }
+        if expire_source {
+            sim.uninit(source_id.unwrap());
+            assert_eq!(
+                sim.projectiles.get(id).unwrap().source_id,
+                crate::sim::combat::RAD_NO_ATTACKER
+            );
+        }
+        let mut runtime = SimRuntime::from_simulation(sim);
+        runtime.resources.rules = RuleSet::from_ini(&ini).unwrap();
+        runtime.resources.overlay_registry =
+            crate::map::overlay_types::OverlayTypeRegistry::from_ini(&ini, Some(&art));
+
+        let _ = runtime.advance_frame(&[], 16, super::TickLane::Ordinary);
+        if old_height == 1 {
+            let bullet = runtime.simulation.projectiles.get(id).expect(
+                "crossing below ground does not trigger the OLD-height predicate until next visit",
+            );
+            assert!(bullet.in_logic_vector);
+            assert_eq!(bullet.position.z, 207);
+            assert_eq!(
+                runtime
+                    .simulation
+                    .overlay_grid
+                    .as_ref()
+                    .unwrap()
+                    .cell(5, 5)
+                    .overlay_data,
+                0
+            );
+            let _ = runtime.advance_frame(&[], 16, super::TickLane::Ordinary);
+        }
+        assert!(runtime.simulation.projectiles.get(id).is_none());
+        let hits_target = with_source && !expire_source;
+        let overlays = runtime.simulation.overlay_grid.as_ref().unwrap();
+        assert_eq!(
+            overlays.cell(5, 5).overlay_data,
+            if hits_target { 0 } else { 0x10 }
+        );
+        assert_eq!(
+            overlays.cell(12, 5).overlay_data,
+            if hits_target { 0x10 } else { 0 },
+            "only a still-live JumpJet firer converts overshoot mode2 to the target-location mode1 snap"
+        );
+        assert!(
+            runtime.simulation.pending_projectile_detonations.is_empty(),
+            "production commits in the Bullet slot, with no test-only pending handoff"
+        );
+    }
+}
+
+#[test]
+fn homing_mode_one_fuse_snaps_to_cell_location_below_bridge_aim_point() {
+    let mut sim = Simulation::new();
+    install_common_raw_terrain(&mut sim, 16, 16, 2, Some((5, 5)));
+    let aim = cell_target_coord(sim.resolved_terrain.as_ref(), 5, 5);
+    assert_eq!(aim.z, 624);
+    let mut shot = gsi_05_04_guided_projectile(
+        crate::sim::combat::RAD_NO_ATTACKER,
+        ProjectileTarget::Cell { rx: 5, ry: 5 },
+        aim,
+    );
+    shot.origin = ProjectileCoord::new(4 * 256 + 128, 5 * 256 + 128, 400);
+    shot.speed_leptons_per_frame = 4;
+    shot.velocity = ProjectileVelocity::new(4, 0, 0);
+    shot.ranged_fuse = true;
+    let guidance = shot.guidance.as_mut().unwrap();
+    guidance.max_speed = 4;
+    guidance.fuse_reference = shot.origin;
+    let id = sim.allocate_stable_id();
+    sim.admit_projectile(id, shot);
+    let result = sim.projectiles.advance(
+        0,
+        &BTreeMap::new(),
+        sim.resolved_terrain.as_ref(),
+        &sim.shared_cell_dummy,
+        |_, _| None,
+    );
+    assert_eq!(result.detonations.len(), 1);
+    assert_eq!(
+        result.detonations[0].impact,
+        ProjectileCoord::new(aim.x, aim.y, 208)
+    );
+    assert_eq!(
+        result.detonations[0].reason,
+        crate::sim::projectile::ProjectileDetonationReason::Fuse
+    );
 }
 
 fn gsi_05_02_mixed_fixture() -> (Simulation, [u64; 6]) {
@@ -4907,7 +5065,7 @@ fn gsi_05_04_high_flying_source_and_target_become_explicit_null() {
         ProjectileTarget::Entity(target_id),
         ProjectileCoord::new(13 * 256 + 128, 15 * 256 + 64, 208),
     );
-    spawn.origin = ProjectileCoord::new(1024, 1024, 0);
+    spawn.origin = ProjectileCoord::new(1024, 1024, 1000);
     sim.admit_projectile(projectile_id, spawn);
     sim.lifecycle_test_events.clear();
 

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -268,7 +268,19 @@ impl Simulation {
             );
             return true;
         }
-        if self.projectiles.get(id).is_some() {
+        if let Some(projectile) = self.projectiles.get(id) {
+            // BulletClass::AI @ 0x00467C3C reads the live firer (+0xB0),
+            // then its +0x84 TechnoType receiver and JumpJet (+0xD94).
+            // Do not cache this on launch: PointerExpired can null the firer.
+            let source_is_jumpjet = rules.is_some_and(|rules| {
+                self.substrate
+                    .entities
+                    .get(projectile.source_id)
+                    .is_some_and(|source| {
+                        self.object_type(source.type_ref, rules)
+                            .is_some_and(|kind| kind.jumpjet)
+                    })
+            });
             // `BulletClass::AI 0x0046699D` reads the GLOBAL frame counter's
             // parity for the half-rate course-locked acceleration ramp, so the
             // Logic slot has to hand the flight loop the current frame.
@@ -299,6 +311,7 @@ impl Simulation {
                     },
                     terrain,
                     &shared_cell_dummy,
+                    source_is_jumpjet,
                     |projectile, candidate| {
                         super::projectile_collides_at(
                             terrain,

--- a/tools/projectile_oracle/homing_impact.py
+++ b/tools/projectile_oracle/homing_impact.py
@@ -1,0 +1,140 @@
+"""Execute retail BulletClass AI admission/clamp/snap instruction ranges.
+
+Only external floor and target-coordinate inputs are supplied by hooks; the
+branching, ObjectClass height getter/setter, and Bullet coordinate setter run
+the original executable bytes. This does not certify the upstream homing
+trajectory, target-coordinate producers, or downstream warhead implementation.
+"""
+
+import hashlib
+import json
+import struct
+from pathlib import Path
+
+from unicorn import Uc, UC_ARCH_X86, UC_MODE_32, UC_HOOK_CODE
+from unicorn.x86_const import (
+    UC_X86_REG_EAX, UC_X86_REG_EBP, UC_X86_REG_EBX, UC_X86_REG_ECX,
+    UC_X86_REG_EIP, UC_X86_REG_ESI, UC_X86_REG_ESP, UC_X86_REG_FPCW,
+)
+
+from tools.rmg_oracle.harness import _load_image, GAMEMD, NATIVE_FPCW
+
+BASE = 0x20000000
+SP = BASE + 0xE000
+BULLET, TYPE, TARGET, TARGET_VTABLE = BASE, BASE + 0x1000, BASE + 0x2000, BASE + 0x3000
+TARGET_AIM, TARGET_LOCATION = BASE + 0x4000, BASE + 0x4010
+SOURCE, SOURCE_VTABLE, SOURCE_TYPE, SOURCE_GET_TYPE = BASE + 0x5000, BASE + 0x6000, BASE + 0x7000, BASE + 0x4020
+
+
+def write_i32(uc, address, value):
+    uc.mem_write(address, struct.pack("<I", value & 0xFFFFFFFF))
+
+
+def read_i32(uc, address):
+    return struct.unpack("<i", uc.mem_read(address, 4))[0]
+
+
+def coord(uc, address):
+    return list(struct.unpack("<iii", uc.mem_read(address, 12)))
+
+
+def setup(old_height, candidate_z, airburst, inaccurate, target_present=True):
+    uc = Uc(UC_ARCH_X86, UC_MODE_32)
+    _load_image(uc)
+    uc.mem_map(BASE, 0x10000)
+    uc.reg_write(UC_X86_REG_ESP, SP)
+    uc.reg_write(UC_X86_REG_EBP, BULLET)
+    uc.reg_write(UC_X86_REG_EBX, BULLET + 0xE8)
+    uc.reg_write(UC_X86_REG_FPCW, NATIVE_FPCW)
+    write_i32(uc, BULLET, 0x007E46E4)
+    write_i32(uc, BULLET + 0xAC, TYPE)
+    write_i32(uc, BULLET + 0x10C, TARGET if target_present else 0)
+    uc.mem_write(BULLET + 0x9C, struct.pack("<iii", 500, 128, 208 + old_height))
+    uc.mem_write(BULLET + 0xE8, struct.pack("<ddd", 4.0, 0.0, 0.0))
+    uc.mem_write(TYPE + 0x294, bytes([airburst]))
+    uc.mem_write(TYPE + 0x2A2, bytes([inaccurate]))
+    uc.mem_write(SP + 0x24, struct.pack("<iii", 504, 128, candidate_z))
+    uc.mem_write(SP + 0x30, struct.pack("<iii", 640, 128, 624))
+    write_i32(uc, TARGET, TARGET_VTABLE)
+    write_i32(uc, TARGET_VTABLE + 0x58, TARGET_AIM)
+    write_i32(uc, TARGET_VTABLE + 0x48, TARGET_LOCATION)
+    floor_queries = []
+
+    def hook(uc, address, size, user):
+        sp = uc.reg_read(UC_X86_REG_ESP)
+        if address == 0x00578080:
+            argument = read_i32(uc, sp + 4)
+            floor_queries.append(coord(uc, argument))
+            uc.reg_write(UC_X86_REG_EAX, 208)
+            uc.reg_write(UC_X86_REG_EIP, read_i32(uc, sp))
+            uc.reg_write(UC_X86_REG_ESP, sp + 8)
+        elif address in (TARGET_AIM, TARGET_LOCATION):
+            argument = read_i32(uc, sp + 4)
+            result = (640, 128, 624 if address == TARGET_AIM else 208)
+            uc.mem_write(argument, struct.pack("<iii", *result))
+            uc.reg_write(UC_X86_REG_EAX, argument)
+            uc.reg_write(UC_X86_REG_EIP, read_i32(uc, sp))
+            uc.reg_write(UC_X86_REG_ESP, sp + 8)
+        elif address == SOURCE_GET_TYPE:
+            uc.reg_write(UC_X86_REG_EAX, SOURCE_TYPE)
+            uc.reg_write(UC_X86_REG_EIP, read_i32(uc, sp))
+            uc.reg_write(UC_X86_REG_ESP, sp + 4)
+
+    uc.hook_add(UC_HOOK_CODE, hook)
+    return uc, floor_queries
+
+
+def main():
+    admissions = []
+    for velocity in [(4, 0, 0), (3, 4, 0), (0, 0, 4), (3, 4, 12)]:
+        for height in (-1, 0, 1):
+            for distance in (1, 2, 3, 6, 7, 1000):
+                for airburst in (False, True):
+                    for empty_target in (False, True):
+                        uc, queries = setup(height, 207, airburst, False)
+                        uc.mem_write(BULLET + 0xE8, struct.pack("<ddd", *velocity))
+                        write_i32(uc, SP + 0x10, distance)
+                        if empty_target:
+                            uc.mem_write(SP + 0x30, bytes(12))
+                        uc.emu_start(0x00466DB1, 0x00466E6B, count=10000)
+                        admissions.append(dict(height=height, distance=distance, velocity=velocity,
+                            airburst=airburst, empty_target=empty_target,
+                            impact=bool(uc.mem_read(SP + 0x18, 1)[0]),
+                            candidate=coord(uc, SP + 0x24), floor_queries=queries))
+    handoffs = []
+    for height in (-1, 0, 1):
+        for mode in (0, 1, 2):
+            for airburst in (False, True):
+                for inaccurate in (False, True):
+                    for present in (False, True):
+                        uc, queries = setup(height, 208 + height, airburst, inaccurate, present)
+                        uc.mem_write(BULLET + 0x9C, struct.pack("<iii", 504, 128, 208 + height))
+                        uc.emu_start(0x00467BF0, 0x00467C0C, count=10000)
+                        write_i32(uc, SP + 0x60, mode)
+                        uc.emu_start(0x00467CA9, 0x00467E53, count=10000)
+                        handoffs.append(dict(height=height, fuse_mode=mode, airburst=airburst,
+                            inaccurate=inaccurate, target_present=present,
+                            impact=coord(uc, BULLET + 0x9C), floor_queries=queries))
+    source_modes = []
+    for present in (False, True):
+        for jumpjet in (False, True):
+            for mode in (0, 1, 2):
+                uc, _ = setup(1, 209, False, False)
+                write_i32(uc, BULLET + 0xB0, SOURCE if present else 0)
+                write_i32(uc, SOURCE, SOURCE_VTABLE)
+                write_i32(uc, SOURCE_VTABLE + 0x84, SOURCE_GET_TYPE)
+                uc.mem_write(SOURCE_TYPE + 0xD94, bytes([jumpjet]))
+                uc.reg_write(UC_X86_REG_ESI, mode)
+                uc.emu_start(0x00467C3C, 0x00467C6A, count=10000)
+                source_modes.append(dict(source_present=present, source_jumpjet=jumpjet,
+                    detector_mode=mode, admitted_mode=uc.reg_read(UC_X86_REG_ESI)))
+    output = dict(binary_sha256=hashlib.sha256(GAMEMD.read_bytes()).hexdigest(),
+        coverage="admission 0x466DB1..0x466E6B; common impact clamp 0x467BF0..0x467C0C; mode1 final snap 0x467CA9..0x467E53 (near-object flag zero)",
+        admissions=admissions, handoffs=handoffs, source_modes=source_modes)
+    path = Path(__file__).parent / "homing_impact_vectors.json"
+    path.write_text(json.dumps(output, indent=2) + "\n")
+    print(f"Wrote {len(admissions)} admission and {len(handoffs)} handoff vectors: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/projectile_oracle/homing_impact_vectors.json
+++ b/tools/projectile_oracle/homing_impact_vectors.json
@@ -1,0 +1,9042 @@
+{
+  "binary_sha256": "1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c",
+  "coverage": "admission 0x466DB1..0x466E6B; common impact clamp 0x467BF0..0x467C0C; mode1 final snap 0x467CA9..0x467E53 (near-object flag zero)",
+  "admissions": [
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        640,
+        128,
+        624
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        640,
+        128,
+        624
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        4,
+        0,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        640,
+        128,
+        624
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        640,
+        128,
+        624
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        0
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        640,
+        128,
+        624
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        640,
+        128,
+        624
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        0,
+        0,
+        4
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          207
+        ],
+        [
+          500,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          208
+        ],
+        [
+          500,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        640,
+        128,
+        624
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        640,
+        128,
+        624
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 2,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        640,
+        128,
+        624
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 3,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        640,
+        128,
+        624
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 6,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": true,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 7,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": false,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": false,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "distance": 1000,
+      "velocity": [
+        3,
+        4,
+        12
+      ],
+      "airburst": true,
+      "empty_target": true,
+      "impact": false,
+      "candidate": [
+        504,
+        128,
+        207
+      ],
+      "floor_queries": [
+        [
+          500,
+          128,
+          209
+        ]
+      ]
+    }
+  ],
+  "handoffs": [
+    {
+      "height": -1,
+      "fuse_mode": 0,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 0,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 0,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 0,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 0,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 0,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 0,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 0,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 1,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 1,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        640,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 1,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 1,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 1,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 1,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 1,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 1,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 2,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 2,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 2,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 2,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 2,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 2,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 2,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": -1,
+      "fuse_mode": 2,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          207
+        ],
+        [
+          504,
+          128,
+          207
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 0,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 0,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 0,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 0,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 0,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 0,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 0,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 0,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 1,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 1,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        640,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 1,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 1,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 1,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 1,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 1,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 1,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 2,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 2,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 2,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 2,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 2,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 2,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 2,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 0,
+      "fuse_mode": 2,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          208
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 0,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 0,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 0,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 0,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 0,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 0,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 0,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 0,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 1,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 1,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        640,
+        128,
+        208
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 1,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 1,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 1,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 1,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 1,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 1,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 2,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 2,
+      "airburst": false,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 2,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 2,
+      "airburst": false,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 2,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 2,
+      "airburst": true,
+      "inaccurate": false,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 2,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": false,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    },
+    {
+      "height": 1,
+      "fuse_mode": 2,
+      "airburst": true,
+      "inaccurate": true,
+      "target_present": true,
+      "impact": [
+        504,
+        128,
+        209
+      ],
+      "floor_queries": [
+        [
+          504,
+          128,
+          209
+        ]
+      ]
+    }
+  ],
+  "source_modes": [
+    {
+      "source_present": false,
+      "source_jumpjet": false,
+      "detector_mode": 0,
+      "admitted_mode": 0
+    },
+    {
+      "source_present": false,
+      "source_jumpjet": false,
+      "detector_mode": 1,
+      "admitted_mode": 1
+    },
+    {
+      "source_present": false,
+      "source_jumpjet": false,
+      "detector_mode": 2,
+      "admitted_mode": 2
+    },
+    {
+      "source_present": false,
+      "source_jumpjet": true,
+      "detector_mode": 0,
+      "admitted_mode": 0
+    },
+    {
+      "source_present": false,
+      "source_jumpjet": true,
+      "detector_mode": 1,
+      "admitted_mode": 1
+    },
+    {
+      "source_present": false,
+      "source_jumpjet": true,
+      "detector_mode": 2,
+      "admitted_mode": 2
+    },
+    {
+      "source_present": true,
+      "source_jumpjet": false,
+      "detector_mode": 0,
+      "admitted_mode": 0
+    },
+    {
+      "source_present": true,
+      "source_jumpjet": false,
+      "detector_mode": 1,
+      "admitted_mode": 1
+    },
+    {
+      "source_present": true,
+      "source_jumpjet": false,
+      "detector_mode": 2,
+      "admitted_mode": 2
+    },
+    {
+      "source_present": true,
+      "source_jumpjet": true,
+      "detector_mode": 0,
+      "admitted_mode": 0
+    },
+    {
+      "source_present": true,
+      "source_jumpjet": true,
+      "detector_mode": 1,
+      "admitted_mode": 1
+    },
+    {
+      "source_present": true,
+      "source_jumpjet": true,
+      "detector_mode": 2,
+      "admitted_mode": 1
+    }
+  ]
+}


### PR DESCRIPTION
Homing missiles now use the bullet's pre-move floor-relative height to admit ground contact, then deliver the native committed-height clamp and final target-location selection through the live projectile visitor. This fixes missed ground impacts and distinguishes a bridge cell's raw location from its elevated aim point. The live firer's JumpJet flag converts fuse mode 2 to 1; Airburst and Inaccurate gate the final snap.

Native evidence: BulletClass AI 0x00466DB1–0x00466E6B and 0x00467BF0–0x00467E53, ObjectClass GetHeight/SetHeight/SetCoords at 0x005F5F40/0x005F5FA0/0x005F6940, CellClass slots 0x00486840/0x00486890, TechnoType JumpJet parser 0x007151EC–0x00715200, and LogicClass dispatch at 0x0055AFB0. Independent review read the bodies, callers, receivers, and runtime delivery. An executable retail oracle supplies 288 admission, 72 handoff, and 12 source-mode vectors. Snapshot version 126 avoids incompatible local formats 124 and 125.

Validation: homing-focused tests 41 passed; projectile tests 28 passed; lifecycle tests 129 passed; full `cargo test -p vera20k --lib`: 8271 passed, 0 failed, 78 ignored. After the version-only correction, `cargo test -p vera20k --lib sim::snapshot::tests::`: 83 passed, 0 failed.

The actual SimRuntime frame regressions exercise damage, cleanup, live firer expiry, and bridge-cell target selection. Oracle coverage is limited to its instruction ranges and controlled external inputs. Native double trajectory/pitch, target-coordinate producers, bridge flight, shared collision probe, and ballistic admission remain open; this does not close GSI-08.07 or GSI-08.08.

