### PR TITLE
Describe current engine ownership and numeric contracts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,8 +94,8 @@ rfd = "0.14"
 # --- Math ---
 # glam provides fast vector/matrix math for rendering (screen coords, camera).
 glam = "0.29"
-# fixed-point math for deterministic simulation. ALL sim math uses this, never floats.
-# This ensures multiplayer lockstep stays in sync across different machines.
+# Fixed-point arithmetic for simulation positions and other fixed-width mechanisms.
+# Native floating-point mechanisms document their numeric contract at their owner.
 fixed = { version = "1", features = ["serde"] }
 
 # --- Serialization ---

--- a/src/app/audio_runtime.rs
+++ b/src/app/audio_runtime.rs
@@ -1,9 +1,10 @@
 //! Process-wide audio runtime (F12 `AppAudioRuntime`): output players and
 //! sound/EVA registries that live for the whole process.
 //!
-//! Per-match audio state (event queue, EVA latches) lives in
-//! `app::match_audio::MatchAudioState`; this owner survives matches. The
-//! registries are reloaded on each map load today (redundant but harmless —
+//! The per-match event queue lives in
+//! `app::match_audio::MatchAudioState`; gameplay EVA latches live in sim.
+//! This process audio owner survives matches. The registries are reloaded on
+//! each map load today (redundant but harmless —
 //! they consume no map-specific input); that behavior is unchanged here.
 
 use crate::assets::asset_manager::AssetManager;

--- a/src/app/match_audio.rs
+++ b/src/app/match_audio.rs
@@ -6,8 +6,8 @@
 //! under-attack cadence) are sim-owned (`sim::house_eva`, the combat death
 //! and damage sites); this owner only carries their events to the player.
 //! Process/device-wide audio (players, registries, volumes) stays outside
-//! this owner; grouping those into `AppAudioRuntime` lands with the F12
-//! AppState owner reorganization.
+//! this owner, in `AppAudioRuntime`. `match_runtime::sound_dispatch` interprets
+//! ordered simulation events into this queue for the local listener.
 
 use crate::audio::events::SoundEventQueue;
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,8 +1,9 @@
-//! Process-wide application state owned by the app orchestrator.
+//! Application orchestration through eight explicit state owners.
 //!
-//! The top-level `AppState` path remains stable while focused ownership groups
-//! are introduced incrementally. Platform lifecycle and pacing are the first
-//! extracted group; unrelated presentation, input, and match state stay flat.
+//! Platform, renderer, diagnostics, frontend, match, process assets, audio and
+//! persistence each own their state and lifecycle. AppState coordinates these
+//! owners; match-scoped input and presentation live inside MatchState.
+//! The architecture guards keep unrelated flat fields from returning.
 
 use super::{BTreeMap, OverlayTypeRegistry, ResolvedTerrainGrid};
 

--- a/src/architecture_guards.rs
+++ b/src/architecture_guards.rs
@@ -1,29 +1,22 @@
-//! Source-level dependency guards for the engine domain-boundaries ledger
-//! (`docs/plans/2026-08-15-engine-domain-boundaries-design.md`, local).
+//! Source-level guards for current engine ownership and dependency boundaries.
 //!
-//! Installed ahead of F14 per the validation protocol: every boundary the
-//! design forbids is scanned now, boundaries that are already clean are held
-//! at zero, and the finite F04/F05/F06 remainder is pinned by an explicit
-//! exception inventory that may only shrink. Production code only:
-//! `tests.rs` / `*_tests.rs` files and `#[cfg(test)]` items are excluded, so
-//! test-only reverse edges (tracked by the ledger for F14 relocation) do not
-//! appear here. `cfg(any(test, debug_assertions))` items are deliberately
-//! treated as production — they compile into debug builds.
+//! LAYER_RULES forbids reverse production dependencies and the exception list is
+//! empty. The scanner excludes tests.rs, *_tests.rs and #[cfg(test)] items;
+//! cfg(any(test, debug_assertions)) remains production because debug builds use it.
+//! A separate guard checks the entire sim tree, including tests, for upper-layer
+//! references. Other guards pin frame API callers and AppState owner boundaries.
 //!
