### PR TITLE
Add per-phase working briefs and write the Phase 8 brief

### DIFF
--- a/docs/plans/2026-07-30-clean-slate-system-implementation-order.md
+++ b/docs/plans/2026-07-30-clean-slate-system-implementation-order.md
@@ -1,13 +1,11 @@
 # Clean-Slate System Implementation Order
 
-> **Repository execution note:** use this as the primary dependency-order and
-> system-coverage guide. For an actual clean-slate rebuild, follow the phases
-> and rows in order. In the existing repository, do not blindly reimplement
-> row 1 through row 336: use the System Map row status and the selection
-> procedure below to find the first incomplete mechanism in a player-visible
-> loop. The
-> [`Complete parity work queue`](2026-07-30-complete-parity-work-queue.md)
-> remains a supplemental loop-membership and routing reference.
+> **Repository execution note:** this is the dependency order and the row
+> enumeration, nothing more. Row status lives in the System Map registry and
+> per-phase working state lives in [`phase-briefs/`](phase-briefs/README.md);
+> a goal session reads its phase brief first. For a clean-slate rebuild,
+> follow the phases and rows in order. In the existing repository, never
+> reimplement rows 1–336 blindly.
 >
 > **Reviewed 2026-08-09:** a six-lane evidence review verified taxonomy
 > coverage and the Phase 15 SKIP list, corrected two dead-mission rows
@@ -27,52 +25,25 @@ repository one stable place to answer:
 - what systems exist;
 - which systems precede others;
 - how much production implementation currently exists;
-- how to select the next bounded implementation without rebuilding work that
-  is already present.
+- where the per-phase working state lives (the phase briefs).
 
 This is still an evaluated planning overlay on the System Map, not a claim
 that missing map fields determine priority. Player-visible production loops,
 current Rust, and active `gamemd.exe` evidence decide the actual task.
 
-## How to use this in the existing repository
+## Working briefs
 
-Use the list as a dependency guide around one end-to-end loop, not as 336
-isolated projects:
+This document does not prescribe a working mode. Each targeted phase has a
+brief under [`phase-briefs/`](phase-briefs/README.md) that carries what a
+session needs and this list cannot: current Rust owners per row, native
+anchors, registry status, loop membership, prior PRs, corrections to research
+the rows depend on, inherited residuals, harness coverage and the open
+mechanism queue. The two goal modes (exhaustive phase close, bounded slice)
+are defined there, and the goal prompt names which one applies.
 
-1. Pick one ordinary-stock player loop with a concrete visible result:
-   movement, attack/death, harvest/credit, build/place, factory exit,
-   reveal/radar, transport, save/load, or power recovery.
-2. Enumerate that loop's GSI rows using this document and
-   `system_map/topology.v2.json`.
-3. Reinspect the current committed Rust owner, tests, evidence, relevant INI
-   data, and git history. The System Map row status is a lead, never a
-   substitute for this check.
-4. Trace the loop in its actual runtime stage order and locate its **first
-   player-visible or determinism-relevant divergence**.
-5. Use this document's dependency order to identify the smallest coherent prerequisite
-   capability—not merely the smallest patch—that the divergence needs. This may include
-   bounded foundational work required to avoid duplicate authority, temporary adapters,
-   architectural drift, or predictable rework. Deliver a separable foundation first.
-   Do not implement an entire earlier phase or absorb unrelated backlog.
-6. Independently review the evidence-to-code mapping and run the scoped
-   deterministic plus production-path check.
-7. Rerun the parent loop. If its end-to-end check passes, close it and select
-   the next loop. If it does not, record the residuals and leave the next slice
-   in that same loop. Stop after the bounded slice and handoff.
-
-Phase 0 is therefore a set of standing contracts, not a mandatory prelude that
-must be rebuilt in isolation.
-
-### What each status tells the implementing agent
-
-| Status | What to do |
-|---|---|
-| `VERIFIED_PARITY` | Reuse it. Reopen only when a new production trace demonstrates drift or a substantive code change invalidates its evidence. |
-| `IMPLEMENTED_UNVERIFIED` | Audit or trace it before adding behavior. The likely task is verification or a small drift fix, not a rewrite. |
-| `PARTIAL` | Find the first missing or drifting mechanism exercised by the selected loop and patch only that bounded owner. |
-| `SCAFFOLD` | Verify active-YR behavior and prerequisites, then connect or replace the scaffold with a production owner. |
-| `ABSENT` | Verify active-YR reachability before designing the new owner; absence alone is not permission to port TS or dead code. |
-| `NOT_APPLICABLE_PROVEN` | Skip it for ordinary stock YR. Preserve the negative evidence and do not implement it speculatively. |
+A phase heading below links its brief once one exists and its closure record
+once the phase is closed. Phase 0 is a set of standing contracts, not a
+prelude to rebuild in isolation.
 
 ## Status
 
