### PR TITLE
Preserve map authority when revealing garrison survivors

### DIFF
--- a/src/sim/production/production_sell.rs
+++ b/src/sim/production/production_sell.rs
@@ -440,6 +440,7 @@ fn place_garrison_passenger_at_cell(
     building_ry: u16,
     building_width: u16,
     building_height: u16,
+    context: UninitContext<'_>,
 ) -> bool {
     // Owner transfer (if any) goes through the substrate chokepoint first, so
     // the by_owner index stays in sync; then take the mutable borrow for the
@@ -460,7 +461,7 @@ fn place_garrison_passenger_at_cell(
         pax.passenger_role = PassengerRole::None;
     }
     let (sub_x, sub_y) = lepton::subcell_lepton_offset(pax_sub_cell);
-    let reveal = sim.try_reveal_entity(
+    let reveal = sim.try_reveal_entity_with_context(
         passenger_id,
         RevealRequest {
             position: RevealPosition {
@@ -475,6 +476,7 @@ fn place_garrison_passenger_at_cell(
             placement: PlacementEvidence::MarkSucceeded,
             logic_eligible: true,
         },
+        context,
     );
     if !matches!(reveal, RevealOutcome::Revealed { .. }) {
         return false;
@@ -541,6 +543,7 @@ fn eject_garrison_passengers_at_edges(
             ry,
             width,
             height,
+            uninit_context,
         ) {
             ejected += 1;
         }

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -51,9 +51,10 @@ pub(crate) enum PointerExpiryControl {
     Uninit,
 }
 
-/// Borrowed map authority carried through one synchronous ObjectClass UnInit
-/// tree. Ordinary entry points use the Simulation-owned terrain; combat uses
-/// this context while that same terrain is staged outside `Simulation`.
+/// Borrowed map authority carried through one synchronous receiver lifecycle
+/// tree, including nested survivor Reveal as well as UnInit. Ordinary entry
+/// points use the Simulation-owned terrain; combat uses this context while
+/// that same terrain is staged outside `Simulation`.
 /// Native clear/repair routines always query the global MapClass: Unit clear
 /// `0x00744210` (RemoveContent `0x0047EA90`, vt+0xF4), Aircraft clear
 /// `0x005F6120` (vtable `0x007E22A4`), Building reservation clear `0x004561F0`,
@@ -495,11 +496,12 @@ impl Simulation {
         cells: &[(u16, u16)],
         position: RevealPosition,
         exact_z_leptons: Option<i32>,
+        context: UninitContext<'_>,
     ) -> bool {
         match category {
             EntityCategory::Unit => {
                 let (ground_level, ground_z, live_structural_bridge) =
-                    self.raw_occupation_cell_facts(position, UninitContext::default());
+                    self.raw_occupation_cell_facts(position, context);
                 if Self::raw_occupation_reaches_deck(
                     position,
                     exact_z_leptons,
@@ -523,7 +525,7 @@ impl Simulation {
             }
             EntityCategory::Infantry => {
                 let (ground_level, ground_z, live_structural_bridge) =
-                    self.raw_occupation_cell_facts(position, UninitContext::default());
+                    self.raw_occupation_cell_facts(position, context);
                 let mask = infantry_raw_occupation_mask(position.sub_x, position.sub_y);
                 // Native: `InfantryClass::MarkCellOccupancy` @ `0x005217C0`
                 // selects the deck only at/above the bridge plane and only
@@ -562,7 +564,7 @@ impl Simulation {
             }
             EntityCategory::Aircraft => {
                 let (ground_level, ground_z, live_structural_bridge) =
-                    self.raw_occupation_cell_facts(position, UninitContext::default());
+                    self.raw_occupation_cell_facts(position, context);
                 if Self::raw_occupation_reaches_deck(
                     position,
                     exact_z_leptons,
@@ -716,6 +718,19 @@ impl Simulation {
         stable_id: u64,
         request: RevealRequest,
     ) -> RevealOutcome {
+        self.try_reveal_entity_with_context(stable_id, request, UninitContext::default())
+    }
+
+    /// A nested receiver Reveal uses the same map authority as its enclosing
+    /// destruction transaction. SellBuilding @ 0x00458060 still reaches the
+    /// global MapClass membership writer in Techno Unlimbo @ 0x006F6CC0..6CFE.
+    /// Source: active gamemd.exe call and instruction bodies.
+    pub(crate) fn try_reveal_entity_with_context(
+        &mut self,
+        stable_id: u64,
+        request: RevealRequest,
+        context: UninitContext<'_>,
+    ) -> RevealOutcome {
         let Some(entity) = self.substrate.entities.get(stable_id) else {
             return RevealOutcome::Failed(RevealFailure::MissingObject);
         };
@@ -731,7 +746,7 @@ impl Simulation {
             return RevealOutcome::Failed(RevealFailure::RejectedEarly);
         }
         if request.placement == PlacementEvidence::EvaluateMark
-            && !self.reveal_position_is_in_playfield(request.position)
+            && !self.reveal_position_is_in_playfield(request.position, context)
         {
             return RevealOutcome::Failed(RevealFailure::RejectedEarly);
         }
@@ -754,7 +769,7 @@ impl Simulation {
         // TechnoClass+0x3D5 byte from mode-one MapClass membership. Headless
         // fixtures have no MapClass authority, so they retain the constructor
         // default and their consumers explicitly leave the byte unenforced.
-        self.establish_entity_playfield_membership_on_unlimbo(stable_id);
+        self.establish_entity_playfield_membership_on_unlimbo(stable_id, context);
         #[cfg(test)]
         self.trace_lifecycle_for_test(LifecycleTestEvent::RevealCoordinatesCommitted);
 
@@ -769,7 +784,7 @@ impl Simulation {
 
         let attached_upgrade = request.placement == PlacementEvidence::AttachedUpgrade;
         if !attached_upgrade {
-            if !self.mark_entity_put(stable_id) {
+            if !self.mark_entity_put(stable_id, context) {
                 if let Some(entity) = self.substrate.entities.get_mut(stable_id) {
                     entity.lifecycle.in_limbo = true;
                 }
@@ -792,8 +807,9 @@ impl Simulation {
         // This precedes display/Logic exposure and must not run on either
         // failed placement path above.
         let reveal_slope = self.substrate.entities.get(stable_id).and_then(|entity| {
-            self.resolved_terrain
-                .as_ref()?
+            context
+                .terrain()
+                .or(self.resolved_terrain.as_ref())?
                 .cell(entity.position.rx, entity.position.ry)
                 .map(|cell| cell.slope_type)
         });
@@ -819,7 +835,7 @@ impl Simulation {
         if !attached_upgrade {
             self.append_live_build_const(stable_id);
             self.refresh_waypoint_edge_from_committed_structure(stable_id);
-            self.mark_building_base_reservation(stable_id);
+            self.mark_building_base_reservation_with_arg(stable_id, false, context);
             self.fill_base_plan_from_successful_building_unlimbo(stable_id);
         }
         self.lifecycle_outputs
@@ -929,7 +945,7 @@ impl Simulation {
         }
     }
 
-    fn mark_entity_put(&mut self, stable_id: u64) -> bool {
+    fn mark_entity_put(&mut self, stable_id: u64, context: UninitContext<'_>) -> bool {
         let Some(entity) = self.substrate.entities.get(stable_id) else {
             return false;
         };
@@ -1024,6 +1040,7 @@ impl Simulation {
                         &cells,
                         raw_position,
                         exact_z_leptons,
+                        context,
                     ) {
                         #[cfg(test)]
                         self.trace_lifecycle_for_test(LifecycleTestEvent::RawOccupationMarked);
@@ -1069,14 +1086,18 @@ impl Simulation {
     /// `ObjectClass::Reveal @ 0x005F4EC0` before Mark(PUT). A normal constructed
     /// scenario always has MapClass bounds; unbounded synthetic fixtures retain
     /// their historical permissive behavior.
-    fn reveal_position_is_in_playfield(&self, position: RevealPosition) -> bool {
+    fn reveal_position_is_in_playfield(
+        &self,
+        position: RevealPosition,
+        context: UninitContext<'_>,
+    ) -> bool {
         let Some(bounds) = self.playfield_bounds else {
             return true;
         };
         crate::sim::cell_rect::cell_is_in_playfield_height_aware(
             (i32::from(position.rx), i32::from(position.ry)),
             Some(bounds),
-            self.resolved_terrain.as_ref(),
+            context.terrain().or(self.resolved_terrain.as_ref()),
         )
     }
 
@@ -1098,10 +1119,6 @@ impl Simulation {
             "base-reservation owner must be present in ScenarioSession.house_order"
         );
         index
-    }
-
-    fn mark_building_base_reservation(&mut self, stable_id: u64) -> bool {
-        self.mark_building_base_reservation_with_arg(stable_id, false, UninitContext::default())
     }
 
     fn mark_building_base_reservation_with_arg(
@@ -1461,7 +1478,7 @@ impl Simulation {
     /// Test/fixture helper retained at the transaction boundary.  It is
     /// idempotent and updates the authoritative `cell_marked` fact.
     pub(crate) fn add_entity_occupancy(&mut self, stable_id: u64) {
-        let _ = self.mark_entity_put(stable_id);
+        let _ = self.mark_entity_put(stable_id, UninitContext::default());
     }
 
     /// Existing movement and fixture boundary; common lifecycle code calls the

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -238,6 +238,91 @@ fn receiver_fatal_limbo_clears_sparse_map_dummy_reservation() {
 }
 
 #[test]
+fn receiver_garrison_survivor_keeps_height_aware_playfield_membership() {
+    let rules =
+        crate::rules::ruleset::RuleSet::from_ini(&crate::rules::ini_parser::IniFile::from_str(
+            "[InfantryTypes]\n0=OCCUPANT\n[BuildingTypes]\n0=GARRISON\n\
+             [OCCUPANT]\nStrength=100\nArmor=none\n\
+             [GARRISON]\nStrength=100\nArmor=concrete\nFoundation=2x2\nCanBeOccupied=yes\n\
+             [Warheads]\n0=KILLWH\n[KILLWH]\nCellSpread=0\n\
+             Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+        ))
+        .expect("garrison survivor rules");
+    let mut sim = Simulation::new();
+    sim.session.map_width = 16;
+    sim.session.map_height = 16;
+    sim.playfield_bounds =
+        Some(crate::sim::cell_rect::PlayfieldBounds::from_normalized_local_size(16, 2, 2, 12, 3));
+    install_common_raw_terrain(&mut sim, 16, 16, 4, None);
+    let building_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, building_id, EntityCategory::Structure);
+    let passenger_id = sim.allocate_stable_id();
+    insert_entity(&mut sim, passenger_id, EntityCategory::Infantry);
+    let building_type = sim.interner.intern("GARRISON");
+    let passenger_type = sim.interner.intern("OCCUPANT");
+    {
+        let passenger = sim.substrate.entities.get_mut(passenger_id).unwrap();
+        passenger.type_ref = passenger_type;
+        passenger.passenger_role = PassengerRole::Inside {
+            transport_id: building_id,
+        };
+    }
+    {
+        let building = sim.substrate.entities.get_mut(building_id).unwrap();
+        building.type_ref = building_type;
+        building.foundation = "2x2".to_string();
+        let mut cargo = PassengerCargo::new(5, 1);
+        assert!(cargo.board(passenger_id, 1));
+        building.passenger_role = PassengerRole::Transport { cargo };
+    }
+    assert!(matches!(
+        sim.try_reveal_entity(building_id, common_raw_request(13, 13, 4, 128, 128)),
+        RevealOutcome::Revealed { .. }
+    ));
+    assert!(
+        sim.substrate
+            .entities
+            .get(building_id)
+            .unwrap()
+            .in_playfield
+    );
+
+    let warhead = sim.interner.intern("KILLWH");
+    let hit = crate::sim::combat::EntityDamageEvent::direct_receiver(
+        building_id,
+        100,
+        0,
+        crate::sim::combat::RAD_NO_ATTACKER,
+        None,
+        warhead,
+        crate::sim::combat::ReceiverCallFlags {
+            ignore_defenses: true,
+            arg6: false,
+        },
+    );
+    sim.commit_noncombat_aoe_hits(&rules, None, &[hit]);
+
+    let passenger = sim.substrate.entities.get(passenger_id).unwrap();
+    assert!(passenger.lifecycle.object_alive);
+    assert!(!passenger.lifecycle.in_limbo);
+    assert_eq!(
+        (
+            passenger.position.rx,
+            passenger.position.ry,
+            passenger.position.z
+        ),
+        (15, 15, 4)
+    );
+    // SellBuilding @ 0x00458060 calls Infantry Unlimbo; Techno Unlimbo
+    // @ 0x006F6CC0..0x006F6CFE writes mode-one global MapClass membership,
+    // including during the ejection helper's temporary editor-mode bracket.
+    assert!(
+        passenger.in_playfield,
+        "survivor must use actual level-four map membership"
+    );
+}
+
+#[test]
 fn receiver_borrowed_map_uninit_clears_aircraft_bridge_occupation() {
     let mut sim = Simulation::new();
     install_common_raw_terrain(&mut sim, 8, 8, 0xFE, Some((3, 4)));

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -4202,20 +4202,31 @@ impl Simulation {
     /// Exact mode-one query for the stored TechnoClass+0x3D5 writer family.
     /// Absence means there is no live MapClass authority, not rectangular or
     /// permissive fallback authority.
-    fn entity_playfield_membership_mode_one(&self, stable_id: u64) -> Option<bool> {
+    fn entity_playfield_membership_mode_one(
+        &self,
+        stable_id: u64,
+        terrain: Option<&ResolvedTerrainGrid>,
+    ) -> Option<bool> {
         let bounds = self.playfield_bounds?;
         let entity = self.substrate.entities.get(stable_id)?;
         Some(crate::sim::cell_rect::cell_is_in_playfield_height_aware(
             (i32::from(entity.position.rx), i32::from(entity.position.ry)),
             Some(bounds),
-            self.resolved_terrain.as_ref(),
+            terrain,
         ))
     }
 
     /// Unlimbo's exact establishment writer (`TechnoClass::Unlimbo @
     /// 0x006F6CFE`).
-    pub(crate) fn establish_entity_playfield_membership_on_unlimbo(&mut self, stable_id: u64) {
-        let Some(member) = self.entity_playfield_membership_mode_one(stable_id) else {
+    fn establish_entity_playfield_membership_on_unlimbo(
+        &mut self,
+        stable_id: u64,
+        context: UninitContext<'_>,
+    ) {
+        let Some(member) = self.entity_playfield_membership_mode_one(
+            stable_id,
+            context.terrain().or(self.resolved_terrain.as_ref()),
+        ) else {
             return;
         };
         if let Some(entity) = self.substrate.entities.get_mut(stable_id) {
@@ -4252,7 +4263,8 @@ impl Simulation {
         {
             return;
         }
-        if self.entity_playfield_membership_mode_one(stable_id) == Some(true)
+        if self.entity_playfield_membership_mode_one(stable_id, self.resolved_terrain.as_ref())
+            == Some(true)
             && let Some(entity) = self.substrate.entities.get_mut(stable_id)
         {
             entity.in_playfield = true;
@@ -4262,7 +4274,8 @@ impl Simulation {
     /// Teleport arrival's exceptional exact outside clear (`0x00719A99`). An
     /// inside arrival does not promote a previously-false byte.
     fn clear_entity_playfield_membership_after_teleport(&mut self, stable_id: u64) {
-        if self.entity_playfield_membership_mode_one(stable_id) == Some(false)
+        if self.entity_playfield_membership_mode_one(stable_id, self.resolved_terrain.as_ref())
+            == Some(false)
             && let Some(entity) = self.substrate.entities.get_mut(stable_id)
         {
             entity.in_playfield = false;


### PR DESCRIPTION
A passenger ejected from a destroyed garrison can survive and reveal at a valid elevated map-edge cell but receive `in_playfield=false`. The receiver stages terrain outside `Simulation`; successful ejection called the ordinary Reveal entry, which used level-zero fallback for its stored membership. Target acquisition consumes that flag.

Forward the enclosing borrowed map context through successful garrison placement and the common Reveal operation's map readers: membership, admission, raw occupation, slope sampling and reservation marking. Ordinary entry points retain resident-map defaults. Remove the now-redundant reservation wrapper and restrict the membership writer to its actual lifecycle caller. This is a native-backed prerequisite correction; the broader receiver staging/ownership refactor remains open.

Native evidence: Building death calls `SellBuilding(0,0)` at `0x00442635..0x0044263B`; `SellBuilding @ 0x00458060` calls occupant Unlimbo; `TechnoClass::Unlimbo @ 0x006F6CC0..0x006F6CFE` queries global MapClass in mode one and writes `+0x3D5`, including during the temporary editor-mode bracket. The independent read-only critic inspected active bodies, callers and virtual dispatch data.

The regression uses flat level-four terrain and an equal-height building/exit. Before the fix, survival, Reveal and position checks passed but the membership assertion failed. It avoids the separate pre-existing exit-coordinate discrepancy. The correction does not change exit selection, coordinates, predicates, RNG or lifecycle ordering. Coherent raw-mark/slope/reservation access is not a claim of newly demonstrated garrison parity.

Validation:
- Before correction: `test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 8524 filtered out; finished in 0.01s`
- `cargo test -p vera20k --lib sim::world::lifecycle_tests::`: `test result: ok. 134 passed; 0 failed; 0 ignored; 0 measured; 8391 filtered out; finished in 0.02s`
- Final `cargo test -p vera20k --lib`: `test result: ok. 8444 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 21.89s`
- Full coverage includes production sell/destruction/no-exit/scatter/LIFO paths, ordinary lifecycle map readers, and movement/teleport membership writers. `git diff --check` passes.
- Independent read-only review found no blocking defect. Existing tests retain distinct coverage; none were removed.
