### PR TITLE
Centralize entity identity and terrain mutation authority

### DIFF
--- a/src/app/diagnostics/debug_panel.rs
+++ b/src/app/diagnostics/debug_panel.rs
@@ -265,9 +265,9 @@ pub(crate) fn draw_debug_panel(ctx: &egui::Context, state: &AppState) {
                         };
                         found.push(format!(
                             "{}({}) [{}] hp={}/{}",
-                            sim.interner.resolve(entity.type_ref),
+                            sim.interner.resolve(entity.type_ref()),
                             cat_str,
-                            sim.interner.resolve(entity.owner),
+                            sim.interner.resolve(entity.owner()),
                             entity.health.current,
                             entity.health.max,
                         ));
@@ -289,7 +289,7 @@ pub(crate) fn draw_debug_panel(ctx: &egui::Context, state: &AppState) {
                             continue;
                         }
                         let foundation = rules
-                            .object(sim.interner.resolve(entity.type_ref))
+                            .object(sim.interner.resolve(entity.type_ref()))
                             .map(|obj| obj.foundation.as_str())
                             .unwrap_or("1x1");
                         let (fw, fh) = crate::sim::production::foundation_dimensions(foundation);
@@ -305,11 +305,11 @@ pub(crate) fn draw_debug_panel(ctx: &egui::Context, state: &AppState) {
                                 egui::Color32::from_rgb(160, 120, 0),
                                 format!(
                                     "In footprint: {} ({}) @ ({},{}) {}",
-                                    sim.interner.resolve(entity.type_ref),
+                                    sim.interner.resolve(entity.type_ref()),
                                     foundation,
                                     ex,
                                     ey,
-                                    sim.interner.resolve(entity.owner)
+                                    sim.interner.resolve(entity.owner())
                                 ),
                             );
                         }