@@ -87,31 +58,10 @@ until a gamemd-derived executable comparison demonstrates equivalence.
 Each closed phase links a closure record under `docs/gap-scans/` from its
 phase heading below: the disparity scans that enumerated the phase's
 mechanisms, the reverse audits, the merged PR list and the remaining
-residuals. A new session should start from that record, not from a fresh
-enumeration. The 2026-07-30 four-way audit that once filled this section is
-superseded by the registry; its counts are no longer reproduced here.
-
-### Copyable goal-agent contract
-
-```text
-Use docs/plans/2026-07-30-clean-slate-system-implementation-order.md as the
-dependency order, docs/system-map/registry.v2.json as row status, and the
-phase closure record linked from the phase heading as the residual list. Own
-exactly one bounded slice.
-
-Select one ordinary-stock end-to-end loop, enumerate its GSI participants,
-and reconcile current HEAD, Rust production owners, tests, research, INIs,
-parity evidence, git history, dirty files, and parallel ownership. Trace the
-participants in actual runtime stage order and locate the first player-visible
-or determinism-relevant divergence. Use the clean-slate dependency order to identify
-and close the smallest coherent foundational prerequisite capability—not merely the
-smallest patch—the loop needs. Deliver a separable foundation first, with its own
-evidence, validation, and review. Do not rebuild already-present foundations or expand
-into unrelated backlog. Obtain an independent review and run scoped deterministic and
-production-path checks. Rerun the parent loop: close it only
-if its end-to-end check passes; otherwise record residuals and leave the next
-slice in that same loop. Write the handoff, then stop.
-```
+residuals. A new session starts from the phase brief, which links that
+record; it does not re-enumerate. The 2026-07-30 four-way audit that once
+filled this section is superseded by the registry; its counts are no longer
+reproduced here.
 
 ## Legend
 
@@ -331,6 +281,8 @@ slice in that same loop. Write the handoff, then stop.
 165. **GSI-15.07** — Music catalog, selection and transitions
 
 ## Phase 8 — Production, construction, power and radar
+
+> Brief: [`phase-briefs/phase-08-production-power-radar.md`](phase-briefs/phase-08-production-power-radar.md) (OPEN).
 
 166. **GSI-04.08** — Walls, gates, fences, pavement and buildable overlays
 167. **GSI-05.17** — Factory identity, registration and lifecycle
@@ -629,4 +581,4 @@ not a binary-proven dependency chain, because System Map v2 does not encode
 complete causal edges for all 336 rows.
 
 Source registry:
-[`system_map/registry.v2.json`](../../system_map/registry.v2.json).
+[`docs/system-map/registry.v2.json`](../system-map/registry.v2.json).

