### PR TITLE
Reload the skirmish ore growth timer at ftol(Growth x 0.3)

### DIFF
--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -1488,6 +1488,10 @@ impl MapLoadInitial {
             theater: map_data.header.theater.clone(),
             game_mode_nonzero: true,
             no_damage: false,
+            // Skirmish start forces `TiberiumGrows|TiberiumSpreads` (`OR 0xC0`
+            // at `0x005E74CD`), copied into the scenario at `0x00687C23`.
+            tiberium_grows_flag: true,
+            tiberium_spreads_flag: true,
             map_width: resolved_terrain.width(),
             map_height: resolved_terrain.height(),
             local_left: map_data.header.local_left as u16,
@@ -2269,6 +2273,10 @@ pub(crate) fn load_map_from_initial(
         // Campaign/editor reads `[SpecialFlags] Inert=`. Nonzero game modes
         // replace active SpecialFlags from session staging.
         no_damage: false,
+        // Skirmish start forces `TiberiumGrows|TiberiumSpreads` (`OR 0xC0`
+        // at `0x005E74CD`), copied into the scenario at `0x00687C23`.
+        tiberium_grows_flag: true,
+        tiberium_spreads_flag: true,
         // Native Resize constructs a square cell-array extent of SizeW+SizeH.
         map_width: scenario_cell_extent,
         map_height: scenario_cell_extent,

--- a/src/headless_scenario.rs
+++ b/src/headless_scenario.rs
@@ -265,6 +265,10 @@ pub fn load(retail_dir: &Path, map_file_name: &str, seed: u32) -> Result<Headles
         theater: map.header.theater.clone(),
         game_mode_nonzero: true,
         no_damage: false,
+        // Skirmish start forces `TiberiumGrows|TiberiumSpreads` (`OR 0xC0`
+        // at `0x005E74CD`), copied into the scenario at `0x00687C23`.
+        tiberium_grows_flag: true,
+        tiberium_spreads_flag: true,
         map_width: scenario_cell_extent,
         map_height: scenario_cell_extent,
         local_left: map.header.local_left as u16,

--- a/src/sim/ore_growth.rs
+++ b/src/sim/ore_growth.rs
@@ -2,10 +2,13 @@
 //!
 //! The active YR per-type queues read and write `OverlayGrid` directly. The
 //! older scan/reservoir path remains only for tests without native registries.
-//! All tuning comes from INI files:
-//! - rules.ini [General]: GrowthRate, TiberiumGrows, TiberiumSpreads
-//! - map INI [Basic]: TiberiumGrowthEnabled
-//! - map INI [SpecialFlags]: TiberiumGrows, TiberiumSpreads
+//! Native gates (see [`OreGrowthConfig::resolve`]):
+//! - map INI [Basic] `TiberiumGrowthEnabled` (`ScenarioClass+0x34A6`) gates
+//!   both per-type drivers;
+//! - `ScenarioClass` flags bits `0x40`/`0x80` (`TiberiumGrows`/
+//!   `TiberiumSpreads`): forced on at every skirmish/multiplayer start, read
+//!   from the map `[SpecialFlags]` only in GameMode 0;
+//! - rules.ini [General] `GrowthRate` drives only the legacy scan fallback.
 //!
 //! ## Algorithm (matching RA1 MapClass::Logic)
 //! 1. Incremental scan: each tick processes a fraction of the map
@@ -67,7 +70,13 @@ const GROWTH_BATCH_MIN: u32 = 5;
 const GROWTH_BATCH_MAX: u32 = 50;
 const SPREAD_BATCH_MIN: u32 = 5;
 const SPREAD_BATCH_MAX: u32 = 25;
-const TIMER_MULTIPLIER_PPM: u32 = 1_000_000;
+/// `GrowthDriver_AllTypes @ 0x00722CA9`: the `0.3` double at `0x007E5138`
+/// (bytes `33 33 33 33 33 33 D3 3F`) loaded when `ScenarioClass` flags bit
+/// `0x40` (`TiberiumGrows`) is set.
+const NATIVE_GROWTH_RELOAD_FAST_MULTIPLIER_BITS: u64 = 0x3FD3_3333_3333_3333;
+/// `0x00722CB1`: the `1.0` double at `0x007E1718` (`00 .. F0 3F`) loaded
+/// when the bit is clear.
+const NATIVE_GROWTH_RELOAD_UNIT_MULTIPLIER_BITS: u64 = 0x3FF0_0000_0000_0000;
 const SPREAD_GERMINATION_DENSITY: u8 = 3;
 
 /// 8 adjacent directions for spread: N, NE, E, SE, S, SW, W, NW.
@@ -82,36 +91,55 @@ const ADJACENT_OFFSETS: [(i32, i32); 8] = [
     (-1, -1),
 ];
 
-/// Effective ore growth configuration resolved from merged INI sources.
-///
-/// Constructed once at map load. The resolution order is:
-/// map [SpecialFlags] > map [Basic] > rules.ini [General]
-/// All flags must be true for growth/spread to be active.
+/// Effective ore growth configuration resolved once at map load.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OreGrowthConfig {
-    /// Whether ore cells grow denser over time.
+    /// `ScenarioClass+0x34A6` (`[Basic] TiberiumGrowthEnabled`, default 1 from
+    /// `Set_Defaults @ 0x00683848`, read at `Read_INI_Basic @ 0x0068A57A`):
+    /// the entry gate of both `GrowthDriver_AllTypes @ 0x00722C48` and
+    /// `SpreadDriver_AllTypes @ 0x007221B8`, and of `CanGrowTiberium`.
     pub grows: bool,
-    /// Whether rich ore spreads to adjacent empty cells.
+    /// `ScenarioClass` flags bit `0x80` (`TiberiumSpreads`): the
+    /// `CellClass::CanSpreadTiberium @ 0x00483690` gate.
     pub spreads: bool,
+    /// `ScenarioClass` flags bit `0x40` (`TiberiumGrows`): selects the
+    /// `Growth * 0.3` growth-timer reload (`0x00722CA4`).
+    #[serde(default)]
+    pub tiberium_grows_flag: bool,
     /// Seconds per full map growth scan cycle (from GrowthRate= in minutes, converted
     /// to integer seconds at config construction to avoid f32 in the tick path).
     pub growth_rate_seconds: u32,
 }
 
 impl OreGrowthConfig {
-    /// Resolve effective config from rules.ini [General] + map [Basic] + map [SpecialFlags].
+    /// Resolve the native gates for this session.
     ///
-    /// Resolution: each flag must be true at ALL levels to be enabled.
-    /// GrowthRate comes only from rules.ini (not overridable per-map).
-    pub fn from_ini(
+    /// `[Basic] TiberiumGrowthEnabled` is read in every game mode. The
+    /// `TiberiumGrows`/`TiberiumSpreads` flag bits come from the session when
+    /// GameMode != 0 (`Full_Init @ 0x00687C23` overwrites the scenario dword
+    /// with the session dword every skirmish/multiplayer start forces to
+    /// `| 0xC0`) and from the map `[SpecialFlags]` only in GameMode 0
+    /// (`0x006B8CA0`, default = the pre-existing bit; VERA keeps `true` there,
+    /// gamemd's pre-read campaign default UNCHECKED). `[General]
+    /// TiberiumGrows/TiberiumSpreads` have no gamemd reader (the only readers of
+    /// those key strings are `[SpecialFlags]` I/O at `0x006B8B30`/`0x006B8CA0`
+    /// and `[MultiplayerDialogSettings]` at `0x006720AA`) and no longer gate.
+    /// GrowthRate comes only from rules.ini (legacy scan fallback).
+    pub fn resolve(
         general: &GeneralRules,
         basic: &BasicSection,
         special_flags: &SpecialFlagsSection,
+        session: &crate::sim::scenario_session::ScenarioSession,
     ) -> Self {
-        let grows = general.tiberium_grows
-            && basic.tiberium_growth_enabled.unwrap_or(true)
-            && special_flags.tiberium_grows.unwrap_or(true);
-        let spreads = general.tiberium_spreads && special_flags.tiberium_spreads.unwrap_or(true);
+        let grows = basic.tiberium_growth_enabled.unwrap_or(true);
+        let (tiberium_grows_flag, spreads) = if session.game_mode_nonzero {
+            (session.tiberium_grows_flag, session.tiberium_spreads_flag)
+        } else {
+            (
+                special_flags.tiberium_grows.unwrap_or(true),
+                special_flags.tiberium_spreads.unwrap_or(true),
+            )
+        };
         let growth_rate_minutes = general.growth_rate_minutes.max(0.01);
         // Convert f32 minutes → integer seconds at the INI boundary via
         // fixed-point to avoid platform-dependent f32 multiplication rounding.
@@ -120,15 +148,17 @@ impl OreGrowthConfig {
             (rate_fixed * SimFixed::from_num(60)).to_num::<i32>().max(1) as u32;
 
         log::info!(
-            "OreGrowthConfig: grows={}, spreads={}, rate={}s",
+            "OreGrowthConfig: grows={}, spreads={}, tiberium_grows_flag={}, rate={}s",
             grows,
             spreads,
+            tiberium_grows_flag,
             growth_rate_seconds,
         );
 
         Self {
             grows,
             spreads,
+            tiberium_grows_flag,
             growth_rate_seconds,
         }
     }
@@ -138,9 +168,36 @@ impl OreGrowthConfig {
         Self {
             grows: false,
             spreads: false,
+            tiberium_grows_flag: false,
             growth_rate_seconds: 300, // 5 minutes
         }
     }
+}
+
+/// `TiberiumClass::GrowthDriver_AllTypes @ 0x00722C40`, reload at
+/// `0x00722C9E..0x00722CE3`: after `GrowthProcessor` returns, `FLD` the `0.3`
+/// double (`ScenarioClass` flags `& 0x40`) or `1.0`, `FILD` the `Growth=`
+/// int (`TiberiumClass+0xA8`), `FMUL`, then `Math::ftol @ 0x007C5F00`
+/// (`FISTP qword`), storing the low dword into the timer duration
+/// (`TiberiumClass+0x124`).
+///
+/// Rounding: `WinMain @ 0x006BBFC1` calls `_controlfp(_RC_CHOP, _MCW_RC)`
+/// (`0x300, 0x300`) and `0x007C5EE4` then captures that control word
+/// (`0x0E7F`: 53-bit precision, round toward zero) for `ftol`, so both the
+/// multiply and the conversion truncate. Stock `Growth=2200` therefore reloads
+/// to **659** (2200 x 0.3 chops just below 660), `Growth=10000` to 2999.
+pub(crate) fn native_growth_timer_reload(growth: u32, tiberium_grows_flag: bool) -> u32 {
+    let multiplier_bits = if tiberium_grows_flag {
+        NATIVE_GROWTH_RELOAD_FAST_MULTIPLIER_BITS
+    } else {
+        NATIVE_GROWTH_RELOAD_UNIT_MULTIPLIER_BITS
+    };
+    let multiplier = X87Chop53::load_f64(NativeF64Bits::from_bits(multiplier_bits))
+        .expect("retail reload multipliers are finite normals");
+    let product = X87Chop53::mul(X87Chop53::load_i32(growth as i32), multiplier);
+    // `|growth| <= i32::MAX` and the multiplier is at most 1.0, so the
+    // conversion cannot overflow; native keeps EAX (the low dword).
+    X87Chop53::ftol_i64(product).map_or(0, |value| value as u32)
 }
 
 /// Queued ore growth cell inserted by native-style AddToGrowthQueue callers.
@@ -744,10 +801,12 @@ impl OreGrowthState {
         current_frame: u32,
         growth_enabled: bool,
         spread_enabled: bool,
+        tiberium_grows_flag: bool,
         mut radar_dirty_cells: Option<&mut Vec<(u16, u16)>>,
         mut radar_dirty_generation: Option<&mut u64>,
         mut tactical_dirty_cells: Option<&mut Vec<(u16, u16)>>,
     ) -> NativeGrowthProcessStats {
+        // `0x00722C48`: `ScenarioClass+0x34A6` gates the whole driver.
         if !growth_enabled {
             return NativeGrowthProcessStats::default();
         }
@@ -785,9 +844,10 @@ impl OreGrowthState {
                 self.native_tiberium.classes.get_mut(type_id.0 as usize),
                 tiberium_types.get(type_id),
             ) {
+                // `0x00722C9E..0x00722CE3`: see `native_growth_timer_reload`.
                 class.growth_timer = NativeTiberiumTimer {
                     start_frame: current_frame,
-                    interval: scaled_timer_interval(ty.growth, TIMER_MULTIPLIER_PPM),
+                    interval: native_growth_timer_reload(ty.growth, tiberium_grows_flag),
                 };
             }
         }
@@ -1071,9 +1131,12 @@ impl OreGrowthState {
                 self.native_tiberium.classes.get_mut(type_id.0 as usize),
                 tiberium_types.get(type_id),
             ) {
+                // `SpreadDriver_AllTypes @ 0x00722205..0x00722227`: the raw
+                // `Spread=` int (`TiberiumClass+0x9C`) reloads the timer; no
+                // multiplier and no flag test on this driver.
                 class.spread_timer = NativeTiberiumTimer {
                     start_frame: current_frame,
-                    interval: scaled_timer_interval(ty.spread, TIMER_MULTIPLIER_PPM),
+                    interval: ty.spread,
                 };
             }
         }
@@ -1715,11 +1778,6 @@ fn native_timer_due(timer: NativeTiberiumTimer, current_frame: u32) -> bool {
     current_frame.wrapping_sub(timer.start_frame) >= timer.interval
 }
 
-fn scaled_timer_interval(base: u32, multiplier_ppm: u32) -> u32 {
-    ((u64::from(base) * u64::from(multiplier_ppm)) / TIMER_MULTIPLIER_PPM as u64)
-        .min(u64::from(u32::MAX)) as u32
-}
-
 fn priority_f32(entry: &NativeTiberiumQueueEntry) -> f32 {
     f32::from_bits(entry.priority_bits)
 }
@@ -2166,6 +2224,7 @@ mod tests {
         OreGrowthConfig {
             grows,
             spreads,
+            tiberium_grows_flag: false,
             growth_rate_seconds: 1, // Very fast for testing
         }
     }
@@ -3039,6 +3098,7 @@ SpreadPercentage=.06
             100,
             true,
             true,
+            false,
             Some(&mut radar_dirty),
             Some(&mut radar_generation),
             Some(&mut tactical_dirty),
@@ -3074,6 +3134,123 @@ SpreadPercentage=.06
             "the native overlay path does not maintain a duplicate ResourceNode stock"
         );
         assert_eq!(rng.logical_state(), expected_rng.logical_state());
+    }
+
+    /// `GrowthDriver_AllTypes @ 0x00722C9E..0x00722CE3` under the chop control
+    /// word `0x0E7F`: `ftol(2200 * 0.3)` is 659, not 660, because the 53-bit
+    /// truncated product sits one ulp below 660; `Growth=10000` gives 2999.
+    /// Without flags bit `0x40` the raw `Growth=` reloads.
+    #[test]
+    fn gsi_09_04_growth_reload_is_chopped_growth_times_point_three_when_flag_set() {
+        assert_eq!(native_growth_timer_reload(2200, true), 659);
+        assert_eq!(native_growth_timer_reload(10000, true), 2999);
+        assert_eq!(native_growth_timer_reload(2200, false), 2200);
+        assert_eq!(native_growth_timer_reload(10000, false), 10000);
+        assert_eq!(native_growth_timer_reload(0, true), 0);
+        assert_eq!(native_growth_timer_reload(1, true), 0);
+        // `10 * 0.3` chops one ulp below 3.0, so the truncating `ftol` gives 2.
+        assert_eq!(native_growth_timer_reload(10, true), 2);
+    }
+
+    /// The driver fires on frame 0 (due timers), reloads to 659, and fires
+    /// again on frames 659 and 1318 in skirmish; the same `Growth=2200` type
+    /// without the flag reloads to 2200 and does not refire inside 1400 frames.
+    #[test]
+    fn gsi_09_04_growth_driver_fires_at_native_skirmish_cadence() {
+        let (_ini, overlay_registry, tiberium_types) = tiberium_rebuild_fixture();
+        let riparius = TiberiumTypeId(0);
+        assert_eq!(tiberium_types.get(riparius).unwrap().growth, 2200);
+        let mut nodes = BTreeMap::new();
+        let mut run = |tiberium_grows_flag: bool| -> Vec<u32> {
+            let mut overlay_grid = OverlayGrid::new(8, 8);
+            let mut state = make_state(8, 8);
+            state.reset_native_tiberium_classes(tiberium_types.len(), 0);
+            let mut rng = SimRng::new(3);
+            let mut fired = Vec::new();
+            for frame in 0..1400u32 {
+                let before = state.native_tiberium_state().classes[0].growth_timer;
+                state.tick_native_growth_driver(
+                    &mut overlay_grid,
+                    &overlay_registry,
+                    &tiberium_types,
+                    None,
+                    &BTreeSet::new(),
+                    None,
+                    &mut nodes,
+                    &mut rng,
+                    frame,
+                    true,
+                    true,
+                    tiberium_grows_flag,
+                    None,
+                    None,
+                    None,
+                );
+                let after = state.native_tiberium_state().classes[0].growth_timer;
+                if after != before || frame == 0 {
+                    assert_eq!(after.start_frame, frame);
+                    fired.push(frame);
+                }
+            }
+            let interval = state.native_tiberium_state().classes[0]
+                .growth_timer
+                .interval;
+            assert_eq!(
+                interval,
+                native_growth_timer_reload(2200, tiberium_grows_flag)
+            );
+            fired
+        };
+
+        assert_eq!(run(true), vec![0, 659, 1318]);
+        assert_eq!(run(false), vec![0]);
+    }
+
+    /// `OreGrowthConfig::resolve`: GameMode != 0 takes the session bits and
+    /// ignores the map `[SpecialFlags]` keys (never read there, `0x006B8CA0`);
+    /// GameMode 0 reads the map keys; `[General] TiberiumGrows/TiberiumSpreads`
+    /// gate nothing; `[Basic] TiberiumGrowthEnabled` gates in every mode.
+    #[test]
+    fn gsi_09_04_config_resolves_flag_bits_from_session_in_nonzero_game_mode() {
+        use crate::map::basic::{BasicSection, SpecialFlagsSection};
+        use crate::rules::ini_parser::IniFile;
+        use crate::sim::scenario_session::{ScenarioDescriptor, ScenarioSession};
+
+        let general = crate::rules::ruleset::RuleSet::from_ini(&IniFile::from_str(
+            "[General]\nTiberiumGrows=no\nTiberiumSpreads=no\n",
+        ))
+        .expect("rules")
+        .general;
+        assert!(!general.tiberium_grows && !general.tiberium_spreads);
+        let map_off = SpecialFlagsSection {
+            tiberium_grows: Some(false),
+            tiberium_spreads: Some(false),
+            ..SpecialFlagsSection::default()
+        };
+        let basic = BasicSection::default();
+
+        let skirmish = ScenarioSession::from_descriptor(&ScenarioDescriptor {
+            game_mode_nonzero: true,
+            tiberium_grows_flag: true,
+            tiberium_spreads_flag: true,
+            ..ScenarioDescriptor::default()
+        });
+        let config = OreGrowthConfig::resolve(&general, &basic, &map_off, &skirmish);
+        assert!(config.grows && config.spreads && config.tiberium_grows_flag);
+
+        let campaign = ScenarioSession::from_descriptor(&ScenarioDescriptor::default());
+        let config = OreGrowthConfig::resolve(&general, &basic, &map_off, &campaign);
+        assert!(config.grows && !config.spreads && !config.tiberium_grows_flag);
+        let config =
+            OreGrowthConfig::resolve(&general, &basic, &SpecialFlagsSection::default(), &campaign);
+        assert!(config.grows && config.spreads && config.tiberium_grows_flag);
+
+        let basic_off = BasicSection {
+            tiberium_growth_enabled: Some(false),
+            ..BasicSection::default()
+        };
+        let config = OreGrowthConfig::resolve(&general, &basic_off, &map_off, &skirmish);
+        assert!(!config.grows && config.spreads && config.tiberium_grows_flag);
     }
 
     /// `GrowthProcessor @ 0x00722F00`: seed 9 draws five attempts, and with
