### PR TITLE
Gate refinery unload smoke and SpecialAnim on the native dump gates

### DIFF
--- a/src/sim/components.rs
+++ b/src/sim/components.rs
@@ -1020,16 +1020,27 @@ pub struct ParachuteAnim {
     pub elapsed_frames: u16,
 }
 
-/// Emitted by the refinery dock state machine for one successful dump-gate
-/// whole-slot drain. The authoritative master-frame tail consumes it to arm
-/// SpecialAnim slot 10 and spawn particle systems at the refinery smoke offsets
-/// before the returned state hash. The queue itself is transient and serde-skipped.
+/// Emitted by the refinery dock state machine for EVERY due dump gate of
+/// `UnitClass::Mission_Unload @ 0x0073D630` state 3 (`HarvesterDumpRate × 900
+/// <= unit+0xF8`, `0x0073E355..0x0073E374`), including the final gate that finds
+/// no cargo. The authoritative master-frame tail consumes it to spawn the
+/// refinery smoke burst (`BuildingClass` vtable+0x468 → `0x00459900`, fired
+/// first on each gate at `0x0073E37E`), start SpecialAnim slot 10 only while
+/// none is live (`building+0x584 == NULL`, `0x0073E384`), and cut the running
+/// SpecialAnim on the empty gate (`ClearAnimSlot(0xA)`, `0x0073E530`) before
+/// the returned state hash. The queue itself is transient and serde-skipped.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BaleDepositEvent {
     /// Refinery stable_id where the bale was deposited.
     pub building_id: u64,
     /// Sim tick when this event was emitted (for ordering / debugging).
     pub tick: u64,
+    /// One StorageClass slot drained on this gate (credits were paid;
+    /// `0x0073E4A2..0x0073E4DA`).
+    pub drained: bool,
+    /// The gate found no cargo (`FindFirstNonEmptySlot == -1`,
+    /// `0x0073E4DC..0x0073E534`): state 3 → 4 and the SpecialAnim is cut.
+    pub empty: bool,
 }
 
 /// Emitted by the tank-bunker lifecycle when the walls rise (install) or fall

--- a/src/sim/miner/miner_dock_sequence.rs
+++ b/src/sim/miner/miner_dock_sequence.rs
@@ -726,6 +726,79 @@ fn abort_missing_unload_building(sim: &mut Simulation, snap: &mut MinerSnapshot,
     snap.state = dock_abort_state(snap);
 }
 
+/// Contact-gone abandonment of an unload, `Mission_Unload @ 0x0073DEEB..0x0073DF55`.
+///
+/// Native side effects, in order:
+/// - `vtable+0x484 (0,1)` = `UnitClass::Enter_Idle_Mode @ 0x00738970`. With the
+///   CURRENT mission still Unload (`+0xAC == 0x10`) its final
+///   `Assign_Mission` is skipped (`0x00738D0x` gate excludes 0x19/0xB/0x10/9),
+///   and the harvester branch bails on `In_Radio_Contact` anyway; the
+///   `FootClass` base (`0x004D82B0`) only drops target/destination. No mission
+///   is assigned here — NOT a Harvest resume.
+/// - `+0x6D1 = 0`: the unload-active latch (and with it the UnloadingClass
+///   image) is cleared.
+/// - locomotor `Is_Moving` → `vtable+0x500` (`0x004D55C0` → locomotor
+///   `Stop_Moving`).
+/// - `Is_Ready_To_Commence` → `Commence`: only an already QUEUED mission is
+///   promoted (fieldwise no-op on an empty queue).
+/// - `return 1`: the unit stays in Unload and re-dispatches next frame, repeating
+///   this until something queues a mission for it.
+///
+/// Rust keeps the miner parked in `Pivoting` with the latch cleared, re-checking
+/// every frame; a promoted queued mission leaves the dock sequence through the
+/// same zeroed handler cursor the state-4 exit uses, and releases the miner's
+/// live contact and radio-bus slot exactly as that exit does.
+///
+/// Residual (VERA-internal, gamemd equivalent UNCHECKED beyond the dispatch
+/// order): native runs the `In_Radio_Contact` check at `0x0073DEE7` BEFORE the
+/// `+0xBC` state dispatch, so states 3 (dumping) and 4 (exit) abandon the unload
+/// on contact loss as well. Rust asks only at `Pivoting`; `Unloading` and
+/// `Departing` never re-check. No production path currently drops a contact
+/// without also resetting the dock phase (`interrupt_docked_miners`,
+/// `abort_invalid_refinery`, `abort_missing_unload_building`), so the gap has
+/// no trigger today; a future contact-drop that leaves the phase in place would
+/// let the drain continue one gate longer than native.
+fn abort_unload_contact_lost(sim: &mut Simulation, snap: &mut MinerSnapshot, ref_sid: u64) {
+    if let Some(entity) = sim.substrate.entities.get_mut(snap.entity_id) {
+        // Enter_Idle_Mode base: drop target/destination; +0x500: Stop_Moving.
+        entity.facing_target = None;
+        entity.movement_target = None;
+        entity.drive_track = None;
+        entity.forced_drive_track = None;
+        // +0x6D1 = 0 drops the UnloadingClass image with the latch.
+        entity.display_type_override = None;
+    }
+    snap.miner.dock_pivot_facing = None;
+    clear_unload_cluster(snap);
+
+    let now = sim.session.binary_frame;
+    let commenced = matches!(sim.mission_commence_exact(snap.entity_id, now), Ok(true));
+    if commenced {
+        // Commence zeroed the handler cursor (== SearchOre); the dock
+        // bookkeeping goes with it, as on the state-4 exit: registry slot and
+        // pad, radio-bus BREAK, and the miner's live-contact mirror.
+        sim.production
+            .dock_reservations
+            .cancel_miner(ref_sid, snap.entity_id);
+        bus_break(sim, snap.entity_id, ref_sid);
+        clear_refinery_contact(sim, snap.entity_id, ref_sid);
+        snap.miner.reserved_refinery = None;
+        snap.miner.dock_queued = false;
+        snap.miner.dock_phase = RefineryDockPhase::Approach;
+        clear_enter_retry(snap);
+        clear_mission_deploy_delay(snap);
+        snap.miner.exit_cell = None;
+        if snap.miner.is_full() {
+            snap.miner.target_ore_cell = None;
+        }
+        snap.state = MinerState::SearchOre;
+        return;
+    }
+    // `return 1`: re-dispatch next frame, still in the Unload-equivalent.
+    schedule_mission_deploy_delay(snap, now, 1);
+    snap.miner.dock_phase = RefineryDockPhase::Pivoting;
+}
+
 // ---------------------------------------------------------------------------
 // Main dock sequence handler
 // ---------------------------------------------------------------------------