--- a/docs/plans/phase-briefs/README.md
+++ b/docs/plans/phase-briefs/README.md
@@ -1,0 +1,90 @@
+# Phase briefs
+
+One brief per phase of
+[`2026-07-30-clean-slate-system-implementation-order.md`](../2026-07-30-clean-slate-system-implementation-order.md).
+A goal session reads the brief for its phase **before** the plan, the registry
+or the research index. The brief is the handover between sessions working the
+same phase; the plan is only the dependency order.
+
+Briefs are written when a phase is first targeted and updated by the session
+that changes the phase's state (a merged PR, a corrected claim, a new residual).
+Closed phases keep their brief and link the closure record under
+`docs/gap-scans/`; phases that were never targeted have no brief yet.
+
+## Template
+
+Copy the sections in this order. Keep each section current, not cumulative:
+replace stale rows, do not append a diary.
+
+```markdown
+# Phase N brief — <phase title>
+
+Rows <first>–<last> of the plan. State: OPEN | IN PROGRESS | CLOSED <date>.
+
+## Rows
+
+| Row | GSI | Rust owner(s) | Native anchor(s) | Registry | Notes |
+
+One line per row. Owners are current file paths (check they exist). Anchors are
+symbol + address with the research doc that established them. Registry is
+`native_evidence / rust_implementation / parity` from `registry.v2.json`.
+
+## Loops
+
+Which `topology.v2.json` loops the rows sit in, and which stage each row owns.
+The loop is what a session traces; rows alone do not order the work.
+
+## Prior work
+
+Merged PRs that moved these rows, newest first, one line each. Rows closed by
+evidence rather than code, with the evidence.
+
+## Corrections
+
+Claims in research, System Map or code comments that a session must not
+trust, with the evidence that corrected them. Sessions add to this list; they
+never silently fix the source doc without also recording the correction here.
+
+## Inherited residuals
+
+Residuals recorded by other phases that land on these rows (trigger, effect,
+frequency, where labelled).
+
+## Coverage
+
+What the global parity harness fixture and the retail oracles exercise for
+these rows, so a moved hash pin is read correctly.
+
+## Open queue
+
+Mechanisms found DRIFT/MISSING and not yet merged, with owner branch and review
+state. Empty when the phase is closed or not yet scanned.
+
+## Start here
+
+The first concrete action for a fresh session.
+```
+
+## Goal modes
+
+Two modes run against a brief. The goal prompt names the mode; the brief does
+not prescribe one.
+
+**Exhaustive phase close.** Every row in the phase is an ownership hypothesis.
+Scan each row's mechanisms from the binary, build every DRIFT/MISSING mechanism
+with a builder and an independent read-only critic, merge one mechanism per PR,
+run a phase-wide reverse audit, and close only when no omission or regression
+remains and `cargo test -p vera20k --lib` passes. Parity stays
+`UNCHECKED`/`DRIFT` in the registry until a gamemd-derived executable
+comparison demonstrates it; closure is by evidence, not by claim.
+
+**Bounded slice.** Select one ordinary-stock end-to-end loop from the brief's
+loop list, trace it in runtime stage order, find the first player-visible or
+determinism-relevant divergence, and close the smallest coherent prerequisite
+capability (not merely the smallest patch). Deliver a separable foundation
+first with its own evidence, validation and review. Rerun the parent loop;
+close it only if its end-to-end check passes, otherwise record residuals in
+the brief and stop after the handoff.
+
+Both modes update the brief and the System Map registry for touched, verified
+rows (`python -m tools.system_map check --require-sources`).

