### PR TITLE
Name deterministic hash schema policies and feature gates

### DIFF
--- a/src/sim/world/hash_schema.rs
+++ b/src/sim/world/hash_schema.rs
@@ -1,0 +1,174 @@
+//! Historical projections of the deterministic Rust hash stream.
+//!
+//! These policies preserve the existing provenance probes; they do not promise
+//! snapshot loading compatibility or native parity for arbitrary versions.
+
+#[derive(Clone, Copy)]
+pub(super) enum HashSchema {
+    Current,
+    #[cfg(test)]
+    Before(u16),
+}
+
+/// First hash schema containing each gated layout. A feature can select an
+/// alternate encoding, not just append fields: retain both sides of its fold.
+#[derive(Clone, Copy)]
+#[repr(u16)]
+pub(super) enum HashFeature {
+    Lifecycle = 28,
+    Mission = 29,
+    MasterFrame = 43,
+    EntityAnimation = 44,
+    BuildingAnimOverlays = 45,
+    TerminalScore = 46,
+    PlayfieldAuthority = 47,
+    TechnoPlayfield = 87,
+    SensorDeposit = 88,
+    RealCellBridgeFlags = 90,
+    BaseDefenseResponse = 97,
+    TechnoConstructor = 104,
+    SparkDummyLevelSlope = 107,
+    AlternateBaseCenter = 108,
+    NavalBuildConst = 109,
+    BasePlan = 110,
+    BasePlanCenter = 111,
+    HouseDeployLatches = 112,
+    HouseUpdateActivation = 113,
+    CrateAuthority = 114,
+    WallRuntime = 115,
+    DisguiseDetect = 117,
+    HouseHarvesterNoOre = 132,
+    HouseEva = 133,
+    CreditIncome = 135,
+}
+
+impl HashSchema {
+    pub(super) const fn includes(self, _feature: HashFeature) -> bool {
+        match self {
+            Self::Current => true,
+            #[cfg(test)]
+            Self::Before(version) => (_feature as u16) < version,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn historical_policies_preserve_original_positional_masks() {
+        // Frozen from the 25-argument calls before this refactor (main c1983f56).
+        // Bit positions retain the original parameter order; expected masks
+        // are the old call values, independent of the new version predicate.
+        let features = [
+            HashFeature::Lifecycle,
+            HashFeature::Mission,
+            HashFeature::MasterFrame,
+            HashFeature::EntityAnimation,
+            HashFeature::BuildingAnimOverlays,
+            HashFeature::TerminalScore,
+            HashFeature::PlayfieldAuthority,
+            HashFeature::TechnoPlayfield,
+            HashFeature::SensorDeposit,
+            HashFeature::RealCellBridgeFlags,
+            HashFeature::BaseDefenseResponse,
+            HashFeature::TechnoConstructor,
+            HashFeature::SparkDummyLevelSlope,
+            HashFeature::AlternateBaseCenter,
+            HashFeature::NavalBuildConst,
+            HashFeature::BasePlan,
+            HashFeature::BasePlanCenter,
+            HashFeature::HouseDeployLatches,
+            HashFeature::HouseUpdateActivation,
+            HashFeature::CrateAuthority,
+            HashFeature::WallRuntime,
+            HashFeature::DisguiseDetect,
+            HashFeature::HouseHarvesterNoOre,
+            HashFeature::HouseEva,
+            HashFeature::CreditIncome,
+        ];
+        let cases = [
+            ("state_hash", HashSchema::Current, 0x01ffffffu32),
+            (
+                "state_hash_without_mission_v29",
+                HashSchema::Before(29),
+                0x00000001u32,
+            ),
+            (
+                "state_hash_before_lifecycle_v28_and_mission_v29",
+                HashSchema::Before(28),
+                0x00000000u32,
+            ),
+            (
+                "state_hash_without_spark_dummy_level_slope_v107",
+                HashSchema::Before(107),
+                0x00000fffu32,
+            ),
+            (
+                "state_hash_without_naval_build_const_v109",
+                HashSchema::Before(109),
+                0x00003fffu32,
+            ),
+            (
+                "state_hash_without_base_plan_v110",
+                HashSchema::Before(110),
+                0x00007fffu32,
+            ),
+            (
+                "state_hash_without_base_plan_center_v111",
+                HashSchema::Before(111),
+                0x0000ffffu32,
+            ),
+            (
+                "state_hash_without_house_deploy_latches_v112",
+                HashSchema::Before(112),
+                0x0001ffffu32,
+            ),
+            (
+                "state_hash_without_house_update_activation_v113",
+                HashSchema::Before(113),
+                0x0003ffffu32,
+            ),
+            (
+                "state_hash_without_crate_authority_v114",
+                HashSchema::Before(114),
+                0x0007ffffu32,
+            ),
+            (
+                "state_hash_without_disguise_detect_v117",
+                HashSchema::Before(117),
+                0x001fffffu32,
+            ),
+            (
+                "state_hash_without_house_harvester_no_ore_v132",
+                HashSchema::Before(132),
+                0x003fffffu32,
+            ),
+            (
+                "state_hash_without_house_eva_v133",
+                HashSchema::Before(133),
+                0x007fffffu32,
+            ),
+            (
+                "state_hash_without_credit_income_v135",
+                HashSchema::Before(135),
+                0x00ffffffu32,
+            ),
+            (
+                "state_hash_without_wall_runtime_v115",
+                HashSchema::Before(115),
+                0x000fffffu32,
+            ),
+        ];
+        for (name, schema, expected) in cases {
+            let actual = features
+                .iter()
+                .enumerate()
+                .fold(0u32, |mask, (bit, &feature)| {
+                    mask | (u32::from(schema.includes(feature)) << bit)
+                });
+            assert_eq!(actual, expected, "{name}");
+        }
+    }
+}

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod authored_load_host;
 pub(crate) mod bridge_orchestrator;
 pub(crate) mod building_anim;
 pub mod edge_cell;
+mod hash_schema;
 mod lifecycle;
 mod load_object_lifecycle;
 mod logic_vector;

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -9,6 +9,7 @@
 use std::hash::{Hash, Hasher};
 
 use super::Simulation;
+use super::hash_schema::{HashFeature, HashSchema};
 
 fn hash_projectile_target(
     target: crate::sim::projectile::ProjectileTarget,
@@ -437,10 +438,7 @@ impl Simulation {
     /// Hashes clocks, Scenario RNG, production, fog, alliances, and all entity
     /// components in stable-entity-ID order (EntityStore keys_sorted) for determinism.
     pub fn state_hash(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, true, true, true, true, true,
-        )
+        self.state_hash_with_schema(HashSchema::Current)
     }
 
     /// Test-only provenance probe for the v29 Mission hash rebaseline.
@@ -449,11 +447,7 @@ impl Simulation {
     /// Mission/hash layout from representable final state.
     #[cfg(test)]
     pub(crate) fn state_hash_without_mission_v29(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false, false, false, false, false, false, false, false, false, false,
-            false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(29))
     }
 
     /// Test-only provenance probe for the historical pre-v28 baseline.
@@ -462,21 +456,14 @@ impl Simulation {
     /// schema changes do not invalidate that earlier proof.
     #[cfg(test)]
     pub(crate) fn state_hash_before_lifecycle_v28_and_mission_v29(&self) -> u64 {
-        self.state_hash_with_schema(
-            false, false, false, false, false, false, false, false, false, false, false, false,
-            false, false, false, false, false, false, false, false, false, false, false, false,
-            false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(28))
     }
 
     /// Test-only provenance probe for the v107 unconditional Spark dummy
     /// level/slope fold. It reconstructs the committed v106 hash layout.
     #[cfg(test)]
     pub(crate) fn state_hash_without_spark_dummy_level_slope_v107(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, false, false,
-            false, false, false, false, false, false, false, false, false, false, false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(107))
     }
 
     /// Test-only provenance probe for the v109 naval BuildConst folds. It
@@ -484,10 +471,7 @@ impl Simulation {
     /// earlier schema addition.
     #[cfg(test)]
     pub(crate) fn state_hash_without_naval_build_const_v109(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            false, false, false, false, false, false, false, false, false, false, false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(109))
     }
 
     /// Test-only provenance probe for the v110 BasePlan folds. It reconstructs
@@ -495,47 +479,32 @@ impl Simulation {
     /// addition, including naval BuildConst order and membership.
     #[cfg(test)]
     pub(crate) fn state_hash_without_base_plan_v110(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, false, false, false, false, false, false, false, false, false, false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(110))
     }
 
     /// Test-only provenance probe for the schema-v111 BasePlan-center fold.
     #[cfg(test)]
     pub(crate) fn state_hash_without_base_plan_center_v111(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, false, false, false, false, false, false, false, false, false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(111))
     }
 
     /// Test-only provenance probe for the schema-v112 House deploy-latch fold.
     #[cfg(test)]
     pub(crate) fn state_hash_without_house_deploy_latches_v112(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, false, false, false, false, false, false, false, false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(112))
     }
 
     /// Test-only provenance probe for the schema-v113 House-update activation
     /// fold. It reconstructs the committed v112 CurrentIQ/latch order.
     #[cfg(test)]
     pub(crate) fn state_hash_without_house_update_activation_v113(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, false, false, false, false, false, false, false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(113))
     }
 
     /// Test-only provenance probe for the schema-v114 raw crate-slot fold.
     #[cfg(test)]
     pub(crate) fn state_hash_without_crate_authority_v114(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, false, false, false, false, false, false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(114))
     }
 
     /// Test-only provenance probe for the schema-v117 disguise-detect folds:
