### PR TITLE
Re-idle a harvester on owner change and record the last audit residuals

### DIFF
--- a/docs/system-map/mechanisms.v1.json
+++ b/docs/system-map/mechanisms.v1.json
@@ -246,7 +246,7 @@
         },
         {
           "name": "refund configuration",
-          "detail": "Type cost, owner cost modifiers, and General RefundPercent determine the amount.",
+          "detail": "Native: type cost, owner cost modifiers, and General RefundPercent determine the amount (BuildingClass sell refund 0x00711F60, no health term for a human house). Rust DRIFT: production_sell.rs uses a fixed SELL_REFUND_PERCENT=50 scaled by health percent; owned by GSI-09.14.",
           "external_source": "Retail TechnoType cost and merged rules RefundPercent"
         }
       ],
@@ -336,9 +336,9 @@
         },
         {
           "kind": "state-transition",
-          "status": "VERIFIED",
-          "basis": "mixed",
-          "detail": "RefundPercent is rules-driven and the stock full-health GAPOWR fixture credits 400.",
+          "status": "UNCHECKED",
+          "basis": "unverified",
+          "detail": "DRIFT: native computes house-adjusted cost x General RefundPercent with no health term for a human house (0x00711F60, 09.01 scan); Rust src/sim/production/production_sell.rs applies a fixed SELL_REFUND_PERCENT=50 x health percent. The stock full-health GAPOWR fixture still credits 400 on both, so the fixture cannot certify the mechanism. Fix belongs to GSI-09.14.",
           "evidence": [
             "docs/research/traces/2026-07-25-loop-012-power-outage-recovery-trace.md:122-147",
             "ini/rulesmd.ini:25",

--- a/src/sim/docking/building_dock.rs
+++ b/src/sim/docking/building_dock.rs
@@ -417,13 +417,29 @@ pub(crate) fn mission_enter_dispatch(sim: &mut Simulation, rules: &RuleSet, id: 
         if linked && hp >= max_hp {
             // 0x0043C824..C842: linked sender whose 0x22 answers 10 (ratio >=
             // 1.0) gets 10 back; Mission_Enter 0x004D92D0 then BREAKs and
-            // calls Enter_Idle_Mode (Guard for a plain unit, 0x00738970).
-            // The unit leaves Enter; the epilogue draw below still happens.
+            // calls Enter_Idle_Mode(0, 1) at 0x004D92E2 (Guard for a plain
+            // unit, 0x00738970; a Harvester=yes unit takes the harvester arm:
+            // Harvest, or Guard for a human owner standing off ore — with the
+            // depot contact already broken, the arm's radio gate only sees a
+            // refinery link). The unit leaves Enter; the epilogue draw below
+            // still happens.
             break_depot_contact(sim, id, dock_building_id);
-            queue_mission(sim, id, MissionType::Guard);
             if let Some(unit) = sim.substrate.entities.get_mut(id) {
                 unit.dock_state = None;
                 unit.movement_target = None;
+            }
+            let is_miner = sim
+                .substrate
+                .entities
+                .get(id)
+                .is_some_and(|unit| unit.miner.is_some());
+            let selector = if is_miner {
+                crate::sim::world::harvester_enter_idle_mode_selector(sim, id, rules, false)
+            } else {
+                Some(MissionType::Guard)
+            };
+            if let Some(selector) = selector {
+                queue_mission(sim, id, selector);
             }
         } else if !linked {
             // 0x0043C8A4..C8C3: not a contact and a slot is free or own ⇒ the
@@ -1601,6 +1617,62 @@ mod tests {
         assert_eq!(
             depot_exit_cell(&sim, Some(&grid), DEPOT_RX, DEPOT_RY, "3x3"),
             Some((DEPOT_RX + 1, DEPOT_RY + 3))
+        );
+    }
+
+    /// A repaired (full-HP) linked waiter that is a Harvester=yes unit takes
+    /// the harvester arm of `Enter_Idle_Mode @ 0x00738970` after the BREAK
+    /// (`FootClass::Mission_Enter` 0x004D92E2, args (0, 1)): Harvest for a
+    /// non-human house regardless of land, Guard for a human house standing
+    /// off ore. Plain units keep the Guard exit.
+    #[test]
+    fn linked_full_health_miner_waiter_takes_the_harvester_idle_arm() {
+        use crate::sim::miner::{Miner, MinerConfig, MinerKind};
+        use crate::sim::mission::MissionId;
+
+        fn build(human: bool) -> (Simulation, RuleSet) {
+            let (mut sim, rules, _grid) = setup(0);
+            if human {
+                let owner_id = sim.interner.intern("Americans");
+                sim.houses.get_mut(&owner_id).unwrap().is_human = true;
+            }
+            spawn_entity(&mut sim, 1, "MTNK", EntityCategory::Unit, 14, 11, 300, 300);
+            {
+                let unit = sim.substrate.entities.get_mut(1).unwrap();
+                unit.miner = Some(Miner::new(MinerKind::War, &MinerConfig::default(), 0));
+                let mut ds = DockState::approach(DEPOT);
+                ds.phase = DockPhase::WaitForDock;
+                unit.dock_state = Some(ds);
+                unit.mark_live_contact_with(DEPOT);
+            }
+            sim.substrate
+                .entities
+                .get_mut(DEPOT)
+                .unwrap()
+                .mark_live_contact_with(1);
+            sim.mission_assign_exact(1, MissionId::from_known(MissionType::Enter), 0)
+                .expect("unit exists");
+            assert!(linked(&sim, 1));
+            (sim, rules)
+        }
+
+        let (mut sim, rules) = build(false);
+        mission_enter_dispatch(&mut sim, &rules, 1);
+        assert!(!linked(&sim, 1));
+        assert!(phase(&sim, 1).is_none());
+        assert_eq!(
+            sim.substrate.entities.get(1).unwrap().mission.queued(),
+            MissionId::from_known(MissionType::Harvest),
+            "a non-human house's miner always re-queues Harvest"
+        );
+
+        let (mut sim, rules) = build(true);
+        mission_enter_dispatch(&mut sim, &rules, 1);
+        assert!(!linked(&sim, 1));
+        assert_eq!(
+            sim.substrate.entities.get(1).unwrap().mission.queued(),
+            MissionId::from_known(MissionType::Guard),
+            "a human house's miner standing off ore parks on Guard"
         );
     }
 }

--- a/src/sim/miner/miner_tests.rs
+++ b/src/sim/miner/miner_tests.rs
@@ -9894,3 +9894,155 @@ fn player_move_arrival_in_radio_contact_assigns_nothing() {
     assert_eq!(e.mission.current().known(), Some(MissionType::Move));
     assert_eq!(e.mission.queued(), MissionId::NONE);
 }
+
+/// Registers `Americans` (the `spawn_miner` owner) and `YuriCountry` (the
+/// captor) with explicit `is_human` so the selector's
+/// `houses.get(owner)` gate reads a real house, not the absent-house
+/// fallback.
+fn register_capture_houses(
+    sim: &mut Simulation,
+    old_is_human: bool,
+    new_is_human: bool,
+) -> crate::sim::intern::InternedId {
+    use crate::sim::house_state::HouseState;
+    let old = sim.interner.intern("Americans");
+    sim.houses
+        .insert(old, HouseState::new(old, 0, None, old_is_human, 0, 10));
+    let captor = sim.interner.intern("YuriCountry");
+    sim.houses.insert(
+        captor,
+        HouseState::new(captor, 1, None, new_is_human, 0, 10),
+    );
+    captor
+}
+
+/// `TechnoClass::ChangeOwner @ 0x007014A0` on a harvesting miner standing on
+/// ore: the forced `Queue_Mission(Guard, commence_now = 1)` commits Guard on
+/// the spot, then the `Enter_Idle_Mode(0, 1)` call at 0x00701849 takes the
+/// harvester arm of `UnitClass::Enter_Idle_Mode @ 0x00738970` and re-queues
+/// Harvest for the NEW owner (the arm reads the owner after the `+0x21C`
+/// swap). Target and destination are cleared on the way. Both houses are
+/// human here: on ore the land check passes for either kind of owner.
+#[test]
+fn captured_harvesting_miner_requeues_harvest_for_the_new_owner() {
+    use crate::sim::mission::{MissionId, MissionType};
+
+    let rules = miner_rules();
+    let mut sim = Simulation::new();
+    let captor = register_capture_houses(&mut sim, true, true);
+    let miner_id = spawn_miner(&mut sim, 1, MinerKind::War, 10, 10);
+    place_ore(&mut sim, 10, 10, 100);
+    sim.mission_assign_exact(miner_id, MissionId::from_known(MissionType::Harvest), 0)
+        .expect("miner exists");
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(miner_id)
+            .unwrap()
+            .mission
+            .current()
+            .known(),
+        Some(MissionType::Harvest)
+    );
+
+    sim.change_owner_with_rules(miner_id, captor, &rules);
+
+    let miner = sim.substrate.entities.get(miner_id).expect("miner present");
+    assert_eq!(miner.owner, captor);
+    assert_eq!(
+        miner.mission.current().known(),
+        Some(MissionType::Guard),
+        "ChangeOwner force-queues Guard and commences it on a ready unit"
+    );
+    assert_eq!(
+        miner.mission.queued(),
+        MissionId::from_known(MissionType::Harvest),
+        "the idle-mode harvester arm re-queues Harvest on ore"
+    );
+    assert!(miner.attack_target.is_none());
+    assert!(miner.navigation.nav_com.is_none());
+    assert!(miner.movement_target.is_none());
+}
+
+/// Same owner change, miner standing off ore, captured by a HUMAN house
+/// (the old owner is AI, so the outcome can only come from the NEW owner's
+/// `IsControlledByHuman`): the arm's `IsControlledByHuman && LandType != 5`
+/// branch selects Guard, which is already current, so nothing is queued —
+/// the captured miner parks.
+#[test]
+fn captured_miner_off_ore_under_a_human_house_parks_on_guard() {
+    use crate::sim::mission::{MissionId, MissionType};
+
+    let rules = miner_rules();
+    let mut sim = Simulation::new();
+    let captor = register_capture_houses(&mut sim, false, true);
+    let miner_id = spawn_miner(&mut sim, 1, MinerKind::War, 10, 10);
+    place_ore(&mut sim, 20, 20, 100);
+    sim.mission_assign_exact(miner_id, MissionId::from_known(MissionType::Harvest), 0)
+        .expect("miner exists");
+
+    sim.change_owner_with_rules(miner_id, captor, &rules);
+
+    let miner = sim.substrate.entities.get(miner_id).expect("miner present");
+    assert_eq!(miner.owner, captor);
+    assert_eq!(miner.mission.current().known(), Some(MissionType::Guard));
+    assert_eq!(miner.mission.queued(), MissionId::NONE);
+}
+
+/// The mirror case: a HUMAN player's miner off ore captured by an AI house.
+/// The Guard branch at 0x00738970 requires the NEW owner to pass
+/// `IsControlledByHuman` (the arm runs after the `+0x21C` swap); an AI
+/// captor always takes Harvest, so the miner re-queues Harvest even though
+/// the human it was taken from would have parked it.
+#[test]
+fn captured_miner_off_ore_under_an_ai_house_requeues_harvest() {
+    use crate::sim::mission::{MissionId, MissionType};
+
+    let rules = miner_rules();
+    let mut sim = Simulation::new();
+    let captor = register_capture_houses(&mut sim, true, false);
+    let miner_id = spawn_miner(&mut sim, 1, MinerKind::War, 10, 10);
+    place_ore(&mut sim, 20, 20, 100);
+    sim.mission_assign_exact(miner_id, MissionId::from_known(MissionType::Harvest), 0)
+        .expect("miner exists");
+
+    sim.change_owner_with_rules(miner_id, captor, &rules);
+
+    let miner = sim.substrate.entities.get(miner_id).expect("miner present");
+    assert_eq!(miner.owner, captor);
+    assert_eq!(miner.mission.current().known(), Some(MissionType::Guard));
+    assert_eq!(
+        miner.mission.queued(),
+        MissionId::from_known(MissionType::Harvest),
+        "an AI captor skips the human land check and re-queues Harvest off ore"
+    );
+}
+
+/// A miner in radio contact (docked at its refinery) when captured by a
+/// human house: the harvester arm's `In_Radio_Contact` early return assigns
+/// nothing beyond the forced Guard.
+#[test]
+fn captured_miner_in_radio_contact_gets_only_the_forced_guard() {
+    use crate::sim::mission::{MissionId, MissionType};
+
+    let rules = miner_rules();
+    let mut sim = Simulation::new();
+    let captor = register_capture_houses(&mut sim, true, true);
+    let miner_id = spawn_miner(&mut sim, 1, MinerKind::War, 10, 10);
+    spawn_refinery(&mut sim, 2, 12, 12);
+    place_ore(&mut sim, 10, 10, 100);
+    sim.mission_assign_exact(miner_id, MissionId::from_known(MissionType::Harvest), 0)
+        .expect("miner exists");
+    sim.substrate
+        .entities
+        .get_mut(miner_id)
+        .unwrap()
+        .mark_live_contact_with(2);
+
+    sim.change_owner_with_rules(miner_id, captor, &rules);
+
+    let miner = sim.substrate.entities.get(miner_id).expect("miner present");
+    assert_eq!(miner.owner, captor);
+    assert_eq!(miner.mission.current().known(), Some(MissionType::Guard));
+    assert_eq!(miner.mission.queued(), MissionId::NONE);
+}

--- a/src/sim/production/factory.rs
+++ b/src/sim/production/factory.rs
@@ -279,6 +279,15 @@ impl Factory {
         // removed (NOT the full cost — that is the legacy DRIFT). `.max(0)` documents
         // intent; the invariant `balance <= original_balance` holds (the stepper only
         // decrements balance), so it never fires in a well-formed shadow.
+        //
+        // RESIDUAL (DRIFT, rare): `FactoryClass::AbandonProduction @ 0x004C9FF0`
+        // refunds `Add_Credits(Type->GetCost(Object->Owner) - Balance)` — the type's
+        // cost virtual (`TechnoTypeClass` vtable `+0x84`, house-adjusted) evaluated
+        // AT CANCEL TIME, not the cost snapshot taken at StartProduction. The two
+        // agree unless the owner's cost multiplier changed mid-build (a FactoryPlant
+        // completed or lost while this object was in progress). Trigger: cancel
+        // after such a change; effect: refund off by the multiplier delta on the
+        // whole cost, one-shot; frequency: rare. Downstream: money only.
         let refund = (self.original_balance - self.balance).max(0);
         economy.add_credits(refund); // ORACLE economy in P4 (saturating add)
 

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -25,6 +25,7 @@ mod projectile_collision;
 mod receiver_transaction;
 mod substrate;
 mod techno_ai;
+pub(crate) use techno_ai::harvester_enter_idle_mode_selector;
 #[cfg(test)]
 pub(crate) use techno_ai::ObjectAiCtx;
 pub(crate) mod techno_ai_cloak;
@@ -5123,7 +5124,126 @@ impl Simulation {
         {
             house.build_const_order.push(stable_id);
         }
+        // `TechnoClass::ChangeOwner` closes with the mission half (the
+        // `+0x484` call at 0x00701849 reads the NEW owner's
+        // IsControlledByHuman). A rules-less transfer (tests only) cannot
+        // read the type and skips it.
+        if let Some(rules) = rules {
+            self.change_owner_harvester_idle_arm(stable_id, rules);
+        }
         self.refresh_waypoint_edge_from_committed_structure(stable_id);
+    }
+
+    /// The mission half of `TechnoClass::ChangeOwner @ 0x007014A0` for a
+    /// war/chrono miner (decompiled 2026-09-06):
+    /// - 0x007014E1/0x007014F1: `Assign_Target(0)` (`+0x3C8`) and
+    ///   `Assign_Destination(0, 1)` (`+0x480`);
+    /// - then `Queue_Mission(Guard, commence_now = 1)` (`+0x1E8` =
+    ///   `MissionClass::Queue_Mission @ 0x005B35E0`) unless current is
+    ///   Selling(0x13) — for a ready unit that commits Guard on the spot;
+    /// - after the `+0x21C` house swap: unless the object is in radio contact
+    ///   with a `WeaponsFactory=` building (`BuildingType+0x16BD`, the
+    ///   war-factory exit link; not a refinery), `Assign_Destination(0, 1)`,
+    ///   `Assign_Target(0)` and `Enter_Idle_Mode(0, 1)` at 0x00701849, whose
+    ///   harvester arm ([`harvester_enter_idle_mode_selector`]) re-queues
+    ///   Harvest for the new owner, Guard when that owner is human and the
+    ///   miner stands off ore, and nothing while in radio contact (a miner
+    ///   docked at its refinery) or while the Guard above is still only
+    ///   queued (a miner caught mid-track: current stays Harvest, the arm
+    ///   returns, and the queued Guard promotes when it stops).
+    ///
+    /// The forced Guard is skipped at 0x00701553 when RTTI == Unit,
+    /// `UnitType+0xE13 IsSimpleDeployer` is set and current == Unload — not
+    /// a stock miner, so this arm does not model it.
+    ///
+    /// Stock reach on a miner: mind control (`CaptureManagerClass::CaptureUnit
+    /// @ 0x00471DB8`, `FreeUnit @ 0x004720DA`, `PsychicDominator::
+    /// MindControlArea @ 0x0053B298`) — VERA has no owner-swapping mind
+    /// control yet, so this chokepoint is where it lands when it does.
+    ///
+    /// `+0x484` census (`search_instructions CALL [+0x484]`), the sites a
+    /// miner can reach besides Move arrival, this owner change and the depot
+    /// exit, with their gates; none is run by VERA today:
+    /// - `DriveLocomotionClass::Stop_And_Scatter @ 0x004B48BE` → `+0x484(0,1)`
+    ///   after `Stop_Moving` when the NavQueue is non-empty. VERA scatter is
+    ///   UNCHECKED; natively a human-parked Guard miner scattered on ore
+    ///   would re-queue Harvest through this call.
+    /// - `FootClass::Enter_Destination @ 0x004DA1A6` (call at 0x004DA1C0;
+    ///   callers `EventClass::Execute` 0x004C7453/0x004C759C and
+    ///   `UnitClass::Receive_Radio` 0x00737546) → `+0x484(0,1)` when
+    ///   NavCom == 0, current == Guard and no WeaponsFactory contact.
+    /// - `FootClass::Check_Destination_Is_UnitRepair_Dock @ 0x004DBA15` →
+    ///   `+0x484(0, !depot-contact)` when NavCom == 0 && TarCom == 0
+    ///   (virtual slot; miner reachability unestablished).
+    /// - `FootClass::ReceiveDamage @ 0x004D74C7`, gated on
+    ///   `MissionControl[current].NoThreat && !Zombie`; no retail mission
+    ///   sets either, so the call is unreachable on stock data.
+    ///
+    /// Residual (VERA-internal, gamemd equivalent UNCHECKED): every other
+    /// category takes the same `Queue_Mission(Guard, 1)` natively; a captured
+    /// building or garrison keeps its mission here. Trigger: engineer capture
+    /// / garrison transfer; effect: no forced Guard; frequency: per capture.
+    fn change_owner_harvester_idle_arm(&mut self, stable_id: u64, rules: &RuleSet) {
+        let is_dispatchable_miner = self.substrate.entities.get(stable_id).is_some_and(|e| {
+            e.category == EntityCategory::Unit
+                && e.miner
+                    .as_ref()
+                    .is_some_and(|m| m.kind != crate::sim::miner::MinerKind::Slave)
+        });
+        if !is_dispatchable_miner {
+            return;
+        }
+        use crate::sim::mission::{MissionId, MissionType};
+        let now = self.session.binary_frame;
+        let selling = self
+            .substrate
+            .entities
+            .get(stable_id)
+            .is_some_and(|e| e.mission.current().known() == Some(MissionType::Selling));
+        if let Some(entity) = self.substrate.entities.get_mut(stable_id) {
+            crate::sim::mission::concrete_effects::represented_assign_target(entity, None);
+            crate::sim::mission::concrete_effects::represented_assign_destination_mode_one(
+                entity, None,
+            );
+            entity.movement_target = None;
+        }
+        let readiness = crate::sim::mission::authority::LiveReadyInputProvider { rules };
+        if !selling {
+            // `Queue_Mission(Guard, 1)`: the queue write, then Ready_To_Commence
+            // (`+0x200`) and Commence (`+0x1EC`). The immediate promotion runs
+            // through the host's promotion step so the recorded readiness
+            // degradation (absent locomotor producers read as "not moving")
+            // applies here exactly as it does at the per-tick AI position.
+            let _ = self.mission_queue_exact(
+                stable_id,
+                MissionId::from_known(MissionType::Guard),
+                0,
+                now,
+                &readiness,
+            );
+            self.mission_host_promote(stable_id, now, rules);
+        }
+        let in_factory_contact = self.substrate.entities.get(stable_id).is_some_and(|e| {
+            e.radio_contacts.iter_live().any(|other| {
+                self.substrate
+                    .entities
+                    .get(other)
+                    .and_then(|b| self.object_type(b.type_ref, rules))
+                    .is_some_and(|obj| obj.weapons_factory)
+            })
+        });
+        if in_factory_contact {
+            return;
+        }
+        if let Some(selector) = harvester_enter_idle_mode_selector(self, stable_id, rules, false) {
+            let _ = self.mission_queue_exact(
+                stable_id,
+                MissionId::from_known(selector),
+                0,
+                now,
+                &readiness,
+            );
+        }
     }
 
     /// Legacy non-lifecycle contact scrub retained only for separately classified

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -15,6 +15,7 @@
 //! (invariant #2).
 
 mod mission_handlers;
+pub(crate) use mission_handlers::harvester_enter_idle_mode_selector;
 
 use mission_handlers::*;
 

--- a/src/sim/world/techno_ai/mission_handlers.rs
+++ b/src/sim/world/techno_ai/mission_handlers.rs
@@ -52,10 +52,11 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
         // Move is the other split: a player Move order puts the miner on
         // `UnitClass::Mission_Move` (slot `+0x22C` = 0x00740A90, tail
         // `FootClass::Mission_Move @ 0x004D4200`), whose arrival
-        // `Enter_Idle_Mode(0,1)` at 0x004D4242 is the ONLY thing that returns
-        // a harvester to Harvest (or Guard) — see
-        // `harvester_enter_idle_mode_evaluation`. The Harvest handler declines
-        // Move for the same single-writer reason.
+        // `Enter_Idle_Mode(0,1)` at 0x004D4242 returns a harvester to Harvest
+        // (or Guard) — see `harvester_enter_idle_mode_evaluation`; the same
+        // slot is also entered from the owner change (0x00701849) and the
+        // depot's repaired-BREAK exit (0x004D92E2). The Harvest handler
+        // declines Move for the same single-writer reason.
         //
         // Enter with a repair-depot `DockState` is the third split: a
         // harvester ordered to a depot (`Command::RepairAtDepot`) dispatches
@@ -166,7 +167,7 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
             } else if input.category == EntityCategory::Unit && input.harvester_miner {
                 // The same arrival hook, harvester arm of
                 // `UnitClass::Enter_Idle_Mode @ 0x00738970`.
-                harvester_enter_idle_mode_evaluation(sim, id, rules, input)
+                harvester_enter_idle_mode_evaluation(sim, id, rules)
             } else {
                 // The arrival branch. `FootClass::Mission_Move` calls the class
                 // arrival hook and returns one frame; the hook is the ONLY
@@ -700,20 +701,9 @@ pub(super) fn move_arrival_evaluation(
 /// `DriveLocomotionClass::Process @ 0x004B0763` (destination reached with an
 /// empty NavQueue: `Stop_Moving`, then `Enter_Idle_Mode(0,1)`). Both land in
 /// the same body; the Unit slot `0x00740A90` only precedes the Foot body
-/// with its deploy latches.
-///
-/// Body, decompiled 2026-09-06, no-destination branch for `Harvester=`/
-/// `Weeder=` (`UnitType+0xE0E`/`+0xE0F`):
-/// - `RadioClass::In_Radio_Contact` ⇒ return (nothing assigned);
-/// - current (`+0xAC`) or queued (`+0xB4`) == Harvest(10) ⇒ return;
-/// - selector = Harvest; when `param_2 == 0` (both callers pass 0) AND
-///   `HouseClass::IsControlledByHuman @ 0x0050B730`: the cell under the unit
-///   (`MapClass::Get_CellClass_At_Coord`) has `LandType` (`CellClass+0xEC`)
-///   ≠ 5 (Tiberium; 0xB Weeds for a Weeder) ⇒ selector = Guard(5). An AI
-///   house always takes Harvest;
-/// - `Assign_Target(0)` (`+0x3C8`), `Assign_Destination(0, 1)` (`+0x480`);
-/// - tail gate: current ∉ {Patrol 0x19, AreaGuard 0xB, Unload 0x10, Eaten 9}
-///   ⇒ `+0x1E8(selector, 0)`. Current is Move here, so it always commits.
+/// with its deploy latches. The selector itself is
+/// [`harvester_enter_idle_mode_selector`], shared with the other stock
+/// callers of the same slot (owner change, depot exit).
 ///
 /// So a human's miner moved onto bare ground parks on Guard (the harvester
 /// Guard override's chrono arms or a player order put it back); moved onto
@@ -725,23 +715,79 @@ fn harvester_enter_idle_mode_evaluation(
     sim: &Simulation,
     id: u64,
     rules: &RuleSet,
-    input: MissionHandlerInput,
 ) -> MissionHandlerEvaluation {
-    let Some(entity) = sim.substrate.entities.get(id) else {
+    let Some(selector) = harvester_enter_idle_mode_selector(sim, id, rules, false) else {
         return MissionHandlerEvaluation::cadence(1);
     };
-    if !entity.radio_contacts.is_empty() {
-        return MissionHandlerEvaluation::cadence(1);
+    MissionHandlerEvaluation {
+        delay: 1,
+        clear_stale_attack_target: false,
+        clear_attack_target: true,
+        queue: Some(selector),
     }
-    if input.mission == Some(MissionType::Harvest)
+}
+
+/// The no-destination harvester selector of `UnitClass::Enter_Idle_Mode @
+/// 0x00738970`, for a unit whose `Harvester=`/`Weeder=` flag
+/// (`UnitType+0xE0E`/`+0xE0F`) is set. Returns the mission the body commits
+/// through `Queue_Mission(selector, 0)` (`+0x1E8` = 0x005B35E0), or `None`
+/// on one of its early returns (nothing assigned).
+///
+/// Body, decompiled 2026-09-06:
+/// - `RadioClass::In_Radio_Contact` ⇒ return (nothing assigned);
+/// - current (`+0xAC`) or queued (`+0xB4`) == Harvest(10) ⇒ return;
+/// - selector = Harvest; when `param_2 == 0` AND the OWNER passes
+///   `HouseClass::IsControlledByHuman @ 0x0050B730`: the cell under the unit
+///   (`MapClass::Get_CellClass_At_Coord`) has `LandType` (`CellClass+0xEC`)
+///   ≠ 5 (Tiberium; 0xB Weeds for a Weeder) ⇒ selector = Guard(5). An AI
+///   house always takes Harvest; so does every caller passing `param_2 = 1`
+///   (`TechnoClass::Unlimbo @ 0x006F6E2A` calls `+0x484(1, 1)`, which is why
+///   a freshly built miner always leaves the factory on Harvest);
+/// - `Assign_Target(0)` (`+0x3C8`), `Assign_Destination(0, 1)` (`+0x480`) —
+///   the callers own those writes;
+/// - tail gate: current ∉ {Patrol 0x19, AreaGuard 0xB, Unload 0x10, Eaten 9}
+///   ⇒ `+0x1E8(selector, 0)`.
+///
+/// Stock callers of the slot on a miner and where VERA runs them: the Move
+/// arrival (`FootClass::Mission_Move` 0x004D4242, [`harvester_enter_idle_mode_evaluation`]);
+/// `TechnoClass::ChangeOwner @ 0x00701849` after the house swap
+/// (`Simulation::change_owner_harvester_idle_arm`); `FootClass::Mission_Enter
+/// @ 0x004D92E2` after a depot's "already repaired" BREAK
+/// (`building_dock::mission_enter_dispatch`). The destination-installed
+/// branch (`NavCom != 0 ⇒ Move`) is not modelled here: every VERA caller
+/// reaches the selector with the destination already cleared.
+///
+/// `skip_human_land_check` is native `param_2 != 0`.
+pub(crate) fn harvester_enter_idle_mode_selector(
+    sim: &Simulation,
+    id: u64,
+    rules: &RuleSet,
+    skip_human_land_check: bool,
+) -> Option<MissionType> {
+    let entity = sim.substrate.entities.get(id)?;
+    if !entity.radio_contacts.is_empty() {
+        return None;
+    }
+    let current = entity.mission.current().known();
+    if current == Some(MissionType::Harvest)
         || entity.mission.queued() == MissionId::from_known(MissionType::Harvest)
     {
-        return MissionHandlerEvaluation::cadence(1);
+        return None;
     }
-    let human = sim
-        .houses
-        .get(&entity.owner)
-        .is_none_or(|house| house.is_controlled_by_human(sim.session.game_mode_nonzero));
+    if matches!(
+        current,
+        Some(MissionType::Patrol)
+            | Some(MissionType::AreaGuard)
+            | Some(MissionType::Unload)
+            | Some(MissionType::Eaten)
+    ) {
+        return None;
+    }
+    let human = !skip_human_land_check
+        && sim
+            .houses
+            .get(&entity.owner)
+            .is_none_or(|house| house.is_controlled_by_human(sim.session.game_mode_nonzero));
     let weeder = sim
         .object_type(entity.type_ref, rules)
         .is_some_and(|obj| !obj.harvester && obj.weeder);
@@ -751,17 +797,11 @@ fn harvester_enter_idle_mode_evaluation(
         crate::rules::terrain_rules::LandType::Tiberium
     };
     let land_matches = cell_land_type_is(sim, entity.position.rx, entity.position.ry, wanted_land);
-    let selector = if human && !land_matches {
+    Some(if human && !land_matches {
         MissionType::Guard
     } else {
         MissionType::Harvest
-    };
-    MissionHandlerEvaluation {
-        delay: 1,
-        clear_stale_attack_target: false,
-        clear_attack_target: true,
-        queue: Some(selector),
-    }
+    })
 }
 
 /// `CellClass+0xEC` (`LandType`) of one cell: the resolved terrain's land

--- a/src/sim/world/world_spawn.rs
+++ b/src/sim/world/world_spawn.rs
@@ -779,10 +779,20 @@ impl Simulation {
     /// Commit the spawn-time Harvest mission for a freshly stored miner so the
     /// host's mission dispatch has a truthful `current` from birth (cursor
     /// `SearchOre` == the zeroed handler state a fresh Assign writes).
-    /// UNCHECKED: the native creation-mission family (Enter_Idle_Mode /
-    /// initial-unit assigns, roadmap Track B1) is unverified — this preserves
-    /// the legacy spawn-into-SearchOre behavior. Slave Miners are excluded
-    /// (their own system drives them; never Harvest-dispatched).
+    ///
+    /// Native: `TechnoClass::Unlimbo @ 0x006F6CA0` calls `Enter_Idle_Mode(1, 1)`
+    /// at 0x006F6E2A and immediately promotes it (`+0x200` Ready_To_Commence,
+    /// `+0x1EC` Commence). With `param_2 = 1` the harvester arm of
+    /// `UnitClass::Enter_Idle_Mode @ 0x00738970` skips the human/off-ore Guard
+    /// check, so a Harvester=yes unit entering the world always takes Harvest
+    /// — human or AI, on ore or not. `BuildingClass::ExitObject` then
+    /// `Queue_Mission(Harvest)` again at 0x00444ED4, a no-op on an object
+    /// already on Harvest (`MissionClass::Queue_Mission @ 0x005B35E0` skips a
+    /// mission equal to the current one with nothing else queued), so this
+    /// single commit is the whole native outcome — not a double assignment.
+    /// The Unlimbo caller order (idle arm before the ExitObject queue) is not
+    /// otherwise observable. Slave Miners are excluded (their own system drives
+    /// them; never Harvest-dispatched).
     ///
     /// Returns whether the object was a dispatchable miner, i.e. whether this
     /// call owns its spawn mission.


### PR DESCRIPTION
Final Phase 7 audit round. A census of the 85 `+0x484` (`Enter_Idle_Mode`) call sites reachable for a `Harvester=yes` unit found three beyond the Move arrival landed in #257: `TechnoClass::ChangeOwner` 0x00701849 (mind control via `CaptureManagerClass` and the Psychic Dominator), `TechnoClass::Unlimbo` 0x006F6E2A (factory exit; called with (1,1) so a fresh miner always takes Harvest and `ExitObject`'s queue is a no-op), and the depot repaired-BREAK exit in `FootClass::Mission_Enter` 0x004D92E2. `ChangeOwner` @ 0x007014A0 clears target/destination, queues Guard with commence, swaps the owner and calls `Enter_Idle_Mode(0,1)` unless in contact with a WeaponsFactory; the harvester arm reads the NEW owner's human flag.

The shared harvester idle selector now runs at VERA's owner-change chokepoint (engineer capture, garrison transfer, sold-building ejection today; pre-wired for the mind-control lane) and at the depot's repaired-BREAK exit. Tests register both houses with explicit human/AI flags and pin all four native outcomes.

Also recorded: `FactoryClass::AbandonProduction` @ 0x004C9FF0 refunds cost-at-cancel-time (VERA refunds the paid amount); the System Map sell-refund commit is downgraded from VERIFIED to UNCHECKED naming the drift (GSI-09.14's row; checker output unchanged); a stale comment corrected; the remaining `+0x484` sites listed with their gates.

Independent read-only critic verified the census spot checks, the ChangeOwner sequence, the Unlimbo/Mission_Enter arguments, the refund expression and the map edit, and passed after the test fixtures registered the houses explicitly.

Validation:
- `cargo test -p vera20k --lib`: `test result: ok. 8439 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 14.48s`
