### PR TITLE
Speak the sidebar, placement, capture and outcome EVA lines

### DIFF
--- a/src/app/input/commands.rs
+++ b/src/app/input/commands.rs
@@ -374,6 +374,16 @@ pub(crate) fn place_ready_building_at_cursor(state: &mut AppState, type_id: &str
                     reason.label()
                 );
             }
+            // `DisplayClass::BandBox_LeftUp 0x004ABAAC/0x004ABABA`: a
+            // placement click whose pending building is not placeable
+            // (`+0x1180` clear, `BuildingClass 0x00452670` refused the cell)
+            // or not adjacent (`+0x1181` clear) goes to `0x004ABC76..
+            // 0x004ABC80 PlayEVA("EVA_CannotDeployHere", -1)` on the clicking
+            // machine, before any event is queued.
+            crate::app::input::dispatch::push_local_eva(
+                state,
+                crate::app::input::sidebar_eva::EVA_CANNOT_DEPLOY_HERE,
+            );
             return;
         }
     }

--- a/src/app/input/context_order.rs
+++ b/src/app/input/context_order.rs
@@ -515,6 +515,9 @@ pub(crate) fn try_queue_context_order_at_screen_point(
     // entry of the selection array speak.
     let mut speaker_id: Option<u64> = None;
     let selected_ids = selected_stable_ids_in_order(state);
+    // `EVA_NewRallyPointEstablished` is spoken by the click handler itself,
+    // after the sim borrow below ends.
+    let mut rally_announce = false;
 
     if let Some(rt) = state.match_state.sim_runtime.as_mut() {
         let resources = &rt.resources;
@@ -749,6 +752,25 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                     let struct_owner_id = sim.interner.get(&struct_own).unwrap_or(owner_id);
                     let producer_ids =
                         selected_rally_producer_ids(sim, &selected_ids, struct_owner_id);
+                    // `BuildingClass::SetRallyPoint 0x00443A2B..0x00443A69`,
+                    // called per selected factory with announce = 1 by the
+                    // map-click handlers `FUN_00443410` / `FUN_004436F0`:
+                    // after the rally `EventClass` is pushed, the
+                    // clicking machine speaks `EVA_NewRallyPointEstablished`
+                    // when the factory's owner is the local player
+                    // (`0x00443A3C CALL 0x0050B6F0`) and the type is neither
+                    // a `ConstructionYard=` nor a `ResourceDestination=`.
+                    // One `PlayEVA` per factory; VoxClass drops same-entry
+                    // duplicates, so one request per click is equivalent.
+                    rally_announce = struct_owner_id == owner_id && producer_ids.iter().any(|id| {
+                        sim.entities().get(*id).is_some_and(|entity| {
+                            Some(&resources.rules)
+                                .and_then(|r| r.object(sim.interner.resolve(entity.type_ref)))
+                                .is_some_and(
+                                    crate::app::match_runtime::eva_producers::rally_point_announces,
+                                )
+                        })
+                    });
                     queued.push(CommandEnvelope::new(
                         struct_owner_id,
                         execute_tick,
@@ -1300,6 +1322,12 @@ pub(crate) fn try_queue_context_order_at_screen_point(
     }
     if consumed_order_mode && state.match_state.input.queued_order_mode != OrderMode::Move {
         state.match_state.input.queued_order_mode = OrderMode::Move;
+    }
+    if rally_announce {
+        crate::app::input::dispatch::push_local_eva(
+            state,
+            crate::app::match_runtime::eva_producers::EVA_NEW_RALLY_POINT_ESTABLISHED,
+        );
     }
     finish_order(state, queued, speaker_id)
 }

--- a/src/app/input/dispatch.rs
+++ b/src/app/input/dispatch.rs
@@ -26,6 +26,7 @@ use crate::app::input::entity_pick::{
     map_entity_creation_order, pick_entity_at_point,
 };
 use crate::app::input::hotkeys::{HotkeyCommand, HotkeyFallback, HotkeyResolution};
+use crate::app::input::sidebar_eva;
 use crate::app::presentation::sidebar_render::current_sidebar_view;
 use crate::app::types::OrderMode;
 use crate::audio::events::GameSoundEvent;
@@ -154,14 +155,23 @@ pub(crate) fn tactical_mouse(state: &mut AppState, button: MouseButton, btn_stat
                     return;
                 }
                 if state.match_state.input.targeting_mode.is_some()
-                    || state.match_state.match_presentation.sidebar_gadget_state.repair_mode_on
-                    || state.match_state.match_presentation.sidebar_gadget_state.sell_mode_on
+                    || state
+                        .match_state
+                        .match_presentation
+                        .sidebar_gadget_state
+                        .repair_mode_on
+                    || state
+                        .match_state
+                        .match_presentation
+                        .sidebar_gadget_state
+                        .sell_mode_on
                 {
                     return; // suppress selection drag while a targeting / repair / sell mode is active
                 }
-                state
-                    .match_state.input.selection_state
-                    .begin_drag(state.match_state.input.cursor_x, state.match_state.input.cursor_y);
+                state.match_state.input.selection_state.begin_drag(
+                    state.match_state.input.cursor_x,
+                    state.match_state.input.cursor_y,
+                );
             } else {
                 // Case 0x202 gates the whole release on the same shared capture
                 // byte and does NOT test which button set it. With the byte
@@ -188,7 +198,8 @@ pub(crate) fn tactical_mouse(state: &mut AppState, button: MouseButton, btn_stat
                 // Only an active band box owns a clamped tactical endpoint.
                 // A pending press is still an ordinary click at the actual
                 // release point, including after sticky capture routing.
-                let release_point = if state.match_state.input.selection_state.is_band_box_active() {
+                let release_point = if state.match_state.input.selection_state.is_band_box_active()
+                {
                     let (tactical_width, tactical_height) =
                         crate::app::input::camera::tactical_viewport_size_px(
                             state.render_width(),
@@ -201,10 +212,15 @@ pub(crate) fn tactical_mouse(state: &mut AppState, button: MouseButton, btn_stat
                         tactical_height,
                     )
                 } else {
-                    (state.match_state.input.cursor_x, state.match_state.input.cursor_y)
+                    (
+                        state.match_state.input.cursor_x,
+                        state.match_state.input.cursor_y,
+                    )
                 };
                 let mut action: SelectAction = state
-                    .match_state.input.selection_state
+                    .match_state
+                    .input
+                    .selection_state
                     .end_drag(release_point.0, release_point.1);
                 // BandBox_LeftUp 0x004AB9B0 does not early-return when nothing
                 // was armed: with the band flag clear it falls straight through
@@ -258,9 +274,16 @@ pub(crate) fn tactical_mouse(state: &mut AppState, button: MouseButton, btn_stat
                 }
                 let mut queued_selection: Option<SelectionMutation> = None;
                 let mut held_type_select_batch = false;
-                if let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) {
+                if let Some(sim) = state
+                    .match_state
+                    .sim_runtime
+                    .as_ref()
+                    .map(|rt| &rt.simulation)
+                {
                     let screen_order =
-                        crate::app::presentation::instances::tactical_screen_entity_encounter_order(state);
+                        crate::app::presentation::instances::tactical_screen_entity_encounter_order(
+                            state,
+                        );
                     let current_selection = selected_stable_ids_in_order(state);
                     let map_order = map_entity_creation_order(sim.entities());
                     let held_type_select = type_select_held;
@@ -271,8 +294,10 @@ pub(crate) fn tactical_mouse(state: &mut AppState, button: MouseButton, btn_stat
                     };
                     match action {
                         SelectAction::Click(sx, sy) => {
-                            let world_x: f32 = sx / state.match_state.input.zoom_level + state.match_state.input.camera_x;
-                            let world_y: f32 = sy / state.match_state.input.zoom_level + state.match_state.input.camera_y;
+                            let world_x: f32 = sx / state.match_state.input.zoom_level
+                                + state.match_state.input.camera_x;
+                            let world_y: f32 = sy / state.match_state.input.zoom_level
+                                + state.match_state.input.camera_y;
                             let fog_ref = if state.match_state.sandbox_full_visibility {
                                 None
                             } else {
@@ -290,7 +315,12 @@ pub(crate) fn tactical_mouse(state: &mut AppState, button: MouseButton, btn_stat
                                     state.rules(),
                                     Some(&sim.houses),
                                     &state.height_map(),
-                                    Some(&state.match_state.match_presentation.tactical_bridge_inverse_map),
+                                    Some(
+                                        &state
+                                            .match_state
+                                            .match_presentation
+                                            .tactical_bridge_inverse_map,
+                                    ),
                                     Some(&sim.interner),
                                 );
                                 queued_selection = if let Some(clicked_id) = picked {
@@ -319,7 +349,12 @@ pub(crate) fn tactical_mouse(state: &mut AppState, button: MouseButton, btn_stat
                                         state.rules(),
                                         Some(&sim.houses),
                                         &state.height_map(),
-                                        Some(&state.match_state.match_presentation.tactical_bridge_inverse_map),
+                                        Some(
+                                            &state
+                                                .match_state
+                                                .match_presentation
+                                                .tactical_bridge_inverse_map,
+                                        ),
                                         Some(&sim.interner),
                                         sim.playfield_bounds.is_some(),
                                     )
@@ -339,7 +374,12 @@ pub(crate) fn tactical_mouse(state: &mut AppState, button: MouseButton, btn_stat
                                     state.rules(),
                                     Some(&sim.houses),
                                     &state.height_map(),
-                                    Some(&state.match_state.match_presentation.tactical_bridge_inverse_map),
+                                    Some(
+                                        &state
+                                            .match_state
+                                            .match_presentation
+                                            .tactical_bridge_inverse_map,
+                                    ),
                                     Some(&sim.interner),
                                     sim.playfield_bounds.is_some(),
                                 );
@@ -359,22 +399,23 @@ pub(crate) fn tactical_mouse(state: &mut AppState, button: MouseButton, btn_stat
                                 max_y / z + state.match_state.input.camera_y,
                             );
                             if held_type_select {
-                                queued_selection = Some(compute_type_select_box_mutation_with_playfield(
-                                    sim.entities(),
-                                    &screen_order,
-                                    scope_order,
-                                    &current_selection,
-                                    fog_ref,
-                                    preferred_local_owner_name(state).as_deref(),
-                                    min_x,
-                                    min_y,
-                                    max_x,
-                                    max_y,
-                                    shift,
-                                    state.rules(),
-                                    Some(&sim.interner),
-                                    sim.playfield_bounds.is_some(),
-                                ));
+                                queued_selection =
+                                    Some(compute_type_select_box_mutation_with_playfield(
+                                        sim.entities(),
+                                        &screen_order,
+                                        scope_order,
+                                        &current_selection,
+                                        fog_ref,
+                                        preferred_local_owner_name(state).as_deref(),
+                                        min_x,
+                                        min_y,
+                                        max_x,
+                                        max_y,
+                                        shift,
+                                        state.rules(),
+                                        Some(&sim.interner),
+                                        sim.playfield_bounds.is_some(),
+                                    ));
                                 held_type_select_batch = true;
                             } else {
                                 let preflight_order = band_preflight_order
@@ -459,9 +500,10 @@ pub(crate) fn tactical_mouse(state: &mut AppState, button: MouseButton, btn_stat
                 // no other button already holds it. Everything the player sees
                 // happens on the release edge.
                 if state.match_state.input.tactical_mouse.press_may_arm() {
-                    state
-                        .match_state.input.tactical_mouse
-                        .begin_right_drag((state.match_state.input.cursor_x, state.match_state.input.cursor_y));
+                    state.match_state.input.tactical_mouse.begin_right_drag((
+                        state.match_state.input.cursor_x,
+                        state.match_state.input.cursor_y,
+                    ));
                 }
             } else {
                 state.match_state.input.tactical_mouse.right_held = false;
@@ -469,7 +511,11 @@ pub(crate) fn tactical_mouse(state: &mut AppState, button: MouseButton, btn_stat
                     // The cancel ladder runs only when the drag threshold was
                     // never crossed. A right drag that panned the map ends
                     // silently — the selection survives it.
-                    let run_cancel_ladder = !state.match_state.input.tactical_mouse.right_threshold_crossed;
+                    let run_cancel_ladder = !state
+                        .match_state
+                        .input
+                        .tactical_mouse
+                        .right_threshold_crossed;
                     state.match_state.input.tactical_mouse.release();
                     if run_cancel_ladder {
                         right_click_cancel_ladder(state);
@@ -496,9 +542,27 @@ fn right_click_cancel_ladder(state: &mut AppState) {
         state.match_state.input.building_placement_preview = None;
         return;
     }
-    if state.match_state.match_presentation.sidebar_gadget_state.repair_mode_on || state.match_state.match_presentation.sidebar_gadget_state.sell_mode_on {
-        state.match_state.match_presentation.sidebar_gadget_state.repair_mode_on = false;
-        state.match_state.match_presentation.sidebar_gadget_state.sell_mode_on = false;
+    if state
+        .match_state
+        .match_presentation
+        .sidebar_gadget_state
+        .repair_mode_on
+        || state
+            .match_state
+            .match_presentation
+            .sidebar_gadget_state
+            .sell_mode_on
+    {
+        state
+            .match_state
+            .match_presentation
+            .sidebar_gadget_state
+            .repair_mode_on = false;
+        state
+            .match_state
+            .match_presentation
+            .sidebar_gadget_state
+            .sell_mode_on = false;
         return;
     }
     queue_selection_snapshot_command(state, Vec::new(), false);
@@ -514,7 +578,12 @@ fn band_caught_drawn_object(
     max_x: f32,
     max_y: f32,
 ) -> bool {
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
         return false;
     };
     let z = state.match_state.input.zoom_level;
@@ -552,7 +621,9 @@ pub(crate) fn minimap_mouse(state: &mut AppState, button: MouseButton, btn_state
         MouseButton::Right => {
             // A right-press centers the view on the clicked cell (no command);
             // right-release just releases the gadget's sticky capture.
-            if btn_state.is_pressed() && crate::app::presentation::sidebar_render::is_cursor_over_minimap(state) {
+            if btn_state.is_pressed()
+                && crate::app::presentation::sidebar_render::is_cursor_over_minimap(state)
+            {
                 crate::app::presentation::sidebar_render::update_camera_from_minimap_cursor(state);
             }
         }
@@ -593,8 +664,10 @@ pub(crate) fn handle_cursor_moved_in_game(state: &mut AppState) {
         return;
     }
     // Clamp drag position to the tactical viewport (exclude sidebar area).
-    let (tactical_width, tactical_height) =
-        crate::app::input::camera::tactical_viewport_size_px(state.render_width(), state.render_height());
+    let (tactical_width, tactical_height) = crate::app::input::camera::tactical_viewport_size_px(
+        state.render_width(),
+        state.render_height(),
+    );
     let clamped_endpoint = clamp_tactical_drag_endpoint(
         state.match_state.input.cursor_x,
         state.match_state.input.cursor_y,
@@ -607,9 +680,10 @@ pub(crate) fn handle_cursor_moved_in_game(state: &mut AppState) {
     // only replaced on the release, and only when the box caught something.
     // The threshold is measured from the live mouse point. Once active, the
     // rendered/stored endpoint is restricted to the tactical surface.
-    state
-        .match_state.input.selection_state
-        .update_drag(state.match_state.input.cursor_x, state.match_state.input.cursor_y);
+    state.match_state.input.selection_state.update_drag(
+        state.match_state.input.cursor_x,
+        state.match_state.input.cursor_y,
+    );
     if state.match_state.input.selection_state.is_band_box_active() {
         state.match_state.input.selection_state.drag_current = Some(clamped_endpoint);
     }
@@ -826,6 +900,106 @@ pub(crate) fn tab_scroll_slot(tab: SidebarTab) -> usize {
     }
 }
 
+/// The local player's queue of record, in queue order (empty without a sim).
+fn local_queue_view(state: &AppState) -> Vec<crate::sim::production::QueueItemView> {
+    let Some(owner) = preferred_local_owner_name(state) else {
+        return Vec::new();
+    };
+    match (
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation),
+        state.rules(),
+    ) {
+        (Some(sim), Some(rules)) => {
+            crate::sim::production::queue_view_for_owner(sim, rules, &owner)
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// The interned id a type name already has in the sim (never interns).
+fn local_interned(state: &AppState, type_id: &str) -> Option<crate::sim::intern::InternedId> {
+    state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .and_then(|rt| rt.simulation.interner.get(type_id))
+}
+
+/// The `EVA_SelectTarget` decision for the local player's superweapon
+/// `section`: its live view (ready, online) and the type's `Action=`.
+fn local_super_weapon_select_target_line(state: &AppState, section: &str) -> Option<&'static str> {
+    let owner = preferred_local_owner_name(state)?;
+    let sim = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)?;
+    let rules = state.rules()?;
+    let type_id = sim.interner.get(section)?;
+    let owner_iid = sim.interner.get(&owner)?;
+    let view = crate::sim::superweapon::superweapon_views_for_owner(sim, rules, &owner_iid)
+        .into_iter()
+        .find(|view| view.type_id == type_id)?;
+    let action = rules.super_weapon(section)?.action.as_deref();
+    sidebar_eva::select_target_line(view.is_ready, view.is_online, action)
+}
+
+/// Speak an app-local EVA line (`VoxClass::PlayEVA(name, -1)` inside a click
+/// handler): the entry's own `Type=`/`Priority=` route it.
+pub(crate) fn push_local_eva(state: &mut AppState, event: &str) {
+    state
+        .match_state
+        .match_audio
+        .sound_events
+        .push(crate::audio::events::GameSoundEvent::Eva {
+            event: event.to_string(),
+            type_override: None,
+        });
+}
+
+/// A left click on a build cameo — `SelectClass::Action @ 0x006AAD00`, the
+/// `(param_2 & 1)` branch. The cameo is only clickable when the option is
+/// enabled, which is the `HouseClass::CheckBuildLimit` pass the native line
+/// requires (`sidebar_eva::build_click_outcome`'s `buildable`).
+fn sidebar_build_click(state: &mut AppState, type_id: &str) {
+    let category = state
+        .rules()
+        .and_then(|rules| rules.object(type_id))
+        .map(crate::sim::production::category_for_object);
+    let Some(category) = category else {
+        queue_build_by_type(state, type_id);
+        return;
+    };
+    let queue = local_queue_view(state);
+    let type_iid = local_interned(state, type_id);
+    match sidebar_eva::held_click(&queue, category, type_iid) {
+        sidebar_eva::HeldClick::Resume => {
+            push_local_eva(state, sidebar_eva::start_line_for(category));
+            toggle_pause_build_queue(state, category);
+        }
+        sidebar_eva::HeldClick::NoFundsSameType => {
+            push_local_eva(state, sidebar_eva::start_line_for(category));
+        }
+        sidebar_eva::HeldClick::Fresh => {
+            let outcome = sidebar_eva::build_click_outcome(
+                category,
+                sidebar_eva::factory_busy(&queue, category),
+                true,
+            );
+            if let Some(line) = outcome.eva {
+                push_local_eva(state, line);
+            }
+            if outcome.queue {
+                queue_build_by_type(state, type_id);
+            }
+        }
+    }
+}
+
 pub(crate) fn apply_sidebar_action(state: &mut AppState, action: SidebarAction) {
     match action {
         SidebarAction::None => {}
@@ -834,31 +1008,62 @@ pub(crate) fn apply_sidebar_action(state: &mut AppState, action: SidebarAction) 
             // carry the outgoing strip's position over — nor throw it away. Park
             // the row we are leaving and restore the one we are entering.
             if tab != state.match_state.match_presentation.active_sidebar_tab {
-                state.match_state.match_presentation.sidebar_scroll_rows_parked[tab_scroll_slot(state.match_state.match_presentation.active_sidebar_tab)] =
+                state
+                    .match_state
+                    .match_presentation
+                    .sidebar_scroll_rows_parked
+                    [tab_scroll_slot(state.match_state.match_presentation.active_sidebar_tab)] =
                     state.match_state.match_presentation.sidebar_scroll_rows;
                 state.match_state.match_presentation.active_sidebar_tab = tab;
-                state.match_state.match_presentation.sidebar_scroll_rows = state.match_state.match_presentation.sidebar_scroll_rows_parked[tab_scroll_slot(tab)];
+                state.match_state.match_presentation.sidebar_scroll_rows = state
+                    .match_state
+                    .match_presentation
+                    .sidebar_scroll_rows_parked[tab_scroll_slot(tab)];
             }
         }
         SidebarAction::BuildType(type_id) => {
-            queue_build_by_type(state, &type_id);
+            sidebar_build_click(state, &type_id);
         }
         SidebarAction::ArmPlacement(type_id) => {
             state.match_state.input.targeting_mode =
                 Some(crate::app::types::TargetingMode::BuildingPlacement(type_id));
-            state.match_state.match_presentation.sidebar_gadget_state.repair_mode_on = false;
-            state.match_state.match_presentation.sidebar_gadget_state.sell_mode_on = false;
+            state
+                .match_state
+                .match_presentation
+                .sidebar_gadget_state
+                .repair_mode_on = false;
+            state
+                .match_state
+                .match_presentation
+                .sidebar_gadget_state
+                .sell_mode_on = false;
         }
         SidebarAction::ClearPlacementMode => {
             state.match_state.input.targeting_mode = None;
             state.match_state.input.building_placement_preview = None;
         }
         SidebarAction::ArmSuperWeapon(section) => {
-            state.match_state.input.targeting_mode = Some(crate::app::types::TargetingMode::SuperWeapon(section));
+            // `SelectClass::Action 0x006AAFA7`: a ready, targeted superweapon
+            // cameo speaks `EVA_SelectTarget` on the clicking machine
+            // (`sidebar_eva::select_target_line`). The cameo only arms when
+            // its view is ready, so the not-ready silence is the hit test's.
+            if let Some(line) = local_super_weapon_select_target_line(state, &section) {
+                push_local_eva(state, line);
+            }
+            state.match_state.input.targeting_mode =
+                Some(crate::app::types::TargetingMode::SuperWeapon(section));
             // Mutual exclusion: clear building-placement preview AND repair/sell modes.
             state.match_state.input.building_placement_preview = None;
-            state.match_state.match_presentation.sidebar_gadget_state.repair_mode_on = false;
-            state.match_state.match_presentation.sidebar_gadget_state.sell_mode_on = false;
+            state
+                .match_state
+                .match_presentation
+                .sidebar_gadget_state
+                .repair_mode_on = false;
+            state
+                .match_state
+                .match_presentation
+                .sidebar_gadget_state
+                .sell_mode_on = false;
             log::info!(
                 "SuperWeapon armed: type={}",
                 state.armed_super_weapon_type().unwrap_or("")
@@ -869,15 +1074,35 @@ pub(crate) fn apply_sidebar_action(state: &mut AppState, action: SidebarAction) 
             log::info!("SuperWeapon targeting cleared");
         }
         SidebarAction::TogglePauseQueue(category) => {
+            // `SelectClass::Action 0x006AB007/0x006AB108` (right click on the
+            // running build → `EVA_OnHold`) and `0x006AB498` (left click on
+            // the held build → `EVA_Building`/`EVA_Training`): VERA's pause
+            // button is that pair. Native needs a factory to hold.
+            let queue = local_queue_view(state);
+            if sidebar_eva::factory_busy(&queue, category) {
+                let paused = sidebar_eva::factory_paused(&queue, category);
+                push_local_eva(state, sidebar_eva::pause_toggle_line(category, paused));
+            }
             toggle_pause_build_queue(state, category);
         }
         SidebarAction::CycleProducer(category) => {
             cycle_active_producer(state, category);
         }
         SidebarAction::CancelBuild(type_id) => {
+            // `SelectClass::Action 0x006AAE39`: `EVA_Canceled`, see
+            // `sidebar_eva::cancel_line`.
+            let queue = local_queue_view(state);
+            let type_iid = local_interned(state, &type_id);
+            if let Some(line) = sidebar_eva::cancel_line(&queue, type_iid) {
+                push_local_eva(state, line);
+            }
             cancel_build_by_type(state, &type_id);
         }
         SidebarAction::CancelLastBuild => {
+            let queue = local_queue_view(state);
+            if let Some(line) = sidebar_eva::cancel_line(&queue, None) {
+                push_local_eva(state, line);
+            }
             cancel_last_build(state);
         }
         SidebarAction::CycleOwner => {
@@ -931,9 +1156,23 @@ pub(crate) fn report_black_cell_causes(state: &mut AppState) {
         return;
     };
 
-    let owner = crate::app::input::commands::preferred_local_owner_name(state)
-        .and_then(|name| state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation)?.interner.get(&name));
-    let fog = match (state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation), owner) {
+    let owner = crate::app::input::commands::preferred_local_owner_name(state).and_then(|name| {
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation)?
+            .interner
+            .get(&name)
+    });
+    let fog = match (
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation),
+        owner,
+    ) {
         _ if state.match_state.sandbox_full_visibility => None,
         (Some(sim), Some(id)) => Some((id, &sim.fog)),
         _ => None,
@@ -1005,12 +1244,21 @@ pub(crate) fn report_black_cell_causes(state: &mut AppState) {
 
 pub(crate) fn toggle_unit_inspector(state: &mut AppState) {
     state.diag.debug_unit_inspector = !state.diag.debug_unit_inspector;
-    if let Some(sim) = state.match_state.sim_runtime.as_mut().map(|rt| &mut rt.simulation) {
+    if let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_mut()
+        .map(|rt| &mut rt.simulation)
+    {
         // F10: sim owns the write; the app only requests the toggle.
         sim.set_debug_event_logging(state.diag.debug_unit_inspector);
         log::info!(
             "Debug unit inspector: {}",
-            if state.diag.debug_unit_inspector { "ON" } else { "OFF" }
+            if state.diag.debug_unit_inspector {
+                "ON"
+            } else {
+                "OFF"
+            }
         );
     }
 }
@@ -1045,7 +1293,14 @@ pub(crate) fn toggle_debug_pause(state: &mut AppState) {
     if !state.match_state.paused {
         state.platform.frame_pacer.reset_for_immediate_frame();
     }
-    log::info!("Debug pause: {}", if state.match_state.paused { "ON" } else { "OFF" });
+    log::info!(
+        "Debug pause: {}",
+        if state.match_state.paused {
+            "ON"
+        } else {
+            "OFF"
+        }
+    );
 }
 
 /// Handle one-shot gameplay hotkeys (called on key press, not held).
@@ -1073,7 +1328,9 @@ pub(crate) fn handle_type_select_key_edge(
             return false;
         }
         state
-            .match_state.input.type_select
+            .match_state
+            .input
+            .type_select
             .press(physical_code, std::time::Instant::now(), repeat);
         return true;
     }
@@ -1081,7 +1338,9 @@ pub(crate) fn handle_type_select_key_edge(
         return false;
     }
     let execute_tap = state
-        .match_state.input.type_select
+        .match_state
+        .input
+        .type_select
         .release(physical_code, std::time::Instant::now());
     if execute_tap {
         execute_type_select_tap(state);
@@ -1092,10 +1351,16 @@ pub(crate) fn handle_type_select_key_edge(
 fn execute_type_select_tap(state: &mut AppState) {
     state.match_state.input.type_select.prepare_tap_scope();
     let result = {
-        let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+        let Some(sim) = state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation)
+        else {
             return;
         };
-        let screen_order = crate::app::presentation::instances::tactical_screen_entity_encounter_order(state);
+        let screen_order =
+            crate::app::presentation::instances::tactical_screen_entity_encounter_order(state);
         let map_order = map_entity_creation_order(sim.entities());
         let current = selected_stable_ids_in_order(state);
         let fog = (!state.match_state.sandbox_full_visibility).then_some(&sim.fog);
@@ -1115,7 +1380,11 @@ fn execute_type_select_tap(state: &mut AppState) {
     let outcome = result.outcome;
     let across_map = result.across_map;
     apply_selection_mutation(state, result.mutation, false, TYPE_SELECT_TAP_VOICE_POLICY);
-    state.match_state.input.type_select.finish_tap(outcome, across_map);
+    state
+        .match_state
+        .input
+        .type_select
+        .finish_tap(outcome, across_map);
     crate::app::input::messages::post_type_select_feedback(state, outcome.csf_key());
     // Native marks the tactical display dirty here but does not start action
     // lines. The visible-window event loop already requests a redraw from
@@ -1141,7 +1410,9 @@ pub(crate) fn handle_hotkey_pressed(
             | HotkeyFallback::ArrowDown,
         ) => {}
         HotkeyResolution::Unhandled => {
-            if KeyModifiers::from_modifiers_state(state.match_state.input.hotkey_modifiers).dev_chord() {
+            if KeyModifiers::from_modifiers_state(state.match_state.input.hotkey_modifiers)
+                .dev_chord()
+            {
                 handle_dev_hotkey_pressed(state, physical_code);
             }
         }
@@ -1336,20 +1607,52 @@ fn handle_options_hotkey(state: &mut AppState) {
     if state.match_state.paused {
         state.match_state.paused = false;
         state.platform.frame_pacer.reset_for_immediate_frame();
-        if state.match_state.match_presentation.software_cursor.is_some() {
+        if state
+            .match_state
+            .match_presentation
+            .software_cursor
+            .is_some()
+        {
             state.platform.window.set_cursor_visible(false);
         }
         log::info!("Game resumed");
     } else if state.match_state.input.targeting_mode.is_some() {
         state.match_state.input.targeting_mode = None;
         state.match_state.input.building_placement_preview = None;
-    } else if state.match_state.match_presentation.sidebar_gadget_state.repair_mode_on || state.match_state.match_presentation.sidebar_gadget_state.sell_mode_on {
-        state.match_state.match_presentation.sidebar_gadget_state.repair_mode_on = false;
-        state.match_state.match_presentation.sidebar_gadget_state.sell_mode_on = false;
+    } else if state
+        .match_state
+        .match_presentation
+        .sidebar_gadget_state
+        .repair_mode_on
+        || state
+            .match_state
+            .match_presentation
+            .sidebar_gadget_state
+            .sell_mode_on
+    {
+        state
+            .match_state
+            .match_presentation
+            .sidebar_gadget_state
+            .repair_mode_on = false;
+        state
+            .match_state
+            .match_presentation
+            .sidebar_gadget_state
+            .sell_mode_on = false;
     } else {
         state.match_state.paused = true;
-        state.match_state.match_presentation.in_game_options.on_open();
-        if state.match_state.match_presentation.software_cursor.is_some() {
+        state
+            .match_state
+            .match_presentation
+            .in_game_options
+            .on_open();
+        if state
+            .match_state
+            .match_presentation
+            .software_cursor
+            .is_some()
+        {
             state.platform.window.set_cursor_visible(true);
         }
         log::info!("Game paused");
@@ -1363,7 +1666,8 @@ fn handle_dev_hotkey_pressed(state: &mut AppState, code: winit::keyboard::KeyCod
         // stock YR binds to the first camera bookmark. Moved onto the dev chord,
         // which stock binds nothing to.
         KeyCode::F1 => {
-            state.match_state.match_presentation.show_hotkey_help = !state.match_state.match_presentation.show_hotkey_help;
+            state.match_state.match_presentation.show_hotkey_help =
+                !state.match_state.match_presentation.show_hotkey_help;
         }
         KeyCode::KeyM => {
             quicksave(state);
@@ -1372,14 +1676,26 @@ fn handle_dev_hotkey_pressed(state: &mut AppState, code: winit::keyboard::KeyCod
             quickload(state);
         }
         KeyCode::F5 => {
-            state.match_state.match_presentation.show_save_load_panel = !state.match_state.match_presentation.show_save_load_panel;
+            state.match_state.match_presentation.show_save_load_panel =
+                !state.match_state.match_presentation.show_save_load_panel;
             if state.match_state.match_presentation.show_save_load_panel {
                 state.persistence.invalidate_save_list();
                 // Show OS cursor for egui interaction.
-                if state.match_state.match_presentation.software_cursor.is_some() {
+                if state
+                    .match_state
+                    .match_presentation
+                    .software_cursor
+                    .is_some()
+                {
                     state.platform.window.set_cursor_visible(true);
                 }
-            } else if state.match_state.match_presentation.software_cursor.is_some() && !state.match_state.paused {
+            } else if state
+                .match_state
+                .match_presentation
+                .software_cursor
+                .is_some()
+                && !state.match_state.paused
+            {
                 // Re-hide OS cursor so the software cursor takes over.
                 state.platform.window.set_cursor_visible(false);
             }
@@ -1420,7 +1736,8 @@ fn handle_dev_hotkey_pressed(state: &mut AppState, code: winit::keyboard::KeyCod
         }
         KeyCode::BracketRight => {
             if state.diag.debug_show_pathgrid {
-                let current = crate::app::diagnostics::debug_overlays::resolve_debug_speed_type(state);
+                let current =
+                    crate::app::diagnostics::debug_overlays::resolve_debug_speed_type(state);
                 let next = current.cycle_next();
                 state.diag.debug_terrain_cost_speed_type = Some(next);
                 log::info!("Terrain cost overlay: {}", next.name());
@@ -1428,7 +1745,8 @@ fn handle_dev_hotkey_pressed(state: &mut AppState, code: winit::keyboard::KeyCod
         }
         KeyCode::BracketLeft => {
             if state.diag.debug_show_pathgrid {
-                let current = crate::app::diagnostics::debug_overlays::resolve_debug_speed_type(state);
+                let current =
+                    crate::app::diagnostics::debug_overlays::resolve_debug_speed_type(state);
                 let prev = current.cycle_prev();
                 state.diag.debug_terrain_cost_speed_type = Some(prev);
                 log::info!("Terrain cost overlay: {}", prev.name());
@@ -1468,7 +1786,12 @@ fn handle_dev_hotkey_pressed(state: &mut AppState, code: winit::keyboard::KeyCod
 // ---------------------------------------------------------------------------
 
 fn quicksave(state: &mut AppState) {
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
         log::warn!("Quicksave: no active simulation");
         return;
     };
@@ -1529,7 +1852,12 @@ pub(crate) fn save_with_name(state: &mut AppState, raw_name: &str) {
         log::warn!("Save As: empty or whitespace-only name, ignored");
         return;
     }
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
         log::warn!("Save As: no active simulation");
         return;
     };
@@ -1706,7 +2034,11 @@ pub(crate) fn load_save_file(state: &mut AppState, path: &std::path::Path) {
     let preparation = crate::app::persistence::PreparedLoad::from_repository(
         crate::app::persistence::LoadPreparationView::new(
             &state.persistence.repository,
-            state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation),
+            state
+                .match_state
+                .sim_runtime
+                .as_ref()
+                .map(|rt| &rt.simulation),
             state.match_state.loaded_map_hash,
             state.rules(),
             state.terrain_template(),
@@ -1781,14 +2113,30 @@ fn commit_prepared_load(
     ));
     crate::app::loading::transitions::sync_in_game_options_speed_from_sim(state);
     state.match_state.match_presentation.combat_lights.clear();
-    crate::app::match_runtime::sim_tick::upsert_occupied_overlay_render_entries(state, occupied_overlays);
+    // The restored world's strips are seeded silently on the first refresh
+    // below (`SidebarClass::AddCameo` init gate), not read as insertions
+    // against the outgoing timeline's cameos.
+    state
+        .match_state
+        .match_presentation
+        .sidebar_projection
+        .reset_cameo_seed();
+    crate::app::match_runtime::sim_tick::upsert_occupied_overlay_render_entries(
+        state,
+        occupied_overlays,
+    );
 
     // F10: the fog view cache was discarded with the load (nonserialized) —
     // rebuild it for the local owner BEFORE the first tactical render, and
     // invalidate the render dirty-gates: the view generation restarts from
     // zero, so an equal counter no longer proves an unchanged view.
     if let Some(owner) = crate::app::input::commands::preferred_local_owner_name(state) {
-        if let Some(sim) = state.match_state.sim_runtime.as_mut().map(|rt| &mut rt.simulation) {
+        if let Some(sim) = state
+            .match_state
+            .sim_runtime
+            .as_mut()
+            .map(|rt| &mut rt.simulation)
+        {
             sim.prepare_fog_view_for(&owner);
         }
     }
@@ -1810,18 +2158,48 @@ fn commit_prepared_load(
     // Rebuild transient lighting from the loaded live entity set so destroyed
     // light-source buildings do not leave stale point lights behind.
     if let Some(resolved_terrain) = state.terrain_template() {
-        state.match_state.match_presentation.lighting_grid = crate::app::loading::init::rebuild_lighting_grid_from_sim(
-            resolved_terrain,
-            &state.match_state.match_presentation.map_lighting_config,
-            state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation),
-            state.rules(),
-            state.match_state.match_presentation.in_game_options.detail_level,
-        );
-        state.match_state.match_presentation.pending_lighting_refresh = None;
-        state.match_state.match_presentation.applied_lighting_sources.clear();
-        state.match_state.match_presentation.applied_lighting_profile = None;
-        state.match_state.match_presentation.applied_lighting_detail_level = state.match_state.match_presentation.in_game_options.detail_level.min(2);
-        state.match_state.match_presentation.last_lighting_view_fingerprint = None;
+        state.match_state.match_presentation.lighting_grid =
+            crate::app::loading::init::rebuild_lighting_grid_from_sim(
+                resolved_terrain,
+                &state.match_state.match_presentation.map_lighting_config,
+                state
+                    .match_state
+                    .sim_runtime
+                    .as_ref()
+                    .map(|rt| &rt.simulation),
+                state.rules(),
+                state
+                    .match_state
+                    .match_presentation
+                    .in_game_options
+                    .detail_level,
+            );
+        state
+            .match_state
+            .match_presentation
+            .pending_lighting_refresh = None;
+        state
+            .match_state
+            .match_presentation
+            .applied_lighting_sources
+            .clear();
+        state
+            .match_state
+            .match_presentation
+            .applied_lighting_profile = None;
+        state
+            .match_state
+            .match_presentation
+            .applied_lighting_detail_level = state
+            .match_state
+            .match_presentation
+            .in_game_options
+            .detail_level
+            .min(2);
+        state
+            .match_state
+            .match_presentation
+            .last_lighting_view_fingerprint = None;
     }
 
     // Reset timing to prevent a burst of ticks after the load.
@@ -1917,7 +2295,12 @@ pub(crate) fn is_alt_held(state: &AppState) -> bool {
 /// sim tick, reconciliation trusts the committed selected bits and admits any
 /// lifecycle-transferred selection that was not issued by input.
 pub(crate) fn selected_stable_ids_in_order(state: &AppState) -> Vec<u64> {
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
         return Vec::new();
     };
     let mut ordered = Vec::new();
@@ -1941,7 +2324,12 @@ pub(crate) fn selected_stable_ids_in_order(state: &AppState) -> Vec<u64> {
 /// Synchronize the app ledger after the due selection commands and lifecycle
 /// removals have committed for this frame.
 pub(crate) fn reconcile_selection_order_after_sim(state: &mut AppState) {
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
         state.match_state.input.selection_order.clear();
         state.match_state.input.selection_order_pending = false;
         return;
@@ -1974,7 +2362,9 @@ pub(crate) fn reconcile_selection_order_after_sim(state: &mut AppState) {
     }
     let prior_len = state.match_state.input.selection_order.len();
     let mut reconciled: Vec<u64> = state
-        .match_state.input.selection_order
+        .match_state
+        .input
+        .selection_order
         .iter()
         .copied()
         .filter(|id| {
@@ -2005,7 +2395,12 @@ fn apply_selection_mutation(
     if !mutation.clear && mutation.deselect.is_empty() && mutation.select.is_empty() {
         return false;
     }
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
         return false;
     };
     let mut ordered = selected_stable_ids_in_order(state);
@@ -2029,7 +2424,8 @@ fn apply_selection_mutation(
                 .teleport_state
                 .as_ref()
                 .is_some_and(|teleport| teleport.warp_out_active())
-            && state.rules()
+            && state
+                .rules()
                 .is_none_or(|rules| rules.object(type_id).is_none_or(|object| object.selectable));
         if !admitted || ordered.contains(&id) {
             continue;
@@ -2042,7 +2438,11 @@ fn apply_selection_mutation(
     if reset_type_select_scope {
         state.match_state.input.type_select.reset_scope();
     } else if native_selection_mode_reset {
-        state.match_state.input.type_select.note_successful_selection_mutation(false);
+        state
+            .match_state
+            .input
+            .type_select
+            .note_successful_selection_mutation(false);
     }
     for id in selection_voice_recipients(
         voice_policy,
@@ -2256,7 +2656,14 @@ fn queue_stop_for_selected(state: &mut AppState) {
 /// - Selected structure with `UndeploysInto` → `Command::UndeployBuilding` (ConYard → MCV)
 fn queue_deploy_undeploy_for_selected(state: &mut AppState) {
     let selected_ids = selected_stable_ids_in_order(state);
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else { return };
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
+        return;
+    };
     if selected_ids.is_empty() {
         return;
     }
@@ -2427,7 +2834,12 @@ const LEPTONS_PER_CELL: i64 = crate::util::lepton::LEPTONS_PER_CELL_I32 as i64;
 
 /// Live members of a control group, in the sim's iteration order.
 fn live_group_members(state: &AppState, group: &[u64]) -> Vec<u64> {
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
         return Vec::new();
     };
     group
@@ -2441,7 +2853,14 @@ fn live_group_members(state: &AppState, group: &[u64]) -> Vec<u64> {
 /// arm must stay out of the lockstep stream.
 fn center_camera_on_group(state: &mut AppState, group: &[u64]) {
     let points: Vec<(i64, i64)> = {
-        let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else { return };
+        let Some(sim) = state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation)
+        else {
+            return;
+        };
         group
             .iter()
             .filter_map(|id| sim.entities().get(*id))
@@ -2476,7 +2895,9 @@ fn handle_control_group_command(
     // already left its group.
     let live_group = live_group_members(state, &group);
     let last_press = state
-        .match_state.input.last_control_group_press
+        .match_state
+        .input
+        .last_control_group_press
         .map(|(slot, at)| (slot, at.elapsed()));
     let action = action_override.unwrap_or_else(|| {
         control_group_press_action(
@@ -2491,7 +2912,11 @@ fn handle_control_group_command(
 
     match action {
         GroupPressAction::Assign => {
-            assign_control_group(&mut state.match_state.input.control_groups, group_idx, selected);
+            assign_control_group(
+                &mut state.match_state.input.control_groups,
+                group_idx,
+                selected,
+            );
         }
         GroupPressAction::Center => {
             // Alt+digit selects the group as well as centring; a bare
@@ -2513,7 +2938,8 @@ fn handle_control_group_command(
         GroupPressAction::Recall => {
             // A recall on an empty group still clears the selection: the
             // deselect-all runs before the select loop, unconditionally.
-            state.match_state.input.last_control_group_press = Some((group_idx, std::time::Instant::now()));
+            state.match_state.input.last_control_group_press =
+                Some((group_idx, std::time::Instant::now()));
             queue_selection_snapshot_command(state, live_group, false);
             apply_selection_action_line_policy(state, ORDINARY_SELECTION_ACTION_LINE_POLICY);
         }
@@ -2527,10 +2953,20 @@ fn handle_control_group_command(
 /// flash their current orders for the 25-frame window. TypeSelect tap preserves
 /// the prior timer instead.
 fn apply_selection_action_line_policy(state: &mut AppState, policy: SelectionActionLinePolicy) {
-    let Some(tick) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation).map(|sim| sim.session.tick) else {
+    let Some(tick) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+        .map(|sim| sim.session.tick)
+    else {
         return;
     };
-    apply_selection_action_line_policy_at_tick(&mut state.match_state.match_presentation.target_lines, tick, policy);
+    apply_selection_action_line_policy_at_tick(
+        &mut state.match_state.match_presentation.target_lines,
+        tick,
+        policy,
+    );
 }
 
 fn apply_selection_action_line_policy_at_tick(
@@ -2545,8 +2981,17 @@ fn apply_selection_action_line_policy_at_tick(
 
 /// Emit the modeled VoiceSelect side effect for one successful Select call.
 fn emit_selection_voice(state: &mut AppState, entity_id: u64) {
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else { return };
-    let Some(rules) = state.rules().map(|r| r) else { return };
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
+        return;
+    };
+    let Some(rules) = state.rules().map(|r| r) else {
+        return;
+    };
 
     if let Some(event) = selection_voice_event(sim, rules, entity_id) {
         state.match_state.match_audio.sound_events.push(event);
@@ -2575,54 +3020,59 @@ fn jump_camera_to_base(state: &mut AppState) {
     let owner_name = owner.as_deref();
 
     // Collect the target cell from simulation entities before mutating state.
-    let target: Option<(u16, u16)> = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation).and_then(|sim| {
-        let rules = state.rules();
-        // First pass: look for a ConYard (structure with UndeploysInto=).
-        let conyard = sim.entities().values().find(|e| {
-            e.category == EntityCategory::Structure
-                && owner_name.map_or(true, |o| {
-                    sim.interner.resolve(e.owner).eq_ignore_ascii_case(o)
-                })
-                && rules
-                    .and_then(|r| r.object(sim.interner.resolve(e.type_ref)))
-                    .map_or(false, |o| o.undeploys_into.is_some())
-        });
-        if let Some(entity) = conyard {
+    let target: Option<(u16, u16)> = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+        .and_then(|sim| {
+            let rules = state.rules();
+            // First pass: look for a ConYard (structure with UndeploysInto=).
+            let conyard = sim.entities().values().find(|e| {
+                e.category == EntityCategory::Structure
+                    && owner_name.map_or(true, |o| {
+                        sim.interner.resolve(e.owner).eq_ignore_ascii_case(o)
+                    })
+                    && rules
+                        .and_then(|r| r.object(sim.interner.resolve(e.type_ref)))
+                        .map_or(false, |o| o.undeploys_into.is_some())
+            });
+            if let Some(entity) = conyard {
+                log::info!(
+                    "H: jumping to ConYard {} at ({}, {})",
+                    sim.interner.resolve(entity.type_ref),
+                    entity.position.rx,
+                    entity.position.ry
+                );
+                return Some((entity.position.rx, entity.position.ry));
+            }
+            // Second pass: look for an MCV (unit with DeploysInto=).
+            let mcv = sim.entities().values().find(|e| {
+                e.category != EntityCategory::Structure
+                    && owner_name.map_or(true, |o| {
+                        sim.interner.resolve(e.owner).eq_ignore_ascii_case(o)
+                    })
+                    && rules
+                        .and_then(|r| r.object(sim.interner.resolve(e.type_ref)))
+                        .map_or(false, |o| o.deploys_into.is_some())
+            });
+            if let Some(entity) = mcv {
+                log::info!(
+                    "H: jumping to MCV {} at ({}, {})",
+                    sim.interner.resolve(entity.type_ref),
+                    entity.position.rx,
+                    entity.position.ry
+                );
+                return Some((entity.position.rx, entity.position.ry));
+            }
             log::info!(
-                "H: jumping to ConYard {} at ({}, {})",
-                sim.interner.resolve(entity.type_ref),
-                entity.position.rx,
-                entity.position.ry
+                "H: no ConYard/MCV found (owner={:?}, entities={}, rules={})",
+                owner_name,
+                sim.entities().len(),
+                rules.is_some()
             );
-            return Some((entity.position.rx, entity.position.ry));
-        }
-        // Second pass: look for an MCV (unit with DeploysInto=).
-        let mcv = sim.entities().values().find(|e| {
-            e.category != EntityCategory::Structure
-                && owner_name.map_or(true, |o| {
-                    sim.interner.resolve(e.owner).eq_ignore_ascii_case(o)
-                })
-                && rules
-                    .and_then(|r| r.object(sim.interner.resolve(e.type_ref)))
-                    .map_or(false, |o| o.deploys_into.is_some())
+            None
         });
-        if let Some(entity) = mcv {
-            log::info!(
-                "H: jumping to MCV {} at ({}, {})",
-                sim.interner.resolve(entity.type_ref),
-                entity.position.rx,
-                entity.position.ry
-            );
-            return Some((entity.position.rx, entity.position.ry));
-        }
-        log::info!(
-            "H: no ConYard/MCV found (owner={:?}, entities={}, rules={})",
-            owner_name,
-            sim.entities().len(),
-            rules.is_some()
-        );
-        None
-    });
 
     if let Some((rx, ry)) = target {
         crate::app::input::camera::center_camera_on_cell(state, rx, ry);
@@ -2630,7 +3080,9 @@ fn jump_camera_to_base(state: &mut AppState) {
     }
 
     // Fallback: jump to the first multiplayer start waypoint.
-    if let Some(wp) = crate::map::waypoints::first_multiplayer_start(&state.match_state.match_presentation.waypoints) {
+    if let Some(wp) = crate::map::waypoints::first_multiplayer_start(
+        &state.match_state.match_presentation.waypoints,
+    ) {
         log::info!(
             "H: falling back to start waypoint at ({}, {})",
             wp.rx,

--- a/src/app/input/mod.rs
+++ b/src/app/input/mod.rs
@@ -13,5 +13,6 @@ pub(crate) mod hotkeys;
 pub(crate) mod state;
 pub(crate) mod in_game_options;
 pub(crate) mod messages;
+pub(crate) mod sidebar_eva;
 pub(crate) mod tooltips;
 pub(crate) mod transport_orders;

--- a/src/app/input/sidebar_eva.rs
+++ b/src/app/input/sidebar_eva.rs
@@ -1,0 +1,461 @@
+//! App-local EVA lines spoken by the sidebar itself — `SelectClass::Action @
+//! 0x006AAD00` (cameo clicks) and `SidebarClass::AddCameo @ 0x006A63E0` /
+//! `StripClass::AddEntry @ 0x006A87F0` (a new cameo). These are spoken only
+//! on the clicking machine (`PlayEVA` runs inside the click handler, before
+//! the `EventClass` is queued), so they are app events, not sim events.
+//!
+//! Every call site passes type `-1` (`OR EDX,0xffffffff` at `0x006AAE31`,
+//! `0x006AAF9F`, `0x006AAFFF`, `0x006AB100`, `0x006AB3A9`, `0x006AB490`,
+//! `0x006AB68B`, `0x006AB6C1`, `0x006A640D`, `0x006A882F`): the entry's own
+//! `Type=` / `Priority=` route them (stock: all STANDARD LOW except
+//! `EVA_NewConstructionOptions`, QUEUE LOW). Strings: `0x83FB38` Building,
+//! `0x83FB48` Training, `0x83FB58` UnableToComply, `0x83FB6C` OnHold,
+//! `0x83FB78` SelectTarget, `0x83FB8C` Canceled, `0x83FA64`
+//! NewConstructionOptions.
+//!
+//! `EVA_SelectTarget` (`0x006AAFA7`) is the superweapon cameo click — VERA's
+//! `SidebarAction::ArmSuperWeapon` (`select_target_line`).
+
+use std::collections::BTreeSet;
+
+use crate::sim::intern::InternedId;
+use crate::sim::production::{BuildQueueState, ProductionCategory, QueueItemView};
+
+pub(crate) const EVA_BUILDING: &str = "EVA_Building";
+pub(crate) const EVA_TRAINING: &str = "EVA_Training";
+pub(crate) const EVA_ON_HOLD: &str = "EVA_OnHold";
+pub(crate) const EVA_CANCELED: &str = "EVA_Canceled";
+pub(crate) const EVA_UNABLE_TO_COMPLY: &str = "EVA_UnableToComply";
+pub(crate) const EVA_SELECT_TARGET: &str = "EVA_SelectTarget";
+pub(crate) const EVA_NEW_CONSTRUCTION_OPTIONS: &str = "EVA_NewConstructionOptions";
+pub(crate) const EVA_CANNOT_DEPLOY_HERE: &str = "EVA_CannotDeployHere";
+
+/// What a fresh left click on a build cameo does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BuildClickOutcome {
+    /// The line spoken, if any.
+    pub eva: Option<&'static str>,
+    /// Whether the build command is issued at all.
+    pub queue: bool,
+}
+
+/// `SelectClass::Action 0x006AB5F0..0x006AB6CE`, the fresh-click branch.
+///
+/// `iVar6 = HouseClass::GetFactory(rtti, naval)`; the factory is *busy* when
+/// it exists and is not (`object == 0 || IsDone`) with an empty queue
+/// (`0x006AB61A..0x006AB67B`). Busy + `RTTI == 7` (BuildingType, both the
+/// structure and defense strips) → `EVA_UnableToComply` and **no event**
+/// (`0x006AB67F CMP EBP,0x7 ; ... 0x006AB693 CALL PlayEVA ; JMP end`).
+/// Busy + a unit strip → queued silently (`local_8d = 1`, no line). Idle →
+/// `EVA_Training` for `RTTI == 0x10` (InfantryType, `0x006AB6A1`) else
+/// `EVA_Building`, both only when `HouseClass::CheckBuildLimit` passed
+/// (`0x006AB6BB TEST AL,AL ; JNZ skip`) — the caller feeds that gate as
+/// `buildable` (the cameo is only clickable when the option is enabled).
+pub(crate) fn build_click_outcome(
+    category: ProductionCategory,
+    factory_busy: bool,
+    buildable: bool,
+) -> BuildClickOutcome {
+    if !buildable {
+        return BuildClickOutcome {
+            eva: None,
+            queue: false,
+        };
+    }
+    let structure_strip = matches!(
+        category,
+        ProductionCategory::Building | ProductionCategory::Defense
+    );
+    if factory_busy {
+        return if structure_strip {
+            BuildClickOutcome {
+                eva: Some(EVA_UNABLE_TO_COMPLY),
+                queue: false,
+            }
+        } else {
+            BuildClickOutcome {
+                eva: None,
+                queue: true,
+            }
+        };
+    }
+    BuildClickOutcome {
+        eva: Some(start_line_for(category)),
+        queue: true,
+    }
+}
+
+/// `0x006AB484..0x006AB498` / `0x006AB6A1..0x006AB6C9`: infantry trains,
+/// everything else builds.
+pub(crate) fn start_line_for(category: ProductionCategory) -> &'static str {
+    if category == ProductionCategory::Infantry {
+        EVA_TRAINING
+    } else {
+        EVA_BUILDING
+    }
+}
+
+/// The hold/resume toggle. Native has no toggle gadget: a right click on a
+/// building cameo suspends it (`0x006AB007 EVA_OnHold`, event `0xF`), and a
+/// left click on a held cameo resumes it (`0x006AB498 EVA_Building` /
+/// `EVA_Training`, event `0xE`). VERA's pause button is that pair.
+pub(crate) fn pause_toggle_line(
+    category: ProductionCategory,
+    currently_paused: bool,
+) -> &'static str {
+    if currently_paused {
+        start_line_for(category)
+    } else {
+        EVA_ON_HOLD
+    }
+}
+
+/// What a left click on a cameo does when the category's active build is
+/// stalled (`SelectClass::Action 0x006AB5B3`: `local_94` — the factory
+/// producing THIS cameo's type — exists and `nRate == 0 || IsSuspended`, and
+/// `!IsComplete`): the click resumes it and speaks `EVA_Building` /
+/// `EVA_Training` (`0x006AB498`) with a `0xE` (produce) event — no new item.
+/// Only the same type takes that branch; another cameo in the category
+/// goes through the fresh-click branch with a busy factory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HeldClick {
+    /// Player-paused active item of this type: resume it and speak the start
+    /// line.
+    Resume,
+    /// The active item of this type is stalled for money (`nRate == 0`):
+    /// speak the start line; VERA's `NoFunds` resumes by itself, so no
+    /// command is issued.
+    NoFundsSameType,
+    /// The fresh-click branch (`0x006AB5F0..`).
+    Fresh,
+}
+
+pub(crate) fn held_click(
+    queue: &[QueueItemView],
+    category: ProductionCategory,
+    type_id: Option<InternedId>,
+) -> HeldClick {
+    let Some(type_id) = type_id else {
+        return HeldClick::Fresh;
+    };
+    let active = queue
+        .iter()
+        .find(|item| item.queue_category == category && item.state != BuildQueueState::Done);
+    match active {
+        Some(item) if item.type_id == type_id && item.state == BuildQueueState::Paused => {
+            HeldClick::Resume
+        }
+        Some(item) if item.type_id == type_id && item.state == BuildQueueState::NoFunds => {
+            HeldClick::NoFundsSameType
+        }
+        _ => HeldClick::Fresh,
+    }
+}
+
+/// The right-click / cancel-button line. Native right-click
+/// (`0x006AADF0..0x006AB1FF`): the cameo's own factory running → `EVA_OnHold`
+/// + suspend; already suspended or `nRate == 0` (a completed factory has
+/// `Set_Rate(0)`) → `EVA_Canceled` (`0x006AAE39`) + abandon; a copy that only
+/// sits in the queue behind the active build (`FactoryClass::IsInQueue`) is
+/// removed silently. VERA's cancel skips the hold step and abandons at once,
+/// so cancelling the ACTIVE item of its category speaks `EVA_Canceled` and a
+/// tail copy stays silent (VERA-internal mapping of the two-step native
+/// flow, gamemd equivalent UNCHECKED for the hold step).
+///
+/// `type_id == None` is the sidebar cancel button (`cancel_last`: the tail
+/// item if any, else the active build).
+pub(crate) fn cancel_line(
+    queue: &[QueueItemView],
+    type_id: Option<InternedId>,
+) -> Option<&'static str> {
+    match type_id {
+        Some(type_id) => {
+            let category = queue
+                .iter()
+                .find(|item| item.type_id == type_id)?
+                .queue_category;
+            let mut in_category = queue.iter().filter(|item| item.queue_category == category);
+            let active = in_category.next()?;
+            if in_category.any(|item| item.type_id == type_id) {
+                return None;
+            }
+            (active.type_id == type_id).then_some(EVA_CANCELED)
+        }
+        None => {
+            let last = queue.last()?;
+            let only_one = queue
+                .iter()
+                .filter(|item| item.queue_category == last.queue_category)
+                .count()
+                == 1;
+            only_one.then_some(EVA_CANCELED)
+        }
+    }
+}
+
+/// `HouseClass::GetFactory` "busy" per category: any queue entry that is
+/// not finished. `NoFunds`/`Paused` are the native `nRate == 0 ||
+/// IsSuspended` factory, still a factory with an object.
+pub(crate) fn factory_busy(queue: &[QueueItemView], category: ProductionCategory) -> bool {
+    queue
+        .iter()
+        .any(|item| item.queue_category == category && item.state != BuildQueueState::Done)
+}
+
+/// Whether the category's active build is player-suspended (`FactoryClass::
+/// IsSuspended`, the state the resume branch tests at `0x006AB5B3`).
+pub(crate) fn factory_paused(queue: &[QueueItemView], category: ProductionCategory) -> bool {
+    queue
+        .iter()
+        .any(|item| item.queue_category == category && item.state == BuildQueueState::Paused)
+}
+
+/// `SelectClass::Action 0x006AAED5..0x006AAFAC`, the superweapon strip
+/// (`RTTI == 0x1F`) on a left click (`param_2 & 1`) of a cameo below the
+/// house's super count (`[PlayerPtr+0x264]`). `0x006AAEEA CALL 0x006CC360`
+/// is the readiness test: `SuperClass+0x70` (IsSuspended) set → false;
+/// `Type+0xE5` (`UseChargeDrain=`) → `+0x7C != 0`; else `+0x6F` (IsReady).
+/// Not ready → `0x006AAFB1` (a no-op) and nothing is spoken. Then
+/// `0x006AAF08 CMP [Type+0xBC], 0` — `Action=` (`SuperWeaponTypeClass::
+/// ReadINI 0x006CEA20`, `CCINIClass::ReadAction`, `None` = 0): a targeted
+/// weapon arms the pending-super state (`[0x8809A0] = index`),
+/// `Unselect_All`, and speaks `EVA_SelectTarget` (`0x006AAFA7`); an
+/// untargeted one fires at once through event `0x12` (`0x006AAF3C`) and
+/// stays silent. Every stock `[*Special]` carries an `Action=`.
+///
+/// `is_online` is VERA's `!is_suspended`; `is_ready` stands in for both the
+/// charged flag and the charge-drain `+0x7C` state.
+pub(crate) fn select_target_line(
+    is_ready: bool,
+    is_online: bool,
+    action: Option<&str>,
+) -> Option<&'static str> {
+    let targeted = action.is_some_and(|action| !action.eq_ignore_ascii_case("none"));
+    (is_ready && is_online && targeted).then_some(EVA_SELECT_TARGET)
+}
+
+/// `SidebarClass::AddCameo 0x006A63F0..0x006A6415`: an entry not already in
+/// the strip (`piVar4[1] == rtti && *piVar4 == index` scan), when
+/// `[0xA8E7AC] == 0` (not inside scenario init) and the RTTI is not
+/// `0x1F` (SuperWeaponType, `0x006A6406 CMP ESI,0x1F`), speaks
+/// `EVA_NewConstructionOptions` once per insertion; the VoxClass same-type
+/// duplicate rule folds a burst into one line.
+///
+/// `previous` is `None` on the first observation after a scenario starts —
+/// that is the init-nesting window, so the seed is silent. Returns the new
+/// set and whether at least one non-superweapon cameo was inserted.
+pub(crate) fn new_construction_options(
+    previous: Option<&BTreeSet<InternedId>>,
+    current: BTreeSet<InternedId>,
+) -> (BTreeSet<InternedId>, bool) {
+    let inserted = previous.is_some_and(|prev| current.iter().any(|id| !prev.contains(id)));
+    (current, inserted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn item(category: ProductionCategory, state: BuildQueueState) -> QueueItemView {
+        QueueItemView {
+            type_id: InternedId::default(),
+            display_name: String::new(),
+            queue_category: category,
+            state,
+            remaining_ms: 0,
+            total_ms: 1,
+        }
+    }
+
+    #[test]
+    fn idle_structure_strip_says_building_and_queues() {
+        let out = build_click_outcome(ProductionCategory::Building, false, true);
+        assert_eq!(out.eva, Some(EVA_BUILDING));
+        assert!(out.queue);
+        let out = build_click_outcome(ProductionCategory::Defense, false, true);
+        assert_eq!(out.eva, Some(EVA_BUILDING));
+    }
+
+    #[test]
+    fn idle_infantry_strip_says_training() {
+        let out = build_click_outcome(ProductionCategory::Infantry, false, true);
+        assert_eq!(out.eva, Some(EVA_TRAINING));
+        assert!(out.queue);
+        for category in [
+            ProductionCategory::Vehicle,
+            ProductionCategory::Aircraft,
+            ProductionCategory::Ship,
+        ] {
+            assert_eq!(
+                build_click_outcome(category, false, true).eva,
+                Some(EVA_BUILDING),
+                "{category:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn busy_structure_strip_refuses_with_unable_to_comply() {
+        for category in [ProductionCategory::Building, ProductionCategory::Defense] {
+            let out = build_click_outcome(category, true, true);
+            assert_eq!(out.eva, Some(EVA_UNABLE_TO_COMPLY));
+            assert!(!out.queue, "{category:?}");
+        }
+    }
+
+    #[test]
+    fn busy_unit_strip_queues_silently() {
+        for category in [
+            ProductionCategory::Infantry,
+            ProductionCategory::Vehicle,
+            ProductionCategory::Aircraft,
+            ProductionCategory::Ship,
+        ] {
+            let out = build_click_outcome(category, true, true);
+            assert_eq!(out.eva, None, "{category:?}");
+            assert!(out.queue);
+        }
+    }
+
+    #[test]
+    fn build_limit_reached_is_silent_and_does_nothing() {
+        let out = build_click_outcome(ProductionCategory::Infantry, false, false);
+        assert_eq!(
+            out,
+            BuildClickOutcome {
+                eva: None,
+                queue: false
+            }
+        );
+    }
+
+    #[test]
+    fn pause_toggle_holds_then_resumes_with_the_start_line() {
+        assert_eq!(
+            pause_toggle_line(ProductionCategory::Vehicle, false),
+            EVA_ON_HOLD
+        );
+        assert_eq!(
+            pause_toggle_line(ProductionCategory::Vehicle, true),
+            EVA_BUILDING
+        );
+        assert_eq!(
+            pause_toggle_line(ProductionCategory::Infantry, true),
+            EVA_TRAINING
+        );
+    }
+
+    #[test]
+    fn factory_busy_and_paused_read_only_their_own_category() {
+        let queue = vec![
+            item(ProductionCategory::Vehicle, BuildQueueState::Paused),
+            item(ProductionCategory::Building, BuildQueueState::Done),
+        ];
+        assert!(factory_busy(&queue, ProductionCategory::Vehicle));
+        assert!(factory_paused(&queue, ProductionCategory::Vehicle));
+        assert!(!factory_busy(&queue, ProductionCategory::Building));
+        assert!(!factory_busy(&queue, ProductionCategory::Infantry));
+        assert!(!factory_paused(&queue, ProductionCategory::Building));
+        let building = vec![item(ProductionCategory::Building, BuildQueueState::NoFunds)];
+        assert!(factory_busy(&building, ProductionCategory::Building));
+        assert!(!factory_paused(&building, ProductionCategory::Building));
+    }
+
+    #[test]
+    fn held_click_resumes_only_the_paused_active_type() {
+        let a = InternedId::from_index(1);
+        let b = InternedId::from_index(2);
+        let mut paused = item(ProductionCategory::Vehicle, BuildQueueState::Paused);
+        paused.type_id = a;
+        let mut tail = item(ProductionCategory::Vehicle, BuildQueueState::Queued);
+        tail.type_id = b;
+        let queue = vec![paused, tail];
+        assert_eq!(
+            held_click(&queue, ProductionCategory::Vehicle, Some(a)),
+            HeldClick::Resume
+        );
+        assert_eq!(
+            held_click(&queue, ProductionCategory::Vehicle, Some(b)),
+            HeldClick::Fresh
+        );
+        assert_eq!(
+            held_click(&queue, ProductionCategory::Infantry, Some(a)),
+            HeldClick::Fresh
+        );
+        let mut broke = item(ProductionCategory::Vehicle, BuildQueueState::NoFunds);
+        broke.type_id = a;
+        assert_eq!(
+            held_click(&[broke], ProductionCategory::Vehicle, Some(a)),
+            HeldClick::NoFundsSameType
+        );
+        assert_eq!(
+            held_click(&queue, ProductionCategory::Vehicle, None),
+            HeldClick::Fresh
+        );
+    }
+
+    #[test]
+    fn cancel_line_speaks_for_the_active_item_only() {
+        let a = InternedId::from_index(1);
+        let b = InternedId::from_index(2);
+        let mut active = item(ProductionCategory::Infantry, BuildQueueState::Building);
+        active.type_id = a;
+        let mut tail = item(ProductionCategory::Infantry, BuildQueueState::Queued);
+        tail.type_id = b;
+        let mut tail_same = item(ProductionCategory::Infantry, BuildQueueState::Queued);
+        tail_same.type_id = a;
+        // Active item with no tail copy: Canceled.
+        assert_eq!(cancel_line(&[active.clone()], Some(a)), Some(EVA_CANCELED));
+        // A tail copy of the same type is what gets removed: silent.
+        assert_eq!(cancel_line(&[active.clone(), tail_same], Some(a)), None);
+        // A different tail item: silent.
+        assert_eq!(cancel_line(&[active.clone(), tail.clone()], Some(b)), None);
+        // Unknown type: silent.
+        assert_eq!(cancel_line(&[active.clone()], Some(b)), None);
+        // Cancel button: the tail goes first (silent), then the active build.
+        assert_eq!(cancel_line(&[active.clone(), tail], None), None);
+        assert_eq!(cancel_line(&[active], None), Some(EVA_CANCELED));
+        assert_eq!(cancel_line(&[], None), None);
+        // A completed building awaiting placement is the active item.
+        let mut ready = item(ProductionCategory::Building, BuildQueueState::Done);
+        ready.type_id = a;
+        assert_eq!(cancel_line(&[ready], Some(a)), Some(EVA_CANCELED));
+    }
+
+    #[test]
+    fn super_weapon_click_speaks_select_target_only_when_ready_and_targeted() {
+        assert_eq!(
+            select_target_line(true, true, Some("LightningStorm")),
+            Some(EVA_SELECT_TARGET)
+        );
+        assert_eq!(select_target_line(false, true, Some("Nuke")), None);
+        assert_eq!(
+            select_target_line(true, false, Some("IronCurtain")),
+            None,
+            "`+0x70` IsSuspended refuses the click"
+        );
+        assert_eq!(select_target_line(true, true, None), None);
+        assert_eq!(
+            select_target_line(true, true, Some("None")),
+            None,
+            "`Action=None` fires through event 0x12 and stays silent"
+        );
+    }
+
+    #[test]
+    fn new_cameo_speaks_only_after_the_silent_seed() {
+        let a = InternedId::from_index(1);
+        let b = InternedId::from_index(2);
+        let (seed, spoke) = new_construction_options(None, BTreeSet::from([a]));
+        assert!(!spoke, "the scenario-init window is silent");
+        let (same, spoke) = new_construction_options(Some(&seed), BTreeSet::from([a]));
+        assert!(!spoke, "an unchanged strip inserts nothing");
+        let (grown, spoke) = new_construction_options(Some(&same), BTreeSet::from([a, b]));
+        assert!(spoke);
+        // A cameo that leaves and comes back is a fresh insertion.
+        let (shrunk, spoke) = new_construction_options(Some(&grown), BTreeSet::from([a]));
+        assert!(!spoke);
+        let (_, spoke) = new_construction_options(Some(&shrunk), BTreeSet::from([a, b]));
+        assert!(spoke);
+    }
+}

--- a/src/app/loading/transitions.rs
+++ b/src/app/loading/transitions.rs
@@ -155,6 +155,13 @@ pub(crate) fn apply_map_load_result(state: &mut AppState, result: init::MapLoadR
                 },
             });
     state.match_state.match_presentation.combat_lights.clear();
+    // A new simulation is a new scenario for `SidebarClass::AddCameo`'s
+    // init gate: its first projection must seed the strip silently.
+    state
+        .match_state
+        .match_presentation
+        .sidebar_projection
+        .reset_cameo_seed();
     sync_in_game_options_speed_from_sim(state);
     if let Some(sim) = state
         .match_state

--- a/src/app/match_runtime/eva_producers.rs
+++ b/src/app/match_runtime/eva_producers.rs
@@ -1,0 +1,432 @@
+//! The listener-side halves of the sim-emitted EVA lines, and the
+//! `VoxClass::PlayEVA @ 0x00752700` call-site census that scopes them.
+//!
+//! The sim emits a named event for every gamemd site whose predicate is a sim
+//! fact (`SimSoundEvent`); this module turns those into `GameSoundEvent::Eva`
+//! requests by applying the gates gamemd evaluates against `PlayerPtr`
+//! (`0x00A83D4C`) — the local player the sim cannot see — and the two jump
+//! tables that pick a line per superweapon. Lines gamemd speaks inside the
+//! click handler itself (before its `EventClass` is queued) are app events
+//! and live next to the click: `crate::app::input::sidebar_eva`,
+//! `crate::app::input::commands::place_ready_building_at_cursor`,
+//! `crate::app::input::context_order` (rally).
+//!
+//! # `PlayEVA` census (75 xrefs, `get_xrefs_to 0x00752700`; plus the five
+//! direct `QueueVoice @ 0x00752480` callers)
+//!
+//! Reachable in a stock skirmish and produced (site → line → VERA owner):
+//! - `0x004D9911` `TechnoClass::Death_Announcement` → `EVA_UnitLost` (combat).
+//! - `HouseClass::NotifyUnderAttack 0x004F94FB/0x004F95B3`,
+//!   `UnitClass::ReceiveDamage 0x00738530` → under-attack family (combat).
+//! - `HouseClass::Update 0x004F8BA0/0x004F8D14` → funds / low power
+//!   (`sim::house_eva`).
+//! - `StripClass::AI 0x006A8E2F` → `EVA_ConstructionComplete`;
+//!   `HouseClass::Place_Production 0x004FB644` → `EVA_UnitReady`
+//!   (production queue).
+//! - `HouseClass::Place_Production 0x004FB377` (placement `Unlimbo` failed,
+//!   `0x004FB369 CMP EBP,[PlayerPtr]`), `UnitClass::Deploy 0x0073950A`,
+//!   `DisplayClass::BandBox_LeftUp 0x004ABC80` (invalid placement click,
+//!   `0x004ABAAC/0x004ABABA` on Display `+0x1180/+0x1181`) →
+//!   `EVA_CannotDeployHere` (sim event ×2, app click ×1).
+//! - `SidebarClass::AddCameo 0x006A6415`, `StripClass::AddEntry 0x006A8837`
+//!   → `EVA_NewConstructionOptions` (`[0xA8E7AC]==0`, RTTI `!= 0x1F`; app
+//!   sidebar projection).
+//! - `SelectClass::Action 0x006AAE39/0x006AAFA7/0x006AB007/0x006AB108/
+//!   0x006AB3B1/0x006AB498/0x006AB693/0x006AB6C9` → Canceled / SelectTarget /
+//!   OnHold ×2 / UnableToComply ×2 / Building|Training ×2 (app sidebar).
+//! - `BuildingClass::SetRallyPoint 0x00443A69` → `EVA_NewRallyPointEstablished`
+//!   (click handler; app rally order).
+//! - `BuildingClass::Sell 0x00449CE5` (state 2) / `0x0044AB36` (upgrade) →
+//!   `EVA_StructureSold`; `BuildingClass::ToggleRepair 0x004470B7` →
+//!   `EVA_Repairing` (sim events).
+//! - `BuildingClass::ChangeOwner 0x00448428/0x0044848A` (+ `0x00448459`
+//!   `QueueVoice(CaptureEvaEvent)`) → TechBuildingLost / BuildingCaptured /
+//!   per-type capture line (sim event).
+//! - `SuperClass::AI_Ready 0x006CBE63` → `*Ready` (sim event, table below);
+//!   `BuildingClass::OnConstructionComplete 0x00446995` → `*Detected` (sim
+//!   event, table below); `SuperClass::Launch` ×7 → `*Activated` (landed).
+//! - `HouseClass::MPlayer_Defeated 0x004FC3BC` → `EVA_PlayerDefeated` (sim
+//!   event); `0x004FC2EA`, `Flag_To_Win 0x004FCBA9`, `Flag_To_Lose
+//!   0x004FCDA1` → outcome lines (landed); `GameExit::BattleControlTerminated
+//!   0x00686616` (landed).
+//! - `AddGarrisonOccupant 0x005229C1`, `CheckAutoSellOrCivilian 0x004582D8`
+//!   (`EVA_StructureAbandoned`), `InfantryClass::PerCellProcess 0x00519BC9`
+//!   (bridge), `TechnoClass::AI_Update 0x006FA0CB/0x006FA139` (promotion),
+//!   `LightningStorm::Process 0x0053AB11` — landed earlier.
+//!
+//! Reachable in a stock skirmish, prerequisite mechanism missing in VERA
+//! (documented, not produced):
+//! - `FootClass::OnSold 0x004D9F94` → `EVA_UnitSold` (no unit selling).
+//! - `0x00448226` (primary-factory setter, `[this+0x3D3]=1` then
+//!   `0x0050B6F0`) → `EVA_PrimaryBuildingSelected` (no primary factory).
+//! - `BuildingClass::MissionRepairAndProduce 0x0044B973/0x0044BDC5`
+//!   (`CreateRadarEvent(8)` → `EVA_UnitRepaired`), `0x0044BFEA` (available
+//!   money `== 0` → `EVA_InsufficientFunds`), `0x0044C507` (`+0x41A` →
+//!   `EVA_Repairing`) (no service-depot unit repair).
+//! - `BuildingClass::OnSpyInfiltrate 0x00457288..0x0045758B` (infiltration
+//!   family, `0x0050B6F0` on the spy owner / building owner) (no spy entry).
+//! - `RadarClass::PlaceBeacon 0x00430D78` (`EVA_BeaconPlaced`), `0x00430F1B`
+//!   (`CreateRadarEvent(0xB)` → `EVA_BeaconDetected`) (no beacons).
+//! - `HouseClass::MakeAlly 0x004F9F35` (`EVA_AllianceRequested` string
+//!   `0x82479C`), `MakeEnemy 0x004FA1D5` (`EVA_AllianceBroken`) (no in-match
+//!   diplomacy).
+//! - `HouseClass::RobotTanksBackOnline 0x0050E0D0`, `LostPoweredCenter
+//!   0x0050E19B`, `Removed_From_Game 0x00502776` (`EVA_RobotTanksOffline`,
+//!   `[0xA8E7AC]==0`) (no robot control centre).
+//! - Crate handlers `0x00482EBB/0x004830AA/0x0048328A` (`EVA_UnitArmor|Speed|
+//!   FirePowerUpgraded`, spoken when a local-player unit's multiplier was
+//!   exactly `1.0`, `0x00482E61..0x00482E8D`) (no stat-upgrade crates).
+//! - `TemporalClass::InitiateWarp 0x0071B05F` (`EVA_OreMinerUnderAttack`
+//!   after `CreateRadarEvent(4)`) (no temporal erase).
+//!
+//! Excluded (not reachable from stock-skirmish input):
+//! - `BuildingClass::ReadFromINI 0x0044FD1A`, `GoOnline 0x00452355`,
+//!   `GoOffline 0x004523DE` (`EVA_BuildingOnLine/OffLine`): callers are
+//!   `ReadFromINI` (map-placed player buildings), `EventClass::Execute` (the
+//!   TS power-toggle event YR exposes no UI for) and `TriggerAction::Execute`.
+//! - `SuperClass::AI_Charging 0x006CC179` (`*Ready` on a superweapon granted
+//!   already charged, `SuperClass::Grant 0x006CB560` `+0x6E`): the
+//!   building-complete grant passes 0.
+//! - `QueueVoice` direct: `TriggerAction::Execute 0x006DE911`,
+//!   `RadarClass::PlayRadarMovie 0x006579BB` (campaign), `FUN_00771620`
+//!   (no callers), `0x005BC7CE` (unlabeled, walks the whole `[DialogList]`
+//!   with a `[0xABF220]` cursor — a menu sampler, not the match loop).
+//!
+//! ## Dependency rules
+//! - App-side; may read `sim` state and `rules`, never mutate the sim.
+
+use crate::map::houses::{HouseAllianceMap, is_allied_with};
+use crate::rules::object_type::ObjectType;
+use crate::rules::superweapon_type::SuperWeaponKind;
+
+/// `EVA_NewRallyPointEstablished` (string `0x00818E58`), spoken at
+/// `0x00443A69` by the click handler.
+pub(crate) const EVA_NEW_RALLY_POINT_ESTABLISHED: &str = "EVA_NewRallyPointEstablished";
+/// String `0x00819030`.
+pub(crate) const EVA_STRUCTURE_SOLD: &str = "EVA_StructureSold";
+/// String `0x00818F18`.
+pub(crate) const EVA_REPAIRING: &str = "EVA_Repairing";
+/// String `0x00818FAC`.
+pub(crate) const EVA_BUILDING_CAPTURED: &str = "EVA_BuildingCaptured";
+/// String `0x00818FC4`.
+pub(crate) const EVA_TECH_BUILDING_LOST: &str = "EVA_TechBuildingLost";
+/// String `0x00824B70`.
+pub(crate) const EVA_PLAYER_DEFEATED: &str = "EVA_PlayerDefeated";
+
+/// `SuperClass::AI_Ready @ 0x006CBCA0`: `0x006CBDD7 MOV EAX,[Type+0xB4]`
+/// (`Type=`), `CMP EAX,0xB ; JA skip`, then the `0x006CBEA8` jump table. Read
+/// from the table bytes: 0 → `0x8424D4`, 1 → `0x8424BC`, 2 → `0x84248C`,
+/// 3 → `0x842458`, 4 → `0x006CBE68` (no line), 5/6 → `0x842440`,
+/// 7 → `0x842470`, 8 → `0x84242C`, 9 → `0x842414`, 10 → `0x8424A4`,
+/// 11 → `0x8423FC`. `SuperClass::AI_Charging` (call site `0x006CC179`)
+/// shares the same case → string map.
+pub(crate) fn super_weapon_ready_event(kind: SuperWeaponKind) -> Option<&'static str> {
+    Some(match kind {
+        SuperWeaponKind::MultiMissile => "EVA_NuclearMissileReady",
+        SuperWeaponKind::IronCurtain => "EVA_IronCurtainReady",
+        SuperWeaponKind::LightningStorm => "EVA_LightningStormReady",
+        SuperWeaponKind::ChronoSphere => "EVA_ChronosphereReady",
+        SuperWeaponKind::ChronoWarp => return None,
+        SuperWeaponKind::ParaDrop | SuperWeaponKind::AmerParaDrop => "EVA_ReinforcementsReady",
+        SuperWeaponKind::PsychicDominator => "EVA_PsychicDominatorReady",
+        SuperWeaponKind::SpyPlane => "EVA_SpyPlaneReady",
+        SuperWeaponKind::GeneticConverter => "EVA_GeneticMutatorReady",
+        SuperWeaponKind::ForceShield => "EVA_ForceShieldReady",
+        SuperWeaponKind::PsychicReveal => "EVA_PsychicRevealReady",
+    })
+}
+
+/// `BuildingClass::OnConstructionComplete @ 0x00445F80`: `0x0044693D MOV
+/// EAX,[Type+0x16F0]` (the `SuperWeapon=` **list index**, not `Type=`),
+/// `CMP EAX,0x9 ; JA skip`, `JMP [EAX*4+0x00446FC0]`. Table bytes:
+/// 0 → `0x0044694F` (`0x818F00`), 1 → `0x0044695B` (`0x818EE8`),
+/// 2 → `0x00446967` (`0x818ED0`, the misnamed `EVA_WeatherDeviceReady`),
+/// 3 → `0x0044698B` (`0x818E78`), 4/5/6/8 → `0x0044699A` (no line),
+/// 7 → `0x00446973` (`0x818EB0`), 9 → `0x0044697F` (`0x818E94`). Stock
+/// `[SuperWeaponTypes]` order puts NukeSpecial, IronCurtainSpecial,
+/// LightningStormSpecial, ChronoSphereSpecial, ..., PsychicDominatorSpecial
+/// (7), ..., GeneticConverterSpecial (9) on exactly those slots.
+pub(crate) fn super_weapon_detected_event(list_index: usize) -> Option<&'static str> {
+    match list_index {
+        0 => Some("EVA_NuclearSiloDetected"),
+        1 => Some("EVA_IronCurtainDetected"),
+        2 => Some("EVA_WeatherDeviceReady"),
+        3 => Some("EVA_ChronosphereDetected"),
+        7 => Some("EVA_PsychicDominatorDetected"),
+        9 => Some("EVA_GeneticMutatorDetected"),
+        _ => None,
+    }
+}
+
+/// The listener gates of the `*Detected` block (`0x004468AD..0x00446935`),
+/// evaluated by the machine that hears the line:
+/// - `0x004468B3 CALL 0x0050B6F0` — the building's owner is the local player
+///   → silent;
+/// - `0x004468CD CALL HouseClass::IsAlliedWith(owner, PlayerPtr)` — the
+///   owner counts the local player as an ally → silent;
+/// - `0x004468DA MOV EAX,[0xA8B538]` — the local player was defeated
+///   (`MPlayer_Defeated 0x004FC205` sets it) → silent;
+/// - `0x004468E7 MOV EAX,[0xA8B238]` — `GameMode == 0` (campaign) → silent;
+/// - `0x004468FA..0x00446935` — the superweapon's `AuxBuilding=` is set and
+///   the building's owner owns none of it → silent.
+pub(crate) fn super_weapon_detected_allowed(
+    alliances: &HouseAllianceMap,
+    owner_name: &str,
+    local_name: &str,
+    local_defeated: bool,
+    game_mode_nonzero: bool,
+    aux_building_satisfied: bool,
+) -> bool {
+    !owner_name.eq_ignore_ascii_case(local_name)
+        && !is_allied_with(alliances, owner_name, local_name)
+        && !local_defeated
+        && game_mode_nonzero
+        && aux_building_satisfied
+}
+
+/// The lines the capture block speaks on the local machine
+/// (`BuildingClass::ChangeOwner 0x004483FB..0x0044848F`), in native order:
+/// a `NeedsEngineer=` building says `EVA_TechBuildingLost` when the OLD
+/// owner is local (`0x00448415`) and then queues the type's
+/// `CaptureEvaEvent=` when the NEW owner is local (`0x0044842F..0x00448459`);
+/// any other building says `EVA_BuildingCaptured` once the radar event was
+/// accepted (`0x0044847C`) — for whichever side is local (the outer gate
+/// `0x004483C6/0x004483D1` already required one of them to be).
+pub(crate) fn capture_eva_events(
+    tech_building: bool,
+    radar_accepted: bool,
+    capture_eva_event: Option<&str>,
+    local_is_old_owner: bool,
+    local_is_new_owner: bool,
+) -> Vec<String> {
+    let mut lines = Vec::new();
+    if !(local_is_old_owner || local_is_new_owner) {
+        return lines;
+    }
+    if tech_building {
+        if local_is_old_owner {
+            lines.push(EVA_TECH_BUILDING_LOST.to_string());
+        }
+        if local_is_new_owner && let Some(event) = capture_eva_event {
+            lines.push(event.to_string());
+        }
+    } else if radar_accepted {
+        lines.push(EVA_BUILDING_CAPTURED.to_string());
+    }
+    lines
+}
+
+/// `BuildingClass::SetRallyPoint 0x00443A45..0x00443A5D`: the rally click
+/// announces unless the factory is a `ConstructionYard=` (`Type+0x16B9`) or
+/// a `ResourceDestination=` (`Type+0x5ED`, stored by
+/// `TechnoTypeClass::ReadINI 0x007143FE`; stock refineries). The owner gate
+/// (`0x00443A3C CALL 0x0050B6F0`) is the caller's — the click is local.
+pub(crate) fn rally_point_announces(obj: &ObjectType) -> bool {
+    !obj.construction_yard && !obj.resource_destination
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ready_table_follows_the_type_index_jump_table() {
+        use SuperWeaponKind as K;
+        assert_eq!(
+            super_weapon_ready_event(K::MultiMissile),
+            Some("EVA_NuclearMissileReady")
+        );
+        assert_eq!(
+            super_weapon_ready_event(K::IronCurtain),
+            Some("EVA_IronCurtainReady")
+        );
+        assert_eq!(
+            super_weapon_ready_event(K::LightningStorm),
+            Some("EVA_LightningStormReady")
+        );
+        assert_eq!(
+            super_weapon_ready_event(K::ChronoSphere),
+            Some("EVA_ChronosphereReady")
+        );
+        assert_eq!(
+            super_weapon_ready_event(K::ChronoWarp),
+            None,
+            "case 4 jumps past PlayEVA"
+        );
+        assert_eq!(
+            super_weapon_ready_event(K::ParaDrop),
+            Some("EVA_ReinforcementsReady")
+        );
+        assert_eq!(
+            super_weapon_ready_event(K::AmerParaDrop),
+            Some("EVA_ReinforcementsReady")
+        );
+        assert_eq!(
+            super_weapon_ready_event(K::PsychicDominator),
+            Some("EVA_PsychicDominatorReady")
+        );
+        assert_eq!(
+            super_weapon_ready_event(K::SpyPlane),
+            Some("EVA_SpyPlaneReady")
+        );
+        assert_eq!(
+            super_weapon_ready_event(K::GeneticConverter),
+            Some("EVA_GeneticMutatorReady")
+        );
+        assert_eq!(
+            super_weapon_ready_event(K::ForceShield),
+            Some("EVA_ForceShieldReady")
+        );
+        assert_eq!(
+            super_weapon_ready_event(K::PsychicReveal),
+            Some("EVA_PsychicRevealReady")
+        );
+    }
+
+    #[test]
+    fn detected_table_follows_the_list_index_jump_table() {
+        assert_eq!(
+            super_weapon_detected_event(0),
+            Some("EVA_NuclearSiloDetected")
+        );
+        assert_eq!(
+            super_weapon_detected_event(1),
+            Some("EVA_IronCurtainDetected")
+        );
+        assert_eq!(
+            super_weapon_detected_event(2),
+            Some("EVA_WeatherDeviceReady")
+        );
+        assert_eq!(
+            super_weapon_detected_event(3),
+            Some("EVA_ChronosphereDetected")
+        );
+        for silent in [4, 5, 6, 8, 10, 11, 12] {
+            assert_eq!(super_weapon_detected_event(silent), None, "index {silent}");
+        }
+        assert_eq!(
+            super_weapon_detected_event(7),
+            Some("EVA_PsychicDominatorDetected")
+        );
+        assert_eq!(
+            super_weapon_detected_event(9),
+            Some("EVA_GeneticMutatorDetected")
+        );
+    }
+
+    #[test]
+    fn detected_listener_gates_match_native_order() {
+        let mut alliances = HouseAllianceMap::new();
+        assert!(super_weapon_detected_allowed(
+            &alliances,
+            "Russians",
+            "Americans",
+            false,
+            true,
+            true
+        ));
+        assert!(!super_weapon_detected_allowed(
+            &alliances,
+            "Americans",
+            "Americans",
+            false,
+            true,
+            true
+        ));
+        assert!(!super_weapon_detected_allowed(
+            &alliances,
+            "Russians",
+            "Americans",
+            true,
+            true,
+            true
+        ));
+        assert!(!super_weapon_detected_allowed(
+            &alliances,
+            "Russians",
+            "Americans",
+            false,
+            false,
+            true
+        ));
+        assert!(!super_weapon_detected_allowed(
+            &alliances,
+            "Russians",
+            "Americans",
+            false,
+            true,
+            false
+        ));
+        // One-way: only the OWNER's ally bit is read (`IsAlliedWith(owner, PlayerPtr)`).
+        alliances
+            .entry("RUSSIANS".to_string())
+            .or_default()
+            .insert("AMERICANS".to_string());
+        assert!(!super_weapon_detected_allowed(
+            &alliances,
+            "Russians",
+            "Americans",
+            false,
+            true,
+            true
+        ));
+        assert!(super_weapon_detected_allowed(
+            &alliances,
+            "Americans",
+            "Russians",
+            false,
+            true,
+            true
+        ));
+    }
+
+    #[test]
+    fn capture_lines_follow_the_change_owner_block() {
+        // Ordinary building: the radar result gates one line for either side.
+        assert_eq!(
+            capture_eva_events(false, true, None, false, true),
+            vec![EVA_BUILDING_CAPTURED.to_string()]
+        );
+        assert_eq!(
+            capture_eva_events(false, true, None, true, false),
+            vec![EVA_BUILDING_CAPTURED.to_string()]
+        );
+        assert!(capture_eva_events(false, false, None, true, false).is_empty());
+        assert!(capture_eva_events(false, true, None, false, false).is_empty());
+        // Tech building: lost line for a local old owner, per-type line for a
+        // local new owner, no radar-gated line at all.
+        assert_eq!(
+            capture_eva_events(true, false, Some("EVA_OilRefineryCaptured"), false, true),
+            vec!["EVA_OilRefineryCaptured".to_string()]
+        );
+        assert_eq!(
+            capture_eva_events(true, false, Some("EVA_OilRefineryCaptured"), true, false),
+            vec![EVA_TECH_BUILDING_LOST.to_string()]
+        );
+        assert!(capture_eva_events(true, false, None, false, true).is_empty());
+        assert!(capture_eva_events(true, true, None, false, false).is_empty());
+    }
+
+    #[test]
+    fn rally_line_skips_construction_yards_and_resource_destinations() {
+        use crate::rules::ini_parser::IniFile;
+        use crate::rules::ruleset::RuleSet;
+        let ini = IniFile::from_str(
+            "[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n\
+             [BuildingTypes]\n0=GACNST\n1=GAREFN\n2=GAWEAP\n\
+             [GACNST]\nStrength=1000\nArmor=wood\nConstructionYard=yes\n\
+             [GAREFN]\nStrength=1000\nArmor=wood\nRefinery=yes\nResourceDestination=yes\n\
+             [GAWEAP]\nStrength=1000\nArmor=wood\nFactory=UnitType\n",
+        );
+        let rules = RuleSet::from_ini(&ini).expect("rally test rules should parse");
+        assert!(rally_point_announces(
+            rules.object("GAWEAP").expect("GAWEAP")
+        ));
+        assert!(!rally_point_announces(
+            rules.object("GACNST").expect("GACNST")
+        ));
+        assert!(!rally_point_announces(
+            rules.object("GAREFN").expect("GAREFN")
+        ));
+    }
+}

--- a/src/app/match_runtime/mod.rs
+++ b/src/app/match_runtime/mod.rs
@@ -1,6 +1,7 @@
 //! Match runtime owner (F12): the per-frame simulation advance transaction,
 //! the local frame pacer, and the scenario exit cascade.
 
+pub(crate) mod eva_producers;
 pub(crate) mod frame_pacer;
 pub(crate) mod scenario_exit;
 pub(crate) mod sim_tick;

--- a/src/app/match_runtime/sim_tick.rs
+++ b/src/app/match_runtime/sim_tick.rs
@@ -12,6 +12,7 @@ use std::time::Instant;
 
 use crate::app::AppState;
 use crate::app::input::commands::{preferred_local_owner, preferred_local_owner_name};
+use crate::app::match_runtime::eva_producers;
 
 /// Chance in 100 that a techno speaks its `VoiceFeedback=` line on the
 /// half-strength crossing. `TechnoClass::ReceiveDamage @ 0x007026BD
@@ -237,6 +238,18 @@ pub(crate) fn drive_local_player_outcome_voice_wait(state: &mut AppState, wall_m
 /// `EVA_YouAreVictorious` (`0x00824C2C`) and `Flag_To_Lose 0x004FCDA1`
 /// `EVA_YouHaveLost` (`0x00824C08`), both with `EDX = -1` (the entry's own
 /// type; stock rows are STANDARD NORMAL). The side column is the consumer's.
+/// `HouseClass::IsHumanPlayer @ 0x0050B6F0` as the EVA sites use it: in a
+/// multiplayer game it is `this == PlayerPtr`, the local player. The sim
+/// carries house identity; the app holds the local name.
+fn owner_is_local(
+    interner: &crate::sim::intern::StringInterner,
+    owner: crate::sim::intern::InternedId,
+    local_owner_name: Option<&str>,
+) -> bool {
+    let owner_str = interner.resolve(owner);
+    local_owner_name.is_some_and(|local| local.eq_ignore_ascii_case(owner_str))
+}
+
 fn outcome_eva_event(kind: crate::sim::house_state::HouseOutcomeKind) -> &'static str {
     match kind {
         crate::sim::house_state::HouseOutcomeKind::Victory => "EVA_YouAreVictorious",
@@ -1746,6 +1759,152 @@ fn advance_one_simulation_frame(state: &mut AppState, tick_lane: TickLane) -> bo
                         }
                         GameSoundEvent::Eva {
                             event: event.to_string(),
+                            type_override: None,
+                        }
+                    }
+                    SimSoundEvent::StructureSold { owner } => {
+                        // `BuildingClass::Sell 0x00449CC1 MOV AL,[EBP+0x41A]`
+                        // (`0x0044AB22` on the upgrade path): only the local
+                        // player's own building speaks; `EDX = -1`.
+                        if !owner_is_local(&sim.interner, owner, local_owner_name.as_deref()) {
+                            continue;
+                        }
+                        GameSoundEvent::Eva {
+                            event: eva_producers::EVA_STRUCTURE_SOLD.to_string(),
+                            type_override: None,
+                        }
+                    }
+                    SimSoundEvent::Repairing { owner } => {
+                        // `BuildingClass::ToggleRepair 0x004470A4 CALL
+                        // 0x0050B6F0`: the owner is the local player.
+                        if !owner_is_local(&sim.interner, owner, local_owner_name.as_deref()) {
+                            continue;
+                        }
+                        GameSoundEvent::Eva {
+                            event: eva_producers::EVA_REPAIRING.to_string(),
+                            type_override: None,
+                        }
+                    }
+                    SimSoundEvent::BuildingCaptured {
+                        old_owner,
+                        new_owner,
+                        tech_building,
+                        radar_accepted,
+                        capture_eva_event,
+                    } => {
+                        // `BuildingClass::ChangeOwner 0x004483C6/0x004483D1
+                        // CALL 0x0050B6F0` on the old and the new owner; the
+                        // lines are `eva_producers::capture_eva_events`. Every
+                        // call passes `EDX = -1` (the `0x00448459 QueueVoice`
+                        // passes `-1, -1` too).
+                        let local = local_owner_name.as_deref();
+                        let local_is_old = owner_is_local(&sim.interner, old_owner, local);
+                        let local_is_new = owner_is_local(&sim.interner, new_owner, local);
+                        let capture_event = capture_eva_event.map(|id| sim.interner.resolve(id));
+                        for event in eva_producers::capture_eva_events(
+                            tech_building,
+                            radar_accepted,
+                            capture_event,
+                            local_is_old,
+                            local_is_new,
+                        ) {
+                            state
+                                .match_state
+                                .match_audio
+                                .sound_events
+                                .push(GameSoundEvent::Eva {
+                                    event,
+                                    type_override: None,
+                                });
+                        }
+                        continue;
+                    }
+                    SimSoundEvent::SuperWeaponReady { owner, sw_type } => {
+                        // `HouseClass::Update 0x004F8E42 CMP ESI,[PlayerPtr] ;
+                        // SETZ CL ; PUSH ECX` is `SuperClass::AI_Ready`'s
+                        // announce argument (`0x006CBDCF TEST CL,CL`).
+                        if !owner_is_local(&sim.interner, owner, local_owner_name.as_deref()) {
+                            continue;
+                        }
+                        let type_name = sim.interner.resolve(sw_type);
+                        let Some(event) = resources
+                            .rules
+                            .super_weapon(type_name)
+                            .and_then(|sw| eva_producers::super_weapon_ready_event(sw.kind))
+                        else {
+                            continue;
+                        };
+                        GameSoundEvent::Eva {
+                            event: event.to_string(),
+                            type_override: None,
+                        }
+                    }
+                    SimSoundEvent::SuperWeaponDetected { owner, sw_type } => {
+                        // `BuildingClass::OnConstructionComplete
+                        // 0x004468AD..0x00446995`; the gates are the
+                        // listener's (`eva_producers::super_weapon_detected_allowed`)
+                        // and the line comes off the `[SuperWeaponTypes]`
+                        // list index (`0x00446948` jump table).
+                        let Some(local_name) = local_owner_name.as_deref() else {
+                            continue;
+                        };
+                        let owner_name = sim.interner.resolve(owner).to_string();
+                        let type_name = sim.interner.resolve(sw_type).to_string();
+                        let local_defeated = sim
+                            .interner
+                            .get(local_name)
+                            .and_then(|id| sim.houses.get(&id))
+                            .is_some_and(|house| house.is_defeated);
+                        // `0x004468FA..0x00446935`: `AuxBuilding=` absent, or
+                        // the building's own house owns one
+                        // (`CountOwnedInstances` on `Owner+0x5550`).
+                        let aux_satisfied = match resources
+                            .rules
+                            .super_weapon(&type_name)
+                            .and_then(|sw| sw.aux_building.as_deref())
+                        {
+                            None => true,
+                            Some(aux) => sim.substrate.entities.values().any(|e| {
+                                e.owner == owner
+                                    && !e.dying
+                                    && !e.lifecycle.in_limbo
+                                    && e.category == crate::map::entities::EntityCategory::Structure
+                                    && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case(aux)
+                            }),
+                        };
+                        if !eva_producers::super_weapon_detected_allowed(
+                            &sim.house_alliances,
+                            &owner_name,
+                            local_name,
+                            local_defeated,
+                            sim.session.game_mode_nonzero,
+                            aux_satisfied,
+                        ) {
+                            continue;
+                        }
+                        let Some(event) = resources
+                            .rules
+                            .super_weapon_order
+                            .iter()
+                            .position(|section| section.eq_ignore_ascii_case(&type_name))
+                            .and_then(eva_producers::super_weapon_detected_event)
+                        else {
+                            continue;
+                        };
+                        GameSoundEvent::Eva {
+                            event: event.to_string(),
+                            type_override: None,
+                        }
+                    }
+                    SimSoundEvent::PlayerDefeated { house } => {
+                        // `HouseClass::MPlayer_Defeated 0x004FC1B5 CMP EAX,ESI`
+                        // splits the local branch (`EVA_YouHaveLost`, owned by
+                        // `MatchOutcome`) from the `0x004FC3BC` line.
+                        if owner_is_local(&sim.interner, house, local_owner_name.as_deref()) {
+                            continue;
+                        }
+                        GameSoundEvent::Eva {
+                            event: eva_producers::EVA_PLAYER_DEFEATED.to_string(),
                             type_override: None,
                         }
                     }

--- a/src/app/presentation/sidebar_render.rs
+++ b/src/app/presentation/sidebar_render.rs
@@ -30,7 +30,11 @@ pub(crate) use crate::app::presentation::sidebar_build::{
 /// Return the one retained sidebar projection. Reading it never advances
 /// credits, clears targeting, or clamps scroll state.
 pub(crate) fn current_sidebar_view(state: &AppState) -> Option<&SidebarView> {
-    state.match_state.match_presentation.sidebar_projection.view()
+    state
+        .match_state
+        .match_presentation
+        .sidebar_projection
+        .view()
 }
 
 /// Advance the displayed balance at the authoritative gameplay-frame seam.
@@ -43,12 +47,19 @@ pub(crate) fn advance_sidebar_credits_after_frame(
         return;
     }
     let owner_name = preferred_local_owner_name(state).unwrap_or_else(|| "Americans".to_string());
-    let Some(sim) = state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation) else {
+    let Some(sim) = state
+        .match_state
+        .sim_runtime
+        .as_ref()
+        .map(|rt| &rt.simulation)
+    else {
         return;
     };
     let credits = production::credits_for_owner(sim, &owner_name);
     state
-        .match_state.match_presentation.sidebar_projection
+        .match_state
+        .match_presentation
+        .sidebar_projection
         .advance_credits(&owner_name, credits);
 }
 
@@ -68,7 +79,14 @@ pub(crate) fn refresh_sidebar_projection(state: &mut AppState) {
         power_drained,
         sw_views,
     )) = (|| {
-        let (sim, rules) = (state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation)?, state.rules()?);
+        let (sim, rules) = (
+            state
+                .match_state
+                .sim_runtime
+                .as_ref()
+                .map(|rt| &rt.simulation)?,
+            state.rules()?,
+        );
         let producer_focus = [
             production::ProductionCategory::Building,
             production::ProductionCategory::Defense,
@@ -102,9 +120,35 @@ pub(crate) fn refresh_sidebar_projection(state: &mut AppState) {
         ))
     })()
     else {
-        state.match_state.match_presentation.sidebar_projection.replace_view(None);
+        state
+            .match_state
+            .match_presentation
+            .sidebar_projection
+            .replace_view(None);
         return;
     };
+
+    // `SidebarClass::AddCameo 0x006A63D6..0x006A6415`: a build cameo the
+    // strip did not hold (`visible_in_sidebar` is the strip entry set; the
+    // superweapon strip is the `RTTI == 0x1F` exclusion) speaks
+    // `EVA_NewConstructionOptions` once the scenario-init nesting counter
+    // is back to zero — the first projection of a match is that window.
+    let cameos: std::collections::BTreeSet<_> = build_options
+        .iter()
+        .filter(|opt| opt.visible_in_sidebar())
+        .map(|opt| opt.type_id)
+        .collect();
+    if state
+        .match_state
+        .match_presentation
+        .sidebar_projection
+        .note_cameos(cameos)
+    {
+        crate::app::input::dispatch::push_local_eva(
+            state,
+            crate::app::input::sidebar_eva::EVA_NEW_CONSTRUCTION_OPTIONS,
+        );
+    }
 
     // Resolve CSF display names (e.g., "Name:MTNK" → "Grizzly Battle Tank").
     if let Some(csf) = &state.process_assets.csf {
@@ -119,7 +163,9 @@ pub(crate) fn refresh_sidebar_projection(state: &mut AppState) {
         }
     }
     let display_credits = state
-        .match_state.match_presentation.sidebar_projection
+        .match_state
+        .match_presentation
+        .sidebar_projection
         .displayed_credits_or_seed(&owner_name, credits);
     let (tab_btn_size, repair_btn_size, sell_btn_size, scroll_down_btn_size, scroll_up_btn_size) = {
         let scale = state.match_state.match_presentation.ui_scale;
@@ -140,17 +186,27 @@ pub(crate) fn refresh_sidebar_projection(state: &mut AppState) {
         &mut state.match_state.input.building_placement_preview,
         &ready_buildings,
         &sw_views,
-        state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation).map(|s| &s.interner),
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation)
+            .map(|s| &s.interner),
     );
     // App targeting state -> the sidebar-owned armed projection (F06 seam).
-    let armed_entry = state.match_state.input.targeting_mode.as_ref().map(|mode| match mode {
-        crate::app::types::TargetingMode::BuildingPlacement(section) => {
-            sidebar::ArmedSidebarEntry::BuildingPlacement(section.clone())
-        }
-        crate::app::types::TargetingMode::SuperWeapon(section) => {
-            sidebar::ArmedSidebarEntry::SuperWeapon(section.clone())
-        }
-    });
+    let armed_entry = state
+        .match_state
+        .input
+        .targeting_mode
+        .as_ref()
+        .map(|mode| match mode {
+            crate::app::types::TargetingMode::BuildingPlacement(section) => {
+                sidebar::ArmedSidebarEntry::BuildingPlacement(section.clone())
+            }
+            crate::app::types::TargetingMode::SuperWeapon(section) => {
+                sidebar::ArmedSidebarEntry::SuperWeapon(section.clone())
+            }
+        });
     let mut view = sidebar::build_sidebar_view_with_spec(
         state.match_state.match_presentation.sidebar_layout_spec,
         state.render_width() as f32,
@@ -166,7 +222,12 @@ pub(crate) fn refresh_sidebar_projection(state: &mut AppState) {
         armed_entry.as_ref(),
         &producer_focus,
         state.match_state.match_presentation.sidebar_scroll_rows,
-        state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation).map(|sim| &sim.interner),
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation)
+            .map(|sim| &sim.interner),
         &sw_views,
         &state.match_state.match_presentation.sidebar_gadget_state,
         repair_btn_size,
@@ -175,12 +236,21 @@ pub(crate) fn refresh_sidebar_projection(state: &mut AppState) {
         scroll_up_btn_size,
     );
     state.match_state.match_presentation.sidebar_scroll_rows = view.scroll_rows;
-    if let Some(atlas) = state.match_state.match_presentation.sidebar_cameo_atlas.as_ref() {
+    if let Some(atlas) = state
+        .match_state
+        .match_presentation
+        .sidebar_cameo_atlas
+        .as_ref()
+    {
         for item in &mut view.items {
             item.has_cameo_art = atlas.get(&item.type_id).is_some();
         }
     }
-    state.match_state.match_presentation.sidebar_projection.replace_view(Some(view));
+    state
+        .match_state
+        .match_presentation
+        .sidebar_projection
+        .replace_view(Some(view));
 }
 
 pub(crate) fn sync_targeting_mode(
@@ -216,7 +286,9 @@ pub(crate) fn sync_targeting_mode(
 pub(crate) fn is_cursor_over_minimap(state: &AppState) -> bool {
     // Minimap interaction disabled when radar is not online.
     let minimap_visible: bool = state
-        .match_state.match_presentation.radar_anim
+        .match_state
+        .match_presentation
+        .radar_anim
         .as_ref()
         .map_or(true, |ra| ra.is_minimap_visible());
     if !minimap_visible {
@@ -254,10 +326,7 @@ pub(crate) fn update_camera_from_minimap_cursor(state: &mut AppState) {
     let Some(minimap) = state.match_state.match_presentation.minimap.as_ref() else {
         return;
     };
-    let runtime = state
-        .match_state
-        .sim_runtime
-        .as_ref();
+    let runtime = state.match_state.sim_runtime.as_ref();
     let native_facts = runtime.and_then(|runtime| {
         let view = runtime.view();
         Some((
@@ -301,8 +370,10 @@ pub(crate) fn update_camera_from_minimap_cursor(state: &mut AppState) {
     // Mapless/headless presentation fixture adapter only.
     let sw = state.render_width() as f32;
     let sh = state.render_height() as f32;
-    let (tactical_w, tactical_h) =
-        crate::app::input::camera::tactical_viewport_size_px(state.render_width(), state.render_height());
+    let (tactical_w, tactical_h) = crate::app::input::camera::tactical_viewport_size_px(
+        state.render_width(),
+        state.render_height(),
+    );
     let z = state.match_state.input.zoom_level;
     let (cx, cy) = minimap.camera_top_left_for_screen_point_in_rect(
         state.match_state.input.cursor_x,
@@ -324,15 +395,22 @@ pub(crate) fn update_camera_from_minimap_cursor(state: &mut AppState) {
 pub(crate) fn active_minimap_content_screen_rect(state: &AppState) -> crate::sidebar::Rect {
     let aperture = active_minimap_screen_rect(state);
     let Some(minimap) = state.match_state.match_presentation.minimap.as_ref() else {
-        return crate::sidebar::Rect { x: aperture.x, y: aperture.y, w: 0.0, h: 0.0 };
+        return crate::sidebar::Rect {
+            x: aperture.x,
+            y: aperture.y,
+            w: 0.0,
+            h: 0.0,
+        };
     };
-    let Some([x, y, w, h]) = minimap.content_screen_rect_in_rect(
-        aperture.x,
-        aperture.y,
-        aperture.w,
-        aperture.h,
-    ) else {
-        return crate::sidebar::Rect { x: aperture.x, y: aperture.y, w: 0.0, h: 0.0 };
+    let Some([x, y, w, h]) =
+        minimap.content_screen_rect_in_rect(aperture.x, aperture.y, aperture.w, aperture.h)
+    else {
+        return crate::sidebar::Rect {
+            x: aperture.x,
+            y: aperture.y,
+            w: 0.0,
+            h: 0.0,
+        };
     };
     crate::sidebar::Rect { x, y, w, h }
 }
@@ -381,7 +459,15 @@ pub(crate) fn current_sidebar_theme(
 ) -> crate::render::sidebar_chrome::SidebarTheme {
     preferred_local_owner_name(state)
         .and_then(|owner| {
-            sidebar_theme_for_owner_sources(state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation), &state.match_state.match_presentation.house_roster, &owner)
+            sidebar_theme_for_owner_sources(
+                state
+                    .match_state
+                    .sim_runtime
+                    .as_ref()
+                    .map(|rt| &rt.simulation),
+                &state.match_state.match_presentation.house_roster,
+                &owner,
+            )
         })
         .unwrap_or(crate::render::sidebar_chrome::SidebarTheme::Allied)
 }
@@ -389,7 +475,11 @@ pub(crate) fn current_sidebar_theme(
 pub(crate) fn current_sidebar_chrome(
     state: &AppState,
 ) -> Option<&crate::render::sidebar_chrome::SidebarChromeAtlas> {
-    let set = state.match_state.match_presentation.sidebar_chrome.as_ref()?;
+    let set = state
+        .match_state
+        .match_presentation
+        .sidebar_chrome
+        .as_ref()?;
     let theme = current_sidebar_theme(state);
     set.for_theme(theme)
 }

--- a/src/app/sidebar_projection.rs
+++ b/src/app/sidebar_projection.rs
@@ -4,15 +4,22 @@
 //! explicit simulation, input, resize, and match-replacement transitions that
 //! rebuild the projection.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use crate::sidebar::SidebarView;
+use crate::sim::intern::InternedId;
 use crate::sim::world::TickLane;
 
 #[derive(Debug, Default)]
 pub(crate) struct SidebarProjectionState {
     displayed_credits: HashMap<String, i32>,
     current_view: Option<SidebarView>,
+    /// The build cameos the strips held at the last projection — the
+    /// `StripClass` entry list `SidebarClass::AddCameo @ 0x006A63E0` scans
+    /// before inserting. `None` until the first projection of a match, which
+    /// is the scenario-init window (`[0xA8E7AC] != 0`) where insertions are
+    /// silent.
+    cameo_types: Option<BTreeSet<InternedId>>,
 }
 
 impl SidebarProjectionState {
@@ -23,7 +30,30 @@ impl SidebarProjectionState {
     }
 
     pub(crate) fn replace_view(&mut self, view: Option<SidebarView>) {
+        if view.is_none() {
+            self.cameo_types = None;
+        }
         self.current_view = view;
+    }
+
+    /// Forget the strip entry list: the next `note_cameos` is a scenario's
+    /// first projection again (`[0xA8E7AC] != 0`, silent). Called wherever a
+    /// simulation is installed — a new match or an in-scenario load — so a
+    /// different pre-placed base never reads as freshly inserted cameos.
+    pub(crate) fn reset_cameo_seed(&mut self) {
+        self.cameo_types = None;
+    }
+
+    /// Record the build cameos now shown and report whether at least one was
+    /// inserted since the previous projection
+    /// (`crate::app::input::sidebar_eva::new_construction_options`).
+    pub(crate) fn note_cameos(&mut self, current: BTreeSet<InternedId>) -> bool {
+        let (set, inserted) = crate::app::input::sidebar_eva::new_construction_options(
+            self.cameo_types.as_ref(),
+            current,
+        );
+        self.cameo_types = Some(set);
+        inserted
     }
 
     /// Return the owner's retained display value, seeding a newly observed
@@ -128,6 +158,27 @@ mod tests {
     }
 
     #[test]
+    fn installing_another_sim_reseeds_the_cameo_strip_silently() {
+        let a = InternedId::from_index(1);
+        let b = InternedId::from_index(2);
+        let mut projection = SidebarProjectionState::default();
+        // Sim A: the first projection seeds silently, growth speaks.
+        assert!(!projection.note_cameos(BTreeSet::from([a])));
+        assert!(projection.note_cameos(BTreeSet::from([a, b])));
+        // Sim B with a different pre-placed base: without the reset its
+        // first refresh would read `b`-less/`a`-less strips as insertions.
+        projection.reset_cameo_seed();
+        assert!(
+            !projection.note_cameos(BTreeSet::from([b])),
+            "the first refresh after a sim install is the init window"
+        );
+        assert!(projection.note_cameos(BTreeSet::from([a, b])));
+        // Leaving the match still clears the seed.
+        projection.replace_view(None);
+        assert!(!projection.note_cameos(BTreeSet::from([a])));
+    }
+
+    #[test]
     fn credits_advance_once_per_committed_ordinary_frame() {
         let mut projection = SidebarProjectionState::default();
         projection.displayed_credits_or_seed("Americans", 100);
@@ -183,7 +234,9 @@ mod tests {
 
     #[test]
     fn sidebar_credit_gate_matrix() {
-        use crate::app::match_runtime::sim_tick::{RuntimePassInputs, SessionMode, decide_runtime_pass};
+        use crate::app::match_runtime::sim_tick::{
+            RuntimePassInputs, SessionMode, decide_runtime_pass,
+        };
 
         // Baseline wall-clock pass: active window, accepted startup receipt,
         // elapsed pacer window, nothing paused, no menu. Every freeze case

--- a/src/rules/object_type.rs
+++ b/src/rules/object_type.rs
@@ -859,6 +859,22 @@ pub struct ObjectType {
     /// when an enemy Engineer or Spy is selected and hovering this building.
     pub capturable: bool,
 
+    /// `NeedsEngineer=` — `BuildingTypeClass::ReadINI 0x0046023E..0x0046024B`
+    /// stores it at `+0x1552`. A tech building that starts neutral and is
+    /// taken by an engineer; `BuildingClass::ChangeOwner 0x00448401` routes
+    /// the capture announcement on it (`EVA_TechBuildingLost` for the local
+    /// old owner instead of the radar-gated `EVA_BuildingCaptured`).
+    pub needs_engineer: bool,
+
+    /// `CaptureEvaEvent=` — `BuildingTypeClass::ReadINI 0x00460258..0x00460265`
+    /// stores the `VoxClass` entry index at `+0x1554` (`-1` when absent).
+    /// `BuildingClass::ChangeOwner 0x00448443..0x00448459` queues it
+    /// (`QueueVoice(index, -1, -1)`) for a local NEW owner of a
+    /// `NeedsEngineer=` building (stock: `EVA_OilRefineryCaptured` on
+    /// `CAOILD`, `EVA_HospitalCaptured`, ...). The name is kept; the app
+    /// resolves it through the EVA registry.
+    pub capture_eva_event: Option<String>,
+
     /// Whether this building can be repaired via the Repair command.
     /// Parsed from `Repairable=yes` in rules.ini. Defaults to true for buildings.
     pub repairable: bool,
@@ -1882,6 +1898,12 @@ impl ObjectType {
             engineer: section.get_bool("Engineer").unwrap_or(false),
             deployer: section.get_bool("Deployer").unwrap_or(false),
             capturable: section.get_bool("Capturable").unwrap_or(false),
+            needs_engineer: section.get_bool("NeedsEngineer").unwrap_or(false),
+            capture_eva_event: section
+                .get("CaptureEvaEvent")
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string),
             // Repairable defaults to true — most buildings can be repaired in RA2.
             repairable: section.get_bool("Repairable").unwrap_or(true),
             can_be_occupied: section.get_bool("CanBeOccupied").unwrap_or(false),

--- a/src/rules/ruleset.rs
+++ b/src/rules/ruleset.rs
@@ -2703,6 +2703,11 @@ pub struct RuleSet {
     pub radar_event_config: RadarEventConfig,
     /// All superweapon types indexed by ID (e.g., "LightningStormSpecial" → SuperWeaponType).
     pub super_weapons: HashMap<String, SuperWeaponType>,
+    /// `[SuperWeaponTypes]` in list order — the `SuperWeaponTypeClass` array
+    /// index gamemd switches on where it does not use `Type=` (the
+    /// `BuildingClass::OnConstructionComplete 0x00446948` `*Detected` jump
+    /// table indexes this list: stock `1=NukeSpecial` is index 0).
+    pub super_weapon_order: Vec<String>,
     /// Default particle systems from `[CombatDamage]` (smoke, sparks, debris, fire-stream).
     pub combat_damage: CombatDamageDefaults,
     /// Pre-resolved bridge-related warhead names (`[CombatDamage]
@@ -3302,6 +3307,7 @@ impl RuleSet {
         // Step 8: Parse superweapon type registry.
         let mut super_weapons: HashMap<String, SuperWeaponType> = HashMap::new();
         let sw_ids: Vec<String> = parse_registry(ini, "SuperWeaponTypes");
+        let super_weapon_order: Vec<String> = sw_ids.clone();
         for sw_id in &sw_ids {
             if let Some(section) = ini.section(sw_id) {
                 if let Some(sw) = SuperWeaponType::from_ini_section(sw_id, section) {
@@ -3482,6 +3488,7 @@ impl RuleSet {
             radiation,
             radar_event_config,
             super_weapons,
+            super_weapon_order,
             combat_damage,
             bridge_warheads,
             missile_spawn,

--- a/src/sim/movement/locomotor_tests.rs
+++ b/src/sim/movement/locomotor_tests.rs
@@ -224,6 +224,8 @@ fn make_obj(locomotor: LocomotorKind, category: ObjectCategory) -> ObjectType {
         engineer: false,
         deployer: false,
         capturable: false,
+        needs_engineer: false,
+        capture_eva_event: None,
         repairable: true,
         can_be_occupied: false,
         can_occupy_fire: false,

--- a/src/sim/movement/teleport_movement.rs
+++ b/src/sim/movement/teleport_movement.rs
@@ -687,6 +687,8 @@ mod tests {
             engineer: false,
             deployer: false,
             capturable: false,
+            needs_engineer: false,
+            capture_eva_event: None,
             repairable: false,
             can_be_occupied: false,
             can_occupy_fire: false,

--- a/src/sim/production/production_placement_tests.rs
+++ b/src/sim/production/production_placement_tests.rs
@@ -22,8 +22,8 @@ use crate::rules::ini_parser::IniFile;
 use crate::rules::object_type::ObjectCategory;
 use crate::rules::ruleset::RuleSet;
 use crate::rules::terrain_rules::{LandType, SpeedCostProfile, TerrainClass};
-use crate::sim::command::{Command, CommandEnvelope};
 use crate::sim::combat::AttackTarget;
+use crate::sim::command::{Command, CommandEnvelope};
 use crate::sim::components::{BuildingUp, Health};
 use crate::sim::game_entity::GameEntity;
 use crate::sim::mission::MissionType;
@@ -1551,6 +1551,15 @@ fn placement_command_rejects_marked_ground_mobiles_until_they_are_unmarked() {
             !tick.spawned_entities,
             "rejected placement must not report a spawned entity"
         );
+        // `HouseClass::Place_Production 0x004FB369..0x004FB377`: the failed
+        // Unlimbo speaks `EVA_CannotDeployHere` for the placing house.
+        assert!(
+            sim.sound_events.iter().any(|event| matches!(
+                event,
+                crate::sim::world::SimSoundEvent::CannotDeployHere { owner } if *owner == americans
+            )),
+            "rejected placement must emit EVA_CannotDeployHere for {blocker_type}"
+        );
         assert_eq!(sim.substrate.entities.len(), entities_before);
         assert_eq!(sim.substrate.next_stable_object_id, next_id_before);
         assert_eq!(
@@ -2353,7 +2362,9 @@ fn gsi_04_07_wall_placement_publishes_connectivity_neighbor_auto_destruction() {
         sim.radar_terrain_dirty_generation, 5,
         "each first-unique native radar callback is published at its inline visit"
     );
-    let live_path = sim.path_grid_snapshot().expect("hosted placement path authority");
+    let live_path = sim
+        .path_grid_snapshot()
+        .expect("hosted placement path authority");
     assert!(
         live_path.is_walkable(13, 10),
         "removed neighbor must be passable before placement returns"

--- a/src/sim/production/production_sell.rs
+++ b/src/sim/production/production_sell.rs
@@ -14,7 +14,8 @@ use crate::sim::movement::locomotor::MovementLayer;
 use crate::sim::passenger::PassengerRole;
 use crate::sim::pathfinding::cell_entry::{TerrainCheckResult, check_terrain};
 use crate::sim::world::{
-    PlacementEvidence, RevealOutcome, RevealPosition, RevealRequest, Simulation, UninitContext,
+    PlacementEvidence, RevealOutcome, RevealPosition, RevealRequest, SimSoundEvent, Simulation,
+    UninitContext,
 };
 use crate::util::lepton;
 
@@ -772,6 +773,18 @@ pub fn sell_building(sim: &mut Simulation, rules: &RuleSet, stable_id: u64) -> b
     if refund > 0 {
         *credits_entry_for_owner(sim, &owner_name) += refund;
     }
+    // `BuildingClass::Sell 0x00449C99..0x00449CE5` (sell state 2, the
+    // building is gone): `[this+0x6DD]` — the build-animation-complete flag,
+    // set at `0x004467C9` (construction complete), cleared in sell state 0
+    // and again at the end of sell state 1, so state 2 waits for the
+    // sell-down animation — `[this+0x41A]` (owner is the local player) and
+    // `UndeploysInto=` (`Type+0x408`) null → `PlayEVA("EVA_StructureSold")`.
+    // A Construction Yard undeploys into its MCV instead and stays silent.
+    // The app applies the local-owner half.
+    if obj.undeploys_into.is_none() {
+        sim.sound_events
+            .push(SimSoundEvent::StructureSold { owner: owner_id });
+    }
     log::info!(
         "Building {} sold by {}: refunded {} credits, ejected {} crew + {} garrison, undocked {} miners",
         type_id,
@@ -798,6 +811,15 @@ pub fn toggle_repair(sim: &mut Simulation, stable_id: u64) -> bool {
     } else {
         entity.repairing = true;
         log::info!("Repair started on entity {}", stable_id);
+        // `BuildingClass::ToggleRepair @ 0x00446FF0`: once the flag is on
+        // and `Health != Type.Strength` (`0x00447059`), the local owner
+        // (`0x004470A4 CALL 0x0050B6F0`) gets the sidebar flash and
+        // `PlayEVA("EVA_Repairing")` (`0x004470B7`). The app applies the
+        // local-owner half.
+        if entity.health.current != entity.health.max {
+            let owner = entity.owner;
+            sim.sound_events.push(SimSoundEvent::Repairing { owner });
+        }
     }
     true
 }
@@ -943,6 +965,7 @@ mod tests {
     use super::*;
     use crate::rules::ini_parser::IniFile;
     use crate::rules::locomotor_type::LocomotorKind;
+    use crate::sim::components::Health;
     use crate::sim::game_entity::GameEntity;
     use crate::sim::movement::locomotor::LocomotorState;
     use crate::sim::occupancy::CellListInsertion;
@@ -1535,5 +1558,104 @@ mod tests {
 
         sim.flush_pending_delete();
         assert!(sim.substrate.entities.get(passenger_id).is_none());
+    }
+
+    fn sell_eva_rules() -> RuleSet {
+        let ini = IniFile::from_str(
+            "[InfantryTypes]\n[VehicleTypes]\n0=AMCV\n[AircraftTypes]\n\
+             [BuildingTypes]\n0=GAPOWR\n1=GACNST\n\n\
+             [AMCV]\nStrength=450\nArmor=heavy\nSpeed=5\nDeploysInto=GACNST\n\n\
+             [GAPOWR]\nStrength=100\nArmor=wood\nCost=800\n\n\
+             [GACNST]\nStrength=1000\nArmor=wood\nCost=3000\nConstructionYard=yes\nUndeploysInto=AMCV\n",
+        );
+        RuleSet::from_ini(&ini).expect("sell eva rules should parse")
+    }
+
+    fn insert_structure(sim: &mut Simulation, id: u64, type_id: &str, owner: &str) {
+        let mut entity = GameEntity::test_default(id, type_id, owner, 10, 10);
+        entity.category = EntityCategory::Structure;
+        entity.owner = sim.interner.intern(owner);
+        entity.type_ref = sim.interner.intern(type_id);
+        sim.substrate.entities.insert(entity);
+    }
+
+    fn sold_events(sim: &Simulation, owner: crate::sim::intern::InternedId) -> usize {
+        sim.sound_events
+            .iter()
+            .filter(
+                |event| matches!(event, SimSoundEvent::StructureSold { owner: o } if *o == owner),
+            )
+            .count()
+    }
+
+    /// `BuildingClass::Sell 0x00449CD1 MOV ECX,[EAX+0x408] ; TEST ; JNZ skip`:
+    /// a type with `UndeploysInto=` never speaks.
+    #[test]
+    fn selling_announces_structure_sold_unless_the_type_undeploys() {
+        let rules = sell_eva_rules();
+        let mut sim = Simulation::new();
+        let owner = sim.interner.intern("Americans");
+        sim.houses.insert(
+            owner,
+            crate::sim::house_state::HouseState::new(owner, 0, None, true, 0, 10),
+        );
+        insert_structure(&mut sim, 1, "GAPOWR", "Americans");
+        insert_structure(&mut sim, 2, "GACNST", "Americans");
+
+        assert!(sell_building(&mut sim, &rules, 1));
+        assert_eq!(
+            sold_events(&sim, owner),
+            1,
+            "a power plant sale speaks once"
+        );
+
+        sim.sound_events.clear();
+        assert!(sell_building(&mut sim, &rules, 2));
+        assert_eq!(
+            sold_events(&sim, owner),
+            0,
+            "a Construction Yard (UndeploysInto=) sale is silent"
+        );
+    }
+
+    /// `BuildingClass::ToggleRepair 0x00447053..0x004470B7`: the line needs the
+    /// flag to end up ON and `Health != Type.Strength`.
+    #[test]
+    fn repair_toggle_announces_only_when_switching_on_a_damaged_building() {
+        let mut sim = Simulation::new();
+        let owner = sim.interner.intern("Americans");
+        insert_structure(&mut sim, 1, "GAPOWR", "Americans");
+        insert_structure(&mut sim, 2, "GAPOWR", "Americans");
+        {
+            let damaged = sim.substrate.entities.get_mut(1).expect("damaged plant");
+            damaged.health = Health {
+                current: 40,
+                max: 100,
+            };
+            let intact = sim.substrate.entities.get_mut(2).expect("intact plant");
+            intact.health = Health {
+                current: 100,
+                max: 100,
+            };
+        }
+        let repairing = |sim: &Simulation| {
+            sim.sound_events
+                .iter()
+                .filter(
+                    |event| matches!(event, SimSoundEvent::Repairing { owner: o } if *o == owner),
+                )
+                .count()
+        };
+
+        assert!(toggle_repair(&mut sim, 1));
+        assert_eq!(
+            repairing(&sim),
+            1,
+            "switching repair on a damaged building speaks"
+        );
+        assert!(toggle_repair(&mut sim, 1));
+        assert_eq!(repairing(&sim), 1, "switching it off is silent");
+        assert!(toggle_repair(&mut sim, 2));
+        assert_eq!(repairing(&sim), 1, "a building at full strength is silent");
     }
 }

--- a/src/sim/superweapon/mod.rs
+++ b/src/sim/superweapon/mod.rs
@@ -23,7 +23,7 @@ use crate::rules::ruleset::RuleSet;
 use crate::rules::superweapon_type::SuperWeaponKind;
 use crate::sim::intern::InternedId;
 use crate::sim::timer::CdTimer;
-use crate::sim::world::Simulation;
+use crate::sim::world::{SimSoundEvent, Simulation};
 
 /// Per-house, per-superweapon-type runtime state.
 ///
@@ -219,6 +219,7 @@ pub fn tick_superweapon_instances(sim: &mut Simulation, rules: &RuleSet) {
     // Phase 1: Charge/suspend lifecycle for all instances.
     // Collect owners to avoid borrow conflict on sim.super_weapons.
     let owners: Vec<InternedId> = sim.super_weapons.keys().copied().collect();
+    let mut became_ready: Vec<(InternedId, InternedId)> = Vec::new();
     for owner_id in owners {
         let is_low_power = sim
             .power_states
@@ -251,9 +252,18 @@ pub fn tick_superweapon_instances(sim: &mut Simulation, rules: &RuleSet) {
                 if inst.charge_timer().expired(current_frame as i32) {
                     inst.is_ready = true;
                     inst.ready_tick = current_frame as i32;
+                    became_ready.push((owner_id, inst.type_id));
                 }
             }
         }
+    }
+    // `SuperClass::AI_Ready @ 0x006CBCA0`: `+0x6F` set at `0x006CBDB6`, then
+    // `0x006CBE63 PlayEVA(<Type=-indexed *Ready line>, -1)` when the announce
+    // argument (`house == PlayerPtr`, `HouseClass::Update 0x004F8E42`) holds.
+    // The app applies that local-owner half.
+    for (owner, sw_type) in became_ready {
+        sim.sound_events
+            .push(SimSoundEvent::SuperWeaponReady { owner, sw_type });
     }
 }
 
@@ -385,5 +395,49 @@ mod frame_tests {
         instance.resume(0);
         assert_eq!(instance.charge_progress(1, 4), 0.75);
         assert_eq!(instance.charge_progress(2, 4), 1.0);
+    }
+
+    /// `SuperClass::AI_Ready 0x006CBDCC MOV [ESI+0x6F],BL` then `0x006CBE63
+    /// PlayEVA`: the ready line is a sim fact emitted once, at expiry.
+    #[test]
+    fn charge_expiry_emits_super_weapon_ready_once() {
+        use crate::rules::ini_parser::IniFile;
+        let ini = IniFile::from_str(
+            "[SuperWeaponTypes]\n1=NukeSpecial\n[NukeSpecial]\nType=MultiMissile\n\
+             RechargeTime=1\nIsPowered=no\n\
+             [InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n",
+        );
+        let rules = RuleSet::from_ini(&ini).expect("superweapon ready rules should parse");
+        let mut sim = Simulation::new();
+        let owner = sim.interner.intern("Americans");
+        let sw = sim.interner.intern("NukeSpecial");
+        let mut instance = SuperWeaponInstance::new(sw, owner);
+        instance.activate(10, sim.session.binary_frame);
+        sim.super_weapons.entry(owner).or_default().insert(sw, instance);
+        sim.super_weapons_initialized = true;
+        let ready = |sim: &Simulation| {
+            sim.sound_events
+                .iter()
+                .filter(|event| {
+                    matches!(
+                        event,
+                        SimSoundEvent::SuperWeaponReady { owner: o, sw_type }
+                            if *o == owner && *sw_type == sw
+                    )
+                })
+                .count()
+        };
+
+        sim.session.binary_frame += 5;
+        tick_superweapon_instances(&mut sim, &rules);
+        assert_eq!(ready(&sim), 0, "still charging");
+
+        sim.session.binary_frame += 10;
+        tick_superweapon_instances(&mut sim, &rules);
+        assert_eq!(ready(&sim), 1, "the expiry tick announces");
+        assert!(sim.super_weapons[&owner][&sw].is_ready);
+
+        tick_superweapon_instances(&mut sim, &rules);
+        assert_eq!(ready(&sim), 1, "a ready weapon is not re-announced");
     }
 }

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -387,6 +387,69 @@ pub enum SimSoundEvent {
     /// (`EVA_InsufficientFunds` `0x004F8BA0`, `EVA_LowPower` `0x004F8D14`)
     /// for a human house; `event` is the `evamd.ini` section name.
     HouseEva { owner: InternedId, event: &'static str },
+    /// `BuildingClass::Sell @ 0x00449B70`, sell state 2 (`0x00449C99..
+    /// 0x00449CE5`, the building is gone): `+0x6DD` (the build-animation-
+    /// complete flag: set at `0x004467C9`, cleared in sell states 0 and 1,
+    /// so state 2 waits for the sell-down animation to finish),
+    /// `TechnoClass+0x41A` (owner is the local player) and `UndeploysInto=`
+    /// (`Type+0x408`) null — a Construction Yard undeploys instead and stays
+    /// silent. The upgrade-sell path (`0x0044AB22..0x0044AB36`) speaks on
+    /// `+0x41A` alone; VERA sells no upgrades. App plays `EVA_StructureSold`.
+    /// Timing DRIFT, recorded: native speaks after the sell-down animation
+    /// (state 1); VERA's sale is synchronous, so the line comes at the click.
+    StructureSold { owner: InternedId },
+    /// `BuildingClass::ToggleRepair @ 0x00446FF0` (`0x004470B7`): repair
+    /// switched on while `Health != Type.Strength` (`0x00447059`) and the
+    /// owner is the local player (`0x004470A4 CALL 0x0050B6F0`). App plays
+    /// `EVA_Repairing` for the local owner.
+    Repairing { owner: InternedId },
+    /// `BuildingClass::ChangeOwner @ 0x00448260` announce block
+    /// (`0x004483C0..0x0044848F`) for an engineer capture
+    /// (`InfantryClass::PerCellProcess 0x00519A27 PUSH 1` = announce). Native
+    /// gate: the OLD or the NEW owner is the local player (`0x004483C6` /
+    /// `0x004483D1 CALL 0x0050B6F0`), the new owner's type not
+    /// `MultiplayPassive` (`0x004483E1`). `tech_building` is `NeedsEngineer=`
+    /// (`Type+0x1552`, `0x00448401`): clear → `CreateRadarEvent(10, cell)`
+    /// (`0x00448472 MOV ECX,0xA`) and, when accepted, `EVA_BuildingCaptured`
+    /// (`0x0044848A`); set → `EVA_TechBuildingLost` for a local OLD owner
+    /// (`0x00448415`, ECX = `this->Owner`) and the type's `CaptureEvaEvent=`
+    /// (`Type+0x1554`, `0x00448459 QueueVoice`) for a local NEW owner. The
+    /// sim cannot see the local player: it emits for any human-controlled
+    /// side and the app applies the local test. `radar_accepted` carries the
+    /// radar result.
+    BuildingCaptured {
+        old_owner: InternedId,
+        new_owner: InternedId,
+        tech_building: bool,
+        radar_accepted: bool,
+        capture_eva_event: Option<InternedId>,
+    },
+    /// `SuperClass::AI_Ready @ 0x006CBCA0` (`0x006CBE63`): the charge
+    /// expired and `+0x6F` (IsReady) was set (`0x006CBDCC`); the announce
+    /// argument is `house == PlayerPtr` (`0x004F8E42..0x004F8E47` in
+    /// `HouseClass::Update`). `sw_type` is the `[SuperWeaponTypes]` section;
+    /// the app maps its `Type=` onto the `*Ready` line through the
+    /// `0x006CBDE6` jump table (`0x006CBEA8`).
+    SuperWeaponReady { owner: InternedId, sw_type: InternedId },
+    /// `BuildingClass::OnConstructionComplete @ 0x00445F80`
+    /// (`0x004468AD..0x00446995`): a building whose type carries
+    /// `SuperWeapon=` finished building up. Native speaks only when the owner
+    /// is not the local player (`0x004468B3`), not allied with it
+    /// (`0x004468CD IsAlliedWith(PlayerPtr)`), `[0xA8B538] == 0` (local
+    /// player not defeated, `0x004468DA`), `GameMode != 0` (`0x004468E7`),
+    /// and the type's `AuxBuilding=` is absent or owned by the building's
+    /// owner (`0x0044692E CountOwnedInstances`); the line comes from the
+    /// `[SuperWeaponTypes]` list index (`0x00446948` table at `0x00446FC0`).
+    /// The app applies the listener gates and the table.
+    SuperWeaponDetected { owner: InternedId, sw_type: InternedId },
+    /// `HouseClass::MPlayer_Defeated @ 0x004FC0B0`, non-local branch
+    /// (`0x004FC30C..0x004FC3BC`): a house whose type is not
+    /// `MultiplayPassive` (`0x004FC30F`) was defeated. Native also skips the
+    /// line for the observer house (`0x004FC343 CMP ESI,[0xAC1198]`), which
+    /// VERA does not model. App plays `EVA_PlayerDefeated` when `house` is
+    /// not the local player (the local defeat is `EVA_YouHaveLost` via
+    /// [`SimSoundEvent::MatchOutcome`]).
+    PlayerDefeated { house: InternedId },
     /// A superweapon fired. `sw_type` is the interned `[SuperWeaponTypes]`
     /// section name of the launched weapon — the discriminator the app layer
     /// needs to pick the cue, and the same object gamemd switches on.
@@ -5167,6 +5230,12 @@ impl Simulation {
                 house.owned_building_count == 0 && house.owned_unit_count == 0
             };
             if should_defeat {
+                // `HouseClass::MPlayer_Defeated 0x004FC30F..0x004FC3BC`: the
+                // defeat of any non-passive house is announced (the passive
+                // gate is the `continue` above); the app decides local vs
+                // other.
+                self.sound_events
+                    .push(SimSoundEvent::PlayerDefeated { house: owner });
                 let accepted = if let Some(h) = self.houses.get_mut(&owner) {
                     h.is_defeated = true;
                     // A house that owns nothing (or, in Short Game, has no base
@@ -6040,6 +6109,33 @@ impl Simulation {
         }
     }
 
+    /// `BuildingClass::OnConstructionComplete @ 0x00445F80`, the
+    /// `SuperWeapon=` announce block (`0x004468AD..0x00446995`): a completed
+    /// building whose type names a `[SuperWeaponTypes]` section
+    /// (`Type+0x16F0 != -1`) reports itself. Only the owner-independent half
+    /// lives here; the listener gates (local player, `IsAlliedWith(PlayerPtr)`,
+    /// `[0xA8B538]`, `GameMode`, `AuxBuilding` ownership) are the app's.
+    fn announce_super_weapon_building_complete(&mut self, stable_id: u64, rules: &RuleSet) {
+        let Some((owner, type_ref)) = self
+            .substrate
+            .entities
+            .get(stable_id)
+            .filter(|e| e.category == EntityCategory::Structure && !e.dying)
+            .map(|e| (e.owner, e.type_ref))
+        else {
+            return;
+        };
+        let Some(section) = rules
+            .object(self.interner.resolve(type_ref))
+            .and_then(|obj| obj.super_weapon.clone())
+        else {
+            return;
+        };
+        let sw_type = self.interner.intern(&section);
+        self.sound_events
+            .push(SimSoundEvent::SuperWeaponDetected { owner, sw_type });
+    }
+
     /// Advance build-up animations and return completed building stable IDs.
     fn tick_building_up(&mut self) -> Vec<u64> {
         // Collect keys first to allow &mut iteration via get_mut().
@@ -6747,6 +6843,7 @@ impl Simulation {
         if let Some(rules) = rules {
             for &stable_id in &completed_buildings {
                 self.add_building_sensor_array_if_powered(stable_id, rules);
+                self.announce_super_weapon_building_complete(stable_id, rules);
             }
             *spawned_entities |= production::spawn_completed_refinery_free_units(
                 self,

--- a/src/sim/world/world_commands.rs
+++ b/src/sim/world/world_commands.rs
@@ -1372,7 +1372,7 @@ impl Simulation {
                 }
                 let owner_s = self.interner.resolve(*owner).to_string();
                 let type_s = self.interner.resolve(*type_id).to_string();
-                production::place_ready_building_with_overlays(
+                let placed = production::place_ready_building_with_overlays(
                     self,
                     rules,
                     &owner_s,
@@ -1382,7 +1382,16 @@ impl Simulation {
                     path_grid,
                     height_map,
                     overlay_registry,
-                )
+                );
+                if !placed {
+                    // `HouseClass::Place_Production 0x004FB369..0x004FB377`:
+                    // a placement event whose Unlimbo fails speaks
+                    // `EVA_CannotDeployHere` when `this == PlayerPtr`; the
+                    // app applies the local-owner half.
+                    self.sound_events
+                        .push(SimSoundEvent::CannotDeployHere { owner: *owner });
+                }
+                placed
             }
             Command::CancelLastProduction { owner } => {
                 let Some(rules) = rules else { return false };
@@ -2455,6 +2464,9 @@ impl Simulation {
                 }
             }
         }
+        // `EVA_NewRallyPointEstablished` is not a sim fact: `BuildingClass::
+        // SetRallyPoint 0x00443A69` speaks inside the click handler, after the
+        // rally EventClass is pushed and before it executes — the app owns it.
         true
     }
 

--- a/src/sim/world/world_orders.rs
+++ b/src/sim/world/world_orders.rs
@@ -7,7 +7,7 @@
 
 use std::collections::BTreeSet;
 
-use super::Simulation;
+use super::{SimSoundEvent, Simulation};
 use crate::map::entities::EntityCategory;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::combat;
@@ -315,6 +315,7 @@ impl Simulation {
             let dy = (eng_ry as i32 - bld_ry as i32).abs();
 
             if dx <= 1 && dy <= 1 {
+                self.announce_engineer_capture(building_id, engineer_owner, rules);
                 // CAPTURE: the ownership chokepoint moves HouseState counts,
                 // the by-owner index, and the entity owner exactly once.
                 self.change_owner_with_rules(building_id, engineer_owner, rules);
@@ -324,6 +325,78 @@ impl Simulation {
             }
         }
         any_captured
+    }
+
+    /// `BuildingClass::ChangeOwner @ 0x00448260` announce block
+    /// (`0x004483C0..0x0044848F`), run before the owner swap because native
+    /// reads `this->Owner` (the OLD owner) there. The engineer capture site
+    /// (`InfantryClass::PerCellProcess 0x00519A27 PUSH 1`) passes
+    /// announce=true. Native gates: the old or the new owner is the local
+    /// player (`0x004483C6`/`0x004483D1 CALL 0x0050B6F0`) and the new
+    /// owner's type is not `MultiplayPassive` (`0x004483E1 HouseType+0x1A6`).
+    /// The sim has no local player, so it pre-filters on a human-controlled
+    /// house on either side and the app applies the local test (equal in the
+    /// single-human skirmish; VERA-internal, gamemd equivalent UNCHECKED for
+    /// two-human matches, where the radar event would also be local).
+    /// `NeedsEngineer=` types skip the radar event (`0x00448407`); the rest
+    /// go through `CreateRadarEvent(10, cell)` (`0x00448472 MOV ECX,0xA`)
+    /// whose accept result gates `EVA_BuildingCaptured` — type table row 10
+    /// (`0x007F0A38`: dedup 8, blink 100, unique 0) has no uniqueness
+    /// dedupe, so on stock data the radar accepts every capture. The type's
+    /// `CaptureEvaEvent=` (`Type+0x1554`, `0x00448443..0x00448459`) rides
+    /// along for the app's local-new-owner branch.
+    pub(crate) fn announce_engineer_capture(
+        &mut self,
+        building_id: u64,
+        new_owner: InternedId,
+        rules: &RuleSet,
+    ) {
+        let Some((old_owner, type_ref, rx, ry)) = self
+            .substrate
+            .entities
+            .get(building_id)
+            .map(|e| (e.owner, e.type_ref, e.position.rx, e.position.ry))
+        else {
+            return;
+        };
+        if old_owner == new_owner {
+            return;
+        }
+        let game_mode_nonzero = self.session.game_mode_nonzero;
+        let human = |sim: &Self, house: InternedId| {
+            sim.houses
+                .get(&house)
+                .is_some_and(|h| h.is_controlled_by_human(game_mode_nonzero))
+        };
+        if !(human(self, old_owner) || human(self, new_owner)) {
+            return;
+        }
+        if self
+            .houses
+            .get(&new_owner)
+            .is_some_and(|h| h.multiplay_passive)
+        {
+            return;
+        }
+        let (tech_building, capture_eva_event) = self
+            .object_type(type_ref, rules)
+            .map(|obj| (obj.needs_engineer, obj.capture_eva_event.clone()))
+            .unwrap_or((false, None));
+        let capture_eva_event = capture_eva_event.map(|name| self.interner.intern(&name));
+        let radar_accepted = !tech_building
+            && self.radar_events.push_owned(
+                crate::sim::radar::RadarEventType::BuildingCaptured,
+                rx,
+                ry,
+                None,
+            );
+        self.sound_events.push(SimSoundEvent::BuildingCaptured {
+            old_owner,
+            new_owner,
+            tech_building,
+            radar_accepted,
+            capture_eva_event,
+        });
     }
 
     /// Tick bridge-repair orders: any engineer with `capture_target` pointing

--- a/src/sim/world/world_spawn.rs
+++ b/src/sim/world/world_spawn.rs
@@ -1855,6 +1855,17 @@ impl Simulation {
         };
 
         // Check that all footprint cells are free before deploying.
+        //
+        // Follow-up (documented, not wired): `UnitClass::Deploy @ 0x007393C0`
+        // speaks `EVA_CannotDeployHere` (`0x0073950A`) only when the owner
+        // is a human player AND `Type+0x5EC` (`ResourceGatherer=`, `ReadINI
+        // 0x007143E4`) is clear (`0x007394EB..0x0073950A`); a blocked
+        // ResourceGatherer deploy stays silent. VERA's `CannotDeployHere`
+        // events below do not yet apply that type gate. Stock: `[SMIN]`
+        // (slave miner, `ResourceGatherer=yes`, `DeploysInto=YAREFN`) is the
+        // one such unit — a blocked slave-miner deploy speaks in VERA and
+        // not in gamemd. DRIFT, recorded; trigger: every blocked human
+        // slave-miner deploy.
         let (fw, fh) = foundation_dimensions(&foundation);
         for dy in 0..fh {
             for dx in 0..fw {

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -9767,3 +9767,190 @@ fn gsi_05_14_death_debris_joins_the_live_order_the_hash_and_the_snapshot() {
     );
     sim.debug_assert_logic_membership_consistent();
 }
+
+fn capture_eva_rules() -> RuleSet {
+    let ini = IniFile::from_str(
+        "[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n\
+         [BuildingTypes]\n0=GAPOWR\n1=CAOILD\n\n\
+         [GAPOWR]\nStrength=100\nArmor=wood\nCapturable=yes\n\n\
+         [CAOILD]\nStrength=1000\nArmor=wood\nCapturable=yes\nNeedsEngineer=yes\n\
+         CaptureEvaEvent=EVA_OilRefineryCaptured\n",
+    );
+    RuleSet::from_ini(&ini).expect("capture eva rules should parse")
+}
+
+fn captured_events(
+    sim: &Simulation,
+) -> Vec<(InternedId, InternedId, bool, bool, Option<InternedId>)> {
+    sim.sound_events
+        .iter()
+        .filter_map(|event| match event {
+            SimSoundEvent::BuildingCaptured {
+                old_owner,
+                new_owner,
+                tech_building,
+                radar_accepted,
+                capture_eva_event,
+            } => Some((
+                *old_owner,
+                *new_owner,
+                *tech_building,
+                *radar_accepted,
+                *capture_eva_event,
+            )),
+            _ => None,
+        })
+        .collect()
+}
+
+/// `BuildingClass::ChangeOwner 0x004483FB..0x0044848F`: an ordinary building
+/// goes through `CreateRadarEvent(10, cell)` and announces only when the radar
+/// queue accepted the event. Native row 10 of the `0x007F0998` type table
+/// (`0x007F0A38`: dedup 8, visibility 0, blink 100, unique 0) is NOT unique,
+/// so a second capture next to a live diamond is accepted too.
+#[test]
+fn engineer_capture_of_an_ordinary_building_is_gated_by_the_radar_event() {
+    let rules = capture_eva_rules();
+    let mut sim = Simulation::new();
+    sim.session.game_mode_nonzero = true;
+    let player = insert_house_with_counts(&mut sim, "Americans", 0, 0);
+    let enemy = insert_house_with_counts(&mut sim, "Russians", 2, 0);
+    sim.houses.get_mut(&enemy).expect("enemy").is_human = false;
+    insert_test_entity_for_owner(&mut sim, 1, enemy, "GAPOWR", EntityCategory::Structure);
+    insert_test_entity_for_owner(&mut sim, 2, enemy, "GAPOWR", EntityCategory::Structure);
+    sim.substrate
+        .entities
+        .get_mut(2)
+        .expect("second plant")
+        .position
+        .rx = 11;
+
+    sim.announce_engineer_capture(1, player, &rules);
+    assert_eq!(
+        captured_events(&sim),
+        vec![(enemy, player, false, true, None)]
+    );
+    assert_eq!(
+        sim.radar_events
+            .iter()
+            .filter(|event| event.event_type == crate::sim::radar::RadarEventType::BuildingCaptured)
+            .count(),
+        1,
+        "`0x00448472 MOV ECX,0xA` creates the type-10 radar event"
+    );
+
+    // A second capture one cell away while the first diamond lives: type 10
+    // is not unique, so the radar event and the line both go through.
+    sim.sound_events.clear();
+    sim.announce_engineer_capture(2, player, &rules);
+    assert_eq!(
+        captured_events(&sim),
+        vec![(enemy, player, false, true, None)]
+    );
+    assert_eq!(
+        sim.radar_events
+            .iter()
+            .filter(|event| event.event_type == crate::sim::radar::RadarEventType::BuildingCaptured)
+            .count(),
+        2
+    );
+}
+
+/// `0x00448401 MOV CL,[Type+0x1552]` (`NeedsEngineer=`): no radar event; the
+/// old owner's `EVA_TechBuildingLost` and the new owner's `CaptureEvaEvent=`
+/// are the app's to route.
+#[test]
+fn engineer_capture_of_a_tech_building_carries_its_capture_eva_event() {
+    let rules = capture_eva_rules();
+    let mut sim = Simulation::new();
+    sim.session.game_mode_nonzero = true;
+    let player = insert_house_with_counts(&mut sim, "Americans", 0, 0);
+    let civilian = insert_passive_house_with_counts(&mut sim, "Neutral", 1, 0);
+    insert_test_entity_for_owner(&mut sim, 1, civilian, "CAOILD", EntityCategory::Structure);
+
+    sim.announce_engineer_capture(1, player, &rules);
+    let line = sim.interner.get("EVA_OilRefineryCaptured");
+    assert!(
+        line.is_some(),
+        "the CaptureEvaEvent name is interned for the app"
+    );
+    assert_eq!(
+        captured_events(&sim),
+        vec![(civilian, player, true, false, line)]
+    );
+    assert_eq!(
+        sim.radar_events.len(),
+        0,
+        "NeedsEngineer skips CreateRadarEvent"
+    );
+}
+
+/// `0x004483C6/0x004483D1`: a human house on one side is required, and
+/// `0x004483E1`: a `MultiplayPassive` new owner never announces.
+#[test]
+fn engineer_capture_is_silent_without_a_human_side_or_into_a_passive_house() {
+    let rules = capture_eva_rules();
+    let mut sim = Simulation::new();
+    // Skirmish: `IsControlledByHuman` is the human flag alone (`0x0050B730`).
+    sim.session.game_mode_nonzero = true;
+    let ai_a = insert_house_with_counts(&mut sim, "Russians", 1, 0);
+    let ai_b = insert_house_with_counts(&mut sim, "Cubans", 0, 0);
+    let civilian = insert_passive_house_with_counts(&mut sim, "Neutral", 0, 0);
+    let player = insert_house_with_counts(&mut sim, "Americans", 1, 0);
+    for ai in [ai_a, ai_b] {
+        let house = sim.houses.get_mut(&ai).expect("ai house");
+        house.is_human = false;
+        house.player_control = false;
+    }
+    insert_test_entity_for_owner(&mut sim, 1, ai_a, "GAPOWR", EntityCategory::Structure);
+    insert_test_entity_for_owner(&mut sim, 2, player, "GAPOWR", EntityCategory::Structure);
+
+    sim.announce_engineer_capture(1, ai_b, &rules);
+    assert!(
+        captured_events(&sim).is_empty(),
+        "AI-vs-AI capture: nobody listens"
+    );
+    sim.announce_engineer_capture(2, civilian, &rules);
+    assert!(
+        captured_events(&sim).is_empty(),
+        "passive new owner is silent"
+    );
+    assert_eq!(sim.radar_events.len(), 0);
+}
+
+/// `HouseClass::MPlayer_Defeated 0x004FC30F..0x004FC3BC`: every non-passive
+/// defeat is announced; the app splits local from other.
+#[test]
+fn defeat_of_a_non_passive_house_emits_player_defeated() {
+    let rules = short_game_defeat_test_rules();
+    let mut sim = Simulation::new();
+    let player = insert_house_with_counts(&mut sim, "Americans", 1, 0);
+    let enemy = insert_house_with_counts(&mut sim, "Russians", 0, 0);
+    let civilian = insert_passive_house_with_counts(&mut sim, "Neutral", 0, 0);
+
+    sim.check_defeat(Some(&rules));
+
+    let defeated: Vec<InternedId> = sim
+        .sound_events
+        .iter()
+        .filter_map(|event| match event {
+            SimSoundEvent::PlayerDefeated { house } => Some(*house),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(defeated, vec![enemy]);
+    assert!(!sim.houses[&player].is_defeated);
+    assert!(
+        !sim.houses[&civilian].is_defeated,
+        "passive houses are never evaluated"
+    );
+
+    // A house already flagged defeated is not announced again.
+    sim.sound_events.clear();
+    sim.check_defeat(Some(&rules));
+    assert!(
+        sim.sound_events
+            .iter()
+            .all(|event| !matches!(event, SimSoundEvent::PlayerDefeated { .. }))
+    );
+}


### PR DESCRIPTION
The stock-skirmish EVA lines Rust never produced are now spoken at their native sites. A census of the 75 `PlayEVA` call sites (plus 5 direct `QueueVoice` callers) classifies each as reachable, prerequisite-missing, or excluded, and lives in the `eva_producers` module doc. Newly produced: the `SelectClass::Action` sidebar lines (Building/Training via CheckBuildLimit, OnHold/Canceled, UnableToComply, SelectTarget at 0x006AAFA7 for a ready, online, `Action=` superweapon), EVA_NewConstructionOptions on cameo insertion behind the scenario-init gate, EVA_CannotDeployHere from the invalid placement click and sim placement/deploy failures, EVA_NewRallyPointEstablished (0x00443A69, app-local), EVA_StructureSold (sell state 2), EVA_Repairing, EVA_BuildingCaptured / TechBuildingLost plus `CaptureEvaEvent=` (radar row 10 has no dedupe), superweapon Ready (by Type=) and Detected (by `[SuperWeaponTypes]` index with the ally/spectator gates), and EVA_PlayerDefeated. Lines whose prerequisite mechanism VERA lacks are documented with addresses. The NewConstructionOptions seed is reset on every sim install.

App-local click lines stay in the app; sim facts reach the app as named EVA events; earlier producers are unchanged; parity harness unchanged.

Residuals recorded in code: the sold line follows VERA's synchronous sale rather than the sell-down animation; the Slave Miner deploy failure speaks where native is silent (`ResourceGatherer=` gate at 0x007394F5, follow-up); UseChargeDrain readiness uses the ready flag.

Two independent read-only critics reviewed successive revisions against the bodies; the second passed.

Validation:
- `cargo test -p vera20k --lib`: `test result: ok. 8408 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 17.95s`