@@ -544,20 +513,14 @@ impl Simulation {
     /// v115 hash layout.
     #[cfg(test)]
     pub(crate) fn state_hash_without_disguise_detect_v117(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, true, false, false, false, false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(117))
     }
 
     /// Test-only provenance probe for the schema-v132 `HouseClass+0x242`
     /// harvester no-ore latch fold. It reconstructs the committed v117 layout.
     #[cfg(test)]
     pub(crate) fn state_hash_without_house_harvester_no_ore_v132(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, true, true, false, false, false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(132))
     }
 
     /// Test-only provenance probe for the schema-v133 House EVA advice folds
@@ -565,10 +528,7 @@ impl Simulation {
     /// the committed v132 layout.
     #[cfg(test)]
     pub(crate) fn state_hash_without_house_eva_v133(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, true, true, true, false, false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(133))
     }
 
     /// Test-only provenance probe for the schema-v135 credit-income folds
@@ -577,50 +537,17 @@ impl Simulation {
     /// reconstructs the committed v133/v134 layout.
     #[cfg(test)]
     pub(crate) fn state_hash_without_credit_income_v135(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, true, true, true, true, false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(135))
     }
 
     /// Test-only provenance probe for the schema-v115 retained wall-count and
     /// shared-dummy overlay folds.
     #[cfg(test)]
     pub(crate) fn state_hash_without_wall_runtime_v115(&self) -> u64 {
-        self.state_hash_with_schema(
-            true, true, true, true, true, true, true, true, true, true, true, true, true, true,
-            true, true, true, true, true, true, false, false, false, false, false,
-        )
+        self.state_hash_with_schema(HashSchema::Before(115))
     }
 
