### PR TITLE
Unload transports and the Nighthawk through the native Unload mission

### DIFF
--- a/src/app/input/context_order.rs
+++ b/src/app/input/context_order.rs
@@ -695,6 +695,16 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                 if let Some(target) = hover.as_ref() {
                     if selected_ids.contains(&target.stable_id) {
                         if let Some(entity) = sim.entities().get(target.stable_id) {
+                            // Self-click on a loaded transport → unload.
+                            if let Some(cmd) = super::transport_orders::transport_unload_command(
+                                entity,
+                                resources
+                                    .rules
+                                    .object(sim.interner.resolve(entity.type_ref)),
+                            ) {
+                                queued.push(CommandEnvelope::new(owner_id, execute_tick, cmd));
+                                return finish_order(state, queued, speaker_id);
+                            }
                             if entity.category == EntityCategory::Structure {
                                 let obj = Some(&resources.rules)
                                     .and_then(|r| r.object(sim.interner.resolve(entity.type_ref)));
@@ -1029,6 +1039,11 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                                 Some(Command::ToggleInfantryDeploy {
                                     entity_id: target.stable_id,
                                 })
+                            } else if let Some(cmd) =
+                                super::transport_orders::transport_unload_command(entity, obj)
+                            {
+                                // Loaded transport → unload passengers.
+                                Some(cmd)
                             } else {
                                 // MCV → ConYard
                                 if obj.map_or(false, |o| o.deploys_into.is_some() || o.deployer) {

--- a/src/app/input/dispatch.rs
+++ b/src/app/input/dispatch.rs
@@ -2292,7 +2292,13 @@ fn queue_deploy_undeploy_for_selected(state: &mut AppState) {
                     }
                 }
                 _ => {
-                    if obj.map_or(false, |o| o.deploys_into.is_some()) {
+                    // A loaded transport (APC, Flak Track, IFV, BFRT, LCAC,
+                    // Nighthawk) unloads on the deploy key.
+                    if let Some(cmd) =
+                        super::transport_orders::transport_unload_command(entity, obj)
+                    {
+                        commands.push(cmd);
+                    } else if obj.map_or(false, |o| o.deploys_into.is_some()) {
                         commands.push(Command::DeployMcv { entity_id });
                     }
                 }

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -14,3 +14,4 @@ pub(crate) mod state;
 pub(crate) mod in_game_options;
 pub(crate) mod messages;
 pub(crate) mod tooltips;
+pub(crate) mod transport_orders;

--- a/src/app/input/transport_orders.rs
+++ b/src/app/input/transport_orders.rs
@@ -1,0 +1,95 @@
+//! Deploy-key / self-click resolution for passenger transports.
+//!
+//! In gamemd the deploy action on a vehicle or aircraft that carries
+//! passengers is the Unload mission: `UnitClass::Mission_Unload @ 0x0073D630`
+//! takes its transport branch on `Type+0x5E0 Passengers > 0` and the Aircraft
+//! Unload slot `0x004151E0` serves the Nighthawk. Every input site that turns
+//! the deploy key or a self-click into a command goes through this one
+//! resolver so the three sites cannot disagree on which objects unload.
+
+use crate::map::entities::EntityCategory;
+use crate::rules::object_type::ObjectType;
+use crate::sim::command::Command;
+use crate::sim::game_entity::GameEntity;
+
+/// The unload command for a vehicle/aircraft transport with passengers aboard,
+/// or `None` when the entity is not such a transport or its hold is empty.
+pub(crate) fn transport_unload_command(
+    entity: &GameEntity,
+    obj: Option<&ObjectType>,
+) -> Option<Command> {
+    if !matches!(
+        entity.category,
+        EntityCategory::Unit | EntityCategory::Aircraft
+    ) {
+        return None;
+    }
+    if !obj.is_some_and(|o| o.passengers > 0) {
+        return None;
+    }
+    if !entity.passenger_role.cargo().is_some_and(|c| !c.is_empty()) {
+        return None;
+    }
+    Some(Command::UnloadPassengers {
+        transport_id: entity.stable_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rules::ini_parser::IniFile;
+    use crate::rules::ruleset::RuleSet;
+    use crate::sim::passenger::{PassengerCargo, PassengerRole};
+
+    fn rules() -> RuleSet {
+        let ini = IniFile::from_str(
+            "[InfantryTypes]\n0=E1\n[VehicleTypes]\n0=BFRT\n1=MTNK\n[AircraftTypes]\n0=SHAD\n\
+             [BuildingTypes]\n\n[E1]\nStrength=125\nSize=1\n\n[BFRT]\nStrength=600\n\
+             Passengers=5\nOpenTopped=yes\n\n[MTNK]\nStrength=300\n\n[SHAD]\nStrength=200\n\
+             Passengers=5\nLandable=yes\n",
+        );
+        RuleSet::from_ini(&ini).expect("rules")
+    }
+
+    fn entity(id: u64, type_id: &str, category: EntityCategory, loaded: bool) -> GameEntity {
+        let mut e = GameEntity::test_default(id, type_id, "Americans", 10, 10);
+        e.category = category;
+        let mut cargo = PassengerCargo::new(5, 0);
+        if loaded {
+            cargo.board(99, 1);
+        }
+        e.passenger_role = PassengerRole::Transport { cargo };
+        e
+    }
+
+    #[test]
+    fn deploy_key_on_loaded_apc_issues_unload() {
+        let rules = rules();
+        let bfrt = entity(7, "BFRT", EntityCategory::Unit, true);
+        assert_eq!(
+            transport_unload_command(&bfrt, rules.object("BFRT")),
+            Some(Command::UnloadPassengers { transport_id: 7 })
+        );
+        let shad = entity(8, "SHAD", EntityCategory::Aircraft, true);
+        assert_eq!(
+            transport_unload_command(&shad, rules.object("SHAD")),
+            Some(Command::UnloadPassengers { transport_id: 8 })
+        );
+    }
+
+    #[test]
+    fn deploy_key_ignores_empty_holds_and_non_transports() {
+        let rules = rules();
+        let empty = entity(7, "BFRT", EntityCategory::Unit, false);
+        assert_eq!(transport_unload_command(&empty, rules.object("BFRT")), None);
+        let tank = entity(9, "MTNK", EntityCategory::Unit, true);
+        assert_eq!(transport_unload_command(&tank, rules.object("MTNK")), None);
+        let mut building = entity(10, "BFRT", EntityCategory::Structure, true);
+        building.category = EntityCategory::Structure;
+        assert_eq!(
+            transport_unload_command(&building, rules.object("BFRT")),
+            None
+        );
+    }
+}

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -1179,6 +1179,12 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         sound_id: sim.interner.resolve(deploy_sound_id).to_string(),
                         source: Some(sound_source_at_cell(rx, ry)),
                     },
+                    SimSoundEvent::LeaveTransport { sound_id, rx, ry } => {
+                        GameSoundEvent::LeaveTransport {
+                            sound_id: sim.interner.resolve(sound_id).to_string(),
+                            source: Some(sound_source_at_cell(rx, ry)),
+                        }
+                    }
                     SimSoundEvent::EntityUndeployed {
                         undeploy_sound_id,
                         rx,

--- a/src/audio/events.rs
+++ b/src/audio/events.rs
@@ -142,6 +142,15 @@ pub enum GameSoundEvent {
         source: Option<SoundSource>,
     },
 
+    /// A transport placed an ejected passenger — play the transport type's
+    /// LeaveTransportSound at the transport's screen position.
+    LeaveTransport {
+        /// sound.ini ID from the transport type's LeaveTransportSound= field.
+        sound_id: String,
+        /// Screen position of the sound source (for spatial audio).
+        source: Option<SoundSource>,
+    },
+
     /// An infantry entity entered the Undeploying phase — play UndeploySound.
     EntityUndeployed {
         /// sound.ini ID from the entity's UndeploySound= field.
@@ -355,6 +364,7 @@ impl GameSoundEvent {
             | Self::EntityDestroyed { sound_id, .. }
             | Self::EntityCrushed { sound_id, .. }
             | Self::EntityDeployed { sound_id, .. }
+            | Self::LeaveTransport { sound_id, .. }
             | Self::EntityUndeployed { sound_id, .. }
             | Self::ChronoTeleport { sound_id, .. }
             | Self::UnitPromoted { sound_id, .. }
@@ -388,6 +398,7 @@ impl GameSoundEvent {
             | Self::EntityDestroyed { source, .. }
             | Self::EntityCrushed { source, .. }
             | Self::EntityDeployed { source, .. }
+            | Self::LeaveTransport { source, .. }
             | Self::EntityUndeployed { source, .. }
             | Self::ChronoTeleport { source, .. }
             | Self::UnitPromoted { source, .. }

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -448,6 +448,13 @@ pub struct ObjectType {
     pub deploy_sound: Option<String>,
     /// Sound ID played when this unit undeploys.
     pub undeploy_sound: Option<String>,
+    /// `LeaveTransportSound=` — `TechnoTypeClass+0x568`. Read in
+    /// `TechnoTypeClass::ReadINI` right after `EnterTransportSound=`
+    /// (`+0x564`, key push at `0x00713432`); played by
+    /// `UnitClass::Mission_Unload @ 0x0073D630` at the transport's own
+    /// coordinate (`0x0073DC28`..`0x0073DC67`) once an ejected passenger has
+    /// been placed.
+    pub leave_transport_sound: Option<String>,
     /// Sound played at the destination cell when this unit warps in
     /// (chrono teleport arrival).
     pub chrono_in_sound: Option<String>,
@@ -1648,6 +1655,11 @@ impl ObjectType {
             crush_sound: section.get("CrushSound").map(|s| s.to_string()),
             deploy_sound: section.get("DeploySound").map(|s| s.to_string()),
             undeploy_sound: section.get("UndeploySound").map(|s| s.to_string()),
+            leave_transport_sound: section
+                .get("LeaveTransportSound")
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
             chrono_in_sound: section.get("ChronoInSound").map(|s| s.to_string()),
             chrono_out_sound: section.get("ChronoOutSound").map(|s| s.to_string()),
             has_turret: section.get_bool("Turret").unwrap_or(false),

--- a/src/sim/game_entity.rs
+++ b/src/sim/game_entity.rs
@@ -921,6 +921,14 @@ pub struct GameEntity {
     /// recovers above `ConditionYellow`.
     #[serde(default)]
     pub damage_smoke_system_id: Option<u64>,
+    /// `UnitClass+0x6E4`: the number of passengers a transport's Unload keeps
+    /// aboard. Written by `UnitClass::Mission_Unload @ 0x0073D630` state 0
+    /// (`0x0073D830`/`0x0073D83C`: a `TurretCount > 0` transport keeps one
+    /// unless it carries exactly one) and read by state 3's
+    /// `cargo > keep` gate (`0x0073D8C3`). Zero for every other object.
+    /// Hashed only when non-zero (see `world_hash`).
+    #[serde(default)]
+    pub transport_unload_keep_count: u32,
     /// Debug event log — records movement/state transitions for the inspector panel.
     /// Only allocated when debug inspector is active (X hotkey). Not included in state hashing.
     #[serde(skip)]
@@ -1266,6 +1274,7 @@ impl GameEntity {
             object_is_falling_down: 0,
             damage_particle_live_until: 0,
             damage_smoke_system_id: None,
+            transport_unload_keep_count: 0,
             debug_log: None,
         }
     }

--- a/src/sim/mission/state.rs
+++ b/src/sim/mission/state.rs
@@ -192,9 +192,16 @@ impl MissionCom {
         self.handler_state = value;
     }
 
+    /// Handler-owned `+0xB8 = 1` write. `UnitClass::Mission_Unload` state 4
+    /// (`0x0073DCC7`) sets it immediately after its `Queue_Mission(Guard)`
+    /// cleared it, so the queued Guard promotes past the moving-defer gate.
+    pub(crate) fn set_movement_bypass_latch(&mut self) {
+        self.movement_bypass_latch = 1;
+    }
+
     #[cfg(test)]
     pub(super) fn set_movement_bypass_after_verified_queue(&mut self) {
-        self.movement_bypass_latch = 1;
+        self.set_movement_bypass_latch();
     }
 }
 

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -110,6 +110,7 @@ pub mod radiation;
 // --- Passengers, transport, slaves ---
 pub mod parity_digest;
 pub mod passenger;
+pub mod transport_unload;
 pub mod slave_miner;
 pub mod spawn_manager;
 mod spawn_manager_tests;

--- a/src/sim/movement/locomotor_tests.rs
+++ b/src/sim/movement/locomotor_tests.rs
@@ -88,6 +88,7 @@ fn make_obj(locomotor: LocomotorKind, category: ObjectCategory) -> ObjectType {
         crush_sound: None,
         deploy_sound: None,
         undeploy_sound: None,
+        leave_transport_sound: None,
         chrono_in_sound: None,
         chrono_out_sound: None,
         has_turret: false,

--- a/src/sim/movement/teleport_movement.rs
+++ b/src/sim/movement/teleport_movement.rs
@@ -551,6 +551,7 @@ mod tests {
             crush_sound: None,
             deploy_sound: None,
             undeploy_sound: None,
+            leave_transport_sound: None,
             chrono_in_sound: None,
             chrono_out_sound: None,
             has_turret: false,

--- a/src/sim/passenger.rs
+++ b/src/sim/passenger.rs
@@ -2,7 +2,9 @@
 //!
 //! Handles infantry entering transports (Passengers>0), building garrisons
 //! (CanBeOccupied=yes), IFV weapon swapping (Gunner=yes), and passenger
-//! death on transport destruction.
+//! death on transport destruction. Vehicle/aircraft unloading is the Unload
+//! mission handler in `crate::sim::transport_unload`; only garrison eviction
+//! stays on the per-tick `OrderIntent::Unloading` path here.
 //!
 //! ## Original engine reference
 //! The original engine uses a linked-list at offsets +0x1D0/+0x1CC for passenger
@@ -32,10 +34,16 @@ use crate::util::lepton;
 /// Passenger cargo state, attached as `Option<PassengerCargo>` on transport entities.
 ///
 /// Tracks which entities are currently inside this transport/garrison.
-/// Passengers are stored as a Vec of stable_ids for deterministic ordering.
+/// Passengers are stored as a Vec of stable_ids in native CargoClass list
+/// order: index 0 is the list HEAD. `CargoClass::AddPassenger @ 0x004733A0`
+/// PREPENDS (`passenger->next = head; head = passenger`, `0x004733FA`..
+/// `0x00473400`) and `CargoClass::RemoveFirstPassenger @ 0x00473430` pops the
+/// head, so every native consumer — transport unload, paradrop, sell eject —
+/// releases the LAST boarded passenger first.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PassengerCargo {
-    /// Stable IDs of entities currently inside, in boarding order (FIFO unload).
+    /// Stable IDs of entities currently inside, head first: the most recently
+    /// boarded passenger sits at index 0 (LIFO unload).
     pub passengers: Vec<u64>,
     /// `Size=` captured for each entry in `passengers`, at the same index.
     ///
@@ -79,13 +87,14 @@ impl PassengerCargo {
         self.count() < self.capacity && (self.size_limit == 0 || passenger_size <= self.size_limit)
     }
 
-    /// Add a passenger. Returns false if full or too large.
+    /// Add a passenger at the list head (`CargoClass::AddPassenger @
+    /// 0x004733A0` prepends). Returns false if full or too large.
     pub fn board(&mut self, stable_id: u64, passenger_size: u32) -> bool {
         if !self.can_accept(passenger_size) {
             return false;
         }
-        self.passengers.push(stable_id);
-        self.passenger_sizes.push(passenger_size);
+        self.passengers.insert(0, stable_id);
+        self.passenger_sizes.insert(0, passenger_size);
         self.total_size += passenger_size;
         true
     }
@@ -96,8 +105,8 @@ impl PassengerCargo {
     /// limbo-created infantry; it is driven by `*ParaDropNum`, not by PDPLANE's
     /// `Passengers=` or `SizeLimit=`.
     pub fn board_forced(&mut self, stable_id: u64, passenger_size: u32) {
-        self.passengers.push(stable_id);
-        self.passenger_sizes.push(passenger_size);
+        self.passengers.insert(0, stable_id);
+        self.passenger_sizes.insert(0, passenger_size);
         self.total_size += passenger_size;
     }
 
@@ -113,7 +122,8 @@ impl PassengerCargo {
         }
     }
 
-    /// Remove and return the first passenger and its recorded size.
+    /// Remove and return the list HEAD (the most recently boarded passenger)
+    /// and its recorded size — `CargoClass::RemoveFirstPassenger @ 0x00473430`.
     pub fn unload_first(&mut self) -> Option<(u64, u32)> {
         if self.passengers.is_empty() {
             None
@@ -125,7 +135,8 @@ impl PassengerCargo {
         }
     }
 
-    /// Restore a failed FIFO unload at the cargo head.
+    /// Restore a failed head-pop at the cargo head (the native failure path
+    /// re-runs `AddPassenger`, which prepends).
     pub fn restore_front(&mut self, stable_id: u64, passenger_size: u32) {
         self.passengers.insert(0, stable_id);
         self.passenger_sizes.insert(0, passenger_size);
@@ -384,16 +395,20 @@ const NEIGHBORS: [(i16, i16); 8] = [
 /// the transport's cell. If so, execute boarding. If the transport is
 /// destroyed or full, cancel boarding.
 ///
-/// Phase B: For transports with `OrderIntent::Unloading`, eject one
-/// passenger per tick to an adjacent unoccupied cell. Clear the order
-/// when all passengers are out.
+/// Phase B: For `CanBeOccupied=` buildings with `OrderIntent::Unloading`,
+/// eject one occupant per tick to an adjacent unoccupied cell. Clear the
+/// order when all occupants are out.
+///
+/// Vehicle and aircraft transports do NOT unload here: their Unload is a
+/// mission handler (`crate::sim::transport_unload`, the `Passengers > 0`
+/// branch of `UnitClass::Mission_Unload @ 0x0073D630`) dispatched from the
+/// per-object AI host on the `[Unload] Rate` cadence.
+///
 /// Returns `true` if any entity's ownership changed this tick (garrison
 /// transfer or revert), signalling that the sprite atlas needs a rebuild.
 pub fn tick_passenger_system(sim: &mut Simulation, rules: &RuleSet) -> bool {
     let order = sim.live_object_order_snapshot();
-    let boarding_changed = tick_boarding_and_garrison_reconciliation_in_order(sim, rules, &order);
-    let unloading_changed = tick_unloading(sim, rules);
-    boarding_changed || unloading_changed
+    tick_boarding_and_garrison_reconciliation_in_order(sim, rules, &order)
 }
 
 /// Local surrogate for gamemd's live object-vector walk for the garrison owner slice.
@@ -624,7 +639,11 @@ fn reconcile_civilian_garrison_owner_for_building(
                 Some((
                     building.type_ref,
                     building.owner,
-                    cargo.passengers.first().copied(),
+                    // The FIRST occupant to enter: the cargo list is head-first
+                    // (`AddPassenger` prepends), so the earliest entry is the
+                    // tail. VERA-internal ownership rule, gamemd equivalent
+                    // UNCHECKED; preserved unchanged across the LIFO change.
+                    cargo.passengers.last().copied(),
                     cargo.is_empty(),
                     !cargo.is_empty()
                         && is_at_or_below_red_hp(
@@ -656,7 +675,7 @@ fn reconcile_civilian_garrison_owner_for_building(
                 let cargo = building.passenger_role.cargo()?;
                 Some((
                     building.owner,
-                    cargo.passengers.first().copied(),
+                    cargo.passengers.last().copied(),
                     cargo.is_empty(),
                 ))
             })
@@ -893,7 +912,9 @@ fn is_can_be_occupied_unloading_transport(
         .is_some_and(|obj| obj.can_be_occupied)
 }
 
-fn reveal_unloaded_passenger(
+/// Reveal a cargo passenger at an exit cell. The passenger's `sub_cell` and
+/// `facing` must already be written by the caller; its role is cleared here.
+pub(crate) fn reveal_unloaded_passenger(
     sim: &mut Simulation,
     transport_id: u64,
     passenger_id: u64,
@@ -934,7 +955,7 @@ fn reveal_unloaded_passenger(
     )
 }
 
-fn restore_unloaded_passenger_after_reveal_failure(
+pub(crate) fn restore_unloaded_passenger_after_reveal_failure(
     sim: &mut Simulation,
     rules: &RuleSet,
     transport_id: u64,
@@ -1091,157 +1112,6 @@ fn process_unloading_transport(sim: &mut Simulation, rules: &RuleSet, transport_
             t.order_intent = None;
         }
     }
-}
-
-fn tick_unloading(sim: &mut Simulation, rules: &RuleSet) -> bool {
-    // Snapshot transports that are unloading — must collect fully before mutating.
-    let keys: Vec<u64> = sim.substrate.entities.keys_sorted();
-    let unload_snapshot: Vec<u64> = keys
-        .iter()
-        .filter_map(|&id| {
-            let e = sim.substrate.entities.get(id)?;
-            if matches!(e.order_intent, Some(OrderIntent::Unloading)) {
-                Some(id)
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    for transport_id in unload_snapshot {
-        if is_can_be_occupied_unloading_transport(sim, rules, transport_id) {
-            continue;
-        }
-
-        let (trx, try_, tz) = match sim.substrate.entities.get(transport_id) {
-            Some(e) => (e.position.rx, e.position.ry, e.position.z),
-            None => continue,
-        };
-
-        // Collect occupied cell positions (skip transported/dying entities).
-        let occupied_cells: Vec<(u16, u16)> = {
-            let all_keys: Vec<u64> = sim.substrate.entities.keys_sorted();
-            all_keys
-                .iter()
-                .filter_map(|&eid| {
-                    let e = sim.substrate.entities.get(eid)?;
-                    if !e.passenger_role.is_inside_transport() && !e.dying && e.is_alive() {
-                        Some((e.position.rx, e.position.ry))
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        };
-
-        // Find an adjacent free cell for the passenger to exit to.
-        // Simple search: first unoccupied neighbor in 8 directions.
-        let exit_cell = NEIGHBORS.iter().find_map(|&(dx, dy)| {
-            let nx = trx as i16 + dx;
-            let ny = try_ as i16 + dy;
-            if nx < 0 || ny < 0 {
-                return None;
-            }
-            let (nx, ny) = (nx as u16, ny as u16);
-            let occupied = occupied_cells.iter().any(|&(ox, oy)| ox == nx && oy == ny);
-            if occupied { None } else { Some((nx, ny)) }
-        });
-
-        let Some((exit_rx, exit_ry)) = exit_cell else {
-            // No free cell — skip this tick, try again next tick.
-            continue;
-        };
-
-        // Pop the first passenger from the cargo.
-        let passenger = sim
-            .substrate
-            .entities
-            .get_mut(transport_id)
-            .and_then(|t| t.passenger_role.cargo_mut())
-            .and_then(|cargo| cargo.unload_first());
-
-        let Some((pax_id, pax_size)) = passenger else {
-            // Cargo empty — clear unload order.
-            if let Some(t) = sim.substrate.entities.get_mut(transport_id) {
-                t.order_intent = None;
-            }
-            continue;
-        };
-
-        let pax_type_str = sim
-            .substrate
-            .entities
-            .get(pax_id)
-            .map(|e| sim.interner.resolve(e.type_ref).to_string())
-            .unwrap_or_default();
-        let reveal_outcome =
-            reveal_unloaded_passenger(sim, transport_id, pax_id, exit_rx, exit_ry, tz);
-        if !matches!(reveal_outcome, RevealOutcome::Revealed { .. }) {
-            restore_unloaded_passenger_after_reveal_failure(
-                sim,
-                rules,
-                transport_id,
-                pax_id,
-                pax_size,
-                reveal_outcome,
-            );
-            continue;
-        }
-
-        // Scatter: issue a short move to a random adjacent cell so ejected
-        // infantry flee the building footprint (gamemd mission 0xF / Scatter).
-        let scatter_speed = scatter_speed_for_passenger(sim, rules, pax_id, &pax_type_str);
-        let start_dir = sim.scatter_rng().next_u32() as usize % 8;
-        for i in 0..8 {
-            let (dx, dy) = NEIGHBORS[(start_dir + i) % 8];
-            let sx = exit_rx as i32 + dx as i32;
-            let sy = exit_ry as i32 + dy as i32;
-            if sx >= 0 && sy >= 0 {
-                let dest = (sx as u16, sy as u16);
-                let occupied = occupied_cells
-                    .iter()
-                    .any(|&(ox, oy)| ox == dest.0 && oy == dest.1);
-                if !occupied {
-                    movement::issue_direct_move(
-                        &mut sim.substrate.entities,
-                        pax_id,
-                        dest,
-                        scatter_speed,
-                    );
-                    break;
-                }
-            }
-        }
-
-        // When the transport is empty, clear any passenger-driven weapon override
-        // (covers both Gunner=yes IFV swap and open-topped passenger weapon).
-        let is_empty = sim
-            .substrate
-            .entities
-            .get(transport_id)
-            .and_then(|t| t.passenger_role.cargo())
-            .is_some_and(|c| c.is_empty());
-        if is_empty {
-            if let Some(t) = sim.substrate.entities.get_mut(transport_id) {
-                t.weapon_override = None;
-            }
-        }
-
-        // If cargo is now empty, clear the unload order. Civilian garrison owner
-        // revert is deferred to the building reconciliation turn.
-        let cargo_empty = sim
-            .substrate
-            .entities
-            .get(transport_id)
-            .and_then(|t| t.passenger_role.cargo())
-            .is_some_and(|c| c.is_empty());
-        if cargo_empty {
-            if let Some(t) = sim.substrate.entities.get_mut(transport_id) {
-                t.order_intent = None;
-            }
-        }
-    }
-    false
 }
 
 #[cfg(test)]
@@ -1519,25 +1389,30 @@ ConditionYellow=50%
         assert!(cargo.disembark(101));
         assert_eq!(cargo.count(), 2);
         assert_eq!(cargo.total_size, 2);
-        assert_eq!(cargo.passengers, vec![100, 102]);
+        // Head-first list order: the last boarded sits at index 0.
+        assert_eq!(cargo.passengers, vec![102, 100]);
         assert_eq!(cargo.passenger_sizes, vec![1, 1]);
 
         // Disembarking non-existent ID returns false
         assert!(!cargo.disembark(999));
     }
 
+    /// `CargoClass::AddPassenger @ 0x004733A0` prepends and
+    /// `RemoveFirstPassenger @ 0x00473430` pops the head: the last boarded
+    /// passenger leaves first.
     #[test]
-    fn test_unload_first_fifo() {
+    fn test_unload_first_is_lifo_head_pop() {
         let mut cargo = PassengerCargo::new(5, 0);
         cargo.board(100, 1);
         cargo.board(101, 2);
         cargo.board(102, 3);
 
-        assert_eq!(cargo.unload_first(), Some((100, 1)));
-        assert_eq!(cargo.total_size, 5);
-        assert_eq!(cargo.unload_first(), Some((101, 2)));
-        assert_eq!(cargo.total_size, 3);
+        assert_eq!(cargo.passengers, vec![102, 101, 100]);
         assert_eq!(cargo.unload_first(), Some((102, 3)));
+        assert_eq!(cargo.total_size, 3);
+        assert_eq!(cargo.unload_first(), Some((101, 2)));
+        assert_eq!(cargo.total_size, 1);
+        assert_eq!(cargo.unload_first(), Some((100, 1)));
         assert_eq!(cargo.total_size, 0);
         assert_eq!(cargo.unload_first(), None);
         assert!(cargo.is_empty());
@@ -1550,11 +1425,11 @@ ConditionYellow=50%
         cargo.board(100, 3);
         cargo.board(101, 1);
 
-        let entry = cargo.unload_first().expect("front passenger");
+        let entry = cargo.unload_first().expect("head passenger");
         cargo.restore_front(entry.0, entry.1);
 
-        assert_eq!(cargo.passengers, vec![100, 101]);
-        assert_eq!(cargo.passenger_sizes, vec![3, 1]);
+        assert_eq!(cargo.passengers, vec![101, 100]);
+        assert_eq!(cargo.passenger_sizes, vec![1, 3]);
         assert_eq!(cargo.total_size, 4);
     }
 

--- a/src/sim/transport_unload.rs
+++ b/src/sim/transport_unload.rs
@@ -1,0 +1,1159 @@
+//! Transport passenger unload — the Unload mission handlers for vehicle and
+//! aircraft transports (`Passengers > 0`).
+//!
+//! Vehicle: the `Type+0x5E0 > 0` branch of `UnitClass::Mission_Unload @
+//! 0x0073D630` (vtable `+0x23C` at `0x007F5EAC`), states on `unit+0xBC`
+//! through the jump table at `0x0073E5C0`, body `0x0073D70E`..`0x0073DCCE`.
+//! Aircraft: the Aircraft Unload slot `0x004151E0` (vtable `+0x23C` at
+//! `0x007E24E0`; the Ghidra label `AircraftClass__Mission_Hunt` is wrong).
+//!
+//! Every dispatch that does not `return 10` / `return 1` early exits through
+//! the common epilogue `ftol([Unload] Rate × 900) + RandomRanged(0, 2)`
+//! (`0x0073E289`..`0x0073E2B5`; aircraft tail at the end of `0x004151E0`), so
+//! one passenger leaves per 14..16 frames on stock `[Unload] Rate=.016`.
+//!
+//! Depends on `sim/`, `rules/`, `map/` only — never render/ui/sidebar/audio/net.
+
+use crate::map::entities::EntityCategory;
+use crate::rules::locomotor_type::{MovementZone, SpeedType};
+use crate::rules::ruleset::RuleSet;
+use crate::sim::cell_rect::{
+    IsClearToMoveResult, LiveCellPassabilityQuery, evaluate_live_cell_passability,
+};
+use crate::sim::find_nearby_cell::{
+    NearbyAnchorGate, NearbyFootprint, NearbyQuery, NearbySearchOptions, PassabilityArgs,
+    RADIUS_HARD_CAP, find_nearby_passable_cell_with_options,
+};
+use crate::sim::game_entity::GameEntity;
+use crate::sim::mission::authority::EntityReadyInputProvider;
+use crate::sim::mission::{DockTeardown, MissionId, MissionType};
+use crate::sim::movement::FacingClass;
+use crate::sim::movement::bump_crush;
+use crate::sim::movement::locomotor::MovementLayer;
+use crate::sim::movement::ready_producer::is_moving_now_for;
+use crate::sim::passenger::{
+    PassengerRole, restore_unloaded_passenger_after_reveal_failure, reveal_unloaded_passenger,
+};
+use crate::sim::pathfinding::PathGrid;
+use crate::sim::pathfinding::passability::LandType;
+use crate::sim::world::{RevealOutcome, SimSoundEvent, Simulation};
+use crate::util::fixed_math::SIM_ZERO;
+use crate::util::lepton::CELL_CENTER_LEPTON;
+
+/// `g_DirectionOffsets @ 0x0089F688`: eight `(dx, dy)` cell deltas indexed by
+/// octant (facing >> 13). Index 6 is `g_dwDirectionOffset_W @ 0x0089F6A0` =
+/// `(-1, 0)`, the same table the refinery-unload branch of the same handler
+/// uses to find the refinery west of the dock pad; facing East (`0x4000`,
+/// octant 2) is `+x`.
+const OCTANT_OFFSETS: [(i32, i32); 8] = [
+    (0, -1),  // 0 N
+    (1, -1),  // 1 NE
+    (1, 0),   // 2 E
+    (1, 1),   // 3 SE
+    (0, 1),   // 4 S
+    (-1, 1),  // 5 SW
+    (-1, 0),  // 6 W
+    (-1, -1), // 7 NW
+];
+
+/// `DAT_008458D0`: `[4, 5, 6, 7, 0, 1, 2, 3]` — the octant the transport
+/// turns to so that its REAR faces the chosen exit cell.
+const fn opposite_octant(octant: usize) -> usize {
+    (octant + 4) & 7
+}
+
+/// Handler states on `unit+0xBC` (`MissionCom::handler_state`).
+const STATE_PICK_EXIT: u32 = 0;
+const STATE_TURNING: u32 = 1;
+const STATE_EJECT: u32 = 3;
+const STATE_DONE: u32 = 4;
+
+/// Aircraft handler states on `aircraft+0xBC`. Native state 1 (written only
+/// at `0x0041541F`, inside the team arm) is EXCLUDED: VERA has no teams.
+const AIR_STATE_CHECK_LANDED: u32 = 0;
+const AIR_STATE_WAIT_STOP: u32 = 2;
+const AIR_STATE_EJECT: u32 = 3;
+const AIR_STATE_RESET: u32 = 4;
+
+/// Early return `0xA` — "still moving / driving to land, ask again in 10".
+const WAIT_MOVING_FRAMES: i32 = 10;
+
+/// `ftol([Unload] Rate × 900) + RandomRanged(0, 2)` on the Scenario stream
+/// (`Random__RandomRanged` at `0x0073E2B0` on `*(0x00A8B230)+0x218`). The
+/// base is computed FIRST and consumes no RNG; the draw follows.
+fn unload_epilogue(sim: &mut Simulation, rules: &RuleSet) -> i32 {
+    let base = rules
+        .mission_control
+        .rate_frames(MissionType::Unload)
+        .min(i32::MAX as u32) as i32;
+    let jitter = sim.scenario_rng.next_range_u32_inclusive(0, 2) as i32;
+    base.saturating_add(jitter)
+}
+
+/// Whether this entity's type takes the transport branch of the Unit Unload
+/// handler (`Type+0x5E0 Passengers > 0`, gate at `0x0073D6EC`).
+pub(crate) fn is_vehicle_transport_type(
+    sim: &Simulation,
+    entity: &GameEntity,
+    rules: &RuleSet,
+) -> bool {
+    sim.object_type(entity.type_ref, rules)
+        .is_some_and(|obj| obj.passengers > 0)
+}
+
+fn cargo_count(entity: &GameEntity) -> u32 {
+    entity
+        .passenger_role
+        .cargo()
+        .map_or(0, |cargo| cargo.count())
+}
+
+fn cell_from(base: (u16, u16), delta: (i32, i32)) -> Option<(u16, u16)> {
+    let x = i32::from(base.0) + delta.0;
+    let y = i32::from(base.1) + delta.1;
+    (x >= 0 && y >= 0 && x <= i32::from(u16::MAX) && y <= i32::from(u16::MAX))
+        .then_some((x as u16, y as u16))
+}
+
+fn cell_in_map(sim: &Simulation, path_grid: Option<&PathGrid>, cell: (u16, u16)) -> bool {
+    if let Some(terrain) = sim.resolved_terrain.as_ref() {
+        return terrain.cell(cell.0, cell.1).is_some();
+    }
+    if let Some(grid) = path_grid {
+        return cell.0 < grid.width() && cell.1 < grid.height();
+    }
+    true
+}
+
+/// Terrain level of a cell for the reveal Z, or the transport's own Z.
+fn cell_level_or(sim: &Simulation, cell: (u16, u16), fallback: u8) -> u8 {
+    sim.resolved_terrain
+        .as_ref()
+        .and_then(|terrain| terrain.cell(cell.0, cell.1))
+        .map_or(fallback, |c| c.level)
+}
+
+/// The FNPC `allow_bridge_cells == 0` reject and the placement skip at
+/// `0x0073D9EB` (`CellClass+0x140 & 0x100`, the structural bridge flag).
+fn cell_has_structural_bridge(
+    sim: &Simulation,
+    path_grid: Option<&PathGrid>,
+    cell: (u16, u16),
+) -> bool {
+    path_grid
+        .and_then(|grid| grid.cell(cell.0, cell.1))
+        .is_some_and(|c| c.has_structural_bridge())
+        || sim
+            .resolved_terrain
+            .as_ref()
+            .and_then(|terrain| terrain.cell(cell.0, cell.1))
+            .is_some_and(|c| c.bridge_facts.has_structural_bridge())
+}
+
+/// Land passability of a cell for one speed type, from the resolved terrain
+/// speed table (a zero cost is impassable), falling back to the path grid.
+fn land_passable_for(
+    sim: &Simulation,
+    path_grid: Option<&PathGrid>,
+    cell: (u16, u16),
+    speed_type: SpeedType,
+) -> bool {
+    match sim
+        .resolved_terrain
+        .as_ref()
+        .and_then(|terrain| terrain.cell(cell.0, cell.1))
+    {
+        Some(terrain_cell) => terrain_cell
+            .speed_costs
+            .cost_for_speed_type(speed_type)
+            .is_none_or(|cost| cost > 0),
+        None => path_grid.is_none_or(|grid| grid.is_walkable(cell.0, cell.1)),
+    }
+}
+
+/// One octant candidate of the exit-cell scorer `FUN_00740B60` (UnitClass
+/// vtable `+0x304`, called with a NULL passenger at `0x0073D7F4`): the cell's
+/// LandType row must have a non-zero Foot column, the cell must carry no
+/// vehicle/building occupation and must not be full of infantry
+/// (`CellClass+0x124 & 0xE0 == 0`, `& 0x1F != 0x1F`), and the nearest object
+/// in it, when any, must be an ally of the transport's owner
+/// (`HouseClass::Is_Ally_ByObject`, `0x00740CE7`..`0x00740CF3`).
+///
+/// VERA-internal: the Rust cell holds three infantry sub-cells, so "full" is
+/// the sub-cell allocator's refusal; every ground occupant is alliance-tested
+/// rather than only the nearest one.
+fn octant_cell_open(
+    sim: &Simulation,
+    path_grid: Option<&PathGrid>,
+    cell: (u16, u16),
+    transport_owner: &str,
+) -> bool {
+    if !cell_in_map(sim, path_grid, cell) {
+        return false;
+    }
+    if !land_passable_for(sim, path_grid, cell, SpeedType::Foot) {
+        return false;
+    }
+    let occupancy = sim.substrate.occupancy.get(cell.0, cell.1);
+    if !bump_crush::cell_passable_for_infantry(occupancy, MovementLayer::Ground) {
+        return false;
+    }
+    if let Some(occ) = occupancy {
+        for occupant in occ.iter_layer(MovementLayer::Ground) {
+            let Some(other) = sim.substrate.entities.get(occupant.entity_id) else {
+                continue;
+            };
+            let other_owner = sim.interner.resolve(other.owner);
+            if !crate::map::houses::is_allied_with(
+                &sim.house_alliances,
+                transport_owner,
+                other_owner,
+            ) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// `FUN_00740B60` with a NULL passenger: score the eight neighbour cells and
+/// return `(exit cell, octant the transport must FACE)`.
+///
+/// Per octant (`0x00740BB0`..`0x00740D5B`): `0x80` when the cell is open,
+/// `-0x80` otherwise; minus the absolute difference between the octant's
+/// 8-bit facing (`(char)(octant << 5)`) and the 8-bit facing of the
+/// transport's REAR (`(char)(((facing16 + 0x7FFF) >> 7 + 1) >> 1)`), both
+/// taken as SIGNED bytes before the subtraction (so the south octant reads
+/// `-128`, not `128`); octant 4 (S) is penalised by a further `-100`
+/// (`0x00740D3B`). The first strictly-greatest score wins (`local_38 < score`,
+/// initial `-1`). Only a positive best writes a cell (`0x00740D7E`); the
+/// returned octant is `DAT_008458D0[best]` = the opposite octant, so the
+/// transport ends up with its back to the exit.
+///
+/// The `UnitType+0xC94` (`IsTrain=`) override that returns the current facing
+/// octant instead (`0x00740DC5`) is not represented: no stock YR unit sets
+/// the key and it is not parsed.
+fn pick_exit_octant(
+    sim: &Simulation,
+    path_grid: Option<&PathGrid>,
+    entity: &GameEntity,
+) -> Option<((u16, u16), usize)> {
+    let owner = sim.interner.resolve(entity.owner);
+    let base = (entity.position.rx, entity.position.ry);
+    let facing16 = u16::from(entity.facing) << 8;
+    let rear16 = facing16.wrapping_add(0x7FFF);
+    let rear8 = i32::from((((u32::from(rear16) >> 7) + 1) >> 1) as u8 as i8);
+
+    let mut best_score: i32 = -1;
+    let mut best_octant: usize = 0;
+    for octant in 0..8usize {
+        let open = cell_from(base, OCTANT_OFFSETS[octant])
+            .is_some_and(|cell| octant_cell_open(sim, path_grid, cell, owner));
+        let mut score: i32 = if open { 0x80 } else { -0x80 };
+        let dir8 = i32::from(((octant as u32) << 5) as u8 as i8);
+        score -= (dir8 - rear8).abs();
+        if octant == 4 {
+            score -= 100;
+        }
+        if best_score == -1 || best_score < score {
+            best_score = score;
+            best_octant = octant;
+        }
+    }
+    if best_score <= 0 {
+        return None;
+    }
+    let cell = cell_from(base, OCTANT_OFFSETS[best_octant])?;
+    Some((cell, opposite_octant(best_octant)))
+}
+
+/// `Do_Turn(octant << 13)` on the transport's hull (`0x0073D86C`, locomotor
+/// slot `+0x4C`): arm the body `FacingClass` toward the 8-bit facing
+/// `octant * 32` at the unit's `ROT=`.
+fn start_hull_turn(entity: &mut GameEntity, octant: usize, now: u32) {
+    let target8 = ((octant as u32) << 5) as u8;
+    let rot = entity
+        .locomotor
+        .as_ref()
+        .map_or(0, |loco| loco.rot)
+        .clamp(0, 0x7F) as u8;
+    entity.facing_target = Some(target8);
+    let mut body = FacingClass::new(u16::from(entity.facing) << 8, rot);
+    body.set(u16::from(target8) << 8, now);
+    entity.body_facing = Some(body);
+}
+
+/// State 1's `+0x6AF == 0` read (`0x0073D892`): the hull turn has finished.
+fn hull_turn_finished(entity: &GameEntity, now: u32) -> bool {
+    entity
+        .body_facing
+        .as_ref()
+        .is_none_or(|body| !body.is_rotating(now))
+}
+
+/// Per-tick `PrimaryFacing.Current()` refresh for a transport turning in
+/// place for its unload. The movement tick only rotates objects that hold a
+/// movement target, so the idle hull turn armed by [`start_hull_turn`] is
+/// advanced here from the same frame-anchored `FacingClass` gamemd reads.
+/// VERA-internal representation of a native pure-function read.
+pub(crate) fn refresh_idle_hull_turn(sim: &mut Simulation, id: u64) {
+    let now = sim.session.binary_frame;
+    let Some(entity) = sim.substrate.entities.get_mut(id) else {
+        return;
+    };
+    if entity.mission.current() != MissionId::from_known(MissionType::Unload)
+        || entity.mission.handler_state() != STATE_TURNING
+        || entity.movement_target.is_some()
+    {
+        return;
+    }
+    let Some(body) = entity.body_facing.as_ref() else {
+        return;
+    };
+    entity.facing = (body.current(now) >> 8) as u8;
+}
+
+fn finish_hull_turn(entity: &mut GameEntity) {
+    if let Some(target) = entity.facing_target.take() {
+        entity.facing = target;
+    }
+    entity.body_facing = None;
+}
+
+/// `ObjectClass::IsCellOccupied` (vtable `+0x1AC`) for the ejected passenger at
+/// one cell, as called at `0x0073D994` / `0x0073D9C2` with
+/// `(cell, octant, level, NULL, alt=1)`. A zero return is "may enter".
+fn passenger_can_enter(
+    sim: &Simulation,
+    rules: &RuleSet,
+    path_grid: Option<&PathGrid>,
+    passenger: &GameEntity,
+    cell: (u16, u16),
+) -> bool {
+    if !cell_in_map(sim, path_grid, cell) {
+        return false;
+    }
+    let obj = sim.object_type(passenger.type_ref, rules);
+    let speed_type = passenger
+        .locomotor
+        .as_ref()
+        .map(|loco| loco.speed_type)
+        .or_else(|| obj.map(|o| o.speed_type))
+        .unwrap_or(SpeedType::Foot);
+    let movement_zone = obj.map_or(MovementZone::Normal, |o| o.movement_zone);
+    let land_passable = land_passable_for(sim, path_grid, cell, speed_type);
+    if path_grid.is_none() && sim.resolved_terrain.is_none() {
+        // Headless fixtures have no Cell substrate: only the occupancy verdict
+        // is available.
+        let occupancy = sim.substrate.occupancy.get(cell.0, cell.1);
+        return if passenger.category == EntityCategory::Infantry {
+            bump_crush::cell_passable_for_infantry(occupancy, MovementLayer::Ground)
+        } else {
+            occupancy.is_none_or(|occ| occ.is_empty_on(MovementLayer::Ground))
+        };
+    }
+    matches!(
+        evaluate_live_cell_passability(LiveCellPassabilityQuery {
+            target: cell,
+            speed_type,
+            movement_zone,
+            requested_zone: None,
+            actual_zone: 0,
+            requested_layer: None,
+            ignore_infantry: false,
+            ignore_vehicles: false,
+            land_passable,
+            path_grid,
+            resolved_terrain: sim.resolved_terrain.as_ref(),
+            raw_occupation: Some(&sim.substrate.raw_cell_occupation),
+        }),
+        IsClearToMoveResult::Clear { .. } | IsClearToMoveResult::ClearWinged
+    )
+}
+
+/// `FootClass::Find_Nearby_Passable_Cell` seeded at `seed` for `mover`'s own
+/// speed type — the state-0 water→land pre-move (`0x0073D7B0`) and the
+/// vehicle-passenger placement search (`0x0073DADD`, seeded at the exit cell
+/// with the passenger's `Type+0x67C` SpeedType). Bridge cells are refused
+/// and the terrain-level gate is on; the remaining flag arguments are not
+/// individually decoded (bounded reuse of the free-unit query shape).
+fn find_nearby_passable_for(
+    sim: &Simulation,
+    rules: &RuleSet,
+    path_grid: Option<&PathGrid>,
+    mover: &GameEntity,
+    seed: (u16, u16),
+    speed_type_override: Option<SpeedType>,
+) -> Option<(u16, u16)> {
+    let obj = sim.object_type(mover.type_ref, rules)?;
+    let speed_type = speed_type_override.unwrap_or_else(|| {
+        mover
+            .locomotor
+            .as_ref()
+            .map_or(obj.speed_type, |loco| loco.speed_type)
+    });
+    let query = NearbyQuery {
+        passability: PassabilityArgs {
+            speed_type,
+            required_zone_id: None,
+            movement_zone: obj.movement_zone,
+            bridge_aware_zone: false,
+        },
+        footprint: NearbyFootprint::SINGLE,
+        anchor_gate: NearbyAnchorGate::UnverifiedCompatibilityBypass,
+        allow_bridge_cells: false,
+        check_height: true,
+        check_occupancy: false,
+        radius_cap: RADIUS_HARD_CAP,
+        target_cell: None,
+        path_grid,
+        resolved_terrain: sim.resolved_terrain.as_ref(),
+        overlay_grid: sim.overlay_grid.as_ref(),
+        occupancy: Some(&sim.substrate.occupancy),
+        entities: Some(&sim.substrate.entities),
+        zone_grid: sim.zone_grid.as_ref(),
+        playfield_bounds: sim.playfield_bounds,
+    };
+    find_nearby_passable_cell_with_options(
+        (i32::from(seed.0), i32::from(seed.1)),
+        &query,
+        NearbySearchOptions::default(),
+        sim.session.binary_frame,
+    )
+}
+
+/// `Set_Destination(cell, 1)` for an object the handler wants driven — the
+/// production representation is the same pathed move `Command::Move` issues.
+/// Without a path grid (headless fixtures) nothing moves.
+fn issue_pathed_move(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    path_grid: Option<&PathGrid>,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+    id: u64,
+    dest: (u16, u16),
+) {
+    let Some(grid) = path_grid else {
+        return;
+    };
+    let Some(info) = sim.resolve_move_info(id, Some(rules)) else {
+        return;
+    };
+    let owner = sim
+        .substrate
+        .entities
+        .get(id)
+        .map(|entity| sim.interner.resolve(entity.owner).to_string())
+        .unwrap_or_default();
+    let (entity_blocks, entity_block_map) = bump_crush::build_entity_block_set(
+        &sim.substrate.entities,
+        &owner,
+        &sim.house_alliances,
+        &sim.interner,
+        Some(rules),
+    );
+    let cost_grid = sim.terrain_costs.get(&info.speed_type);
+    let blocker_neighbor_counts = bump_crush::build_blocker_neighbor_counts_with_overlays(
+        &sim.substrate.entities,
+        grid.width(),
+        grid.height(),
+        sim.resolved_terrain.as_ref(),
+        sim.overlay_grid.as_ref(),
+        overlay_registry,
+        &sim.interner,
+        Some(rules),
+    );
+    let _ = crate::sim::movement::issue_move_command_with_layered(
+        &mut sim.substrate.entities,
+        grid,
+        id,
+        dest,
+        info.speed,
+        false,
+        cost_grid,
+        Some(&entity_blocks),
+        sim.resolved_terrain.as_ref(),
+        sim.zone_grid.as_ref(),
+        Some(&entity_block_map),
+        info.mover_is_crusher,
+        Some(&blocker_neighbor_counts),
+        sim.playfield_bounds,
+        Some(&mut sim.substrate.cell_occupation),
+    );
+}
+
+fn queue_guard(sim: &mut Simulation, id: u64) {
+    let now = sim.session.binary_frame;
+    let _ = sim.mission_queue_exact(
+        id,
+        MissionId::from_known(MissionType::Guard),
+        0,
+        now,
+        &EntityReadyInputProvider,
+    );
+}
+
+/// Pop the cargo head (`FUN_004DE710` → `CargoClass::RemoveFirstPassenger @
+/// 0x00473430`). The wrapper's `Type+0x805 && count == 0 → vtable+0x4D8`
+/// tail is the Gunner weapon reset once the hold is empty; VERA's
+/// representation of that swap is the transport's `weapon_override`.
+fn pop_cargo_head(sim: &mut Simulation, transport_id: u64) -> Option<(u64, u32)> {
+    let transport = sim.substrate.entities.get_mut(transport_id)?;
+    let popped = transport.passenger_role.cargo_mut()?.unload_first()?;
+    if transport
+        .passenger_role
+        .cargo()
+        .is_some_and(|cargo| cargo.is_empty())
+    {
+        transport.weapon_override = None;
+    }
+    Some(popped)
+}
+
+/// Outcome of one state-3 ejection attempt.
+enum EjectOutcome {
+    /// Placed at the exit cell; the passenger was given `dest`.
+    Placed,
+    /// No octant accepted the passenger; it was put back at the cargo head.
+    Failed,
+}
+
+/// State 3 (`0x0073D8B7`..`0x0073DCA6`): pop the head passenger, scan the
+/// eight octants for an exit cell and place it.
+///
+/// Scan start `((facing16 + 0x7FFF) >> 12 + 1) >> 1 & 7` (`0x0073D8F4`..
+/// `0x0073D922`) — the octant BEHIND the transport, which state 0 turned to
+/// face away from the exit cell. Two passes: with the retry byte set
+/// (`[ESP+0x12] = 1`, `0x0073D8EF`) a candidate needs BOTH the adjacent cell
+/// and the cell beyond it enterable; the first time the scan hits `i == 7`
+/// still rejecting, the byte clears and the scan restarts at `i = 1`
+/// (`0x0073DA15`..`0x0073DA27`), accepting an adjacent cell alone. A
+/// candidate carrying the structural bridge flag is skipped without the
+/// wrap (`0x0073D9EB`..`0x0073DA02`). The placement coordinate is the exit
+/// cell's centre; infantry route through `PlaceInfantryInCell`
+/// (`0x0073DA7C`), vehicles through `Find_Nearby_Passable_Cell` seeded at the
+/// exit cell (`0x0073DADD`), whose result overwrites the exit-cell slot
+/// `[ESP+0x14]` (`0x0073DAE8`). `Unlimbo(coord, octant * 32)` follows
+/// (`0x0073DB6A`); on success the passenger's transporter link `+0x11C` is
+/// cleared, `Queue_Mission(Move)` (`0x0073DBDB`) and `Set_Destination` to the
+/// cell BEYOND (`[ESP+0x30]`) on the strict pass or to `[ESP+0x14]` on the
+/// relaxed pass (`0x0073DBE1`..`0x0073DC06`) — the exit cell for infantry,
+/// the FNPC placement cell for a vehicle passenger — and `LeaveTransportSound`
+/// plays at the transport (`0x0073DC28`..`0x0073DC67`). Any failure
+/// re-inserts the passenger with `AddPassenger` (`0x0073DC78`) and re-applies
+/// the gunner weapon (`0x0073DC96`).
+///
+/// Infantry `Unlimbo` (`InfantryClass::Unlimbo @ 0x0051DFF0`) runs
+/// `PlaceInfantryInCell` a second time from the already-adjusted sub-cell
+/// coordinate, but draws no RNG there: the handler increments
+/// `g_MapEditorMode` (`0x00A8E7AC`) at `0x0073DA48` before the `+0xD8`
+/// `Unlimbo` call (`0x0073DB6A`) and decrements it at `0x0073DB79` after,
+/// so `InfantryClass::Unlimbo` passes `priority = 1` and
+/// `CellClass::PlaceInfantryInCell @ 0x00481180` takes the no-occupancy-test
+/// branch (`LAB_00481437`: offset-table lookup, no `RandomRanged(0, 3)`).
+/// The single draw here is therefore the whole native budget. The infantry
+/// placement writes only the coordinate (`0x0073DA83`), leaving the exit
+/// cell in `[ESP+0x14]` for the relaxed-pass destination.
+fn eject_head_passenger(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    path_grid: Option<&PathGrid>,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+    transport_id: u64,
+) -> EjectOutcome {
+    let Some((pax_id, pax_size)) = pop_cargo_head(sim, transport_id) else {
+        return EjectOutcome::Failed;
+    };
+    let (base, facing, transport_z, leave_sound) = {
+        let transport = sim
+            .substrate
+            .entities
+            .get(transport_id)
+            .expect("transport resolved before the head pop");
+        let obj = sim.object_type(transport.type_ref, rules);
+        (
+            (transport.position.rx, transport.position.ry),
+            transport.facing,
+            transport.position.z,
+            obj.and_then(|o| o.leave_transport_sound.clone()),
+        )
+    };
+    let Some(passenger_snapshot) = sim.substrate.entities.get(pax_id) else {
+        // A cargo id that no longer resolves cannot be placed; keep the
+        // native failure shape (re-insert) so the count stays coherent.
+        restore_head(sim, rules, transport_id, pax_id, pax_size);
+        return EjectOutcome::Failed;
+    };
+    let passenger_is_infantry = passenger_snapshot.category == EntityCategory::Infantry;
+
+    let facing16 = u16::from(facing) << 8;
+    let start = ((((u32::from(facing16.wrapping_add(0x7FFF))) >> 12) + 1) >> 1) as usize & 7;
+    let mut strict_pass = true;
+    let mut i: usize = 0;
+    // `(exit cell, beyond cell on the strict pass, octant)`.
+    let mut placement: Option<((u16, u16), Option<(u16, u16)>, usize)> = None;
+    while i < 8 {
+        let octant = (start + i) & 7;
+        let exit_cell = cell_from(base, OCTANT_OFFSETS[octant]);
+        let beyond_cell = exit_cell.and_then(|cell| cell_from(cell, OCTANT_OFFSETS[octant]));
+        let (adjacent_ok, beyond_ok) = match (exit_cell, beyond_cell) {
+            (Some(exit), Some(beyond)) => {
+                let passenger = sim
+                    .substrate
+                    .entities
+                    .get(pax_id)
+                    .expect("passenger resolved above");
+                (
+                    passenger_can_enter(sim, rules, path_grid, passenger, exit),
+                    passenger_can_enter(sim, rules, path_grid, passenger, beyond),
+                )
+            }
+            _ => (false, false),
+        };
+        let accept = adjacent_ok && (beyond_ok || !strict_pass);
+        if !accept {
+            if strict_pass && i == 7 {
+                strict_pass = false;
+                i = 1;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+        let (exit, beyond) = (
+            exit_cell.expect("accepted cell exists"),
+            beyond_cell.expect("accepted cell exists"),
+        );
+        if cell_has_structural_bridge(sim, path_grid, exit) {
+            i += 1;
+            continue;
+        }
+        placement = Some((exit, strict_pass.then_some(beyond), octant));
+        break;
+    }
+
+    let Some((exit, strict_beyond, octant)) = placement else {
+        restore_head(sim, rules, transport_id, pax_id, pax_size);
+        return EjectOutcome::Failed;
+    };
+
+    // Placement coordinate: the exit cell centre (`x * 256 + 0x80`).
+    let (place_cell, sub_cell) = if passenger_is_infantry {
+        // `PlaceInfantryInCell` from the cell centre: quadrant 0, so the
+        // centre-row `RandomRanged(0, 3)` draw is made on the Scenario stream.
+        let occupancy = sim.substrate.occupancy.get(exit.0, exit.1);
+        let spot = bump_crush::allocate_sub_cell_with_preference(
+            occupancy,
+            MovementLayer::Ground,
+            None,
+            CELL_CENTER_LEPTON,
+            CELL_CENTER_LEPTON,
+            &mut sim.scenario_rng,
+        );
+        (exit, spot)
+    } else {
+        let passenger = sim
+            .substrate
+            .entities
+            .get(pax_id)
+            .expect("passenger resolved above");
+        let cell =
+            find_nearby_passable_for(sim, rules, path_grid, passenger, exit, None).unwrap_or(exit);
+        (cell, None)
+    };
+    if passenger_is_infantry && sub_cell.is_none() {
+        restore_head(sim, rules, transport_id, pax_id, pax_size);
+        return EjectOutcome::Failed;
+    }
+    // Relaxed pass: `[ESP+0x14]` — the exit cell for infantry, the FNPC
+    // placement cell for a vehicle (`0x0073DAE8` overwrote the slot).
+    let dest = strict_beyond.unwrap_or(place_cell);
+
+    if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
+        passenger.sub_cell = sub_cell;
+        passenger.facing = ((octant as u32) << 5) as u8;
+        if let Some(loco) = passenger.locomotor.as_mut() {
+            loco.layer = MovementLayer::Ground;
+        }
+    }
+    let z = cell_level_or(sim, place_cell, transport_z);
+    let outcome =
+        reveal_unloaded_passenger(sim, transport_id, pax_id, place_cell.0, place_cell.1, z);
+    if !matches!(outcome, RevealOutcome::Revealed { .. }) {
+        restore_unloaded_passenger_after_reveal_failure(
+            sim,
+            rules,
+            transport_id,
+            pax_id,
+            pax_size,
+            outcome,
+        );
+        reapply_gunner_weapon(sim, rules, transport_id, pax_id);
+        return EjectOutcome::Failed;
+    }
+
+    // OpenTopped: `TechnoClass::ClearInOpenTransport` (`0x007104A0`) drops the
+    // passenger's in-transport firing membership; VERA's open-topped registry
+    // is the logic-object registration the Reveal above re-establishes.
+    if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
+        passenger.passenger_role = PassengerRole::None;
+        passenger.attack_target = None;
+        passenger.passively_acquired_target = false;
+        passenger.order_intent = None;
+    }
+    sim.queue_megamission_with_teardown(pax_id, MissionType::Move, DockTeardown::None);
+    issue_pathed_move(sim, rules, path_grid, overlay_registry, pax_id, dest);
+
+    if let Some(sound) = leave_sound {
+        let sound_id = sim.interner.intern(&sound);
+        sim.sound_events.push(SimSoundEvent::LeaveTransport {
+            sound_id,
+            rx: base.0,
+            ry: base.1,
+        });
+    }
+    EjectOutcome::Placed
+}
+
+/// The failure tail of the vehicle handler (`0x0073DC71`..`0x0073DCA6`):
+/// `CargoClass::AddPassenger @ 0x004733A0` re-inserts the passenger at the
+/// head, then `Type+0x805 (Gunner=)` calls UnitClass vtable `+0x4D4`
+/// (`0x00746420`, undefined as a Ghidra function; decoded from bytes) with
+/// the passenger: it re-adopts the passenger's `+0x274` attachment and
+/// applies `InfantryType+0x688 (IFVMode=)` through `FUN_0070DC70`, i.e. the
+/// gunner weapon swap that the pop's `+0x4D8` (`0x007464E0`, the inverse)
+/// undid when the hold emptied. Aircraft/Techno bind those slots to the
+/// three-byte stubs `0x004DE750`/`0x004DE760`, so only a Gunner unit swaps.
+fn restore_head(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    transport_id: u64,
+    pax_id: u64,
+    pax_size: u32,
+) {
+    if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
+        passenger.passenger_role = PassengerRole::Inside { transport_id };
+    }
+    if let Some(cargo) = sim
+        .substrate
+        .entities
+        .get_mut(transport_id)
+        .and_then(|transport| transport.passenger_role.cargo_mut())
+    {
+        cargo.restore_front(pax_id, pax_size);
+    }
+    reapply_gunner_weapon(sim, rules, transport_id, pax_id);
+}
+
+/// UnitClass `+0x4D4` (`0x00746420`) for a `Gunner=yes` transport: the
+/// re-added head passenger's `IFVMode=` becomes the transport's weapon slot
+/// again. VERA's representation of that swap is `weapon_override`.
+fn reapply_gunner_weapon(sim: &mut Simulation, rules: &RuleSet, transport_id: u64, pax_id: u64) {
+    let Some(transport) = sim.substrate.entities.get(transport_id) else {
+        return;
+    };
+    if !sim
+        .object_type(transport.type_ref, rules)
+        .is_some_and(|obj| obj.gunner)
+    {
+        return;
+    }
+    let Some(passenger) = sim.substrate.entities.get(pax_id) else {
+        return;
+    };
+    let ifv_mode = sim
+        .object_type(passenger.type_ref, rules)
+        .map_or(0, |obj| obj.ifv_mode);
+    if let Some(transport) = sim.substrate.entities.get_mut(transport_id) {
+        transport.weapon_override = Some(
+            crate::sim::combat::combat_weapon::WeaponOverride::IfvSlot(ifv_mode),
+        );
+    }
+}
+
+/// The `Passengers > 0` branch of `UnitClass::Mission_Unload @ 0x0073D630`.
+///
+/// Returns the handler's dispatch delay; the caller writes the epilogue.
+pub(crate) fn unit_mission_unload(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    path_grid: Option<&PathGrid>,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+    id: u64,
+) -> i32 {
+    let now = sim.session.binary_frame;
+    let Some(entity) = sim.substrate.entities.get(id) else {
+        return unload_epilogue(sim, rules);
+    };
+    match entity.mission.handler_state() {
+        STATE_PICK_EXIT => {
+            // `ILocomotion::Is_Moving` (`0x0073D729`) → `return 10`.
+            if is_moving_now_for(entity, now) || entity.movement_target.is_some() {
+                return WAIT_MOVING_FRAMES;
+            }
+            // No NavCom and the current cell's LandType is Water (`+0xEC == 2`,
+            // `0x0073D769`): drive to the nearest passable cell first and
+            // `return 10` — a hover transport unloads on land.
+            let on_water = sim
+                .resolved_terrain
+                .as_ref()
+                .and_then(|terrain| terrain.cell(entity.position.rx, entity.position.ry))
+                .is_some_and(|cell| cell.yr_cell_land_type == LandType::Water.as_index());
+            if entity.navigation.nav_com.is_none() && on_water {
+                // `PUSH 0x2` at `0x0073D790`: the search runs for speed-type
+                // index 2 — Wheel in the native `SpeedType` order (Foot 0,
+                // Track 1, Wheel 2, Hover 3, ...), a land-only type — not for
+                // the transport's own (hover) type, which is what makes a
+                // hover transport leave the water before it unloads.
+                let seed = (entity.position.rx, entity.position.ry);
+                if let Some(cell) = find_nearby_passable_for(
+                    sim,
+                    rules,
+                    path_grid,
+                    entity,
+                    seed,
+                    Some(SpeedType::Wheel),
+                ) {
+                    // `Set_Destination` only — the committed selector stays
+                    // Unload and state 0 re-runs once the drive has ended.
+                    issue_pathed_move(sim, rules, path_grid, overlay_registry, id, cell);
+                }
+                return WAIT_MOVING_FRAMES;
+            }
+            let cargo = cargo_count(entity);
+            let pick = pick_exit_octant(sim, path_grid, entity);
+            if let (true, Some((_exit_cell, face_octant))) = (cargo != 0, pick) {
+                // `FUN_0070DC60` → `Type+0x808 TurretCount > 0` (`0x00717880`):
+                // a turreted transport (the IFV) keeps its last passenger —
+                // `+0x6E4 = (cargo == 1 ? 0 : 1)` (`0x0073D82C`..`0x0073D83C`).
+                let turreted = sim
+                    .object_type(entity.type_ref, rules)
+                    .is_some_and(|obj| obj.turret_count > 0);
+                if let Some(entity) = sim.substrate.entities.get_mut(id) {
+                    if turreted {
+                        entity.transport_unload_keep_count = if cargo == 1 { 0 } else { 1 };
+                    }
+                    start_hull_turn(entity, face_octant, now);
+                    entity.mission.set_handler_state(STATE_TURNING);
+                }
+                return 1;
+            }
+            // Nothing to unload or nowhere to unload: `Queue_Mission(Guard)`
+            // (`0x0073D887`) and the epilogue.
+            queue_guard(sim, id);
+            unload_epilogue(sim, rules)
+        }
+        STATE_TURNING => {
+            if hull_turn_finished(entity, now) {
+                if let Some(entity) = sim.substrate.entities.get_mut(id) {
+                    finish_hull_turn(entity);
+                    entity.mission.set_handler_state(STATE_EJECT);
+                }
+                return 1;
+            }
+            unload_epilogue(sim, rules)
+        }
+        STATE_EJECT => {
+            if cargo_count(entity) > entity.transport_unload_keep_count {
+                let _ = eject_head_passenger(sim, rules, path_grid, overlay_registry, id);
+            } else if let Some(entity) = sim.substrate.entities.get_mut(id) {
+                entity.mission.set_handler_state(STATE_DONE);
+            }
+            unload_epilogue(sim, rules)
+        }
+        STATE_DONE => {
+            // `Queue_Mission(Guard)` then `+0xB8 = 1` (`0x0073DCC1`..`0x0073DCC7`).
+            queue_guard(sim, id);
+            if let Some(entity) = sim.substrate.entities.get_mut(id) {
+                entity.mission.set_movement_bypass_latch();
+            }
+            unload_epilogue(sim, rules)
+        }
+        _ => unload_epilogue(sim, rules),
+    }
+}
+
+/// Whether the aircraft is on the ground: `GetHeight() == 0` (vtable `+0x1C8`,
+/// `0x004151F0`) and the flight-altitude float `+0x2E8 == 0.0` (`0x00415200`).
+fn aircraft_landed(entity: &GameEntity) -> bool {
+    entity
+        .locomotor
+        .as_ref()
+        .is_none_or(|loco| loco.altitude == SIM_ZERO)
+}
+
+/// The Aircraft Unload slot `0x004151E0` (Nighthawk and any other landed
+/// `Passengers > 0` aircraft). Timer-gated inside; writes its own epilogue.
+///
+/// Team-less state graph (`+0x5A4 == NULL`, the only case VERA carries):
+///
+/// - State 0 (`0x004151FB`): `GetHeight() == 0` (`0x004151FF`) and
+///   `+0x2E8 == 0.0` (`0x0041520D`) → the team test at `0x00415228` jumps a
+///   team-less aircraft straight to state 3 (`0x00415250`); the
+///   destination-equals-position compare (`0x0041522A`..`0x0041524E`) runs
+///   ONLY for a team. Not landed → `0x00415290`: the airfield branch needs
+///   `Type+0xC95` = `IsDropship=` (`TechnoTypeClass::ReadINI`
+///   `0x00712350`..`0x00712373`, key string `0x0084447C`; `AirportBound=` is
+///   a different field, `AircraftType+0xE0D`, `0x0041CC6E`), and no retail
+///   rulesmd.ini type sets `IsDropship`, so a team-less `[SHAD]` (Nighthawk,
+///   `Passengers=5`, `Landable=yes`) ALWAYS takes state 2 (`0x0041530C`).
+///   Both arms fall into the epilogue at `0x0041525A` (one
+///   `RandomRanged(0, 2)` draw).
+/// - State 3 early-out: `+0x418 != 0` returns before the hold test
+///   (`0x004154BB`..`0x004154C3`); its writer and meaning are UNCHECKED and
+///   VERA does not represent it.
+/// - State 1 (`0x0041542A`): written only at `0x0041541F` inside the team
+///   arm — EXCLUDED, unreachable without teams.
+/// - State 2 (`0x00415480`): locomotor `Is_Moving` (`+0x10`, `0x0041549D`)
+///   false → state 3 (`0x004154A4`); `return 1` either way (`0x004154B1`),
+///   NO epilogue draw while it polls.
+/// - State 3 (`0x004154BB`..): cargo empty → `Enter_Idle_Mode` (vtable
+///   `+0x484` = `0x004176F0`); a non-carryall pops the cargo head
+///   (`RemoveFirstPassenger @ 0x00473430`), leaves its own cell list, ejects
+///   through vtable `+0x100` = `0x00415B10` (see [`eject_from_aircraft`]),
+///   re-enters, and — when that emptied the hold — goes idle in the same
+///   dispatch; epilogue draw.
+/// - State 4 (`0x004155C0`): → 0, `return 1`.
+pub(crate) fn dispatch_aircraft_unload(
+    sim: &mut Simulation,
+    id: u64,
+    rules: &RuleSet,
+    path_grid: Option<&PathGrid>,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+) {
+    let now = sim.session.binary_frame;
+    let Some(entity) = sim.substrate.entities.get(id) else {
+        return;
+    };
+    if entity.dying
+        || entity.category != EntityCategory::Aircraft
+        || entity.mission.current() != MissionId::from_known(MissionType::Unload)
+        || !entity.mission.dispatch_timer().due(now)
+    {
+        return;
+    }
+    let delay = match entity.mission.handler_state() {
+        AIR_STATE_CHECK_LANDED => {
+            // Team-less: landed → 3 (`0x00415250`), otherwise → 2
+            // (`0x0041530C`). The destination compare is team-only.
+            let next = if aircraft_landed(entity) {
+                AIR_STATE_EJECT
+            } else {
+                AIR_STATE_WAIT_STOP
+            };
+            if let Some(entity) = sim.substrate.entities.get_mut(id) {
+                entity.mission.set_handler_state(next);
+            }
+            unload_epilogue(sim, rules)
+        }
+        AIR_STATE_WAIT_STOP => {
+            // `Is_Moving` false (`0x0041549D`): for the Jumpjet locomotor that
+            // is only true once it has landed — the native locomotor lands on
+            // its own when the linked object's mission is Unload. VERA's
+            // jumpjet does not yet auto-land on Unload (recorded residual), so
+            // the landed altitude gate is applied here as well; an airborne
+            // Nighthawk keeps waiting rather than dropping its cargo mid-air.
+            if entity.movement_target.is_none() && aircraft_landed(entity) {
+                if let Some(entity) = sim.substrate.entities.get_mut(id) {
+                    entity.mission.set_handler_state(AIR_STATE_EJECT);
+                }
+            }
+            1
+        }
+        AIR_STATE_EJECT => {
+            if cargo_count(entity) == 0 {
+                aircraft_enter_idle_mode(sim, id);
+            } else {
+                let ejected = eject_from_aircraft(sim, rules, path_grid, overlay_registry, id);
+                let hold_empty = sim
+                    .substrate
+                    .entities
+                    .get(id)
+                    .is_some_and(|entity| cargo_count(entity) == 0);
+                // `!ejected`: VERA's bounded escape from a refused ejection
+                // (native loses the passenger and keeps ejecting the rest;
+                // see [`eject_from_aircraft`]). The hold keeps the passenger
+                // and the mission leaves through the same empty-hold exit, so
+                // this dispatch's epilogue draw is the last one.
+                if hold_empty || !ejected {
+                    aircraft_enter_idle_mode(sim, id);
+                }
+            }
+            unload_epilogue(sim, rules)
+        }
+        AIR_STATE_RESET => {
+            if let Some(entity) = sim.substrate.entities.get_mut(id) {
+                entity.mission.set_handler_state(AIR_STATE_CHECK_LANDED);
+            }
+            1
+        }
+        _ => unload_epilogue(sim, rules),
+    };
+    if let Some(entity) = sim.substrate.entities.get_mut(id) {
+        entity.mission.write_dispatch_epilogue(now as i32, delay);
+    }
+}
+
+/// `AircraftClass::Enter_Idle_Mode @ 0x004176F0` for a landed, human-owned,
+/// team-less transport whose hold just emptied (the `+0x484(0, 1)` calls at
+/// `0x004155B5` — hold already empty on state-3 entry — and `0x004155A2`
+/// — the ejection just emptied it).
+///
+/// Native trace: the mission is not suspended (`+0x1FC` = `0x005B3A10`,
+/// `+0xB0 == -1`); `+0x3D4` is clear — `AircraftClass::Unlimbo @ 0x00414310`
+/// sets it only for a type that is not (`Selectable=` `ObjectType+0x230` and
+/// `Landable=` `AircraftType+0xE0A`) or whose weapon 0 carries `Camera=`
+/// (`WeaponType+0x147`), which is the off-map paradrop/spy-plane class, never
+/// a landable transport — so the landed branch (`GetDisplayLayer == 2`,
+/// `0x0041ADC0`) runs `Set_Destination(NULL, 1)` (`+0x480` = `0x0041AA80`),
+/// `Assign_Target(NULL)` (`+0x3C8` = `0x006FCDB0`) and, for a human house,
+/// picks Guard (5). The airfield hunt is gated on `Ammo (+0x2FC) == 0`, which
+/// a `[SHAD]` without `Ammo=` never satisfies.
+///
+/// Radio residual: the last ejection left the aircraft in radio contact with
+/// the passenger (`Transmit_Message(HELLO)` `0x00415C2E`, then `UNLOADED`
+/// `0x00415C3F`, which `TechnoClass::Receive_Radio @ 0x006F4AB0` answers
+/// with TETHER `0x18`), so `In_Radio_Contact` steers the first idle pass to
+/// Enter (7) (`0x00417AD4`..); `AircraftClass::Mission_Enter @ 0x00419C80`
+/// then idles in states 6/7 until the passenger's first cell step breaks the
+/// tether (UNLOAD `8` → UNTETHER + OVER_OUT), after which `Enter_Idle_Mode`
+/// re-runs without contact and lands on Guard. VERA has no transport tether;
+/// the transient Enter label is not represented and the aircraft goes to
+/// Guard directly. VERA-internal shortcut, gamemd end state matched.
+fn aircraft_enter_idle_mode(sim: &mut Simulation, id: u64) {
+    if let Some(entity) = sim.substrate.entities.get_mut(id) {
+        entity.navigation.nav_com = None;
+        entity.movement_target = None;
+        entity.attack_target = None;
+        entity.passively_acquired_target = false;
+    }
+    queue_guard(sim, id);
+}
+
+/// `DAT_00817A58`: the aircraft ejection scan order, octants S, SW, SE, NW,
+/// NE, N, W, E. The ninth entry is the dword that follows the table at
+/// `0x00817A78` (value 4, read from the binary): the no-neighbour path leaves
+/// the loop counter at 8 and `0x00415BB7` indexes the table with it.
+const AIRCRAFT_EXIT_SCAN: [usize; 9] = [4, 5, 3, 7, 1, 0, 6, 2, 4];
+
+/// AircraftClass vtable `+0x100` = `0x00415B10` (Ghidra label
+/// `AircraftClass__Can_Enter_Cell` is wrong): the state-3 ejector.
+///
+/// `0x00415B32`..`0x00415BAB`: for each table octant, the candidate cell is
+/// the aircraft cell plus `g_DirectionOffsets[octant & 7]`, kept in
+/// `[ESP+0x10]`, and the passenger's `IsCellOccupied(cell, -1, -1, 0, 1)`
+/// (vtable `+0x1AC`, `0x00415B8F`) ends the scan on the first zero return.
+/// When every neighbour refuses, the counter stops at 8: the facing index
+/// reads past the table (octant 4, S) and the destination stays the last
+/// scanned cell (E). `0x00415BB1`..`0x00415BF3`: `Unlimbo(aircraft coord,
+/// octant * 32)` — always the aircraft's own coordinate, whatever the scan
+/// found. `InfantryClass::Unlimbo @ 0x0051DFF0` runs `PlaceInfantryInCell`
+/// from that coordinate (ground Z), so the centre-quadrant `RandomRanged(0,
+/// 3)` draw happens exactly when the aircraft sits within 0x3C leptons of its
+/// cell centre (`0x00481180`), and a full cell fails `Unlimbo`. The caller
+/// (`0x0041553E`) tests that result only to clear `passenger+0x424`
+/// (`0x00415548`); nothing re-adds a failed passenger — natively it stays
+/// popped from the hold (`0x00415511`) and in limbo for good, and the next
+/// dispatch ejects the next passenger. VERA-internal bounded escape instead
+/// (trigger: three infantry already standing in the aircraft cell, rare;
+/// DRIFT — native loses the unit): the passenger goes back to the cargo head
+/// ([`restore_head`]), this returns `false`, and the caller leaves Unload for
+/// Guard through the empty-hold exit, so nothing retries and no further
+/// epilogue draws happen. Returns `true` when the passenger left the hold. On
+/// success: `Queue_Mission(Move)` (`0x00415C05`), `Set_Destination(scan
+/// cell, 1)` (`0x00415C21`), then the radio handshake described on
+/// [`aircraft_enter_idle_mode`]. No `LeaveTransportSound` on this path.
+fn eject_from_aircraft(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    path_grid: Option<&PathGrid>,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+    aircraft_id: u64,
+) -> bool {
+    let Some((pax_id, pax_size)) = pop_cargo_head(sim, aircraft_id) else {
+        return false;
+    };
+    let (cell, z, sub_x, sub_y) = match sim.substrate.entities.get(aircraft_id) {
+        Some(aircraft) => (
+            (aircraft.position.rx, aircraft.position.ry),
+            aircraft.position.z,
+            aircraft.position.sub_x,
+            aircraft.position.sub_y,
+        ),
+        None => return false,
+    };
+    let Some(passenger_snapshot) = sim.substrate.entities.get(pax_id) else {
+        restore_head(sim, rules, aircraft_id, pax_id, pax_size);
+        return false;
+    };
+    let is_infantry = passenger_snapshot.category == EntityCategory::Infantry;
+
+    let mut index = 8usize;
+    let mut scan_cell: Option<(u16, u16)> = None;
+    for (i, &octant) in AIRCRAFT_EXIT_SCAN[..8].iter().enumerate() {
+        let candidate = cell_from(cell, OCTANT_OFFSETS[octant & 7]);
+        scan_cell = candidate;
+        let passenger = sim
+            .substrate
+            .entities
+            .get(pax_id)
+            .expect("passenger resolved above");
+        if candidate.is_some_and(|c| passenger_can_enter(sim, rules, path_grid, passenger, c)) {
+            index = i;
+            break;
+        }
+    }
+    let facing = ((AIRCRAFT_EXIT_SCAN[index] & 7) as u32 * 32) as u8;
+
+    let sub_cell = if is_infantry {
+        let occupancy = sim.substrate.occupancy.get(cell.0, cell.1);
+        let spot = bump_crush::allocate_sub_cell_with_preference(
+            occupancy,
+            MovementLayer::Ground,
+            None,
+            sub_x,
+            sub_y,
+            &mut sim.scenario_rng,
+        );
+        if spot.is_none() {
+            restore_head(sim, rules, aircraft_id, pax_id, pax_size);
+            return false;
+        }
+        spot
+    } else {
+        None
+    };
+    if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
+        passenger.sub_cell = sub_cell;
+        passenger.facing = facing;
+        if let Some(loco) = passenger.locomotor.as_mut() {
+            loco.layer = MovementLayer::Ground;
+        }
+    }
+    let outcome = reveal_unloaded_passenger(sim, aircraft_id, pax_id, cell.0, cell.1, z);
+    if !matches!(outcome, RevealOutcome::Revealed { .. }) {
+        restore_unloaded_passenger_after_reveal_failure(
+            sim,
+            rules,
+            aircraft_id,
+            pax_id,
+            pax_size,
+            outcome,
+        );
+        return false;
+    }
+    if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
+        passenger.passenger_role = PassengerRole::None;
+        passenger.attack_target = None;
+        passenger.passively_acquired_target = false;
+        passenger.order_intent = None;
+    }
+    sim.queue_megamission_with_teardown(pax_id, MissionType::Move, DockTeardown::None);
+    if let Some(dest) = scan_cell {
+        issue_pathed_move(sim, rules, path_grid, overlay_registry, pax_id, dest);
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/sim/transport_unload/tests.rs
+++ b/src/sim/transport_unload/tests.rs
@@ -1,0 +1,944 @@
+//! Transport unload handler tests: cadence, LIFO order, the pre-turn, the
+//! IFV keep-one rule, the hover water→land pre-move, Move cancellation and
+//! the landed-only aircraft gate.
+
+use std::collections::BTreeMap;
+
+use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid, zone_class};
+use crate::rules::ini_parser::IniFile;
+use crate::rules::ruleset::RuleSet;
+use crate::rules::terrain_rules::{SpeedCostProfile, TerrainClass};
+use crate::sim::command::Command;
+use crate::sim::mission::{MissionId, MissionType};
+use crate::sim::passenger::PassengerRole;
+use crate::sim::pathfinding::PathGrid;
+use crate::sim::pathfinding::passability::LandType;
+use crate::sim::world::{ConcealOutcome, SimSoundEvent, Simulation};
+use crate::util::fixed_math::{SIM_ZERO, SimFixed};
+
+const OWNER: &str = "Americans";
+const MAP: u16 = 40;
+
+fn rules() -> RuleSet {
+    let ini = IniFile::from_str(
+        "[InfantryTypes]\n0=E1\n[VehicleTypes]\n0=BFRT\n1=FV\n2=LCRF\n3=BGGY\n\
+         [AircraftTypes]\n0=SHAD\n\
+         [BuildingTypes]\n[Countries]\n0=Americans\n\n\
+         [General]\nFixtureOnly=1\n\n\
+         [Unload]\nRate=.016\n[Move]\nRate=.016\n[Guard]\nRate=.03\n\n\
+         [E1]\nStrength=125\nArmor=none\nSpeed=4\nSize=1\nIFVMode=1\n\
+         Locomotor={4A582744-9839-11d1-B709-00A024DDAFD1}\n\n\
+         [BFRT]\nStrength=600\nArmor=heavy\nSpeed=4\nROT=5\nPassengers=5\nSizeLimit=2\n\
+         OpenTopped=yes\nLeaveTransportSound=ExitTransport\n\
+         Locomotor={4A582741-9839-11d1-B709-00A024DDAFD1}\n\n\
+         [FV]\nStrength=200\nArmor=light\nSpeed=4\nROT=5\nPassengers=3\nTurret=yes\n\
+         TurretCount=4\nGunner=yes\nLocomotor={4A582741-9839-11d1-B709-00A024DDAFD1}\n\n\
+         [BGGY]\nStrength=100\nArmor=light\nSpeed=6\nROT=5\nSize=1\n\
+         Locomotor={4A582741-9839-11d1-B709-00A024DDAFD1}\n\n\
+         [LCRF]\nStrength=300\nArmor=light\nSpeed=6\nROT=5\nPassengers=12\nSpeedType=Hover\n\
+         MovementZone=Amphibious\nLocomotor={4A582742-9839-11d1-B709-00A024DDAFD1}\n\n\
+         [SHAD]\nStrength=200\nArmor=light\nSpeed=14\nROT=5\nPassengers=5\nLandable=yes\n\
+         SizeLimit=2\nSpeedType=Hover\nMovementZone=Fly\n\
+         Locomotor={92612C46-F71F-11d1-AC9F-006008055BB5}\n",
+    );
+    RuleSet::from_ini(&ini).expect("transport unload test rules parse")
+}
+
+/// Stock-shaped `[Clear]` speed row: passable for every land mover, not for
+/// pure Float movers.
+fn clear_costs() -> SpeedCostProfile {
+    SpeedCostProfile {
+        foot: Some(100),
+        track: Some(100),
+        wheel: Some(100),
+        float: Some(0),
+        amphibious: Some(100),
+        float_beach: Some(100),
+        hover: Some(100),
+    }
+}
+
+fn clear_cell(rx: u16, ry: u16) -> ResolvedTerrainCell {
+    let land_type = LandType::Clear.as_index();
+    ResolvedTerrainCell {
+        rx,
+        ry,
+        source_tile_index: 0,
+        source_sub_tile: 0,
+        final_tile_index: 0,
+        final_sub_tile: 0,
+        is_wood_bridge_repair_tile: false,
+        level: 0,
+        filled_clear: true,
+        tileset_index: None,
+        land_type,
+        yr_cell_land_type: land_type,
+        slope_type: 0,
+        template_height: 0,
+        render_offset_x: 0,
+        render_offset_y: 0,
+        terrain_class: TerrainClass::Clear,
+        speed_costs: clear_costs(),
+        is_water: false,
+        is_cliff_like: false,
+        is_rough: false,
+        is_road: false,
+        accepts_smudge: true,
+        allows_tiberium: true,
+        height_in_pixels: 0,
+        variant: 0,
+        has_ramp: false,
+        canonical_ramp: None,
+        ground_walk_blocked: false,
+        terrain_object_blocks: false,
+        terrain_object_occupation: None,
+        overlay_blocks: false,
+        overlay_zone_type: None,
+        outside_playfield: false,
+        zone_type: zone_class::GROUND,
+        base_ground_walk_blocked: false,
+        base_build_blocked: false,
+        base_land_type: land_type,
+        base_yr_cell_land_type: land_type,
+        base_terrain_class: TerrainClass::Clear,
+        base_speed_costs: clear_costs(),
+        build_blocked: false,
+        has_bridge_deck: false,
+        bridge_walkable: false,
+        bridge_transition: false,
+        bridge_deck_level: 0,
+        bridge_layer: None,
+        bridge_facts: crate::map::bridge_facts::BridgeCellFacts::default(),
+        tube_index: None,
+        radar_left: [0; 3],
+        radar_right: [0; 3],
+        has_damaged_data: false,
+        bridgehead_anchor_class_at_load: None,
+    }
+}
+
+fn water_cell(rx: u16, ry: u16) -> ResolvedTerrainCell {
+    let mut cell = clear_cell(rx, ry);
+    let water = LandType::Water.as_index();
+    cell.land_type = water;
+    cell.yr_cell_land_type = water;
+    cell.base_land_type = water;
+    cell.base_yr_cell_land_type = water;
+    cell.is_water = true;
+    cell.terrain_class = TerrainClass::Water;
+    cell.base_terrain_class = TerrainClass::Water;
+    let costs = SpeedCostProfile {
+        foot: Some(0),
+        track: Some(0),
+        wheel: Some(0),
+        float: Some(100),
+        amphibious: Some(100),
+        float_beach: Some(100),
+        hover: Some(100),
+    };
+    cell.speed_costs = costs;
+    cell.base_speed_costs = costs;
+    cell
+}
+
+fn flat_terrain(water: impl Fn(u16, u16) -> bool) -> ResolvedTerrainGrid {
+    let mut cells = Vec::with_capacity(usize::from(MAP) * usize::from(MAP));
+    for ry in 0..MAP {
+        for rx in 0..MAP {
+            cells.push(if water(rx, ry) {
+                water_cell(rx, ry)
+            } else {
+                clear_cell(rx, ry)
+            });
+        }
+    }
+    ResolvedTerrainGrid::from_cells(MAP, MAP, cells)
+}
+
+struct Fixture {
+    sim: Simulation,
+    rules: RuleSet,
+    grid: PathGrid,
+    heights: BTreeMap<(u16, u16), u8>,
+}
+
+impl Fixture {
+    fn new(water: impl Fn(u16, u16) -> bool) -> Self {
+        let rules = rules();
+        let mut sim = Simulation::new();
+        let span = i32::from(MAP);
+        sim.playfield_bounds = Some(crate::map::playfield::PlayfieldBounds {
+            base: 0,
+            off_fc: -span,
+            off_100: -span,
+            off_104: span * 2,
+            off_108: span * 2,
+        });
+        sim.install_resolved_terrain_for_new_map(flat_terrain(water));
+        Self {
+            sim,
+            rules,
+            grid: PathGrid::test_all_passable(MAP, MAP),
+            heights: BTreeMap::new(),
+        }
+    }
+
+    fn spawn(&mut self, type_id: &str, rx: u16, ry: u16, facing: u8) -> u64 {
+        self.sim
+            .spawn_object(type_id, OWNER, rx, ry, facing, &self.rules, &self.heights)
+            .unwrap_or_else(|| panic!("spawn {type_id}"))
+    }
+
+    /// Board `count` conscripts in spawn order (native `AddPassenger` prepends,
+    /// so the last of these sits at the cargo head).
+    fn board(&mut self, transport: u64, count: usize) -> Vec<u64> {
+        let (trx, try_) = {
+            let t = self
+                .sim
+                .substrate
+                .entities
+                .get(transport)
+                .expect("transport");
+            (t.position.rx, t.position.ry)
+        };
+        let mut ids = Vec::new();
+        for i in 0..count {
+            let pax = self.spawn("E1", trx + 2 + i as u16, try_ + 2, 0);
+            assert_eq!(
+                self.sim.techno_limbo_with_rules(pax, &self.rules),
+                ConcealOutcome::Concealed
+            );
+            let boarded = self
+                .sim
+                .substrate
+                .entities
+                .get_mut(transport)
+                .and_then(|t| t.passenger_role.cargo_mut())
+                .is_some_and(|cargo| cargo.board(pax, 1));
+            assert!(boarded, "cargo accepts passenger {i}");
+            self.sim
+                .substrate
+                .entities
+                .get_mut(pax)
+                .expect("passenger")
+                .passenger_role = PassengerRole::Inside {
+                transport_id: transport,
+            };
+            ids.push(pax);
+        }
+        ids
+    }
+
+    fn apply(&mut self, cmd: Command) -> bool {
+        self.sim.apply_command(
+            OWNER,
+            &cmd,
+            Some(&self.rules),
+            Some(&self.grid),
+            &self.heights,
+        )
+    }
+
+    fn tick(&mut self) {
+        let _ = self.sim.advance_tick(
+            &[],
+            Some(&self.rules),
+            &self.heights,
+            Some(&self.grid),
+            None,
+            66,
+        );
+    }
+
+    fn frame(&self) -> u32 {
+        self.sim.session.binary_frame
+    }
+
+    fn revealed(&self, id: u64) -> bool {
+        self.sim
+            .substrate
+            .entities
+            .get(id)
+            .is_some_and(|e| !e.lifecycle.in_limbo)
+    }
+
+    fn cargo_ids(&self, transport: u64) -> Vec<u64> {
+        self.sim
+            .substrate
+            .entities
+            .get(transport)
+            .and_then(|t| t.passenger_role.cargo())
+            .map(|c| c.passengers.clone())
+            .unwrap_or_default()
+    }
+
+    fn mission(&self, id: u64) -> MissionId {
+        self.sim
+            .substrate
+            .entities
+            .get(id)
+            .expect("entity")
+            .mission
+            .current()
+    }
+
+    /// The queued slot (`MissionClass +0xB4`): `Queue_Mission` writes here and
+    /// `effective()` keeps reporting the current mission until `Commence`.
+    fn mission_queued(&self, id: u64) -> MissionId {
+        self.sim
+            .substrate
+            .entities
+            .get(id)
+            .expect("entity")
+            .mission
+            .queued()
+    }
+
+    fn facing(&self, id: u64) -> u8 {
+        self.sim.substrate.entities.get(id).expect("entity").facing
+    }
+
+    fn cell(&self, id: u64) -> (u16, u16) {
+        let e = self.sim.substrate.entities.get(id).expect("entity");
+        (e.position.rx, e.position.ry)
+    }
+
+    /// Tick until every id is revealed, recording the frame each surfaced and
+    /// the mission it held at that moment.
+    fn run_until_revealed(&mut self, ids: &[u64], max_ticks: usize) -> Vec<(u64, u32)> {
+        self.run_until_revealed_with_missions(ids, max_ticks)
+            .into_iter()
+            .map(|(id, frame, _)| (id, frame))
+            .collect()
+    }
+
+    fn run_until_revealed_with_missions(
+        &mut self,
+        ids: &[u64],
+        max_ticks: usize,
+    ) -> Vec<(u64, u32, MissionId)> {
+        let mut order = Vec::new();
+        for _ in 0..max_ticks {
+            self.tick();
+            for &id in ids {
+                if self.revealed(id) && !order.iter().any(|(seen, _, _)| *seen == id) {
+                    let mission = self
+                        .sim
+                        .substrate
+                        .entities
+                        .get(id)
+                        .expect("passenger")
+                        .mission
+                        .effective();
+                    order.push((id, self.frame(), mission));
+                }
+            }
+            if order.len() == ids.len() {
+                break;
+            }
+        }
+        order
+    }
+}
+
+/// Five conscripts in a BFRT: the hull turns first, then one passenger leaves
+/// per `[Unload] Rate` dispatch (14..16 frames apart), last boarded first.
+#[test]
+fn bfrt_unloads_one_per_dispatch_in_reverse_boarding_order_after_turning() {
+    let mut fx = Fixture::new(|_, _| false);
+    let bfrt = fx.spawn("BFRT", 20, 20, 0);
+    let pax = fx.board(bfrt, 5);
+    assert_eq!(
+        fx.cargo_ids(bfrt),
+        pax.iter().rev().copied().collect::<Vec<_>>()
+    );
+
+    assert!(fx.apply(Command::UnloadPassengers { transport_id: bfrt }));
+
+    let order = fx.run_until_revealed_with_missions(&pax, 200);
+    let ids: Vec<u64> = order.iter().map(|(id, _, _)| *id).collect();
+    assert_eq!(
+        ids,
+        pax.iter().rev().copied().collect::<Vec<_>>(),
+        "cargo head (last boarded) leaves first"
+    );
+    // Facing 0 (N): the scorer picks octant 5 (SW), so the transport faces
+    // octant 1 (NE, 0x20) with its rear to the exit cell before ejecting.
+    assert_eq!(
+        fx.facing(bfrt),
+        0x20,
+        "hull turned to put its rear to the exit"
+    );
+    for pair in order.windows(2) {
+        let gap = pair[1].1 - pair[0].1;
+        assert!(
+            (14..=16).contains(&gap),
+            "one passenger per [Unload] Rate dispatch: gap {gap} frames"
+        );
+    }
+    // Turn (0x20 at ROT=5 → 6 frames) plus at least one turning dispatch
+    // precede the first ejection.
+    assert!(order[0].1 >= 8, "first ejection at frame {}", order[0].1);
+    // Each ejected passenger surfaced holding `Queue_Mission(Move)`.
+    for (id, _, mission) in &order {
+        assert_eq!(
+            *mission,
+            MissionId::from_known(MissionType::Move),
+            "passenger {id} left on Move"
+        );
+    }
+    let leave_sounds = fx
+        .sim
+        .sound_events
+        .iter()
+        .filter(|e| matches!(e, SimSoundEvent::LeaveTransport { rx: 20, ry: 20, .. }))
+        .count();
+    assert!(leave_sounds >= 1, "LeaveTransportSound at the transport");
+
+    for _ in 0..40 {
+        fx.tick();
+    }
+    assert_eq!(fx.mission(bfrt), MissionId::from_known(MissionType::Guard));
+    assert!(fx.cargo_ids(bfrt).is_empty());
+}
+
+/// `TurretCount > 0`: `+0x6E4 = (cargo == 1 ? 0 : 1)` — the IFV keeps its
+/// last passenger (the first boarded, at the cargo tail).
+#[test]
+fn turreted_transport_keeps_its_last_passenger() {
+    let mut fx = Fixture::new(|_, _| false);
+    let fv = fx.spawn("FV", 20, 20, 0);
+    let pax = fx.board(fv, 3);
+    assert!(fx.apply(Command::UnloadPassengers { transport_id: fv }));
+    for _ in 0..120 {
+        fx.tick();
+    }
+    assert_eq!(fx.cargo_ids(fv), vec![pax[0]], "first boarded stays aboard");
+    assert!(fx.revealed(pax[1]) && fx.revealed(pax[2]));
+    assert_eq!(fx.mission(fv), MissionId::from_known(MissionType::Guard));
+
+    // Exactly one aboard: keep-count 0, it unloads.
+    let mut fx = Fixture::new(|_, _| false);
+    let fv = fx.spawn("FV", 20, 20, 0);
+    let pax = fx.board(fv, 1);
+    assert!(fx.apply(Command::UnloadPassengers { transport_id: fv }));
+    for _ in 0..80 {
+        fx.tick();
+    }
+    assert!(fx.revealed(pax[0]));
+    assert!(fx.cargo_ids(fv).is_empty());
+}
+
+/// A hover landing craft on water drives to land first (`LandType == 2` and
+/// no NavCom → `Find_Nearby_Passable_Cell` + `Set_Destination`, `return 10`),
+/// then unloads onto land.
+#[test]
+fn hover_transport_on_water_moves_to_shore_before_unloading() {
+    let mut fx = Fixture::new(|rx, _| rx < 25);
+    let lcrf = fx.spawn("LCRF", 20, 20, 0x40);
+    let pax = fx.board(lcrf, 2);
+    assert!(fx.apply(Command::UnloadPassengers { transport_id: lcrf }));
+
+    for _ in 0..3 {
+        fx.tick();
+    }
+    let moving = fx
+        .sim
+        .substrate
+        .entities
+        .get(lcrf)
+        .is_some_and(|e| e.movement_target.is_some() || e.navigation.nav_com.is_some());
+    assert!(moving, "the landing craft is driven toward land first");
+    assert_eq!(
+        fx.cargo_ids(lcrf).len(),
+        2,
+        "nobody is dropped into the water"
+    );
+
+    let order = fx.run_until_revealed(&pax, 600);
+    assert_eq!(order.len(), 2, "both passengers landed: {order:?}");
+    let (trx, _) = fx.cell(lcrf);
+    assert!(
+        trx >= 25,
+        "transport reached land before unloading (x={trx})"
+    );
+    for &id in &pax {
+        let (rx, _) = fx.cell(id);
+        assert!(rx >= 25, "passenger {id} placed on land (x={rx})");
+    }
+}
+
+/// A Move order re-assigns the mission and interrupts the unload.
+#[test]
+fn move_order_cancels_a_running_unload() {
+    let mut fx = Fixture::new(|_, _| false);
+    let bfrt = fx.spawn("BFRT", 20, 20, 0);
+    let pax = fx.board(bfrt, 5);
+    assert!(fx.apply(Command::UnloadPassengers { transport_id: bfrt }));
+    let mut out = 0usize;
+    for _ in 0..60 {
+        fx.tick();
+        out = pax.iter().filter(|&&id| fx.revealed(id)).count();
+        if out >= 2 {
+            break;
+        }
+    }
+    assert!(out >= 2 && out < 5, "unload in progress ({out} out)");
+
+    assert!(fx.apply(Command::Move {
+        entity_id: bfrt,
+        target_rx: 30,
+        target_ry: 30,
+        queue: false,
+        group_id: None,
+    }));
+    for _ in 0..80 {
+        fx.tick();
+    }
+    let now_out = pax.iter().filter(|&&id| fx.revealed(id)).count();
+    assert_eq!(
+        now_out, out,
+        "no further passenger leaves after the Move order"
+    );
+    assert_eq!(fx.cargo_ids(bfrt).len(), 5 - out);
+    assert_ne!(fx.mission(bfrt), MissionId::from_known(MissionType::Unload));
+}
+
+/// The Aircraft Unload slot ejects only once `GetHeight() == 0 && altitude ==
+/// 0.0`; an airborne Nighthawk holds its cargo.
+#[test]
+fn nighthawk_unloads_only_when_landed() {
+    let mut fx = Fixture::new(|_, _| false);
+    let shad = fx.spawn("SHAD", 20, 20, 0);
+    let pax = fx.board(shad, 2);
+    {
+        let loco = fx
+            .sim
+            .substrate
+            .entities
+            .get_mut(shad)
+            .expect("aircraft")
+            .locomotor
+            .as_mut()
+            .expect("locomotor");
+        loco.altitude = SimFixed::from_num(600);
+    }
+    assert!(fx.apply(Command::UnloadPassengers { transport_id: shad }));
+    assert_eq!(fx.mission(shad), MissionId::from_known(MissionType::Unload));
+    for _ in 0..30 {
+        {
+            let loco = fx
+                .sim
+                .substrate
+                .entities
+                .get_mut(shad)
+                .expect("aircraft")
+                .locomotor
+                .as_mut()
+                .expect("locomotor");
+            loco.altitude = SimFixed::from_num(600);
+        }
+        super::dispatch_aircraft_unload(&mut fx.sim, shad, &fx.rules, Some(&fx.grid), None);
+        fx.sim.session.binary_frame += 1;
+    }
+    assert_eq!(fx.cargo_ids(shad).len(), 2, "airborne: nothing leaves");
+
+    {
+        let loco = fx
+            .sim
+            .substrate
+            .entities
+            .get_mut(shad)
+            .expect("aircraft")
+            .locomotor
+            .as_mut()
+            .expect("locomotor");
+        loco.altitude = SIM_ZERO;
+    }
+    let mut frames = Vec::new();
+    for _ in 0..80 {
+        super::dispatch_aircraft_unload(&mut fx.sim, shad, &fx.rules, Some(&fx.grid), None);
+        fx.sim.session.binary_frame += 1;
+        for &id in &pax {
+            if fx.revealed(id) && !frames.iter().any(|(seen, _)| *seen == id) {
+                frames.push((id, fx.frame()));
+            }
+        }
+    }
+    assert_eq!(
+        frames.len(),
+        2,
+        "landed: both passengers leave ({frames:?})"
+    );
+    assert_eq!(frames[0].0, pax[1], "cargo head first");
+    let gap = frames[1].1 - frames[0].1;
+    assert!((14..=16).contains(&gap), "one per [Unload] dispatch: {gap}");
+    for &id in &pax {
+        assert_eq!(fx.cell(id), (20, 20), "placed at the aircraft's cell");
+    }
+    assert!(fx.cargo_ids(shad).is_empty());
+}
+
+/// `0x00415B10`: five conscripts leave a landed Nighthawk one per `[Unload]`
+/// dispatch, each `Unlimbo`ed at the aircraft's own cell and sent on a Move
+/// to the first table-order neighbour (`DAT_00817A58`: S, SW, SE, NW, NE, N,
+/// W, E) its `IsCellOccupied` accepted; the aircraft ends up in Guard.
+/// Native gives no distinctness guarantee across passengers — the scan
+/// restarts at S every time — so the assertion is membership in the eight
+/// neighbours plus the table's first entry for the first passenger.
+#[test]
+fn nighthawk_ejects_five_passengers_to_scanned_neighbours() {
+    let mut fx = Fixture::new(|_, _| false);
+    let shad = fx.spawn("SHAD", 20, 20, 0);
+    let pax = fx.board(shad, 5);
+    {
+        let loco = fx
+            .sim
+            .substrate
+            .entities
+            .get_mut(shad)
+            .expect("aircraft")
+            .locomotor
+            .as_mut()
+            .expect("locomotor");
+        loco.altitude = SIM_ZERO;
+    }
+    assert!(fx.apply(Command::UnloadPassengers { transport_id: shad }));
+
+    // (id, reveal frame, mission, destination) captured the tick each surfaces.
+    let mut out: Vec<(u64, u32, MissionId, Option<(u16, u16)>)> = Vec::new();
+    for _ in 0..200 {
+        fx.tick();
+        for &id in &pax {
+            if fx.revealed(id) && !out.iter().any(|(seen, ..)| *seen == id) {
+                let e = fx.sim.substrate.entities.get(id).expect("passenger");
+                let dest = e
+                    .movement_target
+                    .as_ref()
+                    .and_then(|t| t.path.last().copied())
+                    .or(match e.navigation.nav_com {
+                        Some(crate::sim::components::NavTargetRef::Cell { rx, ry }) => {
+                            Some((rx, ry))
+                        }
+                        _ => None,
+                    });
+                out.push((id, fx.frame(), e.mission.effective(), dest));
+            }
+        }
+        if out.len() == pax.len() {
+            break;
+        }
+    }
+    assert_eq!(out.len(), 5, "all five passengers ejected: {out:?}");
+    assert_eq!(
+        out.iter().map(|(id, ..)| *id).collect::<Vec<_>>(),
+        pax.iter().rev().copied().collect::<Vec<_>>(),
+        "cargo head first"
+    );
+    for pair in out.windows(2) {
+        let gap = pair[1].1 - pair[0].1;
+        assert!(
+            (14..=16).contains(&gap),
+            "one per [Unload] dispatch: gap {gap} ({out:?})"
+        );
+    }
+    let neighbours: Vec<(u16, u16)> = super::OCTANT_OFFSETS
+        .iter()
+        .map(|(dx, dy)| ((20 + dx) as u16, (20 + dy) as u16))
+        .collect();
+    for (id, _, mission, dest) in &out {
+        assert_eq!(
+            *mission,
+            MissionId::from_known(MissionType::Move),
+            "passenger {id} left on Queue_Mission(Move)"
+        );
+        let dest = dest.unwrap_or_else(|| panic!("passenger {id} has a Move destination"));
+        assert!(
+            neighbours.contains(&dest),
+            "passenger {id} sent to a neighbour of the aircraft cell, got {dest:?}"
+        );
+    }
+    // Table order starts at S (octant 4): an empty map sends the first
+    // passenger south.
+    assert_eq!(out[0].3, Some((20, 21)), "first passenger scanned S first");
+
+    for _ in 0..40 {
+        fx.tick();
+    }
+    assert!(fx.cargo_ids(shad).is_empty());
+    assert_eq!(fx.mission(shad), MissionId::from_known(MissionType::Guard));
+}
+
+/// The failure tail (`0x0073DC71`..`0x0073DC96`): a Gunner IFV whose only
+/// passenger cannot leave (every neighbour carries the structural bridge
+/// flag the state-3 scan skips at `0x0073D9EB`) re-adds the passenger and
+/// re-applies the gunner weapon through `+0x4D4`, so the weapon override
+/// the pop's `+0x4D8` cleared is back after every refused dispatch.
+#[test]
+fn ifv_keeps_gunner_weapon_when_every_exit_is_refused() {
+    use crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL;
+    use crate::sim::combat::combat_weapon::WeaponOverride;
+
+    let mut fx = Fixture::new(|_, _| false);
+    {
+        let terrain = fx.sim.resolved_terrain.as_mut().expect("terrain");
+        for (dx, dy) in super::OCTANT_OFFSETS {
+            let cell = terrain
+                .cell_mut((20 + dx) as u16, (20 + dy) as u16)
+                .expect("neighbour cell");
+            cell.bridge_facts.raw_flags |= BRIDGE_FLAG_STRUCTURAL;
+        }
+    }
+    let fv = fx.spawn("FV", 20, 20, 0);
+    let pax = fx.board(fv, 1);
+    fx.sim
+        .substrate
+        .entities
+        .get_mut(fv)
+        .expect("ifv")
+        .weapon_override = Some(WeaponOverride::IfvSlot(1));
+    assert!(fx.apply(Command::UnloadPassengers { transport_id: fv }));
+
+    let mut reached_eject = false;
+    for _ in 0..120 {
+        fx.tick();
+        let e = fx.sim.substrate.entities.get(fv).expect("ifv");
+        if e.mission.current() == MissionId::from_known(MissionType::Unload)
+            && e.mission.handler_state() == super::STATE_EJECT
+        {
+            reached_eject = true;
+        }
+        assert_eq!(
+            e.weapon_override,
+            Some(WeaponOverride::IfvSlot(1)),
+            "gunner weapon retained across a refused ejection"
+        );
+    }
+    assert!(reached_eject, "the handler reached state 3");
+    assert!(!fx.revealed(pax[0]), "nobody left");
+    assert_eq!(fx.cargo_ids(fv), vec![pax[0]]);
+}
+
+/// The relaxed pass with a vehicle passenger: every cell two steps out is
+/// water, so no octant satisfies the strict "adjacent AND beyond" pair and
+/// the restart at `i = 1` (`0x0073DA15`..`0x0073DA27`) accepts octant
+/// `start + 1` alone. The passenger is placed on the
+/// `Find_Nearby_Passable_Cell` result seeded at that exit cell (`0x0073DADD`,
+/// stored over `[ESP+0x14]` at `0x0073DAE8`) and `Set_Destination` receives
+/// the same slot (`0x0073DBF4`), not the cell beyond.
+#[test]
+fn relaxed_pass_drives_vehicle_passenger_to_the_fnpc_cell() {
+    let ring_two = |x: u16, y: u16| (i32::from(x) - 20).abs().max((i32::from(y) - 20).abs()) == 2;
+    let mut fx = Fixture::new(ring_two);
+    let bfrt = fx.spawn("BFRT", 20, 20, 0);
+    let bggy = fx.spawn("BGGY", 24, 24, 0);
+    assert_eq!(
+        fx.sim.techno_limbo_with_rules(bggy, &fx.rules),
+        ConcealOutcome::Concealed
+    );
+    let boarded = fx
+        .sim
+        .substrate
+        .entities
+        .get_mut(bfrt)
+        .and_then(|t| t.passenger_role.cargo_mut())
+        .is_some_and(|cargo| cargo.board(bggy, 1));
+    assert!(boarded, "cargo accepts the vehicle");
+    fx.sim
+        .substrate
+        .entities
+        .get_mut(bggy)
+        .expect("passenger")
+        .passenger_role = PassengerRole::Inside { transport_id: bfrt };
+    // Facing 0: state 0 picks octant 5 (SW) and turns the hull to NE (0x20),
+    // so the state-3 scan starts at octant 5; the strict pass fails
+    // everywhere (ring two is water) and the relaxed restart accepts octant
+    // 6 (W), exit cell (19, 20). The FNPC expectation is taken now, with the
+    // passenger still in limbo, exactly as the handler sees it.
+    let exit = (19u16, 20u16);
+    let expected = {
+        let pax = fx.sim.substrate.entities.get(bggy).expect("passenger");
+        super::find_nearby_passable_for(&fx.sim, &fx.rules, Some(&fx.grid), pax, exit, None)
+            .expect("FNPC result")
+    };
+    assert!(fx.apply(Command::UnloadPassengers { transport_id: bfrt }));
+
+    let order = fx.run_until_revealed_with_missions(&[bggy], 200);
+    assert_eq!(order.len(), 1, "the vehicle left: {order:?}");
+    assert_eq!(order[0].2, MissionId::from_known(MissionType::Move));
+    assert_eq!(fx.facing(bfrt), 0x20);
+    assert_eq!(fx.cell(bggy), expected, "placed on the FNPC cell");
+    assert_eq!(fx.facing(bggy), 0xC0, "octant 6 * 32");
+    let e = fx.sim.substrate.entities.get(bggy).expect("passenger");
+    let dest = e
+        .movement_target
+        .as_ref()
+        .and_then(|t| t.path.last().copied())
+        .or(match e.navigation.nav_com {
+            Some(crate::sim::components::NavTargetRef::Cell { rx, ry }) => Some((rx, ry)),
+            _ => None,
+        });
+    assert_ne!(
+        dest,
+        Some((18, 20)),
+        "relaxed pass never targets the cell beyond"
+    );
+    assert!(
+        dest.is_none_or(|d| d == expected),
+        "Set_Destination got the FNPC slot, not the exit/beyond cell: {dest:?}"
+    );
+}
+
+fn set_altitude(fx: &mut Fixture, id: u64, altitude: i32) {
+    let loco = fx
+        .sim
+        .substrate
+        .entities
+        .get_mut(id)
+        .expect("aircraft")
+        .locomotor
+        .as_mut()
+        .expect("locomotor");
+    loco.altitude = SimFixed::from_num(altitude);
+}
+
+fn handler_state(fx: &Fixture, id: u64) -> u32 {
+    fx.sim
+        .substrate
+        .entities
+        .get(id)
+        .expect("entity")
+        .mission
+        .handler_state()
+}
+
+/// Team-less state graph of `0x004151E0`: a flying Nighthawk ordered to
+/// unload takes state 0 → 2 (`0x0041530C`, one epilogue draw at
+/// `0x0041525A`), then state 2 polls with `return 1` (`0x004154B1`) and draws
+/// NO Scenario RNG while it descends; once landed it moves to state 3
+/// (`0x004154A4`, still no draw) and the ejection dispatch draws again.
+#[test]
+fn descending_nighthawk_draws_no_scenario_rng_until_it_ejects() {
+    let mut fx = Fixture::new(|_, _| false);
+    let shad = fx.spawn("SHAD", 20, 20, 0);
+    let pax = fx.board(shad, 2);
+    set_altitude(&mut fx, shad, 600);
+    assert!(fx.apply(Command::UnloadPassengers { transport_id: shad }));
+
+    // First dispatch: state 0 → 2 with exactly one epilogue draw.
+    let before = fx.sim.scenario_rng.state();
+    super::dispatch_aircraft_unload(&mut fx.sim, shad, &fx.rules, Some(&fx.grid), None);
+    fx.sim.session.binary_frame += 1;
+    assert_eq!(handler_state(&fx, shad), super::AIR_STATE_WAIT_STOP);
+    assert_ne!(
+        fx.sim.scenario_rng.state(),
+        before,
+        "state-0 epilogue draws once"
+    );
+
+    // Descend 20 leptons per frame: 30 airborne dispatches, zero draws.
+    let mut altitude = 600;
+    let mut airborne_draws = 0;
+    while altitude > 0 {
+        altitude -= 20;
+        set_altitude(&mut fx, shad, altitude);
+        let before = fx.sim.scenario_rng.state();
+        super::dispatch_aircraft_unload(&mut fx.sim, shad, &fx.rules, Some(&fx.grid), None);
+        fx.sim.session.binary_frame += 1;
+        if fx.sim.scenario_rng.state() != before {
+            airborne_draws += 1;
+        }
+        if altitude > 0 {
+            assert_eq!(handler_state(&fx, shad), super::AIR_STATE_WAIT_STOP);
+            assert_eq!(fx.cargo_ids(shad).len(), 2, "nothing leaves mid-air");
+        }
+    }
+    assert_eq!(airborne_draws, 0, "state 2 polls without an epilogue draw");
+    // The landed poll moved to state 3 with `return 1`: the next frame ejects.
+    assert_eq!(handler_state(&fx, shad), super::AIR_STATE_EJECT);
+    assert_eq!(fx.cargo_ids(shad).len(), 2);
+    let before = fx.sim.scenario_rng.state();
+    super::dispatch_aircraft_unload(&mut fx.sim, shad, &fx.rules, Some(&fx.grid), None);
+    assert!(
+        fx.revealed(pax[1]),
+        "cargo head ejected on the state-3 dispatch"
+    );
+    assert_ne!(
+        fx.sim.scenario_rng.state(),
+        before,
+        "state-3 epilogue draws"
+    );
+}
+
+/// VERA-internal bounded escape (native `0x00415511`/`0x0041553E` loses the
+/// passenger): with the aircraft cell already holding three infantry, the
+/// first ejection fails, the passenger stays in the hold, the aircraft leaves
+/// Unload for Guard, and the handler draws nothing more.
+#[test]
+fn nighthawk_failed_ejection_keeps_cargo_and_leaves_for_guard() {
+    let mut fx = Fixture::new(|_, _| false);
+    let blockers: Vec<u64> = (0..3).map(|_| fx.spawn("E1", 20, 20, 0)).collect();
+    let spots: Vec<Option<u8>> = blockers
+        .iter()
+        .map(|&id| fx.sim.substrate.entities.get(id).expect("blocker").sub_cell)
+        .collect();
+    assert_eq!(
+        spots.iter().flatten().count(),
+        3,
+        "three functional sub-cells taken: {spots:?}"
+    );
+    let shad = fx.spawn("SHAD", 20, 20, 0);
+    let pax = fx.board(shad, 2);
+    // LIFO hold: the last boarder is the head (`AddPassenger @ 0x004733A0`
+    // prepends). The refused ejection must leave exactly this order.
+    let held = fx.cargo_ids(shad);
+    assert_eq!(held, pax.iter().rev().copied().collect::<Vec<_>>());
+    set_altitude(&mut fx, shad, 0);
+    assert!(fx.apply(Command::UnloadPassengers { transport_id: shad }));
+
+    // State 0 → 3 (landed, team-less), one draw.
+    super::dispatch_aircraft_unload(&mut fx.sim, shad, &fx.rules, Some(&fx.grid), None);
+    assert_eq!(handler_state(&fx, shad), super::AIR_STATE_EJECT);
+    // Advance to the state-3 dispatch: the ejection is refused.
+    for _ in 0..20 {
+        fx.sim.session.binary_frame += 1;
+        super::dispatch_aircraft_unload(&mut fx.sim, shad, &fx.rules, Some(&fx.grid), None);
+        if fx.mission_queued(shad) == MissionId::from_known(MissionType::Guard) {
+            break;
+        }
+    }
+    assert_eq!(
+        fx.mission_queued(shad),
+        MissionId::from_known(MissionType::Guard),
+        "one failed attempt queues Guard"
+    );
+    assert_eq!(
+        fx.cargo_ids(shad),
+        held,
+        "hold order retained after the refusal"
+    );
+    assert!(
+        pax.iter().all(|&id| !fx.revealed(id)),
+        "nobody left the hold"
+    );
+
+    // Let the queued Guard commence, then prove the handler stays silent.
+    for _ in 0..30 {
+        fx.tick();
+        if fx.mission(shad) == MissionId::from_known(MissionType::Guard) {
+            break;
+        }
+    }
+    assert_eq!(fx.mission(shad), MissionId::from_known(MissionType::Guard));
+    let before = fx.sim.scenario_rng.state();
+    for _ in 0..60 {
+        fx.sim.session.binary_frame += 1;
+        super::dispatch_aircraft_unload(&mut fx.sim, shad, &fx.rules, Some(&fx.grid), None);
+    }
+    assert_eq!(
+        fx.sim.scenario_rng.state(),
+        before,
+        "no further Unload draws"
+    );
+    assert_eq!(fx.cargo_ids(shad), held, "cargo still retained");
+}

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -2348,7 +2348,9 @@ fn lifecycle_authority_transport_uninits_passengers_in_cargo_order_before_carrie
     sim.lifecycle_test_events.clear();
 
     sim.uninit(1);
-    assert_eq!(sim.substrate.pending_delete, vec![2, 3, 1]);
+    // Cargo list order is head-first: `CargoClass::AddPassenger @ 0x004733A0`
+    // prepends, so the passenger boarded last (3) is walked first.
+    assert_eq!(sim.substrate.pending_delete, vec![3, 2, 1]);
     let notify_order = sim
         .lifecycle_test_events
         .iter()
@@ -2357,7 +2359,7 @@ fn lifecycle_authority_transport_uninits_passengers_in_cargo_order_before_carrie
             _ => None,
         })
         .collect::<Vec<_>>();
-    assert_eq!(notify_order, vec![2, 3, 1]);
+    assert_eq!(notify_order, vec![3, 2, 1]);
     assert!(matches!(
         sim.substrate.entities.get(2).unwrap().passenger_role,
         PassengerRole::None

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -294,6 +294,15 @@ pub enum SimSoundEvent {
         rx: u16,
         ry: u16,
     },
+    /// A transport placed an ejected passenger — `UnitClass::Mission_Unload @
+    /// 0x0073D630` plays the transport type's `LeaveTransportSound=`
+    /// (`+0x568`) through `VocClass::PlayAtCoord` at the TRANSPORT's own
+    /// coordinate (`0x0073DC28`..`0x0073DC67`), once per placed passenger.
+    LeaveTransport {
+        sound_id: InternedId,
+        rx: u16,
+        ry: u16,
+    },
     /// A miner docked at a refinery — play the building's deploy sound.
     /// The app layer should select the healthy or damaged sound variant
     /// based on the refinery's health ratio vs ConditionYellow.

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -554,6 +554,17 @@ fn techno_ai_shell(
             }
             drop_unsensed_cloaked_target_step(sim, id);
             mission_counter_step(sim, id);
+            // The Aircraft Unload slot `0x004151E0` (vtable `+0x23C`), the one
+            // aircraft mission handler absorbed so far; timer-gated inside.
+            if let Some(rules) = rules {
+                crate::sim::transport_unload::dispatch_aircraft_unload(
+                    sim,
+                    id,
+                    rules,
+                    ctx.path_grid,
+                    ctx.overlay_registry,
+                );
+            }
         }
     }
 }
@@ -1013,6 +1024,10 @@ fn unit_techno_bracket(
     if let Some(rules) = rules {
         dispatch_supported_foot_mission_cadence(sim, id, rules, ctx);
     }
+    // A transport turning in place for its Unload reads its hull
+    // `PrimaryFacing.Current()` every frame; the movement tick only turns
+    // objects that hold a movement target, so the idle turn is advanced here.
+    crate::sim::transport_unload::refresh_idle_hull_turn(sim, id);
     // Passive / opportunity target acquisition sits between mission dispatch
     // and the second IsAlive guard, before the object's own locomotion.
     passive_acquire_step(sim, id, rules, ctx);

--- a/src/sim/world/techno_ai/mission_handlers.rs
+++ b/src/sim/world/techno_ai/mission_handlers.rs
@@ -378,6 +378,26 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
                 queue,
             }
         }
+        // The transport branch of `UnitClass::Mission_Unload @ 0x0073D630`
+        // (`Type+0x5E0 Passengers > 0`, gate `0x0073D6EC`). The handler owns
+        // its side effects and every return value — the `return 10` / `return
+        // 1` early exits and the `[Unload] Rate + RandomRanged(0, 2)`
+        // epilogue — so it is committed as a plain cadence here. The refinery
+        // (`Harvester=`), `DeploysInto=` and `IsSimpleDeployer=` branches of
+        // the same slot are other lanes and fall through to the default arm.
+        (EntityCategory::Unit, Some(MissionType::Unload))
+            if sim.substrate.entities.get(id).is_some_and(|entity| {
+                crate::sim::transport_unload::is_vehicle_transport_type(sim, entity, rules)
+            }) =>
+        {
+            MissionHandlerEvaluation::cadence(crate::sim::transport_unload::unit_mission_unload(
+                sim,
+                rules,
+                ctx.path_grid,
+                ctx.overlay_registry,
+                id,
+            ))
+        }
         (EntityCategory::Unit, Some(MissionType::Guard)) => {
             // **VERA-internal, gamemd equivalent UNCHECKED — this mapping is
             // wrong and the arm is dead.** The "three byte latches, then

--- a/src/sim/world/world_commands.rs
+++ b/src/sim/world/world_commands.rs
@@ -1780,10 +1780,58 @@ impl Simulation {
                 if !has_passengers {
                     return false;
                 }
-                if let Some(e) = self.substrate.entities.get_mut(*transport_id) {
-                    e.order_intent = Some(OrderIntent::Unloading);
+                let category = self
+                    .substrate
+                    .entities
+                    .get(*transport_id)
+                    .map(|t| t.category);
+                match category {
+                    Some(crate::map::entities::EntityCategory::Structure) => {
+                        // Garrison eviction stays on the per-tick order path.
+                        if let Some(e) = self.substrate.entities.get_mut(*transport_id) {
+                            e.order_intent = Some(OrderIntent::Unloading);
+                        }
+                        true
+                    }
+                    Some(crate::map::entities::EntityCategory::Unit)
+                    | Some(crate::map::entities::EntityCategory::Aircraft) => {
+                        // Vehicle/aircraft transports unload through the Unload
+                        // mission (`UnitClass::Mission_Unload @ 0x0073D630`
+                        // transport branch; Aircraft slot `0x004151E0`).
+                        let Some(rules) = rules else { return false };
+                        let is_transport = self
+                            .substrate
+                            .entities
+                            .get(*transport_id)
+                            .and_then(|t| self.object_type(t.type_ref, rules))
+                            .is_some_and(|obj| obj.passengers > 0);
+                        if !is_transport || !self.order_actor_admits(*transport_id) {
+                            return false;
+                        }
+                        if category == Some(crate::map::entities::EntityCategory::Aircraft) {
+                            // Aircraft readiness has no live transition-latch
+                            // producer, so a queued mission would never
+                            // promote; commit through Assign.
+                            let now = self.session.binary_frame;
+                            let _ = self.mission_assign_exact(
+                                *transport_id,
+                                crate::sim::mission::MissionId::from_known(MissionType::Unload),
+                                now,
+                            );
+                        } else {
+                            self.queue_megamission_with_teardown(
+                                *transport_id,
+                                MissionType::Unload,
+                                DockTeardown::All,
+                            );
+                        }
+                        if let Some(e) = self.substrate.entities.get_mut(*transport_id) {
+                            e.order_intent = None;
+                        }
+                        true
+                    }
+                    _ => false,
                 }
-                true
             }
             Command::HarvestCell {
                 entity_id,

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -1808,6 +1808,13 @@ impl Simulation {
                         passenger_size.hash(hasher);
                     }
                     cargo.total_size.hash(hasher);
+                    // `UnitClass+0x6E4` keep-count, written only by a
+                    // transport's own Unload state 0. Folded only when set so
+                    // objects that never unloaded (every pinned harness
+                    // object) keep their v-schema bytes.
+                    if entity.transport_unload_keep_count != 0 {
+                        entity.transport_unload_keep_count.hash(hasher);
+                    }
                 }
                 crate::sim::passenger::PassengerRole::Boarding {
                     target_transport_id,


### PR DESCRIPTION
Transports can now be unloaded. `UnitClass::Mission_Unload` @ 0x0073D630 handles `Passengers > 0` units in four states: wait for the locomotor, drive a hover transport to land first, score the eight octants (vtable +0x304 → `FUN_00740B60`) and turn the rear to the exit (`Do_Turn` 0x0073D86C, table `DAT_008458D0` = (oct+4)&7), keep one passenger when `TurretCount > 0` (+0x6E4), then pop the cargo head (LIFO: `CargoClass::AddPassenger` @ 0x004733A0 prepends), scan from the rear in two passes, place by sub-cell or `Find_Nearby_Passable_Cell` (relaxed-pass destination = that result), `Unlimbo(coord, oct×32)`, Move + destination, `LeaveTransportSound`, one Scenario `RandomRanged(0,2)` per epilogue (0x0073E2B0), Guard on completion. The Aircraft Unload slot 0x004151E0 sends a team-less Nighthawk to state 2 until landed and still (no draw), then ejects each passenger via 0x00415B10 (fixed table [4,5,3,7,1,0,6,2], Unlimbo at the aircraft coordinate, Move to the scanned neighbour) and idles through `Enter_Idle_Mode` 0x004176F0.

Previous Rust could not unload a vehicle or aircraft at all (`UnloadPassengers` was emitted only for occupied structures; the dormant helper was per-tick, FIFO, RNG-scattered and silent). Player-visible: every APC/IFV/Flak Track/LCAC/Nighthawk unload.

Changes: deploy key and self-click commit Unload through the mission authority for vehicles and aircraft with cargo; new `transport_unload` module with the native state machines, LIFO cargo, scorer, two-pass scan, placement, Move hand-off, keep-count (hashed only when non-zero), aircraft ejector and idle exit; `LeaveTransportSound` parsed and raised as a sim→app event; Move order overrides the unload.

Residuals recorded in code: a refused aircraft ejection keeps the passenger and leaves for Guard (native loses the unit); +0x418 early-out, team arms, IsTrain, carryall and aircraft Gunner re-apply not represented; VERA's jumpjet does not auto-land on Unload.

Four independent read-only critic rounds reviewed successive revisions against the bodies; the last two passed.

Validation:
- `cargo test -p vera20k --lib`: `test result: ok. 8380 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 16.65s`