@@ -1155,6 +1228,19 @@ fn phase_pivoting(
         return;
     }
 
+    // `0x0073DEE0`: every harvester-branch Unload dispatch first asks
+    // `RadioClass::In_Radio_Contact` (0x0065AE30, any non-null entry in the
+    // `+0xE4`×`+0xE8` contact array; mislabeled `PathType__Has_Valid_Steps`)
+    // BEFORE the facing gate. Contacts gone → the unload is abandoned.
+    if !sim
+        .production
+        .dock_reservations
+        .has_contact(ref_sid, snap.entity_id)
+    {
+        abort_unload_contact_lost(sim, snap, ref_sid);
+        return;
+    }
+
     if sync_dock_facing(sim, rules, snap) {
         // Mission 0x10 has reached its facing gate. Radio 0x15 only queued
         // that mission; unload-active effects begin here.
@@ -1299,11 +1385,15 @@ fn phase_unloading(
             }
         }
 
-        // One deposit event per slot drain — drives one SpecialAnim play
-        // and one smoke-particle spawn per slot.
+        // One deposit event per due dump gate. Native fires the refinery smoke
+        // burst (vtable+0x468, `0x0073E37E`) and the `+0x584 == NULL` SpecialAnim
+        // start (`0x0073E384..0x0073E3BA`) BEFORE it looks at the cargo, so the
+        // gate that drains a slot and the gate that finds nothing both emit.
         sim.bale_events.push(BaleDepositEvent {
             building_id: unload_building_id,
             tick: sim.session.tick,
+            drained: true,
+            empty: false,
         });
 
         snap.miner.unload_accumulator = 0;
@@ -1315,7 +1405,22 @@ fn phase_unloading(
     // returned -1, so stock Mission_Deploy_Building state 3 advances to
     // state 4. Do not seed another dump-gate cooldown here; the due
     // mission-deploy delay and accumulator gate have already fired.
-    snap.miner.home_refinery = mission_deploy_unload_building(sim, snap.entity_id);
+    //
+    // This gate still ran the smoke burst and the SpecialAnim-start check
+    // (`0x0073E37E..0x0073E3BA`), then `0x0073E4DC..0x0073E534`: slot-8
+    // ProductionAnim (stock GAREFN/NAREFN define none → no-op), `+0xBC = 4`,
+    // and `ClearAnimSlot(0xA)` while `+0x584` is still alive — the SpecialAnim
+    // is cut, not played out.
+    let unload_building = mission_deploy_unload_building(sim, snap.entity_id);
+    if let Some(building_id) = unload_building {
+        sim.bale_events.push(BaleDepositEvent {
+            building_id,
+            tick: sim.session.tick,
+            drained: false,
+            empty: true,
+        });
+    }
+    snap.miner.home_refinery = unload_building;
     schedule_mission_deploy_delay(snap, sim.session.binary_frame, 1);
     snap.miner.dock_phase = RefineryDockPhase::Departing;
 }