-    fn state_hash_with_schema(
-        &self,
-        include_lifecycle_v28: bool,
-        include_mission_v29: bool,
-        include_master_frame_v43: bool,
-        include_entity_animation_v44: bool,
-        include_building_anim_overlays_v45: bool,
-        include_terminal_score_v46: bool,
-        include_playfield_authority_v47: bool,
-        include_techno_playfield_v87: bool,
-        include_sensor_deposit_v88: bool,
-        include_real_cell_bridge_flags_v90: bool,
-        include_base_defense_response_v97: bool,
-        include_techno_constructor_v104: bool,
-        include_spark_dummy_level_slope_v107: bool,
-        include_alternate_base_center_v108: bool,
-        include_naval_build_const_v109: bool,
-        include_base_plan_v110: bool,
-        include_base_plan_center_v111: bool,
-        include_house_deploy_latches_v112: bool,
-        include_house_update_activation_v113: bool,
-        include_crate_authority_v114: bool,
-        include_wall_runtime_v115: bool,
-        include_disguise_detect_v117: bool,
-        include_house_harvester_no_ore_v132: bool,
-        include_house_eva_v133: bool,
-        include_credit_income_v135: bool,
-    ) -> u64 {
+    fn state_hash_with_schema(&self, schema: HashSchema) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
 
         self.session.tick.hash(&mut hasher);
@@ -632,12 +559,12 @@ impl Simulation {
         self.substrate.next_occupancy_enter_order.hash(&mut hasher);
         // YR LogicClass trigger latches are save/lockstep state, even though
         // their camera/message outcomes stay app-owned and are not hashed.
-        if include_master_frame_v43 {
+        if schema.includes(HashFeature::MasterFrame) {
             self.trigger_runtime.hash_state(&mut hasher);
             self.team_script_vm
                 .hash_state(self.session.binary_frame as i32, &mut hasher);
         }
-        if include_playfield_authority_v47 {
+        if schema.includes(HashFeature::PlayfieldAuthority) {
             self.hash_playfield_authority(&mut hasher);
         }
 
@@ -648,7 +575,7 @@ impl Simulation {
             id.hash(&mut hasher);
         }
 
-        if include_lifecycle_v28 {
+        if schema.includes(HashFeature::Lifecycle) {
             // PendingDeleteList is an independent ordered substrate fact. The
             // length delimiter distinguishes queue boundaries before the ordered
             // IDs are folded (duplicates are intentionally preserved here).
@@ -663,26 +590,15 @@ impl Simulation {
         self.substrate.fold_base_reservations(&mut hasher);
 
         self.session.fold_game_options(&mut hasher);
-        self.hash_houses(
-            &mut hasher,
-            include_base_defense_response_v97,
-            include_alternate_base_center_v108,
-            include_naval_build_const_v109,
-            include_base_plan_v110,
-            include_base_plan_center_v111,
-            include_house_deploy_latches_v112,
-            include_house_update_activation_v113,
-            include_house_harvester_no_ore_v132,
-            include_house_eva_v133,
-        );
-        if include_terminal_score_v46 {
+        self.hash_houses(&mut hasher, schema);
+        if schema.includes(HashFeature::TerminalScore) {
             self.hash_terminal_score_snapshot(&mut hasher);
         }
         self.hash_production(&mut hasher);
         self.hash_power_states(&mut hasher);
-        self.hash_fog_and_alliances(&mut hasher, include_disguise_detect_v117);
+        self.hash_fog_and_alliances(&mut hasher, schema);
         self.hash_bridge_state(&mut hasher);
-        if include_real_cell_bridge_flags_v90 {
+        if schema.includes(HashFeature::RealCellBridgeFlags) {
             // `resolved_terrain` is derived/skipped. Fold the exact saved real
             // CellClass `0x1180` values once through their serialized authority.
             // Historical pre-v28/pre-v29 provenance probes must omit both this
@@ -692,13 +608,13 @@ impl Simulation {
             b"dynamic-terrain-cells-v1".hash(&mut hasher);
             self.dynamic_terrain_cells.hash(&mut hasher);
         }
-        self.hash_overlay_grid(&mut hasher, include_wall_runtime_v115);
-        if include_crate_authority_v114 {
+        self.hash_overlay_grid(&mut hasher, schema);
+        if schema.includes(HashFeature::CrateAuthority) {
             self.hash_crate_authority(&mut hasher);
         }
         self.hash_smudge_grid(&mut hasher);
         self.hash_radiation(&mut hasher);
-        if include_master_frame_v43 {
+        if schema.includes(HashFeature::MasterFrame) {
             self.hash_projectiles(&mut hasher);
             let shared_dummy_handle = self.effective_shared_cell_dummy();
             let shared_dummy = shared_dummy_handle.snapshot();
@@ -706,7 +622,7 @@ impl Simulation {
             // Unlike the requested coordinate, native `+0x140 & 0x1180`
             // survives ordinary lookups and changes later bridge/FNPC/target
             // behavior even when no Bullet currently retains the dummy.
-            if include_spark_dummy_level_slope_v107 {
+            if schema.includes(HashFeature::SparkDummyLevelSlope) {
                 b"shared-cell-dummy-spark-v4".hash(&mut hasher);
                 shared_dummy.bridge_flags_0x1180.hash(&mut hasher);
                 shared_dummy.level.hash(&mut hasher);
@@ -719,7 +635,7 @@ impl Simulation {
             // cleanup and later changes lookup-dependent wall behavior. Native
             // Resize reconstructs the process object, so this is synchronized
             // live-state authority rather than Scenario payload authority.
-            if include_wall_runtime_v115 {
+            if schema.includes(HashFeature::WallRuntime) {
                 b"shared-cell-dummy-overlay-v1".hash(&mut hasher);
                 shared_dummy_overlay.hash(&mut hasher);
             }
@@ -729,7 +645,7 @@ impl Simulation {
                 // A retained Bullet pointer additionally makes coordinate
                 // deterministic future behavior. Preserve the complete v106
                 // field/tag order for historical provenance probes.
-                if include_spark_dummy_level_slope_v107 {
+                if schema.includes(HashFeature::SparkDummyLevelSlope) {
                     b"shared-cell-dummy-target-v3".hash(&mut hasher);
                     shared_dummy.coord.hash(&mut hasher);
                 } else {
@@ -742,21 +658,7 @@ impl Simulation {
             self.hash_waves(&mut hasher);
         }
         self.hash_super_weapons(&mut hasher);
-        self.hash_entities(
-            &mut hasher,
-            include_lifecycle_v28,
-            include_mission_v29,
-            include_entity_animation_v44,
-            include_building_anim_overlays_v45,
-            include_techno_playfield_v87,
-            include_sensor_deposit_v88,
-            include_base_defense_response_v97,
-            include_techno_constructor_v104,
-            include_naval_build_const_v109,
-            include_base_plan_v110,
-            include_disguise_detect_v117,
-            include_credit_income_v135,
-        );
+        self.hash_entities(&mut hasher, schema);
         self.hash_anims(&mut hasher);
         self.hash_voxel_anims(&mut hasher);
         self.hash_particle_systems(&mut hasher);
@@ -912,19 +814,7 @@ impl Simulation {
     }
 
     /// Hash per-player house state (BTreeMap = deterministic order).
-    fn hash_houses(
-        &self,
-        hasher: &mut impl Hasher,
-        include_base_defense_response_v97: bool,
-        include_alternate_base_center_v108: bool,
-        include_naval_build_const_v109: bool,
-        include_base_plan_v110: bool,
-        include_base_plan_center_v111: bool,
-        include_house_deploy_latches_v112: bool,
-        include_house_update_activation_v113: bool,
-        include_house_harvester_no_ore_v132: bool,
-        include_house_eva_v133: bool,
-    ) {
+    fn hash_houses(&self, hasher: &mut impl Hasher, schema: HashSchema) {
         for (owner, house) in &self.houses {
             owner.hash(hasher);
             house.credits.hash(hasher);
@@ -948,11 +838,11 @@ impl Simulation {
             house.tech_level.hash(hasher);
             hash_house_ai_activation_fields(
                 house,
-                include_house_deploy_latches_v112,
-                include_house_update_activation_v113,
+                schema.includes(HashFeature::HouseDeployLatches),
+                schema.includes(HashFeature::HouseUpdateActivation),
                 hasher,
             );
-            if include_base_defense_response_v97 {
+            if schema.includes(HashFeature::BaseDefenseResponse) {
                 house.strategy_emergency.hash(hasher);
             } else {
                 house.strategy_emergency.mode.hash(hasher);
@@ -982,17 +872,18 @@ impl Simulation {
             } else {
                 0u8.hash(hasher);
             }
-            if include_alternate_base_center_v108 {
+            if schema.includes(HashFeature::AlternateBaseCenter) {
                 house.alternate_base_center.hash(hasher);
             }
-            if include_naval_build_const_v109 && !house.build_const_order.is_empty() {
+            if schema.includes(HashFeature::NavalBuildConst) && !house.build_const_order.is_empty()
+            {
                 b"naval-build-const-house-v1".hash(hasher);
                 house.build_const_order.len().hash(hasher);
                 for stable_id in &house.build_const_order {
                     stable_id.hash(hasher);
                 }
             }
-            if include_base_plan_v110 {
+            if schema.includes(HashFeature::BasePlan) {
                 house.base_plan.percent_built.hash(hasher);
                 house.base_plan.nodes.len().hash(hasher);
                 for node in &house.base_plan.nodes {
@@ -1002,17 +893,17 @@ impl Simulation {
                     node.retry_count.hash(hasher);
                 }
             }
-            if include_base_plan_center_v111 {
+            if schema.includes(HashFeature::BasePlanCenter) {
                 house.base_plan_center.hash(hasher);
             }
             house.base_reservation.hash(hasher);
             house.waypoint_edge.hash(hasher);
-            if include_house_harvester_no_ore_v132 {
+            if schema.includes(HashFeature::HouseHarvesterNoOre) {
                 // `HouseClass+0x242`, the sticky harvester no-ore latch — a
                 // raw House byte in the native save block and lockstep CRC.
                 house.harvester_no_ore.hash(hasher);
             }
-            if include_house_eva_v133 {
+            if schema.includes(HashFeature::HouseEva) {
                 // `HouseClass+0x57D4` funds-nag TimerStruct and the
                 // `[0xA8F040]` low-power guard (`HouseClass::Update
                 // 0x004F8B3C..0x004F8DAB`): both live in the native save.
@@ -1175,7 +1066,7 @@ impl Simulation {
     }
 
     /// Hash fog-of-war visibility and house alliance data.
-    fn hash_fog_and_alliances(&self, hasher: &mut impl Hasher, include_disguise_detect_v117: bool) {
+    fn hash_fog_and_alliances(&self, hasher: &mut impl Hasher, schema: HashSchema) {
         self.fog.width.hash(hasher);
         self.fog.height.hash(hasher);
         for (owner, fog) in &self.fog.by_owner {
@@ -1198,7 +1089,7 @@ impl Simulation {
         self.fog.fogged_object_cells.hash(hasher);
         self.fog.fogged_objects.hash(hasher);
         self.fog.sensors_by_house.hash(hasher);
-        if include_disguise_detect_v117 {
+        if schema.includes(HashFeature::DisguiseDetect) {
             // `CellClass+0xAC[house]` disguise-detect counters.
             // Behaviour-affecting like their `SensorsOfHouses` sibling above:
             // `FUN_004870F0` reads them inside `IsDisguisedTo`, which decides
@@ -1254,7 +1145,7 @@ impl Simulation {
         }
     }
 
-    fn hash_overlay_grid(&self, hasher: &mut impl Hasher, include_wall_runtime_v115: bool) {
+    fn hash_overlay_grid(&self, hasher: &mut impl Hasher, schema: HashSchema) {
         let Some(overlay_grid) = &self.overlay_grid else {
             0u8.hash(hasher);
             return;
@@ -1272,7 +1163,7 @@ impl Simulation {
                 cell.wall_owner.hash(hasher);
             }
         }
-        if include_wall_runtime_v115 {
+        if schema.includes(HashFeature::WallRuntime) {
             b"retained-wall-neighbor-counts-v1".hash(hasher);
             match overlay_grid.retained_wall_neighbor_counts() {
                 None => 0u8.hash(hasher),
@@ -1374,25 +1265,10 @@ impl Simulation {
 
     /// Hash all entity components in stable-entity-ID order.
     /// BTreeMap iterates in key order (= stable_id), so no manual sort needed.
-    fn hash_entities(
-        &self,
-        hasher: &mut impl Hasher,
-        include_lifecycle_v28: bool,
-        include_mission_v29: bool,
-        include_entity_animation_v44: bool,
-        include_building_anim_overlays_v45: bool,
-        include_techno_playfield_v87: bool,
-        include_sensor_deposit_v88: bool,
-        include_base_defense_response_v97: bool,
-        include_techno_constructor_v104: bool,
-        include_naval_build_const_v109: bool,
-        include_base_plan_v110: bool,
-        include_disguise_detect_v117: bool,
-        include_credit_income_v135: bool,
-    ) {
+    fn hash_entities(&self, hasher: &mut impl Hasher, schema: HashSchema) {
         for entity in self.substrate.entities.values() {
             entity.stable_id.hash(hasher);
-            if include_credit_income_v135 {
+            if schema.includes(HashFeature::CreditIncome) {
                 // GSI-09.01: the `BuildingClass+0x6D0/+0x6D8` ProduceCash
                 // timer and the `TechnoClass+0x1CC/+0x1D0` drain link pair.
                 // All three drive future wallet writes, so a divergence here
@@ -1401,14 +1277,14 @@ impl Simulation {
                 entity.drain_target.hash(hasher);
                 entity.draining_me.hash(hasher);
             }
-            if include_techno_constructor_v104
+            if schema.includes(HashFeature::TechnoConstructor)
                 && (entity.techno_ctor_random_word != 0 || entity.structure_upgrade_link.is_some())
             {
                 b"techno-constructor-v1".hash(hasher);
                 entity.techno_ctor_random_word.hash(hasher);
                 entity.structure_upgrade_link.hash(hasher);
             }
-            if include_techno_constructor_v104 {
+            if schema.includes(HashFeature::TechnoConstructor) {
                 // Constructor-owned SlaveManager identities live in the
                 // transitional ProductionState registry until the manager is
                 // promoted to its own component. Both the ordered pool and
@@ -1437,7 +1313,7 @@ impl Simulation {
             entity.occupancy_enter_order.hash(hasher);
             entity.air_spatial_bucket.hash(hasher);
             entity.air_spatial_enter_order.hash(hasher);
-            if include_lifecycle_v28 {
+            if schema.includes(HashFeature::Lifecycle) {
                 // Independent lifecycle axes and deterministic Rust bookkeeping.
                 // Keep this order fixed: it is part of the lockstep hash contract.
                 entity.lifecycle.object_alive.hash(hasher);
@@ -1447,7 +1323,7 @@ impl Simulation {
                 entity.dirty_rect_eligible.hash(hasher);
                 entity.owned_count_released.hash(hasher);
             }
-            if include_techno_playfield_v87 {
+            if schema.includes(HashFeature::TechnoPlayfield) {
                 // TechnoClass+0x3D5 is mutable admission state, not a derived
                 // position query: ordinary movement is promote-only while
                 // teleport and Set_Clipped_LocalSize own exact demotions.
@@ -1477,14 +1353,16 @@ impl Simulation {
                 0u8.hash(hasher);
             }
             entity.body_frame_counter.hash(hasher);
-            if include_entity_animation_v44 && let Some(animation) = entity.animation.as_ref() {
+            if schema.includes(HashFeature::EntityAnimation)
+                && let Some(animation) = entity.animation.as_ref()
+            {
                 b"entity-animation-v1".hash(hasher);
                 animation.sequence.hash(hasher);
                 animation.frame_index.hash(hasher);
                 animation.elapsed_frames.hash(hasher);
                 animation.finished.hash(hasher);
             }
-            if include_building_anim_overlays_v45
+            if schema.includes(HashFeature::BuildingAnimOverlays)
                 && let Some(overlays) = entity.building_anim_overlays.as_ref()
             {
                 b"building-anim-overlays-v1".hash(hasher);
@@ -1511,11 +1389,11 @@ impl Simulation {
             entity.building_hidden_occupancy.hash(hasher);
             entity.base_reservation_spacing.hash(hasher);
             entity.determines_waypoint_edge.hash(hasher);
-            if include_naval_build_const_v109 && entity.build_const_eligible {
+            if schema.includes(HashFeature::NavalBuildConst) && entity.build_const_eligible {
                 b"naval-build-const-entity-v1".hash(hasher);
                 entity.build_const_eligible.hash(hasher);
             }
-            if include_base_plan_v110 {
+            if schema.includes(HashFeature::BasePlan) {
                 entity.base_plan_type_index.hash(hasher);
                 entity.base_plan_is_defense.hash(hasher);
                 entity.base_plan_has_undeploy_target.hash(hasher);
@@ -1535,7 +1413,7 @@ impl Simulation {
             entity.armor_multiplier.bits().hash(hasher);
             entity.berserk.hash(hasher);
             entity.was_attacked_by_enemy.hash(hasher);
-            if include_base_defense_response_v97 {
+            if schema.includes(HashFeature::BaseDefenseResponse) {
                 b"base-defense-response-v1".hash(hasher);
                 entity.base_defense_response.hash(hasher);
             }
@@ -1656,7 +1534,7 @@ impl Simulation {
             } else {
                 0u8.hash(hasher);
             }
-            if include_sensor_deposit_v88 {
+            if schema.includes(HashFeature::SensorDeposit) {
                 if let Some(deposit) = entity.sensor_deposit {
                     1u8.hash(hasher);
                     deposit.owner.hash(hasher);
@@ -1664,7 +1542,7 @@ impl Simulation {
                     deposit.add_radius.hash(hasher);
                     deposit.remove_radius.hash(hasher);
                     deposit.building_array.hash(hasher);
-                    if include_disguise_detect_v117 {
+                    if schema.includes(HashFeature::DisguiseDetect) {
                         // The cached `DetectDisguiseRange=` circle. It is the
                         // radius Limbo will decrement, so it selects which
                         // cells leave the disguise-detect plane.
@@ -1923,7 +1801,7 @@ impl Simulation {
                 0u8.hash(hasher);
             }
 
-            if include_mission_v29 {
+            if schema.includes(HashFeature::Mission) {
                 hash_mission_com(&entity.mission, hasher);
                 hash_mission_leaf(&entity.mission_leaf, hasher);
                 entity.occupier.hash(hasher);


### PR DESCRIPTION
Adding a hash-schema feature previously required editing 25 positional booleans at 15 current/historical entry points, then repeating subsets through the House and entity fold helpers. The call sites concealed which layout each historical probe selected.

A private HashSchema policy and named HashFeature introductions now express those selections and travel through the folds as one value. Existing historical entry points remain intact. Current production hashing includes every feature. Historical policies describe the existing provenance projections, not snapshot-loading compatibility.

Independent read-only review matched all 25 feature thresholds, all 15 prior flag vectors, and all 722 lexical hash-write expressions in their original order. The alternate historical layouts and tag bytes are retained. A frozen-original-mask regression test protects the caller mapping. There is no hash golden rebaseline, snapshot version bump, new serialization, or changed RNG call.

Final validation: cargo test -p vera20k --lib — test result: ok. 8434 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 16.38s. Includes committed historical/replay hash baselines and all prior refactors. git diff --check passed. No new native parity claim.