@@ -325,7 +325,7 @@ pub(crate) fn draw_debug_panel(ctx: &egui::Context, state: &AppState) {
                     .entities()
                     .values()
                     .filter(|e| e.selected)
-                    .map(|e| e.stable_id)
+                    .map(|e| e.stable_id())
                     .collect();
                 if selected.is_empty() {
                     ui.label("Selected: (none)");
@@ -334,7 +334,7 @@ pub(crate) fn draw_debug_panel(ctx: &egui::Context, state: &AppState) {
                         if let Some(entity) = sim.entities().get(sid) {
                             ui.label(format!(
                                 "Sel: {} @ ({},{}) sub=({},{})",
-                                sim.interner.resolve(entity.type_ref),
+                                sim.interner.resolve(entity.type_ref()),
                                 entity.position.rx,
                                 entity.position.ry,
                                 entity.position.sub_x,
@@ -393,7 +393,7 @@ pub(crate) fn draw_debug_panel(ctx: &egui::Context, state: &AppState) {
                     ui.label(
                         egui::RichText::new(format!(
                             "Miner: {} ({:?})",
-                            sim.interner.resolve(entity.type_ref),
+                            sim.interner.resolve(entity.type_ref()),
                             miner.kind
                         ))
                         .strong(),
@@ -441,7 +441,7 @@ pub(crate) fn draw_debug_panel(ctx: &egui::Context, state: &AppState) {
                         let ref_type = sim
                             .entities()
                             .get(ref_id)
-                            .map(|e| sim.interner.resolve(e.type_ref))
+                            .map(|e| sim.interner.resolve(e.type_ref()))
                             .unwrap_or("?");
                         ui.label(format!("Refinery: {} (id={})", ref_type, ref_id));
                     }
@@ -497,8 +497,8 @@ pub(crate) fn draw_event_history_panel(ctx: &egui::Context, state: &AppState) {
                     ui.label(
                         egui::RichText::new(format!(
                             "{} (id={})",
-                            sim.interner.resolve(entity.type_ref),
-                            entity.stable_id
+                            sim.interner.resolve(entity.type_ref()),
+                            entity.stable_id()
                         ))
                         .strong()
                         .color(egui::Color32::from_rgb(20, 20, 20)),
@@ -525,7 +525,7 @@ pub(crate) fn draw_event_history_panel(ctx: &egui::Context, state: &AppState) {
                     ui.label(
                         egui::RichText::new(format!(
                             "{} — inspector not active when spawned",
-                            sim.interner.resolve(entity.type_ref)
+                            sim.interner.resolve(entity.type_ref())
                         ))
                         .color(egui::Color32::from_rgb(140, 140, 140)),
                     );

--- a/src/app/diagnostics/tactical_capture/placement.rs
+++ b/src/app/diagnostics/tactical_capture/placement.rs
@@ -145,7 +145,7 @@ pub(crate) fn first_valid_placement(
         .is_some_and(|entity| {
             entity.is_active()
                 && entity.category == EntityCategory::Structure
-                && sim.interner.resolve(entity.owner) == owner
+                && sim.interner.resolve(entity.owner()) == owner
                 && (entity.position.rx, entity.position.ry) == anchor_cell
         });
     if !anchor_valid {

--- a/src/app/diagnostics/tactical_capture/session.rs
+++ b/src/app/diagnostics/tactical_capture/session.rs
@@ -480,9 +480,9 @@ impl TacticalCaptureSession {
             .iter_sorted()
             .filter(|(_, entity)| {
                 entity.is_active()
-                    && sim.interner.resolve(entity.owner) == owner
+                    && sim.interner.resolve(entity.owner()) == owner
                     && rules
-                        .object(sim.interner.resolve(entity.type_ref))
+                        .object(sim.interner.resolve(entity.type_ref()))
                         .is_some_and(|object| object.deploys_into.is_some())
             })
             .collect();
@@ -492,7 +492,7 @@ impl TacticalCaptureSession {
             deployers.len()
         );
         let mcv = deployers[0].1;
-        let mcv_type_id = sim.interner.resolve(mcv.type_ref).to_owned();
+        let mcv_type_id = sim.interner.resolve(mcv.type_ref()).to_owned();
         let mcv_rule = rules
             .object(&mcv_type_id)
             .context("local MCV has no merged rule")?;
@@ -762,9 +762,9 @@ impl TacticalCaptureSession {
             .entities()
             .iter_sorted()
             .map(|(_, entity)| TacticalEntityObservation {
-                stable_id: entity.stable_id,
-                owner: sim.interner.resolve(entity.owner).to_owned(),
-                type_id: sim.interner.resolve(entity.type_ref).to_owned(),
+                stable_id: entity.stable_id(),
+                owner: sim.interner.resolve(entity.owner()).to_owned(),
+                type_id: sim.interner.resolve(entity.type_ref()).to_owned(),
                 cell: (entity.position.rx, entity.position.ry),
                 facing: entity.facing,
                 active: entity.is_active(),
@@ -1080,10 +1080,10 @@ impl TacticalCaptureSession {
             if !entity.is_active()
                 || entity.dying
                 || entity.building_up.is_some()
-                || sim.interner.resolve(entity.owner) != self.request.profile().launch.player_name
+                || sim.interner.resolve(entity.owner()) != self.request.profile().launch.player_name
                 || !sim
                     .interner
-                    .resolve(entity.type_ref)
+                    .resolve(entity.type_ref())
                     .eq_ignore_ascii_case(&binding.type_id)
                 || (entity.position.rx, entity.position.ry) != binding.cell
             {
@@ -1107,7 +1107,7 @@ impl TacticalCaptureSession {
             if !entity.is_active()
                 || !sim
                     .interner
-                    .resolve(entity.type_ref)
+                    .resolve(entity.type_ref())
                     .eq_ignore_ascii_case(expected_harvester)
             {
                 return Ok(false);

--- a/src/app/frontend/skirmish.rs
+++ b/src/app/frontend/skirmish.rs
@@ -2745,7 +2745,7 @@ pub fn deployable_building_types<'a>(
 
     // Collect deploy targets for any units currently on the map.
     for entity in entities.values() {
-        let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
+        let type_str = interner.map_or("", |i| i.resolve(entity.type_ref()));
         if let Some(obj) = rules.object(type_str) {
             if let Some(ref target_id) = obj.deploys_into {
                 if let Some(target_obj) = rules.object(target_id) {

--- a/src/app/input/commands.rs
+++ b/src/app/input/commands.rs
@@ -166,7 +166,7 @@ fn own_building_id(state: &AppState, stable_id: u64) -> Option<u64> {
     (entity.category == EntityCategory::Structure
         && sim
             .interner
-            .resolve(entity.owner)
+            .resolve(entity.owner())
             .eq_ignore_ascii_case(&owner))
     .then_some(stable_id)
 }
@@ -671,7 +671,7 @@ pub(crate) fn preferred_local_owner(state: &AppState) -> Option<String> {
         .map(|rt| &rt.simulation)?;
     // Sandbox fallback: prefer owner of selected unit first.
     for entity in sim.entities().values() {
-        let owner_str = sim.interner.resolve(entity.owner);
+        let owner_str = sim.interner.resolve(entity.owner());
         if entity.selected && is_playable_house_name(owner_str) {
             return Some(owner_str.to_string());
         }
@@ -687,7 +687,7 @@ pub(crate) fn preferred_local_owner(state: &AppState) -> Option<String> {
     // Prefer owners that currently have structures.
     let mut structure_counts: HashMap<String, usize> = HashMap::new();
     for entity in sim.entities().values() {
-        let owner_str = sim.interner.resolve(entity.owner);
+        let owner_str = sim.interner.resolve(entity.owner());
         if entity.category == EntityCategory::Structure && is_playable_house_name(owner_str) {
             *structure_counts.entry(owner_str.to_string()).or_insert(0) += 1;
         }
@@ -718,7 +718,7 @@ pub(crate) fn preferred_local_owner(state: &AppState) -> Option<String> {
     let mut owners: Vec<String> = sim
         .entities()
         .values()
-        .map(|e| sim.interner.resolve(e.owner).to_string())
+        .map(|e| sim.interner.resolve(e.owner()).to_string())
         .filter(|o| is_playable_house_name(o))
         .collect();
     owners.sort();
@@ -744,7 +744,7 @@ pub(crate) fn collect_playable_owners(state: &AppState) -> Vec<String> {
         .map(|rt| &rt.simulation)
     {
         for entity in sim.entities().values() {
-            let owner_str = sim.interner.resolve(entity.owner);
+            let owner_str = sim.interner.resolve(entity.owner());
             if is_playable_house_name(owner_str) {
                 owners.push(owner_str.to_string());
             }

--- a/src/app/input/context_order.rs
+++ b/src/app/input/context_order.rs
@@ -236,7 +236,7 @@ fn emit_entity_order_voice(state: &mut AppState, speaker_id: u64, voice_field: &
     let Some(entity) = sim.entities().get(speaker_id) else {
         return;
     };
-    let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref)) else {
+    let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref())) else {
         return;
     };
     let Some(id) = voice_id_for_key(obj, voice_field) else {
@@ -372,7 +372,7 @@ fn entity_can_attack_move(
     ) {
         return false;
     }
-    let Some(obj) = rules.and_then(|r| r.object(sim.interner.resolve(entity.type_ref))) else {
+    let Some(obj) = rules.and_then(|r| r.object(sim.interner.resolve(entity.type_ref()))) else {
         return false;
     };
     if obj.prevent_attack_move {
@@ -541,7 +541,7 @@ pub(crate) fn try_queue_context_order_at_screen_point(
             if entity.category == EntityCategory::Structure {
                 _structure_count += 1;
                 if structure_owner.is_none() {
-                    structure_owner = Some(sim.interner.resolve(entity.owner).to_string());
+                    structure_owner = Some(sim.interner.resolve(entity.owner()).to_string());
                 }
             } else {
                 mobile_count += 1;
@@ -610,7 +610,7 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                     let rules = Some(&resources.rules)?;
                     sim.entities().get(target.stable_id).and_then(|e| {
                         rules
-                            .is_refinery_type(sim.interner.resolve(e.type_ref))
+                            .is_refinery_type(sim.interner.resolve(e.type_ref()))
                             .then_some(target.stable_id)
                     })
                 })
@@ -703,14 +703,14 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                                 entity,
                                 resources
                                     .rules
-                                    .object(sim.interner.resolve(entity.type_ref)),
+                                    .object(sim.interner.resolve(entity.type_ref())),
                             ) {
                                 queued.push(CommandEnvelope::new(owner_id, execute_tick, cmd));
                                 return finish_order(state, queued, speaker_id);
                             }
                             if entity.category == EntityCategory::Structure {
                                 let obj = Some(&resources.rules)
-                                    .and_then(|r| r.object(sim.interner.resolve(entity.type_ref)));
+                                    .and_then(|r| r.object(sim.interner.resolve(entity.type_ref())));
                                 let cmd = if obj.map_or(false, |o| o.can_be_occupied)
                                     && entity.passenger_role.cargo().is_some_and(|c| !c.is_empty())
                                 {
@@ -765,7 +765,7 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                     rally_announce = struct_owner_id == owner_id && producer_ids.iter().any(|id| {
                         sim.entities().get(*id).is_some_and(|entity| {
                             Some(&resources.rules)
-                                .and_then(|r| r.object(sim.interner.resolve(entity.type_ref)))
+                                .and_then(|r| r.object(sim.interner.resolve(entity.type_ref())))
                                 .is_some_and(
                                     crate::app::match_runtime::eva_producers::rally_point_announces,
                                 )
@@ -849,7 +849,7 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                     }
                     let rules = Some(&resources.rules)?;
                     let building = sim.entities().get(target.stable_id)?;
-                    let obj = rules.object(sim.interner.resolve(building.type_ref))?;
+                    let obj = rules.object(sim.interner.resolve(building.type_ref()))?;
                     if !obj.can_c4 || obj.invisible_in_game {
                         return None;
                     }
@@ -871,7 +871,7 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                             sim.entities().get(sid).is_some_and(|e| {
                                 e.category == EntityCategory::Infantry
                                     && Some(&resources.rules)
-                                        .and_then(|r| r.object(sim.interner.resolve(e.type_ref)))
+                                        .and_then(|r| r.object(sim.interner.resolve(e.type_ref())))
                                         .map_or(false, |o| o.c4)
                             })
                         })
@@ -902,8 +902,8 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                     }
                     let rules = Some(&resources.rules)?;
                     let building = sim.entities().get(target.stable_id)?;
-                    let btype_str = sim.interner.resolve(building.type_ref);
-                    let bowner_str = sim.interner.resolve(building.owner);
+                    let btype_str = sim.interner.resolve(building.type_ref());
+                    let bowner_str = sim.interner.resolve(building.owner());
                     let obj = rules.object(btype_str)?;
                     if !obj.capturable && !obj.bridge_repair_hut {
                         return None;
@@ -925,7 +925,7 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                             sim.entities().get(sid).is_some_and(|e| {
                                 e.category == EntityCategory::Infantry
                                     && Some(&resources.rules)
-                                        .and_then(|r| r.object(sim.interner.resolve(e.type_ref)))
+                                        .and_then(|r| r.object(sim.interner.resolve(e.type_ref())))
                                         .map_or(false, |o| o.engineer)
                             })
                         })
@@ -956,7 +956,7 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                     }
                     let rules = Some(&resources.rules)?;
                     let building = sim.entities().get(target.stable_id)?;
-                    let obj = rules.object(sim.interner.resolve(building.type_ref))?;
+                    let obj = rules.object(sim.interner.resolve(building.type_ref()))?;
                     obj.unit_repair.then_some(target.stable_id)
                 });
                 if let Some(depot_id) = depot_target {
@@ -1032,7 +1032,7 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                     if selected_ids.contains(&target.stable_id) {
                         if let Some(entity) = sim.entities().get(target.stable_id) {
                             let obj = Some(&resources.rules)
-                                .and_then(|r| r.object(sim.interner.resolve(entity.type_ref)));
+                                .and_then(|r| r.object(sim.interner.resolve(entity.type_ref())));
                             let cmd = if entity.category == EntityCategory::Structure {
                                 // Garrisoned building → unload occupants.
                                 if obj.map_or(false, |o| o.can_be_occupied)
@@ -1201,7 +1201,7 @@ pub(crate) fn try_queue_context_order_at_screen_point(
                         .entities()
                         .get(stable_id)
                         .and_then(|e| {
-                            let type_str = sim.interner.resolve(e.type_ref);
+                            let type_str = sim.interner.resolve(e.type_ref());
                             Some(&resources.rules)
                                 .and_then(|r| r.object(type_str))
                                 .map(|obj| crate::sim::combat::combat_weapon::is_armed(e, obj))
@@ -1342,7 +1342,7 @@ fn selected_rally_producer_ids(
         .copied()
         .filter(|stable_id| {
             sim.entities().get(*stable_id).is_some_and(|entity| {
-                entity.category == EntityCategory::Structure && entity.owner == owner
+                entity.category == EntityCategory::Structure && entity.owner() == owner
             })
         })
         .collect();

--- a/src/app/input/cursor.rs
+++ b/src/app/input/cursor.rs
@@ -169,7 +169,7 @@ pub(crate) fn current_cursor_feedback_kind(state: &AppState) -> Option<CursorFee
         .as_ref()
         .and_then(|h| sim.entities().get(h.stable_id))
         .map_or(ActionDistanceTarget::CellCentre(hover_rx, hover_ry), |e| {
-            ActionDistanceTarget::Object(e.stable_id)
+            ActionDistanceTarget::Object(e.stable_id())
         });
     let best_id = select_best_for_action(sim, &selected, action_target, state.rules());
 
@@ -187,7 +187,7 @@ pub(crate) fn current_cursor_feedback_kind(state: &AppState) -> Option<CursorFee
     if modifier == crate::app::input::context_order::OrderModifier::ForceFire {
         let best_is_armed = best_id.is_some_and(|id| {
             sim.entities().get(id).is_some_and(|e| {
-                let type_str = sim.interner.resolve(e.type_ref);
+                let type_str = sim.interner.resolve(e.type_ref());
                 state
                     .rules()
                     .and_then(|r| r.object(type_str))
@@ -442,7 +442,7 @@ fn capability_cursor_for_hover(
 
     let hovered_entity = sim.entities().get(hover.stable_id);
     let hovered_obj =
-        rules.and_then(|r| hovered_entity.and_then(|e| r.object(sim.interner.resolve(e.type_ref))));
+        rules.and_then(|r| hovered_entity.and_then(|e| r.object(sim.interner.resolve(e.type_ref()))));
 
     // 1. Deployer self-hover — the cursor is over the selected unit itself.
     //    Show the deploy cursor for units with Deployer=yes (e.g. GGI, Guardian GI)
@@ -452,7 +452,7 @@ fn capability_cursor_for_hover(
     if selected.len() == 1 && selected[0] == hover.stable_id {
         let entity = sim.entities().get(selected[0]);
         let obj =
-            entity.and_then(|e| rules.and_then(|r| r.object(sim.interner.resolve(e.type_ref))));
+            entity.and_then(|e| rules.and_then(|r| r.object(sim.interner.resolve(e.type_ref()))));
         if let Some(obj) = obj {
             if obj.deployer || obj.deploys_into.is_some() {
                 // DRIFT, recorded not fixed: this branch does not see the order
@@ -500,7 +500,7 @@ fn capability_cursor_for_hover(
             sim.entities().get(best_id),
             sim.entities()
                 .get(best_id)
-                .and_then(|e| rules.and_then(|r| r.object(sim.interner.resolve(e.type_ref)))),
+                .and_then(|e| rules.and_then(|r| r.object(sim.interner.resolve(e.type_ref())))),
         ) {
             // 2. C4 plant: SEAL / Tanya / Psi-Corp Trooper hovering an enemy
             //    structure with CanC4=yes, not InvisibleInGame, not iron-curtained.
@@ -614,7 +614,7 @@ fn capability_cursor_for_hover(
             if sel_entity.miner.is_some()
                 && matches!(hover.kind, HoverTargetKind::FriendlyStructure)
                 && hovered_entity.is_some_and(|e| {
-                    rules.is_some_and(|r| r.is_refinery_type(sim.interner.resolve(e.type_ref)))
+                    rules.is_some_and(|r| r.is_refinery_type(sim.interner.resolve(e.type_ref())))
                 })
             {
                 return CursorFeedbackKind::Enter;
@@ -711,7 +711,7 @@ fn resolved_unit_in_range(
     let Some(entity) = sim.entities().get(actor_id) else {
         return false;
     };
-    let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref)) else {
+    let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref())) else {
         return false;
     };
     for slot in [obj.primary.as_ref(), obj.secondary.as_ref()] {
@@ -876,7 +876,7 @@ fn select_best_for_action(
             // and `[YAGGUN]` all author slot 0 — so the frequency is zero on
             // retail data. Downstream: cursor/order dispatch only, no sim
             // state.
-            let obj = rules.and_then(|r| r.object(sim.interner.resolve(entity.type_ref)));
+            let obj = rules.and_then(|r| r.object(sim.interner.resolve(entity.type_ref())));
             let has_weapon = obj.is_some_and(|o| {
                 [o.primary.as_ref(), o.secondary.as_ref()]
                     .into_iter()

--- a/src/app/input/dispatch.rs
+++ b/src/app/input/dispatch.rs
@@ -1911,8 +1911,8 @@ pub(crate) fn selected_stable_ids_in_order(state: &AppState) -> Vec<u64> {
     }
     if !state.match_state.input.selection_order_pending {
         for entity in sim.entities().values() {
-            if entity.selected && !ordered.contains(&entity.stable_id) {
-                insert_selected_id(&mut ordered, entity.stable_id, sim, state.rules());
+            if entity.selected && !ordered.contains(&entity.stable_id()) {
+                insert_selected_id(&mut ordered, entity.stable_id(), sim, state.rules());
             }
         }
     }
@@ -1946,7 +1946,7 @@ pub(crate) fn reconcile_selection_order_after_sim(state: &mut AppState) {
             .entities()
             .values()
             .filter(|entity| entity.selected)
-            .map(|entity| entity.stable_id)
+            .map(|entity| entity.stable_id())
             .collect();
         let same_membership = committed.len() == state.match_state.input.selection_order.len()
             && committed
@@ -1973,8 +1973,8 @@ pub(crate) fn reconcile_selection_order_after_sim(state: &mut AppState) {
         .collect();
     let lifecycle_removed = reconciled.len() < prior_len;
     for entity in sim.entities().values() {
-        if entity.selected && !reconciled.contains(&entity.stable_id) {
-            insert_selected_id(&mut reconciled, entity.stable_id, sim, state.rules());
+        if entity.selected && !reconciled.contains(&entity.stable_id()) {
+            insert_selected_id(&mut reconciled, entity.stable_id(), sim, state.rules());
         }
     }
     if lifecycle_removed {
@@ -2015,7 +2015,7 @@ fn apply_selection_mutation(
         let Some(entity) = sim.entities().get(id) else {
             continue;
         };
-        let type_id = sim.interner.resolve(entity.type_ref);
+        let type_id = sim.interner.resolve(entity.type_ref());
         let admitted = entity.lifecycle.object_alive
             && !entity.lifecycle.in_limbo
             && !entity
@@ -2070,7 +2070,7 @@ fn insert_selected_id(
     rules: Option<&crate::rules::ruleset::RuleSet>,
 ) {
     let positive_damage_primary = sim.entities().get(id).is_some_and(|entity| {
-        let type_id = sim.interner.resolve(entity.type_ref);
+        let type_id = sim.interner.resolve(entity.type_ref());
         rules
             .and_then(|rules| rules.object(type_id))
             .and_then(|object| object.primary.as_deref())
@@ -2274,7 +2274,7 @@ fn queue_deploy_undeploy_for_selected(state: &mut AppState) {
             let Some(entity) = sim.entities().get(entity_id) else {
                 continue;
             };
-            let obj = rules.and_then(|r| r.object(sim.interner.resolve(entity.type_ref)));
+            let obj = rules.and_then(|r| r.object(sim.interner.resolve(entity.type_ref())));
             match entity.category {
                 crate::map::entities::EntityCategory::Structure => {
                     // Garrisoned building → evacuate occupants.
@@ -2602,7 +2602,7 @@ fn selection_voice_event(
     entity_id: u64,
 ) -> Option<GameSoundEvent> {
     let entity = sim.entities().get(entity_id)?;
-    let object = rules.object(sim.interner.resolve(entity.type_ref))?;
+    let object = rules.object(sim.interner.resolve(entity.type_ref()))?;
     Some(GameSoundEvent::UnitSelected {
         speaker_id: entity_id,
         sound_id: object.voice_select.clone()?,
@@ -2629,16 +2629,16 @@ fn jump_camera_to_base(state: &mut AppState) {
             let conyard = sim.entities().values().find(|e| {
                 e.category == EntityCategory::Structure
                     && owner_name.map_or(true, |o| {
-                        sim.interner.resolve(e.owner).eq_ignore_ascii_case(o)
+                        sim.interner.resolve(e.owner()).eq_ignore_ascii_case(o)
                     })
                     && rules
-                        .and_then(|r| r.object(sim.interner.resolve(e.type_ref)))
+                        .and_then(|r| r.object(sim.interner.resolve(e.type_ref())))
                         .map_or(false, |o| o.undeploys_into.is_some())
             });
             if let Some(entity) = conyard {
                 log::info!(
                     "H: jumping to ConYard {} at ({}, {})",
-                    sim.interner.resolve(entity.type_ref),
+                    sim.interner.resolve(entity.type_ref()),
                     entity.position.rx,
                     entity.position.ry
                 );
@@ -2648,16 +2648,16 @@ fn jump_camera_to_base(state: &mut AppState) {
             let mcv = sim.entities().values().find(|e| {
                 e.category != EntityCategory::Structure
                     && owner_name.map_or(true, |o| {
-                        sim.interner.resolve(e.owner).eq_ignore_ascii_case(o)
+                        sim.interner.resolve(e.owner()).eq_ignore_ascii_case(o)
                     })
                     && rules
-                        .and_then(|r| r.object(sim.interner.resolve(e.type_ref)))
+                        .and_then(|r| r.object(sim.interner.resolve(e.type_ref())))
                         .map_or(false, |o| o.deploys_into.is_some())
             });
             if let Some(entity) = mcv {
                 log::info!(
                     "H: jumping to MCV {} at ({}, {})",
-                    sim.interner.resolve(entity.type_ref),
+                    sim.interner.resolve(entity.type_ref()),
                     entity.position.rx,
                     entity.position.ry
                 );

--- a/src/app/input/entity_pick.rs
+++ b/src/app/input/entity_pick.rs
@@ -44,7 +44,7 @@ pub(crate) struct TypeSelectTapResult {
 
 /// EntityStore keys are monotonic object identities, hence creation order.
 pub(crate) fn map_entity_creation_order(entities: &EntityStore) -> Vec<u64> {
-    entities.values().map(|entity| entity.stable_id).collect()
+    entities.values().map(|entity| entity.stable_id()).collect()
 }
 
 /// Y-axis weight in the elliptical pick distance formula.
@@ -123,8 +123,8 @@ pub(crate) fn hover_target_at_point(
     let mut best: Option<(u64, f32)> = None;
     for entity in sim.entities().values() {
         let is_structure = entity.category == EntityCategory::Structure;
-        let type_str = sim.interner.resolve(entity.type_ref);
-        let owner_str = sim.interner.resolve(entity.owner);
+        let type_str = sim.interner.resolve(entity.type_ref());
+        let owner_str = sim.interner.resolve(entity.owner());
         let (sx, sy) = if is_structure {
             crate::render::locomotor_visual::screen_position(entity)
         } else {
@@ -183,7 +183,7 @@ pub(crate) fn hover_target_at_point(
         };
         match best {
             Some((_, best_dist_sq)) if dist_sq >= best_dist_sq => {}
-            _ => best = Some((encode_hover_kind_with_id(kind, entity.stable_id), dist_sq)),
+            _ => best = Some((encode_hover_kind_with_id(kind, entity.stable_id()), dist_sq)),
         }
     }
     best.map(|(encoded, _)| decode_hover_kind_with_id(encoded))
@@ -300,7 +300,7 @@ pub(crate) fn compute_click_selection_snapshot_with_playfield(
     };
 
     let picked = entities.get(picked_sid)?;
-    let type_str = interner.map_or("", |i| i.resolve(picked.type_ref));
+    let type_str = interner.map_or("", |i| i.resolve(picked.type_ref()));
     let admitted = static_selection_gate(picked, type_str, rules, require_playfield_membership);
     // A shift-click adds when the selection it is joining is the local player's,
     // whatever was clicked. The native ACTION_SELECT arm asks
@@ -336,7 +336,7 @@ pub(crate) fn compute_click_selection_snapshot_with_playfield(
     let owner_is_local = |entity: &crate::sim::game_entity::GameEntity| -> bool {
         match (local_owner, interner) {
             (Some(owner), Some(names)) => {
-                names.resolve(entity.owner).eq_ignore_ascii_case(owner)
+                names.resolve(entity.owner()).eq_ignore_ascii_case(owner)
             }
             _ => true,
         }
@@ -421,7 +421,7 @@ pub(crate) fn band_rect_contains_drawn_object(
             // Bulk-registered, shroud or no shroud.
             return true;
         }
-        let owner_str = interner.map_or("", |i| i.resolve(entity.owner));
+        let owner_str = interner.map_or("", |i| i.resolve(entity.owner()));
         is_drawn_for_local_owner(fog, local_owner, owner_str, entity, local_owner_id)
     })
 }
@@ -612,7 +612,7 @@ pub(crate) fn compute_type_select_tap_with_playfield(
     let mut selected = current_selection.to_vec();
     if selected.len() == 1 {
         let nonlocal = entities.get(selected[0]).is_some_and(|entity| {
-            let owner = interner.map_or("", |i| i.resolve(entity.owner));
+            let owner = interner.map_or("", |i| i.resolve(entity.owner()));
             local_owner.is_some_and(|local| !owner.eq_ignore_ascii_case(local))
         });
         if nonlocal {
@@ -626,8 +626,8 @@ pub(crate) fn compute_type_select_tap_with_playfield(
         let Some(entity) = entities.get(id) else {
             continue;
         };
-        let own = interner.map_or("", |i| i.resolve(entity.type_ref));
-        push_exact_seed(&mut seeds, entity.type_ref);
+        let own = interner.map_or("", |i| i.resolve(entity.type_ref()));
+        push_exact_seed(&mut seeds, entity.type_ref());
         if let Some(object) = rules.and_then(|r| r.object(own)) {
             if let Some(deploys_into) = object.deploys_into.as_deref() {
                 if let Some(type_ref) = interner.and_then(|i| i.get(deploys_into)) {
@@ -724,11 +724,11 @@ fn type_select_candidates(
         .iter()
         .filter_map(|id| {
             let entity = entities.get(*id)?;
-            let owner = interner.map_or("", |i| i.resolve(entity.owner));
-            let type_id = interner.map_or("", |i| i.resolve(entity.type_ref));
+            let owner = interner.map_or("", |i| i.resolve(entity.owner()));
+            let type_id = interner.map_or("", |i| i.resolve(entity.type_ref()));
             if !entity.lifecycle.object_alive
                 || local_owner.is_some_and(|local| !owner.eq_ignore_ascii_case(local))
-                || !seeds.contains(&entity.type_ref)
+                || !seeds.contains(&entity.type_ref())
                 || (screen_only
                     && entity.category != EntityCategory::Structure
                     && !is_drawn_for_local_owner(fog, local_owner, owner, entity, local_owner_id))
@@ -759,7 +759,7 @@ fn type_select_final_admissions(
         .copied()
         .filter(|id| {
             entities.get(*id).is_some_and(|entity| {
-                let type_id = interner.map_or("", |i| i.resolve(entity.type_ref));
+                let type_id = interner.map_or("", |i| i.resolve(entity.type_ref()));
                 static_selection_gate(entity, type_id, rules, require_playfield_membership)
             })
         })
@@ -806,7 +806,7 @@ pub(crate) fn compute_type_select_click_mutation_with_playfield(
     let Some(clicked) = entities.get(clicked_id) else {
         return SelectionMutation::default();
     };
-    let clicked_type = clicked.type_ref;
+    let clicked_type = clicked.type_ref();
     if additive && current_selection.contains(&clicked_id) {
         return SelectionMutation {
             deselect: exact_type_group(
@@ -902,8 +902,8 @@ pub(crate) fn compute_type_select_box_mutation_with_playfield(
         if !entity.lifecycle.object_alive || sx < min_x || sx > max_x || sy < min_y || sy > max_y {
             continue;
         }
-        if !represented_types.contains(&entity.type_ref) {
-            represented_types.push(entity.type_ref);
+        if !represented_types.contains(&entity.type_ref()) {
+            represented_types.push(entity.type_ref());
         }
     }
 
@@ -942,11 +942,11 @@ fn exact_type_group(
         .iter()
         .filter_map(|id| {
             let entity = entities.get(*id)?;
-            let owner = interner.map_or("", |i| i.resolve(entity.owner));
-            let type_id = interner.map_or("", |i| i.resolve(entity.type_ref));
+            let owner = interner.map_or("", |i| i.resolve(entity.owner()));
+            let type_id = interner.map_or("", |i| i.resolve(entity.type_ref()));
             if !entity.lifecycle.object_alive
                 || entity.lifecycle.in_limbo
-                || entity.type_ref != type_ref
+                || entity.type_ref() != type_ref
                 || local_owner.is_some_and(|local| !owner.eq_ignore_ascii_case(local))
                 || (selecting
                     && !static_selection_gate(entity, type_id, rules, require_playfield_membership))
@@ -982,8 +982,8 @@ fn entities_in_rect(
             if !(sx >= min_x && sx <= max_x && sy >= min_y && sy <= max_y) {
                 return None;
             }
-            let owner_str = interner.map_or("", |i| i.resolve(entity.owner));
-            let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
+            let owner_str = interner.map_or("", |i| i.resolve(entity.owner()));
+            let type_str = interner.map_or("", |i| i.resolve(entity.type_ref()));
             if !is_local_band_candidate(
                 local_owner,
                 owner_str,
@@ -997,7 +997,7 @@ fn entities_in_rect(
             if !can_be_selected_now(entity, entities, rules, interner) {
                 return None;
             }
-            Some(entity.stable_id)
+            Some(entity.stable_id())
         })
         .collect()
 }
@@ -1102,7 +1102,7 @@ fn building_covers_cell(
         {
             return false;
         }
-        let type_str = interner.map_or("", |i| i.resolve(candidate.type_ref));
+        let type_str = interner.map_or("", |i| i.resolve(candidate.type_ref()));
         let foundation = rules
             .and_then(|r| r.object(type_str))
             .map(|o| o.foundation.as_str())
@@ -1176,7 +1176,7 @@ pub(crate) fn pick_entity_at_point(
         if !entity.lifecycle.object_alive || entity.lifecycle.in_limbo {
             continue;
         }
-        let owner_str = interner.map_or("", |i| i.resolve(entity.owner));
+        let owner_str = interner.map_or("", |i| i.resolve(entity.owner()));
         if entity.category != EntityCategory::Structure
             && !is_drawn_for_local_owner(fog, local_owner, owner_str, entity, local_owner_id)
         {
@@ -1194,7 +1194,7 @@ pub(crate) fn pick_entity_at_point(
         // submarine cannot be moused over at all and no explicit attack order
         // against it can be issued.
         if let (Some(fog_state), Some(owner_id)) = (fog, local_owner_id)
-            && entity.owner != owner_id
+            && entity.owner() != owner_id
             && entity
                 .cloak
                 .as_ref()
@@ -1212,7 +1212,7 @@ pub(crate) fn pick_entity_at_point(
         if distance < PICK_DISTANCE_THRESHOLD as i32
             && best.is_none_or(|(_, best_distance)| distance < best_distance)
         {
-            best = Some((entity.stable_id, distance));
+            best = Some((entity.stable_id(), distance));
         }
     }
 
@@ -1229,7 +1229,7 @@ pub(crate) fn pick_entity_at_point(
         {
             return None;
         }
-        let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
+        let type_str = interner.map_or("", |i| i.resolve(entity.type_ref()));
         let foundation = rules
             .and_then(|r| r.object(type_str))
             .map(|o| o.foundation.as_str())
@@ -1243,7 +1243,7 @@ pub(crate) fn pick_entity_at_point(
             height_map,
             bridge_height_map,
         )
-        .then_some(entity.stable_id)
+        .then_some(entity.stable_id())
     })
 }
 

--- a/src/app/input/transport_orders.rs
+++ b/src/app/input/transport_orders.rs
@@ -31,7 +31,7 @@ pub(crate) fn transport_unload_command(
         return None;
     }
     Some(Command::UnloadPassengers {
-        transport_id: entity.stable_id,
+        transport_id: entity.stable_id(),
     })
 }
 

--- a/src/app/loading/init.rs
+++ b/src/app/loading/init.rs
@@ -1816,7 +1816,7 @@ fn collect_live_building_lights(
                 )
         })
         .filter_map(|entity| {
-            let type_id = sim.interner.resolve(entity.type_ref);
+            let type_id = sim.interner.resolve(entity.type_ref());
             let obj = rules.object(type_id)?;
             let light = lighting::point_light_from_object(
                 entity.position.rx,
@@ -1829,7 +1829,7 @@ fn collect_live_building_lights(
                     obj.light_blue_tint,
                 ],
             )?;
-            Some((entity.stable_id, light))
+            Some((entity.stable_id(), light))
         })
         .collect()
 }
@@ -3009,7 +3009,7 @@ pub(crate) fn load_map_from_initial(
                 .keys_sorted()
                 .into_iter()
                 .filter_map(|id| sim.substrate.entities.get(id))
-                .find(|e| e.owner == owner_id)
+                .find(|e| e.owner() == owner_id)
                 .map(|e| (e.position.rx, e.position.ry))
         });
     let (camera_anchor_x, camera_anchor_y): (f32, f32) = if let Some((rx, ry)) = local_start_cell {

--- a/src/app/match_runtime/sound_dispatch.rs
+++ b/src/app/match_runtime/sound_dispatch.rs
@@ -690,11 +690,11 @@ pub(super) fn dispatch_sim_sound_events(
                 {
                     None => true,
                     Some(aux) => sim.substrate.entities.values().any(|e| {
-                        e.owner == owner
+                        e.owner() == owner
                             && !e.dying
                             && !e.lifecycle.in_limbo
                             && e.category == crate::map::entities::EntityCategory::Structure
-                            && sim.interner.resolve(e.type_ref).eq_ignore_ascii_case(aux)
+                            && sim.interner.resolve(e.type_ref()).eq_ignore_ascii_case(aux)
                     }),
                 };
                 if !eva_producers::super_weapon_detected_allowed(

--- a/src/app/presentation/chute_anim.rs
+++ b/src/app/presentation/chute_anim.rs
@@ -55,7 +55,7 @@ pub(crate) fn tick_parachute_anims(state: &mut AppState) {
         .filter(|e| {
             e.lifecycle.object_alive && !e.lifecycle.in_limbo && e.parachute_state.is_some()
         })
-        .map(|e| e.stable_id)
+        .map(|e| e.stable_id())
         .filter(|sid| !state.match_state.match_presentation.parachute_anims.iter().any(|a| a.target_id == *sid))
         .collect();
 

--- a/src/app/presentation/instances/helpers.rs
+++ b/src/app/presentation/instances/helpers.rs
@@ -38,8 +38,8 @@ pub(crate) fn tactical_entity_encounter_order(
         }
     }
     for entity in sim.entities().values() {
-        if seen.insert(entity.stable_id) {
-            registered.push(entity.stable_id);
+        if seen.insert(entity.stable_id()) {
+            registered.push(entity.stable_id());
         }
     }
 
@@ -61,7 +61,7 @@ pub(crate) fn tactical_entity_encounter_order(
             };
             let (coord, y_sort_adjust) = if entity.category == EntityCategory::Structure {
                 let object_type =
-                    rules.and_then(|rules| rules.object(sim.interner.resolve(entity.type_ref)));
+                    rules.and_then(|rules| rules.object(sim.interner.resolve(entity.type_ref())));
                 crate::app::presentation::render::draw_plan_lowering::building_ground_order_parts(
                     location,
                     object_type.is_some_and(|object| object.turret_anim_is_voxel),
@@ -195,7 +195,7 @@ fn compose_tactical_screen_entity_encounter_order(
         .into_iter()
         .filter(|id| {
             sim.entities().get(*id).is_some_and(|entity| {
-                let owner = sim.interner.resolve(entity.owner);
+                let owner = sim.interner.resolve(entity.owner());
                 let admitted = if bulk_register_live_buildings
                     && entity.category == EntityCategory::Structure
                 {

--- a/src/app/presentation/instances/shp.rs
+++ b/src/app/presentation/instances/shp.rs
@@ -112,12 +112,12 @@ pub(crate) fn build_shp_instances(
             continue;
         }
         // Common visibility, passenger, limbo, and DrawState admission is shared below.
-        let owner_str = sim.interner.resolve(entity.owner);
+        let owner_str = sim.interner.resolve(entity.owner());
         let active_disguise = entity.disguise.as_ref().filter(|state| state.disguised);
         let type_str = active_disguise
             .and_then(|state| state.disguise_type)
             .map(|id| sim.interner.resolve(id))
-            .unwrap_or_else(|| sim.interner.resolve(entity.type_ref));
+            .unwrap_or_else(|| sim.interner.resolve(entity.type_ref()));
         let remap_owner = active_disguise
             .and_then(|state| state.disguised_as_house)
             .map(|id| sim.interner.resolve(id))
@@ -300,7 +300,7 @@ pub(crate) fn build_shp_instances(
             EntityDrawBand::Ground => apply_bridge_depth_bias(state, entity, base_depth),
         };
         if entity.parachute_state.is_some() {
-            parachute_body_depths.insert(entity.stable_id, depth);
+            parachute_body_depths.insert(entity.stable_id(), depth);
         }
         let tint = shp_body_tint(
             &state.match_state.match_presentation.lighting_grid,
@@ -371,7 +371,7 @@ pub(crate) fn build_shp_instances(
                 z: i32::from(pos.z),
             };
             if let Some(parent) =
-                ground_order.object_draw(entity.stable_id, coord, SpriteEncoding::Plain)
+                ground_order.object_draw(entity.stable_id(), coord, SpriteEncoding::Plain)
             {
                 ground_objects.push(PlannedGroundObjectInstance::object(
                     parent,
@@ -384,7 +384,7 @@ pub(crate) fn build_shp_instances(
         } else if band == EntityDrawBand::Top {
             top_instances.push(body);
             top_pages.push(entry.page as usize);
-            top_ids.push(entity.stable_id);
+            top_ids.push(entity.stable_id());
         } else {
             target_pages.expect("Ground SHP target was selected")[entry.page as usize].push(body);
         }
@@ -436,7 +436,7 @@ pub(crate) fn build_shp_instances(
                     entity.building_anim_overlays.as_ref(),
                     crate::app::presentation::building_anim::building_anim_elapsed_logic_frames(
                         state,
-                        entity.stable_id,
+                        entity.stable_id(),
                     ),
                     Some(&sim.session.game_options),
                     Some(&sim.interner),
@@ -489,10 +489,10 @@ pub(crate) fn build_shp_instances(
                 z: i32::from(pos.z),
             };
             let actual_type = state.rules()
-                .and_then(|rules| rules.object(sim.interner.resolve(entity.type_ref)));
+                .and_then(|rules| rules.object(sim.interner.resolve(entity.type_ref())));
             if let Some(parent) = actual_type.and_then(|object_type| {
                 ground_order.building_object_draw(
-                    entity.stable_id,
+                    entity.stable_id(),
                     location,
                     object_type,
                     SpriteEncoding::Plain,

--- a/src/app/presentation/instances/units.rs
+++ b/src/app/presentation/instances/units.rs
@@ -291,13 +291,13 @@ pub(crate) fn build_unit_instances(
         }
         // Common visibility, passenger, limbo, and DrawState admission is shared below.
         let pos = &entity.position;
-        let owner_str = sim.interner.resolve(entity.owner);
+        let owner_str = sim.interner.resolve(entity.owner());
         // Disguise remains the outer display-type choice. For an ordinary
         // undisguised Unit, `NoSpawnAlt` is selected from the current docked
         // slot count at draw time; the serialized override remains solely the
         // miner dock sub-FSM's UnloadingClass (HORV/CMON) hint.
         let active_disguise = entity.disguise.as_ref().filter(|state| state.disguised);
-        let base_type = sim.interner.resolve(entity.type_ref);
+        let base_type = sim.interner.resolve(entity.type_ref());
         let no_spawn_alt = state.rules()
             .and_then(|rules| rules.object(base_type))
             .is_some_and(|object| object.no_spawn_alt);
@@ -514,10 +514,10 @@ pub(crate) fn build_unit_instances(
             };
             let parent = if entity.category == EntityCategory::Structure {
                 state.rules()
-                    .and_then(|rules| rules.object(sim.interner.resolve(entity.type_ref)))
+                    .and_then(|rules| rules.object(sim.interner.resolve(entity.type_ref())))
                     .and_then(|object_type| {
                         ground_order.building_object_draw(
-                            entity.stable_id,
+                            entity.stable_id(),
                             location,
                             object_type,
                             crate::render::tactical_draw_plan::SpriteEncoding::Voxel,
@@ -525,7 +525,7 @@ pub(crate) fn build_unit_instances(
                     })
             } else {
                 ground_order.object_draw(
-                    entity.stable_id,
+                    entity.stable_id(),
                     location,
                     crate::render::tactical_draw_plan::SpriteEncoding::Voxel,
                 )

--- a/src/app/presentation/selection_brackets.rs
+++ b/src/app/presentation/selection_brackets.rs
@@ -351,12 +351,12 @@ pub(crate) fn build_selection_bracket_instances(
         if e.category != EntityCategory::Structure || !e.selected {
             continue;
         }
-        let type_str = sim.interner.resolve(e.type_ref);
+        let type_str = sim.interner.resolve(e.type_ref());
         if !is_visible(
             local_owner_id,
             &sim.fog,
             &e.position,
-            e.owner,
+            e.owner(),
             ignore_visibility,
         ) {
             continue;

--- a/src/app/presentation/target_lines.rs
+++ b/src/app/presentation/target_lines.rs
@@ -171,14 +171,14 @@ pub(crate) fn build_factory_rally_line_instances(
         if !entity.selected || entity.category != EntityCategory::Structure {
             continue;
         }
-        let owner = sim.interner.resolve(entity.owner);
+        let owner = sim.interner.resolve(entity.owner());
         if owner != local_owner {
             continue;
         }
         let Some((rx, ry)) = entity.rally_target else {
             continue;
         };
-        let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref)) else {
+        let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref())) else {
             continue;
         };
         if !obj.has_rally_line() {

--- a/src/app/presentation/ui_overlays.rs
+++ b/src/app/presentation/ui_overlays.rs
@@ -176,16 +176,16 @@ pub(crate) fn build_building_status_instances(
         if e.category != EntityCategory::Structure {
             continue;
         }
-        if !e.selected && hovered_structure_id != Some(e.stable_id) {
+        if !e.selected && hovered_structure_id != Some(e.stable_id()) {
             continue;
         }
         let health = &e.health;
-        let type_str = sim.interner.resolve(e.type_ref);
+        let type_str = sim.interner.resolve(e.type_ref());
         if !status_entity_visible_plain(
             local_owner_id,
             &sim.fog,
             &e.position,
-            e.owner,
+            e.owner(),
             ignore_visibility,
         ) {
             continue;
@@ -380,10 +380,10 @@ pub(crate) fn build_occupant_pip_instances(
         if e.category != EntityCategory::Structure {
             continue;
         }
-        if !e.selected && hovered_structure_id != Some(e.stable_id) {
+        if !e.selected && hovered_structure_id != Some(e.stable_id()) {
             continue;
         }
-        let type_str = sim.interner.resolve(e.type_ref);
+        let type_str = sim.interner.resolve(e.type_ref());
         let Some(obj) = rules.and_then(|r| r.object(type_str)) else {
             continue;
         };
@@ -394,7 +394,7 @@ pub(crate) fn build_occupant_pip_instances(
             local_owner_id,
             &sim.fog,
             &e.position,
-            e.owner,
+            e.owner(),
             ignore_visibility,
         ) {
             continue;
@@ -451,7 +451,7 @@ pub(crate) fn build_occupant_pip_instances(
                 sim.entities()
                     .get(pax_id)
                     .and_then(|pax| {
-                        rules.and_then(|r| r.object(sim.interner.resolve(pax.type_ref)))
+                        rules.and_then(|r| r.object(sim.interner.resolve(pax.type_ref())))
                     })
                     .map(|pax_obj| pax_obj.occupy_pip)
                     .unwrap_or(7) // default PersonGreen
@@ -499,7 +499,7 @@ pub(crate) fn build_occupant_pip_instances(
             local_owner_id,
             &sim.fog,
             &e.position,
-            e.owner,
+            e.owner(),
             ignore_visibility,
         ) {
             continue;
@@ -566,7 +566,7 @@ pub(crate) fn build_unit_status_bg_instances(
             continue;
         }
         let (draw_background, _) =
-            unit_status_visibility(e.selected, hovered_unit_id == Some(e.stable_id));
+            unit_status_visibility(e.selected, hovered_unit_id == Some(e.stable_id()));
         if !draw_background {
             continue;
         }
@@ -574,7 +574,7 @@ pub(crate) fn build_unit_status_bg_instances(
             local_owner_id,
             &sim.fog,
             &e.position,
-            e.owner,
+            e.owner(),
             ignore_visibility,
         ) {
             continue;
@@ -597,7 +597,7 @@ pub(crate) fn build_unit_status_bg_instances(
             )
         };
         let bracket_delta: f32 = state.rules()
-            .and_then(|r| r.object(sim.interner.resolve(e.type_ref)))
+            .and_then(|r| r.object(sim.interner.resolve(e.type_ref())))
             .map(|obj| obj.pixel_selection_bracket_delta as f32)
             .unwrap_or(0.0);
         let (off_x, off_y) = overlay.pipbrd_offset(is_infantry);
@@ -655,7 +655,7 @@ pub(crate) fn build_unit_status_fill_instances(
         }
         let health = &e.health;
         let (_, draw_pips) =
-            unit_status_visibility(e.selected, hovered_unit_id == Some(e.stable_id));
+            unit_status_visibility(e.selected, hovered_unit_id == Some(e.stable_id()));
         if !draw_pips {
             continue;
         }
@@ -663,7 +663,7 @@ pub(crate) fn build_unit_status_fill_instances(
             local_owner_id,
             &sim.fog,
             &e.position,
-            e.owner,
+            e.owner(),
             ignore_visibility,
         ) {
             continue;
@@ -684,7 +684,7 @@ pub(crate) fn build_unit_status_fill_instances(
             UNIT_PIPS_VEHICLE
         };
         let bracket_delta: f32 = state.rules()
-            .and_then(|r| r.object(sim.interner.resolve(e.type_ref)))
+            .and_then(|r| r.object(sim.interner.resolve(e.type_ref())))
             .map(|obj| obj.pixel_selection_bracket_delta as f32)
             .unwrap_or(0.0);
         let (pip_off_x, pip_off_y) = overlay.pip_offset(is_infantry);
@@ -813,7 +813,7 @@ pub(crate) fn build_cargo_pip_instances(state: &AppState, sw: f32, sh: f32) -> V
             continue;
         }
         let obj = state.rules()
-            .and_then(|r| r.object(sim.interner.resolve(e.type_ref)));
+            .and_then(|r| r.object(sim.interner.resolve(e.type_ref())));
         let is_tiberium_scale = obj
             .map(|o| o.pip_scale == crate::rules::object_type::PipScale::Tiberium)
             .unwrap_or(false);
@@ -827,7 +827,7 @@ pub(crate) fn build_cargo_pip_instances(state: &AppState, sw: f32, sh: f32) -> V
             local_owner_id,
             &sim.fog,
             &e.position,
-            e.owner,
+            e.owner(),
             ignore_visibility,
         ) {
             continue;
@@ -963,12 +963,12 @@ pub(crate) fn build_building_radius_ring_instances(
             local_owner_id,
             &sim.fog,
             &e.position,
-            e.owner,
+            e.owner(),
             ignore_visibility,
         ) {
             continue;
         }
-        let type_str = sim.interner.resolve(e.type_ref);
+        let type_str = sim.interner.resolve(e.type_ref());
         let Some(obj) = rules.object(type_str) else {
             continue;
         };

--- a/src/map/authored_overlay.rs
+++ b/src/map/authored_overlay.rs
@@ -451,8 +451,7 @@ fn mirror_real_overlay_pair(
         return;
     };
     let value = cells.read(cell.target);
-    terrain.cells[index].bridge_facts.overlay_id = value.overlay_id();
-    terrain.cells[index].bridge_facts.state_byte = value.state();
+    terrain.mirror_authored_overlay_pair(index, value.overlay_id(), value.state());
 }
 
 /// One consuming authored-reader transaction. It owns the exact packed y/x
@@ -656,7 +655,7 @@ impl<'load, 'resources, H: AuthoredOverlayLoadHost>
         self.host
             .publish_dirty(MapLoadDirtyKind::BaseMarkTactical, anchor)
             .map_err(AuthoredOverlayFinalizeError::Host)?;
-        let slope_type = self.terrain.cells[anchor_index].slope_type;
+        let slope_type = self.terrain.cells()[anchor_index].slope_type;
         if slope_type > 4 && overlay_id != 0xB2 {
             self.host
                 .finish_slope_survivor(handle)
@@ -737,7 +736,7 @@ impl<'load, 'resources, H: AuthoredOverlayLoadHost>
         self.cells
             .write_identity(anchor.target, i32::from(overlay_id));
         if let NativeOverlayCellTarget::Real(index) = anchor.target {
-            self.terrain.cells[index].bridge_facts.overlay_id = Some(overlay_id);
+            self.terrain.mirror_authored_overlay_identity(index, Some(overlay_id));
         }
     }
 
@@ -768,7 +767,7 @@ impl<'load, 'resources, H: AuthoredOverlayLoadHost>
             mirror_real_overlay_pair(self.terrain, &self.cells, anchor);
             let world_z = match anchor.target {
                 NativeOverlayCellTarget::Real(index) => i32::from(
-                    self.terrain.cells[index].level as i8,
+                    self.terrain.cells()[index].level as i8,
                 )
                 .wrapping_mul(crate::util::lepton::GROUND_LEVEL_HEIGHT_LEPTONS),
                 NativeOverlayCellTarget::Dummy => 0,
@@ -849,7 +848,7 @@ impl<'load, 'resources, H: AuthoredOverlayLoadHost>
         let target = self.cells.target(packed.0, packed.1);
         self.cells.write_state(target, state);
         if let NativeOverlayCellTarget::Real(index) = target {
-            self.terrain.cells[index].bridge_facts.state_byte = state;
+            self.terrain.mirror_authored_overlay_state(index, state);
         }
     }
 

--- a/src/map/resolved_terrain.rs
+++ b/src/map/resolved_terrain.rs
@@ -47,6 +47,9 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
+#[path = "resolved_terrain_mutation.rs"]
+mod mutation;
+
 pub const YR_CELL_LAND_TUNNEL: u8 = 10;
 
 /// Identifies whether map overlays still require the ordinary authored-map
@@ -1345,7 +1348,10 @@ pub fn tile_anim_pixel_offset_to_leptons(x_offset: i32, y_offset: i32) -> (i32, 
 pub struct ResolvedTerrainGrid {
     width: u16,
     height: u16,
-    pub cells: Vec<ResolvedTerrainCell>,
+    #[cfg(test)]
+    pub(crate) cells: Vec<ResolvedTerrainCell>,
+    #[cfg(not(test))]
+    cells: Vec<ResolvedTerrainCell>,
     /// One live identity handle, normally bound to the process owner before
     /// scenario construction. Synthetic constructors own a fresh detached
     /// handle; derived clones share it.
@@ -2469,8 +2475,19 @@ impl ResolvedTerrainGrid {
         }
     }
 
-    /// Mutable access to a cell by map coordinates.
-    pub fn cell_mut(&mut self, rx: u16, ry: u16) -> Option<&mut ResolvedTerrainCell> {
+    /// Immutable cells in the grid's established storage order.
+    pub fn cells(&self) -> &[ResolvedTerrainCell] {
+        &self.cells
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cell_mut(&mut self, rx: u16, ry: u16) -> Option<&mut ResolvedTerrainCell> {
+        let idx = self.index(rx, ry)?;
+        self.cells.get_mut(idx)
+    }
+
+    #[cfg(not(test))]
+    fn cell_mut(&mut self, rx: u16, ry: u16) -> Option<&mut ResolvedTerrainCell> {
         let idx = self.index(rx, ry)?;
         self.cells.get_mut(idx)
     }

--- a/src/map/resolved_terrain_mutation.rs
+++ b/src/map/resolved_terrain_mutation.rs
@@ -1,0 +1,179 @@
+//! Mutation authority for runtime terrain projections and authored overlay mirrors.
+//! Grid storage and its derived land/blocking/zone metadata never escape mutably
+//! in production. Authored identity/data passes remain separate literal writes.
+
+use super::{ResolvedTerrainGrid, overlay_reduced_zone_type, recalc_zone_type, zone_class};
+use crate::map::overlay_types::{OverlayTypeFlags, retained_overlay_land};
+use crate::rules::terrain_rules::{LandType, SpeedCostProfile, TerrainClass};
+
+impl ResolvedTerrainGrid {
+    // Authored loading writes identity and state in separate native passes.
+    // These are literal mirrors, deliberately not runtime Recalc transactions.
+    pub(in crate::map) fn mirror_authored_overlay_identity(
+        &mut self,
+        index: usize,
+        id: Option<u8>,
+    ) {
+        self.cells[index].bridge_facts.overlay_id = id;
+    }
+
+    pub(in crate::map) fn mirror_authored_overlay_state(&mut self, index: usize, state: u8) {
+        self.cells[index].bridge_facts.state_byte = state;
+    }
+
+    pub(in crate::map) fn mirror_authored_overlay_pair(
+        &mut self,
+        index: usize,
+        id: Option<u8>,
+        state: u8,
+    ) {
+        self.mirror_authored_overlay_identity(index, id);
+        self.mirror_authored_overlay_state(index, state);
+    }
+
+    /// Commit the overlay-derived Land, blocking and Zone projection together.
+    /// Literal overlay storage/removal belongs to OverlayGrid. `land_flags` may
+    /// retain the removed Tiberium's Land branch on a slope, as in RecalcAttributes
+    /// (`0x0047D2B0`); `flags` always describes the surviving overlay identity.
+    pub(crate) fn apply_overlay_attributes(
+        &mut self,
+        rx: u16,
+        ry: u16,
+        flags: Option<&OverlayTypeFlags>,
+        land_flags: Option<&OverlayTypeFlags>,
+    ) -> bool {
+        let overlay_zone = overlay_reduced_zone_type(flags);
+        let new_blocks = matches!(
+            overlay_zone,
+            Some(zone_class::WALL) | Some(zone_class::IMPASSABLE)
+        );
+
+        let Some(terrain_cell) = self.cell_mut(rx, ry) else {
+            return false;
+        };
+
+        let old_overlay_zone_type = terrain_cell.overlay_zone_type;
+        let old = (
+            terrain_cell.overlay_blocks,
+            terrain_cell.zone_type,
+            terrain_cell.land_type,
+            terrain_cell.yr_cell_land_type,
+            terrain_cell.terrain_class,
+            terrain_cell.speed_costs,
+            terrain_cell.is_water,
+            terrain_cell.is_cliff_like,
+            terrain_cell.is_rough,
+            terrain_cell.is_road,
+            terrain_cell.ground_walk_blocked,
+            terrain_cell.build_blocked,
+        );
+
+        restore_pristine_land(terrain_cell);
+        // Ground blocking follows whichever land the cell ends up with. With no
+        // overlay land that is the pristine terrain value already cached in
+        // `base_ground_walk_blocked`; with one it is the overlay's `Land=` row.
+        // `CellClass__RecalcAttributes` @ `0x0047D2B0` recomputes LandType from
+        // scratch on every overlay change and keeps no separate blocked bit, so
+        // neither value may outlive the land that produced it.
+        let mut land_ground_blocked = terrain_cell.base_ground_walk_blocked;
+        if let Some(flags) = land_flags {
+            if let Some(land) = retained_overlay_land(flags, terrain_cell.slope_type) {
+                apply_overlay_land(terrain_cell, land, flags.land_speed_costs);
+                // The ramp exemption is a property of the tile, not the land row,
+                // so it survives the override exactly as it does in the pristine
+                // value baked into `base_ground_walk_blocked`.
+                land_ground_blocked =
+                    terrain_cell.canonical_ramp.is_none() && flags.land_ground_blocked;
+            }
+        }
+
+        terrain_cell.overlay_blocks = new_blocks;
+        terrain_cell.overlay_zone_type = overlay_zone;
+        terrain_cell.ground_walk_blocked =
+            land_ground_blocked || terrain_cell.terrain_object_blocks || new_blocks;
+        terrain_cell.build_blocked = terrain_cell.base_build_blocked
+            || terrain_cell.terrain_object_blocks
+            || new_blocks
+            || terrain_cell.has_bridge_deck;
+        terrain_cell.zone_type = recalc_zone_type(
+            terrain_cell.outside_playfield,
+            terrain_cell.overlay_zone_type,
+            terrain_cell.land_type,
+            terrain_cell.speed_costs.wheel,
+            terrain_cell.terrain_object_occupation,
+        );
+
+        let new = (
+            terrain_cell.overlay_blocks,
+            terrain_cell.zone_type,
+            terrain_cell.land_type,
+            terrain_cell.yr_cell_land_type,
+            terrain_cell.terrain_class,
+            terrain_cell.speed_costs,
+            terrain_cell.is_water,
+            terrain_cell.is_cliff_like,
+            terrain_cell.is_rough,
+            terrain_cell.is_road,
+            terrain_cell.ground_walk_blocked,
+            terrain_cell.build_blocked,
+        );
+        old_overlay_zone_type != terrain_cell.overlay_zone_type || old != new
+    }
+
+    /// Commit occupation and its derived blocking/Zone fields at the same seam.
+    /// Preserve the occupation writer's pristine-ground predicate: it differs
+    /// from the overlay writer's effective-Land predicate.
+    pub(crate) fn set_terrain_object_occupation(
+        &mut self,
+        cell: (u16, u16),
+        occupation: Option<u8>,
+    ) {
+        let Some(terrain_cell) = self.cell_mut(cell.0, cell.1) else {
+            return;
+        };
+        let blocked = occupation.is_some_and(|occupation| occupation != 0);
+        terrain_cell.terrain_object_occupation = occupation;
+        terrain_cell.terrain_object_blocks = blocked;
+        terrain_cell.ground_walk_blocked =
+            terrain_cell.base_ground_walk_blocked || terrain_cell.overlay_blocks || blocked;
+        terrain_cell.build_blocked = terrain_cell.base_build_blocked
+            || terrain_cell.overlay_blocks
+            || terrain_cell.has_bridge_deck
+            || blocked;
+        terrain_cell.zone_type = recalc_zone_type(
+            terrain_cell.outside_playfield,
+            terrain_cell.overlay_zone_type,
+            terrain_cell.land_type,
+            terrain_cell.speed_costs.wheel,
+            terrain_cell.terrain_object_occupation,
+        );
+    }
+}
+
+fn restore_pristine_land(cell: &mut crate::map::resolved_terrain::ResolvedTerrainCell) {
+    cell.land_type = cell.base_land_type;
+    cell.yr_cell_land_type = cell.base_yr_cell_land_type;
+    cell.terrain_class = cell.base_terrain_class;
+    cell.speed_costs = cell.base_speed_costs;
+    let base_land = LandType::from_index(cell.base_land_type);
+    cell.is_water = base_land.is_some_and(LandType::is_water);
+    cell.is_cliff_like = base_land.is_some_and(LandType::is_cliff_like)
+        || matches!(cell.base_terrain_class, TerrainClass::Cliff);
+    cell.is_rough = base_land.is_some_and(LandType::is_rough);
+    cell.is_road = base_land.is_some_and(LandType::is_road);
+}
+
+fn apply_overlay_land(
+    cell: &mut crate::map::resolved_terrain::ResolvedTerrainCell,
+    land: LandType,
+    speed_costs: Option<SpeedCostProfile>,
+) {
+    cell.land_type = land.as_index();
+    cell.yr_cell_land_type = land.as_index();
+    cell.terrain_class = land.terrain_class();
+    cell.speed_costs = speed_costs.unwrap_or_default();
+    cell.is_water = land.is_water();
+    cell.is_cliff_like = land.is_cliff_like();
+    cell.is_rough = land.is_rough();
+    cell.is_road = land.is_road();
+}

--- a/src/map/terrain.rs
+++ b/src/map/terrain.rs
@@ -692,7 +692,7 @@ pub fn build_terrain_grid_from_resolved(
     local_bounds: Option<LocalBounds>,
     anchor_variant_table: Option<crate::map::theater::BridgeAnchorVariantTable>,
 ) -> TerrainGrid {
-    let mut cells: Vec<TerrainCell> = Vec::with_capacity(resolved.cells.len());
+    let mut cells: Vec<TerrainCell> = Vec::with_capacity(resolved.cells().len());
     let mut min_x: f32 = f32::MAX;
     let mut min_y: f32 = f32::MAX;
     let mut max_x: f32 = f32::MIN;

--- a/src/render/radar_tracker.rs
+++ b/src/render/radar_tracker.rs
@@ -87,7 +87,7 @@ pub(super) fn radar_entity_owner_color(
         .as_ref()
         .filter(|disguise| disguise.disguised)
         .and_then(|disguise| disguise.disguised_as_house)
-        .unwrap_or(entity.owner);
+        .unwrap_or(entity.owner());
     let owner_str = interner.map_or("", |interner| interner.resolve(color_owner));
     // Building and mobile tracker entries share RenderCellPixel's owner/remap
     // path. Khaki is terrain-only. The existing RGBA ramp is not yet proof of
@@ -111,20 +111,20 @@ pub(super) fn radar_pixel_candidate_eligible(
     let Some(entity) = entities.get(entry.stable_id) else {
         return false;
     };
-    let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
+    let type_str = interner.map_or("", |i| i.resolve(entity.type_ref()));
     let object = rules.and_then(|rules| rules.object(type_str));
 
     if let Some(local_owner) = local_owner {
-        let friendly = entity.owner == local_owner
+        let friendly = entity.owner() == local_owner
             || interner.is_some_and(|interner| {
-                fog.is_friendly_id(local_owner, entity.owner, interner)
+                fog.is_friendly_id(local_owner, entity.owner(), interner)
             });
         if !full_visibility {
             let (rx, ry) = projection
                 .pixel_to_cell(entry.x, entry.y)
                 .unwrap_or((entity.position.rx, entity.position.ry));
             let owner_is_human = radar_owner_is_human_player(
-                entity.owner,
+                entity.owner(),
                 local_owner,
                 houses,
                 game_mode_nonzero,
@@ -143,7 +143,7 @@ pub(super) fn radar_pixel_candidate_eligible(
 
     if object.is_some_and(|object| object.insignificant && !object.radar_visible)
         && !houses
-            .get(&entity.owner)
+            .get(&entity.owner())
             .is_some_and(|house| !house.multiplay_passive)
     {
         return false;

--- a/src/render/radar_visibility.rs
+++ b/src/render/radar_visibility.rs
@@ -307,7 +307,7 @@ pub(super) fn build_radar_object_update(
     playfield_bounds: Option<crate::map::playfield::PlayfieldBounds>,
     resolved_terrain: Option<&crate::map::resolved_terrain::ResolvedTerrainGrid>,
 ) -> RadarObjectUpdate {
-    let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
+    let type_str = interner.map_or("", |i| i.resolve(entity.type_ref()));
     let object = rules.and_then(|rules| rules.object(type_str));
     let (raw_x, raw_y) = radar_raw_coord_leptons(entity);
     let origin = projection.native_surface.map_or_else(
@@ -334,7 +334,7 @@ pub(super) fn build_radar_object_update(
     let foundation = (entity.category == EntityCategory::Structure)
         .then(|| parse_foundation_size(&entity.foundation));
     let owner_is_human_player = local_owner.is_none_or(|local_owner| {
-        radar_owner_is_human_player(entity.owner, local_owner, houses, game_mode_nonzero)
+        radar_owner_is_human_player(entity.owner(), local_owner, houses, game_mode_nonzero)
     });
     let (coord_x, coord_y) = radar_object_get_coords_leptons(entity);
     let current_cell = radar_fog_cell_from_leptons(coord_x, coord_y);
@@ -370,9 +370,9 @@ pub(super) fn build_radar_object_update(
     let allied_with_current_player = full_visibility
         || local_owner.is_none()
         || local_owner.is_some_and(|local_owner| {
-            entity.owner == local_owner
+            entity.owner() == local_owner
                 || interner
-                    .is_some_and(|interner| fog.is_friendly_id(local_owner, entity.owner, interner))
+                    .is_some_and(|interner| fog.is_friendly_id(local_owner, entity.owner(), interner))
         });
     let effective_type_invisible =
         object.is_some_and(|object| object.invisible || object.invisible_in_game);
@@ -421,8 +421,8 @@ pub(super) fn build_radar_object_update(
     };
 
     RadarObjectUpdate {
-        stable_id: entity.stable_id,
-        owner: entity.owner,
+        stable_id: entity.stable_id(),
+        owner: entity.owner(),
         origin,
         event_source_cell,
         enemy_sensed_prefilter,
@@ -432,7 +432,7 @@ pub(super) fn build_radar_object_update(
         visibility,
         // AddObjectToTracker @ 0x00655560 compares directly to g_PlayerPtr,
         // narrower than IsHumanPlayer's single-player shroud exception.
-        local_front: local_owner == Some(entity.owner),
+        local_front: local_owner == Some(entity.owner()),
     }
 }
 

--- a/src/render/sprite_atlas.rs
+++ b/src/render/sprite_atlas.rs
@@ -333,8 +333,8 @@ pub fn collect_needed_base_keys(
         if entity.is_voxel {
             continue;
         }
-        let owner_str = interner.map_or("", |i| i.resolve(entity.owner));
-        let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
+        let owner_str = interner.map_or("", |i| i.resolve(entity.owner()));
+        let type_str = interner.map_or("", |i| i.resolve(entity.type_ref()));
         let color_idx: HouseColorIndex = house_colors
             .get(owner_str)
             .copied()
@@ -512,8 +512,8 @@ pub fn build_sprite_atlas(
         if entity.is_voxel {
             continue;
         }
-        let owner_str = interner.map_or("", |i| i.resolve(entity.owner));
-        let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
+        let owner_str = interner.map_or("", |i| i.resolve(entity.owner()));
+        let type_str = interner.map_or("", |i| i.resolve(entity.type_ref()));
         let color_idx: HouseColorIndex = house_colors
             .get(owner_str)
             .copied()
@@ -1170,13 +1170,13 @@ fn compute_building_bounds(
     let mut building_types: HashSet<String> = entities
         .values()
         .filter(|e| e.category == EntityCategory::Structure && !e.is_voxel)
-        .map(|e| interner.map_or("".to_string(), |i| i.resolve(e.type_ref).to_string()))
+        .map(|e| interner.map_or("".to_string(), |i| i.resolve(e.type_ref()).to_string()))
         .collect();
     if let Some(r) = rules {
         let deploy_targets: Vec<String> = entities
             .values()
             .filter_map(|e| {
-                let t = interner.map_or("", |i| i.resolve(e.type_ref));
+                let t = interner.map_or("", |i| i.resolve(e.type_ref()));
                 r.object(t).and_then(|o| o.deploys_into.clone())
             })
             .collect();

--- a/src/render/unit_atlas.rs
+++ b/src/render/unit_atlas.rs
@@ -279,7 +279,7 @@ pub fn collect_needed_unit_keys(
         if !entity.is_voxel {
             continue;
         }
-        let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
+        let type_str = interner.map_or("", |i| i.resolve(entity.type_ref()));
         let is_ground_vehicle: bool = entity.category != EntityCategory::Aircraft;
         for variant in unit_atlas_variants(type_str, rules) {
             seed_unit_variant_keys(
@@ -301,7 +301,7 @@ pub fn collect_needed_unit_keys(
             if entity.is_voxel || entity.category != EntityCategory::Structure {
                 continue;
             }
-            let btype_str = interner.map_or("", |i| i.resolve(entity.type_ref));
+            let btype_str = interner.map_or("", |i| i.resolve(entity.type_ref()));
             let obj = match rules.and_then(|r| r.object(btype_str)) {
                 Some(o) => o,
                 None => continue,
@@ -365,7 +365,7 @@ pub fn build_unit_atlas(
         if !entity.is_voxel {
             continue;
         }
-        let type_str = interner.map_or("", |i| i.resolve(entity.type_ref));
+        let type_str = interner.map_or("", |i| i.resolve(entity.type_ref()));
         let is_ground_vehicle: bool = entity.category != EntityCategory::Aircraft;
         for variant in unit_atlas_variants(type_str, rules) {
             seed_unit_variant_keys(
@@ -387,7 +387,7 @@ pub fn build_unit_atlas(
             if entity.is_voxel || entity.category != EntityCategory::Structure {
                 continue;
             }
-            let btype_str = interner.map_or("", |i| i.resolve(entity.type_ref));
+            let btype_str = interner.map_or("", |i| i.resolve(entity.type_ref()));
             let obj = match rules.and_then(|r| r.object(btype_str)) {
                 Some(o) => o,
                 None => continue,

--- a/src/sim/ai.rs
+++ b/src/sim/ai.rs
@@ -168,7 +168,7 @@ fn try_deploy_mcv(
     for entity in sim.substrate.entities.values() {
         if !sim
             .interner
-            .resolve(entity.owner)
+            .resolve(entity.owner())
             .eq_ignore_ascii_case(owner)
         {
             continue;
@@ -177,7 +177,7 @@ fn try_deploy_mcv(
             continue;
         }
         let is_deployable: bool = sim
-            .object_type(entity.type_ref, rules)
+            .object_type(entity.type_ref(), rules)
             .is_some_and(|obj| obj.deploys_into.is_some());
         if is_deployable {
             let owner_id = sim.interner.get(owner)?;
@@ -185,7 +185,7 @@ fn try_deploy_mcv(
                 owner_id,
                 execute_tick,
                 Command::DeployMcv {
-                    entity_id: entity.stable_id,
+                    entity_id: entity.stable_id(),
                 },
             ));
         }
@@ -210,8 +210,8 @@ where
         !e.dying
             && !e.lifecycle.in_limbo
             && e.category == EntityCategory::Structure
-            && sim.interner.resolve(e.owner).eq_ignore_ascii_case(owner)
-            && matches(sim.interner.resolve(e.type_ref))
+            && sim.interner.resolve(e.owner()).eq_ignore_ascii_case(owner)
+            && matches(sim.interner.resolve(e.type_ref()))
     })
 }
 
@@ -489,7 +489,7 @@ fn send_attack_wave(
     for entity in sim.substrate.entities.values() {
         if !sim
             .interner
-            .resolve(entity.owner)
+            .resolve(entity.owner())
             .eq_ignore_ascii_case(owner)
         {
             continue;
@@ -503,12 +503,12 @@ fn send_attack_wave(
         ) {
             continue;
         }
-        if production::is_harvester_type(rules, sim.interner.resolve(entity.type_ref)) {
+        if production::is_harvester_type(rules, sim.interner.resolve(entity.type_ref())) {
             continue;
         }
         // Check if unit has no movement target (idle).
         if entity.movement_target.is_none() {
-            idle_units.push((entity.stable_id, entity.position.rx, entity.position.ry));
+            idle_units.push((entity.stable_id(), entity.position.rx, entity.position.ry));
         }
     }
     idle_units.sort_by_key(|(sid, _, _)| *sid);
@@ -555,7 +555,7 @@ fn find_base_center(sim: &Simulation, owner: &str) -> Option<(u16, u16)> {
             && entity.category == EntityCategory::Structure
             && sim
                 .interner
-                .resolve(entity.owner)
+                .resolve(entity.owner())
                 .eq_ignore_ascii_case(owner)
         {
             sum_x += i64::from(entity.position.rx);
@@ -584,7 +584,7 @@ fn find_nearest_enemy_structure(sim: &Simulation, owner: &str) -> Option<(u16, u
         if entity.category != EntityCategory::Structure {
             continue;
         }
-        let e_owner = sim.interner.resolve(entity.owner);
+        let e_owner = sim.interner.resolve(entity.owner());
         if e_owner.eq_ignore_ascii_case(owner) {
             continue;
         }
@@ -778,8 +778,8 @@ fn count_refineries(sim: &Simulation, owner: &str, rules: &RuleSet) -> usize {
         .filter(|e| {
             !e.dying
                 && e.category == EntityCategory::Structure
-                && sim.interner.resolve(e.owner).eq_ignore_ascii_case(owner)
-                && rules.is_refinery_type(sim.interner.resolve(e.type_ref))
+                && sim.interner.resolve(e.owner()).eq_ignore_ascii_case(owner)
+                && rules.is_refinery_type(sim.interner.resolve(e.type_ref()))
         })
         .count()
 }

--- a/src/sim/aircraft/attack_mission.rs
+++ b/src/sim/aircraft/attack_mission.rs
@@ -98,7 +98,7 @@ pub fn tick_attack_state(
     let entity_ry = entity.position.ry;
     let entity_facing = entity.facing;
     let entity_veterancy = entity.veterancy;
-    let type_ref = entity.type_ref;
+    let type_ref = entity.type_ref();
 
     // Look up type info.
     let type_str = interner.resolve(type_ref);

--- a/src/sim/aircraft/drop_payload.rs
+++ b/src/sim/aircraft/drop_payload.rs
@@ -153,7 +153,7 @@ pub fn try_drop(
         prior_movement_layer,
     ) = match sim.substrate.entities.get(passenger_id) {
         Some(passenger) => {
-            let object_type = sim.object_type(passenger.type_ref, rules);
+            let object_type = sim.object_type(passenger.type_ref(), rules);
             (
                 passenger.category,
                 passenger.lifecycle.object_alive && passenger.lifecycle.in_limbo,

--- a/src/sim/aircraft/mod.rs
+++ b/src/sim/aircraft/mod.rs
@@ -180,7 +180,7 @@ pub fn tick_aircraft_missions(
                 return None;
             }
             Some(MissionSnap {
-                id: e.stable_id,
+                id: e.stable_id(),
                 mission: mission.clone(),
                 release_tail: e.aircraft_release_tail,
             })
@@ -241,7 +241,7 @@ pub fn tick_aircraft_missions(
                     Some(e) => e,
                     None => continue,
                 };
-                let type_str = sim.interner.resolve(entity.type_ref);
+                let type_str = sim.interner.resolve(entity.type_ref());
                 let obj = rules.object(type_str);
                 // Weapon-array slot 0 (`TechnoTypeClass+0x898`) is the armed
                 // test here rather than `combat_weapon::is_armed`
@@ -262,8 +262,8 @@ pub fn tick_aircraft_missions(
                 let nearest = find_nearest_airfield_for(
                     sim,
                     rules,
-                    entity.owner,
-                    entity.type_ref,
+                    entity.owner(),
+                    entity.type_ref(),
                     (entity.position.rx, entity.position.ry),
                 );
 
@@ -351,7 +351,7 @@ pub fn tick_aircraft_missions(
                 } else if *sub_state == 10 {
                     // Restore cruise altitude on RTB.
                     if let Some(entity) = sim.substrate.entities.get(snap.id) {
-                        let type_str = sim.interner.resolve(entity.type_ref);
+                        let type_str = sim.interner.resolve(entity.type_ref());
                         if let Some(obj) = rules.object(type_str) {
                             let cruise =
                                 crate::sim::movement::locomotor::LocomotorState::from_object_type(
@@ -435,15 +435,15 @@ pub fn tick_aircraft_missions(
                     let nearest = find_nearest_airfield_for(
                         sim,
                         rules,
-                        entity.owner,
-                        entity.type_ref,
+                        entity.owner(),
+                        entity.type_ref(),
                         (entity.position.rx, entity.position.ry),
                     );
                     if let Some((af_id, af_rx, af_ry)) = nearest {
                         m.new_mission = AircraftMission::ReturnToBase { airfield_id: af_id };
                         m.move_to = Some((af_rx, af_ry));
                     } else {
-                        let type_str = sim.interner.resolve(entity.type_ref);
+                        let type_str = sim.interner.resolve(entity.type_ref());
                         let airport_bound =
                             rules.object(type_str).map_or(false, |o| o.airport_bound);
                         if airport_bound {
@@ -469,7 +469,7 @@ pub fn tick_aircraft_missions(
                     continue;
                 }
                 let af = sim.substrate.entities.get(*airfield_id).unwrap();
-                let type_str = sim.interner.resolve(af.type_ref);
+                let type_str = sim.interner.resolve(af.type_ref());
                 let (fw, fh) = rules
                     .object(type_str)
                     .map(|o| foundation_dimensions(&o.foundation))
@@ -518,7 +518,7 @@ pub fn tick_aircraft_missions(
                             .substrate
                             .entities
                             .get(*airfield_id)
-                            .map_or(entity.type_ref, |af| af.type_ref);
+                            .map_or(entity.type_ref(), |af| af.type_ref());
                         let type_str = sim.interner.resolve(af_type_ref);
                         let max_slots = rules
                             .object(type_str)
@@ -545,7 +545,7 @@ pub fn tick_aircraft_missions(
                             // multi-pad airfields visibly spread occupants.
                             if let Some((px, py)) =
                                 sim.substrate.entities.get(*airfield_id).and_then(|af| {
-                                    let obj = sim.object_type(af.type_ref, rules)?;
+                                    let obj = sim.object_type(af.type_ref(), rules)?;
                                     let foundation = crate::sim::production::foundation_dimensions(
                                         &obj.foundation,
                                     );
@@ -793,7 +793,7 @@ pub fn tick_aircraft_missions(
             .entities
             .get(id)
             .and_then(|e| {
-                let obj = sim.object_type(e.type_ref, rules)?;
+                let obj = sim.object_type(e.type_ref(), rules)?;
                 Some(crate::util::fixed_math::ra2_speed_to_leptons_per_second(
                     obj.speed.max(1),
                 ))
@@ -917,10 +917,10 @@ fn find_nearest_airfield_for(
         if entity.health.current == 0 || entity.dying || entity.lifecycle.in_limbo {
             continue;
         }
-        if entity.owner != owner {
+        if entity.owner() != owner {
             continue;
         }
-        let entity_type_str = sim.interner.resolve(entity.type_ref);
+        let entity_type_str = sim.interner.resolve(entity.type_ref());
         let Some(obj) = rules.object(entity_type_str) else {
             continue;
         };
@@ -941,7 +941,7 @@ fn find_nearest_airfield_for(
         let dist = dx * dx + dy * dy;
 
         if best.is_none() || dist < best.unwrap().3 {
-            best = Some((entity.stable_id, dock_rx, dock_ry, dist));
+            best = Some((entity.stable_id(), dock_rx, dock_ry, dist));
         }
     }
 

--- a/src/sim/aircraft/paradrop_mission.rs
+++ b/src/sim/aircraft/paradrop_mission.rs
@@ -79,7 +79,7 @@ pub fn tick_approach(
     // Mission_Open only queues Mission_Rescue here; Drop_Payload owns the
     // successful-drop sound/reveal side effects.
     if dist_leptons <= radius {
-        let exit = compute_exit_cell(sim, aircraft.owner, target_rx, target_ry, path_grid);
+        let exit = compute_exit_cell(sim, aircraft.owner(), target_rx, target_ry, path_grid);
         return ApproachOutcome {
             new_mission: AircraftMission::ParaDropOverfly {
                 exit_rx: exit.0,

--- a/src/sim/anim_class.rs
+++ b/src/sim/anim_class.rs
@@ -1549,7 +1549,7 @@ impl Simulation {
                 (
                     entity.health.current,
                     entity.health.max,
-                    entity.type_ref,
+                    entity.type_ref(),
                     entity.position.clone(),
                     entity.damage_fire_state_active,
                     entity.category,

--- a/src/sim/animation.rs
+++ b/src/sim/animation.rs
@@ -363,6 +363,7 @@ fn tick_animations_impl(
         if entity.dying && !tick_dying {
             continue;
         }
+        let type_ref = entity.type_ref();
         let Some(anim) = entity.animation.as_mut() else {
             // Dying entity with no animation → ready for despawn.
             if entity.dying {
@@ -378,7 +379,7 @@ fn tick_animations_impl(
                 continue;
             }
             let Some(seq_set) =
-                sequence_set_for_type(sequences, rules, interner.resolve(entity.type_ref))
+                sequence_set_for_type(sequences, rules, interner.resolve(type_ref))
             else {
                 dying_finished.push(id);
                 continue;
@@ -403,7 +404,7 @@ fn tick_animations_impl(
         let preserving_fire_action = sequence_is_fire_action(anim.sequence) && !has_fire_action;
 
         // Look up this type's sequence definitions for transition checks.
-        let seq_set = sequence_set_for_type(sequences, rules, interner.resolve(entity.type_ref));
+        let seq_set = sequence_set_for_type(sequences, rules, interner.resolve(type_ref));
 
         // Deploy state takes priority over the standard Stand/Walk/Attack cascade.
         // The visual reflects the sim phase; DeployedFire is the auto-transition

--- a/src/sim/combat/base_defense_response.rs
+++ b/src/sim/combat/base_defense_response.rs
@@ -302,18 +302,18 @@ pub(crate) fn respond_to_base_attack(
     };
     let Some(victim_object) = context
         .rules
-        .object(context.interner.resolve(victim.type_ref))
+        .object(context.interner.resolve(victim.type_ref()))
     else {
         return;
     };
     let Some(attacker_object) = context
         .rules
-        .object(context.interner.resolve(attacker.type_ref))
+        .object(context.interner.resolve(attacker.type_ref()))
     else {
         return;
     };
-    let victim_owner = victim.owner;
-    let attacker_owner = attacker.owner;
+    let victim_owner = victim.owner();
+    let attacker_owner = attacker.owner();
     let budget = attacker_object
         .cost
         .wrapping_mul(context.rules.general.computer_base_defense_response);
@@ -394,7 +394,7 @@ pub(crate) fn respond_to_base_attack(
             }
             let Some(candidate_object) = context
                 .rules
-                .object(context.interner.resolve(candidate.type_ref))
+                .object(context.interner.resolve(candidate.type_ref()))
             else {
                 continue;
             };
@@ -493,7 +493,7 @@ pub(crate) fn respond_to_base_attack(
         };
         let Some(responder_object) = context
             .rules
-            .object(context.interner.resolve(responder_entity.type_ref))
+            .object(context.interner.resolve(responder_entity.type_ref()))
         else {
             continue;
         };

--- a/src/sim/combat/base_defense_response/admission.rs
+++ b/src/sim/combat/base_defense_response/admission.rs
@@ -157,7 +157,7 @@ pub(super) fn current_target_disposition(
         Some(TargetKind::Entity(id))
             if entities.get(id).is_some_and(|target| {
                 rules
-                    .object(interner.resolve(target.type_ref))
+                    .object(interner.resolve(target.type_ref()))
                     .is_some_and(|object| is_armed(target, object))
             }) =>
         {
@@ -258,7 +258,7 @@ pub(crate) fn responder_peek_fire_error(
         || candidate
             .passenger_role
             .inside_transport_id()
-            .is_some_and(|transport_id| transport_id == target.stable_id)
+            .is_some_and(|transport_id| transport_id == target.stable_id())
     {
         return ResponderPeekFireError::Illegal;
     }
@@ -317,10 +317,10 @@ pub(super) fn candidate_admitted(
     context: &BaseDefenseResponseContext<'_>,
 ) -> bool {
     if !candidate.is_object_alive()
-        || candidate.owner != victim_owner
+        || candidate.owner() != victim_owner
         || context
             .teams
-            .team_for_member(candidate.stable_id)
+            .team_for_member(candidate.stable_id())
             .is_some_and(|(_, is_base_defense)| !is_base_defense)
         || !candidate.base_defense_response.recruitable_a
         || !candidate.base_defense_response.recruitable_b
@@ -347,7 +347,7 @@ pub(super) fn candidate_admitted(
                             .entities
                             .get(attacker_id)
                             .expect("entry retained attacker")
-                            .type_ref,
+                            .type_ref(),
                     ),
                 )
                 .expect("entry retained attacker type"),

--- a/src/sim/combat/combat_aoe.rs
+++ b/src/sim/combat/combat_aoe.rs
@@ -428,13 +428,13 @@ pub(crate) fn apply_aoe_damage_with_terrain_and_scenario<O: Into<AoEDamageOrigin
     }
     let mut origin = origin.into();
     if origin.source_house.is_none() && origin.source_id != super::RAD_NO_ATTACKER {
-        origin.source_house = entities.get(origin.source_id).map(|source| source.owner);
+        origin.source_house = entities.get(origin.source_id).map(|source| source.owner());
     }
     let ground_source_admitted = handles
         .is_some_and(|handles| handles.is_crush(origin.warhead_ref))
         || entities
             .get(origin.source_id)
-            .and_then(|source| rules.object(interner.resolve(source.type_ref)))
+            .and_then(|source| rules.object(interner.resolve(source.type_ref())))
             .is_some_and(|source_type| source_type.damage_self);
 
     let cell_spread: SimFixed = warhead.cell_spread;
@@ -663,7 +663,7 @@ pub(crate) fn apply_aoe_damage_with_terrain_and_scenario<O: Into<AoEDamageOrigin
         push_entity_aoe_damage(
             &mut result,
             entities,
-            entity.stable_id,
+            entity.stable_id(),
             impact_rx,
             impact_ry,
             entity.position.rx,
@@ -828,7 +828,7 @@ fn airborne_ids_in_spatial_order(
         buckets
             .entry(entity.air_spatial_bucket.expect("filtered above"))
             .or_default()
-            .push((entity.air_spatial_enter_order, entity.stable_id));
+            .push((entity.air_spatial_enter_order, entity.stable_id()));
     }
     for entries in buckets.values_mut() {
         entries.sort_unstable();
@@ -951,7 +951,7 @@ fn push_airborne_aoe_damage(
     }
 
     result.push_entity(EntityDamageEvent::area(
-        entity.stable_id,
+        entity.stable_id(),
         base_damage,
         distance_leptons,
         source_id,
@@ -1056,7 +1056,7 @@ fn push_entity_aoe_damage(
     }
 
     result.push_entity(EntityDamageEvent::area(
-        entity.stable_id,
+        entity.stable_id(),
         base_damage,
         distance_leptons,
         source_id,

--- a/src/sim/combat/combat_fire_gate.rs
+++ b/src/sim/combat/combat_fire_gate.rs
@@ -40,7 +40,7 @@ pub fn collect_fire_blocked_entities(
         if let Some(ref state) = entity.teleport_state {
             match state.phase {
                 TeleportPhase::Relocate => {
-                    blocked.insert(entity.stable_id);
+                    blocked.insert(entity.stable_id());
                     continue;
                 }
                 TeleportPhase::ChronoDelay => {}
@@ -49,14 +49,14 @@ pub fn collect_fire_blocked_entities(
 
         // Rockets are projectiles, not weapon-bearing units — never fire.
         if entity.rocket_state.is_some() {
-            blocked.insert(entity.stable_id);
+            blocked.insert(entity.stable_id());
             continue;
         }
 
         // Aircraft with 0 ammo cannot fire — must reload at an airfield first.
         if let Some(ref ammo) = entity.aircraft_ammo {
             if ammo.current <= 0 {
-                blocked.insert(entity.stable_id);
+                blocked.insert(entity.stable_id());
                 continue;
             }
         }
@@ -66,14 +66,14 @@ pub fn collect_fire_blocked_entities(
         // Docked-idle aircraft are parked on helipad — don't fire.
         if let Some(ref mission) = entity.aircraft_mission {
             if mission.is_attacking() || mission.is_docked_idle() {
-                blocked.insert(entity.stable_id);
+                blocked.insert(entity.stable_id());
                 continue;
             }
         }
 
         // Buildings still deploying cannot fire.
         if entity.building_up.is_some() {
-            blocked.insert(entity.stable_id);
+            blocked.insert(entity.stable_id());
             continue;
         }
 
@@ -81,7 +81,7 @@ pub fn collect_fire_blocked_entities(
         if entity.category == EntityCategory::Structure {
             if let Some(rules) = rules {
                 if !power_system::is_building_powered(power_states, rules, entity, interner) {
-                    blocked.insert(entity.stable_id);
+                    blocked.insert(entity.stable_id());
                     continue;
                 }
             }
@@ -92,11 +92,11 @@ pub fn collect_fire_blocked_entities(
         // garrisonable building is defenseless.
         if entity.category == EntityCategory::Structure {
             if let Some(rules) = rules {
-                if let Some(obj) = rules.object(interner.resolve(entity.type_ref)) {
+                if let Some(obj) = rules.object(interner.resolve(entity.type_ref())) {
                     if obj.can_be_occupied
                         && entity.passenger_role.cargo().map_or(true, |c| c.is_empty())
                     {
-                        blocked.insert(entity.stable_id);
+                        blocked.insert(entity.stable_id());
                     }
                 }
             }

--- a/src/sim/combat/combat_targeting.rs
+++ b/src/sim/combat/combat_targeting.rs
@@ -162,7 +162,7 @@ pub(crate) fn acquire_best_target_for_entity(
             return None;
         }
     }
-    let obj = rules.object(interner.resolve(entity.type_ref))?;
+    let obj = rules.object(interner.resolve(entity.type_ref()))?;
     // Native `TechnoClass::Greatest_Threat @ 0x006F8DF0` has no weapon
     // early-out of its own; the armed requirement sits upstream in
     // `TechnoClass::CanAcquireTarget @ 0x007091D0`, whose last term is
@@ -176,8 +176,8 @@ pub(crate) fn acquire_best_target_for_entity(
     }
 
     let snapshot = AttackerSnapshot {
-        stable_id: entity.stable_id,
-        owner: entity.owner,
+        stable_id: entity.stable_id(),
+        owner: entity.owner(),
         category: entity.category,
         target: super::TargetKind::Entity(0), // Dummy — no current target when acquiring fresh
         pos_rx: entity.position.rx,
@@ -186,7 +186,7 @@ pub(crate) fn acquire_best_target_for_entity(
         pos_exact_z_leptons: entity.position.exact_z_leptons,
         sub_x: entity.position.sub_x,
         sub_y: entity.position.sub_y,
-        type_id: entity.type_ref,
+        type_id: entity.type_ref(),
         facing: entity.facing,
         veterancy: entity.veterancy,
         cooldown_ticks: 0,
@@ -282,18 +282,18 @@ fn can_retaliate(
     terrain: Option<&ResolvedTerrainGrid>,
     alliances: Option<&HouseAllianceMap>,
 ) -> bool {
-    let obj = match rules.object(interner.resolve(entity.type_ref)) {
+    let obj = match rules.object(interner.resolve(entity.type_ref())) {
         Some(o) => o,
         None => return false,
     };
-    let Some(attacker_obj) = rules.object(interner.resolve(attacker.type_ref)) else {
+    let Some(attacker_obj) = rules.object(interner.resolve(attacker.type_ref())) else {
         return false;
     };
     let target_facts = techno_target_facts(
         attacker,
         attacker_obj,
         terrain,
-        is_ally_by_object(alliances, interner, entity.owner, attacker.owner),
+        is_ally_by_object(alliances, interner, entity.owner(), attacker.owner()),
     );
     let selected =
         match select_weapon_for_target(rules, obj, &attacker_facts(entity, obj), &target_facts) {
@@ -331,7 +331,7 @@ pub(crate) fn calculate_ai_threat_score(
     alliances: Option<&HouseAllianceMap>,
 ) -> Option<X87Value> {
     let scorer = entities.get(scorer_id)?;
-    let scorer_type = rules.object(interner.resolve(scorer.type_ref))?;
+    let scorer_type = rules.object(interner.resolve(scorer.type_ref()))?;
     let coefficients = super::greatest_threat::ThreatCoefficients::resolve(
         rules,
         scorer_type,
@@ -398,7 +398,7 @@ pub(crate) fn should_retaliate_from_damage(
         return false;
     }
 
-    let Some(victim_type) = rules.object(interner.resolve(victim.type_ref)) else {
+    let Some(victim_type) = rules.object(interner.resolve(victim.type_ref())) else {
         return false;
     };
     if !victim_type.can_retaliate
@@ -426,8 +426,8 @@ pub(crate) fn should_retaliate_from_damage(
         return false;
     }
 
-    let victim_owner = interner.resolve(victim.owner);
-    let attacker_owner = interner.resolve(attacker.owner);
+    let victim_owner = interner.resolve(victim.owner());
+    let attacker_owner = interner.resolve(attacker.owner());
     if is_allied_with(alliances, victim_owner, attacker_owner)
         || is_allied_with(alliances, attacker_owner, victim_owner)
     {
@@ -438,19 +438,19 @@ pub(crate) fn should_retaliate_from_damage(
     // coordinate and keeps its current target only when that score is strictly
     // greater. Equal or lower permits the normal retaliation path.
     let is_human = houses
-        .get(&victim.owner)
+        .get(&victim.owner())
         .is_some_and(|house| house.is_human);
     if is_human && victim.attack_target.is_some() {
         return false;
     }
-    let Some(attacker_type) = rules.object(interner.resolve(attacker.type_ref)) else {
+    let Some(attacker_type) = rules.object(interner.resolve(attacker.type_ref())) else {
         return false;
     };
     let attacker_as_target = techno_target_facts(
         attacker,
         attacker_type,
         terrain,
-        is_ally_by_object(Some(alliances), interner, victim.owner, attacker.owner),
+        is_ally_by_object(Some(alliances), interner, victim.owner(), attacker.owner()),
     );
     let Some(selected) = select_weapon_for_target(
         rules,

--- a/src/sim/combat/combat_weapon.rs
+++ b/src/sim/combat/combat_weapon.rs
@@ -1052,9 +1052,9 @@ pub(crate) fn select_weapon_against<'a>(
     let target_facts = match *target {
         TargetKind::Entity(target_id) => {
             let target_entity = entities.get(target_id)?;
-            let target_obj = rules.object(interner.resolve(target_entity.type_ref))?;
+            let target_obj = rules.object(interner.resolve(target_entity.type_ref()))?;
             let is_ally =
-                is_ally_by_object(alliances, interner, attacker_owner, target_entity.owner);
+                is_ally_by_object(alliances, interner, attacker_owner, target_entity.owner());
             techno_target_facts(target_entity, target_obj, terrain, is_ally)
         }
         TargetKind::Cell(rx, ry) => cell_target_facts(rx, ry, terrain),

--- a/src/sim/combat/greatest_threat.rs
+++ b/src/sim/combat/greatest_threat.rs
@@ -344,8 +344,8 @@ pub(crate) fn calculate_threat_score(
 ) -> Option<X87Value> {
     let scorer = entities.get(scorer_id)?;
     let candidate = entities.get(candidate_id)?;
-    let scorer_type = rules.object(interner.resolve(scorer.type_ref))?;
-    let candidate_type = rules.object(interner.resolve(candidate.type_ref))?;
+    let scorer_type = rules.object(interner.resolve(scorer.type_ref()))?;
+    let candidate_type = rules.object(interner.resolve(candidate.type_ref()))?;
     let coeff_a = load_threat_double(coefficients.my_effectiveness)?;
     let coeff_b = load_threat_double(coefficients.target_effectiveness)?;
     let coeff_c = load_threat_double(coefficients.target_special_threat)?;
@@ -360,7 +360,7 @@ pub(crate) fn calculate_threat_score(
         scorer,
         scorer_type,
         terrain,
-        is_ally_by_object(alliances, interner, candidate.owner, scorer.owner),
+        is_ally_by_object(alliances, interner, candidate.owner(), scorer.owner()),
     );
     if let Some(selected) = select_weapon_for_target(
         rules,
@@ -374,7 +374,7 @@ pub(crate) fn calculate_threat_score(
         if candidate
             .attack_target
             .as_ref()
-            .is_some_and(|target| target.target == super::TargetKind::Entity(scorer.stable_id))
+            .is_some_and(|target| target.target == super::TargetKind::Entity(scorer.stable_id()))
         {
             term = X87Chop53::neg(term);
         }
@@ -396,7 +396,7 @@ pub(crate) fn calculate_threat_score(
         candidate,
         candidate_type,
         terrain,
-        is_ally_by_object(alliances, interner, scorer.owner, candidate.owner),
+        is_ally_by_object(alliances, interner, scorer.owner(), candidate.owner()),
     );
     let selected_scorer_weapon = select_weapon_for_target(
         rules,
@@ -620,12 +620,12 @@ impl ScanIndex {
                 x + slack >= min.0 && x - slack <= max.0 && y + slack >= min.1 && y - slack <= max.1
             })
             .collect();
-        ordered.sort_by_key(|entity| (entity.occupancy_enter_order, entity.stable_id));
+        ordered.sort_by_key(|entity| (entity.occupancy_enter_order, entity.stable_id()));
 
         let mut cells = OccupancyGrid::new();
         let mut airborne: BTreeMap<(u16, u16), Vec<u64>> = BTreeMap::new();
         for entity in ordered {
-            let sid = entity.stable_id;
+            let sid = entity.stable_id();
             let Some(layer) = cell_list_layer_for_entity(entity) else {
                 airborne
                     .entry((entity.position.rx, entity.position.ry))
@@ -723,13 +723,13 @@ impl ScanContext<'_> {
 
     /// `HouseClass::Is_Ally_ByObject` — allied houses and the owner itself.
     fn is_ally(&self, candidate: &GameEntity) -> bool {
-        if candidate.owner == self.attacker.owner {
+        if candidate.owner() == self.attacker.owner {
             return true;
         }
         self.fog.is_some_and(|fog| {
             fog.is_friendly(
                 self.interner.resolve(self.attacker.owner),
-                self.interner.resolve(candidate.owner),
+                self.interner.resolve(candidate.owner()),
             )
         })
     }
@@ -1103,7 +1103,7 @@ fn global_list_scan(ctx: &ScanContext<'_>) -> Option<u64> {
         };
         if score > best_score {
             best_score = score;
-            best = Some(candidate.stable_id);
+            best = Some(candidate.stable_id());
         }
     }
     best
@@ -1154,7 +1154,7 @@ fn evaluate_candidate(ctx: &ScanContext<'_>, candidate: &GameEntity) -> Option<i
     // its armor is at or below the `0.02f` floor. `select_weapon_for_target`
     // is the `SelectWeaponAgainst @ 0x006F3330` ladder and already carries the
     // 0% fallback, so a `None` here is native's `FIRE_ILLEGAL`.
-    let candidate_obj = ctx.rules.object(ctx.interner.resolve(candidate.type_ref))?;
+    let candidate_obj = ctx.rules.object(ctx.interner.resolve(candidate.type_ref()))?;
     let scanner_facts = ctx
         .entities
         .get(ctx.attacker.stable_id)
@@ -1168,7 +1168,7 @@ fn evaluate_candidate(ctx: &ScanContext<'_>, candidate: &GameEntity) -> Option<i
             ctx.alliances(),
             ctx.interner,
             ctx.attacker.owner,
-            candidate.owner,
+            candidate.owner(),
         ),
     );
     let selected = select_weapon_for_target(
@@ -1203,7 +1203,7 @@ fn evaluate_candidate(ctx: &ScanContext<'_>, candidate: &GameEntity) -> Option<i
                 candidate.position.ry,
             )
         }),
-        candidate.owner == ctx.attacker.owner,
+        candidate.owner() == ctx.attacker.owner,
     ) {
         return None;
     }
@@ -1216,7 +1216,7 @@ fn evaluate_candidate(ctx: &ScanContext<'_>, candidate: &GameEntity) -> Option<i
     // G10/G11 — the ally arm and the self test. The cell walk already stopped
     // on the first hostile, but the airborne pre-pass and the retarget callers
     // arrive here directly.
-    if candidate.stable_id == ctx.attacker.stable_id || ctx.is_ally(candidate) {
+    if candidate.stable_id() == ctx.attacker.stable_id || ctx.is_ally(candidate) {
         return None;
     }
     if candidate.passenger_role.is_inside_transport() {
@@ -1298,7 +1298,7 @@ fn evaluate_candidate(ctx: &ScanContext<'_>, candidate: &GameEntity) -> Option<i
         ScanRange::NoCutoff => true,
         ScanRange::CanFireAt => match (ctx.terrain, ctx.entities.get(ctx.attacker.stable_id)) {
             (Some(terrain), Some(attacker_entity)) => {
-                let candidate_target = super::TargetKind::Entity(candidate.stable_id);
+                let candidate_target = super::TargetKind::Entity(candidate.stable_id());
                 let src = super::in_range::fire_source_coords(
                     attacker_entity,
                     &candidate_target,
@@ -1478,7 +1478,7 @@ fn evaluate_candidate(ctx: &ScanContext<'_>, candidate: &GameEntity) -> Option<i
     let score = calculate_threat_score(
         ctx.entities,
         ctx.attacker.stable_id,
-        candidate.stable_id,
+        candidate.stable_id(),
         ctx.rules,
         ctx.interner,
         ctx.terrain,

--- a/src/sim/combat/in_range.rs
+++ b/src/sim/combat/in_range.rs
@@ -182,7 +182,7 @@ pub(crate) fn compute_effective_max_range_leptons(
         if let Some(target_entity) = entities.get(target_id) {
             // AirRange bonus when target is high-flying.
             if is_high_flying(target_entity) {
-                if let Some(attacker_obj) = rules.object(interner.resolve(attacker.type_ref)) {
+                if let Some(attacker_obj) = rules.object(interner.resolve(attacker.type_ref())) {
                     if let Some(air_bonus) = attacker_obj.air_range_bonus {
                         range_lep += cells_fixed_to_leptons(air_bonus);
                     }
@@ -190,7 +190,7 @@ pub(crate) fn compute_effective_max_range_leptons(
             }
             // Foundation bonus when target is a building: (FoundationW + FoundationH) * 64 lep.
             if target_entity.category == EntityCategory::Structure {
-                if let Some(target_obj) = rules.object(interner.resolve(target_entity.type_ref)) {
+                if let Some(target_obj) = rules.object(interner.resolve(target_entity.type_ref())) {
                     let (fw, fh) = foundation_dimensions(&target_obj.foundation);
                     range_lep += (fw as i64 + fh as i64) * 0x40;
                 }
@@ -384,7 +384,7 @@ fn line_of_fire_clear(
         // stock rules leave off, and a fixture interner that never saw this
         // owner must not panic the range gate. An unresolvable owner matches
         // no alliance, which is the same verdict the stock rule gives.
-        interner.try_resolve(attacker.owner).unwrap_or_default(),
+        interner.try_resolve(attacker.owner()).unwrap_or_default(),
         rules,
         terrain,
         interner,
@@ -593,7 +593,7 @@ fn resolve_entity_target_coords(
     interner: &StringInterner,
 ) -> (u16, u16, SimFixed, SimFixed) {
     if t.category == EntityCategory::Structure {
-        if let Some(obj) = rules.object(interner.resolve(t.type_ref)) {
+        if let Some(obj) = rules.object(interner.resolve(t.type_ref())) {
             let (fw, fh) = foundation_dimensions(&obj.foundation);
             let offset_x = (fw.saturating_sub(1) as i32) * 128;
             let offset_y = (fh.saturating_sub(1) as i32) * 128;

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -555,7 +555,7 @@ pub(crate) fn combat_target_category(
     interner: &StringInterner,
 ) -> EntityCategory {
     if rules
-        .object(interner.resolve(entity.type_ref))
+        .object(interner.resolve(entity.type_ref()))
         .is_some_and(|obj| obj.considered_aircraft)
     {
         EntityCategory::Aircraft
@@ -720,7 +720,7 @@ impl EntityDamageEvent {
             event.payload.firer_id,
             entities
                 .get(event.payload.firer_id)
-                .map(|firer| firer.owner),
+                .map(|firer| firer.owner()),
             event.payload.warhead,
             ReceiverCallFlags {
                 ignore_defenses: false,
@@ -860,7 +860,7 @@ fn target_coords(
     let mut sub_y = entity.position.sub_y;
 
     if entity.category == EntityCategory::Structure {
-        if let Some(obj) = rules.and_then(|r| r.object(interner.resolve(entity.type_ref))) {
+        if let Some(obj) = rules.and_then(|r| r.object(interner.resolve(entity.type_ref()))) {
             let (fw, fh) = foundation_dimensions(&obj.foundation);
             // Shift from NW corner cell center to foundation geometric center.
             // (fw-1)*128 leptons in X, (fh-1)*128 leptons in Y.
@@ -930,14 +930,14 @@ pub(crate) fn can_fire_at_target(
     let Some(attacker) = entities.get(attacker_id) else {
         return false;
     };
-    let Some(attacker_obj) = rules.object(interner.resolve(attacker.type_ref)) else {
+    let Some(attacker_obj) = rules.object(interner.resolve(attacker.type_ref())) else {
         return false;
     };
     let Some(selected) = select_weapon_against(
         rules,
         attacker_obj,
         &combat_weapon::attacker_facts(attacker, attacker_obj),
-        attacker.owner,
+        attacker.owner(),
         target,
         entities,
         interner,
@@ -986,12 +986,12 @@ pub(crate) fn pursuit_selected_weapon<'a>(
     terrain: Option<&ResolvedTerrainGrid>,
     alliances: Option<&HouseAllianceMap>,
 ) -> Option<&'a WeaponType> {
-    let attacker_obj = rules.object(interner.resolve(entity.type_ref))?;
+    let attacker_obj = rules.object(interner.resolve(entity.type_ref()))?;
     let selected = select_weapon_against(
         rules,
         attacker_obj,
         &combat_weapon::attacker_facts(entity, attacker_obj),
-        entity.owner,
+        entity.owner(),
         target,
         entities,
         interner,
@@ -1247,7 +1247,7 @@ pub fn issue_attack_cell_command(
 ) -> bool {
     // Read attacker position + weapon presence before mutable borrow.
     let attacker_info = entities.get(attacker_id).map(|a| {
-        let type_str = interner.resolve(a.type_ref);
+        let type_str = interner.resolve(a.type_ref());
         let has_weapon = rules
             .and_then(|r| r.object(type_str))
             .is_some_and(|obj| combat_weapon::is_armed(a, obj));
@@ -2655,7 +2655,7 @@ fn handle_entity_deaths(
             let air_impact = combat_aoe::air_impact_from_entity(e, terrain.as_deref());
             let world_z_leptons = object_world_z_leptons(e, terrain.as_deref());
             (
-                e.type_ref,
+                e.type_ref(),
                 e.position.rx,
                 e.position.ry,
                 e.position.sub_x,
@@ -2663,7 +2663,7 @@ fn handle_entity_deaths(
                 e.position.z,
                 world_z_leptons,
                 air_impact,
-                e.owner,
+                e.owner(),
                 e.animation.is_some(),
                 e.category,
                 e.veterancy,
@@ -3242,7 +3242,7 @@ fn apply_building_receive_prelude(
     if target.category != EntityCategory::Structure {
         return BuildingReceivePrelude::Continue;
     }
-    let Some(target_type) = rules.object(interner.resolve(target.type_ref)) else {
+    let Some(target_type) = rules.object(interner.resolve(target.type_ref())) else {
         return BuildingReceivePrelude::Continue;
     };
 
@@ -3250,7 +3250,7 @@ fn apply_building_receive_prelude(
         return BuildingReceivePrelude::ReturnZero;
     }
     if event.attacker_id != RAD_NO_ATTACKER && !target_type.is_1x1_with_undeploy() {
-        if let Some(owner) = houses.get_mut(&target.owner) {
+        if let Some(owner) = houses.get_mut(&target.owner()) {
             owner
                 .strategy_emergency
                 .note_building_attack(current_tick as u32 as i32);
@@ -3275,13 +3275,13 @@ fn resolve_receive_damage(
     let receiver_flags = event.receiver_flags?;
     let target = entities.get(event.target_id)?;
     let warhead = rules.warhead(interner.resolve(event.warhead_ref))?;
-    let target_type = rules.object(interner.resolve(target.type_ref));
+    let target_type = rules.object(interner.resolve(target.type_ref()));
     let source = (event.attacker_id != RAD_NO_ATTACKER)
         .then(|| entities.get(event.attacker_id))
         .flatten();
     let source_house = event
         .source_house
-        .or_else(|| source.map(|entity| entity.owner));
+        .or_else(|| source.map(|entity| entity.owner()));
     // InfantryClass mutates the positive raw i32 before forwarding to the
     // shared Techno receiver. Its sign is therefore Techno's original-sign
     // snapshot used by the IC/FS gate below.
@@ -3299,8 +3299,8 @@ fn resolve_receive_damage(
             interner.resolve(other),
         )
     };
-    let attacker_is_allied = source_house.is_some_and(|owner| allied(owner, target.owner));
-    let source_house_is_allied = source_house.is_some_and(|owner| allied(target.owner, owner));
+    let attacker_is_allied = source_house.is_some_and(|owner| allied(owner, target.owner()));
+    let source_house_is_allied = source_house.is_some_and(|owner| allied(target.owner(), owner));
 
     let target_is_building = target.category == EntityCategory::Structure;
     let target_view = damage::TargetDamageView {
@@ -3322,7 +3322,7 @@ fn resolve_receive_damage(
     };
     let type_immune = target_type.is_some_and(|object| object.type_immune)
         && source.is_some_and(|source| {
-            source.type_ref == target.type_ref && source.owner == target.owner
+            source.type_ref() == target.type_ref() && source.owner() == target.owner()
         });
     let bunker_blocked = if target_is_building && target.bunker_occupant.is_some() {
         // Linked Building branch is intentionally the inverse of the installed
@@ -3364,12 +3364,12 @@ fn resolve_receive_damage(
         psionics_immune: target_type.is_some_and(|object| object.immune_to_psionics),
         target_is_building,
     };
-    let defender_country_armor = houses.get(&target.owner).map_or(1.0, |house| {
+    let defender_country_armor = houses.get(&target.owner()).map_or(1.0, |house| {
         let difficulty_armor = rules.general.difficulty_armor[house.difficulty.table_index()];
         let country_name = house
             .country
             .map(|country| interner.resolve(country))
-            .unwrap_or_else(|| interner.resolve(target.owner));
+            .unwrap_or_else(|| interner.resolve(target.owner()));
         let (country_armor, category_armor) = target_type
             .map(|object| rules.country_armor_factors(country_name, object))
             .unwrap_or((1.0, 1.0));
@@ -3419,7 +3419,7 @@ fn resolve_receive_damage(
             crate::sim::superweapon::invulnerability::InvulnKind::ForceShield => 6,
         };
         InvulnerabilityImpactEffect {
-            target_id: target.stable_id,
+            target_id: target.stable_id(),
             doubled_damage,
             warhead_ref: event.warhead_ref,
             coord: receiver_effect_coord(target, terrain),
@@ -3521,7 +3521,7 @@ fn postmortem_duration_for_event(
         return None;
     }
     let warhead = rules.warhead(interner.resolve(event.warhead_ref))?;
-    let object = rules.object(interner.resolve(target.type_ref))?;
+    let object = rules.object(interner.resolve(target.type_ref()))?;
     (warhead.causes_delay_kill && object.eligible_for_delay_kill)
         .then(|| postmortem_delay_duration(warhead, event.distance_leptons.unwrap_or(0)))
 }
@@ -3928,14 +3928,14 @@ fn commit_damage_events_with_isolation(
         ) {
             BuildingReceivePrelude::ReturnZero => continue,
             BuildingReceivePrelude::Respond => {
-                if let Some(victim_owner) = entities.get(event.target_id).map(|victim| victim.owner)
+                if let Some(victim_owner) = entities.get(event.target_id).map(|victim| victim.owner())
                 {
                     let attacker_house_index = entities
                         .get(event.attacker_id)
                         .and_then(|attacker| {
                             house_order
                                 .iter()
-                                .position(|owner| *owner == attacker.owner)
+                                .position(|owner| *owner == attacker.owner())
                         })
                         .map_or(-1, |index| index as i32);
                     if let Some(owner) = houses.get_mut(&victim_owner) {
@@ -3966,13 +3966,13 @@ fn commit_damage_events_with_isolation(
         // both null source object and null source house explicitly.
         let attacker_owner: Option<InternedId> = event.source_house.or_else(|| {
             (attacker_id != RAD_NO_ATTACKER)
-                .then(|| entities.get(attacker_id).map(|attacker| attacker.owner))
+                .then(|| entities.get(attacker_id).map(|attacker| attacker.owner()))
                 .flatten()
         });
         // UpdateAngerNodes reads source->Owner directly; the separately
         // captured source-house ABI argument is not used by this callback.
         let live_source_owner = (attacker_id != RAD_NO_ATTACKER)
-            .then(|| entities.get(attacker_id).map(|source| source.owner))
+            .then(|| entities.get(attacker_id).map(|source| source.owner()))
             .flatten();
         let receiver_outcome = event.distance_leptons.map(|_| {
             resolve_receive_damage(
@@ -4107,7 +4107,7 @@ fn commit_damage_events_with_isolation(
                 && attacker_owner.is_some_and(|source_owner| {
                     !crate::map::houses::is_allied_with(
                         alliances,
-                        interner.resolve(target.owner),
+                        interner.resolve(target.owner()),
                         interner.resolve(source_owner),
                     )
                 });
@@ -4116,10 +4116,10 @@ fn commit_damage_events_with_isolation(
                 && let Some(source_owner) = live_source_owner
                 && let Some(final_damage) =
                     receive_outcome.and_then(|outcome| outcome.post_object_damage)
-                && let Some(target_type) = rules.object(interner.resolve(target.type_ref))
+                && let Some(target_type) = rules.object(interner.resolve(target.type_ref()))
             {
                 threat_feedback = Some((
-                    target.owner,
+                    target.owner(),
                     source_owner,
                     final_damage,
                     target_type.strength,
@@ -4223,7 +4223,7 @@ fn commit_damage_events_with_isolation(
             ) && target.category == EntityCategory::Structure
                 && target.lifecycle.object_alive
                 && rules
-                    .object(interner.resolve(target.type_ref))
+                    .object(interner.resolve(target.type_ref()))
                     .is_some_and(|object| object.damage_sound.is_none())
             {
                 building_damage_cue = Some((target.position.rx, target.position.ry));
@@ -4254,7 +4254,7 @@ fn commit_damage_events_with_isolation(
             // the owner gate, so the event is emitted for every house.
             if receive_state == Some(damage::DamageState::Yellow)
                 && rules
-                    .object(interner.resolve(target.type_ref))
+                    .object(interner.resolve(target.type_ref()))
                     .is_some_and(|object| {
                         object
                             .voice_feedback
@@ -4263,8 +4263,8 @@ fn commit_damage_events_with_isolation(
                     })
             {
                 voice_feedback_cue = Some((
-                    target.owner,
-                    target.type_ref,
+                    target.owner(),
+                    target.type_ref(),
                     target.position.rx,
                     target.position.ry,
                 ));
@@ -4280,10 +4280,10 @@ fn commit_damage_events_with_isolation(
             && attacker_id != RAD_NO_ATTACKER
             && entities.get(target_id).is_some_and(|target| {
                 rules
-                    .object(interner.resolve(target.type_ref))
+                    .object(interner.resolve(target.type_ref()))
                     .is_some_and(|object| object.to_protect)
                     && houses
-                        .get(&target.owner)
+                        .get(&target.owner())
                         .is_some_and(|house| !house.is_human)
             });
         if protected_techno_response
@@ -4313,7 +4313,7 @@ fn commit_damage_events_with_isolation(
             let now = current_tick as i32;
             let cloaking_speed = entities
                 .get(target_id)
-                .and_then(|target| rules.object(interner.resolve(target.type_ref)))
+                .and_then(|target| rules.object(interner.resolve(target.type_ref())))
                 .map_or(1, |object| object.cloaking_speed);
             let surfaced = entities
                 .get_mut(target_id)
@@ -4475,7 +4475,7 @@ fn commit_damage_events_with_isolation(
             let scatter = if surviving_infantry_result {
                 attacker_coord.and_then(|attacker_coord| {
                     let target = entities.get(target_id)?;
-                    let target_type = rules.object(interner.resolve(target.type_ref));
+                    let target_type = rules.object(interner.resolve(target.type_ref()));
                     let infantry_is_fraidycat = target_type.is_some_and(|object| object.fraidycat);
                     let has_scatter_ability = target_type.is_some_and(|object| {
                         (target.veterancy >= VETERAN_VETERANCY && object.veteran_scatter)
@@ -4488,7 +4488,7 @@ fn commit_damage_events_with_isolation(
                         occupancy,
                         rules,
                         houses
-                            .get(&target.owner)
+                            .get(&target.owner())
                             .is_some_and(|house| house.is_human),
                         infantry_is_fraidycat,
                         has_scatter_ability,
@@ -4520,7 +4520,7 @@ fn commit_damage_events_with_isolation(
             let Some(target) = entities.get_mut(target_id) else {
                 continue;
             };
-            if let Some(obj) = rules.object(interner.resolve(target.type_ref)) {
+            if let Some(obj) = rules.object(interner.resolve(target.type_ref())) {
                 infantry::apply_fear_from_damage(
                     obj,
                     target,
@@ -4547,7 +4547,7 @@ fn commit_damage_events_with_isolation(
             // are overlay mutations, a sold building dying is rare).
             if damage > 0
                 && !became_fatal
-                && let Some(obj) = rules.object(interner.resolve(target.type_ref))
+                && let Some(obj) = rules.object(interner.resolve(target.type_ref()))
             {
                 // `BuildingClass::ReceiveDamage @ 0x00442230`: with a non-null
                 // source, a non-zero damage result and `Insignificant=` clear,
@@ -4576,7 +4576,7 @@ fn commit_damage_events_with_isolation(
                     under_attack_events.push(UnderAttackEvent {
                         rx: target.position.rx,
                         ry: target.position.ry,
-                        owner: target.owner,
+                        owner: target.owner(),
                         miner,
                         structure,
                     });
@@ -4908,7 +4908,7 @@ fn emit_projectile_shrapnel(
     let center_ry = detonation.impact.y / 256;
     let source_owner = entities
         .get(detonation.source_id)
-        .map(|source| source.owner);
+        .map(|source| source.owner());
     // Random CellClass selections must capture their target coordinate at the
     // lookup call point: every miss returns the same mutable process dummy, so
     // resolving a collected list afterward would give all missed children the
@@ -4949,7 +4949,7 @@ fn emit_projectile_shrapnel(
             crate::map::houses::are_houses_friendly(
                 house_alliances,
                 interner.resolve(owner),
-                interner.resolve(target.owner),
+                interner.resolve(target.owner()),
             )
         });
         if allied {
@@ -6032,7 +6032,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             if !entity.is_fully_deployed() || entity.dying || !entity.is_alive() {
                 continue;
             }
-            let Some(obj) = rules.object(interner.resolve(entity.type_ref)) else {
+            let Some(obj) = rules.object(interner.resolve(entity.type_ref())) else {
                 continue;
             };
             if !obj.deploy_fire || !obj.immune_to_radiation {
@@ -6093,12 +6093,12 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             }
             (
                 true,
-                entity.owner,
+                entity.owner(),
                 entity.position.rx,
                 entity.position.ry,
                 entity.position.sub_x,
                 entity.position.sub_y,
-                entity.type_ref,
+                entity.type_ref(),
                 entity.barrel_facing,
             )
         };
@@ -6132,7 +6132,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
 
         // Resolve occupant type + veterancy for garrison weapon validation.
         let (occ_type, occ_vet) = match entities.get(occ_id) {
-            Some(occ) => (occ.type_ref, occ.veterancy),
+            Some(occ) => (occ.type_ref(), occ.veterancy),
             None => continue,
         };
 
@@ -6146,7 +6146,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
         let mut best_target: Option<(i64, u8, u64)> = None;
         let owner_str = interner.resolve(owner);
         for candidate in entities.values() {
-            if candidate.stable_id == id
+            if candidate.stable_id() == id
                 || candidate.health.current == 0
                 || candidate.dying
                 || candidate.lifecycle.in_limbo
@@ -6154,11 +6154,11 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             {
                 continue;
             }
-            if candidate.owner == owner {
+            if candidate.owner() == owner {
                 continue;
             }
             if let Some(fog_state) = fog {
-                let candidate_owner_str = interner.resolve(candidate.owner);
+                let candidate_owner_str = interner.resolve(candidate.owner());
                 if fog_state.is_friendly(owner_str, candidate_owner_str) {
                     continue;
                 }
@@ -6168,7 +6168,7 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             }
             let target_cat = combat_target_category(candidate, rules, interner);
             let target_armor = rules
-                .object(interner.resolve(candidate.type_ref))
+                .object(interner.resolve(candidate.type_ref()))
                 .map(|o| o.armor.as_str())
                 .unwrap_or("none");
             // Use garrison weapon (OccupyWeapon) for target compatibility check.
@@ -6208,11 +6208,11 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             // Same VERA-internal two-bucket ordering as `threat_class`, on the
             // native `Is_Armed` model rather than `Primary=` so a `[SREF]` or
             // `[YAGGUN]` candidate is not ranked as an unarmed bystander.
-            let class = match rules.object(interner.resolve(candidate.type_ref)) {
+            let class = match rules.object(interner.resolve(candidate.type_ref())) {
                 Some(o) if combat_weapon::is_armed(candidate, o) => 0u8,
                 _ => 1,
             };
-            let rank = (dist_sq, class, candidate.stable_id);
+            let rank = (dist_sq, class, candidate.stable_id());
             match best_target {
                 Some(current) if rank >= current => {}
                 _ => best_target = Some(rank),
@@ -6345,14 +6345,14 @@ pub(crate) fn tick_combat_with_fog_and_main_rng_with_terrain_area(
             None => continue,
         };
         let garrison = garrison_cargo.and_then(|(fire_idx, count, occ_id)| {
-            let obj = rules.object(interner.resolve(entity.type_ref))?;
+            let obj = rules.object(interner.resolve(entity.type_ref()))?;
             if !obj.can_be_occupied || !obj.can_occupy_fire {
                 return None;
             }
             let occ = entities.get(occ_id)?;
             let (fw, fh) = foundation_dimensions(&obj.foundation);
             Some(GarrisonSnapshot {
-                occupant_type_id: occ.type_ref,
+                occupant_type_id: occ.type_ref(),
                 occupant_veterancy: occ.veterancy,
                 fire_index: fire_idx,
                 occupant_count: count,
@@ -6984,8 +6984,8 @@ pub(crate) fn build_attacker_snapshot(
     garrison: Option<GarrisonSnapshot>,
 ) -> AttackerSnapshot {
     AttackerSnapshot {
-        stable_id: entity.stable_id,
-        owner: entity.owner,
+        stable_id: entity.stable_id(),
+        owner: entity.owner(),
         category: entity.category,
         target,
         pos_rx: entity.position.rx,
@@ -6994,7 +6994,7 @@ pub(crate) fn build_attacker_snapshot(
         pos_exact_z_leptons: entity.position.exact_z_leptons,
         sub_x: entity.position.sub_x,
         sub_y: entity.position.sub_y,
-        type_id: entity.type_ref,
+        type_id: entity.type_ref(),
         facing: entity.facing,
         veterancy: entity.veterancy,
         cooldown_ticks,
@@ -7115,10 +7115,10 @@ pub(crate) fn award_kill_experience(
         .map(|victim| {
             (
                 rules
-                    .object(interner.resolve(victim.type_ref))
+                    .object(interner.resolve(victim.type_ref()))
                     .map_or(0, |obj| obj.cost),
                 self::veterancy::rank_of(victim.veterancy_raw),
-                victim.owner,
+                victim.owner(),
             )
         })
     else {
@@ -7127,12 +7127,12 @@ pub(crate) fn award_kill_experience(
     let Some(killer) = entities.get(killer_id) else {
         return;
     };
-    let Some(killer_type) = rules.object(interner.resolve(killer.type_ref)) else {
+    let Some(killer_type) = rules.object(interner.resolve(killer.type_ref())) else {
         return;
     };
-    let killer_owner = killer.owner;
+    let killer_owner = killer.owner();
     let trainable_cost = |id: u64| -> Option<(u64, i32)> {
-        let object = rules.object(interner.resolve(entities.get(id)?.type_ref))?;
+        let object = rules.object(interner.resolve(entities.get(id)?.type_ref()))?;
         object.trainable.then_some((id, object.cost))
     };
     // Branch 1: a passenger firing from an OpenTopped transport pays its
@@ -7141,7 +7141,7 @@ pub(crate) fn award_kill_experience(
     let open_transporter = match killer.passenger_role {
         crate::sim::passenger::PassengerRole::Inside { transport_id } => entities
             .get(transport_id)
-            .and_then(|transport| rules.object(interner.resolve(transport.type_ref)))
+            .and_then(|transport| rules.object(interner.resolve(transport.type_ref())))
             .is_some_and(|transport_type| transport_type.open_topped)
             .then_some(transport_id),
         _ => None,
@@ -7227,7 +7227,7 @@ pub(crate) fn capture_kill_credit(
     };
     victim.killed_by = Some(killer_owner);
     victim.kill_award_points = score_award_for_victim(
-        rules.object(interner.resolve(victim.type_ref)),
+        rules.object(interner.resolve(victim.type_ref())),
         victim.veterancy,
     );
 }
@@ -7327,8 +7327,8 @@ pub(crate) fn resolve_attacker_fire(
                 tsy,
                 t.health.current,
                 combat_target_category(t, rules, interner),
-                t.type_ref,
-                t.owner,
+                t.type_ref(),
+                t.owner(),
                 t.category == EntityCategory::Infantry && infantry::is_prone_for_damage(t),
             )
         }),
@@ -7427,7 +7427,7 @@ pub(crate) fn resolve_attacker_fire(
         TargetKind::Entity(target_id) => {
             let Some((target_entity, target_obj)) = entities.get(target_id).and_then(|t| {
                 rules
-                    .object(interner.resolve(t.type_ref))
+                    .object(interner.resolve(t.type_ref()))
                     .map(|target_obj| (t, target_obj))
             }) else {
                 if delayed_building_slot.is_none() {
@@ -7439,7 +7439,7 @@ pub(crate) fn resolve_attacker_fire(
                 fog.map(|fog_state| &fog_state.alliances),
                 interner,
                 snap.owner,
-                target_entity.owner,
+                target_entity.owner(),
             );
             combat_weapon::techno_target_facts(
                 target_entity,
@@ -8375,7 +8375,7 @@ pub(crate) fn resolve_attacker_fire(
                 TargetKind::Cell(_, _) => None,
             })
             .filter(|target| target.category == EntityCategory::Structure)
-            .and_then(|target| rules.object(interner.resolve(target.type_ref)))
+            .and_then(|target| rules.object(interner.resolve(target.type_ref())))
             .map(|target_type| {
                 rules.building_launch_height(target_type)
                     .wrapping_mul(200)

--- a/src/sim/credit_income.rs
+++ b/src/sim/credit_income.rs
@@ -146,7 +146,7 @@ pub(crate) fn produce_cash_on_owner_change(
     if entity.category != EntityCategory::Structure {
         return;
     }
-    let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref)) else {
+    let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref())) else {
         return;
     };
     let old_passive = sim
@@ -244,8 +244,8 @@ pub(crate) fn produce_cash_step(sim: &mut Simulation, stable_id: u64, rules: &Ru
     if !entity.produce_cash_timer.fires_now(frame) {
         return;
     }
-    let owner = entity.owner;
-    let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref)) else {
+    let owner = entity.owner();
+    let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref())) else {
         return;
     };
     let amount = obj.produce_cash_amount;
@@ -290,7 +290,7 @@ pub(crate) fn building_at_cell_in_store(entities: &EntityStore, rx: u16, ry: u16
         let (width, height) = crate::rules::foundation::foundation_dimensions(&entity.foundation);
         let (bx, by) = (entity.position.rx, entity.position.ry);
         (rx >= bx && rx < bx.saturating_add(width) && ry >= by && ry < by.saturating_add(height))
-            .then_some(entity.stable_id)
+            .then_some(entity.stable_id())
     })
 }
 
@@ -404,10 +404,10 @@ pub(crate) fn drain_common_step(sim: &mut Simulation, stable_id: u64, rules: &Ru
     let Some(entity) = sim.substrate.entities.get(stable_id) else {
         return;
     };
-    let victim_owner = entity.owner;
+    let victim_owner = entity.owner();
     let draining_me = entity.draining_me;
     let drain_target = entity.drain_target;
-    let type_ref = entity.type_ref;
+    let type_ref = entity.type_ref();
 
     if let Some(drainer_id) = draining_me
         && rules
@@ -421,7 +421,7 @@ pub(crate) fn drain_common_step(sim: &mut Simulation, stable_id: u64, rules: &Ru
                 .substrate
                 .entities
                 .get(drainer_id)
-                .map(|drainer| drainer.owner)
+                .map(|drainer| drainer.owner())
             {
                 let mut amount = rules.general.drain_money_amount;
                 let available = available_money(sim, victim_owner);
@@ -439,7 +439,7 @@ pub(crate) fn drain_common_step(sim: &mut Simulation, stable_id: u64, rules: &Ru
             .substrate
             .entities
             .get(victim_id)
-            .map(|victim| victim.owner)
+            .map(|victim| victim.owner())
         && crate::map::houses::are_houses_friendly(
             &sim.house_alliances,
             sim.interner.resolve(target_owner),

--- a/src/sim/docking/aircraft_dock.rs
+++ b/src/sim/docking/aircraft_dock.rs
@@ -262,10 +262,10 @@ fn find_nearest_airfield(
         if entity.health.current == 0 || entity.dying || entity.lifecycle.in_limbo {
             continue;
         }
-        if entity.owner != owner {
+        if entity.owner() != owner {
             continue;
         }
-        let entity_type_str = sim.interner.resolve(entity.type_ref);
+        let entity_type_str = sim.interner.resolve(entity.type_ref());
         let Some(obj) = rules.object(entity_type_str) else {
             continue;
         };
@@ -286,7 +286,7 @@ fn find_nearest_airfield(
         let dist = cell_dist_sq(from.0, from.1, dock_rx, dock_ry);
 
         if best.is_none() || dist < best.unwrap().3 {
-            best = Some((entity.stable_id, dock_rx, dock_ry, dist));
+            best = Some((entity.stable_id(), dock_rx, dock_ry, dist));
         }
     }
 
@@ -320,7 +320,7 @@ pub fn tick_aircraft_docks(sim: &mut Simulation, rules: &RuleSet) {
         .entities
         .values()
         .filter(|e| !e.dying)
-        .map(|e| e.stable_id)
+        .map(|e| e.stable_id())
         .collect();
     sim.production.airfield_docks.cleanup_dead(&alive);
 
@@ -359,9 +359,9 @@ pub fn tick_aircraft_docks(sim: &mut Simulation, rules: &RuleSet) {
             }
             let air_phase = e.locomotor.as_ref().map(|l| l.air_phase);
             Some(AircraftSnap {
-                id: e.stable_id,
-                owner: e.owner,
-                type_ref: e.type_ref,
+                id: e.stable_id(),
+                owner: e.owner(),
+                type_ref: e.type_ref(),
                 rx: e.position.rx,
                 ry: e.position.ry,
                 current_ammo: ammo.current,
@@ -449,7 +449,7 @@ pub fn tick_aircraft_docks(sim: &mut Simulation, rules: &RuleSet) {
                     if af.health.current == 0 || af.dying {
                         return None;
                     }
-                    let obj = sim.object_type(af.type_ref, rules)?;
+                    let obj = sim.object_type(af.type_ref(), rules)?;
                     let (w, h) = crate::sim::production::foundation_dimensions(&obj.foundation);
                     Some((af_sid, af.position.rx + w / 2, af.position.ry + h / 2))
                 });
@@ -501,7 +501,7 @@ pub fn tick_aircraft_docks(sim: &mut Simulation, rules: &RuleSet) {
                     .substrate
                     .entities
                     .get(af_sid)
-                    .and_then(|af| sim.object_type(af.type_ref, rules))
+                    .and_then(|af| sim.object_type(af.type_ref(), rules))
                     .map(|obj| obj.number_of_docks.max(1))
                     .unwrap_or(1);
 
@@ -520,7 +520,7 @@ pub fn tick_aircraft_docks(sim: &mut Simulation, rules: &RuleSet) {
                     // to whatever was previously targeted (building center)
                     // when the building has no DockingOffset%d in art.
                     if let Some((px, py)) = sim.substrate.entities.get(af_sid).and_then(|af| {
-                        let obj = sim.object_type(af.type_ref, rules)?;
+                        let obj = sim.object_type(af.type_ref(), rules)?;
                         let foundation =
                             crate::sim::production::foundation_dimensions(&obj.foundation);
                         obj.pads.get(pad_index as usize).map(|pad| {
@@ -627,7 +627,7 @@ pub fn tick_aircraft_docks(sim: &mut Simulation, rules: &RuleSet) {
             .entities
             .get(id)
             .and_then(|e| {
-                let obj = sim.object_type(e.type_ref, rules)?;
+                let obj = sim.object_type(e.type_ref(), rules)?;
                 Some(crate::util::fixed_math::ra2_speed_to_leptons_per_second(
                     obj.speed.max(1),
                 ))

--- a/src/sim/docking/building_dock.rs
+++ b/src/sim/docking/building_dock.rs
@@ -384,7 +384,7 @@ pub(crate) fn mission_enter_dispatch(sim: &mut Simulation, rules: &RuleSet, id: 
                 ds.phase,
                 unit.health.current,
                 unit.health.max,
-                unit.owner,
+                unit.owner(),
             ))
         })
     else {
@@ -403,8 +403,8 @@ pub(crate) fn mission_enter_dispatch(sim: &mut Simulation, rules: &RuleSet, id: 
         .substrate
         .entities
         .get(dock_building_id)
-        .filter(|depot| depot.health.current > 0 && !depot.dying && depot.owner == owner)
-        .and_then(|depot| sim.object_type(depot.type_ref, rules))
+        .filter(|depot| depot.health.current > 0 && !depot.dying && depot.owner() == owner)
+        .and_then(|depot| sim.object_type(depot.type_ref(), rules))
         .filter(|obj| obj.unit_repair)
         .map(|obj| usize::from(obj.number_of_docks.max(1)));
 
@@ -508,9 +508,9 @@ pub fn tick_building_docks(sim: &mut Simulation, rules: &RuleSet, path_grid: Opt
         .filter_map(|e| {
             let ds = e.dock_state.as_ref()?;
             Some(DockSnapshot {
-                id: e.stable_id,
-                owner: e.owner,
-                type_ref: e.type_ref,
+                id: e.stable_id(),
+                owner: e.owner(),
+                type_ref: e.type_ref(),
                 rx: e.position.rx,
                 ry: e.position.ry,
                 hp: e.health.current,
@@ -570,10 +570,10 @@ pub fn tick_building_docks(sim: &mut Simulation, rules: &RuleSet, path_grid: Opt
                 if depot.health.current == 0 || depot.dying {
                     return None;
                 }
-                if depot.owner != snap.owner {
+                if depot.owner() != snap.owner {
                     return None;
                 }
-                let obj = sim.object_type(depot.type_ref, rules)?;
+                let obj = sim.object_type(depot.type_ref(), rules)?;
                 if !obj.unit_repair {
                     return None;
                 }
@@ -740,7 +740,7 @@ pub fn tick_building_docks(sim: &mut Simulation, rules: &RuleSet, path_grid: Opt
         if m.deduct_credits > 0 {
             if let Some(house) = crate::sim::house_state::house_state_for_owner_mut(
                 &mut sim.houses,
-                sim.interner.resolve(entity.owner),
+                sim.interner.resolve(entity.owner()),
                 &sim.interner,
             ) {
                 house.credits = (house.credits - m.deduct_credits).max(0);

--- a/src/sim/docking/bunker_install.rs
+++ b/src/sim/docking/bunker_install.rs
@@ -339,7 +339,7 @@ fn start_install_force_track(
         .substrate
         .entities
         .get(unit_id)
-        .map(|u| (u.position.rx, u.position.ry, u.type_ref))
+        .map(|u| (u.position.rx, u.position.ry, u.type_ref()))
     else {
         return false;
     };

--- a/src/sim/docking/bunker_link.rs
+++ b/src/sim/docking/bunker_link.rs
@@ -42,7 +42,7 @@ pub fn can_auto_deploy_here(sim: &Simulation, unit_id: u64, rules: &RuleSet) -> 
     let Some(unit) = sim.substrate.entities.get(unit_id) else {
         return false;
     };
-    let Some(obj) = sim.object_type(unit.type_ref, rules) else {
+    let Some(obj) = sim.object_type(unit.type_ref(), rules) else {
         return false;
     };
     obj.bunkerable && obj.primary.is_some()

--- a/src/sim/entity_store.rs
+++ b/src/sim/entity_store.rs
@@ -18,6 +18,10 @@ use std::collections::BTreeMap;
 
 use crate::sim::game_entity::GameEntity;
 
+/// Only this module can authorize a live indexed-owner write.
+/// Payload consumers can read owner identity but cannot construct this capability.
+pub(crate) struct OwnerChangeAuthority(());
+
 /// Container for all game entities, keyed by stable_id.
 ///
 /// Uses `BTreeMap<u64, GameEntity>` for deterministic sorted iteration
@@ -69,12 +73,12 @@ impl EntityStore {
     /// If an entity with the same id already existed (rare — stable_ids are
     /// monotonic), its old owner entry is removed first.
     pub fn insert(&mut self, entity: GameEntity) -> u64 {
-        let id = entity.stable_id;
-        let owner = entity.owner;
-        let type_ref = entity.type_ref;
+        let id = entity.stable_id();
+        let owner = entity.owner();
+        let type_ref = entity.type_ref();
         if let Some(old) = self.entities.insert(id, entity) {
-            self.index_remove(old.owner, id);
-            self.type_count_remove(old.owner, old.type_ref);
+            self.index_remove(old.owner(), id);
+            self.type_count_remove(old.owner(), old.type_ref());
         }
         self.index_add(owner, id);
         self.type_count_add(owner, type_ref);
@@ -86,8 +90,8 @@ impl EntityStore {
     pub fn remove(&mut self, stable_id: u64) -> Option<GameEntity> {
         let removed = self.entities.remove(&stable_id);
         if let Some(ref e) = removed {
-            self.index_remove(e.owner, stable_id);
-            self.type_count_remove(e.owner, e.type_ref);
+            self.index_remove(e.owner(), stable_id);
+            self.type_count_remove(e.owner(), e.type_ref());
         }
         removed
     }
@@ -126,7 +130,7 @@ impl EntityStore {
             if entity.dock_entered_with == Some(stable_id) {
                 entity.dock_entered_with = None;
             }
-            if entity.stable_id == stable_id {
+            if entity.stable_id() == stable_id {
                 entity.radio_contacts.clear_all();
                 entity.dock_entered_with = None;
             }
@@ -138,7 +142,10 @@ impl EntityStore {
         self.entities.get(&stable_id)
     }
 
-    /// Look up an entity by stable_id (mutable).
+    /// Mutate ordinary entity payload. Indexed identity is read through accessors;
+    /// live ownership changes use the world lifecycle and `change_owner` below.
+    /// Replacing a stored entity wholesale is unsupported: remove/insert through
+    /// the owning lifecycle instead so its indexes and registrations are updated.
     pub fn get_mut(&mut self, stable_id: u64) -> Option<&mut GameEntity> {
         self.entities.get_mut(&stable_id)
     }
@@ -206,10 +213,10 @@ impl EntityStore {
     /// No-op if the entity is absent or already owned by `new_owner`.
     pub fn change_owner(&mut self, stable_id: u64, new_owner: crate::sim::intern::InternedId) {
         let (old_owner, type_ref) = match self.entities.get_mut(&stable_id) {
-            Some(e) if e.owner != new_owner => {
-                let old = e.owner;
-                e.owner = new_owner;
-                (old, e.type_ref)
+            Some(e) if e.owner() != new_owner => {
+                let old = e.owner();
+                e.set_owner_from_store(new_owner, OwnerChangeAuthority(()));
+                (old, e.type_ref())
             }
             _ => return,
         };
@@ -262,15 +269,15 @@ impl EntityStore {
     }
 
     /// Rebuild the per-owner index from primary storage.
-    /// Called after deserialization or any bulk mutation that bypasses insert/remove.
-    pub fn rebuild_owner_index(&mut self) {
+    /// Owned by Deserialize; synthetic fixtures may also rebuild after raw setup.
+    pub(crate) fn rebuild_owner_index(&mut self) {
         self.by_owner.clear();
         self.by_owner_type.clear();
         for (&id, entity) in &self.entities {
-            self.by_owner.entry(entity.owner).or_default().push(id);
+            self.by_owner.entry(entity.owner()).or_default().push(id);
             *self
                 .by_owner_type
-                .entry((entity.owner, entity.type_ref))
+                .entry((entity.owner(), entity.type_ref()))
                 .or_insert(0) += 1;
         }
         // BTreeMap iteration is already sorted by key; Vecs are sorted because

--- a/src/sim/game_entity.rs
+++ b/src/sim/game_entity.rs
@@ -332,9 +332,14 @@ pub struct StructureUpgradeLink {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GameEntity {
     // --- Always present (every entity has these) ---
+    // Indexed identity is private in production. Synthetic fixtures retain raw
+    // setup access; conditional declarations preserve the exact serde field order.
     /// Deterministic stable ID — primary key, used for cross-entity references,
     /// replay logs, state hashing, and networking. Never reused.
-    pub stable_id: u64,
+    #[cfg(test)]
+    pub(crate) stable_id: u64,
+    #[cfg(not(test))]
+    stable_id: u64,
     /// Low word of the one raw Scenario RNG draw performed by the active-retail
     /// `TechnoClass` constructor (`0x006F3254`, stored at native `+0x3C8`).
     /// Later report-selection consumers read this persistent value; placement
@@ -366,11 +371,17 @@ pub struct GameEntity {
     #[serde(default)]
     pub body_frame_counter: u32,
     /// Owning player/faction name (e.g., "Americans", "Soviet") — interned for zero-cost clones.
-    pub owner: InternedId,
+    #[cfg(test)]
+    pub(crate) owner: InternedId,
+    #[cfg(not(test))]
+    owner: InternedId,
     /// Current and maximum hit points.
     pub health: Health,
     /// rules.ini section name (e.g., "HTNK", "E1", "GAPOWR") — interned for zero-cost clones.
-    pub type_ref: InternedId,
+    #[cfg(test)]
+    pub(crate) type_ref: InternedId,
+    #[cfg(not(test))]
+    type_ref: InternedId,
     /// Entity category: Unit, Infantry, Aircraft, or Structure.
     pub category: EntityCategory,
     /// Rules foundation string for structure footprint occupancy.
@@ -954,6 +965,30 @@ pub struct GameEntity {
 }
 
 impl GameEntity {
+    /// Immutable storage key. Construction and snapshot decoding establish it.
+    pub fn stable_id(&self) -> u64 {
+        self.stable_id
+    }
+
+    /// Indexed ownership. Live transfers go through Simulation's owner lifecycle
+    /// and EntityStore's index update; ordinary payload mutation cannot assign it.
+    pub fn owner(&self) -> InternedId {
+        self.owner
+    }
+
+    /// Immutable indexed type identity, established by construction/decoding.
+    pub fn type_ref(&self) -> InternedId {
+        self.type_ref
+    }
+
+    pub(crate) fn set_owner_from_store(
+        &mut self,
+        owner: InternedId,
+        _: crate::sim::entity_store::OwnerChangeAuthority,
+    ) {
+        self.owner = owner;
+    }
+
     /// The Harvest FSM cursor of record, decoded from
     /// `MissionCom::handler_state`. `None` when the entity has no Miner
     /// component. An out-of-vocabulary cursor decodes as `SearchOre` (the

--- a/src/sim/gate_runtime.rs
+++ b/src/sim/gate_runtime.rs
@@ -155,11 +155,11 @@ pub fn request_gate_open_for_cell(
         if candidate.category != EntityCategory::Structure {
             continue;
         }
-        let Some(obj) = rules.object(interner.resolve(candidate.type_ref)) else {
+        let Some(obj) = rules.object(interner.resolve(candidate.type_ref())) else {
             continue;
         };
         if !obj.gate
-            || !are_houses_friendly(alliances, mover_owner, interner.resolve(candidate.owner))
+            || !are_houses_friendly(alliances, mover_owner, interner.resolve(candidate.owner()))
         {
             continue;
         }
@@ -182,13 +182,13 @@ pub fn tick_gate_runtimes(
     let gate_ids: Vec<u64> = entities
         .values()
         .filter(|entity| entity.building_gate.is_some())
-        .map(|entity| entity.stable_id)
+        .map(|entity| entity.stable_id())
         .collect();
 
     for gate_id in gate_ids {
         let Some((origin, type_ref)) = entities
             .get(gate_id)
-            .map(|gate| ((gate.position.rx, gate.position.ry), gate.type_ref))
+            .map(|gate| ((gate.position.rx, gate.position.ry), gate.type_ref()))
         else {
             continue;
         };

--- a/src/sim/house_eva.rs
+++ b/src/sim/house_eva.rs
@@ -61,10 +61,10 @@ pub fn funds_nag_factory_count(
         .filter(|e| {
             !e.dying
                 && !e.lifecycle.in_limbo
-                && e.owner == owner
+                && e.owner() == owner
                 && e.category == EntityCategory::Structure
                 && rules
-                    .object(interner.resolve(e.type_ref))
+                    .object(interner.resolve(e.type_ref()))
                     .and_then(|obj| obj.factory)
                     .is_some_and(|factory| {
                         // Naval yards are `Factory=UnitType` + `Naval=yes`
@@ -112,11 +112,11 @@ pub fn owns_build_power_plant(
     entities.values().any(|e| {
         !e.dying
             && !e.lifecycle.in_limbo
-            && e.owner == owner
+            && e.owner() == owner
             && e.category == EntityCategory::Structure
             && build_power
                 .iter()
-                .any(|name| name.eq_ignore_ascii_case(interner.resolve(e.type_ref)))
+                .any(|name| name.eq_ignore_ascii_case(interner.resolve(e.type_ref())))
     })
 }
 
@@ -165,10 +165,10 @@ pub fn tick_house_eva(sim: &mut Simulation, rules: &RuleSet) {
                 .filter(|e| {
                     !e.dying
                         && !e.lifecycle.in_limbo
-                        && e.owner == owner
+                        && e.owner() == owner
                         && e.category == EntityCategory::Structure
                 })
-                .filter_map(|e| rules.object(sim.interner.resolve(e.type_ref)))
+                .filter_map(|e| rules.object(sim.interner.resolve(e.type_ref())))
                 .map(|obj| obj.storage)
                 .fold(0i32, i32::saturating_add);
             if silo_nearly_full(capacity, 0) {

--- a/src/sim/infantry.rs
+++ b/src/sim/infantry.rs
@@ -223,13 +223,13 @@ pub fn tick_fear_for_entities(
         let Some(entity) = entities.get_mut(id) else {
             continue;
         };
-        let Some(obj) = rules.object(interner.resolve(entity.type_ref)) else {
+        let Some(obj) = rules.object(interner.resolve(entity.type_ref())) else {
             continue;
         };
         // `HouseState::is_human` is this model's collapsed player-control fact —
         // the same byte pair gamemd's `IsPlayerControl` reads.
         let player_controlled = houses
-            .get(&entity.owner)
+            .get(&entity.owner())
             .is_some_and(|house| house.is_human);
         if let Some(sequence) = tick_fear_decay_and_prone(obj, entity, player_controlled) {
             if let Some(anim) = entity.animation.as_mut() {
@@ -422,13 +422,13 @@ pub fn tick_idle_actions(
         if entity.infantry.is_none() || !idle_action_ready(entity, frame) {
             continue;
         }
-        let type_name = interner.resolve(entity.type_ref);
+        let type_name = interner.resolve(entity.type_ref());
         let Some(obj) = rules.object(type_name) else {
             continue;
         };
         let biased_type = type_name.eq_ignore_ascii_case(IDLE_BIASED_TYPE);
         let player_controlled = houses
-            .get(&entity.owner)
+            .get(&entity.owner())
             .is_some_and(|house| house.is_human);
 
         // The wait is re-armed first, before any decision — gamemd re-arms even

--- a/src/sim/miner/miner_dock_sequence.rs
+++ b/src/sim/miner/miner_dock_sequence.rs
@@ -473,7 +473,7 @@ fn resolve_refinery_cells(
     if entity.dying || entity.health.current == 0 {
         return None;
     }
-    let obj = sim.object_type(entity.type_ref, rules);
+    let obj = sim.object_type(entity.type_ref(), rules);
     let (w, h) = obj
         .map(|o| foundation_dimensions(&o.foundation))
         .unwrap_or((1, 1));
@@ -518,7 +518,7 @@ fn mission_deploy_unload_building(sim: &Simulation, miner_id: u64) -> Option<u64
                 && !entity.dying
                 && entity.health.current > 0
             {
-                Some(entity.stable_id)
+                Some(entity.stable_id())
             } else {
                 None
             }
@@ -568,7 +568,7 @@ fn entity_full_speed(sim: &Simulation, rules: &RuleSet, entity_id: u64) -> SimFi
     let Some(entity) = sim.substrate.entities.get(entity_id) else {
         return ra2_speed_to_leptons_per_second(4);
     };
-    let obj = sim.object_type(entity.type_ref, rules);
+    let obj = sim.object_type(entity.type_ref(), rules);
     crate::sim::combat::veterancy::entity_mover_speed_leptons_per_second(
         entity,
         obj,
@@ -1376,7 +1376,7 @@ fn phase_unloading(
             .substrate
             .entities
             .get(unload_building_id)
-            .map(|b| sim.interner.resolve(b.owner).to_string())
+            .map(|b| sim.interner.resolve(b.owner()).to_string())
             .expect("west-cell unload building should exist");
 
         // P7: per-country IncomeMult folds into the base credits (single truncation,

--- a/src/sim/miner/miner_system.rs
+++ b/src/sim/miner/miner_system.rs
@@ -157,7 +157,7 @@ fn return_exceeds_too_far_threshold(
     // never produced (foreign-interner fixtures) degrades to a 1x1 footprint.
     let (w, h) = sim
         .interner
-        .try_resolve(refinery.type_ref)
+        .try_resolve(refinery.type_ref())
         .and_then(|name| rules.object_case_insensitive(name))
         .map(|obj| foundation_dimensions(&obj.foundation))
         .unwrap_or((1, 1));
@@ -566,7 +566,7 @@ fn sweep_dead_dock_reservations_for_keys(sim: &mut Simulation, order: &[u64]) {
         .entities
         .values()
         .filter(|e| !e.dying)
-        .map(|e| e.stable_id)
+        .map(|e| e.stable_id())
         .collect();
     sim.production.dock_reservations.cleanup_dead(&alive_sids);
 }
@@ -592,7 +592,7 @@ pub(super) fn build_miner_snapshot(
     // Use the authentic RA2 speed formula: Speed=4 → ~0.586 cells/sec.
     // `FootClass::GetCurrentSpeed @ 0x004DB1A0`: the miner's drive loop asks the
     // same getter every mover does, so a `FASTER` miner takes the multiply here.
-    let obj = sim.object_type(entity.type_ref, rules);
+    let obj = sim.object_type(entity.type_ref(), rules);
     let speed: SimFixed = crate::sim::combat::veterancy::entity_mover_speed_leptons_per_second(
         entity,
         obj,
@@ -608,8 +608,8 @@ pub(super) fn build_miner_snapshot(
     );
     Some(MinerSnapshot {
         entity_id: id,
-        owner: entity.owner,
-        type_id: entity.type_ref,
+        owner: entity.owner(),
+        type_id: entity.type_ref(),
         rx: entity.position.rx,
         ry: entity.position.ry,
         speed,
@@ -1690,7 +1690,7 @@ fn refinery_building_in_cell(sim: &Simulation, rules: &RuleSet, cell: (u16, u16)
             entity.category == EntityCategory::Structure
                 && !entity.dying
                 && sim
-                    .object_type(entity.type_ref, rules)
+                    .object_type(entity.type_ref(), rules)
                     .is_some_and(|obj| obj.refinery)
         })
     })
@@ -1707,7 +1707,7 @@ fn building_nearby_passable_cell(
 ) -> Option<(u16, u16)> {
     let building = sim.substrate.entities.get(building_sid)?;
     let (w, h) = sim
-        .object_type(building.type_ref, rules)
+        .object_type(building.type_ref(), rules)
         .map(|obj| foundation_dimensions(&obj.foundation))
         .unwrap_or((1, 1));
     let (x, y) = building_get_coords_xy(building, w, h);
@@ -2262,7 +2262,7 @@ fn find_docking_bay(
             if entity.category != EntityCategory::Structure {
                 continue;
             }
-            let e_type = sim.interner.resolve(entity.type_ref);
+            let e_type = sim.interner.resolve(entity.type_ref());
             if !e_type.eq_ignore_ascii_case(dock_type) || entity.lifecycle.in_limbo {
                 continue;
             }
@@ -2397,7 +2397,7 @@ fn refinery_accepts_can_load(
         && !sim
             .production
             .dock_reservations
-            .would_admit(refinery.stable_id, miner_sid, capacity)
+            .would_admit(refinery.stable_id(), miner_sid, capacity)
     {
         return false;
     }
@@ -2442,7 +2442,7 @@ fn refinery_dock_for_sid(sim: &Simulation, rules: &RuleSet, ref_sid: u64) -> Opt
     if entity.dying || entity.health.current == 0 {
         return None;
     }
-    let obj = sim.object_type(entity.type_ref, rules);
+    let obj = sim.object_type(entity.type_ref(), rules);
     let (w, h) = obj
         .map(|o| foundation_dimensions(&o.foundation))
         .unwrap_or((1, 1));
@@ -2465,7 +2465,7 @@ fn refinery_dock_capacity_for_sid(
     if entity.dying || entity.health.current == 0 {
         return None;
     }
-    sim.object_type(entity.type_ref, rules)
+    sim.object_type(entity.type_ref(), rules)
         .map(|o| o.number_of_docks.max(1) as usize)
         .or(Some(1))
 }
@@ -2479,7 +2479,7 @@ fn chrono_return_staging_cell_for_sid(
     path_grid: Option<&PathGrid>,
 ) -> Option<(u16, u16)> {
     let entity = sim.substrate.entities.get(ref_sid)?;
-    let obj = sim.object_type(entity.type_ref, rules);
+    let obj = sim.object_type(entity.type_ref(), rules);
     let (w, h) = obj
         .map(|o| foundation_dimensions(&o.foundation))
         .unwrap_or((1, 1));
@@ -3042,7 +3042,7 @@ pub(crate) fn count_purifiers_for_owner(sim: &Simulation, rules: &RuleSet, owner
         .values()
         .filter(|e| {
             counts_as_purifier(sim, rules, e)
-                && sim.interner.resolve(e.owner).eq_ignore_ascii_case(owner)
+                && sim.interner.resolve(e.owner()).eq_ignore_ascii_case(owner)
         })
         .count() as i32
 }
@@ -3064,7 +3064,7 @@ pub(crate) fn counts_as_purifier(
         && e.building_up.is_none()
         && e.category == EntityCategory::Structure
         && sim
-            .object_type(e.type_ref, rules)
+            .object_type(e.type_ref(), rules)
             .is_some_and(|obj| obj.ore_purifier)
 }
 

--- a/src/sim/mission/authority.rs
+++ b/src/sim/mission/authority.rs
@@ -116,8 +116,8 @@ pub(crate) fn override_mission_on_blocked_step(
     // object with no owner is not an ally, and gets attacked.
     if crate::map::houses::is_allied_with(
         alliances,
-        interner.resolve(mover_entity.owner),
-        interner.resolve(blocker_entity.owner),
+        interner.resolve(mover_entity.owner()),
+        interner.resolve(blocker_entity.owner()),
     ) {
         return false;
     }
@@ -302,7 +302,7 @@ struct LiveUnitWorld<'a> {
 impl LiveUnitWorld<'_> {
     fn weapons_factory(&self, entity: &crate::sim::game_entity::GameEntity) -> bool {
         self.rules
-            .object(self.sim.interner.resolve(entity.type_ref))
+            .object(self.sim.interner.resolve(entity.type_ref()))
             .is_some_and(|obj| obj.weapons_factory)
     }
 }

--- a/src/sim/movement/air_movement.rs
+++ b/src/sim/movement/air_movement.rs
@@ -343,7 +343,7 @@ pub fn tick_air_movement(
                     log::debug!(
                         "air_move entity={} type={} speed={} fly_speed={} dt={} alt={} dist_lep={} facing={}",
                         entity_id,
-                        entity.type_ref,
+                        entity.type_ref(),
                         target.speed,
                         fly_speed,
                         dt,

--- a/src/sim/movement/bump_crush.rs
+++ b/src/sim/movement/bump_crush.rs
@@ -118,7 +118,7 @@ pub fn build_entity_block_sets(
         // With rules, expand to the full foundation so A* sees every occupied
         // cell — without it, only the anchor blocks (legacy behavior).
         if entity.category == EntityCategory::Structure {
-            if let Some(obj) = rules.and_then(|r| r.object(interner.resolve(entity.type_ref))) {
+            if let Some(obj) = rules.and_then(|r| r.object(interner.resolve(entity.type_ref()))) {
                 let foundation_cells = crate::sim::production::building_base_foundation_cells(
                     pos.0,
                     pos.1,
@@ -149,7 +149,7 @@ pub fn build_entity_block_sets(
         }
         // Enemy units: soft-block with code 5 (cost 20x).
         let blocker_is_infantry = entity.category == EntityCategory::Infantry;
-        let entity_owner_str = interner.resolve(entity.owner);
+        let entity_owner_str = interner.resolve(entity.owner());
         let is_friendly =
             crate::map::houses::are_houses_friendly(alliances, mover_owner, entity_owner_str);
         if !is_friendly {
@@ -300,7 +300,7 @@ pub(crate) fn build_blocker_neighbor_counts_with_overlays(
         let pos = (entity.position.rx, entity.position.ry);
         if entity.category == EntityCategory::Structure {
             let (width, height) = rules
-                .and_then(|r| r.object(interner.resolve(entity.type_ref)))
+                .and_then(|r| r.object(interner.resolve(entity.type_ref())))
                 .map(|obj| crate::sim::production::foundation_dimensions(&obj.foundation))
                 .unwrap_or((1, 1));
             counts.add_building_expanded_foundation(pos.0, pos.1, width, height);
@@ -764,7 +764,7 @@ pub fn emit_crush_kill_sounds_at(
 ) {
     let rx = crush_coord.0.clamp(0, i32::from(u16::MAX)) as u16;
     let ry = crush_coord.1.clamp(0, i32::from(u16::MAX)) as u16;
-    let type_str = interner.resolve(victim.type_ref).to_string();
+    let type_str = interner.resolve(victim.type_ref()).to_string();
     let Some(obj) = rules.object(&type_str) else {
         return;
     };
@@ -933,7 +933,7 @@ pub fn classify_drive_crush_phase(
     let Some(crusher) = entities.get(crusher_id) else {
         return DriveCrushOutcome::None;
     };
-    let crusher_owner = interner.resolve(crusher.owner);
+    let crusher_owner = interner.resolve(crusher.owner());
     // Per-cell pre-scan, exactly once, before the dispatch walk.
     let elite_in_cell = match phase {
         DriveCrushPhase::EnteringCell => cell_has_elite_occupant(occ, crusher_id, entities),
@@ -954,7 +954,7 @@ pub fn classify_drive_crush_phase(
                 }
             }
             DriveCrushPhase::FullyInCell => {
-                let victim_owner = interner.resolve(victim.owner);
+                let victim_owner = interner.resolve(victim.owner());
                 if crate::map::houses::are_houses_friendly(alliances, crusher_owner, victim_owner) {
                     continue;
                 }
@@ -1059,7 +1059,7 @@ pub fn blocker_is_fraidycat(
         return false;
     }
     rules
-        .and_then(|rules| rules.object(interner.resolve(blocker.type_ref)))
+        .and_then(|rules| rules.object(interner.resolve(blocker.type_ref())))
         .is_some_and(|obj| obj.fraidycat)
 }
 

--- a/src/sim/movement/mod.rs
+++ b/src/sim/movement/mod.rs
@@ -154,7 +154,7 @@ pub(crate) fn install_forced_drive_track(
     // established the mover is on the ground plane.
     let current_cell = (entity.position.rx, entity.position.ry);
     let current_layer = locomotor::MovementLayer::Ground;
-    let entity_stable_id = entity.stable_id;
+    let entity_stable_id = entity.stable_id();
 
     let drive = entity
         .drive_locomotion

--- a/src/sim/movement/movement_occupancy.rs
+++ b/src/sim/movement/movement_occupancy.rs
@@ -389,7 +389,7 @@ pub(super) fn build_live_building_entry_skip_map(
         if building.category != EntityCategory::Structure {
             continue;
         }
-        let Some(obj) = rules.object(interner.resolve(building.type_ref)) else {
+        let Some(obj) = rules.object(interner.resolve(building.type_ref())) else {
             continue;
         };
         let gate_skip = gate_helpers
@@ -398,11 +398,11 @@ pub(super) fn build_live_building_entry_skip_map(
                 .building_gate
                 .is_some_and(|state| state.can_garrison_passable());
         let infantry_entry_target = mover.category == EntityCategory::Infantry
-            && (mover.capture_target == Some(building.stable_id)
+            && (mover.capture_target == Some(building.stable_id())
                 || mover
                     .c4_plant
-                    .is_some_and(|plant| plant.target_building_id == building.stable_id));
-        let has_contact = vehicle_row_helpers && mover.has_live_contact_with(building.stable_id);
+                    .is_some_and(|plant| plant.target_building_id == building.stable_id()));
+        let has_contact = vehicle_row_helpers && mover.has_live_contact_with(building.stable_id());
         let has_vehicle_exception =
             vehicle_row_helpers && (has_contact || obj.unit_repair || obj.bunker || obj.bib);
         if !has_vehicle_exception && !gate_skip && !infantry_entry_target {
@@ -427,8 +427,8 @@ pub(super) fn build_live_building_entry_skip_map(
                     branch: VehicleBuildingEntryBranch::RadioContact {
                         mover_has_contact: has_contact,
                     },
-                    checked_building_id: building.stable_id,
-                    candidate_building_id: Some(building.stable_id),
+                    checked_building_id: building.stable_id(),
+                    candidate_building_id: Some(building.stable_id()),
                     candidate_x: cx,
                     building_origin_x: building.position.rx,
                     number_impassable_rows: obj.number_impassable_rows,
@@ -466,7 +466,7 @@ pub(super) fn build_live_building_entry_skip_map(
                 skips
                     .entry((cx, cy))
                     .or_default()
-                    .insert(building.stable_id);
+                    .insert(building.stable_id());
             }
         }
     }

--- a/src/sim/movement/movement_tick.rs
+++ b/src/sim/movement/movement_tick.rs
@@ -294,7 +294,7 @@ fn snapshot_mover(
         omni_crusher: e.omni_crusher,
         regular_crusher: e.regular_crusher,
         drive_accelerates: e.drive_accelerates,
-        owner: e.owner,
+        owner: e.owner(),
         too_big_to_fit_under_bridge: e.too_big_to_fit_under_bridge,
         on_bridge: e.on_bridge,
         runtime_bridge_transition: e.runtime_bridge_transition,
@@ -695,7 +695,7 @@ fn process_pending_drive_arrivals(
         let movement_zone = Some(loco.movement_zone);
         let terrain_cost = terrain_costs.get(&loco.speed_type);
         let (entity_blocks, entity_block_map) = entity_block_sets
-            .get(&entity.owner)
+            .get(&entity.owner())
             .map(|(b, m)| (Some(b), Some(m)))
             .unwrap_or((None, None));
         let mut occupied_blocks = entity_blocks.cloned().unwrap_or_default();
@@ -742,7 +742,7 @@ fn process_pending_drive_arrivals(
             entity.navigation.pending_arrival_clear = true;
             continue;
         }
-        let obj = rules.and_then(|r| r.object(interner.resolve(entity.type_ref)));
+        let obj = rules.and_then(|r| r.object(interner.resolve(entity.type_ref())));
         let speed_multiplier = loco.speed_multiplier;
         // Copy out (Copy type) before `loco`'s borrow of `entity` ends: only
         // Drive-kind movers ride drive-track curve tables below — hover (and
@@ -1675,7 +1675,7 @@ fn tick_movement_with_grids_scoped(
         if let Some(entity) = entities.get(id) {
             let _ = drive_locomotion::process_drive_locomotion_shell(entity);
             if entity.navigation.pending_arrival_clear {
-                mover_owners.insert(entity.owner);
+                mover_owners.insert(entity.owner());
             }
             if forced_drive_processed.contains(&id)
                 || tube_processed.contains(&id)
@@ -1687,7 +1687,7 @@ fn tick_movement_with_grids_scoped(
             let layer = entity.movement_layer_or_ground();
             if !matches!(layer, MovementLayer::Air | MovementLayer::Underground) {
                 movers.push(id);
-                mover_owners.insert(entity.owner);
+                mover_owners.insert(entity.owner());
             }
         }
     }
@@ -1764,7 +1764,7 @@ fn tick_movement_with_grids_scoped(
                 return None;
             }
             let rules = rules?;
-            let obj = rules.object(interner.resolve(entity.type_ref))?;
+            let obj = rules.object(interner.resolve(entity.type_ref()))?;
             Some(obj.crawls)
         });
         let entity_cost_grid: Option<&TerrainCostGrid> =
@@ -2801,7 +2801,7 @@ fn tick_movement_with_grids_scoped(
             // the score-screen kill credit is captured here, against the same
             // shared helper the damage loop uses. Running infantry over is
             // routine, so without this the Kills column reads visibly low.
-            let crusher_owner = entities.get(kill.crusher_id).map(|crusher| crusher.owner);
+            let crusher_owner = entities.get(kill.crusher_id).map(|crusher| crusher.owner());
             if let Some(victim) = entities.get_mut(victim_id) {
                 victim.health.current = 0;
                 if let Some(rules) = rules {

--- a/src/sim/movement/path_markers.rs
+++ b/src/sim/movement/path_markers.rs
@@ -307,19 +307,19 @@ pub(super) fn snapshot_bridge_marker_peers(
                     base_height_leptons.wrapping_add(locomotor.altitude.to_num::<i32>())
                 });
             let speed = rules
-                .and_then(|rules| rules.object(interner.resolve(entity.type_ref)))
+                .and_then(|rules| rules.object(interner.resolve(entity.type_ref())))
                 .map_or(0, |object| object.speed);
             let foot_derived = matches!(
                 entity.category,
                 EntityCategory::Unit | EntityCategory::Infantry | EntityCategory::Aircraft
             );
             (
-                entity.stable_id,
+                entity.stable_id(),
                 BridgeMarkerPeer {
                     category: entity.category,
                     foot_derived,
                     locomotor_kind: entity.locomotor.as_ref().map(|locomotor| locomotor.kind),
-                    type_ref: entity.type_ref,
+                    type_ref: entity.type_ref(),
                     speed,
                     path_start,
                     path_directions,

--- a/src/sim/movement/scatter.rs
+++ b/src/sim/movement/scatter.rs
@@ -237,7 +237,7 @@ pub fn scatter_units_from_cell(
         .iter()
         .filter_map(|&id| {
             let entity = entities.get(id)?;
-            if entity.owner != owner {
+            if entity.owner() != owner {
                 return None;
             }
             match entity.category {
@@ -387,7 +387,7 @@ fn resolve_entity_speed(
     };
     // `FootClass::GetCurrentSpeed @ 0x004DB1A0`: FASTER scales the truncated
     // per-frame type speed ahead of the locomotor fraction.
-    let obj = rules.and_then(|r| r.object(interner.resolve(entity.type_ref)));
+    let obj = rules.and_then(|r| r.object(interner.resolve(entity.type_ref())));
     let base_speed = crate::sim::combat::veterancy::entity_mover_speed_leptons_per_second(
         entity,
         obj,
@@ -409,7 +409,7 @@ fn resolve_entity_speed(
 fn build_entity_block_set(entities: &EntityStore, exclude_id: u64) -> BTreeSet<(u16, u16)> {
     let mut blocks = BTreeSet::new();
     for entity in entities.values() {
-        if entity.stable_id == exclude_id || entity.dying || !entity.lifecycle.cell_marked {
+        if entity.stable_id() == exclude_id || entity.dying || !entity.lifecycle.cell_marked {
             continue;
         }
         // Only block cells occupied by vehicles/structures — infantry share cells.

--- a/src/sim/movement/tube_movement.rs
+++ b/src/sim/movement/tube_movement.rs
@@ -246,7 +246,7 @@ pub(crate) fn tick_active_tube_object(
     };
     let category = entity.category;
     let speed = rules
-        .and_then(|rules| rules.object(interner.resolve(entity.type_ref)))
+        .and_then(|rules| rules.object(interner.resolve(entity.type_ref())))
         .map_or(0, |object| native_type_speed(object.speed));
     let budget = if category == EntityCategory::Unit {
         speed.wrapping_mul(3) / 2
@@ -562,7 +562,7 @@ fn scatter_exit_blockers(
             continue;
         }
         let fraidycat = rules
-            .and_then(|rules| rules.object(interner.resolve(blocker.type_ref)))
+            .and_then(|rules| rules.object(interner.resolve(blocker.type_ref())))
             .is_some_and(|object| object.fraidycat);
         let mission_control = rules.map(|rules| &rules.mission_control);
         bump_crush::scatter_blocker(

--- a/src/sim/movement/turret.rs
+++ b/src/sim/movement/turret.rs
@@ -211,7 +211,7 @@ pub(crate) fn facing_update(
         hull_destination: None,
         turret_destination_is_idle_return: false,
     };
-    let obj = rules.and_then(|r| r.object(interner.resolve(entity.type_ref)));
+    let obj = rules.and_then(|r| r.object(interner.resolve(entity.type_ref())));
     let has_turret = entity.barrel_facing.is_some();
 
     // --- A. AIM ---------------------------------------------------------
@@ -314,7 +314,7 @@ pub(crate) fn current_weapon_is_omni_fire(
     interner: &crate::sim::intern::StringInterner,
 ) -> bool {
     let Some(rules) = rules else { return false };
-    let Some(obj) = rules.object(interner.resolve(entity.type_ref)) else {
+    let Some(obj) = rules.object(interner.resolve(entity.type_ref())) else {
         return false;
     };
     let index: i32 = if obj.turret_count > 0 {
@@ -446,7 +446,7 @@ pub fn tick_turret_rotation(
                 interner.resolve(
                     entities
                         .get(update.id)
-                        .map(|e| e.type_ref)
+                        .map(|e| e.type_ref())
                         .unwrap_or_default(),
                 ),
             )

--- a/src/sim/occupancy.rs
+++ b/src/sim/occupancy.rs
@@ -660,7 +660,7 @@ impl CellOccupationGrid {
                 grid.mark_vehicle_on_layer(
                     entity.position.rx,
                     entity.position.ry,
-                    entity.stable_id,
+                    entity.stable_id(),
                     layer,
                 );
             }
@@ -671,7 +671,7 @@ impl CellOccupationGrid {
                 .flat_map(|drive| [drive.occupation_handoff, drive.occupation_head_to])
                 .flatten()
             {
-                grid.mark_vehicle_on_layer(mark.rx, mark.ry, entity.stable_id, mark.layer);
+                grid.mark_vehicle_on_layer(mark.rx, mark.ry, entity.stable_id(), mark.layer);
             }
         }
         grid
@@ -685,18 +685,18 @@ impl CellOccupationGrid {
     pub(crate) fn reconcile_entity(&mut self, entity: &GameEntity) {
         let old_footprints = self
             .footprints_by_owner
-            .get_mut(&entity.stable_id)
+            .get_mut(&entity.stable_id())
             .map(std::mem::take)
             .unwrap_or_default();
         for footprint in old_footprints.iter() {
-            self.clear_vehicle_plane(footprint, entity.stable_id);
+            self.clear_vehicle_plane(footprint, entity.stable_id());
         }
 
         if entity.category != EntityCategory::Unit
             || !entity.lifecycle.cell_marked
             || entity.passenger_role.is_inside_transport()
         {
-            self.footprints_by_owner.remove(&entity.stable_id);
+            self.footprints_by_owner.remove(&entity.stable_id());
             return;
         }
         let current_cleared = entity
@@ -707,7 +707,7 @@ impl CellOccupationGrid {
             self.mark_vehicle_on_layer(
                 entity.position.rx,
                 entity.position.ry,
-                entity.stable_id,
+                entity.stable_id(),
                 layer,
             );
         }
@@ -718,14 +718,14 @@ impl CellOccupationGrid {
             .flat_map(|drive| [drive.occupation_handoff, drive.occupation_head_to])
             .flatten()
         {
-            self.mark_vehicle_on_layer(mark.rx, mark.ry, entity.stable_id, mark.layer);
+            self.mark_vehicle_on_layer(mark.rx, mark.ry, entity.stable_id(), mark.layer);
         }
         if self
             .footprints_by_owner
-            .get(&entity.stable_id)
+            .get(&entity.stable_id())
             .is_some_and(OwnerOccupationFootprints::is_empty)
         {
-            self.footprints_by_owner.remove(&entity.stable_id);
+            self.footprints_by_owner.remove(&entity.stable_id());
         }
     }
 
@@ -1217,7 +1217,7 @@ impl OccupancyGrid {
     pub fn rebuild(entities: &crate::sim::entity_store::EntityStore) -> Self {
         let mut grid = Self::new();
         let mut ordered: Vec<&GameEntity> = entities.values().collect();
-        ordered.sort_by_key(|entity| (entity.occupancy_enter_order, entity.stable_id));
+        ordered.sort_by_key(|entity| (entity.occupancy_enter_order, entity.stable_id()));
         for entity in ordered {
             // Global storage, native-alive, limbo, and cell-list membership are
             // independent facts. Only an object whose Mark transaction succeeded
@@ -1232,7 +1232,7 @@ impl OccupancyGrid {
             let Some(layer) = cell_list_layer_for_entity(entity) else {
                 continue;
             };
-            let sid = entity.stable_id;
+            let sid = entity.stable_id();
             let sub = if entity.category == EntityCategory::Infantry {
                 entity.sub_cell
             } else {

--- a/src/sim/overlay_grid.rs
+++ b/src/sim/overlay_grid.rs
@@ -10,11 +10,12 @@
 use crate::map::authored_overlay::{FinalizedOverlayCell, FinalizedOverlayPayload};
 use crate::map::overlay::{OverlayDataPack, OverlayEntry};
 use crate::map::overlay_types::{
-    OverlayTypeRegistry, clears_tiberium_on_slope, is_bridge_overlay_index, retained_overlay_land,
+    OverlayTypeRegistry, clears_tiberium_on_slope, is_bridge_overlay_index,
 };
 use crate::map::resolved_terrain::{
-    ResolvedTerrainGrid, overlay_reduced_zone_type, recalc_zone_type,
+    ResolvedTerrainGrid,
 };
+#[cfg(test)]
 use crate::rules::terrain_rules::{LandType, SpeedCostProfile, TerrainClass};
 use crate::sim::intern::InternedId;
 use crate::sim::occupancy::OBJECT_OCCUPATION_BIT;
@@ -975,8 +976,6 @@ pub fn recalc_overlay_passability(
     rx: u16,
     ry: u16,
 ) -> bool {
-    use crate::map::resolved_terrain::zone_class;
-
     let Some(slope_type) = resolved_terrain.cell(rx, ry).map(|cell| cell.slope_type) else {
         return false;
     };
@@ -989,89 +988,10 @@ pub fn recalc_overlay_passability(
         cleared_resource_for_slope = true;
     }
     let flags = overlay_id.and_then(|id| registry.flags(id));
-    let overlay_zone = overlay_reduced_zone_type(flags);
-    let new_blocks = matches!(
-        overlay_zone,
-        Some(zone_class::WALL) | Some(zone_class::IMPASSABLE)
-    );
-
-    let Some(terrain_cell) = resolved_terrain.cell_mut(rx, ry) else {
-        return false;
-    };
-
-    let old_overlay_zone_type = terrain_cell.overlay_zone_type;
-    let old = (
-        terrain_cell.overlay_blocks,
-        terrain_cell.zone_type,
-        terrain_cell.land_type,
-        terrain_cell.yr_cell_land_type,
-        terrain_cell.terrain_class,
-        terrain_cell.speed_costs,
-        terrain_cell.is_water,
-        terrain_cell.is_cliff_like,
-        terrain_cell.is_rough,
-        terrain_cell.is_road,
-        terrain_cell.ground_walk_blocked,
-        terrain_cell.build_blocked,
-    );
-
-    restore_pristine_land(terrain_cell);
-    let current_land_flags = if cleared_resource_for_slope {
-        source_flags
-    } else {
-        flags
-    };
-    // Ground blocking follows whichever land the cell ends up with. With no
-    // overlay land that is the pristine terrain value already cached in
-    // `base_ground_walk_blocked`; with one it is the overlay's `Land=` row.
-    // `CellClass__RecalcAttributes` @ `0x0047D2B0` recomputes LandType from
-    // scratch on every overlay change and keeps no separate blocked bit, so
-    // neither value may outlive the land that produced it.
-    let mut land_ground_blocked = terrain_cell.base_ground_walk_blocked;
-    if let Some(flags) = current_land_flags {
-        if let Some(land) = retained_overlay_land(flags, slope_type) {
-            apply_overlay_land(terrain_cell, land, flags.land_speed_costs);
-            // The ramp exemption is a property of the tile, not the land row,
-            // so it survives the override exactly as it does in the pristine
-            // value baked into `base_ground_walk_blocked`.
-            land_ground_blocked =
-                terrain_cell.canonical_ramp.is_none() && flags.land_ground_blocked;
-        }
-    }
-
-    terrain_cell.overlay_blocks = new_blocks;
-    terrain_cell.overlay_zone_type = overlay_zone;
-    terrain_cell.ground_walk_blocked =
-        land_ground_blocked || terrain_cell.terrain_object_blocks || new_blocks;
-    terrain_cell.build_blocked = terrain_cell.base_build_blocked
-        || terrain_cell.terrain_object_blocks
-        || new_blocks
-        || terrain_cell.has_bridge_deck;
-    terrain_cell.zone_type = recalc_zone_type(
-        terrain_cell.outside_playfield,
-        terrain_cell.overlay_zone_type,
-        terrain_cell.land_type,
-        terrain_cell.speed_costs.wheel,
-        terrain_cell.terrain_object_occupation,
-    );
-
-    let new = (
-        terrain_cell.overlay_blocks,
-        terrain_cell.zone_type,
-        terrain_cell.land_type,
-        terrain_cell.yr_cell_land_type,
-        terrain_cell.terrain_class,
-        terrain_cell.speed_costs,
-        terrain_cell.is_water,
-        terrain_cell.is_cliff_like,
-        terrain_cell.is_rough,
-        terrain_cell.is_road,
-        terrain_cell.ground_walk_blocked,
-        terrain_cell.build_blocked,
-    );
-    cleared_resource_for_slope
-        || old_overlay_zone_type != terrain_cell.overlay_zone_type
-        || old != new
+    let land_flags = if cleared_resource_for_slope { source_flags } else { flags };
+    // Do not short circuit the projection when literal storage was cleared.
+    let projection_changed = resolved_terrain.apply_overlay_attributes(rx, ry, flags, land_flags);
+    cleared_resource_for_slope || projection_changed
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1115,34 +1035,6 @@ pub(crate) fn recalc_wall_mutation_passability(
         navigation_changed,
         zone_changed,
     }
-}
-
-fn restore_pristine_land(cell: &mut crate::map::resolved_terrain::ResolvedTerrainCell) {
-    cell.land_type = cell.base_land_type;
-    cell.yr_cell_land_type = cell.base_yr_cell_land_type;
-    cell.terrain_class = cell.base_terrain_class;
-    cell.speed_costs = cell.base_speed_costs;
-    let base_land = LandType::from_index(cell.base_land_type);
-    cell.is_water = base_land.is_some_and(LandType::is_water);
-    cell.is_cliff_like = base_land.is_some_and(LandType::is_cliff_like)
-        || matches!(cell.base_terrain_class, TerrainClass::Cliff);
-    cell.is_rough = base_land.is_some_and(LandType::is_rough);
-    cell.is_road = base_land.is_some_and(LandType::is_road);
-}
-
-fn apply_overlay_land(
-    cell: &mut crate::map::resolved_terrain::ResolvedTerrainCell,
-    land: LandType,
-    speed_costs: Option<SpeedCostProfile>,
-) {
-    cell.land_type = land.as_index();
-    cell.yr_cell_land_type = land.as_index();
-    cell.terrain_class = land.terrain_class();
-    cell.speed_costs = speed_costs.unwrap_or_default();
-    cell.is_water = land.is_water();
-    cell.is_cliff_like = land.is_cliff_like();
-    cell.is_rough = land.is_rough();
-    cell.is_road = land.is_road();
 }
 
 /// A request to damage a wall overlay at a specific cell.
@@ -1253,7 +1145,7 @@ fn native_runtime_overlay_cell_lookup(
     let narrowed_x = i32::from(x as i16);
     let narrowed_y = i32::from(y as i16);
     if let Some(index) = terrain.native_fixed_cell_index(x as i16, y as i16)
-        && let Some(cell) = terrain.cells.get(index)
+        && let Some(cell) = terrain.cells().get(index)
         && cell.rx < width
         && cell.ry < height
     {

--- a/src/sim/particles/spark_world.rs
+++ b/src/sim/particles/spark_world.rs
@@ -313,10 +313,10 @@ impl<'a> SparkCollisionWorld<'a> {
             // Native stops at the first building in the selected object list.
             let object = self
                 .sim
-                .object_type(entity.type_ref, self.rules)
-                .ok_or(SparkWorldError::MissingObjectType(entity.stable_id))?;
+                .object_type(entity.type_ref(), self.rules)
+                .ok_or(SparkWorldError::MissingObjectType(entity.stable_id()))?;
             if object.laser_fence {
-                return Err(SparkWorldError::UnsupportedLaserFence(entity.stable_id));
+                return Err(SparkWorldError::UnsupportedLaserFence(entity.stable_id()));
             }
             let undeploys_from_one_by_one = object
                 .undeploys_into

--- a/src/sim/particles/spawn.rs
+++ b/src/sim/particles/spawn.rs
@@ -194,7 +194,7 @@ impl Simulation {
 
         let Some((coords, owner_entity, system_types)) =
             self.substrate.entities.get(stable_id).and_then(|entity| {
-                let object = rules.object(self.interner.resolve(entity.type_ref))?;
+                let object = rules.object(self.interner.resolve(entity.type_ref()))?;
                 let offset = damage_smoke_offset(object);
                 let coords = IVec3::new(
                     i32::from(entity.position.rx)

--- a/src/sim/passenger.rs
+++ b/src/sim/passenger.rs
@@ -271,7 +271,7 @@ pub fn can_enter_transport(
         );
     } else {
         // Vehicle transports: strict same-owner.
-        if passenger.owner != transport.owner {
+        if passenger.owner() != transport.owner() {
             return false;
         }
     }
@@ -304,8 +304,8 @@ pub fn can_dock_occupier_garrison(
     if !passenger_obj.occupier {
         return false;
     }
-    let same_owner = passenger.owner == building.owner;
-    if !same_owner && !owner_is_multiplay_passive(building.owner, houses) {
+    let same_owner = passenger.owner() == building.owner();
+    if !same_owner && !owner_is_multiplay_passive(building.owner(), houses) {
         return false;
     }
     if cargo.count() == building_obj.max_number_occupants {
@@ -352,10 +352,10 @@ pub fn can_entity_enter_garrison(
     let Some(building) = sim.substrate.entities.get(building_id) else {
         return false;
     };
-    let Some(passenger_obj) = sim.object_type(passenger.type_ref, rules) else {
+    let Some(passenger_obj) = sim.object_type(passenger.type_ref(), rules) else {
         return false;
     };
-    let Some(building_obj) = sim.object_type(building.type_ref, rules) else {
+    let Some(building_obj) = sim.object_type(building.type_ref(), rules) else {
         return false;
     };
     let Some(cargo) = building.passenger_role.cargo() else {
@@ -491,13 +491,13 @@ fn process_boarding_passenger(sim: &mut Simulation, rules: &RuleSet, pax_id: u64
         .substrate
         .entities
         .get(pax_id)
-        .map(|e| sim.interner.resolve(e.type_ref).to_string())
+        .map(|e| sim.interner.resolve(e.type_ref()).to_string())
         .unwrap_or_default();
     let transport_type_str = sim
         .substrate
         .entities
         .get(transport_id)
-        .map(|e| sim.interner.resolve(e.type_ref).to_string())
+        .map(|e| sim.interner.resolve(e.type_ref()).to_string())
         .unwrap_or_default();
 
     let pax_size = rules.object(&pax_type_str).map(|obj| obj.size).unwrap_or(1);
@@ -508,7 +508,7 @@ fn process_boarding_passenger(sim: &mut Simulation, rules: &RuleSet, pax_id: u64
     let pax_obj = rules.object(&pax_type_str);
     let pax_ifv_mode = pax_obj.map(|obj| obj.ifv_mode).unwrap_or(0);
     let pax_open_transport_weapon = pax_obj.map(|obj| obj.open_transport_weapon).unwrap_or(-1);
-    let entering_owner = sim.substrate.entities.get(pax_id).map(|pax| pax.owner);
+    let entering_owner = sim.substrate.entities.get(pax_id).map(|pax| pax.owner());
 
     let can_board = sim
         .substrate
@@ -637,8 +637,8 @@ fn reconcile_civilian_garrison_owner_for_building(
             .and_then(|building| {
                 let cargo = building.passenger_role.cargo()?;
                 Some((
-                    building.type_ref,
-                    building.owner,
+                    building.type_ref(),
+                    building.owner(),
                     // The FIRST occupant to enter: the cargo list is head-first
                     // (`AddPassenger` prepends), so the earliest entry is the
                     // tail. VERA-internal ownership rule, gamemd equivalent
@@ -674,7 +674,7 @@ fn reconcile_civilian_garrison_owner_for_building(
             .and_then(|building| {
                 let cargo = building.passenger_role.cargo()?;
                 Some((
-                    building.owner,
+                    building.owner(),
                     cargo.passengers.last().copied(),
                     cargo.is_empty(),
                 ))
@@ -690,7 +690,7 @@ fn reconcile_civilian_garrison_owner_for_building(
     if !cargo_empty && is_civilian_garrison_owner(&sim.interner, current_owner) {
         let Some(new_owner) = first_passenger
             .and_then(|passenger_id| sim.substrate.entities.get(passenger_id))
-            .map(|passenger| passenger.owner)
+            .map(|passenger| passenger.owner())
         else {
             return false;
         };
@@ -908,7 +908,7 @@ fn is_can_be_occupied_unloading_transport(
     if !matches!(entity.order_intent, Some(OrderIntent::Unloading)) {
         return false;
     }
-    sim.object_type(entity.type_ref, rules)
+    sim.object_type(entity.type_ref(), rules)
         .is_some_and(|obj| obj.can_be_occupied)
 }
 
@@ -1060,7 +1060,7 @@ fn process_unloading_transport(sim: &mut Simulation, rules: &RuleSet, transport_
         .substrate
         .entities
         .get(pax_id)
-        .map(|e| sim.interner.resolve(e.type_ref).to_string())
+        .map(|e| sim.interner.resolve(e.type_ref()).to_string())
         .unwrap_or_default();
     let reveal_outcome = reveal_unloaded_passenger(sim, transport_id, pax_id, exit_rx, exit_ry, tz);
     if !matches!(reveal_outcome, RevealOutcome::Revealed { .. }) {

--- a/src/sim/pathfinding/cell_entry.rs
+++ b/src/sim/pathfinding/cell_entry.rs
@@ -1063,7 +1063,7 @@ fn classify_blocker(
         return CellEntryResult::Impassable;
     };
     let is_friendly =
-        houses::are_houses_friendly(alliances, mover_owner, interner.resolve(blocker.owner));
+        houses::are_houses_friendly(alliances, mover_owner, interner.resolve(blocker.owner()));
     if !is_friendly {
         return CellEntryResult::OccupiedEnemy { blocker_id };
     }

--- a/src/sim/power_system.rs
+++ b/src/sim/power_system.rs
@@ -82,10 +82,10 @@ fn recalculate_power_for_owner(
         if entity.dying || entity.lifecycle.in_limbo {
             continue;
         }
-        if entity.category != EntityCategory::Structure || entity.owner != owner_id {
+        if entity.category != EntityCategory::Structure || entity.owner() != owner_id {
             continue;
         }
-        let Some(obj) = rules.object(interner.resolve(entity.type_ref)) else {
+        let Some(obj) = rules.object(interner.resolve(entity.type_ref())) else {
             continue;
         };
 
@@ -156,9 +156,9 @@ pub fn tick_power_states(
         if !entity.dying
             && !entity.lifecycle.in_limbo
             && entity.category == EntityCategory::Structure
-            && !owners.contains(&entity.owner)
+            && !owners.contains(&entity.owner())
         {
-            owners.push(entity.owner);
+            owners.push(entity.owner());
         }
     }
     owners.sort();
@@ -204,7 +204,7 @@ pub fn is_building_powered(
     if entity.category != EntityCategory::Structure {
         return true;
     }
-    let Some(obj) = rules.object(interner.resolve(entity.type_ref)) else {
+    let Some(obj) = rules.object(interner.resolve(entity.type_ref())) else {
         return true;
     };
     // Power plants (positive Power=) are never deactivated.
@@ -217,7 +217,7 @@ pub fn is_building_powered(
     }
     // Check if owner is in low power.
     let is_low = power_states
-        .get(&entity.owner)
+        .get(&entity.owner())
         .is_some_and(|state| state.is_low_power);
     !is_low
 }
@@ -257,9 +257,9 @@ pub fn has_active_radar(
         !e.dying
             && !e.lifecycle.in_limbo
             && e.category == EntityCategory::Structure
-            && e.owner == owner_id
+            && e.owner() == owner_id
             && rules
-                .object(interner.resolve(e.type_ref))
+                .object(interner.resolve(e.type_ref()))
                 .is_some_and(|obj| obj.radar)
     })
 }

--- a/src/sim/production/production_placement.rs
+++ b/src/sim/production/production_placement.rs
@@ -505,10 +505,10 @@ fn evaluate_building_placement(
             .values()
             .filter(|e| {
                 e.category == EntityCategory::Structure
-                    && sim.interner.resolve(e.owner).eq_ignore_ascii_case(owner)
+                    && sim.interner.resolve(e.owner()).eq_ignore_ascii_case(owner)
             })
             .map(|e| {
-                let type_str = sim.interner.resolve(e.type_ref);
+                let type_str = sim.interner.resolve(e.type_ref());
                 let bn = rules.object(type_str).map_or(false, |o| o.base_normal);
                 format!(
                     "{}@({},{}) bn={}",
@@ -702,7 +702,7 @@ pub(super) fn structure_occupies_cell(
         if e.category != EntityCategory::Structure {
             return false;
         }
-        let Some(existing) = rules.object(interner.resolve(e.type_ref)) else {
+        let Some(existing) = rules.object(interner.resolve(e.type_ref())) else {
             return false;
         };
         // Wall entities render and behave as overlays — they don't block building
@@ -741,8 +741,8 @@ fn is_within_build_area(
         if e.category != EntityCategory::Structure {
             continue;
         }
-        let provider_owner = sim.interner.resolve(e.owner);
-        let Some(existing) = sim.object_type(e.type_ref, rules) else {
+        let provider_owner = sim.interner.resolve(e.owner());
+        let Some(existing) = sim.object_type(e.type_ref(), rules) else {
             continue;
         };
         if provider_owner.eq_ignore_ascii_case(owner) {

--- a/src/sim/production/production_queue.rs
+++ b/src/sim/production/production_queue.rs
@@ -288,10 +288,10 @@ pub fn build_options_for_owner(sim: &Simulation, rules: &RuleSet, owner: &str) -
         );
         // Log owned structures and their factory status.
         for e in sim.substrate.entities.values() {
-            if sim.interner.resolve(e.owner).eq_ignore_ascii_case(owner)
+            if sim.interner.resolve(e.owner()).eq_ignore_ascii_case(owner)
                 && e.category == crate::map::entities::EntityCategory::Structure
             {
-                let ts = sim.interner.resolve(e.type_ref);
+                let ts = sim.interner.resolve(e.type_ref());
                 log::warn!(
                     "[BUILD-DIAG]   structure '{}' building_up={} factory_type={:?}",
                     ts,
@@ -619,7 +619,7 @@ fn tick_production_impl(
                     .entities
                     .get(af_id)
                     .and_then(|af| {
-                        let af_type = sim.interner.resolve(af.type_ref);
+                        let af_type = sim.interner.resolve(af.type_ref());
                         let af_obj = rules.object(af_type)?;
                         Some(af_obj.number_of_docks.max(1))
                     })

--- a/src/sim/production/production_refinery.rs
+++ b/src/sim/production/production_refinery.rs
@@ -57,8 +57,8 @@ pub(crate) fn spawn_completed_refinery_free_units(
                 }
                 let (width, height) = foundation_dimensions(&entity.foundation);
                 Some((
-                    entity.owner,
-                    entity.type_ref,
+                    entity.owner(),
+                    entity.type_ref(),
                     entity.position.rx,
                     entity.position.ry,
                     width,

--- a/src/sim/production/production_sell.rs
+++ b/src/sim/production/production_sell.rs
@@ -391,7 +391,7 @@ fn sellbuilding_direct_scatter_handoff(
         i32::from(target_ry) - i32::from(pax.position.ry),
     );
     let start_cell = (pax.position.rx, pax.position.ry);
-    let type_name = sim.interner.resolve(pax.type_ref).to_string();
+    let type_name = sim.interner.resolve(pax.type_ref()).to_string();
     // `FootClass::GetCurrentSpeed @ 0x004DB1A0`: a veteran garrison occupant
     // ejected by the sale scatters at its FASTER speed.
     let sell_obj = rules.object(&type_name);
@@ -568,7 +568,7 @@ fn eject_garrison_occupants(sim: &mut Simulation, rules: &RuleSet, building_id: 
             Some(c) if !c.is_empty() => c,
             _ => return 0,
         };
-        let obj = match sim.object_type(entity.type_ref, rules) {
+        let obj = match sim.object_type(entity.type_ref(), rules) {
             Some(o) => o,
             None => return 0,
         };
@@ -680,7 +680,7 @@ pub(crate) fn eject_red_hp_garrison(
         if cargo.is_empty() {
             return 0;
         }
-        let Some(obj) = sim.object_type(entity.type_ref, rules) else {
+        let Some(obj) = sim.object_type(entity.type_ref(), rules) else {
             return 0;
         };
         if !obj.can_be_occupied {
@@ -693,7 +693,7 @@ pub(crate) fn eject_red_hp_garrison(
             entity.position.z,
             fw,
             fh,
-            entity.owner,
+            entity.owner(),
             cargo.passengers.clone(),
         )
     };
@@ -736,8 +736,8 @@ pub fn sell_building(sim: &mut Simulation, rules: &RuleSet, stable_id: u64) -> b
             return false;
         }
         (
-            sim.interner.resolve(entity.owner).to_string(),
-            sim.interner.resolve(entity.type_ref).to_string(),
+            sim.interner.resolve(entity.owner()).to_string(),
+            sim.interner.resolve(entity.type_ref()).to_string(),
             entity.position.clone(),
             Some(entity.health),
         )
@@ -817,7 +817,7 @@ pub fn toggle_repair(sim: &mut Simulation, stable_id: u64) -> bool {
         // `PlayEVA("EVA_Repairing")` (`0x004470B7`). The app applies the
         // local-owner half.
         if entity.health.current != entity.health.max {
-            let owner = entity.owner;
+            let owner = entity.owner();
             sim.sound_events.push(SimSoundEvent::Repairing { owner });
         }
     }
@@ -841,7 +841,7 @@ fn tick_ai_low_credit_sell_decisions(sim: &mut Simulation, rules: &RuleSet) {
         .entities
         .values()
         .filter(|entity| entity.category == EntityCategory::Structure)
-        .map(|entity| entity.stable_id)
+        .map(|entity| entity.stable_id())
         .collect();
 
     for stable_id in building_ids {
@@ -852,7 +852,7 @@ fn tick_ai_low_credit_sell_decisions(sim: &mut Simulation, rules: &RuleSet) {
                     && f64::from(entity.health.current) / f64::from(entity.health.max)
                         < f64::from(rules.general.condition_red);
                 (
-                    entity.owner,
+                    entity.owner(),
                     entity.is_active()
                         && !entity.lifecycle.in_limbo
                         && entity.was_attacked_by_enemy
@@ -916,9 +916,9 @@ pub fn tick_repairs(sim: &mut Simulation, rules: &RuleSet) {
         })
         .map(|e| {
             (
-                e.stable_id,
-                sim.interner.resolve(e.owner).to_string(),
-                sim.interner.resolve(e.type_ref).to_string(),
+                e.stable_id(),
+                sim.interner.resolve(e.owner()).to_string(),
+                sim.interner.resolve(e.type_ref()).to_string(),
                 e.health.current,
                 e.health.max,
             )

--- a/src/sim/production/production_spawn.rs
+++ b/src/sim/production/production_spawn.rs
@@ -287,7 +287,7 @@ pub fn mark_war_factory_spawn_contact(
 ) -> bool {
     let Some((producer_type, produced_is_vehicle)) =
         sim.substrate.entities.get(producer_id).and_then(|p| {
-            let producer_type = sim.interner.resolve(p.type_ref).to_string();
+            let producer_type = sim.interner.resolve(p.type_ref()).to_string();
             let produced = sim.substrate.entities.get(produced_id)?;
             Some((
                 producer_type,
@@ -766,12 +766,12 @@ pub(in crate::sim) fn produced_unit_unlimbo_entry_at_resolved_cell(
             let Some(blocker) = sim.substrate.entities.get(occupant.entity_id) else {
                 return ProductionUnitAdmission::nonzero(7, layer);
             };
-            let blocker_owner = sim.interner.resolve(blocker.owner);
+            let blocker_owner = sim.interner.resolve(blocker.owner());
             let allied =
                 crate::map::houses::are_houses_friendly(&sim.house_alliances, owner, blocker_owner);
 
             if blocker.category == EntityCategory::Structure {
-                let Some(blocker_type) = rules.object(sim.interner.resolve(blocker.type_ref))
+                let Some(blocker_type) = rules.object(sim.interner.resolve(blocker.type_ref()))
                 else {
                     return ProductionUnitAdmission::nonzero(7, layer);
                 };
@@ -782,7 +782,7 @@ pub(in crate::sim) fn produced_unit_unlimbo_entry_at_resolved_cell(
                     decide_live_vehicle_building_entry(LiveVehicleBuildingEntry {
                         mover_category: EntityCategory::Unit,
                         branch: VehicleBuildingEntryBranch::UnitRepairOrBunker,
-                        checked_building_id: blocker.stable_id,
+                        checked_building_id: blocker.stable_id(),
                         candidate_building_id: first_building,
                         candidate_x: cell.0,
                         building_origin_x: blocker.position.rx,
@@ -800,7 +800,7 @@ pub(in crate::sim) fn produced_unit_unlimbo_entry_at_resolved_cell(
                         cell.0.wrapping_add(1),
                         cell.1,
                         layer,
-                    ) != Some(blocker.stable_id)
+                    ) != Some(blocker.stable_id())
                 {
                     continue;
                 }
@@ -846,7 +846,7 @@ pub(in crate::sim) fn produced_unit_unlimbo_entry_at_resolved_cell(
                 // Ordinary buildings, including CABHUT, are blockers. The
                 // selected producer id is threaded explicitly; only the live
                 // helper above can skip that same yard occupant.
-                let _selected_producer = blocker.stable_id == producer_id;
+                let _selected_producer = blocker.stable_id() == producer_id;
                 return ProductionUnitAdmission::nonzero(if allied { 7 } else { 5 }, layer);
             }
 
@@ -867,7 +867,7 @@ pub(in crate::sim) fn produced_unit_unlimbo_entry_at_resolved_cell(
                 crush_capability,
                 bump_crush::CrushTarget::from_entity(blocker, sim.session.binary_frame),
             ) {
-                crush_victims.push(blocker.stable_id);
+                crush_victims.push(blocker.stable_id());
                 continue;
             }
             return ProductionUnitAdmission::nonzero(5, layer);
@@ -963,7 +963,7 @@ pub(in crate::sim) fn produced_unit_unlimbo_entry_at_resolved_cell(
                         crate::map::houses::are_houses_friendly(
                             &sim.house_alliances,
                             owner,
-                            sim.interner.resolve(infantry.owner),
+                            sim.interner.resolve(infantry.owner()),
                         )
                     })
             {
@@ -1648,10 +1648,10 @@ pub fn find_helipad_for_aircraft(
         if entity.health.current == 0 || entity.dying || entity.lifecycle.in_limbo {
             continue;
         }
-        if entity.owner != owner_id {
+        if entity.owner() != owner_id {
             continue;
         }
-        let type_str = sim.interner.resolve(entity.type_ref);
+        let type_str = sim.interner.resolve(entity.type_ref());
         let Some(obj) = rules.object(type_str) else {
             continue;
         };
@@ -1662,14 +1662,14 @@ pub fn find_helipad_for_aircraft(
         if !sim
             .production
             .airfield_docks
-            .has_free_slot(entity.stable_id, max_slots)
+            .has_free_slot(entity.stable_id(), max_slots)
         {
             continue;
         }
         let (fw, fh) = crate::sim::production::foundation_dimensions(&obj.foundation);
         let cx = entity.position.rx + fw / 2;
         let cy = entity.position.ry + fh / 2;
-        return Some((entity.stable_id, cx, cy));
+        return Some((entity.stable_id(), cx, cy));
     }
 
     None

--- a/src/sim/production/production_tech.rs
+++ b/src/sim/production/production_tech.rs
@@ -208,12 +208,12 @@ fn has_any_override_building(sim: &Simulation, owner: &str, overrides: &[String]
     sim.substrate.entities.values().any(|e| {
         !e.dying
             && !e.lifecycle.in_limbo
-            && sim.interner.resolve(e.owner).eq_ignore_ascii_case(owner)
+            && sim.interner.resolve(e.owner()).eq_ignore_ascii_case(owner)
             && e.category == EntityCategory::Structure
             && e.building_up.is_none()
             && overrides
                 .iter()
-                .any(|ov| ov.eq_ignore_ascii_case(sim.interner.resolve(e.type_ref)))
+                .any(|ov| ov.eq_ignore_ascii_case(sim.interner.resolve(e.type_ref())))
     })
 }
 
@@ -235,7 +235,7 @@ fn count_owned_and_queued(sim: &Simulation, owner: &str, type_id: &str) -> u32 {
             .substrate
             .entities
             .values()
-            .filter(|e| !e.dying && e.owner == oid && e.type_ref == tid)
+            .filter(|e| !e.dying && e.owner() == oid && e.type_ref() == tid)
             .count() as u32,
         _ => 0,
     };
@@ -310,10 +310,10 @@ fn first_missing_prereq(
         let ok = sim.substrate.entities.values().any(|e| {
             !e.dying
                 && !e.lifecycle.in_limbo
-                && sim.interner.resolve(e.owner).eq_ignore_ascii_case(owner)
+                && sim.interner.resolve(e.owner()).eq_ignore_ascii_case(owner)
                 && e.category == EntityCategory::Structure
                 && e.building_up.is_none()
-                && structure_satisfies_prerequisite(rules, sim.interner.resolve(e.type_ref), p)
+                && structure_satisfies_prerequisite(rules, sim.interner.resolve(e.type_ref()), p)
         });
         if !ok {
             return Some(p.clone());
@@ -359,10 +359,10 @@ fn has_factory_for_owner(
     entities.values().any(|e| {
         !e.dying
             && !e.lifecycle.in_limbo
-            && interner.resolve(e.owner).eq_ignore_ascii_case(owner)
+            && interner.resolve(e.owner()).eq_ignore_ascii_case(owner)
             && e.category == EntityCategory::Structure
             && e.building_up.is_none()
-            && is_production_factory(rules, interner.resolve(e.type_ref), category)
+            && is_production_factory(rules, interner.resolve(e.type_ref()), category)
     })
 }
 
@@ -638,10 +638,10 @@ pub(in crate::sim::production) fn matching_factory_count_for_owner(
         .filter(|e| {
             !e.dying
                 && !e.lifecycle.in_limbo
-                && interner.resolve(e.owner).eq_ignore_ascii_case(owner)
+                && interner.resolve(e.owner()).eq_ignore_ascii_case(owner)
                 && e.category == EntityCategory::Structure
                 && e.building_up.is_none()
-                && is_production_factory(rules, interner.resolve(e.type_ref), category)
+                && is_production_factory(rules, interner.resolve(e.type_ref()), category)
         })
         .count() as u32
 }
@@ -663,7 +663,7 @@ pub fn producer_candidates_for_owner_category(
         if e.lifecycle.in_limbo {
             continue;
         }
-        if !interner.resolve(e.owner).eq_ignore_ascii_case(owner) {
+        if !interner.resolve(e.owner()).eq_ignore_ascii_case(owner) {
             continue;
         }
         if e.category != EntityCategory::Structure {
@@ -672,14 +672,14 @@ pub fn producer_candidates_for_owner_category(
         if e.building_up.is_some() {
             continue;
         }
-        let type_ref_str = interner.resolve(e.type_ref);
+        let type_ref_str = interner.resolve(e.type_ref());
         let is_match = is_production_factory(rules, type_ref_str, category);
         if require_matching_factory && !is_match {
             continue;
         }
         if !require_matching_factory || is_match {
             preferred_factories.push((
-                e.stable_id,
+                e.stable_id(),
                 e.position.rx,
                 e.position.ry,
                 type_ref_str.to_string(),

--- a/src/sim/production/war_factory_exit.rs
+++ b/src/sim/production/war_factory_exit.rs
@@ -47,7 +47,7 @@ pub fn tick_war_factory_exit_contacts(
                 if producer.dying || producer.category != EntityCategory::Structure {
                     return None;
                 }
-                if !exact_land_vehicle_exit_factory(rules, interner.resolve(producer.type_ref)) {
+                if !exact_land_vehicle_exit_factory(rules, interner.resolve(producer.type_ref())) {
                     return None;
                 }
                 let on_footprint = occupancy
@@ -61,7 +61,7 @@ pub fn tick_war_factory_exit_contacts(
                 if on_footprint {
                     return None;
                 }
-                Some((mover.stable_id, producer_id))
+                Some((mover.stable_id(), producer_id))
             })
             .collect()
     };

--- a/src/sim/radio/receive.rs
+++ b/src/sim/radio/receive.rs
@@ -167,7 +167,7 @@ fn refinery_hello(sim: &mut Simulation, ref_sid: u64, miner_sid: u64) -> RadioRe
     // Ally gate = owner equality (no ally graph in sim/ yet; stock skirmish docks
     // at the own-owner refinery only — swap for `is_ally()` when it lands).
     let miner_owner = match sim.substrate.entities.get(miner_sid) {
-        Some(m) => m.owner,
+        Some(m) => m.owner(),
         None => return RadioResponse::None,
     };
     let Some(refinery) = sim.substrate.entities.get_mut(ref_sid) else {
@@ -176,7 +176,7 @@ fn refinery_hello(sim: &mut Simulation, ref_sid: u64, miner_sid: u64) -> RadioRe
     if refinery.dying || refinery.health.current == 0 {
         return RadioResponse::None;
     }
-    if refinery.owner != miner_owner {
+    if refinery.owner() != miner_owner {
         return RadioResponse::Negatory;
     }
     // Idempotent (already linked ⇒ ROGER) is folded into `insert`. A saturated
@@ -253,7 +253,7 @@ fn bunker_receive(
 /// Sim-state admission gate (no rules): own-owner, alive, not occupied, idle.
 /// The rules-gated Bunkerable+weapon check runs at command time (EnterBunker).
 fn bunker_admits(sim: &Simulation, bld: u64, unit: u64) -> bool {
-    let Some(unit_owner) = sim.substrate.entities.get(unit).map(|u| u.owner) else {
+    let Some(unit_owner) = sim.substrate.entities.get(unit).map(|u| u.owner()) else {
         return false;
     };
     let Some(b) = sim.substrate.entities.get(bld) else {
@@ -262,7 +262,7 @@ fn bunker_admits(sim: &Simulation, bld: u64, unit: u64) -> bool {
     if b.dying || b.health.current == 0 {
         return false;
     }
-    if b.owner != unit_owner {
+    if b.owner() != unit_owner {
         return false;
     }
     if b.bunker_occupant.is_some() {

--- a/src/sim/runtime.rs
+++ b/src/sim/runtime.rs
@@ -950,7 +950,7 @@ where
         overlay_registry,
         lat_enabled,
         cliff_back_impassability,
-        terrain.cells.len(),
+        terrain.cells().len(),
     );
     let shape = crate::map::authored_overlay::NativeOverlayMapShape::new(
         i32::try_from(map_data.header.width).unwrap_or(i32::MAX),
@@ -1151,7 +1151,7 @@ pub(crate) fn map_wall_owner_candidate_from_building(
     );
 
     crate::sim::overlay_grid::MapWallOwnerCandidate {
-        owner: entity.owner,
+        owner: entity.owner(),
         world_x,
         world_y,
         world_z,
@@ -1205,7 +1205,7 @@ pub(crate) fn finalize_constructed_scenario(
             .map(|entity| {
                 let country = sim
                     .houses
-                    .get(&entity.owner)
+                    .get(&entity.owner())
                     .and_then(|house| house.country)
                     .map(|country| sim.interner.resolve(country));
                 map_wall_owner_candidate_from_building(

--- a/src/sim/selection.rs
+++ b/src/sim/selection.rs
@@ -190,7 +190,7 @@ pub fn deselect_all(entities: &mut EntityStore) {
     let selected_ids: Vec<u64> = entities
         .values()
         .filter(|e| e.selected)
-        .map(|e| e.stable_id)
+        .map(|e| e.stable_id())
         .collect();
     for id in selected_ids {
         if let Some(e) = entities.get_mut(id) {

--- a/src/sim/sensor_lifecycle.rs
+++ b/src/sim/sensor_lifecycle.rs
@@ -205,7 +205,7 @@ impl Simulation {
                 .get_mut(stable_id)
                 .and_then(|entity| {
                     let deposit = entity.sensor_deposit.take()?;
-                    Some((deposit, entity.owner))
+                    Some((deposit, entity.owner()))
                 })?;
         if deposit.detect_disguise_radius > 0 {
             // `BuildingClass::RemoveDetectDisguiseAt @ 0x00455980`, reached
@@ -253,9 +253,9 @@ impl Simulation {
     pub(crate) fn add_unit_sensor_after_unlimbo(&mut self, stable_id: u64, rules: &RuleSet) {
         let Some((owner, center, radius, in_limbo)) =
             self.substrate.entities.get(stable_id).and_then(|entity| {
-                let object = rules.object(self.interner.resolve(entity.type_ref))?;
+                let object = rules.object(self.interner.resolve(entity.type_ref()))?;
                 Some((
-                    entity.owner,
+                    entity.owner(),
                     (entity.position.rx, entity.position.ry),
                     unit_sensor_radius(entity.category, object)?,
                     entity.lifecycle.in_limbo,
@@ -295,7 +295,7 @@ impl Simulation {
     pub(crate) fn add_building_sensor_array_if_powered(&mut self, stable_id: u64, rules: &RuleSet) {
         let Some((owner, center, sight, remove_radius, detect_radius, powered, in_limbo)) =
             self.substrate.entities.get(stable_id).and_then(|entity| {
-                let object = rules.object(self.interner.resolve(entity.type_ref))?;
+                let object = rules.object(self.interner.resolve(entity.type_ref()))?;
                 if entity.category != EntityCategory::Structure
                     || object.category != ObjectCategory::Building
                 {
@@ -315,7 +315,7 @@ impl Simulation {
                     return None;
                 }
                 Some((
-                    entity.owner,
+                    entity.owner(),
                     (entity.position.rx, entity.position.ry),
                     sight,
                     object.cloak_radius_in_cells,

--- a/src/sim/slave_miner.rs
+++ b/src/sim/slave_miner.rs
@@ -150,7 +150,7 @@ pub(super) fn tick_slave_harvesters(
         };
         snapshots.push(SlaveSnapshot {
             entity_id: id,
-            owner: entity.owner,
+            owner: entity.owner(),
             rx: entity.position.rx,
             ry: entity.position.ry,
             harvester: sh.clone(),
@@ -381,7 +381,7 @@ fn handle_slave_deposit(
         .substrate
         .entities
         .get(snap.harvester.master_id)
-        .map_or(snap.owner, |master| master.owner);
+        .map_or(snap.owner, |master| master.owner());
     let owner_str = sim.interner.resolve(master_owner).to_string();
     let income_ppm = income_ppm_for_owner(&sim.houses, &sim.interner, rules, &owner_str);
     let purifier_count = effective_purifier_count(sim, rules, &owner_str);
@@ -526,14 +526,14 @@ pub(crate) fn deploy_slave_miner_with_overlay_context(
     // Read deploy data before mutating.
     let deploy_data = {
         let entity = sim.substrate.entities.get(stable_id)?;
-        let type_str = sim.interner.resolve(entity.type_ref);
+        let type_str = sim.interner.resolve(entity.type_ref());
         let obj = rules.object_case_insensitive(type_str)?;
         let target_type: &str = obj.deploys_into.as_deref()?;
         // Verify target exists in rules.
         rules.object(target_type)?;
         let enslaves: String = obj.enslaves.clone()?;
         let slaves_number: i32 = obj.slaves_number.max(0);
-        let owner_str = sim.interner.resolve(entity.owner).to_string();
+        let owner_str = sim.interner.resolve(entity.owner()).to_string();
         Some((
             owner_str,
             entity.position.rx,
@@ -660,11 +660,11 @@ pub(crate) fn undeploy_slave_miner_with_overlay_context(
     // Read undeploy data.
     let undeploy_data = {
         let entity = sim.substrate.entities.get(stable_id)?;
-        let type_str = sim.interner.resolve(entity.type_ref);
+        let type_str = sim.interner.resolve(entity.type_ref());
         let obj = rules.object_case_insensitive(type_str)?;
         let target_type: &str = obj.undeploys_into.as_deref()?;
         rules.object(target_type)?;
-        let owner_str = sim.interner.resolve(entity.owner).to_string();
+        let owner_str = sim.interner.resolve(entity.owner()).to_string();
         Some((
             owner_str,
             entity.position.rx,
@@ -768,8 +768,8 @@ pub(super) fn tick_slave_regen(
             continue;
         };
 
-        let master_type = sim.interner.resolve(master.type_ref).to_string();
-        let owner = sim.interner.resolve(master.owner).to_string();
+        let master_type = sim.interner.resolve(master.type_ref()).to_string();
+        let owner = sim.interner.resolve(master.owner()).to_string();
         let mrx: u16 = master.position.rx;
         let mry: u16 = master.position.ry;
         let mz: u8 = master.position.z;

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -836,7 +836,7 @@ impl RestoredObjectIndex {
                 &mut identities,
                 "EntityStore",
                 registry_id,
-                entity.stable_id,
+                entity.stable_id(),
             )?;
             highest_id = highest_id.max(registry_id);
         }
@@ -1637,9 +1637,9 @@ impl Simulation {
         validate_passenger_size_tables(self)?;
         restore_object_references(self, &identities)?;
 
-        // Rust's native-shaped re-registration order:
-        // 1. class registry indexes, 2. Logic slots (including ParticleSystem),
-        // 3. CellClass-style lists.
+        // EntityStore already restored its indexes during Deserialize (Clone
+        // retains them too). Reference restoration above changes no indexed identity.
+        // Continue with Logic slots (including ParticleSystem), then CellClass lists.
         // Bullet Load 46AE9C..46AEB0 starts both embedded timers at the
         // already-restored global frame with duration zero. Only C4/CC gates
         // AI through Check (4E11F0); retain the saved reference/watermark.
@@ -1648,7 +1648,6 @@ impl Simulation {
                 .arm_timer
                 .start(self.session.binary_frame as i32, 0);
         }
-        self.substrate.entities.rebuild_owner_index();
         self.rebuild_logic_membership();
         self.substrate.occupancy =
             crate::sim::occupancy::OccupancyGrid::rebuild(&self.substrate.entities);
@@ -1676,7 +1675,7 @@ impl Simulation {
                 continue;
             }
 
-            let type_ref = entity.type_ref;
+            let type_ref = entity.type_ref();
             let world = Self::movement_sound_world(entity);
             let Some(configured_sound) = self
                 .object_type(type_ref, rules)

--- a/src/sim/spawn_manager.rs
+++ b/src/sim/spawn_manager.rs
@@ -504,7 +504,7 @@ fn step_ready_docked(
         return;
     }
 
-    let owner_type = sim.interner.resolve(owner.type_ref).to_string();
+    let owner_type = sim.interner.resolve(owner.type_ref()).to_string();
     let launch_rx = owner.position.rx;
     let launch_ry = owner.position.ry;
     let launch_z = owner.position.z;
@@ -703,7 +703,7 @@ fn restore_docked_child(sim: &mut Simulation, rules: &RuleSet, owner_id: u64, sl
         .substrate
         .entities
         .get(child_id)
-        .map(|c| sim.interner.resolve(c.type_ref).to_string());
+        .map(|c| sim.interner.resolve(c.type_ref()).to_string());
     if let Some(obj) = child_type.as_deref().and_then(|name| rules.object(name))
         && let Some(child) = sim.substrate.entities.get_mut(child_id)
     {
@@ -731,7 +731,7 @@ fn regenerate_child(sim: &mut Simulation, rules: &RuleSet, owner_id: u64, slot_i
     let Some((owner_house, rx, ry, z, facing)) =
         sim.substrate.entities.get(owner_id).map(|owner| {
             (
-                sim.interner.resolve(owner.owner).to_string(),
+                sim.interner.resolve(owner.owner()).to_string(),
                 owner.position.rx,
                 owner.position.ry,
                 owner.position.z,
@@ -855,7 +855,7 @@ fn step_manager_mode(
                 // they are kept apart because a mod can separate them.
                 let child_missile_spawn = child_slot
                     .and_then(|child| sim.substrate.entities.get(child))
-                    .map(|child| sim.interner.resolve(child.type_ref).to_string())
+                    .map(|child| sim.interner.resolve(child.type_ref()).to_string())
                     .and_then(|name| rules.object(&name))
                     .map(|obj| obj.missile_spawn)
                     .unwrap_or(is_missile_family);
@@ -1078,7 +1078,7 @@ fn child_air_speed(
     sim.substrate
         .entities
         .get(child_id)
-        .map(|c| sim.interner.resolve(c.type_ref).to_string())
+        .map(|c| sim.interner.resolve(c.type_ref()).to_string())
         .and_then(|name| rules.object(&name))
         .map(|obj| crate::util::fixed_math::ra2_speed_to_leptons_per_second(obj.speed.max(1)))
         .unwrap_or(crate::util::fixed_math::SimFixed::from_num(8))
@@ -1152,7 +1152,7 @@ fn launch_missile_child(
         .substrate
         .entities
         .get(child_id)
-        .map(|c| sim.interner.resolve(c.type_ref).to_string());
+        .map(|c| sim.interner.resolve(c.type_ref()).to_string());
     // The six-phase rocket machine runs in LEPTONS per second (its ascent
     // altitude, acceleration and terminal constants are lepton-domain, and its
     // own attach test uses a 300-scale speed), so the raw INI `Speed=` goes
@@ -1226,7 +1226,7 @@ pub fn detonate_missiles(sim: &mut Simulation, detonated: &[u64]) {
         let Some((rx, ry, payload, owner)) = sim.substrate.entities.get(missile_id).and_then(|e| {
             e.rocket_state
                 .as_ref()
-                .map(|r| (r.target_rx, r.target_ry, r.payload, e.owner))
+                .map(|r| (r.target_rx, r.target_ry, r.payload, e.owner()))
         }) else {
             continue;
         };

--- a/src/sim/superweapon/force_shield.rs
+++ b/src/sim/superweapon/force_shield.rs
@@ -63,11 +63,11 @@ pub fn launch(
         .filter(|e| e.category == EntityCategory::Structure)
         .filter(|e| e.health.current > 0 && !e.dying)
         .filter(|e| {
-            let other = sim.interner.resolve(e.owner);
+            let other = sim.interner.resolve(e.owner());
             are_houses_friendly(&sim.house_alliances, &owner_str, other)
         })
         .filter(|e| {
-            sim.object_type(e.type_ref, rules)
+            sim.object_type(e.type_ref(), rules)
                 .map(|o| !o.no_force_shield)
                 .unwrap_or(true)
         })
@@ -80,7 +80,7 @@ pub fn launch(
             let dy = ey - target_y_leptons;
             dx * dx + dy * dy <= radius_sq
         })
-        .map(|e| e.stable_id)
+        .map(|e| e.stable_id())
         .collect();
 
     // 4. Apply invulnerability.

--- a/src/sim/superweapon/genetic_converter.rs
+++ b/src/sim/superweapon/genetic_converter.rs
@@ -195,7 +195,7 @@ fn apply_mutate_per_cell(
                 .iter()
                 .any(|(rx, ry)| e.position.rx == *rx && e.position.ry == *ry)
         })
-        .map(|e| (e.stable_id, e.position.rx, e.position.ry))
+        .map(|e| (e.stable_id(), e.position.rx, e.position.ry))
         .collect();
 
     let mut killed: Vec<(u16, u16)> = Vec::new();

--- a/src/sim/superweapon/iron_curtain.rs
+++ b/src/sim/superweapon/iron_curtain.rs
@@ -46,7 +46,7 @@ pub fn launch(
                 .any(|(rx, ry)| e.position.rx == *rx && e.position.ry == *ry)
         })
         .filter(|e| e.health.current > 0 && !e.dying)
-        .map(|e| e.stable_id)
+        .map(|e| e.stable_id())
         .collect();
 
     // 3. Apply effect per entity.

--- a/src/sim/superweapon/mod.rs
+++ b/src/sim/superweapon/mod.rs
@@ -207,7 +207,7 @@ pub fn tick_superweapon_instances(sim: &mut Simulation, rules: &RuleSet) {
             .entities
             .values()
             .filter(|e| e.category == crate::map::entities::EntityCategory::Structure && !e.dying)
-            .map(|e| e.owner)
+            .map(|e| e.owner())
             .collect::<std::collections::BTreeSet<_>>()
             .into_iter()
             .collect();
@@ -295,7 +295,7 @@ pub fn refresh_super_weapons_for_owner(sim: &mut Simulation, rules: &RuleSet, ow
     // Collect all SW type IDs (as strings) granted by living buildings of this owner.
     let mut granted_strs: Vec<String> = Vec::new();
     for (_, entity) in sim.substrate.entities.iter_sorted() {
-        if entity.owner != owner {
+        if entity.owner() != owner {
             continue;
         }
         if entity.category != crate::map::entities::EntityCategory::Structure {
@@ -304,7 +304,7 @@ pub fn refresh_super_weapons_for_owner(sim: &mut Simulation, rules: &RuleSet, ow
         if entity.dying || entity.lifecycle.in_limbo {
             continue;
         }
-        let type_str = sim.interner.resolve(entity.type_ref);
+        let type_str = sim.interner.resolve(entity.type_ref());
         if let Some(obj) = rules.object(type_str) {
             if let Some(ref sw_id) = obj.super_weapon {
                 if rules.super_weapon(sw_id).is_some() {

--- a/src/sim/terrain_object.rs
+++ b/src/sim/terrain_object.rs
@@ -7,7 +7,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::hash::Hash;
 
-use crate::map::resolved_terrain::{ResolvedTerrainGrid, recalc_zone_type};
+use crate::map::resolved_terrain::{ResolvedTerrainGrid};
 use crate::rules::ruleset::RuleSet;
 use crate::rules::terrain_object_type::TerrainObjectType;
 use crate::rules::warhead_type::WarheadType;
@@ -450,7 +450,7 @@ pub fn mark_terrain_occupation(
         production.terrain_occupation_bits.remove(&cell);
     }
     if let Some(grid) = resolved_terrain {
-        set_resolved_terrain_object_occupation(grid, cell, Some(terrain.occupation_bits));
+        grid.set_terrain_object_occupation(cell, Some(terrain.occupation_bits));
     }
 }
 
@@ -462,7 +462,7 @@ pub fn unmark_terrain_occupation(
     let cell = terrain.cell();
     production.terrain_occupation_bits.remove(&cell);
     if let Some(grid) = resolved_terrain {
-        set_resolved_terrain_object_occupation(grid, cell, None);
+        grid.set_terrain_object_occupation(cell, None);
     }
 }
 
@@ -519,7 +519,7 @@ fn limbo_terrain_object_at_cell_parts(
     );
     authority.terrain_occupation_bits.remove(&source_cell);
     if let Some(grid) = resolved_terrain {
-        set_resolved_terrain_object_occupation(grid, source_cell, None);
+        grid.set_terrain_object_occupation(source_cell, None);
     }
     if let Some(terrain) = authority.terrain_objects.get_mut(&stable_id) {
         terrain.lifecycle = TerrainObjectLifecycle::Limbo;
@@ -572,32 +572,6 @@ pub(crate) fn damage_terrain_object_at_cell(
     };
     let _ = area_state.restore_into(production, raw_occupation);
     result
-}
-
-fn set_resolved_terrain_object_occupation(
-    grid: &mut ResolvedTerrainGrid,
-    cell: (u16, u16),
-    occupation: Option<u8>,
-) {
-    let Some(terrain_cell) = grid.cell_mut(cell.0, cell.1) else {
-        return;
-    };
-    let blocked = occupation.is_some_and(|occupation| occupation != 0);
-    terrain_cell.terrain_object_occupation = occupation;
-    terrain_cell.terrain_object_blocks = blocked;
-    terrain_cell.ground_walk_blocked =
-        terrain_cell.base_ground_walk_blocked || terrain_cell.overlay_blocks || blocked;
-    terrain_cell.build_blocked = terrain_cell.base_build_blocked
-        || terrain_cell.overlay_blocks
-        || terrain_cell.has_bridge_deck
-        || blocked;
-    terrain_cell.zone_type = recalc_zone_type(
-        terrain_cell.outside_playfield,
-        terrain_cell.overlay_zone_type,
-        terrain_cell.land_type,
-        terrain_cell.speed_costs.wheel,
-        terrain_cell.terrain_object_occupation,
-    );
 }
 
 #[cfg(test)]

--- a/src/sim/tiberium/mod.rs
+++ b/src/sim/tiberium/mod.rs
@@ -240,7 +240,7 @@ pub(crate) fn live_cell_rejects_tiberium(
         if entity.category != EntityCategory::Structure || !entity.is_alive() {
             continue;
         }
-        let type_name = context.interner.resolve(entity.type_ref);
+        let type_name = context.interner.resolve(entity.type_ref());
         let invisible_exception = context
             .rules
             .object(type_name)

--- a/src/sim/transport_unload.rs
+++ b/src/sim/transport_unload.rs
@@ -97,7 +97,7 @@ pub(crate) fn is_vehicle_transport_type(
     entity: &GameEntity,
     rules: &RuleSet,
 ) -> bool {
-    sim.object_type(entity.type_ref, rules)
+    sim.object_type(entity.type_ref(), rules)
         .is_some_and(|obj| obj.passengers > 0)
 }
 
@@ -203,7 +203,7 @@ fn octant_cell_open(
             let Some(other) = sim.substrate.entities.get(occupant.entity_id) else {
                 continue;
             };
-            let other_owner = sim.interner.resolve(other.owner);
+            let other_owner = sim.interner.resolve(other.owner());
             if !crate::map::houses::is_allied_with(
                 &sim.house_alliances,
                 transport_owner,
@@ -238,7 +238,7 @@ fn pick_exit_octant(
     path_grid: Option<&PathGrid>,
     entity: &GameEntity,
 ) -> Option<((u16, u16), usize)> {
-    let owner = sim.interner.resolve(entity.owner);
+    let owner = sim.interner.resolve(entity.owner());
     let base = (entity.position.rx, entity.position.ry);
     let facing16 = u16::from(entity.facing) << 8;
     let rear16 = facing16.wrapping_add(0x7FFF);
@@ -333,7 +333,7 @@ fn passenger_can_enter(
     if !cell_in_map(sim, path_grid, cell) {
         return false;
     }
-    let obj = sim.object_type(passenger.type_ref, rules);
+    let obj = sim.object_type(passenger.type_ref(), rules);
     let speed_type = passenger
         .locomotor
         .as_ref()
@@ -385,7 +385,7 @@ fn find_nearby_passable_for(
     seed: (u16, u16),
     speed_type_override: Option<SpeedType>,
 ) -> Option<(u16, u16)> {
-    let obj = sim.object_type(mover.type_ref, rules)?;
+    let obj = sim.object_type(mover.type_ref(), rules)?;
     let speed_type = speed_type_override.unwrap_or_else(|| {
         mover
             .locomotor
@@ -443,7 +443,7 @@ fn issue_pathed_move(
         .substrate
         .entities
         .get(id)
-        .map(|entity| sim.interner.resolve(entity.owner).to_string())
+        .map(|entity| sim.interner.resolve(entity.owner()).to_string())
         .unwrap_or_default();
     let (entity_blocks, entity_block_map) = bump_crush::build_entity_block_set(
         &sim.substrate.entities,
@@ -570,7 +570,7 @@ fn eject_head_passenger(
             .entities
             .get(transport_id)
             .expect("transport resolved before the head pop");
-        let obj = sim.object_type(transport.type_ref, rules);
+        let obj = sim.object_type(transport.type_ref(), rules);
         (
             (transport.position.rx, transport.position.ry),
             transport.facing,
@@ -753,7 +753,7 @@ fn reapply_gunner_weapon(sim: &mut Simulation, rules: &RuleSet, transport_id: u6
         return;
     };
     if !sim
-        .object_type(transport.type_ref, rules)
+        .object_type(transport.type_ref(), rules)
         .is_some_and(|obj| obj.gunner)
     {
         return;
@@ -762,7 +762,7 @@ fn reapply_gunner_weapon(sim: &mut Simulation, rules: &RuleSet, transport_id: u6
         return;
     };
     let ifv_mode = sim
-        .object_type(passenger.type_ref, rules)
+        .object_type(passenger.type_ref(), rules)
         .map_or(0, |obj| obj.ifv_mode);
     if let Some(transport) = sim.substrate.entities.get_mut(transport_id) {
         transport.weapon_override = Some(
@@ -827,7 +827,7 @@ pub(crate) fn unit_mission_unload(
                 // a turreted transport (the IFV) keeps its last passenger —
                 // `+0x6E4 = (cargo == 1 ? 0 : 1)` (`0x0073D82C`..`0x0073D83C`).
                 let turreted = sim
-                    .object_type(entity.type_ref, rules)
+                    .object_type(entity.type_ref(), rules)
                     .is_some_and(|obj| obj.turret_count > 0);
                 if let Some(entity) = sim.substrate.entities.get_mut(id) {
                     if turreted {

--- a/src/sim/trigger_runtime.rs
+++ b/src/sim/trigger_runtime.rs
@@ -495,7 +495,7 @@ fn count_techtype(sim: &Simulation, type_id: &str) -> usize {
         .values()
         .filter(|e| {
             sim.interner
-                .resolve(e.type_ref)
+                .resolve(e.type_ref())
                 .eq_ignore_ascii_case(type_id)
         })
         .count()

--- a/src/sim/vision/mod.rs
+++ b/src/sim/vision/mod.rs
@@ -1295,7 +1295,7 @@ pub(crate) fn entity_has_sight_ability(
     rules: Option<&crate::rules::ruleset::RuleSet>,
 ) -> bool {
     rules
-        .and_then(|rules| rules.object(interner.resolve(entity.type_ref)))
+        .and_then(|rules| rules.object(interner.resolve(entity.type_ref())))
         .is_some_and(|object| {
             crate::sim::combat::veterancy::has_weapon_ability(
                 crate::sim::combat::veterancy::rank_of(entity.veterancy_raw),
@@ -1401,7 +1401,7 @@ pub(crate) fn reveal_entity_vision(
     }
     let vis = fog
         .by_owner
-        .entry(entity.owner)
+        .entry(entity.owner())
         .or_insert_with(|| OwnerVisibility::new(width, height));
     let height_leptons: i32 = entity_height_leptons(entity);
 

--- a/src/sim/voxel_frame_catalog.rs
+++ b/src/sim/voxel_frame_catalog.rs
@@ -178,7 +178,7 @@ pub(crate) fn build_voxel_frame_catalog(
         if !entity.is_voxel {
             continue;
         }
-        let type_str = interner.resolve(entity.type_ref);
+        let type_str = interner.resolve(entity.type_ref());
         for variant in unit_atlas_variants(type_str, rules) {
             for &layer in seed_layers_for(
                 asset_manager,

--- a/src/sim/world/building_anim.rs
+++ b/src/sim/world/building_anim.rs
@@ -121,7 +121,7 @@ fn trigger_crane_anim(sim: &mut Simulation, rules: &RuleSet, art: &ArtRegistry, 
         let Some(entity) = sim.entities().get(producer.stable_id) else {
             return;
         };
-        let type_id = sim.interner.resolve(entity.type_ref).to_string();
+        let type_id = sim.interner.resolve(entity.type_ref()).to_string();
         let rules_image = rules
             .object(&type_id)
             .map(|object| object.image.clone())
@@ -249,7 +249,7 @@ fn consume_bale_events(sim: &mut Simulation, rules: &RuleSet, art: &ArtRegistry)
             let Some(building) = sim.entities().get(event.building_id) else {
                 continue;
             };
-            let type_name = sim.interner.resolve(building.type_ref);
+            let type_name = sim.interner.resolve(building.type_ref());
             let Some(object) = rules.object(type_name) else {
                 continue;
             };
@@ -460,7 +460,7 @@ fn consume_bunker_wall_events(sim: &mut Simulation, rules: &RuleSet, art: &ArtRe
             let Some(building) = sim.entities().get(event.building_id) else {
                 continue;
             };
-            let type_name = sim.interner.resolve(building.type_ref);
+            let type_name = sim.interner.resolve(building.type_ref());
             let Some(object) = rules.object(type_name) else {
                 continue;
             };

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -822,7 +822,7 @@ impl Simulation {
             self.substrate.entities.get(stable_id).and_then(|entity| {
                 (entity.category == EntityCategory::Structure && entity.base_plan_type_index >= 0)
                     .then_some((
-                        entity.owner,
+                        entity.owner(),
                         entity.base_plan_type_index,
                         crate::sim::base_plan::pack_base_plan_cell(
                             i32::from(entity.position.rx),
@@ -860,7 +860,7 @@ impl Simulation {
             self.substrate.entities.get(stable_id).and_then(|entity| {
                 (entity.category == EntityCategory::Structure && entity.base_plan_type_index >= 0)
                     .then_some((
-                        entity.owner,
+                        entity.owner(),
                         entity.base_plan_type_index,
                         crate::sim::base_plan::pack_base_plan_cell(
                             i32::from(entity.position.rx),
@@ -898,7 +898,7 @@ impl Simulation {
                 && entity.lifecycle.object_alive
                 && !entity.lifecycle.in_limbo
                 && entity.lifecycle.cell_marked)
-                .then_some((entity.owner, (entity.position.rx, entity.position.ry)))
+                .then_some((entity.owner(), (entity.position.rx, entity.position.ry)))
         }) else {
             return;
         };
@@ -1194,7 +1194,7 @@ impl Simulation {
                 == Some(crate::sim::movement::locomotor::MovementLayer::Ground))
         .then(|| {
             (
-                entity.owner,
+                entity.owner(),
                 building_base_reservation_rect(
                     entity.position.rx,
                     entity.position.ry,
@@ -1219,7 +1219,7 @@ impl Simulation {
         {
             return false;
         }
-        let owner = entity.owner;
+        let owner = entity.owner();
         let rect = building_base_reservation_rect(
             entity.position.rx,
             entity.position.ry,
@@ -1948,7 +1948,7 @@ impl Simulation {
         let Some((owner, category, already_released, destroyed, killed_by, award, dont_score)) =
             self.substrate.entities.get(stable_id).map(|entity| {
                 (
-                    entity.owner,
+                    entity.owner(),
                     entity.category,
                     entity.owned_count_released,
                     entity.health.current == 0,
@@ -2048,10 +2048,10 @@ impl Simulation {
         let Some((owner, category, dont_score, type_ref, veterancy)) =
             self.substrate.entities.get(stable_id).map(|target| {
                 (
-                    target.owner,
+                    target.owner(),
                     target.category,
                     target.dont_score,
-                    target.type_ref,
+                    target.type_ref(),
                     target.veterancy,
                 )
             })
@@ -2340,7 +2340,7 @@ impl Simulation {
         let current_target_matches = listener.attack_target.as_ref().is_some_and(
             |target| matches!(target.target, TargetKind::Entity(id) if id == expired_id),
         );
-        let listener_owner = listener.owner;
+        let listener_owner = listener.owner();
         let passive_scan_remaining = listener
             .passive_scan_timer
             .remaining(self.session.binary_frame);
@@ -2640,7 +2640,7 @@ impl Simulation {
                 expired.health.current,
                 expired.mission.current().known()
                     == Some(crate::sim::mission::MissionType::Selling),
-                Some(expired.owner),
+                Some(expired.owner()),
             )
         })
         else {

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -1897,7 +1897,7 @@ impl Simulation {
                     if category != EntityCategory::Structure {
                         return None;
                     }
-                    let object = rules.object(self.interner.resolve(entity.type_ref))?;
+                    let object = rules.object(self.interner.resolve(entity.type_ref()))?;
                     let passenger_ids = entity
                         .passenger_role
                         .cargo()
@@ -1910,8 +1910,8 @@ impl Simulation {
                         crate::sim::production::foundation_dimensions(&object.foundation);
                     Some(crate::sim::combat::DestroyedGarrisonBuilding {
                         building_id: stable_id,
-                        type_id: entity.type_ref,
-                        owner: entity.owner,
+                        type_id: entity.type_ref(),
+                        owner: entity.owner(),
                         rx: entity.position.rx,
                         ry: entity.position.ry,
                         z: entity.position.z,
@@ -2309,7 +2309,7 @@ impl Simulation {
                 let Some(firer) = transaction.entities.get(request.firer_id) else {
                     break;
                 };
-                let Some(object_type) = rules.object(transaction.interner.resolve(firer.type_ref)) else {
+                let Some(object_type) = rules.object(transaction.interner.resolve(firer.type_ref())) else {
                     break;
                 };
                 let Some(weapon_name) = crate::sim::combat::combat_weapon::primary_for_tier(
@@ -2326,7 +2326,7 @@ impl Simulation {
                     break;
                 };
                 let warhead_ref = transaction.interner.intern(warhead_name);
-                let source_house = Some(firer.owner);
+                let source_house = Some(firer.owner());
                 let mut shared_damage = raw_ambient_damage;
 
                 // The shared dummy is still a native CellClass entry, so the
@@ -2787,7 +2787,7 @@ impl Simulation {
             .entities
             .get(dead_id)
             .filter(|building| building.category == EntityCategory::Structure)
-            .and_then(|building| self.object_type(building.type_ref, rules))
+            .and_then(|building| self.object_type(building.type_ref(), rules))
             .is_some_and(|obj| obj.refinery);
         if is_refinery {
             crate::sim::miner::interrupt_refinery_docked_miners(self, rules, dead_id);
@@ -2817,7 +2817,7 @@ impl Simulation {
                 self.substrate
                     .entities
                     .get(dead_id)
-                    .map(|entity| (entity.owner, entity.category))
+                    .map(|entity| (entity.owner(), entity.category))
             })
             .collect();
 
@@ -3054,7 +3054,7 @@ impl Simulation {
         };
         let Some(obj) = self
             .interner
-            .try_resolve(entity.type_ref)
+            .try_resolve(entity.type_ref())
             .and_then(|type_name| rules.object(type_name))
         else {
             return;
@@ -3064,7 +3064,7 @@ impl Simulation {
             entity.category,
             entity.position.rx,
             entity.position.ry,
-            entity.owner,
+            entity.owner(),
         );
         if let Some(event) = event {
             self.dispatch_unit_lost_events(&[event]);
@@ -3895,7 +3895,7 @@ impl Simulation {
             });
         let active = entity.move_sound_active;
         let countdown = entity.move_sound_countdown;
-        let type_ref = entity.type_ref;
+        let type_ref = entity.type_ref();
         let world = Self::movement_sound_world(entity);
         let qualifies = (movement_changed || moving_now) && !falling_or_crashing;
 
@@ -4136,7 +4136,7 @@ impl Simulation {
                     && entity.category != EntityCategory::Structure
                     && self
                         .houses
-                        .get(&entity.owner)
+                        .get(&entity.owner())
                         .is_some_and(|house| house.is_human);
                 Some((stable_id, member, reveal))
             })
@@ -4532,27 +4532,27 @@ impl Simulation {
                 debug_assert!(
                     entity.lifecycle.in_limbo,
                     "dead entity {} must have completed Conceal before alive clear",
-                    entity.stable_id
+                    entity.stable_id()
                 );
                 debug_assert!(
                     !entity.lifecycle.cell_marked,
                     "dead entity {} must be unmarked before alive clear",
-                    entity.stable_id
+                    entity.stable_id()
                 );
                 debug_assert!(
                     !entity.in_logic_vector,
                     "dead entity {} must leave LogicVector before alive clear",
-                    entity.stable_id
+                    entity.stable_id()
                 );
                 debug_assert!(
                     entity.owned_count_released,
                     "dead entity {} must release owned count exactly once before alive clear",
-                    entity.stable_id
+                    entity.stable_id()
                 );
                 debug_assert!(
-                    self.substrate.pending_delete.contains(&entity.stable_id),
+                    self.substrate.pending_delete.contains(&entity.stable_id()),
                     "dead entity {} must remain pending until finalization",
-                    entity.stable_id
+                    entity.stable_id()
                 );
             }
             if entity.lifecycle.cell_marked
@@ -4563,9 +4563,9 @@ impl Simulation {
                     debug_assert!(
                         self.substrate
                             .occupancy
-                            .contains_entity(rx, ry, entity.stable_id),
+                            .contains_entity(rx, ry, entity.stable_id()),
                         "cell-marked entity {} missing occupancy at ({rx}, {ry})",
-                        entity.stable_id
+                        entity.stable_id()
                     );
                 }
             }
@@ -4623,7 +4623,7 @@ impl Simulation {
         if let Some(rules) = rules {
             for e in self.substrate.entities.values() {
                 if crate::sim::miner::miner_system::counts_as_purifier(self, rules, e) {
-                    *purifiers.entry(e.owner).or_insert(0) += 1;
+                    *purifiers.entry(e.owner()).or_insert(0) += 1;
                 }
             }
         }
@@ -4900,7 +4900,7 @@ impl Simulation {
                 && entity.lifecycle.object_alive
                 && !entity.lifecycle.in_limbo
                 && entity.lifecycle.cell_marked)
-                .then_some(entity.owner)
+                .then_some(entity.owner())
         }) else {
             return;
         };
@@ -4928,7 +4928,7 @@ impl Simulation {
             .substrate
             .entities
             .get(stable_id)
-            .map(|entity| (entity.owner, entity.build_const_eligible))
+            .map(|entity| (entity.owner(), entity.build_const_eligible))
         else {
             return;
         };
@@ -4969,7 +4969,7 @@ impl Simulation {
         let Some((old_owner, category, has_spawn_manager, build_const_eligible)) =
             self.substrate.entities.get(stable_id).map(|entity| {
                 (
-                    entity.owner,
+                    entity.owner(),
                     entity.category,
                     entity.spawn_manager.is_some(),
                     entity.build_const_eligible,
@@ -5143,7 +5143,7 @@ impl Simulation {
                 self.substrate
                     .entities
                     .get(other)
-                    .and_then(|b| self.object_type(b.type_ref, rules))
+                    .and_then(|b| self.object_type(b.type_ref(), rules))
                     .is_some_and(|obj| obj.weapons_factory)
             })
         });
@@ -5310,12 +5310,12 @@ impl Simulation {
         };
 
         self.substrate.entities.values().any(|entity| {
-            entity.owner == owner
+            entity.owner() == owner
                 && entity.category == EntityCategory::Unit
                 && !entity.dying
                 && rules.general.base_unit_types.iter().any(|type_id| {
                     self.interner
-                        .resolve(entity.type_ref)
+                        .resolve(entity.type_ref())
                         .eq_ignore_ascii_case(type_id)
                 })
         })
@@ -5451,7 +5451,7 @@ impl Simulation {
                 (entity.category == EntityCategory::Structure).then_some((
                     entity.position.rx,
                     entity.position.ry,
-                    self.interner.resolve(entity.type_ref).to_string(),
+                    self.interner.resolve(entity.type_ref()).to_string(),
                 ))
             })
             .collect();
@@ -5831,7 +5831,7 @@ impl Simulation {
                     && entity.mission.current() != selling
                     && entity.mission.queued() != selling
                     && self
-                        .object_type(entity.type_ref, rules)
+                        .object_type(entity.type_ref(), rules)
                         .is_some_and(|object| object.spy_sat);
                 if !coarse_candidate {
                     continue;
@@ -5869,7 +5869,7 @@ impl Simulation {
             {
                 continue;
             }
-            let Some(obj) = self.object_type(entity.type_ref, rules) else {
+            let Some(obj) = self.object_type(entity.type_ref(), rules) else {
                 continue;
             };
             if entity.building_up.is_some() {
@@ -5884,7 +5884,7 @@ impl Simulation {
                 )
             {
                 effects.gap_generators.push((
-                    entity.owner,
+                    entity.owner(),
                     entity.position.rx,
                     entity.position.ry,
                     i32::from(obj.gap_radius_in_cells),
@@ -6052,7 +6052,7 @@ impl Simulation {
             let mut entity_stats: DiagMap<String, (u32, u16, u16, u16, u16)> = DiagMap::new();
             for entity in self.substrate.entities.values() {
                 let entry = entity_stats
-                    .entry(self.interner.resolve(entity.owner).to_string())
+                    .entry(self.interner.resolve(entity.owner()).to_string())
                     .or_insert((0, u16::MAX, u16::MAX, 0, 0));
                 entry.0 += 1;
                 entry.1 = entry.1.min(entity.position.rx);
@@ -6086,7 +6086,7 @@ impl Simulation {
             .entities
             .get(stable_id)
             .filter(|e| e.category == EntityCategory::Structure && !e.dying)
-            .map(|e| (e.owner, e.type_ref))
+            .map(|e| (e.owner(), e.type_ref()))
         else {
             return;
         };
@@ -6454,7 +6454,7 @@ impl Simulation {
                             entity.regular_crusher,
                             entity.omni_crusher,
                         ),
-                        self.interner.resolve(entity.owner),
+                        self.interner.resolve(entity.owner()),
                         locomotor_kind,
                         false,
                         &self.substrate.occupancy,
@@ -6924,7 +6924,7 @@ impl Simulation {
                         .substrate
                         .entities
                         .get(entity_id)
-                        .map(|entity| entity.type_ref)
+                        .map(|entity| entity.type_ref())
                     else {
                         continue;
                     };
@@ -7444,7 +7444,7 @@ impl Simulation {
                     self.substrate
                         .entities
                         .get(dead_id)
-                        .map(|entity| (entity.owner, entity.category))
+                        .map(|entity| (entity.owner(), entity.category))
                 })
                 .collect();
             // Animated infantry remain represented and live until their death
@@ -8020,7 +8020,7 @@ impl Simulation {
             return false;
         };
         let category = entity.category;
-        let owner = entity.owner;
+        let owner = entity.owner();
         let regular_crusher = entity.regular_crusher;
         let omni_crusher = entity.omni_crusher;
         let locomotor = entity.locomotor.as_ref();

--- a/src/sim/world/object_turn.rs
+++ b/src/sim/world/object_turn.rs
@@ -164,7 +164,7 @@ impl Simulation {
                 if entity.category != EntityCategory::Unit || entity.is_voxel {
                     return None;
                 }
-                let object = rules?.object(sim.interner.resolve(entity.type_ref))?;
+                let object = rules?.object(sim.interner.resolve(entity.type_ref()))?;
                 Some(crate::sim::animation::ShpVehicleCadence {
                     walk_rate: object.walk_rate,
                     idle_rate: object.idle_rate,

--- a/src/sim/world/projectile_collision.rs
+++ b/src/sim/world/projectile_collision.rs
@@ -1359,7 +1359,7 @@ impl ProjectileCollisionWorld<'_> {
         if object.category == EntityCategory::Structure
             && let Some(kind) = self
                 .rules
-                .and_then(|rules| rules.object(self.interner.resolve(object.type_ref)))
+                .and_then(|rules| rules.object(self.interner.resolve(object.type_ref())))
         {
             let (width, height) = crate::rules::foundation::foundation_dimensions(&kind.foundation);
             coord.x = coord.x.wrapping_add(i32::from(width) * 128 - 128);
@@ -1377,8 +1377,8 @@ impl ProjectileCollisionWorld<'_> {
         };
         crate::map::houses::is_allied_with(
             self.alliances,
-            self.interner.resolve(source.owner),
-            self.interner.resolve(other.owner),
+            self.interner.resolve(source.owner()),
+            self.interner.resolve(other.owner()),
         )
     }
 
@@ -1423,7 +1423,7 @@ impl ProjectileCollisionWorld<'_> {
             .into_iter()
             .flat_map(|occupants| occupants.iter_layer(MovementLayer::Ground))
             .filter_map(|occupant| self.entities.get(occupant.entity_id))
-            .map(|object| (object.stable_id, self.raw_location(object)));
+            .map(|object| (object.stable_id(), self.raw_location(object)));
         let mut best = None;
         let mut best_distance = 0;
         for object in objects {
@@ -1526,7 +1526,7 @@ impl ProjectileCollisionWorld<'_> {
                         .get(id)
                         .and_then(|object| {
                             self.rules.and_then(|rules| {
-                                rules.object(self.interner.resolve(object.type_ref))
+                                rules.object(self.interner.resolve(object.type_ref()))
                             })
                         })
                         .is_some_and(|kind| {
@@ -1739,7 +1739,7 @@ impl ProjectileCollisionWorld<'_> {
         if target.category == EntityCategory::Structure
             && let Some(kind) = self
                 .rules
-                .and_then(|rules| rules.object(self.interner.resolve(target.type_ref)))
+                .and_then(|rules| rules.object(self.interner.resolve(target.type_ref())))
         {
             let (width, height) = crate::rules::foundation::foundation_dimensions(&kind.foundation);
             distance = distance
@@ -1847,7 +1847,7 @@ impl ProjectileCollisionWorld<'_> {
             && crate::map::houses::is_allied_with(
                 self.alliances,
                 self.interner.resolve(owner),
-                self.interner.resolve(source.owner),
+                self.interner.resolve(source.owner()),
             )
         {
             return false;
@@ -1875,7 +1875,7 @@ impl ProjectileCollisionWorld<'_> {
     fn high_flying(&self, target: &crate::sim::game_entity::GameEntity) -> bool {
         if target.category == EntityCategory::Aircraft
             && self.rules.is_some_and(|rules| {
-                let name = self.interner.resolve(target.type_ref);
+                let name = self.interner.resolve(target.type_ref());
                 name.eq_ignore_ascii_case(&rules.missile_spawn.v3.type_name)
                     || name.eq_ignore_ascii_case(&rules.missile_spawn.dmisl.type_name)
             })

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -267,7 +267,7 @@ impl Simulation {
                     .entities
                     .get(projectile.source_id)
                     .is_some_and(|source| {
-                        self.object_type(source.type_ref, rules)
+                        self.object_type(source.type_ref(), rules)
                             .is_some_and(|kind| kind.jumpjet)
                     })
             });
@@ -372,7 +372,7 @@ impl Simulation {
             let Some(rules) = rules else {
                 return true;
             };
-            let type_ref = entity.type_ref;
+            let type_ref = entity.type_ref();
             let type_name = self.interner.resolve(type_ref);
             let sequence_set = rules.animation_sequence(type_name);
             let finished = crate::sim::animation::tick_dying_animation(
@@ -604,7 +604,7 @@ fn veterancy_promotion_step(sim: &mut Simulation, id: u64, rules: &RuleSet) {
     else {
         return;
     };
-    let owner = entity.owner;
+    let owner = entity.owner();
     let (rx, ry) = (entity.position.rx, entity.position.ry);
     let (sound, elite) = match promotion {
         crate::sim::combat::veterancy::Promotion::Elite => {
@@ -655,7 +655,7 @@ fn refresh_mover_speed_after_promotion(sim: &mut Simulation, id: u64, rules: &Ru
     if entity.movement_target.is_none() {
         return;
     }
-    let obj = sim.object_type(entity.type_ref, rules);
+    let obj = sim.object_type(entity.type_ref(), rules);
     let loco_multiplier = entity
         .locomotor
         .as_ref()
@@ -697,7 +697,7 @@ fn self_heal_step(sim: &mut Simulation, id: u64, rules: &RuleSet) {
     };
     let Some(object) = sim
         .interner
-        .try_resolve(entity.type_ref)
+        .try_resolve(entity.type_ref())
         .and_then(|type_id| rules.object(type_id))
     else {
         return;
@@ -742,7 +742,7 @@ fn drop_unsensed_cloaked_target_step(sim: &mut Simulation, id: u64) {
     else {
         return;
     };
-    let owner = entity.owner;
+    let owner = entity.owner();
     let owner_str = sim.interner.resolve(owner).to_owned();
     let Some(target) = sim.substrate.entities.get(target_id) else {
         return;
@@ -757,7 +757,7 @@ fn drop_unsensed_cloaked_target_step(sim: &mut Simulation, id: u64) {
     let target_cell = (target.position.rx, target.position.ry);
     if sim
         .fog
-        .is_friendly(&owner_str, sim.interner.resolve(target.owner))
+        .is_friendly(&owner_str, sim.interner.resolve(target.owner()))
     {
         return;
     }
@@ -821,7 +821,7 @@ fn techno_common_pre(sim: &mut Simulation, id: u64, rules: Option<&RuleSet>) {
     let Some(entity) = sim.substrate.entities.get(id) else {
         return;
     };
-    let Some(object_type) = rules.object(sim.interner.resolve(entity.type_ref)) else {
+    let Some(object_type) = rules.object(sim.interner.resolve(entity.type_ref())) else {
         return;
     };
     if !object_type.disguise_when_still || entity.locomotor.is_none() {
@@ -856,7 +856,7 @@ fn techno_common_pre(sim: &mut Simulation, id: u64, rules: Option<&RuleSet>) {
     let disguise_type = sim
         .interner
         .intern(&rules.general.default_mirage_disguises[index]);
-    let owner = sim.substrate.entities.get(id).map(|e| e.owner);
+    let owner = sim.substrate.entities.get(id).map(|e| e.owner());
     if let Some(entity) = sim.substrate.entities.get_mut(id) {
         let state = entity.disguise.get_or_insert_with(Default::default);
         state.acquire(sim.session.binary_frame, Some(disguise_type), owner);
@@ -915,7 +915,7 @@ fn techno_common_post(sim: &mut Simulation, id: u64, rules: Option<&RuleSet>) {
     };
     let cur = entity.health.current as i64;
     let max = entity.health.max as i64;
-    let type_ref = entity.type_ref;
+    let type_ref = entity.type_ref();
     let live_until_in = entity.damage_particle_live_until;
     let Some(obj) = rules.object(sim.interner.resolve(type_ref)) else {
         return;
@@ -1175,7 +1175,7 @@ fn can_acquire_target(sim: &Simulation, id: u64, rules: &RuleSet) -> bool {
     let Some(entity) = sim.substrate.entities.get(id) else {
         return false;
     };
-    let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref)) else {
+    let Some(obj) = rules.object(sim.interner.resolve(entity.type_ref())) else {
         return false;
     };
     if !obj.can_passive_acquire {
@@ -1274,7 +1274,7 @@ fn passive_target_scan(
         .substrate
         .entities
         .get(id)
-        .and_then(|e| rules.object(sim.interner.resolve(e.type_ref)))
+        .and_then(|e| rules.object(sim.interner.resolve(e.type_ref())))
         .is_some_and(|obj| obj.distributed_fire);
     if spreads_fire {
         if holds_passive_target {
@@ -1447,7 +1447,7 @@ fn passive_acquire_step(
         return;
     }
     let opportunity_fire = rules
-        .object(sim.interner.resolve(entity.type_ref))
+        .object(sim.interner.resolve(entity.type_ref()))
         .is_some_and(|obj| obj.opportunity_fire);
     if !passive_acquire_gate(
         mission,

--- a/src/sim/world/techno_ai/mission_handlers.rs
+++ b/src/sim/world/techno_ai/mission_handlers.rs
@@ -128,7 +128,7 @@ pub(super) fn dispatch_supported_foot_mission_cadence(
                 && entity.deploy_state.is_some()
                 && sim
                     .interner
-                    .try_resolve(entity.type_ref)
+                    .try_resolve(entity.type_ref())
                     .and_then(|name| rules.object(name))
                     .is_some_and(|obj| {
                         obj.deploy_fire && !obj.immune_to_radiation && obj.undeploy_delay < 0
@@ -786,10 +786,10 @@ pub(crate) fn harvester_enter_idle_mode_selector(
     let human = !skip_human_land_check
         && sim
             .houses
-            .get(&entity.owner)
+            .get(&entity.owner())
             .is_none_or(|house| house.is_controlled_by_human(sim.session.game_mode_nonzero));
     let weeder = sim
-        .object_type(entity.type_ref, rules)
+        .object_type(entity.type_ref(), rules)
         .is_some_and(|obj| !obj.harvester && obj.weeder);
     let wanted_land = if weeder {
         crate::rules::terrain_rules::LandType::Weeds
@@ -1051,7 +1051,7 @@ fn retaliate_and_scan(
         .substrate
         .entities
         .get(id)
-        .and_then(|entity| sim.interner.try_resolve(entity.type_ref))
+        .and_then(|entity| sim.interner.try_resolve(entity.type_ref()))
         .and_then(|name| rules.object(name))
         .is_some_and(|obj| obj.distributed_fire);
     if spreads_fire {
@@ -1207,7 +1207,7 @@ fn evaluate_foot_hunt(
     rules: &RuleSet,
     ctx: super::ObjectAiCtx<'_>,
 ) -> MissionHandlerEvaluation {
-    let type_ref = sim.substrate.entities.get(id).map(|entity| entity.type_ref);
+    let type_ref = sim.substrate.entities.get(id).map(|entity| entity.type_ref());
     let stupid_hunt = type_ref
         .and_then(|type_ref| sim.interner.try_resolve(type_ref))
         .and_then(|name| rules.object(name))
@@ -1510,7 +1510,7 @@ fn harvester_guard_override_requeues_harvest(sim: &Simulation, id: u64, rules: &
     let Some(miner) = entity.miner.as_ref() else {
         return false;
     };
-    let Some(unit_type) = sim.object_type(entity.type_ref, rules) else {
+    let Some(unit_type) = sim.object_type(entity.type_ref(), rules) else {
         return false;
     };
     if !unit_type.harvester {
@@ -1518,7 +1518,7 @@ fn harvester_guard_override_requeues_harvest(sim: &Simulation, id: u64, rules: &
     }
     let human = sim
         .houses
-        .get(&entity.owner)
+        .get(&entity.owner())
         .is_none_or(|house| house.is_controlled_by_human(sim.session.game_mode_nonzero));
     if !human {
         // Arm (ii), `0x00740880..0x0074092C`.
@@ -1526,7 +1526,7 @@ fn harvester_guard_override_requeues_harvest(sim: &Simulation, id: u64, rules: &
             sim.interner.get(dock_type).is_some_and(|type_ref| {
                 sim.substrate
                     .entities
-                    .count_owned_of_type(entity.owner, type_ref)
+                    .count_owned_of_type(entity.owner(), type_ref)
                     > 0
             })
         });
@@ -1535,7 +1535,7 @@ fn harvester_guard_override_requeues_harvest(sim: &Simulation, id: u64, rules: &
         }
         let no_ore = sim
             .houses
-            .get(&entity.owner)
+            .get(&entity.owner())
             .is_some_and(|house| house.harvester_no_ore);
         return !(unit_type.harvester && no_ore);
     }
@@ -1556,9 +1556,9 @@ fn harvester_guard_override_requeues_harvest(sim: &Simulation, id: u64, rules: &
                 sim.substrate.entities.get(sid).is_some_and(|building| {
                     building.category == EntityCategory::Structure
                         && !building.dying
-                        && building.owner == entity.owner
+                        && building.owner() == entity.owner()
                         && sim
-                            .object_type(building.type_ref, rules)
+                            .object_type(building.type_ref(), rules)
                             .is_some_and(|obj| obj.refinery)
                 })
             });
@@ -1798,7 +1798,7 @@ fn foot_type_takes_cadence_band(
     attacker: &crate::sim::game_entity::GameEntity,
     close_primary_range_leptons: i64,
 ) -> bool {
-    let Some(object) = rules.object(sim.interner.resolve(attacker.type_ref)) else {
+    let Some(object) = rules.object(sim.interner.resolve(attacker.type_ref())) else {
         return false;
     };
     if attacker.category == EntityCategory::Infantry && object.close_range {

--- a/src/sim/world/techno_ai_cloak.rs
+++ b/src/sim/world/techno_ai_cloak.rs
@@ -25,7 +25,7 @@ fn stock_cloak_tick_facts(
     if entity.category != EntityCategory::Unit || entity.cloak.is_none() {
         return None;
     }
-    let object = rules.object(sim.interner.resolve(entity.type_ref))?;
+    let object = rules.object(sim.interner.resolve(entity.type_ref()))?;
     let rank_cloak = entity.veterancy >= 100 && object.veteran_cloak
         || entity.veterancy >= 200 && object.elite_cloak;
     if !object.cloakable && !rank_cloak {
@@ -87,7 +87,7 @@ fn stock_cloak_tick_facts(
             .entities
             .get(contact_id)
             .filter(|contact| contact.category == EntityCategory::Structure)
-            .and_then(|contact| rules.object(sim.interner.resolve(contact.type_ref)))
+            .and_then(|contact| rules.object(sim.interner.resolve(contact.type_ref())))
             .is_some_and(|contact_type| contact_type.weapons_factory)
     });
     let current_frame = sim.session.binary_frame as i32;
@@ -105,7 +105,7 @@ fn stock_cloak_tick_facts(
     // substituted `fog.is_cell_visible(owner, ...)` here, which is true for an
     // owner standing on its own cell — inverting both gates below.
     let cloaked_by_own_house =
-        owner_cloak_field_bit(sim, entity.owner, entity.position.rx, entity.position.ry);
+        owner_cloak_field_bit(sim, entity.owner(), entity.position.rx, entity.position.ry);
 
     // `TechnoClass::CanAutoCloak @ 0x006FBDC0`, in native step order.
     //
@@ -229,7 +229,7 @@ fn sensor_targeters_in_native_dispatch_order(sim: &Simulation, cloaker_id: u64) 
     let Some(cloaker) = sim.substrate.entities.get(cloaker_id) else {
         return Vec::new();
     };
-    let cloaker_owner = cloaker.owner;
+    let cloaker_owner = cloaker.owner();
     let cloaker_cell = (cloaker.position.rx, cloaker.position.ry);
 
     // TechnoClass+0x420 @ 0x006F4EB0 reverse-scans g_TechnoClass_Array,
@@ -245,10 +245,10 @@ fn sensor_targeters_in_native_dispatch_order(sim: &Simulation, cloaker_id: u64) 
                 .attack_target
                 .as_ref()
                 .is_some_and(|target| target.target == TargetKind::Entity(cloaker_id));
-            let admitted = targeter.owner == cloaker_owner
+            let admitted = targeter.owner() == cloaker_owner
                 || sim
                     .fog
-                    .has_sensor_for_house(targeter.owner, cloaker_cell.0, cloaker_cell.1);
+                    .has_sensor_for_house(targeter.owner(), cloaker_cell.0, cloaker_cell.1);
             (targets_cloaker && admitted).then_some(targeter_id)
         })
         .collect()
@@ -287,7 +287,7 @@ pub(crate) fn sensor_reevaluate_stock_cloak(
         return SensorCloakReevaluation::default();
     };
     let inside_friendly_cloak_field = sim.substrate.entities.get(id).is_some_and(|entity| {
-        owner_cloak_field_bit(sim, entity.owner, entity.position.rx, entity.position.ry)
+        owner_cloak_field_bit(sim, entity.owner(), entity.position.rx, entity.position.ry)
     });
     if !inside_friendly_cloak_field || !facts.can_auto_cloak {
         return SensorCloakReevaluation::default();
@@ -486,7 +486,7 @@ pub(crate) fn uncloak_on_sensor_neighbour_after_cell_entry(
     {
         return false;
     }
-    let owner = mover.owner;
+    let owner = mover.owner();
     let owner_str = sim.interner.resolve(owner).to_owned();
     let (rx, ry) = (i32::from(mover.position.rx), i32::from(mover.position.ry));
 
@@ -512,12 +512,12 @@ pub(crate) fn uncloak_on_sensor_neighbour_after_cell_entry(
         let Some(other) = sim.substrate.entities.get(nearest) else {
             continue;
         };
-        let other_owner_str = sim.interner.resolve(other.owner);
-        if sim.fog.is_friendly(&owner_str, other_owner_str) || other.owner == owner {
+        let other_owner_str = sim.interner.resolve(other.owner());
+        if sim.fog.is_friendly(&owner_str, other_owner_str) || other.owner() == owner {
             continue;
         }
         let detects = rules
-            .object(sim.interner.resolve(other.type_ref))
+            .object(sim.interner.resolve(other.type_ref()))
             .is_some_and(|object| object.sensors);
         if !detects {
             continue;
@@ -532,7 +532,7 @@ pub(crate) fn uncloak_on_sensor_neighbour_after_cell_entry(
         .substrate
         .entities
         .get(id)
-        .and_then(|entity| rules.object(sim.interner.resolve(entity.type_ref)))
+        .and_then(|entity| rules.object(sim.interner.resolve(entity.type_ref())))
         .map_or(1, |object| object.cloaking_speed);
     let now = sim.session.binary_frame as i32;
     let surfaced = sim
@@ -582,7 +582,7 @@ pub(super) fn tick_stock_cloak_producer(sim: &mut Simulation, id: u64, rules: &R
         .substrate
         .entities
         .get(id)
-        .map(|entity| (entity.category, entity.type_ref, entity.veterancy))
+        .map(|entity| (entity.category, entity.type_ref(), entity.veterancy))
     else {
         return;
     };

--- a/src/sim/world/unit_post.rs
+++ b/src/sim/world/unit_post.rs
@@ -94,7 +94,7 @@ pub(crate) fn apply_unit_facing(
     for update in updates {
         let id = update.entity_id;
         let rot_byte: u8 = rules
-            .object(interner.resolve(entities.get(id).map(|e| e.type_ref).unwrap_or_default()))
+            .object(interner.resolve(entities.get(id).map(|e| e.type_ref()).unwrap_or_default()))
             .map(|obj| obj.turret_rot.clamp(0, 0xFF) as u8)
             .unwrap_or(5);
         let Some(entity) = entities.get_mut(id) else {

--- a/src/sim/world/world_commands.rs
+++ b/src/sim/world/world_commands.rs
@@ -563,7 +563,7 @@ impl Simulation {
             .map(|l| l.speed_multiplier)
             .unwrap_or(SimFixed::from_num(1));
 
-        let obj = rules.and_then(|r| self.object_type(e.type_ref, r));
+        let obj = rules.and_then(|r| self.object_type(e.type_ref(), r));
         // `FootClass::GetCurrentSpeed @ 0x004DB1A0`: every ordered move asks the
         // getter for the speed, so the `FASTER` multiply belongs here, between
         // the truncated type speed and the locomotor fraction — not only on the
@@ -1202,7 +1202,7 @@ impl Simulation {
                     .entities
                     .get(*entity_id)
                     .is_some_and(|entity| {
-                        self.object_type(entity.type_ref, rules)
+                        self.object_type(entity.type_ref(), rules)
                             .is_some_and(|obj| obj.enslaves.is_some() && obj.deploys_into.is_some())
                     })
                 {
@@ -1226,7 +1226,7 @@ impl Simulation {
                     .entities
                     .get(*entity_id)
                     .is_some_and(|entity| {
-                        self.object_type(entity.type_ref, rules).is_some_and(|obj| {
+                        self.object_type(entity.type_ref(), rules).is_some_and(|obj| {
                             obj.enslaves.is_some() && obj.undeploys_into.is_some()
                         })
                     })
@@ -1248,7 +1248,7 @@ impl Simulation {
                 let Some(rules) = rules else { return false };
                 // INI gate: only DeployFire=yes types respond.
                 let type_str = match self.substrate.entities.get(*entity_id) {
-                    Some(e) => self.interner.resolve(e.type_ref).to_string(),
+                    Some(e) => self.interner.resolve(e.type_ref()).to_string(),
                     None => return false,
                 };
                 let Some(obj) = rules.object(&type_str) else {
@@ -1541,10 +1541,10 @@ impl Simulation {
                 }
                 // Validate depot exists, is friendly, and has UnitRepair=yes.
                 let depot_info = self.substrate.entities.get(*depot_id).and_then(|depot| {
-                    if !command_owner.eq_ignore_ascii_case(self.interner.resolve(depot.owner)) {
+                    if !command_owner.eq_ignore_ascii_case(self.interner.resolve(depot.owner())) {
                         return None;
                     }
-                    let obj = self.object_type(depot.type_ref, rules)?;
+                    let obj = self.object_type(depot.type_ref(), rules)?;
                     if !obj.unit_repair {
                         return None;
                     }
@@ -1660,7 +1660,7 @@ impl Simulation {
                 }
                 // Validate transport exists and has cargo capacity.
                 let transport_info = self.substrate.entities.get(*transport_id).and_then(|t| {
-                    let obj = self.object_type(t.type_ref, rules)?;
+                    let obj = self.object_type(t.type_ref(), rules)?;
                     let cargo = t.passenger_role.cargo()?;
                     Some((t.position.rx, t.position.ry, obj.clone(), cargo.clone()))
                 });
@@ -1669,7 +1669,7 @@ impl Simulation {
                 };
                 // Validate passenger can enter.
                 let pax_ok = self.substrate.entities.get(*passenger_id).and_then(|p| {
-                    let pobj = self.object_type(p.type_ref, rules)?;
+                    let pobj = self.object_type(p.type_ref(), rules)?;
                     if passenger::can_enter_transport(
                         p,
                         self.substrate.entities.get(*transport_id)?,
@@ -1807,7 +1807,7 @@ impl Simulation {
                             .substrate
                             .entities
                             .get(*transport_id)
-                            .and_then(|t| self.object_type(t.type_ref, rules))
+                            .and_then(|t| self.object_type(t.type_ref(), rules))
                             .is_some_and(|obj| obj.passengers > 0);
                         if !is_transport || !self.order_actor_admits(*transport_id) {
                             return false;
@@ -1903,7 +1903,7 @@ impl Simulation {
                 }
                 // Validate attacker has C4=yes flag.
                 let c4_ok = self.substrate.entities.get(*attacker_id).and_then(|e| {
-                    let obj = self.object_type(e.type_ref, rules)?;
+                    let obj = self.object_type(e.type_ref(), rules)?;
                     obj.c4.then_some(())
                 });
                 if c4_ok.is_none() {
@@ -1923,7 +1923,7 @@ impl Simulation {
                         if b.dying {
                             return None;
                         }
-                        let obj = self.object_type(b.type_ref, rules)?;
+                        let obj = self.object_type(b.type_ref(), rules)?;
                         if !obj.can_c4 || obj.invisible_in_game {
                             return None;
                         }
@@ -1933,7 +1933,7 @@ impl Simulation {
                         ) {
                             return None;
                         }
-                        Some((b.position.rx, b.position.ry, b.owner))
+                        Some((b.position.rx, b.position.ry, b.owner()))
                     });
                 let Some((trx, try_, target_owner)) = target_info else {
                     return false;
@@ -2040,7 +2040,7 @@ impl Simulation {
                 }
                 // Validate engineer has Engineer=yes flag.
                 let eng_ok = self.substrate.entities.get(*engineer_id).and_then(|e| {
-                    let obj = self.object_type(e.type_ref, rules)?;
+                    let obj = self.object_type(e.type_ref(), rules)?;
                     obj.engineer.then_some(())
                 });
                 if eng_ok.is_none() {
@@ -2058,11 +2058,11 @@ impl Simulation {
                         if b.dying {
                             return None;
                         }
-                        let obj = self.object_type(b.type_ref, rules)?;
+                        let obj = self.object_type(b.type_ref(), rules)?;
                         if !obj.capturable && !obj.bridge_repair_hut {
                             return None;
                         }
-                        Some((b.position.rx, b.position.ry, b.owner))
+                        Some((b.position.rx, b.position.ry, b.owner()))
                     });
                 let Some((trx, try_, target_owner)) = target_info else {
                     return false;
@@ -2453,9 +2453,9 @@ impl Simulation {
                 .get(stable_id)
                 .is_some_and(|entity| {
                     entity.category == crate::map::entities::EntityCategory::Structure
-                        && command_owner.eq_ignore_ascii_case(self.interner.resolve(entity.owner))
+                        && command_owner.eq_ignore_ascii_case(self.interner.resolve(entity.owner()))
                         && self
-                            .object_type(entity.type_ref, rules)
+                            .object_type(entity.type_ref(), rules)
                             .is_some_and(|obj| obj.has_rally_line())
                 });
             if eligible {
@@ -2602,7 +2602,7 @@ impl Simulation {
         {
             return false;
         }
-        let type_ref = entity.type_ref;
+        let type_ref = entity.type_ref();
         let selectable = rules.is_none_or(|r| {
             r.object(self.interner.resolve(type_ref))
                 .is_none_or(|obj| obj.selectable)
@@ -2636,7 +2636,7 @@ impl Simulation {
         self.substrate
             .entities
             .get(stable_id)
-            .is_some_and(|e| command_owner.eq_ignore_ascii_case(self.interner.resolve(e.owner)))
+            .is_some_and(|e| command_owner.eq_ignore_ascii_case(self.interner.resolve(e.owner())))
     }
 
     /// The acting object's half of the native order-admission gate.
@@ -2762,7 +2762,7 @@ impl Simulation {
         if miner.miner.is_none() {
             return false;
         }
-        let harvester_type = self.interner.resolve(miner.type_ref);
+        let harvester_type = self.interner.resolve(miner.type_ref());
         let Some(refinery) = self.substrate.entities.get(refinery_id) else {
             return false;
         };
@@ -2772,11 +2772,11 @@ impl Simulation {
         if refinery.health.current == 0 || refinery.dying || refinery.building_up.is_some() {
             return false;
         }
-        let refinery_owner = self.interner.resolve(refinery.owner);
+        let refinery_owner = self.interner.resolve(refinery.owner());
         if !are_houses_friendly(&self.house_alliances, command_owner, refinery_owner) {
             return false;
         }
-        let refinery_type = self.interner.resolve(refinery.type_ref);
+        let refinery_type = self.interner.resolve(refinery.type_ref());
         rules.is_refinery_type(refinery_type)
             && rules.harvester_can_dock_at(harvester_type, refinery_type)
     }
@@ -2792,8 +2792,8 @@ impl Simulation {
         };
         !are_houses_friendly(
             &self.house_alliances,
-            self.interner.resolve(attacker.owner),
-            self.interner.resolve(target.owner),
+            self.interner.resolve(attacker.owner()),
+            self.interner.resolve(target.owner()),
         )
     }
 

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -1267,7 +1267,7 @@ impl Simulation {
     /// BTreeMap iterates in key order (= stable_id), so no manual sort needed.
     fn hash_entities(&self, hasher: &mut impl Hasher, schema: HashSchema) {
         for entity in self.substrate.entities.values() {
-            entity.stable_id.hash(hasher);
+            entity.stable_id().hash(hasher);
             if schema.includes(HashFeature::CreditIncome) {
                 // GSI-09.01: the `BuildingClass+0x6D0/+0x6D8` ProduceCash
                 // timer and the `TechnoClass+0x1CC/+0x1D0` drain link pair.
@@ -1289,7 +1289,7 @@ impl Simulation {
                 // transitional ProductionState registry until the manager is
                 // promoted to its own component. Both the ordered pool and
                 // each child's active harvest cursor affect future simulation.
-                if let Some(slave_ids) = self.production.slave_bindings.get(&entity.stable_id) {
+                if let Some(slave_ids) = self.production.slave_bindings.get(&entity.stable_id()) {
                     b"constructor-slave-pool-v1".hash(hasher);
                     slave_ids.len().hash(hasher);
                     for slave_id in slave_ids {
@@ -1380,10 +1380,10 @@ impl Simulation {
                     anim.finished.hash(hasher);
                 }
             }
-            entity.owner.hash(hasher);
+            entity.owner().hash(hasher);
             entity.health.current.hash(hasher);
             entity.health.max.hash(hasher);
-            entity.type_ref.hash(hasher);
+            entity.type_ref().hash(hasher);
             (entity.category as u8).hash(hasher);
             entity.foundation.hash(hasher);
             entity.building_hidden_occupancy.hash(hasher);

--- a/src/sim/world/world_orders.rs
+++ b/src/sim/world/world_orders.rs
@@ -177,7 +177,7 @@ impl Simulation {
                     // `FootClass::GetCurrentSpeed @ 0x004DB1A0`: a resumed order
                     // re-queries the getter like any other, so the FASTER stage
                     // runs here too.
-                    let obj = rules.and_then(|r| self.object_type(e.type_ref, r));
+                    let obj = rules.and_then(|r| self.object_type(e.type_ref(), r));
                     let bs: SimFixed =
                         crate::sim::combat::veterancy::entity_mover_speed_leptons_per_second(
                             e,
@@ -264,9 +264,9 @@ impl Simulation {
             .entities
             .values()
             .filter(|e| {
-                e.capture_target.is_some() && !e.dying && !turn_suppressed.contains(&e.stable_id)
+                e.capture_target.is_some() && !e.dying && !turn_suppressed.contains(&e.stable_id())
             })
-            .map(|e| (e.stable_id, e.capture_target.unwrap(), e.owner))
+            .map(|e| (e.stable_id(), e.capture_target.unwrap(), e.owner()))
             .collect();
 
         for (engineer_id, building_id, engineer_owner) in captures {
@@ -276,7 +276,7 @@ impl Simulation {
                 .entities
                 .get(building_id)
                 .and_then(|b| {
-                    self.object_type(b.type_ref, rules)
+                    self.object_type(b.type_ref(), rules)
                         .map(|t| t.bridge_repair_hut)
                 })
                 .unwrap_or(false);
@@ -355,7 +355,7 @@ impl Simulation {
             .substrate
             .entities
             .get(building_id)
-            .map(|e| (e.owner, e.type_ref, e.position.rx, e.position.ry))
+            .map(|e| (e.owner(), e.type_ref(), e.position.rx, e.position.ry))
         else {
             return;
         };
@@ -436,7 +436,7 @@ impl Simulation {
                     if e.dying {
                         return None;
                     }
-                    Some((e.capture_target?, e.owner))
+                    Some((e.capture_target?, e.owner()))
                 })
             else {
                 key_idx += 1;
@@ -449,7 +449,7 @@ impl Simulation {
                 .entities
                 .get(building_id)
                 .and_then(|b| {
-                    self.object_type(b.type_ref, rules)
+                    self.object_type(b.type_ref(), rules)
                         .map(|t| t.bridge_repair_hut)
                 })
                 .unwrap_or(false);
@@ -718,7 +718,7 @@ impl Simulation {
         for sid in self.substrate.entities.keys_sorted() {
             if let Some(e) = self.substrate.entities.get(sid) {
                 let bridge_hut = rules
-                    .object(self.interner.resolve(e.type_ref))
+                    .object(self.interner.resolve(e.type_ref()))
                     .is_some_and(|object| object.bridge_repair_hut);
                 if e.pending_c4_detonation.is_some() && !e.dying && bridge_hut {
                     det_keys.push(sid);
@@ -822,7 +822,7 @@ impl Simulation {
             .get(building_id)
             .and_then(|building| {
                 let pending = building.pending_c4_detonation?;
-                let object = rules.object(self.interner.resolve(building.type_ref))?;
+                let object = rules.object(self.interner.resolve(building.type_ref()))?;
                 Some((
                     pending,
                     i32::from(building.health.current),
@@ -866,7 +866,7 @@ impl Simulation {
         rules: &RuleSet,
     ) -> Option<Vec<(u16, u16)>> {
         let target = self.substrate.entities.get(target_id)?;
-        let obj = self.object_type(target.type_ref, rules)?;
+        let obj = self.object_type(target.type_ref(), rules)?;
         // Infantry building-entry resolves through normal building cell lookup.
         // AddOccupy/RemoveOccupy only affect hidden occupancy counters.
         Some(c4_base_foundation_cells(
@@ -986,7 +986,7 @@ impl Simulation {
             // Queue a Move command for the next tick. Simpler than
             // reimplementing the pathfind call; 1-tick delay is below the
             // human-observable threshold.
-            if let Some(owner) = self.substrate.entities.get(sid).map(|e| e.owner) {
+            if let Some(owner) = self.substrate.entities.get(sid).map(|e| e.owner()) {
                 self.queue_command(crate::sim::command::CommandEnvelope::new(
                     owner,
                     self.session.tick + 1,
@@ -1027,7 +1027,7 @@ impl Simulation {
             .get(building_id)
             .and_then(|b| {
                 rules
-                    .object(self.interner.resolve(b.type_ref))
+                    .object(self.interner.resolve(b.type_ref()))
                     .map(|t| t.bridge_repair_hut)
             })
             .unwrap_or(false);
@@ -1280,7 +1280,7 @@ impl Simulation {
                         .substrate
                         .entities
                         .get(entity_id)
-                        .map(|e| self.interner.resolve(e.owner).to_string())
+                        .map(|e| self.interner.resolve(e.owner()).to_string())
                         .unwrap_or_default();
                     let (entity_blocks, entity_block_map) = bump_crush::build_entity_block_set(
                         &self.substrate.entities,

--- a/src/sim/world/world_spawn.rs
+++ b/src/sim/world/world_spawn.rs
@@ -1471,8 +1471,8 @@ impl Simulation {
     /// Store a freshly constructed object in native-style limbo and account for
     /// its owner. Placement is a separate, result-bearing Reveal transaction.
     fn store_spawned_limbo(&mut self, mut ge: GameEntity) -> u64 {
-        let stable_id = ge.stable_id;
-        let owner = self.interner.resolve(ge.owner).to_string();
+        let stable_id = ge.stable_id();
+        let owner = self.interner.resolve(ge.owner()).to_string();
         let category = ge.category;
 
         // This boundary receives newly constructed objects. Make those constructor
@@ -1519,7 +1519,7 @@ impl Simulation {
             .remove(stable_id)
             .expect("constructor object existence checked above");
         debug_assert!(entity.lifecycle.in_limbo && !entity.lifecycle.cell_marked);
-        let owner = self.interner.resolve(entity.owner).to_string();
+        let owner = self.interner.resolve(entity.owner()).to_string();
         self.decrement_owned_count(&owner, entity.category);
         for child_id in spawn_children.into_iter().chain(slave_children) {
             if self.substrate.entities.contains(child_id) {
@@ -1655,8 +1655,8 @@ impl Simulation {
         if entity.category != EntityCategory::Unit || self.resolved_terrain.is_none() {
             return PlacementEvidence::EvaluateMark;
         }
-        let owner = self.interner.resolve(entity.owner).to_string();
-        let type_id = self.interner.resolve(entity.type_ref).to_string();
+        let owner = self.interner.resolve(entity.owner()).to_string();
+        let type_id = self.interner.resolve(entity.type_ref()).to_string();
         let admission = crate::sim::production::produced_unit_unlimbo_entry_at_resolved_cell(
             self,
             rules,
@@ -1684,7 +1684,7 @@ impl Simulation {
         }
         let Some((slave_type, slave_count, owner, rx, ry, z, facing, capacity)) =
             self.substrate.entities.get(parent_id).and_then(|parent| {
-                let parent_type = self.interner.resolve(parent.type_ref);
+                let parent_type = self.interner.resolve(parent.type_ref());
                 let object = rules.object_case_insensitive(parent_type)?;
                 let slave_type = object.enslaves.as_deref()?;
                 let slave_object = rules.object_case_insensitive(slave_type)?;
@@ -1694,7 +1694,7 @@ impl Simulation {
                 Some((
                     slave_type.to_string(),
                     object.slaves_number as usize,
-                    self.interner.resolve(parent.owner).to_string(),
+                    self.interner.resolve(parent.owner()).to_string(),
                     parent.position.rx,
                     parent.position.ry,
                     parent.position.z,
@@ -1739,7 +1739,7 @@ impl Simulation {
                     entity.category,
                     entity.veterancy,
                     entity.in_playfield,
-                    entity.type_ref,
+                    entity.type_ref(),
                 )
             })
         else {
@@ -1786,6 +1786,7 @@ impl Simulation {
             let Some(entity) = self.substrate.entities.get_mut(sid) else {
                 continue;
             };
+            let type_ref = entity.type_ref();
             let Some(ref mut va) = entity.voxel_animation else {
                 continue;
             };
@@ -1797,7 +1798,7 @@ impl Simulation {
             ]
             .iter()
             .filter_map(|layer| {
-                frame_counts.get(&(self.interner.resolve(entity.type_ref).to_string(), *layer))
+                frame_counts.get(&(self.interner.resolve(type_ref).to_string(), *layer))
             })
             .copied()
             .max()
@@ -1827,7 +1828,7 @@ impl Simulation {
     ) -> bool {
         // Read deploy data from EntityStore before mutating.
         let deploy_data = self.substrate.entities.get(stable_id).and_then(|entity| {
-            let type_str = self.interner.resolve(entity.type_ref);
+            let type_str = self.interner.resolve(entity.type_ref());
             let yard_type = construction_yard_type_for_mcv(type_str, rules)?;
             let yard_obj = rules.object(&yard_type)?;
             let (spawn_rx, spawn_ry) = deploy_origin_from_unit_cell(
@@ -1836,7 +1837,7 @@ impl Simulation {
                 &yard_obj.foundation,
             );
             Some((
-                entity.owner,
+                entity.owner(),
                 spawn_rx,
                 spawn_ry,
                 entity.position.z,
@@ -1887,12 +1888,12 @@ impl Simulation {
                     // command batch) no longer blocks an MCV deploy footprint.
                     if e.dying
                         || e.lifecycle.in_limbo
-                        || e.stable_id == stable_id
+                        || e.stable_id() == stable_id
                         || e.category != EntityCategory::Structure
                     {
                         return false;
                     }
-                    let Some(existing) = self.object_type(e.type_ref, rules) else {
+                    let Some(existing) = self.object_type(e.type_ref(), rules) else {
                         return false;
                     };
                     if existing.wall {
@@ -2028,13 +2029,13 @@ impl Simulation {
             if !self.can_undeploy_building_runtime(stable_id, rules) {
                 return None;
             }
-            let type_str = self.interner.resolve(entity.type_ref);
+            let type_str = self.interner.resolve(entity.type_ref());
             let unit_type = undeploy_target_for_building(type_str, rules)?;
             let obj = rules.object(type_str)?;
             let (center_rx, center_ry) =
                 undeploy_unit_cell(entity.position.rx, entity.position.ry, &obj.foundation);
             Some((
-                entity.owner,
+                entity.owner(),
                 center_rx,
                 center_ry,
                 entity.position.z,
@@ -2071,10 +2072,10 @@ impl Simulation {
         let Some(entity) = self.substrate.entities.get(stable_id) else {
             return false;
         };
-        let Some(obj) = self.object_type(entity.type_ref, rules) else {
+        let Some(obj) = self.object_type(entity.type_ref(), rules) else {
             return false;
         };
-        if obj.construction_yard && self.owner_has_building_production_busy(entity.owner) {
+        if obj.construction_yard && self.owner_has_building_production_busy(entity.owner()) {
             return false;
         }
         self.can_undeploy_building_runtime(stable_id, rules)
@@ -2090,7 +2091,7 @@ impl Simulation {
         {
             return false;
         }
-        let type_str = self.interner.resolve(entity.type_ref);
+        let type_str = self.interner.resolve(entity.type_ref());
         let Some(obj) = rules.object(type_str) else {
             return false;
         };
@@ -2111,7 +2112,7 @@ impl Simulation {
             return false;
         }
         self.houses
-            .get(&entity.owner)
+            .get(&entity.owner())
             .is_some_and(|house| house.is_human)
     }
 


### PR DESCRIPTION
Indexed entity identity is now read-only to production consumers: EntityStore holds the owner-change capability, stable/type identity have no setters, and snapshot restore no longer repeats the index rebuild already done by deserialization. Mutable entity payload access remains; deliberate whole-value replacement is an explicitly unsupported residual.

ResolvedTerrainGrid now owns complete overlay and terrain-object projection mutations. Callers supply source facts through narrow operations instead of updating public cells and coordinating derived flags. Distinct native ground-blocking formulas and authored-load pass order remain intact. Most changed files are mechanical accessor migrations (99 independently audited).

Two independent read-only critics accepted both bounded improvements and reviewed the snapshot rebuild removal. No behavior or serialization rebaseline and no mirror tests added.

Validation on refreshed origin/main 31aae779:
- cargo check -p vera20k passed for final production visibility (15.37s).
- cargo test -p vera20k --lib: test result: ok. 8439 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 15.95s
- Retail shared-loader Dustbowl construction and 30-frame determinism: test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 8519 filtered out; finished in 2.13s

These are Rust regression checks, not a new gamemd parity claim. Existing native identities and evidence remain beside the moved terrain formulas.
