### PR TITLE
Grant skirmish opening credits by MultiplayerAICM and leftover budget

### DIFF
--- a/src/app/frontend/skirmish.rs
+++ b/src/app/frontend/skirmish.rs
@@ -1107,19 +1107,31 @@ mod tests {
         );
     }
 
+    /// gamemd-derived: `ScenarioClass__Post_Map_Init @ 0x006869BE..0x00686A7E`
+    /// grants `ftol(MultiplayerAICM[difficulty] * 0.01 * Available_Money)` to
+    /// every non-human, non-MultiplayPassive house. Stock `400,0,0` makes a
+    /// Hard AI open with 5x its balance; Normal and Easy add 0.
     #[test]
-    fn gsi_03_17_post_map_init_doubles_only_participating_nonpassive_ai_credits() {
+    fn gsi_09_01_post_map_init_grants_multiplayer_ai_cm_percent_by_difficulty() {
         let mut session = test_session();
-        let passive_ai = SkirmishAiSlot {
-            color_index: 3,
-            ..session.opponents[0].clone()
-        };
-        session.opponents.push(passive_ai);
+        session.opponents[0].difficulty = AiDifficulty::Hard;
+        for (color_index, difficulty) in [
+            (3, AiDifficulty::Hard),
+            (4, AiDifficulty::Normal),
+            (5, AiDifficulty::Easy),
+        ] {
+            session.opponents.push(SkirmishAiSlot {
+                color_index,
+                difficulty,
+                ..session.opponents[0].clone()
+            });
+        }
         let mut sim = Simulation::new();
         sim.session.game_options = session
             .options
             .to_game_options(session.opponents.len() as i32);
-        let rules = test_standard_launch_rules();
+        let mut rules = test_standard_launch_rules();
+        rules.general.multiplayer_ai_cm = vec![400, 0, 0];
         populate_launch_houses(&mut sim, &normalized_launch_slots(&session), &rules);
         populate_special_houses(&mut sim, &HouseRoster::default(), &rules);
 
@@ -1141,18 +1153,49 @@ mod tests {
             HouseState::new(observer, 0, None, false, 10_000, 10),
         );
 
-        apply_skirmish_ai_opening_credits(&mut sim);
+        apply_skirmish_ai_opening_credits(&mut sim, &rules);
 
         let credits = |owner: &str| {
             crate::sim::house_state::house_state_for_owner(&sim.houses, owner, &sim.interner)
                 .map(|house| house.credits)
         };
         assert_eq!(credits("Player"), Some(10_000));
-        assert_eq!(credits("Computer1"), Some(20_000));
-        assert_eq!(credits("Computer2"), Some(10_000));
+        assert_eq!(credits("Computer1"), Some(50_000), "Hard: +400%");
+        assert_eq!(
+            credits("Computer2"),
+            Some(10_000),
+            "passive Hard AI skipped"
+        );
+        assert_eq!(credits("Computer3"), Some(10_000), "Normal: +0%");
+        assert_eq!(credits("Computer4"), Some(10_000), "Easy: +0%");
         assert_eq!(credits("Neutral"), Some(10_000));
         assert_eq!(credits("Special"), Some(10_000));
         assert_eq!(credits("Observer"), Some(10_000));
+    }
+
+    /// The x87 product is chopped by `Math__ftol @ 0x007C5F00`; a missing list
+    /// entry (empty constructor vector at `0x00667034`) grants nothing.
+    #[test]
+    fn gsi_09_01_ai_opening_grant_truncates_and_tolerates_missing_entries() {
+        let mut session = test_session();
+        session.opponents[0].difficulty = AiDifficulty::Hard;
+        let mut sim = Simulation::new();
+        sim.session.game_options = session
+            .options
+            .to_game_options(session.opponents.len() as i32);
+        let mut rules = test_standard_launch_rules();
+        populate_launch_houses(&mut sim, &normalized_launch_slots(&session), &rules);
+        let ai = sim.interner.get("Computer1").expect("AI house");
+        sim.houses.get_mut(&ai).expect("AI house").credits = 12_345;
+
+        rules.general.multiplayer_ai_cm = Vec::new();
+        apply_skirmish_ai_opening_credits(&mut sim, &rules);
+        assert_eq!(sim.houses[&ai].credits, 12_345);
+
+        // 7 * 0.01 * 12345 = 864.15... -> 864 under chop.
+        rules.general.multiplayer_ai_cm = vec![7, 0, 0];
+        apply_skirmish_ai_opening_credits(&mut sim, &rules);
+        assert_eq!(sim.houses[&ai].credits, 12_345 + 864);
     }
 
     #[test]
@@ -2255,6 +2298,96 @@ mod tests {
             .count();
         assert_eq!(player_units, 5);
         assert_eq!(ai_units, 4);
+
+        // gamemd-derived leftover budget (`Generate_Starting_Units @
+        // 0x005D6F91..0x005D6F9C`): budget = ((3/2 + 500) / 3) * 2 = 334.
+        // Player spends 3xMTNK + E1 = 600 (remainder < 0, nothing credited);
+        // Computer1 has no infantry, stops at 3xHTNK = 300 and is credited 34.
+        let credits = |owner: &str| {
+            crate::sim::house_state::house_state_for_owner(&sim.houses, owner, &sim.interner)
+                .map(|house| house.credits)
+        };
+        assert_eq!(credits("Player"), Some(10_000));
+        assert_eq!(credits("Computer1"), Some(10_034));
+    }
+
+    /// A budget spent exactly credits nothing (`TEST EAX,EAX; JLE` at
+    /// `0x005D6F95`): budget = ((3/2 + 300) / 3) * 3 = 300, and each house
+    /// places 2 vehicles + 1 infantry = 300.
+    #[test]
+    fn gsi_09_01_exactly_spent_starting_budget_credits_nothing() {
+        let mut sim = Simulation::new();
+        let mut session = test_session();
+        session.options.unit_count = 3;
+        let terrain = test_terrain(64, 64);
+        let starts = test_launch_starts();
+        let map = test_map_with_starts(&starts);
+        let ini = IniFile::from_str(
+            "[General]\nBaseUnit=AMCV,SMCV,PCV\n\
+             [VehicleTypes]\n1=AMCV\n2=SMCV\n3=MTNK\n4=HTNK\n\
+             [InfantryTypes]\n1=E1\n\
+             [AMCV]\nOwner=Americans\nCost=1000\nTechLevel=1\nAllowedToStartInMultiplayer=yes\n\
+             [SMCV]\nOwner=Russians\nCost=1000\nTechLevel=1\nAllowedToStartInMultiplayer=yes\n\
+             [MTNK]\nOwner=Americans\nCost=100\nTechLevel=1\nAllowedToStartInMultiplayer=yes\n\
+             [HTNK]\nOwner=Russians\nCost=100\nTechLevel=1\nAllowedToStartInMultiplayer=yes\n\
+             [E1]\nOwner=Americans,Russians\nCost=100\nTechLevel=1\nAllowedToStartInMultiplayer=yes\n",
+        );
+        let rules = RuleSet::from_ini(&ini).expect("exact-budget rules parse");
+
+        let result = apply_explicit_skirmish_launch_session(
+            &mut sim,
+            &map,
+            &roster_with_neutral_and_playable(),
+            &rules,
+            &test_height_map(),
+            &terrain,
+            &launch_descriptor(&session),
+        );
+
+        assert_eq!(result.spawned_mcvs, 2);
+        assert_eq!(sim.entities().len(), 8);
+        let credits = |owner: &str| {
+            crate::sim::house_state::house_state_for_owner(&sim.houses, owner, &sim.interner)
+                .map(|house| house.credits)
+        };
+        assert_eq!(credits("Player"), Some(10_000));
+        assert_eq!(credits("Computer1"), Some(10_000));
+    }
+
+    /// `Post_Map_Init` calls `Generate_Starting_Units` at `0x00686937` before
+    /// the AI grant loop at `0x006869BE`, so the Hard multiplier applies to the
+    /// balance that already includes the credited leftover budget.
+    #[test]
+    fn gsi_09_01_ai_grant_multiplies_post_leftover_balance() {
+        let mut sim = Simulation::new();
+        let mut session = test_session();
+        session.options.unit_count = 2;
+        session.opponents[0].difficulty = AiDifficulty::Hard;
+        let terrain = test_terrain(64, 64);
+        let starts = test_launch_starts();
+        let map = test_map_with_starts(&starts);
+        let mut rules = test_starting_unit_rules();
+        rules.general.multiplayer_ai_cm = vec![400, 0, 0];
+
+        let result = apply_explicit_skirmish_launch_session(
+            &mut sim,
+            &map,
+            &roster_with_neutral_and_playable(),
+            &rules,
+            &test_height_map(),
+            &terrain,
+            &launch_descriptor(&session),
+        );
+        assert_eq!(result.spawned_mcvs, 2);
+
+        apply_skirmish_ai_opening_credits(&mut sim, &rules);
+
+        let credits = |owner: &str| {
+            crate::sim::house_state::house_state_for_owner(&sim.houses, owner, &sim.interner)
+                .map(|house| house.credits)
+        };
+        assert_eq!(credits("Player"), Some(10_000));
+        assert_eq!(credits("Computer1"), Some((10_000 + 34) * 5));
     }
 
     /// gamemd-derived: active YR

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -406,6 +406,15 @@ pub struct GeneralRules {
     /// Unit types that count as a player's home when no buildings remain.
     /// Parsed from `[General] BaseUnit=`. Stock YR: AMCV, SMCV, PCV.
     pub base_unit_types: Vec<String>,
+    /// `[General] MultiplayerAICM=` — `RulesClass+0x1304` int list read by
+    /// `RulesClass__ReadGeneral` at `0x00670512..0x0067053B`. Indexed directly
+    /// by `HouseClass+0x184` difficulty (0 = Hard, 1 = Normal, 2 = Easy) in
+    /// `ScenarioClass__Post_Map_Init @ 0x00686A52..0x00686A5E`; each entry is a
+    /// percentage of the AI house's opening balance granted once at match start.
+    /// Stock `rulesmd.ini:88` is `400,0,0`. The constructor default is an empty
+    /// vector (`0x00667034`), which native would index out of bounds; VERA treats
+    /// a missing entry as 0 (no grant).
+    pub multiplayer_ai_cm: Vec<i32>,
     /// Aircraft types in native Rules `PadAircraft` order. BuildingType's
     /// virtual value calculation reads the first two entries for the bundled
     /// helipad-cost branch.
@@ -1158,6 +1167,7 @@ impl Default for GeneralRules {
             sov_paradrop_list: vec![("E2".to_string(), 9)],
             yuri_paradrop_list: vec![("INIT".to_string(), 6)],
             base_unit_types: vec!["AMCV".to_string(), "SMCV".to_string(), "PCV".to_string()],
+            multiplayer_ai_cm: Vec::new(),
             pad_aircraft_types: Vec::new(),
             separate_aircraft: false,
             prism_type: None,
@@ -1879,6 +1889,15 @@ impl GeneralRules {
                         .collect()
                 })
                 .unwrap_or_else(|| defaults.base_unit_types),
+            multiplayer_ai_cm: general
+                .get_list("MultiplayerAICM")
+                .map(|items| {
+                    items
+                        .into_iter()
+                        .filter_map(crate::rules::ini_value::parse_read_int_value)
+                        .collect()
+                })
+                .unwrap_or_else(|| defaults.multiplayer_ai_cm),
             pad_aircraft_types: general
                 .get_list("PadAircraft")
                 .map(|items| {
@@ -4997,6 +5016,19 @@ CellSpread=0
     }
 
     #[test]
+    fn parse_multiplayer_ai_cm_list_in_source_order() {
+        // rulesmd.ini:88 `MultiplayerAICM=400,0,0` (Hard, Normal, Easy).
+        let ini = IniFile::from_str("[General]\nMultiplayerAICM=400,0,0\n");
+        let general = GeneralRules::from_ini(&ini);
+        assert_eq!(general.multiplayer_ai_cm, vec![400, 0, 0]);
+
+        // RulesClass constructor leaves the +0x1304 vector empty (0x00667034).
+        let ini = IniFile::from_str("[General]\n");
+        let general = GeneralRules::from_ini(&ini);
+        assert!(general.multiplayer_ai_cm.is_empty());
+    }
+
+    #[test]
     fn parse_tier1_superweapon_rules() {
         let ini_text = "[General]\n\
 ForceShieldRadius=5\n\
@@ -5502,7 +5534,10 @@ MutateWarhead=MyMutate\n\
         assert_eq!(ftol_scale(52, rules.general.veteran_rof), 31);
         assert_eq!(ftol_scale(65, rules.general.veteran_combat), 71);
         assert_eq!(ftol_scale(15, rules.general.veteran_speed), 18);
-        assert_eq!(self_heal_interval_frames(rules.general.repair_rate_minutes), 14);
+        assert_eq!(
+            self_heal_interval_frames(rules.general.repair_rate_minutes),
+            14
+        );
         assert_eq!(
             rules.general.upgrade_veteran_sound.as_deref(),
             Some("UpgradeVeteran")
@@ -5566,8 +5601,9 @@ BuildingGarrisonedSound=BuildingGarrisoned
             Some("BaseUnderAttackSiren")
         );
 
-        let absent =
-            GeneralRules::from_ini(&IniFile::from_str("[General]\nFlightLevel=500\n[AudioVisual]\n"));
+        let absent = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\n",
+        ));
         assert_eq!(absent.base_under_attack_sound, None);
     }
 
@@ -5584,8 +5620,9 @@ BuildingGarrisonedSound=BuildingGarrisoned
             Some("BuildingGenericDie")
         );
 