@@ -3721,6 +3898,7 @@ SpreadPercentage=.06
         let config = OreGrowthConfig {
             grows: true,
             spreads: false,
+            tiberium_grows_flag: false,
             growth_rate_seconds: 1,
         };
         let mut state = make_state(10, 10);
@@ -3755,6 +3933,7 @@ SpreadPercentage=.06
         let slow = OreGrowthConfig {
             grows: true,
             spreads: false,
+            tiberium_grows_flag: false,
             growth_rate_seconds: 6000, // 100 minutes
         };
         let mut state_slow = make_state(100, 100);

--- a/src/sim/runtime.rs
+++ b/src/sim/runtime.rs
@@ -850,8 +850,12 @@ pub(crate) fn initialize_native_tiberium_queues(
     overlay_grid: Option<&crate::sim::overlay_grid::OverlayGrid>,
     native_rect: (u16, u16),
 ) -> Option<crate::sim::ore_growth::NativeTiberiumRebuildStats> {
-    sim.production.ore_growth_config =
-        crate::sim::ore_growth::OreGrowthConfig::from_ini(&rules.general, basic, special_flags);
+    sim.production.ore_growth_config = crate::sim::ore_growth::OreGrowthConfig::resolve(
+        &rules.general,
+        basic,
+        special_flags,
+        &sim.session,
+    );
     let (width, height) = overlay_grid
         .map(|grid| (grid.width(), grid.height()))
         .or_else(|| {
@@ -892,8 +896,8 @@ pub(crate) fn initialize_native_tiberium_queues(
                 &rules.tiberium_types,
                 sim.resolved_terrain.as_ref(),
                 &source_object_cells,
-                basic.tiberium_growth_enabled.unwrap_or(true),
-                rules.general.tiberium_spreads && special_flags.tiberium_spreads.unwrap_or(true),
+                sim.production.ore_growth_config.grows,
+                sim.production.ore_growth_config.spreads,
                 sim.session.binary_frame,
                 native_rect,
             ),

--- a/src/sim/scenario_post_map.rs
+++ b/src/sim/scenario_post_map.rs
@@ -72,10 +72,11 @@ impl Simulation {
         let tiberium_queues = if input.tiberium_queues_preinitialized {
             None
         } else if let Some(overlay_grid) = self.overlay_grid.as_ref() {
-            self.production.ore_growth_config = crate::sim::ore_growth::OreGrowthConfig::from_ini(
+            self.production.ore_growth_config = crate::sim::ore_growth::OreGrowthConfig::resolve(
                 &input.rules.general,
                 input.basic,
                 input.special_flags,
+                &self.session,
             );
             self.production.ore_growth_state =
                 crate::sim::ore_growth::OreGrowthState::new(input.map_width, input.map_height);
@@ -101,18 +102,18 @@ impl Simulation {
                         &input.rules.tiberium_types,
                         self.resolved_terrain.as_ref(),
                         &source_object_cells,
-                        input.basic.tiberium_growth_enabled.unwrap_or(true),
-                        input.rules.general.tiberium_spreads
-                            && input.special_flags.tiberium_spreads.unwrap_or(true),
+                        self.production.ore_growth_config.grows,
+                        self.production.ore_growth_config.spreads,
                         self.session.binary_frame,
                         (input.map_width, input.map_height),
                     ),
             )
         } else {
-            self.production.ore_growth_config = crate::sim::ore_growth::OreGrowthConfig::from_ini(
+            self.production.ore_growth_config = crate::sim::ore_growth::OreGrowthConfig::resolve(
                 &input.rules.general,
                 input.basic,
                 input.special_flags,
+                &self.session,
             );
             self.production.ore_growth_state =
                 crate::sim::ore_growth::OreGrowthState::new(input.map_width, input.map_height);

--- a/src/sim/scenario_session.rs
+++ b/src/sim/scenario_session.rs
@@ -175,6 +175,19 @@ pub struct ScenarioDescriptor {
     /// Native `ScenarioClass` flags bit `0x20`. The shared direct and area
     /// damage entries return before any receiver or terrain mutation while set.
     pub no_damage: bool,
+    /// Native `ScenarioClass` flags bit `0x40` (`[SpecialFlags] TiberiumGrows`,
+    /// bit layout from the writer `0x006B8B30`). Every skirmish/multiplayer
+    /// start forces it on (`OR 0xC0` at `0x005E74CD` on the ordinary skirmish
+    /// path, `0x005B6ACF`/`0x005B7326`/`0x005BB209` on the network/modem
+    /// paths; `Full_Init @ 0x00687C23` copies the session dword into the
+    /// scenario when GameMode != 0). Its only reader is the growth driver's
+    /// timer reload (`0x00722CA4`: `Growth * 0.3` when set, `* 1.0` when not).
+    /// Campaign (GameMode 0) reads the map key instead (`0x006B8CA0`).
+    pub tiberium_grows_flag: bool,
+    /// Native `ScenarioClass` flags bit `0x80` (`TiberiumSpreads`), forced on
+    /// by the same skirmish/multiplayer sites. Gates
+    /// `CellClass::CanSpreadTiberium @ 0x00483690`.
+    pub tiberium_spreads_flag: bool,
     /// Map-authored global-light profiles plus their tick-zero mutable state.
     pub lighting: ScenarioLightingState,
     /// Authoritative map bounds in the CANONICAL CELL-ARRAY frame (max cell
@@ -205,6 +218,8 @@ impl ScenarioDescriptor {
             seed: header.seed,
             map_name: header.scenario_name(),
             no_damage: header.special_flags & 0x20 != 0,
+            tiberium_grows_flag: header.special_flags & 0x40 != 0,
+            tiberium_spreads_flag: header.special_flags & 0x80 != 0,
             ..Self::default()
         }
     }
@@ -233,6 +248,13 @@ pub struct ScenarioSession {
     /// Persisted native `ScenarioClass` flags bit `0x20`.
     #[serde(default)]
     pub no_damage: bool,
+    /// Persisted native `ScenarioClass` flags bit `0x40` (`TiberiumGrows`);
+    /// see the descriptor field of the same name.
+    #[serde(default)]
+    pub tiberium_grows_flag: bool,
+    /// Persisted native `ScenarioClass` flags bit `0x80` (`TiberiumSpreads`).
+    #[serde(default)]
+    pub tiberium_spreads_flag: bool,
     /// Persistent fixed-integer global-light configuration and transition state.
     pub lighting: ScenarioLightingState,
     /// Authoritative map bounds in the canonical cell-array frame (max cell
@@ -288,6 +310,13 @@ impl ScenarioSession {
         // the native ScenarioFlags 0x20 state lockstep-visible.
         if s.no_damage {
             b"scenario-no-damage-v1".hash(hasher);
+        }
+        // Same legacy-preserving shape for the `0x40`/`0x80` tiberium bits.
+        if s.tiberium_grows_flag {
+            b"scenario-tiberium-grows-v1".hash(hasher);
+        }
+        if s.tiberium_spreads_flag {
+            b"scenario-tiberium-spreads-v1".hash(hasher);
         }
         (s.map_width, s.map_height).hash(hasher);
         (s.local_left, s.local_top, s.local_width, s.local_height).hash(hasher);
@@ -357,6 +386,8 @@ impl ScenarioSession {
             theater: desc.theater.clone(),
             game_mode_nonzero: desc.game_mode_nonzero,
             no_damage: desc.no_damage,
+            tiberium_grows_flag: desc.tiberium_grows_flag,
+            tiberium_spreads_flag: desc.tiberium_spreads_flag,
             lighting: desc.lighting,
             map_width: desc.map_width,
             map_height: desc.map_height,
@@ -631,5 +662,41 @@ mod tests {
             .sim;
         assert!(restored.session.no_damage);
         assert_eq!(restored.state_hash(), inert.state_hash());
+    }
+
+    /// The `0x40`/`0x80` `TiberiumGrows`/`TiberiumSpreads` bits reach the
+    /// session from the descriptor and the native replay header, are
+    /// lockstep-visible, and survive a snapshot.
+    #[test]
+    fn gsi_09_04_tiberium_flag_bits_roundtrip_and_change_hash() {
+        let mut header = crate::sim::replay::NativeReplayHeader::new(0x1234_5678, "skirmish.map");
+        header.special_flags = 0xC0;
+        let descriptor = ScenarioDescriptor::from_native_replay_header(&header);
+        assert!(descriptor.tiberium_grows_flag);
+        assert!(descriptor.tiberium_spreads_flag);
+        assert!(!descriptor.no_damage);
+
+        let mut forced = Simulation::from_descriptor(&descriptor);
+        assert!(forced.session.tiberium_grows_flag && forced.session.tiberium_spreads_flag);
+        let clear = Simulation::from_descriptor(&ScenarioDescriptor {
+            tiberium_grows_flag: false,
+            tiberium_spreads_flag: false,
+            ..descriptor.clone()
+        });
+        assert_ne!(forced.state_hash(), clear.state_hash());
+        let grows_only = Simulation::from_descriptor(&ScenarioDescriptor {
+            tiberium_spreads_flag: false,
+            ..descriptor.clone()
+        });
+        assert_ne!(forced.state_hash(), grows_only.state_hash());
+        assert_ne!(clear.state_hash(), grows_only.state_hash());
+
+        forced.scenario_rng = crate::sim::rng::SimRng::new(0);
+        let bytes = crate::sim::snapshot::GameSnapshot::save(&forced, 1, 2, "skirmish.map", 0);
+        let restored = crate::sim::snapshot::GameSnapshot::load(&bytes)
+            .expect("snapshot load")
+            .sim;
+        assert!(restored.session.tiberium_grows_flag && restored.session.tiberium_spreads_flag);
+        assert_eq!(restored.state_hash(), forced.state_hash());
     }
 }

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -406,7 +406,11 @@ use crate::sim::world::Simulation;
 // direction and captured gravity, and retains the Floater policy.
 // v130 replaces the visit counter with the signed frame-anchored Bullet Arm timer
 // and retains Dropping so Check runs before detector-only admission is suppressed.
-const SNAPSHOT_VERSION: u32 = 130;
+// v131 persists the `ScenarioClass` flags bits `0x40`/`0x80` (`TiberiumGrows`/
+// `TiberiumSpreads`) on the session and the growth-driver reload selector on
+// `OreGrowthConfig`. A v130 skirmish save would restore them clear and reload the
+// growth timer at the raw `Growth=` instead of `ftol(Growth * 0.3)`.
+const SNAPSHOT_VERSION: u32 = 131;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -1624,7 +1628,9 @@ impl Simulation {
         // already-restored global frame with duration zero. Only C4/CC gates
         // AI through Check (4E11F0); retain the saved reference/watermark.
         for (_, projectile) in self.projectiles.iter_mut() {
-            projectile.arm_timer.start(self.session.binary_frame as i32, 0);
+            projectile
+                .arm_timer
+                .start(self.session.binary_frame as i32, 0);
         }
         self.substrate.entities.rebuild_owner_index();
         self.rebuild_logic_membership();
@@ -2052,6 +2058,7 @@ mod tests {
             sim.production.ore_growth_config = OreGrowthConfig {
                 grows: true,
                 spreads: true,
+                tiberium_grows_flag: false,
                 growth_rate_seconds: 1,
             };
             sim.production.ore_growth_state = OreGrowthState::new(size, size);
@@ -3164,9 +3171,11 @@ mod tests {
     /// sharing one version number defeat the mismatch guard entirely.
     /// 123 -> 126 adds the retained homing Inaccurate flag; 124 and 125 are
     /// reserved by the concurrent parasite and audio-lane changes.
+    /// 130 -> 131 persists the session `TiberiumGrows`/`TiberiumSpreads`
+    /// flag bits and the `OreGrowthConfig` growth-reload selector.
     #[test]
-    fn projectile_frame_timer_snapshot_version_is_130() {
-        assert_eq!(super::SNAPSHOT_VERSION, 130);
+    fn tiberium_flag_bits_snapshot_version_is_131() {
+        assert_eq!(super::SNAPSHOT_VERSION, 131);
     }
 
     #[test]

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -3950,6 +3950,7 @@ impl Simulation {
                     self.session.binary_frame,
                     self.production.ore_growth_config.grows,
                     self.production.ore_growth_config.spreads,
+                    self.production.ore_growth_config.tiberium_grows_flag,
                     Some(&mut self.radar_terrain_dirty_cells),
                     Some(&mut self.radar_terrain_dirty_generation),
                     Some(&mut self.tactical_dirty_cells),


### PR DESCRIPTION
In skirmish gamemd reloads each TiberiumType's growth timer at `ftol(Growth × 0.3)` (`TiberiumClass::GrowthDriver_AllTypes` @ 0x00722C40: `TEST byte [ScenarioClass],0x40`, `FLD [0x007E5138]` = 0.3, `FMUL`, `Math::ftol` under the process's 0x0E7F chop control word), because every skirmish/multiplayer start forces session SpecialFlags bits 0xC0 (`OR 0xC0` @ 0x005E74CD, copied by `Full_Init` @ 0x00687C23 when GameMode ≠ 0). The spread driver (`SpreadDriver_AllTypes` @ 0x007221B0) reloads the raw `Spread=`. Stock Riparius grows every 659 frames natively; Rust reloaded the raw 2200, so ore densified about 3.3× too slowly all game.

The session now carries the two native tiberium bits, set on the app and headless skirmish paths, folded into the lockstep identity once and persisted with SNAPSHOT_VERSION 131. The growth reload evaluates the product through the native x87 chop helpers (2200 → 659, 10000 → 2999). The drivers gate on `[Basic] TiberiumGrowthEnabled` plus the session bits as native does. The old `[General] TiberiumGrows/TiberiumSpreads` and skirmish `[SpecialFlags]` gates have no native reader (the key strings reach only 0x006720AA, 0x006B8B30 and 0x006B8CA0, the last only when GameMode == 0) and are removed from the sim. Global harness pins are unchanged because that fixture builds its world with the flags clear.

Independent read-only critic re-read both driver bodies, the constants, the ftol control-word path, the 0x40/0x80 consumers, the forcing and copy sites and the `[SpecialFlags]` reader gate, and passed the change.

Validation:
- `cargo test -p vera20k --lib`: `test result: ok. 8292 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 13.02s`

Residuals: the FMUL truncation relies on the process control word at driver time (consistent with `_controlfp(0x300,0x300)` in WinMain, not runtime-traced); campaign maps omitting `[SpecialFlags] TiberiumGrows` keep VERA's `true` default where native keeps the pre-read bit (campaign is outside this phase).