--- a/src/sim/miner/miner_tests.rs
+++ b/src/sim/miner/miner_tests.rs
@@ -4437,12 +4437,19 @@ fn unloading_emits_one_event_per_slot_drain() {
 
     tick_miners_n(&mut sim, &rules, 200);
 
+    let drained: Vec<_> = sim.bale_events.iter().filter(|e| e.drained).collect();
+    assert_eq!(
+        drained.len(),
+        1,
+        "pure-ore cargo must drain in one slot dump = one drain BaleDepositEvent",
+    );
+    assert_eq!(drained[0].building_id, 2);
     assert_eq!(
         sim.bale_events.len(),
-        1,
-        "pure-ore cargo must drain in one slot dump = one BaleDepositEvent",
+        2,
+        "the empty gate that ends state 3 emits its own (smoke-only) event",
     );
-    assert_eq!(sim.bale_events[0].building_id, 2);
+    assert!(sim.bale_events[1].empty && !sim.bale_events[1].drained);
 
     // --- 5 ore + 3 gems = 2 slots → 2 events ---
     let mut sim = Simulation::new();
@@ -4477,9 +4484,14 @@ fn unloading_emits_one_event_per_slot_drain() {
     tick_miners_n(&mut sim, &rules, 200);
 
     assert_eq!(
-        sim.bale_events.len(),
+        sim.bale_events.iter().filter(|e| e.drained).count(),
         2,
-        "ore + gem cargo must produce two BaleDepositEvents (one per slot)",
+        "ore + gem cargo must produce two drain BaleDepositEvents (one per slot)",
+    );
+    assert_eq!(
+        sim.bale_events.len(),
+        3,
+        "two drain gates plus the empty gate",
     );
     for event in &sim.bale_events {
         assert_eq!(event.building_id, 2);
@@ -5235,13 +5247,23 @@ fn full_dock_cycle_war_miner() {
     // 10 bales x ~14 ticks unload, then stock state-4 handoff.
     tick_miners_n(&mut sim, &rules, 400);
 
-    // Bale events: one per slot drain. Pre-loaded with pure ore → 1 slot → 1 event.
+    // Bale events: one per due dump gate. Pure ore → 1 slot drain + the empty
+    // gate that ends state 3 (both fire the refinery smoke burst, 0x0073E37E).
+    let drained = sim.bale_events.iter().filter(|e| e.drained).count();
     assert_eq!(
-        sim.bale_events.len(),
+        drained,
         1,
-        "expected 1 bale event (one slot drain), got {}",
+        "expected 1 slot-drain event, got {} of {}",
+        drained,
         sim.bale_events.len(),
     );
+    assert_eq!(
+        sim.bale_events.len(),
+        2,
+        "expected the drain gate plus the empty gate, got {}",
+        sim.bale_events.len(),
+    );
+    assert!(sim.bale_events[1].empty, "the last gate found no cargo");
 
     // Credits: bale_count * bale_value (no purifier in miner_rules).
     let credits_after = credits_for_owner(&sim, "Americans");
@@ -7819,11 +7841,16 @@ fn harvest_seam_dispatch_matches_miner_fsm() {
     let credits_before = credits_for_owner(&sim, "Americans");
     tick_miners_n(&mut sim, &rules, 400);
 
-    // One slot drain → one bale event; full ore payout (10 × 25).
+    // One slot drain → one drain event (plus the empty gate); full ore payout (10 × 25).
+    assert_eq!(
+        sim.bale_events.iter().filter(|e| e.drained).count(),
+        1,
+        "seam: one slot drain → one drain event"
+    );
     assert_eq!(
         sim.bale_events.len(),
-        1,
-        "seam: one slot drain → one bale event"
+        2,
+        "seam: drain gate plus the empty gate"
     );
     assert_eq!(
         credits_for_owner(&sim, "Americans") - credits_before,
@@ -8884,4 +8911,431 @@ fn refinery_selection_too_far_test_uses_foundation_centre() {
         Some(3),
         "free refinery inside HarvesterTooFarDistance by centre distance must win the narrow pass",
     );
+}
+
+// ---------------------------------------------------------------------------
+// GSI-07.39: refinery-side unload presentation (Mission_Unload state 3 gates)
+// and the contact-gone abandonment at unload start.
+// ---------------------------------------------------------------------------
+
+/// `miner_rules()` plus a refinery smoke particle system and a long-running
+/// SpecialAnim so the overlay is still alive at the next 15-frame gate.
+fn miner_rules_with_refinery_art() -> RuleSet {
+    let ini = IniFile::from_str(
+        "[InfantryTypes]\n\
+         [VehicleTypes]\n\
+         0=HARV\n\
+         [AircraftTypes]\n\
+         [BuildingTypes]\n\
+         0=GAREFN\n\
+         [Particles]\n\
+         0=RefSmokeParticle\n\
+         [ParticleSystems]\n\
+         0=RefSmokeSystem\n\
+         [HARV]\n\
+         Name=War Miner\n\
+         Cost=1400\n\
+         Strength=600\n\
+         Armor=heavy\n\
+         Speed=4\n\
+         ROT=5\n\
+         Sight=5\n\
+         TechLevel=1\n\
+         Owner=Americans\n\
+         Harvester=yes\n\
+         Dock=GAREFN\n\
+         [GAREFN]\n\
+         Name=Ore Refinery\n\
+         Image=GAREFN\n\
+         Cost=2000\n\
+         Strength=900\n\
+         Armor=wood\n\
+         TechLevel=1\n\
+         Owner=Americans\n\
+         Foundation=4x3\n\
+         Refinery=yes\n\
+         RefinerySmokeParticleSystem=RefSmokeSystem\n\
+         RefinerySmokeOffsetOne=10,-20,30\n\
+         [RefSmokeParticle]\n\
+         BehavesLike=Smoke\n\
+         MaxEC=10\n\
+         MaxDC=4\n\
+         StartStateAI=0\n\
+         EndStateAI=10\n\
+         StateAIAdvance=4\n\
+         [RefSmokeSystem]\n\
+         BehavesLike=Smoke\n\
+         HoldsWhat=RefSmokeParticle\n\
+         Spawns=yes\n\
+         ParticleCap=10\n\
+         SpawnFrames=1\n\
+         Lifetime=200\n",
+    );
+    let mut rules = RuleSet::from_ini(&ini).expect("miner rules with refinery art");
+    let art = crate::rules::art_data::ArtRegistry::from_ini(&IniFile::from_str(
+        "[GAREFN]\n\
+         SpecialAnim=GAREFNOR\n\
+         [GAREFNOR]\n\
+         Start=0\n\
+         LoopStart=0\n\
+         LoopEnd=200\n\
+         Rate=100\n",
+    ));
+    rules.merge_art_data(&art);
+    rules
+}
+
+/// Miner on the pad facing East, `MissionQueued`, with the given cargo and a
+/// registry contact (the HELLO admission the dock FSM reads).
+fn spawn_queued_unload_miner(sim: &mut Simulation, cargo: &[(ResourceType, u16)]) -> u64 {
+    spawn_refinery(sim, 2, 10, 10);
+    let miner_id = spawn_miner(sim, 1, MinerKind::War, 13, 11);
+    {
+        let entity = sim
+            .substrate
+            .entities
+            .get_mut(miner_id)
+            .expect("miner entity");
+        entity.movement_target = None;
+        entity.facing = 0x40;
+        let miner = entity.miner.as_mut().expect("miner component");
+        for (resource_type, value) in cargo {
+            miner.cargo.push(CargoBale {
+                resource_type: *resource_type,
+                value: *value,
+            });
+        }
+        entity.mission.set_handler_state(MinerState::Dock.cursor());
+        miner.dock_phase = RefineryDockPhase::MissionQueued;
+        miner.reserved_refinery = Some(2);
+    }
+    assert!(sim.production.dock_reservations.try_reserve(2, miner_id));
+    // The frame tail's smoke spawn registers the particle system in the live
+    // object order; once that order is non-empty `tick_miners` walks only it,
+    // so both fixture objects must be members too.
+    for id in [2, miner_id] {
+        sim.substrate.logic.try_push(id).expect("logic slot");
+        sim.substrate
+            .entities
+            .get_mut(id)
+            .expect("fixture entity")
+            .in_logic_vector = true;
+    }
+    miner_id
+}
+
+/// Per-tick observation of the refinery presentation: smoke system count and
+/// whether the SpecialAnim slot is live after this tick's frame tail.
+struct UnloadPresentationTrace {
+    smoke_count: Vec<usize>,
+    slot_live: Vec<bool>,
+}
+
+fn trace_unload_presentation(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    ticks: usize,
+) -> UnloadPresentationTrace {
+    let special = sim.interner.intern("GAREFNOR");
+    let mut trace = UnloadPresentationTrace {
+        smoke_count: Vec::with_capacity(ticks),
+        slot_live: Vec::with_capacity(ticks),
+    };
+    for _ in 0..ticks {
+        tick_miners_n(sim, rules, 1);
+        // The authoritative frame tail that consumes the bale events.
+        crate::sim::world::building_anim::finalize(sim, &[], true, Some(rules));
+        trace.smoke_count.push(sim.particle_systems().len());
+        trace.slot_live.push(
+            sim.substrate
+                .entities
+                .get(2)
+                .expect("refinery")
+                .building_anim_overlays
+                .as_ref()
+                .is_some_and(|o| o.anims.iter().any(|a| a.anim_type == special)),
+        );
+    }
+    trace
+}
+
+/// Ticks at which the SpecialAnim slot went absent → live (a `SetAnimSlotImage(10)`).
+fn slot_starts(trace: &UnloadPresentationTrace) -> Vec<usize> {
+    let mut starts = Vec::new();
+    let mut prev = false;
+    for (i, live) in trace.slot_live.iter().enumerate() {
+        if *live && !prev {
+            starts.push(i + 1);
+        }
+        prev = *live;
+    }
+    starts
+}
+
+/// Ticks at which the smoke count rose (one refinery burst per due gate).
+fn smoke_bursts(trace: &UnloadPresentationTrace) -> Vec<usize> {
+    let mut bursts = Vec::new();
+    let mut prev = 0usize;
+    for (i, count) in trace.smoke_count.iter().enumerate() {
+        if *count > prev {
+            bursts.push(i + 1);
+        }
+        prev = *count;
+    }
+    bursts
+}
+
+/// Ore-only cargo: two due gates (ore drain, then the empty gate). Native
+/// `0x0073E37E` fires the vtable+0x468 smoke burst on both, starts the
+/// SpecialAnim once (`+0x584 == NULL`), and `ClearAnimSlot(0xA)` cuts it on the
+/// empty gate ~15 frames after it started.
+#[test]
+fn ore_only_unload_smokes_twice_and_cuts_special_anim_on_empty_gate() {
+    let mut sim = Simulation::new();
+    let rules = miner_rules_with_refinery_art();
+    let miner_id = spawn_queued_unload_miner(&mut sim, &[(ResourceType::Ore, 25); 5]);
+
+    let trace = trace_unload_presentation(&mut sim, &rules, 60);
+
+    let bursts = smoke_bursts(&trace);
+    assert_eq!(
+        bursts.len(),
+        2,
+        "ore-only: one smoke burst per due gate (ore drain + empty gate), got {bursts:?}"
+    );
+    assert_eq!(
+        *trace.smoke_count.last().expect("trace"),
+        2,
+        "two RefinerySmokeParticleSystem instances (one offset defined)"
+    );
+    let starts = slot_starts(&trace);
+    assert_eq!(
+        starts.len(),
+        1,
+        "SpecialAnim starts exactly once, got starts at {starts:?}"
+    );
+    assert_eq!(
+        starts[0], bursts[0],
+        "SpecialAnim starts on the first (ore) gate"
+    );
+    let gap = bursts[1] - bursts[0];
+    assert!(
+        (14..=16).contains(&gap),
+        "empty gate follows the drain by one HarvesterDumpRate×900 gate (~15 frames), got {gap}"
+    );
+    assert!(
+        trace.slot_live[bursts[1] - 2],
+        "SpecialAnim still live the tick before the empty gate (not played out)"
+    );
+    assert!(
+        !trace.slot_live[bursts[1] - 1],
+        "empty gate cuts the SpecialAnim (ClearAnimSlot 0xA @ 0x0073E534)"
+    );
+    assert!(
+        !trace.slot_live.last().expect("trace"),
+        "SpecialAnim stays cleared after the unload"
+    );
+    assert!(get_miner(&sim, miner_id).cargo.is_empty(), "cargo drained");
+}
+
+/// Ore + gem cargo: three due gates (ore, gem, empty). Smoke ×3; the
+/// SpecialAnim started on the ore gate is still alive on the gem gate, so
+/// `+0x584 != NULL` skips the restart (`0x0073E38C`), and the empty gate cuts it.
+#[test]
+fn ore_and_gem_unload_smokes_thrice_and_starts_special_anim_once() {
+    let mut sim = Simulation::new();
+    let rules = miner_rules_with_refinery_art();
+    let mut cargo = vec![(ResourceType::Ore, 25u16); 5];
+    cargo.extend([(ResourceType::Gem, 50u16); 3]);
+    let miner_id = spawn_queued_unload_miner(&mut sim, &cargo);
+
+    let trace = trace_unload_presentation(&mut sim, &rules, 80);
+
+    let bursts = smoke_bursts(&trace);
+    assert_eq!(
+        bursts.len(),
+        3,
+        "ore+gem: one smoke burst per due gate (ore, gem, empty), got {bursts:?}"
+    );
+    assert_eq!(*trace.smoke_count.last().expect("trace"), 3);
+    for pair in bursts.windows(2) {
+        let gap = pair[1] - pair[0];
+        assert!(
+            (14..=16).contains(&gap),
+            "gates are one HarvesterDumpRate×900 apart (~15 frames), got {gap} in {bursts:?}"
+        );
+    }
+    let starts = slot_starts(&trace);
+    assert_eq!(
+        starts,
+        vec![bursts[0]],
+        "SpecialAnim starts on the ore gate only; the gem gate finds +0x584 live and does not restart"
+    );
+    assert!(
+        trace.slot_live[bursts[1] - 1],
+        "SpecialAnim is live through the gem gate"
+    );
+    assert!(
+        !trace.slot_live[bursts[2] - 1],
+        "empty gate cuts the SpecialAnim"
+    );
+    assert!(get_miner(&sim, miner_id).cargo.is_empty());
+}
+
+/// Contact gone between MissionQueued and unload start (`0x0073DEE0`):
+/// `In_Radio_Contact` false → `Enter_Idle_Mode(0,1)` (no mission assigned
+/// while the current mission is Unload), `+0x6D1 = 0`, Stop_Moving, Commence of
+/// a queued mission only, `return 1`. The miner abandons the unload without
+/// depositing and parks, re-dispatching each frame, until a mission is queued.
+#[test]
+fn contact_gone_at_unload_start_abandons_unload_without_deposit() {
+    use crate::sim::mission::{MissionId, MissionType};
+
+    let mut sim = Simulation::new();
+    let rules = miner_rules_with_refinery_art();
+    let capacity = {
+        let m = Miner::new(MinerKind::War, &MinerConfig::default(), 0);
+        m.capacity_bales as usize
+    };
+    let cargo = vec![(ResourceType::Ore, 25u16); capacity];
+    let miner_id = spawn_queued_unload_miner(&mut sim, &cargo);
+    let credits_before = credits_for_owner(&sim, "Americans");
+
+    // Tick 1: MissionQueued → Pivoting (radio 0x15 only queued mission 0x10).
+    tick_miners_n(&mut sim, &rules, 1);
+    assert_eq!(
+        get_miner(&sim, miner_id).dock_phase,
+        RefineryDockPhase::Pivoting
+    );
+
+    // Seed the bus/live-contact shadow the HELLO path would have left so the
+    // exit's release is observable: refinery radio slot + miner mirror.
+    crate::sim::miner::miner_dock_sequence::bus_hello(&mut sim, miner_id, 2, 1, true);
+    sim.substrate
+        .entities
+        .get_mut(miner_id)
+        .expect("miner")
+        .mark_live_contact_with(2);
+    assert!(
+        sim.substrate
+            .entities
+            .get(2)
+            .expect("refinery")
+            .radio_contacts
+            .contains(miner_id)
+    );
+
+    // The refinery drops the contact before the Unload dispatch runs.
+    sim.production
+        .dock_reservations
+        .release_contact(2, miner_id);
+
+    tick_miners_n(&mut sim, &rules, 40);
+    crate::sim::world::building_anim::finalize(&mut sim, &[], true, Some(&rules));
+
+    let m = get_miner(&sim, miner_id);
+    assert_eq!(m.cargo.len(), capacity, "no slot drained without a contact");
+    assert_eq!(
+        credits_for_owner(&sim, "Americans"),
+        credits_before,
+        "no deposit credited"
+    );
+    assert!(sim.bale_events.is_empty(), "no dump-gate event emitted");
+    assert!(
+        sim.particle_systems().is_empty(),
+        "no refinery smoke burst without a contact"
+    );
+    assert!(!m.unload_active, "+0x6D1 unload latch cleared");
+    assert_eq!(
+        m.dock_phase,
+        RefineryDockPhase::Pivoting,
+        "parked in the Unload-equivalent, re-dispatching each frame"
+    );
+    assert_eq!(m.state, MinerState::Dock);
+    let entity = sim.substrate.entities.get(miner_id).expect("miner");
+    assert_eq!(
+        entity.display_type_override, None,
+        "UnloadingClass image dropped with the latch"
+    );
+    assert!(entity.movement_target.is_none(), "Stop_Moving");
+
+    // A queued mission is what ends the loop: Is_Ready_To_Commence → Commence
+    // promotes it and the dock sequence is left through the zeroed cursor.
+    let now = sim.session.binary_frame;
+    sim.mission_queue_exact(
+        miner_id,
+        MissionId::from_known(MissionType::Harvest),
+        0,
+        now,
+        &crate::sim::mission::authority::EntityReadyInputProvider,
+    )
+    .expect("miner exists");
+    tick_miners_n(&mut sim, &rules, 1);
+    let m = get_miner(&sim, miner_id);
+    assert_ne!(
+        m.state,
+        MinerState::Dock,
+        "commenced mission leaves the dock"
+    );
+    assert_eq!(m.dock_phase, RefineryDockPhase::Approach);
+    assert_eq!(m.reserved_refinery, None);
+    assert_eq!(m.cargo.len(), capacity, "cargo still intact");
+    // The exit releases the contact the way the state-4 exit does: bus BREAK
+    // and the miner's live-contact mirror both drop.
+    let entity = sim.substrate.entities.get(miner_id).expect("miner");
+    assert!(
+        !entity.has_live_contact_with(2),
+        "commenced exit clears the miner's live contact"
+    );
+    assert_eq!(
+        entity.dock_entered_with, None,
+        "bus BREAK clears dock_entered_with"
+    );
+    assert!(
+        !sim.substrate
+            .entities
+            .get(2)
+            .expect("refinery")
+            .radio_contacts
+            .contains(miner_id),
+        "bus BREAK frees the refinery radio slot"
+    );
+    assert!(!sim.production.dock_reservations.has_contact(2, miner_id));
+}
+
+/// Retail GAREFN/NAREFN define `SpecialAnim` but no `SpecialAnimDamaged`.
+/// `SetAnimSlotImage(10, damaged=1, …) @ 0x00451750` reads only the slot-local
+/// damaged name (`+0xF5C`) and creates nothing when it is empty, so a refinery
+/// at/below ConditionYellow (`GetHealthRatio <= Rules+0x1700`, `0x0073E39B`)
+/// unloads with the smoke bursts only.
+#[test]
+fn damaged_refinery_ore_only_unload_smokes_twice_without_special_anim() {
+    let mut sim = Simulation::new();
+    let rules = miner_rules_with_refinery_art();
+    let miner_id = spawn_queued_unload_miner(&mut sim, &[(ResourceType::Ore, 25); 5]);
+    {
+        let refinery = sim.substrate.entities.get_mut(2).expect("refinery");
+        refinery.health.max = 1000;
+        refinery.health.current =
+            u16::try_from(rules.general.condition_yellow_x1000).expect("ratio fits");
+    }
+
+    let trace = trace_unload_presentation(&mut sim, &rules, 60);
+
+    let bursts = smoke_bursts(&trace);
+    assert_eq!(
+        bursts.len(),
+        2,
+        "damaged refinery still smokes on both due gates, got {bursts:?}"
+    );
+    assert_eq!(*trace.smoke_count.last().expect("trace"), 2);
+    assert!(
+        slot_starts(&trace).is_empty(),
+        "no SpecialAnimDamaged defined: slot 10 never starts"
+    );
+    assert!(
+        trace.slot_live.iter().all(|live| !live),
+        "base SpecialAnim is never used as a fallback"
+    );
+    assert!(get_miner(&sim, miner_id).cargo.is_empty(), "cargo drained");
 }

--- a/src/sim/miner/mod.rs
+++ b/src/sim/miner/mod.rs
@@ -190,7 +190,9 @@ pub enum RefineryDockPhase {
     Pivoting,
     /// Per-slot deposit pulse. Each timer crossing (HarvesterDumpRate × 900
     /// = 14.4 ticks) drains one StorageClass slot — all bales of one
-    /// resource type at once — and emits a single BaleDepositEvent.
+    /// resource type at once — and emits one BaleDepositEvent per due gate
+    /// (`drained` on a slot drain, `empty` on the final no-cargo gate; the
+    /// refinery smoke burst fires on both, `0x0073E37E`).
     /// Slot order matches gamemd: Ore (slot 0) first, Gems (slot 1) second.
     /// On the first empty-slot gate after the last drain: transition to
     /// Departing for the stock state-4 cleanup.

--- a/src/sim/world/building_anim.rs
+++ b/src/sim/world/building_anim.rs
@@ -5,8 +5,11 @@
 //! render the resulting entity components and particle systems without writing
 //! back into `Simulation`.
 //!
-//! Refinery provenance: `Mission_Deploy_Building @ 0x0073D630` reaches the
-//! due dump-gate particle emitter at `0x00459900`; see
+//! Refinery provenance: `UnitClass::Mission_Unload @ 0x0073D630` state 3 reaches
+//! the due dump-gate particle emitter through `BuildingClass` vtable+0x468
+//! (`0x007E4324` → `0x00459900`) on every due gate, starts SpecialAnim slot 10
+//! only while `+0x584 == NULL`, and cuts it with `ClearAnimSlot(0xA)` on the
+//! empty gate; see `consume_bale_events` and
 //! `docs/research/miner/REFINERY_DOCK_ANIM_SLOTS_GHIDRA_REPORT.md`. This slice
 //! preserves the existing Rust crane and bunker slot projections; their exact
 //! native trigger selection remains UNCHECKED here.
@@ -25,7 +28,7 @@ use super::Simulation;
 /// refinery bales reset their Special animation and spawn smoke, tank-bunker
 /// events apply their ordered wall animations, and only then do all active
 /// overlays receive this frame's logic visit.
-pub(super) fn finalize(
+pub(crate) fn finalize(
     sim: &mut Simulation,
     placed_building_owners: &[InternedId],
     frame_committed: bool,
@@ -181,6 +184,45 @@ fn trigger_crane_anim(sim: &mut Simulation, rules: &RuleSet, art: &ArtRegistry, 
     }
 }
 
+/// The `damaged` argument of the dump-gate `SetAnimSlotImage(10, damaged, 0, 0)`
+/// call: `Mission_Unload @ 0x0073E38E..0x0073E3AF` calls
+/// `ObjectClass::GetHealthRatio (0x005F5C60)` and `FCOMP`s it against
+/// `Rules+0x1700` — the `[General] ConditionYellow` ratio (`RulesClass::ReadINI`
+/// reads the "ConditionYellow" string at `0x0083A370`, loads the default from
+/// `+0x1700` at `0x0066B36A` and `FSTP`s the result back to `+0x1700` at
+/// `0x0066B37F`; ConditionRed follows at `+0x1708`). `damaged = ratio <=
+/// ConditionYellow`. Integer math keeps the sim float-free.
+fn at_or_below_condition_yellow(current: u16, max: u16, condition_yellow_x1000: i64) -> bool {
+    let current_x1000 = current as i64 * 1000;
+    let threshold_x1000 = max.max(1) as i64 * condition_yellow_x1000;
+    current_x1000 <= threshold_x1000
+}
+
+/// Refinery-side presentation of `Mission_Unload` state 3 dump gates
+/// (`0x0073E37A..0x0073E3BF`, `0x0073E4DC..0x0073E534`), one event per gate:
+///
+/// 1. `vtable+0x468` (`0x00459900`): for each non-zero
+///    `RefinerySmokeOffsetOne..Four` (`type+0x7CC/0x7D8/0x7E4/0x7F0`) a new
+///    `RefinerySmokeParticleSystem` (`type+0x774`) at building coord + offset.
+///    Fires on EVERY due gate, the empty one included.
+/// 2. `SetAnimSlotImage(10, damaged, 0, 0)` ONLY while `building+0x584 == NULL`
+///    (`0x0073E384`): a running SpecialAnim is never restarted.
+///    `SetAnimSlotImage @ 0x00451750` with `damaged != 0` reads ONLY the
+///    slot-local damaged name (`type + slot*0x44 + 0xF5C`, slot 10 =
+///    `SpecialAnimDamaged`) and returns without creating anything when it is
+///    empty — there is NO fallback to the base `SpecialAnim` (`+0xF4C`).
+///    Retail artmd.ini GAREFN/NAREFN define `SpecialAnim` but no
+///    `SpecialAnimDamaged`, so a yellow/red stock refinery unloads with smoke
+///    only.
+/// 3. Empty gate: `ClearAnimSlot(0xA)` while `+0x584` is alive (`0x0073E526..
+///    0x0073E534`) — the SpecialAnim is cut. (Slot-8 ProductionAnim is
+///    undefined for stock refineries, so its `SetAnimSlotImage` is a no-op.)
+///
+/// Follow-up (not implemented here): at `LAB_0073E539`, after a SUCCESSFUL
+/// drain, `unit+0x5A4 != 0 && queued mission ∉ {-1, 10}` (a player redirect
+/// mid-unload) also runs slot-8 `SetAnimSlotImage`, sets state 4 and
+/// `ClearAnimSlot(10)` on that gate. Rust cuts the SpecialAnim only on the
+/// empty gate; a mid-unload redirect currently lets it run until then.
 fn consume_bale_events(sim: &mut Simulation, rules: &RuleSet, art: &ArtRegistry) {
     if sim.bale_events.is_empty() {
         return;
@@ -188,7 +230,13 @@ fn consume_bale_events(sim: &mut Simulation, rules: &RuleSet, art: &ArtRegistry)
 
     struct PreparedBale {
         building_id: u64,
+        empty: bool,
+        /// (name, loop_start, loop_end, start_frame, rate) of the variant this
+        /// gate would start.
         special_anim: Option<(String, u16, u16, u16, u16)>,
+        /// Every name the SpecialAnim slot can hold (base + Damaged variant),
+        /// for the live-slot test and the empty-gate cut.
+        special_slot_names: Vec<String>,
         particle_spawns: Vec<(
             crate::rules::particle_system_type::ParticleSystemTypeId,
             glam::IVec3,
@@ -208,23 +256,54 @@ fn consume_bale_events(sim: &mut Simulation, rules: &RuleSet, art: &ArtRegistry)
             let Some(art_entry) = art.resolve_metadata_entry(type_name, &object.image) else {
                 continue;
             };
+            let damaged = at_or_below_condition_yellow(
+                building.health.current,
+                building.health.max,
+                rules.general.condition_yellow_x1000,
+            );
 
-            let special_anim = art_entry.building_anims.iter().find_map(|anim| {
-                if !matches!(anim.kind, BuildingAnimKind::Special)
-                    || anim.loop_end <= anim.loop_start
-                {
+            let special_config = art_entry
+                .building_anims
+                .iter()
+                .find(|anim| matches!(anim.kind, BuildingAnimKind::Special));
+            let special_slot_names: Vec<String> = special_config
+                .map(|config| {
+                    let mut names = vec![config.anim_type.to_uppercase()];
+                    if let Some(variant) = &config.damaged_variant {
+                        names.push(variant.anim_type.to_uppercase());
+                    }
+                    names
+                })
+                .unwrap_or_default();
+            let special_anim = special_config.and_then(|config| {
+                let (name, loop_start, loop_end, start_frame) =
+                    match (damaged, &config.damaged_variant) {
+                        (true, Some(variant)) => (
+                            variant.anim_type.as_str(),
+                            variant.loop_start,
+                            variant.loop_end,
+                            variant.start_frame.max(variant.loop_start),
+                        ),
+                        // `SetAnimSlotImage(…, damaged=1)` reads only `+0xF5C`
+                        // (SpecialAnimDamaged) and creates nothing when it is
+                        // empty; no fallback to the base SpecialAnim.
+                        (true, None) => return None,
+                        (false, _) => (
+                            config.anim_type.as_str(),
+                            config.loop_start,
+                            config.loop_end,
+                            config.start_frame.max(config.loop_start),
+                        ),
+                    };
+                if loop_end <= loop_start {
                     return None;
                 }
                 Some((
-                    anim.anim_type.to_uppercase(),
-                    anim.loop_start,
-                    anim.loop_end,
-                    anim.start_frame.max(anim.loop_start),
-                    building_anim_rate_logic_frames(
-                        art,
-                        &anim.anim_type,
-                        Some(&sim.session.game_options),
-                    ),
+                    name.to_uppercase(),
+                    loop_start,
+                    loop_end,
+                    start_frame,
+                    building_anim_rate_logic_frames(art, name, Some(&sim.session.game_options)),
                 ))
             });
 
@@ -245,7 +324,9 @@ fn consume_bale_events(sim: &mut Simulation, rules: &RuleSet, art: &ArtRegistry)
             }
             prepared.push(PreparedBale {
                 building_id: event.building_id,
+                empty: event.empty,
                 special_anim,
+                special_slot_names,
                 particle_spawns,
             });
         }
@@ -253,28 +334,51 @@ fn consume_bale_events(sim: &mut Simulation, rules: &RuleSet, art: &ArtRegistry)
     };
 
     for event in prepared {
-        if let Some((anim_name, loop_start, loop_end, start_frame, rate)) = event.special_anim {
-            let anim_type = sim.interner.intern(&anim_name);
-            let new_state = AnimOverlayState {
-                anim_type,
-                frame: start_frame,
-                loop_start,
-                loop_end,
-                rate_logic_frames: u32::from(rate),
-                elapsed_logic_frames: 0,
-                finished: false,
-            };
-            if let Some(building) = sim.entities_mut().get_mut(event.building_id) {
-                if let Some(overlays) = building.building_anim_overlays.as_mut() {
-                    if let Some(existing) = overlays
+        let slot_names: Vec<InternedId> = event
+            .special_slot_names
+            .iter()
+            .map(|name| sim.interner.intern(name))
+            .collect();
+        let new_state =
+            event
+                .special_anim
+                .map(
+                    |(anim_name, loop_start, loop_end, start_frame, rate)| AnimOverlayState {
+                        anim_type: sim.interner.intern(&anim_name),
+                        frame: start_frame,
+                        loop_start,
+                        loop_end,
+                        rate_logic_frames: u32::from(rate),
+                        elapsed_logic_frames: 0,
+                        finished: false,
+                    },
+                );
+        if let Some(building) = sim.entities_mut().get_mut(event.building_id) {
+            let slot_live = building
+                .building_anim_overlays
+                .as_ref()
+                .is_some_and(|overlays| {
+                    overlays
                         .anims
-                        .iter_mut()
-                        .find(|active| active.anim_type == anim_type)
-                    {
-                        *existing = new_state;
-                    } else {
-                        overlays.anims.push(new_state);
+                        .iter()
+                        .any(|active| slot_names.contains(&active.anim_type))
+                });
+            if event.empty {
+                // `ClearAnimSlot(0xA)`: cut whatever the slot holds. (The
+                // `+0x584 == NULL` start that precedes it on this gate would
+                // be cleared in the same dispatch, so it is not materialized.)
+                if slot_live && let Some(overlays) = building.building_anim_overlays.as_mut() {
+                    overlays
+                        .anims
+                        .retain(|active| !slot_names.contains(&active.anim_type));
+                    if overlays.anims.is_empty() {
+                        building.building_anim_overlays = None;
                     }
+                }
+            } else if !slot_live && let Some(new_state) = new_state {
+                // `+0x584 == NULL` → `SetAnimSlotImage(10, …)`.
+                if let Some(overlays) = building.building_anim_overlays.as_mut() {
+                    overlays.anims.push(new_state);
                 } else {
                     building.building_anim_overlays = Some(BuildingAnimOverlays {
                         anims: vec![new_state],
@@ -639,6 +743,8 @@ mod tests {
         sim.bale_events.push(BaleDepositEvent {
             building_id: 41,
             tick: 12,
+            drained: true,
+            empty: false,
         });
 
         let queued_hash = sim.state_hash();
@@ -685,6 +791,126 @@ mod tests {
         assert_eq!(sim.state_hash(), finalized_hash);
     }
 
+    /// Put the building exactly AT the ConditionYellow ratio: the native gate
+    /// is `GetHealthRatio <= Rules+0x1700` (`FCOMP` @ 0x0073E39B), so the
+    /// boundary itself selects the damaged image.
+    fn set_health_at_condition_yellow(sim: &mut Simulation, rules: &RuleSet, building_id: u64) {
+        let building = sim.entities_mut().get_mut(building_id).expect("building");
+        building.health.max = 1000;
+        building.health.current =
+            u16::try_from(rules.general.condition_yellow_x1000).expect("ratio fits");
+    }
+
+    #[test]
+    fn damaged_refinery_without_special_anim_damaged_smokes_but_starts_no_overlay() {
+        // Retail GAREFN/NAREFN: SpecialAnim only, no SpecialAnimDamaged.
+        // `SetAnimSlotImage(10, 1, 0, 0)` reads an empty `+0xF5C` and returns.
+        let rules = refinery_rules_and_art();
+        let mut sim = Simulation::new();
+        insert_building(&mut sim, 41, "GAREFN", 7, 9);
+        set_health_at_condition_yellow(&mut sim, &rules, 41);
+
+        // Ore-only unload: the ore drain gate, then the empty gate.
+        sim.bale_events.push(BaleDepositEvent {
+            building_id: 41,
+            tick: 12,
+            drained: true,
+            empty: false,
+        });
+        finalize(&mut sim, &[], true, Some(&rules));
+        assert_eq!(sim.particle_systems().len(), 1, "drain gate smokes");
+        assert!(
+            sim.entities()
+                .get(41)
+                .expect("refinery")
+                .building_anim_overlays
+                .is_none(),
+            "no SpecialAnimDamaged defined: nothing starts in slot 10"
+        );
+
+        sim.bale_events.push(BaleDepositEvent {
+            building_id: 41,
+            tick: 27,
+            drained: false,
+            empty: true,
+        });
+        finalize(&mut sim, &[], true, Some(&rules));
+        assert_eq!(sim.particle_systems().len(), 2, "empty gate smokes too");
+        assert!(
+            sim.entities()
+                .get(41)
+                .expect("refinery")
+                .building_anim_overlays
+                .is_none(),
+            "empty-gate ClearAnimSlot(0xA) has nothing to cut"
+        );
+        assert!(sim.bale_events.is_empty());
+    }
+
+    #[test]
+    fn damaged_refinery_uses_defined_special_anim_damaged_variant() {
+        let mut rules = refinery_rules_and_art();
+        let art = ArtRegistry::from_ini(&IniFile::from_str(
+            "[GAREFN]\n\
+             SpecialAnim=GAREFN_B\n\
+             SpecialAnimDamaged=GAREFN_BD\n\
+             [GAREFN_B]\n\
+             Start=2\n\
+             LoopStart=1\n\
+             LoopEnd=5\n\
+             Rate=300\n\
+             [GAREFN_BD]\n\
+             Start=3\n\
+             LoopStart=2\n\
+             LoopEnd=6\n\
+             Rate=300\n",
+        ));
+        rules.merge_art_data(&art);
+        let mut sim = Simulation::new();
+        insert_building(&mut sim, 41, "GAREFN", 7, 9);
+        set_health_at_condition_yellow(&mut sim, &rules, 41);
+
+        sim.bale_events.push(BaleDepositEvent {
+            building_id: 41,
+            tick: 12,
+            drained: true,
+            empty: false,
+        });
+        finalize(&mut sim, &[], true, Some(&rules));
+
+        let overlays = sim
+            .entities()
+            .get(41)
+            .expect("refinery")
+            .building_anim_overlays
+            .as_ref()
+            .expect("damaged variant starts");
+        assert_eq!(overlays.anims.len(), 1);
+        let overlay = &overlays.anims[0];
+        assert_eq!(sim.interner.resolve(overlay.anim_type), "GAREFN_BD");
+        assert_eq!(overlay.frame, 3);
+        assert_eq!(overlay.loop_start, 2);
+        assert_eq!(overlay.loop_end, 6);
+        assert_eq!(sim.particle_systems().len(), 1);
+
+        // The empty gate cuts the damaged variant like the base one.
+        sim.bale_events.push(BaleDepositEvent {
+            building_id: 41,
+            tick: 27,
+            drained: false,
+            empty: true,
+        });
+        finalize(&mut sim, &[], true, Some(&rules));
+        assert!(
+            sim.entities()
+                .get(41)
+                .expect("refinery")
+                .building_anim_overlays
+                .is_none(),
+            "ClearAnimSlot(0xA) cuts the damaged variant"
+        );
+    }
+
     #[test]
     fn bale_event_waits_for_complete_rules_art_then_drains_once() {
         let rules = refinery_rules_and_art();
@@ -697,6 +923,8 @@ mod tests {
         sim.bale_events.push(BaleDepositEvent {
             building_id: 41,
             tick: 12,
+            drained: true,
+            empty: false,
         });
 
         finalize(&mut sim, &[], true, None);
@@ -721,6 +949,8 @@ mod tests {
         sim.bale_events.push(BaleDepositEvent {
             building_id: 41,
             tick: 12,
+            drained: true,
+            empty: false,
         });
         sim
     }
@@ -776,6 +1006,8 @@ mod tests {
         sim.bale_events.push(BaleDepositEvent {
             building_id: 41,
             tick: 12,
+            drained: true,
+            empty: false,
         });
 
         let output = sim.advance_app_frame(


### PR DESCRIPTION
Refinery unload presentation now follows `UnitClass::Mission_Unload` @ 0x0073D630 state 3. The refinery's smoke burst (building vtable+0x468 → 0x00459900, one `RefinerySmokeParticleSystem` per non-zero `RefinerySmokeOffset`) fires on every due dump gate (`HarvesterDumpRate × 900 <= +0xF8`, 0x0073E355), including the final empty gate, before any cargo test. The slot-10 `SpecialAnim` is created through `SetAnimSlotImage` @ 0x00451750 only while the slot is empty (+0x584, 0x0073E384), with the Damaged variant when the health ratio is `<= ConditionYellow` (Rules+0x1700) and nothing at all when that variant is undefined (stock GAREFN/NAREFN define only `SpecialAnim`). The empty gate sets state 4 and cuts the anim with `ClearAnimSlot(10)` @ 0x00451E40. At unload start (0x0073DEE0) a miner whose refinery contact is gone (`RadioClass::In_Radio_Contact` @ 0x0065AE30, previously mislabeled) drops target/destination, clears the latch, stops and commences any queued mission; `Enter_Idle_Mode` @ 0x00738970 assigns nothing while the mission is Unload.

Previous Rust emitted one smoke/anim event per successful drain only, restarted a live SpecialAnim, never cut it, showed the base anim on a damaged refinery, and had no contact-gone abort. Player-visible on every unload: smoke count and the ore-pile animation cadence.

Changes: `BaleDepositEvent { drained, empty }` per due gate; consumer spawns smoke per event, starts the SpecialAnim only when none is live with native damaged selection, cuts on the empty gate; contact-gone abort releases contact and bus slot. Residuals recorded in code: native re-checks the contact on every state-3/4 dispatch; mid-unload redirect cut at LAB_0073E539 is a follow-up; health sampled at frame tail.

Two independent read-only critics reviewed successive revisions against the bodies; the second passed.

Validation:
- `cargo test -p vera20k --lib`: `test result: ok. 8318 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 24.73s`
