### PR TITLE
Park an ore-less harvester on Guard and radio the refinery at five cells

### DIFF
--- a/src/sim/entity_store.rs
+++ b/src/sim/entity_store.rs
@@ -40,6 +40,19 @@ pub struct EntityStore {
     /// returns `&[]`, identical to a fresh rebuild. Deterministic iteration via
     /// BTreeMap key order + sorted Vecs.
     by_owner: BTreeMap<crate::sim::intern::InternedId, Vec<u64>>,
+    /// Per-(owner, type) instance count over the stored entities — the O(1)
+    /// answer `HouseClass::CountOwnedInstances @ 0x0049FAE0` gives from its
+    /// per-house per-type counter array. Maintained incrementally next to
+    /// `by_owner` (`insert`/`remove`/`change_owner`) and rebuilt with it.
+    /// Counts every stored entity of the type, limbo and dying included; see
+    /// [`Self::count_owned_of_type`] for the native-vs-Rust window.
+    by_owner_type: BTreeMap<
+        (
+            crate::sim::intern::InternedId,
+            crate::sim::intern::InternedId,
+        ),
+        u32,
+    >,
 }
 
 impl EntityStore {
@@ -48,6 +61,7 @@ impl EntityStore {
         Self {
             entities: BTreeMap::new(),
             by_owner: BTreeMap::new(),
+            by_owner_type: BTreeMap::new(),
         }
     }
 
@@ -57,10 +71,13 @@ impl EntityStore {
     pub fn insert(&mut self, entity: GameEntity) -> u64 {
         let id = entity.stable_id;
         let owner = entity.owner;
+        let type_ref = entity.type_ref;
         if let Some(old) = self.entities.insert(id, entity) {
             self.index_remove(old.owner, id);
+            self.type_count_remove(old.owner, old.type_ref);
         }
         self.index_add(owner, id);
+        self.type_count_add(owner, type_ref);
         id
     }
 
@@ -70,8 +87,32 @@ impl EntityStore {
         let removed = self.entities.remove(&stable_id);
         if let Some(ref e) = removed {
             self.index_remove(e.owner, stable_id);
+            self.type_count_remove(e.owner, e.type_ref);
         }
         removed
+    }
+
+    /// Stored instances of `type_ref` owned by `owner` — O(1).
+    ///
+    /// Native `HouseClass::CountOwnedInstances @ 0x0049FAE0` reads the
+    /// house's per-type counter array (`House+0x4`/`+0x8`, grown on demand
+    /// and zero-filled), which counts an object from Unlimbo until Limbo.
+    /// This count runs from `insert` until `remove` instead, so it differs
+    /// only at the edges: a stored-but-in-limbo entity counts here (native
+    /// excludes it; production structures sit in limbo only inside the spawn
+    /// call that reveals or discards them, so no dispatch observes the gap),
+    /// while a dying structure counts in both until it leaves the store /
+    /// Limbos. Storage-order/type-index details of the native array are not
+    /// modelled; only the `> 0` test and the count itself are consumed.
+    pub fn count_owned_of_type(
+        &self,
+        owner: crate::sim::intern::InternedId,
+        type_ref: crate::sim::intern::InternedId,
+    ) -> u32 {
+        self.by_owner_type
+            .get(&(owner, type_ref))
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Clear all RadioClass-style live contacts involving `stable_id`.
@@ -164,16 +205,40 @@ impl EntityStore {
     /// (callers own that, because count semantics differ by transfer kind).
     /// No-op if the entity is absent or already owned by `new_owner`.
     pub fn change_owner(&mut self, stable_id: u64, new_owner: crate::sim::intern::InternedId) {
-        let old_owner = match self.entities.get_mut(&stable_id) {
+        let (old_owner, type_ref) = match self.entities.get_mut(&stable_id) {
             Some(e) if e.owner != new_owner => {
                 let old = e.owner;
                 e.owner = new_owner;
-                old
+                (old, e.type_ref)
             }
             _ => return,
         };
         self.index_remove(old_owner, stable_id);
         self.index_add(new_owner, stable_id);
+        self.type_count_remove(old_owner, type_ref);
+        self.type_count_add(new_owner, type_ref);
+    }
+
+    fn type_count_add(
+        &mut self,
+        owner: crate::sim::intern::InternedId,
+        type_ref: crate::sim::intern::InternedId,
+    ) {
+        *self.by_owner_type.entry((owner, type_ref)).or_insert(0) += 1;
+    }
+
+    /// Drop the entry when it reaches zero so the map matches a fresh rebuild.
+    fn type_count_remove(
+        &mut self,
+        owner: crate::sim::intern::InternedId,
+        type_ref: crate::sim::intern::InternedId,
+    ) {
+        if let Some(count) = self.by_owner_type.get_mut(&(owner, type_ref)) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                self.by_owner_type.remove(&(owner, type_ref));
+            }
+        }
     }
 
     /// Insert `id` into its owner bucket at the sorted (ascending) position.
@@ -200,8 +265,13 @@ impl EntityStore {
     /// Called after deserialization or any bulk mutation that bypasses insert/remove.
     pub fn rebuild_owner_index(&mut self) {
         self.by_owner.clear();
+        self.by_owner_type.clear();
         for (&id, entity) in &self.entities {
             self.by_owner.entry(entity.owner).or_default().push(id);
+            *self
+                .by_owner_type
+                .entry((entity.owner, entity.type_ref))
+                .or_insert(0) += 1;
         }
         // BTreeMap iteration is already sorted by key; Vecs are sorted because
         // entities BTreeMap iterates in ascending stable_id order.
@@ -220,6 +290,7 @@ impl<'de> serde::Deserialize<'de> for EntityStore {
         let mut store = Self {
             entities,
             by_owner: BTreeMap::new(),
+            by_owner_type: BTreeMap::new(),
         };
         store.rebuild_owner_index();
         Ok(store)
@@ -509,6 +580,56 @@ mod tests {
         // Unknown owner returns empty slice.
         let unknown = interner.intern("Yuri");
         assert_eq!(store.ids_for_owner(unknown), &[] as &[u64]);
+    }
+
+    #[test]
+    fn per_owner_type_count_tracks_insert_remove_change_owner_and_rebuild() {
+        use crate::sim::intern::StringInterner;
+        let mut interner = StringInterner::new();
+        let americans = interner.intern("Americans");
+        let soviets = interner.intern("Russians");
+        let refinery = interner.intern("GAREFN");
+        let tank = interner.intern("HTNK");
+        let mut store = EntityStore::new();
+
+        let mut e1 = GameEntity::test_default(1, "GAREFN", "Americans", 5, 5);
+        e1.owner = americans;
+        e1.type_ref = refinery;
+        let mut e2 = GameEntity::test_default(2, "GAREFN", "Americans", 6, 6);
+        e2.owner = americans;
+        e2.type_ref = refinery;
+        let mut e3 = GameEntity::test_default(3, "HTNK", "Americans", 7, 7);
+        e3.owner = americans;
+        e3.type_ref = tank;
+        store.insert(e1);
+        store.insert(e2);
+        store.insert(e3);
+        assert_eq!(store.count_owned_of_type(americans, refinery), 2);
+        assert_eq!(store.count_owned_of_type(americans, tank), 1);
+        assert_eq!(store.count_owned_of_type(soviets, refinery), 0);
+
+        store.change_owner(2, soviets);
+        assert_eq!(store.count_owned_of_type(americans, refinery), 1);
+        assert_eq!(store.count_owned_of_type(soviets, refinery), 1);
+
+        store.remove(1);
+        assert_eq!(store.count_owned_of_type(americans, refinery), 0);
+        assert!(!store.by_owner_type.contains_key(&(americans, refinery)));
+
+        // Re-inserting an existing id retires the old entry's count first.
+        let mut e2b = GameEntity::test_default(2, "HTNK", "Russians", 6, 6);
+        e2b.owner = soviets;
+        e2b.type_ref = tank;
+        store.insert(e2b);
+        assert_eq!(store.count_owned_of_type(soviets, refinery), 0);
+        assert_eq!(store.count_owned_of_type(soviets, tank), 1);
+
+        let before = store.by_owner_type.clone();
+        store.rebuild_owner_index();
+        assert_eq!(
+            store.by_owner_type, before,
+            "rebuild reproduces the incremental map"
+        );
     }
 
     #[test]

--- a/src/sim/house_state.rs
+++ b/src/sim/house_state.rs
@@ -384,6 +384,29 @@ pub struct HouseState {
     /// directly enter House CRC.
     #[serde(default)]
     pub ai_activation: HouseAiActivationLatches,
+    /// Native `HouseClass+0x242`: "a harvester of this house found no ore".
+    ///
+    /// Exhaustive instruction census (`search_instructions` operand `+0x242]`,
+    /// 1,164,209 instructions, 4 hits, 2026-09-05):
+    /// - `HouseClass__Constructor` `0x004F5771` writes BL (= 0);
+    /// - `UnitClass::Mission_Harvest @ 0x0073E5E0` writes 1 at `0x0073E911`
+    ///   on the state-0 scan-miss path (no ore in `TiberiumLongScan`, no
+    ///   destination, no archive) when the type is `Harvester=yes`;
+    /// - `UnitClass::Mission_Guard @ 0x00740810` reads it at `0x00740922` —
+    ///   the AI-house arm re-queues Harvest only while it is clear;
+    /// - `HouseClass__AI_Choose_Unit` reads it at `0x004FEB7B` (AI harvester
+    ///   production bias).
+    ///
+    /// No clearing writer exists anywhere: once set it stays set for the rest
+    /// of the match (save/load carries the raw House block). The
+    /// `Mission_Guard` arm (ii) reader is implemented
+    /// (`techno_ai/mission_handlers.rs`, AI houses only); the
+    /// `AI_Choose_Unit` reader belongs to the deferred AI lane, which is why
+    /// AI-house miners take a VERA-internal re-scan bridge instead of the
+    /// native Guard park (`miner_system::handle_going_to_idle`).
+    /// Persisted and hashed (schema v132).
+    #[serde(default)]
+    pub harvester_no_ore: bool,
 }
 
 impl HouseState {
@@ -521,6 +544,7 @@ impl HouseState {
             economy: Economy::default(),
             strategy_emergency: HouseStrategyEmergencyState::default(),
             ai_activation: HouseAiActivationLatches::default(),
+            harvester_no_ore: false,
         }
     }
 }

--- a/src/sim/miner/harvest_mission.rs
+++ b/src/sim/miner/harvest_mission.rs
@@ -30,6 +30,15 @@
 //! slave-host preamble's Rate epilogue — Slave hosts are dispatched by
 //! `slave_miner.rs`, never through this handler.
 //!
+//! Guard hand-offs (`UnitClass::Mission_Harvest @ 0x0073E5E0`): the preamble
+//! queues Guard when the house owns no instance of any `Dock=` type, and
+//! state 4 (105 frames after a scan miss) queues Guard after moving the
+//! miner off a refinery cell — both `Queue_Mission(5, 0)`, promoted by the
+//! host's Ready-to-Commence step. A miner on Guard is no longer dispatched
+//! here; the harvester Guard override's chrono arms
+//! (`techno_ai/mission_handlers.rs`) or a player order (`Command::HarvestCell`
+//! → `mission_assign_exact(Harvest)`, `Command::MinerReturn`) put it back.
+//!
 //! Dispatch gating residual: the host dispatches on Miner-component presence
 //! plus "the committed mission is not Guard", not strictly on
 //! `current == Harvest`. Guard is gated because the Stop command force-assigns

--- a/src/sim/miner/miner_dock_sequence.rs
+++ b/src/sim/miner/miner_dock_sequence.rs
@@ -18,7 +18,7 @@
 use crate::map::entities::EntityCategory;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::components::BaleDepositEvent;
-use crate::sim::miner::{MinerConfig, MinerState, RefineryDockPhase, ResourceType};
+use crate::sim::miner::{MinerConfig, MinerKind, MinerState, RefineryDockPhase, ResourceType};
 use crate::sim::mission::MissionType;
 use crate::sim::movement;
 use crate::sim::movement::facing_class::FacingClass;
@@ -1068,6 +1068,44 @@ fn phase_mission_enter(
             bus_enter_dock(sim, snap.entity_id, ref_sid);
             sync_dock_facing(sim, rules, snap);
             snap.miner.dock_phase = RefineryDockPhase::FaceSync;
+        }
+        schedule_enter_retry(sim, rules, snap);
+        return;
+    }
+
+    // A war miner now reaches Mission_Enter from up to `HarvesterTooFarDistance`
+    // (5 cells) out — the state-2 HELLO handoff at `0x0073EE51` — not from
+    // adjacency. Native Mission_Enter drives to the CAN_DOCK cell through the
+    // ordinary pathfinder; VERA's direct move below is a straight line that
+    // ignores the grid, which is only safe from a neighbouring cell. Path to
+    // the `QueueingCell` first (it sits beside the pad on stock refineries)
+    // and take the direct step from there. VERA-internal shape, gamemd
+    // equivalent UNCHECKED beyond "the pathfinder gets it there". Chrono keeps
+    // its existing shape: its inbound leg is the teleport locomotor's.
+    //
+    // Residual (VERA-internal): the hop assumes the `QueueingCell` is
+    // adjacent to the accepted CAN_DOCK cell, which holds for every stock
+    // refinery (art `QueueingCell=4,1` beside the pad). A modded refinery
+    // whose `QueueingCell` is NOT adjacent to the pad loops here: the miner
+    // reaches the queue cell, is still not adjacent to `accepted_cell`, and
+    // is routed back to the queue cell on every enter retry, never taking
+    // the direct step. Trigger: modded art only; stock play never hits it.
+    // Effect: that miner never docks. Fix belongs with the native
+    // pathfinder-driven Mission_Enter drive, not here.
+    if !moving
+        && snap.miner.kind == MinerKind::War
+        && !is_adjacent_or_at((snap.rx, snap.ry), accepted_cell)
+    {
+        if let Some(grid) = path_grid {
+            issue_move_if_idle(
+                sim,
+                rules,
+                grid,
+                snap.entity_id,
+                wait_queue,
+                snap.speed,
+                overlay_registry,
+            );
         }
         schedule_enter_retry(sim, rules, snap);
         return;

--- a/src/sim/miner/miner_system.rs
+++ b/src/sim/miner/miner_system.rs
@@ -23,6 +23,8 @@ use crate::sim::miner::{
     CargoBale, Miner, MinerConfig, MinerKind, MinerState, RefineryDockPhase, ResourceNode,
     ResourceType,
 };
+use crate::sim::mission::authority::EntityReadyInputProvider;
+use crate::sim::mission::{MissionId, MissionType};
 use crate::sim::movement;
 use crate::sim::movement::locomotor::MovementLayer;
 use crate::sim::occupancy::OccupancyGrid;
@@ -751,6 +753,30 @@ pub(super) fn process_miner_with_resource_authority(
         return;
     }
 
+    // `UnitClass::Mission_Harvest @ 0x0073E5E0` preamble (decompiled
+    // 2026-09-05): after the non-harvester (`return 0x1C2`) and slave-host
+    // exits, the handler walks the type's `Dock=` list (`Type+0x3EC`, count
+    // `+0x3F8`) and enters its state switch only for the FIRST dock type with
+    // `HouseClass::CountOwnedInstances > 0`. When no entry has one — the
+    // house lost its last refinery, or the type lists no `Dock=` at all — it
+    // falls out of the loop to `Queue_Mission(Guard, 0); return 1`. The
+    // `IsControlledByHuman` test at the head only decides whether the
+    // `+0x3F8 == 0` case takes the same Guard queue early or reaches it
+    // through the empty loop; both houses end on Guard, so the human test is
+    // inert and not modelled.
+    //
+    // The `Dock` cursor is exempt: past the state-3 hand-off its phases run
+    // under native Mission_Enter / Mission_Deploy (the miner is no longer
+    // dispatched through Mission_Harvest there), and those handlers carry no
+    // dock-ownership preamble — a mind-controlled miner still finishes
+    // unloading into the refinery it entered. VERA dispatches the Dock
+    // cursor from this handler for structural reasons only.
+    if snap.state != MinerState::Dock && !house_owns_dock_instance(sim, rules, snap) {
+        queue_guard_from_harvest(sim, snap);
+        snap.dispatch_delay = DISPATCH_NEXT_FRAME;
+        return;
+    }
+
     let state_before = format!("{:?}", snap.state);
     match snap.state {
         MinerState::SearchOre => handle_search_ore(
@@ -803,9 +829,19 @@ pub(super) fn process_miner_with_resource_authority(
             arm_rate_epilogue(sim, rules, snap);
         }
         MinerState::WaitNoOre => {
-            handle_wait_no_ore(snap, sim.session.binary_frame);
-            // Native idle state falls straight into the default epilogue.
-            arm_rate_epilogue(sim, rules, snap);
+            if handle_going_to_idle(
+                sim,
+                rules,
+                config,
+                path_grid,
+                overlay_registry,
+                snap,
+                resource_authority,
+            ) {
+                // Native state 4 has no `return 1` exit: every dispatch falls
+                // into the default Rate epilogue (`0x0073EF97`).
+                arm_rate_epilogue(sim, rules, snap);
+            }
         }
         MinerState::ForcedReturn => {
             handle_forced_return(sim, rules, config, path_grid, overlay_registry, snap);
@@ -1026,19 +1062,32 @@ fn handle_search_ore(
             }
         }
         ScanOutcome::NoOre => {
-            // Native: no ore, no owner destination, no archive parks the
-            // handler in the idle state and returns the fixed 105-frame wait
-            // directly — bypassing the Rate epilogue, so no RNG draw. The
-            // dispatch delay carries the wait; the internal rescan gate is
-            // armed to the same expiry (the gate fires inclusively at
-            // start + duration), so the two never double-count. What runs when
-            // the wait expires — and how far it is from gamemd's own idle tail
-            // — is documented on `handle_wait_no_ore`.
+            // `0x0073E8EE..0x0073E91C`: no ore, no destination, no archive
+            // writes state 4, `Techno+0x3D0 = 1` and, for a `Harvester=yes`
+            // type, `House+0x242 = 1`, then returns the fixed 105-frame wait
+            // directly — bypassing the Rate epilogue, so no RNG draw. What
+            // runs when the wait expires is `handle_going_to_idle`.
+            //
+            // `+0x3D0` is not carried on the entity: its only in-handler
+            // reader is the state-4 RepairBay probe, whose outcome the same
+            // dispatch overwrites (see `handle_going_to_idle`), and state 4 is
+            // reachable from this arm alone, where the byte is always 1. Its
+            // other readers (`BuildingClass::MissionRepairAndProduce`
+            // `0x0044C4BC`, AI-house only) are outside this lane.
             snap.state = MinerState::WaitNoOre;
+            // `rescan_cooldown` is no longer read by the idle state (native
+            // state 4 has no internal gate); it stays armed for snapshot/hash
+            // continuity of the persisted `Miner` block.
             snap.miner.rescan_cooldown.arm(
                 sim.session.binary_frame,
                 u32::from(config.rescan_cooldown_ticks),
             );
+            if let Some(house) = sim.houses.get_mut(&snap.owner) {
+                // `MOV byte ptr [ECX+0x242], 1` at `0x0073E911`, gated on
+                // `UnitType+0xE0E` (`Harvester=yes`) — true for every kind
+                // dispatched here (slave hosts never reach this handler).
+                house.harvester_no_ore = true;
+            }
             snap.dispatch_delay = i32::from(config.rescan_cooldown_ticks);
         }
     }
@@ -1377,9 +1426,11 @@ fn handle_return(
             ) {
                 return;
             }
-        } else {
-            snap.state = MinerState::WaitNoOre;
         }
+        // No bay from either pass (the house still owns a dock instance, or
+        // the preamble would already have queued Guard): native state 2 sets
+        // no destination and leaves through the Rate epilogue, re-running the
+        // whole selection on the next dispatch. Stay put.
         return;
     };
 
@@ -1435,6 +1486,11 @@ fn handle_return(
         return;
     }
 
+    // Fallback contact test. With the close-return radio now covering every
+    // kind inside its too-far distance and the far paths covering the rest,
+    // this arm is reached only when the distance decision itself is
+    // unavailable (refinery dying / off-grid coordinates); it is kept as the
+    // VERA-internal safety net, gamemd equivalent UNCHECKED.
     let at_dock = (snap.rx, snap.ry) == dock;
     let contact = if snap.miner.kind == MinerKind::Chrono {
         at_dock
@@ -1474,35 +1530,184 @@ fn handle_return(
     }
 }
 
-/// The idle cursor gamemd's Harvest handler parks in when its bounded ore scan
-/// found nothing — gamemd's only entry into this cursor. The scan-miss
-/// return carries the whole 105-frame wait as the dispatch delay, so gamemd's
-/// body has no internal gate of its own; the wait expiring *is* the next
-/// dispatch. VERA's `rescan_cooldown` anchor mirrors that same expiry, so the
-/// gate below never adds a second wait on top of it.
+/// `UnitClass::Mission_Harvest @ 0x0073E5E0` state 4 (GOING-TO-IDLE), the
+/// cursor the scan-miss return parks in — gamemd's only entry into it. The
+/// miss return carries the whole 105-frame wait as the dispatch delay, so the
+/// body has no internal gate; the wait expiring *is* this dispatch. Body
+/// (decompiled 2026-09-05, `0x0073EEA6..0x0073EF71`):
 ///
-/// UNIMPLEMENTED NATIVE TAIL, recorded rather than half-built: gamemd's body
-/// queues the miner off Harvest onto the mission whose handler is the
-/// harvester Guard override, and that override is the half that brings the
-/// miner back — its player arm re-queues Harvest when a refinery the house
-/// owns sits in one of the eight neighbouring cells, which is exactly where a
-/// refinery's own free miner stands. VERA does not model that arm (the
-/// residual is recorded at the Unit Guard dispatch arm in
-/// `sim/world/techno_ai.rs`), so queueing the handoff from here would strand
-/// the miner for the rest of the match instead of cycling it. Until the
-/// override's harvester arm exists, this keeps VERA's own re-search exit:
-/// VERA-internal, gamemd equivalent UNCHECKED. It reproduces the retry cadence
-/// a miner parked beside its refinery shows in gamemd and never loses the
-/// unit; it diverges for a miner parked *away* from any refinery, which gamemd
-/// leaves sitting on Guard while this keeps re-scanning every 105 frames.
+/// 1. `if Techno+0x3D0` (always 1 here, set by the miss return):
+///    `Find_Docking_Bay(Rules+0x850 [General]RepairBay=, 0, 1)` →
+///    `Queue_Mission(Hunt 0xF, 0)` when null else `Queue_Mission(Repair 0x14,
+///    0)`. **Inert, EXCLUDED**: `MissionClass::Queue_Mission @ 0x005B35E0`
+///    only overwrites `QueuedMission` (no Commence — `commence_now` is 0 and
+///    the guard `current == Wait && mission == Guard || current == Selling`
+///    never holds on Harvest), and step 3 below queues Guard over it in the
+///    same dispatch. `Find_Docking_Bay @ 0x004DF040` → `FootClass::
+///    Find_Nearest_Dock_Of_Type @ 0x004DEE80` is a pure scan (no radio, no
+///    reservation; `g_MapEditorMode` untouched on this call), so neither the
+///    probe nor the overwritten queue has an observable effect. Stock
+///    `RepairBay=GADEPT,NADEPT,CAOUTP` exists, but the branch outcome is dead
+///    either way.
+/// 2. `Look_up_building_in_cell(own cell)`: a building whose type has
+///    `+0x16BB` (`Refinery=`) or `+0x16BC` (weeder dock, no stock type) set →
+///    `Set_Destination(FUN_00703590(building))` — `Find_Nearby_Passable_Cell`
+///    seeded at the building's `GetCoords` cell (foundation centre) for the
+///    unit's movement zone. Ownership is not tested.
+/// 3. `Queue_Mission(Guard 5, 0)`; fall into the Rate epilogue.
 ///
-/// The other entries into this cursor (no live refinery, from the return and
-/// forced-return handlers) are VERA-internal as well and share the same exit.
-fn handle_wait_no_ore(snap: &mut MinerSnapshot, now: u32) {
-    if !snap.miner.rescan_cooldown.due(now) {
-        return;
+/// The queued Guard is promoted by the per-object AI host's
+/// Ready-to-Commence step; while the miner is still driving off the refinery
+/// the promotion defers and this state simply re-runs (re-queueing Guard is
+/// idempotent). Once on Guard the Harvest handler is no longer dispatched;
+/// what brings a miner back is `UnitClass::Mission_Guard @ 0x00740810` (the
+/// chrono arms in `techno_ai/mission_handlers.rs`) or a player order
+/// (`Command::HarvestCell` / `MinerReturn`, EventClass MEGAMISSION →
+/// `Queue_Mission(mission, 0)` at `0x004C73B9`). A human war miner therefore
+/// parks on Guard until re-ordered — native behaviour.
+///
+/// Step 2's cell search is VERA-internal in detail (the native range/flag
+/// arguments of `Find_Nearby_Passable_Cell` are not modelled; the same
+/// `find_nearby_passable_cell_with_index` helper the return staging uses
+/// stands in), gamemd equivalent UNCHECKED beyond the seed cell.
+///
+/// **Non-human houses take a VERA-internal bridge instead, gamemd equivalent
+/// = AI lane (`AI_Choose_Unit` 0x004FEB7B / `Mission_Guard` arm ii)
+/// UNCHECKED.** Natively an AI miner parked on Guard is brought back by
+/// `UnitClass::Mission_Guard` arm (ii), which re-queues Harvest only while
+/// `House+0x242` is clear — and the scan miss that led here has just set it,
+/// with no clearing writer. What keeps a native AI economy alive after that
+/// is house/team logic (`AI_Choose_Unit` reading `+0x242`, team recruitment),
+/// none of which VERA runs yet (`sim/ai.rs` never issues `HarvestCell`/
+/// `MinerReturn` and skips harvesters). Until that lane lands, an AI-house
+/// miner does not park: state 4 drops straight back into the state-0 scan,
+/// which on a miss re-arms the same fixed 105-frame wait (the pre-Guard-park
+/// perpetual re-scan cadence, `House+0x242` still written native-true on
+/// every miss). Returns whether the caller must run the Rate epilogue —
+/// false on the bridge, whose exit is the scan's own.
+fn handle_going_to_idle(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    config: &MinerConfig,
+    path_grid: Option<&PathGrid>,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+    snap: &mut MinerSnapshot,
+    resource_authority: ResourceQueryAuthority,
+) -> bool {
+    let human = sim
+        .houses
+        .get(&snap.owner)
+        .is_none_or(|house| house.is_controlled_by_human(sim.session.game_mode_nonzero));
+    if !human {
+        snap.state = MinerState::SearchOre;
+        handle_search_ore(
+            sim,
+            rules,
+            config,
+            path_grid,
+            overlay_registry,
+            snap,
+            resource_authority,
+        );
+        return false;
     }
-    snap.state = MinerState::SearchOre;
+    if let Some(grid) = path_grid
+        && let Some(refinery_sid) = refinery_building_in_cell(sim, rules, (snap.rx, snap.ry))
+        && let Some(exit) = building_nearby_passable_cell(sim, rules, refinery_sid, grid)
+    {
+        issue_move_if_idle(
+            sim,
+            Some(rules),
+            grid,
+            snap.entity_id,
+            exit,
+            snap.speed,
+            overlay_registry,
+        );
+    }
+    queue_guard_from_harvest(sim, snap);
+    true
+}
+
+/// `Queue_Mission(Guard, 0)` from inside the Harvest handler (preamble and
+/// state 4). No Commence: the host's Ready-to-Commence step promotes it.
+fn queue_guard_from_harvest(sim: &mut Simulation, snap: &MinerSnapshot) {
+    let now = sim.session.binary_frame;
+    let _ = sim.mission_queue_exact(
+        snap.entity_id,
+        MissionId::from_known(MissionType::Guard),
+        0,
+        now,
+        &EntityReadyInputProvider,
+    );
+}
+
+/// `HouseClass::CountOwnedInstances > 0` for at least one entry of the
+/// harvester type's `Dock=` list, as the Harvest preamble loop tests it.
+///
+/// Reads the store's O(1) per-(owner, type) count
+/// (`EntityStore::count_owned_of_type`), the analogue of the native per-house
+/// per-type counter array `CountOwnedInstances @ 0x0049FAE0` indexes. Native
+/// counts an instance from Unlimbo until Limbo, so a refinery still under
+/// construction and a dying one both count; the Rust count spans store
+/// insert..remove and so agrees on both (the earlier `!in_limbo && !dying &&
+/// health > 0` scan excluded the dying case — a mismatch, now removed). A
+/// `Dock=` name the interner has never seen has no instances. A miner whose
+/// type is unknown to the rules cannot evaluate the list and reads as "owns
+/// one" (fixture tolerance; no production type lacks a rules entry).
+fn house_owns_dock_instance(sim: &Simulation, rules: &RuleSet, snap: &MinerSnapshot) -> bool {
+    let Some(harvester) = rules.object_case_insensitive(sim.interner.resolve(snap.type_id)) else {
+        return true;
+    };
+    harvester.dock.iter().any(|dock_type| {
+        sim.interner.get(dock_type).is_some_and(|type_ref| {
+            sim.substrate
+                .entities
+                .count_owned_of_type(snap.owner, type_ref)
+                > 0
+        })
+    })
+}
+
+/// `Look_up_building_in_cell` for the state-4 refinery test: the structure
+/// occupying `cell` whose type is `Refinery=yes` (BuildingType `+0x16BB`).
+/// Any owner qualifies, as native tests only the type flag.
+fn refinery_building_in_cell(sim: &Simulation, rules: &RuleSet, cell: (u16, u16)) -> Option<u64> {
+    let occupancy = sim.substrate.occupancy.get(cell.0, cell.1)?;
+    occupancy.blockers(MovementLayer::Ground).find(|&sid| {
+        sim.substrate.entities.get(sid).is_some_and(|entity| {
+            entity.category == EntityCategory::Structure
+                && !entity.dying
+                && sim
+                    .object_type(entity.type_ref, rules)
+                    .is_some_and(|obj| obj.refinery)
+        })
+    })
+}
+
+/// `FUN_00703590`: `Find_Nearby_Passable_Cell` seeded at the building's
+/// `GetCoords` cell (`BuildingClass::GetCoords @ 0x00447AC0` = NW +
+/// `((W-1)*128, (H-1)*128)` leptons, cell = coord >> 8).
+fn building_nearby_passable_cell(
+    sim: &Simulation,
+    rules: &RuleSet,
+    building_sid: u64,
+    grid: &PathGrid,
+) -> Option<(u16, u16)> {
+    let building = sim.substrate.entities.get(building_sid)?;
+    let (w, h) = sim
+        .object_type(building.type_ref, rules)
+        .map(|obj| foundation_dimensions(&obj.foundation))
+        .unwrap_or((1, 1));
+    let (x, y) = building_get_coords_xy(building, w, h);
+    super::miner_dock_sequence::find_nearby_passable_cell_with_index(
+        (x >> 8) as i32,
+        (y >> 8) as i32,
+        grid,
+        Some(&sim.substrate.occupancy),
+        super::miner_dock_sequence::EXIT_SEARCH_MAX_RADIUS,
+        u64::from(sim.session.binary_frame),
+    )
 }
 
 fn handle_forced_return(
@@ -1529,11 +1734,8 @@ fn handle_forced_return(
                 return;
             }
         } else {
-            snap.state = MinerState::WaitNoOre;
-            snap.miner.rescan_cooldown.arm(
-                sim.session.binary_frame,
-                u32::from(config.rescan_cooldown_ticks),
-            );
+            // VERA-internal cursor: keep retrying the selection on the Rate
+            // cadence, the way native state 2 does with no bay.
             return;
         }
     }
@@ -1648,7 +1850,10 @@ fn begin_return(
         }
         snap.state = MinerState::ReturnToRefinery;
     } else {
-        snap.state = MinerState::WaitNoOre;
+        // No bay this dispatch: native state 2 sets nothing and retries on
+        // the next Rate-epilogue dispatch. (A house with no dock instance at
+        // all never gets here — the preamble queues Guard first.)
+        snap.state = MinerState::ReturnToRefinery;
     }
 }
 
@@ -1661,23 +1866,25 @@ fn try_begin_close_return_radio(
     snap: &mut MinerSnapshot,
     ref_sid: u64,
 ) -> bool {
-    // Close-radio HELLO + state=Dock fast-path is currently chrono-only.
-    // HARV close path uses the existing adjacency-based contact check in
-    // `handle_return`. The binary sends HELLO at HarvesterTooFarDistance
-    // (5 cells) for HARV too, but generalizing the close-radio path here
-    // surfaced a phase_mission_enter direct-move limitation that needs a
-    // deeper fix; see 2026-05-24 audit follow-up.
-    if snap.miner.kind != MinerKind::Chrono {
-        return false;
-    }
+    // `UnitClass::Mission_Harvest @ 0x0073E5E0` state 2, the close-return
+    // radio (decompiled 2026-09-05, HARV branch `0x0073EBB1..0x0073EE68`,
+    // CMIN branch `0x0073EDE3..0x0073EE4B`): with no NavCom, the narrow
+    // `Find_Docking_Bay(Dock, 0, 0)` result within the kind's too-far
+    // distance (`HarvesterTooFarDistance` Rules+0xD78 for HARV,
+    // `ChronoHarvTooFarDistance` Rules+0xD7C for a `Teleporter=` type, both
+    // x256 leptons against the 3-D `GetCoords` distance) gets
+    // `Transmit_Radio(HELLO=2, bay)` on THAT dispatch (`0x0073EE51`); a reply
+    // of 1 writes state 3, whose next dispatch is `Queue_Mission(Enter, 0);
+    // return 1`. So a war miner hands off to Mission_Enter up to 5 cells out,
+    // never on adjacency. Both kinds share the shape; only the threshold
+    // differs.
+    let threshold = match snap.miner.kind {
+        MinerKind::Chrono => config.too_far_threshold_chrono,
+        MinerKind::War => config.too_far_threshold_standard,
+        MinerKind::Slave => return false,
+    };
 
-    match return_exceeds_too_far_threshold(
-        sim,
-        rules,
-        snap.entity_id,
-        ref_sid,
-        config.too_far_threshold_chrono,
-    ) {
+    match return_exceeds_too_far_threshold(sim, rules, snap.entity_id, ref_sid, threshold) {
         Some(false) => {}
         Some(true) | None => return false,
     }
@@ -1698,43 +1905,104 @@ fn try_begin_close_return_radio(
         admission == ContactAdmission::Accepted,
     );
 
-    if let Some(entity) = sim.substrate.entities.get_mut(snap.entity_id) {
-        entity.movement_target = None;
-    }
-
-    snap.state = MinerState::Dock;
-    snap.miner.dock_queued = admission != ContactAdmission::Accepted;
     if admission == ContactAdmission::Accepted {
+        if let Some(entity) = sim.substrate.entities.get_mut(snap.entity_id) {
+            entity.movement_target = None;
+        }
+        snap.state = MinerState::Dock;
+        snap.miner.dock_queued = false;
         // G5: the accepted close-return HELLO queues Mission_Enter via the
         // Harvest epilogue; arm the retry so the first CAN_DOCK waits the
         // ~14-16f cadence (and draws the RandomRanged(0,2) the dispatch
         // consumes), instead of an always-due next-tick collapse.
         super::miner_dock_sequence::schedule_enter_retry(sim, rules, snap);
         snap.miner.dock_phase = RefineryDockPhase::MissionEnter;
-    } else {
-        snap.miner.dock_enter_retry.clear();
-        snap.miner.dock_phase = RefineryDockPhase::Approach;
+        return true;
     }
 
-    if admission != ContactAdmission::Accepted {
-        if let Some(staging) = chrono_return_staging_cell_for_sid(sim, rules, ref_sid, path_grid)
-            && !is_adjacent_or_at((snap.rx, snap.ry), staging)
-            && let Some(grid) = path_grid
-        {
-            issue_move_if_idle(
-                sim,
-                Some(rules),
-                grid,
-                snap.entity_id,
-                staging,
-                snap.speed,
-                overlay_registry,
-            );
+    // HELLO refused (`0x0073EE68` falls through): the wide pass
+    // `Find_Docking_Bay(Dock, 0, 1)` under `g_MapEditorMode++`, and when its
+    // bay is farther than 0x300 leptons (`CMP EAX,0x300; JG` @ 0x0073ECD0)
+    // OR the type is a Teleporter, the staging destination = bay NW cell +
+    // `QueueingCell` (`BuildingType+0x1618/+0x161C`) through
+    // `Find_Nearby_Passable_Cell`; otherwise no destination — the state
+    // simply re-runs on the next Rate dispatch.
+    //
+    // **VERA-internal, gamemd equivalent UNCHECKED — staging seed.** Rust
+    // seeds the staging cell from the already-selected narrow-pass `ref_sid`
+    // where native re-runs `Find_Docking_Bay(Dock, 0, 1)` (the WIDE pass,
+    // no free-contact-slot gate) and seeds from THAT bay. The two differ
+    // only when the house owns two refineries of the Dock type within the
+    // 5-cell (`HarvesterTooFarDistance`) close radius and the nearer one's
+    // slot is taken: native stages beside the other refinery, Rust beside
+    // the refused one. Player effect: a miner waiting on the wrong side of a
+    // twin-refinery cluster for one Rate dispatch. Frequency: rare (needs
+    // two own refineries inside 5 cells with the nearer slot busy).
+    // Downstream risk: none beyond the wait position; the next HELLO retry
+    // re-selects.
+    match snap.miner.kind {
+        MinerKind::Chrono => {
+            // Chrono keeps its existing Dock/Approach re-HELLO cadence and
+            // staging drive (adjacency guard is VERA-internal; native sets
+            // the destination unconditionally for a Teleporter).
+            if let Some(entity) = sim.substrate.entities.get_mut(snap.entity_id) {
+                entity.movement_target = None;
+            }
+            snap.state = MinerState::Dock;
+            snap.miner.dock_queued = true;
+            snap.miner.dock_enter_retry.clear();
+            snap.miner.dock_phase = RefineryDockPhase::Approach;
+            if let Some(staging) =
+                chrono_return_staging_cell_for_sid(sim, rules, ref_sid, path_grid)
+                && !is_adjacent_or_at((snap.rx, snap.ry), staging)
+                && let Some(grid) = path_grid
+            {
+                issue_move_if_idle(
+                    sim,
+                    Some(rules),
+                    grid,
+                    snap.entity_id,
+                    staging,
+                    snap.speed,
+                    overlay_registry,
+                );
+            }
         }
+        MinerKind::War => {
+            // Stay in state 2 (ReturnToRefinery) and retry HELLO every Rate
+            // dispatch; beyond 3 cells drive to the staging cell first.
+            snap.state = MinerState::ReturnToRefinery;
+            snap.miner.dock_queued = true;
+            if return_exceeds_too_far_threshold(
+                sim,
+                rules,
+                snap.entity_id,
+                ref_sid,
+                REFUSED_HELLO_STAGING_CELLS,
+            ) == Some(true)
+                && let Some(staging) =
+                    chrono_return_staging_cell_for_sid(sim, rules, ref_sid, path_grid)
+                && let Some(grid) = path_grid
+            {
+                let _ = issue_stock_miner_drive_move_with_overlay_registry(
+                    sim,
+                    rules,
+                    grid,
+                    snap.entity_id,
+                    staging,
+                    overlay_registry,
+                );
+            }
+        }
+        MinerKind::Slave => {}
     }
 
     true
 }
+
+/// `0x0073ECD0`: a non-Teleporter miner whose refused-HELLO wide-pass bay is
+/// within `0x300` leptons (3 cells) gets no staging destination.
+const REFUSED_HELLO_STAGING_CELLS: u16 = 3;
 
 fn try_issue_chrono_far_return_teleport(
     sim: &mut Simulation,
@@ -2824,8 +3092,68 @@ mod harvest_scan_dispatch_tests {
         RuleSet::from_ini(&ini).expect("scan rules")
     }
 
-    /// A War Miner parked at `cell` with the Harvest cursor on the search state.
+    const REFINERY_ID: u64 = 2;
+    /// NW cell of the fixture refinery (4x3 footprint, occupancy marked).
+    const REFINERY_NW: (u16, u16) = (50, 50);
+
+    /// A War Miner parked at `cell` with the Harvest cursor on the search
+    /// state, plus the owned refinery the Harvest preamble requires (a house
+    /// with no `Dock=` instance is queued straight onto Guard) and the
+    /// owning house registered so `House+0x242` has somewhere to land.
     fn spawn_search_miner(sim: &mut Simulation, cell: (u16, u16)) {
+        spawn_search_miner_without_refinery(sim, cell);
+        spawn_owned_refinery(sim, REFINERY_NW);
+        register_house(sim);
+    }
+
+    fn register_house(sim: &mut Simulation) {
+        let owner = sim.interner.intern("Americans");
+        sim.houses.insert(
+            owner,
+            crate::sim::house_state::HouseState::new(owner, 0, None, true, 0, 10),
+        );
+    }
+
+    fn spawn_owned_refinery(sim: &mut Simulation, nw: (u16, u16)) {
+        let owner = sim.interner.intern("Americans");
+        let type_ref = sim.interner.intern("GAREFN");
+        let mut ge = GameEntity::new_at_frame_zero_for_test(
+            REFINERY_ID,
+            nw.0,
+            nw.1,
+            0,
+            0,
+            owner,
+            Health {
+                current: 900,
+                max: 900,
+            },
+            type_ref,
+            EntityCategory::Structure,
+            0,
+            5,
+            false,
+        );
+        ge.lifecycle.in_limbo = false;
+        sim.substrate.entities.insert(ge);
+        for y in nw.1..nw.1 + 3 {
+            for x in nw.0..nw.0 + 4 {
+                sim.substrate.occupancy.add(
+                    x,
+                    y,
+                    REFINERY_ID,
+                    MovementLayer::Ground,
+                    None,
+                    crate::sim::occupancy::CellListInsertion::AppendBuilding,
+                );
+            }
+        }
+        if sim.substrate.next_stable_object_id <= REFINERY_ID {
+            sim.substrate.next_stable_object_id = REFINERY_ID + 1;
+        }
+    }
+
+    fn spawn_search_miner_without_refinery(sim: &mut Simulation, cell: (u16, u16)) {
         let owner = sim.interner.intern("Americans");
         let type_ref = sim.interner.intern("HARV");
         let mut ge = GameEntity::new_at_frame_zero_for_test(
@@ -3013,95 +3341,412 @@ mod harvest_scan_dispatch_tests {
         );
     }
 
-    /// The park must stay recoverable. gamemd's idle tail hands the miner to
-    /// the harvester Guard override, whose player arm puts it straight back on
-    /// Harvest beside its own refinery; VERA has the handoff's destination but
-    /// not that return arm, so a miner queued off Harvest here would never come
-    /// back. A refinery's free miner that misses its first scan is the concrete
-    /// case — a 1400-credit unit lost for the match if this regresses.
+    /// `0x0073E5E0` state 0 miss → state 4 → 105 frames → `Queue_Mission(Guard)`
+    /// (`House+0x242` written on the miss), never a re-scan of its own. Once
+    /// promoted, the Harvest handler is no longer dispatched for the miner.
     #[test]
-    fn the_park_re_searches_after_the_wait_instead_of_retiring_the_miner() {
+    fn scan_miss_waits_105_frames_then_queues_guard_and_latches_the_house() {
         let rules = scan_rules();
         let config = MinerConfig::from_rules(&rules);
         let grid = PathGrid::new(64, 64);
         let mut sim = Simulation::new();
         spawn_search_miner(&mut sim, (10, 10));
+        let owner = sim.interner.intern("Americans");
+        assert!(!sim.houses[&owner].harvester_no_ore);
 
         tick_miners(&mut sim, &rules, &config, Some(&grid));
-        assert_eq!(
-            sim.substrate
-                .entities
-                .get(MINER_ID)
-                .expect("miner")
-                .miner_state(),
-            Some(MinerState::WaitNoOre)
+        {
+            let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+            assert_eq!(entity.miner_state(), Some(MinerState::WaitNoOre));
+            assert_eq!(entity.mission.dispatch_timer().delay(), 105);
+            assert_eq!(entity.mission.queued().known(), None);
+        }
+        assert!(
+            sim.houses[&owner].harvester_no_ore,
+            "`MOV [House+0x242], 1` at 0x0073E911 lands on the scan miss"
         );
 
-        // Ore appears inside the scan radius while the miner is parked.
+        // Ore appears inside the scan radius while the miner waits: gamemd's
+        // state 4 never looks.
         seed_ore(&mut sim, (10, 14));
-
-        // The idle state's own dispatch, one full wait later, runs the exit.
-        sim.session.binary_frame += u32::from(config.rescan_cooldown_ticks);
+        sim.session.binary_frame += 105;
+        let scenario_before = sim.rng_state().scenario;
         tick_miners(&mut sim, &rules, &config, Some(&grid));
 
         let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.mission.queued().known(), Some(MissionType::Guard));
         assert_eq!(
-            entity.mission.queued().known(),
-            None,
-            "nothing may queue the miner off Harvest while the Guard override's \
-             harvester return arm is unmodelled"
-        );
-        assert_ne!(
             entity.miner_state(),
             Some(MinerState::WaitNoOre),
-            "the park must be recoverable, not a terminal state"
+            "state 4 re-runs until Guard commences; no return to the scan"
+        );
+        assert_eq!(entity.miner.as_ref().expect("miner").target_ore_cell, None);
+        assert!(
+            entity.movement_target.is_none(),
+            "not on a refinery cell: no exit drive"
+        );
+        assert_ne!(
+            sim.rng_state().scenario,
+            scenario_before,
+            "state 4 always leaves through the Rate epilogue draw"
+        );
+
+        // The host's Ready-to-Commence step promotes the queued Guard.
+        let now = sim.session.binary_frame;
+        sim.mission_host_promote(MINER_ID, now, &rules);
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.mission.current().known(), Some(MissionType::Guard));
+
+        // On Guard the Harvest dispatch declines the miner: the ore stays
+        // untouched and no destination appears.
+        sim.session.binary_frame += 200;
+        tick_miners(&mut sim, &rules, &config, Some(&grid));
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.mission.current().known(), Some(MissionType::Guard));
+        assert_eq!(entity.miner.as_ref().expect("miner").target_ore_cell, None);
+        assert!(entity.movement_target.is_none());
+        assert!(
+            sim.houses[&owner].harvester_no_ore,
+            "no clearing writer exists for House+0x242"
         );
     }
 
+    /// VERA-internal AI bridge (gamemd equivalent = AI lane, UNCHECKED): a
+    /// non-human house's miner never parks. The state-4 dispatch re-enters
+    /// the state-0 scan, so ore that appeared during the wait is taken, and a
+    /// second miss re-arms the same 105-frame wait with `House+0x242` still
+    /// written native-true.
     #[test]
-    fn idling_for_want_of_a_refinery_keeps_the_re_search_exit() {
+    fn ai_house_miner_keeps_rescanning_after_a_no_ore_miss() {
+        let rules = scan_rules();
+        let config = MinerConfig::from_rules(&rules);
+        let grid = PathGrid::new(64, 64);
+        let mut sim = Simulation::new();
+        spawn_search_miner_without_refinery(&mut sim, (10, 10));
+        spawn_owned_refinery(&mut sim, REFINERY_NW);
+        let owner = sim.interner.intern("Americans");
+        sim.houses.insert(
+            owner,
+            crate::sim::house_state::HouseState::new(owner, 0, None, false, 0, 10),
+        );
+
+        tick_miners(&mut sim, &rules, &config, Some(&grid));
+        {
+            let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+            assert_eq!(entity.miner_state(), Some(MinerState::WaitNoOre));
+            assert_eq!(entity.mission.dispatch_timer().delay(), 105);
+        }
+        assert!(sim.houses[&owner].harvester_no_ore);
+
+        // Second miss: back through the scan, another 105-frame wait, no
+        // Guard queue.
+        sim.session.binary_frame += 105;
+        tick_miners(&mut sim, &rules, &config, Some(&grid));
+        {
+            let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+            assert_eq!(entity.mission.queued().known(), None, "no Guard park");
+            assert_eq!(entity.miner_state(), Some(MinerState::WaitNoOre));
+            assert_eq!(entity.mission.dispatch_timer().delay(), 105);
+        }
+
+        // Ore appears: the next re-scan finds it.
+        seed_ore(&mut sim, (10, 14));
+        sim.session.binary_frame += 105;
+        tick_miners(&mut sim, &rules, &config, Some(&grid));
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.mission.queued().known(), None);
+        assert_eq!(entity.miner_state(), Some(MinerState::MoveToOre));
+        assert_eq!(
+            entity.miner.as_ref().expect("miner").target_ore_cell,
+            Some((10, 14))
+        );
+        assert!(
+            sim.houses[&owner].harvester_no_ore,
+            "the bridge does not invent a clearing writer"
+        );
+    }
+
+    /// Preamble: no owned instance of any `Dock=` type → `Queue_Mission(Guard,
+    /// 0); return 1` before the state switch, ore or no ore.
+    #[test]
+    fn house_without_a_dock_instance_queues_guard_before_scanning() {
+        let rules = scan_rules();
+        let config = MinerConfig::from_rules(&rules);
+        let grid = PathGrid::new(64, 64);
+        let mut sim = Simulation::new();
+        spawn_search_miner_without_refinery(&mut sim, (10, 10));
+        register_house(&mut sim);
+        seed_ore(&mut sim, (10, 14));
+
+        let scenario_before = sim.rng_state().scenario;
+        tick_miners(&mut sim, &rules, &config, Some(&grid));
+
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.mission.queued().known(), Some(MissionType::Guard));
+        assert_eq!(entity.mission.dispatch_timer().delay(), DISPATCH_NEXT_FRAME);
+        assert_eq!(
+            entity.miner.as_ref().expect("miner").target_ore_cell,
+            None,
+            "the switch (and its scan) is never entered"
+        );
+        assert_eq!(
+            sim.rng_state().scenario,
+            scenario_before,
+            "return 1, no draw"
+        );
+        let owner = sim.interner.intern("Americans");
+        assert!(!sim.houses[&owner].harvester_no_ore);
+    }
+
+    /// State 4 on a refinery cell: `Set_Destination(FUN_00703590(building))`
+    /// before the Guard queue — the miner drives off the pad it unloaded on.
+    #[test]
+    fn idle_tail_drives_a_miner_off_the_refinery_cell_before_guard() {
+        let rules = scan_rules();
+        let config = MinerConfig::from_rules(&rules);
+        let grid = PathGrid::new(64, 64);
+        let mut sim = Simulation::new();
+        // Standing on the stock pad cell (NW + (3, 1)) inside the footprint.
+        let pad = (REFINERY_NW.0 + 3, REFINERY_NW.1 + 1);
+        spawn_search_miner(&mut sim, pad);
+
+        tick_miners(&mut sim, &rules, &config, Some(&grid));
+        sim.session.binary_frame += 105;
+        tick_miners(&mut sim, &rules, &config, Some(&grid));
+
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.mission.queued().known(), Some(MissionType::Guard));
+        let goal = entity
+            .movement_target
+            .as_ref()
+            .and_then(|m| m.final_goal.or_else(|| m.path.last().copied()))
+            .expect("exit destination set from the refinery cell");
+        let inside = (REFINERY_NW.0..REFINERY_NW.0 + 4).contains(&goal.0)
+            && (REFINERY_NW.1..REFINERY_NW.1 + 3).contains(&goal.1);
+        assert!(
+            !inside,
+            "exit cell {goal:?} must be a passable cell outside the footprint"
+        );
+    }
+
+    /// The production re-order path: a war miner parked on Guard goes back to
+    /// work only through a player order. `Command::HarvestCell` (the right
+    /// click on ore) is the MEGAMISSION Harvest assignment
+    /// (`Queue_Mission(mission, 0)` @ 0x004C73B9 natively; VERA assigns
+    /// Harvest + the MoveToOre cursor), after which the Harvest dispatch gate
+    /// re-engages.
+    #[test]
+    fn player_harvest_order_returns_a_parked_war_miner_to_work() {
         let rules = scan_rules();
         let config = MinerConfig::from_rules(&rules);
         let grid = PathGrid::new(64, 64);
         let mut sim = Simulation::new();
         spawn_search_miner(&mut sim, (10, 10));
-        // Full cargo with no refinery on the map drives the return handler into
-        // the idle cursor. That entry is VERA-internal with no gamemd
-        // counterpart, and it shares the scan-miss park's re-search exit.
-        {
-            let entity = sim.substrate.entities.get_mut(MINER_ID).expect("miner");
-            entity
-                .mission
-                .set_handler_state(MinerState::ReturnToRefinery.cursor());
-            let miner = entity.miner.as_mut().expect("miner");
-            let capacity = miner.capacity_bales;
-            miner.cargo = (0..capacity)
-                .map(|_| CargoBale {
-                    resource_type: ResourceType::Ore,
-                    value: 25,
-                })
-                .collect();
-        }
 
         tick_miners(&mut sim, &rules, &config, Some(&grid));
+        sim.session.binary_frame += 105;
+        tick_miners(&mut sim, &rules, &config, Some(&grid));
+        let now = sim.session.binary_frame;
+        sim.mission_host_promote(MINER_ID, now, &rules);
         assert_eq!(
             sim.substrate
                 .entities
                 .get(MINER_ID)
                 .expect("miner")
-                .miner_state(),
-            Some(MinerState::WaitNoOre)
+                .mission
+                .current()
+                .known(),
+            Some(MissionType::Guard)
         );
 
-        sim.session.binary_frame += u32::from(config.rescan_cooldown_ticks);
+        seed_ore(&mut sim, (10, 14));
+        let applied = sim.apply_command(
+            "Americans",
+            &crate::sim::command::Command::HarvestCell {
+                entity_id: MINER_ID,
+                target_rx: 10,
+                target_ry: 14,
+            },
+            Some(&rules),
+            Some(&grid),
+            &std::collections::BTreeMap::new(),
+        );
+        assert!(applied);
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.mission.current().known(), Some(MissionType::Harvest));
+        assert_eq!(entity.miner_state(), Some(MinerState::MoveToOre));
+
+        // The Harvest handler dispatches again and drives to the ordered cell.
+        sim.session.binary_frame += 1;
+        tick_miners(&mut sim, &rules, &config, Some(&grid));
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.mission.current().known(), Some(MissionType::Harvest));
+        assert_eq!(
+            entity
+                .movement_target
+                .as_ref()
+                .and_then(|m| m.final_goal.or_else(|| m.path.last().copied())),
+            Some((10, 14)),
+            "the dispatch gate re-engaged and the MoveToOre cursor drove to the order"
+        );
+    }
+
+    /// A full War Miner at `cell` with the finding-home cursor, its refinery at
+    /// (10, 10): the fixture for the state-2 return contact.
+    fn spawn_returning_war_miner(sim: &mut Simulation, cell: (u16, u16)) {
+        spawn_search_miner_without_refinery(sim, cell);
+        spawn_owned_refinery(sim, (10, 10));
+        register_house(sim);
+        let entity = sim.substrate.entities.get_mut(MINER_ID).expect("miner");
+        entity
+            .mission
+            .set_handler_state(MinerState::ReturnToRefinery.cursor());
+        let miner = entity.miner.as_mut().expect("miner");
+        let capacity = miner.capacity_bales;
+        miner.cargo = (0..capacity)
+            .map(|_| CargoBale {
+                resource_type: ResourceType::Ore,
+                value: 25,
+            })
+            .collect();
+    }
+
+    /// State 2, HARV: the narrow bay within `HarvesterTooFarDistance` gets
+    /// HELLO on the same dispatch (`0x0073EE51`) and the accepted reply hands
+    /// off to the Enter sequence 4.5 cells out — before any adjacency.
+    #[test]
+    fn war_miner_hello_at_four_cells_hands_off_to_enter_before_adjacency() {
+        let rules = scan_rules();
+        let config = MinerConfig::from_rules(&rules);
+        let grid = PathGrid::new(64, 64);
+        let mut sim = Simulation::new();
+        // Refinery centre = (3072, 2944) leptons; cell (16, 11) is 1152
+        // leptons (4.5 cells) east of it.
+        spawn_returning_war_miner(&mut sim, (16, 11));
+
         tick_miners(&mut sim, &rules, &config, Some(&grid));
 
         let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
-        assert_eq!(
-            entity.mission.queued().known(),
-            None,
-            "the VERA-internal no-refinery park queues no mission either"
+        let miner = entity.miner.as_ref().expect("miner");
+        assert_eq!(miner.reserved_refinery, Some(REFINERY_ID));
+        assert_eq!(entity.miner_state(), Some(MinerState::Dock));
+        assert_eq!(miner.dock_phase, RefineryDockPhase::MissionEnter);
+        assert!(!miner.dock_queued);
+        assert!(
+            sim.production
+                .dock_reservations
+                .has_contact(REFINERY_ID, MINER_ID),
+            "HELLO accepted on the same dispatch"
         );
-        assert_eq!(entity.miner_state(), Some(MinerState::SearchOre));
+        assert_eq!((entity.position.rx, entity.position.ry), (16, 11));
+        assert!(
+            !is_adjacent_or_at(
+                (16, 11),
+                refinery_dock_for_sid(&sim, &rules, REFINERY_ID).unwrap()
+            ),
+            "the hand-off happened without adjacency to the CAN_DOCK cell"
+        );
+    }
+
+    const BLOCKER_ID: u64 = 99;
+
+    /// A live non-miner vehicle that can hold the refinery's contact slot
+    /// (the dead-reservation sweep keeps contacts only for live objects).
+    fn spawn_slot_holder(sim: &mut Simulation) {
+        let owner = sim.interner.intern("Americans");
+        let type_ref = sim.interner.intern("MTNK");
+        let mut ge = GameEntity::new_at_frame_zero_for_test(
+            BLOCKER_ID,
+            30,
+            30,
+            0,
+            0,
+            owner,
+            Health {
+                current: 300,
+                max: 300,
+            },
+            type_ref,
+            EntityCategory::Unit,
+            0,
+            5,
+            true,
+        );
+        ge.lifecycle.in_limbo = false;
+        sim.substrate.entities.insert(ge);
+        assert!(
+            sim.production
+                .dock_reservations
+                .try_reserve(REFINERY_ID, BLOCKER_ID)
+        );
+    }
+
+    /// Refused HELLO, HARV farther than 0x300 leptons from the bay: drive to
+    /// the `QueueingCell` staging cell and stay in state 2 (retry every Rate
+    /// dispatch).
+    #[test]
+    fn refused_hello_beyond_three_cells_stages_the_war_miner_and_keeps_state_two() {
+        let rules = scan_rules();
+        let config = MinerConfig::from_rules(&rules);
+        let grid = PathGrid::new(64, 64);
+        let mut sim = Simulation::new();
+        spawn_returning_war_miner(&mut sim, (16, 11));
+        // Another object holds the refinery's single contact slot.
+        spawn_slot_holder(&mut sim);
+
+        tick_miners(&mut sim, &rules, &config, Some(&grid));
+
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        let miner = entity.miner.as_ref().expect("miner");
+        assert_eq!(entity.miner_state(), Some(MinerState::ReturnToRefinery));
+        assert!(miner.dock_queued);
+        assert!(
+            !sim.production
+                .dock_reservations
+                .has_contact(REFINERY_ID, MINER_ID)
+        );
+        let goal = entity
+            .movement_target
+            .as_ref()
+            .and_then(|m| m.final_goal.or_else(|| m.path.last().copied()))
+            .expect("4.5 cells out: Set_Destination(staging)");
+        let staging = chrono_return_staging_cell_for_sid(&sim, &rules, REFINERY_ID, Some(&grid))
+            .expect("staging cell");
+        assert_eq!(goal, staging);
+    }
+
+    /// Refused HELLO, HARV within 0x300 leptons: no destination at all; the
+    /// state re-runs (and re-HELLOs) on the next Rate dispatch.
+    #[test]
+    fn refused_hello_within_three_cells_sets_no_destination() {
+        let rules = scan_rules();
+        let config = MinerConfig::from_rules(&rules);
+        let grid = PathGrid::new(64, 64);
+        let mut sim = Simulation::new();
+        // Cell (14, 11): 640 leptons (2.5 cells) east of the centre.
+        spawn_returning_war_miner(&mut sim, (14, 11));
+        spawn_slot_holder(&mut sim);
+
+        tick_miners(&mut sim, &rules, &config, Some(&grid));
+
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.miner_state(), Some(MinerState::ReturnToRefinery));
+        assert!(
+            entity.movement_target.is_none(),
+            "`CMP EAX,0x300; JG` not taken"
+        );
+
+        // Slot frees: the next dispatch's HELLO is accepted and hands off.
+        sim.production
+            .dock_reservations
+            .cancel_miner(REFINERY_ID, BLOCKER_ID);
+        sim.session.binary_frame += 20;
+        tick_miners(&mut sim, &rules, &config, Some(&grid));
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.miner_state(), Some(MinerState::Dock));
+        assert_eq!(
+            entity.miner.as_ref().expect("miner").dock_phase,
+            RefineryDockPhase::MissionEnter
+        );
     }
 }

--- a/src/sim/miner/miner_tests.rs
+++ b/src/sim/miner/miner_tests.rs
@@ -212,6 +212,41 @@ fn spawn_structure_owned(
     }
 }
 
