### PR TITLE
Drive in-game music from the THEMEMD catalog as ThemeClass does

### DIFF
--- a/src/app/audio_runtime.rs
+++ b/src/app/audio_runtime.rs
@@ -10,8 +10,12 @@ use crate::assets::asset_manager::AssetManager;
 use crate::audio::music::MusicPlayer;
 use crate::audio::sfx::SfxPlayer;
 use crate::audio::theme::{
-    MusicOutputState, PreparedTrack, ThemeAction, ThemeGates, ThemeRuntime,
+    MusicOutputState, PreparedTrack, ThemeAction, ThemeAllowContext, ThemeGates, ThemeRuntime,
 };
+
+/// `AudioSystem__Pump @ 0x00406F70` runs its services only when more than
+/// 0x21 ms elapsed since the previous pass.
+const THEME_POLL_GATE_MS: u64 = 0x21;
 use crate::rules::sound_ini::{EvaRegistry, SoundRegistry};
 
 pub(crate) const fn derive_launcher_audio_available(
@@ -68,6 +72,8 @@ fn apply_theme_action_to_output(
 pub(crate) struct AppAudioRuntime {
     /// Always-present device-independent Theme owner.
     pub(crate) theme: ThemeRuntime,
+    /// Last wall time the Theme AI ran (the audio pump's own > 33 ms gate).
+    pub(crate) last_theme_poll_ms: Option<u64>,
     /// Background music player (rodio). `None` when audio output is disabled
     /// or initialization failed.
     pub(crate) music_player: Option<MusicPlayer>,
@@ -125,11 +131,20 @@ impl AppAudioRuntime {
         self.update_theme(assets, wall_ms);
         let gates = self.theme_gates();
         let physical = self.music_output_state();
-        let action = self.theme.play_menu_theme(assets, gates, physical);
+        let action = self.theme.play_menu_theme(assets, gates, physical, wall_ms);
         self.apply_theme_action(action);
     }
 
+    /// `ThemeClass::AI @ 0x007209D0` as driven by `AudioSystem__Pump @
+    /// 0x00406F70`: every screen, rate-gated to more than 33 ms.
     pub(crate) fn update_theme(&mut self, assets: &AssetManager, wall_ms: u64) {
+        if self
+            .last_theme_poll_ms
+            .is_some_and(|last| wall_ms.saturating_sub(last) <= THEME_POLL_GATE_MS)
+        {
+            return;
+        }
+        self.last_theme_poll_ms = Some(wall_ms);
         let gates = self.theme_gates();
         let physical = self.music_output_state();
         if physical == MusicOutputState::Finished
@@ -141,21 +156,31 @@ impl AppAudioRuntime {
         self.apply_theme_action(action);
     }
 
-    pub(crate) fn play_theme(&mut self, track: &str, assets: &AssetManager) -> bool {
+    /// `Play_Song(From_Name(track))`.
+    pub(crate) fn play_theme(&mut self, track: &str, assets: &AssetManager, wall_ms: u64) -> bool {
         let gates = self.theme_gates();
         let physical = self.music_output_state();
-        let action = self.theme.play_track(track, assets, gates, physical);
+        let action = self
+            .theme
+            .play_track(track, assets, gates, physical, wall_ms);
         let logical_started = action.start.is_some();
         self.apply_theme_action(action);
         logical_started
     }
 
+    /// Start_Scenario tail: seed the presentation shuffle stream, pin the
+    /// local player's side, then `Stop(1)` / `Queue_Song([Basic] Theme)`.
     pub(crate) fn request_scenario_theme(
         &mut self,
         requested_section: Option<&str>,
         assets: &AssetManager,
+        match_seed: u32,
+        context: ThemeAllowContext,
+        resolve_side: impl Fn(&str) -> Option<i32>,
         wall_ms: u64,
     ) {
+        self.theme.initialize_catalog(assets);
+        self.theme.begin_scenario(match_seed, context, resolve_side);
         let gates = self.theme_gates();
         let physical = self.music_output_state();
         let action =
@@ -164,20 +189,36 @@ impl AppAudioRuntime {
         self.apply_theme_action(action);
     }
 
+    /// `Main_Tick @ 0x0055D360` head rule while a scenario runs.
+    pub(crate) fn main_tick_theme(&mut self, in_game_music: bool, wall_ms: u64) {
+        let gates = self.theme_gates();
+        let physical = self.music_output_state();
+        let action = self
+            .theme
+            .main_tick(in_game_music, gates, physical, wall_ms);
+        self.apply_theme_action(action);
+    }
+
     pub(crate) fn cancel_scenario_theme_request(&mut self) {
         let action = self.theme.cancel_scenario_theme_request();
         self.apply_theme_action(action);
     }
 
+    /// `ThemeClass::Stop(fade=0)`.
     pub(crate) fn stop_theme(&mut self) {
-        let action = self.theme.stop(self.theme_gates());
+        let gates = self.theme_gates();
+        let physical = self.music_output_state();
+        let action = self.theme.stop(gates, false, physical, 0);
         self.apply_theme_action(action);
     }
 
-    pub(crate) fn queue_then_stop_score_zero(&mut self) {
+    /// Launcher ScoreVolume zero (`0x0055FAA0`): `Queue(cur)` then `Stop(0)`.
+    pub(crate) fn queue_then_stop_score_zero(&mut self, wall_ms: u64) {
         let gates = self.theme_gates();
         let physical = self.music_output_state();
-        let action = self.theme.queue_then_stop_score_zero(gates, physical);
+        let action = self
+            .theme
+            .queue_then_stop_score_zero(gates, physical, wall_ms);
         self.apply_theme_action(action);
     }
 }
@@ -221,6 +262,42 @@ mod tests {
         assert!(derive_launcher_audio_available(true, true, false));
         assert!(derive_launcher_audio_available(true, false, true));
         assert!(derive_launcher_audio_available(true, true, true));
+    }
+
+    fn empty_assets(label: &str) -> AssetManager {
+        let dir = std::env::temp_dir().join(format!(
+            "vera20k-audio-runtime-{}-{label}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("test asset dir");
+        AssetManager::from_loose_root_for_test(&dir)
+    }
+
+    /// `AudioSystem__Pump @ 0x00406F70` services `ThemeClass::AI` only when
+    /// more than 0x21 ms passed; the owner carries that gate itself so the
+    /// unconditional per-frame pump (`frame.rs`, outside every screen gate)
+    /// reaches AI on the menu, loading and score screens alike.
+    #[test]
+    fn theme_poll_carries_the_audio_pump_rate_gate_independent_of_screen() {
+        let assets = empty_assets("poll-gate");
+        let mut runtime = AppAudioRuntime {
+            theme: ThemeRuntime::default(),
+            last_theme_poll_ms: None,
+            music_player: None,
+            sfx_player: None,
+            sound_registry: SoundRegistry::default(),
+            audio_indices: Vec::new(),
+            audio_indices_enabled: false,
+            launcher_audio_available: true,
+            theme_startup_suppressed: false,
+            eva_registry: EvaRegistry::default(),
+        };
+        runtime.update_theme(&assets, 100);
+        assert_eq!(runtime.last_theme_poll_ms, Some(100));
+        runtime.update_theme(&assets, 133);
+        assert_eq!(runtime.last_theme_poll_ms, Some(100), "33 ms is not > 0x21");
+        runtime.update_theme(&assets, 134);
+        assert_eq!(runtime.last_theme_poll_ms, Some(134));
     }
 
     #[test]

--- a/src/app/in_game.rs
+++ b/src/app/in_game.rs
@@ -15,13 +15,15 @@ impl App {
     /// Hand the scenario RNG cursor back to the offline shell when a match ends.
     pub(super) fn capture_returned_skirmish_rng(state: &mut AppState) {
         let gameplay_rng = state
-            .match_state.sim_runtime
+            .match_state
+            .sim_runtime
             .as_ref()
             .map(|rt| &rt.simulation)
             .map(crate::sim::world::Simulation::clone_scenario_rng);
         if let Some(gameplay_rng) = gameplay_rng
             && state
-                .frontend.offline_skirmish_runtime
+                .frontend
+                .offline_skirmish_runtime
                 .capture_returned_gameplay_rng(gameplay_rng)
         {
             log::info!("Returned gameplay Scenario cursor to the offline shell");
@@ -30,7 +32,8 @@ impl App {
 
     pub(super) fn return_to_main_menu(state: &mut AppState) {
         state.match_state.paused = false;
-        state.match_state.match_presentation.in_game_menu = crate::ui::pause_menu::InGameMenuState::Closed;
+        state.match_state.match_presentation.in_game_menu =
+            crate::ui::pause_menu::InGameMenuState::Closed;
         state.match_state.match_presentation.in_game_options_anchor = None;
         // Persist the deterministic diagnostic log before its owning sim is
         // torn down.
@@ -122,8 +125,16 @@ impl App {
     /// cancels that instead and the machine stays out of it.
     pub(super) fn in_game_menu_owns_escape(state: &AppState) -> bool {
         let in_world_mode_armed = state.match_state.input.targeting_mode.is_some()
-            || state.match_state.match_presentation.sidebar_gadget_state.repair_mode_on
-            || state.match_state.match_presentation.sidebar_gadget_state.sell_mode_on;
+            || state
+                .match_state
+                .match_presentation
+                .sidebar_gadget_state
+                .repair_mode_on
+            || state
+                .match_state
+                .match_presentation
+                .sidebar_gadget_state
+                .sell_mode_on;
         crate::ui::pause_menu::escape_belongs_to_modal_machine(
             state.match_state.match_presentation.in_game_menu,
             in_world_mode_armed,
@@ -140,7 +151,11 @@ impl App {
         if state.match_state.match_presentation.in_game_menu == InGameMenuState::Options {
             crate::app::persistence::options::in_game_options_close(state);
         }
-        let next = state.match_state.match_presentation.in_game_menu.on_escape();
+        let next = state
+            .match_state
+            .match_presentation
+            .in_game_menu
+            .on_escape();
         Self::enter_in_game_menu_state(state, next);
     }
 
@@ -168,7 +183,10 @@ impl App {
         if was_open != will_be_open
             && !crate::app::match_runtime::sim_tick::current_session_mode(state).is_network()
         {
-            let now_ms = crate::app::match_runtime::sim_tick::monotonic_frame_pacer_ms(state, Instant::now());
+            let now_ms = crate::app::match_runtime::sim_tick::monotonic_frame_pacer_ms(
+                state,
+                Instant::now(),
+            );
             if will_be_open {
                 state.match_state.scenario_elapsed_clock.pause(now_ms);
             } else {
@@ -185,19 +203,33 @@ impl App {
         if next == InGameMenuState::Options {
             // Reset the transient interaction flags so the drag-gated
             // value-label quirk resets on every open.
-            state.match_state.match_presentation.in_game_options.on_open();
+            state
+                .match_state
+                .match_presentation
+                .in_game_options
+                .on_open();
         }
 
         state.match_state.paused = next.is_open();
         if next.is_open() {
             // Show the OS cursor so the modal is clickable.
-            if state.match_state.match_presentation.software_cursor.is_some() {
+            if state
+                .match_state
+                .match_presentation
+                .software_cursor
+                .is_some()
+            {
                 state.platform.window.set_cursor_visible(true);
             }
         } else {
             // Elapsed modal time must not cause a catch-up frame.
             state.platform.frame_pacer.reset_for_immediate_frame();
-            if state.match_state.match_presentation.software_cursor.is_some() {
+            if state
+                .match_state
+                .match_presentation
+                .software_cursor
+                .is_some()
+            {
                 state.platform.window.set_cursor_visible(false);
             }
         }
@@ -213,9 +245,9 @@ impl App {
 
         let outcome = match state.match_state.match_presentation.in_game_menu {
             InGameMenuState::Closed => ModalOutcome::Stay,
-            InGameMenuState::Menu => {
-                pause_menu::resolve_menu_action(pause_menu::draw_in_game_menu(&state.renderer.egui.ctx))
-            }
+            InGameMenuState::Menu => pause_menu::resolve_menu_action(
+                pause_menu::draw_in_game_menu(&state.renderer.egui.ctx),
+            ),
             InGameMenuState::AbortConfirm => {
                 let leave_label =
                     Self::csf_label(state, ABORT_CONFIRM_LEAVE_KEY, ABORT_CONFIRM_LEAVE_FALLBACK);
@@ -247,7 +279,9 @@ impl App {
     pub(super) fn sync_in_game_menu_with_options_overlay(state: &mut AppState) {
         use crate::ui::pause_menu::InGameMenuState;
 
-        if state.match_state.match_presentation.in_game_menu == InGameMenuState::Options && !state.match_state.paused {
+        if state.match_state.match_presentation.in_game_menu == InGameMenuState::Options
+            && !state.match_state.paused
+        {
             Self::enter_in_game_menu_state(state, InGameMenuState::Menu);
         }
     }
@@ -289,14 +323,16 @@ impl App {
         let local_owner = crate::app::input::commands::preferred_local_owner(state);
         let local_owner_id = local_owner.as_deref().and_then(|owner| {
             state
-                .match_state.sim_runtime
+                .match_state
+                .sim_runtime
                 .as_ref()
                 .map(|rt| &rt.simulation)
                 .and_then(|sim| sim.interner.get(owner))
         });
         let local_outcome_exit_ready = local_owner_id.is_some_and(|owner| {
             state
-                .match_state.sim_runtime
+                .match_state
+                .sim_runtime
                 .as_ref()
                 .map(|rt| &rt.simulation)
                 .and_then(|sim| sim.houses.get(&owner))
@@ -304,7 +340,8 @@ impl App {
                 .is_some_and(|outcome| outcome.exit_ready)
         });
         let executed_owner = state
-            .match_state.sim_runtime
+            .match_state
+            .sim_runtime
             .as_mut()
             .map(|rt| &mut rt.simulation)
             .and_then(|sim| sim.take_executed_exit_owner());
@@ -316,7 +353,9 @@ impl App {
             return;
         }
         if matches!(
-            crate::app::match_runtime::scenario_exit::arbitrate_executed_exit(local_outcome_exit_ready),
+            crate::app::match_runtime::scenario_exit::arbitrate_executed_exit(
+                local_outcome_exit_ready
+            ),
             crate::app::match_runtime::scenario_exit::ExecutedExitDisposition::Outcome
         ) {
             // Main_Game observes the ready victory/loss route first. The EXIT
@@ -335,10 +374,11 @@ impl App {
         // GameExit__BattleControlTerminated @ 0x00686570 starts Theme's fade,
         // then fades the independent audio master, bounds its voice pump to
         // 300 timer buckets, and finally hard-stops audio.
-        let mut scenario_exit = crate::app::match_runtime::scenario_exit::ScenarioExitCascade::start(
-            wall_ms,
-            crate::app::match_runtime::scenario_exit::ScenarioExitDestination::MainMenu,
-        );
+        let mut scenario_exit =
+            crate::app::match_runtime::scenario_exit::ScenarioExitCascade::start(
+                wall_ms,
+                crate::app::match_runtime::scenario_exit::ScenarioExitDestination::MainMenu,
+            );
         // `0x00686570` requests EVA_BattleControlTerminated as an INTERRUPT
         // immediately before waiting for the two simultaneous audio fades.
         if let Some(action) = scenario_exit.take_start_voice_action() {
@@ -380,7 +420,9 @@ impl App {
     /// overlay is hidden — caller checks `show_dev_overlay` before
     /// calling.
     pub(super) fn handle_dev_overlay(state: &mut AppState) {
-        use crate::app::diagnostics::dev_overlay::{DevOverlayAction, DevOverlayInfo, RecentSaveRow};
+        use crate::app::diagnostics::dev_overlay::{
+            DevOverlayAction, DevOverlayInfo, RecentSaveRow,
+        };
 
         // Build the recent-saves snapshot from the existing cache.
         state.persistence.refresh_save_list_if_dirty();
@@ -399,7 +441,9 @@ impl App {
                     .unwrap_or("?")
                     .to_string(),
                 tick: e.header.tick,
-                age_str: crate::app::persistence::save_load_panel::format_timestamp(e.header.save_timestamp),
+                age_str: crate::app::persistence::save_load_panel::format_timestamp(
+                    e.header.save_timestamp,
+                ),
             })
             .collect();
 
@@ -435,7 +479,11 @@ impl App {
         let mut info = DevOverlayInfo {
             sim_speed_tps: state.match_state.sim_speed_tps,
             paused: state.match_state.paused,
-            music_volume: state.audio.music_player.as_ref().map_or(0.5, |p| p.volume()),
+            music_volume: state
+                .audio
+                .music_player
+                .as_ref()
+                .map_or(0.5, |p| p.volume()),
             sfx_volume: state.audio.sfx_player.as_ref().map_or(0.7, |p| p.volume()),
             show_pathgrid: state.diag.debug_show_pathgrid,
             show_cell_grid: state.diag.debug_show_cell_grid,
@@ -449,7 +497,12 @@ impl App {
             } else {
                 1000.0 / state.match_state.sim_speed_tps as f32
             },
-            entity_count: state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation).map_or(0, |s| s.entities().len()),
+            entity_count: state
+                .match_state
+                .sim_runtime
+                .as_ref()
+                .map(|rt| &rt.simulation)
+                .map_or(0, |s| s.entities().len()),
             save_name_buf: &mut save_name,
             last_save_tick: state.persistence.last_save_tick,
             last_save_age,
@@ -458,7 +511,10 @@ impl App {
             recent_saves,
         };
 
-        let action = crate::app::diagnostics::dev_overlay::draw_dev_overlay(&state.renderer.egui.ctx, &mut info);
+        let action = crate::app::diagnostics::dev_overlay::draw_dev_overlay(
+            &state.renderer.egui.ctx,
+            &mut info,
+        );
 
         // Restore the (possibly-edited) buffer.
         state.diag.dev_overlay_save_name = save_name;
@@ -476,7 +532,10 @@ impl App {
             }
             DevOverlayAction::ResetGameSpeed => {
                 state.match_state.sim_speed_tps = crate::app::types::default_yr_skirmish_tps();
-                log::info!("Game speed reset to {} tps", state.match_state.sim_speed_tps);
+                log::info!(
+                    "Game speed reset to {} tps",
+                    state.match_state.sim_speed_tps
+                );
             }
             DevOverlayAction::SetMusicVolume(v) => {
                 if let Some(p) = &mut state.audio.music_player {
@@ -512,7 +571,8 @@ impl App {
                 dispatch::toggle_unit_inspector(state);
             }
             DevOverlayAction::ToggleRevealMap => {
-                state.match_state.sandbox_full_visibility = !state.match_state.sandbox_full_visibility;
+                state.match_state.sandbox_full_visibility =
+                    !state.match_state.sandbox_full_visibility;
                 log::info!(
                     "Reveal map: {}",
                     if state.match_state.sandbox_full_visibility {
@@ -559,7 +619,11 @@ impl App {
     /// calls this instead of exiting immediately; `render_frame` drives it to
     /// completion and then exits the event loop.
     pub(super) fn start_quit_cascade(state: &mut AppState) {
-        let start_volume = state.audio.music_player.as_ref().map_or(0.0, |p| p.volume());
+        let start_volume = state
+            .audio
+            .music_player
+            .as_ref()
+            .map_or(0.0, |p| p.volume());
         state.frontend.quit_cascade = Some(crate::app::frontend::quit_cascade::QuitCascade::start(
             Instant::now(),
             start_volume,
@@ -571,16 +635,19 @@ impl App {
             return;
         }
         let poll_voices = state
-            .match_state.scenario_exit
+            .match_state
+            .scenario_exit
             .as_ref()
             .is_some_and(|exit| exit.needs_voice_poll(wall_ms));
         let voices_active = poll_voices
             && state
-                .audio.sfx_player
+                .audio
+                .sfx_player
                 .as_mut()
                 .is_some_and(|sfx| sfx.pump_and_check_voices());
         let tick = state
-            .match_state.scenario_exit
+            .match_state
+            .scenario_exit
             .as_mut()
             .expect("scenario exit remains present")
             .tick(wall_ms, voices_active);
@@ -608,20 +675,20 @@ impl App {
         // ScoreDialog__WndProc @ 0x005C9B10 resolves the literal SCORE theme
         // and starts it immediately on WM_INITDIALOG. Keep this after the
         // hard stop and output-scale restoration so ScoreX begins audible.
-        if let Some(crate::app::match_runtime::scenario_exit::ScenarioExitAudioAction::PlayTheme(theme)) =
-            tick.after_stop
+        if let Some(crate::app::match_runtime::scenario_exit::ScenarioExitAudioAction::PlayTheme(
+            theme,
+        )) = tick.after_stop
             && let Some(assets) = state.process_assets.manager()
         {
-            let _ = state.audio.play_theme(theme, assets);
+            let _ = state.audio.play_theme(theme, assets, wall_ms);
         }
         if !tick.finished {
             return;
         }
 
-        let destination = state
-            .match_state.scenario_exit
-            .as_mut()
-            .and_then(crate::app::match_runtime::scenario_exit::ScenarioExitCascade::take_destination);
+        let destination = state.match_state.scenario_exit.as_mut().and_then(
+            crate::app::match_runtime::scenario_exit::ScenarioExitCascade::take_destination,
+        );
         state.match_state.scenario_exit = None;
         match destination {
             Some(crate::app::match_runtime::scenario_exit::ScenarioExitDestination::Score {

--- a/src/app/initialize.rs
+++ b/src/app/initialize.rs
@@ -5,18 +5,15 @@ use std::path::Path;
 use crate::app::frontend::startup_options::{RetailStartupOptions, ScreenSize};
 use crate::app::persistence::options_profile::{RetailOptionsLoad, RetailOptionsProfile};
 
-use super::presentation::render;
 use super::frontend::list_maps;
+use super::presentation::render;
 use super::{
     ActiveEventLoop, App, AppState, Arc, AssetManager, BTreeMap, BasicSection, BatchRenderer,
     BitFont, CellLightGrid, DEV_SKIRMISH_SHELL_ENV, EguiIntegration, GameConfig, GameScreen,
-    GpuContext, HashMap, HashSet, HouseRoster, Instant, LightingConfig,
-    ModifiersState, MusicPlayer, PhysicalSize, PlatformState, RandomMapGenerationRetention,
-    Result,
-    SelectionState, SfxPlayer, SidebarChromeLayoutSpec,
-    SidebarTab, StartupAudioDisposition, Window, WindowAttributes,
-    auto_detect_ui_scale, frontend::startup_splash,
-    should_load_audio_indices,
+    GpuContext, HashMap, HashSet, HouseRoster, Instant, LightingConfig, ModifiersState,
+    MusicPlayer, PhysicalSize, PlatformState, RandomMapGenerationRetention, Result, SelectionState,
+    SfxPlayer, SidebarChromeLayoutSpec, SidebarTab, StartupAudioDisposition, Window,
+    WindowAttributes, auto_detect_ui_scale, frontend::startup_splash, should_load_audio_indices,
 };
 
 fn startup_window_projection(
@@ -51,6 +48,7 @@ trait StartupAudioProfileOperations {
     fn set_sound_volume(&mut self, volume: f64);
     fn set_voice_volume(&mut self, volume: f64);
     fn set_score_volume(&mut self, volume: f64);
+    fn set_score_repeat_shuffle(&mut self, repeat: bool, shuffle: bool);
 }
 
 impl StartupAudioProfileOperations for crate::app::audio_runtime::AppAudioRuntime {
@@ -71,6 +69,10 @@ impl StartupAudioProfileOperations for crate::app::audio_runtime::AppAudioRuntim
             player.set_volume(volume);
         }
     }
+
+    fn set_score_repeat_shuffle(&mut self, repeat: bool, shuffle: bool) {
+        self.theme.set_score_options(repeat, shuffle);
+    }
 }
 
 fn apply_startup_audio_profile(
@@ -78,10 +80,13 @@ fn apply_startup_audio_profile(
     operations: &mut impl StartupAudioProfileOperations,
 ) {
     // gamemd-derived: the Audio tail of `OptionsClass__ReadFromINI @ 0x005FA620`
-    // applies SoundVolume, VoiceVolume, then ScoreVolume through distinct owners.
+    // applies SoundVolume, VoiceVolume, then ScoreVolume through distinct owners,
+    // then writes IsScoreRepeat / IsScoreShuffle straight into `g_Theme+0x10` /
+    // `+0x12` (`0x005FAB1C` / `0x005FAB5B`).
     operations.set_sound_volume(f64::from(profile.sound_volume));
     operations.set_voice_volume(f64::from(profile.voice_volume));
     operations.set_score_volume(f64::from(profile.score_volume));
+    operations.set_score_repeat_shuffle(profile.is_score_repeat, profile.is_score_shuffle);
 }
 
 impl App {
@@ -255,13 +260,12 @@ impl App {
         // presented swapchain frame stays composited while this thread blocks,
         // and the hold armed above is measured from that present, so a slow
         // load is spent inside the five seconds instead of before them.
-        let (startup_rules, startup_rules_projection, startup_native_rules) =
-            startup_asset_manager
-                .as_ref()
-                .and_then(crate::app::loading::init_helpers::load_startup_rules)
-                .map(crate::app::loading::init_helpers::StartupRulesLoad::into_parts)
-                .map(|(rules, projection, owner)| (rules, projection, Some(owner)))
-                .unwrap_or((None, None, None));
+        let (startup_rules, startup_rules_projection, startup_native_rules) = startup_asset_manager
+            .as_ref()
+            .and_then(crate::app::loading::init_helpers::load_startup_rules)
+            .map(crate::app::loading::init_helpers::StartupRulesLoad::into_parts)
+            .map(|(rules, projection, owner)| (rules, projection, Some(owner)))
+            .unwrap_or((None, None, None));
         let startup_sound_registry = startup_asset_manager
             .as_ref()
             .map(crate::app::loading::transitions::load_sound_registry)
@@ -338,7 +342,9 @@ impl App {
                 .iter()
                 .enumerate()
                 .map(|(idx, map)| {
-                    crate::map::skirmish_scenarios::SkirmishScenarioRecord::from_map_menu_entry(idx, map)
+                    crate::map::skirmish_scenarios::SkirmishScenarioRecord::from_map_menu_entry(
+                        idx, map,
+                    )
                 })
                 .collect()
         } else {
@@ -457,14 +463,14 @@ impl App {
             .initialize_sfx_output
             .then(SfxPlayer::new)
             .flatten();
-        let launcher_audio_available =
-            crate::app::audio_runtime::derive_launcher_audio_available(
-                startup_options.audio_enabled,
-                music_player.is_some(),
-                sfx_player.is_some(),
-            );
+        let launcher_audio_available = crate::app::audio_runtime::derive_launcher_audio_available(
+            startup_options.audio_enabled,
+            music_player.is_some(),
+            sfx_player.is_some(),
+        );
         let mut startup_audio_runtime = crate::app::audio_runtime::AppAudioRuntime {
             theme: crate::audio::theme::ThemeRuntime::default(),
+            last_theme_poll_ms: None,
             music_player,
             sfx_player,
             sound_registry: startup_sound_registry,
@@ -481,183 +487,185 @@ impl App {
         let mut state = AppState {
             platform: PlatformState::new(window, game_config, shell_client_size),
             match_state: crate::app::match_runtime::state::MatchState {
-            sim_runtime: None,
-            input: crate::app::input::state::MatchInputState {
-            minimap_dragging: false,
-            selection_state: SelectionState::new(),
-            selection_order: Vec::new(),
-            selection_order_pending: false,
-            selection_voice_enabled: true,
-            queued_order_mode: render::OrderMode::Move,
-            control_groups: vec![Vec::new(); 10],
-            last_control_group_press: None,
-            follow_target: None,
-            spawn_pick_pending: false,
-            targeting_mode: None,
-            building_placement_preview: None,
-                camera_x: 0.0,
-                camera_y: 0.0,
-                zoom_level: 1.0,
-                zoom_target: 1.0,
-                zoom_anchor_world: [0.0, 0.0],
-                zoom_anchor_screen: [0.0, 0.0],
-                edge_scroll: crate::app::input::camera::EdgeScrollState::default(),
-                tactical_mouse: crate::app::input::camera::TacticalMouseState::default(),
-                view_bookmarks: crate::app::input::camera::ViewBookmarks::default(),
-                cursor_x: 0.0,
-                cursor_y: 0.0,
-                keys_held: HashSet::new(),
-                hotkey_bindings,
-                hotkey_modifiers: ModifiersState::empty(),
-                type_select: crate::app::types::TypeSelectInputState::default(),
-                retail_screenshot_requested: false,
-            },
-            match_presentation: crate::app::presentation::state::MatchPresentationState {
-            power_bar_anim: crate::sidebar::PowerBarAnimState::new(),
-            sidebar_gadget_state: crate::sidebar::gadget_flash::SidebarGadgetState::new(),
-            in_game_gadgets: crate::app::input::gadget_input::InGameGadgets::new(),
-            sidebar_projection: Default::default(),
-            active_sidebar_tab: SidebarTab::default_active_tab(),
-            sidebar_layout_spec,
-            sidebar_layout_spec_base: base_sidebar_layout_spec,
-            ui_scale,
-            sidebar_scroll_rows: 0,
-            sidebar_scroll_rows_parked: [0; 4],
-            tooltips: startup_tooltips,
-            tooltip_epoch: Instant::now(),
-            message_list: crate::ui::messages::MessageList::new(
-                3,
-                0,
-                crate::ui::messages::MESSAGE_MAX_VISIBLE_RETAIL,
-                0,
-            ),
-            message_clock: crate::ui::messages::PauseAwareClock::default(),
-            in_game_menu: crate::ui::pause_menu::InGameMenuState::default(),
-            in_game_options: startup_in_game_options,
-            in_game_options_anchor: None,
-            show_hotkey_help: false,
-            show_save_load_panel: false,
-            combat_lights: Default::default(),
-            minimap: None,
-            radar_anim: None,
-            radar_animation_source: None,
-            radar_content_insets: None,
-            has_radar: false,
-            selection_overlay: None,
-            shroud_buffer: None,
-            tactical_bridge_inverse_map: BTreeMap::new(),
-            theater_name: "TEMPERATE".to_string(),
-            theater_ext: "tem".to_string(),
-            target_lines: startup_target_lines,
-            pending_fire_effects: Vec::new(),
-            garrison_muzzle_flashes: Vec::new(),
-            weapon_muzzle_flashes: Vec::new(),
-            projectile_visuals: Vec::new(),
-            parachute_anims: Vec::new(),
-            idle_anim_elapsed_ms: 0,
-            building_anim_phase_base: std::collections::BTreeMap::new(),
-            cached_overlay_instances: Vec::new(),
-            cached_unit_instances: Vec::new(),
-            cached_unit_pages: Vec::new(),
-                terrain_grid: None,
-                installed_playfield_authority: None,
-                overlays: Default::default(),
-                terrain_objects: Vec::new(),
-                waypoints: HashMap::new(),
-                cell_tags: HashMap::new(),
-                tags: HashMap::new(),
-                overlay_names: BTreeMap::new(),
-                overlay_radar_colors: HashMap::new(),
-                house_color_map: HashMap::new(),
-                house_roster: HouseRoster::default(),
-                lighting_grid: CellLightGrid::new(),
-                applied_lighting_sources: Vec::new(),
-                applied_lighting_profile: None,
-                applied_lighting_detail_level: 2,
-                pending_lighting_refresh: None,
-                last_lighting_view_fingerprint: None,
-                map_lighting_config: LightingConfig::default(),
-                tile_atlas: None,
-                unit_atlas: None,
-                palette_set: None,
-                sprite_atlas: None,
-                overlay_atlas: None,
-                bridge_atlas: None,
-                bridge_railing_atlas: None,
-                sidebar_cameo_atlas: None,
-                sidebar_chrome: None,
-                software_cursor: startup_software_cursor,
-            },
-            match_audio: Default::default(),
-            match_diagnostics: Default::default(),
-            map_basic: BasicSection::default(),
-            loaded_map_source: None,
-            loaded_map_hash: None,
-            scenario_outcome: None,
-            scenario_exit: None,
-            scenario_elapsed_clock: crate::app::match_runtime::frame_pacer::ScenarioElapsedClock::new(),
-            configured_input_delay_ticks: input_delay_ticks,
-            local_player_owner: None,
-            local_owner_override: None,
-            sandbox_full_visibility: false,
-            paused: false,
-            // KD-3: unify the two game-speed sources. `in_game_options.game_speed`
-            // (in the presentation owner) is the single source of truth; seed it
-            // from the skirmish-setup speed (internal 1) and derive
-            // `sim_speed_tps` from the same value, so the Options slider
-            // reflects the current pace. The resulting tps is unchanged from
-            // the prior `default_yr_skirmish_tps()` (= GS1 -> 63).
-            sim_speed_tps: crate::app::types::tps_for_game_speed(
-                crate::app::types::DEFAULT_YR_SKIRMISH_GAME_SPEED,
-            ),
+                sim_runtime: None,
+                input: crate::app::input::state::MatchInputState {
+                    minimap_dragging: false,
+                    selection_state: SelectionState::new(),
+                    selection_order: Vec::new(),
+                    selection_order_pending: false,
+                    selection_voice_enabled: true,
+                    queued_order_mode: render::OrderMode::Move,
+                    control_groups: vec![Vec::new(); 10],
+                    last_control_group_press: None,
+                    follow_target: None,
+                    spawn_pick_pending: false,
+                    targeting_mode: None,
+                    building_placement_preview: None,
+                    camera_x: 0.0,
+                    camera_y: 0.0,
+                    zoom_level: 1.0,
+                    zoom_target: 1.0,
+                    zoom_anchor_world: [0.0, 0.0],
+                    zoom_anchor_screen: [0.0, 0.0],
+                    edge_scroll: crate::app::input::camera::EdgeScrollState::default(),
+                    tactical_mouse: crate::app::input::camera::TacticalMouseState::default(),
+                    view_bookmarks: crate::app::input::camera::ViewBookmarks::default(),
+                    cursor_x: 0.0,
+                    cursor_y: 0.0,
+                    keys_held: HashSet::new(),
+                    hotkey_bindings,
+                    hotkey_modifiers: ModifiersState::empty(),
+                    type_select: crate::app::types::TypeSelectInputState::default(),
+                    retail_screenshot_requested: false,
+                },
+                match_presentation: crate::app::presentation::state::MatchPresentationState {
+                    power_bar_anim: crate::sidebar::PowerBarAnimState::new(),
+                    sidebar_gadget_state: crate::sidebar::gadget_flash::SidebarGadgetState::new(),
+                    in_game_gadgets: crate::app::input::gadget_input::InGameGadgets::new(),
+                    sidebar_projection: Default::default(),
+                    active_sidebar_tab: SidebarTab::default_active_tab(),
+                    sidebar_layout_spec,
+                    sidebar_layout_spec_base: base_sidebar_layout_spec,
+                    ui_scale,
+                    sidebar_scroll_rows: 0,
+                    sidebar_scroll_rows_parked: [0; 4],
+                    tooltips: startup_tooltips,
+                    tooltip_epoch: Instant::now(),
+                    message_list: crate::ui::messages::MessageList::new(
+                        3,
+                        0,
+                        crate::ui::messages::MESSAGE_MAX_VISIBLE_RETAIL,
+                        0,
+                    ),
+                    message_clock: crate::ui::messages::PauseAwareClock::default(),
+                    in_game_menu: crate::ui::pause_menu::InGameMenuState::default(),
+                    in_game_options: startup_in_game_options,
+                    in_game_options_anchor: None,
+                    show_hotkey_help: false,
+                    show_save_load_panel: false,
+                    combat_lights: Default::default(),
+                    minimap: None,
+                    radar_anim: None,
+                    radar_animation_source: None,
+                    radar_content_insets: None,
+                    has_radar: false,
+                    selection_overlay: None,
+                    shroud_buffer: None,
+                    tactical_bridge_inverse_map: BTreeMap::new(),
+                    theater_name: "TEMPERATE".to_string(),
+                    theater_ext: "tem".to_string(),
+                    target_lines: startup_target_lines,
+                    pending_fire_effects: Vec::new(),
+                    garrison_muzzle_flashes: Vec::new(),
+                    weapon_muzzle_flashes: Vec::new(),
+                    projectile_visuals: Vec::new(),
+                    parachute_anims: Vec::new(),
+                    idle_anim_elapsed_ms: 0,
+                    building_anim_phase_base: std::collections::BTreeMap::new(),
+                    cached_overlay_instances: Vec::new(),
+                    cached_unit_instances: Vec::new(),
+                    cached_unit_pages: Vec::new(),
+                    terrain_grid: None,
+                    installed_playfield_authority: None,
+                    overlays: Default::default(),
+                    terrain_objects: Vec::new(),
+                    waypoints: HashMap::new(),
+                    cell_tags: HashMap::new(),
+                    tags: HashMap::new(),
+                    overlay_names: BTreeMap::new(),
+                    overlay_radar_colors: HashMap::new(),
+                    house_color_map: HashMap::new(),
+                    house_roster: HouseRoster::default(),
+                    lighting_grid: CellLightGrid::new(),
+                    applied_lighting_sources: Vec::new(),
+                    applied_lighting_profile: None,
+                    applied_lighting_detail_level: 2,
+                    pending_lighting_refresh: None,
+                    last_lighting_view_fingerprint: None,
+                    map_lighting_config: LightingConfig::default(),
+                    tile_atlas: None,
+                    unit_atlas: None,
+                    palette_set: None,
+                    sprite_atlas: None,
+                    overlay_atlas: None,
+                    bridge_atlas: None,
+                    bridge_railing_atlas: None,
+                    sidebar_cameo_atlas: None,
+                    sidebar_chrome: None,
+                    software_cursor: startup_software_cursor,
+                },
+                match_audio: Default::default(),
+                match_diagnostics: Default::default(),
+                map_basic: BasicSection::default(),
+                loaded_map_source: None,
+                loaded_map_hash: None,
+                scenario_outcome: None,
+                scenario_exit: None,
+                scenario_elapsed_clock:
+                    crate::app::match_runtime::frame_pacer::ScenarioElapsedClock::new(),
+                configured_input_delay_ticks: input_delay_ticks,
+                local_player_owner: None,
+                local_owner_override: None,
+                sandbox_full_visibility: false,
+                paused: false,
+                // KD-3: unify the two game-speed sources. `in_game_options.game_speed`
+                // (in the presentation owner) is the single source of truth; seed it
+                // from the skirmish-setup speed (internal 1) and derive
+                // `sim_speed_tps` from the same value, so the Options slider
+                // reflects the current pace. The resulting tps is unchanged from
+                // the prior `default_yr_skirmish_tps()` (= GS1 -> 63).
+                sim_speed_tps: crate::app::types::tps_for_game_speed(
+                    crate::app::types::DEFAULT_YR_SKIRMISH_GAME_SPEED,
+                ),
             },
             frontend: crate::app::frontend::state::FrontendState {
-            screen: GameScreen::default(),
-            available_maps,
-            scenario_catalog,
-            skirmish_modes,
-            skirmish_settings,
-            loading_session: None,
-            frontend_main_rng: crate::sim::rng::SimRng::new(u64::from(frontend_seed.value)),
-            next_match_correlation: 1,
-            active_loading_correlation: None,
-            loaded_startup: None,
-            rust_l0_receipt: None,
-            random_map_generation: None,
-            random_map_retention: RandomMapGenerationRetention::default(),
-            skirmish_preview_texture: None,
-            loading_screen_atlas: None,
-            loading_progress: crate::app::loading::pump::LoadingProgressState::standard_skirmish(),
-            frontend_rules: startup_rules,
-            shell_preview_overlay_registry: None,
-            dev_skirmish_shell_enabled,
-            skirmish_shell_state,
-            offline_skirmish_runtime,
-            skirmish_shell_last_painted_pressed_button: None,
-            skirmish_shell_chrome,
-            main_menu_shell_state: crate::ui::main_menu_shell::MainMenuShellState::default(),
-            single_player_shell_state:
-                crate::ui::single_player_shell::SinglePlayerShellState::default(),
-            shell_controller: crate::ui::shell::controller::DialogController::default(),
-            main_menu_shell_chrome,
-            main_menu_movie: None,
-            main_menu_movie_identity: None,
-            main_menu_movie_last_step: Instant::now(),
-            main_menu_shell_failed,
-            version_txt,
-            shell_first_paint_slide: None,
-            shell_slide_active_shell: None,
-            shell_slide_generation: 0,
-            quit_cascade: None,
-            startup_splash,
-            exit_confirm_modal: None,
-            options_dialog: None,
-            movies_credits_dialog: None,
-            campaign_select: None,
-            score_screen: None,
-            score_shell_state: Default::default(),
-            finished_game_count: 0,
-            shell_route: Default::default(),
+                screen: GameScreen::default(),
+                available_maps,
+                scenario_catalog,
+                skirmish_modes,
+                skirmish_settings,
+                loading_session: None,
+                frontend_main_rng: crate::sim::rng::SimRng::new(u64::from(frontend_seed.value)),
+                next_match_correlation: 1,
+                active_loading_correlation: None,
+                loaded_startup: None,
+                rust_l0_receipt: None,
+                random_map_generation: None,
+                random_map_retention: RandomMapGenerationRetention::default(),
+                skirmish_preview_texture: None,
+                loading_screen_atlas: None,
+                loading_progress:
+                    crate::app::loading::pump::LoadingProgressState::standard_skirmish(),
+                frontend_rules: startup_rules,
+                shell_preview_overlay_registry: None,
+                dev_skirmish_shell_enabled,
+                skirmish_shell_state,
+                offline_skirmish_runtime,
+                skirmish_shell_last_painted_pressed_button: None,
+                skirmish_shell_chrome,
+                main_menu_shell_state: crate::ui::main_menu_shell::MainMenuShellState::default(),
+                single_player_shell_state:
+                    crate::ui::single_player_shell::SinglePlayerShellState::default(),
+                shell_controller: crate::ui::shell::controller::DialogController::default(),
+                main_menu_shell_chrome,
+                main_menu_movie: None,
+                main_menu_movie_identity: None,
+                main_menu_movie_last_step: Instant::now(),
+                main_menu_shell_failed,
+                version_txt,
+                shell_first_paint_slide: None,
+                shell_slide_active_shell: None,
+                shell_slide_generation: 0,
+                quit_cascade: None,
+                startup_splash,
+                exit_confirm_modal: None,
+                options_dialog: None,
+                movies_credits_dialog: None,
+                campaign_select: None,
+                score_screen: None,
+                score_shell_state: Default::default(),
+                finished_game_count: 0,
+                shell_route: Default::default(),
             },
             renderer: crate::app::renderer_state::RendererState {
                 gpu,
@@ -716,8 +724,10 @@ impl App {
 
         if std::env::var("RA2_QUICKPLAY").is_ok() {
             let skirmish_settings = state.frontend.skirmish_settings.clone();
-            let request =
-                crate::app::loading::pump::LoadingRequest::generic_map_load("auto", skirmish_settings);
+            let request = crate::app::loading::pump::LoadingRequest::generic_map_load(
+                "auto",
+                skirmish_settings,
+            );
             crate::app::loading::pump::begin_loading(&mut state, request);
         }
 
@@ -734,6 +744,7 @@ mod tests {
         Sound(f64),
         Voice(f64),
         Score(f64),
+        RepeatShuffle(bool, bool),
     }
 
     #[derive(Default)]
@@ -753,6 +764,11 @@ mod tests {
         fn set_score_volume(&mut self, volume: f64) {
             self.calls.push(StartupAudioCall::Score(volume));
         }
+
+        fn set_score_repeat_shuffle(&mut self, repeat: bool, shuffle: bool) {
+            self.calls
+                .push(StartupAudioCall::RepeatShuffle(repeat, shuffle));
+        }
     }
 
     #[test]
@@ -761,6 +777,8 @@ mod tests {
             sound_volume: 0.125,
             voice_volume: 0.5,
             score_volume: 0.875,
+            is_score_repeat: true,
+            is_score_shuffle: false,
             ..Default::default()
         };
         let mut operations = RecordingStartupAudioOperations::default();
@@ -773,6 +791,7 @@ mod tests {
                 StartupAudioCall::Sound(0.125),
                 StartupAudioCall::Voice(0.5),
                 StartupAudioCall::Score(0.875),
+                StartupAudioCall::RepeatShuffle(true, false),
             ]
         );
     }

--- a/src/app/loading/pump.rs
+++ b/src/app/loading/pump.rs
@@ -5,17 +5,16 @@
 //! the app loop before map-load phases are split into a fully pumpable job.
 
 use crate::app::AppState;
-use crate::app::loading::init::{self, MapLoadInitial, MapLoadResult};
-use crate::app::loading::fresh_scenario::FreshScenarioLoadContextDescriptor;
 use crate::app::loading::composition::{
     LoadingCompositionSnapshot, LoadingParticipantId, LoadingStartAssignment, MmpbRegionRect,
     RANDOM_MAP_PREVIEW_FILE, build_loading_composition, build_random_map_loading_composition,
     loading_base_origin,
 };
+use crate::app::loading::fresh_scenario::FreshScenarioLoadContextDescriptor;
+use crate::app::loading::init::{self, MapLoadInitial, MapLoadResult};
 use crate::app::loading::progress_row::{
     LoadingProgressRowLayout, LoadingProgressRowSnapshot, layout_standard_skirmish_progress_row,
 };
-use crate::sim::scenario_bootstrap::StockOfflinePrefixProjection;
 use crate::assets::asset_manager::AssetManager;
 use crate::assets::pal_file::Color;
 use crate::assets::pcx_file::PcxFile;
@@ -37,6 +36,7 @@ use crate::rules::color_scheme::{
     scheme_hsv_by_entry,
 };
 use crate::rules::house_colors::{HouseColorIndex, HouseColorRamps};
+use crate::sim::scenario_bootstrap::StockOfflinePrefixProjection;
 use crate::skirmish_launch::{LaunchCountry, SkirmishLaunchSession};
 use crate::ui::game_screen::GameScreen;
 use crate::ui::main_menu::SkirmishSettings;
@@ -359,16 +359,15 @@ impl LoadingRequest {
             }
             FreshScenarioLoadState::Pending => {}
         }
-        self.fresh_scenario_load = FreshScenarioLoadState::Ready(
-            FreshScenarioLoadContextDescriptor::admit_stock_offline(
+        self.fresh_scenario_load =
+            FreshScenarioLoadState::Ready(FreshScenarioLoadContextDescriptor::admit_stock_offline(
                 self.startup
                     .as_ref()
                     .expect("live loading request retains startup authority"),
                 initial.map_data(),
                 initial.map_source(),
                 &mut self.accepted_rmg_start_staging,
-            )?,
-        );
+            )?);
         Ok(())
     }
 
@@ -601,25 +600,72 @@ pub(crate) fn begin_loading(state: &mut AppState, request: LoadingRequest) {
     clear_loading_state(state);
     let mut session = LoadingSession::from_request(request);
     session.job.ra2_dir = state
-        .platform.game_config
+        .platform
+        .game_config
         .as_ref()
         .map(|config| config.paths.ra2_dir.clone());
-    // Retail has one process-global MIX list and LoadFileFromMIX cache. Lease
-    // that same manager through the loading job instead of reconstructing it
-    // at the shell -> scenario boundary (F11 slot: Available -> Loading).
-    session.job.asset_manager = state.process_assets.lease_for_loading();
     // Resolve the backing fill from the live rules `[Colors]` schemes now that
     // `state.rules` is reachable (the native ctor only sees the launch session).
     if let (Some(native), Some(rules)) = (session.native.as_mut(), state.rules()) {
         native.resolve_player_colors(&rules.color_schemes, &rules.house_color_ramps);
     }
+    let now_ms = crate::app::match_runtime::sim_tick::monotonic_frame_pacer_ms(
+        state,
+        std::time::Instant::now(),
+    );
+    let session = lease_loading_assets_and_play_loading_theme(
+        &mut state.process_assets,
+        &mut state.audio,
+        session,
+        now_ms,
+    );
     state.frontend.loading_session = Some(session);
     state.frontend.screen = GameScreen::Loading;
 }
 
+/// The shell -> scenario boundary of `begin_loading`: lease the process asset
+/// manager into the loading job, then issue the LOADING theme through it.
+///
+/// Retail has one process-global MIX list and LoadFileFromMIX cache. Lease
+/// that same manager through the loading job instead of reconstructing it
+/// (F11 slot: Available -> Loading). `ScenarioClass__Start_Scenario @
+/// 0x00683AB0` then plays `From_Name("LOADING")` (`0x00683D0F`) via
+/// `Play_Song` (`0x00683D1A`) before `Read_Scenario` (`0x00684620`): a hard
+/// replacement of the shell INTRO stream that loops (Repeat=yes) under the
+/// loading screen until the post-read `Stop(1)` / `Queue_Song`. Native never
+/// loses its MIX list across that boundary, so the request must resolve the
+/// manager through the lease rather than the (now empty) resident slot.
+fn lease_loading_assets_and_play_loading_theme(
+    process_assets: &mut crate::app::process_assets::ProcessAssets,
+    audio: &mut crate::app::audio_runtime::AppAudioRuntime,
+    mut session: LoadingSession,
+    now_ms: u64,
+) -> LoadingSession {
+    session.job.asset_manager = process_assets.lease_for_loading();
+    if let Some(assets) = audio_service_asset_manager(process_assets, Some(&session)) {
+        let _ = audio.play_theme("LOADING", assets, now_ms);
+    }
+    session
+}
+
+/// The asset manager the audio service polls Theme with: the resident
+/// process manager, or the one leased to the loading job while the loading
+/// screen owns it. `AudioSystem__Pump @ 0x00406F70` keeps reaching
+/// `ThemeClass::AI` under the loading screen with the same process-global
+/// MIX list, so the lease must not blind the poll (LOADING repeats there).
+pub(crate) fn audio_service_asset_manager<'a>(
+    process_assets: &'a crate::app::process_assets::ProcessAssets,
+    loading_session: Option<&'a LoadingSession>,
+) -> Option<&'a AssetManager> {
+    process_assets
+        .manager()
+        .or_else(|| loading_session.and_then(loading_asset_manager))
+}
+
 pub(crate) fn loading_map_name(state: &AppState) -> Option<&str> {
     state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .map(|session| session.request.selected_map_file())
 }
@@ -663,7 +709,8 @@ fn replace_match_startup_slots(
 /// screen's progress row. `None` outside a skirmish launch.
 pub(crate) fn launch_player_name(state: &AppState) -> Option<String> {
     state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .and_then(|session| session.request.skirmish_launch_session())
         .map(|launch| launch.player_name.clone())
@@ -671,7 +718,8 @@ pub(crate) fn launch_player_name(state: &AppState) -> Option<String> {
 
 pub(crate) fn is_native_loading_session(state: &AppState) -> bool {
     state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .is_some_and(|session| session.native.is_some())
 }
@@ -762,7 +810,10 @@ pub(crate) fn pump_loading_after_present(state: &mut AppState) -> LoadingPump {
             // split-borrows (gpu/depth_view/batch shared, vxl_compute &mut,
             // native.progress &mut, native.atlas shared, request shared) all
             // hold simultaneously.
-            let render_size = [state.renderer.gpu.config.width, state.renderer.gpu.config.height];
+            let render_size = [
+                state.renderer.gpu.config.width,
+                state.renderer.gpu.config.height,
+            ];
             // The pre-parse swallowed the loader's raw 8 so it could not present
             // before the first frame; hand it over now for either native cadence.
             if let Some(native) = session.native.as_mut()
@@ -783,10 +834,7 @@ pub(crate) fn pump_loading_after_present(state: &mut AppState) -> LoadingPump {
             }
             // `session.native` and `session.request` are disjoint fields, so the
             // launch-session/settings borrows below coexist with the native split.
-            let fresh_scenario_context = match session
-                .request
-                .take_fresh_scenario_load_context()
-            {
+            let fresh_scenario_context = match session.request.take_fresh_scenario_load_context() {
                 Ok(context) => context,
                 Err(err) => {
                     restore_job_asset_manager(state, &mut session);
@@ -809,8 +857,8 @@ pub(crate) fn pump_loading_after_present(state: &mut AppState) -> LoadingPump {
             let shared_cell_dummy = state.process_assets.shared_cell_dummy.clone();
             let (native_rules_owner, tile_variant_selector_cache) =
                 state.process_assets.native_rules_mut_with_tile_cache();
-            let native_rules_owner = native_rules_owner
-                .expect("native Rules availability checked before split borrow");
+            let native_rules_owner =
+                native_rules_owner.expect("native Rules availability checked before split borrow");
             let load_result = match session.native.as_mut() {
                 // Only repaint when the atlas is present; without it the bar
                 // cannot draw, so fall back to the gate-only sink.
@@ -945,7 +993,8 @@ fn ensure_session_job_asset_manager(
     if session.job.ra2_dir.is_none() {
         session.job.ra2_dir = Some(
             state
-                .platform.game_config
+                .platform
+                .game_config
                 .as_ref()
                 .map(|config| config.paths.ra2_dir.clone())
                 .ok_or_else(|| anyhow::anyhow!("missing game config for loading job assets"))?,
@@ -996,7 +1045,8 @@ fn restore_job_asset_manager(state: &mut AppState, session: &mut LoadingSession)
 /// and visibly handed off only after the first frame has been presented.
 fn prepare_scenario_initial_before_first_frame(state: &mut AppState) -> anyhow::Result<()> {
     let should_prepare = state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .and_then(|session| session.native.as_ref())
         .is_some_and(|native| {
@@ -1004,9 +1054,13 @@ fn prepare_scenario_initial_before_first_frame(state: &mut AppState) -> anyhow::
                 .progress_cadence
                 .prepares_scenario_before_first_frame()
         })
-        && state.frontend.loading_session.as_ref().is_some_and(|session| {
-            matches!(session.job.phase, LoadingJobPhase::InitialMapSelection)
-        });
+        && state
+            .frontend
+            .loading_session
+            .as_ref()
+            .is_some_and(|session| {
+                matches!(session.job.phase, LoadingJobPhase::InitialMapSelection)
+            });
     if !should_prepare {
         return Ok(());
     }
@@ -1142,14 +1196,16 @@ fn ensure_loading_composition_snapshot(state: &mut AppState) {
         };
         let launch_session = context.stock_offline_launch().session();
         let projection = context.stock_offline_projection();
-        let render_size = [state.renderer.gpu.config.width, state.renderer.gpu.config.height];
+        let render_size = [
+            state.renderer.gpu.config.width,
+            state.renderer.gpu.config.height,
+        ];
         match native.progress_cadence {
             NativeLoadingProgressCadence::SelectedMap => {
                 let LoadingJobPhase::RemainingLegacyLoad(Some(initial)) = &session.job.phase else {
                     return;
                 };
-                let assignments =
-                    selected_map_start_assignments(launch_session, Some(projection));
+                let assignments = selected_map_start_assignments(launch_session, Some(projection));
                 build_loading_composition(
                     initial.map_data(),
                     launch_session,
@@ -1167,8 +1223,7 @@ fn ensure_loading_composition_snapshot(state: &mut AppState) {
                     .ra2_dir
                     .as_deref()
                     .and_then(decode_random_map_loading_preview);
-                let assignments =
-                    selected_map_start_assignments(launch_session, Some(projection));
+                let assignments = selected_map_start_assignments(launch_session, Some(projection));
                 build_random_map_loading_composition(
                     launch_session,
                     state.process_assets.csf.as_ref(),
@@ -1183,7 +1238,8 @@ fn ensure_loading_composition_snapshot(state: &mut AppState) {
     };
 
     if let Some(native) = state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_mut()
         .and_then(|session| session.native.as_mut())
     {
@@ -1226,7 +1282,8 @@ pub(crate) fn ensure_native_loading_atlas(state: &mut AppState) -> anyhow::Resul
         return Ok(());
     };
     if state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .and_then(|session| session.native.as_ref())
         .and_then(|native| native.atlas.as_ref())
@@ -1235,7 +1292,8 @@ pub(crate) fn ensure_native_loading_atlas(state: &mut AppState) -> anyhow::Resul
         return Ok(());
     }
     if state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .and_then(loading_asset_manager)
         .is_none()
@@ -1243,7 +1301,8 @@ pub(crate) fn ensure_native_loading_atlas(state: &mut AppState) -> anyhow::Resul
         ensure_job_asset_manager(state)?;
     }
     let loading_archives_ready = state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_mut()
         .and_then(|session| session.job.asset_manager.as_mut())
         .ok_or_else(|| {
@@ -1258,7 +1317,8 @@ pub(crate) fn ensure_native_loading_atlas(state: &mut AppState) -> anyhow::Resul
     prepare_scenario_initial_before_first_frame(state)?;
     ensure_loading_composition_snapshot(state);
     let Some(assets) = state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .and_then(loading_asset_manager)
     else {
@@ -1268,13 +1328,15 @@ pub(crate) fn ensure_native_loading_atlas(state: &mut AppState) -> anyhow::Resul
     };
     let width = LoadingScreenWidth::for_render_width(state.renderer.gpu.config.width);
     let progress_ramp = state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .and_then(|session| session.native.as_ref())
         .map(|native| native.progress_ramp)
         .ok_or_else(|| anyhow::anyhow!("native loading session lost its progress ramp"))?;
     let prepared_preview = state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .and_then(|session| session.native.as_ref())
         .and_then(|native| native.composition.as_ref())
@@ -1285,7 +1347,8 @@ pub(crate) fn ensure_native_loading_atlas(state: &mut AppState) -> anyhow::Resul
             rgba: preview.image.rgba.clone(),
         });
     let marker_remaps = state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .and_then(|session| session.native.as_ref())
         .and_then(|native| native.composition.as_ref())
@@ -1322,7 +1385,8 @@ pub(crate) fn ensure_native_loading_atlas(state: &mut AppState) -> anyhow::Resul
         composition_input,
     );
     if let Some(native) = state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_mut()
         .and_then(|session| session.native.as_mut())
     {
@@ -1330,7 +1394,8 @@ pub(crate) fn ensure_native_loading_atlas(state: &mut AppState) -> anyhow::Resul
         native.atlas = atlas;
     }
     if state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .and_then(|session| session.native.as_ref())
         .is_some_and(|native| native.first_renderer_ready)
@@ -1368,7 +1433,8 @@ pub(crate) fn render_loading_screen(
             .advance_progress(native.progress_cadence.effective_percent(3));
     }
     let Some(native) = state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .and_then(|session| session.native.as_ref())
     else {
@@ -1389,7 +1455,10 @@ pub(crate) fn render_loading_screen(
         &native.progress,
         native.backing_rgb,
         native.text_rgb,
-        [state.renderer.gpu.config.width, state.renderer.gpu.config.height],
+        [
+            state.renderer.gpu.config.width,
+            state.renderer.gpu.config.height,
+        ],
     );
     let instances = frame_plan.instances;
     let text_draws = frame_plan.text_draws;
@@ -1403,7 +1472,8 @@ pub(crate) fn render_loading_screen(
         1.0,
     );
     let Some((buffer, count)) = state
-        .renderer.batch_renderer
+        .renderer
+        .batch_renderer
         .create_instance_buffer(&state.renderer.gpu, &instances)
     else {
         return LoadingRenderResult::NativeFailed(anyhow::anyhow!(
@@ -1414,7 +1484,8 @@ pub(crate) fn render_loading_screen(
         .iter()
         .map(|draw| {
             state
-                .renderer.batch_renderer
+                .renderer
+                .batch_renderer
                 .create_instance_buffer(&state.renderer.gpu, &draw.backing)
         })
         .collect::<Vec<_>>();
@@ -1422,7 +1493,8 @@ pub(crate) fn render_loading_screen(
         .iter()
         .map(|draw| {
             state
-                .renderer.batch_renderer
+                .renderer
+                .batch_renderer
                 .create_instance_buffer(&state.renderer.gpu, &draw.text.instances)
         })
         .collect::<Vec<_>>();
@@ -1449,9 +1521,12 @@ pub(crate) fn render_loading_screen(
         timestamp_writes: None,
         occlusion_query_set: None,
     });
-    state
-        .renderer.batch_renderer
-        .draw_with_buffer_passthrough(&mut pass, &atlas.texture, &buffer, count);
+    state.renderer.batch_renderer.draw_with_buffer_passthrough(
+        &mut pass,
+        &atlas.texture,
+        &buffer,
+        count,
+    );
     for ((draw, backing_buffer), text_buffer) in text_draws
         .iter()
         .zip(backing_buffers.iter())
@@ -1483,10 +1558,16 @@ pub(crate) fn render_loading_screen(
             *count,
         );
     }
-    pass.set_scissor_rect(0, 0, state.renderer.gpu.config.width, state.renderer.gpu.config.height);
+    pass.set_scissor_rect(
+        0,
+        0,
+        state.renderer.gpu.config.width,
+        state.renderer.gpu.config.height,
+    );
     drop(pass);
     state
-        .renderer.shell_surface_presenter
+        .renderer
+        .shell_surface_presenter
         .encode_present(encoder, destination);
     LoadingRenderResult::NativeRendered
 }
@@ -1504,7 +1585,8 @@ fn selected_loading_art_variant(state: &AppState) -> Option<LoadingArtVariant> {
         return None;
     }
     state
-        .frontend.loading_session
+        .frontend
+        .loading_session
         .as_ref()
         .and_then(|session| session.native.as_ref())
         .map(|native| native.variant)
@@ -2358,6 +2440,81 @@ mod tests {
         .expect("valid test startup must acknowledge")
     }
 
+    /// `begin_loading`'s shell -> scenario boundary: the LOADING request
+    /// (`Start_Scenario @ 0x00683AB0`, `Play_Song(From_Name("LOADING"))` @
+    /// `0x00683D1A`) must resolve the process asset manager *through the
+    /// loading-job lease*, and the audio pump's Theme poll must keep reaching
+    /// AI while that lease is out. Exercises the production leaf that
+    /// `begin_loading` calls and the resolver `pump_audio_service` uses.
+    #[test]
+    fn begin_loading_plays_loading_theme_and_polls_theme_through_the_lease() {
+        let dir =
+            std::env::temp_dir().join(format!("vera20k-loading-theme-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("test asset dir");
+        std::fs::write(
+            dir.join("thememd.ini"),
+            b"[Themes]\n1=INTRO\n2=LOADING\n\n[INTRO]\nName=Intro\nSound=intro\nRepeat=yes\n\n\
+              [LOADING]\nName=Loading\nSound=loading\nRepeat=yes\n",
+        )
+        .expect("write thememd.ini");
+        let mut process_assets = crate::app::process_assets::ProcessAssets::from_startup(
+            Some(AssetManager::from_loose_root_for_test(&dir)),
+            None,
+            None,
+            None,
+        );
+        let mut audio = crate::app::audio_runtime::AppAudioRuntime {
+            theme: crate::audio::theme::ThemeRuntime::default(),
+            last_theme_poll_ms: None,
+            music_player: None,
+            sfx_player: None,
+            sound_registry: Default::default(),
+            audio_indices: Vec::new(),
+            audio_indices_enabled: false,
+            launcher_audio_available: true,
+            theme_startup_suppressed: false,
+            eva_registry: Default::default(),
+        };
+        let session = LoadingSession::from_request(LoadingRequest::unverified_legacy_skirmish(
+            test_launch_session(LaunchCountry::America),
+            unverified_seed(1),
+            SkirmishSettings::default(),
+        ));
+
+        let session = lease_loading_assets_and_play_loading_theme(
+            &mut process_assets,
+            &mut audio,
+            session,
+            500,
+        );
+
+        assert!(
+            process_assets.manager().is_none() && process_assets.is_leased(),
+            "the manager is leased into the loading job"
+        );
+        let loading = audio.theme.from_name("LOADING");
+        assert!(loading >= 0, "catalog resolves LOADING");
+        let slots = audio.theme.slots();
+        assert_eq!(
+            slots.retained, loading,
+            "Play_Song(LOADING) was issued while the resident slot was empty"
+        );
+        assert_eq!(
+            slots.pending, loading,
+            "LOADING repeats under the loading screen"
+        );
+
+        // The audio pump's poll resolves the leased manager and advances AI.
+        assert!(
+            audio_service_asset_manager(&process_assets, None).is_none(),
+            "resident slot alone cannot serve the poll during a lease"
+        );
+        let assets = audio_service_asset_manager(&process_assets, Some(&session))
+            .expect("leased manager serves the Theme poll");
+        audio.update_theme(assets, 600);
+        assert_eq!(audio.last_theme_poll_ms, Some(600));
+    }
+
     #[test]
     fn loading_side_comes_from_first_launch_node_country() {
         let session = LoadingSession::from_request(LoadingRequest::unverified_legacy_skirmish(
@@ -2463,8 +2620,7 @@ mod tests {
         );
         let generated = crate::map::rmg::GeneratedMap {
             map_file: map,
-            mapgen_continuation:
-                crate::map::rmg::RmgRng::new(0x1234).into_continuation(),
+            mapgen_continuation: crate::map::rmg::RmgRng::new(0x1234).into_continuation(),
             construction_trace: crate::map::rmg::RmgConstructionTrace::default(),
             start_waypoints: vec![(0, 10, 20), (1, 30, 40)],
             stages_run: Vec::new(),
@@ -2608,10 +2764,8 @@ mod tests {
             initial.map_data(),
             Some(projection),
         );
-        let regenerated_session = crate::app::loading::init::scenario_start_waypoints_for_load(
-            initial.map_data(),
-            None,
-        );
+        let regenerated_session =
+            crate::app::loading::init::scenario_start_waypoints_for_load(initial.map_data(), None);
         assert_eq!(
             staged_session
                 .iter()
@@ -2758,12 +2912,7 @@ mod tests {
                     must_ally: false,
                 };
             }
-            let accepted = accepted_random_map_with_starts(
-                &selected,
-                0x2345,
-                &starts,
-                &starts,
-            );
+            let accepted = accepted_random_map_with_starts(&selected, 0x2345, &starts, &starts);
             let mut map = prefix_test_map(&starts);
             map.basic.new_ini_format = Some(4);
             let source = crate::app::frontend::list_maps::LoadedMapSource::Generated {
@@ -2801,9 +2950,7 @@ mod tests {
 
     #[test]
     fn accepted_and_resolved_legacy_share_one_stock_cursor_shape() {
-        use crate::app::loading::fresh_scenario::{
-            FreshScenarioFamily, FreshStartupProvenance,
-        };
+        use crate::app::loading::fresh_scenario::{FreshScenarioFamily, FreshStartupProvenance};
 
         let starts = [(0, 20, 24), (1, 42, 46)];
         let source = crate::app::frontend::list_maps::LoadedMapSource::Loose {
@@ -2812,16 +2959,12 @@ mod tests {
         };
         let mut map = prefix_test_map(&starts);
         map.basic.new_ini_format = Some(4);
-        let initial = crate::app::loading::init::MapLoadInitial::from_test_map_source(
-            map,
-            source,
-        );
+        let initial = crate::app::loading::init::MapLoadInitial::from_test_map_source(map, source);
         let seed = 0x3456_789A;
         let mut next = 1;
         let prepared = prepared_startup(&mut next, seed);
         let legacy_session = prepared.session.launch_session().clone();
-        let mut accepted =
-            LoadingRequest::accepted_skirmish(prepared, SkirmishSettings::default());
+        let mut accepted = LoadingRequest::accepted_skirmish(prepared, SkirmishSettings::default());
         let mut resolved_legacy = LoadingRequest::unverified_legacy_skirmish(
             legacy_session,
             unverified_seed(seed),
@@ -2839,7 +2982,9 @@ mod tests {
         assert_eq!(accepted_context.family(), legacy_context.family());
         assert_eq!(accepted_context.match_seed(), legacy_context.match_seed());
         assert_eq!(
-            accepted_context.stock_offline_projection().final_gathered_starts(),
+            accepted_context
+                .stock_offline_projection()
+                .final_gathered_starts(),
             legacy_context
                 .stock_offline_projection()
                 .final_gathered_starts()
@@ -2892,11 +3037,8 @@ mod tests {
             source,
         );
         let accepted = accepted_random_map_with_starts(selected, 0x4567, &starts, &starts);
-        let mut generic = LoadingRequest::generic_map_load(
-            selected,
-            SkirmishSettings::default(),
-        )
-        .with_accepted_random_map(Some(accepted));
+        let mut generic = LoadingRequest::generic_map_load(selected, SkirmishSettings::default())
+            .with_accepted_random_map(Some(accepted));
         let generic_err = generic
             .prepare_fresh_scenario_load_context(&initial)
             .unwrap_err();
@@ -2917,9 +3059,7 @@ mod tests {
         let unresolved_err = unresolved
             .prepare_fresh_scenario_load_context(&initial)
             .unwrap_err();
-        assert!(
-            format!("{unresolved_err:#}").contains("local slot still has a random country")
-        );
+        assert!(format!("{unresolved_err:#}").contains("local slot still has a random country"));
         assert!(unresolved.fresh_scenario_load_context().is_none());
         assert!(unresolved.accepted_rmg_start_staging.is_some());
 
@@ -2964,10 +3104,9 @@ mod tests {
         // carry the same Waypoint::index even though the assignment table has
         // three distinct positions.
         let map = prefix_test_map(&[(0, 20, 24), (2, 42, 46), (3, 54, 58)]);
-        let descriptor = crate::sim::scenario_bootstrap::MatchLaunchDescriptor::from_resolved(
-            launch.clone(),
-        )
-        .unwrap();
+        let descriptor =
+            crate::sim::scenario_bootstrap::MatchLaunchDescriptor::from_resolved(launch.clone())
+                .unwrap();
         let plan = crate::sim::scenario_bootstrap::prepare_stock_offline_scenario_prefix_plan(
             &descriptor,
             &map,
@@ -3026,10 +3165,7 @@ mod tests {
         );
         assert_eq!(markers.len(), 2);
         assert_eq!(markers[1].waypoint.index, 2);
-        assert_eq!(
-            markers[1].participant,
-            LoadingParticipantId::Opponent(1)
-        );
+        assert_eq!(markers[1].participant, LoadingParticipantId::Opponent(1));
     }
 
     #[test]
@@ -3217,7 +3353,8 @@ mod tests {
             .prepare_fresh_scenario_load_context(&initial)
             .unwrap_err();
         assert!(
-            format!("{err:#}").contains("requires an exact Loose, MIX, or accepted generated source"),
+            format!("{err:#}")
+                .contains("requires an exact Loose, MIX, or accepted generated source"),
             "unexpected error: {err:#}"
         );
 
@@ -3243,9 +3380,7 @@ mod tests {
             unverified_seed(0x1818),
             SkirmishSettings::default(),
         );
-        let pending_err = pending
-            .take_fresh_scenario_load_context()
-            .unwrap_err();
+        let pending_err = pending.take_fresh_scenario_load_context().unwrap_err();
         assert!(
             format!("{pending_err:#}").contains("before fresh scenario admission"),
             "unexpected error: {pending_err:#}"
@@ -3263,9 +3398,7 @@ mod tests {
         let _context = pending
             .take_fresh_scenario_load_context()
             .expect("ready context transfers once");
-        let transferred_err = pending
-            .take_fresh_scenario_load_context()
-            .unwrap_err();
+        let transferred_err = pending.take_fresh_scenario_load_context().unwrap_err();
         assert!(
             format!("{transferred_err:#}").contains("transfers exactly once"),
             "unexpected error: {transferred_err:#}"
@@ -3351,8 +3484,7 @@ mod tests {
         let active_scenario_waypoints = map.waypoints.clone();
         let generated = crate::map::rmg::GeneratedMap {
             map_file: map,
-            mapgen_continuation:
-                crate::map::rmg::RmgRng::new(0x4567).into_continuation(),
+            mapgen_continuation: crate::map::rmg::RmgRng::new(0x4567).into_continuation(),
             construction_trace: crate::map::rmg::RmgConstructionTrace::default(),
             start_waypoints: vec![(0, 70, 70), (1, 90, 70), (2, 70, 90)],
             stages_run: Vec::new(),

--- a/src/app/loading/transitions.rs
+++ b/src/app/loading/transitions.rs
@@ -5,8 +5,8 @@
 use std::collections::{BTreeMap, HashMap};
 
 use crate::app::loading::init;
-use crate::app::presentation::render;
 use crate::app::match_runtime::sim_tick;
+use crate::app::presentation::render;
 use crate::map::basic::BasicSection;
 use crate::map::houses::HouseRoster;
 use crate::map::overlay_types::OverlayTypeRegistry;
@@ -31,7 +31,8 @@ const CLEAR_COLOR: wgpu::Color = wgpu::Color {
 /// app's live match, including both fresh-map handoff and in-scenario load.
 pub(crate) fn sync_in_game_options_speed_from_sim(state: &mut AppState) {
     let Some(game_speed) = state
-        .match_state.sim_runtime
+        .match_state
+        .sim_runtime
         .as_ref()
         .map(|rt| &rt.simulation)
         .and_then(crate::sim::world::Simulation::projected_in_game_options_speed)
@@ -39,7 +40,11 @@ pub(crate) fn sync_in_game_options_speed_from_sim(state: &mut AppState) {
     else {
         return;
     };
-    state.match_state.match_presentation.in_game_options.game_speed = game_speed;
+    state
+        .match_state
+        .match_presentation
+        .in_game_options
+        .game_speed = game_speed;
     state.match_state.sim_speed_tps = crate::app::types::tps_for_game_speed(game_speed);
 }
 
@@ -117,7 +122,10 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
     state.match_state.loaded_map_source = Some(result.scenario.map_source);
     state.match_state.loaded_map_hash = result.scenario.map_hash;
     state.match_state.match_presentation.terrain_grid = result.scenario.terrain_grid;
-    state.match_state.match_presentation.installed_playfield_authority = None;
+    state
+        .match_state
+        .match_presentation
+        .installed_playfield_authority = None;
     state.frontend.shell_preview_overlay_registry = Some(result.scenario.overlay_registry.clone());
     // F10 lifecycle: a new match install closes the outgoing diagnostic
     // segment before the runtime slot is overwritten — the old install
@@ -126,24 +134,34 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
     // old header.
     crate::app::match_runtime::sim_tick::close_replay_segment_for_new_timeline(state);
     let match_rules = result.scenario.rules;
-    state.match_state.sim_runtime = result.scenario.simulation.zip(match_rules).map(|(simulation, rules)| crate::sim::runtime::SimRuntime {
-        simulation,
-        resources: crate::sim::runtime::SimResources {
-            height_map: result.scenario.height_map,
-            bridge_height_map: result.scenario.bridge_height_map,
-            overlay_registry: result.scenario.overlay_registry,
-            terrain_template: result.scenario.resolved_terrain,
-            rules,
-            trigger_graph: result.scenario.trigger_graph,
-            triggers: result.scenario.triggers,
-            events: result.scenario.events,
-            actions: result.scenario.actions,
-            waypoints: result.scenario.waypoints.clone(),
-        },
-    });
+    state.match_state.sim_runtime =
+        result
+            .scenario
+            .simulation
+            .zip(match_rules)
+            .map(|(simulation, rules)| crate::sim::runtime::SimRuntime {
+                simulation,
+                resources: crate::sim::runtime::SimResources {
+                    height_map: result.scenario.height_map,
+                    bridge_height_map: result.scenario.bridge_height_map,
+                    overlay_registry: result.scenario.overlay_registry,
+                    terrain_template: result.scenario.resolved_terrain,
+                    rules,
+                    trigger_graph: result.scenario.trigger_graph,
+                    triggers: result.scenario.triggers,
+                    events: result.scenario.events,
+                    actions: result.scenario.actions,
+                    waypoints: result.scenario.waypoints.clone(),
+                },
+            });
     state.match_state.match_presentation.combat_lights.clear();
     sync_in_game_options_speed_from_sim(state);
-    if let Some(sim) = state.match_state.sim_runtime.as_mut().map(|rt| &mut rt.simulation) {
+    if let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_mut()
+        .map(|rt| &mut rt.simulation)
+    {
         sim.set_input_delay_ticks(state.match_state.configured_input_delay_ticks);
     }
     state.match_state.match_presentation.unit_atlas = result.presentation.unit_atlas;
@@ -151,19 +169,26 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
     state.match_state.match_presentation.sprite_atlas = result.presentation.sprite_atlas;
     state.match_state.match_presentation.overlay_atlas = result.presentation.overlay_atlas;
     state.match_state.match_presentation.bridge_atlas = result.presentation.bridge_atlas;
-    state.match_state.match_presentation.bridge_railing_atlas = result.presentation.bridge_railing_atlas;
-    state.match_state.match_presentation.sidebar_cameo_atlas = result.presentation.sidebar_cameo_atlas;
+    state.match_state.match_presentation.bridge_railing_atlas =
+        result.presentation.bridge_railing_atlas;
+    state.match_state.match_presentation.sidebar_cameo_atlas =
+        result.presentation.sidebar_cameo_atlas;
     state.match_state.match_presentation.sidebar_chrome = result.presentation.sidebar_chrome;
     if let Some(ref fnt) = result.presentation.fnt_file {
-        state.renderer.bit_font =
-            crate::render::bit_font::BitFont::from_fnt(&state.renderer.gpu, &state.renderer.batch_renderer, fnt);
+        state.renderer.bit_font = crate::render::bit_font::BitFont::from_fnt(
+            &state.renderer.gpu,
+            &state.renderer.batch_renderer,
+            fnt,
+        );
     }
 
     // Initialize radar animation from the default (Allied) sidebar chrome atlas.
     // Uses pre-rendered radar.shp frames for the 33-frame open/close animation.
     // Also extract content insets derived from the transparent opening in frame 0.
     let allied_radar = state
-        .match_state.match_presentation.sidebar_chrome
+        .match_state
+        .match_presentation
+        .sidebar_chrome
         .as_ref()
         .and_then(|set| set.resolve_theme(crate::render::sidebar_chrome::SidebarTheme::Allied))
         .map(|resolved| {
@@ -176,13 +201,14 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
         });
     if let Some((identity, frames, [w, h], insets)) = allied_radar {
         state.match_state.match_presentation.radar_animation_source = Some(identity);
-        state.match_state.match_presentation.radar_anim = crate::render::radar_anim::RadarAnimState::new(
-            &state.renderer.gpu,
-            &state.renderer.batch_renderer,
-            frames,
-            w,
-            h,
-        );
+        state.match_state.match_presentation.radar_anim =
+            crate::render::radar_anim::RadarAnimState::new(
+                &state.renderer.gpu,
+                &state.renderer.batch_renderer,
+                frames,
+                w,
+                h,
+            );
         state.match_state.match_presentation.radar_content_insets = Some(insets);
     } else {
         state.match_state.match_presentation.radar_animation_source = None;
@@ -192,26 +218,60 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
     state.match_state.match_presentation.has_radar = false;
 
     state.match_state.match_presentation.software_cursor = result.presentation.software_cursor;
-    state.match_state.match_presentation.overlays.replace_from_source(result.scenario.overlays);
+    state
+        .match_state
+        .match_presentation
+        .overlays
+        .replace_from_source(result.scenario.overlays);
     state.match_state.match_presentation.terrain_objects = result.scenario.terrain_objects;
     state.match_state.match_presentation.waypoints = result.scenario.waypoints;
     state.match_state.match_presentation.cell_tags = result.scenario.cell_tags;
     state.match_state.match_presentation.tags = result.scenario.tags;
-    if let Some(sim) = state.match_state.sim_runtime.as_mut().map(|rt| &mut rt.simulation) {
+    if let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_mut()
+        .map(|rt| &mut rt.simulation)
+    {
         sim.install_trigger_runtime(result.scenario.trigger_runtime);
     }
     state.match_state.match_presentation.overlay_names = result.presentation.overlay_names;
-    state.match_state.match_presentation.overlay_radar_colors = result.presentation.overlay_radar_colors;
+    state.match_state.match_presentation.overlay_radar_colors =
+        result.presentation.overlay_radar_colors;
     state.match_state.match_presentation.house_color_map = result.presentation.house_color_map;
     state.match_state.match_presentation.house_roster = result.scenario.house_roster;
-    state.match_state.match_presentation.tactical_bridge_inverse_map = result.scenario.tactical_bridge_inverse_map;
+    state
+        .match_state
+        .match_presentation
+        .tactical_bridge_inverse_map = result.scenario.tactical_bridge_inverse_map;
     state.match_state.match_presentation.lighting_grid = result.presentation.lighting_grid;
-    state.match_state.match_presentation.applied_lighting_sources.clear();
-    state.match_state.match_presentation.applied_lighting_profile = None;
-    state.match_state.match_presentation.applied_lighting_detail_level = state.match_state.match_presentation.in_game_options.detail_level.min(2);
-    state.match_state.match_presentation.pending_lighting_refresh = None;
+    state
+        .match_state
+        .match_presentation
+        .applied_lighting_sources
+        .clear();
+    state
+        .match_state
+        .match_presentation
+        .applied_lighting_profile = None;
+    state
+        .match_state
+        .match_presentation
+        .applied_lighting_detail_level = state
+        .match_state
+        .match_presentation
+        .in_game_options
+        .detail_level
+        .min(2);
+    state
+        .match_state
+        .match_presentation
+        .pending_lighting_refresh = None;
     state.match_state.match_presentation.map_lighting_config = result.scenario.map_lighting_config;
-    state.match_state.match_presentation.last_lighting_view_fingerprint = None;
+    state
+        .match_state
+        .match_presentation
+        .last_lighting_view_fingerprint = None;
     // F04: the app no longer stores a second ArtRegistry; presentation
     // borrows the sole copy owned by RuleSet (state.rules).
     state.process_assets.csf = result.presentation.csf;
@@ -223,7 +283,11 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
     // selected detail mask and its corresponding building-light gate.
     let initial_lighting = match (
         state.terrain_template(),
-        state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation),
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation),
         state.rules(),
     ) {
         (Some(terrain), Some(sim), Some(rules)) => {
@@ -231,7 +295,11 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
                 &state.match_state.match_presentation.map_lighting_config,
                 Some(sim),
                 Some(rules),
-                state.match_state.match_presentation.in_game_options.detail_level,
+                state
+                    .match_state
+                    .match_presentation
+                    .in_game_options
+                    .detail_level,
             );
             let fingerprint = view.fingerprint;
             let profile = view.profile;
@@ -244,17 +312,34 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
     };
     if let Some((fingerprint, profile, detail_level, point_lights, grid)) = initial_lighting {
         state.match_state.match_presentation.lighting_grid = grid;
-        state.match_state.match_presentation.last_lighting_view_fingerprint = Some(fingerprint);
-        state.match_state.match_presentation.applied_lighting_profile = Some(profile);
-        state.match_state.match_presentation.applied_lighting_detail_level = detail_level;
-        state.match_state.match_presentation.applied_lighting_sources = point_lights;
+        state
+            .match_state
+            .match_presentation
+            .last_lighting_view_fingerprint = Some(fingerprint);
+        state
+            .match_state
+            .match_presentation
+            .applied_lighting_profile = Some(profile);
+        state
+            .match_state
+            .match_presentation
+            .applied_lighting_detail_level = detail_level;
+        state
+            .match_state
+            .match_presentation
+            .applied_lighting_sources = point_lights;
     }
     // Map load hands over a world anchor point; the transition applies the
     // active tactical rectangle and live zoom.
-    let (tactical_width, tactical_height) =
-        crate::app::input::camera::tactical_viewport_size_px(state.render_width(), state.render_height());
+    let (tactical_width, tactical_height) = crate::app::input::camera::tactical_viewport_size_px(
+        state.render_width(),
+        state.render_height(),
+    );
     let (camera_x, camera_y) = crate::app::input::camera::tactical_camera_top_left(
-        (result.scenario.camera_anchor_x, result.scenario.camera_anchor_y),
+        (
+            result.scenario.camera_anchor_x,
+            result.scenario.camera_anchor_y,
+        ),
         tactical_width as f32,
         tactical_height as f32,
         state.match_state.input.zoom_level,
@@ -275,7 +360,10 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
     state.match_state.input.building_placement_preview = None;
     state.match_state.match_presentation.active_sidebar_tab = SidebarTab::default_active_tab();
     state.match_state.match_presentation.sidebar_scroll_rows = 0;
-    state.match_state.match_presentation.sidebar_scroll_rows_parked = [0; 4];
+    state
+        .match_state
+        .match_presentation
+        .sidebar_scroll_rows_parked = [0; 4];
     // Re-init the message surface per scenario (the native list is
     // re-initialized at scenario start): drops stale rows from the previous
     // game and any dangling pause span, so a pause→quit→new-map sequence
@@ -287,13 +375,25 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
         crate::ui::messages::MESSAGE_MAX_VISIBLE_RETAIL,
         0,
     );
-    state.match_state.match_presentation.message_clock = crate::ui::messages::PauseAwareClock::default();
-    let map_title: &str = state.match_state.map_basic.name.as_deref().unwrap_or("Unknown Map");
-    state.platform.window.set_title(&format!("RA2 - {}", map_title));
+    state.match_state.match_presentation.message_clock =
+        crate::ui::messages::PauseAwareClock::default();
+    let map_title: &str = state
+        .match_state
+        .map_basic
+        .name
+        .as_deref()
+        .unwrap_or("Unknown Map");
     state
         .platform
         .window
-        .set_cursor_visible(state.match_state.match_presentation.software_cursor.is_none());
+        .set_title(&format!("RA2 - {}", map_title));
+    state.platform.window.set_cursor_visible(
+        state
+            .match_state
+            .match_presentation
+            .software_cursor
+            .is_none(),
+    );
 
     // Install current sim authority before the first camera/minimap frame. A
     // campaign trigger may already have changed LocalSize before presentation
@@ -339,8 +439,10 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
     state.match_state.input.minimap_dragging = false;
     state.match_state.input.tactical_mouse = Default::default();
     state.match_state.input.keys_held.clear();
-    let (tactical_width, tactical_height) =
-        crate::app::input::camera::tactical_viewport_size_px(state.render_width(), state.render_height());
+    let (tactical_width, tactical_height) = crate::app::input::camera::tactical_viewport_size_px(
+        state.render_width(),
+        state.render_height(),
+    );
     state.match_state.input.cursor_x = tactical_width as f32 * 0.5;
     state.match_state.input.cursor_y = tactical_height as f32 * 0.5;
 
@@ -356,7 +458,8 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
     // Loads SHROUD.SHP brightness data and the 256-byte edge LUT.
     if let Some(am) = state.process_assets.manager() {
         if let Some(grid) = state
-            .match_state.sim_runtime
+            .match_state
+            .sim_runtime
             .as_ref()
             .map(|rt| &rt.simulation)
             .and_then(crate::sim::world::Simulation::path_grid)
@@ -365,17 +468,18 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
                 if let Ok(shp) = crate::assets::shp_file::ShpFile::from_bytes(shp_data) {
                     let (frame_pixels, cw, ch) =
                         crate::render::shroud_buffer::extract_shp_brightness(&shp);
-                    state.match_state.match_presentation.shroud_buffer = Some(crate::render::shroud_buffer::ShroudBuffer::new(
-                        &state.renderer.gpu,
-                        state.render_width(),
-                        state.render_height(),
-                        grid.width(),
-                        grid.height(),
-                        frame_pixels,
-                        cw,
-                        ch,
-                        crate::render::shroud_buffer::SHROUD_EDGE_LUT,
-                    ));
+                    state.match_state.match_presentation.shroud_buffer =
+                        Some(crate::render::shroud_buffer::ShroudBuffer::new(
+                            &state.renderer.gpu,
+                            state.render_width(),
+                            state.render_height(),
+                            grid.width(),
+                            grid.height(),
+                            frame_pixels,
+                            cw,
+                            ch,
+                            crate::render::shroud_buffer::SHROUD_EDGE_LUT,
+                        ));
                 }
             }
         }
@@ -403,23 +507,93 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
     // Load sound.ini / soundmd.ini for SFX sound ID resolution.
     if let Some(assets) = state.process_assets.manager() {
         state.audio.sound_registry = load_sound_registry(assets);
-        state.audio.audio_indices = if crate::app::should_load_audio_indices(state.audio.audio_indices_enabled)
-        {
-            load_audio_indices(assets)
-        } else {
-            Vec::new()
-        };
+        state.audio.audio_indices =
+            if crate::app::should_load_audio_indices(state.audio.audio_indices_enabled) {
+                load_audio_indices(assets)
+            } else {
+                Vec::new()
+            };
         state.audio.eva_registry = load_eva_registry(assets);
     }
 
-    // Start_Scenario resolves `[Basic] Theme` as a theme-section key, then
-    // leaves the current shell stream in place while Theme owns its fade and
-    // deferred QueueSong/automatic request.
+    // `Start_Scenario @ 0x00683AB0` after `Read_Scenario`: `[Basic] Theme`
+    // resolves through `From_Name` (`0x004758F0`); -1 -> `Stop(fade=1)` of the
+    // LOADING stream, else `Queue_Song(index)`. `Main_Tick` then issues
+    // `Queue_Song(-2)` and the audio pump's AI picks the first allowed track
+    // once the fade lands. The shuffle stream is a presentation-side copy of
+    // `g_MainRng` seeded from the match seed (never the sim's own cursor), and
+    // `Is_Allowed`'s `Side=` gate compares the local player's side.
+    //
+    // VERA-internal residual (gamemd has no equivalent screen): when the map
+    // routes through `GameScreen::SpawnPick` below, `Main_Tick`'s head rule
+    // (`main_tick_theme` inside `advance_in_game_runtime`, gated on
+    // `GameScreen::InGame` in `frame.rs`) does not run until the player picks
+    // a start. After the `Stop(1)` fade of the LOADING stream lands, Theme sits
+    // with retained == -1 and no `Queue_Song(-2)`, so the spawn-pick screen is
+    // silent; the first score track starts on the first in-game frame. Maps
+    // with a resolvable `[Basic] Theme=` are unaffected (the queued index is
+    // consumed by the audio pump's AI as soon as the fade completes).
     let music_now_ms = sim_tick::monotonic_frame_pacer_ms(state, std::time::Instant::now());
+    let (match_seed, local_side) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| {
+            let simulation = &rt.simulation;
+            let local_side = state
+                .match_state
+                .local_player_owner
+                .as_deref()
+                .and_then(|owner| {
+                    crate::sim::house_state::house_state_for_owner(
+                        &simulation.houses,
+                        owner,
+                        &simulation.interner,
+                    )
+                })
+                .map(|house| i32::from(house.side_index));
+            (simulation.session.seed as u32, local_side)
+        })
+        .unwrap_or((0, None));
+    // `Side=` names resolve against the live `[Sides]` registry (native
+    // `0x004756F0` → `0x006A46D0`); unresolved names never match any player.
+    let side_names: Vec<String> = state
+        .audio
+        .theme
+        .entries()
+        .iter()
+        .filter_map(|entry| entry.side_name.clone())
+        .collect();
+    let side_indices: Vec<(String, i32)> = state
+        .rules()
+        .map(|rules| {
+            side_names
+                .iter()
+                .filter_map(|name| {
+                    rules
+                        .side_index(name)
+                        .map(|index| (name.to_ascii_uppercase(), i32::from(index.0)))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     if let Some(assets) = state.process_assets.manager() {
         state.audio.request_scenario_theme(
             state.match_state.map_basic.theme.as_deref(),
             assets,
+            match_seed,
+            crate::audio::theme::ThemeAllowContext {
+                local_side,
+                // Skirmish (`g_GameMode != 0`) skips the campaign `Scenario=` gate.
+                campaign_scenario: None,
+            },
+            |name| {
+                let wanted = name.to_ascii_uppercase();
+                side_indices
+                    .iter()
+                    .find(|(candidate, _)| *candidate == wanted)
+                    .map(|(_, index)| *index)
+            },
             music_now_ms,
         );
     }
@@ -429,7 +603,8 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
         state.frontend.screen = GameScreen::SpawnPick;
         if returns_scenario_rng_to_offline_shell {
             state
-                .frontend.offline_skirmish_runtime
+                .frontend
+                .offline_skirmish_runtime
                 .mark_gameplay_rng_return_pending();
         }
         log::info!("Transitioned to SpawnPick — player must choose a start location");
@@ -438,13 +613,15 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
             crate::match_bootstrap::LoadingStartup::Accepted(prepared) => {
                 let receipt = (|| {
                     let simulation = state
-                        .match_state.sim_runtime
+                        .match_state
+                        .sim_runtime
                         .as_ref()
                         .map(|rt| &rt.simulation)
                         .ok_or_else(|| "accepted map load produced no Simulation".to_string())?;
-                    let active_correlation = state.frontend.active_loading_correlation.ok_or_else(|| {
-                        "accepted map load lost its active correlation".to_string()
-                    })?;
+                    let active_correlation =
+                        state.frontend.active_loading_correlation.ok_or_else(|| {
+                            "accepted map load lost its active correlation".to_string()
+                        })?;
                     crate::match_bootstrap::RustL0Observation {
                         startup: &prepared,
                         simulation,
@@ -462,14 +639,13 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
                         state.frontend.loaded_startup = Some(prepared);
                         state.frontend.rust_l0_receipt = Some(receipt);
                         state.frontend.active_loading_correlation = None;
-                        let now_ms = sim_tick::monotonic_frame_pacer_ms(
-                            state,
-                            std::time::Instant::now(),
-                        );
+                        let now_ms =
+                            sim_tick::monotonic_frame_pacer_ms(state, std::time::Instant::now());
                         state.match_state.scenario_elapsed_clock.start(now_ms);
                         state.frontend.screen = GameScreen::InGame;
                         state
-                            .frontend.offline_skirmish_runtime
+                            .frontend
+                            .offline_skirmish_runtime
                             .mark_gameplay_rng_return_pending();
                         log::info!("Transitioned to InGame after Rust L0 acknowledgement");
                     }
@@ -488,13 +664,13 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
                 state.frontend.active_loading_correlation = None;
                 state.frontend.loaded_startup = None;
                 state.frontend.rust_l0_receipt = None;
-                let now_ms =
-                    sim_tick::monotonic_frame_pacer_ms(state, std::time::Instant::now());
+                let now_ms = sim_tick::monotonic_frame_pacer_ms(state, std::time::Instant::now());
                 state.match_state.scenario_elapsed_clock.start(now_ms);
                 state.frontend.screen = GameScreen::InGame;
                 if returns_scenario_rng_to_offline_shell {
                     state
-                        .frontend.offline_skirmish_runtime
+                        .frontend
+                        .offline_skirmish_runtime
                         .mark_gameplay_rng_return_pending();
                 }
                 log::info!("Transitioned to InGame on noncertifying startup path");
@@ -629,8 +805,7 @@ pub(crate) fn build_minimap_overlay_data(
     rules: Option<&crate::rules::ruleset::RuleSet>,
 ) -> Vec<crate::render::minimap::MinimapOverlayDatum> {
     use crate::render::minimap::{
-        MinimapCellRadarSource, MinimapOverlayDatum, OverlayClassification,
-        minimap_overlay_datum,
+        MinimapCellRadarSource, MinimapOverlayDatum, OverlayClassification, minimap_overlay_datum,
     };
 
     let mut data = Vec::with_capacity(overlays.len() + terrain_objects.len());

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -735,6 +735,17 @@ pub(crate) fn monotonic_frame_pacer_ms(state: &AppState, now: Instant) -> u64 {
 /// "menu open is not really a pause" carve-out here; that would be a
 /// regression against the binary.
 pub(crate) fn pump_audio_service(state: &mut AppState, now_ms: u64) {
+    // `AudioSystem__Pump @ 0x00406F70` reaches `ThemeClass__AI @ 0x007209D0`
+    // on every screen (menu, loading, in-game, pause, score, inactive window);
+    // the Theme owner carries the pump's own > 33 ms gate. While the loading
+    // job holds the process asset-manager lease, the poll goes through the
+    // leased manager so the looping LOADING theme keeps being serviced.
+    if let Some(assets) = crate::app::loading::pump::audio_service_asset_manager(
+        &state.process_assets,
+        state.frontend.loading_session.as_ref(),
+    ) {
+        state.audio.update_theme(assets, now_ms);
+    }
     let paused = state.match_state.paused;
     let registry = &state.audio.sound_registry;
     let audio_indices = &state.audio.audio_indices;
@@ -1118,11 +1129,14 @@ fn advance_in_game_runtime_mode(
     // keep running behind a pause, an open menu and a loading screen alike.
     // Pause is expressed separately, by suspending the events and stopping the
     // playing channels (`GamePause::Enter @ 0x00406F00`).
+    // `ThemeClass::AI` itself runs from `pump_audio_service` on every screen;
+    // only `Main_Tick @ 0x0055D360`'s scenario-running head rule (retained ==
+    // -1 -> `Queue_Song(-2)`; `InGameMusic == 0` -> `Stop(1)` + `Queue(-3)`)
+    // belongs to the in-game frame.
     let music_now_ms = monotonic_frame_pacer_ms(state, Instant::now());
     crate::app::presentation::building_anim::drain_sound_events(state);
-    if let Some(assets) = state.process_assets.manager() {
-        state.audio.update_theme(assets, music_now_ms);
-    }
+    let in_game_music = state.persistence.options_profile.in_game_music;
+    state.audio.main_tick_theme(in_game_music, music_now_ms);
     if decision.tactical_mutation {
         crate::app::input::camera::update_camera(state);
         update_building_placement_preview(state);
@@ -1261,75 +1275,60 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         anim_id,
                         sound_id,
                         world,
-                    } => {
-                        GameSoundEvent::AnimationStarted {
-                            anim_id,
-                            sound_id: sim.interner.resolve(sound_id).to_string(),
-                            source: Some(anim_world_sound_source(world)),
-                        }
-                    }
+                    } => GameSoundEvent::AnimationStarted {
+                        anim_id,
+                        sound_id: sim.interner.resolve(sound_id).to_string(),
+                        source: Some(anim_world_sound_source(world)),
+                    },
                     SimSoundEvent::AnimationStopped {
                         anim_id,
                         stop_sound_id,
                         world,
-                    } => {
-                        GameSoundEvent::AnimationStopped {
-                            anim_id,
-                            stop_sound_id: stop_sound_id
-                                .map(|id| sim.interner.resolve(id).to_string()),
-                            source: Some(anim_world_sound_source(world)),
-                        }
-                    }
+                    } => GameSoundEvent::AnimationStopped {
+                        anim_id,
+                        stop_sound_id: stop_sound_id.map(|id| sim.interner.resolve(id).to_string()),
+                        source: Some(anim_world_sound_source(world)),
+                    },
                     SimSoundEvent::WeaponFired {
                         report_sound_id,
                         rx,
                         ry,
-                    } => {
-                        GameSoundEvent::WeaponFired {
-                            sound_id: sim.interner.resolve(report_sound_id).to_string(),
-                            source: Some(sound_source_at_cell(rx, ry)),
-                        }
-                    }
+                    } => GameSoundEvent::WeaponFired {
+                        sound_id: sim.interner.resolve(report_sound_id).to_string(),
+                        source: Some(sound_source_at_cell(rx, ry)),
+                    },
                     SimSoundEvent::EntityDied {
                         die_sound_id,
                         rx,
                         ry,
-                    } => {
-                        GameSoundEvent::EntityDestroyed {
-                            sound_id: sim.interner.resolve(die_sound_id).to_string(),
-                            source: Some(sound_source_at_cell(rx, ry)),
-                        }
-                    }
+                    } => GameSoundEvent::EntityDestroyed {
+                        sound_id: sim.interner.resolve(die_sound_id).to_string(),
+                        source: Some(sound_source_at_cell(rx, ry)),
+                    },
                     SimSoundEvent::EntityCrushed {
                         crush_sound_id,
                         rx,
                         ry,
-                    } => {
-                        GameSoundEvent::EntityCrushed {
-                            sound_id: sim.interner.resolve(crush_sound_id).to_string(),
-                            source: Some(sound_source_at_cell(rx, ry)),
-                        }
-                    }
+                    } => GameSoundEvent::EntityCrushed {
+                        sound_id: sim.interner.resolve(crush_sound_id).to_string(),
+                        source: Some(sound_source_at_cell(rx, ry)),
+                    },
                     SimSoundEvent::EntityDeployed {
                         deploy_sound_id,
                         rx,
                         ry,
-                    } => {
-                        GameSoundEvent::EntityDeployed {
-                            sound_id: sim.interner.resolve(deploy_sound_id).to_string(),
-                            source: Some(sound_source_at_cell(rx, ry)),
-                        }
-                    }
+                    } => GameSoundEvent::EntityDeployed {
+                        sound_id: sim.interner.resolve(deploy_sound_id).to_string(),
+                        source: Some(sound_source_at_cell(rx, ry)),
+                    },
                     SimSoundEvent::EntityUndeployed {
                         undeploy_sound_id,
                         rx,
                         ry,
-                    } => {
-                        GameSoundEvent::EntityUndeployed {
-                            sound_id: sim.interner.resolve(undeploy_sound_id).to_string(),
-                            source: Some(sound_source_at_cell(rx, ry)),
-                        }
-                    }
+                    } => GameSoundEvent::EntityUndeployed {
+                        sound_id: sim.interner.resolve(undeploy_sound_id).to_string(),
+                        source: Some(sound_source_at_cell(rx, ry)),
+                    },
                     SimSoundEvent::DockDeploy { .. } => {
                         // UNCHECKED residual, deliberately silent. This variant
                         // has no producer: nothing in `sim/` pushes it, and
@@ -1686,12 +1685,10 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             source: Some(sound_source_at_cell(rx, ry)),
                         }
                     }
-                    SimSoundEvent::C4Planted { rx, ry } => {
-                        GameSoundEvent::C4Planted {
-                            sound_id: "SealPlaceBomb".to_string(),
-                            source: Some(sound_source_at_cell(rx, ry)),
-                        }
-                    }
+                    SimSoundEvent::C4Planted { rx, ry } => GameSoundEvent::C4Planted {
+                        sound_id: "SealPlaceBomb".to_string(),
+                        source: Some(sound_source_at_cell(rx, ry)),
+                    },
                     SimSoundEvent::RefineryExitSfx { rx, ry } => {
                         // Positional SFX from [AudioVisual] BunkerWallsDownSound.
                         // Skip when rules don't configure the sound (matches

--- a/src/app/shell_main_menu.rs
+++ b/src/app/shell_main_menu.rs
@@ -213,7 +213,11 @@ impl crate::app::persistence::options::launcher::LauncherParentOperations
     }
 
     fn queue_then_stop_score_zero(&mut self) {
-        self.state.audio.queue_then_stop_score_zero();
+        let now_ms = crate::app::match_runtime::sim_tick::monotonic_frame_pacer_ms(
+            self.state,
+            Instant::now(),
+        );
+        self.state.audio.queue_then_stop_score_zero(now_ms);
     }
 
     fn store_sound_volume(&mut self, value: f32) {
@@ -283,19 +287,26 @@ impl App {
     }
 
     fn score_shell_layout(state: &AppState) -> crate::ui::score_shell::ScoreShellLayout {
-        crate::ui::score_shell::compute_layout(state.renderer.gpu.config.width, state.renderer.gpu.config.height)
+        crate::ui::score_shell::compute_layout(
+            state.renderer.gpu.config.width,
+            state.renderer.gpu.config.height,
+        )
     }
 
     pub(super) fn handle_score_shell_mouse_move(state: &mut AppState) {
         let layout = Self::score_shell_layout(state);
-        state.frontend.score_shell_state.continue_hovered =
-            layout.hit_continue(state.match_state.input.cursor_x.round() as i32, state.match_state.input.cursor_y.round() as i32);
+        state.frontend.score_shell_state.continue_hovered = layout.hit_continue(
+            state.match_state.input.cursor_x.round() as i32,
+            state.match_state.input.cursor_y.round() as i32,
+        );
     }
 
     pub(super) fn handle_score_shell_mouse_down(state: &mut AppState) {
         let layout = Self::score_shell_layout(state);
-        let inside =
-            layout.hit_continue(state.match_state.input.cursor_x.round() as i32, state.match_state.input.cursor_y.round() as i32);
+        let inside = layout.hit_continue(
+            state.match_state.input.cursor_x.round() as i32,
+            state.match_state.input.cursor_y.round() as i32,
+        );
         state.frontend.score_shell_state.continue_pressed = inside;
         if inside {
             Self::play_main_menu_button_sound(state);
@@ -307,8 +318,10 @@ impl App {
     /// shell, so there is no cancel path to mirror.
     pub(super) fn handle_score_shell_mouse_up(state: &mut AppState) {
         let layout = Self::score_shell_layout(state);
-        let inside =
-            layout.hit_continue(state.match_state.input.cursor_x.round() as i32, state.match_state.input.cursor_y.round() as i32);
+        let inside = layout.hit_continue(
+            state.match_state.input.cursor_x.round() as i32,
+            state.match_state.input.cursor_y.round() as i32,
+        );
         let activated = state.frontend.score_shell_state.continue_pressed && inside;
         state.frontend.score_shell_state.continue_pressed = false;
         if activated {
@@ -343,8 +356,10 @@ impl App {
 
     fn refresh_single_player_load_state(state: &mut AppState) {
         state.persistence.refresh_save_list_if_dirty();
-        state.frontend.single_player_shell_state.load_saved_game_enabled =
-            !state.persistence.save_list_cache.entries().is_empty();
+        state
+            .frontend
+            .single_player_shell_state
+            .load_saved_game_enabled = !state.persistence.save_list_cache.entries().is_empty();
     }
 
     fn open_single_player_shell(state: &mut AppState) {
@@ -356,8 +371,14 @@ impl App {
         crate::app::frontend::main_menu_shell_render::clear_ra2ts_movie_session(state);
         crate::app::frontend::shell_transition::invalidate_main_menu_dialog_instance(state);
         state.frontend.shell_route = crate::app::shell_route::ShellRoute::SinglePlayer;
-        state.frontend.single_player_shell_state.pressed_owner_draw_button = None;
-        state.frontend.single_player_shell_state.hovered_owner_draw_button = None;
+        state
+            .frontend
+            .single_player_shell_state
+            .pressed_owner_draw_button = None;
+        state
+            .frontend
+            .single_player_shell_state
+            .hovered_owner_draw_button = None;
         state.frontend.single_player_shell_state.hover_started_at = None;
         Self::refresh_single_player_load_state(state);
     }
@@ -369,8 +390,14 @@ impl App {
         crate::app::frontend::main_menu_shell_render::clear_ra2ts_movie_session(state);
         crate::app::frontend::shell_transition::invalidate_main_menu_dialog_instance(state);
         state.frontend.shell_route = crate::app::shell_route::ShellRoute::MainMenu;
-        state.frontend.single_player_shell_state.pressed_owner_draw_button = None;
-        state.frontend.single_player_shell_state.hovered_owner_draw_button = None;
+        state
+            .frontend
+            .single_player_shell_state
+            .pressed_owner_draw_button = None;
+        state
+            .frontend
+            .single_player_shell_state
+            .hovered_owner_draw_button = None;
         state.frontend.single_player_shell_state.hover_started_at = None;
     }
 
@@ -390,7 +417,10 @@ impl App {
         state.frontend.shell_route = crate::app::shell_route::ShellRoute::Skirmish {
             return_to_single_player: true,
         };
-        state.frontend.skirmish_shell_state.pressed_owner_draw_button = None;
+        state
+            .frontend
+            .skirmish_shell_state
+            .pressed_owner_draw_button = None;
         state.frontend.skirmish_shell_last_painted_pressed_button = None;
         Self::ensure_active_cooperative_shell_selection(state);
         // The skirmish dialog (0x102) slides its controls in on first paint like
@@ -409,7 +439,10 @@ impl App {
         state.frontend.skirmish_shell_state.dropdown_scroll_drag = None;
         state.frontend.skirmish_shell_state.dropdown_scroll_press = None;
         state.frontend.skirmish_shell_state.trackbar_drag = None;
-        state.frontend.skirmish_shell_state.pressed_owner_draw_button = None;
+        state
+            .frontend
+            .skirmish_shell_state
+            .pressed_owner_draw_button = None;
         crate::ui::skirmish_shell::blur_player_name_edit(&mut state.frontend.skirmish_shell_state);
         state.frontend.skirmish_shell_last_painted_pressed_button = None;
         state.frontend.skirmish_preview_texture = None;
@@ -460,7 +493,10 @@ impl App {
                 }
             } else {
                 state.frontend.dev_skirmish_shell_enabled = false;
-                state.frontend.skirmish_shell_state.pressed_owner_draw_button = None;
+                state
+                    .frontend
+                    .skirmish_shell_state
+                    .pressed_owner_draw_button = None;
             }
         }
         // Confirm modal can be open over the legacy egui menu too; draw it in
@@ -470,9 +506,13 @@ impl App {
         // Degraded fallback (shell chrome failed to load) has no SHP cursor of
         // its own, so keep the OS cursor visible here rather than hiding it and
         // leaving the egui menu with no pointer at all.
-        state
-            .renderer.egui
-            .end_frame_and_render(&state.renderer.gpu, encoder, view, &state.platform.window, false);
+        state.renderer.egui.end_frame_and_render(
+            &state.renderer.gpu,
+            encoder,
+            view,
+            &state.platform.window,
+            false,
+        );
         if confirm {
             event_loop.exit();
             return Ok(());
@@ -500,7 +540,8 @@ impl App {
     /// English string when the table is absent or missing the key.
     pub(super) fn csf_label(state: &AppState, key: &str, fallback: &str) -> String {
         state
-            .process_assets.csf
+            .process_assets
+            .csf
             .as_ref()
             .map(|csf| csf.text(key).into_owned())
             .unwrap_or_else(|| fallback.to_string())
@@ -630,23 +671,39 @@ impl App {
     /// render path reads. Slice-2/Slice-3 boundary: render is retired off these in
     /// Slice 3, after which the controller is the sole authority.
     fn mirror_shell_controller_to_main_menu(state: &mut AppState) {
-        state.frontend.main_menu_shell_state.pressed_owner_draw_button = state
-            .frontend.shell_controller
+        state
+            .frontend
+            .main_menu_shell_state
+            .pressed_owner_draw_button = state
+            .frontend
+            .shell_controller
             .pressed()
             .and_then(crate::ui::main_menu_shell::MainMenuControlId::from_resource_id);
-        state.frontend.main_menu_shell_state.hovered_owner_draw_button = state
-            .frontend.shell_controller
+        state
+            .frontend
+            .main_menu_shell_state
+            .hovered_owner_draw_button = state
+            .frontend
+            .shell_controller
             .hovered()
             .and_then(crate::ui::main_menu_shell::MainMenuControlId::from_resource_id);
     }
 
     fn mirror_shell_controller_to_single_player(state: &mut AppState) {
-        state.frontend.single_player_shell_state.pressed_owner_draw_button = state
-            .frontend.shell_controller
+        state
+            .frontend
+            .single_player_shell_state
+            .pressed_owner_draw_button = state
+            .frontend
+            .shell_controller
             .pressed()
             .and_then(crate::ui::single_player_shell::SinglePlayerControlId::from_resource_id);
-        state.frontend.single_player_shell_state.hovered_owner_draw_button = state
-            .frontend.shell_controller
+        state
+            .frontend
+            .single_player_shell_state
+            .hovered_owner_draw_button = state
+            .frontend
+            .shell_controller
             .hovered()
             .and_then(crate::ui::single_player_shell::SinglePlayerControlId::from_resource_id);
         state.frontend.single_player_shell_state.hover_started_at =
@@ -662,7 +719,8 @@ impl App {
         let x = state.match_state.input.cursor_x.round() as i32;
         let y = state.match_state.input.cursor_y.round() as i32;
         state
-            .frontend.shell_controller
+            .frontend
+            .shell_controller
             .ensure_active(crate::ui::shell::descriptor::DialogId(0x00E2), false);
         state.frontend.shell_controller.on_pointer_down(x, y, &feed);
         let pressed = state.frontend.shell_controller.pressed().is_some();
@@ -684,7 +742,8 @@ impl App {
         let x = state.match_state.input.cursor_x.round() as i32;
         let y = state.match_state.input.cursor_y.round() as i32;
         state
-            .frontend.shell_controller
+            .frontend
+            .shell_controller
             .ensure_active(crate::ui::shell::descriptor::DialogId(0x00E2), false);
         state.frontend.shell_controller.on_pointer_move(x, y, &feed);
         Self::mirror_shell_controller_to_main_menu(state);
@@ -702,7 +761,8 @@ impl App {
         let x = state.match_state.input.cursor_x.round() as i32;
         let y = state.match_state.input.cursor_y.round() as i32;
         state
-            .frontend.shell_controller
+            .frontend
+            .shell_controller
             .ensure_active(crate::ui::shell::descriptor::DialogId(0x00E2), false);
         let activated = state.frontend.shell_controller.on_pointer_up(x, y, &feed);
         Self::mirror_shell_controller_to_main_menu(state);
@@ -739,7 +799,9 @@ impl App {
         let feed = Self::exit_confirm_modal_feed(state);
         let x = state.match_state.input.cursor_x.round() as i32;
         let y = state.match_state.input.cursor_y.round() as i32;
-        if state.frontend.shell_controller.top_id() != Some(crate::ui::shell::descriptor::DialogId(0x0120)) {
+        if state.frontend.shell_controller.top_id()
+            != Some(crate::ui::shell::descriptor::DialogId(0x0120))
+        {
             return;
         }
         state.frontend.shell_controller.on_pointer_down(x, y, &feed);
@@ -749,7 +811,9 @@ impl App {
         let feed = Self::exit_confirm_modal_feed(state);
         let x = state.match_state.input.cursor_x.round() as i32;
         let y = state.match_state.input.cursor_y.round() as i32;
-        if state.frontend.shell_controller.top_id() != Some(crate::ui::shell::descriptor::DialogId(0x0120)) {
+        if state.frontend.shell_controller.top_id()
+            != Some(crate::ui::shell::descriptor::DialogId(0x0120))
+        {
             return;
         }
         let activated = state.frontend.shell_controller.on_pointer_up(x, y, &feed);
@@ -777,9 +841,13 @@ impl App {
         let feed = Self::single_player_shell_button_feed(&layout);
         let x = state.match_state.input.cursor_x.round() as i32;
         let y = state.match_state.input.cursor_y.round() as i32;
-        let load_enabled = state.frontend.single_player_shell_state.load_saved_game_enabled;
+        let load_enabled = state
+            .frontend
+            .single_player_shell_state
+            .load_saved_game_enabled;
         state
-            .frontend.shell_controller
+            .frontend
+            .shell_controller
             .ensure_active(crate::ui::shell::descriptor::DialogId(0x0100), false);
         // Refresh the Load Saved Game disabled guard before the gesture; the
         // override persists through the matching release (ensure_active only resets
@@ -802,7 +870,8 @@ impl App {
         let x = state.match_state.input.cursor_x.round() as i32;
         let y = state.match_state.input.cursor_y.round() as i32;
         state
-            .frontend.shell_controller
+            .frontend
+            .shell_controller
             .ensure_active(crate::ui::shell::descriptor::DialogId(0x0100), false);
         // Hover path is enable-UNfiltered: a disabled Load Saved Game still
         // hover-tracks and arms its tooltip timer, exactly as before.
@@ -815,9 +884,13 @@ impl App {
         let feed = Self::single_player_shell_button_feed(&layout);
         let x = state.match_state.input.cursor_x.round() as i32;
         let y = state.match_state.input.cursor_y.round() as i32;
-        let load_enabled = state.frontend.single_player_shell_state.load_saved_game_enabled;
+        let load_enabled = state
+            .frontend
+            .single_player_shell_state
+            .load_saved_game_enabled;
         state
-            .frontend.shell_controller
+            .frontend
+            .shell_controller
             .ensure_active(crate::ui::shell::descriptor::DialogId(0x0100), false);
         state.frontend.shell_controller.set_disabled(
             crate::ui::single_player_shell::SinglePlayerControlId::LoadSavedGame0x689.resource_id(),
@@ -861,7 +934,8 @@ impl App {
         if state.frontend.screen != GameScreen::MainMenu || state.frontend.quit_cascade.is_some() {
             return;
         }
-        let now_ms = crate::app::match_runtime::sim_tick::monotonic_frame_pacer_ms(state, Instant::now());
+        let now_ms =
+            crate::app::match_runtime::sim_tick::monotonic_frame_pacer_ms(state, Instant::now());
         if let Some(assets) = state.process_assets.manager() {
             state.audio.maintain_main_menu_theme(assets, now_ms);
         }
@@ -871,7 +945,9 @@ impl App {
         let Some(sound_id) = sound_id else {
             return;
         };
-        let (Some(sfx), Some(assets)) = (&mut state.audio.sfx_player, state.process_assets.manager()) else {
+        let (Some(sfx), Some(assets)) =
+            (&mut state.audio.sfx_player, state.process_assets.manager())
+        else {
             return;
         };
         sfx.play_sound(
@@ -897,7 +973,11 @@ impl App {
                 Self::close_single_player_shell(state);
             }
             SinglePlayerShellAction::LoadSavedGame => {
-                if state.frontend.single_player_shell_state.load_saved_game_enabled {
+                if state
+                    .frontend
+                    .single_player_shell_state
+                    .load_saved_game_enabled
+                {
                     state.match_state.match_presentation.show_save_load_panel = true;
                     state.persistence.invalidate_save_list();
                 }
@@ -957,9 +1037,12 @@ impl App {
         // teardown pops back to it with focus restored. (ensure_active would
         // reset_to-clobber the stack — the prior "0x120 over 0xE2" comment
         // described behavior that never happened.)
-        if state.frontend.shell_controller.top_id() != Some(crate::ui::shell::descriptor::DialogId(0x0120)) {
+        if state.frontend.shell_controller.top_id()
+            != Some(crate::ui::shell::descriptor::DialogId(0x0120))
+        {
             state
-                .frontend.shell_controller
+                .frontend
+                .shell_controller
                 .push(crate::ui::shell::descriptor::DialogId(0x0120), true);
         }
         state.frontend.exit_confirm_modal = Some(modal);
@@ -987,7 +1070,9 @@ impl App {
     /// and mouse close path converges here.
     pub(super) fn close_exit_confirm_modal_from_controller(state: &mut AppState) {
         state.frontend.exit_confirm_modal = None;
-        if state.frontend.shell_controller.top_id() == Some(crate::ui::shell::descriptor::DialogId(0x0120)) {
+        if state.frontend.shell_controller.top_id()
+            == Some(crate::ui::shell::descriptor::DialogId(0x0120))
+        {
             state.frontend.shell_controller.pop();
         }
     }
@@ -1087,7 +1172,8 @@ impl App {
 
         if let Some(mut campaign) = state.frontend.campaign_select.take() {
             let csf = |key: &str, fallback: &str| Self::csf_label(state, key, fallback);
-            let action = dialogs::draw_campaign_select(&state.renderer.egui.ctx, &csf, &mut campaign);
+            let action =
+                dialogs::draw_campaign_select(&state.renderer.egui.ctx, &csf, &mut campaign);
             match action {
                 // The side/difficulty -> scenario mapping and first-mission
                 // launch are not decoded; Back returns to the SP shell.
@@ -1103,10 +1189,12 @@ impl App {
     }
 
     pub(super) fn invalidate_main_menu_movie_if_base_changed(state: &mut AppState) {
-        let movie_base =
-            crate::ui::main_menu_shell::movie_base_for_screen_width(state.renderer.gpu.config.width);
+        let movie_base = crate::ui::main_menu_shell::movie_base_for_screen_width(
+            state.renderer.gpu.config.width,
+        );
         if state
-            .frontend.main_menu_movie_identity
+            .frontend
+            .main_menu_movie_identity
             .is_some_and(|identity| identity.base() != movie_base)
         {
             crate::app::frontend::main_menu_shell_render::clear_ra2ts_movie_session(state);

--- a/src/audio/theme.rs
+++ b/src/audio/theme.rs
@@ -2,31 +2,55 @@
 //!
 //! Active Yuri's Revenge keeps Theme data and the logical active/retained/
 //! pending slots alive even when its optional stream player is absent.  This
-//! module mirrors that ownership: rodio remains in `music`, while aliases,
+//! module mirrors that ownership: rodio remains in `music`, while the catalog,
 //! playlist selection, sentinels, scenario queueing, and lifecycle transitions
 //! remain testable without an audio device.
-
-use std::collections::{HashMap, HashSet};
+//!
+//! gamemd-derived: singleton `g_Theme @ 0x00A83D10`; ctor `0x00720960`,
+//! catalog load `0x00720590` (THEMEMD.INI only, string `0x00825D94`), entry
+//! reader `0x00720480`, availability scan `0x007207F0`, `From_Name`
+//! `0x00721210`, `Is_Allowed` `0x00721140`, `Next_Song` `0x00720A80`,
+//! `Queue_Song` `0x00720B20`, `Play_Song` `0x00720BB0`, `Stop` `0x00720EA0`,
+//! `AI` `0x007209D0` (audio pump `0x00406F70`, every screen, > 33 ms).
 
 use crate::assets::asset_manager::AssetManager;
 use crate::assets::aud_file;
 use crate::audio::sfx::decode_wav;
-use crate::rules::ini_parser::IniFile;
+use crate::rules::ini_parser::{IniFile, IniSection};
+use crate::sim::rng::SimRng;
 
-const SCENARIO_THEME_FADE_MS: u64 = 1_000;
+/// Theme fade length. Native is rate-based, not duration-based: the stream's
+/// own `VolumeInterp` (`stream+0x14 -> +0x10`) is initialised by
+/// `StreamPlayer__PlayFile` with `SetTargetImmediate(0x4000)` (`MOV EDX,0x4000`
+/// @ `0x00407E7D`); the stream constructor (`FUN_00401000`) builds that
+/// interpolator with `FUN_00407100` (rate `0x10624D`, 1000 ms per-tick elapsed
+/// cap) and then `FUN_004071A0(range 0x4000, 1000 ms)`, which recomputes the
+/// same rate `(0x4000 << 16) / 1000 = 0x10624D` per ms; `0x004080C0` -> `VolumeInterp__SetTarget @
+/// 0x00407170` retargets it to 0, and `VolumeInterp__Tick @ 0x004071C0` steps
+/// `current += rate * elapsed_ms` toward `target << 16`. Because the stream
+/// interpolator always starts at full scale 0x4000 — ScoreVolume lives in a
+/// separate interpolator (`0x0087E744`, `OptionsClass::SetScoreVolume @
+/// 0x005FA4A0` targets `volume * 0x4000`) that multiplies on top — the fade
+/// takes `(0x4000 << 16) / 0x10624D` = 1000.0007 ms for every ScoreVolume.
+/// VERA-internal residual: the native integer stepper needs 1001 whole
+/// milliseconds to reach zero and clamps a stalled frame's elapsed at 1000 ms;
+/// Rust uses a 1000 ms linear ramp on wall time (at most 1 ms difference,
+/// inaudible, per fade).
+const THEME_FADE_MS: u64 = 1_000;
+const THEME_INI_NAME: &str = "thememd.ini";
 const MENU_THEME_SECTION: &str = "INTRO";
+/// `Next_Song` shuffle rejection budget (`CMP EDI,0x3E8` @ `0x00720AC6`).
+const SHUFFLE_TRIES: u32 = 1_000;
 
-const FALLBACK_TRACKS: &[&str] = &[
-    "Grinder", "Power", "Fortific", "InDeep", "Tension", "EagleHun", "Industro", "Jank",
-    "200Meter", "BlowItUp", "Destroy", "Burn", "Motorize", "HM2", "Ra2-Opt", "RA2-Sco", "Drok",
-    "Bully", "OptionX", "ScoreX", "BrainFre", "Deceiver", "PhatAtta", "Defend", "Tactics",
-    "TranceLV",
-];
+/// Native slot sentinels (`g_Theme+0x0/+0x4/+0x8`).
+pub(crate) const THEME_NONE: i32 = -1;
+pub(crate) const THEME_AUTO: i32 = -2;
+pub(crate) const THEME_HOLD: i32 = -3;
 
 /// The physical stream observation supplied to Theme's AI.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MusicOutputState {
-    /// No music stream object exists. This is never a completion signal.
+    /// No music stream object exists (`g_Theme+0x2C == NULL`).
     Unavailable,
     /// A stream object exists but no source is active.
     Idle,
@@ -36,37 +60,53 @@ pub(crate) enum MusicOutputState {
     Finished,
 }
 
-/// Theme's literal pending sentinels plus a resolved track identity.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ThemeRequest {
-    /// Native `-1`.
-    None,
-    /// Native `-2`.
-    Auto,
-    /// Native `-3`.
-    Hold,
-    Track(String),
-}
-
-impl Default for ThemeRequest {
-    fn default() -> Self {
-        Self::None
+impl MusicOutputState {
+    fn stream_exists(self) -> bool {
+        self != Self::Unavailable
     }
 }
 
-/// Resolved Start_Scenario request. `Auto` is native index `-1` at the
-/// scenario boundary and becomes Theme's `-2` automatic pending request.
+/// One `[Themes]` entry (native 0x290-byte record, ctor inside `0x00720590`,
+/// reader `0x00720480`, scan `0x007207F0`).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ScenarioThemeRequest {
-    Auto,
-    Specific(String),
+pub(crate) struct ThemeEntry {
+    /// `[Themes]` value = section key (+0x000). `From_Name` matches this only.
+    pub(crate) key: String,
+    /// `Sound=` with leading `$`/`#` stripped (+0x100); `.WAV` appended at play.
+    pub(crate) sound: String,
+    /// `Scenario=` (+0x280, default 0).
+    pub(crate) scenario: i32,
+    /// `Normal=` (+0x288, default yes).
+    pub(crate) normal: bool,
+    /// `Repeat=` (+0x289, default no). Keyed by entry, never by `Sound=` stem.
+    pub(crate) repeat: bool,
+    /// `Side=` name (+0x28C holds the resolved index; default -1 = any side).
+    pub(crate) side_name: Option<String>,
+    /// Resolved `Side=` index, -1 when unset. Unknown names natively register
+    /// a fresh `SideClass` that never equals the player's side.
+    pub(crate) side: i32,
+    /// `CCFileClass::IsAvailable(Sound + ".WAV")` (+0x28A).
+    pub(crate) available: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct ThemeSlots {
-    pub(crate) active: Option<String>,
-    pub(crate) retained: Option<String>,
-    pub(crate) pending: ThemeRequest,
+    /// +0x00 currently playing index.
+    pub(crate) active: i32,
+    /// +0x04 last requested index (`Next_Song`'s "previous").
+    pub(crate) retained: i32,
+    /// +0x08 pending index or sentinel.
+    pub(crate) pending: i32,
+}
+
+impl Default for ThemeSlots {
+    fn default() -> Self {
+        Self {
+            active: THEME_NONE,
+            retained: THEME_NONE,
+            pending: THEME_NONE,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -103,124 +143,212 @@ impl ThemeAction {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-struct ScenarioFade {
-    started_at_ms: Option<u64>,
-    completion_due: bool,
-    owns_pending: bool,
-    internal_scale: f64,
-}
-
-impl ScenarioFade {
-    fn reset(&mut self) {
-        self.started_at_ms = None;
-        self.completion_due = false;
-        self.owns_pending = false;
-        self.internal_scale = 1.0;
-    }
+/// `Is_Allowed` player/scenario context (`g_PlayerPtr->HouseType->+0xBC`,
+/// `g_GameMode`, `Scen+0x1254`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct ThemeAllowContext {
+    /// Local player's side index; `None` when no player exists (shell).
+    pub(crate) local_side: Option<i32>,
+    /// `Some(scenario number)` only in campaign (`g_GameMode == 0`); skirmish
+    /// (`g_GameMode != 0`) skips the `Scenario=` gate.
+    pub(crate) campaign_scenario: Option<i32>,
 }
 
 /// Process-lifetime logical Theme owner.
 #[derive(Debug)]
 pub(crate) struct ThemeRuntime {
     catalog_loaded: bool,
-    aliases: HashMap<String, String>,
-    scenario_theme_sections: HashMap<String, String>,
-    playlist: Vec<String>,
-    playlist_index: usize,
-    repeating_tracks: HashSet<String>,
-    global_repeat: bool,
-    menu_theme: Option<String>,
+    entries: Vec<ThemeEntry>,
     slots: ThemeSlots,
-    scenario_fade: ScenarioFade,
+    /// +0x10 `IsScoreRepeat`.
+    global_repeat: bool,
+    /// +0x11 fading flag plus the interpolator start time.
+    fading: bool,
+    fade_started_at_ms: Option<u64>,
+    /// +0x12 `IsScoreShuffle`.
+    shuffle: bool,
+    /// Whether Start_Scenario owns the pending slot (scenario reset cancel).
+    scenario_owns_pending: bool,
+    allow_context: ThemeAllowContext,
+    /// VERA-internal: the shuffle draw. Native draws `g_MainRng @ 0x00886B88`
+    /// (`MOV ECX,0x886B88` @ `0x00720AB5`), which `Init_Random_Number_System @
+    /// 0x0052FC20` seeds from `g_RngSeed` right after `Scen->Random`, and which
+    /// sim bodies (`TechnoClass__ReceiveDamage`, `FootClass__AI`,
+    /// `HouseClass__Update`) also consume. Drawing it from the wall-clock audio
+    /// pump would make sim RNG consumption depend on audio timing, so VERA
+    /// keeps a presentation-side copy seeded from the same match seed at
+    /// Start_Scenario; the gamemd draw sequence is deliberately not reproduced.
+    shuffle_rng: SimRng,
 }
 
 impl Default for ThemeRuntime {
     fn default() -> Self {
+        // ctor 0x00720960: slots -1, repeat 0, fading 0, shuffle 0.
         Self {
             catalog_loaded: false,
-            aliases: HashMap::new(),
-            scenario_theme_sections: HashMap::new(),
-            playlist: FALLBACK_TRACKS
-                .iter()
-                .map(|track| (*track).to_string())
-                .collect(),
-            playlist_index: 0,
-            repeating_tracks: HashSet::new(),
-            global_repeat: false,
-            menu_theme: None,
+            entries: Vec::new(),
             slots: ThemeSlots::default(),
-            scenario_fade: ScenarioFade {
-                internal_scale: 1.0,
-                ..Default::default()
-            },
+            global_repeat: false,
+            fading: false,
+            fade_started_at_ms: None,
+            shuffle: false,
+            scenario_owns_pending: false,
+            allow_context: ThemeAllowContext::default(),
+            shuffle_rng: SimRng::new(0),
         }
     }
 }
 
-/// gamemd-derived: the device-independent Theme lifecycle is owned by
-/// `ThemeClass` constructor `0x00720960`, AI `0x007209D0`, Next
-/// `0x00720A80`, Queue `0x00720B20`, Play `0x00720BB0`, and Stop
-/// `0x00720EA0`. These bodies operate on logical `[active, retained, pending]`
-/// identities independently of the optional physical StreamPlayer.
 impl ThemeRuntime {
-    /// Load Theme configuration once, independently of physical output.
+    /// Catalog load `0x00720590` + scan `0x007207F0`, once per process.
     pub(crate) fn initialize_catalog(&mut self, assets: &AssetManager) {
         if self.catalog_loaded {
             return;
         }
-
-        let base = load_theme_ini(assets, "theme.ini");
-        let md = load_theme_ini(assets, "thememd.ini");
-        for ini in [base.as_ref(), md.as_ref()].into_iter().flatten() {
-            merge_theme_aliases(&mut self.aliases, ini);
-            merge_theme_section_stems(&mut self.scenario_theme_sections, ini);
-            merge_repeating_tracks(&mut self.repeating_tracks, ini, &self.aliases);
+        if let Some(bytes) = assets.get_ref(THEME_INI_NAME)
+            && let Ok(ini) = IniFile::from_bytes(bytes)
+        {
+            self.entries = catalog_from_ini(&ini);
         }
-
-        let mut playlist = Vec::new();
-        if let Some(ini) = base.as_ref() {
-            playlist = playlist_from_theme_ini(ini, &self.aliases);
-        }
-        if let Some(ini) = md.as_ref() {
-            for track in playlist_from_theme_ini(ini, &self.aliases) {
-                if !playlist
-                    .iter()
-                    .any(|candidate| candidate.eq_ignore_ascii_case(&track))
-                {
-                    playlist.push(track);
-                }
-            }
-        }
-        if !playlist.is_empty() {
-            self.playlist = playlist;
-            self.playlist_index = 0;
-        }
-
-        for ini in [base.as_ref(), md.as_ref()].into_iter().flatten() {
-            if let Some((stem, repeats)) = menu_theme_from_ini(ini, &self.aliases) {
-                if repeats {
-                    self.repeating_tracks.insert(stem.to_ascii_uppercase());
-                }
-                self.menu_theme = Some(stem);
-            }
+        for entry in &mut self.entries {
+            entry.available = !entry.sound.is_empty()
+                && assets.get_ref(&format!("{}.wav", entry.sound)).is_some();
         }
         self.catalog_loaded = true;
+    }
+
+    #[cfg(test)]
+    fn with_entries(entries: Vec<ThemeEntry>) -> Self {
+        Self {
+            catalog_loaded: true,
+            entries,
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn entries(&self) -> &[ThemeEntry] {
+        &self.entries
+    }
+
+    #[cfg(test)]
+    pub(crate) fn slots(&self) -> ThemeSlots {
+        self.slots
+    }
+
+    /// `OptionsClass__ReadFromINI @ 0x005FA620` writes `IsScoreRepeat` to
+    /// `0x00A83D20` (@ `0x005FAB1C`) and `IsScoreShuffle` to `0x00A83D22`
+    /// (@ `0x005FAB5B`).
+    pub(crate) fn set_score_options(&mut self, repeat: bool, shuffle: bool) {
+        self.global_repeat = repeat;
+        self.shuffle = shuffle;
+    }
+
+    /// Start_Scenario-time context: reseed the presentation shuffle stream
+    /// from the match seed and pin the local player's side for `Is_Allowed`.
+    pub(crate) fn begin_scenario(
+        &mut self,
+        match_seed: u32,
+        context: ThemeAllowContext,
+        resolve_side: impl Fn(&str) -> Option<i32>,
+    ) {
+        self.shuffle_rng = SimRng::new(u64::from(match_seed));
+        self.allow_context = context;
+        for entry in &mut self.entries {
+            entry.side = match entry.side_name.as_deref() {
+                None => -1,
+                Some(name) => resolve_side(name).unwrap_or(i32::MAX),
+            };
+        }
     }
 
     fn admitted(&self, gates: ThemeGates) -> bool {
         self.catalog_loaded && gates.launcher_audio_available && !gates.startup_suppressed
     }
 
-    fn resolve_track_name(&self, track_name: &str) -> String {
-        self.aliases
-            .get(&track_name.to_ascii_uppercase())
-            .cloned()
-            .unwrap_or_else(|| track_name.to_string())
+    /// `ThemeClass__From_Name @ 0x00721210`: case-insensitive section-key
+    /// match (`0x007C8D20`); -1 for null, empty, or unknown names.
+    pub(crate) fn from_name(&self, name: &str) -> i32 {
+        if name.is_empty() {
+            return THEME_NONE;
+        }
+        self.entries
+            .iter()
+            .position(|entry| entry.key.eq_ignore_ascii_case(name))
+            .map_or(THEME_NONE, |index| index as i32)
     }
 
-    fn track_repeats(&self, stem: &str) -> bool {
-        self.global_repeat || self.repeating_tracks.contains(&stem.to_ascii_uppercase())
+    fn entry(&self, index: i32) -> Option<&ThemeEntry> {
+        usize::try_from(index)
+            .ok()
+            .and_then(|i| self.entries.get(i))
+    }
+
+    fn entry_repeats(&self, index: i32) -> bool {
+        self.entry(index).is_some_and(|entry| entry.repeat)
+    }
+
+    /// `ThemeClass__Is_Allowed @ 0x00721140`.
+    pub(crate) fn is_allowed(&self, index: i32) -> bool {
+        if index == THEME_HOLD || index == THEME_AUTO {
+            return true;
+        }
+        // `idx >= count` (unsigned compare, so -1 too) is denied.
+        let Some(entry) = self.entry(index) else {
+            return false;
+        };
+        if !entry.available || !entry.normal {
+            return false;
+        }
+        if let Some(local_side) = self.allow_context.local_side
+            && entry.side != -1
+            && local_side != entry.side
+        {
+            return false;
+        }
+        if let Some(scenario) = self.allow_context.campaign_scenario
+            && scenario < entry.scenario
+        {
+            return false;
+        }
+        true
+    }
+
+    /// `ThemeClass__Next_Song @ 0x00720A80`.
+    fn next_song(&mut self, prev: i32) -> i32 {
+        let count = self.entries.len() as i32;
+        if prev >= 0 && (self.entry_repeats(prev) || self.global_repeat) {
+            return prev;
+        }
+        if self.shuffle {
+            let mut tries = 0u32;
+            let mut draw;
+            loop {
+                draw = self.shuffle_rng.next_range_i32_inclusive(0, count - 1);
+                tries += 1;
+                if tries >= SHUFFLE_TRIES {
+                    break;
+                }
+                if draw != prev && self.is_allowed(draw) {
+                    break;
+                }
+            }
+            return if tries == SHUFFLE_TRIES { 0 } else { draw };
+        }
+        let mut index = prev;
+        let mut probes = count + 1;
+        loop {
+            index += 1;
+            if index >= count {
+                index = 0;
+            }
+            probes -= 1;
+            if probes == 0 {
+                return 0;
+            }
+            if self.is_allowed(index) {
+                return index;
+            }
+        }
     }
 
     pub(crate) fn play_track(
@@ -229,32 +357,29 @@ impl ThemeRuntime {
         assets: &AssetManager,
         gates: ThemeGates,
         physical: MusicOutputState,
+        wall_ms: u64,
     ) -> ThemeAction {
         self.initialize_catalog(assets);
+        let index = self.from_name(track_name);
         let mut prepare = |stem: &str| prepare_track(stem, assets);
-        self.play_request_with(
-            ThemeRequest::Track(track_name.to_string()),
-            gates,
-            physical,
-            &mut prepare,
-        )
+        self.play_song(index, gates, physical, wall_ms, &mut prepare)
     }
 
+    /// `Main__PrepareSession @ 0x0052D9A0`: `Play(From_Name("INTRO"))`.
     pub(crate) fn play_menu_theme(
         &mut self,
         assets: &AssetManager,
         gates: ThemeGates,
         physical: MusicOutputState,
+        wall_ms: u64,
     ) -> ThemeAction {
-        self.initialize_catalog(assets);
-        let Some(stem) = self.menu_theme.clone() else {
-            return ThemeAction::default();
-        };
-        let mut prepare = |resolved: &str| prepare_track(resolved, assets);
-        self.play_request_with(ThemeRequest::Track(stem), gates, physical, &mut prepare)
+        self.play_track(MENU_THEME_SECTION, assets, gates, physical, wall_ms)
     }
 
-    /// Resolve and queue Start_Scenario's Theme in one authority call.
+    /// `ScenarioClass__Start_Scenario @ 0x00683AB0` after `Read_Scenario`:
+    /// `Scen+0x1C70 == -1` (no resolvable `[Basic] Theme=`) → `Stop(fade=1)`;
+    /// else `Queue_Song(index)`. `[Basic] Theme=` resolves through
+    /// `0x004758F0` = `From_Name` of the read string.
     pub(crate) fn request_scenario_theme(
         &mut self,
         requested_section: Option<&str>,
@@ -264,23 +389,85 @@ impl ThemeRuntime {
         wall_ms: u64,
     ) -> ThemeAction {
         self.initialize_catalog(assets);
-        let request =
-            resolve_scenario_theme_section(requested_section, &self.scenario_theme_sections);
-        let request = match request {
-            ScenarioThemeRequest::Auto => ThemeRequest::Auto,
-            ScenarioThemeRequest::Specific(stem) => ThemeRequest::Track(stem),
-        };
+        let index = requested_section
+            .map(str::trim)
+            .map_or(THEME_NONE, |section| self.from_name(section));
         let admitted = self.admitted(gates);
-        let action = self.queue_request(request, gates, physical, wall_ms);
-        if admitted {
-            self.scenario_fade.owns_pending = true;
+        let action = if index == THEME_NONE {
+            self.stop(gates, true, physical, wall_ms)
+        } else {
+            self.queue_song(index, gates, physical, wall_ms)
+        };
+        self.scenario_owns_pending = admitted;
+        action
+    }
+
+    /// `Main_Tick @ 0x0055D360` head while a scenario runs: `cur = retained,
+    /// or pending when retained == -1`; `InGameMusic == 0 && cur != -3` →
+    /// `Stop(1)` + `Queue(-3)`; else `cur == -1` → `Queue(-2)`.
+    pub(crate) fn main_tick(
+        &mut self,
+        in_game_music: bool,
+        gates: ThemeGates,
+        physical: MusicOutputState,
+        wall_ms: u64,
+    ) -> ThemeAction {
+        if !self.admitted(gates) || !physical.stream_exists() {
+            return ThemeAction::default();
+        }
+        let current = if self.slots.retained == THEME_NONE {
+            self.slots.pending
+        } else {
+            self.slots.retained
+        };
+        if !in_game_music {
+            if current != THEME_HOLD {
+                let stopped = self.stop(gates, true, physical, wall_ms);
+                return stopped.then(self.queue_song(THEME_HOLD, gates, physical, wall_ms));
+            }
+            ThemeAction::default()
+        } else if current == THEME_NONE {
+            self.queue_song(THEME_AUTO, gates, physical, wall_ms)
+        } else {
+            ThemeAction::default()
+        }
+    }
+
+    /// Fade bookkeeping shared by AI/Queue/Play/Stop: when fading and the
+    /// interpolator reached its target (`0x004080D0 == 0`), `StreamPlayer__Stop`.
+    fn settle_fade(&mut self, wall_ms: u64) -> ThemeAction {
+        let mut action = ThemeAction::default();
+        if self.fading
+            && let Some(started) = self.fade_started_at_ms
+            && wall_ms.saturating_sub(started) >= THEME_FADE_MS
+        {
+            action.stop_output = true;
+            action.theme_scale = Some(1.0);
+            self.fading = false;
+            self.fade_started_at_ms = None;
         }
         action
     }
 
-    pub(crate) fn queue_request(
+    fn start_fade(&mut self, wall_ms: u64) {
+        self.fading = true;
+        self.fade_started_at_ms = Some(wall_ms);
+    }
+
+    /// Whether the stream is still audible from Theme's point of view: a
+    /// physically playing source, or a fade that has not reached its target.
+    fn still_playing(&self, physical: MusicOutputState, wall_ms: u64) -> bool {
+        physical == MusicOutputState::Playing
+            && !(self.fading
+                && self
+                    .fade_started_at_ms
+                    .is_some_and(|started| wall_ms.saturating_sub(started) >= THEME_FADE_MS))
+    }
+
+    /// `ThemeClass__Queue_Song @ 0x00720B20`.
+    pub(crate) fn queue_song(
         &mut self,
-        request: ThemeRequest,
+        index: i32,
         gates: ThemeGates,
         physical: MusicOutputState,
         wall_ms: u64,
@@ -288,76 +475,84 @@ impl ThemeRuntime {
         if !self.admitted(gates) {
             return ThemeAction::default();
         }
-
-        let avoids_fade = matches!(request, ThemeRequest::None | ThemeRequest::Auto)
-            || matches!(
-                &request,
-                ThemeRequest::Track(track)
-                    if self
-                        .slots
-                        .retained
-                        .as_deref()
-                        .is_some_and(|retained| retained.eq_ignore_ascii_case(track))
-            );
-        self.slots.pending = request;
-        self.scenario_fade.reset();
-
-        if !avoids_fade && physical == MusicOutputState::Playing {
-            self.scenario_fade.started_at_ms = Some(wall_ms);
-        } else if physical != MusicOutputState::Unavailable
-            && physical != MusicOutputState::Playing
-            && !matches!(self.slots.pending, ThemeRequest::None | ThemeRequest::Hold)
+        self.slots.pending = index;
+        self.scenario_owns_pending = false;
+        let mut action = ThemeAction::default();
+        if index != THEME_NONE
+            && index != THEME_AUTO
+            && index != self.slots.retained
+            && physical.stream_exists()
         {
-            self.scenario_fade.completion_due = true;
+            action = self.settle_fade(wall_ms);
+            if self.still_playing(physical, wall_ms) {
+                self.start_fade(wall_ms);
+            }
         }
-
-        ThemeAction {
-            theme_scale: Some(1.0),
-            ..Default::default()
-        }
+        action
     }
 
-    /// Launcher ScoreVolume zero performs the native Queue(active else
-    /// retained) followed immediately by Stop(false).
+    /// Launcher ScoreVolume zero (`0x0055FAA0`): `Queue(active, else retained)`
+    /// followed immediately by `Stop(0)`.
     pub(crate) fn queue_then_stop_score_zero(
         &mut self,
         gates: ThemeGates,
         physical: MusicOutputState,
+        wall_ms: u64,
     ) -> ThemeAction {
         if !self.admitted(gates) {
             return ThemeAction::default();
         }
-        let request = self
-            .slots
-            .active
-            .clone()
-            .or_else(|| self.slots.retained.clone())
-            .map(ThemeRequest::Track)
-            .unwrap_or(ThemeRequest::None);
-        let queued = self.queue_request(request, gates, physical, 0);
-        queued.then(self.stop(gates))
+        let request = if self.slots.active != THEME_NONE {
+            self.slots.active
+        } else {
+            self.slots.retained
+        };
+        let queued = self.queue_song(request, gates, physical, wall_ms);
+        queued.then(self.stop(gates, false, physical, wall_ms))
     }
 
-    pub(crate) fn stop(&mut self, gates: ThemeGates) -> ThemeAction {
-        if !self.admitted(gates) || self.slots.active.is_none() {
+    /// `ThemeClass__Stop @ 0x00720EA0`. `fade` while playing starts the
+    /// 1000 ms ramp and marks fading; every path clears all three slots. The
+    /// immediate path (`fade == 0`, or nothing playing) only issues
+    /// `StreamPlayer__Stop` and leaves `+0x11` as it stands — `Play_Song`
+    /// clears it — so a stale flag survives here too; its only later effect is
+    /// one redundant stop/scale-reset from `settle_fade`.
+    pub(crate) fn stop(
+        &mut self,
+        gates: ThemeGates,
+        fade: bool,
+        physical: MusicOutputState,
+        wall_ms: u64,
+    ) -> ThemeAction {
+        if !self.admitted(gates) || self.slots.active == THEME_NONE {
             return ThemeAction::default();
         }
-        self.slots = ThemeSlots::default();
-        self.scenario_fade.reset();
-        ThemeAction {
-            stop_output: true,
-            theme_scale: Some(1.0),
-            ..Default::default()
+        let mut action = ThemeAction::default();
+        if fade && physical.stream_exists() {
+            action = self.settle_fade(wall_ms);
+            if self.still_playing(physical, wall_ms) {
+                self.start_fade(wall_ms);
+                self.slots = ThemeSlots::default();
+                self.scenario_owns_pending = false;
+                return action;
+            }
         }
+        self.slots = ThemeSlots::default();
+        self.scenario_owns_pending = false;
+        action.stop_output = true;
+        action.theme_scale = Some(1.0);
+        action
     }
 
-    /// Cancel only Start_Scenario's queued/fade ownership during scenario
-    /// reset. Active and retained identities remain owned by Theme.
+    /// Cancel only Start_Scenario's queued ownership during scenario reset.
+    /// Active and retained identities remain owned by Theme.
     pub(crate) fn cancel_scenario_theme_request(&mut self) -> ThemeAction {
-        if self.scenario_fade.owns_pending {
-            self.slots.pending = ThemeRequest::None;
+        if self.scenario_owns_pending {
+            self.slots.pending = THEME_NONE;
         }
-        self.scenario_fade.reset();
+        self.scenario_owns_pending = false;
+        self.fading = false;
+        self.fade_started_at_ms = None;
         ThemeAction {
             theme_scale: Some(1.0),
             ..Default::default()
@@ -373,11 +568,63 @@ impl ThemeRuntime {
     ) -> ThemeAction {
         self.initialize_catalog(assets);
         let mut prepare = |stem: &str| prepare_track(stem, assets);
-        self.update_with(gates, physical, wall_ms, &mut prepare)
+        self.ai(gates, physical, wall_ms, &mut prepare)
     }
 
-    fn update_with(
+    /// `ThemeClass__AI @ 0x007209D0`.
+    ///
+    /// VERA-internal: with no stream object native consumes the pending slot
+    /// every poll (silently cycling `Play_Song`); Rust idles instead so an
+    /// audio-less process does not churn the catalog.
+    fn ai(
         &mut self,
+        gates: ThemeGates,
+        physical: MusicOutputState,
+        wall_ms: u64,
+        prepare: &mut impl FnMut(&str) -> Option<PreparedTrack>,
+    ) -> ThemeAction {
+        if !self.admitted(gates) || !physical.stream_exists() {
+            return ThemeAction::default();
+        }
+        let mut action = ThemeAction::default();
+        if physical == MusicOutputState::Playing {
+            if self.fading
+                && let Some(started) = self.fade_started_at_ms
+            {
+                let elapsed = wall_ms.saturating_sub(started);
+                if elapsed < THEME_FADE_MS {
+                    action.theme_scale = Some(1.0 - elapsed as f64 / THEME_FADE_MS as f64);
+                    return action;
+                }
+                action = self.settle_fade(wall_ms);
+            } else {
+                return action;
+            }
+        }
+
+        let pending = self.slots.pending;
+        if pending == THEME_NONE || pending == THEME_HOLD {
+            return action;
+        }
+        self.scenario_owns_pending = false;
+        let index = if pending == THEME_AUTO {
+            self.next_song(self.slots.retained)
+        } else {
+            pending
+        };
+        // Play_Song sees the stream released (fade stop or natural end).
+        action =
+            action.then(self.play_song(index, gates, MusicOutputState::Idle, wall_ms, prepare));
+        // AI unconditionally restores -2 after attempting Play.
+        self.slots.pending = THEME_AUTO;
+        action
+    }
+
+    /// `ThemeClass__Play_Song @ 0x00720BB0`. The score-volume gate (`+0xC`)
+    /// and the dead CD-check branch are not modelled.
+    fn play_song(
+        &mut self,
+        index: i32,
         gates: ThemeGates,
         physical: MusicOutputState,
         wall_ms: u64,
@@ -386,155 +633,50 @@ impl ThemeRuntime {
         if !self.admitted(gates) {
             return ThemeAction::default();
         }
-
         let mut action = ThemeAction::default();
-        let mut completion = physical == MusicOutputState::Finished;
-
-        if let Some(started_at_ms) = self.scenario_fade.started_at_ms {
-            if physical == MusicOutputState::Playing {
-                let elapsed = wall_ms.saturating_sub(started_at_ms);
-                if elapsed < SCENARIO_THEME_FADE_MS {
-                    self.scenario_fade.internal_scale =
-                        1.0 - elapsed as f64 / SCENARIO_THEME_FADE_MS as f64;
-                    action.theme_scale = Some(self.scenario_fade.internal_scale);
-                    return action;
-                }
-                action.stop_output = true;
+        if physical.stream_exists() {
+            action = self.settle_fade(wall_ms);
+            if self.still_playing(physical, wall_ms) && self.slots.retained == index {
+                return action;
             }
-            self.scenario_fade.started_at_ms = None;
-            self.scenario_fade.internal_scale = 1.0;
-            action.theme_scale = Some(1.0);
-            completion = true;
         }
-
-        completion |= self.scenario_fade.completion_due;
-        self.scenario_fade.completion_due = false;
-        if !completion {
+        // Inline Stop(0).
+        if self.slots.active != THEME_NONE {
+            self.slots = ThemeSlots::default();
+            action.stop_output = true;
+            action.theme_scale = Some(1.0);
+        }
+        self.fading = false;
+        self.fade_started_at_ms = None;
+        if index == THEME_NONE || index == THEME_HOLD {
             return action;
         }
-
-        let pending = self.slots.pending.clone();
-        self.scenario_fade.owns_pending = false;
-        let requested = match pending {
-            ThemeRequest::None | ThemeRequest::Hold => return action,
-            ThemeRequest::Track(track) => Some(track),
-            ThemeRequest::Auto => self.next_song(),
-        };
-
-        if let Some(track) = requested {
-            action = action.then(self.play_request_with(
-                ThemeRequest::Track(track),
-                gates,
-                MusicOutputState::Idle,
-                prepare,
-            ));
+        if index >= 0 {
+            self.slots.retained = index;
+            if physical.stream_exists() {
+                let stem = self.entry(index).map(|entry| entry.sound.clone());
+                match stem.as_deref().and_then(|stem| prepare(stem)) {
+                    Some(prepared) => {
+                        action.start = Some(prepared);
+                        action.theme_scale = Some(1.0);
+                        self.slots.active = index;
+                    }
+                    None => {
+                        // PlayFile's failure is ignored natively (active :=
+                        // index while nothing streams); Rust leaves active -1
+                        // so AI's next poll consumes pending the same way.
+                        self.slots.active = THEME_NONE;
+                    }
+                }
+            } else {
+                self.slots.active = THEME_NONE;
+            }
+            if !self.global_repeat && !self.entry_repeats(index) {
+                return action;
+            }
         }
-        // ThemeClass::AI unconditionally restores Auto after attempting Play.
-        self.slots.pending = ThemeRequest::Auto;
+        self.slots.pending = index;
         action
-    }
-
-    fn next_song(&mut self) -> Option<String> {
-        if let Some(retained) = self.slots.retained.as_deref()
-            && self.track_repeats(retained)
-        {
-            return Some(retained.to_string());
-        }
-        let len = self.playlist.len();
-        if len == 0 {
-            return None;
-        }
-        let track = self.playlist[self.playlist_index % len].clone();
-        self.playlist_index = (self.playlist_index + 1) % len;
-        Some(track)
-    }
-
-    fn play_request_with(
-        &mut self,
-        request: ThemeRequest,
-        gates: ThemeGates,
-        physical: MusicOutputState,
-        prepare: &mut impl FnMut(&str) -> Option<PreparedTrack>,
-    ) -> ThemeAction {
-        if !self.admitted(gates) {
-            return ThemeAction::default();
-        }
-
-        match request {
-            ThemeRequest::Auto => {
-                self.slots.pending = ThemeRequest::Auto;
-                return ThemeAction::default();
-            }
-            ThemeRequest::None | ThemeRequest::Hold => {
-                if self.slots.active.is_none() {
-                    return ThemeAction::default();
-                }
-                self.slots = ThemeSlots::default();
-                self.scenario_fade.reset();
-                return ThemeAction {
-                    stop_output: true,
-                    theme_scale: Some(1.0),
-                    ..Default::default()
-                };
-            }
-            ThemeRequest::Track(requested) => {
-                let resolved = self.resolve_track_name(&requested);
-                if physical == MusicOutputState::Playing
-                    && self
-                        .slots
-                        .retained
-                        .as_deref()
-                        .is_some_and(|retained| retained.eq_ignore_ascii_case(&resolved))
-                {
-                    return ThemeAction::default();
-                }
-
-                let repeat = self.track_repeats(&resolved);
-                let prior_active = self.slots.active.is_some();
-                let pending_base = if prior_active {
-                    ThemeRequest::None
-                } else {
-                    self.slots.pending.clone()
-                };
-                let mut action = ThemeAction::default();
-                if prior_active {
-                    self.slots = ThemeSlots::default();
-                    action.stop_output = true;
-                }
-                self.scenario_fade.reset();
-                action.theme_scale = Some(1.0);
-                self.slots.retained = Some(resolved.clone());
-
-                let Some(prepared) = prepare(&resolved) else {
-                    self.slots.active = None;
-                    self.slots.pending = if repeat {
-                        ThemeRequest::Track(resolved.clone())
-                    } else if physical != MusicOutputState::Unavailable
-                        && matches!(pending_base, ThemeRequest::None)
-                    {
-                        // Native's stream-object resource/acquisition failure
-                        // retries when the replacement base is `-1`.
-                        ThemeRequest::Track(resolved.clone())
-                    } else {
-                        pending_base
-                    };
-                    return action;
-                };
-
-                self.slots.active = Some(resolved.clone());
-                self.slots.retained = Some(resolved.clone());
-                self.slots.pending = if repeat {
-                    ThemeRequest::Track(resolved.clone())
-                } else {
-                    pending_base
-                };
-                if let Some(next_index) = playlist_index_after_specific(&self.playlist, &resolved) {
-                    self.playlist_index = next_index;
-                }
-                action.start = Some(prepared);
-                action
-            }
-        }
     }
 }
 
@@ -589,123 +731,84 @@ fn prepare_track(track_name: &str, assets: &AssetManager) -> Option<PreparedTrac
     None
 }
 
-fn load_theme_ini(assets: &AssetManager, name: &str) -> Option<IniFile> {
-    let bytes = assets.get_ref(name)?;
-    IniFile::from_bytes(bytes).ok()
+fn find_section<'a>(ini: &'a IniFile, name: &str) -> Option<&'a IniSection> {
+    ini.section(name).or_else(|| {
+        ini.section_names()
+            .into_iter()
+            .find(|candidate| candidate.eq_ignore_ascii_case(name))
+            .and_then(|candidate| ini.section(candidate))
+    })
 }
 
-fn merge_theme_aliases(into: &mut HashMap<String, String>, ini: &IniFile) {
-    for section_name in ini.section_names() {
-        let Some(sound) = ini
-            .section(section_name)
-            .and_then(|section| section.get("Sound"))
-            .filter(|sound| !sound.is_empty())
-        else {
-            continue;
-        };
-        let sound = sound.to_string();
-        into.insert(section_name.to_ascii_uppercase(), sound.clone());
-        into.insert(sound.to_ascii_uppercase(), sound);
-    }
-}
-
-fn merge_theme_section_stems(into: &mut HashMap<String, String>, ini: &IniFile) {
+/// Catalog load `0x00720590`: every non-empty `[Themes]` value in source
+/// order becomes an entry keyed by that value (duplicates re-read the existing
+/// entry); `0x00720480` fills the section fields with the ctor defaults
+/// (Normal=1, Repeat=0, Scenario=0, Side=-1, Sound="").
+pub(crate) fn catalog_from_ini(ini: &IniFile) -> Vec<ThemeEntry> {
+    let mut entries: Vec<ThemeEntry> = Vec::new();
     let Some(themes) = ini.section("Themes") else {
-        return;
+        return entries;
     };
-    for section_name in themes.get_values() {
-        let Some(sound) = ini
-            .section(section_name)
-            .and_then(|section| section.get("Sound"))
-            .filter(|sound| !sound.is_empty())
-        else {
-            continue;
-        };
-        into.insert(section_name.to_ascii_uppercase(), sound.to_string());
-    }
-}
-
-fn merge_repeating_tracks(
-    into: &mut HashSet<String>,
-    ini: &IniFile,
-    aliases: &HashMap<String, String>,
-) {
-    for section_name in ini.section_names() {
-        let Some(section) = ini.section(section_name) else {
-            continue;
-        };
-        if !section.get_bool("Repeat").unwrap_or(false) {
+    for key in themes.get_values() {
+        if key.is_empty() {
             continue;
         }
-        if let Some(stem) = aliases.get(&section_name.to_ascii_uppercase()) {
-            into.insert(stem.to_ascii_uppercase());
-        }
-    }
-}
-
-fn resolve_scenario_theme_section(
-    requested_section: Option<&str>,
-    sections: &HashMap<String, String>,
-) -> ScenarioThemeRequest {
-    let Some(requested) = requested_section
-        .map(str::trim)
-        .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case("No theme"))
-    else {
-        return ScenarioThemeRequest::Auto;
-    };
-    sections
-        .get(&requested.to_ascii_uppercase())
-        .cloned()
-        .map(ScenarioThemeRequest::Specific)
-        .unwrap_or(ScenarioThemeRequest::Auto)
-}
-
-fn playlist_index_after_specific(playlist: &[String], stem: &str) -> Option<usize> {
-    let index = playlist
-        .iter()
-        .position(|candidate| candidate.eq_ignore_ascii_case(stem))?;
-    Some((index + 1) % playlist.len())
-}
-
-fn menu_theme_from_ini(ini: &IniFile, aliases: &HashMap<String, String>) -> Option<(String, bool)> {
-    let section = ini.section(MENU_THEME_SECTION)?;
-    let stem = aliases
-        .get(&MENU_THEME_SECTION.to_ascii_uppercase())
-        .cloned()
-        .or_else(|| {
-            section
-                .get("Sound")
-                .filter(|sound| !sound.is_empty())
-                .map(str::to_string)
-        })?;
-    Some((stem, section.get_bool("Repeat").unwrap_or(false)))
-}
-
-fn playlist_from_theme_ini(ini: &IniFile, aliases: &HashMap<String, String>) -> Vec<String> {
-    let Some(themes) = ini.section("Themes") else {
-        return Vec::new();
-    };
-    themes
-        .get_values()
-        .into_iter()
-        .filter(|value| !value.is_empty())
-        .filter_map(|theme_name| {
-            let sound = aliases.get(&theme_name.to_ascii_uppercase())?;
-            if ini
-                .section(theme_name)
-                .and_then(|section| section.get("Normal"))
-                .is_some_and(|value| value.eq_ignore_ascii_case("no"))
-            {
-                return None;
+        let existing = entries
+            .iter()
+            .position(|entry| entry.key.eq_ignore_ascii_case(key));
+        let index = match existing {
+            Some(index) => index,
+            None => {
+                entries.push(ThemeEntry {
+                    key: key.to_string(),
+                    sound: String::new(),
+                    scenario: 0,
+                    normal: true,
+                    repeat: false,
+                    side_name: None,
+                    side: -1,
+                    available: false,
+                });
+                entries.len() - 1
             }
-            Some(sound.clone())
-        })
-        .collect()
+        };
+        let entry = &mut entries[index];
+        let Some(section) = find_section(ini, &entry.key) else {
+            continue;
+        };
+        if let Some(sound) = section.get("Sound") {
+            entry.sound = sound.trim_start_matches(['$', '#']).to_string();
+        }
+        if let Some(scenario) = section.get_i32("Scenario") {
+            entry.scenario = scenario;
+        }
+        if let Some(normal) = section.get_bool("Normal") {
+            entry.normal = normal;
+        }
+        if let Some(repeat) = section.get_bool("Repeat") {
+            entry.repeat = repeat;
+        }
+        if let Some(side) = section.get("Side") {
+            entry.side_name = Some(side.to_string());
+        }
+    }
+    entries
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const STOCK_SHAPED: &str = "[Themes]\n1=INTRO\n2=;Grinder\n14=SCORE\n15=LOADING\n\
+        16=CREDITS\n17=RA2Options\n19=\n21=BrainFreeze\n22=Drok\n23=Deceiver\n24=PhatAttack\n\
+        [INTRO]\nName=THEME:Intro\nSound=Drok\nNormal=no\nRepeat=yes\n\
+        [LOADING]\nSound=Bully\nNormal=no\nRepeat=yes\n\
+        [CREDITS]\nSound=OptionX\nNormal=no\nRepeat=yes\n\
+        [SCORE]\nSound=ScoreX\nNormal=no\nRepeat=yes\n\
+        [BrainFreeze]\nSound=BrainFre\nNormal=yes\n\
+        [Drok]\nSound=Drok\nNormal=yes\n\
+        [Deceiver]\nSound=$Deceiver\nNormal=yes\nSide=Soviet\n\
+        [PhatAttack]\nSound=PhatAtta\nNormal=yes\nScenario=3\n";
 
     fn gates(enabled: bool) -> ThemeGates {
         ThemeGates {
@@ -714,23 +817,12 @@ mod tests {
         }
     }
 
-    fn runtime() -> ThemeRuntime {
-        ThemeRuntime {
-            catalog_loaded: true,
-            aliases: [("INTRO".to_string(), "Drok".to_string())]
-                .into_iter()
-                .collect(),
-            scenario_theme_sections: [("FORTIFICATION".to_string(), "Fortific".to_string())]
-                .into_iter()
-                .collect(),
-            playlist: ["Grinder", "Power", "Fortific", "InDeep"]
-                .into_iter()
-                .map(str::to_string)
-                .collect(),
-            repeating_tracks: ["DROK".to_string()].into_iter().collect(),
-            menu_theme: Some("Drok".to_string()),
-            ..Default::default()
+    fn stock_runtime() -> ThemeRuntime {
+        let mut entries = catalog_from_ini(&IniFile::from_str(STOCK_SHAPED));
+        for entry in &mut entries {
+            entry.available = !entry.sound.is_empty();
         }
+        ThemeRuntime::with_entries(entries)
     }
 
     fn prepared(stem: &str) -> Option<PreparedTrack> {
@@ -742,367 +834,473 @@ mod tests {
     }
 
     #[test]
-    fn constructor_and_failed_common_gates_preserve_all_slots() {
-        let mut theme = runtime();
-        assert_eq!(theme.slots, ThemeSlots::default());
-        theme.slots = ThemeSlots {
-            active: Some("A".into()),
-            retained: Some("R".into()),
-            pending: ThemeRequest::Hold,
-        };
-        let before = theme.slots.clone();
-        let action = theme.queue_request(
-            ThemeRequest::Track("Q".into()),
-            gates(false),
-            MusicOutputState::Playing,
-            10,
+    fn catalog_is_index_keyed_in_themes_order_with_per_entry_repeat() {
+        let theme = stock_runtime();
+        let keys: Vec<&str> = theme.entries().iter().map(|e| e.key.as_str()).collect();
+        assert_eq!(
+            keys,
+            [
+                "INTRO",
+                "SCORE",
+                "LOADING",
+                "CREDITS",
+                "RA2Options",
+                "BrainFreeze",
+                "Drok",
+                "Deceiver",
+                "PhatAttack"
+            ]
         );
-        assert_eq!(theme.slots, before);
-        assert!(!action.stop_output && action.start.is_none());
+        let intro = &theme.entries()[0];
+        let drok = &theme.entries()[6];
+        assert_eq!(intro.sound, "Drok");
+        assert!(intro.repeat && !intro.normal);
+        assert_eq!(drok.sound, "Drok");
+        assert!(
+            !drok.repeat && drok.normal,
+            "Repeat= belongs to the entry, not the stem"
+        );
+        let options = &theme.entries()[4];
+        assert_eq!(options.sound, "");
+        assert!(options.normal && !options.available);
+        assert_eq!(theme.entries()[7].sound, "Deceiver", "leading $ stripped");
+        assert_eq!(theme.entries()[7].side_name.as_deref(), Some("Soviet"));
+        assert_eq!(theme.entries()[8].scenario, 3);
+        assert_eq!(theme.from_name("intro"), 0);
+        assert_eq!(theme.from_name("Drok"), 6);
+        assert_eq!(
+            theme.from_name("BrainFre"),
+            -1,
+            "Sound= stems are not aliases"
+        );
+        assert_eq!(theme.from_name(""), -1);
+    }
 
+    /// Catalog load `0x00720590` opens only `THEMEMD.INI` (`0x00825D94`); the
+    /// RA2 `theme.ini` is never merged. Scan `0x007207F0` marks availability
+    /// from `Sound + ".WAV"`.
+    #[test]
+    fn catalog_reads_thememd_only_and_scans_wav_availability() {
+        let dir =
+            std::env::temp_dir().join(format!("vera20k-theme-catalog-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("test asset dir");
+        std::fs::write(
+            dir.join("theme.ini"),
+            "[Themes]\n1=Grinder\n2=Drok\n[Grinder]\nSound=Grinder\nNormal=yes\n\
+             [Drok]\nSound=Drok\nNormal=yes\nRepeat=yes\n",
+        )
+        .expect("write theme.ini");
+        std::fs::write(
+            dir.join("thememd.ini"),
+            "[Themes]\n1=INTRO\n2=Drok\n[INTRO]\nSound=Drok\nNormal=no\nRepeat=yes\n\
+             [Drok]\nSound=Drok\nNormal=yes\n",
+        )
+        .expect("write thememd.ini");
+        std::fs::write(dir.join("DROK.WAV"), b"RIFF").expect("write wav");
+        std::fs::write(dir.join("GRINDER.WAV"), b"RIFF").expect("write wav");
+        let assets = AssetManager::from_loose_root_for_test(&dir);
+
+        let mut theme = ThemeRuntime::default();
+        theme.initialize_catalog(&assets);
+        let keys: Vec<&str> = theme.entries().iter().map(|e| e.key.as_str()).collect();
+        assert_eq!(keys, ["INTRO", "Drok"], "theme.ini [Themes] is not merged");
+        assert_eq!(theme.from_name("Grinder"), THEME_NONE);
+        assert!(theme.entries()[0].repeat && !theme.entries()[0].normal);
+        assert!(
+            !theme.entries()[1].repeat,
+            "theme.ini's [Drok] Repeat=yes must not leak in"
+        );
+        assert!(theme.entries().iter().all(|entry| entry.available));
+
+        // Missing THEMEMD.INI leaves an empty catalog even with theme.ini present.
+        std::fs::remove_file(dir.join("thememd.ini")).expect("remove thememd.ini");
+        let assets = AssetManager::from_loose_root_for_test(&dir);
+        let mut theme = ThemeRuntime::default();
+        theme.initialize_catalog(&assets);
+        assert!(theme.entries().is_empty());
+    }
+
+    #[test]
+    fn is_allowed_filters_availability_normal_side_and_campaign_scenario() {
+        let mut theme = stock_runtime();
+        assert!(theme.is_allowed(THEME_AUTO) && theme.is_allowed(THEME_HOLD));
+        assert!(!theme.is_allowed(99));
+        assert!(!theme.is_allowed(0), "Normal=no");
+        assert!(!theme.is_allowed(4), "file unavailable");
+        assert!(theme.is_allowed(5));
+        // Side= resolved against the local player's side.
+        theme.begin_scenario(
+            7,
+            ThemeAllowContext {
+                local_side: Some(0),
+                campaign_scenario: None,
+            },
+            |name| (name == "Soviet").then_some(1),
+        );
+        assert!(!theme.is_allowed(7));
+        assert!(theme.is_allowed(8), "Scenario= ignored outside campaign");
+        theme.begin_scenario(
+            7,
+            ThemeAllowContext {
+                local_side: Some(1),
+                campaign_scenario: Some(2),
+            },
+            |name| (name == "Soviet").then_some(1),
+        );
+        assert!(theme.is_allowed(7));
+        assert!(!theme.is_allowed(8), "campaign scenario 2 < Scenario=3");
+        theme.begin_scenario(
+            7,
+            ThemeAllowContext {
+                local_side: Some(1),
+                campaign_scenario: None,
+            },
+            |_| None,
+        );
+        assert!(!theme.is_allowed(7), "unknown Side= never matches");
+        theme.begin_scenario(7, ThemeAllowContext::default(), |_| None);
+        assert!(
+            theme.is_allowed(7),
+            "no player (shell) skips the Side= gate"
+        );
+    }
+
+    #[test]
+    fn cyclic_next_song_starts_after_prev_and_honors_repeat() {
+        let mut theme = stock_runtime();
+        assert_eq!(
+            theme.next_song(-1),
+            5,
+            "first allowed after -1 is BrainFreeze"
+        );
+        assert_eq!(theme.next_song(5), 6);
+        assert_eq!(theme.next_song(8), 5, "wraps past the shell-only entries");
+        assert_eq!(theme.next_song(0), 0, "INTRO repeats");
+        theme.set_score_options(true, false);
+        assert_eq!(theme.next_song(5), 5, "global repeat returns prev");
+        let mut empty = ThemeRuntime::with_entries(Vec::new());
+        assert_eq!(empty.next_song(-1), 0);
+    }
+
+    #[test]
+    fn shuffle_rejects_prev_and_disallowed_with_a_fixed_presentation_rng() {
+        let mut theme = stock_runtime();
+        theme.set_score_options(false, true);
+        theme.begin_scenario(0x1234, ThemeAllowContext::default(), |_| None);
+        let mut expected = SimRng::new(0x1234);
+        let count = theme.entries().len() as i32;
+        let mut prev = -1;
+        for _ in 0..16 {
+            let mut want;
+            loop {
+                want = expected.next_range_i32_inclusive(0, count - 1);
+                if want != prev && (5..=8).contains(&want) {
+                    break;
+                }
+            }
+            let got = theme.next_song(prev);
+            assert_eq!(got, want);
+            assert_ne!(got, prev);
+            prev = got;
+        }
+        // No allowed entry at all: 1000 rejections then index 0.
+        let mut none = ThemeRuntime::with_entries(vec![ThemeEntry {
+            key: "X".into(),
+            sound: "X".into(),
+            scenario: 0,
+            normal: false,
+            repeat: false,
+            side_name: None,
+            side: -1,
+            available: true,
+        }]);
+        none.set_score_options(false, true);
+        assert_eq!(none.next_song(-1), 0);
+    }
+
+    #[test]
+    fn start_scenario_hand_off_loading_then_fade_then_first_allowed() {
+        let mut theme = stock_runtime();
+        let mut ok = prepared;
+        // Shell: INTRO playing (Play sets pending = INTRO because Repeat=yes).
+        let action = theme.play_song(0, gates(true), MusicOutputState::Idle, 0, &mut ok);
+        assert_eq!(action.start.as_ref().map(|p| p.stem.as_str()), Some("Drok"));
+        assert_eq!(
+            theme.slots(),
+            ThemeSlots {
+                active: 0,
+                retained: 0,
+                pending: 0
+            }
+        );
+
+        // Start_Scenario: Play(From_Name("LOADING")) hard-replaces INTRO.
+        let loading = theme.from_name("LOADING");
+        let action = theme.play_song(
+            loading,
+            gates(true),
+            MusicOutputState::Playing,
+            100,
+            &mut ok,
+        );
+        assert!(action.stop_output);
+        assert_eq!(
+            action.start.as_ref().map(|p| p.stem.as_str()),
+            Some("Bully")
+        );
+        assert_eq!(
+            theme.slots(),
+            ThemeSlots {
+                active: 2,
+                retained: 2,
+                pending: 2
+            }
+        );
+
+        // Map without [Basic] Theme= -> Stop(fade=1): fading, slots cleared.
+        let action = theme.stop(gates(true), true, MusicOutputState::Playing, 200);
+        assert!(!action.stop_output);
+        assert!(theme.fading);
+        assert_eq!(theme.slots(), ThemeSlots::default());
+
+        // Main_Tick: nothing retained -> Queue(-2) (no fade for -2).
+        theme.main_tick(true, gates(true), MusicOutputState::Playing, 210);
+        assert_eq!(theme.slots().pending, THEME_AUTO);
+
+        // AI during the fade reports the ramp and waits.
+        let action = theme.ai(gates(true), MusicOutputState::Playing, 700, &mut ok);
+        assert_eq!(action.theme_scale, Some(0.5));
+        assert!(action.start.is_none());
+
+        // Fade reached target: stop the stream, Next_Song(-1) = BrainFreeze.
+        let action = theme.ai(gates(true), MusicOutputState::Playing, 1_200, &mut ok);
+        assert!(action.stop_output);
+        assert_eq!(
+            action.start.as_ref().map(|p| p.stem.as_str()),
+            Some("BrainFre")
+        );
+        assert_eq!(
+            theme.slots(),
+            ThemeSlots {
+                active: 5,
+                retained: 5,
+                pending: THEME_AUTO
+            }
+        );
+        assert!(!theme.fading);
+
+        // Natural end -> next cyclic track (Drok entry, index 6, not INTRO).
+        let action = theme.ai(gates(true), MusicOutputState::Finished, 5_000, &mut ok);
+        assert_eq!(action.start.as_ref().map(|p| p.stem.as_str()), Some("Drok"));
+        assert_eq!(
+            theme.slots(),
+            ThemeSlots {
+                active: 6,
+                retained: 6,
+                pending: THEME_AUTO
+            }
+        );
+    }
+
+    #[test]
+    fn scenario_with_basic_theme_queues_and_fades_the_loading_track() {
+        let mut theme = stock_runtime();
+        let mut ok = prepared;
+        theme.play_song(2, gates(true), MusicOutputState::Idle, 0, &mut ok);
+        let action = theme.queue_song(7, gates(true), MusicOutputState::Playing, 50);
+        assert!(!action.stop_output);
+        assert!(theme.fading);
+        assert_eq!(theme.slots().pending, 7);
+        let action = theme.ai(gates(true), MusicOutputState::Playing, 1_100, &mut ok);
+        assert!(action.stop_output);
+        assert_eq!(
+            theme.slots(),
+            ThemeSlots {
+                active: 7,
+                retained: 7,
+                pending: THEME_AUTO
+            }
+        );
+    }
+
+    #[test]
+    fn main_tick_in_game_music_off_holds_with_fade_and_minus_three() {
+        let mut theme = stock_runtime();
+        let mut ok = prepared;
+        theme.play_song(5, gates(true), MusicOutputState::Idle, 0, &mut ok);
+        theme.main_tick(false, gates(true), MusicOutputState::Playing, 10);
+        assert!(theme.fading);
+        assert_eq!(
+            theme.slots(),
+            ThemeSlots {
+                active: -1,
+                retained: -1,
+                pending: THEME_HOLD
+            }
+        );
+        let before = theme.slots();
+        theme.main_tick(false, gates(true), MusicOutputState::Playing, 20);
+        assert_eq!(theme.slots(), before);
+        let action = theme.ai(gates(true), MusicOutputState::Playing, 1_100, &mut ok);
+        assert!(action.stop_output && action.start.is_none());
+        assert_eq!(theme.slots().pending, THEME_HOLD, "-3 is never consumed");
+    }
+
+    #[test]
+    fn queue_sentinels_and_same_retained_track_do_not_fade() {
+        let mut theme = stock_runtime();
+        theme.slots = ThemeSlots {
+            active: 5,
+            retained: 5,
+            pending: THEME_HOLD,
+        };
+        for request in [THEME_NONE, THEME_AUTO, 5] {
+            theme.queue_song(request, gates(true), MusicOutputState::Playing, 100);
+            assert_eq!(theme.slots().pending, request);
+            assert!(!theme.fading);
+        }
+        theme.queue_song(THEME_HOLD, gates(true), MusicOutputState::Playing, 300);
+        assert!(theme.fading);
+        assert_eq!(theme.fade_started_at_ms, Some(300));
+    }
+
+    #[test]
+    fn play_same_retained_while_playing_is_a_no_op_and_failed_gates_preserve_slots() {
+        let mut theme = stock_runtime();
+        let mut ok = prepared;
+        theme.play_song(5, gates(true), MusicOutputState::Idle, 0, &mut ok);
+        let before = theme.slots();
+        let action = theme.play_song(5, gates(true), MusicOutputState::Playing, 10, &mut ok);
+        assert!(action.start.is_none() && !action.stop_output);
+        assert_eq!(theme.slots(), before);
+
+        let action = theme.queue_song(7, gates(false), MusicOutputState::Playing, 10);
+        assert!(!action.stop_output && action.start.is_none());
+        assert_eq!(theme.slots(), before);
         let suppressed = ThemeGates {
             launcher_audio_available: true,
             startup_suppressed: true,
         };
-        theme.stop(suppressed);
-        assert_eq!(theme.slots, before);
+        theme.stop(suppressed, false, MusicOutputState::Playing, 10);
+        assert_eq!(theme.slots(), before);
     }
 
     #[test]
-    fn queue_sentinels_and_same_retained_track_preserve_native_fade_rules() {
-        let mut theme = runtime();
-        theme.slots.active = Some("A".into());
-        theme.slots.retained = Some("R".into());
-        for request in [ThemeRequest::None, ThemeRequest::Auto] {
-            theme.queue_request(request.clone(), gates(true), MusicOutputState::Playing, 100);
-            assert_eq!(theme.slots.pending, request);
-            assert!(theme.scenario_fade.started_at_ms.is_none());
-        }
-        theme.queue_request(
-            ThemeRequest::Track("R".into()),
-            gates(true),
-            MusicOutputState::Playing,
-            200,
-        );
-        assert!(theme.scenario_fade.started_at_ms.is_none());
-        theme.queue_request(
-            ThemeRequest::Hold,
-            gates(true),
-            MusicOutputState::Playing,
-            300,
-        );
-        assert_eq!(theme.scenario_fade.started_at_ms, Some(300));
-    }
-
-    #[test]
-    fn play_success_failure_repeat_and_same_track_rows_are_literal() {
-        let mut theme = runtime();
-        theme.slots = ThemeSlots {
-            active: Some("Old".into()),
-            retained: Some("Old".into()),
-            pending: ThemeRequest::Hold,
-        };
+    fn play_sentinels_stop_and_auto_sets_pending() {
+        let mut theme = stock_runtime();
         let mut ok = prepared;
-        let action = theme.play_request_with(
-            ThemeRequest::Track("Power".into()),
+        theme.play_song(5, gates(true), MusicOutputState::Idle, 0, &mut ok);
+        let action = theme.play_song(
+            THEME_NONE,
             gates(true),
             MusicOutputState::Playing,
+            1,
             &mut ok,
         );
-        assert!(action.stop_output && action.start.is_some());
-        assert_eq!(
-            theme.slots,
-            ThemeSlots {
-                active: Some("Power".into()),
-                retained: Some("Power".into()),
-                pending: ThemeRequest::None,
-            }
-        );
-
-        let before = theme.slots.clone();
-        let action = theme.play_request_with(
-            ThemeRequest::Track("Power".into()),
+        assert!(action.stop_output);
+        assert_eq!(theme.slots(), ThemeSlots::default());
+        theme.play_song(5, gates(true), MusicOutputState::Idle, 2, &mut ok);
+        let action = theme.play_song(
+            THEME_AUTO,
             gates(true),
             MusicOutputState::Playing,
+            3,
             &mut ok,
         );
-        assert_eq!(theme.slots, before);
-        assert!(!action.stop_output && action.start.is_none());
-
-        theme.slots = ThemeSlots {
-            active: None,
-            retained: Some("Old".into()),
-            pending: ThemeRequest::Hold,
-        };
-        let mut missing = |_stem: &str| None;
-        theme.play_request_with(
-            ThemeRequest::Track("Power".into()),
-            gates(true),
-            MusicOutputState::Unavailable,
-            &mut missing,
-        );
-        assert_eq!(theme.slots.active, None);
-        assert_eq!(theme.slots.retained.as_deref(), Some("Power"));
-        assert_eq!(theme.slots.pending, ThemeRequest::Hold);
-
-        theme.slots.pending = ThemeRequest::None;
-        theme.play_request_with(
-            ThemeRequest::Track("Power".into()),
-            gates(true),
-            MusicOutputState::Idle,
-            &mut missing,
-        );
-        assert_eq!(theme.slots.pending, ThemeRequest::Track("Power".into()));
-
-        theme.play_request_with(
-            ThemeRequest::Track("INTRO".into()),
-            gates(true),
-            MusicOutputState::Unavailable,
-            &mut ok,
-        );
+        assert!(action.stop_output);
         assert_eq!(
-            theme.slots,
+            theme.slots(),
             ThemeSlots {
-                active: Some("Drok".into()),
-                retained: Some("Drok".into()),
-                pending: ThemeRequest::Track("Drok".into()),
+                active: -1,
+                retained: -1,
+                pending: THEME_AUTO
             }
         );
     }
 
     #[test]
-    fn replacing_active_preplay_failures_use_stream_object_specific_pending_rows() {
-        for (physical, expected_pending) in [
-            (MusicOutputState::Unavailable, ThemeRequest::None),
-            (
-                MusicOutputState::Playing,
-                ThemeRequest::Track("Power".to_string()),
-            ),
-        ] {
-            let mut theme = runtime();
-            theme.slots = ThemeSlots {
-                active: Some("Old".into()),
-                retained: Some("Old".into()),
-                pending: ThemeRequest::Hold,
-            };
-            let mut missing = |_stem: &str| None;
-            let action = theme.play_request_with(
-                ThemeRequest::Track("Power".into()),
-                gates(true),
-                physical,
-                &mut missing,
-            );
-            assert!(action.stop_output);
-            assert_eq!(theme.slots.active, None);
-            assert_eq!(theme.slots.retained.as_deref(), Some("Power"));
-            assert_eq!(theme.slots.pending, expected_pending);
-        }
-    }
-
-    #[test]
-    fn stop_and_direct_sentinel_rows_preserve_active_absent_state() {
-        let mut theme = runtime();
-        theme.slots = ThemeSlots {
-            active: None,
-            retained: Some("R".into()),
-            pending: ThemeRequest::Hold,
-        };
-        let before = theme.slots.clone();
-        assert!(!theme.stop(gates(true)).stop_output);
-        assert_eq!(theme.slots, before);
-
+    fn ai_ignores_none_hold_and_unavailable_and_restores_auto_after_failure() {
+        let mut theme = stock_runtime();
         let mut ok = prepared;
-        theme.play_request_with(
-            ThemeRequest::None,
-            gates(true),
-            MusicOutputState::Idle,
-            &mut ok,
+        theme.slots = ThemeSlots {
+            active: 5,
+            retained: 5,
+            pending: THEME_NONE,
+        };
+        theme.ai(gates(true), MusicOutputState::Finished, 1, &mut ok);
+        assert_eq!(
+            theme.slots(),
+            ThemeSlots {
+                active: 5,
+                retained: 5,
+                pending: THEME_NONE
+            }
         );
-        assert_eq!(theme.slots, before);
-        theme.slots.active = Some("A".into());
-        assert!(
-            theme
-                .play_request_with(
-                    ThemeRequest::Hold,
-                    gates(true),
-                    MusicOutputState::Playing,
-                    &mut ok,
-                )
-                .stop_output
+        theme.slots.pending = THEME_HOLD;
+        theme.ai(gates(true), MusicOutputState::Finished, 2, &mut ok);
+        assert_eq!(theme.slots().pending, THEME_HOLD);
+        theme.slots.pending = THEME_AUTO;
+        theme.ai(gates(true), MusicOutputState::Unavailable, 3, &mut ok);
+        assert_eq!(
+            theme.slots(),
+            ThemeSlots {
+                active: 5,
+                retained: 5,
+                pending: THEME_AUTO
+            }
         );
-        assert_eq!(theme.slots, ThemeSlots::default());
-    }
 
-    #[test]
-    fn completion_auto_specific_hold_and_unavailable_are_distinct() {
-        let mut theme = runtime();
-        theme.slots = ThemeSlots {
-            active: Some("Drok".into()),
-            retained: Some("Drok".into()),
-            pending: ThemeRequest::Track("Drok".into()),
-        };
-        let mut ok = prepared;
-        let action = theme.update_with(gates(true), MusicOutputState::Finished, 1_000, &mut ok);
-        assert!(action.start.is_some());
-        assert_eq!(theme.slots.active.as_deref(), Some("Drok"));
-        assert_eq!(theme.slots.retained.as_deref(), Some("Drok"));
-        assert_eq!(theme.slots.pending, ThemeRequest::Auto);
-
-        let action = theme.update_with(gates(true), MusicOutputState::Finished, 1_500, &mut ok);
-        assert!(action.start.is_some(), "Auto repeats retained INTRO");
-        assert_eq!(theme.slots.active.as_deref(), Some("Drok"));
-        assert_eq!(theme.slots.retained.as_deref(), Some("Drok"));
-        assert_eq!(theme.slots.pending, ThemeRequest::Auto);
-
-        let before = theme.slots.clone();
-        let action = theme.update_with(gates(true), MusicOutputState::Unavailable, 2_000, &mut ok);
-        assert!(action.start.is_none());
-        assert_eq!(theme.slots, before, "Unavailable is not Finished");
-
-        theme.slots.pending = ThemeRequest::Hold;
-        let before = theme.slots.clone();
-        theme.update_with(gates(true), MusicOutputState::Finished, 3_000, &mut ok);
-        assert_eq!(theme.slots, before);
-
-        theme.slots.pending = ThemeRequest::None;
-        let before = theme.slots.clone();
-        theme.update_with(gates(true), MusicOutputState::Finished, 4_000, &mut ok);
-        assert_eq!(theme.slots, before, "None completion preserves stale A/R");
-    }
-
-    #[test]
-    fn ai_auto_success_and_failure_restore_auto_after_attempt() {
-        let mut theme = runtime();
-        theme.slots = ThemeSlots {
-            active: Some("Power".into()),
-            retained: Some("Power".into()),
-            pending: ThemeRequest::Auto,
-        };
-        theme.playlist_index = 2;
-        let mut ok = prepared;
-        theme.update_with(gates(true), MusicOutputState::Finished, 100, &mut ok);
-        assert_eq!(theme.slots.active.as_deref(), Some("Fortific"));
-        assert_eq!(theme.slots.retained.as_deref(), Some("Fortific"));
-        assert_eq!(theme.slots.pending, ThemeRequest::Auto);
-
-        theme.slots.pending = ThemeRequest::Auto;
         let mut missing = |_stem: &str| None;
-        theme.update_with(gates(true), MusicOutputState::Finished, 200, &mut missing);
-        assert_eq!(theme.slots.active, None);
-        assert_eq!(theme.slots.retained.as_deref(), Some("InDeep"));
-        assert_eq!(theme.slots.pending, ThemeRequest::Auto);
+        theme.ai(gates(true), MusicOutputState::Finished, 4, &mut missing);
+        assert_eq!(
+            theme.slots(),
+            ThemeSlots {
+                active: -1,
+                retained: 6,
+                pending: THEME_AUTO
+            }
+        );
     }
 
     #[test]
     fn score_zero_is_queue_then_stop_not_unconditional_reset() {
-        let mut theme = runtime();
+        let mut theme = stock_runtime();
         theme.slots = ThemeSlots {
-            active: Some("A".into()),
-            retained: Some("R".into()),
-            pending: ThemeRequest::Hold,
+            active: 5,
+            retained: 6,
+            pending: THEME_HOLD,
         };
-        let action = theme.queue_then_stop_score_zero(gates(true), MusicOutputState::Playing);
+        let action = theme.queue_then_stop_score_zero(gates(true), MusicOutputState::Playing, 0);
         assert!(action.stop_output);
-        assert_eq!(theme.slots, ThemeSlots::default());
+        assert_eq!(theme.slots(), ThemeSlots::default());
 
         theme.slots = ThemeSlots {
-            active: None,
-            retained: Some("R".into()),
-            pending: ThemeRequest::Hold,
+            active: -1,
+            retained: 6,
+            pending: THEME_HOLD,
         };
-        let action = theme.queue_then_stop_score_zero(gates(true), MusicOutputState::Idle);
+        let action = theme.queue_then_stop_score_zero(gates(true), MusicOutputState::Idle, 0);
         assert!(!action.stop_output);
-        assert_eq!(theme.slots.active, None);
-        assert_eq!(theme.slots.retained.as_deref(), Some("R"));
-        assert_eq!(theme.slots.pending, ThemeRequest::Track("R".into()));
-    }
-
-    #[test]
-    fn scenario_specific_fades_then_ai_starts_and_restores_auto() {
-        let mut theme = runtime();
-        theme.slots = ThemeSlots {
-            active: Some("Drok".into()),
-            retained: Some("Drok".into()),
-            pending: ThemeRequest::Track("Drok".into()),
-        };
-        let action = theme.queue_request(
-            ThemeRequest::Track("Fortific".into()),
-            gates(true),
-            MusicOutputState::Playing,
-            100,
-        );
-        assert_eq!(action.theme_scale, Some(1.0));
-        let mut ok = prepared;
         assert_eq!(
-            theme
-                .update_with(gates(true), MusicOutputState::Playing, 600, &mut ok)
-                .theme_scale,
-            Some(0.5)
+            theme.slots(),
+            ThemeSlots {
+                active: -1,
+                retained: 6,
+                pending: 6
+            }
         );
-        let action = theme.update_with(gates(true), MusicOutputState::Playing, 1_100, &mut ok);
-        assert!(action.stop_output && action.start.is_some());
-        assert_eq!(theme.slots.active.as_deref(), Some("Fortific"));
-        assert_eq!(theme.slots.retained.as_deref(), Some("Fortific"));
-        assert_eq!(theme.slots.pending, ThemeRequest::Auto);
     }
 
     #[test]
     fn scenario_cancel_clears_only_scenario_owned_pending() {
-        let mut theme = runtime();
-        theme.slots.pending = ThemeRequest::Auto;
+        let mut theme = stock_runtime();
+        theme.slots.pending = THEME_AUTO;
         theme.cancel_scenario_theme_request();
-        assert_eq!(theme.slots.pending, ThemeRequest::Auto);
+        assert_eq!(theme.slots().pending, THEME_AUTO);
 
-        theme.queue_request(
-            ThemeRequest::Track("Fortific".into()),
-            gates(true),
-            MusicOutputState::Playing,
-            10,
-        );
-        theme.scenario_fade.owns_pending = true;
+        theme.queue_song(7, gates(true), MusicOutputState::Playing, 10);
+        theme.scenario_owns_pending = true;
         theme.cancel_scenario_theme_request();
-        assert_eq!(theme.slots.pending, ThemeRequest::None);
-    }
-
-    #[test]
-    fn resolver_uses_section_keys_and_playlist_specific_advances() {
-        let ini = IniFile::from_str(
-            "[Themes]\n0=Fortification\n1=Power\n\
-             [Fortification]\nSound=Fortific\nNormal=yes\n\
-             [Power]\nSound=Power\nNormal=yes\n",
-        );
-        let mut sections = HashMap::new();
-        merge_theme_section_stems(&mut sections, &ini);
-        for requested in [None, Some("No theme"), Some("Missing"), Some("Fortific")] {
-            assert_eq!(
-                resolve_scenario_theme_section(requested, &sections),
-                ScenarioThemeRequest::Auto
-            );
-        }
-        assert_eq!(
-            resolve_scenario_theme_section(Some("fOrTiFiCaTiOn"), &sections),
-            ScenarioThemeRequest::Specific("Fortific".into())
-        );
-        let playlist = ["Grinder", "Power", "Fortific", "InDeep"]
-            .into_iter()
-            .map(str::to_string)
-            .collect::<Vec<_>>();
-        assert_eq!(
-            playlist[playlist_index_after_specific(&playlist, "fOrTiFiC").unwrap()],
-            "InDeep"
-        );
-    }
-
-    #[test]
-    fn menu_theme_metadata_honors_repeat_and_absence() {
-        let ini = IniFile::from_str("[INTRO]\nSound=Drok\nNormal=no\nRepeat=yes\n");
-        let mut aliases = HashMap::new();
-        merge_theme_aliases(&mut aliases, &ini);
-        assert_eq!(
-            menu_theme_from_ini(&ini, &aliases),
-            Some(("Drok".into(), true))
-        );
-        let absent = IniFile::from_str("[SCORE]\nSound=Score\n");
-        assert_eq!(menu_theme_from_ini(&absent, &HashMap::new()), None);
+        assert_eq!(theme.slots().pending, THEME_NONE);
     }
 }


### PR DESCRIPTION
In-game music now follows `ThemeClass` (g_Theme @ 0x00A83D10). The catalog is read only from THEMEMD.INI (0x00825D94) into an index-keyed list in `[Themes]` order with per-entry Repeat and availability. `Start_Scenario` @ 0x00683AB0 plays LOADING before `Read_Scenario`, then `Stop(fade)` when the map has no `[Basic] Theme=`; `Main_Tick` @ 0x0055D360 queues -2 when nothing is retained; `Next_Song` @ 0x00720A80 cycles or shuffles (`RandomRanged` on g_MainRng 0x00886B88, 1000-try loop) through `Is_Allowed` @ 0x00721140; `ThemeClass::AI` runs from `AudioSystem::Pump` @ 0x00406F70 on every screen after more than 0x21 ms. The fade is the stream interpolator's own 0x4000-scale ramp (0x00407E7D), 1000 ms at any ScoreVolume.

Previous Rust merged RA2's theme.ini into the YR playlist, keyed Repeat by stem (INTRO's Repeat leaked onto Drok), never faded the menu theme at match start, played no LOADING theme, had no shuffle or Is_Allowed, and polled the theme only in-game. Player-visible every skirmish: the menu track kept playing forever instead of Bully during load and BrainFreeze onward.

Changes: index-keyed THEMEMD catalog; LOADING played through the leased asset manager at load start and the audio pump resolving the same manager during loading; post-load Stop(fade)/Queue(-2) hand-off and Main_Tick head on the production path; Next_Song cyclic/shuffle with Is_Allowed driven by `IsScoreRepeat`/`IsScoreShuffle`; shuffle draws a presentation-side RNG copy, never a World stream. sim/ untouched; parity harness unchanged.

Residuals recorded in code: the SpawnPick screen (no native equivalent) leaves silence after the post-load fade until a spawn is picked; the native integer fade stepper reaches zero 1 ms later; the ScoreVolume gate and the in-game Sound dialog are out of scope.

Two independent read-only critics reviewed successive revisions against the bodies; the second passed after the loading-lease defect was fixed.

Validation:
- `cargo test -p vera20k --lib`: `test result: ok. 8322 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 12.99s`