-        let absent =
-            GeneralRules::from_ini(&IniFile::from_str("[General]\nFlightLevel=500\n[AudioVisual]\n"));
+        let absent = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\n",
+        ));
         assert_eq!(absent.building_die_sound, None);
 
         let empty = GeneralRules::from_ini(&IniFile::from_str(
@@ -5608,8 +5645,9 @@ BuildingGarrisonedSound=BuildingGarrisoned
             Some("BuildingDamaged")
         );
 
-        let absent =
-            GeneralRules::from_ini(&IniFile::from_str("[General]\nFlightLevel=500\n[AudioVisual]\n"));
+        let absent = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\n",
+        ));
         assert_eq!(absent.building_damage_sound, None);
 
         let empty = GeneralRules::from_ini(&IniFile::from_str(
@@ -5638,8 +5676,9 @@ BuildingGarrisonedSound=BuildingGarrisoned
             "strtok collapses the empty field between the two commas"
         );
 
-        let absent =
-            GeneralRules::from_ini(&IniFile::from_str("[General]\nFlightLevel=500\n[AudioVisual]\n"));
+        let absent = GeneralRules::from_ini(&IniFile::from_str(
+            "[General]\nFlightLevel=500\n[AudioVisual]\n",
+        ));
         assert!(absent.lightning_sounds.is_empty());
 
         let empty = GeneralRules::from_ini(&IniFile::from_str(

--- a/src/sim/scenario_bootstrap.rs
+++ b/src/sim/scenario_bootstrap.rs
@@ -30,7 +30,7 @@ use crate::sim::world::{PlacementEvidence, Simulation};
 use crate::skirmish_launch::{
     LaunchCountry, LaunchStartPosition, LaunchTeam, PreFillHouseRoster, SkirmishLaunchSession,
 };
-use crate::util::native_x87::{X87Chop53, sqrt_approx_f32};
+use crate::util::native_x87::{NativeF64Bits, X87Chop53, sqrt_approx_f32};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct NativeStartBounds {
@@ -1571,16 +1571,49 @@ pub(crate) fn populate_launch_houses(
     }
 }
 
+/// Bit pattern of the `0.01` double at `0x007E3808` read by
+/// `ScenarioClass__Post_Map_Init @ 0x00686A52` (`FMUL qword [0x007E3808]`).
+const NATIVE_AI_CM_PERCENT_MULTIPLIER_BITS: u64 = 0x3F84_7AE1_47AE_147B;
+
+/// gamemd-derived AI opening grant: `ftol(MultiplayerAICM[diff] * 0.01 * money)`.
+///
+/// Active YR `ScenarioClass__Post_Map_Init @ 0x00686A52..0x00686A6B`:
+/// `FILD MultiplayerAICM[house+0x184]; FMUL qword [0x007E3808] (0.01);
+/// FIMUL money; CALL Math__ftol @ 0x007C5F00`. The process control word is
+/// `0x0E7F` (RC = chop, PC = 53): `WinMain @ 0x006BBFC1` calls
+/// `_controlfp(0x300, 0x300)` (`_RC_CHOP`) and `0x007C5EE4` captures the word
+/// at `0x00822D80` for `ftol`. Both multiplies therefore truncate toward zero at
+/// 53 bits and the final conversion truncates; plain f64 round-to-nearest
+/// differs (e.g. `3 * 0.01 * 100` chops to 2, not 3). `Math__ftol` returns the
+/// low dword of `FISTP qword`, so the i64 result is narrowed with `as i32`; an
+/// out-of-range operand stores the x87 integer indefinite (low dword 0).
+pub(crate) fn native_ai_opening_grant(coefficient: i32, money: i32) -> i32 {
+    let percent = X87Chop53::load_f64(NativeF64Bits::from_bits(
+        NATIVE_AI_CM_PERCENT_MULTIPLIER_BITS,
+    ))
+    .expect("0.01 is a finite normal double");
+    let scaled = X87Chop53::mul(X87Chop53::load_i32(coefficient), percent);
+    let product = X87Chop53::mul(scaled, X87Chop53::load_i32(money));
+    X87Chop53::ftol_i64(product).map_or(0, |value| value as i32)
+}
+
 /// Apply the generated skirmish AI opening-credit grant at the Post_Map_Init handoff.
 ///
-/// Active YR `ScenarioClass__Post_Map_Init @ 0x00686890` visits each non-human,
-/// non-`MultiplayPassive` house, calls the secondary vslot body at `0x004F6990`,
-/// then passes its result to `HouseClass__Add_Credits @ 0x004F9950`. Generated
-/// stock Battle houses have no stored resources at this point, so the returned
-/// amount is their current balance and each participating AI finishes with twice
-/// the lobby-selected credits. The AI-owner list keeps this launch-only helper
-/// away from special and nonparticipant houses without recreating native pointers.
-pub(crate) fn apply_skirmish_ai_opening_credits(sim: &mut Simulation) {
+/// Active YR `ScenarioClass__Post_Map_Init @ 0x00686890`, loop `0x006869BE..
+/// 0x00686A7E`: for each house with `+0x1EC == 0` (not human) whose HouseType
+/// `+0x1A6 == 0` (not `MultiplayPassive`), it calls the house secondary vslot
+/// `+0x18` (`0x004F6990`: `ftol(storage_total * factor + credits)`, storage is
+/// empty for generated Battle houses so this is the current balance), then
+/// computes [`native_ai_opening_grant`] and passes the result to
+/// `HouseClass__Add_Credits @ 0x004F9950`. Stock `MultiplayerAICM=400,0,0`
+/// therefore gives a Hard AI 5x its balance and leaves Normal/Easy unchanged.
+///
+/// Sequencing: `Generate_Starting_Units @ 0x005D6D80` is called earlier in the
+/// same function (`0x00686937`), so the balance multiplied here already carries
+/// the leftover starting-unit budget credited by `seed_starting_extra_units`
+/// (pure integer arithmetic on the native side: `CDQ/SAR/IDIV` budget thirds
+/// and integer cost subtraction, no x87 involvement).
+pub(crate) fn apply_skirmish_ai_opening_credits(sim: &mut Simulation, rules: &RuleSet) {
     for ai in &sim.ai_players {
         let Some(house) = sim.houses.get_mut(&ai.owner) else {
             continue;
@@ -1588,8 +1621,14 @@ pub(crate) fn apply_skirmish_ai_opening_credits(sim: &mut Simulation) {
         if house.is_human || house.multiplay_passive {
             continue;
         }
-        let opening_grant = house.credits;
-        house.credits += opening_grant;
+        let coefficient = rules
+            .general
+            .multiplayer_ai_cm
+            .get(house.difficulty.table_index())
+            .copied()
+            .unwrap_or(0);
+        let grant = native_ai_opening_grant(coefficient, house.credits);
+        house.credits = house.credits.wrapping_add(grant);
     }
 }
 
@@ -1925,6 +1964,24 @@ fn seed_starting_extra_units_with_overlay_registry(
             );
             spawned += 1;
             spent = spent.wrapping_add(candidate.cost);
+        }
+        // gamemd-derived: `MultiplayerGameMode__Generate_Starting_Units @
+        // 0x005D6D80` hands each non-MultiplayPassive house its own copy of the
+        // budget by reference; the extra-unit callback (`0x005D70F0`) subtracts
+        // each placed unit's cost at `0x005D73EF..0x005D73F3`, and the caller
+        // then reads the remainder at `0x005D6F91` and, when it is still > 0,
+        // calls `HouseClass__Add_Credits @ 0x004F9950` (`0x005D6F99..0x005D6F9C`).
+        // Human houses are included; the starting MCV is not charged.
+        let remaining = budget.wrapping_sub(spent);
+        if remaining > 0
+            && let Some(house) = crate::sim::house_state::house_state_for_owner_mut(
+                &mut sim.houses,
+                &slot.owner_name,
+                &sim.interner,
+            )
+            && !house.multiplay_passive
+        {
+            house.credits = house.credits.wrapping_add(remaining);
         }
     }
 
@@ -2497,6 +2554,38 @@ pub(crate) fn initialize_map_roster_houses(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// x87 chop (cw `0x0E7F`) versus f64 round-to-nearest for the AI opening
+    /// grant: `3 * 0.01` chops just below `0.03`, `* 100` chops just below `3.0`,
+    /// and `Math__ftol` truncates to 2 where `((3.0 * 0.01) * 100.0) as i32`
+    /// gives 3. The stock `400,0,0 x 10000` case agrees under both modes.
+    #[test]
+    fn native_ai_opening_grant_chops_where_round_to_nearest_differs() {
+        assert_eq!(
+            ((3.0_f64 * 0.01) * 100.0) as i32,
+            3,
+            "round-to-nearest baseline"
+        );
+        assert_eq!(
+            native_ai_opening_grant(3, 100),
+            2,
+            "chop at 53 bits then ftol"
+        );
+        assert_eq!(native_ai_opening_grant(3, 200), 5);
+        assert_eq!(
+            native_ai_opening_grant(400, 10_000),
+            40_000,
+            "stock Hard AI"
+        );
+        assert_eq!(native_ai_opening_grant(0, 10_000), 0, "stock Normal/Easy");
+        assert_eq!(native_ai_opening_grant(7, 12_345), 864);
+        assert_eq!(native_ai_opening_grant(400, 0), 0);
+        assert_eq!(
+            native_ai_opening_grant(-100, 10_000),
+            -10_000,
+            "negative chops toward zero"
+        );
+    }
     use crate::map::bridge_facts::BridgeCellFacts;
     use crate::map::resolved_terrain::{ResolvedTerrainCell, zone_class};
     use crate::rules::ini_parser::IniFile;

--- a/src/sim/scenario_post_map.rs
+++ b/src/sim/scenario_post_map.rs
@@ -157,7 +157,7 @@ impl Simulation {
             {
                 skirmish_order[1] = Some(ScenarioPostMapStep::AiOpeningCredits);
             }
-            crate::sim::scenario_bootstrap::apply_skirmish_ai_opening_credits(self);
+            crate::sim::scenario_bootstrap::apply_skirmish_ai_opening_credits(self, input.rules);
             #[cfg(test)]
             {
                 skirmish_order[2] = Some(ScenarioPostMapStep::LaunchAlliances);
@@ -773,7 +773,9 @@ mod tests {
         assert!(output.navigation_published);
         assert!(sim.path_grid().is_some());
         assert_eq!(sim.houses[&player].credits, 5_000);
-        assert_eq!(sim.houses[&computer].credits, 10_000);
+        // The fixture AI is Easy and the fixture rules carry no MultiplayerAICM
+        // entry for it, so Post_Map_Init adds ftol(0 * 0.01 * 5000) = 0.
+        assert_eq!(sim.houses[&computer].credits, 5_000);
         assert_eq!(
             output.crates,
             Some(CratePlacement {


### PR DESCRIPTION
Skirmish opening credits now follow gamemd. `ScenarioClass::Post_Map_Init` (loop 0x006869BE..0x00686A7E) grants every non-human, non-MultiplayPassive house `ftol(MultiplayerAICM[difficulty] × 0.01 × Available_Money)`: `FILD` the `Rules+0x1308` entry indexed by `House+0x184` (0 Hard, 1 Normal, 2 Easy), `FMUL` the 0.01 double at 0x007E3808, `FIMUL` the balance from 0x004F6990, `Math::ftol` under the 0x0E7F chop control word. Retail `MultiplayerAICM=400,0,0` means a Hard AI opens at five times the lobby credits and Normal/Easy gain nothing; Rust doubled every AI.

`Generate_Starting_Units` @ 0x005D6D80 budgets each non-passive house `((n/2 + Σcost)/n) × UnitCount` in truncating integer math and credits any positive remainder to that house (0x005D6F91..0x005D6F9C) before the grant loop runs (call at 0x00686937). Rust discarded the remainder.

Changes: `MultiplayerAICM` parsed from `[General]`; the grant evaluated through the native x87 chop helpers in native operation order (missing entry yields 0, VERA-internal); leftover budget credited per house inside the seeding loop so the grant multiplies the post-remainder balance. Tests pin Hard 10000 → 50000, Normal/Easy/human/passive unchanged, the chop-vs-nearest case 3 × 100 → 2, the leftover credit (fixture 10000 → 10034), and the order.

Independent read-only critic re-read the Post_Map_Init loop, 0x004F6990, `Add_Credits`, the constant bytes, and the Generate_Starting_Units budget/callback/credit sites, recomputed the chop example and the fixture's 34-credit remainder by hand, and passed the change.

Validation:
- `cargo test -p vera20k --lib`: `test result: ok. 8297 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 26.59s`

Residual: a house with no eligible starting-unit candidates makes native abort the whole generation; Rust continues with later houses (unreachable with retail rules).