+/// An owned `Dock=` instance far from the action, with no occupancy and no
+/// LogicVector slot: the Harvest preamble (`0x0073E5E0`) queues Guard for a
+/// house that owns no instance of any `Dock=` type, so fixtures that only
+/// exercise the scan/harvest states still need one on the books.
+fn spawn_inert_dock_instance(sim: &mut Simulation) {
+    const INERT_DOCK_ID: u64 = 900;
+    if sim.substrate.entities.get(INERT_DOCK_ID).is_some() {
+        return;
+    }
+    let owner_id = sim.interner.intern("Americans");
+    let type_id = sim.interner.intern("GAREFN");
+    let mut ge = GameEntity::new_at_frame_zero_for_test(
+        INERT_DOCK_ID,
+        60,
+        60,
+        0,
+        0,
+        owner_id,
+        Health {
+            current: 900,
+            max: 900,
+        },
+        type_id,
+        EntityCategory::Structure,
+        0,
+        5,
+        false,
+    );
+    ge.lifecycle.in_limbo = false;
+    sim.substrate.entities.insert(ge);
+    if sim.substrate.next_stable_object_id <= INERT_DOCK_ID {
+        sim.substrate.next_stable_object_id = INERT_DOCK_ID + 1;
+    }
+}
+
 fn occupy_structure_cells(
     sim: &mut Simulation,
     sid: u64,
@@ -633,7 +668,7 @@ fn war_miner_does_not_teleport() {
 // Test 7: Dock queuing — only one miner at a refinery at a time
 // ==========================================================================
 #[test]
-fn return_close_enough_to_refinery_enters_dock() {
+fn return_within_too_far_distance_hands_off_to_enter_on_the_same_dispatch() {
     let mut sim = Simulation::new();
     let rules = miner_rules();
     let config = MinerConfig::default();
@@ -666,10 +701,14 @@ fn return_close_enough_to_refinery_enters_dock() {
     let grid = PathGrid::new(276, 276);
     super::miner_system::tick_miners(&mut sim, &rules, &config, Some(&grid));
 
+    // Inside `HarvesterTooFarDistance`, state 2 sends HELLO on this same
+    // dispatch (`0x0073EE51`) and the accepted reply is the Enter hand-off —
+    // no approach phase, no adjacency requirement.
     let entity = sim.substrate.entities.get(miner_id).expect("miner entity");
     let miner = entity.miner.as_ref().expect("miner component");
     assert_eq!(entity.miner_state().unwrap(), MinerState::Dock);
-    assert_eq!(miner.dock_phase, RefineryDockPhase::Approach);
+    assert_eq!(miner.dock_phase, RefineryDockPhase::MissionEnter);
+    assert!(sim.production.dock_reservations.has_contact(99, miner_id));
 }
 
 #[test]
@@ -2432,16 +2471,16 @@ fn search_ore_becomes_wait_when_empty() {
 }
 
 // ==========================================================================
-// Test 14: the no-ore park sits out the whole wait, then re-searches
+// Test 14: the no-ore park sits out the whole wait, then queues Guard
 // ==========================================================================
-/// The park must stay recoverable. gamemd's scan-miss return carries the whole
-/// 105-frame wait as the dispatch delay itself, so the frame the wait expires
-/// *is* the next dispatch and that dispatch is the exit. VERA keeps a re-search
-/// exit there rather than gamemd's queue-off-Harvest handoff (VERA-internal, see
-/// `miner_system::handle_wait_no_ore`), so what this pins is: no early rescan
-/// while the gate is closed, and a live miner on the far side of it.
+/// gamemd's scan-miss return carries the whole 105-frame wait as the dispatch
+/// delay itself, so the frame the wait expires *is* the next dispatch, and
+/// that dispatch is `Mission_Harvest` state 4 (`miner_system::
+/// handle_going_to_idle`): `Queue_Mission(Guard, 0)` plus the Rate epilogue,
+/// with no re-scan. What this pins is: nothing happens early, and the exit is
+/// the Guard queue on the exact expiry frame.
 #[test]
-fn wait_no_ore_rescans_after_cooldown() {
+fn wait_no_ore_queues_guard_when_the_wait_expires() {
     let mut sim = Simulation::new();
     let rules = miner_rules();
     let config = MinerConfig::default();
@@ -2499,39 +2538,39 @@ fn wait_no_ore_rescans_after_cooldown() {
         "the 105-frame wait is not shortened by ore appearing during it"
     );
 
-    // The expiry frame is the next dispatch, and that dispatch is the exit.
+    // The expiry frame is the next dispatch, and that dispatch is gamemd's
+    // state 4: `Queue_Mission(Guard, 0)` and the Rate epilogue — never a
+    // re-scan, whatever grew during the wait.
     tick_miners_n(&mut sim, &rules, 1);
     assert_eq!(sim.session.binary_frame, start_frame + wait);
+    let entity = sim.substrate.entities.get(miner_id).expect("miner");
     assert_eq!(
-        get_miner(&sim, miner_id).state,
-        MinerState::SearchOre,
-        "the park exits on the frame the wait expires, not a cadence later"
+        entity.mission.queued().known(),
+        Some(crate::sim::mission::MissionType::Guard),
+        "the wait expiring is the Guard hand-off, on that exact frame"
+    );
+    assert_eq!(entity.miner_state(), Some(MinerState::WaitNoOre));
+    assert_eq!(
+        entity.miner.as_ref().expect("miner").target_ore_cell,
+        None,
+        "state 4 does not look at the ore that appeared during the wait",
     );
 
-    // The exit itself takes the default Rate epilogue, so the re-search runs on
-    // the following Harvest dispatch — one whole epilogue window later at most.
+    // Until the host promotes the queue, every further dispatch re-runs
+    // state 4 on the Rate cadence — still no scan.
     let base = super::miner_dock_sequence::mission_base_frames(
         &rules,
         crate::sim::mission::MissionType::Harvest,
         super::miner_system::HARVEST_RATE_FALLBACK_FRAMES,
     );
-    // + the RandomRanged(0, 2) ceiling the epilogue adds on top of the base.
     tick_miners_n(
         &mut sim,
         &rules,
         usize::from(base) + super::miner_system::RATE_EPILOGUE_JITTER_MAX_FRAMES as usize,
     );
     let m = get_miner(&sim, miner_id);
-    assert_ne!(
-        m.state,
-        MinerState::WaitNoOre,
-        "the park must be recoverable, not a terminal state",
-    );
-    assert_eq!(
-        m.target_ore_cell,
-        Some((20, 20)),
-        "the re-search must pick the ore that appeared during the wait",
-    );
+    assert_eq!(m.state, MinerState::WaitNoOre);
+    assert_eq!(m.target_ore_cell, None);
 }
 
 // ==========================================================================
@@ -2608,7 +2647,7 @@ fn harvester_uses_dock_list_for_refinery_selection() {
 }
 
 #[test]
-fn harvester_waits_when_no_dock_compatible_refinery_exists() {
+fn harvester_queues_guard_when_no_dock_compatible_refinery_exists() {
     let mut sim = Simulation::new();
     let rules = dock_rules();
     let miner_id = sim
@@ -2634,9 +2673,21 @@ fn harvester_waits_when_no_dock_compatible_refinery_exists() {
 
     tick_miners_n(&mut sim, &rules, 1);
 
+    // No owned instance of any `Dock=` type: the Harvest preamble queues
+    // Guard before the state switch, so selection never runs.
     let miner = get_miner(&sim, miner_id);
     assert_eq!(miner.reserved_refinery, None);
-    assert_eq!(miner.state, MinerState::WaitNoOre);
+    assert_eq!(miner.state, MinerState::ReturnToRefinery);
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(miner_id)
+            .expect("miner")
+            .mission
+            .queued()
+            .known(),
+        Some(crate::sim::mission::MissionType::Guard)
+    );
 }
 
 // ==========================================================================
@@ -3222,6 +3273,8 @@ fn unreachable_ore_filtered_out() {
     use std::collections::BTreeMap;
 
     let mut sim = Simulation::new();
+
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
 
     // Build a 16x16 path grid with an impassable wall column at x=8 that
@@ -3275,6 +3328,8 @@ fn reachable_ore_picked_over_closer_unreachable() {
     use std::collections::BTreeMap;
 
     let mut sim = Simulation::new();
+
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
 
     // 16x16 grid with an impassable wall column at x=8.
@@ -3328,6 +3383,8 @@ fn harvester_on_tiberium_falls_back_to_neighbor_zone() {
     use std::collections::BTreeMap;
 
     let mut sim = Simulation::new();
+
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
 
     // 16x16 grid. Wall column at x=8 splits LEFT and RIGHT zones.
@@ -5276,10 +5333,22 @@ fn full_dock_cycle_war_miner() {
     );
 
     let entity = sim.substrate.entities.get(miner_id).expect("entity");
+    // The Mission_Deploy state-4 hand-off itself installs no exit move, but
+    // with no ore on the map the following scan misses and, 105 frames
+    // later, Mission_Harvest state 4 finds the miner on a refinery cell and
+    // sets `FUN_00703590`'s nearby passable cell as its destination before
+    // queueing Guard — so by now the miner has stepped off the pad.
+    let inside_footprint =
+        (10..14).contains(&entity.position.rx) && (10..13).contains(&entity.position.ry);
+    assert!(
+        !inside_footprint,
+        "the Harvest idle tail moved the miner off the refinery footprint, got {:?}",
+        (entity.position.rx, entity.position.ry)
+    );
     assert_eq!(
-        (entity.position.rx, entity.position.ry),
-        (13, 11),
-        "stock state-4 handoff should not force a queue-cell exit move"
+        entity.mission.queued().known(),
+        Some(crate::sim::mission::MissionType::Guard),
+        "state 4 queued Guard behind the exit move"
     );
     assert!(entity.forced_drive_track.is_none());
 
@@ -5545,6 +5614,7 @@ fn tick_miners_overlay_n(
 #[test]
 fn harvester_takes_one_bale_per_gate_over_eleven_gates() {
     let mut sim = Simulation::new();
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
     let config = MinerConfig::default();
     let gate = usize::from(config.harvest_tick_interval) + 1;
@@ -5655,6 +5725,8 @@ fn harvester_clears_density_zero_overlay_without_bale_and_moves_on() {
     let next = (21u16, 20u16);
 
     let mut sim = Simulation::new();
+
+    spawn_inert_dock_instance(&mut sim);
     sim.overlay_grid = Some(OverlayGrid::new(64, 64));
     {
         let overlay = sim.overlay_grid.as_mut().expect("overlay grid");
@@ -5757,6 +5829,7 @@ fn harvester_clears_density_zero_overlay_without_bale_and_moves_on() {
 #[test]
 fn harvester_caps_extraction_at_remaining_capacity() {
     let mut sim = Simulation::new();
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
     let config = MinerConfig::default();
 
@@ -6120,6 +6193,7 @@ fn chrono_filling_extraction_does_not_warp_before_state2_tick() {
 #[test]
 fn harvester_continues_to_short_scan_when_partial_then_empty() {
     let mut sim = Simulation::new();
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
     let config = MinerConfig::default();
 
@@ -7095,6 +7169,8 @@ fn scan_skips_tree_blocked_ore_cell() {
     use std::collections::BTreeMap;
 
     let mut sim = Simulation::new();
+
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
 
     // 32×32 all-passable grid except for one tree on the would-be best ore
@@ -7148,6 +7224,8 @@ fn scan_skips_cell_occupied_by_other_miner() {
     use std::collections::BTreeMap;
 
     let mut sim = Simulation::new();
+
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
 
     let grid = PathGrid::new(32, 32);
@@ -7209,6 +7287,8 @@ fn scan_ring_0_allows_harvesters_own_cell() {
     use std::collections::BTreeMap;
 
     let mut sim = Simulation::new();
+
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
 
     let grid = PathGrid::new(32, 32);
@@ -7316,6 +7396,8 @@ fn move_to_ore_avoids_tree_blocked_cell_from_start() {
     use std::collections::BTreeMap;
 
     let mut sim = Simulation::new();
+
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
 
     let mut grid = PathGrid::new(32, 32);
@@ -7372,6 +7454,8 @@ fn move_to_ore_holds_target_while_destination_is_held() {
     use std::collections::BTreeMap;
 
     let mut sim = Simulation::new();
+
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
 
     let mut grid = PathGrid::new(32, 32);
@@ -7506,6 +7590,8 @@ fn move_to_ore_rescans_and_rejects_blocked_cell_once_destination_clears() {
     use std::collections::BTreeMap;
 
     let mut sim = Simulation::new();
+
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
 
     let mut grid = PathGrid::new(32, 32);
@@ -7592,6 +7678,8 @@ fn move_to_ore_target_stable_when_world_unchanged() {
     const POISON_TARGET: (u16, u16) = (16, 12);
 
     let mut sim = Simulation::new();
+
+    spawn_inert_dock_instance(&mut sim);
     let rules = miner_rules();
 
     let grid = PathGrid::new(32, 32);
@@ -8323,6 +8411,7 @@ fn coordinate_runtime_trace_miner_arrival_and_extraction_four_directions() {
 
     for (label, start, behind) in approaches {
         let mut sim = Simulation::new();
+        spawn_inert_dock_instance(&mut sim);
         let rules = miner_rules();
         place_ore(&mut sim, target.0, target.1, 120);
         place_ore(&mut sim, behind.0, behind.1, 120);
@@ -8697,7 +8786,7 @@ fn refinery_selection_ignores_nearer_allied_refinery() {
 /// With only another house's refinery on the map the scan finds nothing:
 /// the miner does not convoy to (and pay) the other house.
 #[test]
-fn refinery_selection_with_only_foreign_refinery_finds_nothing() {
+fn refinery_selection_with_only_foreign_refinery_queues_guard() {
     let mut sim = Simulation::new();
     let rules = miner_rules();
     let miner_id = spawn_miner(&mut sim, 1, MinerKind::War, 5, 10);
@@ -8706,9 +8795,21 @@ fn refinery_selection_with_only_foreign_refinery_finds_nothing() {
 
     tick_miners_n(&mut sim, &rules, 1);
 
+    // The other house's refinery is not an owned dock instance either: the
+    // preamble queues Guard and selection never runs.
     let m = get_miner(&sim, miner_id);
     assert_eq!(m.reserved_refinery, None);
-    assert_eq!(m.state, MinerState::WaitNoOre);
+    assert_eq!(m.state, MinerState::ReturnToRefinery);
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(miner_id)
+            .expect("miner")
+            .mission
+            .queued()
+            .known(),
+        Some(crate::sim::mission::MissionType::Guard)
+    );
 }
 
 /// Narrow pass inside HarvesterTooFarDistance (5 cells): the nearer refinery

--- a/src/sim/miner/mod.rs
+++ b/src/sim/miner/mod.rs
@@ -260,7 +260,9 @@ pub struct MinerConfig {
     /// Too-far threshold for Chrono Miners (much larger because they teleport back)
     /// (ChronoHarvTooFarDistance).
     pub too_far_threshold_chrono: u16,
-    /// Ticks to wait before re-scanning in WaitNoOre state.
+    /// The fixed handler return of the state-0 scan miss (`return 0x69` at
+    /// `0x0073E91C`): frames until the GOING-TO-IDLE state (`WaitNoOre`)
+    /// dispatches and queues Guard. Not an INI value.
     pub rescan_cooldown_ticks: u8,
 }
 

--- a/src/sim/miner/outbound_drive_tests.rs
+++ b/src/sim/miner/outbound_drive_tests.rs
@@ -318,6 +318,37 @@ fn spawn_stock_miner(
     id
 }
 
+/// An owned `Dock=` instance with no cell mark and no LogicVector slot: the
+/// Harvest preamble (`0x0073E5E0`) queues Guard for a house that owns no
+/// instance of any `Dock=` type, and these outbound fixtures never return.
+fn spawn_inert_dock_instance(sim: &mut Simulation) {
+    const INERT_DOCK_ID: u64 = 900;
+    let owner_id = sim.interner.intern("Americans");
+    let type_id = sim.interner.intern("GAREFN");
+    let mut ge = crate::sim::game_entity::GameEntity::new_at_frame_zero_for_test(
+        INERT_DOCK_ID,
+        1,
+        1,
+        0,
+        0,
+        owner_id,
+        crate::sim::components::Health {
+            current: 900,
+            max: 900,
+        },
+        type_id,
+        crate::map::entities::EntityCategory::Structure,
+        0,
+        5,
+        false,
+    );
+    ge.lifecycle.in_limbo = false;
+    sim.substrate.entities.insert(ge);
+    if sim.substrate.next_stable_object_id <= INERT_DOCK_ID {
+        sim.substrate.next_stable_object_id = INERT_DOCK_ID + 1;
+    }
+}
+
 fn spawn_stock_refinery(
     sim: &mut Simulation,
     oracle: &OutboundContractOracle,
@@ -524,6 +555,7 @@ fn production_stock_miners_use_drive_command_for_adjacent_ore() {
         let grid = PathGrid::new(GRID_SIZE, GRID_SIZE);
         install_world(&mut sim, &oracle, &grid, &[target], &[target], true);
         let entity_id = spawn_stock_miner(&mut sim, &oracle, type_id, kind);
+        spawn_inert_dock_instance(&mut sim);
         let start_position = position_tuple(&sim, entity_id);
         arm_search(&mut sim, entity_id);
         let rng_before_search = sim.rng_state();
@@ -670,6 +702,7 @@ fn production_harv_outbound_drive_uses_rule_profile() {
     let grid = PathGrid::new(GRID_SIZE, GRID_SIZE);
     install_world(&mut sim, &oracle, &grid, &[target], &[target], true);
     let entity_id = spawn_stock_miner(&mut sim, &oracle, "HARV", MinerKind::War);
+    spawn_inert_dock_instance(&mut sim);
     arm_search(&mut sim, entity_id);
     let rng_before = sim.rng_state();
     // Scan, Set_Destination and the Rate epilogue are one dispatch: one draw.
@@ -1100,6 +1133,7 @@ fn production_cmin_outbound_drive_keeps_teleport_primary() {
     let grid = PathGrid::new(GRID_SIZE, GRID_SIZE);
     install_world(&mut sim, &oracle, &grid, &[target], &[target], true);
     let entity_id = spawn_stock_miner(&mut sim, &oracle, "CMIN", MinerKind::Chrono);
+    spawn_inert_dock_instance(&mut sim);
     arm_search(&mut sim, entity_id);
     let rng_before = sim.rng_state();
 
@@ -1184,6 +1218,7 @@ fn production_cmin_failed_outbound_issue_restores_locomotor_exactly() {
     grid.set_blocked(target.0, target.1, false);
     install_world(&mut sim, &oracle, &grid, &[target], &[target], false);
     let entity_id = spawn_stock_miner(&mut sim, &oracle, "CMIN", MinerKind::Chrono);
+    spawn_inert_dock_instance(&mut sim);
     arm_search(&mut sim, entity_id);
     let rng_before = sim.rng_state();
     let scenario_after_scan = scenario_after_one_epilogue_draw(&mut sim);
@@ -1242,6 +1277,7 @@ fn production_harv_navcom_without_movement_target_is_not_reissued() {
     // cell is staged mid-test below so it can tempt a scan that must not run.
     install_world(&mut sim, &oracle, &grid, &[original], &[original], true);
     let entity_id = spawn_stock_miner(&mut sim, &oracle, "HARV", MinerKind::War);
+    spawn_inert_dock_instance(&mut sim);
     arm_search(&mut sim, entity_id);
 
     // One dispatch acquires `original` and takes NavCom ownership.
@@ -1310,6 +1346,7 @@ fn production_harv_navcom_defers_removed_target_revalidation() {
     // place mid-test below, after the NavCom is already owned.
     install_world(&mut sim, &oracle, &grid, &[original], &[original], true);
     let entity_id = spawn_stock_miner(&mut sim, &oracle, "HARV", MinerKind::War);
+    spawn_inert_dock_instance(&mut sim);
     arm_search(&mut sim, entity_id);
 
     // One dispatch acquires `original` and takes NavCom ownership.
@@ -1373,6 +1410,7 @@ fn production_cmin_arrival_clears_navcom_same_tick_and_releases_drive() {
     let grid = PathGrid::new(GRID_SIZE, GRID_SIZE);
     install_world(&mut sim, &oracle, &grid, &[target], &[target], true);
     let entity_id = spawn_stock_miner(&mut sim, &oracle, "CMIN", MinerKind::Chrono);
+    spawn_inert_dock_instance(&mut sim);
     arm_search(&mut sim, entity_id);
 
     // The scan dispatch installs the outbound command.

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -410,7 +410,11 @@ use crate::sim::world::Simulation;
 // `TiberiumSpreads`) on the session and the growth-driver reload selector on
 // `OreGrowthConfig`. A v130 skirmish save would restore them clear and reload the
 // growth timer at the raw `Growth=` instead of `ftol(Growth * 0.3)`.
-const SNAPSHOT_VERSION: u32 = 131;
+// v132 persists the `HouseClass+0x242` harvester no-ore latch on `HouseState`
+// (set by `UnitClass::Mission_Harvest` state 0, never cleared). A v131 save
+// would restore it clear for a house whose harvester had already exhausted
+// its scan, and the state hash folds it.
+const SNAPSHOT_VERSION: u32 = 132;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -3173,9 +3177,10 @@ mod tests {
     /// reserved by the concurrent parasite and audio-lane changes.
     /// 130 -> 131 persists the session `TiberiumGrows`/`TiberiumSpreads`
     /// flag bits and the `OreGrowthConfig` growth-reload selector.
+    /// 131 -> 132 persists the `HouseClass+0x242` harvester no-ore latch.
     #[test]
-    fn tiberium_flag_bits_snapshot_version_is_131() {
-        assert_eq!(super::SNAPSHOT_VERSION, 131);
+    fn house_harvester_no_ore_snapshot_version_is_132() {
+        assert_eq!(super::SNAPSHOT_VERSION, 132);
     }
 
     #[test]
@@ -4536,6 +4541,30 @@ mod tests {
         assert_eq!(restored_due, original_due);
         assert_eq!(restored.session.lighting, original.session.lighting);
         assert_eq!(restored.state_hash(), original.state_hash());
+    }
+
+    /// `HouseClass+0x242` rides the raw House block in the native save; a
+    /// v132 snapshot carries it and the restored hash still matches.
+    #[test]
+    fn house_harvester_no_ore_latch_roundtrips_at_v132() {
+        let mut sim = Simulation::with_seed(0x242);
+        let owner = sim.interner.intern("Americans");
+        let mut house = crate::sim::house_state::HouseState::new(owner, 0, None, true, 5_000, 10);
+        house.harvester_no_ore = true;
+        sim.houses.insert(owner, house);
+        sim.scenario_rng = crate::sim::rng::SimRng::new(0);
+        let expected_hash = sim.state_hash();
+
+        let bytes = GameSnapshot::save(&sim, 0, 0, "house_no_ore_latch", 0);
+        assert_eq!(
+            GameSnapshot::read_header(&bytes).unwrap().version,
+            super::SNAPSHOT_VERSION
+        );
+        let restored = GameSnapshot::load(&bytes)
+            .expect("v132 house latch snapshot")
+            .sim;
+        assert!(restored.houses[&owner].harvester_no_ore);
+        assert_eq!(restored.state_hash(), expected_hash);
     }
 
     #[test]

--- a/src/sim/world/techno_ai/mission_handlers.rs
+++ b/src/sim/world/techno_ai/mission_handlers.rs
@@ -42,15 +42,12 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
         // A miner's dispatch is owned by the absorbed Harvest handler, which
         // writes its own epilogue — except on Guard, which the Harvest handler
         // now declines. That is the native split: a vehicle on Guard enters the
-        // harvester Guard override, which layers the slave/refinery checks and
-        // then tail-calls the same FootClass Guard handler every other unit
-        // uses; a vehicle on Harvest enters the Harvest handler. Exactly one of
-        // the two runs, so the timer keeps a single writer.
-        //
-        // RESIDUAL, not modelled: the harvester Guard override's player arm
-        // re-queues Harvest when a Refinery the house owns sits in one of the
-        // eight neighbouring cells, so a retail miner stopped next to its
-        // refinery goes back to work on its own. VERA's stays put.
+        // harvester Guard override (`UnitClass::Mission_Guard @ 0x00740810`,
+        // the human chrono arms live on the Unit Guard arm below), which
+        // layers the slave/refinery checks and then tail-calls the same
+        // FootClass Guard handler every other unit uses; a vehicle on Harvest
+        // enters the Harvest handler. Exactly one of the two runs, so the
+        // timer keeps a single writer.
         if entity.miner.is_some() && mission != Some(MissionType::Guard) {
             return;
         }
@@ -398,7 +395,11 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
             // either arm. Player effect: none. Frequency: zero. Downstream
             // risk: the wrong native mapping would be carried straight into any
             // future deploy work; the shape belongs on the Move arm.
-            if input.unit_deploy_begin_active {
+            if harvester_guard_override_requeues_harvest(sim, id, rules) {
+                // `Queue_Mission(10, 0); return 1` at `0x0074092C` /
+                // `0x00740960` — no RNG draw, the Foot body is not reached.
+                MissionHandlerEvaluation::queue(1, MissionType::Harvest)
+            } else if input.unit_deploy_begin_active {
                 MissionHandlerEvaluation::queue(1, MissionType::Harvest)
             } else if input.unit_deploy_reverse_active {
                 MissionHandlerEvaluation::queue(1, MissionType::Unload)
@@ -1274,6 +1275,117 @@ fn evaluate_foot_guard_cadence(
     }
 }
 
+/// The harvester arms of `UnitClass::Mission_Guard @ 0x00740810` (decompiled
+/// 2026-09-05), run ahead of the `FootClass::Mission_Guard @ 0x004D5070`
+/// tail-call for a `Harvester=`/`Weeder=` type (`UnitType+0xE0E`/`+0xE0F`):
+///
+/// - (ii) **AI house** (`HouseClass::IsControlledByHuman @ 0x0050B730`
+///   false): walk the type's `Dock=` list (`Type+0x3EC`, count `+0x3F8`)
+///   and stop at the FIRST entry with `HouseClass::CountOwnedInstances >
+///   0`; there, NOT (`Harvester` `+0xE0E` && `House+0x242`) →
+///   `Queue_Mission(Harvest, 0); return 1`, else `break` (later Dock
+///   entries are not consulted — irrelevant here, the test is
+///   entry-independent). No owned instance of any entry → fall through.
+///   The `+0x242` latch is `HouseState::harvester_no_ore`, written
+///   native-true by the Harvest scan miss and never cleared; the Rust
+///   ownership count is `EntityStore::count_owned_of_type` (see its doc for
+///   the Unlimbo..Limbo vs insert..remove window).
+/// - (iii) **human house && `Teleporter=`** (`UnitType+0xCD4`): walk the 8
+///   neighbour cells (`MapCoord_StepByDir_GetCell`); a building there whose
+///   type has `+0x16BB` (`Refinery=`) and whose owner `+0x21C` is this house
+///   → queue Harvest, return 1. Else `Get_Storage_Percentage() == 1.0` and
+///   the locomotor's `Is_Moving` (ILocomotion slot `+0x10`) true → queue
+///   Harvest, return 1. `TeleportLocomotionClass::Is_Moving @ 0x00718080`
+///   is `byte +0x30 == 1`, true only for the Relocate tick — the
+///   `ready_producer` Teleport producer (`is_moving_now_for`), never "a
+///   teleport state exists". A human WAR miner has no arm here: once on
+///   Guard it stays until a player order.
+///
+/// Neither arm draws RNG. The slave-recall gate (i) ahead of both, the
+/// `DeploysInto` AI arm (iv) and the weeder latch (v) are outside this lane.
+/// A house missing from the registry reads as human (VERA fixtures register
+/// no houses by default).
+fn harvester_guard_override_requeues_harvest(sim: &Simulation, id: u64, rules: &RuleSet) -> bool {
+    let Some(entity) = sim.substrate.entities.get(id) else {
+        return false;
+    };
+    let Some(miner) = entity.miner.as_ref() else {
+        return false;
+    };
+    let Some(unit_type) = sim.object_type(entity.type_ref, rules) else {
+        return false;
+    };
+    if !unit_type.harvester {
+        return false;
+    }
+    let human = sim
+        .houses
+        .get(&entity.owner)
+        .is_none_or(|house| house.is_controlled_by_human(sim.session.game_mode_nonzero));
+    if !human {
+        // Arm (ii), `0x00740880..0x0074092C`.
+        let owns_dock = unit_type.dock.iter().any(|dock_type| {
+            sim.interner.get(dock_type).is_some_and(|type_ref| {
+                sim.substrate
+                    .entities
+                    .count_owned_of_type(entity.owner, type_ref)
+                    > 0
+            })
+        });
+        if !owns_dock {
+            return false;
+        }
+        let no_ore = sim
+            .houses
+            .get(&entity.owner)
+            .is_some_and(|house| house.harvester_no_ore);
+        return !(unit_type.harvester && no_ore);
+    }
+    if !unit_type.teleporter {
+        return false;
+    }
+    let (rx, ry) = (i32::from(entity.position.rx), i32::from(entity.position.ry));
+    for (dx, dy) in NEIGHBOUR_8 {
+        let (Ok(cx), Ok(cy)) = (u16::try_from(rx + dx), u16::try_from(ry + dy)) else {
+            continue;
+        };
+        let Some(cell) = sim.substrate.occupancy.get(cx, cy) else {
+            continue;
+        };
+        let own_refinery = cell
+            .blockers(crate::sim::movement::locomotor::MovementLayer::Ground)
+            .any(|sid| {
+                sim.substrate.entities.get(sid).is_some_and(|building| {
+                    building.category == EntityCategory::Structure
+                        && !building.dying
+                        && building.owner == entity.owner
+                        && sim
+                            .object_type(building.type_ref, rules)
+                            .is_some_and(|obj| obj.refinery)
+                })
+            });
+        if own_refinery {
+            return true;
+        }
+    }
+    // `Is_Moving` on the teleport locomotor: the Relocate tick only.
+    miner.is_full()
+        && crate::sim::movement::ready_producer::is_moving_now_for(entity, sim.session.binary_frame)
+}
+
+/// `MapCoord_StepByDir_GetCell(dir)` for dir 0..8 — the eight neighbours in
+/// facing order starting north, clockwise. Only membership matters here.
+const NEIGHBOUR_8: [(i32, i32); 8] = [
+    (0, -1),
+    (1, -1),
+    (1, 0),
+    (1, 1),
+    (0, 1),
+    (-1, 1),
+    (-1, 0),
+    (-1, -1),
+];
+
 /// The un-overridden `MissionClass` handler's return value, in frames.
 ///
 /// Every base mission stub in the original is the same two instructions —
@@ -1623,4 +1735,319 @@ fn attack_target_is_stale(sim: &Simulation, id: u64) -> bool {
         .entities
         .get(*target_id)
         .is_some_and(|target| !target.dying && target.is_alive())
+}
+
+#[cfg(test)]
+mod harvester_guard_override_tests {
+    use super::*;
+    use crate::rules::ini_parser::IniFile;
+    use crate::rules::locomotor_type::LocomotorKind;
+    use crate::sim::game_entity::GameEntity;
+    use crate::sim::miner::{CargoBale, Miner, MinerConfig, MinerKind, ResourceType};
+    use crate::sim::movement::locomotor::{LocomotorState, MovementLayer};
+    use crate::sim::movement::teleport_movement::{TeleportPhase, TeleportState};
+    use crate::sim::occupancy::CellListInsertion;
+
+    const MINER_ID: u64 = 1;
+    const REFINERY_ID: u64 = 2;
+    const REFINERY_NW: (u16, u16) = (10, 10);
+
+    fn rules() -> RuleSet {
+        RuleSet::from_ini(&IniFile::from_str(
+            "[InfantryTypes]\n[VehicleTypes]\n0=HARV\n1=CMIN\n[AircraftTypes]\n\
+             [BuildingTypes]\n0=GAREFN\n\
+             [HARV]\nHarvester=yes\nDock=GAREFN\nSpeed=4\n\
+             [CMIN]\nHarvester=yes\nTeleporter=yes\nDock=GAREFN\nSpeed=4\n\
+             [GAREFN]\nFoundation=4x3\nRefinery=yes\n",
+        ))
+        .expect("guard override rules")
+    }
+
+    fn spawn_refinery(sim: &mut Simulation, owner: &str) {
+        let owner = sim.interner.intern(owner);
+        let type_ref = sim.interner.intern("GAREFN");
+        let mut ge = GameEntity::new_at_frame_zero_for_test(
+            REFINERY_ID,
+            REFINERY_NW.0,
+            REFINERY_NW.1,
+            0,
+            0,
+            owner,
+            crate::sim::components::Health {
+                current: 900,
+                max: 900,
+            },
+            type_ref,
+            EntityCategory::Structure,
+            0,
+            5,
+            false,
+        );
+        ge.lifecycle.in_limbo = false;
+        sim.substrate.entities.insert(ge);
+        for y in REFINERY_NW.1..REFINERY_NW.1 + 3 {
+            for x in REFINERY_NW.0..REFINERY_NW.0 + 4 {
+                sim.substrate.occupancy.add(
+                    x,
+                    y,
+                    REFINERY_ID,
+                    MovementLayer::Ground,
+                    None,
+                    CellListInsertion::AppendBuilding,
+                );
+            }
+        }
+    }
+
+    /// A miner of `kind` at `cell`, committed to Guard with a due timer.
+    fn spawn_guard_miner(sim: &mut Simulation, kind: MinerKind, cell: (u16, u16)) {
+        let owner = sim.interner.intern("Americans");
+        let type_name = match kind {
+            MinerKind::Chrono => "CMIN",
+            _ => "HARV",
+        };
+        let type_ref = sim.interner.intern(type_name);
+        let mut ge = GameEntity::new_at_frame_zero_for_test(
+            MINER_ID,
+            cell.0,
+            cell.1,
+            0,
+            0,
+            owner,
+            crate::sim::components::Health {
+                current: 400,
+                max: 400,
+            },
+            type_ref,
+            EntityCategory::Unit,
+            0,
+            5,
+            true,
+        );
+        ge.locomotor = Some(LocomotorState::for_test_kind(match kind {
+            MinerKind::Chrono => LocomotorKind::Teleport,
+            _ => LocomotorKind::Drive,
+        }));
+        ge.miner = Some(Miner::new(kind, &MinerConfig::default(), 0));
+        sim.substrate.entities.insert(ge);
+        sim.mission_assign_exact(MINER_ID, MissionId::from_known(MissionType::Guard), 0)
+            .expect("assign Guard");
+    }
+
+    fn fill_cargo(sim: &mut Simulation) {
+        let entity = sim.substrate.entities.get_mut(MINER_ID).expect("miner");
+        let miner = entity.miner.as_mut().expect("miner");
+        let capacity = miner.capacity_bales;
+        miner.cargo = (0..capacity)
+            .map(|_| CargoBale {
+                resource_type: ResourceType::Ore,
+                value: 25,
+            })
+            .collect();
+    }
+
+    fn dispatch(sim: &mut Simulation, rules: &RuleSet) {
+        dispatch_supported_foot_mission_cadence(
+            sim,
+            MINER_ID,
+            rules,
+            super::super::ObjectAiCtx {
+                path_grid: None,
+                overlay_registry: None,
+                terrain_spawner_cells: None,
+                miner_config: None,
+            },
+        );
+    }
+
+    fn queued(sim: &Simulation) -> Option<MissionType> {
+        sim.substrate
+            .entities
+            .get(MINER_ID)
+            .expect("miner")
+            .mission
+            .queued()
+            .known()
+    }
+
+    /// Arm (iii), neighbour refinery: `0x00740922..0x0074092C`.
+    #[test]
+    fn chrono_miner_on_guard_beside_its_own_refinery_requeues_harvest() {
+        let rules = rules();
+        let mut sim = Simulation::new();
+        spawn_refinery(&mut sim, "Americans");
+        // (14, 11) touches footprint cell (13, 11).
+        spawn_guard_miner(&mut sim, MinerKind::Chrono, (14, 11));
+
+        let scenario_before = sim.rng_state().scenario;
+        dispatch(&mut sim, &rules);
+
+        assert_eq!(queued(&sim), Some(MissionType::Harvest));
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.mission.dispatch_timer().delay(), 1, "return 1");
+        assert_eq!(
+            sim.rng_state().scenario,
+            scenario_before,
+            "the Foot Guard body (and its draw) is never reached"
+        );
+    }
+
+    #[test]
+    fn chrono_miner_beside_another_houses_refinery_stays_on_guard() {
+        let rules = rules();
+        let mut sim = Simulation::new();
+        spawn_refinery(&mut sim, "Russians");
+        spawn_guard_miner(&mut sim, MinerKind::Chrono, (14, 11));
+
+        dispatch(&mut sim, &rules);
+
+        assert_eq!(queued(&sim), None, "`building+0x21C == this->Owner` fails");
+    }
+
+    fn set_teleport_phase(sim: &mut Simulation, phase: TeleportPhase) {
+        sim.substrate
+            .entities
+            .get_mut(MINER_ID)
+            .expect("miner")
+            .teleport_state = Some(TeleportState {
+            phase,
+            target_rx: 14,
+            target_ry: 11,
+            being_warped_ticks: 30,
+        });
+    }
+
+    /// Arm (iii), second test: full storage and the teleport locomotor's
+    /// `Is_Moving` (`0x00718080`: `+0x30 == 1`, the Relocate tick only) →
+    /// Harvest; full-but-idle and the post-warp ChronoDelay phase both fall
+    /// through.
+    #[test]
+    fn full_chrono_miner_mid_warp_requeues_harvest_away_from_any_refinery() {
+        let rules = rules();
+        let mut sim = Simulation::new();
+        spawn_refinery(&mut sim, "Americans");
+        spawn_guard_miner(&mut sim, MinerKind::Chrono, (40, 40));
+        fill_cargo(&mut sim);
+        // Full but not moving: falls through to the Foot Guard body.
+        dispatch(&mut sim, &rules);
+        assert_eq!(queued(&sim), None);
+
+        // A teleport state that is NOT the Relocate tick is not `Is_Moving`.
+        set_teleport_phase(&mut sim, TeleportPhase::ChronoDelay);
+        sim.session.binary_frame += 40;
+        dispatch(&mut sim, &rules);
+        assert_eq!(
+            queued(&sim),
+            None,
+            "the post-warp chrono delay is not the locomotor's moving flag"
+        );
+
+        set_teleport_phase(&mut sim, TeleportPhase::Relocate);
+        sim.session.binary_frame += 40;
+        dispatch(&mut sim, &rules);
+        assert_eq!(queued(&sim), Some(MissionType::Harvest));
+    }
+
+    /// An empty chrono miner on the Relocate tick has no arm: storage must
+    /// read 100% first.
+    #[test]
+    fn empty_chrono_miner_mid_warp_stays_on_guard() {
+        let rules = rules();
+        let mut sim = Simulation::new();
+        spawn_refinery(&mut sim, "Americans");
+        spawn_guard_miner(&mut sim, MinerKind::Chrono, (40, 40));
+        set_teleport_phase(&mut sim, TeleportPhase::Relocate);
+
+        dispatch(&mut sim, &rules);
+
+        assert_eq!(queued(&sim), None);
+    }
+
+    fn register_house(sim: &mut Simulation, is_human: bool) {
+        let owner = sim.interner.intern("Americans");
+        sim.houses.insert(
+            owner,
+            crate::sim::house_state::HouseState::new(owner, 0, None, is_human, 0, 10),
+        );
+    }
+
+    /// Arm (ii): AI house, owns a `Dock=` instance, `House+0x242` clear →
+    /// `Queue_Mission(Harvest, 0); return 1` (`0x0074092C`), no RNG draw.
+    #[test]
+    fn ai_war_miner_on_guard_requeues_harvest_while_house_no_ore_latch_is_clear() {
+        let rules = rules();
+        let mut sim = Simulation::new();
+        register_house(&mut sim, false);
+        spawn_refinery(&mut sim, "Americans");
+        spawn_guard_miner(&mut sim, MinerKind::War, (40, 40));
+
+        let scenario_before = sim.rng_state().scenario;
+        dispatch(&mut sim, &rules);
+
+        assert_eq!(queued(&sim), Some(MissionType::Harvest));
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.mission.dispatch_timer().delay(), 1, "return 1");
+        assert_eq!(sim.rng_state().scenario, scenario_before);
+    }
+
+    /// Arm (ii) with `Harvester=yes && House+0x242` set → `break`, the Foot
+    /// Guard body runs instead.
+    #[test]
+    fn ai_war_miner_on_guard_stays_when_house_no_ore_latch_is_set() {
+        let rules = rules();
+        let mut sim = Simulation::new();
+        register_house(&mut sim, false);
+        let owner = sim.interner.intern("Americans");
+        sim.houses.get_mut(&owner).expect("house").harvester_no_ore = true;
+        spawn_refinery(&mut sim, "Americans");
+        spawn_guard_miner(&mut sim, MinerKind::War, (40, 40));
+
+        dispatch(&mut sim, &rules);
+
+        assert_eq!(queued(&sim), None);
+    }
+
+    /// Arm (ii) needs `CountOwnedInstances > 0` for some `Dock=` entry.
+    #[test]
+    fn ai_war_miner_on_guard_without_a_dock_instance_stays_on_guard() {
+        let rules = rules();
+        let mut sim = Simulation::new();
+        register_house(&mut sim, false);
+        spawn_guard_miner(&mut sim, MinerKind::War, (40, 40));
+
+        dispatch(&mut sim, &rules);
+
+        assert_eq!(queued(&sim), None);
+    }
+
+    /// A human house never enters arm (ii): a war miner parks.
+    #[test]
+    fn human_war_miner_on_guard_with_latch_clear_stays_on_guard() {
+        let rules = rules();
+        let mut sim = Simulation::new();
+        register_house(&mut sim, true);
+        spawn_refinery(&mut sim, "Americans");
+        spawn_guard_miner(&mut sim, MinerKind::War, (40, 40));
+
+        dispatch(&mut sim, &rules);
+
+        assert_eq!(queued(&sim), None);
+    }
+
+    /// A human WAR miner has no arm in `UnitClass::Mission_Guard`: parked is
+    /// parked until a player order.
+    #[test]
+    fn war_miner_on_guard_beside_its_refinery_stays_on_guard() {
+        let rules = rules();
+        let mut sim = Simulation::new();
+        spawn_refinery(&mut sim, "Americans");
+        spawn_guard_miner(&mut sim, MinerKind::War, (14, 11));
+        fill_cargo(&mut sim);
+
+        dispatch(&mut sim, &rules);
+
+        assert_eq!(queued(&sim), None);
+        let entity = sim.substrate.entities.get(MINER_ID).expect("miner");
+        assert_eq!(entity.mission.current().known(), Some(MissionType::Guard));
+    }
 }

--- a/src/sim/world/world_commands.rs
+++ b/src/sim/world/world_commands.rs
@@ -1811,8 +1811,16 @@ impl Simulation {
                 // Clear in-progress movement so the miner re-paths to the new target.
                 e.movement_target = None;
                 // Commit the Harvest mission and the MoveToOre cursor of
-                // record (same shape as MinerReturn above; UNCHECKED native
-                // command mission shape, legacy behavior preserved).
+                // record. Native (EventClass::Execute MEGAMISSION,
+                // disassembled 2026-09-05): the client's mission byte passes
+                // through `FootClass 0x004DF0E0` (vtable `+0x4A4`, unchanged
+                // unless 0x1D) into `Queue_Mission(mission, 0)` at
+                // `0x004C73B9`, then clears SuspendedNavCom/SuspendedTarCom.
+                // VERA assigns instead of queueing — the miner therefore
+                // leaves Guard on this frame rather than at the host's next
+                // Ready-to-Commence step (a one-frame shape difference,
+                // VERA-internal). This is the production path that returns a
+                // war miner parked on Guard by the Harvest idle tail to work.
                 let now = self.session.binary_frame;
                 let _ = self.mission_assign_exact(
                     *entity_id,

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -439,7 +439,7 @@ impl Simulation {
     pub fn state_hash(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, true, true,
         )
     }
 
@@ -451,7 +451,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             true, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -463,7 +463,7 @@ impl Simulation {
     pub(crate) fn state_hash_before_lifecycle_v28_and_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             false, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -473,7 +473,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_spark_dummy_level_slope_v107(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, false, false,
-            false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -484,7 +484,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_naval_build_const_v109(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -495,7 +495,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_base_plan_v110(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, false, false, false, false, false, false, false,
+            true, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -504,7 +504,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_base_plan_center_v111(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, false, false, false, false, false, false,
+            true, true, false, false, false, false, false, false, false,
         )
     }
 
@@ -513,7 +513,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_house_deploy_latches_v112(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, false, false, false, false, false,
+            true, true, true, false, false, false, false, false, false,
         )
     }
 
@@ -523,7 +523,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_house_update_activation_v113(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, false, false, false, false,
+            true, true, true, true, false, false, false, false, false,
         )
     }
 
@@ -532,7 +532,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_crate_authority_v114(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, false, false, false,
+            true, true, true, true, true, false, false, false, false,
         )
     }
 
@@ -544,7 +544,17 @@ impl Simulation {
     pub(crate) fn state_hash_without_disguise_detect_v117(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, true, false,
+            true, true, true, true, true, true, true, false, false,
+        )
+    }
+
+    /// Test-only provenance probe for the schema-v132 `HouseClass+0x242`
+    /// harvester no-ore latch fold. It reconstructs the committed v117 layout.
+    #[cfg(test)]
+    pub(crate) fn state_hash_without_house_harvester_no_ore_v132(&self) -> u64 {
+        self.state_hash_with_schema(
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, true, false,
         )
     }
 
@@ -554,7 +564,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_wall_runtime_v115(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, false, false,
+            true, true, true, true, true, true, false, false, false,
         )
     }
 
@@ -582,6 +592,7 @@ impl Simulation {
         include_crate_authority_v114: bool,
         include_wall_runtime_v115: bool,
         include_disguise_detect_v117: bool,
+        include_house_harvester_no_ore_v132: bool,
     ) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
 
@@ -634,6 +645,7 @@ impl Simulation {
             include_base_plan_center_v111,
             include_house_deploy_latches_v112,
             include_house_update_activation_v113,
+            include_house_harvester_no_ore_v132,
         );
         if include_terminal_score_v46 {
             self.hash_terminal_score_snapshot(&mut hasher);
@@ -881,6 +893,7 @@ impl Simulation {
         include_base_plan_center_v111: bool,
         include_house_deploy_latches_v112: bool,
         include_house_update_activation_v113: bool,
+        include_house_harvester_no_ore_v132: bool,
     ) {
         for (owner, house) in &self.houses {
             owner.hash(hasher);
@@ -964,6 +977,11 @@ impl Simulation {
             }
             house.base_reservation.hash(hasher);
             house.waypoint_edge.hash(hasher);
+            if include_house_harvester_no_ore_v132 {
+                // `HouseClass+0x242`, the sticky harvester no-ore latch — a
+                // raw House byte in the native save block and lockstep CRC.
+                house.harvester_no_ore.hash(hasher);
+            }
         }
     }
 
@@ -3054,6 +3072,31 @@ mod rally_hash_tests {
         assert_eq!(
             baseline.state_hash_without_base_plan_center_v111(),
             changed.state_hash_without_base_plan_center_v111()
+        );
+    }
+
+    /// `HouseClass+0x242` (the sticky harvester no-ore latch) is folded once,
+    /// under the v132 flag only.
+    #[test]
+    fn house_harvester_no_ore_affects_only_current_v132_hash_schema() {
+        use crate::sim::house_state::HouseState;
+
+        fn fixture(latched: bool) -> Simulation {
+            let mut sim = Simulation::new();
+            let owner = sim.interner.intern("Americans");
+            let mut house = HouseState::new(owner, 0, Some(owner), true, 0, 10);
+            house.harvester_no_ore = latched;
+            sim.houses.insert(owner, house);
+            sim
+        }
+
+        let baseline = fixture(false);
+        let latched = fixture(true);
+
+        assert_ne!(baseline.state_hash(), latched.state_hash());
+        assert_eq!(
+            baseline.state_hash_without_house_harvester_no_ore_v132(),
+            latched.state_hash_without_house_harvester_no_ore_v132()
         );
     }
 


### PR DESCRIPTION
Harvesters that run out of ore now follow `UnitClass::Mission_Harvest` @ 0x0073E5E0: a scan miss with no NavCom and no archive sets `Techno+0x3D0` and the sticky `House+0x242` (0x0073E911, never cleared), waits 105 frames, then state 4 drives off a refinery cell and queues Guard (the RepairBay probe is inert because `MissionClass::Queue_Mission` @ 0x005B35E0 is a pure overwrite). A house with no `Dock=` type parks its harvesters on Guard from the preamble. `UnitClass::Mission_Guard` @ 0x00740810 re-queues Harvest for an AI house that owns a Dock type while `+0x242` is clear, and for a human chrono miner adjacent to an own refinery or full while its teleport locomotor is in its Relocate tick (`Is_Moving` @ 0x00718080); a human war miner has no arm. In state 2 a war miner radios HELLO on the same dispatch when the narrow `Find_Docking_Bay` result is within `HarvesterTooFarDistance` (0x0073EE51); a refused HELLO beyond 0x300 leptons drives to the QueueingCell staging cell, closer just retries.

Previous Rust re-scanned every 105 frames forever, kept no house latch, sent the close HELLO only for chrono miners, and had no Guard harvester arms. Player-visible: a retail war miner with no ore in 48 cells stays parked until re-ordered; VERA resumed on its own.

Changes: native park for human houses with the player's harvest order (`Command::HarvestCell`, matching MEGAMISSION → `Queue_Mission` at 0x004C73B9) proven to re-engage the miner; `harvester_no_ore` persisted and hashed under schema v132 (SNAPSHOT_VERSION 132); chrono Guard arms via the existing teleport producer; war-miner HELLO at up to five cells with the refused-HELLO split; O(1) per-house per-type ownership count mirroring `CountOwnedInstances` @ 0x0049FAE0. Non-human houses keep a VERA-internal re-scan after the miss, labeled as such, because the native AI recovery (AI_Choose_Unit / Mission_Guard arm ii) belongs to the deferred AI lane.

Residuals recorded in code: refused-HELLO staging seeds from the narrow result where native uses the wide pass; the war-miner Mission_Enter routing assumes an adjacent QueueingCell (stock 4,1); the Dock cursor skips the preamble loop for one dispatch after an accepted HELLO.

Two independent read-only critics reviewed successive revisions against the bodies; the second passed.

Validation:
- `cargo test -p vera20k --lib`: `test result: ok. 8340 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 11.92s`
