### PR TITLE
Rebuild receiver navigation from retained map authority

### DIFF
--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -2086,9 +2086,9 @@ pub(crate) trait CombatInlineHooks {
     fn rebuild_cliff_navigation(
         &mut self,
         _rules: &RuleSet,
-        _terrain: &mut Option<crate::map::resolved_terrain::ResolvedTerrainGrid>,
-        _entities: &mut EntityStore,
-        _interner: &mut StringInterner,
+        _terrain: Option<&ResolvedTerrainGrid>,
+        _entities: &EntityStore,
+        _interner: &StringInterner,
     ) {
     }
 

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -6254,6 +6254,11 @@ fn wave_tail_consumes_wall_roll_before_mandatory_cliff_chance_roll() {
 
 #[test]
 fn wave_cliff_collapse_consumes_exact_body_rng_and_spawns_row_major_anims() {
+    use crate::rules::locomotor_type::MovementZone;
+    use crate::sim::pathfinding::zone_hierarchy::{
+        ZonePrecheckExclusions, ZonePrecheckOutcome, zone_precheck_flat,
+    };
+
     let ini = crate::rules::ini_parser::IniFile::from_str(
         "[CombatDamage]\nCollapseChance=100\n\
          [InfantryTypes]\n\
@@ -6292,28 +6297,95 @@ fn wave_cliff_collapse_consumes_exact_body_rng_and_spawns_row_major_anims() {
         });
     }
     let mut cells = Vec::new();
-    for ry in 0..4 {
-        for rx in 0..6 {
-            let mut cell = common_raw_terrain_cell(rx, ry, 1, false);
-            let sub_tile = (ry * 6 + rx) as u8;
-            if ![0, 5, 18, 23].contains(&usize::from(sub_tile)) {
-                cell.final_tile_index = 100;
-                cell.final_sub_tile = sub_tile;
+    for ry in 0..16 {
+        for rx in 0..16 {
+            let on_bridge = ry == 10 && (10..=11).contains(&rx);
+            let mut cell = common_raw_terrain_cell(rx, ry, 1, on_bridge);
+            if rx < 6 && ry < 4 {
+                let sub_tile = (ry * 6 + rx) as u8;
+                if ![0, 5, 18, 23].contains(&usize::from(sub_tile)) {
+                    cell.final_tile_index = 100;
+                    cell.final_sub_tile = sub_tile;
+                }
+            }
+            // The far bank is isolated by impassable cells. Connectivity to it
+            // must come from the remote bridge's native endpoint record.
+            if on_bridge
+                || ((11..=13).contains(&rx) && (9..=11).contains(&ry) && (rx, ry) != (12, 10))
+            {
+                cell.ground_walk_blocked = true;
+                cell.zone_type = 6;
+            }
+            if ry == 10 && (rx == 9 || rx == 12) {
+                cell.final_tile_index = 1006;
+                cell.final_sub_tile = 4;
             }
             cells.push(cell);
         }
     }
-    let mut terrain = ResolvedTerrainGrid::from_cells(6, 4, cells);
+    let mut terrain = ResolvedTerrainGrid::from_cells(16, 16, cells);
     terrain.test_install_destroyable_cliff_catalog(100);
+    terrain.test_set_high_bridge_set_starts(Some(1000), None);
+    sim.bridge_state = Some(
+        crate::sim::bridge_state::BridgeRuntimeState::from_resolved_terrain(&terrain, true, 1500),
+    );
+    let bridge_records = sim
+        .bridge_state
+        .as_ref()
+        .unwrap()
+        .endpoint_records()
+        .to_vec();
+    assert_eq!(bridge_records.len(), 1);
+    assert!(bridge_records[0].active);
+    assert_eq!(bridge_records[0].endpoint_a, (9, 10));
+    assert_eq!(bridge_records[0].endpoint_b, (12, 10));
     let pristine_terrain = terrain.clone();
     sim.resolved_terrain = Some(terrain);
-    let mut overlay = crate::sim::overlay_grid::OverlayGrid::new(6, 4);
+    assert!(sim.rebuild_dynamic_navigation(&rules));
+    let remote_bridge_route = |zones: &crate::sim::pathfinding::zone_map::ZoneGrid| {
+        let hierarchy = zones.hierarchy_for(MovementZone::Normal).unwrap();
+        let start = hierarchy.level(0).unwrap().zone_at(9, 10);
+        let goal = hierarchy.level(0).unwrap().zone_at(12, 10);
+        (
+            zones.can_reach(
+                MovementZone::Normal,
+                (9, 10),
+                MovementLayer::Ground,
+                (12, 10),
+                MovementLayer::Ground,
+            ),
+            matches!(
+                zone_precheck_flat(
+                    hierarchy,
+                    start,
+                    goal,
+                    MovementZone::Normal,
+                    &ZonePrecheckExclusions::default()
+                ),
+                ZonePrecheckOutcome::Passed(_)
+            ),
+        )
+    };
+    assert_eq!(
+        remote_bridge_route(sim.zone_grid.as_ref().unwrap()),
+        (true, true)
+    );
+    let without_bridge_records = crate::sim::pathfinding::zone_map::ZoneGrid::build_with_terrain(
+        sim.path_grid.as_ref().unwrap(),
+        &sim.terrain_costs,
+        sim.resolved_terrain.as_ref(),
+        &[],
+        16,
+        16,
+    );
+    assert_eq!(remote_bridge_route(&without_bridge_records), (false, false));
+    let mut overlay = crate::sim::overlay_grid::OverlayGrid::new(16, 16);
     let decal = overlay_registry.id_for_name("DECAL").expect("test decal");
     overlay.place_overlay(0, 0, decal, 11);
     overlay.place_overlay(1, 0, decal, 12);
     overlay.retain_zero_wall_plane_for_tests();
     sim.overlay_grid = Some(overlay);
-    let mut smudge = crate::sim::smudge_grid::SmudgeGrid::new(6, 4);
+    let mut smudge = crate::sim::smudge_grid::SmudgeGrid::new(16, 16);
     for (rx, frame_offset) in [(0, 0), (1, 1)] {
         smudge.test_force_set(
             rx,
@@ -6383,6 +6455,26 @@ fn wave_cliff_collapse_consumes_exact_body_rng_and_spawns_row_major_anims() {
         expected_rng.logical_state()
     );
     assert_eq!(sim.dynamic_terrain_cells.len(), 20);
+    // Check before any later frame repair: native cliff collapse rebuilds
+    // connectivity synchronously with the retained global bridge vector.
+    assert_eq!(
+        remote_bridge_route(sim.zone_grid.as_ref().unwrap()),
+        (true, true)
+    );
+    assert_eq!(
+        sim.zone_grid.as_ref().unwrap().bridge_records(),
+        bridge_records
+    );
+    let canonical_path = crate::sim::pathfinding::PathGrid::from_resolved_terrain_with_bridges(
+        sim.resolved_terrain.as_ref().unwrap(),
+        sim.bridge_state.as_ref(),
+    );
+    for rx in 9..=12 {
+        assert_eq!(
+            sim.path_grid.as_ref().unwrap().cell(rx, 10),
+            canonical_path.cell(rx, 10)
+        );
+    }
     assert_eq!(sim.radar_terrain_dirty_cells.len(), 20);
     assert_eq!(sim.tactical_dirty_cells.len(), 20);
     let overlay = sim.overlay_grid.as_ref().unwrap();

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -22,6 +22,7 @@ mod hash_schema;
 mod lifecycle;
 mod load_object_lifecycle;
 mod logic_vector;
+mod navigation;
 mod object_turn;
 #[cfg(test)]
 use object_turn::shp_vehicle_counter_admitted;
@@ -1539,17 +1540,24 @@ impl crate::sim::combat::CombatInlineHooks for SimulationCombatInlineHooks<'_, '
     fn rebuild_cliff_navigation(
         &mut self,
         rules: &RuleSet,
-        borrowed_terrain: &mut Option<crate::map::resolved_terrain::ResolvedTerrainGrid>,
-        borrowed_entities: &mut EntityStore,
-        borrowed_interner: &mut StringInterner,
+        terrain: Option<&ResolvedTerrainGrid>,
+        entities: &EntityStore,
+        interner: &StringInterner,
     ) {
-        std::mem::swap(&mut self.sim.resolved_terrain, borrowed_terrain);
-        std::mem::swap(&mut self.sim.substrate.entities, borrowed_entities);
-        std::mem::swap(&mut self.sim.interner, borrowed_interner);
-        let _ = self.sim.rebuild_dynamic_navigation(rules);
-        std::mem::swap(&mut self.sim.interner, borrowed_interner);
-        std::mem::swap(&mut self.sim.substrate.entities, borrowed_entities);
-        std::mem::swap(&mut self.sim.resolved_terrain, borrowed_terrain);
+        let Some(terrain) = terrain else {
+            return;
+        };
+        // CollapseDestroyableCliff calls global RebuildZoneConnectivity at
+        // 0x005812AC / 0x00581995, before footprint cleanup. Rebuild 0x0056C510
+        // reads the retained Map+0x54 bridge vector (0x0056C6CB..0x0056C7CC).
+        // Source: active gamemd.exe instructions and Wave caller 0x0075F4B2.
+        // Read the receiver's live map directly; only navigation caches mutate.
+        navigation::NavigationCaches {
+            terrain_costs: &mut self.sim.terrain_costs,
+            zones: &mut self.sim.zone_grid,
+            path: &mut self.sim.path_grid,
+        }
+        .rebuild_dynamic(terrain, self.bridge_state, entities, interner, rules);
     }
 
     fn mark_cliff_radar_dirty(&mut self, cell: (u16, u16)) {
@@ -2552,9 +2560,9 @@ impl Simulation {
                             .expect("world cliff hook")
                             .rebuild_cliff_navigation(
                                 rules,
-                                &mut transaction.resolved_terrain,
-                                &mut transaction.entities,
-                                &mut transaction.interner,
+                                transaction.resolved_terrain.as_ref(),
+                                &transaction.entities,
+                                &transaction.interner,
                             );
 
                         // Pass three's externally represented effects remain
@@ -5453,37 +5461,18 @@ impl Simulation {
         let Some(terrain) = self.resolved_terrain.as_ref() else {
             return false;
         };
-        let mut grid =
-            PathGrid::from_resolved_terrain_with_bridges(terrain, self.bridge_state.as_ref());
-        self.terrain_costs = build_canonical_terrain_cost_grids(terrain);
-
-        let mut structures: Vec<(u16, u16, String)> = self
-            .substrate
-            .entities
-            .values()
-            .filter_map(|entity| {
-                (entity.category == EntityCategory::Structure).then_some((
-                    entity.position.rx,
-                    entity.position.ry,
-                    self.interner.resolve(entity.type_ref()).to_string(),
-                ))
-            })
-            .collect();
-        structures.sort_by(|a, b| {
-            a.0.cmp(&b.0)
-                .then_with(|| a.1.cmp(&b.1))
-                .then_with(|| a.2.cmp(&b.2))
-        });
-        for (rx, ry, type_id) in structures {
-            let object_type = rules.object(&type_id);
-            let foundation = object_type
-                .map(|object| object.foundation.as_str())
-                .unwrap_or("1x1");
-            let has_bib = object_type.is_some_and(|object| object.bib);
-            grid.block_building_movement_cells(rx, ry, foundation, has_bib);
+        navigation::NavigationCaches {
+            terrain_costs: &mut self.terrain_costs,
+            zones: &mut self.zone_grid,
+            path: &mut self.path_grid,
         }
-
-        self.rebuild_zone_grid(&grid);
+        .rebuild_dynamic(
+            terrain,
+            self.bridge_state.as_ref(),
+            &self.substrate.entities,
+            &self.interner,
+            rules,
+        );
         true
     }
 
@@ -5545,70 +5534,30 @@ impl Simulation {
     /// Tries an incremental update first (diffing against the previous PathGrid).
     /// Falls back to full rebuild if too many cells changed or no previous state.
     pub fn rebuild_zone_grid(&mut self, path_grid: &PathGrid) {
-        if self.resolved_terrain.is_none() {
+        let Some(terrain) = self.resolved_terrain.as_ref() else {
             return;
+        };
+        navigation::NavigationCaches {
+            terrain_costs: &mut self.terrain_costs,
+            zones: &mut self.zone_grid,
+            path: &mut self.path_grid,
         }
-
-        // Try incremental update if we have previous state.
-        if let (Some(prev), Some(zones)) = (self.path_grid.as_deref(), &mut self.zone_grid) {
-            if let Some(changed) = prev.diff_cells(path_grid) {
-                if changed.is_empty()
-                    && self
-                        .resolved_terrain
-                        .as_ref()
-                        .is_some_and(|terrain| zones.movement_classes_match(terrain))
-                {
-                    // PathGrid does not carry CellClass reduced zone type.
-                    // Boolean path state and retained base classes must both
-                    // match before connectivity can be reused.
-                    self.path_grid = Some(Arc::new(path_grid.clone()));
-                    return;
-                }
-                if !changed.is_empty()
-                    && crate::sim::pathfinding::zone_incremental::try_incremental_update(
-                        zones,
-                        &changed,
-                        path_grid,
-                        &self.terrain_costs,
-                        self.resolved_terrain.as_ref(),
-                        self.bridge_state
-                            .as_ref()
-                            .map(|bs| bs.endpoint_records())
-                            .unwrap_or(&[]),
-                    )
-                {
-                    log::trace!("zone: incremental update ({} cells changed)", changed.len(),);
-                    self.path_grid = Some(Arc::new(path_grid.clone()));
-                    return;
-                }
-            }
-        }
-
-        // Full rebuild fallback.
-        self.rebuild_zone_grid_full(path_grid);
+        .rebuild_zones(path_grid, terrain, self.bridge_state.as_ref());
     }
 
     /// Rebuild without the PathGrid-only incremental shortcut. Reduced zone
     /// type can change while boolean walkability stays identical (notably a
     /// live OccupationBits=0 terrain object changing Building to Ground).
     fn rebuild_zone_grid_full(&mut self, path_grid: &PathGrid) {
-        let Some(terrain) = &self.resolved_terrain else {
+        let Some(terrain) = self.resolved_terrain.as_ref() else {
             return;
         };
-        let width = terrain.width();
-        let height = terrain.height();
-        self.zone_grid = Some(ZoneGrid::build_with_terrain(
-            path_grid,
-            &self.terrain_costs,
-            self.resolved_terrain.as_ref(),
-            self.bridge_state
-                .as_ref()
-                .map(|bs| bs.endpoint_records())
-                .unwrap_or(&[]),
-            width,
-            height,
-        ));
-        self.path_grid = Some(Arc::new(path_grid.clone()));
+        navigation::NavigationCaches {
+            terrain_costs: &mut self.terrain_costs,
+            zones: &mut self.zone_grid,
+            path: &mut self.path_grid,
+        }
+        .rebuild_zones_full(path_grid, terrain, self.bridge_state.as_ref());
     }
 
     /// Refresh navigation authority after inline overlay mutation or terrain

--- a/src/sim/world/navigation.rs
+++ b/src/sim/world/navigation.rs
@@ -1,0 +1,120 @@
+//! Navigation cache rebuilds read one explicit live map and bridge view.
+//!
+//! The cache borrows never move gameplay authority out of Simulation. Resident
+//! world rebuilds and synchronous receiver rebuilds share the same policy.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crate::map::entities::EntityCategory;
+use crate::map::resolved_terrain::ResolvedTerrainGrid;
+use crate::rules::locomotor_type::SpeedType;
+use crate::rules::ruleset::RuleSet;
+use crate::sim::bridge_state::BridgeRuntimeState;
+use crate::sim::entity_store::EntityStore;
+use crate::sim::intern::StringInterner;
+use crate::sim::pathfinding::PathGrid;
+use crate::sim::pathfinding::terrain_cost::{TerrainCostGrid, build_canonical_terrain_cost_grids};
+use crate::sim::pathfinding::zone_map::ZoneGrid;
+
+pub(super) struct NavigationCaches<'a> {
+    pub(super) terrain_costs: &'a mut BTreeMap<SpeedType, TerrainCostGrid>,
+    pub(super) zones: &'a mut Option<ZoneGrid>,
+    pub(super) path: &'a mut Option<Arc<PathGrid>>,
+}
+
+impl NavigationCaches<'_> {
+    pub(super) fn rebuild_dynamic(
+        &mut self,
+        terrain: &ResolvedTerrainGrid,
+        bridges: Option<&BridgeRuntimeState>,
+        entities: &EntityStore,
+        interner: &StringInterner,
+        rules: &RuleSet,
+    ) {
+        let mut grid = PathGrid::from_resolved_terrain_with_bridges(terrain, bridges);
+        *self.terrain_costs = build_canonical_terrain_cost_grids(terrain);
+
+        let mut structures: Vec<(u16, u16, String)> = entities
+            .values()
+            .filter_map(|entity| {
+                (entity.category == EntityCategory::Structure).then_some((
+                    entity.position.rx,
+                    entity.position.ry,
+                    interner.resolve(entity.type_ref()).to_string(),
+                ))
+            })
+            .collect();
+        structures.sort_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then_with(|| a.1.cmp(&b.1))
+                .then_with(|| a.2.cmp(&b.2))
+        });
+        for (rx, ry, type_id) in structures {
+            let object_type = rules.object(&type_id);
+            let foundation = object_type
+                .map(|object| object.foundation.as_str())
+                .unwrap_or("1x1");
+            let has_bib = object_type.is_some_and(|object| object.bib);
+            grid.block_building_movement_cells(rx, ry, foundation, has_bib);
+        }
+
+        self.rebuild_zones(&grid, terrain, bridges);
+    }
+
+    pub(super) fn rebuild_zones(
+        &mut self,
+        path_grid: &PathGrid,
+        terrain: &ResolvedTerrainGrid,
+        bridges: Option<&BridgeRuntimeState>,
+    ) {
+        if let (Some(prev), Some(zones)) = (self.path.as_deref(), self.zones.as_mut()) {
+            if let Some(changed) = prev.diff_cells(path_grid) {
+                if changed.is_empty() && zones.movement_classes_match(terrain) {
+                    // PathGrid does not carry CellClass reduced zone type.
+                    // Both path state and retained base classes must match.
+                    *self.path = Some(Arc::new(path_grid.clone()));
+                    return;
+                }
+                if !changed.is_empty()
+                    && crate::sim::pathfinding::zone_incremental::try_incremental_update(
+                        zones,
+                        &changed,
+                        path_grid,
+                        self.terrain_costs,
+                        Some(terrain),
+                        bridges
+                            .map(BridgeRuntimeState::endpoint_records)
+                            .unwrap_or(&[]),
+                    )
+                {
+                    log::trace!("zone: incremental update ({} cells changed)", changed.len());
+                    *self.path = Some(Arc::new(path_grid.clone()));
+                    return;
+                }
+            }
+        }
+        self.rebuild_zones_full(path_grid, terrain, bridges);
+    }
+
+    /// Bypass reuse when a changed reduced zone type needs a full rebuild even
+    /// though boolean walkability remains identical (e.g. OccupationBits=0).
+    pub(super) fn rebuild_zones_full(
+        &mut self,
+        path_grid: &PathGrid,
+        terrain: &ResolvedTerrainGrid,
+        bridges: Option<&BridgeRuntimeState>,
+    ) {
+        *self.zones = Some(ZoneGrid::build_with_terrain(
+            path_grid,
+            self.terrain_costs,
+            Some(terrain),
+            bridges
+                .map(BridgeRuntimeState::endpoint_records)
+                .unwrap_or(&[]),
+            terrain.width(),
+            terrain.height(),
+        ));
+        *self.path = Some(Arc::new(path_grid.clone()));
+    }
+}


### PR DESCRIPTION
Wave cliff collapse rebuilt navigation while the receiver transaction held the bridge runtime outside Simulation. A changed map could therefore lose connectivity across an intact remote bridge until a later rebuild.

Navigation rebuilds now take immutable terrain, bridge, entity and rules inputs and mutate only the three navigation caches. Resident and receiver callers share the existing rebuild policy, removing six state swaps. The cliff callback supplies retained bridge endpoint records at the same synchronous point.

Native evidence: Wave calls collapse at 0x0075F4B2; collapse invokes MapClass rebuild at 0x005812AC/0x00581995. Rebuild 0x0056C510 reads the retained Map+0x54 bridge vector at 0x0056C6CB..0x0056C7CC. This corrects the demonstrated missing-map-input behavior; broader receiver staging remains open.

Validation:
- Extended the production Wave AI regression with a separate native-derived bridge record, both route/hierarchy checks, and a no-record control. The corrected fixture failed before the change and passes after it; existing exact RNG, row-major animation and snapshot assertions remain.
- Lifecycle: test result: ok. 134 passed; 0 failed; 0 ignored; 0 measured; 8391 filtered out; finished in 0.03s
- Full: test result: ok. 8444 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 22.72s
- Independent read-only source/native/fixture review found no blocking findings. Coverage is the Rust production Wave entry with constructed map inputs, not native-executable or full-frame parity.
