### PR TITLE
Queue EVA lines through a VoxClass-shaped priority model

### DIFF
--- a/src/app/in_game.rs
+++ b/src/app/in_game.rs
@@ -640,11 +640,14 @@ impl App {
             .as_ref()
             .is_some_and(|exit| exit.needs_voice_poll(wall_ms));
         let voices_active = poll_voices
-            && state
-                .audio
-                .sfx_player
-                .as_mut()
-                .is_some_and(|sfx| sfx.pump_and_check_voices());
+            && match (&mut state.audio.sfx_player, state.process_assets.manager()) {
+                (Some(sfx), Some(assets)) => sfx.pump_and_check_voices(
+                    &state.audio.sound_registry,
+                    assets,
+                    &state.audio.audio_indices,
+                ),
+                _ => false,
+            };
         let tick = state
             .match_state
             .scenario_exit
@@ -713,24 +716,20 @@ impl App {
     ) {
         match action {
             crate::app::match_runtime::scenario_exit::ScenarioExitVoiceAction::InterruptBattleControlTerminated => {
-                let Some(owner) = state.match_state.local_player_owner.as_deref() else {
+                if state.match_state.local_player_owner.is_none() {
                     log::warn!("Battle-control termination EVA has no pinned local owner");
                     return;
-                };
-                let faction = crate::app::presentation::building_anim::eva_faction_key(owner, &state.match_state.match_presentation.house_roster);
-                let fallback = match faction {
-                    "Russian" => "csof015",
-                    "Yuri" => "cyur015",
-                    _ => "ceva015",
-                };
-                let sound_id = state
-                    .audio.eva_registry
-                    .get("EVA_BattleControlTerminated", faction)
-                    .unwrap_or(fallback)
-                    .to_string();
+                }
+                // `GameExit::BattleControlTerminated 0x00686616`:
+                // `VoxClass::PlayEVA("EVA_BattleControlTerminated", 2)` — the
+                // INTERRUPT override; the entry itself is STANDARD CRITICAL.
+                let eva_side = crate::app::presentation::building_anim::local_eva_side(state);
                 if let (Some(sfx), Some(assets)) = (&mut state.audio.sfx_player, state.process_assets.manager()) {
-                    let _ = sfx.interrupt_eva_sound(
-                        &sound_id,
+                    let _ = sfx.play_eva(
+                        "EVA_BattleControlTerminated",
+                        Some(crate::rules::sound_ini::EvaType::Interrupt),
+                        &state.audio.eva_registry,
+                        eva_side,
                         &state.audio.sound_registry,
                         assets,
                         &state.audio.audio_indices,

--- a/src/app/loading/transitions.rs
+++ b/src/app/loading/transitions.rs
@@ -764,33 +764,33 @@ pub(crate) fn load_audio_indices(
     indices
 }
 
-/// Load eva.ini / evamd.ini and build an EvaRegistry.
-/// YR-first: evamd.ini takes precedence, eva.ini fills gaps.
+/// Build the `VoxClass` registry the way `Init_Game @ 0x0052C8A0` does:
+/// `VoxClass::ReadEVAINI @ 0x00753000` on the `EVAMD.INI` CCINI (string
+/// `0x00825DF0`, "Reading EVAMD.INI" `0x00825DFC`) and nothing else. gamemd
+/// never opens `eva.ini`, so an RA2-only section is not a YR line.
 pub(crate) fn load_eva_registry(
     assets: &crate::assets::asset_manager::AssetManager,
+) -> crate::rules::sound_ini::EvaRegistry {
+    build_eva_registry(|name| assets.get(name))
+}
+
+/// The lookup-agnostic half of [`load_eva_registry`].
+pub(crate) fn build_eva_registry(
+    lookup: impl Fn(&str) -> Option<Vec<u8>>,
 ) -> crate::rules::sound_ini::EvaRegistry {
     use crate::rules::ini_parser::IniFile;
     use crate::rules::sound_ini::EvaRegistry;
 
-    let mut registry: Option<EvaRegistry> = None;
-    for name in ["evamd.ini", "eva.ini"] {
-        if let Some(bytes) = assets.get(name) {
-            // EVA INI files from MIX archives may contain non-UTF8 bytes (Windows-1252).
-            let text = String::from_utf8_lossy(&bytes);
-            let ini: IniFile = IniFile::from_str(&text);
-            match &mut registry {
-                None => {
-                    registry = Some(EvaRegistry::from_ini(&ini));
-                    log::info!("Loaded {} for EVA", name);
-                }
-                Some(reg) => {
-                    reg.merge_fallback(&ini);
-                    log::info!("Merged fallback {} for EVA", name);
-                }
-            }
-        }
-    }
-    registry.unwrap_or_default()
+    let Some(bytes) = lookup("evamd.ini") else {
+        log::warn!("Failed to find EVAMD.INI — EVA lines will be silent");
+        return EvaRegistry::default();
+    };
+    // EVA INI files from MIX archives may contain non-UTF8 bytes (Windows-1252).
+    let text = String::from_utf8_lossy(&bytes);
+    let ini: IniFile = IniFile::from_str(&text);
+    let registry = EvaRegistry::from_ini(&ini);
+    log::info!("Loaded evamd.ini for EVA");
+    registry
 }
 
 /// Build overlay classification data for the minimap from map overlay entries.
@@ -850,6 +850,40 @@ pub(crate) fn clear_screen(encoder: &mut wgpu::CommandEncoder, view: &wgpu::Text
         timestamp_writes: None,
         occlusion_query_set: None,
     });
+}
+
+#[cfg(test)]
+mod eva_registry_tests {
+    use super::build_eva_registry;
+    use crate::rules::sound_ini::EvaSide;
+
+    /// `Init_Game @ 0x0052C8A0` reads `EVAMD.INI` only (`0x00825DF0`); an
+    /// `eva.ini` sitting next to it is never opened, so its entries do not
+    /// exist and it cannot override or fill a YR row.
+    #[test]
+    fn eva_registry_reads_evamd_only_and_ignores_eva_ini() {
+        let evamd = "[DialogList]\n0=EVA_UnitLost\n[EVA_UnitLost]\nAllied=ceva064\n";
+        let eva = "[DialogList]\n0=EVA_UnitLost\n1=EVA_Ra2Only\n\
+                   [EVA_UnitLost]\nAllied=old064\nRussian=old064r\n\
+                   [EVA_Ra2Only]\nAllied=ra2only\n";
+        let lookup = |name: &str| -> Option<Vec<u8>> {
+            match name {
+                "evamd.ini" => Some(evamd.as_bytes().to_vec()),
+                "eva.ini" => Some(eva.as_bytes().to_vec()),
+                _ => None,
+            }
+        };
+        let reg = build_eva_registry(lookup);
+        assert_eq!(reg.len(), 1);
+        assert_eq!(reg.get("EVA_UnitLost", EvaSide::Allied), Some("ceva064"));
+        assert_eq!(reg.get("EVA_UnitLost", EvaSide::Russian), None);
+        assert!(reg.entry("EVA_Ra2Only").is_none());
+
+        // Only eva.ini present: nothing is read at all.
+        let reg =
+            build_eva_registry(|name: &str| (name == "eva.ini").then(|| eva.as_bytes().to_vec()));
+        assert!(reg.is_empty());
+    }
 }
 
 #[cfg(test)]

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -222,17 +222,17 @@ fn announce_local_state_evas(state: &mut AppState) {
         (low_power, funds_stalled, current_dying, newly_dying)
     };
 
-    let mut cues: Vec<(&'static str, &'static str)> = Vec::new();
+    let mut cues: Vec<&'static str> = Vec::new();
     if low_power && !state.match_state.match_audio.eva_low_power_active {
-        cues.push(("EVA_LowPower", "ceva053"));
+        cues.push("EVA_LowPower");
     }
     state.match_state.match_audio.eva_low_power_active = low_power;
     if funds_stalled && !state.match_state.match_audio.eva_funds_stalled {
-        cues.push(("EVA_InsufficientFunds", "ceva050"));
+        cues.push("EVA_InsufficientFunds");
     }
     state.match_state.match_audio.eva_funds_stalled = funds_stalled;
     if !newly_dying.is_empty() {
-        cues.push(("EVA_UnitLost", "ceva064"));
+        cues.push("EVA_UnitLost");
     }
     // Prune despawned corpses, then record this frame's announcements.
     state
@@ -246,34 +246,16 @@ fn announce_local_state_evas(state: &mut AppState) {
         .eva_announced_dying
         .extend(newly_dying);
 
-    if cues.is_empty() {
-        return;
-    }
-    let faction = crate::app::presentation::building_anim::eva_faction_key(
-        &owner,
-        &state.match_state.match_presentation.house_roster,
-    );
-    let sound_ids: Vec<String> = cues
-        .iter()
-        .map(|(cue, fallback)| {
-            state
-                .audio
-                .eva_registry
-                .get(cue, faction)
-                .unwrap_or(fallback)
-                .to_string()
-        })
-        .collect();
-    let (Some(sfx), Some(assets)) = (&mut state.audio.sfx_player, state.process_assets.manager())
-    else {
-        return;
-    };
-    for sound_id in &sound_ids {
-        sfx.queue_eva_sound(
-            sound_id,
-            &state.audio.sound_registry,
-            assets,
-            &state.audio.audio_indices,
+    // Each is a `VoxClass::PlayEVA(name, -1)`; the entry's own `Type=` and
+    // `Priority=` route it (`EVA_LowPower` QUEUE IMPORTANT,
+    // `EVA_InsufficientFunds` STANDARD NORMAL, `EVA_UnitLost` STANDARD
+    // IMPORTANT on stock data).
+    for cue in cues {
+        state.match_state.match_audio.sound_events.push(
+            crate::audio::events::GameSoundEvent::Eva {
+                event: cue.to_string(),
+                type_override: None,
+            },
         );
     }
 }
@@ -316,11 +298,14 @@ pub(crate) fn drive_local_player_outcome_voice_wait(state: &mut AppState, wall_m
         );
     }
 
-    let voices_active = state
-        .audio
-        .sfx_player
-        .as_mut()
-        .is_some_and(|sfx| sfx.pump_and_check_voices());
+    let voices_active = match (&mut state.audio.sfx_player, state.process_assets.manager()) {
+        (Some(sfx), Some(assets)) => sfx.pump_and_check_voices(
+            &state.audio.sound_registry,
+            assets,
+            &state.audio.audio_indices,
+        ),
+        _ => false,
+    };
     let finished = state
         .match_state
         .scenario_outcome
@@ -356,27 +341,14 @@ pub(crate) fn drive_local_player_outcome_voice_wait(state: &mut AppState, wall_m
     );
 }
 
-fn outcome_eva_entry(
-    kind: crate::sim::house_state::HouseOutcomeKind,
-    faction: &str,
-) -> (&'static str, &'static str) {
-    match (kind, faction) {
-        (crate::sim::house_state::HouseOutcomeKind::Victory, "Russian") => {
-            ("EVA_YouAreVictorious", "csof022")
-        }
-        (crate::sim::house_state::HouseOutcomeKind::Victory, "Yuri") => {
-            ("EVA_YouAreVictorious", "cyur022")
-        }
-        (crate::sim::house_state::HouseOutcomeKind::Victory, _) => {
-            ("EVA_YouAreVictorious", "ceva022")
-        }
-        (crate::sim::house_state::HouseOutcomeKind::Defeat, "Russian") => {
-            ("EVA_YouHaveLost", "csof023")
-        }
-        (crate::sim::house_state::HouseOutcomeKind::Defeat, "Yuri") => {
-            ("EVA_YouHaveLost", "cyur023")
-        }
-        (crate::sim::house_state::HouseOutcomeKind::Defeat, _) => ("EVA_YouHaveLost", "ceva023"),
+/// The outcome line: `HouseClass::Flag_To_Win 0x004FCBA9` plays
+/// `EVA_YouAreVictorious` (`0x00824C2C`) and `Flag_To_Lose 0x004FCDA1`
+/// `EVA_YouHaveLost` (`0x00824C08`), both with `EDX = -1` (the entry's own
+/// type; stock rows are STANDARD NORMAL). The side column is the consumer's.
+fn outcome_eva_event(kind: crate::sim::house_state::HouseOutcomeKind) -> &'static str {
+    match kind {
+        crate::sim::house_state::HouseOutcomeKind::Victory => "EVA_YouAreVictorious",
+        crate::sim::house_state::HouseOutcomeKind::Defeat => "EVA_YouHaveLost",
     }
 }
 
@@ -512,10 +484,9 @@ pub(crate) struct SuperWeaponLaunchCue {
     /// the system, `StormSound`, is not a launch cue at all — see
     /// [`lightning_storm_begin_cue`].
     pub positional: bool,
-    /// `evamd.ini` event name, if the case plays one.
+    /// `evamd.ini` event name, if the case plays one. Every site passes type
+    /// `-1`, so the entry's own `Type=`/`Priority=` route it.
     pub eva_event: Option<&'static str>,
-    /// The `evamd.ini` entry's `Type=QUEUE` (vs the STANDARD default).
-    pub eva_queued: bool,
 }
 
 /// The launch cue table of `SuperClass::Launch @ 0x006CC390`.
@@ -581,19 +552,17 @@ pub(crate) fn superweapon_launch_cue(
         },
         K::PsychicDominator => SuperWeaponLaunchCue {
             sound_id: general.psychic_dominator_activate_sound.clone(),
-            eva_event: Some("EVA_PsychicDominatorActivated"),
             // `evamd.ini [EVA_PsychicDominatorActivated] Type=QUEUE` — and all
             // three of its faction values are `Dummy`, so on retail data the
             // line resolves to a zero-sample entry and is inaudible; only the
             // `[AudioVisual]` cue is heard.
-            eva_queued: true,
+            eva_event: Some("EVA_PsychicDominatorActivated"),
             ..positional
         },
         K::GeneticConverter => SuperWeaponLaunchCue {
             sound_id: general.genetic_mutator_activate_sound.clone(),
-            eva_event: Some("EVA_GeneticMutatorActivated"),
             // `evamd.ini [EVA_GeneticMutatorActivated] Type=QUEUE`.
-            eva_queued: true,
+            eva_event: Some("EVA_GeneticMutatorActivated"),
             ..positional
         },
         K::ForceShield => SuperWeaponLaunchCue {
@@ -1392,22 +1361,17 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                                 },
                             );
                         }
-                        let faction = crate::app::presentation::building_anim::eva_faction_key(
-                            owner_str,
-                            &state.match_state.match_presentation.house_roster,
-                        );
-                        if let Some(eva_sound_id) = state
-                            .audio
-                            .eva_registry
-                            .get("EVA_UnitPromoted", faction)
-                            .map(str::to_string)
-                        {
-                            state
-                                .match_state
-                                .match_audio
-                                .sound_events
-                                .push(GameSoundEvent::UnitPromotedEva { eva_sound_id });
-                        }
+                        // `0x006FA0C6 MOV ECX,0x843138 ("EVA_UnitPromoted") ; OR
+                        // EDX,-1 ; CALL VoxClass::PlayEVA`: the voice slot, with
+                        // the entry's own type (STANDARD LOW on stock data).
+                        state
+                            .match_state
+                            .match_audio
+                            .sound_events
+                            .push(GameSoundEvent::Eva {
+                                event: "EVA_UnitPromoted".to_string(),
+                                type_override: None,
+                            });
                         continue;
                     }
                     SimSoundEvent::CloakSound {
@@ -1427,17 +1391,11 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         {
                             continue;
                         }
-                        let faction = crate::app::presentation::building_anim::eva_faction_key(
-                            owner_str,
-                            &state.match_state.match_presentation.house_roster,
-                        );
-                        let sound_id = state
-                            .audio
-                            .eva_registry
-                            .get("EVA_ConstructionComplete", faction)
-                            .unwrap_or("ceva048")
-                            .to_string();
-                        GameSoundEvent::BuildingReady { sound_id }
+                        // `StripClass::AI 0x006A8E2F`: `PlayEVA` with type -1.
+                        GameSoundEvent::Eva {
+                            event: "EVA_ConstructionComplete".to_string(),
+                            type_override: None,
+                        }
                     }
                     SimSoundEvent::SuperWeaponLaunched {
                         sw_type, rx, ry, ..
@@ -1456,30 +1414,20 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             &resources.rules.general,
                             sw.start_sound.as_deref(),
                         );
-                        // The EVA sample is picked for the *listening* client's
+                        // The EVA column is picked for the *listening* client's
                         // side, not the launcher's: `VoxClass::PlayEVA` takes
-                        // only the event name and resolves the faction row
-                        // locally.
-                        let eva_sound_id = cue.eva_event.and_then(|event| {
-                            let local = local_owner_name.as_deref()?;
-                            let faction = crate::app::presentation::building_anim::eva_faction_key(
-                                local,
-                                &state.match_state.match_presentation.house_roster,
-                            );
-                            state
-                                .audio
-                                .eva_registry
-                                .get(event, faction)
-                                .map(str::to_string)
-                        });
-                        if cue.sound_id.is_none() && eva_sound_id.is_none() {
+                        // only the event name; the consumer resolves the side.
+                        let eva_event = cue
+                            .eva_event
+                            .filter(|_| local_owner_name.is_some())
+                            .map(str::to_string);
+                        if cue.sound_id.is_none() && eva_event.is_none() {
                             continue;
                         }
                         GameSoundEvent::SuperWeaponActivated {
                             sound_id: cue.sound_id.unwrap_or_default(),
                             source: cue.positional.then(|| sound_source_at_cell(rx, ry)),
-                            eva_sound_id,
-                            eva_queued: cue.eva_queued,
+                            eva_event,
                         }
                     }
                     SimSoundEvent::LightningStormBegan => {
@@ -1496,8 +1444,7 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             // `PlayAtPos` with pan `0x2000`: centred, not at
                             // the storm cell.
                             source: None,
-                            eva_sound_id: None,
-                            eva_queued: false,
+                            eva_event: None,
                         }
                     }
                     SimSoundEvent::SuperWeaponStrike { rx, ry } => {
@@ -1547,17 +1494,11 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         {
                             continue;
                         }
-                        let faction = crate::app::presentation::building_anim::eva_faction_key(
-                            owner_str,
-                            &state.match_state.match_presentation.house_roster,
-                        );
-                        let sound_id = state
-                            .audio
-                            .eva_registry
-                            .get("EVA_UnitReady", faction)
-                            .unwrap_or("ceva062")
-                            .to_string();
-                        GameSoundEvent::UnitReady { sound_id }
+                        // `HouseClass::Place_Production 0x004FB644`: type -1.
+                        GameSoundEvent::Eva {
+                            event: "EVA_UnitReady".to_string(),
+                            type_override: None,
+                        }
                     }
                     SimSoundEvent::MatchOutcome { owner, kind } => {
                         let owner_str = sim.interner.resolve(owner);
@@ -1567,18 +1508,10 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         {
                             continue;
                         }
-                        let faction = crate::app::presentation::building_anim::eva_faction_key(
-                            owner_str,
-                            &state.match_state.match_presentation.house_roster,
-                        );
-                        let (eva_key, fallback) = outcome_eva_entry(kind, faction);
-                        let eva_sound_id = state
-                            .audio
-                            .eva_registry
-                            .get(eva_key, faction)
-                            .unwrap_or(fallback)
-                            .to_string();
-                        GameSoundEvent::OutcomeEva { eva_sound_id }
+                        GameSoundEvent::Eva {
+                            event: outcome_eva_event(kind).to_string(),
+                            type_override: None,
+                        }
                     }
                     SimSoundEvent::WallSold { receiver } => {
                         let receiver_name = sim.interner.resolve(receiver);
@@ -1599,17 +1532,11 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         {
                             continue;
                         }
-                        let faction = crate::app::presentation::building_anim::eva_faction_key(
-                            owner_str,
-                            &state.match_state.match_presentation.house_roster,
-                        );
-                        let sound_id = state
-                            .audio
-                            .eva_registry
-                            .get("EVA_CannotDeployHere", faction)
-                            .unwrap_or("ceva063")
-                            .to_string();
-                        GameSoundEvent::CannotDeployHere { sound_id }
+                        // `UnitClass::Deploy 0x0073950A`: type -1.
+                        GameSoundEvent::Eva {
+                            event: "EVA_CannotDeployHere".to_string(),
+                            type_override: None,
+                        }
                     }
                     SimSoundEvent::StructureGarrisoned { owner } => {
                         // EVA cue: only play for the local human player.
@@ -1620,17 +1547,12 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         {
                             continue;
                         }
-                        let faction = crate::app::presentation::building_anim::eva_faction_key(
-                            owner_str,
-                            &state.match_state.match_presentation.house_roster,
-                        );
-                        let sound_id = state
-                            .audio
-                            .eva_registry
-                            .get("EVA_StructureGarrisoned", faction)
-                            .unwrap_or("ceva107")
-                            .to_string();
-                        GameSoundEvent::StructureGarrisoned { sound_id }
+                        // `BuildingClass::AddGarrisonOccupant 0x005229C1`: type -1
+                        // (stock entry QUEUE NORMAL).
+                        GameSoundEvent::Eva {
+                            event: "EVA_StructureGarrisoned".to_string(),
+                            type_override: None,
+                        }
                     }
                     SimSoundEvent::StructureAbandoned { owner } => {
                         let owner_str = sim.interner.resolve(owner);
@@ -1640,17 +1562,10 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         {
                             continue;
                         }
-                        let faction = crate::app::presentation::building_anim::eva_faction_key(
-                            owner_str,
-                            &state.match_state.match_presentation.house_roster,
-                        );
-                        let sound_id = state
-                            .audio
-                            .eva_registry
-                            .get("EVA_StructureAbandoned", faction)
-                            .unwrap_or("ceva108")
-                            .to_string();
-                        GameSoundEvent::StructureAbandoned { sound_id }
+                        GameSoundEvent::Eva {
+                            event: "EVA_StructureAbandoned".to_string(),
+                            type_override: None,
+                        }
                     }
                     SimSoundEvent::BuildingGarrisonedSfx { owner, rx, ry } => {
                         // Positional SFX: only audible to the local human player
@@ -1826,34 +1741,22 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         } else {
                             Some(sound_source_at_cell(rx, ry))
                         };
-                        // EVA cue gated on local-human owner. Resolves
-                        // `EVA_BridgeRepaired` from the registry (no faction
-                        // fallback needed — bridge repair is faction-agnostic).
+                        // EVA cue gated on local-human owner and the radar
+                        // dedupe result (`InfantryClass::PerCellProcess
+                        // 0x00519BC9`, `PlayEVA` type -1).
                         let owner_str = sim.interner.resolve(owner);
-                        let eva_sound_id = if eva_allowed
+                        let eva_event = (eva_allowed
                             && local_owner_name
                                 .as_deref()
-                                .is_some_and(|l| l.eq_ignore_ascii_case(owner_str))
-                        {
-                            let faction = crate::app::presentation::building_anim::eva_faction_key(
-                                owner_str,
-                                &state.match_state.match_presentation.house_roster,
-                            );
-                            state
-                                .audio
-                                .eva_registry
-                                .get("EVA_BridgeRepaired", faction)
-                                .map(|s| s.to_string())
-                        } else {
-                            None
-                        };
-                        if sound_id.is_empty() && eva_sound_id.is_none() {
+                                .is_some_and(|l| l.eq_ignore_ascii_case(owner_str)))
+                        .then(|| "EVA_BridgeRepaired".to_string());
+                        if sound_id.is_empty() && eva_event.is_none() {
                             continue;
                         }
                         GameSoundEvent::BridgeRepaired {
                             sound_id,
                             source,
-                            eva_sound_id,
+                            eva_event,
                         }
                     }
                     SimSoundEvent::UnderAttack {
@@ -1887,26 +1790,22 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             .match_audio
                             .eva_under_attack_block_until_tick =
                             sim.session.tick + EVA_UNDER_ATTACK_COOLDOWN_TICKS;
-                        let faction = crate::app::presentation::building_anim::eva_faction_key(
-                            owner_str,
-                            &state.match_state.match_presentation.house_roster,
-                        );
-                        let (cue, fallback) = if miner {
-                            ("EVA_OreMinerUnderAttack", "ceva037")
+                        // `HouseClass::NotifyUnderAttack 0x004F94FB/0x004F95B3`,
+                        // `UnitClass::ReceiveDamage 0x00738530`: `PlayEVA` type
+                        // -1 (stock entries STANDARD NORMAL → pending slot).
+                        let cue = if miner {
+                            "EVA_OreMinerUnderAttack"
                         } else {
-                            ("EVA_OurBaseIsUnderAttack", "ceva054")
+                            "EVA_OurBaseIsUnderAttack"
                         };
-                        let eva_sound_id = state
-                            .audio
-                            .eva_registry
-                            .get(cue, faction)
-                            .unwrap_or(fallback)
-                            .to_string();
                         state
                             .match_state
                             .match_audio
                             .sound_events
-                            .push(GameSoundEvent::UnderAttackEva { eva_sound_id });
+                            .push(GameSoundEvent::Eva {
+                                event: cue.to_string(),
+                                type_override: None,
+                            });
                         if let Some(siren) = base_under_attack_siren(miner, &resources.rules) {
                             state.match_state.match_audio.sound_events.push(siren);
                         }
@@ -2612,7 +2511,7 @@ mod tests {
     use super::{
         ExactStepError, ExactStepReceipt, VOICE_FEEDBACK_PERCENT, append_fire_effect_batch,
         base_under_attack_siren, begin_fire_effect_batch, cloak_sound_for_app,
-        finish_fire_effect_batch, lightning_storm_begin_cue, outcome_eva_entry,
+        finish_fire_effect_batch, lightning_storm_begin_cue, outcome_eva_event,
         superweapon_launch_cue, upsert_overlay_entries, validate_exact_step_receipt,
         voice_feedback_speaks, wall_sell_sound_for_local, world_point_to_cell,
     };
@@ -2646,16 +2545,12 @@ mod tests {
         use crate::sim::house_state::HouseOutcomeKind;
 
         assert_eq!(
-            outcome_eva_entry(HouseOutcomeKind::Victory, "Allied"),
-            ("EVA_YouAreVictorious", "ceva022")
+            outcome_eva_event(HouseOutcomeKind::Victory),
+            "EVA_YouAreVictorious"
         );
         assert_eq!(
-            outcome_eva_entry(HouseOutcomeKind::Victory, "Russian"),
-            ("EVA_YouAreVictorious", "csof022")
-        );
-        assert_eq!(
-            outcome_eva_entry(HouseOutcomeKind::Defeat, "Yuri"),
-            ("EVA_YouHaveLost", "cyur023")
+            outcome_eva_event(HouseOutcomeKind::Defeat),
+            "EVA_YouHaveLost"
         );
     }
 
@@ -2787,7 +2682,6 @@ mod tests {
         assert_eq!(nuke.sound_id.as_deref(), Some("NukeSiren"));
         assert!(nuke.positional);
         assert_eq!(nuke.eva_event, Some("EVA_NuclearMissileLaunched"));
-        assert!(!nuke.eva_queued);
 
         // Case 1: EVA only — the arm reaches no VocClass call.
         let ic = cue(K::IronCurtain, None);
@@ -2821,16 +2715,19 @@ mod tests {
             );
         }
 
-        // Cases 7 and 9: positional cue plus a Type=QUEUE EVA line.
+        // Cases 7 and 9: positional cue plus an EVA line (the entry's own
+        // `Type=QUEUE` routes it; the cue table carries only the name).
         let dominator = cue(K::PsychicDominator, None);
         assert_eq!(
             dominator.sound_id.as_deref(),
             Some("PsychicDominatorActivate")
         );
-        assert!(dominator.positional && dominator.eva_queued);
+        assert!(dominator.positional);
+        assert_eq!(dominator.eva_event, Some("EVA_PsychicDominatorActivated"));
         let mutator = cue(K::GeneticConverter, None);
         assert_eq!(mutator.sound_id.as_deref(), Some("GeneticMutatorActivate"));
-        assert!(mutator.positional && mutator.eva_queued);
+        assert!(mutator.positional);
+        assert_eq!(mutator.eva_event, Some("EVA_GeneticMutatorActivated"));
 
         // Case 11: cue only, no EVA.
         let reveal = cue(K::PsychicReveal, None);

--- a/src/app/presentation/building_anim.rs
+++ b/src/app/presentation/building_anim.rs
@@ -38,8 +38,17 @@ pub(crate) use crate::sim::world::building_anim::building_anim_rate_logic_frames
 /// the app-side stand-in for that construction frame — recorded once, the first
 /// logic frame the structure is seen.
 pub(crate) fn refresh_building_anim_phase_bases(state: &mut AppState) {
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
-        state.match_state.match_presentation.building_anim_phase_base.clear();
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
+        state
+            .match_state
+            .match_presentation
+            .building_anim_phase_base
+            .clear();
         return;
     };
     let tick = sim.session.tick;
@@ -49,7 +58,14 @@ pub(crate) fn refresh_building_anim_phase_bases(state: &mut AppState) {
         .filter(|(_, entity)| entity.category == crate::map::entities::EntityCategory::Structure)
         .map(|(id, _)| id)
         .collect();
-    record_building_anim_phase_bases(&mut state.match_state.match_presentation.building_anim_phase_base, &live, tick);
+    record_building_anim_phase_bases(
+        &mut state
+            .match_state
+            .match_presentation
+            .building_anim_phase_base,
+        &live,
+        tick,
+    );
 }
 
 /// Insert a phase base for every newly seen structure and forget the ones that
@@ -77,11 +93,18 @@ fn record_building_anim_phase_bases(
 /// Falls back to zero for a structure with no recorded base, which renders the
 /// animation's first loop frame rather than an arbitrary one.
 pub(crate) fn building_anim_elapsed_logic_frames(state: &AppState, stable_id: u64) -> u32 {
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
         return 0;
     };
     state
-        .match_state.match_presentation.building_anim_phase_base
+        .match_state
+        .match_presentation
+        .building_anim_phase_base
         .get(&stable_id)
         .map(|base| sim.session.tick.saturating_sub(*base).min(u32::MAX as u64) as u32)
         .unwrap_or(0)
@@ -90,14 +113,28 @@ pub(crate) fn building_anim_elapsed_logic_frames(state: &AppState, stable_id: u6
 /// Tick the sidebar power bar animation (segment-by-segment transition).
 pub(crate) fn update_power_bar_anim(state: &mut AppState) {
     let owner_name = preferred_local_owner_name(state);
-    let (power_produced, power_drained) =
-        match (state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation), state.rules(), owner_name.as_deref()) {
-            (Some(sim), Some(rules), Some(owner)) => {
-                production::power_balance_for_owner(sim, rules, owner)
-            }
-            _ => (0, 0),
-        };
-    let theoretical = match (state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation), owner_name.as_deref()) {
+    let (power_produced, power_drained) = match (
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation),
+        state.rules(),
+        owner_name.as_deref(),
+    ) {
+        (Some(sim), Some(rules), Some(owner)) => {
+            production::power_balance_for_owner(sim, rules, owner)
+        }
+        _ => (0, 0),
+    };
+    let theoretical = match (
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation),
+        owner_name.as_deref(),
+    ) {
         (Some(sim), Some(owner)) => production::theoretical_power_for_owner(sim, owner),
         _ => 0,
     };
@@ -111,17 +148,27 @@ pub(crate) fn update_power_bar_anim(state: &mut AppState) {
     let region_top = layout.tabs_y + spec.power_bar_top_y;
     let bar_height_px = (region_bottom - region_top).max(0.0) as i32;
 
-    state.match_state.match_presentation.power_bar_anim.set_max_segments(bar_height_px);
     state
-        .match_state.match_presentation.power_bar_anim
-        .update(power_produced, power_drained, theoretical);
+        .match_state
+        .match_presentation
+        .power_bar_anim
+        .set_max_segments(bar_height_px);
+    state.match_state.match_presentation.power_bar_anim.update(
+        power_produced,
+        power_drained,
+        theoretical,
+    );
     state.match_state.match_presentation.power_bar_anim.tick();
 }
 
 /// Update radar availability from ECS and tick the radar chrome animation.
 pub(crate) fn update_radar_state(state: &mut AppState, dt_ms: f32) {
     let new_has_radar: bool = match (
-        state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation),
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation),
         state.rules(),
         preferred_local_owner_name(state).as_deref(),
     ) {
@@ -138,28 +185,27 @@ pub(crate) fn update_radar_state(state: &mut AppState, dt_ms: f32) {
     }
 }
 
-/// Map an owner's country name to the EVA faction key used in eva.ini sections.
+/// The EVA voice column for this session — `VoxClass::SetSide @ 0x007534E0`.
 ///
-/// Returns "Allied", "Russian", or "Yuri" for lookup in `EvaRegistry::get()`.
-pub(crate) fn eva_faction_key(
-    owner: &str,
-    house_roster: &crate::map::houses::HouseRoster,
-) -> &'static str {
-    // Find the house's country name from the roster.
-    let country = house_roster
-        .houses
-        .iter()
-        .find(|h| h.name.eq_ignore_ascii_case(owner))
-        .and_then(|h| h.country.as_deref())
-        .unwrap_or(owner);
-
-    // Map country to EVA faction key.
-    // Soviet countries use "Russian" (the key name in eva.ini).
-    match country.to_ascii_lowercase().as_str() {
-        "yuricountry" => "Yuri",
-        "russians" | "confederation" | "africans" | "arabs" => "Russian",
-        _ => "Allied",
-    }
+/// Native stores it once per scenario: `ScenarioClass::Full_Init`
+/// (`0x00687801..0x00687807`) passes `Houses[PlayerIndex]->Type(+0x34)->Side
+/// (+0xBC)` — the local country's `Side=` index — to `InitSideMixFiles @
+/// 0x00534FA0`, which calls `SetSide` first (before its own `2 -> 1` MIX
+/// remap, so a Yuri country keeps the Yuri column). A `PlayerIndex` of `-1`
+/// or out of range passes 0. `EvaSide::from_side_index` is the column select
+/// of `PlayNextQueued` (`0x007528E8..0x007528FE`).
+///
+/// VERA resolves the same value from the local house's `side_index`
+/// (`HouseState`, from `rules.country_side_index`) at consume time; the
+/// local owner is fixed for the match, so this equals a once-stored side.
+pub(crate) fn local_eva_side(state: &AppState) -> crate::rules::sound_ini::EvaSide {
+    use crate::rules::sound_ini::EvaSide;
+    let side_index = preferred_local_owner_name(state).and_then(|owner| {
+        let sim = &state.match_state.sim_runtime.as_ref()?.simulation;
+        crate::sim::house_state::house_state_for_owner(&sim.houses, &owner, &sim.interner)
+            .map(|house| i32::from(house.side_index))
+    });
+    EvaSide::from_side_index(side_index.unwrap_or(0))
 }
 
 /// Drain pending sound events from the queue and play them through the SFX player.
@@ -206,12 +252,15 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
     let local_owner_id = local_owner
         .as_deref()
         .and_then(|name| sim.and_then(|sim| sim.interner.get(name)));
-    let (Some(sfx), Some(assets)) = (&mut state.audio.sfx_player, state.process_assets.manager()) else {
+    let eva_side = local_eva_side(state);
+    let (Some(sfx), Some(assets)) = (&mut state.audio.sfx_player, state.process_assets.manager())
+    else {
         return;
     };
     let registry = &state.audio.sound_registry;
     let audio_indices = &state.audio.audio_indices;
-    sfx.advance_voice_queue();
+    let eva_registry = &state.audio.eva_registry;
+    sfx.advance_voice_queue(registry, assets, audio_indices);
 
     // `CellClass+0x12C & 0x18 == 0`: neither explored nor visible. The shroud
     // renderer (`render::shroud_buffer`) blacks out the same cells — never
@@ -256,17 +305,23 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
             | GameSoundEvent::UnitAttackOrder { speaker_id, .. } => {
                 sfx.queue_unit_voice(*speaker_id, event.sound_id());
             }
-            // STANDARD EVA cues are fire-and-forget: play only if voice is idle.
-            GameSoundEvent::BuildingReady { .. }
-            | GameSoundEvent::UnitReady { .. }
-            | GameSoundEvent::CannotDeployHere { .. }
-            | GameSoundEvent::OutcomeEva { .. } => {
-                sfx.play_standard_eva_sound(event.sound_id(), registry, assets, audio_indices);
-            }
-            // Garrison EVA cues are evamd.ini Type=QUEUE.
-            GameSoundEvent::StructureGarrisoned { .. }
-            | GameSoundEvent::StructureAbandoned { .. } => {
-                sfx.queue_eva_sound(event.sound_id(), registry, assets, audio_indices);
+            // `VoxClass::PlayEVA @ 0x00752700`: routing (pending slot, the
+            // QUEUE FIFOs, critical/interrupt lists), the same-type duplicate
+            // rule and the 500 ms gap all come from the entry and the
+            // `VoxClass` state in `sfx` — see `audio::vox`.
+            GameSoundEvent::Eva {
+                event: eva_event,
+                type_override,
+            } => {
+                let _ = sfx.play_eva(
+                    eva_event,
+                    *type_override,
+                    eva_registry,
+                    eva_side,
+                    registry,
+                    assets,
+                    audio_indices,
+                );
             }
             // UI events — always full volume (non-positional).
             GameSoundEvent::UiSound { .. } => {
@@ -399,8 +454,7 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
             GameSoundEvent::SuperWeaponActivated {
                 sound_id,
                 source,
-                eva_sound_id,
-                eva_queued,
+                eva_event,
             } => {
                 // `RulesClass::ReadAudioVisual @ 0x006691E0` and
                 // `SuperWeaponTypeClass::ReadINI @ 0x006CEBE5` both store only
@@ -436,32 +490,41 @@ pub(crate) fn drain_sound_events(state: &mut AppState) {
                         }
                     }
                 }
-                if let Some(eva_sound_id) = eva_sound_id.as_deref().filter(|s| !s.is_empty()) {
-                    if *eva_queued {
-                        let _ = sfx.queue_eva_sound(eva_sound_id, registry, assets, audio_indices);
-                    } else {
-                        sfx.play_standard_eva_sound(eva_sound_id, registry, assets, audio_indices);
-                    }
+                // `VoxClass::PlayEVA(name, -1)` at every `SuperClass::Launch`
+                // site: the entry's own `Type=`/`Priority=` route it.
+                if let Some(eva_event) = eva_event.as_deref().filter(|s| !s.is_empty()) {
+                    let _ = sfx.play_eva(
+                        eva_event,
+                        None,
+                        eva_registry,
+                        eva_side,
+                        registry,
+                        assets,
+                        audio_indices,
+                    );
                 }
             }
             GameSoundEvent::BridgeRepaired {
                 sound_id,
                 source,
-                eva_sound_id,
+                eva_event,
             } => {
                 if !sound_id.is_empty()
                     && let Some(gain) = gain_for(sound_id, *source)
                 {
                     sfx.play_sound_spatial(sound_id, gain, registry, assets, audio_indices);
                 }
-                if let Some(eva_sound_id) = eva_sound_id.as_deref().filter(|s| !s.is_empty()) {
-                    sfx.play_standard_eva_sound(eva_sound_id, registry, assets, audio_indices);
+                if let Some(eva_event) = eva_event.as_deref().filter(|s| !s.is_empty()) {
+                    let _ = sfx.play_eva(
+                        eva_event,
+                        None,
+                        eva_registry,
+                        eva_side,
+                        registry,
+                        assets,
+                        audio_indices,
+                    );
                 }
-            }
-            GameSoundEvent::UnderAttackEva { eva_sound_id } => {
-                // Voice-queued (not immediate): under-attack announcements
-                // wait behind whatever EVA line is currently speaking.
-                let _ = sfx.queue_eva_sound(eva_sound_id, registry, assets, audio_indices);
             }
             // Spatial events — distance volume and pan from the sound's
             // Range/Type/MinVolume against the tactical view.
@@ -533,40 +596,62 @@ fn registry_facts_for_owner(
 pub(crate) fn tick_garrison_muzzle_flashes(state: &mut AppState, dt_ms: u32) {
     // Phase 1: spawn new flashes from pending fire events.
     let new_flashes: Vec<GarrisonMuzzleFlash> = {
-        let sim = match state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) {
+        let sim = match state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation)
+        {
             Some(s) => s,
             None => {
-                state.match_state.match_presentation.garrison_muzzle_flashes.clear();
+                state
+                    .match_state
+                    .match_presentation
+                    .garrison_muzzle_flashes
+                    .clear();
                 return;
             }
         };
         let art_reg = match state.rules().map(|rules| &rules.art_registry) {
             Some(a) => a,
             None => {
-                state.match_state.match_presentation.garrison_muzzle_flashes.clear();
+                state
+                    .match_state
+                    .match_presentation
+                    .garrison_muzzle_flashes
+                    .clear();
                 return;
             }
         };
         let rules = match state.rules() {
             Some(r) => r,
             None => {
-                state.match_state.match_presentation.garrison_muzzle_flashes.clear();
+                state
+                    .match_state
+                    .match_presentation
+                    .garrison_muzzle_flashes
+                    .clear();
                 return;
             }
         };
         let frame_counts = state
-            .match_state.match_presentation.sprite_atlas
+            .match_state
+            .match_presentation
+            .sprite_atlas
             .as_ref()
             .map(|atlas| &atlas.active_anim_frame_counts);
         state
-            .match_state.match_presentation.pending_fire_effects
+            .match_state
+            .match_presentation
+            .pending_fire_effects
             .iter()
             .filter_map(|ev| {
                 let anim_name = ev.occupant_anim.as_ref()?;
                 let anim_section = sim.interner.resolve(*anim_name).to_ascii_uppercase();
-                let origin =
-                    crate::app::presentation::fire_effects::resolve_fire_origin_from_sim(sim, rules, art_reg, ev)
-                        .ok()?;
+                let origin = crate::app::presentation::fire_effects::resolve_fire_origin_from_sim(
+                    sim, rules, art_reg, ev,
+                )
+                .ok()?;
                 let runtime_config = art_reg.anim_runtime_config(&anim_section)?;
                 let total_frames =
                     presentation_anim_frame_count(frame_counts, &anim_section).unwrap_or(1);
@@ -589,26 +674,42 @@ pub(crate) fn tick_garrison_muzzle_flashes(state: &mut AppState, dt_ms: u32) {
             })
             .collect()
     };
-    state.match_state.match_presentation.garrison_muzzle_flashes.extend(new_flashes);
+    state
+        .match_state
+        .match_presentation
+        .garrison_muzzle_flashes
+        .extend(new_flashes);
 
     // Phase 2: advance all flashes and remove finished ones. This is fed from
     // completed fixed sim ticks, not render-frame wall time.
     let Some((sim, art_reg)) = state
-        .match_state.sim_runtime
+        .match_state
+        .sim_runtime
         .as_ref()
-        .map(|rt| (&rt.simulation, &rt.resources.rules.art_registry)) else {
-        state.match_state.match_presentation.garrison_muzzle_flashes.clear();
+        .map(|rt| (&rt.simulation, &rt.resources.rules.art_registry))
+    else {
+        state
+            .match_state
+            .match_presentation
+            .garrison_muzzle_flashes
+            .clear();
         return;
     };
     let empty_frame_counts = HashMap::new();
     let frame_counts = state
-        .match_state.match_presentation.sprite_atlas
+        .match_state
+        .match_presentation
+        .sprite_atlas
         .as_ref()
         .map(|atlas| &atlas.active_anim_frame_counts)
         .unwrap_or(&empty_frame_counts);
-    state.match_state.match_presentation.garrison_muzzle_flashes.retain_mut(|flash| {
-        advance_garrison_muzzle_flash(flash, dt_ms, sim, art_reg, frame_counts)
-    });
+    state
+        .match_state
+        .match_presentation
+        .garrison_muzzle_flashes
+        .retain_mut(|flash| {
+            advance_garrison_muzzle_flash(flash, dt_ms, sim, art_reg, frame_counts)
+        });
 }
 
 fn advance_garrison_muzzle_flash(

--- a/src/audio/events.rs
+++ b/src/audio/events.rs
@@ -55,13 +55,17 @@ impl SoundSource {
 /// A sound event produced by the game simulation or UI.
 #[derive(Debug, Clone)]
 pub enum GameSoundEvent {
-    /// Local player's base structure / harvester is under enemy attack — queue
-    /// the EVA voice (no spatial SFX; the radar diamond is sim-side).
-    UnderAttackEva { eva_sound_id: String },
-
-    /// Accepted local HouseClass win/loss transition — play immediately with
-    /// STANDARD Vox semantics and do not persist/reconstruct across load.
-    OutcomeEva { eva_sound_id: String },
+    /// One `VoxClass::PlayEVA @ 0x00752700` call: the `[DialogList]` event
+    /// name and the call site's type override (`-1` = the entry's own
+    /// `Type=`; only `SelectClass::Action` OnHold/Canceled and
+    /// `GameExit::BattleControlTerminated 0x00686616` pass `2`). The side
+    /// column, `Type=`/`Priority=` routing, duplicate rule and the 500 ms gap
+    /// are the consumer's (`SfxPlayer::play_eva` → `audio::vox`). Producers
+    /// gate on the local player before pushing this.
+    Eva {
+        event: String,
+        type_override: Option<crate::rules::sound_ini::EvaType>,
+    },
 
     /// Start/report sound owned by one authoritative animation object.
     AnimationStarted {
@@ -163,44 +167,11 @@ pub enum GameSoundEvent {
         source: Option<SoundSource>,
     },
 
-    /// The `EVA_UnitPromoted` voice that accompanies `UnitPromoted`.
-    UnitPromotedEva { eva_sound_id: String },
-
     /// One-shot positional `[AudioVisual] CloakSound` requested by an accepted
     /// native StartUncloaking arg-zero transition.
     CloakSound {
         sound_id: String,
         source: Option<SoundSource>,
-    },
-
-    /// A building finished construction — play the EVA "Construction complete" or similar.
-    BuildingReady {
-        /// sound.ini ID for the completion announcement.
-        sound_id: String,
-    },
-
-    /// A unit finished training — play the EVA "Unit ready" or similar.
-    UnitReady {
-        /// sound.ini ID for the unit-ready announcement.
-        sound_id: String,
-    },
-
-    /// EVA cue: a deploy command failed placement validation.
-    CannotDeployHere {
-        /// sound.ini ID for the EVA announcement.
-        sound_id: String,
-    },
-
-    /// EVA cue: a friendly building was garrisoned (first occupant entered).
-    StructureGarrisoned {
-        /// sound.ini ID for the EVA announcement.
-        sound_id: String,
-    },
-
-    /// EVA cue: a friendly garrison was abandoned (last occupant left).
-    StructureAbandoned {
-        /// sound.ini ID for the EVA announcement.
-        sound_id: String,
     },
 
     /// Positional SFX from [AudioVisual] BuildingGarrisonedSound — plays at
@@ -254,7 +225,7 @@ pub enum GameSoundEvent {
     /// Positional SFX + EVA cue from a bridge repair triggered by an engineer
     /// entering a `BridgeRepairHut`. Plays the spatial `[BridgeRepaired]`
     /// sound (resolved from `rules.bridge_rules.repair_sound`) at the hut's
-    /// screen position when `sound_id` is non-empty. When `eva_sound_id` is
+    /// screen position when `sound_id` is non-empty. When `eva_event` is
     /// `Some`, the EVA arm plays it as a non-positional cue (gated upstream
     /// on local-human owner).
     BridgeRepaired {
@@ -263,9 +234,9 @@ pub enum GameSoundEvent {
         sound_id: String,
         /// Screen position for spatial audio.
         source: Option<SoundSource>,
-        /// `Some(eva_id)` when the engineer's owner is the local human;
-        /// `None` otherwise.
-        eva_sound_id: Option<String>,
+        /// `Some("EVA_BridgeRepaired")` when the engineer's owner is the
+        /// local human and the radar dedupe allowed it; `None` otherwise.
+        eva_event: Option<String>,
     },
 
     /// Positional sound emitted when a world-effect animation starts.
@@ -360,11 +331,9 @@ pub enum GameSoundEvent {
         sound_id: String,
         /// Target-cell position, or `None` for a non-positional cue.
         source: Option<SoundSource>,
-        /// Resolved per-faction `evamd.ini` sample, or `None` when the case
-        /// plays no EVA line.
-        eva_sound_id: Option<String>,
-        /// The EVA entry's `Type=QUEUE` (true) vs STANDARD (false).
-        eva_queued: bool,
+        /// `evamd.ini` event name for the `VoxClass::PlayEVA` call, or `None`
+        /// when the case plays no EVA line. Routing comes from the entry.
+        eva_event: Option<String>,
     },
 
     /// Generic UI sound (button click, error beep, etc.).
@@ -390,13 +359,8 @@ impl GameSoundEvent {
             | Self::ChronoTeleport { sound_id, .. }
             | Self::UnitPromoted { sound_id, .. }
             | Self::CloakSound { sound_id, .. }
-            | Self::BuildingReady { sound_id }
-            | Self::UnitReady { sound_id }
-            | Self::CannotDeployHere { sound_id }
             | Self::UiSound { sound_id }
             | Self::BaseUnderAttackSfx { sound_id }
-            | Self::StructureGarrisoned { sound_id }
-            | Self::StructureAbandoned { sound_id }
             | Self::BuildingGarrisonedSfx { sound_id, .. }
             | Self::C4Planted { sound_id, .. }
             | Self::RefineryExitSfx { sound_id, .. }
@@ -409,9 +373,9 @@ impl GameSoundEvent {
             | Self::SuperWeaponActivated { sound_id, .. }
             | Self::WorldEffectStarted { sound_id, .. } => sound_id,
             Self::AnimationStopped { stop_sound_id, .. } => stop_sound_id.as_deref().unwrap_or(""),
-            Self::UnderAttackEva { eva_sound_id }
-            | Self::OutcomeEva { eva_sound_id }
-            | Self::UnitPromotedEva { eva_sound_id } => eva_sound_id,
+            // The event name, not a sample: the sample is a per-side column
+            // the `VoxClass` consumer resolves.
+            Self::Eva { event, .. } => event,
         }
     }
 
@@ -643,22 +607,31 @@ mod tests {
         assert_eq!(evt.sound_id(), "VGCannon1");
     }
 
+    /// An EVA event carries the `[DialogList]` name and the call-site type
+    /// override, never a resolved sample; it is non-positional.
     #[test]
-    fn test_structure_garrisoned_sound_id_accessor() {
-        let evt: GameSoundEvent = GameSoundEvent::StructureGarrisoned {
-            sound_id: "ceva107".to_string(),
+    fn eva_event_carries_the_event_name_and_type_override() {
+        let evt: GameSoundEvent = GameSoundEvent::Eva {
+            event: "EVA_StructureGarrisoned".to_string(),
+            type_override: None,
         };
-        assert_eq!(evt.sound_id(), "ceva107");
+        assert_eq!(evt.sound_id(), "EVA_StructureGarrisoned");
         assert_eq!(evt.screen_pos(), None);
-    }
+        assert_eq!(evt.source(), None);
 
-    #[test]
-    fn test_cannot_deploy_here_sound_id_accessor() {
-        let evt = GameSoundEvent::CannotDeployHere {
-            sound_id: "ceva063".to_string(),
+        let evt = GameSoundEvent::Eva {
+            event: "EVA_BattleControlTerminated".to_string(),
+            type_override: Some(crate::rules::sound_ini::EvaType::Interrupt),
         };
-        assert_eq!(evt.sound_id(), "ceva063");
-        assert_eq!(evt.screen_pos(), None);
+        match evt {
+            GameSoundEvent::Eva { type_override, .. } => {
+                assert_eq!(
+                    type_override,
+                    Some(crate::rules::sound_ini::EvaType::Interrupt)
+                );
+            }
+            _ => unreachable!(),
+        }
     }
 
     #[test]
@@ -687,14 +660,14 @@ mod tests {
         let evt = GameSoundEvent::BridgeRepaired {
             sound_id: "BridgeRepaired".to_string(),
             source: Some(SoundSource::new((32.0, 64.0), (1, 2))),
-            eva_sound_id: Some("EVA_BridgeRepaired".to_string()),
+            eva_event: Some("EVA_BridgeRepaired".to_string()),
         };
 
         assert_eq!(evt.sound_id(), "BridgeRepaired");
         assert_eq!(evt.screen_pos(), Some((32.0, 64.0)));
         match evt {
-            GameSoundEvent::BridgeRepaired { eva_sound_id, .. } => {
-                assert_eq!(eva_sound_id.as_deref(), Some("EVA_BridgeRepaired"));
+            GameSoundEvent::BridgeRepaired { eva_event, .. } => {
+                assert_eq!(eva_event.as_deref(), Some("EVA_BridgeRepaired"));
             }
             _ => unreachable!(),
         }

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -14,3 +14,4 @@ pub mod music;
 pub mod sfx;
 pub(crate) mod theme;
 pub mod voice_queue;
+pub mod vox;

--- a/src/audio/sfx.rs
+++ b/src/audio/sfx.rs
@@ -27,7 +27,7 @@
 //!   rules/sound_ini (SoundRegistry for ID→filename mapping).
 //! - Does NOT depend on render/, ui/, sidebar/, sim/.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::BTreeMap;
 use std::num::NonZero;
 
 use rodio::buffer::SamplesBuffer;
@@ -37,7 +37,10 @@ use crate::assets::asset_manager::AssetManager;
 use crate::assets::aud_file;
 use crate::audio::arbiter::{self, ArbiterAction, EntryFacts, EventId, PlayRequest, SoundArbiter};
 use crate::audio::voice_queue::VoiceQueue;
-use crate::rules::sound_ini::{SoundEntry, SoundRegistry, VOLUME_SCALE, control, sound_type};
+use crate::audio::vox::{VoxNode, VoxQueue, VoxRequest};
+use crate::rules::sound_ini::{
+    EvaRegistry, EvaSide, EvaType, SoundEntry, SoundRegistry, VOLUME_SCALE, control, sound_type,
+};
 
 /// How many passes of a sustaining cue are kept queued on its rodio player:
 /// the one that is sounding plus one waiting behind it.
@@ -707,29 +710,6 @@ struct ResolvedPlayback {
     shifts: PlayShifts,
 }
 
-struct QueuedVoice {
-    sound_id: String,
-    decoded: DecodedAudio,
-    /// Sound-entry linear volume only. The current Voice master is applied
-    /// when this cue reaches the dedicated slot, not when it enters the queue.
-    base_linear: i32,
-}
-
-impl QueuedVoice {
-    fn new(sound_id: String, decoded: DecodedAudio, base_linear: i32) -> Self {
-        Self {
-            sound_id,
-            decoded,
-            base_linear,
-        }
-    }
-
-    fn prepare_for_dequeue(self, scales: SfxOutputScales) -> (String, PreparedSfxOutput) {
-        let output = prepare_direct_voice_output(self.decoded, self.base_linear, scales);
-        (self.sound_id, output)
-    }
-}
-
 /// User-controlled master channel for one secondary output.
 ///
 /// gamemd-derived: `OptionsClass::SetDefaults @ 0x005FA350` and
@@ -884,51 +864,6 @@ struct LoopQueue {
     finished: bool,
 }
 
-/// The EVA/speech suspend counter, `g_VoxSuspendDepth (DAT_00b1d428)`.
-///
-/// `GamePause::Enter @ 0x00406F00` calls `VoxClass::PauseEVA @ 0x007535B0`
-/// unconditionally, which raises this counter (`DAT_00b1d428 += 1`) after
-/// pausing the sounding announcement; `GamePause::Exit @ 0x00406F40` calls
-/// `VoxClass::UnpauseEVA @ 0x00753620`, which lowers it with a floor of 0
-/// (`if (d != 0) { d -= 1; if (d < 0) d = 0; }`).
-///
-/// `VoxClass::PlayNextQueued @ 0x00752780` — the dequeue the pump runs every
-/// pass — gates its **entire** body on `DAT_00b1d428 == 0` (read at
-/// `0x007527D5`; `get_xrefs_to 0x00b1d428` shows the only other readers are
-/// `PauseEVA`/`UnpauseEVA`). So a paused game neither finishes the line it is
-/// speaking nor starts the next queued one.
-#[derive(Debug, Clone, Copy, Default)]
-struct VoiceSuspend {
-    depth: i32,
-}
-
-impl VoiceSuspend {
-    /// One `GamePause::Enter`/`Exit` edge.
-    fn set_paused(&mut self, paused: bool) {
-        if paused {
-            self.depth += 1;
-        } else if self.depth != 0 {
-            self.depth = (self.depth - 1).max(0);
-        }
-    }
-
-    /// `VoxClass::PlayNextQueued`'s `DAT_00b1d428 == 0` gate.
-    fn dequeue_allowed(&self) -> bool {
-        self.depth == 0
-    }
-
-    /// `VoxClass::ResetAll @ 0x007535F0` zeroes `DAT_00b1d428` outright
-    /// (`DAT_00b1d428 = 0;`, after stopping the stream and calling
-    /// `VoxClass::ClearAllQueues`) rather than unwinding it pause by pause.
-    /// A reset therefore drops any depth a `GamePause::Enter` had raised —
-    /// native does not touch the game's own pause state here, and neither
-    /// does VERA, so a reset taken while paused leaves the dequeue ungated
-    /// in both. Harmless in both, because the queue is empty by then.
-    fn reset(&mut self) {
-        self.depth = 0;
-    }
-}
-
 /// Manages sound effect playback with separate SFX pool and voice slot.
 ///
 /// Matches the original engine's architecture:
@@ -962,8 +897,12 @@ pub struct SfxPlayer {
     /// semantics (`VoxClass`) are a separate parity surface that owns this
     /// slot, so folding voices into the pool is deferred to it.
     voice_player: Option<LiveSfxOutput>,
-    /// Queued EVA/voice announcements waiting for the dedicated voice slot.
-    queued_voice: VecDeque<QueuedVoice>,
+    /// The EVA announcement queue (`VoxClass`), including the pause depth
+    /// `DAT_00b1d428` and the suspend depth `DAT_00b1d3d8`.
+    vox: VoxQueue,
+    /// An EVA line was started on `voice_player` and its end has not been
+    /// reported to `vox` yet (`StreamPlayer::GetEndTime` stand-in).
+    eva_stream_open: bool,
     /// Sound id currently occupying the dedicated voice slot, when known.
     current_voice_id: Option<String>,
     /// Stable id of the object whose acknowledgement line owns the voice slot,
@@ -985,8 +924,6 @@ pub struct SfxPlayer {
     /// Whether the game is paused, so [`Self::set_paused`] only acts on the
     /// edge the way `GamePause::Enter`/`Exit` do.
     paused: bool,
-    /// `g_VoxSuspendDepth (DAT_00b1d428)`: the EVA/speech suspend counter.
-    voice_suspend: VoiceSuspend,
     /// Presentation-side RNG standing in for `g_MainRng @ 0x00886B88`.
     rng: SfxRng,
 }
@@ -1006,7 +943,8 @@ impl SfxPlayer {
             loops: BTreeMap::new(),
             now_ms: 0,
             voice_player: None,
-            queued_voice: VecDeque::new(),
+            vox: VoxQueue::new(),
+            eva_stream_open: false,
             current_voice_id: None,
             current_voice_owner: None,
             voice_queue: VoiceQueue::new(),
@@ -1015,7 +953,6 @@ impl SfxPlayer {
             output_scale: 1.0,
             focus_output_scale: 1.0,
             paused: false,
-            voice_suspend: VoiceSuspend::default(),
             rng: SfxRng::from_clock(),
         })
     }
@@ -1374,130 +1311,115 @@ impl SfxPlayer {
         }
     }
 
-    /// Queue an EVA-style announcement without interrupting the current voice.
+    /// `VoxClass::PlayEVA @ 0x00752700`: find the entry by name (`stricmp`
+    /// scan of `0xB1D4A4`; a miss becomes `QueueVoice(-1, ..)`, which its
+    /// index guard rejects), then `QueueVoice(index, type_override, -1)` —
+    /// priority is always the entry's own — and `PlayNextQueued`.
     ///
-    /// This is the narrow app-facing bridge for evamd.ini `Type=QUEUE` cues.
-    /// Full native priority tiers and inter-announcement delay remain a later
-    /// VoxClass parity surface.
-    pub fn queue_eva_sound(
+    /// `side` is the session column `VoxClass::SetSide @ 0x007534E0` stored;
+    /// an empty column is a `PlayFile` of `".WAV"`, which fails, so it is
+    /// treated as a miss here. Returns whether the request entered a queue
+    /// (or the pending slot).
+    pub fn play_eva(
         &mut self,
-        sound_id: &str,
+        event: &str,
+        type_override: Option<EvaType>,
+        eva_registry: &EvaRegistry,
+        side: EvaSide,
         registry: &SoundRegistry,
         assets: &AssetManager,
         audio_indices: &[crate::assets::audio_bag::AudioIndex],
     ) -> bool {
-        self.advance_voice_queue();
-
-        if self.current_voice_id.as_deref() == Some(sound_id)
-            || self
-                .queued_voice
-                .iter()
-                .any(|queued| queued.sound_id == sound_id)
-        {
-            return true;
-        }
-
-        let Some(resolved) = self.resolve_any(sound_id, registry, assets, audio_indices) else {
+        let Some(entry) = eva_registry.entry(event) else {
             return false;
         };
-        self.queued_voice.push_back(QueuedVoice::new(
-            sound_id.to_string(),
-            resolved.decoded,
-            resolved.event_linear,
-        ));
-        self.advance_voice_queue();
-        true
+        let Some(sample) = entry.column(side) else {
+            return false;
+        };
+        let effect = self.vox.queue_voice(
+            VoxRequest {
+                event: &entry.name,
+                sample,
+                eva_type: entry.eva_type,
+                priority: entry.priority,
+            },
+            type_override,
+        );
+        if effect.stop_stream {
+            // `StreamPlayer::Stop` (`0x00752480`, type 2 while current): only
+            // the dedicated voice channel; ordinary and animation SFX are
+            // untouched.
+            if let Some(output) = self.voice_player.take() {
+                output.player.stop();
+            }
+            self.current_voice_id = None;
+            self.eva_stream_open = false;
+        }
+        self.advance_voice_queue(registry, assets, audio_indices);
+        effect.inserted
     }
 
-    /// Play a STANDARD EVA cue only if the voice system is currently idle.
-    ///
-    /// Native STANDARD entries are fire-and-forget; when voice playback or a
-    /// queued announcement is active they are not retained for later playback.
-    pub fn play_standard_eva_sound(
-        &mut self,
-        sound_id: &str,
-        registry: &SoundRegistry,
-        assets: &AssetManager,
-        audio_indices: &[crate::assets::audio_bag::AudioIndex],
-    ) -> bool {
-        self.advance_voice_queue();
-        if self
-            .voice_player
+    /// Whether the dedicated voice slot has audio left to play
+    /// (`StreamPlayer::IsPlaying @ 0x00408070` stand-in; VERA serves unit
+    /// acknowledgements from the same slot, so a unit line counts too).
+    fn voice_slot_busy(&self) -> bool {
+        self.voice_player
             .as_ref()
             .is_some_and(|output| !output.player.empty())
-            || !self.queued_voice.is_empty()
-        {
-            return false;
-        }
-
-        let Some(resolved) = self.resolve_any(sound_id, registry, assets, audio_indices) else {
-            return false;
-        };
-        self.play_voice(
-            resolved.decoded,
-            resolved.event_linear,
-            Some(sound_id.to_string()),
-        )
     }
 
-    /// Replace only the dedicated EVA/voice channel with an INTERRUPT cue.
+    /// `VoxClass::PlayNextQueued @ 0x00752760`, the per-pump dequeue.
     ///
-    /// gamemd `VoxClass__QueueVoice @ 0x00752480`, type 2, discards queued
-    /// voice nodes and stops the current voice before starting the new cue.
-    /// Ordinary and animation SFX are deliberately untouched.
-    pub fn interrupt_eva_sound(
+    /// The native gate is `IsPlaying() == 0 && now > GetEndTime() + gap &&
+    /// DAT_00b1d428 == 0` (`0x00752794..0x007527D5`); [`VoxQueue::take_next`]
+    /// owns it. The stream's end time is reported here the first time the
+    /// slot is seen empty after an EVA line started, so the 500 ms gap runs
+    /// from the observed end (a paused line therefore still gets its gap
+    /// after it resumes and finishes).
+    ///
+    /// Then the sample is loaded and started — `StreamPlayer::PlayFile(name,
+    /// 1)` at `0x0075295C`; a failed load drops the node without touching
+    /// the gap (`0x00752963 JZ`), exactly as a missing `.WAV` does natively
+    /// (the stock `Dummy` columns of `EVA_PsychicDominatorActivated`).
+    pub fn advance_voice_queue(
         &mut self,
-        sound_id: &str,
         registry: &SoundRegistry,
         assets: &AssetManager,
         audio_indices: &[crate::assets::audio_bag::AudioIndex],
-    ) -> bool {
-        self.queued_voice.clear();
-        if let Some(output) = self.voice_player.take() {
-            output.player.stop();
+    ) {
+        let busy = self.voice_slot_busy();
+        if !busy {
+            if self.eva_stream_open {
+                self.vox.stream_ended(self.now_ms);
+                self.eva_stream_open = false;
+            }
+            if self.voice_player.is_some() {
+                self.voice_player = None;
+                self.current_voice_id = None;
+            }
         }
-        self.current_voice_id = None;
-
-        let Some(resolved) = self.resolve_any(sound_id, registry, assets, audio_indices) else {
-            return false;
+        let Some(node) = self.vox.take_next(self.now_ms, busy) else {
+            return;
         };
-        self.play_voice(
-            resolved.decoded,
-            resolved.event_linear,
-            Some(sound_id.to_string()),
-        )
+        self.start_eva_node(node, registry, assets, audio_indices);
     }
 
-    /// Starts the next queued EVA cue if the dedicated voice slot is idle.
-    ///
-    /// `VoxClass::PlayNextQueued @ 0x00752780` wraps its whole body in
-    /// `... && (DAT_00b1d428 == 0)` (`0x007527D5`), so while the game is
-    /// paused the queue does not advance and the slot is not even recycled.
-    ///
-    /// VERA tests it first; in native it is the **last** term of the inner
-    /// `if` at `0x007527D5`, after the `StreamPlayer::IsPlaying` poll and the
-    /// end-time comparison. Equivalent, because every term before it is a
-    /// side-effect-free poll and every side effect — the slot recycle
-    /// `DAT_00b1d4c4 + 0x50 = 2` included — sits inside the gate.
-    pub fn advance_voice_queue(&mut self) {
-        if !self.voice_suspend.dequeue_allowed() {
-            return;
-        }
-        if self
-            .voice_player
-            .as_ref()
-            .is_some_and(|output| !output.player.empty())
-        {
-            return;
-        }
-        self.voice_player = None;
-        self.current_voice_id = None;
-
-        let Some(queued) = self.queued_voice.pop_front() else {
+    fn start_eva_node(
+        &mut self,
+        node: VoxNode,
+        registry: &SoundRegistry,
+        assets: &AssetManager,
+        audio_indices: &[crate::assets::audio_bag::AudioIndex],
+    ) {
+        let Some(resolved) = self.resolve_any(&node.sample, registry, assets, audio_indices) else {
+            log::debug!("EVA {} has no sample {}", node.event, node.sample);
             return;
         };
-        let (sound_id, prepared) = queued.prepare_for_dequeue(self.output_scales());
-        self.play_prepared_voice(prepared, Some(sound_id));
+        let sample = node.sample.clone();
+        if self.play_voice(resolved.decoded, resolved.event_linear, Some(sample)) {
+            self.eva_stream_open = true;
+            self.vox.started(node);
+        }
     }
 
     /// Play decoded audio on the dedicated voice slot, cutting off any current voice.
@@ -1603,7 +1525,7 @@ impl SfxPlayer {
         audio_indices: &[crate::assets::audio_bag::AudioIndex],
     ) {
         self.now_ms = now_ms;
-        self.advance_voice_queue();
+        self.advance_voice_queue(registry, assets, audio_indices);
         self.top_up_loop_queues(now_ms, registry, assets, audio_indices);
         self.report_finished_outputs();
         if !self.arbiter.pump_due(now_ms) {
@@ -1811,7 +1733,7 @@ impl SfxPlayer {
     /// The EVA/speech stream is a **second, unconditional** half of the same
     /// edge: `Enter` calls `VoxClass::PauseEVA @ 0x007535B0` (which reaches
     /// `StreamPlayer::Pause` whenever an announcement is sounding, then
-    /// raises [`VoiceSuspend`]) and tail-calls `SpeechSystem::Pause @
+    /// raises the [`VoxQueue`] pause depth) and tail-calls `SpeechSystem::Pause @
     /// 0x00753500` (`StreamPlayer::Pause` again for the speech stream);
     /// `Exit` calls `SpeechSystem::Resume @ 0x00753510` then
     /// `VoxClass::UnpauseEVA @ 0x00753620`. Neither call sits behind the
@@ -1825,7 +1747,7 @@ impl SfxPlayer {
             return;
         }
         self.paused = paused;
-        self.voice_suspend.set_paused(paused);
+        self.vox.set_paused(paused);
         if paused {
             self.arbiter.suspend_all(now_ms);
             for output in self.live.values() {
@@ -1896,8 +1818,13 @@ impl SfxPlayer {
 
     /// Pump the dedicated voice queue once and report whether any voice work
     /// remains, mirroring the poll performed inside native exit wait loops.
-    pub fn pump_and_check_voices(&mut self) -> bool {
-        self.advance_voice_queue();
+    pub fn pump_and_check_voices(
+        &mut self,
+        registry: &SoundRegistry,
+        assets: &AssetManager,
+        audio_indices: &[crate::assets::audio_bag::AudioIndex],
+    ) -> bool {
+        self.advance_voice_queue(registry, assets, audio_indices);
         self.voices_active()
     }
 
@@ -1917,12 +1844,13 @@ impl SfxPlayer {
         if let Some(output) = self.voice_player.take() {
             output.player.stop();
         }
-        self.queued_voice.clear();
         self.current_voice_id = None;
-        // `VoxClass::ResetAll @ 0x007535F0`: stop the stream, clear every
-        // queue, then `DAT_00b1d428 = 0`. The suspend depth is reset here,
-        // not left to unwind on the next pause edge.
-        self.voice_suspend.reset();
+        // `VoxClass::ResetAll @ 0x007535D0`: current entry done, stop the
+        // stream, `ClearAllQueues`, then `DAT_00b1d428 = 0` and
+        // `DAT_00b1d3d8 = 0`. Both depths are reset here, not left to unwind
+        // on the next pause edge.
+        self.vox.reset_all();
+        self.eva_stream_open = false;
     }
 
     /// Get the current SFX master volume.
@@ -1958,19 +1886,17 @@ impl SfxPlayer {
         self.arbiter.busy_channel_count()
     }
 
-    /// Number of queued EVA/voice announcements waiting on the voice slot.
+    /// Number of EVA announcements waiting in the `VoxClass` queues.
     pub fn queued_voice_count(&self) -> usize {
-        self.queued_voice.len()
+        self.vox.queued_count()
     }
 
-    /// Whether any EVA/voice line is still playing or waiting in the voice queue.
-    /// Non-blocking (rodio `Player::empty()` is a poll). Used by the quit cascade
-    /// to wait for trailing voices before tearing down.
+    /// `VoxClass::PumpAndCheckActive @ 0x007529E0`'s answer: the stream is
+    /// playing or a node waits in any queue. Non-blocking (rodio
+    /// `Player::empty()` is a poll). Used by the quit cascade and the
+    /// victory/defeat savour wait.
     pub fn voices_active(&self) -> bool {
-        self.voice_player
-            .as_ref()
-            .is_some_and(|output| !output.player.empty())
-            || !self.queued_voice.is_empty()
+        self.vox.is_active(self.voice_slot_busy())
     }
 }
 
@@ -2867,25 +2793,25 @@ mod tests {
         assert_eq!(full.initial_volume, half);
     }
 
+    /// A queued EVA node carries only the entry and its sample name; the
+    /// sample is resolved and the Voice master applied when `PlayNextQueued`
+    /// starts it, so the scales at dequeue alone decide the startup volume.
     #[test]
     fn options_profile_queued_eva_uses_current_voice_master_at_dequeue() {
-        // QueuedVoice retains no master snapshot. The scales supplied by the
-        // production dequeue seam alone decide the startup volume.
-        let queued_for_voice_enabled_dequeue =
-            QueuedVoice::new("eva-a".to_string(), test_decoded_audio(), 13107);
-        let (sound_id, started_with_voice_enabled) = queued_for_voice_enabled_dequeue
-            .prepare_for_dequeue(test_output_scales(0.0, 1.0, 1.0, 1.0));
-        assert_eq!(sound_id, "eva-a");
+        let started_with_voice_enabled = prepare_direct_voice_output(
+            test_decoded_audio(),
+            13107,
+            test_output_scales(0.0, 1.0, 1.0, 1.0),
+        );
         assert!(
             (started_with_voice_enabled.initial_volume - native_volume_amplitude(13107)).abs()
                 < f32::EPSILON
         );
-
-        let queued_for_voice_muted_dequeue =
-            QueuedVoice::new("eva-b".to_string(), test_decoded_audio(), 13107);
-        let (sound_id, started_with_voice_muted) = queued_for_voice_muted_dequeue
-            .prepare_for_dequeue(test_output_scales(1.0, 0.0, 1.0, 1.0));
-        assert_eq!(sound_id, "eva-b");
+        let started_with_voice_muted = prepare_direct_voice_output(
+            test_decoded_audio(),
+            13107,
+            test_output_scales(1.0, 0.0, 1.0, 1.0),
+        );
         assert_eq!(started_with_voice_muted.initial_volume, 0.0);
     }
 
@@ -3042,61 +2968,5 @@ mod tests {
     fn test_decode_pcm_empty() {
         let samples = decode_pcm(&[], 1, 16);
         assert!(samples.is_empty());
-    }
-
-    /// Pausing stops the EVA/speech stream **and** freezes the announcement
-    /// queue. `GamePause::Enter @ 0x00406F00` calls
-    /// `VoxClass::PauseEVA @ 0x007535B0` unconditionally, which raises
-    /// `DAT_00b1d428`, and `VoxClass::PlayNextQueued @ 0x00752780` refuses to
-    /// dequeue anything while that counter is non-zero (`0x007527D5`).
-    /// `VoxClass::UnpauseEVA @ 0x00753620` lowers it with a floor of 0.
-    ///
-    /// This pins the decision half. The matching `Player::pause()` on
-    /// `voice_player` is device-side and shares residual R7 with the rest of
-    /// the rodio plumbing.
-    #[test]
-    fn pausing_suspends_the_eva_queue_until_every_pause_is_lifted() {
-        let mut suspend = VoiceSuspend::default();
-        assert!(suspend.dequeue_allowed());
-
-        suspend.set_paused(true);
-        assert!(!suspend.dequeue_allowed());
-        suspend.set_paused(true);
-        assert!(!suspend.dequeue_allowed());
-
-        // Native's counter is a depth, not a flag: one resume is not enough.
-        suspend.set_paused(false);
-        assert!(!suspend.dequeue_allowed());
-        suspend.set_paused(false);
-        assert!(suspend.dequeue_allowed());
-
-        // `if (d != 0) { d -= 1; if (d < 0) d = 0; }` — an unmatched resume
-        // never drives the counter negative, so the next pause still blocks.
-        suspend.set_paused(false);
-        assert!(suspend.dequeue_allowed());
-        suspend.set_paused(true);
-        assert!(!suspend.dequeue_allowed());
-    }
-
-    /// `VoxClass::ResetAll @ 0x007535F0` ends with `DAT_00b1d428 = 0`, so a
-    /// reset drops the whole suspend depth at once instead of unwinding it
-    /// one `GamePause::Exit` at a time. `SfxPlayer::stop_all` is VERA's
-    /// analogue and now does the same.
-    #[test]
-    fn a_reset_clears_the_whole_eva_suspend_depth_at_once() {
-        let mut suspend = VoiceSuspend::default();
-        suspend.set_paused(true);
-        suspend.set_paused(true);
-        assert!(!suspend.dequeue_allowed());
-
-        suspend.reset();
-        assert!(suspend.dequeue_allowed());
-
-        // The depth really is zero, not merely decremented: a single resume
-        // afterwards must not underflow, and a single pause must block again.
-        suspend.set_paused(false);
-        assert!(suspend.dequeue_allowed());
-        suspend.set_paused(true);
-        assert!(!suspend.dequeue_allowed());
     }
 }

--- a/src/audio/vox.rs
+++ b/src/audio/vox.rs
@@ -1,0 +1,652 @@
+//! The EVA announcement queue — gamemd's `VoxClass`.
+//!
+//! Pure decision state; the stream itself lives in [`crate::audio::sfx`].
+//! Native storage this mirrors (all bodies read for this module):
+//!
+//! | native | here |
+//! |---|---|
+//! | interrupt list `0xB1D3C8` (`Type=QUEUED_INTERRUPT` nodes) | `interrupt_list` |
+//! | critical list `0xB1D3F0` (`Priority=CRITICAL` nodes) | `critical_list` |
+//! | pending slot `0xB1D4B8` (one STANDARD/INTERRUPT node) | `pending` |
+//! | four `Type=QUEUE` FIFOs `0xB1D450 + priority * 0xC` | `priority_lists` |
+//! | current entry `0xB1D4C4` (+ type `0xB1D3B8`, priority `0xB1D3E0`) | `current` |
+//! | node sequence counter `0xB1D4C0` (`% 100`) | `seq_counter` |
+//! | 64-bit gap after the stream's end time `0xB1D4D0/0xB1D4D4` | `gap_ms` |
+//! | pause depth `0xB1D428` (`PauseEVA @ 0x007535B0` / `UnpauseEVA @ 0x00753620`) | `pause_depth` |
+//! | suspend depth `0xB1D3D8` (`SuspendEVA @ 0x00753570` / `ResumeEVA @ 0x00753580`) | `suspend_depth` |
+//!
+//! Functions: `VoxClass::QueueVoice @ 0x00752480` ([`VoxQueue::queue_voice`]),
+//! `InsertIntoQueue @ 0x00752590`, `FindInQueues @ 0x00752680`,
+//! `PlayNextQueued @ 0x00752760` ([`VoxQueue::take_next`] + [`VoxQueue::started`]),
+//! `ClearAllQueues @ 0x00752370`, `ResetAll @ 0x007535D0`,
+//! `PumpAndCheckActive @ 0x007529E0` ([`VoxQueue::is_active`]).
+
+use std::collections::VecDeque;
+
+use crate::rules::sound_ini::{EvaPriority, EvaType};
+
+/// `VoxClass::PlayNextQueued @ 0x00752760`: `0x0075296D MOV [0xB1D4D0],0x1F4`
+/// — the gap installed after a line starts successfully; the next line may
+/// start only once `now > end_time + gap` (unsigned 64-bit compare at
+/// `0x007527A1..0x007527CF`).
+pub const INTER_LINE_GAP_MS: u64 = 500;
+
+/// One queue node (native `operator_new(0x20)`: `+0x0C` entry, `+0x14`
+/// priority, `+0x18` type, `+0x1C` sequence).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoxNode {
+    /// Entry identity: the `[DialogList]` name, upper-cased for the
+    /// `stricmp` match `VoxClass::PlayEVA` performs.
+    pub event: String,
+    /// The side column already resolved for this session (native resolves it
+    /// at play time from `0xB1D4C8`; the side is fixed per session by
+    /// `VoxClass::SetSide`, so resolving at queue time is equivalent).
+    pub sample: String,
+    pub eva_type: EvaType,
+    pub priority: EvaPriority,
+    /// `DAT_00B1D4C0 % 100` at insertion; bookkeeping only.
+    pub seq: u32,
+}
+
+/// What `VoxClass::QueueVoice` asks the stream layer to do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct QueueEffect {
+    /// `StreamPlayer::Stop` was called (type 2 while a line was current).
+    pub stop_stream: bool,
+    /// The request was inserted into a queue or the pending slot.
+    pub inserted: bool,
+}
+
+/// One announcement request as `VoxClass::PlayEVA` resolves it.
+#[derive(Debug, Clone, Copy)]
+pub struct VoxRequest<'a> {
+    pub event: &'a str,
+    pub sample: &'a str,
+    pub eva_type: EvaType,
+    pub priority: EvaPriority,
+}
+
+/// `VoxClass` queue state.
+#[derive(Debug, Default)]
+pub struct VoxQueue {
+    interrupt_list: VecDeque<VoxNode>,
+    critical_list: VecDeque<VoxNode>,
+    pending: Option<VoxNode>,
+    priority_lists: [VecDeque<VoxNode>; 4],
+    current: Option<VoxNode>,
+    seq_counter: u32,
+    gap_ms: u64,
+    /// Stand-in for `StreamPlayer::GetEndTime` (`0x00408140`): the moment the
+    /// last line was observed to end, reported by the stream owner.
+    end_time_ms: u64,
+    pause_depth: i32,
+    suspend_depth: i32,
+}
+
+impl VoxQueue {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// `VoxClass::QueueVoice @ 0x00752480`.
+    ///
+    /// Guards (one `if`, `0x00752480..`): the stream player exists, the index
+    /// is valid, `DAT_00B1D3D8 == 0` (not suspended) and the entry is not the
+    /// current one (`iVar1 != DAT_00B1D4C4`). A `-1` type/priority takes the
+    /// entry's own; `PlayEVA` always passes priority `-1`, so only the type
+    /// can be overridden per call site.
+    ///
+    /// Type 2 (INTERRUPT) **while an entry is current**: every interrupt-list
+    /// node is dropped, the current entry is marked done, `StreamPlayer::Stop`,
+    /// `ClearAllQueues`, and the 64-bit gap is zeroed. With no current entry
+    /// a type-2 line is routed like STANDARD and existing nodes survive.
+    ///
+    /// Then `FindInQueues`: a node for this entry **with the same type** is a
+    /// duplicate and the request is dropped (`0x00752566`); otherwise
+    /// `InsertIntoQueue`. The caller runs `PlayNextQueued` afterwards.
+    pub fn queue_voice(
+        &mut self,
+        request: VoxRequest<'_>,
+        type_override: Option<EvaType>,
+    ) -> QueueEffect {
+        let mut effect = QueueEffect::default();
+        let event = request.event.to_ascii_uppercase();
+        if self.suspend_depth != 0 {
+            return effect;
+        }
+        if self
+            .current
+            .as_ref()
+            .is_some_and(|current| current.event == event)
+        {
+            return effect;
+        }
+        let eva_type = type_override.unwrap_or(request.eva_type);
+        let priority = request.priority;
+
+        if self.current.is_some() && eva_type == EvaType::Interrupt {
+            self.interrupt_list.clear();
+            self.current = None;
+            effect.stop_stream = true;
+            self.clear_all_queues();
+            self.gap_ms = 0;
+            // VERA assumption: after `StreamPlayer::Stop` the stream's end
+            // time is not in the future, so the interrupt line starts on the
+            // `PlayNextQueued` that follows. gamemd `GetEndTime`-after-`Stop`
+            // UNCHECKED.
+            self.end_time_ms = 0;
+        }
+
+        let duplicate = self
+            .find_in_queues(&event)
+            .is_some_and(|node| node.eva_type == eva_type);
+        if !duplicate {
+            effect.inserted = self.insert_into_queue(VoxNode {
+                event,
+                sample: request.sample.to_string(),
+                eva_type,
+                priority,
+                seq: self.seq_counter % 100,
+            });
+        }
+        effect
+    }
+
+    /// `VoxClass::InsertIntoQueue @ 0x00752590`. Returns whether the node was
+    /// kept.
+    ///
+    /// `0x007525CF CMP EDI,3` → interrupt list `0xB1D3C8`;
+    /// `0x007525F4 CMP EDI,1` → `0xB1D450 + priority*0xC`;
+    /// `0x00752611 CMP ECX,3` (priority CRITICAL) → critical list `0xB1D3F0`;
+    /// else the pending slot `0xB1D4B8`, taken only if both the interrupt and
+    /// critical lists are empty (`0x00752629..0x0075263F`) and the slot is
+    /// empty or holds a **strictly lower** priority (`0x0075264A CMP
+    /// [EAX+0x14],ECX ; JGE discard`). Otherwise the new node is discarded
+    /// (entry state 2).
+    fn insert_into_queue(&mut self, node: VoxNode) -> bool {
+        self.seq_counter = self.seq_counter.wrapping_add(1);
+        match node.eva_type {
+            EvaType::QueuedInterrupt => {
+                self.interrupt_list.push_back(node);
+                true
+            }
+            EvaType::Queue => {
+                self.priority_lists[node.priority.list_index()].push_back(node);
+                true
+            }
+            _ if node.priority == EvaPriority::Critical => {
+                self.critical_list.push_back(node);
+                true
+            }
+            _ => {
+                let slot_free = self.interrupt_list.is_empty()
+                    && self.critical_list.is_empty()
+                    && self
+                        .pending
+                        .as_ref()
+                        .is_none_or(|pending| pending.priority < node.priority);
+                if slot_free {
+                    self.pending = Some(node);
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// `VoxClass::FindInQueues @ 0x00752680`: critical list, pending slot, the
+    /// four priority lists (`0xB1D474` down to `0xB1D450`), interrupt list.
+    fn find_in_queues(&self, event: &str) -> Option<&VoxNode> {
+        self.critical_list
+            .iter()
+            .find(|node| node.event == event)
+            .or_else(|| self.pending.as_ref().filter(|node| node.event == event))
+            .or_else(|| {
+                self.priority_lists
+                    .iter()
+                    .rev()
+                    .find_map(|list| list.iter().find(|node| node.event == event))
+            })
+            .or_else(|| self.interrupt_list.iter().find(|node| node.event == event))
+    }
+
+    /// The dequeue half of `VoxClass::PlayNextQueued @ 0x00752760`.
+    ///
+    /// Gate: `StreamPlayer::IsPlaying() == 0` (`0x00752794`), `now >
+    /// end_time + gap` (`0x007527A1..0x007527CF`), `DAT_00B1D428 == 0`
+    /// (`0x007527D5`). Then the current entry is marked done
+    /// (`0x007527E2..0x007527F2`) and one node is taken in this order:
+    /// interrupt list (`0x007527F8`) → critical list (`0x00752835`) → pending
+    /// slot (`0x00752866`) → priority lists CRITICAL..LOW (`0x00752878`,
+    /// `0xB1D474` stepping `-0xC` to `0xB1D450`). Taking an interrupt or
+    /// critical node **frees the pending slot** (`0x00752824`/`0x00752855`).
+    ///
+    /// The caller tries to start the returned node and reports success with
+    /// [`Self::started`]; a failed `PlayFile` leaves nothing current and the
+    /// node is simply gone, as at `0x00752963 JZ`.
+    pub fn take_next(&mut self, now_ms: u64, stream_playing: bool) -> Option<VoxNode> {
+        if stream_playing {
+            return None;
+        }
+        if now_ms <= self.end_time_ms.saturating_add(self.gap_ms) {
+            return None;
+        }
+        if self.pause_depth != 0 {
+            return None;
+        }
+        self.current = None;
+        if let Some(node) = self.interrupt_list.pop_front() {
+            self.pending = None;
+            return Some(node);
+        }
+        if let Some(node) = self.critical_list.pop_front() {
+            self.pending = None;
+            return Some(node);
+        }
+        if let Some(node) = self.pending.take() {
+            return Some(node);
+        }
+        self.priority_lists
+            .iter_mut()
+            .rev()
+            .find_map(|list| list.pop_front())
+    }
+
+    /// `0x0075296D..0x0075298E`: after `StreamPlayer::PlayFile` succeeded —
+    /// gap = 500 ms, the node becomes the current entry (state 0).
+    pub fn started(&mut self, node: VoxNode) {
+        self.gap_ms = INTER_LINE_GAP_MS;
+        self.end_time_ms = u64::MAX - INTER_LINE_GAP_MS;
+        self.current = Some(node);
+    }
+
+    /// The stream owner observed the current line end at `now_ms`
+    /// (`StreamPlayer::GetEndTime` stand-in).
+    pub fn stream_ended(&mut self, now_ms: u64) {
+        self.end_time_ms = now_ms;
+    }
+
+    /// `VoxClass::ClearAllQueues @ 0x00752370`: the pending slot, the
+    /// interrupt and critical lists and the four priority lists; the current
+    /// entry is untouched.
+    pub fn clear_all_queues(&mut self) {
+        self.pending = None;
+        self.interrupt_list.clear();
+        self.critical_list.clear();
+        for list in &mut self.priority_lists {
+            list.clear();
+        }
+    }
+
+    /// `VoxClass::ResetAll @ 0x007535D0`: current entry done, `StreamPlayer::Stop`
+    /// (the caller's job — returns `true` when a line was current),
+    /// `ClearAllQueues`, then `DAT_00B1D428 = 0` and `DAT_00B1D3D8 = 0`.
+    pub fn reset_all(&mut self) -> bool {
+        let had_current = self.current.take().is_some();
+        self.clear_all_queues();
+        self.pause_depth = 0;
+        self.suspend_depth = 0;
+        self.gap_ms = 0;
+        self.end_time_ms = 0;
+        had_current
+    }
+
+    /// `PauseEVA @ 0x007535B0` (`DAT_00B1D428 += 1`) / `UnpauseEVA @
+    /// 0x00753620` (`if (d != 0) { d -= 1; if (d < 0) d = 0; }`), one edge
+    /// per call. `GamePause::Enter @ 0x00406F00` / `Exit @ 0x00406F40` are
+    /// the callers.
+    pub fn set_paused(&mut self, paused: bool) {
+        if paused {
+            self.pause_depth += 1;
+        } else if self.pause_depth != 0 {
+            self.pause_depth = (self.pause_depth - 1).max(0);
+        }
+    }
+
+    /// `PlayNextQueued`'s `DAT_00B1D428 == 0` gate.
+    pub fn dequeue_allowed(&self) -> bool {
+        self.pause_depth == 0
+    }
+
+    /// `VoxClass::SuspendEVA @ 0x00753570`: `DAT_00B1D3D8 += 1`. Blocks
+    /// **queueing** (`QueueVoice` guard), not playback. Stock callers:
+    /// `NukeFlash::StartScreenFlash 0x0053B554`, `RadarClass::PlayRadarMovie
+    /// 0x006579C0`.
+    pub fn suspend(&mut self) {
+        self.suspend_depth += 1;
+    }
+
+    /// `VoxClass::ResumeEVA @ 0x00753580`: `if (d != 0) { d -= 1; if (d < 0)
+    /// d = 0; }`.
+    pub fn resume(&mut self) {
+        if self.suspend_depth != 0 {
+            self.suspend_depth = (self.suspend_depth - 1).max(0);
+        }
+    }
+
+    /// `VoxClass::PumpAndCheckActive @ 0x007529E0` after its `PlayNextQueued`:
+    /// stream playing, or any node in the interrupt/critical lists, the
+    /// pending slot or a priority list.
+    pub fn is_active(&self, stream_playing: bool) -> bool {
+        stream_playing || self.queued_count() > 0
+    }
+
+    /// Nodes waiting in any list or the pending slot.
+    pub fn queued_count(&self) -> usize {
+        self.interrupt_list.len()
+            + self.critical_list.len()
+            + usize::from(self.pending.is_some())
+            + self.priority_lists.iter().map(VecDeque::len).sum::<usize>()
+    }
+
+    /// The entry that is current (playing or inside its post-line gap).
+    pub fn current(&self) -> Option<&VoxNode> {
+        self.current.as_ref()
+    }
+
+    #[cfg(test)]
+    fn pending_event(&self) -> Option<&str> {
+        self.pending.as_ref().map(|node| node.event.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(event: &'static str, eva_type: EvaType, priority: EvaPriority) -> VoxRequest<'static> {
+        VoxRequest {
+            event,
+            sample: event,
+            eva_type,
+            priority,
+        }
+    }
+
+    // Stock evamd.ini rows used below (ini/evamd.ini):
+    // EVA_UnitLost STANDARD IMPORTANT; EVA_OurBaseIsUnderAttack STANDARD NORMAL;
+    // EVA_UnitReady / EVA_ConstructionComplete STANDARD LOW;
+    // EVA_LowPower QUEUE IMPORTANT; EVA_NewConstructionOptions QUEUE LOW;
+    // EVA_YouHaveLost STANDARD NORMAL; EVA_NuclearMissileLaunched STANDARD CRITICAL;
+    // EVA_BattleControlTerminated STANDARD CRITICAL (call-site type 2).
+    fn unit_lost() -> VoxRequest<'static> {
+        req("EVA_UnitLost", EvaType::Standard, EvaPriority::Important)
+    }
+    fn base_attack() -> VoxRequest<'static> {
+        req(
+            "EVA_OurBaseIsUnderAttack",
+            EvaType::Standard,
+            EvaPriority::Normal,
+        )
+    }
+    fn unit_ready() -> VoxRequest<'static> {
+        req("EVA_UnitReady", EvaType::Standard, EvaPriority::Low)
+    }
+    fn construction_complete() -> VoxRequest<'static> {
+        req(
+            "EVA_ConstructionComplete",
+            EvaType::Standard,
+            EvaPriority::Low,
+        )
+    }
+    fn low_power() -> VoxRequest<'static> {
+        req("EVA_LowPower", EvaType::Queue, EvaPriority::Important)
+    }
+    fn new_options() -> VoxRequest<'static> {
+        req(
+            "EVA_NewConstructionOptions",
+            EvaType::Queue,
+            EvaPriority::Low,
+        )
+    }
+    fn you_have_lost() -> VoxRequest<'static> {
+        req("EVA_YouHaveLost", EvaType::Standard, EvaPriority::Normal)
+    }
+    fn nuke_launched() -> VoxRequest<'static> {
+        req(
+            "EVA_NuclearMissileLaunched",
+            EvaType::Standard,
+            EvaPriority::Critical,
+        )
+    }
+
+    /// Start whatever is next at `now` and report its event.
+    fn play_next(q: &mut VoxQueue, now: u64) -> Option<String> {
+        let node = q.take_next(now, false)?;
+        let event = node.event.clone();
+        q.started(node);
+        Some(event)
+    }
+
+    /// `InsertIntoQueue 0x0075264A`: the pending slot is replaced only by a
+    /// strictly higher priority; equal or lower is discarded.
+    #[test]
+    fn pending_slot_replacement_is_strict_priority() {
+        let mut q = VoxQueue::new();
+        // Occupy the stream so requests park in the pending slot.
+        q.queue_voice(construction_complete(), None);
+        assert_eq!(
+            play_next(&mut q, 1).as_deref(),
+            Some("EVA_CONSTRUCTIONCOMPLETE")
+        );
+
+        assert!(q.queue_voice(base_attack(), None).inserted);
+        assert_eq!(q.pending_event(), Some("EVA_OURBASEISUNDERATTACK"));
+        // NORMAL pending, IMPORTANT arrives: replaced; the base line never plays.
+        assert!(q.queue_voice(unit_lost(), None).inserted);
+        assert_eq!(q.pending_event(), Some("EVA_UNITLOST"));
+        // IMPORTANT pending, NORMAL arrives: discarded.
+        assert!(!q.queue_voice(base_attack(), None).inserted);
+        assert_eq!(q.pending_event(), Some("EVA_UNITLOST"));
+        // Equal priority from a different entry: `JGE` discards it too.
+        assert!(
+            !q.queue_voice(
+                req(
+                    "EVA_OtherImportant",
+                    EvaType::Standard,
+                    EvaPriority::Important
+                ),
+                None
+            )
+            .inserted
+        );
+        assert_eq!(q.queued_count(), 1);
+    }
+
+    /// A STANDARD line arriving while another plays is kept (pending slot),
+    /// not dropped, and plays after the gap — the M2.1 case.
+    #[test]
+    fn a_standard_line_waits_in_the_pending_slot_while_a_line_plays() {
+        let mut q = VoxQueue::new();
+        q.queue_voice(construction_complete(), None);
+        assert_eq!(
+            play_next(&mut q, 1).as_deref(),
+            Some("EVA_CONSTRUCTIONCOMPLETE")
+        );
+        assert!(q.queue_voice(unit_ready(), None).inserted);
+        assert!(q.take_next(2, true).is_none(), "stream still playing");
+        q.stream_ended(1_000);
+        assert_eq!(play_next(&mut q, 1_501).as_deref(), Some("EVA_UNITREADY"));
+    }
+
+    /// Each `Type=QUEUE` list is FIFO, the lists drain CRITICAL..LOW, and the
+    /// pending slot plays before any of them (`PlayNextQueued` order).
+    #[test]
+    fn queue_lists_are_fifo_per_priority_and_drain_after_the_pending_slot() {
+        let mut q = VoxQueue::new();
+        q.queue_voice(construction_complete(), None);
+        play_next(&mut q, 1);
+        // Two LOW queue lines, one IMPORTANT queue line, then a STANDARD one.
+        assert!(q.queue_voice(new_options(), None).inserted);
+        assert!(
+            q.queue_voice(
+                req("EVA_OtherLowQueue", EvaType::Queue, EvaPriority::Low),
+                None
+            )
+            .inserted
+        );
+        assert!(q.queue_voice(low_power(), None).inserted);
+        assert!(q.queue_voice(unit_lost(), None).inserted);
+        assert_eq!(q.queued_count(), 4);
+
+        let mut order = Vec::new();
+        let mut now = 1_000;
+        for _ in 0..4 {
+            q.stream_ended(now);
+            now += INTER_LINE_GAP_MS + 1;
+            order.push(play_next(&mut q, now).unwrap());
+        }
+        assert_eq!(
+            order,
+            [
+                "EVA_UNITLOST",
+                "EVA_LOWPOWER",
+                "EVA_NEWCONSTRUCTIONOPTIONS",
+                "EVA_OTHERLOWQUEUE",
+            ]
+        );
+        assert!(!q.is_active(false));
+    }
+
+    /// `QueueVoice 0x00752566`: a queued node for the same entry with the same
+    /// type is a duplicate; a different type is not. The current entry is
+    /// refused outright (`iVar1 != DAT_00B1D4C4`), even inside its gap.
+    #[test]
+    fn duplicate_rule_matches_entry_and_type() {
+        let mut q = VoxQueue::new();
+        q.queue_voice(construction_complete(), None);
+        play_next(&mut q, 1);
+        assert!(q.queue_voice(low_power(), None).inserted);
+        assert!(
+            !q.queue_voice(low_power(), None).inserted,
+            "same entry, same type"
+        );
+        assert_eq!(q.queued_count(), 1);
+        // Same entry with an overridden type is a second node.
+        assert!(
+            q.queue_voice(low_power(), Some(EvaType::QueuedInterrupt))
+                .inserted
+        );
+        assert_eq!(q.queued_count(), 2);
+
+        // The current entry is refused while current, including during the gap.
+        assert!(!q.queue_voice(construction_complete(), None).inserted);
+        q.stream_ended(1_000);
+        assert!(q.take_next(1_200, false).is_none());
+        assert!(!q.queue_voice(construction_complete(), None).inserted);
+    }
+
+    /// "You have lost" (STANDARD NORMAL) arriving while "Unit lost" plays is
+    /// kept in the pending slot; a CRITICAL line goes to the critical list,
+    /// is never discarded, plays first and frees the pending slot.
+    #[test]
+    fn outcome_and_critical_lines_are_not_dropped_while_a_line_plays() {
+        let mut q = VoxQueue::new();
+        q.queue_voice(unit_lost(), None);
+        assert_eq!(play_next(&mut q, 1).as_deref(), Some("EVA_UNITLOST"));
+        assert!(q.queue_voice(you_have_lost(), None).inserted);
+        assert!(q.is_active(true));
+        q.stream_ended(3_000);
+        assert_eq!(play_next(&mut q, 3_501).as_deref(), Some("EVA_YOUHAVELOST"));
+
+        let mut q = VoxQueue::new();
+        q.queue_voice(unit_lost(), None);
+        play_next(&mut q, 1);
+        assert!(q.queue_voice(base_attack(), None).inserted);
+        assert!(q.queue_voice(nuke_launched(), None).inserted);
+        // With a critical node waiting, a new STANDARD line cannot take the slot.
+        assert!(!q.queue_voice(unit_ready(), None).inserted);
+        q.stream_ended(1_000);
+        assert_eq!(
+            play_next(&mut q, 1_501).as_deref(),
+            Some("EVA_NUCLEARMISSILELAUNCHED")
+        );
+        // `0x00752855`: the pending "base under attack" was freed with it.
+        assert_eq!(q.pending_event(), None);
+        assert!(!q.is_active(true) || q.queued_count() == 0);
+    }
+
+    /// `0x0075296D`: 500 ms after the line's end time before the next starts;
+    /// the compare is strict (`JBE` → wait when `now <= end + gap`).
+    #[test]
+    fn next_line_waits_five_hundred_ms_after_the_previous_ended() {
+        let mut q = VoxQueue::new();
+        q.queue_voice(construction_complete(), None);
+        play_next(&mut q, 1);
+        q.queue_voice(unit_ready(), None);
+        q.stream_ended(10_000);
+        assert!(q.take_next(10_499, false).is_none());
+        assert!(q.take_next(10_500, false).is_none(), "equality still waits");
+        assert!(q.take_next(10_501, false).is_some());
+    }
+
+    /// Type 2 while a line is current: stream stopped, every queue cleared,
+    /// gap zeroed, and the interrupt line starts at once. With an idle slot a
+    /// type-2 line routes like STANDARD and existing nodes survive.
+    #[test]
+    fn interrupt_cuts_only_when_a_line_is_current() {
+        let mut q = VoxQueue::new();
+        q.queue_voice(construction_complete(), None);
+        play_next(&mut q, 1);
+        q.queue_voice(low_power(), None);
+        q.queue_voice(unit_lost(), None);
+        let bct = req(
+            "EVA_BattleControlTerminated",
+            EvaType::Standard,
+            EvaPriority::Critical,
+        );
+        let effect = q.queue_voice(bct, Some(EvaType::Interrupt));
+        assert!(effect.stop_stream && effect.inserted);
+        assert_eq!(q.queued_count(), 1);
+        assert!(q.current().is_none());
+        // No gap: the interrupt line starts on the very next pump.
+        assert_eq!(
+            play_next(&mut q, 2).as_deref(),
+            Some("EVA_BATTLECONTROLTERMINATED")
+        );
+
+        let mut q = VoxQueue::new();
+        q.queue_voice(low_power(), None);
+        let effect = q.queue_voice(unit_lost(), Some(EvaType::Interrupt));
+        assert!(!effect.stop_stream && effect.inserted);
+        assert_eq!(q.queued_count(), 2, "idle slot: nothing is cleared");
+        assert_eq!(q.pending_event(), Some("EVA_UNITLOST"));
+    }
+
+    /// Pausing stops the queue from advancing until every pause is lifted
+    /// (`DAT_00B1D428`, a depth with a floor of 0), and `ResetAll` zeroes it.
+    #[test]
+    fn pausing_suspends_the_eva_queue_until_every_pause_is_lifted() {
+        let mut q = VoxQueue::new();
+        q.queue_voice(construction_complete(), None);
+        q.set_paused(true);
+        q.set_paused(true);
+        assert!(q.take_next(1, false).is_none());
+        q.set_paused(false);
+        assert!(q.take_next(1, false).is_none());
+        q.set_paused(false);
+        assert!(q.dequeue_allowed());
+        // An unmatched resume never drives the counter negative.
+        q.set_paused(false);
+        q.set_paused(true);
+        assert!(!q.dequeue_allowed());
+
+        q.reset_all();
+        assert!(q.dequeue_allowed());
+        assert_eq!(q.queued_count(), 0);
+    }
+
+    /// `SuspendEVA` (`0xB1D3D8`) blocks queueing, not playback.
+    #[test]
+    fn suspend_blocks_queueing_but_not_dequeue() {
+        let mut q = VoxQueue::new();
+        q.queue_voice(low_power(), None);
+        q.suspend();
+        assert!(!q.queue_voice(unit_lost(), None).inserted);
+        assert_eq!(play_next(&mut q, 1).as_deref(), Some("EVA_LOWPOWER"));
+        q.resume();
+        q.resume();
+        assert!(q.queue_voice(unit_lost(), None).inserted);
+    }
+}

--- a/src/rules/sound_ini.rs
+++ b/src/rules/sound_ini.rs
@@ -735,49 +735,205 @@ fn crt_atoi(value: &str) -> i32 {
     signed.clamp(i64::from(i32::MIN), i64::from(i32::MAX)) as i32
 }
 
-/// Per-faction sound IDs for a single EVA event (e.g., EVA_ConstructionComplete).
-#[derive(Debug, Clone, Default)]
-struct EvaEntry {
-    allied: Option<String>,
-    russian: Option<String>,
-    yuri: Option<String>,
+/// `VoxClass` entry `Type=` (`VoxClass::ReadINI @ 0x00752DB0`, entry `+0x4C`).
+///
+/// Parsed by `stricmp` in this order: `QUEUE` (`0x008467CC`) -> 1,
+/// `STANDARD` (`0x008467C0`) -> 0, `INTERRUPT` (`0x00816120`) -> 2,
+/// `QUEUED_INTERRUPT` (`0x008467AC`) -> 3. An empty or unknown token keeps the
+/// `VoxClass::ReadEVAINI @ 0x00753000` default of 0 (STANDARD). Routing per
+/// value lives in `VoxClass::InsertIntoQueue @ 0x00752590`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EvaType {
+    #[default]
+    Standard,
+    Queue,
+    Interrupt,
+    QueuedInterrupt,
 }
 
-/// Registry of EVA announcements from eva.ini / evamd.ini.
+impl EvaType {
+    fn parse(token: &str) -> Option<Self> {
+        let token = token.trim();
+        if token.eq_ignore_ascii_case("QUEUE") {
+            Some(Self::Queue)
+        } else if token.eq_ignore_ascii_case("STANDARD") {
+            Some(Self::Standard)
+        } else if token.eq_ignore_ascii_case("INTERRUPT") {
+            Some(Self::Interrupt)
+        } else if token.eq_ignore_ascii_case("QUEUED_INTERRUPT") {
+            Some(Self::QueuedInterrupt)
+        } else {
+            None
+        }
+    }
+}
+
+/// `VoxClass` entry `Priority=` (`VoxClass::ReadINI @ 0x00752DB0`, entry
+/// `+0x48`): `LOW` (`0x008161DC`) -> 0, `NORMAL` (`0x008161D4`) -> 1,
+/// `IMPORTANT` (`0x008467A0`) -> 2, `CRITICAL` (`0x008161C0`) -> 3. The
+/// `ReadEVAINI` default is 1 (NORMAL). Ordering is load-bearing: the pending
+/// slot compares `node.priority < new.priority` (`0x0075264A`) and the four
+/// `Type=QUEUE` lists are indexed by this value (`0x007525F9..0x007525FE`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum EvaPriority {
+    Low = 0,
+    #[default]
+    Normal = 1,
+    Important = 2,
+    Critical = 3,
+}
+
+impl EvaPriority {
+    fn parse(token: &str) -> Option<Self> {
+        let token = token.trim();
+        if token.eq_ignore_ascii_case("LOW") {
+            Some(Self::Low)
+        } else if token.eq_ignore_ascii_case("NORMAL") {
+            Some(Self::Normal)
+        } else if token.eq_ignore_ascii_case("IMPORTANT") {
+            Some(Self::Important)
+        } else if token.eq_ignore_ascii_case("CRITICAL") {
+            Some(Self::Critical)
+        } else {
+            None
+        }
+    }
+
+    /// Index into the four `Type=QUEUE` FIFOs (`0xB1D450 + priority * 0xC`).
+    pub fn list_index(self) -> usize {
+        self as usize
+    }
+}
+
+/// The voice column `VoxClass::PlayNextQueued @ 0x00752760` reads for the
+/// session side stored by `VoxClass::SetSide @ 0x007534E0` (`0xB1D4C8`):
+/// `0` -> `Allied=` (`+0x3E`), `1` -> `Russian=` (`+0x35`), anything else ->
+/// `Yuri=` (`+0x2C`) (`0x007528E8..0x007528FE`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EvaSide {
+    #[default]
+    Allied,
+    Russian,
+    Yuri,
+}
+
+impl EvaSide {
+    /// `SetSide(-1)` stores 0 (`0x007534E0`); every other value is stored as
+    /// is and only 0/1 select a named column at play time.
+    pub fn from_side_index(side: i32) -> Self {
+        match side {
+            -1 | 0 => Self::Allied,
+            1 => Self::Russian,
+            _ => Self::Yuri,
+        }
+    }
+}
+
+/// One `[DialogList]` entry of evamd.ini (`VoxClass::ReadINI @ 0x00752DB0`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct EvaEntry {
+    /// The `[DialogList]` value, exact case, used as the entry identity
+    /// (`VoxClass::PlayEVA @ 0x00752700` matches by `stricmp`).
+    pub name: String,
+    /// `Allied=` column (`+0x3E`, `strncpy` 9 bytes). `None` when empty.
+    pub allied: Option<String>,
+    /// `Russian=` column (`+0x35`).
+    pub russian: Option<String>,
+    /// `Yuri=` column (`+0x2C`).
+    pub yuri: Option<String>,
+    /// `Type=` (`+0x4C`), default STANDARD.
+    pub eva_type: EvaType,
+    /// `Priority=` (`+0x48`), default NORMAL.
+    pub priority: EvaPriority,
+    /// `Volume=` (`+0x28`, `ReadDouble` default 1.0). Stored as native does;
+    /// its consumer is outside the queue pipeline (`SetGlobalVolume @
+    /// 0x00752AB0` only stores a clamped byte at `0x00846614`) — carried,
+    /// not applied. gamemd consumer UNCHECKED.
+    pub volume: f32,
+}
+
+impl EvaEntry {
+    fn from_section(name: &str, section: Option<&IniSection>) -> Self {
+        let mut entry = Self {
+            name: name.to_string(),
+            allied: None,
+            russian: None,
+            yuri: None,
+            eva_type: EvaType::Standard,
+            priority: EvaPriority::Normal,
+            volume: 1.0,
+        };
+        // `VoxClass::ReadINI` returns 0 when `FindSectionByName` fails; the
+        // entry keeps its `ReadEVAINI` defaults and empty columns.
+        let Some(section) = section else {
+            return entry;
+        };
+        if let Some(volume) = section
+            .get("Volume")
+            .and_then(|value| value.trim().parse::<f64>().ok())
+        {
+            entry.volume = volume as f32;
+        }
+        if let Some(eva_type) = section.get("Type").and_then(EvaType::parse) {
+            entry.eva_type = eva_type;
+        }
+        if let Some(priority) = section.get("Priority").and_then(EvaPriority::parse) {
+            entry.priority = priority;
+        }
+        // `strncpy(dst, value, 9)` then a forced NUL: at most 8 characters
+        // survive, and an empty value leaves the column empty.
+        let column = |key: &str| -> Option<String> {
+            let value = section.get(key)?.trim();
+            if value.is_empty() {
+                return None;
+            }
+            Some(value.chars().take(8).collect())
+        };
+        entry.allied = column("Allied");
+        entry.russian = column("Russian");
+        entry.yuri = column("Yuri");
+        entry
+    }
+
+    /// The sample name for one side column, `None` when that column is empty.
+    pub fn column(&self, side: EvaSide) -> Option<&str> {
+        match side {
+            EvaSide::Allied => self.allied.as_deref(),
+            EvaSide::Russian => self.russian.as_deref(),
+            EvaSide::Yuri => self.yuri.as_deref(),
+        }
+    }
+}
+
+/// The `VoxClass` entry array (`0xB1D4A4`, count `0xB1D4B0`), built by
+/// `VoxClass::ReadEVAINI @ 0x00753000` from **evamd.ini only** (`Init_Game
+/// @ 0x0052C8A0` hands it the `EVAMD.INI` CCINI, strings `0x00825DF0`,
+/// "Reading EVAMD.INI" `0x00825DFC`; gamemd never opens `eva.ini`).
 ///
-/// Maps EVA event names (e.g., "EVA_ConstructionComplete") to per-faction
-/// audio.bag sound IDs (e.g., Allied="ceva048", Russian="csof048", Yuri="cyur048").
+/// `ReadEVAINI` walks `[DialogList]` by entry index, skips a value that is
+/// already registered (`stricmp` scan), allocates the entry with its defaults
+/// and calls `VoxClass::ReadINI` on the section of the same name.
 #[derive(Debug, Clone, Default)]
 pub struct EvaRegistry {
     entries: HashMap<String, EvaEntry>,
 }
 
 impl EvaRegistry {
-    /// Parse an EvaRegistry from eva.ini / evamd.ini data.
+    /// Parse the registry from evamd.ini data.
     pub fn from_ini(ini: &IniFile) -> Self {
         let mut entries: HashMap<String, EvaEntry> = HashMap::new();
-
-        for name in ini.section_names() {
-            // Only parse EVA_ sections (skip DialogList, etc.).
-            if !name.starts_with("EVA_") {
-                continue;
-            }
-            let Some(section) = ini.section(name) else {
-                continue;
-            };
-
-            let entry = EvaEntry {
-                allied: section.get("Allied").map(|s| s.to_string()),
-                russian: section.get("Russian").map(|s| s.to_string()),
-                yuri: section.get("Yuri").map(|s| s.to_string()),
-            };
-
-            // Only store if at least one faction has a sound.
-            if entry.allied.is_some() || entry.russian.is_some() || entry.yuri.is_some() {
-                entries.insert(name.to_ascii_uppercase(), entry);
+        if let Some(list) = ini.section("DialogList") {
+            for key in list.keys() {
+                let Some(name) = list.get(key).map(str::trim).filter(|n| !n.is_empty()) else {
+                    continue;
+                };
+                let id = name.to_ascii_uppercase();
+                if entries.contains_key(&id) {
+                    continue;
+                }
+                entries.insert(id, EvaEntry::from_section(name, ini.section(name)));
             }
         }
-
         log::info!(
             "EvaRegistry: loaded {} EVA event definitions",
             entries.len()
@@ -785,38 +941,14 @@ impl EvaRegistry {
         Self { entries }
     }
 
-    /// Merge another eva.ini (base RA2) into this registry.
-    /// Only adds entries that don't already exist (YR-first precedence).
-    pub fn merge_fallback(&mut self, ini: &IniFile) {
-        let fallback = EvaRegistry::from_ini(ini);
-        let mut added: usize = 0;
-        for (key, entry) in fallback.entries {
-            if !self.entries.contains_key(&key) {
-                self.entries.insert(key, entry);
-                added += 1;
-            }
-        }
-        if added > 0 {
-            log::info!(
-                "EvaRegistry: merged {} fallback entries (total {})",
-                added,
-                self.entries.len()
-            );
-        }
+    /// `VoxClass::PlayEVA`'s `stricmp` scan: the entry for an event name.
+    pub fn entry(&self, event_name: &str) -> Option<&EvaEntry> {
+        self.entries.get(&event_name.to_ascii_uppercase())
     }
 
-    /// Look up an EVA sound ID by event name and faction key.
-    ///
-    /// `event_name` is e.g., "EVA_ConstructionComplete" (case-insensitive).
-    /// `faction_key` is one of "Allied", "Russian", or "Yuri".
-    pub fn get(&self, event_name: &str, faction_key: &str) -> Option<&str> {
-        let entry = self.entries.get(&event_name.to_ascii_uppercase())?;
-        let sound = match faction_key {
-            "Russian" => entry.russian.as_deref(),
-            "Yuri" => entry.yuri.as_deref(),
-            _ => entry.allied.as_deref(),
-        };
-        sound
+    /// Look up an EVA sample name by event name and side column.
+    pub fn get(&self, event_name: &str, side: EvaSide) -> Option<&str> {
+        self.entry(event_name)?.column(side)
     }
 
     /// Number of EVA event definitions.
@@ -1343,5 +1475,84 @@ mod tests {
         let reg: SoundRegistry = SoundRegistry::from_ini(&ini);
         let entry: &SoundEntry = reg.get("CommentTest").expect("should find entry");
         assert_eq!(entry.sounds, vec!["irocdiea"]);
+    }
+
+    /// `VoxClass::ReadEVAINI @ 0x00753000` walks `[DialogList]` values and
+    /// `VoxClass::ReadINI @ 0x00752DB0` reads `Type=`/`Priority=`/`Volume=`
+    /// and the three columns; defaults are STANDARD / NORMAL / 1.0.
+    #[test]
+    fn eva_registry_carries_type_priority_and_columns_from_dialog_list() {
+        let ini = IniFile::from_str(
+            "[DialogList]\n0=EVA_UnitLost\n1=EVA_LowPower\n2=EVA_Plain\n3=EVA_Missing\n\
+             4=EVA_UnitLost\n\
+             [EVA_UnitLost]\nText=Unit lost.\nRussian=csof064\nAllied=ceva064\nYuri=cyur064\n\
+             Priority= IMPORTANT\n\
+             [EVA_LowPower]\nRussian=csof053\nAllied=ceva053\nYuri=cyur053\nType=queue\n\
+             Priority=Important\nVolume=0.5\n\
+             [EVA_Plain]\nAllied=ceva001\nType=bogus\nPriority=\n\
+             [EVA_NotListed]\nAllied=ceva999\n",
+        );
+        let reg = EvaRegistry::from_ini(&ini);
+        assert_eq!(reg.len(), 4, "duplicate DialogList values register once");
+
+        let lost = reg.entry("eva_unitlost").unwrap();
+        assert_eq!(lost.eva_type, EvaType::Standard);
+        assert_eq!(lost.priority, EvaPriority::Important);
+        assert_eq!(lost.column(EvaSide::Allied), Some("ceva064"));
+        assert_eq!(lost.column(EvaSide::Russian), Some("csof064"));
+        assert_eq!(lost.column(EvaSide::Yuri), Some("cyur064"));
+        assert!((lost.volume - 1.0).abs() < f32::EPSILON);
+
+        let power = reg.entry("EVA_LowPower").unwrap();
+        assert_eq!(power.eva_type, EvaType::Queue, "stricmp: case-insensitive");
+        assert_eq!(power.priority, EvaPriority::Important);
+        assert!((power.volume - 0.5).abs() < f32::EPSILON);
+
+        // Unknown or empty tokens keep the ReadEVAINI defaults.
+        let plain = reg.entry("EVA_Plain").unwrap();
+        assert_eq!(plain.eva_type, EvaType::Standard);
+        assert_eq!(plain.priority, EvaPriority::Normal);
+        assert_eq!(plain.column(EvaSide::Russian), None);
+
+        // A listed name without a section keeps defaults and empty columns.
+        let missing = reg.entry("EVA_Missing").unwrap();
+        assert_eq!(missing.column(EvaSide::Allied), None);
+        // A section that is not in DialogList is not an entry.
+        assert!(reg.entry("EVA_NotListed").is_none());
+        assert_eq!(reg.get("EVA_UnitLost", EvaSide::Russian), Some("csof064"));
+    }
+
+    /// `VoxClass::SetSide @ 0x007534E0` stores the side as is (`-1` → 0);
+    /// `PlayNextQueued 0x007528E8..0x007528FE` selects Allied for 0, Russian
+    /// for 1 and the Yuri column for every other value.
+    #[test]
+    fn eva_side_column_follows_the_native_side_index_select() {
+        assert_eq!(EvaSide::from_side_index(-1), EvaSide::Allied);
+        assert_eq!(EvaSide::from_side_index(0), EvaSide::Allied);
+        assert_eq!(EvaSide::from_side_index(1), EvaSide::Russian);
+        assert_eq!(EvaSide::from_side_index(2), EvaSide::Yuri);
+        assert_eq!(EvaSide::from_side_index(7), EvaSide::Yuri);
+    }
+
+    /// `ReadINI` priority tokens map to the four list indices in the native
+    /// order (`LOW`→0 .. `CRITICAL`→3); `HIGH`/`LOWEST` at `0x008161CC`/
+    /// `0x008161E0` are not consulted by this reader.
+    #[test]
+    fn eva_priority_tokens_match_the_native_parse_table() {
+        assert_eq!(EvaPriority::parse("LOW"), Some(EvaPriority::Low));
+        assert_eq!(EvaPriority::parse("normal"), Some(EvaPriority::Normal));
+        assert_eq!(
+            EvaPriority::parse(" IMPORTANT"),
+            Some(EvaPriority::Important)
+        );
+        assert_eq!(EvaPriority::parse("Critical"), Some(EvaPriority::Critical));
+        assert_eq!(EvaPriority::parse("HIGH"), None);
+        assert_eq!(EvaPriority::Critical.list_index(), 3);
+        assert!(EvaPriority::Low < EvaPriority::Normal);
+        assert_eq!(
+            EvaType::parse("QUEUED_INTERRUPT"),
+            Some(EvaType::QueuedInterrupt)
+        );
+        assert_eq!(EvaType::parse("interrupt"), Some(EvaType::Interrupt));
     }
 }


### PR DESCRIPTION
EVA lines now go through a VoxClass-shaped queue. Native reads EVAMD.INI only (`ReadEVAINI` @ 0x00753000) with per-entry `Type=` (STANDARD/QUEUE/INTERRUPT/QUEUED_INTERRUPT), `Priority=` (LOW..CRITICAL), `Volume=` and the Allied/Russian/Yuri columns. `InsertIntoQueue` @ 0x00752590 routes queued interrupts to the interrupt list, QUEUE lines to four per-priority FIFOs, CRITICAL lines to the critical list, and everything else to one pending slot taken only when both lists are empty and the slot is free or strictly lower priority. `PlayNextQueued` @ 0x00752760 dequeues interrupt → critical → pending → FIFOs, frees the pending slot on interrupt/critical, and starts a line only after a 500 ms gap (0x0075296D) since the previous line ended; the column follows the local house's side. `QueueVoice` @ 0x00752480 refuses the current entry and same-entry-same-type duplicates and honours the suspend counter.

Previous Rust had one FIFO that dropped any STANDARD line while busy (which could silence "You have lost"), ignored Type/Priority, merged RA2's eva.ini, and had no gap. Player-visible in every match with overlapping announcements.

Changes: evamd-only registry with Type/Priority/Volume and side columns; new `VoxQueue` (pending slot, four FIFOs, critical/interrupt lists, duplicate/discard rules, 500 ms gap, suspend/pause depths); sound events carry the EVA event name; side chosen once from the local country; UnitPromoted and outcome lines routed through the queue. sim/ untouched; producer predicates unchanged (those are the next mechanism); parity harness unchanged.

Residuals recorded in code: the voice stream still shares the slot with unit acknowledgements (pre-existing); line end observed at the first empty pump (≤1 frame late); `Volume=` carried but no reader exists in the voice path; suspend/resume producers (nuke flash, radar movie) not yet wired; queue not persisted in saves.

Independent read-only critic re-read the reader, the three queue bodies and thirteen `PlayEVA` call sites and passed the change.

Validation:
- `cargo test -p vera20k --lib`: `test result: ok. 8350 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 12.47s`