--- a/docs/plans/phase-briefs/phase-08-production-power-radar.md
+++ b/docs/plans/phase-briefs/phase-08-production-power-radar.md
@@ -1,0 +1,140 @@
+# Phase 8 brief — Production, construction, power and radar
+
+Rows 166–184 of
+[`2026-07-30-clean-slate-system-implementation-order.md`](../2026-07-30-clean-slate-system-implementation-order.md).
+State: **OPEN** (never targeted as a phase; several rows carry earlier slice
+work).
+
+## Rows
+
+Registry column is `native_evidence / rust_implementation / parity` from
+`docs/system-map/registry.v2.json` at `cca05d50`. Owners were checked to exist
+at that commit; the four `src/app_*.rs` paths still listed in
+`topology.v2.json` for GSI-13.24 moved under `src/app/presentation/` and
+`src/app/shell_skirmish.rs`.
+
+| Row | GSI | Rust owner(s) | Native anchor(s) | Registry | Notes |
+|---|---|---|---|---|---|
+| 166 | 04.08 | `src/sim/production/wall_placement.rs`, `src/sim/gate_runtime.rs`, `src/sim/overlay_grid.rs`, `src/map/overlay.rs` | none recorded | N/A / N/A / N/A (MIXED-SCOPE) | Wall autofill, destruction transactions and spend semantics landed (3b32fe1e, 95f77159, da38da27, PR #194). Gates and LaserFence unscanned. |
+| 167 | 05.17 | `src/sim/production/factory.rs` | none recorded | ANCHORED / PARTIAL / UNCHECKED | Factory lifecycle; save-order research exists (`FACTORYCLASS_*_RESWARM_20260528.md`). |
+| 168 | 09.07 | `src/sim/power_system.rs`, `src/sim/production/production_placement.rs` (place_ready_building), `src/sim/radar.rs` | `HouseClass::AI_AssessPower` 0x00508C30, `UpdateTacticalRadarAvailability` 0x00508DF0 (`POWER_SYSTEM_GHIDRA_REPORT.md`) | ANCHORED / PRESENT / DRIFT | Mechanism blocks MBLK-003/005/006 in `mechanisms.v1.json`. Slice 84991f14 closed live replacement-plant output and Radar=yes recovery. |
+| 169 | 09.08 | `src/sim/production/production_tech.rs`, `src/sim/ai_buildable.rs` | `BUILDINGCLASS_PREREQUISITES_GHIDRA_REPORT.md` (no anchor in topology) | UNCHECKED / PARTIAL / UNCHECKED | Build-time family in `production_tech` is a recorded DRIFT (see Corrections). |
+| 170 | 09.09 | `src/sim/production/factory.rs`, `production_queue.rs` | `BUILD_QUEUE_GHIDRA_REPORT.md`, `FACTORYCLASS_PRODUCTION_DEEP_DIVE.md` | ANCHORED / PRESENT / DRIFT | Abandon/cancel semantics partly fixed (front-most removal); `AbandonProduction` 0x004C9FF0 residual labelled at `factory.rs:283`. |
+| 171 | 09.10 | `src/sim/production/factory.rs`, `production_economy.rs` | `FACTORY_CLASS_BUILD_SPEED_GHIDRA_REPORT.md`, `FACTORY_CREDIT_SYSTEM_GHIDRA_REPORT.md`, `GRIZZLY_FACTORY_STEP_CADENCE_GHIDRA_REPORT.md` | ANCHORED / PRESENT / DRIFT | Per-step charge present; same-tick money order and cancel-refund cost timing inherited from Phase 7 (below). |
+| 172 | 09.11 | `src/sim/production/production_placement.rs`, `src/sim/world/world_commands.rs`, `src/sim/naval_base_placement.rs` | `HouseClass::Place_Production` 0x004FB0E0, `BuildingClass::Can_Enter_Cell` 0x00449440, cell placement passability 0x0047C620 | UNCHECKED / PARTIAL / UNCHECKED | Feature 12948d89 closed marked-ground and overlay rejection with a sealed Dustbowl GAPOWR oracle; damaged-wall/ToTile/LaserFence/gate exceptions and rejection UI/EVA are explicit residuals. Naval placement landed in PR #180. |
+| 173 | 07.23 | `src/sim/world/techno_ai/mission_handlers.rs` (base-stub arm, `:1626`), `src/sim/world/building_anim.rs` | `BUILDINGCLASS_MISSION_GUARD_AND_CONSTRUCTION.md` | UNCHECKED / PARTIAL / UNCHECKED | Construction mission is dispatched as a base stub; no dedicated handler. Verify against `BuildingClass::Mission_Construction` before treating that as parity. |
+| 174 | 09.12 | `src/sim/world/building_anim.rs`, `src/sim/world/lifecycle.rs` | none recorded; `building_anim.rs:15` says trigger selection UNCHECKED | UNCHECKED / PARTIAL / UNCHECKED | Buildup timing bound to rules (14e096ff); activation/GrandOpening order unscanned. |
+| 175 | 07.41 | `src/sim/production/production_spawn.rs`, `war_factory_exit.rs` | `BuildingClass::ExitObject_Main` 0x00443C60 (`GRIZZLY_PRODUCTION_COMPLETE_TO_WAR_FACTORY_EXIT_GHIDRA_REPORT.md`) | UNCHECKED / PARTIAL / UNCHECKED | Two deferred DRIFT residuals labelled at `production_spawn.rs:814` and `:928` (enemy-gate arms). Naval delivery closed 5f100c76. |
+| 176 | 09.16 | `src/sim/deploy.rs` | `AMCV_CANDEPLOY_PREDICATE_GHIDRA_REPORT.md`, `AMCV_DEPLOY_FACING_RULE_GHIDRA_REPORT.md`, `GACNST_*_GHIDRA_REPORT.md` (five docs) | ANCHORED / PRESENT / DRIFT | Last owner change 2026-07-30; redeploy transfer, undeploy refund and free-unit docs exist but are unreconciled with code. |
+| 177 | 09.14 | `src/sim/production/production_sell.rs` | `BUILDINGCLASS_SELL_AND_REPAIR_GHIDRA_REPORT.md`, `GARRISON_SELL*` docs | UNCHECKED / PARTIAL / UNCHECKED | Refund formula is `SELL_REFUND_PERCENT=50 × health%` in code; `MBLK-002` was downgraded to UNCHECKED during Phase 7 (see Corrections). |
+| 178 | 07.24 | `mission_handlers.rs` base stub; sell state machine lives in `production_sell.rs` | `MBLK-001-SELL-MISSION-AUTHORITY` steps | UNCHECKED / PARTIAL / UNCHECKED | Same handler situation as row 173. |
+| 179 | 12.10 | `src/sim/radar.rs`, `src/render/radar_events.rs`, `src/rules/radar_event_config.rs` | `MBLK-004-POWERED-RADAR-GATE`, `GAP_RADAR_SHROUD_MINIMAP_INTERACTION_GHIDRA_REPORT.md` | ANCHORED / PARTIAL / DRIFT | Radar event surfaces composed from gamemd 0x656EC0 / 0x65FA70 (PRs of 2026-08-21). Phase 7 established: event type 10 has no dedupe; sidebar OnHold/Canceled use type −1. |
+| 180 | 14.10 | `src/app/sidebar_projection.rs`, `src/app/input/gadget_input.rs`, `src/app/input/sidebar_eva.rs`, `src/sidebar/sidebar_view.rs` | none recorded | ANCHORED / PARTIAL / DRIFT | Sidebar EVA lines landed in Phase 7 (#254). Credit-counter cadence residual R8. |
+| 181 | 14.08 | `src/app/input/commands.rs`, `src/app/input/context_order.rs`, `src/app/input/dispatch.rs` | none recorded | UNCHECKED / PARTIAL / UNCHECKED | Placement/repair/sell/deploy/rally input; rally-point line research exists (`FACTORY_RALLY_POINT_LINE_CALLER_COLOR_GATE_GHIDRA_REPORT.md`). |
+| 182 | 13.24 | `src/render/sidebar_chrome.rs`, `src/render/sidebar_cameo_atlas.rs`, `src/app/presentation/sidebar_build.rs`, `sidebar_render.rs`, `src/sidebar/power_bar_anim.rs`, `gadget_flash.rs` | `SidebarClass::LoadSHPs` 0x006A5840, `StripClass::Draw` 0x006A9540 | ANCHORED / PRESENT / DRIFT | GPU pixels, blending and progress cadence unverified per topology note. `MBLK-006` power-bar handoff. |
+| 183 | 13.23 | `src/render/minimap.rs`, `native_radar_surface.rs`, `native_radar_terrain.rs`, `native_radar_viewport.rs`, `radar_anim.rs`, `src/app/presentation/render/minimap_transaction.rs` | `CELLCLASS_GETRADARCOLOR_FULL_BRANCH_INVENTORY_GHIDRA_REPORT.md`, `DRAWRADARACTIONLINES_004DC340_ENEMY_LINES_GHIDRA_REPORT.md` | ANCHORED / PRESENT / DRIFT | Map-load radar animation is hardwired to Allied (topology note on 13.24). |
+| 184 | 14.11 | `src/render/minimap_interaction.rs`, `src/app/input/camera.rs` | none recorded | ANCHORED / PARTIAL / DRIFT | Unscanned. |
+
+## Loops
+
+From `topology.v2.json`:
+
+- **LOOP-005-BUILD-PLACE**: 14.10 (1) → 09.08 (2) → 09.09 (3) → 09.10 (4) → 13.24 (6) → 14.08 (7) → 09.11 (9, 12) → 09.12 (14) → 09.07 (15).
+- **LOOP-006-FACTORY-EXIT**: 14.10 → 09.08 → 09.09 → 09.10 → 07.41 (6).
+- **LOOP-012-POWER-OUTAGE-RECOVERY**: 14.08 (1) → 09.14 (2) → 09.07 (5) → 12.10 (6) → 13.24 (7) → 13.23 (8) → 14.10 (10) → 09.08 → 09.09 → 09.10 → 14.08 (15) → 09.11 (16) → 09.12 (18) → 09.07 (19) → 12.10 (20) → 13.24 (21) → 13.23 (22).
+- **LOOP-007-ENGINEER-CAPTURE** stages 14–17 (09.07, 09.08, 09.09, 12.10) and **LOOP-008-REVEAL-RADAR** stages 7–8 (12.10, 13.23) touch this phase from Phase 9/5 loops.
+
+Rows 04.08, 05.17, 07.23, 07.24, 09.16 and 14.11 sit in no recorded loop;
+trace them from their callers (wall placement command, factory
+register/unregister, MCV deploy command, minimap click).
+
+## Prior work
+
+Newest first. None of these ran as a Phase 8 pass; each was a slice or a
+side effect of another phase.
+
+- c23d0d8a (2026-09-06) centralised indexed entity identity; touched
+  `production/`, `power_system.rs`, `building_anim.rs` mechanically.
+- Phase 7 PRs #254 (sidebar/placement EVA lines), #256 (credit tick in
+  `sidebar_projection.rs`), #246 (`building_anim.rs` SpecialAnim gates).
+- da38da27 / 95f77159 (2026-09-01) wall mutation effects and destruction
+  transactions; PR #194 froze wall-spend semantics.
+- 5f100c76 (2026-08-24) naval delivery transaction; b703f20d (2026-08-28)
+  construct factory products at production start.
+- 2026-08-21 radar PRs: 0x656EC0 primary surface, 0x65FA70 sensed events,
+  generated surface for type-5 events.
+- 12948d89 placement legality with sealed Dustbowl GAPOWR oracle;
+  84991f14 replacement-plant power and Radar=yes recovery; PR #180 naval
+  base placement; PR #186 AI deploy latches.
+- 2026-07-30 phase0 authority spine rewrote `deploy.rs`, `power_system.rs`,
+  `radar.rs`.
+
+Nothing in this phase is closed by evidence yet.
+
+## Corrections
+
+Do not trust these until re-read against the binary:
+
+- `production_tech` build-time family bakes a refuted ×0.9 factor; recorded
+  as DRIFT at `factory.rs:397`. Re-derive from `FactoryClass` build speed
+  before touching row 171.
+- `mechanisms.v1.json` `MBLK-002-SELL-REFUND-COMMIT` once claimed a
+  RefundPercent-driven VERIFIED refund; downgraded to UNCHECKED in Phase 7
+  (audit R7). Code uses `SELL_REFUND_PERCENT=50 × health%`.
+- Repair-depot occupant eviction (0x22 → 0x17 loop) belongs to the
+  Hospital/Armory branch at 0x0043CB0C; `Rules+0x16F8` is a constant 1.0, not
+  an INI key (Phase 7 closure record).
+- Radar event type 10 (capture) has no dedupe; sidebar OnHold/Canceled events
+  use type −1 (Phase 7 scan-15-06 correction).
+- Topology `rust_surfaces` for GSI-13.24 list four `src/app_*.rs` files that
+  no longer exist (moved in the F12 batch, 805f2da8).
+- Legacy queue-cancel semantics (`.rev()` last-match, full-cost refund) were
+  a DRIFT; the fix is in `factory.rs:1663` and `production_queue.rs:1052`.
+  Older research describing the legacy behaviour is describing Rust, not
+  gamemd.
+
+## Inherited residuals
+
+From the Phase 7 final audit Part C
+(`../../gap-scans/2026-09-06-phase7-closure/reverse-audit-phase7-final.md`):
+
+- **R4** same-tick money ordering: repair/depot spend runs after the factory
+  step; native runs it before. Visible only near zero balance; every tick both
+  are active. `src/sim/world/mod.rs` §2.23. Lands on row 171.
+- **R6** cancel refund uses the paid amount; native uses `GetCost(house)` at
+  cancel time. Only when a FactoryPlant is built or lost mid-build.
+  `factory.rs:264-283`. Lands on rows 170/171.
+- **R7** sell-refund provenance (above). Lands on row 177.
+- **R8** credit-counter dispatch cadence vs committed frames; visible when
+  render rate ≠ logic rate. `sidebar_projection.rs:120`. Lands on row 180.
+- **R11** drained building power cutoff `+0x5778` and DrainAnim: a drained
+  power plant still supplies power in VERA. Lands on row 168.
+- `production_spawn.rs:814` and `:928` enemy-gate arms (deferred DRIFT).
+  Lands on row 175.
+- Placement residuals from 12948d89: damaged-wall/ToTile/LaserFence/gate
+  exceptions, delayed-command rejection UI/EVA. Lands on rows 172/181.
+
+## Coverage
+
+The global parity harness fixture (`src/sim/world/global_parity_harness_tests.rs`)
+spawns a war factory, a refinery and a harvester but issues no build, place,
+sell or deploy command; it exercises 09.07 only as per-tick power assessment
+over pre-placed buildings and 13.23/13.24 only through draw counts. The
+sealed Dustbowl GAPOWR oracle
+(`src/app/loading/init_helpers_retail_placement_oracle_tests.rs`) covers
+placement legality, four-cell occupancy, buildup and power for one building. A moved hash pin from this
+phase therefore means "composition changed", not "mechanism covered"; parity
+for these rows needs a fixture that builds, places and sells.
+
+## Open queue
+
+Empty. No scan has run against this phase.
+
+## Start here
+
+Scan rows in loop order, not row order: LOOP-005 first (14.10 → 09.08 →
+09.09 → 09.10 → 13.24 → 14.08 → 09.11 → 09.12 → 09.07), then LOOP-012 for the
+sell and power branches, then LOOP-006 for factory exit, then the six
+loop-less rows. Before the first scan, re-read the ×0.9 build-time claim and
+the sell-refund formula against the binary; both feed several rows and both
+are known-wrong somewhere.


### PR DESCRIPTION
The implementation-order plan stops prescribing a working mode. A new
docs/plans/phase-briefs/ directory holds one brief per targeted phase:
current Rust owners per row, native anchors, registry status, loop
membership, prior PRs, corrections to research the rows depend on,
inherited residuals, harness coverage, open queue and a start pointer.
The README carries the template and defines the two goal modes
(exhaustive phase close, bounded slice) that used to live in the plan's
How-to and copyable-contract sections.

Phase 8 gets the first brief, written from registry.v2.json,
topology.v2.json, mechanisms.v1.json, git history and the Phase 7 closure
audit. The stale src/app_*.rs topology paths are noted in the brief and a
dead system_map/registry link in the plan's addendum is fixed.
