### PR TITLE
Announce funds, power, losses and attacks on the native predicates

### DIFF
--- a/src/app/match_audio.rs
+++ b/src/app/match_audio.rs
@@ -1,10 +1,10 @@
 //! Per-match audio state (F11 `MatchAudioState`): the app-side sound event
-//! queue and the EVA edge-detection latches.
+//! queue.
 //!
 //! Everything here is scoped to one match and must reset when a new match
-//! installs — most visibly the under-attack suppression window, which is
-//! tick-indexed: carried into a new match whose tick counter restarts at
-//! zero, it silenced the under-attack EVA line for the first ~30 seconds.
+//! installs. The EVA state predicates (funds nag, low power, unit lost,
+//! under-attack cadence) are sim-owned (`sim::house_eva`, the combat death
+//! and damage sites); this owner only carries their events to the player.
 //! Process/device-wide audio (players, registries, volumes) stays outside
 //! this owner; grouping those into `AppAudioRuntime` lands with the F12
 //! AppState owner reorganization.
@@ -15,17 +15,6 @@ use crate::audio::events::SoundEventQueue;
 pub(crate) struct MatchAudioState {
     /// Sim/app sound events queued for playback this frame.
     pub(crate) sound_events: SoundEventQueue,
-    /// EVA edge-detection: the local house was in low power last frame.
-    pub(crate) eva_low_power_active: bool,
-    /// EVA edge-detection: a local factory was in an underfunded stall last frame.
-    pub(crate) eva_funds_stalled: bool,
-    /// EVA edge-detection: local mobile entities whose death has already been
-    /// announced (pruned as the corpses despawn).
-    pub(crate) eva_announced_dying: std::collections::HashSet<u64>,
-    /// Sim tick until which the under-attack EVA voice is suppressed. The
-    /// native per-house attack-voice repeat delay is UNVERIFIED-pending-trace;
-    /// ~30 s is a conservative interim so sustained fire doesn't spam the line.
-    pub(crate) eva_under_attack_block_until_tick: u64,
 }
 
 impl MatchAudioState {
@@ -40,33 +29,22 @@ impl MatchAudioState {
 mod tests {
     use super::MatchAudioState;
 
-    /// F11: the new-match reset covers the WHOLE owner — most importantly the
-    /// tick-indexed under-attack suppression window (previously carried into
-    /// the next match and silencing its under-attack EVA line) and the queued
-    /// sound events (previously surviving teardown undrained).
+    /// F11: the new-match reset drops the queued sound events (previously
+    /// surviving teardown undrained).
     #[test]
-    fn new_match_reset_clears_the_under_attack_window_and_queued_events() {
+    fn new_match_reset_clears_queued_events() {
         let mut audio = MatchAudioState::default();
         audio
             .sound_events
             .push(crate::audio::events::GameSoundEvent::UiSound {
                 sound_id: "leftover".to_string(),
             });
-        audio.eva_low_power_active = true;
-        audio.eva_funds_stalled = true;
-        audio.eva_announced_dying.insert(41);
-        audio.eva_under_attack_block_until_tick = 40_000;
 
         audio.reset_for_new_match();
 
-        assert!(audio.sound_events.drain().is_empty(), "queued events dropped");
-        assert!(!audio.eva_low_power_active);
-        assert!(!audio.eva_funds_stalled);
-        assert!(audio.eva_announced_dying.is_empty());
-        assert_eq!(
-            audio.eva_under_attack_block_until_tick, 0,
-            "the suppression window must not carry into a match whose tick \
-             counter restarts at zero"
+        assert!(
+            audio.sound_events.drain().is_empty(),
+            "queued events dropped"
         );
     }
 }

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -13,9 +13,6 @@ use std::time::Instant;
 use crate::app::AppState;
 use crate::app::input::commands::{preferred_local_owner, preferred_local_owner_name};
 
-/// Minimum ticks between under-attack EVA voice lines (~30 s at 67 ms/tick).
-/// The native per-house attack-voice repeat delay is UNVERIFIED-pending-trace.
-const EVA_UNDER_ATTACK_COOLDOWN_TICKS: u64 = 450;
 /// Chance in 100 that a techno speaks its `VoiceFeedback=` line on the
 /// half-strength crossing. `TechnoClass::ReceiveDamage @ 0x007026BD
 /// CMP EAX,0x1E ; JGE` against `RandomRanged(0, 99)` — the cue speaks for a
@@ -153,111 +150,6 @@ fn replay_flush_facts(state: &AppState) -> (u64, u64) {
         .map(|d| d.as_secs())
         .unwrap_or(0);
     (session_tick, now)
-}
-
-/// App-side producers for the high-frequency EVA state cues the sim emits no
-/// events for yet: "Low power", "Insufficient funds", "Unit lost".
-///
-/// Each cue is edge-detected against the previous frame's state (the
-/// `AppState.eva_*` trackers) so it fires once per transition; the voice
-/// queue's same-cue dedupe is the repeat suppressor while a cue is already
-/// playing/queued. Native VoxClass priority tiers and re-announce cadence
-/// remain a later parity surface (the queue bridge in `audio/sfx.rs` says the
-/// same) — this wires the producers only.
-fn announce_local_state_evas(state: &mut AppState) {
-    let Some(owner) = crate::app::input::commands::preferred_local_owner_name(state) else {
-        return;
-    };
-    // Read phase (immutable sim borrow): compute this frame's states and the
-    // newly-dying set; commit to the trackers after the borrow ends.
-    let (low_power, funds_stalled, current_dying, newly_dying) = {
-        let Some(sim) = state
-            .match_state
-            .sim_runtime
-            .as_ref()
-            .map(|rt| &rt.simulation)
-        else {
-            return;
-        };
-        let owner_id = sim.interner.get(&owner);
-        let low_power = owner_id
-            .and_then(|id| sim.power_states.get(&id))
-            .is_some_and(|p| p.is_low_power);
-        // Underfunded stall: any local factory holding an active object.
-        let funds_stalled = owner_id.is_some_and(|id| {
-            sim.production
-                .factory_shadow
-                .iter_insertion_ordered()
-                .iter()
-                .any(|f| f.owner == id && f.on_hold && f.object.is_some())
-        });
-        // Local mobile entities currently in their death sequence. Structures
-        // have their own radar/EVA surface (not wired here); instant removals
-        // that never set `dying` (e.g. crush) are a known miss until the sim
-        // emits a death event.
-        let current_dying: Vec<u64> = owner_id
-            .map(|id| {
-                sim.entities()
-                    .values()
-                    .filter(|e| {
-                        e.dying
-                            && e.owner == id
-                            && e.category != crate::map::entities::EntityCategory::Structure
-                    })
-                    .map(|e| e.stable_id)
-                    .collect()
-            })
-            .unwrap_or_default();
-        let newly_dying: Vec<u64> = current_dying
-            .iter()
-            .copied()
-            .filter(|id| {
-                !state
-                    .match_state
-                    .match_audio
-                    .eva_announced_dying
-                    .contains(id)
-            })
-            .collect();
-        (low_power, funds_stalled, current_dying, newly_dying)
-    };
-
-    let mut cues: Vec<&'static str> = Vec::new();
-    if low_power && !state.match_state.match_audio.eva_low_power_active {
-        cues.push("EVA_LowPower");
-    }
-    state.match_state.match_audio.eva_low_power_active = low_power;
-    if funds_stalled && !state.match_state.match_audio.eva_funds_stalled {
-        cues.push("EVA_InsufficientFunds");
-    }
-    state.match_state.match_audio.eva_funds_stalled = funds_stalled;
-    if !newly_dying.is_empty() {
-        cues.push("EVA_UnitLost");
-    }
-    // Prune despawned corpses, then record this frame's announcements.
-    state
-        .match_state
-        .match_audio
-        .eva_announced_dying
-        .retain(|id| current_dying.contains(id));
-    state
-        .match_state
-        .match_audio
-        .eva_announced_dying
-        .extend(newly_dying);
-
-    // Each is a `VoxClass::PlayEVA(name, -1)`; the entry's own `Type=` and
-    // `Priority=` route it (`EVA_LowPower` QUEUE IMPORTANT,
-    // `EVA_InsufficientFunds` STANDARD NORMAL, `EVA_UnitLost` STANDARD
-    // IMPORTANT on stock data).
-    for cue in cues {
-        state.match_state.match_audio.sound_events.push(
-            crate::audio::events::GameSoundEvent::Eva {
-                event: cue.to_string(),
-                type_override: None,
-            },
-        );
-    }
 }
 
 /// Drive the app-owned Vox wait after serialized HouseState reaches its exact
@@ -1054,9 +946,6 @@ fn advance_in_game_runtime_mode(
             };
             state.platform.frame_pacer.record_admitted_frame(now_ms);
         }
-        // High-frequency EVA state cues (low power / insufficient funds /
-        // unit lost) — app-side edge detection over sim state.
-        announce_local_state_evas(state);
         let garrison_flash_elapsed_ticks = state
             .match_state
             .sim_runtime
@@ -1774,25 +1663,11 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         if !eva_allowed || !is_local {
                             continue;
                         }
-                        // Repeat cooldown across both cue kinds (the native
-                        // per-house attack-voice delay is UNVERIFIED — see the
-                        // field doc on AppState).
-                        if sim.session.tick
-                            < state
-                                .match_state
-                                .match_audio
-                                .eva_under_attack_block_until_tick
-                        {
-                            continue;
-                        }
-                        state
-                            .match_state
-                            .match_audio
-                            .eva_under_attack_block_until_tick =
-                            sim.session.tick + EVA_UNDER_ATTACK_COOLDOWN_TICKS;
                         // `HouseClass::NotifyUnderAttack 0x004F94FB/0x004F95B3`,
                         // `UnitClass::ReceiveDamage 0x00738530`: `PlayEVA` type
                         // -1 (stock entries STANDARD NORMAL → pending slot).
+                        // The radar accept (`CreateRadarEvent`, folded into
+                        // `eva_allowed` sim-side) is native's only rate limit.
                         let cue = if miner {
                             "EVA_OreMinerUnderAttack"
                         } else {
@@ -1810,6 +1685,63 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                             state.match_state.match_audio.sound_events.push(siren);
                         }
                         continue;
+                    }
+                    SimSoundEvent::AllyUnderAttack { owner } => {
+                        // `NotifyUnderAttack 0x004F95AE..0x004F95CF`: the ally
+                        // line for the LOCAL listener, then the same siren
+                        // tail as the base line.
+                        let owner_str = sim.interner.resolve(owner);
+                        if !local_owner_name
+                            .as_deref()
+                            .is_some_and(|l| l.eq_ignore_ascii_case(owner_str))
+                        {
+                            continue;
+                        }
+                        state
+                            .match_state
+                            .match_audio
+                            .sound_events
+                            .push(GameSoundEvent::Eva {
+                                event: "EVA_OurAllyIsUnderAttack".to_string(),
+                                type_override: None,
+                            });
+                        if let Some(siren) = base_under_attack_siren(false, &resources.rules) {
+                            state.match_state.match_audio.sound_events.push(siren);
+                        }
+                        continue;
+                    }
+                    SimSoundEvent::UnitLost { owner } => {
+                        // `TechnoClass::Death_Announcement 0x004D9911`:
+                        // `PlayEVA("EVA_UnitLost", -1)` for the local owner
+                        // once the sim's Spawned and radar type-7 gates passed.
+                        let owner_str = sim.interner.resolve(owner);
+                        if !local_owner_name
+                            .as_deref()
+                            .is_some_and(|l| l.eq_ignore_ascii_case(owner_str))
+                        {
+                            continue;
+                        }
+                        GameSoundEvent::Eva {
+                            event: "EVA_UnitLost".to_string(),
+                            type_override: None,
+                        }
+                    }
+                    SimSoundEvent::HouseEva { owner, event } => {
+                        // `HouseClass::Update 0x004F8BA0` / `0x004F8D14`:
+                        // `PlayEVA(name, -1)` — the entry's own `Type=` and
+                        // `Priority=` route it (stock: `EVA_InsufficientFunds`
+                        // STANDARD NORMAL, `EVA_LowPower` QUEUE IMPORTANT).
+                        let owner_str = sim.interner.resolve(owner);
+                        if !local_owner_name
+                            .as_deref()
+                            .is_some_and(|l| l.eq_ignore_ascii_case(owner_str))
+                        {
+                            continue;
+                        }
+                        GameSoundEvent::Eva {
+                            event: event.to_string(),
+                            type_override: None,
+                        }
                     }
                     SimSoundEvent::WorldEffectStarted {
                         sound_id,

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -582,6 +582,12 @@ pub struct ObjectType {
     /// Whether this unit is a resource harvester (Harvester=yes in rules.ini).
     /// Data-driven replacement for hardcoded type ID string checks.
     pub harvester: bool,
+    /// `Spawned=` (`TechnoTypeClass+0xD54`): this type is a carrier/launcher
+    /// child (Hornet, V3/Dreadnought missile). `TechnoTypeClass::ReadINI`
+    /// reads key `"Spawned"` (`0x008437D8`) at `0x00714E7D..0x00714E91`.
+    /// `TechnoClass::Death_Announcement @ 0x004D98C0` (`0x004D98DD`) stays
+    /// silent for such types.
+    pub spawned: bool,
     /// Whether this structure accepts ore/gem delivery (Refinery=yes in rules.ini).
     pub refinery: bool,
     /// Native BuildingType `Weeder=` classification. ExitObject dispatch tests
@@ -1695,6 +1701,7 @@ impl ObjectType {
             insignificant: section.get_bool("Insignificant").unwrap_or(false),
             to_protect: section.get_bool("ToProtect").unwrap_or(false),
             harvester: section.get_bool("Harvester").unwrap_or(false),
+            spawned: section.get_bool("Spawned").unwrap_or(false),
             refinery: section.get_bool("Refinery").unwrap_or(false),
             weeder: section.get_bool("Weeder").unwrap_or(false),
             bib: section.get_bool("Bib").unwrap_or(false),

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -742,6 +742,15 @@ pub struct GeneralRules {
     /// MessageDelay (retail `.6`). The exact native minutes→ticks binding is
     /// untraced (plan deferred item); the driver converts minutes→ms.
     pub message_delay_minutes: f32,
+    /// `[AudioVisual] SpeakDelay=` in MINUTES (retail `2`): the EVA advice
+    /// repeat interval. `RulesClass::ReadAudioVisual` reads key
+    /// `"SpeakDelay"` (`0x0083A270`) through `INIClass::ReadDouble @
+    /// 0x005283D0` into `Rules+0x16A8` (`0x0066B646 FSTP double`);
+    /// `RulesClass::Constructor 0x006674BA` zero-fills it, so a missing key is
+    /// `0.0`. `HouseClass::Update` re-arms its funds/low-power timers to
+    /// `SpeedNormalize(ftol(SpeakDelay * 900.0))` (`0x004F8BB4..0x004F8BCB`,
+    /// `0x007E27F8` = `900.0`).
+    pub speak_delay_minutes: f64,
     /// Sound event for opening shell combo boxes from [AudioVisual] GUIComboOpenSound.
     pub gui_combo_open_sound: Option<String>,
     /// Sound event for closing shell combo boxes from [AudioVisual] GUIComboCloseSound.
@@ -1278,6 +1287,7 @@ impl Default for GeneralRules {
             gui_tab_sound: None,
             incoming_message_sound: None,
             message_delay_minutes: 0.6,
+            speak_delay_minutes: 0.0,
             gui_combo_open_sound: None,
             gui_combo_close_sound: None,
             bunker_walls_down_sound: None,
@@ -2113,6 +2123,9 @@ impl GeneralRules {
             message_delay_minutes: audio_visual
                 .and_then(|s| s.get_f32("MessageDelay"))
                 .unwrap_or(0.6),
+            speak_delay_minutes: audio_visual
+                .and_then(|s| s.get_f64("SpeakDelay"))
+                .unwrap_or(0.0),
             gui_combo_open_sound: audio_visual
                 .and_then(|s| s.get("GUIComboOpenSound"))
                 .map(str::trim)

--- a/src/sim/aircraft/mod.rs
+++ b/src/sim/aircraft/mod.rs
@@ -713,6 +713,15 @@ pub fn tick_aircraft_missions(
 
     // Phase 3: Apply mutations.
     for m in &mutations {
+        // No "Unit lost" here: `AircraftClass::Enter_Idle_Mode @ 0x004176F0`
+        // handles the AirportBound-without-airfield case by calling the
+        // `Crash` slot `+0x3DC` directly (`0x004179FD`, `0x00417B88`; body
+        // `0x004DEBB0`, which runs `RecordKill +0xE0` and the trigger events
+        // but never `Death_Announcement +0x3B8`), and the eventual impact in
+        // `AircraftClass::AI` (`0x00414BB0`, height < -400) is `RecordKill` +
+        // `UnInit` (`0x00414E1F`). Only a damage kill (`AircraftClass::
+        // ReceiveDamage 0x004165C0`, result 4 → `+0x3B8` at `0x00416613`)
+        // announces, and that runs through the combat kill loop.
         if m.self_destruct {
             if let Some(entity) = sim.substrate.entities.get_mut(m.id) {
                 entity.health.current = 0;
@@ -869,6 +878,10 @@ pub fn tick_aircraft_missions(
     }
 
     // Silent despawns for carriers that exited the playfield with empty cargo.
+    // Native is silent too: `AircraftClass::Mission_Rescue @ 0x00415960`
+    // never removes the carrier, and the off-playfield removal in
+    // `AircraftClass::AI` (`0x00414F93` / `0x00414FD1`) is a bare `UnInit`
+    // (`+0xF8`) with no `Death_Announcement` (`+0x3B8`).
     for m in &mutations {
         if m.paradrop_silent_despawn {
             if let Some(entity) = sim.substrate.entities.get_mut(m.id) {

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -6806,10 +6806,19 @@ fn gsi_08_05_non_inviso_projectile_advances_scenario_rng_by_the_reload_jitter() 
     );
 
     assert_eq!(scenario_rng.logical_state(), expected_rng.logical_state());
-    assert!(result.explosion_effects.is_empty(), "non-Inviso Speed=0 still creates a persistent native shot");
+    assert!(
+        result.explosion_effects.is_empty(),
+        "non-Inviso Speed=0 still creates a persistent native shot"
+    );
     assert_eq!(result.projectile_spawns.len(), 1);
     let target = result.projectile_spawns[0].initial_target_position;
-    assert_eq!((target.x, target.y), (i32::from(target_coord.0) * 256 + target_coord.2.to_num::<i32>(), i32::from(target_coord.1) * 256 + target_coord.3.to_num::<i32>()));
+    assert_eq!(
+        (target.x, target.y),
+        (
+            i32::from(target_coord.0) * 256 + target_coord.2.to_num::<i32>(),
+            i32::from(target_coord.1) * 256 + target_coord.3.to_num::<i32>()
+        )
+    );
 }
 
 #[test]
@@ -7670,17 +7679,21 @@ fn deployed_desolator_self_irradiates_and_refires_below_third() {
 }
 
 #[test]
-fn under_attack_events_fire_for_enemy_hit_structures_and_miners_only() {
-    // The Phase-4 damage-apply producer: an enemy-damaged Structure emits a
-    // base ping, an enemy-damaged harvester a miner ping; same-owner damage
-    // and plain-unit victims emit nothing.
+fn under_attack_events_fire_for_sourced_structures_and_harvester_types() {
+    // The damage-apply producer, per `BuildingClass::ReceiveDamage @
+    // 0x00442230` (sourced, non-zero result, `Insignificant=` clear — no
+    // attacker-house test) and `UnitClass::ReceiveDamage 0x007384B9`
+    // (`Harvester=` type flag, any source).
     let rules = RuleSet::from_ini(&IniFile::from_str(
         "[InfantryTypes]\n0=E1\n\n\
-         [VehicleTypes]\n0=HARV\n\n\
+         [VehicleTypes]\n0=HARV\n1=MTNK\n\n\
          [AircraftTypes]\n\n\
-         [BuildingTypes]\n0=CAGAS\n\n\
+         [BuildingTypes]\n0=CAGAS\n1=CATREE\n2=YAREFN\n\n\
          [CAGAS]\nStrength=800\nArmor=wood\n\n\
+         [CATREE]\nStrength=800\nArmor=wood\nInsignificant=yes\n\n\
+         [YAREFN]\nStrength=800\nArmor=wood\nUndeploysInto=HARV\nResourceGatherer=yes\n\n\
          [HARV]\nStrength=1000\nArmor=heavy\nSpeed=4\nHarvester=yes\n\n\
+         [MTNK]\nStrength=1000\nArmor=heavy\nSpeed=4\n\n\
          [E1]\nStrength=125\nArmor=flak\nSpeed=4\nPrimary=M60\n\n\
          [M60]\nDamage=25\nROF=20\nRange=5\nWarhead=SA\n\n\
          [SA]\nVerses=100%,100%,100%,90%,70%,25%,100%,25%,25%,0%,0%\n",
@@ -7716,36 +7729,176 @@ fn under_attack_events_fire_for_enemy_hit_structures_and_miners_only() {
     assert_eq!(result.under_attack_events.len(), 1, "structure hit pings");
     let ev = &result.under_attack_events[0];
     assert!(!ev.miner);
+    assert!(ev.structure);
     assert_eq!(ev.owner, test_intern("Defender"));
     assert_eq!((ev.rx, ev.ry), (8, 5));
 
-    // Enemy-owned harvester (Miner component) → miner ping.
-    let mut harv = make_entity_owned(10, "HARV", 8, 5, 1000, "Defender");
-    harv.miner = Some(crate::sim::miner::Miner::new(
-        crate::sim::miner::MinerKind::War,
-        &crate::sim::miner::MinerConfig::default(),
-        7,
-    ));
+    // `Harvester=` vehicle → miner ping (the type flag, `UnitType+0xE0E`,
+    // not the Rust miner component).
+    let harv = make_entity_owned(10, "HARV", 8, 5, 1000, "Defender");
     let result = run_attack(harv);
     assert_eq!(result.under_attack_events.len(), 1, "harvester hit pings");
     assert!(result.under_attack_events[0].miner);
+    assert!(!result.under_attack_events[0].structure);
 
-    // SAME-owner structure damage → no ping (owner-differs hostility gate).
+    // SAME-owner structure damage → still pings: `BuildingClass::
+    // ReceiveDamage` never compares the source's house before
+    // `NotifyUnderAttack` (force-fire on an own building announces).
     let mut friendly = make_entity_owned(10, "CAGAS", 8, 5, 800, "Attacker");
     friendly.category = EntityCategory::Structure;
     let result = run_attack(friendly);
+    assert_eq!(result.under_attack_events.len(), 1, "own-fire pings");
+    assert_eq!(result.under_attack_events[0].owner, test_intern("Attacker"));
+
+    // `Insignificant=yes` building → `BuildingType+0x232` skip.
+    let mut prop = make_entity_owned(10, "CATREE", 8, 5, 800, "Defender");
+    prop.category = EntityCategory::Structure;
+    let result = run_attack(prop);
     assert!(
         result.under_attack_events.is_empty(),
-        "same-owner damage never pings"
+        "insignificant buildings never ping"
     );
 
-    // Enemy plain unit (no miner, not a structure) → no ping.
-    let plain = make_entity_owned(10, "HARV", 8, 5, 1000, "Defender");
+    // Deployed slave miner (`UndeploysInto=` + `ResourceGatherer=yes`
+    // building) → the ore-miner line through the building path.
+    let mut slave = make_entity_owned(10, "YAREFN", 8, 5, 800, "Defender");
+    slave.category = EntityCategory::Structure;
+    let result = run_attack(slave);
+    assert_eq!(result.under_attack_events.len(), 1);
+    assert!(result.under_attack_events[0].miner);
+    assert!(result.under_attack_events[0].structure);
+
+    // Plain vehicle (not `Harvester=`, not a structure) → no ping.
+    let plain = make_entity_owned(10, "MTNK", 8, 5, 1000, "Defender");
     let result = run_attack(plain);
     assert!(
         result.under_attack_events.is_empty(),
         "plain unit hits do not ping"
     );
+}
+
+/// `TechnoClass::Death_Announcement @ 0x004D98C0` inputs: a damage kill of a
+/// non-building emits one `UnitLostEvent`; a `Spawned=` type (`0x004D98DD`)
+/// and a building (no `+0x3B8` caller in `BuildingClass`) emit none.
+#[test]
+fn unit_lost_events_come_from_damage_kills_of_unspawned_non_buildings() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=E1\n\n\
+         [VehicleTypes]\n0=MTNK\n\n\
+         [AircraftTypes]\n0=HORNET\n\n\
+         [BuildingTypes]\n0=CAGAS\n\n\
+         [CAGAS]\nStrength=10\nArmor=wood\n\n\
+         [MTNK]\nStrength=10\nArmor=heavy\nSpeed=4\n\n\
+         [HORNET]\nStrength=10\nArmor=light\nSpeed=4\nSpawned=yes\n\n\
+         [E1]\nStrength=125\nArmor=flak\nSpeed=4\nPrimary=M60\n\n\
+         [M60]\nDamage=250\nROF=20\nRange=5\nWarhead=SA\n\n\
+         [SA]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("rules parse");
+
+    let mut main_rng = SimRng::new(1);
+    let mut run_kill = |victim: GameEntity| -> CombatTickResult {
+        let mut store = EntityStore::new();
+        store.insert(victim);
+        let mut attacker = make_infantry_entity(1, "E1", 5, 5, 125);
+        attacker.owner = test_intern("Attacker");
+        store.insert(attacker);
+        let mut interner = test_interner();
+        issue_attack_command(&mut store, 1, 10, None, &interner);
+        tick_combat(
+            &mut store,
+            &mut OccupancyGrid::new(),
+            &rules,
+            &mut interner,
+            &mut BTreeMap::new(),
+            0,
+            100,
+            0,
+            &mut main_rng,
+        )
+    };
+
+    let tank = make_entity_owned(10, "MTNK", 8, 5, 10, "Defender");
+    let result = run_kill(tank);
+    assert_eq!(result.unit_lost_events.len(), 1, "vehicle kill announces");
+    assert_eq!(result.unit_lost_events[0].owner, test_intern("Defender"));
+    assert_eq!(
+        (result.unit_lost_events[0].rx, result.unit_lost_events[0].ry),
+        (8, 5)
+    );
+
+    let mut hornet = make_entity_owned(10, "HORNET", 8, 5, 10, "Defender");
+    hornet.category = EntityCategory::Aircraft;
+    let result = run_kill(hornet);
+    assert!(
+        result.unit_lost_events.is_empty(),
+        "Spawned= types are silent"
+    );
+
+    let mut shack = make_entity_owned(10, "CAGAS", 8, 5, 10, "Defender");
+    shack.category = EntityCategory::Structure;
+    let result = run_kill(shack);
+    assert!(
+        result.unit_lost_events.is_empty(),
+        "buildings have no Death_Announcement caller"
+    );
+}
+
+/// `UnitClass::ReceiveDamage @ 0x00737C90`: `0x00737D69 CMP EAX,4` splits the
+/// result. The `Harvester=` ping (`0x007384B9..0x00738530`) lives only in the
+/// `result != 4` arm; a killing blow takes the death arm, where only
+/// `Death_Announcement` (`+0x3B8`) speaks. So a one-shot miner kill is "Unit
+/// lost" alone, never "Ore miner under attack" as well.
+#[test]
+fn harvester_killing_blow_announces_unit_lost_without_the_miner_ping() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=E1\n\n\
+         [VehicleTypes]\n0=HARV\n\n\
+         [AircraftTypes]\n\n\
+         [BuildingTypes]\n\n\
+         [HARV]\nStrength=1000\nArmor=heavy\nSpeed=4\nHarvester=yes\n\n\
+         [E1]\nStrength=125\nArmor=flak\nSpeed=4\nPrimary=M60\n\n\
+         [M60]\nDamage=250\nROF=20\nRange=5\nWarhead=SA\n\n\
+         [SA]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    ))
+    .expect("rules parse");
+
+    let mut main_rng = SimRng::new(1);
+    let mut run_attack = |victim: GameEntity| -> CombatTickResult {
+        let mut store = EntityStore::new();
+        store.insert(victim);
+        let mut attacker = make_infantry_entity(1, "E1", 5, 5, 125);
+        attacker.owner = test_intern("Attacker");
+        store.insert(attacker);
+        let mut interner = test_interner();
+        issue_attack_command(&mut store, 1, 10, None, &interner);
+        tick_combat(
+            &mut store,
+            &mut OccupancyGrid::new(),
+            &rules,
+            &mut interner,
+            &mut BTreeMap::new(),
+            0,
+            100,
+            0,
+            &mut main_rng,
+        )
+    };
+
+    // Non-lethal hit: the `result != 4` arm pings and nothing dies.
+    let result = run_attack(make_entity_owned(10, "HARV", 8, 5, 1000, "Defender"));
+    assert_eq!(result.under_attack_events.len(), 1, "survivor hit pings");
+    assert!(result.under_attack_events[0].miner);
+    assert!(result.unit_lost_events.is_empty(), "nothing died");
+
+    // One-shot kill: result 4 skips the ping; only the death arm speaks.
+    let result = run_attack(make_entity_owned(10, "HARV", 8, 5, 10, "Defender"));
+    assert!(
+        result.under_attack_events.is_empty(),
+        "a killing blow never reaches the miner ping"
+    );
+    assert_eq!(result.unit_lost_events.len(), 1, "the kill announces once");
+    assert_eq!(result.unit_lost_events[0].owner, test_intern("Defender"));
 }
 
 /// Build one ObjectType straight from an INI body, so the `Cost=` parse feeding
@@ -8949,7 +9102,10 @@ fn gsi_05_14_a_dying_building_uses_its_own_debris_anims() {
         .collect();
     let own: usize = names.iter().filter(|n| n.starts_with("DBRI-WM")).count();
     // `MinDebris=3`, `MaxDebris=4` pins the budget at 3 with no draw.
-    assert_eq!(own, 3, "the whole budget comes from DebrisAnims=: {names:?}");
+    assert_eq!(
+        own, 3,
+        "the whole budget comes from DebrisAnims=: {names:?}"
+    );
     assert!(
         !names.iter().any(|n| n.starts_with("DBRIS")),
         "the Rules MetallicDebris arm must not also fire: {names:?}"

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -1645,18 +1645,72 @@ pub struct CombatTickResult {
     /// apply site. Drained by the world into BaseUnderAttack/MinerUnderAttack
     /// radar events + the local player's EVA dispatch.
     pub under_attack_events: Vec<UnderAttackEvent>,
+    /// `Death_Announcement` inputs from this tick's damage kills; the world
+    /// applies the human-owner gate and the radar type-7 dedupe.
+    pub unit_lost_events: Vec<UnitLostEvent>,
 }
 
 /// A "your asset is being shot" ping: a Structure or harvester took damage
-/// from a different house this tick.
+/// this tick.
+///
+/// Native has two producers and neither tests the attacker's house:
+/// `BuildingClass::ReceiveDamage @ 0x00442230` calls
+/// `HouseClass::NotifyUnderAttack` when the source is non-null, the damage
+/// result is non-zero and `BuildingType+0x232 Insignificant` is clear (after
+/// a victim `vtbl+0x80` pre-check whose identity is not pinned and is not
+/// modelled); own-fire on an own building announces. `UnitClass::ReceiveDamage 0x007384B9..0x00738530` pings a
+/// `Harvester=` unit on any non-zero, non-fatal result with or without a
+/// source.
 #[derive(Debug, Clone, Copy)]
 pub struct UnderAttackEvent {
     pub rx: u16,
     pub ry: u16,
     /// The VICTIM's owner — the player whose radar/EVA should react.
     pub owner: InternedId,
-    /// True when the victim is a harvester (miner ping), else a base structure.
+    /// True for the ore-miner line: a `Harvester=` unit, or (via
+    /// `NotifyUnderAttack 0x004F9491..0x004F94A3`) a building whose type has
+    /// `UndeploysInto=` and `ResourceGatherer=yes` — the deployed slave miner.
     pub miner: bool,
+    /// True when produced by the building path, which is the only one that
+    /// reaches `NotifyUnderAttack`'s ally branch.
+    pub structure: bool,
+}
+
+/// `TechnoClass::Death_Announcement @ 0x004D98C0` input: a non-building
+/// techno was killed at a `ReceiveDamage` kill site (`AircraftClass
+/// 0x00416613`, infantry `0x005180F4`, `UnitClass 0x00737DC9/0x00737E39/
+/// 0x00737E68`, all vtable slot `+0x3B8`) and its type is not `Spawned=`.
+/// The world applies the owner-is-human gate and the radar type-7 dedupe.
+#[derive(Debug, Clone, Copy)]
+pub struct UnitLostEvent {
+    pub rx: u16,
+    pub ry: u16,
+    pub owner: InternedId,
+}
+
+/// The `Death_Announcement` (`+0x3B8`) input for one death site.
+///
+/// Every native caller sits in a non-building `ReceiveDamage` override
+/// (`BuildingClass` has none), and `0x004D98DD` skips `Spawned=` types.
+/// Shared by the damage kill loop and the non-damage death sites that
+/// natively route through `+0x16C` (`ReceiveDamage`) with `C4Warhead=`:
+/// `InfantryClass::IronCurtain 0x00522632` and `CellClass::BlowUpBridge
+/// 0x0047DDAE`. Paths that natively skip `ReceiveDamage` (crush
+/// `0x007416A0` → `RecordKill` only, `AircraftClass::Enter_Idle_Mode
+/// 0x004179FD/0x00417B88` → `Crash` slot `+0x3DC`, the off-playfield
+/// `UnInit` at `AircraftClass::AI 0x00414F93/0x00414FD1`) must not call it.
+pub(crate) fn death_announcement_event(
+    obj: &crate::rules::object_type::ObjectType,
+    category: EntityCategory,
+    rx: u16,
+    ry: u16,
+    owner: InternedId,
+) -> Option<UnitLostEvent> {
+    (category != EntityCategory::Structure && !obj.spawned).then_some(UnitLostEvent {
+        rx,
+        ry,
+        owner,
+    })
 }
 
 /// Exact ObjectClass-style world Z for effect and projectile coordinates.
@@ -1967,6 +2021,9 @@ pub(crate) struct DeathEffects {
     pub(crate) smudge_spawn_requests: Vec<SmudgeSpawnRequest>,
     pub(crate) rad_detonations: Vec<crate::sim::radiation::RadDetonation>,
     pub(crate) under_attack_events: Vec<UnderAttackEvent>,
+    /// `Death_Announcement` inputs from this tick's damage kills; the world
+    /// applies the human-owner gate and the radar type-7 dedupe.
+    pub(crate) unit_lost_events: Vec<UnitLostEvent>,
     #[cfg(test)]
     pub(crate) receiver_stage_trace: Vec<ReceiverStageTrace>,
 }
@@ -2320,6 +2377,7 @@ impl DeathEffects {
         self.rad_detonations.append(&mut other.rad_detonations);
         self.under_attack_events
             .append(&mut other.under_attack_events);
+        self.unit_lost_events.append(&mut other.unit_lost_events);
         #[cfg(test)]
         self.receiver_stage_trace
             .append(&mut other.receiver_stage_trace);
@@ -2590,6 +2648,7 @@ fn handle_entity_deaths(
     let mut concrete_smudge_plans: Vec<ConcreteDeathSmudgePlan> = Vec::new();
     let mut rad_detonations: Vec<crate::sim::radiation::RadDetonation> = Vec::new();
     let mut under_attack_events: Vec<UnderAttackEvent> = Vec::new();
+    let mut unit_lost_events: Vec<UnitLostEvent> = Vec::new();
     let mut structure_destroyed: bool = false;
     for &dead_id in dead_entities {
         // ReceiveDamage enters the death helper exactly once at the fatal
@@ -2653,6 +2712,15 @@ fn handle_entity_deaths(
                     ry,
                     &mut death_sounds,
                 );
+                // `TechnoClass::Death_Announcement @ 0x004D98C0` runs at the
+                // Aircraft/Infantry/Unit `ReceiveDamage` kill sites (vtable
+                // `+0x3B8`; `BuildingClass` has none) and skips `Spawned=`
+                // types at `0x004D98DD`. Its owner gate (`0x0050B6F0`) and
+                // the `CreateRadarEvent(7)` dedupe (`0x004D98FE`) need the
+                // house table and radar queue, which the world owns.
+                if let Some(event) = death_announcement_event(obj, category, rx, ry, owner) {
+                    unit_lost_events.push(event);
+                }
                 // gamemd-derived: the debris block of
                 // `TechnoClass::ReceiveDamage @ 0x00701900`
                 // (`0x00702281`..`0x0070256C`). It sits BELOW the two death
@@ -3023,6 +3091,7 @@ fn handle_entity_deaths(
             death_sounds.append(&mut nested.death_sounds);
             smudge_spawn_requests.append(&mut nested.smudge_spawn_requests);
             rad_detonations.append(&mut nested.rad_detonations);
+            unit_lost_events.append(&mut nested.unit_lost_events);
             #[cfg(test)]
             receiver_stage_trace.append(&mut nested.receiver_stage_trace);
             under_attack_events.append(&mut pings);
@@ -3126,6 +3195,7 @@ fn handle_entity_deaths(
         smudge_spawn_requests,
         rad_detonations,
         under_attack_events,
+        unit_lost_events,
         #[cfg(test)]
         receiver_stage_trace,
     }
@@ -4470,14 +4540,55 @@ fn commit_damage_events_with_isolation(
                     rules.general.condition_yellow_x1000,
                 );
             }
-            if damage > 0 && attacker_owner.is_some_and(|ao| ao != target.owner) {
-                let miner = target.miner.is_some();
-                if miner || target.category == EntityCategory::Structure {
+            // Neither native ping survives the killing blow.
+            // `UnitClass::ReceiveDamage @ 0x00737C90`: `0x00737D69 CMP EAX,4`
+            // sends result 4 to the death branch (`+0x3B8`
+            // `Death_Announcement`, `Death_Explosion`); the `Harvester=` ping
+            // (`0x007384B9..0x00738530`) sits only in the `result != 4` arm.
+            // `BuildingClass::ReceiveDamage @ 0x00442230`: case 4 calls
+            // `DestructionEffects` (slot `+0x4EC` = `0x004415F0`, which never
+            // writes `+0x90`) and then, for the stock timer (`+0x530` = 8),
+            // `ObjectClass::UnInit` (`0x005F65F0`, clears `IsAlive +0x90` at
+            // `0x005F6625`), so the `0x00442905` re-test returns 4 before
+            // `NotifyUnderAttack`. RESIDUAL: `DestructionEffects` arms a zero
+            // timer for `BuildingType+0xD15` types and a building whose
+            // current mission is Selling (0x13), leaving `IsAlive` set and the
+            // ping live on their killing blow; neither is modelled here (walls
+            // are overlay mutations, a sold building dying is rare).
+            if damage > 0
+                && !became_fatal
+                && let Some(obj) = rules.object(interner.resolve(target.type_ref))
+            {
+                // `BuildingClass::ReceiveDamage @ 0x00442230`: with a non-null
+                // source, a non-zero damage result and `Insignificant=` clear,
+                // `HouseClass::NotifyUnderAttack` runs — there is no
+                // attacker-house test on that path, so a force-fired own
+                // building announces. (Both native sites first test the
+                // victim's `vtbl+0x80` predicate; its identity is not pinned
+                // here and is not modelled — VERA-internal, gamemd equivalent
+                // UNCHECKED.) `NotifyUnderAttack
+                // 0x004F9491..0x004F94A3` routes a building whose type has
+                // `UndeploysInto=` and `ResourceGatherer=yes` (the deployed
+                // slave miner) to the ore-miner line.
+                //
+                // `UnitClass::ReceiveDamage 0x007384B9..0x00738530`: a
+                // `Harvester=` unit pings on any non-zero non-fatal result,
+                // with or without a source.
+                let ping = if target.category == EntityCategory::Structure {
+                    (attacker_owner.is_some() && !obj.insignificant).then_some((
+                        obj.undeploys_into.is_some() && obj.resource_gatherer,
+                        true,
+                    ))
+                } else {
+                    obj.harvester.then_some((true, false))
+                };
+                if let Some((miner, structure)) = ping {
                     under_attack_events.push(UnderAttackEvent {
                         rx: target.position.rx,
                         ry: target.position.ry,
                         owner: target.owner,
                         miner,
+                        structure,
                     });
                 }
             }
@@ -5801,6 +5912,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             smudge_spawn_requests: Vec::new(),
             unit_facing: Vec::new(),
             under_attack_events: Vec::new(),
+            unit_lost_events: Vec::new(),
         };
     }
 
@@ -6844,6 +6956,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
         smudge_spawn_requests,
         unit_facing,
         under_attack_events,
+        unit_lost_events: death.unit_lost_events,
     }
 }
 

--- a/src/sim/game_options.rs
+++ b/src/sim/game_options.rs
@@ -114,17 +114,30 @@ impl GameOptions {
 
     /// Scale a normalized animation delay through the currently stored speed.
     pub fn normalized_anim_delay(&self, delay: u16) -> u16 {
-        if delay == 0 {
+        self.speed_normalize(i32::from(delay)) as u16
+    }
+
+    /// `GameOptionsClass::SpeedNormalize @ 0x005FB2E0` (receiver `0xA8EB60`,
+    /// `[this]` = the stored speed index): `0 -> 0`; `1..=4` index the 4x8
+    /// table at `0x00832CEC` (`[value*8 + speed]`); otherwise
+    /// `(value << 3) / (speed + 1)` (`0x005FB2FC..0x005FB301`, signed IDIV).
+    ///
+    /// The frame pacer admits one sim tick per `stored_speed * 16 ms` bucket
+    /// (`app::types::tps_for_game_speed`), the same clock native's
+    /// `FrameTimer` runs on, so dividing a frame count by `speed + 1` here
+    /// reproduces native wall-clock cadence at every stored index.
+    pub fn speed_normalize(&self, value: i32) -> i32 {
+        if value == 0 {
             return 0;
         }
         let speed = usize::try_from(self.game_speed)
             .ok()
             .filter(|speed| *speed < 8)
             .expect("stored game speed must be in 0..=7");
-        if delay < 5 {
-            return NORMALIZED_DELAY_SHORT[usize::from(delay - 1)][speed];
+        if (1..5).contains(&value) {
+            return i32::from(NORMALIZED_DELAY_SHORT[(value - 1) as usize][speed]);
         }
-        ((u32::from(delay) << 3) / (speed as u32 + 1)) as u16
+        value.wrapping_shl(3) / (speed as i32 + 1)
     }
 
     /// Override the per-match defaults from a merged rules INI's

--- a/src/sim/house_eva.rs
+++ b/src/sim/house_eva.rs
@@ -1,0 +1,450 @@
+//! `HouseClass::Update @ 0x004F8440` EVA advice block
+//! (`0x004F8B08..0x004F8DAB`): the "Insufficient funds" nag and the
+//! "Low power" one-shot, with their native predicates and cadence.
+//!
+//! Native runs the block only for `this == PlayerPtr` (`0x004F8B08
+//! CMP [0x00A83D4C],ESI`). The sim does not know the local player, so every
+//! human-controlled house evaluates it and the app keeps the local-owner
+//! filter; the timer and guard are per-house state for the same reason.
+//! Running the funds timer and low-power guard for the non-local human
+//! houses (hashed, deterministic) is VERA-internal — native has no such
+//! state for them, so a replay/snapshot carries state gamemd never holds;
+//! gamemd equivalent UNCHECKED for anything but the local player's lines.
+//!
+//! ## Dependency rules
+//! - Part of sim/ — depends on rules/ and sim/ only.
+
+use crate::map::entities::EntityCategory;
+use crate::rules::object_type::FactoryType;
+use crate::rules::ruleset::RuleSet;
+use crate::sim::entity_store::EntityStore;
+use crate::sim::game_options::GameOptions;
+use crate::sim::intern::{InternedId, StringInterner};
+use crate::sim::world::{SimSoundEvent, Simulation};
+
+/// `evamd.ini` section played at `0x004F8BA0`.
+pub const EVA_INSUFFICIENT_FUNDS: &str = "EVA_InsufficientFunds";
+/// `evamd.ini` section played at `0x004F8D14`.
+pub const EVA_LOW_POWER: &str = "EVA_LowPower";
+
+/// `0x004F8B6F CMP EAX,0x64`: the nag runs while available money is below
+/// this.
+const FUNDS_NAG_CREDITS: i32 = 100;
+/// `0x007E27F8`, the double both timer re-arms multiply `SpeakDelay` by
+/// (`0x004F8BBA`, `0x004F8C2E`, `0x004F8D77`): frames per minute at the
+/// unnormalised 15 fps base rate.
+const FRAMES_PER_MINUTE: f64 = 900.0;
+
+/// `SpeedNormalize(ftol(SpeakDelay * 900.0))` — the re-arm value shared by
+/// the funds nag (`0x004F8BAF..0x004F8BCB`), the silo re-arm
+/// (`0x004F8C23..0x004F8C3F`) and the low-power speak timer
+/// (`0x004F8D6B..0x004F8D88`). `Math::ftol @ 0x007C5F00` truncates.
+pub fn speak_delay_frames(rules: &RuleSet, options: &GameOptions) -> i32 {
+    let frames = (rules.general.speak_delay_minutes * FRAMES_PER_MINUTE) as i32;
+    options.speed_normalize(frames)
+}
+
+/// `HouseClass::GetFactoryCount @ 0x00500940` sum used at
+/// `0x004F8B74..0x004F8B94`: `+0x537C` (infantry) + `+0x5380` (vehicle) +
+/// `+0x5384` (building) + `+0x5388` (naval); `+0x5378` (aircraft) is not read.
+/// The native counters follow building Unlimbo/Limbo, so a factory still
+/// building up already counts, while a Dying corpse or a limbo object does
+/// not.
+pub fn funds_nag_factory_count(
+    entities: &EntityStore,
+    rules: &RuleSet,
+    owner: InternedId,
+    interner: &StringInterner,
+) -> u32 {
+    entities
+        .values()
+        .filter(|e| {
+            !e.dying
+                && !e.lifecycle.in_limbo
+                && e.owner == owner
+                && e.category == EntityCategory::Structure
+                && rules
+                    .object(interner.resolve(e.type_ref))
+                    .and_then(|obj| obj.factory)
+                    .is_some_and(|factory| {
+                        // Naval yards are `Factory=UnitType` + `Naval=yes`
+                        // (`GetFactoryCount` case 1/0x28 splits them on the
+                        // naval flag); both counters are summed here.
+                        matches!(
+                            factory,
+                            FactoryType::InfantryType
+                                | FactoryType::UnitType
+                                | FactoryType::BuildingType
+                        )
+                    })
+        })
+        .count() as u32
+}
+
+/// `0x004F8C0B..0x004F8C21`: with the funds timer expired and no nag due,
+/// a nearly full silo bank (`capacity - stored < 30 && capacity > 50`,
+/// `HouseClass+0x310` vs `StorageClass::GetTotal(+0x2FC)` through `ftol`)
+/// re-arms the same timer without any line, pushing the next funds nag out by
+/// one SpeakDelay. There is no `EVA_SilosNeeded` in YR.
+pub const fn silo_nearly_full(capacity: i32, stored: i32) -> bool {
+    capacity - stored < 30 && capacity > 50
+}
+
+/// The house owns a live instance of one of the first three
+/// `[AI] BuildPower=` types (`0x004F8C97..0x004F8CFC` reads exactly
+/// `Rules+0x8B0[0..3]` through `CountOwnedInstances @ 0x0049FAE0` on the
+/// `House+0x5550` per-type counter, which Unlimbo/Limbo maintain).
+pub fn owns_build_power_plant(
+    entities: &EntityStore,
+    rules: &RuleSet,
+    owner: InternedId,
+    interner: &StringInterner,
+) -> bool {
+    let build_power: Vec<&str> = rules
+        .build_power_types
+        .iter()
+        .take(3)
+        .map(String::as_str)
+        .collect();
+    if build_power.is_empty() {
+        return false;
+    }
+    entities.values().any(|e| {
+        !e.dying
+            && !e.lifecycle.in_limbo
+            && e.owner == owner
+            && e.category == EntityCategory::Structure
+            && build_power
+                .iter()
+                .any(|name| name.eq_ignore_ascii_case(interner.resolve(e.type_ref)))
+    })
+}
+
+/// Run the advice block for every human-controlled house in
+/// `ScenarioSession::house_order`, in that order.
+pub fn tick_house_eva(sim: &mut Simulation, rules: &RuleSet) {
+    let now = i64::from(sim.session.binary_frame);
+    let game_mode_nonzero = sim.session.game_mode_nonzero;
+    let delay = speak_delay_frames(rules, &sim.session.game_options);
+    let owners: Vec<InternedId> = sim.session.house_order.clone();
+    for owner in owners {
+        let Some(house) = sim.houses.get(&owner) else {
+            continue;
+        };
+        if !house.is_controlled_by_human(game_mode_nonzero) {
+            continue;
+        }
+        let credits = house.credits;
+        let mut timer = house.eva_funds_timer;
+        let mut guard = house.eva_low_power_guard;
+
+        // --- Insufficient funds, `0x004F8B3C..0x004F8BE1` ---
+        // Available money (`IHouse::Available_Money`, House vtable `0x7EA834`
+        // slot `+0x18` = `0x004F6990`: credits plus stored ore) below 100 and
+        // any infantry/vehicle/building/naval factory owned → the line, the
+        // sidebar credits flash and a re-arm. VERA banks ore straight into
+        // `credits`, so the wallet is the available money.
+        if timer.expired(now)
+            && credits < FUNDS_NAG_CREDITS
+            && funds_nag_factory_count(&sim.substrate.entities, rules, owner, &sim.interner) > 0
+        {
+            sim.sound_events.push(SimSoundEvent::HouseEva {
+                owner,
+                event: EVA_INSUFFICIENT_FUNDS,
+            });
+            timer.arm(now, delay);
+        }
+        // --- Silo re-arm, `0x004F8BE4..0x004F8C53` --- (timer re-read after
+        // the nag's own re-arm). VERA has no ore storage authority, so
+        // `stored` is 0 and the branch is unreachable on any real capacity.
+        if timer.expired(now) {
+            let capacity: i32 = sim
+                .substrate
+                .entities
+                .values()
+                .filter(|e| {
+                    !e.dying
+                        && !e.lifecycle.in_limbo
+                        && e.owner == owner
+                        && e.category == EntityCategory::Structure
+                })
+                .filter_map(|e| rules.object(sim.interner.resolve(e.type_ref)))
+                .map(|obj| obj.storage)
+                .fold(0i32, i32::saturating_add);
+            if silo_nearly_full(capacity, 0) {
+                timer.arm(now, delay);
+            }
+        }
+
+        // --- Low power, `0x004F8C56..0x004F8DAB` ---
+        // Short = `PowerOutput < PowerDrain && PowerDrain != 0 && (Output == 0
+        // || Output / Drain < 1.0)` (`0x004F8C62..0x004F8C91`); otherwise the
+        // guard clears (`0x004F8DAB`). Short without a `BuildPower=` plant
+        // leaves the guard untouched (`0x004F8CFC JLE` straight out).
+        let short = sim
+            .power_states
+            .get(&owner)
+            .is_some_and(|power| power.is_low_power);
+        if !short {
+            guard = false;
+        } else if owns_build_power_plant(&sim.substrate.entities, rules, owner, &sim.interner) {
+            if !guard {
+                sim.sound_events.push(SimSoundEvent::HouseEva {
+                    owner,
+                    event: EVA_LOW_POWER,
+                });
+                guard = true;
+            }
+            // `0x004F8D6B..0x004F8DA6` re-arms `House+0x57BC` here; that
+            // timer has no reader (`search_instructions "0x57bc]"`: the
+            // constructor write and this write only), so it is not modelled.
+        }
+
+        if let Some(house) = sim.houses.get_mut(&owner) {
+            house.eva_funds_timer = timer;
+            house.eva_low_power_guard = guard;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rules::ini_parser::IniFile;
+    use crate::sim::game_entity::GameEntity;
+    use crate::sim::house_state::{HouseFrameTimer, HouseState};
+
+    fn rules() -> RuleSet {
+        RuleSet::from_ini(&IniFile::from_str(
+            "[General]\nSpeakDelayIsInAudioVisual=yes\n\n\
+             [AudioVisual]\nSpeakDelay=2\n\n\
+             [AI]\nBuildPower=NAPOWR,GAPOWR,YAPOWR\n\n\
+             [BuildingTypes]\n0=GAPOWR\n1=GAPILE\n2=GAREFN\n3=GASILO\n\n\
+             [GAPOWR]\nStrength=750\nPower=200\n\n\
+             [GAPILE]\nStrength=500\nPower=-10\nFactory=InfantryType\n\n\
+             [GAREFN]\nStrength=900\nPower=-50\nStorage=2000\n\n\
+             [GASILO]\nStrength=300\nStorage=2000\n",
+        ))
+        .expect("rules parse")
+    }
+
+    fn structure(sim: &mut Simulation, id: u64, type_id: &str, owner: &str, cx: u16) {
+        let mut e = GameEntity::test_default(id, type_id, owner, cx, 5);
+        e.type_ref = sim.interner.intern(type_id);
+        e.owner = sim.interner.intern(owner);
+        e.category = EntityCategory::Structure;
+        e.lifecycle.in_limbo = false;
+        sim.substrate.entities.insert(e);
+    }
+
+    fn sim_with_house(credits: i32, human: bool) -> (Simulation, InternedId) {
+        let mut sim = Simulation::new();
+        let owner = sim.interner.intern("Americans");
+        sim.houses.insert(
+            owner,
+            HouseState::new(owner, 0, Some(owner), human, credits, 10),
+        );
+        sim.session.house_order.push(owner);
+        (sim, owner)
+    }
+
+    fn house_lines(sim: &mut Simulation) -> Vec<&'static str> {
+        sim.sound_events
+            .drain(..)
+            .filter_map(|event| match event {
+                SimSoundEvent::HouseEva { event, .. } => Some(event),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn run_frames(sim: &mut Simulation, rules: &RuleSet, frames: u32) -> Vec<(u32, &'static str)> {
+        let mut lines = Vec::new();
+        for _ in 0..frames {
+            crate::sim::power_system::tick_power_states(
+                &mut sim.power_states,
+                &mut sim.substrate.entities,
+                rules,
+                &sim.interner,
+            );
+            tick_house_eva(sim, rules);
+            let frame = sim.session.binary_frame;
+            for line in house_lines(sim) {
+                lines.push((frame, line));
+            }
+            sim.session.binary_frame += 1;
+        }
+        lines
+    }
+
+    /// `SpeakDelay=2` → `ftol(2 * 900) = 1800` → `SpeedNormalize`: stored
+    /// speed 1 (retail skirmish) gives `(1800 << 3) / 2 = 7200`; speed 4 gives
+    /// `14400 / 5 = 2880`; speed 0 gives `14400`.
+    #[test]
+    fn speak_delay_frames_follows_the_native_speed_normaliser() {
+        let rules = rules();
+        let mut options = GameOptions::default();
+        assert_eq!(options.game_speed, 1);
+        assert_eq!(speak_delay_frames(&rules, &options), 7200);
+        options.game_speed = 4;
+        assert_eq!(speak_delay_frames(&rules, &options), 2880);
+        options.game_speed = 0;
+        assert_eq!(speak_delay_frames(&rules, &options), 14400);
+        options.game_speed = 7;
+        assert_eq!(speak_delay_frames(&rules, &options), 1800);
+    }
+
+    #[test]
+    fn frame_timer_expiry_matches_the_native_timer_struct_test() {
+        let armed = HouseFrameTimer {
+            start_frame: 10,
+            duration: 5,
+        };
+        assert!(!armed.expired(14));
+        assert!(armed.expired(15));
+        let never = HouseFrameTimer {
+            start_frame: -1,
+            duration: 5,
+        };
+        assert!(!never.expired(1_000));
+        let never_zero = HouseFrameTimer {
+            start_frame: -1,
+            duration: 0,
+        };
+        assert!(never_zero.expired(0));
+        assert!(HouseFrameTimer::at_construction(0).expired(1));
+        assert!(!HouseFrameTimer::at_construction(0).expired(0));
+    }
+
+    /// A broke human house with an idle barracks hears the nag once per
+    /// normalised SpeakDelay, no build stalled or queued.
+    #[test]
+    fn funds_nag_repeats_every_speak_delay_while_broke_with_a_factory() {
+        let rules = rules();
+        let (mut sim, owner) = sim_with_house(50, true);
+        sim.session.game_options.game_speed = 4;
+        structure(&mut sim, 1, "GAPILE", "Americans", 3);
+        let lines = run_frames(&mut sim, &rules, 2880 * 2 + 2);
+        let nags: Vec<u32> = lines
+            .iter()
+            .filter(|(_, line)| *line == EVA_INSUFFICIENT_FUNDS)
+            .map(|(frame, _)| *frame)
+            .collect();
+        // Constructor timer (`Duration = 1`) expires at frame 1.
+        assert_eq!(nags, vec![1, 1 + 2880, 1 + 2880 * 2]);
+        assert_eq!(
+            sim.houses[&owner].eva_funds_timer,
+            HouseFrameTimer {
+                start_frame: 1 + 2880 * 2,
+                duration: 2880,
+            }
+        );
+    }
+
+    #[test]
+    fn funds_nag_is_silent_at_one_hundred_credits_or_without_a_factory() {
+        let rules = rules();
+        // Exactly 100 credits: `CMP EAX,0x64 ; JGE` skips.
+        let (mut sim, _) = sim_with_house(100, true);
+        structure(&mut sim, 1, "GAPILE", "Americans", 3);
+        assert!(run_frames(&mut sim, &rules, 40).is_empty());
+        // Broke, but only a refinery (no factory counter).
+        let (mut sim, _) = sim_with_house(0, true);
+        structure(&mut sim, 1, "GAREFN", "Americans", 3);
+        assert!(run_frames(&mut sim, &rules, 40).is_empty());
+        // Broke with a factory, but an AI house never reaches the block.
+        let (mut sim, _) = sim_with_house(0, false);
+        structure(&mut sim, 1, "GAPILE", "Americans", 3);
+        assert!(run_frames(&mut sim, &rules, 40).is_empty());
+    }
+
+    #[test]
+    fn funds_nag_factory_count_excludes_dying_and_limbo_and_non_factories() {
+        let rules = rules();
+        let (mut sim, owner) = sim_with_house(0, true);
+        structure(&mut sim, 1, "GAPILE", "Americans", 3);
+        structure(&mut sim, 2, "GAPILE", "Americans", 4);
+        structure(&mut sim, 3, "GAREFN", "Americans", 5);
+        sim.substrate.entities.get_mut(2).unwrap().dying = true;
+        assert_eq!(
+            funds_nag_factory_count(&sim.substrate.entities, &rules, owner, &sim.interner),
+            1
+        );
+        sim.substrate
+            .entities
+            .get_mut(1)
+            .unwrap()
+            .lifecycle
+            .in_limbo = true;
+        assert_eq!(
+            funds_nag_factory_count(&sim.substrate.entities, &rules, owner, &sim.interner),
+            0
+        );
+    }
+
+    #[test]
+    fn silo_nearly_full_predicate_is_exact() {
+        assert!(silo_nearly_full(100, 80));
+        assert!(!silo_nearly_full(100, 70));
+        assert!(!silo_nearly_full(50, 40));
+        assert!(silo_nearly_full(51, 30));
+    }
+
+    /// Barracks and refinery before any power plant: short on power, but no
+    /// `BuildPower=` type owned → silence, and the guard stays clear.
+    #[test]
+    fn low_power_is_silent_without_a_build_power_plant() {
+        let rules = rules();
+        let (mut sim, owner) = sim_with_house(5_000, true);
+        structure(&mut sim, 1, "GAPILE", "Americans", 3);
+        structure(&mut sim, 2, "GAREFN", "Americans", 5);
+        let lines = run_frames(&mut sim, &rules, 10);
+        assert!(lines.is_empty(), "{lines:?}");
+        assert!(sim.power_states[&owner].is_low_power);
+        assert!(!sim.houses[&owner].eva_low_power_guard);
+    }
+
+    /// With a plant the line plays once, stays silent while short, clears on
+    /// recovery and re-announces on the next shortfall.
+    #[test]
+    fn low_power_announces_once_per_shortfall_with_a_build_power_plant() {
+        let rules = rules();
+        let (mut sim, owner) = sim_with_house(5_000, true);
+        structure(&mut sim, 1, "GAPOWR", "Americans", 3);
+        structure(&mut sim, 2, "GAPILE", "Americans", 4);
+        // Drain 10 vs output 200: fine.
+        assert!(run_frames(&mut sim, &rules, 3).is_empty());
+        // Damage the plant to 1/750 → output 0 < drain 10.
+        sim.substrate.entities.get_mut(1).unwrap().health.current = 1;
+        let lines = run_frames(&mut sim, &rules, 5);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].1, EVA_LOW_POWER);
+        assert!(sim.houses[&owner].eva_low_power_guard);
+        // Repair: guard clears.
+        sim.substrate.entities.get_mut(1).unwrap().health.current = 750;
+        assert!(run_frames(&mut sim, &rules, 2).is_empty());
+        assert!(!sim.houses[&owner].eva_low_power_guard);
+        // Short again: one more line.
+        sim.substrate.entities.get_mut(1).unwrap().health.current = 1;
+        let lines = run_frames(&mut sim, &rules, 5);
+        assert_eq!(lines.len(), 1);
+    }
+
+    /// Short with the guard already set and the plant sold: the guard is not
+    /// cleared by the no-plant exit, so rebuilding the plant while still
+    /// short does not replay the line.
+    #[test]
+    fn low_power_guard_survives_the_no_plant_exit() {
+        let rules = rules();
+        let (mut sim, owner) = sim_with_house(5_000, true);
+        structure(&mut sim, 1, "GAPOWR", "Americans", 3);
+        structure(&mut sim, 2, "GAPILE", "Americans", 4);
+        sim.substrate.entities.get_mut(1).unwrap().health.current = 1;
+        assert_eq!(run_frames(&mut sim, &rules, 2).len(), 1);
+        sim.substrate.entities.get_mut(1).unwrap().dying = true;
+        assert!(run_frames(&mut sim, &rules, 2).is_empty());
+        assert!(sim.houses[&owner].eva_low_power_guard);
+        sim.substrate.entities.get_mut(1).unwrap().dying = false;
+        assert!(run_frames(&mut sim, &rules, 2).is_empty());
+    }
+}

--- a/src/sim/house_state.rs
+++ b/src/sim/house_state.rs
@@ -53,6 +53,53 @@ impl HouseDifficulty {
     }
 }
 
+/// Native `TimerStruct {Start, TimerPtr, Duration}` as `HouseClass::Update`
+/// reads its EVA advice timers (`+0x57D4` funds, `+0x57BC` speak).
+///
+/// Expiry test from `0x004F8B3C..0x004F8B63`: `Start == -1` → expired iff
+/// `Duration == 0`; otherwise expired iff `now - Start >= Duration`. Re-arm
+/// (`0x004F8BD0..0x004F8BE1`) stores `Start = now`, `Duration = value`.
+/// `HouseClass::Constructor 0x004F5D2F/0x004F5D35` starts both timers at the
+/// construction frame with `Duration = 1` (`0x004F5CD0 MOV EAX,1`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct HouseFrameTimer {
+    /// Frame the timer was armed at; `-1` is the native "never started".
+    pub start_frame: i64,
+    /// Armed duration in frames.
+    pub duration: i32,
+}
+
+impl Default for HouseFrameTimer {
+    fn default() -> Self {
+        Self::at_construction(0)
+    }
+}
+
+impl HouseFrameTimer {
+    /// The constructor state: armed at `frame` for one frame.
+    pub const fn at_construction(frame: i64) -> Self {
+        Self {
+            start_frame: frame,
+            duration: 1,
+        }
+    }
+
+    /// `0x004F8B4E..0x004F8B63`.
+    pub const fn expired(&self, now: i64) -> bool {
+        if self.start_frame == -1 {
+            self.duration == 0
+        } else {
+            now - self.start_frame >= self.duration as i64
+        }
+    }
+
+    /// `0x004F8BD0..0x004F8BE1`: `Start = now`, `Duration = duration`.
+    pub const fn arm(&mut self, now: i64, duration: i32) {
+        self.start_frame = now;
+        self.duration = duration;
+    }
+}
+
 /// Accepted native HouseClass match result whose SavourDelay still owns the
 /// scenario's deterministic frame lifetime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -407,6 +454,18 @@ pub struct HouseState {
     /// Persisted and hashed (schema v132).
     #[serde(default)]
     pub harvester_no_ore: bool,
+    /// Native `HouseClass+0x57D4`: the `EVA_InsufficientFunds` nag timer
+    /// (`HouseClass::Update 0x004F8B3C..0x004F8C53`). Only the local player's
+    /// house reaches that block natively; here every human house runs it and
+    /// the app keeps the local filter. Persisted and hashed (schema v133).
+    #[serde(default)]
+    pub eva_funds_timer: HouseFrameTimer,
+    /// Native `[0x00A8F040]`, the `EVA_LowPower` one-shot guard
+    /// (`0x004F8D02` test, `0x004F8D61` set, `0x004F8DAB` clear). It is a
+    /// process global gated behind `this == PlayerPtr`, so one flag per human
+    /// house is the same state. Persisted and hashed (schema v133).
+    #[serde(default)]
+    pub eva_low_power_guard: bool,
 }
 
 impl HouseState {
@@ -545,6 +604,8 @@ impl HouseState {
             strategy_emergency: HouseStrategyEmergencyState::default(),
             ai_activation: HouseAiActivationLatches::default(),
             harvester_no_ore: false,
+            eva_funds_timer: HouseFrameTimer::default(),
+            eva_low_power_guard: false,
         }
     }
 }

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -74,6 +74,7 @@ pub mod docking;
 pub mod aircraft;
 
 // --- Vision, fog of war, power ---
+pub mod house_eva; // HouseClass::Update EVA advice timers (funds nag, low power)
 pub mod power_system;
 pub mod superweapon;
 pub mod vision;

--- a/src/sim/movement/locomotor_tests.rs
+++ b/src/sim/movement/locomotor_tests.rs
@@ -142,6 +142,7 @@ fn make_obj(locomotor: LocomotorKind, category: ObjectCategory) -> ObjectType {
         insignificant: false,
         to_protect: false,
         harvester: false,
+        spawned: false,
         refinery: false,
         weeder: false,
         bib: false,

--- a/src/sim/movement/teleport_movement.rs
+++ b/src/sim/movement/teleport_movement.rs
@@ -605,6 +605,7 @@ mod tests {
             insignificant: false,
             to_protect: false,
             harvester: false,
+            spawned: false,
             refinery: false,
             weeder: false,
             bib: false,

--- a/src/sim/production/production_queue.rs
+++ b/src/sim/production/production_queue.rs
@@ -637,8 +637,25 @@ fn tick_production_impl(
                         });
                 }
             }
-            sim.sound_events
-                .push(crate::sim::world::SimSoundEvent::UnitComplete { owner: owner_id });
+            // `HouseClass::Place_Production 0x004FB5C6..0x004FB644`: for a
+            // human-controlled house (`this == PlayerPtr` in MP, `+0x1EC ||
+            // +0x1ED` in campaign) `CreateRadarEvent(6, object cell)` gates
+            // `EVA_UnitReady` — type 6 dedupes within 2 cells for 200 frames,
+            // so two units leaving one factory in quick succession give one
+            // line. The app still filters the owner to the local player.
+            let unit_ready_allowed =
+                sim.houses.get(&owner_id).is_some_and(|house| {
+                    house.is_controlled_by_human(sim.session.game_mode_nonzero)
+                }) && sim.radar_events.push_owned(
+                    crate::sim::radar::RadarEventType::UnitReady,
+                    rx,
+                    ry,
+                    Some(owner_id),
+                );
+            if unit_ready_allowed {
+                sim.sound_events
+                    .push(crate::sim::world::SimSoundEvent::UnitComplete { owner: owner_id });
+            }
             // Auto-move newly produced unit to rally point (if set).
             // Skip for aircraft docked on helipad — they wait for orders.
             if helipad_airfield.is_none() {

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -414,7 +414,11 @@ use crate::sim::world::Simulation;
 // (set by `UnitClass::Mission_Harvest` state 0, never cleared). A v131 save
 // would restore it clear for a house whose harvester had already exhausted
 // its scan, and the state hash folds it.
-const SNAPSHOT_VERSION: u32 = 132;
+// v133 persists the `HouseClass+0x57D4` funds-nag timer and the `[0xA8F040]`
+// low-power guard on `HouseState` (`HouseClass::Update 0x004F8B3C..0x004F8DAB`).
+// A v132 save would restore the timer at its constructor value and the guard
+// clear, re-announcing "Low power" on load; the state hash folds both.
+const SNAPSHOT_VERSION: u32 = 133;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -3178,9 +3182,11 @@ mod tests {
     /// 130 -> 131 persists the session `TiberiumGrows`/`TiberiumSpreads`
     /// flag bits and the `OreGrowthConfig` growth-reload selector.
     /// 131 -> 132 persists the `HouseClass+0x242` harvester no-ore latch.
+    /// 132 -> 133 persists the `HouseClass+0x57D4` funds-nag timer and the
+    /// `[0xA8F040]` low-power guard.
     #[test]
-    fn house_harvester_no_ore_snapshot_version_is_132() {
-        assert_eq!(super::SNAPSHOT_VERSION, 132);
+    fn house_eva_advice_snapshot_version_is_133() {
+        assert_eq!(super::SNAPSHOT_VERSION, 133);
     }
 
     #[test]
@@ -4564,6 +4570,42 @@ mod tests {
             .expect("v132 house latch snapshot")
             .sim;
         assert!(restored.houses[&owner].harvester_no_ore);
+        assert_eq!(restored.state_hash(), expected_hash);
+    }
+
+    /// `HouseClass+0x57D4` and the low-power guard ride the House block in
+    /// the native save; a v133 snapshot carries them and the restored hash
+    /// still matches.
+    #[test]
+    fn house_eva_advice_state_roundtrips_at_v133() {
+        let mut sim = Simulation::with_seed(0x57D4);
+        let owner = sim.interner.intern("Americans");
+        let mut house = crate::sim::house_state::HouseState::new(owner, 0, None, true, 5_000, 10);
+        house.eva_funds_timer = crate::sim::house_state::HouseFrameTimer {
+            start_frame: 1_234,
+            duration: 2_880,
+        };
+        house.eva_low_power_guard = true;
+        sim.houses.insert(owner, house);
+        sim.scenario_rng = crate::sim::rng::SimRng::new(0);
+        let expected_hash = sim.state_hash();
+
+        let bytes = GameSnapshot::save(&sim, 0, 0, "house_eva_advice", 0);
+        assert_eq!(
+            GameSnapshot::read_header(&bytes).unwrap().version,
+            super::SNAPSHOT_VERSION
+        );
+        let restored = GameSnapshot::load(&bytes)
+            .expect("v133 house EVA snapshot")
+            .sim;
+        assert_eq!(
+            restored.houses[&owner].eva_funds_timer,
+            crate::sim::house_state::HouseFrameTimer {
+                start_frame: 1_234,
+                duration: 2_880,
+            }
+        );
+        assert!(restored.houses[&owner].eva_low_power_guard);
         assert_eq!(restored.state_hash(), expected_hash);
     }
 

--- a/src/sim/superweapon/iron_curtain.rs
+++ b/src/sim/superweapon/iron_curtain.rs
@@ -51,14 +51,22 @@ pub fn launch(
 
     // 3. Apply effect per entity.
     for id in &target_ids {
+        let mut killed = false;
         if let Some(entity) = sim.substrate.entities.get_mut(*id) {
             if entity.category == EntityCategory::Infantry {
-                // IronCurtain kills infantry (matches binary override).
+                // `InfantryClass::IronCurtain @ 0x00522632`: `ReceiveDamage`
+                // (`+0x16C`) with the type's full `Strength=` and `C4Warhead=`,
+                // so the kill runs the normal death branch including
+                // `Death_Announcement` (`+0x3B8`, "Unit lost").
                 entity.health.current = 0;
                 entity.dying = true;
+                killed = true;
             } else {
                 apply_invulnerability(entity, current_frame, duration, InvulnKind::IronCurtain);
             }
+        }
+        if killed {
+            sim.announce_unit_lost_at_death_site(rules, *id);
         }
     }
 
@@ -150,6 +158,46 @@ mod tests {
         assert_eq!(e.health.current, 0);
         assert!(e.dying);
         assert!(e.invulnerability.is_none());
+    }
+
+    /// `InfantryClass::IronCurtain @ 0x00522632` kills through `ReceiveDamage`
+    /// (`+0x16C`, `C4Warhead=`), so the death reaches `Death_Announcement`
+    /// (`+0x3B8`): a human owner hears "Unit lost", deduped by the radar
+    /// type-7 window (`0x004D98FE`, 8 cells / 200 frames) across the grid.
+    #[test]
+    fn ic_infantry_kill_announces_unit_lost_once_per_radar_window() {
+        use crate::sim::house_state::HouseState;
+
+        let rules = test_rules();
+        let mut sim = Simulation::new();
+        let owner = sim.interner.intern("Americans");
+        sim.houses.insert(
+            owner,
+            HouseState::new(owner, 0, Some(owner), true, 5_000, 10),
+        );
+        sim.session.house_order.push(owner);
+        spawn(&mut sim, 1, "E1", 10, 10, EntityCategory::Infantry);
+        spawn(&mut sim, 2, "E1", 11, 11, EntityCategory::Infantry);
+        spawn(&mut sim, 3, "MTNK", 9, 9, EntityCategory::Unit);
+        let sw_test = sim.interner.intern("SWTEST");
+        assert!(launch(&mut sim, &rules, owner, 10, 10, sw_test));
+
+        let lost: Vec<InternedId> = sim
+            .sound_events
+            .iter()
+            .filter_map(|event| match event {
+                SimSoundEvent::UnitLost { owner } => Some(*owner),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            lost,
+            vec![owner],
+            "two infantry kills in one 3x3 grid announce exactly once"
+        );
+        assert!(sim.substrate.entities.get(1).unwrap().dying);
+        assert!(sim.substrate.entities.get(2).unwrap().dying);
+        assert!(!sim.substrate.entities.get(3).unwrap().dying);
     }
 
     #[test]

--- a/src/sim/world/bridge_orchestrator.rs
+++ b/src/sim/world/bridge_orchestrator.rs
@@ -1300,14 +1300,23 @@ fn blow_up_bridge_cell_fallout(
     ry: u16,
     c4_inf_death: u8,
 ) {
-    kill_ground_occupants_at(sim, rx, ry, c4_inf_death);
+    kill_ground_occupants_at(sim, rules, rx, ry, c4_inf_death);
     drop_in_bridge_deck_entities(sim, rx, ry);
     let mut one_cell = BTreeSet::new();
     one_cell.insert((rx, ry));
     spawn_bridge_debris(sim, rules, &one_cell);
 }
 
-fn kill_ground_occupants_at(sim: &mut Simulation, rx: u16, ry: u16, c4_inf_death: u8) {
+/// `CellClass::BlowUpBridge @ 0x0047DDAE`: every ground occupant takes
+/// `ReceiveDamage` (`+0x16C`) with its own HP and `C4Warhead=`, so the kill
+/// runs the normal death branch including `Death_Announcement` (`+0x3B8`).
+fn kill_ground_occupants_at(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    rx: u16,
+    ry: u16,
+    c4_inf_death: u8,
+) {
     use crate::sim::animation::death_sequence_for_inf_death;
     let death_seq = death_sequence_for_inf_death(c4_inf_death);
     let victims: Vec<u64> = sim
@@ -1341,6 +1350,7 @@ fn kill_ground_occupants_at(sim: &mut Simulation, rx: u16, ry: u16, c4_inf_death
                 anim.switch_to(seq);
             }
         }
+        sim.announce_unit_lost_at_death_site(rules, id);
     }
 }
 
@@ -3624,7 +3634,7 @@ mod tests {
         air.on_bridge = false;
         sim.substrate.entities.insert(air);
 
-        kill_ground_occupants_at(&mut sim, 5, 5, 1);
+        kill_ground_occupants_at(&mut sim, &rules_with_voxel_max(0), 5, 5, 1);
 
         let g = sim.substrate.entities.get(1).expect("ground unit present");
         assert_eq!(g.health.current, 0, "ground occupant is force-killed");
@@ -3636,5 +3646,72 @@ mod tests {
             "aircraft overflying the collapse cell must NOT be killed"
         );
         assert!(!a.dying, "aircraft not flagged dying");
+    }
+
+    /// `CellClass::BlowUpBridge @ 0x0047DDAE` kills each ground occupant
+    /// through `ReceiveDamage` (`+0x16C`, `C4Warhead=`), so the deaths reach
+    /// `Death_Announcement` (`+0x3B8`): a human owner hears "Unit lost" once
+    /// per radar type-7 window (`0x004D98FE`); an AI owner hears nothing.
+    #[test]
+    fn bridge_collapse_kill_announces_unit_lost_once_per_radar_window() {
+        use crate::sim::house_state::HouseState;
+        use crate::sim::world::SimSoundEvent;
+
+        let rules = RuleSet::from_ini(&crate::rules::ini_parser::IniFile::from_str(
+            "[VehicleTypes]\n0=MTNK\n[MTNK]\nStrength=300\nArmor=heavy\n",
+        ))
+        .expect("rules parse");
+        let mut sim = Simulation::new();
+        let human = sim.interner.intern("Americans");
+        let ai = sim.interner.intern("Russians");
+        sim.houses.insert(
+            human,
+            HouseState::new(human, 0, Some(human), true, 5_000, 10),
+        );
+        sim.houses
+            .insert(ai, HouseState::new(ai, 0, Some(ai), false, 5_000, 10));
+        sim.session.house_order.push(human);
+        sim.session.house_order.push(ai);
+
+        let mtnk = sim.interner.intern("MTNK");
+        for (id, owner) in [(1u64, human), (2, human), (3, ai)] {
+            let unit = GameEntity::new_at_frame_zero_for_test(
+                id,
+                5,
+                5,
+                0,
+                64,
+                owner,
+                Health {
+                    current: 256,
+                    max: 256,
+                },
+                mtnk,
+                crate::map::entities::EntityCategory::Unit,
+                0,
+                5,
+                true,
+            );
+            sim.substrate.entities.insert(unit);
+        }
+
+        kill_ground_occupants_at(&mut sim, &rules, 5, 5, 1);
+
+        let lost: Vec<_> = sim
+            .sound_events
+            .iter()
+            .filter_map(|event| match event {
+                SimSoundEvent::UnitLost { owner } => Some(*owner),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            lost,
+            vec![human],
+            "two human kills in one cell announce once; the AI kill is silent"
+        );
+        for id in 1..=3 {
+            assert!(sim.substrate.entities.get(id).unwrap().dying);
+        }
     }
 }

--- a/src/sim/world/eva_dispatch_tests.rs
+++ b/src/sim/world/eva_dispatch_tests.rs
@@ -1,0 +1,173 @@
+//! World-side gates for the combat-produced EVA inputs:
+//! `TechnoClass::Death_Announcement @ 0x004D98C0` (owner + radar type 7) and
+//! `HouseClass::NotifyUnderAttack @ 0x004F93E0` (own line, ally line).
+
+use super::{SimSoundEvent, Simulation};
+use crate::sim::combat::{UnderAttackEvent, UnitLostEvent};
+use crate::sim::house_state::HouseState;
+use crate::sim::intern::InternedId;
+
+fn house(sim: &mut Simulation, name: &str, human: bool) -> InternedId {
+    let id = sim.interner.intern(name);
+    sim.houses
+        .insert(id, HouseState::new(id, 0, Some(id), human, 5_000, 10));
+    sim.session.house_order.push(id);
+    id
+}
+
+fn ally(sim: &mut Simulation, asker: &str, other: &str) {
+    sim.house_alliances
+        .entry(asker.to_ascii_uppercase())
+        .or_default()
+        .insert(other.to_ascii_uppercase());
+}
+
+fn unit_lost_owners(sim: &mut Simulation) -> Vec<InternedId> {
+    sim.sound_events
+        .drain(..)
+        .filter_map(|event| match event {
+            SimSoundEvent::UnitLost { owner } => Some(owner),
+            _ => None,
+        })
+        .collect()
+}
+
+fn ally_line_owners(sim: &mut Simulation) -> Vec<InternedId> {
+    sim.sound_events
+        .drain(..)
+        .filter_map(|event| match event {
+            SimSoundEvent::AllyUnderAttack { owner } => Some(owner),
+            _ => None,
+        })
+        .collect()
+}
+
+/// `0x004D98CA` owner gate, then `CreateRadarEvent(7)` (`0x004D98FE`): type 7
+/// dedupes within 8 cells while the previous diamond is alive (200 frames).
+#[test]
+fn unit_lost_announces_for_human_owners_deduped_by_the_radar_window() {
+    let mut sim = Simulation::new();
+    let human = house(&mut sim, "Americans", true);
+    let ai = house(&mut sim, "Russians", false);
+
+    sim.dispatch_unit_lost_events(&[UnitLostEvent {
+        rx: 20,
+        ry: 20,
+        owner: ai,
+    }]);
+    assert!(
+        unit_lost_owners(&mut sim).is_empty(),
+        "AI deaths are silent"
+    );
+
+    sim.dispatch_unit_lost_events(&[UnitLostEvent {
+        rx: 20,
+        ry: 20,
+        owner: human,
+    }]);
+    assert_eq!(unit_lost_owners(&mut sim), vec![human]);
+
+    // A second death 5 cells away inside the window: suppressed.
+    sim.dispatch_unit_lost_events(&[UnitLostEvent {
+        rx: 25,
+        ry: 20,
+        owner: human,
+    }]);
+    assert!(unit_lost_owners(&mut sim).is_empty());
+
+    // 8 cells away: a new diamond, a new line.
+    sim.dispatch_unit_lost_events(&[UnitLostEvent {
+        rx: 28,
+        ry: 20,
+        owner: human,
+    }]);
+    assert_eq!(unit_lost_owners(&mut sim), vec![human]);
+
+    // After the 200-frame blink the first diamond expires and the cell
+    // announces again.
+    for _ in 0..200 {
+        sim.radar_events.tick();
+    }
+    sim.dispatch_unit_lost_events(&[UnitLostEvent {
+        rx: 20,
+        ry: 20,
+        owner: human,
+    }]);
+    assert_eq!(unit_lost_owners(&mut sim), vec![human]);
+}
+
+/// The own line carries the radar accept as `eva_allowed` and nothing else
+/// limits it: two bases 8+ cells apart in the same tick both announce.
+#[test]
+fn under_attack_own_line_has_no_cooldown_beyond_the_radar_dedupe() {
+    let mut sim = Simulation::new();
+    let human = house(&mut sim, "Americans", true);
+    let ping = |rx: u16| UnderAttackEvent {
+        rx,
+        ry: 10,
+        owner: human,
+        miner: false,
+        structure: true,
+    };
+    sim.dispatch_under_attack_events(&[ping(10), ping(12), ping(30)]);
+    let allowed: Vec<bool> = sim
+        .sound_events
+        .drain(..)
+        .filter_map(|event| match event {
+            SimSoundEvent::UnderAttack { eva_allowed, .. } => Some(eva_allowed),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(allowed, vec![true, false, true]);
+}
+
+/// `0x004F955D..0x004F95B3`: a building of a house that lists a human house
+/// as its ally (one-way, the victim's own bitfield) gives that human the ally
+/// line behind `CreateRadarEvent(0x10)`. Harvester pings (`UnitClass` path)
+/// and `MultiplayPassive=` victims in a non-campaign mode do not.
+#[test]
+fn ally_under_attack_reaches_human_allies_of_the_victim_house() {
+    let mut sim = Simulation::new();
+    sim.session.game_mode_nonzero = true;
+    let human = house(&mut sim, "Americans", true);
+    let friend = house(&mut sim, "Russians", false);
+    let stranger = house(&mut sim, "Germans", false);
+    let other_human = house(&mut sim, "British", true);
+    ally(&mut sim, "Russians", "Americans");
+    ally(&mut sim, "Americans", "Germans");
+
+    let ping = |owner: InternedId, rx: u16, structure: bool| UnderAttackEvent {
+        rx,
+        ry: 10,
+        owner,
+        miner: !structure,
+        structure,
+    };
+
+    // The friend's building: the human hears the ally line; British does not
+    // (Russians never listed them).
+    sim.dispatch_under_attack_events(&[ping(friend, 10, true)]);
+    assert_eq!(ally_line_owners(&mut sim), vec![human]);
+    let _ = other_human;
+
+    // A one-way alliance from the human to the stranger is not enough: the
+    // victim's own bitfield decides.
+    sim.dispatch_under_attack_events(&[ping(stranger, 40, true)]);
+    assert!(ally_line_owners(&mut sim).is_empty());
+
+    // The friend's harvester: `UnitClass::ReceiveDamage` has no ally branch.
+    sim.dispatch_under_attack_events(&[ping(friend, 60, false)]);
+    assert!(ally_line_owners(&mut sim).is_empty());
+
+    // Same cell again within the window: the type-0x10 diamond dedupes.
+    sim.dispatch_under_attack_events(&[ping(friend, 10, true)]);
+    assert!(ally_line_owners(&mut sim).is_empty());
+
+    // A passive victim house (`HouseType+0x1A6`) is skipped in MP modes.
+    sim.houses.get_mut(&friend).unwrap().multiplay_passive = true;
+    sim.dispatch_under_attack_events(&[ping(friend, 90, true)]);
+    assert!(ally_line_owners(&mut sim).is_empty());
+    sim.session.game_mode_nonzero = false;
+    sim.dispatch_under_attack_events(&[ping(friend, 120, true)]);
+    assert_eq!(ally_line_owners(&mut sim), vec![human]);
+}

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -32,6 +32,8 @@ mod gsi_04_18_tests;
 #[cfg(test)]
 mod house_ai_activation_tests;
 #[cfg(test)]
+mod eva_dispatch_tests;
+#[cfg(test)]
 mod lifecycle_tests;
 #[cfg(test)]
 mod team_script_vm_tests;
@@ -361,6 +363,21 @@ pub enum SimSoundEvent {
         miner: bool,
         eva_allowed: bool,
     },
+    /// `HouseClass::NotifyUnderAttack @ 0x004F93E0`, non-local branch
+    /// (`0x004F955D..0x004F95B3`): a building of a house that lists `owner`
+    /// (a human house) as its ally took sourced damage and
+    /// `CreateRadarEvent(0x10, cell)` accepted. `EVA_OurAllyIsUnderAttack`
+    /// plus the `BaseUnderAttackSound` siren, both for `owner`.
+    AllyUnderAttack { owner: InternedId },
+    /// `TechnoClass::Death_Announcement @ 0x004D98C0` fired for a unit of
+    /// `owner` (a human house): not `Spawned=`, and `CreateRadarEvent(7, cell)`
+    /// accepted (8-cell, 200-frame dedupe). App plays `EVA_UnitLost` for the
+    /// local owner.
+    UnitLost { owner: InternedId },
+    /// One of the `HouseClass::Update` advice lines
+    /// (`EVA_InsufficientFunds` `0x004F8BA0`, `EVA_LowPower` `0x004F8D14`)
+    /// for a human house; `event` is the `evamd.ini` section name.
+    HouseEva { owner: InternedId, event: &'static str },
     /// A superweapon fired. `sw_type` is the interned `[SuperWeaponTypes]`
     /// section name of the launched weapon — the discriminator the app layer
     /// needs to pick the cue, and the same object gamemd switches on.
@@ -2994,7 +3011,32 @@ impl Simulation {
                 ry,
             });
         }
-        for event in under_attack_events {
+        self.dispatch_under_attack_events(&under_attack_events);
+        self.dispatch_unit_lost_events(&effects.unit_lost_events);
+        debug_assert!(effects.smudge_spawn_requests.is_empty());
+        self.pending_smudge_requests
+            .append(&mut effects.smudge_spawn_requests);
+    }
+
+    /// `HouseClass::NotifyUnderAttack @ 0x004F93E0` for one damaged asset,
+    /// plus the `UnitClass::ReceiveDamage 0x00738530` harvester ping.
+    ///
+    /// The victim's own line: the radar diamond (type 4 miner / type 3 base,
+    /// `0x004F94E4`/`0x004F9544`) is enqueued for the victim house and its
+    /// accept result rides along as `eva_allowed`; the app keeps the
+    /// local-player voice filter. The ally line (`0x004F955D..0x004F95B3`,
+    /// building path only): every *other* human house that the victim house
+    /// lists in its own ally bitfield (`House+0x5788`, read at `0x004F9450`
+    /// through `IsAlliedWith`'s one-way rule) hears
+    /// `EVA_OurAllyIsUnderAttack` behind `CreateRadarEvent(0x10, cell)`,
+    /// unless the victim's country is `MultiplayPassive=` in a non-campaign
+    /// mode (`0x004F945D..0x004F9472`). Native has no other rate limit.
+    pub(crate) fn dispatch_under_attack_events(
+        &mut self,
+        events: &[crate::sim::combat::UnderAttackEvent],
+    ) {
+        let game_mode_nonzero = self.session.game_mode_nonzero;
+        for event in events {
             let event_type = if event.miner {
                 RadarEventType::HarvesterUnderAttack
             } else {
@@ -3010,10 +3052,112 @@ impl Simulation {
                 miner: event.miner,
                 eva_allowed,
             });
+            if !event.structure {
+                continue;
+            }
+            let victim_passive = self
+                .houses
+                .get(&event.owner)
+                .is_some_and(|house| house.multiplay_passive);
+            if game_mode_nonzero && victim_passive {
+                continue;
+            }
+            let victim_name = self.interner.resolve(event.owner).to_string();
+            let listeners: Vec<InternedId> = self
+                .session
+                .house_order
+                .iter()
+                .copied()
+                .filter(|&listener| {
+                    listener != event.owner
+                        && self
+                            .houses
+                            .get(&listener)
+                            .is_some_and(|house| house.is_human)
+                        && crate::map::houses::is_allied_with(
+                            &self.house_alliances,
+                            &victim_name,
+                            self.interner.resolve(listener),
+                        )
+                })
+                .collect();
+            for listener in listeners {
+                if self.radar_events.push_owned(
+                    RadarEventType::AllyUnderAttack,
+                    event.rx,
+                    event.ry,
+                    Some(listener),
+                ) {
+                    self.sound_events
+                        .push(SimSoundEvent::AllyUnderAttack { owner: listener });
+                }
+            }
         }
-        debug_assert!(effects.smudge_spawn_requests.is_empty());
-        self.pending_smudge_requests
-            .append(&mut effects.smudge_spawn_requests);
+    }
+
+    /// `TechnoClass::Death_Announcement @ 0x004D98C0` for this tick's damage
+    /// kills: owner passes `HouseClass::IsHumanPlayer @ 0x0050B6F0`
+    /// (`0x004D98CA`; the local player natively, every human house here with
+    /// the app filtering), then `CreateRadarEvent(7, cell)` (`0x004D98FE`,
+    /// 8-cell / 200-frame dedupe) gates `EVA_UnitLost` (`0x004D9911`).
+    pub(crate) fn dispatch_unit_lost_events(
+        &mut self,
+        events: &[crate::sim::combat::UnitLostEvent],
+    ) {
+        let game_mode_nonzero = self.session.game_mode_nonzero;
+        for event in events {
+            let human = self
+                .houses
+                .get(&event.owner)
+                .is_some_and(|house| house.is_controlled_by_human(game_mode_nonzero));
+            if !human {
+                continue;
+            }
+            if self.radar_events.push_owned(
+                RadarEventType::UnitLost,
+                event.rx,
+                event.ry,
+                Some(event.owner),
+            ) {
+                self.sound_events.push(SimSoundEvent::UnitLost {
+                    owner: event.owner,
+                });
+            }
+        }
+    }
+
+    /// `Death_Announcement` for a death site outside the damage kill loop
+    /// that natively still enters `ReceiveDamage` (`+0x16C`) with
+    /// `C4Warhead=` and so reaches `+0x3B8`: `InfantryClass::IronCurtain
+    /// 0x00522632` and `CellClass::BlowUpBridge 0x0047DDAE`. Applies the same
+    /// `Spawned=` gate ([`crate::sim::combat::death_announcement_event`]),
+    /// owner gate and radar type-7 dedupe as the damage kills. Call it for
+    /// each victim after its HP reached zero at the site.
+    pub(crate) fn announce_unit_lost_at_death_site(
+        &mut self,
+        rules: &crate::rules::ruleset::RuleSet,
+        stable_id: u64,
+    ) {
+        let Some(entity) = self.substrate.entities.get(stable_id) else {
+            return;
+        };
+        let Some(obj) = self
+            .interner
+            .try_resolve(entity.type_ref)
+            .and_then(|type_name| rules.object(type_name))
+        else {
+            return;
+        };
+        let event = crate::sim::combat::death_announcement_event(
+            obj,
+            entity.category,
+            entity.position.rx,
+            entity.position.ry,
+            entity.owner,
+        );
+        if let Some(event) = event {
+            self.dispatch_unit_lost_events(&[event]);
+        }
     }
 
     /// Borrow all three logical RNG objects without exposing mutation.
@@ -7298,6 +7442,11 @@ impl Simulation {
                 rules,
                 &self.interner,
             );
+            // --- Phase 4.1: HouseClass::Update EVA advice ---
+            // DEPENDS ON: this tick's power totals and the house wallets.
+            // PRODUCES: `SimSoundEvent::HouseEva` (funds nag / low power) and
+            //   the per-house timer/guard state folded by the hash.
+            crate::sim::house_eva::tick_house_eva(self, rules);
             // --- Phase 4.5: Superweapons ---
             // DEPENDS ON: power state (suspend/resume gating).
             // PRODUCES: world_effects (bolt anims), damage to entities, sound_events.
@@ -7669,23 +7818,8 @@ impl Simulation {
             // Player-asset damage pings: owner-scoped radar diamond + EVA
             // dispatch (voice gated app-side to the local player; the queue's
             // dedup result rides along as `eva_allowed`, BridgeRepaired-style).
-            for ev in &combat_result.under_attack_events {
-                let event_type = if ev.miner {
-                    RadarEventType::HarvesterUnderAttack
-                } else {
-                    RadarEventType::BaseUnderAttack
-                };
-                let eva_allowed =
-                    self.radar_events
-                        .push_owned(event_type, ev.rx, ev.ry, Some(ev.owner));
-                self.sound_events.push(SimSoundEvent::UnderAttack {
-                    rx: ev.rx,
-                    ry: ev.ry,
-                    owner: ev.owner,
-                    miner: ev.miner,
-                    eva_allowed,
-                });
-            }
+            self.dispatch_under_attack_events(&combat_result.under_attack_events);
+            self.dispatch_unit_lost_events(&combat_result.unit_lost_events);
             // Production commits every request at its native producer. The
             // vectors remain only on hookless combat fixtures; a live world
             // request here would be an ordering regression.

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -439,7 +439,7 @@ impl Simulation {
     pub fn state_hash(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, true, true, true,
         )
     }
 
@@ -451,7 +451,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             true, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -463,7 +463,7 @@ impl Simulation {
     pub(crate) fn state_hash_before_lifecycle_v28_and_mission_v29(&self) -> u64 {
         self.state_hash_with_schema(
             false, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -473,7 +473,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_spark_dummy_level_slope_v107(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, false, false,
-            false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -484,7 +484,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_naval_build_const_v109(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -495,7 +495,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_base_plan_v110(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, false, false, false, false, false, false, false, false,
+            true, false, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -504,7 +504,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_base_plan_center_v111(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, false, false, false, false, false, false, false,
+            true, true, false, false, false, false, false, false, false, false,
         )
     }
 
@@ -513,7 +513,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_house_deploy_latches_v112(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, false, false, false, false, false, false,
+            true, true, true, false, false, false, false, false, false, false,
         )
     }
 
@@ -523,7 +523,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_house_update_activation_v113(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, false, false, false, false, false,
+            true, true, true, true, false, false, false, false, false, false,
         )
     }
 
@@ -532,7 +532,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_crate_authority_v114(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, false, false, false, false,
+            true, true, true, true, true, false, false, false, false, false,
         )
     }
 
@@ -544,7 +544,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_disguise_detect_v117(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, true, false, false,
+            true, true, true, true, true, true, true, false, false, false,
         )
     }
 
@@ -554,7 +554,18 @@ impl Simulation {
     pub(crate) fn state_hash_without_house_harvester_no_ore_v132(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, true, true, false,
+            true, true, true, true, true, true, true, true, false, false,
+        )
+    }
+
+    /// Test-only provenance probe for the schema-v133 House EVA advice folds
+    /// (`+0x57D4` funds timer, `[0xA8F040]` low-power guard). It reconstructs
+    /// the committed v132 layout.
+    #[cfg(test)]
+    pub(crate) fn state_hash_without_house_eva_v133(&self) -> u64 {
+        self.state_hash_with_schema(
+            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
+            true, true, true, true, true, true, true, true, true, false,
         )
     }
 
@@ -564,7 +575,7 @@ impl Simulation {
     pub(crate) fn state_hash_without_wall_runtime_v115(&self) -> u64 {
         self.state_hash_with_schema(
             true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, false, false, false,
+            true, true, true, true, true, true, false, false, false, false,
         )
     }
 
@@ -593,6 +604,7 @@ impl Simulation {
         include_wall_runtime_v115: bool,
         include_disguise_detect_v117: bool,
         include_house_harvester_no_ore_v132: bool,
+        include_house_eva_v133: bool,
     ) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
 
@@ -646,6 +658,7 @@ impl Simulation {
             include_house_deploy_latches_v112,
             include_house_update_activation_v113,
             include_house_harvester_no_ore_v132,
+            include_house_eva_v133,
         );
         if include_terminal_score_v46 {
             self.hash_terminal_score_snapshot(&mut hasher);
@@ -894,6 +907,7 @@ impl Simulation {
         include_house_deploy_latches_v112: bool,
         include_house_update_activation_v113: bool,
         include_house_harvester_no_ore_v132: bool,
+        include_house_eva_v133: bool,
     ) {
         for (owner, house) in &self.houses {
             owner.hash(hasher);
@@ -981,6 +995,13 @@ impl Simulation {
                 // `HouseClass+0x242`, the sticky harvester no-ore latch — a
                 // raw House byte in the native save block and lockstep CRC.
                 house.harvester_no_ore.hash(hasher);
+            }
+            if include_house_eva_v133 {
+                // `HouseClass+0x57D4` funds-nag TimerStruct and the
+                // `[0xA8F040]` low-power guard (`HouseClass::Update
+                // 0x004F8B3C..0x004F8DAB`): both live in the native save.
+                house.eva_funds_timer.hash(hasher);
+                house.eva_low_power_guard.hash(hasher);
             }
         }
     }
@@ -3097,6 +3118,44 @@ mod rally_hash_tests {
         assert_eq!(
             baseline.state_hash_without_house_harvester_no_ore_v132(),
             latched.state_hash_without_house_harvester_no_ore_v132()
+        );
+    }
+
+    /// The v133 House EVA advice folds move only the current schema; the
+    /// dedicated pre-v133 probe reproduces the v132 layout.
+    #[test]
+    fn house_eva_advice_affects_only_current_v133_hash_schema() {
+        use crate::sim::house_state::{HouseFrameTimer, HouseState};
+
+        fn fixture(timer: HouseFrameTimer, guard: bool) -> Simulation {
+            let mut sim = Simulation::new();
+            let owner = sim.interner.intern("Americans");
+            let mut house = HouseState::new(owner, 0, Some(owner), true, 0, 10);
+            house.eva_funds_timer = timer;
+            house.eva_low_power_guard = guard;
+            sim.houses.insert(owner, house);
+            sim
+        }
+
+        let baseline = fixture(HouseFrameTimer::default(), false);
+        let armed = fixture(
+            HouseFrameTimer {
+                start_frame: 40,
+                duration: 2_880,
+            },
+            false,
+        );
+        let guarded = fixture(HouseFrameTimer::default(), true);
+
+        assert_ne!(baseline.state_hash(), armed.state_hash());
+        assert_ne!(baseline.state_hash(), guarded.state_hash());
+        assert_eq!(
+            baseline.state_hash_without_house_eva_v133(),
+            armed.state_hash_without_house_eva_v133()
+        );
+        assert_eq!(
+            baseline.state_hash_without_house_eva_v133(),
+            guarded.state_hash_without_house_eva_v133()
         );
     }
 

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -1723,7 +1723,19 @@ fn gsi_04_07_damage_fatal_transport_lifecycle_brackets_nested_death_weapon() {
         fatal.interner.resolve(nested_fatal.killed_by.unwrap()),
         "Soviet"
     );
-    assert_eq!(result.under_attack_events.len(), 2);
+    // Only the surviving listener (30) pings. The nested-fatal building (31)
+    // takes `BuildingClass::ReceiveDamage` case 4, whose stock 8-frame timer
+    // runs `ObjectClass::UnInit` (`0x005F6625` clears `IsAlive +0x90`) before
+    // the `0x00442905` re-test, so `NotifyUnderAttack` never runs for it.
+    assert_eq!(result.under_attack_events.len(), 1);
+    assert_eq!(
+        (
+            result.under_attack_events[0].rx,
+            result.under_attack_events[0].ry
+        ),
+        (8, 5)
+    );
+    assert!(result.under_attack_events[0].structure);
     assert!(!fatal.substrate.occupancy.contains_entity(8, 5, 10));
     let attacker = fatal.substrate.entities.get(20).unwrap();
     assert!(!attacker.radio_contacts.contains(10));
@@ -5830,8 +5842,7 @@ fn phase14_drive_move_command_preserves_fractions_until_scheduled_visit() {
         assert_eq!(drive.target_speed_fraction, SIM_ONE);
         assert_eq!(drive.current_speed_fraction, expected_current);
         let raw_stage = (movement_speed / SimFixed::from_num(15)).to_num::<i32>();
-        let expected_owner =
-            (SimFixed::from_num(raw_stage) * expected_current).to_num::<i32>();
+        let expected_owner = (SimFixed::from_num(raw_stage) * expected_current).to_num::<i32>();
         assert_eq!(drive.owner_current_speed, expected_owner);
     }
 }
@@ -7686,6 +7697,17 @@ fn crusher_does_not_freeze_in_front_of_infantry() {
         );
         let _ = sim.advance_tick(&[cmd], Some(&rules), &heights, Some(&grid), None, 100);
 
+        // Make the victim's house human so a stray "Unit lost" would be
+        // audible: a crush is `RecordKill` + `UnInit` (`0x007416A0`), never
+        // `ReceiveDamage`, so `Death_Announcement` (`+0x3B8`) must stay silent.
+        if let Some(house) = sim
+            .interner
+            .get(infantry_owner)
+            .and_then(|id| sim.houses.get_mut(&id))
+        {
+            house.is_human = true;
+        }
+
         let mut series: Vec<(bool, (u16, u16))> = Vec::new();
         let mut arrived_at: Option<u64> = None;
         let mut entered_blocker_cell: Option<u64> = None;
@@ -7750,6 +7772,17 @@ fn crusher_does_not_freeze_in_front_of_infantry() {
             arrived_at.is_some(),
             "crusher never reached (16,10) with enemy_infantry={enemy_infantry}: {}",
             stacking_motion_state(&sim, tank)
+        );
+        // `sim.sound_events` accumulates until the app drains it, so the whole
+        // run is visible here.
+        let unit_lost_lines = sim
+            .sound_events
+            .iter()
+            .filter(|event| matches!(event, SimSoundEvent::UnitLost { .. }))
+            .count();
+        assert_eq!(
+            unit_lost_lines, 0,
+            "a crush kill must not announce \"Unit lost\" (enemy_infantry={enemy_infantry})"
         );
     }
 }

--- a/tests/audio_bag_test.rs
+++ b/tests/audio_bag_test.rs
@@ -230,7 +230,7 @@ fn test_sound_registry_with_real_soundmd() {
 #[ignore] // Requires RA2_DIR (retail game files)
 fn test_eva_registry_with_real_evamd() {
     use vera20k::rules::ini_parser::IniFile;
-    use vera20k::rules::sound_ini::EvaRegistry;
+    use vera20k::rules::sound_ini::{EvaRegistry, EvaSide};
 
     let assets = AssetManager::new(Path::new(&ra2_dir())).expect("AssetManager");
 
@@ -247,9 +247,9 @@ fn test_eva_registry_with_real_evamd() {
     );
 
     // Test faction-specific lookup.
-    let allied = registry.get("EVA_ConstructionComplete", "Allied");
-    let soviet = registry.get("EVA_ConstructionComplete", "Russian");
-    let yuri = registry.get("EVA_ConstructionComplete", "Yuri");
+    let allied = registry.get("EVA_ConstructionComplete", EvaSide::Allied);
+    let soviet = registry.get("EVA_ConstructionComplete", EvaSide::Russian);
+    let yuri = registry.get("EVA_ConstructionComplete", EvaSide::Yuri);
     println!(
         "EVA_ConstructionComplete: Allied={:?}, Russian={:?}, Yuri={:?}",
         allied, soviet, yuri
@@ -258,8 +258,8 @@ fn test_eva_registry_with_real_evamd() {
     assert_eq!(soviet, Some("csof048"));
     assert_eq!(yuri, Some("cyur048"));
 
-    let unit_allied = registry.get("EVA_UnitReady", "Allied");
-    let unit_soviet = registry.get("EVA_UnitReady", "Russian");
+    let unit_allied = registry.get("EVA_UnitReady", EvaSide::Allied);
+    let unit_soviet = registry.get("EVA_UnitReady", EvaSide::Russian);
     assert_eq!(unit_allied, Some("ceva062"));
     assert_eq!(unit_soviet, Some("csof062"));
 }


### PR DESCRIPTION
The four EVA state lines now follow their native predicates. `HouseClass::Update` (0x004F8B3C..0x004F8DAB) nags EVA_InsufficientFunds on a house timer while `Available_Money` (0x004F6990) is below 100 and a non-aircraft factory is owned, re-arming with `SpeedNormalize(ftol(SpeakDelay × 900.0))` (constant at 0x007E27F8; the scan's 792.25 was wrong); EVA_LowPower requires an owned BuildPower plant and keeps its guard until power is fine. `Death_Announcement` @ 0x004D98C0 speaks EVA_UnitLost from every vtable +0x3B8 kill site for human-owned non-Spawned units behind radar type 7, including iron-curtain and bridge-collapse deaths; aircraft self-destruct/paradrop are natively silent. `BuildingClass::ReceiveDamage` @ 0x00442230 notifies under attack for any damaging sourced hit that is not Insignificant, with no attacker-house test and no cooldown, plus the ally branch (radar 0x10); `UnitClass::ReceiveDamage` @ 0x00737C90 pings miners only in the non-fatal arm. UnitReady is deduped by radar type 6.

Previous Rust fired the funds line once per stalled build, announced low power without a plant, derived Unit lost from an app-side dying scan, added a 450-tick under-attack cooldown, pinged miners on killing blows, and let iron-curtain and bridge deaths go silent.

Changes: sim-owned house EVA timers (`house_eva`, Phase 4.1) persisted and hashed under schema v133 (SNAPSHOT_VERSION 133); `SpeakDelay` parsed; native speed normaliser; one shared Unit-lost helper used by the combat kill loop, iron curtain and bridge collapse; native under-attack predicate with ally branch; app cooldown/latches removed; `tests/audio_bag_test.rs` updated to the `EvaSide` API from #249 (it had stopped compiling outside `--lib`).

Residuals recorded in code: timers run for every human house where native runs them for PlayerPtr only (deterministic); building ping after a 0-timer DestructionEffects (Selling / BuildingType+0xD15) not modelled; Chrono Legionnaire erase has no VERA path yet.

Two independent read-only critics reviewed successive revisions against the bodies; the second passed.

Validation:
- `cargo test -p vera20k --lib`: `test result: ok. 8368 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 16.36s`
- `cargo test -p vera20k --test audio_bag_test --no-run`: compiles