-//! The `app` pseudo-root matches `crate::app::*`, bare `crate::app` imports,
-//! and root `crate::app_*` modules; the ui rules additionally keep the retired
-//! `skirmish_scenarios` root forbidden so it cannot be recreated. F12 moves
-//! the remaining root app inventory under `src/app/`, after which
-//! `crate::app::` covers the whole layer and F14 adds the no-root-`app_*`
-//! guard.
+//! The app pseudo-root matches crate::app paths and retired root app_* modules.
+//! The ui rule also forbids the retired skirmish_scenarios root. These checks
+//! preserve the current layout rather than describing future migration work.
 
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
 
 /// Directory under `src/` -> reference roots its production code must not
-/// name. Direction contract: ENGINE.md "Architecture boundaries" and the
-/// design's "Proven dependency inversions".
+/// name. The simulation direction contract is in ENGINE.md; the remaining
+/// rules preserve the established lower-layer boundaries.
 const LAYER_RULES: &[(&str, &[&str])] = &[
     ("assets", &["sim", "rules", "map", "render", "sidebar", "ui", "app"]),
     ("util", &["sim", "rules", "map", "render", "sidebar", "ui", "app"]),
@@ -35,10 +28,8 @@ const LAYER_RULES: &[(&str, &[&str])] = &[
     ("sim", &["render", "sidebar", "ui", "audio", "net"]),
 ];
 
-/// The frozen ledger's remaining production exceptions. Entries may only be
-/// REMOVED — by the ledger item that closes them — never added. An edge that
-/// disappears from the source must also be deleted here, so the ratchet
-/// tightens monotonically.
+/// No production exceptions remain. Keep this inventory empty; new reverse
+/// edges must be fixed at their owner rather than exempted from the guard.
 const FROZEN_EXCEPTIONS: &[(&str, &str)] = &[];
 
 #[test]
@@ -472,8 +463,7 @@ fn bare_and_aliased_app_imports_cannot_evade_the_scan() {
     assert!(!group_contains_root("use crate::{apple, ui::x};\n", "app"));
 }
 
-/// F12 finish criterion: `AppState` holds exactly the eight named owners from
-/// the design's Target Architecture — no unrelated flat field may return.
+/// AppState holds exactly eight named owners; unrelated flat state must not return.
 #[test]
 fn app_state_contains_only_named_owners() {
     let state_rs = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/app/state.rs");
@@ -532,7 +522,7 @@ fn app_state_contains_only_named_owners() {
     );
 }
 
-/// F12 finish criterion: the root app inventory lives under `src/app/`;
+/// The app inventory lives under `src/app/`;
 /// `src/lib.rs` declares no root `app_*` module.
 #[test]
 fn no_root_app_modules_remain() {
@@ -556,7 +546,7 @@ fn no_root_app_modules_remain() {
     );
 }
 
-/// F14: after the boundary-test relocation, `sim/` names no presentation,
+/// The entire `sim/` tree names no presentation,
 /// audio, net, or app root anywhere — production AND test code. Unlike the
 /// layer scan above (which strips test items), this ratchet holds the whole
 /// tree at zero so a new sim-side test cannot quietly reintroduce the edge.

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -1,24 +1,24 @@
-//! Game simulation — EntityStore + GameEntity, fixed-point math, deterministic logic.
+//! Deterministic game state, object lifecycle and ordered simulation systems.
 //!
-//! ALL simulation math uses fixed-point arithmetic (I32F16) — never floats.
-//! This is a day-one decision for deterministic multiplayer: identical results
-//! across different machines regardless of CPU floating-point behavior.
+//! Positions commonly use fixed-point arithmetic. Mechanisms whose native
+//! semantics require floating point retain their documented numeric behavior
+//! (for example `bounce` and `voxel_anim`); deterministic behavior depends on
+//! preserving each mechanism's operations, widths and RNG order.
 //!
-//! The simulation is data-driven: all unit stats, weapon damage, build times
-//! come from RuleSet (parsed from rules.ini). Sim code contains pure logic,
-//! never hardcoded game balance numbers.
+//! RuleSet supplies authored rules/art data. Native hardcoded rules and
+//! constants carry evidence near their implementation; see ENGINE.md.
 //!
 //! ## Key types
-//! - `Simulation` — owns EntityStore (BTreeMap<u64, GameEntity>), ticks game state forward
-//! - `GameEntity` — unified plain struct (position, health, owner, locomotor, etc.)
-//! - Systems: movement, combat, harvesting, production, pathfinding
+//! - `world::Simulation` owns mutable gameplay state and object lifecycle.
+//! - `runtime::SimRuntime` binds that state to match rules and map resources.
+//! - `game_entity::GameEntity` holds one techno's components and runtime state.
+//! - Systems include movement, combat, harvesting, production and pathfinding.
 //!
-//! ## Dependency rules â€" THIS IS THE #1 ARCHITECTURAL INVARIANT
-//! - sim/ depends on: rules/, map/
-//! - sim/ NEVER depends on: render/, ui/, sidebar/, audio/, net/
-//! - This isolation is what makes alternative views possible (Commander mode,
-//!   spectator view, headless server) without touching sim code.
-//! - sim/ receives commands but never calls into presentation modules.
+//! ## Dependency rules
+//! - sim/ may depend on rules/, map/ and util/.
+//! - sim/ never depends on render/, ui/, sidebar/, audio/ or net/.
+//! - Commands enter and outputs leave through simulation APIs; presentation
+//!   consumes state without becoming a gameplay authority.
 
 // --- Core types: entity storage, components, commands, RNG, interning ---
 pub mod anim_class;

--- a/src/sim/runtime.rs
+++ b/src/sim/runtime.rs
@@ -1,14 +1,13 @@
-//! SimRuntime — the construction/resource/API boundary around `Simulation`.
+//! Construction and frame API around Simulation and its bound match resources.
 //!
-//! F07: app, headless, and replay execution consume the simulation through
-//! this owner. `SimResources` will absorb the immutable per-match inputs
-//! (rules/art, overlay registry, height/map facts, trigger definitions, base
-//! terrain template) one cone per commit; until a cone moves, the app still
-//! passes that input per frame. `SimView` is the immutable read facade
-//! presentation borrows — no world clone, no mutation.
+//! App, headless and replay execution use SimRuntime. SimResources binds the
+//! rules/art registry, map heights, overlay registry, trigger definitions and
+//! base terrain template; advance_frame reads these without caller-substituted
+//! per-frame resources. Simulation owns live mutable terrain and gameplay state.
+//! SimView provides immutable access for presentation and diagnostics.
 //!
-//! ## Dependency rules
-//! - Part of sim/; NEVER depends on render/, ui/, sidebar/, audio/, net/.
+//! Dependency rules: part of sim/; never depends on render/, ui/, sidebar/,
+//! audio/ or net/.
 
 use crate::map::resolved_terrain::TerrainTileAnimation;
 use crate::rules::ruleset::RuleSet;
@@ -16,7 +15,7 @@ use crate::sim::anim_class::{AnimDrawRuntime, AnimWorldCoord};
 use crate::sim::components::AnimClassSpawnDescriptor;
 use crate::sim::world::Simulation;
 
-/// Immutable per-match resources bound at construction (F07 cones land here).
+/// Per-match resource inputs bound at construction and read during frame advancement.
 
 pub struct SimResources {
     /// Fixed per-cell terrain heights parsed from the loaded map.
@@ -71,8 +70,7 @@ pub struct SimRuntime {
 }
 
 impl SimRuntime {
-    /// Wrap an already-constructed simulation. Scenario construction moves
-    /// here in F09; this keeps the F07 slot move atomic and behavior-free.
+    /// Test adapter for an existing simulation with empty resource inputs.
     #[cfg(test)]
     pub(crate) fn from_simulation(simulation: Simulation) -> Self {
         Self {
@@ -89,15 +87,13 @@ impl SimRuntime {
     }
 }
 
-/// Immutable borrow facade over the committed simulation state. Getters grow
-/// per consumer cone (F10); presentation code reads through these instead of
-/// reaching into `Simulation` fields directly.
+/// Immutable borrow facade over simulation state for presentation and diagnostics.
 pub struct SimView<'a> {
     simulation: &'a Simulation,
 }
 
 impl<'a> SimView<'a> {
-    /// Escape hatch for not-yet-migrated consumers; cones retire it (F10).
+    /// Full immutable state access for consumers without a narrower view method.
     pub fn simulation(&self) -> &'a Simulation {
         self.simulation
     }

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -4,11 +4,14 @@
 //! map data, executes command envelopes on fixed ticks, advances gameplay
 //! systems, and exposes deterministic state hashing for replay/desync checks.
 //!
-//! Implementation is split across sibling files for size:
+//! Responsibility boundaries:
 //! - `world_commands.rs` — command dispatch and selection/ownership helpers
-//! - `world_hash.rs` — deterministic state hashing
+//! - `world_hash.rs` / `hash_schema.rs` — deterministic folds and historical projections
 //! - `world_spawn.rs` — entity spawning from map data and production
 //! - `world_orders.rs` — order-intent tick systems (attack-move, guard, area-guard)
+//! - `lifecycle.rs` / `substrate.rs` — object transitions, stores and registration order
+//! - `receiver_transaction.rs` — shared damage-receiver authority transfer
+//! - `techno_ai.rs` — per-object AI visits within the live Logic walk
 
 pub(crate) mod authored_load_host;
 pub(crate) mod bridge_orchestrator;

--- a/src/sim/world/substrate.rs
+++ b/src/sim/world/substrate.rs
@@ -1,15 +1,16 @@
-//! The object substrate: the single owner of the active-object vector and the
-//! monotonic identity / enter-order counters that the lifecycle contract mutates.
+//! Shared object storage, registration order and spatial occupation authority.
 //!
-//! This is stage 1 of the substrate consolidation — it holds the
-//! bookkeeping/ordering state only. The lifecycle methods
-//! (`reveal`/`conceal`/`unlimbo`/`uninit`) stay on `Simulation` for now because
-//! they also need `EntityStore`/`OccupancyGrid`; they reach this state by path
-//! (`self.substrate.*`). Entity storage and the occupancy grid migrate into the
-//! substrate in later stages.
+//! ObjectSubstrate owns the entity, animation, voxel-animation and particle-system
+//! stores, the LogicVector, identity/enter-order counters and occupation planes.
+//! Terrain, projectile and wave stores remain in their mechanism owners and
+//! participate in the same lifecycle dispatch and global object-ID namespace.
 //!
-//! Dependency rules: part of sim/ — depends only on std + serde + the sibling
-//! `LogicVector`.
+//! Lifecycle operations live on Simulation because Reveal/Conceal/UnInit also
+//! coordinate houses, terrain and other mechanism state. Storage order, active
+//! Logic order and per-cell object order are distinct contracts. Field comments
+//! identify serialized authority versus caches rebuilt after snapshot loading.
+//!
+//! Dependency rules: part of sim/; no presentation, audio or network dependency.
 
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;


### PR DESCRIPTION
Architecture entry points still described migrations that already finished: flat AppState fields, an ordering-only substrate, and per-frame caller-supplied resources. The sim header and Cargo comments also prohibited all floating point despite native numeric mechanisms in bounce/voxel_anim.

Update the verified current owner/resource/numeric contracts, document the touched receiver/hash boundaries, and correct the process/match audio versus gameplay EVA ownership descriptions. No executable source or Cargo configuration value changes.

Independent read-only review verified the descriptions against actual fields and production callers, found the additional stale AppState header, and rechecked the correction. A source comparison confirms every non-comment line is unchanged across all nine files; git diff --check passes. The prior integrated production candidate passed cargo test -p vera20k --lib: test result: ok. 8434 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 16.38s. Per ENGINE.md, this comments-only increment needs no additional Cargo suite.
