### PR TITLE
Close the Phase 7 reverse-audit findings

### DIFF
--- a/src/sim/deploy_tests.rs
+++ b/src/sim/deploy_tests.rs
@@ -251,7 +251,9 @@ fn spawn_infantry(sim: &mut Simulation, type_str: &str, owner: &str, rx: u16, ry
     id
 }
 
-fn clear_terrain_cell(rx: u16, ry: u16) -> ResolvedTerrainCell {
+/// One flat clear-land cell (also reused by `miner_tests` for the resolved
+/// terrain `LandType` fixture).
+pub(crate) fn clear_terrain_cell(rx: u16, ry: u16) -> ResolvedTerrainCell {
     ResolvedTerrainCell {
         rx,
         ry,
@@ -1002,9 +1004,10 @@ fn base_plan_recalc_deploy_late_yard_unlimbo_failure_preserves_source_and_plan()
     assert!(!source.dying);
     assert!(!source.lifecycle.in_limbo);
     assert!(
-        sim.substrate.entities.values().all(|entity| {
-            sim.interner.resolve(entity.type_ref) != "GACNST" || entity.dying
-        }),
+        sim.substrate
+            .entities
+            .values()
+            .all(|entity| { sim.interner.resolve(entity.type_ref) != "GACNST" || entity.dying }),
         "the rejected yard constructor leaves no live target"
     );
     let house = &sim.houses[&owner];

--- a/src/sim/docking/building_dock.rs
+++ b/src/sim/docking/building_dock.rs
@@ -89,10 +89,12 @@ pub struct DockState {
     pub service_timer: u32,
     /// Consecutive ticks with insufficient credits (triggers exit after grace).
     pub no_funds_ticks: u32,
-    /// `Mission_Enter` dispatch cadence: the next `0x0E` probe is due when this
-    /// expires (`ftol([Enter] Rate*900) + RandomRanged(0,2)`, 0x004D946C).
-    /// Unarmed ⇒ due, so the first probe fires on the first tick after the
-    /// order, like the freshly assigned Enter mission's zero dispatch delay.
+    /// Mirror of the unit's `Mission_Enter` handler return
+    /// (`ftol([Enter] Rate*900) + RandomRanged(0,2)`, 0x004D946C): the last
+    /// probe's frame and delay. The GATE is the object's own mission dispatch
+    /// timer (`MissionCom`), written by `mission_enter_dispatch` from the
+    /// object-AI slot; this copy only keeps the dock FSM's per-unit cadence
+    /// readable. Kept in place so the snapshot layout is unchanged.
     #[serde(default)]
     pub enter_retry: MissionTimer,
 }
@@ -352,10 +354,121 @@ fn queue_mission(sim: &mut Simulation, id: u64, mission: MissionType) {
     );
 }
 
+/// `FootClass::Mission_Enter @ 0x004D9290` for a repair-depot waiter, run from
+/// the unit's OWN mission-dispatch slot (the Unit `Enter` arm of the object-AI
+/// shell) so the epilogue draw lands where native draws it: inside this
+/// unit's `TechnoClass::AI` visit, interleaved in object order with every
+/// other object's dispatch draws — not as a batch after production.
+///
+/// Native body, every dispatch:
+/// - `Transmit(0x0E)` to `Contacts[0]` / the archive target (0x004D929F);
+///   reply `1` (or `+0x418`) keeps the unit in Enter, the NavCom drives it;
+///   any other reply ⇒ `Mark(3)` + `Enter_Idle_Mode(0,1)` (0x004D92D0,
+///   0x004D92E2), which is the "repaired ⇒ 10" exit;
+/// - no contact and no archive target ⇒ `Enter_Idle_Mode` (0x004D945C);
+/// - then, on EVERY path, `ftol([Enter] Rate*900)` followed by ONE
+///   `RandomRanged(0, 2)` (0x004D946C..0x004D9497, Scenario stream) — the
+///   handler return. So a dispatch that leaves Enter still draws.
+///
+/// Returns that handler delay; `DockState::enter_retry` mirrors it so the
+/// dock FSM's readers keep a per-unit cadence view. The pad-side servicing
+/// and release stay in [`tick_building_docks`] (native: the building's
+/// `MissionRepairAndProduce` 0x0044B780 repair tick), untouched here.
+pub(crate) fn mission_enter_dispatch(sim: &mut Simulation, rules: &RuleSet, id: u64) -> i32 {
+    let now = sim.session.binary_frame;
+    let Some((dock_building_id, phase, hp, max_hp, owner)) =
+        sim.substrate.entities.get(id).and_then(|unit| {
+            let ds = unit.dock_state.as_ref()?;
+            Some((
+                ds.dock_building_id,
+                ds.phase,
+                unit.health.current,
+                unit.health.max,
+                unit.owner,
+            ))
+        })
+    else {
+        return 1;
+    };
+    if matches!(phase, DockPhase::Servicing | DockPhase::ExitDock) {
+        // On the pad the unit natively sits on the queued Sleep the building
+        // assigned it; VERA keeps Enter as the representation and dispatches
+        // it as a no-draw one-frame return (VERA-internal, the base
+        // `Mission_Sleep` return value UNCHECKED). No probe, no draw.
+        return 1;
+    }
+
+    // Depot still a valid probe target (alive, own house, UnitRepair)?
+    let depot_capacity = sim
+        .substrate
+        .entities
+        .get(dock_building_id)
+        .filter(|depot| depot.health.current > 0 && !depot.dying && depot.owner == owner)
+        .and_then(|depot| sim.object_type(depot.type_ref, rules))
+        .filter(|obj| obj.unit_repair)
+        .map(|obj| usize::from(obj.number_of_docks.max(1)));
+
+    if let Some(dock_capacity) = depot_capacity {
+        let linked = sim
+            .substrate
+            .entities
+            .get(id)
+            .is_some_and(|unit| unit.radio_contacts.contains(dock_building_id));
+        if linked && hp >= max_hp {
+            // 0x0043C824..C842: linked sender whose 0x22 answers 10 (ratio >=
+            // 1.0) gets 10 back; Mission_Enter 0x004D92D0 then BREAKs and
+            // calls Enter_Idle_Mode (Guard for a plain unit, 0x00738970).
+            // The unit leaves Enter; the epilogue draw below still happens.
+            break_depot_contact(sim, id, dock_building_id);
+            queue_mission(sim, id, MissionType::Guard);
+            if let Some(unit) = sim.substrate.entities.get_mut(id) {
+                unit.dock_state = None;
+                unit.movement_target = None;
+            }
+        } else if !linked {
+            // 0x0043C8A4..C8C3: not a contact and a slot is free or own ⇒ the
+            // building HELLOs the sender. VERA sends the HELLO unit→depot; the
+            // linked end state (both slots) is identical. Capacity is the
+            // ctor's max(NumberOfDocks, 1) (0x0043BCBD..BCD0), sized grow-only
+            // here rather than at spawn.
+            if let Some(depot) = sim.substrate.entities.get_mut(dock_building_id) {
+                depot.radio_contacts.set_capacity(dock_capacity);
+            }
+            let _ = radio::transmit(
+                sim,
+                id,
+                dock_building_id,
+                RadioMessage::Hello,
+                RadioPayload::default(),
+            );
+        }
+    }
+    // Depot gone: native has no contact and no archive target ⇒
+    // Enter_Idle_Mode; `tick_building_docks` clears the dock state this
+    // frame. The epilogue draw is unconditional either way.
+
+    // Epilogue: ftol(Rate*900) + RandomRanged(0,2), every dispatch.
+    let mut timer = MissionTimer::default();
+    arm_enter_retry(sim, rules, &mut timer);
+    if let Some(ds) = sim
+        .substrate
+        .entities
+        .get_mut(id)
+        .and_then(|unit| unit.dock_state.as_mut())
+    {
+        ds.enter_retry = timer;
+    }
+    debug_assert_eq!(timer.start_frame, now);
+    i32::try_from(timer.duration).unwrap_or(i32::MAX)
+}
+
 /// Advance building dock state machines for all entities with `dock_state`.
 ///
 /// Called once per tick from `advance_tick()`, after `tick_repairs()`.
-/// Uses the two-phase snapshot pattern to avoid borrow conflicts.
+/// Uses the two-phase snapshot pattern to avoid borrow conflicts. The
+/// waiter's `0x0E` probe and its epilogue draw are NOT here — they run in the
+/// unit's own dispatch slot ([`mission_enter_dispatch`]); this pass only
+/// consumes the resulting link state and owns the pad-side service/release.
 pub fn tick_building_docks(sim: &mut Simulation, rules: &RuleSet, path_grid: Option<&PathGrid>) {
     struct DockSnapshot {
         id: u64,
@@ -370,7 +483,6 @@ pub fn tick_building_docks(sim: &mut Simulation, rules: &RuleSet, path_grid: Opt
         phase: DockPhase,
         service_timer: u32,
         no_funds_ticks: u32,
-        enter_retry: MissionTimer,
     }
 
     let snapshots: Vec<DockSnapshot> = sim
@@ -392,7 +504,6 @@ pub fn tick_building_docks(sim: &mut Simulation, rules: &RuleSet, path_grid: Opt
                 phase: ds.phase,
                 service_timer: ds.service_timer,
                 no_funds_ticks: ds.no_funds_ticks,
-                enter_retry: ds.enter_retry,
             })
         })
         .collect();
@@ -406,7 +517,6 @@ pub fn tick_building_docks(sim: &mut Simulation, rules: &RuleSet, path_grid: Opt
         new_phase: Option<DockPhase>,
         new_timer: Option<u32>,
         new_no_funds: Option<u32>,
-        new_enter_retry: Option<MissionTimer>,
         heal_amount: u16,
         deduct_credits: i32,
         clear_dock: bool,
@@ -421,7 +531,6 @@ pub fn tick_building_docks(sim: &mut Simulation, rules: &RuleSet, path_grid: Opt
             new_phase: None,
             new_timer: None,
             new_no_funds: None,
-            new_enter_retry: None,
             heal_amount: 0,
             deduct_credits: 0,
             clear_dock: false,
@@ -473,51 +582,14 @@ pub fn tick_building_docks(sim: &mut Simulation, rules: &RuleSet, path_grid: Opt
 
         match snap.phase {
             DockPhase::Approach | DockPhase::WaitForDock | DockPhase::EnterDock => {
-                let mut linked = sim
+                // The 0x0E probe (and its draw) already ran in this unit's
+                // own dispatch slot; only the resulting link is read here.
+                let linked = sim
                     .substrate
                     .entities
                     .get(snap.id)
                     .is_some_and(|unit| unit.radio_contacts.contains(snap.dock_building_id));
-
-                // Mission_Enter dispatch: one 0x0E probe per cadence window.
-                if snap.enter_retry.due(sim.session.binary_frame) {
-                    if linked && snap.hp >= snap.max_hp {
-                        // 0x0043C824..C842: linked sender whose 0x22 answers 10
-                        // (ratio >= 1.0) gets 10 back; Mission_Enter 0x004D92D0
-                        // then BREAKs and calls Enter_Idle_Mode (Guard for a
-                        // plain unit, 0x00738970). No re-arm — the unit leaves
-                        // the Enter mission.
-                        break_depot_contact(sim, snap.id, snap.dock_building_id);
-                        queue_mission(sim, snap.id, MissionType::Guard);
-                        m.clear_dock = true;
-                        m.clear_movement = true;
-                        mutations.push(m);
-                        continue;
-                    }
-                    if !linked {
-                        // 0x0043C8A4..C8C3: not a contact and a slot is free or
-                        // own ⇒ the building HELLOs the sender. VERA sends the
-                        // HELLO unit→depot; the linked end state (both slots)
-                        // is identical. Capacity is the ctor's
-                        // max(NumberOfDocks, 1) (0x0043BCBD..BCD0), sized
-                        // grow-only here rather than at spawn.
-                        if let Some(depot) = sim.substrate.entities.get_mut(snap.dock_building_id) {
-                            depot.radio_contacts.set_capacity(dock_capacity);
-                        }
-                        let reply = radio::transmit(
-                            sim,
-                            snap.id,
-                            snap.dock_building_id,
-                            RadioMessage::Hello,
-                            RadioPayload::default(),
-                        );
-                        linked = reply == RadioResponse::Roger;
-                    }
-                    // Epilogue: ftol(Rate*900) + RandomRanged(0,2), every dispatch.
-                    let mut timer = snap.enter_retry;
-                    arm_enter_retry(sim, rules, &mut timer);
-                    m.new_enter_retry = Some(timer);
-                }
+                let _ = dock_capacity;
 
                 if linked {
                     if dist == 0 {
@@ -639,9 +711,6 @@ pub fn tick_building_docks(sim: &mut Simulation, rules: &RuleSet, path_grid: Opt
             }
             if let Some(nf) = m.new_no_funds {
                 ds.no_funds_ticks = nf;
-            }
-            if let Some(retry) = m.new_enter_retry {
-                ds.enter_retry = retry;
             }
         }
 
@@ -963,8 +1032,12 @@ mod tests {
         )
     }
 
+    /// One frame in production order: every unit's own object-AI visit (the
+    /// Enter dispatch with its probe and draw), then the dock pass, then
+    /// movement.
     fn tick(sim: &mut Simulation, rules: &RuleSet, grid: &PathGrid) {
         sim.session.binary_frame = sim.session.binary_frame.wrapping_add(1);
+        visit_units(sim, rules);
         tick_building_docks(sim, rules, Some(grid));
         crate::sim::movement::tick_movement(
             &mut sim.substrate.entities,
@@ -972,6 +1045,26 @@ mod tests {
             &mut sim.pending_lifecycle_requests,
         );
         sim.session.tick += 1;
+    }
+
+    /// The object-AI pass restricted to units, in live-object (stable id)
+    /// order — the slot native `Mission_Enter` dispatches from.
+    fn visit_units(sim: &mut Simulation, rules: &RuleSet) {
+        let units: Vec<u64> = sim
+            .substrate
+            .entities
+            .keys_sorted()
+            .into_iter()
+            .filter(|&id| {
+                sim.substrate
+                    .entities
+                    .get(id)
+                    .is_some_and(|e| e.category == EntityCategory::Unit)
+            })
+            .collect();
+        for id in units {
+            sim.object_ai_visit_one(id, Some(rules), crate::sim::world::ObjectAiCtx::default());
+        }
     }
 
     fn linked(sim: &Simulation, tank: u64) -> bool {
@@ -1081,6 +1174,61 @@ mod tests {
         );
     }
 
+    /// The waiter's `Mission_Enter` epilogue draw sits in the unit's OWN
+    /// object-AI slot, interleaved in live-object order with other objects'
+    /// dispatch draws: visiting waiter 1 draws exactly one `RandomRanged(0,2)`,
+    /// visiting the Guard tank 2 between the waiters draws its own Guard
+    /// cadence jitter, visiting waiter 3 draws one more `(0,2)`, and the
+    /// post-production dock pass draws nothing at all.
+    #[test]
+    fn waiter_probe_draw_sits_in_the_units_own_ai_slot_in_object_order() {
+        let (mut sim, rules, grid) = setup(3);
+        assert!(order_repair(&mut sim, &rules, &grid, 1));
+        assert!(order_repair(&mut sim, &rules, &grid, 3));
+        // Tank 2 idles on Guard with a due dispatch timer.
+        let now = sim.session.binary_frame;
+        sim.mission_assign_exact(2, MissionId::from_known(MissionType::Guard), now)
+            .expect("assign Guard");
+        sim.session.binary_frame += 1;
+        let ctx = crate::sim::world::ObjectAiCtx::default;
+
+        let mut shadow = sim.clone_scenario_rng();
+        sim.object_ai_visit_one(1, Some(&rules), ctx());
+        shadow.next_range_u32_inclusive(0, 2);
+        assert_eq!(
+            sim.scenario_rng.state(),
+            shadow.state(),
+            "waiter 1: exactly one (0,2) draw inside its own AI slot"
+        );
+
+        let before_guard = sim.scenario_rng.state();
+        sim.object_ai_visit_one(2, Some(&rules), ctx());
+        assert_ne!(
+            sim.scenario_rng.state(),
+            before_guard,
+            "the Guard tank's dispatch draws between the two waiters"
+        );
+
+        let mut shadow = sim.clone_scenario_rng();
+        sim.object_ai_visit_one(3, Some(&rules), ctx());
+        shadow.next_range_u32_inclusive(0, 2);
+        assert_eq!(
+            sim.scenario_rng.state(),
+            shadow.state(),
+            "waiter 3: one (0,2) draw after the Guard tank's"
+        );
+
+        let after_ai = sim.scenario_rng.state();
+        tick_building_docks(&mut sim, &rules, Some(&grid));
+        assert_eq!(
+            sim.scenario_rng.state(),
+            after_ai,
+            "the post-production dock pass draws nothing"
+        );
+        assert!(linked(&sim, 1), "first prober holds the slot");
+        assert!(!linked(&sim, 3));
+    }
+
     /// Admission follows whichever waiter's Enter timer fires first after the
     /// pad frees, not arrival order: unit 3's timer is set to fire before
     /// unit 2's, so 3 docks next.
@@ -1103,20 +1251,13 @@ mod tests {
         assert!(!linked(&sim, 1));
         assert_eq!(sim.substrate.entities.get(1).unwrap().health.current, 300);
         assert!(!linked(&sim, 2) && !linked(&sim, 3));
-        // Force the re-probe order: 3 fires before 2.
+        // Force the re-probe order: 3's Enter dispatch timer fires before
+        // 2's (the probe runs from the unit's own mission dispatch slot).
         {
             let e2 = sim.substrate.entities.get_mut(2).unwrap();
-            e2.dock_state
-                .as_mut()
-                .unwrap()
-                .enter_retry
-                .arm(released_at, 10);
+            e2.mission.write_dispatch_epilogue(released_at as i32, 10);
             let e3 = sim.substrate.entities.get_mut(3).unwrap();
-            e3.dock_state
-                .as_mut()
-                .unwrap()
-                .enter_retry
-                .arm(released_at, 3);
+            e3.mission.write_dispatch_epilogue(released_at as i32, 3);
         }
         for _ in 0..5 {
             tick(&mut sim, &rules, &grid);

--- a/src/sim/miner/harvest_mission.rs
+++ b/src/sim/miner/harvest_mission.rs
@@ -40,16 +40,20 @@
 //! → `mission_assign_exact(Harvest)`, `Command::MinerReturn`) put it back.
 //!
 //! Dispatch gating residual: the host dispatches on Miner-component presence
-//! plus "the committed mission is not Guard", not strictly on
+//! plus "the committed mission is neither Guard nor Move", not strictly on
 //! `current == Harvest`. Guard is gated because the Stop command force-assigns
 //! it to a harvesting miner exactly where the retail IDLE event handler does,
-//! and declining it here is what makes Stop actually stop the miner. A Move or
-//! Attack retask still flips `current` away from Harvest while the legacy FSM
-//! keeps driving the behavior (waits out the player move, then resumes) — the
-//! pre-absorption behavior, kept because nothing returns a miner to Harvest
-//! when such an order completes, so the strict gate would retire it for good.
-//! The strict mission-id gate becomes exact once the creation/idle caller
-//! family (roadmap Track B1) commits missions at those points.
+//! and declining it here is what makes Stop actually stop the miner. Move is
+//! gated because a player Move runs the Foot Move handler (`FootClass::
+//! Mission_Move @ 0x004D4200`), whose arrival `Enter_Idle_Mode(0,1)` takes the
+//! harvester arm of `UnitClass::Enter_Idle_Mode @ 0x00738970` — Harvest, or
+//! Guard for a human whose miner stopped on non-ore land — modelled in
+//! `techno_ai/mission_handlers.rs::harvester_enter_idle_mode_evaluation`; the
+//! re-committed Harvest restarts this handler from state 0. An Attack retask
+//! still flips `current` away from Harvest while the legacy FSM keeps driving
+//! (pre-absorption behaviour, kept until the Attack arrival is modelled). The
+//! strict mission-id gate becomes exact once the creation caller family
+//! (roadmap Track B1) commits missions at those points.
 //!
 //! Depends on: `world::Simulation`, `miner::miner_system`.
 //! Must NOT depend on render/ui/sidebar/audio/net (sim invariant #1).
@@ -136,22 +140,26 @@ fn dispatch_harvest_for_object_with_resource_authority(
             return;
         }
         // The native dispatcher routes on the committed mission id, so a miner
-        // that is NOT on Harvest never reaches this handler. VERA cannot adopt
-        // that gate in full yet: no Rust path returns a miner to Harvest when a
-        // Move or Attack order completes (the native Move handler's arrival
-        // transition is unmodelled), so a strict `current == Harvest` gate would
-        // permanently retire any miner the player ever moved.
+        // that is NOT on Harvest never reaches this handler. VERA adopts that
+        // gate for the two ids it commits authoritatively:
+        // - Guard: the Stop command force-assigns it to a miner on Harvest or
+        //   Return, exactly where the retail IDLE event handler does, and the
+        //   Guard slot is a different handler (the harvester Guard override).
+        //   Declining it here is what makes Stop actually stop a miner.
+        // - Move: a player Move order runs the Foot Move handler; its arrival
+        //   `Enter_Idle_Mode(0,1)` (`FootClass::Mission_Move` 0x004D4242 →
+        //   `UnitClass::Enter_Idle_Mode @ 0x00738970` harvester arm) queues
+        //   Harvest — or Guard for a human miner parked on non-ore land — and
+        //   the promoted Harvest re-enters here at state 0.
         //
-        // What IS modelled is the one id VERA commits authoritatively as a
-        // harvest stop: the Stop command force-assigns Guard to a miner on
-        // Harvest or Return, exactly where the retail IDLE event handler does,
-        // and the Guard slot is a different handler. Declining Guard here is
-        // what makes Stop actually stop a miner instead of stalling it for a
-        // beat; the Guard cadence is then owned by the foot Guard arm.
-        //
-        // RESIDUAL: a miner retasked onto Move/Attack still resumes harvesting
-        // when that order finishes, which retail does not do.
-        if entity.mission.current().known() == Some(crate::sim::mission::MissionType::Guard) {
+        // RESIDUAL: a miner retasked onto Attack still resumes harvesting from
+        // its old cursor when that order finishes (the Attack arrival is not
+        // modelled); the strict `current == Harvest` gate waits on it.
+        if matches!(
+            entity.mission.current().known(),
+            Some(crate::sim::mission::MissionType::Guard)
+                | Some(crate::sim::mission::MissionType::Move)
+        ) {
             return;
         }
         // Native Mission_Dispatch gate: run the handler only when the

--- a/src/sim/miner/miner_dock.rs
+++ b/src/sim/miner/miner_dock.rs
@@ -1,11 +1,12 @@
 //! Refinery dock contact management.
 //!
 //! A refinery admits up to `NumberOfDocks` miners into its `Contacts[]` list
-//! (capacity-1 for a stock refinery). The `NumberOfDocks` capacity source is
-//! VERA-internal: natively the slot count `RadioClass+0xE8` is written only by
-//! the `RadioClass` ctor (0x0065A764, = 1) and destructor, never from
-//! `NumberOfDocks=` (gamemd equivalent UNCHECKED beyond `+0xE8 == 1` at
-//! construction; stock refineries are `NumberOfDocks=1`, so it is inert).
+//! (capacity-1 for a stock refinery). The slot count `RadioClass+0xE8` starts
+//! at 1 in the `RadioClass` ctor (0x0065A764) and is then sized by
+//! `BuildingClass::Constructor` 0x0043BCBD..0x0043BCD0: `MOV EAX,[Type+0x1780]`
+//! (`NumberOfDocks=`), `CMP EAX,1 ; JGE`, else `MOV EAX,1`, `PUSH EAX`,
+//! `CALL Set_Contact_Count` — i.e. capacity = `max(NumberOfDocks, 1)`, which is
+//! what the Rust capacity derives (stock refineries are `NumberOfDocks=1`).
 //! gamemd stores **no** wait-queue: a denied
 //! miner re-probes on demand and whichever re-probing miner wins a freed slot
 //! docks next (V3). State lives in `ProductionState.dock_reservations` and is a
@@ -83,9 +84,9 @@ impl RefineryDockContacts {
     /// true when a slot holds null or already holds the caller. The refinery
     /// scanner `FUN_004DEE80` and `BuildingClass::Receive_Radio @ 0x0043C2D0`
     /// case 0xF both consult it before any HELLO is sent, so selection must
-    /// ask without mutating. Capacity floors at 1 like `hello_or_wait`; the
-    /// `NumberOfDocks`-derived capacity callers pass is VERA-internal (native
-    /// `+0xE8` is fixed at 1 by the `RadioClass` ctor — see the module doc).
+    /// ask without mutating. Capacity floors at 1 like `hello_or_wait`, the
+    /// same `max(NumberOfDocks, 1)` the `BuildingClass` ctor passes to
+    /// `Set_Contact_Count` (0x0043BCBD..0x0043BCD0 — see the module doc).
     pub fn would_admit(&self, refinery_sid: u64, miner_sid: u64, capacity: usize) -> bool {
         self.has_contact(refinery_sid, miner_sid)
             || self.contacts.get(&refinery_sid).map_or(0, Vec::len) < capacity.max(1)

--- a/src/sim/miner/miner_system.rs
+++ b/src/sim/miner/miner_system.rs
@@ -1287,6 +1287,17 @@ fn handle_harvest(
         let Some(resource_type) = reduction.resource_type else {
             return;
         };
+        // RESIDUAL (VERA-internal, gamemd equivalent UNCHECKED beyond the
+        // stock map data): native `StorageClass` (`UnitClass+0x33C`) keeps
+        // four per-`TiberiumType` slots and `Mission_Unload` drains them by
+        // `FindFirstNonEmptySlot` in index order 0..3, each slot valued by
+        // its own type's `Value=`; VERA folds every overlay family into
+        // `ResourceType::{Ore, Gem}` (`TiberiumTypeId` 0 / 1 values above).
+        // Trigger: a map placing TIB2/TIB3 (Vinifera/Aboreus) overlays —
+        // no stock skirmish map does. Effect: those bales are valued as
+        // type 0 (Riparius) and drain in the Ore slot, so the unload runs
+        // one 15-frame slot gate fewer than native. Frequency: zero on stock
+        // maps. Downstream: none for the stock ruleset.
         let value = match resource_type {
             ResourceType::Ore => config.ore_bale_value,
             ResourceType::Gem => config.gem_bale_value,
@@ -2212,11 +2223,11 @@ fn select_return_refinery(
 /// - narrow pass only (`wide != 1`, 0x004DEF02): `FUN_0065ADF0` on the
 ///   building with the miner as argument (0x004DEF09) — a free `Contacts[]`
 ///   slot (`+0xE4`, count `+0xE8`) or the miner already tracked. `+0xE8` is
-///   written only by the `RadioClass` ctor (0x0065A764, = 1) and destructor;
-///   no `BuildingClass` writer sets it from `NumberOfDocks=`. Rust derives the
-///   slot capacity from `NumberOfDocks` (VERA-internal, gamemd equivalent
-///   UNCHECKED beyond `+0xE8 == 1` at construction; stock refineries are
-///   `NumberOfDocks=1`, so the derivation is inert for stock play);
+///   1 from the `RadioClass` ctor (0x0065A764) and then set by
+///   `BuildingClass::Constructor` 0x0043BCBD..0x0043BCD0 to
+///   `max([Type+0x1780] NumberOfDocks, 1)` via `Set_Contact_Count`; Rust
+///   derives the slot capacity the same way (stock refineries are
+///   `NumberOfDocks=1`);
 /// - `MapClass::Can_Reach_Zone` from the miner's cell to the building's
 ///   `GetCoords` cell (skipped when `WhatAmI() == Aircraft(2)`, never a
 ///   miner) — see `refinery_zone_reachable`;
@@ -3002,26 +3013,59 @@ pub(crate) fn player_has_purifier(sim: &Simulation, rules: &RuleSet, owner: &str
     count_purifiers_for_owner(sim, rules, owner) > 0
 }
 
-/// Count alive Ore Purifier buildings owned by `owner` (case-insensitive).
+/// Count completed, alive Ore Purifier buildings owned by `owner`
+/// (case-insensitive) — the native `House+0x538C` counter.
 ///
 /// Used by the deposit-bonus formula in `phase_unloading` and by the Slave
 /// Miner deposit path. The bonus is `count × PurifierBonus × amount`, so
 /// every real purifier stacks the bonus linearly.
+///
+/// Native writers of `House+0x538C` (gamemd.exe, read 2026-09-06):
+/// - `BuildingClass::OnConstructionComplete` 0x0044636C..0x0044637C:
+///   `Type+0x16CC` (`OrePurifier=`) → `INC [House+0x538C]` — only when the
+///   build-up finishes, so a purifier still in its construction anim pays
+///   nothing;
+/// - `BuildingClass::ChangeOwner` 0x00448260: `DEC` on the old owner at
+///   0x00448AC2 and `INC` on the new owner at 0x004491EB (the same
+///   register-with-house tail that appends the building to the house's
+///   per-category vectors), so a captured purifier moves with the house;
+/// - `BuildingClass::Limbo` 0x00445925: `DEC` when the building leaves the
+///   map (sale end, destruction).
+///
+/// Rust: `building_up.is_some()` is the construction anim (native
+/// `BSTATE_CONSTRUCTION` before `OnConstructionComplete`), `dying` is the
+/// Limbo'd corpse; a selling building (`building_down`) still counts, as the
+/// native `DEC` only lands at Limbo.
 pub(crate) fn count_purifiers_for_owner(sim: &Simulation, rules: &RuleSet, owner: &str) -> i32 {
     sim.substrate
         .entities
         .values()
         .filter(|e| {
-            // A Dying purifier corpse (sold/destroyed this tick) must not keep
-            // paying its deposit bonus until the end-of-tick drain.
-            !e.dying
-                && e.category == EntityCategory::Structure
+            counts_as_purifier(sim, rules, e)
                 && sim.interner.resolve(e.owner).eq_ignore_ascii_case(owner)
-                && sim
-                    .object_type(e.type_ref, rules)
-                    .is_some_and(|obj| obj.ore_purifier)
         })
         .count() as i32
+}
+
+/// The owner-independent half of the `House+0x538C` predicate: a completed,
+/// alive, on-map `OrePurifier=` structure. Shared by
+/// [`count_purifiers_for_owner`] and the per-tick economy shadow
+/// (`refresh_economy_shadow`) so both count the same buildings.
+pub(crate) fn counts_as_purifier(
+    sim: &Simulation,
+    rules: &RuleSet,
+    e: &crate::sim::game_entity::GameEntity,
+) -> bool {
+    // A Dying purifier corpse (sold/destroyed this tick) must not keep paying
+    // its deposit bonus until the end-of-tick drain; a limbo'd one already
+    // took the native Limbo `DEC`.
+    !e.dying
+        && !e.lifecycle.in_limbo
+        && e.building_up.is_none()
+        && e.category == EntityCategory::Structure
+        && sim
+            .object_type(e.type_ref, rules)
+            .is_some_and(|obj| obj.ore_purifier)
 }
 
 /// Effective purifier count used in the deposit bonus formula.

--- a/src/sim/miner/miner_tests.rs
+++ b/src/sim/miner/miner_tests.rs
@@ -6752,6 +6752,71 @@ fn two_purifiers_stack_the_bonus_linearly() {
     );
 }
 
+/// `House+0x538C` is incremented only by `BuildingClass::OnConstructionComplete`
+/// (0x0044636C..0x0044637C), so a purifier still in its build-up anim pays no
+/// deposit bonus; once the build-up completes it pays. One purifier building
+/// up plus one completed ⇒ exactly +25% (count 1), not +50%.
+#[test]
+fn purifier_under_construction_pays_no_bonus_until_complete() {
+    use crate::sim::components::BuildingUp;
+
+    let mut sim = Simulation::new();
+    let rules = purifier_rules(25);
+
+    let miner_id = spawn_miner(&mut sim, 1, MinerKind::War, 13, 11);
+    spawn_refinery(&mut sim, 2, 10, 10);
+    spawn_structure(&mut sim, 3, "GAPURI", 20, 20);
+    spawn_structure(&mut sim, 4, "GAPURI", 24, 20);
+    sim.substrate
+        .entities
+        .get_mut(4)
+        .expect("purifier 4")
+        .building_up = Some(BuildingUp {
+        elapsed_ticks: 0,
+        total_ticks: 1000,
+    });
+    assert_eq!(
+        super::miner_system::count_purifiers_for_owner(&sim, &rules, "Americans"),
+        1,
+        "a building-up purifier is not in House+0x538C yet"
+    );
+
+    let credits_before = credits_for_owner(&sim, "Americans");
+    {
+        let entity = sim
+            .substrate
+            .entities
+            .get_mut(miner_id)
+            .expect("miner entity");
+        let miner = entity.miner.as_mut().expect("miner component");
+        miner.cargo.push(CargoBale {
+            resource_type: ResourceType::Ore,
+            value: 100,
+        });
+        entity.mission.set_handler_state(MinerState::Dock.cursor());
+        miner.dock_phase = RefineryDockPhase::Unloading;
+        miner.reserved_refinery = Some(2);
+    }
+    sim.production.dock_reservations.try_reserve(2, miner_id);
+    tick_miners_n(&mut sim, &rules, 200);
+    let delta = credits_for_owner(&sim, "Americans") - credits_before;
+    assert_eq!(
+        delta, 125,
+        "only the completed purifier pays: 100 + 25, got {delta}"
+    );
+
+    // Build-up complete ⇒ the second purifier is counted.
+    sim.substrate
+        .entities
+        .get_mut(4)
+        .expect("purifier 4")
+        .building_up = None;
+    assert_eq!(
+        super::miner_system::count_purifiers_for_owner(&sim, &rules, "Americans"),
+        2
+    );
+}
+
 /// AI player with `is_human=false` should receive the virtual-purifier
 /// bonus from `rules.general.ai_virtual_purifiers[house.difficulty]`. With the
 /// default `[4, 2, 0]` and per-house Hard difficulty (native index 0),
@@ -9439,4 +9504,393 @@ fn damaged_refinery_ore_only_unload_smokes_twice_without_special_anim() {
         "base SpecialAnim is never used as a fallback"
     );
     assert!(get_miner(&sim, miner_id).cargo.is_empty(), "cargo drained");
+}
+
+/// `BuildingClass::ReceiveDamage @ 0x00442230` result-4 arm → `UndockUnit @
+/// 0x004593A0` (0x004424EA): a refinery killed by damage while a miner is on
+/// the pad releases the docked miner THAT frame — the `+0x2E4` link and the
+/// contact go, the remaining cargo stays aboard (no deposit), and the miner is
+/// pushed off along the `0x47` `Force_Track`. Before this landed the miner
+/// only noticed at its next slot-drain gate.
+#[test]
+fn refinery_destroyed_by_damage_undocks_the_unloading_miner_same_tick() {
+    use crate::sim::combat::EntityDamageEvent;
+    use crate::sim::house_state::HouseState;
+
+    let ini = IniFile::from_str(
+        "[InfantryTypes]\n\
+         [VehicleTypes]\n0=HARV\n\
+         [AircraftTypes]\n\
+         [BuildingTypes]\n0=GAREFN\n\
+         [Warheads]\n0=KILLWH\n\
+         [HARV]\n\
+         Name=War Miner\nCost=1400\nStrength=600\nArmor=heavy\nSpeed=4\nROT=5\nSight=5\n\
+         TechLevel=1\nOwner=Americans\nHarvester=yes\nDock=GAREFN\n\
+         [GAREFN]\n\
+         Name=Ore Refinery\nCost=2000\nStrength=900\nArmor=wood\nTechLevel=1\n\
+         Owner=Americans\nFoundation=4x3\nRefinery=yes\n\
+         [KILLWH]\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    );
+    let rules = RuleSet::from_ini(&ini).expect("refinery kill rules");
+
+    let mut sim = Simulation::new();
+    let owner = sim.interner.intern("Americans");
+    sim.houses
+        .insert(owner, HouseState::new(owner, 0, None, false, 0, 10));
+    sim.session.house_order = vec![owner];
+    sim.session.binary_frame = 40;
+
+    let miner_id = spawn_miner(&mut sim, 1, MinerKind::War, 11, 11);
+    spawn_refinery(&mut sim, 2, 10, 10);
+    {
+        let entity = sim
+            .substrate
+            .entities
+            .get_mut(miner_id)
+            .expect("miner entity");
+        let miner = entity.miner.as_mut().expect("miner component");
+        for _ in 0..4 {
+            miner.cargo.push(CargoBale {
+                resource_type: ResourceType::Ore,
+                value: 25,
+            });
+        }
+        entity.mission.set_handler_state(MinerState::Dock.cursor());
+        miner.dock_phase = RefineryDockPhase::Unloading;
+        miner.reserved_refinery = Some(2);
+        miner.unload_active = true;
+    }
+    sim.production.dock_reservations.try_reserve(2, miner_id);
+    sim.production.dock_reservations.link_on_pad(2, miner_id);
+    let credits_before = credits_for_owner(&sim, "Americans");
+
+    // Kill the refinery through the damage transaction (not a sale).
+    let warhead = sim.interner.intern("KILLWH");
+    let event = EntityDamageEvent::area(2, 5000, 0, miner_id, Some(owner), warhead);
+    sim.commit_noncombat_aoe_hits(&rules, None, &[event]);
+
+    assert!(
+        sim.substrate
+            .entities
+            .get(2)
+            .is_none_or(|refinery| refinery.dying || refinery.health.current == 0),
+        "the refinery died"
+    );
+    let miner_entity = sim
+        .substrate
+        .entities
+        .get(miner_id)
+        .expect("miner survives");
+    let miner = miner_entity.miner.as_ref().expect("miner component");
+    assert_eq!(miner.reserved_refinery, None, "+0x2E4 link cleared");
+    assert_eq!(miner.dock_phase, RefineryDockPhase::Approach);
+    assert!(!miner.unload_active, "no deposit continues");
+    assert_eq!(miner.cargo.len(), 4, "remaining cargo stays aboard");
+    assert!(
+        miner_entity.radio_contacts.is_empty(),
+        "contact released with the building"
+    );
+    assert!(
+        !sim.production.dock_reservations.has_contact(2, miner_id)
+            && !sim.production.dock_reservations.is_on_pad(2, miner_id)
+    );
+    assert!(
+        miner_entity.forced_drive_track.is_some(),
+        "UndockUnit Head_To(0x47) push-off track installed"
+    );
+    assert_eq!(
+        credits_for_owner(&sim, "Americans"),
+        credits_before,
+        "the cargo on the pad is not deposited"
+    );
+
+    // Nothing pays the bales later either: no refinery is left to dock at.
+    tick_miners_n(&mut sim, &rules, 60);
+    assert_eq!(credits_for_owner(&sim, "Americans"), credits_before);
+    assert_eq!(get_miner(&sim, miner_id).cargo.len(), 4);
+}
+
+/// One object-AI visit of `id` with the miner config wired (the Harvest
+/// dispatch needs it), rules present.
+fn visit_object_ai(sim: &mut Simulation, rules: &RuleSet, id: u64) {
+    let config = MinerConfig::default();
+    sim.session.binary_frame = sim.session.binary_frame.wrapping_add(1);
+    sim.object_ai_visit_one(
+        id,
+        Some(rules),
+        crate::sim::world::ObjectAiCtx {
+            miner_config: Some(&config),
+            ..crate::sim::world::ObjectAiCtx::default()
+        },
+    );
+}
+
+/// `FootClass::Mission_Move @ 0x004D4242` → `UnitClass::Enter_Idle_Mode @
+/// 0x00738970` harvester arm: a war miner whose player Move has finished
+/// (Move committed, NavCom clear, nothing queued) is put back on Harvest by
+/// its own arrival dispatch when it stopped on ore (`LandType == Tiberium`),
+/// and the promoted Harvest restarts the handler from state 0 (`+0xBC = 0`).
+#[test]
+fn player_move_arrival_returns_a_war_miner_to_harvest_on_ore() {
+    use crate::sim::mission::{MissionId, MissionType};
+
+    let mut sim = Simulation::new();
+    let rules = miner_rules();
+    let miner_id = spawn_miner(&mut sim, 1, MinerKind::War, 20, 20);
+    place_ore(&mut sim, 20, 20, 5);
+    // Mid-harvest cursor, then the player Move takes over (Command::Move's
+    // `queue_megamission_with_teardown(Move)` promoted).
+    let now = sim.session.binary_frame;
+    sim.mission_assign_exact(miner_id, MissionId::from_known(MissionType::Harvest), now)
+        .expect("assign Harvest");
+    sim.substrate
+        .entities
+        .get_mut(miner_id)
+        .unwrap()
+        .mission
+        .set_handler_state(MinerState::MoveToOre.cursor());
+    sim.mission_assign_exact(miner_id, MissionId::from_known(MissionType::Move), now)
+        .expect("assign Move");
+    let cursor_on_move = sim
+        .substrate
+        .entities
+        .get(miner_id)
+        .unwrap()
+        .mission
+        .handler_state();
+
+    // Arrival dispatch: the harvester arm queues Harvest (no RNG draw).
+    let rng_before = sim.scenario_rng.state();
+    visit_object_ai(&mut sim, &rules, miner_id);
+    let e = sim.substrate.entities.get(miner_id).unwrap();
+    assert_eq!(e.mission.current().known(), Some(MissionType::Move));
+    assert_eq!(
+        e.mission.queued().known(),
+        Some(MissionType::Harvest),
+        "Enter_Idle_Mode harvester arm commits Harvest on ore"
+    );
+    assert_eq!(
+        e.mission.handler_state(),
+        cursor_on_move,
+        "Harvest FSM declined the Move dispatch"
+    );
+    assert_eq!(sim.scenario_rng.state(), rng_before, "the arm draws no RNG");
+
+    // Next visit: Ready-to-Commence promotes Harvest with a zeroed cursor and
+    // the Harvest handler runs again from state 0.
+    visit_object_ai(&mut sim, &rules, miner_id);
+    let e = sim.substrate.entities.get(miner_id).unwrap();
+    assert_eq!(e.mission.current().known(), Some(MissionType::Harvest));
+    assert!(
+        e.miner.as_ref().unwrap().target_ore_cell.is_some()
+            || MinerState::from_cursor(e.mission.handler_state()).is_some(),
+        "the Harvest handler dispatched from state 0"
+    );
+}
+
+/// The same arm for a HUMAN house whose miner stopped on non-ore land
+/// (`CellClass+0xEC != 5`) selects Guard (5), not Harvest — and an AI house
+/// on the same cell selects Harvest.
+#[test]
+fn player_move_arrival_off_ore_parks_a_human_miner_on_guard_and_an_ai_miner_on_harvest() {
+    use crate::sim::house_state::HouseState;
+    use crate::sim::mission::{MissionId, MissionType};
+
+    for (is_human, expected) in [(true, MissionType::Guard), (false, MissionType::Harvest)] {
+        let mut sim = Simulation::new();
+        let rules = miner_rules();
+        let owner = sim.interner.intern("Americans");
+        sim.houses
+            .insert(owner, HouseState::new(owner, 0, None, is_human, 0, 10));
+        let miner_id = spawn_miner(&mut sim, 1, MinerKind::War, 20, 20);
+        // Ore elsewhere, none under the miner.
+        place_ore(&mut sim, 30, 30, 5);
+        let now = sim.session.binary_frame;
+        sim.mission_assign_exact(miner_id, MissionId::from_known(MissionType::Move), now)
+            .expect("assign Move");
+        visit_object_ai(&mut sim, &rules, miner_id);
+        let e = sim.substrate.entities.get(miner_id).unwrap();
+        assert_eq!(
+            e.mission.queued().known(),
+            Some(expected),
+            "human={is_human}: selector on non-ore land"
+        );
+    }
+}
+
+/// A 64x64 sim carrying the production `CellClass+0xEC` authority: a flat
+/// clear `ResolvedTerrainGrid` plus an `OverlayGrid` with one TIB01 patch on
+/// `cell`, folded into `land_type` by the same `recalc_overlay_passability`
+/// the map loader and every overlay mutation run. No `resource_nodes` exist,
+/// so the legacy fallback in `cell_land_type_is` cannot answer.
+fn sim_with_resolved_tiberium_cell(
+    registry: &crate::map::overlay_types::OverlayTypeRegistry,
+    cell: (u16, u16),
+) -> Simulation {
+    use crate::map::resolved_terrain::ResolvedTerrainGrid;
+    use crate::rules::terrain_rules::LandType;
+    use crate::sim::house_state::HouseState;
+
+    let tib01 = registry.id_for_name("TIB01").expect("TIB01");
+    let mut sim = Simulation::new();
+    let owner = sim.interner.intern("Americans");
+    sim.houses
+        .insert(owner, HouseState::new(owner, 0, None, true, 0, 10));
+    let mut cells = Vec::with_capacity(64 * 64);
+    for ry in 0..64u16 {
+        for rx in 0..64u16 {
+            cells.push(crate::sim::deploy_tests::clear_terrain_cell(rx, ry));
+        }
+    }
+    let mut terrain = ResolvedTerrainGrid::from_cells(64, 64, cells);
+    let mut overlay = OverlayGrid::new(64, 64);
+    overlay.place_overlay(cell.0, cell.1, tib01, 3);
+    assert!(crate::sim::overlay_grid::recalc_overlay_passability(
+        &mut overlay,
+        &mut terrain,
+        registry,
+        cell.0,
+        cell.1,
+    ));
+    assert_eq!(
+        terrain.cell(cell.0, cell.1).unwrap().land_type,
+        LandType::Tiberium.as_index(),
+        "overlay recalc wrote LandType Tiberium (5)"
+    );
+    sim.resolved_terrain = Some(terrain);
+    sim.overlay_grid = Some(overlay);
+    assert!(sim.production.resource_nodes.is_empty());
+    sim
+}
+
+/// Assign Move (no destination) and run one arrival dispatch; returns the
+/// queued selector.
+fn move_arrival_selector(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    miner_id: u64,
+) -> Option<crate::sim::mission::MissionType> {
+    use crate::sim::mission::{MissionId, MissionType};
+
+    let now = sim.session.binary_frame;
+    sim.mission_assign_exact(miner_id, MissionId::from_known(MissionType::Move), now)
+        .expect("assign Move");
+    visit_object_ai(sim, rules, miner_id);
+    sim.substrate
+        .entities
+        .get(miner_id)
+        .unwrap()
+        .mission
+        .queued()
+        .known()
+}
+
+/// The production land-type path: with `resolved_terrain` present the arm
+/// reads `land_type` (not the resource-node fallback), and a human war miner
+/// arriving on a TIB01 overlay cell resumes Harvest.
+#[test]
+fn player_move_arrival_reads_tiberium_land_type_from_resolved_terrain() {
+    use crate::sim::mission::MissionType;
+
+    let (rules, registry) = miner_rules_with_tiberium();
+    let cell = (20u16, 20u16);
+    let mut sim = sim_with_resolved_tiberium_cell(&registry, cell);
+    let miner_id = spawn_miner(&mut sim, 1, MinerKind::War, cell.0, cell.1);
+    assert_eq!(
+        move_arrival_selector(&mut sim, &rules, miner_id),
+        Some(MissionType::Harvest),
+        "resolved terrain LandType 5 selects Harvest"
+    );
+}
+
+/// The same cell after the production reducer fully removes its overlay:
+/// `reduce_tiberium`'s full-removal boundary runs `recalc_overlay_passability`
+/// synchronously, `land_type` drops back to Clear, and the human miner's next
+/// arrival parks on Guard.
+#[test]
+fn player_move_arrival_after_full_harvest_parks_a_human_miner_on_guard() {
+    use crate::rules::terrain_rules::LandType;
+    use crate::sim::mission::MissionType;
+    use crate::sim::tiberium::{ReduceTiberiumContext, reduce_tiberium};
+
+    let (rules, registry) = miner_rules_with_tiberium();
+    let cell = (20u16, 20u16);
+    let mut sim = sim_with_resolved_tiberium_cell(&registry, cell);
+    sim.production
+        .ore_growth_state
+        .reset_native_tiberium_classes(rules.tiberium_types.len(), 0);
+    let outcome = {
+        let mut ctx = ReduceTiberiumContext {
+            resource_nodes: &mut sim.production.resource_nodes,
+            overlay_grid: sim.overlay_grid.as_mut(),
+            ore_growth_state: &mut sim.production.ore_growth_state,
+            overlay_registry: Some(&registry),
+            tiberium_types: Some(&rules.tiberium_types),
+            resolved_terrain: sim.resolved_terrain.as_mut(),
+            source_object_cells: None,
+            live_objects: None,
+            rng: None,
+            binary_frame: 0,
+            spread_enabled: false,
+            radar_dirty_cells: None,
+            radar_dirty_generation: None,
+            tactical_dirty_cells: None,
+        };
+        reduce_tiberium(&mut ctx, cell, 4)
+    };
+    assert!(
+        outcome.fully_removed,
+        "density 3 against 4 is a full removal"
+    );
+    assert_eq!(
+        sim.overlay_grid
+            .as_ref()
+            .unwrap()
+            .cell(cell.0, cell.1)
+            .overlay_id,
+        None
+    );
+    assert_eq!(
+        sim.resolved_terrain
+            .as_ref()
+            .unwrap()
+            .cell(cell.0, cell.1)
+            .unwrap()
+            .land_type,
+        LandType::Clear.as_index(),
+        "full removal recalc restored the base land type"
+    );
+
+    let miner_id = spawn_miner(&mut sim, 1, MinerKind::War, cell.0, cell.1);
+    assert_eq!(
+        move_arrival_selector(&mut sim, &rules, miner_id),
+        Some(MissionType::Guard),
+        "LandType no longer 5 ⇒ a human miner parks on Guard"
+    );
+}
+
+/// `In_Radio_Contact` ⇒ the arm returns without assigning anything: a miner
+/// still linked to a refinery keeps Move and no mission is queued.
+#[test]
+fn player_move_arrival_in_radio_contact_assigns_nothing() {
+    use crate::sim::mission::{MissionId, MissionType};
+
+    let mut sim = Simulation::new();
+    let rules = miner_rules();
+    let miner_id = spawn_miner(&mut sim, 1, MinerKind::War, 20, 20);
+    spawn_refinery(&mut sim, 2, 10, 10);
+    place_ore(&mut sim, 20, 20, 5);
+    sim.substrate
+        .entities
+        .get_mut(miner_id)
+        .unwrap()
+        .radio_contacts
+        .insert(2);
+    let now = sim.session.binary_frame;
+    sim.mission_assign_exact(miner_id, MissionId::from_known(MissionType::Move), now)
+        .expect("assign Move");
+    visit_object_ai(&mut sim, &rules, miner_id);
+    let e = sim.substrate.entities.get(miner_id).unwrap();
+    assert_eq!(e.mission.current().known(), Some(MissionType::Move));
+    assert_eq!(e.mission.queued(), MissionId::NONE);
 }

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -20,6 +20,8 @@ mod logic_vector;
 mod projectile_collision;
 mod substrate;
 mod techno_ai;
+#[cfg(test)]
+pub(crate) use techno_ai::ObjectAiCtx;
 pub(crate) mod techno_ai_cloak;
 pub(crate) mod unit_post;
 mod world_commands;
@@ -1972,6 +1974,13 @@ impl Simulation {
                 if !matches!(category, EntityCategory::Unit | EntityCategory::Structure) {
                     return;
                 }
+                // `BuildingClass::ReceiveDamage` result-4 arm: `UndockUnit`
+                // (0x004424EA) runs first, ahead of the CaptureManager
+                // release, the contact kill/scatter loop and the `+0x4EC`
+                // death — see `undock_refinery_unit_on_death`.
+                if category == EntityCategory::Structure {
+                    self.undock_refinery_unit_on_death(rules, stable_id);
+                }
                 let garrison = self.substrate.entities.get(stable_id).and_then(|entity| {
                     if category != EntityCategory::Structure {
                         return None;
@@ -2956,6 +2965,45 @@ impl Simulation {
         );
     }
 
+    /// `BuildingClass::ReceiveDamage @ 0x00442230`, result-4 (destroyed) arm
+    /// calling 0x004424EA: when the docked-unit link `+0x2E4` is set, the
+    /// unit is first removed from the collected contact vector (so the
+    /// contact kill/scatter loop that follows never touches it), then
+    /// `BuildingClass::UndockUnit @ 0x004593A0` runs — all of this BEFORE the
+    /// `vtable+0x4EC` death/limbo call that breaks the radio contacts.
+    ///
+    /// `UndockUnit` body (disassembled 0x004593A0..0x0045946F): for a docked
+    /// `UnitClass` (`WhatAmI == 1`) it calls the locomotor's `Stop`
+    /// (ILocomotion `+0x58`), then `Head_To` (`+0x70`) with track `0x47` from
+    /// the building's `GetCoords` shifted `(-0x80, +0x80)` — the same
+    /// `Force_Track` push-off the unload exit uses — sets the unit speed
+    /// `1.0` (`vtable+0x544`), clears `+0x2E4` on both objects and `Mark(3)`s
+    /// the building. It touches neither the unit's mission, NavCom, `+0x6D1`
+    /// unload latch nor the contact; those go with the building's own
+    /// limbo/`Destroy(false)` BREAK the same frame. The harvester keeps its
+    /// remaining cargo (no deposit) and its next `Mission_Unload` dispatch
+    /// takes the contact-gone abandonment path.
+    ///
+    /// Rust reuses the sale-time `interrupt_refinery_docked_miners` (the same
+    /// `UndockUnit` shape `BuildingClass::Sell` reaches at 0x0044AAB0): break
+    /// the contact, keep the cargo, install the `0x47` push-off track. Its
+    /// dock-phase reset to `Approach` and the FSM cursor rewrite are
+    /// VERA-internal (gamemd leaves the unit on Unload until the abandonment
+    /// path re-dispatches it; the resulting re-selection of a refinery is the
+    /// same player-visible outcome).
+    fn undock_refinery_unit_on_death(&mut self, rules: &RuleSet, dead_id: u64) {
+        let is_refinery = self
+            .substrate
+            .entities
+            .get(dead_id)
+            .filter(|building| building.category == EntityCategory::Structure)
+            .and_then(|building| self.object_type(building.type_ref, rules))
+            .is_some_and(|obj| obj.refinery);
+        if is_refinery {
+            crate::sim::miner::interrupt_refinery_docked_miners(self, rules, dead_id);
+        }
+    }
+
     /// World-owned half of a non-combat damage transaction. Physical death
     /// consequences already happened recursively in combat; this consumes the
     /// same lifecycle/presentation/terrain outputs without leaving an alternate
@@ -2987,6 +3035,7 @@ impl Simulation {
             production::eject_destruction_garrison(self, rules, event);
         }
         for &dead_id in &effects.immediate_uninit_ids {
+            self.undock_refinery_unit_on_death(rules, dead_id);
             if self
                 .substrate
                 .entities
@@ -4774,20 +4823,16 @@ impl Simulation {
     /// O(houses x entities). `rules` is the advance_tick tail's `Option`; with
     /// `None` the purifier count is 0 (no type data to classify structures by).
     pub(crate) fn refresh_economy_shadow(&mut self, rules: Option<&RuleSet>) {
-        use crate::map::entities::EntityCategory;
-        // One pass: accumulate OrePurifier building count per owner. Mirrors
-        // `count_purifiers_for_owner`'s predicate (category == Structure &&
-        // object_type.ore_purifier) but in a single sweep keyed by owner id.
+        // One pass: accumulate OrePurifier building count per owner through
+        // the same `House+0x538C` predicate as `count_purifiers_for_owner`
+        // (`counts_as_purifier`: completed, alive, on-map purifier — a
+        // `building_up` one is still before `OnConstructionComplete`
+        // 0x0044637C and does not count), in a single sweep keyed by owner id.
         let mut purifiers: std::collections::BTreeMap<crate::sim::intern::InternedId, i32> =
             std::collections::BTreeMap::new();
         if let Some(rules) = rules {
             for e in self.substrate.entities.values() {
-                if !e.lifecycle.in_limbo
-                    && e.category == EntityCategory::Structure
-                    && self
-                        .object_type(e.type_ref, rules)
-                        .is_some_and(|obj| obj.ore_purifier)
-                {
+                if crate::sim::miner::miner_system::counts_as_purifier(self, rules, e) {
                     *purifiers.entry(e.owner).or_insert(0) += 1;
                 }
             }
@@ -7750,6 +7795,7 @@ impl Simulation {
                 production::eject_destruction_garrison(self, rules, event);
             }
             for &dead_id in &combat_result.immediate_uninit_ids {
+                self.undock_refinery_unit_on_death(rules, dead_id);
                 // Eject a bunkered unit before the bunker is removed (UndockUnit).
                 if self
                     .substrate

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -3461,6 +3461,8 @@ mod tests {
         let base = MissionHandlerInput {
             category: EntityCategory::Infantry,
             mission: Some(MissionType::Attack),
+            harvester_miner: false,
+            depot_dock_state: false,
             timer_due: true,
             moving_or_queued: false,
             bunker_delegate: false,
@@ -3560,6 +3562,8 @@ mod tests {
         let base = MissionHandlerInput {
             category: EntityCategory::Infantry,
             mission: Some(MissionType::Attack),
+            harvester_miner: false,
+            depot_dock_state: false,
             timer_due: true,
             moving_or_queued: false,
             bunker_delegate: false,

--- a/src/sim/world/techno_ai/mission_handlers.rs
+++ b/src/sim/world/techno_ai/mission_handlers.rs
@@ -48,7 +48,17 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
         // FootClass Guard handler every other unit uses; a vehicle on Harvest
         // enters the Harvest handler. Exactly one of the two runs, so the
         // timer keeps a single writer.
-        if entity.miner.is_some() && mission != Some(MissionType::Guard) {
+        //
+        // Move is the other split: a player Move order puts the miner on
+        // `UnitClass::Mission_Move` (slot `+0x22C` = 0x00740A90, tail
+        // `FootClass::Mission_Move @ 0x004D4200`), whose arrival
+        // `Enter_Idle_Mode(0,1)` at 0x004D4242 is the ONLY thing that returns
+        // a harvester to Harvest (or Guard) — see
+        // `harvester_enter_idle_mode_evaluation`. The Harvest handler declines
+        // Move for the same single-writer reason.
+        if entity.miner.is_some()
+            && !matches!(mission, Some(MissionType::Guard) | Some(MissionType::Move))
+        {
             return;
         }
         let moving = entity.movement_target.is_some()
@@ -58,6 +68,8 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
         MissionHandlerInput {
             category,
             mission,
+            harvester_miner: entity.miner.is_some(),
+            depot_dock_state: entity.dock_state.is_some(),
             timer_due: entity.mission.dispatch_timer().due(now),
             moving_or_queued: moving || entity.mission.queued() != MissionId::NONE,
             bunker_delegate: entity.bunker_link.installed_in().is_some(),
@@ -138,6 +150,10 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
                     rules,
                     MissionType::Move,
                 ))
+            } else if input.category == EntityCategory::Unit && input.harvester_miner {
+                // The same arrival hook, harvester arm of
+                // `UnitClass::Enter_Idle_Mode @ 0x00738970`.
+                harvester_enter_idle_mode_evaluation(sim, id, rules, input)
             } else {
                 // The arrival branch. `FootClass::Mission_Move` calls the class
                 // arrival hook and returns one frame; the hook is the ONLY
@@ -148,6 +164,15 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
                 // Guard-only arm of the passive-acquire gate.
                 move_arrival_evaluation(rules, input)
             }
+        }
+        // A repair-depot waiter: `FootClass::Mission_Enter @ 0x004D9290` run
+        // from the unit's own dispatch slot so its epilogue `RandomRanged(0,2)`
+        // lands in object-AI order (the building-side servicing stays in
+        // `tick_building_docks`).
+        (EntityCategory::Unit, Some(MissionType::Enter)) if input.depot_dock_state => {
+            MissionHandlerEvaluation::cadence(
+                crate::sim::docking::building_dock::mission_enter_dispatch(sim, rules, id),
+            )
         }
         // `UnitClass::Mission_Attack @ 0x007447A0` is a tail jump to
         // `FootClass::Mission_Attack`, so vehicles belong on this path.
@@ -520,6 +545,13 @@ pub(super) struct MissionHandlerInput {
     /// and every out-of-range id take the switch's default arm rather than
     /// being skipped.
     pub(super) mission: Option<MissionType>,
+    /// The object carries the miner component (`Harvester=`/`Weeder=` type
+    /// flags `UnitTypeClass+0xE0E`/`+0xE0F`): its Move arrival takes the
+    /// harvester arm of `UnitClass::Enter_Idle_Mode`.
+    pub(super) harvester_miner: bool,
+    /// The object holds a repair-depot `DockState`: its Enter dispatch is
+    /// `building_dock::mission_enter_dispatch`.
+    pub(super) depot_dock_state: bool,
     pub(super) timer_due: bool,
     pub(super) moving_or_queued: bool,
     pub(super) bunker_delegate: bool,
@@ -643,6 +675,99 @@ pub(super) fn move_arrival_evaluation(
         clear_attack_target: true,
         queue: Some(MissionType::Guard),
     }
+}
+
+/// The harvester arm of `UnitClass::Enter_Idle_Mode @ 0x00738970` (vtable
+/// `+0x484`), reached from the Move handler's arrival branch.
+///
+/// Callers a player Move order on a war/chrono miner reaches (all verified by
+/// `search_instructions CALL [+0x484]`, 85 sites): `FootClass::Mission_Move @
+/// 0x004D4200` at 0x004D4242 — `NavCom == 0 && !Is_Moving && Queued == -1 ⇒
+/// Enter_Idle_Mode(0,1); return 1` — and the locomotor IDLE event
+/// `DriveLocomotionClass::Process @ 0x004B0763` (destination reached with an
+/// empty NavQueue: `Stop_Moving`, then `Enter_Idle_Mode(0,1)`). Both land in
+/// the same body; the Unit slot `0x00740A90` only precedes the Foot body
+/// with its deploy latches.
+///
+/// Body, decompiled 2026-09-06, no-destination branch for `Harvester=`/
+/// `Weeder=` (`UnitType+0xE0E`/`+0xE0F`):
+/// - `RadioClass::In_Radio_Contact` ⇒ return (nothing assigned);
+/// - current (`+0xAC`) or queued (`+0xB4`) == Harvest(10) ⇒ return;
+/// - selector = Harvest; when `param_2 == 0` (both callers pass 0) AND
+///   `HouseClass::IsControlledByHuman @ 0x0050B730`: the cell under the unit
+///   (`MapClass::Get_CellClass_At_Coord`) has `LandType` (`CellClass+0xEC`)
+///   ≠ 5 (Tiberium; 0xB Weeds for a Weeder) ⇒ selector = Guard(5). An AI
+///   house always takes Harvest;
+/// - `Assign_Target(0)` (`+0x3C8`), `Assign_Destination(0, 1)` (`+0x480`);
+/// - tail gate: current ∉ {Patrol 0x19, AreaGuard 0xB, Unload 0x10, Eaten 9}
+///   ⇒ `+0x1E8(selector, 0)`. Current is Move here, so it always commits.
+///
+/// So a human's miner moved onto bare ground parks on Guard (the harvester
+/// Guard override's chrono arms or a player order put it back); moved onto
+/// ore it resumes Harvest from state 0. The whole arm draws no RNG; the
+/// `Mission_Move` caller returns 1. VERA commits through the queue like
+/// [`move_arrival_evaluation`] (promoted by the next Ready-to-Commence step,
+/// which zeroes the Harvest cursor exactly as native's `+0xBC = 0`).
+fn harvester_enter_idle_mode_evaluation(
+    sim: &Simulation,
+    id: u64,
+    rules: &RuleSet,
+    input: MissionHandlerInput,
+) -> MissionHandlerEvaluation {
+    let Some(entity) = sim.substrate.entities.get(id) else {
+        return MissionHandlerEvaluation::cadence(1);
+    };
+    if !entity.radio_contacts.is_empty() {
+        return MissionHandlerEvaluation::cadence(1);
+    }
+    if input.mission == Some(MissionType::Harvest)
+        || entity.mission.queued() == MissionId::from_known(MissionType::Harvest)
+    {
+        return MissionHandlerEvaluation::cadence(1);
+    }
+    let human = sim
+        .houses
+        .get(&entity.owner)
+        .is_none_or(|house| house.is_controlled_by_human(sim.session.game_mode_nonzero));
+    let weeder = sim
+        .object_type(entity.type_ref, rules)
+        .is_some_and(|obj| !obj.harvester && obj.weeder);
+    let wanted_land = if weeder {
+        crate::rules::terrain_rules::LandType::Weeds
+    } else {
+        crate::rules::terrain_rules::LandType::Tiberium
+    };
+    let land_matches = cell_land_type_is(sim, entity.position.rx, entity.position.ry, wanted_land);
+    let selector = if human && !land_matches {
+        MissionType::Guard
+    } else {
+        MissionType::Harvest
+    };
+    MissionHandlerEvaluation {
+        delay: 1,
+        clear_stale_attack_target: false,
+        clear_attack_target: true,
+        queue: Some(selector),
+    }
+}
+
+/// `CellClass+0xEC` (`LandType`) of one cell: the resolved terrain's land
+/// type when the map carries one (the overlay recompute keeps it current when
+/// ore is placed or removed), else the legacy resource-node fallback (an ore
+/// node ⇒ Tiberium land).
+fn cell_land_type_is(
+    sim: &Simulation,
+    rx: u16,
+    ry: u16,
+    wanted: crate::rules::terrain_rules::LandType,
+) -> bool {
+    if let Some(terrain) = sim.resolved_terrain.as_ref() {
+        return terrain
+            .cell(rx, ry)
+            .is_some_and(|cell| cell.land_type == wanted.as_index());
+    }
+    wanted == crate::rules::terrain_rules::LandType::Tiberium
+        && sim.production.resource_nodes.contains_key(&(rx, ry))
 }
 
 /// The idle-mode selector reached from the Attack handler's no-target exit.


### PR DESCRIPTION
Closes the findings of the Phase 7 reverse audit (three omissions, three regressions among ~85 mechanisms across the twelve rows landed in #242–#255), each verified against gamemd.exe.

- Depot re-probe RNG order: `FootClass::Mission_Enter` @ 0x004D9290 draws its `RandomRanged(0,2)` epilogue inside the waiter's own AI dispatch; the depot probe now runs from the Unit Enter arm of the object-AI dispatch, so Scenario draws interleave in object order as native (snapshot layout unchanged).
- Refinery killed mid-unload: `BuildingClass::ReceiveDamage` result-4 arm → `UndockUnit` @ 0x004593A0 (locomotor stop, Head_To track 0x47 off the pad, +0x2E4 cleared both sides); Rust now undocks on the same tick at `BeforeDeathEffects`.
- Purifier count: `House+0x538C` increments only at `OnConstructionComplete` 0x0044637C / the ChangeOwner register tail 0x004491EB; building-up purifiers no longer pay the bonus (economy shadow aligned).
- `Enter_Idle_Mode` @ 0x00738970 harvester arm: on Move arrival a harvester re-queues Harvest, or Guard when human and off ore, unless in radio contact; reached via `FootClass::Mission_Move` 0x004D4242 and the drive IDLE event 0x004B0763. Tests drive the production LandType path through the resolved terrain grid.
- Stale `+0xE8` provenance corrected (ctor sets `max(NumberOfDocks,1)` at 0x0043BCBD..CD0); per-type cargo slots recorded as a residual.

Residuals recorded in code: the reused sale-path interrupt resets the miner's dock phase (native stays on Unload until its own abandonment); Attack retask on a miner resumes the old FSM cursor; the unit's native mission while servicing on the depot pad is UNCHECKED.

Independent read-only critic re-read the six native bodies and passed; two follow-ups it recommended (resolved-terrain test, economy-shadow predicate) are included.

Validation:
- `cargo test -p vera20k --lib`: `test result: ok. 8427 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 17.44s`
