### PR TITLE
Own factory-held construction, cancellation and release

### DIFF
--- a/docs/system-map/topology.v2.json
+++ b/docs/system-map/topology.v2.json
@@ -432,10 +432,16 @@
       ],
       "rust_surfaces": [
         {
-          "path": "src/sim/production/production_placement.rs",
-          "symbol": "placement_preview_for_owner / place_ready_building / cell_placeable",
+          "path": "src/sim/production/factory_lifecycle.rs",
+          "symbol": "enqueue_by_type / publish_completion / ReadyFactoryObject / revalidate_and_step_factories",
           "coverage": "representative",
-          "observed_at_commit": "12948d89c7e68d0dac14f7e0ed58d9212e844a2e"
+          "observed_at_commit": "73b82957923a824bd4a8a1fddd966b063a497d9f"
+        },
+        {
+          "path": "src/sim/production/production_placement.rs",
+          "symbol": "placement_preview_for_owner_with_overlays / place_ready_building_with_overlays / ReadyFactoryObject settlement",
+          "coverage": "representative",
+          "observed_at_commit": "73b82957923a824bd4a8a1fddd966b063a497d9f"
         },
         {
           "path": "src/sim/world/world_commands.rs",
@@ -451,6 +457,7 @@
         }
       ],
       "notes": [
+        "Factory-held construction, cancellation, completion publication and release now finish in factory_lifecycle. Registry lifecycle kernels are production-private; placement settles the matched identity after its world effects. This preserves phase order and does not close malformed-save admission or whole-loop parity.",
         "Owner of build-ready, placement legality, rejection, and committed foundation handoff.",
         "Feature 12948d89 closes ordinary marked Ground-mobile and live nonempty-overlay rejection in the shared preview/commit predicate, with a sealed-retail Dustbowl GAPOWR oracle through lifecycle, four-cell occupancy, buildup, and power.",
         "Special damaged-wall/ToTile/LaserFence/gate exceptions, delayed-command rejection UI/EVA, and active-retail input/pixel comparison remain explicit residuals."
@@ -1631,10 +1638,12 @@
         "placement helper 0x0047C620"
       ],
       "rust_touchpoints": [
+        {"path": "src/sim/production/factory_lifecycle.rs", "coverage": "representative", "observed_at_commit": "73b82957923a824bd4a8a1fddd966b063a497d9f"},
+        {"path": "src/sim/production/factory_lifecycle_tests.rs", "coverage": "representative", "observed_at_commit": "73b82957923a824bd4a8a1fddd966b063a497d9f"},
         {"path": "src/app_commands.rs", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},
-        {"path": "src/sim/production/factory.rs", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},
-        {"path": "src/sim/production/production_queue.rs", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},
-        {"path": "src/sim/production/production_placement.rs", "coverage": "representative", "observed_at_commit": "12948d89c7e68d0dac14f7e0ed58d9212e844a2e"},
+        {"path": "src/sim/production/factory.rs", "coverage": "representative", "observed_at_commit": "73b82957923a824bd4a8a1fddd966b063a497d9f"},
+        {"path": "src/sim/production/production_queue.rs", "coverage": "representative", "observed_at_commit": "73b82957923a824bd4a8a1fddd966b063a497d9f"},
+        {"path": "src/sim/production/production_placement.rs", "coverage": "representative", "observed_at_commit": "73b82957923a824bd4a8a1fddd966b063a497d9f"},
         {"path": "src/sim/world/world_commands.rs", "coverage": "representative", "observed_at_commit": "e726da11bdafed70d634cc93e871e5a5cd8c6135"},
         {"path": "src/app_init_helpers_retail_placement_oracle_tests.rs", "coverage": "representative", "observed_at_commit": "12948d89c7e68d0dac14f7e0ed58d9212e844a2e"},
         {"path": "src/assets/asset_manager.rs", "coverage": "representative", "observed_at_commit": "7448a5a55d8ee9a7c9daf7b45254d250f4acc69e"},

--- a/src/sim/deploy_tests.rs
+++ b/src/sim/deploy_tests.rs
@@ -1098,7 +1098,7 @@ fn conyard_redeploy_ui_hides_while_building_queue_busy() {
     // production-busy gate sees an active Building factory. This deliberately
     // bypasses producer validation because the minimal fixture has no Factory
     // flag, but it must still model StartProduction's held Techno constructor.
-    let started = sim.production.factory_shadow.enqueue(
+    let started = sim.production.factory_shadow.test_enqueue_kernel(
         owner,
         crate::sim::production::ProductionCategory::Building,
         type_id,
@@ -1107,7 +1107,7 @@ fn conyard_redeploy_ui_hides_while_building_queue_busy() {
         0,
     );
     assert!(started);
-    crate::sim::production::construct_and_link_active_factory_object(
+    crate::sim::production::construct_active_factory_fixture(
         &mut sim,
         &rules,
         owner,

--- a/src/sim/pathfinding/zone_search_tests.rs
+++ b/src/sim/pathfinding/zone_search_tests.rs
@@ -940,7 +940,7 @@ fn gsi_04_12_completed_ground_unit_rally_threads_exact_blocker_counts() {
         crate::sim::house_state::HouseState::new(owner, 0, None, true, STARTING_CREDITS, 10),
     );
     sim.houses.get_mut(&owner).unwrap().rally_point = Some((5, 0));
-    let started = sim.production.factory_shadow.enqueue(
+    let started = sim.production.factory_shadow.test_enqueue_kernel(
         owner,
         ProductionCategory::Vehicle,
         produced_type,
@@ -949,7 +949,7 @@ fn gsi_04_12_completed_ground_unit_rally_threads_exact_blocker_counts() {
         0,
     );
     assert!(started);
-    crate::sim::production::construct_and_link_active_factory_object(
+    crate::sim::production::construct_active_factory_fixture(
         &mut sim,
         &rules,
         owner,

--- a/src/sim/production/factory.rs
+++ b/src/sim/production/factory.rs
@@ -538,6 +538,41 @@ pub(crate) struct RevalAction {
 }
 
 impl FactoryRegistry {
+    /// Seed the queue kernel without constructing a world object. External
+    /// fixtures explicitly finish construction when their scenario requires it.
+    #[cfg(test)]
+    pub(crate) fn test_enqueue_kernel(
+        &mut self,
+        owner: InternedId,
+        category: ProductionCategory,
+        type_id: InternedId,
+        enqueue_order: u64,
+        total_base_frames: u32,
+        cost: i32,
+    ) -> bool {
+        self.enqueue(
+            owner,
+            category,
+            type_id,
+            enqueue_order,
+            total_base_frames,
+            cost,
+        )
+    }
+
+    /// Standalone registry oracle access; live cancellation must also settle
+    /// the held world object through the production lifecycle owner.
+    #[cfg(test)]
+    pub(crate) fn test_cancel_one_kernel(
+        &mut self,
+        owner: InternedId,
+        category: ProductionCategory,
+        type_id: InternedId,
+        economy: &mut Economy,
+    ) -> CancelOutcome {
+        self.cancel_one(owner, category, type_id, economy)
+    }
+
     /// Apply the save/load swizzle result to the optional produced-object
     /// pointer. An unmatched saved identity becomes null; the Factory and its
     /// type/progress state remain intact.
@@ -642,7 +677,7 @@ impl FactoryRegistry {
     /// `cost` is resolved by the caller (which holds `&rules`) so this stays `&sim`-free.
     /// Returns `true` only when this call starts an active object; queued-tail
     /// appends return `false` because their Techno constructor has not run yet.
-    pub(crate) fn enqueue(
+    pub(super) fn enqueue(
         &mut self,
         owner: InternedId,
         category: ProductionCategory,
@@ -748,7 +783,7 @@ impl FactoryRegistry {
     /// revalidation sweep passes `1`.
     /// Returns the popped type, or `None` if the queue was empty (the factory is left idle
     /// for `prune_idle`).
-    pub(crate) fn clear_active_and_advance(
+    pub(super) fn clear_active_and_advance(
         &mut self,
         owner: InternedId,
         category: ProductionCategory,
@@ -763,7 +798,7 @@ impl FactoryRegistry {
     /// Link the EntityStore identity created at StartProduction to the active
     /// factory object. The link is established at progress zero and is retained
     /// through completion and every delivery retry.
-    pub(crate) fn link_active_entity(
+    pub(super) fn link_active_entity(
         &mut self,
         owner: InternedId,
         category: ProductionCategory,
@@ -781,7 +816,7 @@ impl FactoryRegistry {
     /// completed object. Delivery refusal does not clear the object, so later
     /// retries observe `false`; `start_next_queued` constructs the next head with
     /// a fresh `false` latch.
-    pub(crate) fn account_completed_object_once(
+    pub(super) fn account_completed_object_once(
         &mut self,
         owner: InternedId,
         category: ProductionCategory,
@@ -829,7 +864,7 @@ impl FactoryRegistry {
     /// write phase can borrow `&mut houses` without aliasing. Walks `iter_insertion_ordered`
     /// (the deterministic temporal order = `step_all` charge order = hash fold order) so the
     /// plan — and the refund application order — is replay-stable.
-    pub(crate) fn plan_revalidation(
+    pub(super) fn plan_revalidation(
         &self,
         sim: &crate::sim::world::Simulation,
         rules: &RuleSet,
@@ -891,7 +926,7 @@ impl FactoryRegistry {
     /// queued entry (C7 StartNextQueued, cost-seeded, `step_delay = 1` because this sweep runs
     /// BEFORE `step_all` so the promoted build is not charged the same tick). Idle factories
     /// are pruned.
-    pub(crate) fn apply_revalidation(
+    pub(super) fn apply_revalidation(
         &mut self,
         plan: &[RevalAction],
         houses: &mut BTreeMap<InternedId, crate::sim::house_state::HouseState>,
@@ -955,7 +990,7 @@ impl FactoryRegistry {
     /// Stamps are unique (monotonic mint) so there is never a tie. A tail item is removed
     /// uncharged (no refund); the active build (empty tail) is abandoned with the C8 PARTIAL
     /// refund routed through `economy`. The caller prunes an emptied factory.
-    pub(crate) fn cancel_last(
+    pub(super) fn cancel_last(
         &mut self,
         owner: InternedId,
         economy: &mut Economy,
@@ -994,7 +1029,7 @@ impl FactoryRegistry {
     /// as an OWNED map so `step_all` can then run against `&mut houses` without holding a
     /// `&Simulation` borrow (the split-borrow the authority flip needs). Only armed,
     /// steppable factories (object held, not complete/suspended/paused) get inputs.
-    pub fn prepare_step_inputs(
+    pub(super) fn prepare_step_inputs(
         &self,
         sim: &crate::sim::world::Simulation,
         rules: &RuleSet,
@@ -1059,7 +1094,7 @@ impl FactoryRegistry {
     /// `economy.spent_credits` accumulates; `economy.credits` is a transient shim, never
     /// the authority, never hashed. `prepared` (from `prepare_step_inputs`) carries the
     /// producer inputs so this method holds no `&Simulation` borrow.
-    pub fn step_all(
+    pub(super) fn step_all(
         &mut self,
         houses: &mut BTreeMap<InternedId, crate::sim::house_state::HouseState>,
         prepared: &BTreeMap<(InternedId, ProductionCategory), BuildStepTimeInputs>,
@@ -1127,7 +1162,7 @@ impl FactoryRegistry {
     ///
     /// `&mut Economy` is an ORACLE (clone) in P4; the authority-flip slice flips WHO is
     /// passed, not this body.
-    pub fn cancel_one(
+    pub(super) fn cancel_one(
         &mut self,
         owner: InternedId,
         category: ProductionCategory,

--- a/src/sim/production/factory_lifecycle.rs
+++ b/src/sim/production/factory_lifecycle.rs
@@ -1,0 +1,522 @@
+//! Complete mutations of factory-held Techno identity and its accounting.
+//!
+//! The registry owns queue/charge kernels. This world-facing owner completes
+//! their constructor, disposal, ready projection and successor work before an
+//! operation returns. Native StartProduction/AbandonProduction/StartNextQueued:
+//! 0x004C9C70 / 0x004CA0E0 / 0x004CA5A0; see FACTORY_CREDIT_SYSTEM_GHIDRA_REPORT.md.
+//! Delivery selection and placement keep their existing phase positions and
+//! call settlement only after their successful world effects have committed.
+
+use super::CancelOutcome;
+use super::production_queue::{credits_entry_for_owner, credits_for_owner};
+use super::production_tech::{
+    build_option_for_owner, build_time_base_frames, production_category_for_object,
+    should_use_relaxed_build_mode, supports_live_production,
+};
+use super::production_types::{BuildMode, ProductionCategory};
+use crate::rules::object_type::ObjectCategory;
+use crate::rules::ruleset::RuleSet;
+use crate::sim::intern::InternedId;
+use crate::sim::world::{SimSoundEvent, Simulation};
+
+/// Enqueue a specific unit type.
+pub fn enqueue_by_type(sim: &mut Simulation, rules: &RuleSet, owner: &str, type_id: &str) -> bool {
+    let relaxed: bool = should_use_relaxed_build_mode(sim, rules, owner);
+    let mode = if relaxed {
+        BuildMode::PrototypeRelaxed
+    } else {
+        BuildMode::Strict
+    };
+    if let Some(opt) = build_option_for_owner(sim, rules, owner, type_id, mode) {
+        if !opt.enabled {
+            return false;
+        }
+    } else {
+        return false;
+    }
+    let Some(obj) = rules.object(type_id) else {
+        return false;
+    };
+    if !supports_live_production(obj) {
+        return false;
+    }
+    let queue_category = production_category_for_object(obj);
+    let owner_credits = credits_for_owner(sim, owner);
+    if obj.cost <= 0 || owner_credits < obj.cost {
+        return false;
+    }
+    let total_base_frames: u32 = build_time_base_frames(rules, obj);
+    // The upfront debit is RETIRED at the authority flip: the per-step `advance_one_step`
+    // (driven by `step_all` at the Phase-7 head) charges the cost down over the build
+    // against the one wallet (`house.credits`). Enqueue only checks affordability (the
+    // can-afford-to-START gate above) and appends the queue item.
+    let owner_id = sim.interner.intern(owner);
+    let type_interned = sim.interner.intern(type_id);
+    let enqueue_order = next_enqueue_order(sim);
+    let cost = obj.cost.max(0);
+    // P5d: append directly to the registry queue-of-record (create-or-append). With no
+    // active build the registry arms it inline (the retired reconcile SEED); otherwise it
+    // joins the FIFO tail. No upfront debit (the per-step charge owns the cost).
+    let started = sim.production.factory_shadow.enqueue(
+        owner_id,
+        queue_category,
+        type_interned,
+        enqueue_order,
+        total_base_frames,
+        cost,
+    );
+    if started {
+        construct_and_link_active_factory_object(
+            sim,
+            rules,
+            owner_id,
+            queue_category,
+            type_interned,
+        )
+        .expect("validated StartProduction type must construct one Techno");
+    }
+    true
+}
+
+fn next_enqueue_order(sim: &mut Simulation) -> u64 {
+    let order = sim.production.next_enqueue_order;
+    sim.production.next_enqueue_order = sim.production.next_enqueue_order.saturating_add(1);
+    order
+}
+/// Materialize the exact Techno retained by an active factory head. Active
+/// retail `FactoryClass::StartProduction @ 0x004C9C70` calls
+/// `type->CreateInstance(owner)` at start and stores the result at
+/// `Factory+0x58`; queued tail entries do not construct until promoted by
+/// `FactoryClass::StartNextQueued @ 0x004CA5A0`.
+fn construct_and_link_active_factory_object(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    owner_id: InternedId,
+    category: ProductionCategory,
+    type_id: InternedId,
+) -> Option<u64> {
+    let owner = sim.interner.resolve(owner_id).to_string();
+    let type_name = sim.interner.resolve(type_id).to_string();
+    // A factory-held object is still in limbo and has no cell authority. Zero
+    // is only inert storage here; the result-bearing Unlimbo later installs the
+    // selected delivery/placement coordinate on this same stable identity.
+    let stable_id = sim.construct_object_limbo_at_height(&type_name, &owner, 0, 0, 0, 0, rules)?;
+    let linked = sim
+        .production
+        .factory_shadow
+        .link_active_entity(owner_id, category, stable_id);
+    if linked != Some(stable_id) {
+        let _ = sim.discard_constructed_limbo(stable_id);
+        return None;
+    }
+    Some(stable_id)
+}
+/// Cancel the most recently queued item for this owner.
+///
+/// Post-flip refund rule: a queued (tail) item was never charged, so removing it
+/// refunds NOTHING; only the active build (a single-item queue, where the most-recent
+/// item IS the front) is abandoned with the C8 PARTIAL refund (`original_balance -
+/// balance`) routed through the registry against the one wallet (`house.credits`).
+pub fn cancel_last_for_owner(sim: &mut Simulation, _rules: &RuleSet, owner: &str) -> bool {
+    let owner_id = sim.interner.intern(owner);
+    // P5d: the registry owns the queue-of-record. `cancel_last` finds the global-max stamp
+    // across the owner's factories (tail-back, else the active build) and removes it — a
+    // tail item uncharged (QueuedRemoved), the active build with the C8 PARTIAL refund. The
+    // abandon arm only fires for an empty tail, so no StartNextQueued advance is needed.
+    let mut registry = std::mem::take(&mut sim.production.factory_shadow);
+    let outcome = if let Some(house) = sim.houses.get_mut(&owner_id) {
+        let mut wallet = std::mem::take(&mut house.economy);
+        wallet.credits = house.credits;
+        let outcome = registry.cancel_last(owner_id, &mut wallet);
+        house.credits = wallet.credits;
+        house.economy = wallet;
+        outcome
+    } else {
+        let mut throwaway = crate::sim::economy::Economy::default();
+        registry.cancel_last(owner_id, &mut throwaway)
+    };
+    registry.prune_all_idle();
+    sim.production.factory_shadow = registry;
+    if let CancelOutcome::AbandonedActive {
+        entity_id: Some(entity_id),
+        ..
+    } = outcome
+    {
+        let discarded = sim.discard_constructed_limbo(entity_id);
+        debug_assert!(
+            discarded,
+            "AbandonProduction destroys the held limbo object"
+        );
+    }
+    matches!(
+        outcome,
+        CancelOutcome::QueuedRemoved | CancelOutcome::AbandonedActive { .. }
+    )
+}
+
+/// Route a cancel of `type_id` for (owner, category) through the registry `cancel_one`
+/// (the single precedence source: queued-tail FIRST, else active-abandon), charging the
+/// C8 partial refund (or none, for a queued copy) against the ONE wallet
+/// (`house.credits`) via a per-sweep `Economy` shim. The private caller completes held-object disposal and promotion before returning.
+fn registry_cancel_active(
+    sim: &mut Simulation,
+    owner_id: InternedId,
+    category: ProductionCategory,
+    type_id: InternedId,
+) -> CancelOutcome {
+    let mut registry = std::mem::take(&mut sim.production.factory_shadow);
+    let outcome = if let Some(house) = sim.houses.get_mut(&owner_id) {
+        let mut wallet = std::mem::take(&mut house.economy);
+        wallet.credits = house.credits; // load the authoritative balance into the shim
+        let outcome = registry.cancel_one(owner_id, category, type_id, &mut wallet);
+        house.credits = wallet.credits; // store the (possibly refunded) balance back
+        house.economy = wallet;
+        outcome
+    } else {
+        // No house to refund into; the cancel still resolves the registry deterministically.
+        let mut throwaway = crate::sim::economy::Economy::default();
+        registry.cancel_one(owner_id, category, type_id, &mut throwaway)
+    };
+    sim.production.factory_shadow = registry;
+    outcome
+}
+
+/// Cancel one queued/active production of `type_id` for this owner (right-click cameo).
+///
+/// Routed through the registry `cancel_one` (the single precedence source): a QUEUED
+/// tail copy is removed FIRST (FIRST front-to-back match, NO refund — a queued item was
+/// never charged), else the ACTIVE build is abandoned with the C8 PARTIAL refund
+/// (`original_balance - balance`) into the one wallet (`house.credits`). This replaces
+/// the legacy `.rev()` last-match + full-cost refund (a DRIFT under the per-step charge).
+/// When neither matches (or the build is complete-but-held), falls back to the
+/// completed-building ready queue.
+pub fn cancel_by_type_for_owner(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    owner: &str,
+    type_id: &str,
+) -> bool {
+    let owner_id = sim.interner.intern(owner);
+    let type_interned = sim.interner.intern(type_id);
+    // The registry is keyed by ProductionCategory; resolve it from the type (the same
+    // routing `enqueue_by_type` used, so the item is in this category's queue).
+    let category = match rules.object(type_id) {
+        Some(obj) => production_category_for_object(obj),
+        None => return cancel_ready_by_type_for_owner(sim, rules, owner, type_id),
+    };
+
+    match registry_cancel_active(sim, owner_id, category, type_interned) {
+        CancelOutcome::QueuedRemoved => {
+            // A queued (tail) copy was removed in the registry; the active build keeps
+            // running. Sweep any now-idle factory (none here, but keep it uniform).
+            sim.production.factory_shadow.prune_all_idle();
+            true
+        }
+        CancelOutcome::AbandonedActive { entity_id, .. } => {
+            if let Some(entity_id) = entity_id {
+                let discarded = sim.discard_constructed_limbo(entity_id);
+                debug_assert!(
+                    discarded,
+                    "AbandonProduction destroys the held limbo object"
+                );
+            }
+            // C7: the active build was abandoned (object cleared, tail intact). Promote the
+            // next queued entry into the active slot, cost-seeded. EventClass
+            // dispatch is after this tick's `step_all`, so step_delay = 0
+            // charges the promoted build on the next gameplay frame.
+            advance_after_delivery(sim, rules, owner_id, category);
+            sim.production.factory_shadow.prune_all_idle();
+            true
+        }
+        CancelOutcome::NoMatch => {
+            // Not an active/queued build (or a complete-but-held one) -> the ready queue.
+            cancel_ready_by_type_for_owner(sim, rules, owner, type_id)
+        }
+    }
+}
+
+/// Cancel a completed building from the ready_by_owner queue (awaiting placement).
+/// Used as fallback when `cancel_by_type_for_owner` finds nothing in the build queue.
+fn cancel_ready_by_type_for_owner(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    owner: &str,
+    type_id: &str,
+) -> bool {
+    let owner_id = sim.interner.intern(owner);
+    let type_interned = sim.interner.intern(type_id);
+    let Some(ready_queue) = sim.production.ready_by_owner.get_mut(&owner_id) else {
+        return false;
+    };
+    // Remove last instance of this type (consistent with queue cancel using .rev()).
+    let ready_idx = ready_queue
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, tid)| **tid == type_interned)
+        .map(|(i, _)| i);
+    let Some(idx) = ready_idx else {
+        return false;
+    };
+    ready_queue.remove(idx);
+    if ready_queue.is_empty() {
+        sim.production.ready_by_owner.remove(&owner_id);
+    }
+    let category = rules
+        .object(type_id)
+        .map(production_category_for_object)
+        .unwrap_or(ProductionCategory::Building);
+    let held_entity_id = sim
+        .production
+        .factory_shadow
+        .view(owner_id, category)
+        .and_then(|view| view.object)
+        .filter(|object| object.type_id == type_interned)
+        .and_then(|object| object.entity_id);
+    // Refund full cost.
+    if let Some(obj) = rules.object(type_id) {
+        *credits_entry_for_owner(sim, owner) += obj.cost.max(0);
+    }
+    if let Some(entity_id) = held_entity_id {
+        let discarded = sim.discard_constructed_limbo(entity_id);
+        debug_assert!(
+            discarded,
+            "ready-building cancel destroys Factory+0x58 object"
+        );
+    }
+    advance_after_delivery(sim, rules, owner_id, category);
+    true
+}
+/// C7 StartNextQueued after a successful delivery (or a completed-but-undeliverable refund):
+/// clear the delivered active object and promote the next queued entry into the active slot,
+/// cost-seeded from `rules`. Runs in `tick_production` (Phase 7, AFTER `step_all`), so the
+/// promoted build's cadence (`step_delay = 0`) starts on the NEXT tick's sweep — never the
+/// same tick it is promoted.
+fn advance_after_delivery(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    owner_id: InternedId,
+    category: ProductionCategory,
+) {
+    let next_cost = sim
+        .production
+        .factory_shadow
+        .peek_next_queued(owner_id, category)
+        .map(|t| sim.object_type(t, rules).map_or(0, |o| o.cost.max(0)))
+        .unwrap_or(0);
+    let promoted = sim
+        .production
+        .factory_shadow
+        .clear_active_and_advance(owner_id, category, next_cost, 0);
+    if let Some(type_id) = promoted {
+        construct_and_link_active_factory_object(sim, rules, owner_id, category, type_id)
+            .expect("validated promoted production type must construct one Techno");
+    }
+}
+pub(super) fn active_entity_id(
+    sim: &Simulation,
+    owner_id: InternedId,
+    category: ProductionCategory,
+) -> Option<u64> {
+    sim.production
+        .factory_shadow
+        .view(owner_id, category)
+        .and_then(|view| view.object.and_then(|object| object.entity_id))
+        .filter(|&stable_id| sim.substrate.entities.contains(stable_id))
+}
+fn discard_active_factory_entity(
+    sim: &mut Simulation,
+    owner_id: InternedId,
+    category: ProductionCategory,
+) {
+    if let Some(stable_id) = active_entity_id(sim, owner_id, category) {
+        let discarded = sim.discard_constructed_limbo(stable_id);
+        debug_assert!(
+            discarded,
+            "factory-held object must remain in limbo until delivery"
+        );
+    }
+}
+fn consume_ready_building(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    owner_id: crate::sim::intern::InternedId,
+    type_id: crate::sim::intern::InternedId,
+    category: ProductionCategory,
+) -> bool {
+    let Some(ready_queue) = sim.production.ready_by_owner.get_mut(&owner_id) else {
+        return false;
+    };
+    let Some(index) = ready_queue.iter().position(|&queued| queued == type_id) else {
+        return false;
+    };
+    ready_queue.remove(index);
+    if ready_queue.is_empty() {
+        sim.production.ready_by_owner.remove(&owner_id);
+    }
+    advance_after_delivery(sim, rules, owner_id, category);
+    true
+}
+/// Publish the completion edge once, without releasing the held object.
+/// Native counts completion before delivery; refusal must not count again.
+pub(super) fn publish_completion(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    owner: InternedId,
+    category: ProductionCategory,
+) {
+    let Some(type_id) = sim
+        .production
+        .factory_shadow
+        .view(owner, category)
+        .and_then(|view| view.object.map(|object| object.type_id))
+    else {
+        return;
+    };
+    if !sim
+        .production
+        .factory_shadow
+        .account_completed_object_once(owner, category)
+    {
+        return;
+    }
+    if let Some(house) = sim.houses.get_mut(&owner) {
+        house.stats.built = house.stats.built.saturating_add(1);
+    }
+    if rules
+        .object(sim.interner.resolve(type_id))
+        .is_some_and(|object| object.category == ObjectCategory::Building)
+    {
+        sim.production
+            .ready_by_owner
+            .entry(owner)
+            .or_default()
+            .push_back(type_id);
+        sim.sound_events
+            .push(SimSoundEvent::BuildingComplete { owner });
+    }
+}
+
+/// Delivery effects already committed; retain the revealed identity and start
+/// its successor. A refused vehicle delivery must never call this operation.
+pub(super) fn release_delivered_mobile(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    owner: InternedId,
+    category: ProductionCategory,
+) {
+    advance_after_delivery(sim, rules, owner, category);
+}
+
+/// Terminal mobile failure refunds the authored full cost, destroys the held
+/// graph and starts the successor. This is distinct from a retryable refusal.
+pub(super) fn refund_failed_delivery(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    owner: InternedId,
+    category: ProductionCategory,
+) {
+    let type_id = sim
+        .production
+        .factory_shadow
+        .view(owner, category)
+        .and_then(|view| view.object.map(|object| object.type_id));
+    if let Some(object) = type_id.and_then(|type_id| rules.object(sim.interner.resolve(type_id))) {
+        let owner_name = sim.interner.resolve(owner).to_string();
+        *credits_entry_for_owner(sim, &owner_name) += object.cost.max(0);
+    }
+    discard_active_factory_entity(sim, owner, category);
+    advance_after_delivery(sim, rules, owner, category);
+}
+
+/// Matching identity captured by a successful placement admission. The caller
+/// cannot combine an entity ID with another owner's type or factory category.
+pub(super) struct ReadyFactoryObject {
+    owner: InternedId,
+    category: ProductionCategory,
+    type_id: InternedId,
+    entity_id: u64,
+}
+
+impl ReadyFactoryObject {
+    pub(super) fn entity_id(&self) -> u64 {
+        self.entity_id
+    }
+
+    /// Building Unlimbo/build-up/superweapon effects precede factory release.
+    pub(super) fn release_after_placement(self, sim: &mut Simulation, rules: &RuleSet) -> bool {
+        consume_ready_building(sim, rules, self.owner, self.type_id, self.category)
+    }
+
+    /// Primary and autofill overlays are already stamped when the constructor
+    /// identity is consumed. Ready removal and successor construction follow.
+    pub(super) fn consume_after_wall_stamp(self, sim: &mut Simulation, rules: &RuleSet) -> bool {
+        let _ = sim.discard_constructed_limbo(self.entity_id);
+        consume_ready_building(sim, rules, self.owner, self.type_id, self.category)
+    }
+}
+
+pub(super) fn ready_object(
+    sim: &Simulation,
+    owner: InternedId,
+    category: ProductionCategory,
+    type_id: InternedId,
+) -> Option<ReadyFactoryObject> {
+    let object = sim
+        .production
+        .factory_shadow
+        .view(owner, category)?
+        .object?;
+    if object.type_id != type_id {
+        return None;
+    }
+    let entity_id = object
+        .entity_id
+        .filter(|&id| sim.substrate.entities.contains(id))?;
+    Some(ReadyFactoryObject {
+        owner,
+        category,
+        type_id,
+        entity_id,
+    })
+}
+
+/// Fixture-only bridge for tests that deliberately seed a registry kernel.
+#[cfg(test)]
+pub(in crate::sim) fn construct_active_factory_fixture(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    owner: InternedId,
+    category: ProductionCategory,
+    type_id: InternedId,
+) -> Option<u64> {
+    construct_and_link_active_factory_object(sim, rules, owner, category, type_id)
+}
+
+/// Revalidate before the charge sweep at its existing frame phase. Dispose all
+/// abandoned objects before constructing any promoted ones; their delay stays 1.
+pub(in crate::sim) fn revalidate_and_step_factories(sim: &mut Simulation, rules: &RuleSet) {
+    let mut registry = std::mem::take(&mut sim.production.factory_shadow);
+    // P6: prereq/factory-loss revalidation BEFORE the charge sweep. Builds whose
+    // prerequisites or producing factory were lost are abandoned (partial refund)
+    // + now-unbuildable queued items dropped, so a freshly-abandoned factory is not
+    // charged this tick and a freshly-promoted one starts charging next tick.
+    let reval_plan = registry.plan_revalidation(sim, rules);
+    let lifecycle = registry.apply_revalidation(&reval_plan, &mut sim.houses);
+    for entity_id in lifecycle.discarded_entity_ids {
+        let discarded = sim.discard_constructed_limbo(entity_id);
+        debug_assert!(
+            discarded,
+            "prerequisite AbandonProduction destroys its held limbo object"
+        );
+    }
+    sim.production.factory_shadow = registry;
+    for (owner, category, type_id) in lifecycle.promoted {
+        construct_and_link_active_factory_object(sim, rules, owner, category, type_id)
+            .expect("validated revalidation promotion must construct one Techno");
+    }
+    let mut registry = std::mem::take(&mut sim.production.factory_shadow);
+    let prepared = registry.prepare_step_inputs(sim, rules);
+    registry.step_all(&mut sim.houses, &prepared);
+    sim.production.factory_shadow = registry;
+}

--- a/src/sim/production/factory_lifecycle_tests.rs
+++ b/src/sim/production/factory_lifecycle_tests.rs
@@ -1,0 +1,498 @@
+//! Production lifecycle scenarios: registry decisions must finish their held
+//! object graph, accounting and successor work before returning to the caller.
+
+use super::tests::spawn_structure;
+use super::{
+    ProductionCategory, cancel_by_type_for_owner, cancel_last_for_owner, enqueue_by_type,
+    tick_production,
+};
+use crate::rules::{ini_parser::IniFile, ruleset::RuleSet};
+use crate::sim::{intern::InternedId, rng::SimRng, world::Simulation};
+use std::collections::BTreeMap;
+
+pub(super) fn manager_rules() -> RuleSet {
+    RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=E1\n1=SLAV\n\
+         [VehicleTypes]\n0=MTNK\n1=SMIN\n\
+         [AircraftTypes]\n0=HORN\n1=ORCA\n\
+         [BuildingTypes]\n0=GAPILE\n1=GAWEAP\n2=GACNST\n3=YAREFN\n4=TECH\n5=GAAIRC\n6=GAPOWR\n\
+         [E1]\nName=GI\nCost=200\nStrength=100\nArmor=flak\nSpeed=4\nSight=5\nTechLevel=1\nOwner=Americans\n\
+         [SLAV]\nStrength=125\nSpeed=4\nStorage=4\n\
+         [MTNK]\nName=Tank\nCost=700\nStrength=300\nArmor=heavy\nSpeed=6\nSight=6\nTechLevel=1\nOwner=Americans\nSpawns=HORN\nSpawnsNumber=3\nSpawnRegenRate=600\nSpawnReloadRate=25\n\
+         [SMIN]\nCost=900\nStrength=2000\nSpeed=3\nTechLevel=1\nOwner=Americans\nPrerequisite=TECH\nEnslaves=SLAV\nSlavesNumber=2\nSlaveRegenRate=500\nSlaveReloadRate=25\n\
+         [HORN]\nStrength=75\nSpeed=14\nAmmo=1\n\
+         [ORCA]\nCost=1000\nStrength=200\nSpeed=8\nTechLevel=1\nOwner=Americans\n\
+         [GAPILE]\nFactory=InfantryType\n\
+         [GAWEAP]\nFactory=UnitType\n\
+         [GACNST]\nFactory=BuildingType\nConstructionYard=yes\n\
+         [YAREFN]\nCost=1000\nStrength=2000\nFoundation=1x1\nTechLevel=1\nOwner=Americans\nEnslaves=SLAV\nSlavesNumber=2\nSlaveRegenRate=500\nSlaveReloadRate=25\n\
+         [GAPOWR]\nCost=800\nStrength=500\nFoundation=1x1\nTechLevel=1\nOwner=Americans\n\
+         [TECH]\nStrength=500\n\
+         [GAAIRC]\nFactory=AircraftType\nHelipad=yes\n",
+    )).expect("factory manager fixture")
+}
+
+fn world(seed: u64) -> (Simulation, RuleSet, InternedId) {
+    let rules = manager_rules();
+    let mut sim = Simulation::with_seed(seed);
+    sim.intern_rule_type_ids(&rules);
+    sim.resolve_type_handles(&rules);
+    let owner = sim.interner.intern("Americans");
+    sim.houses.insert(
+        owner,
+        crate::sim::house_state::HouseState::new(owner, 0, None, true, 50_000, 10),
+    );
+    spawn_structure(&mut sim, 1, "Americans", "GAWEAP", 10, 10);
+    spawn_structure(&mut sim, 2, "Americans", "GAPILE", 14, 10);
+    spawn_structure(&mut sim, 3, "Americans", "GACNST", 18, 10);
+    spawn_structure(&mut sim, 4, "Americans", "TECH", 22, 10);
+    // Raw structure fixture admission bypasses lifecycle accounting.
+    sim.houses.get_mut(&owner).unwrap().owned_building_count = 4;
+    (sim, rules, owner)
+}
+
+pub(super) fn held_id(sim: &Simulation, owner: InternedId, category: ProductionCategory) -> u64 {
+    sim.production
+        .factory_shadow
+        .view(owner, category)
+        .unwrap()
+        .object
+        .unwrap()
+        .entity_id
+        .unwrap()
+}
+
+pub(super) fn children(sim: &Simulation, parent: u64) -> Vec<u64> {
+    let ids: Vec<_> = if let Some(manager) = sim
+        .substrate
+        .entities
+        .get(parent)
+        .unwrap()
+        .spawn_manager
+        .as_ref()
+    {
+        manager
+            .slots
+            .iter()
+            .map(|slot| slot.spawn.unwrap())
+            .collect()
+    } else {
+        sim.production
+            .slave_bindings
+            .get(&parent)
+            .cloned()
+            .unwrap_or_default()
+    };
+    for &id in &ids {
+        let child = sim
+            .substrate
+            .entities
+            .get(id)
+            .expect("held manager child remains represented");
+        assert!(child.lifecycle.in_limbo && !child.lifecycle.cell_marked);
+        assert!(
+            child.spawn_owner_id == Some(parent)
+                || child
+                    .slave_harvester
+                    .as_ref()
+                    .is_some_and(|slave| slave.master_id == parent)
+        );
+    }
+    ids
+}
+
+fn counts(sim: &Simulation, owner: InternedId) -> (u32, u32) {
+    let house = &sim.houses[&owner];
+    (house.owned_building_count, house.owned_unit_count)
+}
+
+fn assert_gone(sim: &Simulation, parent: u64, child_ids: &[u64]) {
+    assert!(!sim.substrate.entities.contains(parent));
+    assert!(!sim.production.slave_bindings.contains_key(&parent));
+    for &child in child_ids {
+        assert!(!sim.substrate.entities.contains(child));
+    }
+}
+
+fn assert_constructor_words(sim: &Simulation, parent: u64, expected: &mut SimRng) {
+    for id in std::iter::once(parent).chain(children(sim, parent)) {
+        let word = (expected.next_u32() & 0xffff) as u16;
+        assert_eq!(
+            sim.substrate
+                .entities
+                .get(id)
+                .unwrap()
+                .techno_ctor_random_word,
+            word
+        );
+    }
+    assert_eq!(sim.scenario_rng.logical_state(), expected.logical_state());
+}
+
+#[test]
+fn manager_factory_cancellation_finishes_graph_accounting_and_promotion() {
+    for parent_type in ["MTNK", "SMIN"] {
+        let (mut sim, rules, owner) = world(0xfac7_0010);
+        let before = counts(&sim, owner);
+        let mut expected = sim.scenario_rng.clone();
+        assert!(enqueue_by_type(&mut sim, &rules, "Americans", parent_type));
+        let parent = held_id(&sim, owner, ProductionCategory::Vehicle);
+        let child_ids = children(&sim, parent);
+        assert_eq!(child_ids.len(), if parent_type == "MTNK" { 3 } else { 2 });
+        assert_constructor_words(&sim, parent, &mut expected);
+        assert_eq!(
+            counts(&sim, owner),
+            (before.0, before.1 + 1 + child_ids.len() as u32)
+        );
+        let allocated = sim.substrate.next_stable_object_id;
+        assert!(enqueue_by_type(&mut sim, &rules, "Americans", parent_type));
+        assert_eq!(sim.substrate.next_stable_object_id, allocated);
+        assert!(cancel_last_for_owner(&mut sim, &rules, "Americans"));
+        assert_eq!(held_id(&sim, owner, ProductionCategory::Vehicle), parent);
+        assert_eq!(children(&sim, parent), child_ids);
+        assert_eq!(sim.houses[&owner].credits, 50_000);
+        assert_eq!(sim.scenario_rng.logical_state(), expected.logical_state());
+
+        assert!(cancel_last_for_owner(&mut sim, &rules, "Americans"));
+        assert_gone(&sim, parent, &child_ids);
+        assert_eq!(counts(&sim, owner), before);
+        assert_eq!(sim.substrate.next_stable_object_id, allocated);
+        assert_eq!(sim.scenario_rng.logical_state(), expected.logical_state());
+        assert!(
+            sim.production
+                .factory_shadow
+                .view(owner, ProductionCategory::Vehicle)
+                .is_none()
+        );
+
+        assert!(enqueue_by_type(&mut sim, &rules, "Americans", parent_type));
+        let parent = held_id(&sim, owner, ProductionCategory::Vehicle);
+        let child_ids = children(&sim, parent);
+        assert_constructor_words(&sim, parent, &mut expected);
+        let successor_type = if parent_type == "MTNK" {
+            "SMIN"
+        } else {
+            "MTNK"
+        };
+        assert!(enqueue_by_type(
+            &mut sim,
+            &rules,
+            "Americans",
+            successor_type
+        ));
+        assert!(cancel_by_type_for_owner(
+            &mut sim,
+            &rules,
+            "Americans",
+            parent_type
+        ));
+        assert_gone(&sim, parent, &child_ids);
+        let successor = held_id(&sim, owner, ProductionCategory::Vehicle);
+        assert!(successor > parent);
+        assert_constructor_words(&sim, successor, &mut expected);
+        assert_eq!(
+            counts(&sim, owner),
+            (
+                before.0,
+                before.1 + 1 + children(&sim, successor).len() as u32
+            )
+        );
+        assert_eq!(
+            sim.production
+                .factory_shadow
+                .view(owner, ProductionCategory::Vehicle)
+                .unwrap()
+                .progress,
+            0
+        );
+    }
+}
+
+#[test]
+fn ready_manager_cancel_refunds_disposes_and_constructs_one_successor() {
+    let (mut sim, rules, owner) = world(0xfac7_0011);
+    let before = counts(&sim, owner);
+    assert!(enqueue_by_type(&mut sim, &rules, "Americans", "YAREFN"));
+    let parent = held_id(&sim, owner, ProductionCategory::Building);
+    let child_ids = children(&sim, parent);
+    assert_eq!(child_ids.len(), 2);
+    assert!(
+        sim.production
+            .factory_shadow
+            .test_arm_ready(owner, ProductionCategory::Building)
+    );
+    assert!(!tick_production(&mut sim, &rules, &BTreeMap::new(), None));
+    assert_eq!(sim.production.ready_by_owner[&owner].len(), 1);
+    assert!(enqueue_by_type(&mut sim, &rules, "Americans", "YAREFN"));
+    let mut expected = sim.scenario_rng.clone();
+    let credits = sim.houses[&owner].credits;
+    assert!(cancel_by_type_for_owner(
+        &mut sim,
+        &rules,
+        "Americans",
+        "YAREFN"
+    ));
+    // Queue-first cancellation consumes the uncharged tail before ready fallback.
+    assert_eq!(held_id(&sim, owner, ProductionCategory::Building), parent);
+    assert_eq!(sim.houses[&owner].credits, credits);
+    // A different queued type does not intercept cancellation of the ready head.
+    assert!(enqueue_by_type(&mut sim, &rules, "Americans", "GAPOWR"));
+    assert!(cancel_by_type_for_owner(
+        &mut sim,
+        &rules,
+        "Americans",
+        "YAREFN"
+    ));
+    assert_gone(&sim, parent, &child_ids);
+    assert_eq!(sim.houses[&owner].credits, credits + 1000);
+    assert_eq!(counts(&sim, owner), (before.0 + 1, before.1));
+    assert!(
+        sim.production
+            .ready_by_owner
+            .get(&owner)
+            .is_none_or(|ready| ready.is_empty())
+    );
+    let successor = held_id(&sim, owner, ProductionCategory::Building);
+    assert!(successor > parent);
+    assert_eq!(
+        sim.interner
+            .resolve(sim.substrate.entities.get(successor).unwrap().type_ref),
+        "GAPOWR"
+    );
+    assert_constructor_words(&sim, successor, &mut expected);
+    assert_eq!(
+        sim.production
+            .factory_shadow
+            .view(owner, ProductionCategory::Building)
+            .unwrap()
+            .progress,
+        0
+    );
+}
+
+#[test]
+fn prerequisite_revalidation_disposes_manager_and_delays_promoted_first_charge() {
+    let (mut sim, rules, owner) = world(0xfac7_0012);
+    assert!(enqueue_by_type(&mut sim, &rules, "Americans", "SMIN"));
+    assert!(enqueue_by_type(&mut sim, &rules, "Americans", "MTNK"));
+    let parent = held_id(&sim, owner, ProductionCategory::Vehicle);
+    let child_ids = children(&sim, parent);
+    for _ in 0..40 {
+        sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 67);
+    }
+    let spent = {
+        let factory = sim
+            .production
+            .factory_shadow
+            .test_factory_mut(owner, ProductionCategory::Vehicle)
+            .unwrap();
+        assert!(factory.progress > 0 && factory.progress < 54);
+        factory.original_balance - factory.balance
+    };
+    let before = sim.houses[&owner].credits;
+    let mut expected = sim.scenario_rng.clone();
+    // The producing factory remains; only the active type loses its prerequisite.
+    sim.substrate.entities.remove(4);
+    sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 67);
+    assert_gone(&sim, parent, &child_ids);
+    assert_eq!(sim.houses[&owner].credits, before + spent);
+    let successor = held_id(&sim, owner, ProductionCategory::Vehicle);
+    assert_eq!(
+        sim.interner
+            .resolve(sim.substrate.entities.get(successor).unwrap().type_ref),
+        "MTNK"
+    );
+    assert_constructor_words(&sim, successor, &mut expected);
+    assert_eq!(
+        sim.production
+            .factory_shadow
+            .view(owner, ProductionCategory::Vehicle)
+            .unwrap()
+            .progress,
+        0
+    );
+    sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 67);
+    assert_eq!(
+        sim.production
+            .factory_shadow
+            .view(owner, ProductionCategory::Vehicle)
+            .unwrap()
+            .progress,
+        1
+    );
+    assert!(sim.houses[&owner].credits < before + spent);
+}
+
+#[test]
+fn terminal_infantry_delivery_failure_refunds_and_promotes() {
+    let (mut sim, rules, owner) = world(0xfac7_0013);
+    assert!(enqueue_by_type(&mut sim, &rules, "Americans", "E1"));
+    assert!(enqueue_by_type(&mut sim, &rules, "Americans", "E1"));
+    let held = held_id(&sim, owner, ProductionCategory::Infantry);
+    assert!(
+        sim.production
+            .factory_shadow
+            .test_arm_ready(owner, ProductionCategory::Infantry)
+    );
+    // Infantry can fall back to another owned structure when the barracks is
+    // absent. Remove every producer candidate to reach terminal delivery failure.
+    for structure in 1..=4 {
+        sim.substrate.entities.remove(structure);
+    }
+    sim.houses.get_mut(&owner).unwrap().owned_building_count = 0;
+    let before = sim.houses[&owner].credits;
+    let mut expected = sim.scenario_rng.clone();
+    assert!(!tick_production(&mut sim, &rules, &BTreeMap::new(), None));
+    assert!(!sim.substrate.entities.contains(held));
+    assert_eq!(sim.houses[&owner].credits, before + 200);
+    let successor = held_id(&sim, owner, ProductionCategory::Infantry);
+    assert!(successor > held);
+    assert_constructor_words(&sim, successor, &mut expected);
+    assert_eq!(
+        sim.production
+            .factory_shadow
+            .view(owner, ProductionCategory::Infantry)
+            .unwrap()
+            .progress,
+        0
+    );
+}
+
+#[test]
+fn active_cancel_without_house_does_not_create_refund_account() {
+    for cancel_last in [true, false] {
+        let (mut sim, rules, owner) = world(0xfac7_0014);
+        assert!(enqueue_by_type(&mut sim, &rules, "Americans", "SMIN"));
+        let parent = held_id(&sim, owner, ProductionCategory::Vehicle);
+        let child_ids = children(&sim, parent);
+        sim.houses.remove(&owner);
+        let rng = sim.scenario_rng.logical_state();
+        let cancelled = if cancel_last {
+            cancel_last_for_owner(&mut sim, &rules, "Americans")
+        } else {
+            cancel_by_type_for_owner(&mut sim, &rules, "Americans", "SMIN")
+        };
+        assert!(cancelled);
+        assert_gone(&sim, parent, &child_ids);
+        assert!(!sim.houses.contains_key(&owner));
+        assert_eq!(sim.scenario_rng.logical_state(), rng);
+    }
+}
+
+#[test]
+fn missing_type_ready_without_held_object_is_removed_without_refund() {
+    let (mut sim, rules, owner) = world(0xfac7_0015);
+    let missing = sim.interner.intern("REMOVED_TYPE");
+    sim.production
+        .ready_by_owner
+        .entry(owner)
+        .or_default()
+        .push_back(missing);
+    let before = sim.houses[&owner].credits;
+    let rng = sim.scenario_rng.logical_state();
+    assert!(cancel_by_type_for_owner(
+        &mut sim,
+        &rules,
+        "Americans",
+        "REMOVED_TYPE"
+    ));
+    assert_eq!(sim.houses[&owner].credits, before);
+    assert_eq!(sim.scenario_rng.logical_state(), rng);
+    assert!(
+        sim.production
+            .ready_by_owner
+            .get(&owner)
+            .is_none_or(|ready| ready.is_empty())
+    );
+    assert!(
+        sim.production
+            .factory_shadow
+            .view(owner, ProductionCategory::Building)
+            .is_none()
+    );
+}
+
+#[test]
+fn factory_loss_revalidation_disposes_parent_and_children_before_returning() {
+    for parent_type in ["MTNK", "SMIN"] {
+        let (mut sim, rules, owner) = world(0xfac7_0016);
+        assert!(enqueue_by_type(&mut sim, &rules, "Americans", parent_type));
+        assert!(enqueue_by_type(&mut sim, &rules, "Americans", parent_type));
+        let parent = held_id(&sim, owner, ProductionCategory::Vehicle);
+        let child_ids = children(&sim, parent);
+        for _ in 0..40 {
+            sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 67);
+        }
+        let spent = {
+            let factory = sim
+                .production
+                .factory_shadow
+                .test_factory_mut(owner, ProductionCategory::Vehicle)
+                .unwrap();
+            assert!(factory.progress > 0 && factory.progress < 54);
+            factory.original_balance - factory.balance
+        };
+        sim.substrate.entities.remove(1);
+        let before = sim.houses[&owner].credits;
+        let allocated = sim.substrate.next_stable_object_id;
+        let rng = sim.scenario_rng.logical_state();
+        sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 67);
+        assert_gone(&sim, parent, &child_ids);
+        assert_eq!(sim.houses[&owner].credits, before + spent);
+        assert_eq!(sim.houses[&owner].owned_unit_count, 0);
+        assert_eq!(sim.substrate.next_stable_object_id, allocated);
+        assert_eq!(sim.scenario_rng.logical_state(), rng);
+        assert!(
+            sim.production
+                .factory_shadow
+                .view(owner, ProductionCategory::Vehicle)
+                .is_none()
+        );
+    }
+}
+
+#[test]
+fn revalidation_without_house_disposes_held_graph_without_creating_account() {
+    let (mut sim, rules, owner) = world(0xfac7_0017);
+    assert!(enqueue_by_type(&mut sim, &rules, "Americans", "SMIN"));
+    let parent = held_id(&sim, owner, ProductionCategory::Vehicle);
+    let child_ids = children(&sim, parent);
+    sim.substrate.entities.remove(1);
+    sim.houses.remove(&owner);
+    let rng = sim.scenario_rng.logical_state();
+    super::revalidate_and_step_factories(&mut sim, &rules);
+    assert_gone(&sim, parent, &child_ids);
+    assert!(!sim.houses.contains_key(&owner));
+    assert_eq!(sim.scenario_rng.logical_state(), rng);
+}
+
+#[test]
+fn missing_helipad_delivery_refunds_disposes_and_promotes_aircraft() {
+    let (mut sim, rules, owner) = world(0xfac7_0018);
+    spawn_structure(&mut sim, 5, "Americans", "GAAIRC", 26, 10);
+    assert!(enqueue_by_type(&mut sim, &rules, "Americans", "ORCA"));
+    assert!(enqueue_by_type(&mut sim, &rules, "Americans", "ORCA"));
+    let parent = held_id(&sim, owner, ProductionCategory::Aircraft);
+    assert!(
+        sim.production
+            .factory_shadow
+            .test_arm_ready(owner, ProductionCategory::Aircraft)
+    );
+    sim.substrate.entities.remove(5);
+    let before = sim.houses[&owner].credits;
+    let mut expected = sim.scenario_rng.clone();
+    assert!(!tick_production(&mut sim, &rules, &BTreeMap::new(), None));
+    assert!(!sim.substrate.entities.contains(parent));
+    assert_eq!(sim.houses[&owner].credits, before + 1000);
+    let successor = held_id(&sim, owner, ProductionCategory::Aircraft);
+    assert!(successor > parent);
+    assert_constructor_words(&sim, successor, &mut expected);
+    assert_eq!(
+        sim.production
+            .factory_shadow
+            .view(owner, ProductionCategory::Aircraft)
+            .unwrap()
+            .progress,
+        0
+    );
+}

--- a/src/sim/production/mod.rs
+++ b/src/sim/production/mod.rs
@@ -2,12 +2,15 @@
 //!
 //! This is a first playable loop implementation. Split into sub-modules:
 //! - `production_types`: shared types, constants, state containers
-//! - `production_queue`: queue management, enqueue, tick, cancel
+//! - `factory`: queue and per-step charging kernels
+//! - `factory_lifecycle`: held-object birth, completion, cancellation and release
+//! - `production_queue`: queue views and completed mobile delivery
 //! - `production_economy`: resource harvesting and credit delivery
 //! - `production_placement`: building placement, sell, repair
 //! - `production_tech`: tech tree, build options, factory matching, spawn cells
 
 mod factory;
+mod factory_lifecycle;
 mod production_economy;
 mod production_placement;
 mod production_queue;
@@ -25,6 +28,7 @@ pub use self::factory::{
     PRODUCTION_STEPS, PendingObject, STEP_RATE_MAX, STEP_RATE_MIN, SpecialItem, StepOutcome,
     build_step_time, category_for_object,
 };
+pub use self::factory_lifecycle::{cancel_by_type_for_owner, cancel_last_for_owner, enqueue_by_type};
 pub use self::production_economy::is_harvester_type;
 pub use self::production_placement::{
     active_producer_for_owner_category, cycle_active_producer_for_owner_category,
@@ -35,11 +39,10 @@ pub use self::production_placement::{
 #[cfg(test)]
 pub use self::production_queue::seed_resource_nodes_from_overlays;
 pub use self::production_queue::{
-    build_options_for_owner, cancel_by_type_for_owner, cancel_last_for_owner, credits_for_owner,
-    enqueue_by_type, enqueue_default_unit_for_owner, has_strict_build_option_for_owner,
-    power_balance_for_owner, queue_view_for_owner, rally_point_for_owner,
-    ready_buildings_for_owner, set_rally_point_for_owner, theoretical_power_for_owner,
-    tick_production, tick_production_with_overlay_registry,
+    build_options_for_owner, credits_for_owner, enqueue_default_unit_for_owner,
+    has_strict_build_option_for_owner, power_balance_for_owner, queue_view_for_owner,
+    rally_point_for_owner, ready_buildings_for_owner, set_rally_point_for_owner,
+    theoretical_power_for_owner, tick_production, tick_production_with_overlay_registry,
 };
 pub(crate) use self::production_refinery::spawn_completed_refinery_free_units;
 pub(crate) use self::production_sell::{
@@ -60,9 +63,11 @@ pub use self::war_factory_exit::tick_war_factory_exit_contacts;
 
 // Re-exports for external consumers (files outside production/ that previously
 // imported private submodules directly).
+pub(in crate::sim) use self::factory_lifecycle::revalidate_and_step_factories;
+#[cfg(test)]
+pub(in crate::sim) use self::factory_lifecycle::construct_active_factory_fixture;
 #[cfg(test)]
 pub(crate) use self::production_economy::pick_best_resource_node;
-pub(in crate::sim) use self::production_queue::construct_and_link_active_factory_object;
 pub(in crate::sim) use self::production_queue::credits_entry_for_owner;
 pub(in crate::sim) use self::production_spawn::produced_unit_unlimbo_entry_at_resolved_cell;
 
@@ -88,3 +93,7 @@ mod placement_tests;
 #[cfg(test)]
 #[path = "production_replay_tests.rs"]
 mod replay_tests;
+
+#[cfg(test)]
+#[path = "factory_lifecycle_tests.rs"]
+mod lifecycle_tests;

--- a/src/sim/production/production_placement.rs
+++ b/src/sim/production/production_placement.rs
@@ -278,7 +278,8 @@ pub fn place_ready_building_with_overlays(
     }
     if obj.wall {
         let category = production_category_for_object(obj);
-        let Some(factory_entity_id) = ready_factory_entity(sim, owner_id, category, type_interned)
+        let Some(held) =
+            super::factory_lifecycle::ready_object(sim, owner_id, category, type_interned)
         else {
             return false;
         };
@@ -312,8 +313,7 @@ pub fn place_ready_building_with_overlays(
         // Wall placement consumes the factory-created BuildingClass into
         // overlay state; the constructor identity is destroyed, never
         // reconstructed at placement.
-        let _ = sim.discard_constructed_limbo(factory_entity_id);
-        return consume_ready_building(sim, rules, owner_id, type_interned, category);
+        return held.consume_after_wall_stamp(sim, rules);
     }
     let foundation_str: String = rules
         .object(type_id)
@@ -329,11 +329,12 @@ pub fn place_ready_building_with_overlays(
         foundation_str,
     );
     let category = production_category_for_object(obj);
-    let Some(new_sid) = ready_factory_entity(sim, owner_id, category, type_interned) else {
+    let Some(held) = super::factory_lifecycle::ready_object(sim, owner_id, category, type_interned)
+    else {
         return false;
     };
     let Some(new_sid) = sim.unlimbo_held_production_object(
-        new_sid,
+        held.entity_id(),
         rx,
         ry,
         0,
@@ -380,45 +381,7 @@ pub fn place_ready_building_with_overlays(
         crate::sim::superweapon::refresh_super_weapons_for_owner(sim, rules, owner_id);
     }
 
-    consume_ready_building(sim, rules, owner_id, type_interned, category)
-}
-
-fn ready_factory_entity(
-    sim: &Simulation,
-    owner_id: crate::sim::intern::InternedId,
-    category: ProductionCategory,
-    type_id: crate::sim::intern::InternedId,
-) -> Option<u64> {
-    let object = sim
-        .production
-        .factory_shadow
-        .view(owner_id, category)?
-        .object?;
-    (object.type_id == type_id)
-        .then_some(object.entity_id)
-        .flatten()
-        .filter(|&stable_id| sim.substrate.entities.contains(stable_id))
-}
-
-fn consume_ready_building(
-    sim: &mut Simulation,
-    rules: &RuleSet,
-    owner_id: crate::sim::intern::InternedId,
-    type_id: crate::sim::intern::InternedId,
-    category: ProductionCategory,
-) -> bool {
-    let Some(ready_queue) = sim.production.ready_by_owner.get_mut(&owner_id) else {
-        return false;
-    };
-    let Some(index) = ready_queue.iter().position(|&queued| queued == type_id) else {
-        return false;
-    };
-    ready_queue.remove(index);
-    if ready_queue.is_empty() {
-        sim.production.ready_by_owner.remove(&owner_id);
-    }
-    super::production_queue::advance_after_delivery(sim, rules, owner_id, category);
-    true
+    held.release_after_placement(sim, rules)
 }
 
 fn evaluate_building_placement(

--- a/src/sim/production/production_placement_tests.rs
+++ b/src/sim/production/production_placement_tests.rs
@@ -450,6 +450,7 @@ fn gsi_04_07_wall_placement_contract() -> (RuleSet, OverlayTypeRegistry) {
          1=CYCL\n\
          2=GAWALL\n\
          [GACNST]\n\
+         Factory=BuildingType\n\
          Strength=1000\n\
          Armor=wood\n\
          Foundation=2x2\n\
@@ -464,6 +465,7 @@ fn gsi_04_07_wall_placement_contract() -> (RuleSet, OverlayTypeRegistry) {
          Armor=concrete\n\
          Strength=300\n\
          Cost=100\n\
+         TechLevel=1\n\
          Foundation=1x1\n\
          Adjacent=8\n\
          GuardRange=5\n\
@@ -509,10 +511,8 @@ fn ready_building(sim: &mut Simulation, rules: &RuleSet, owner: &str, type_id: &
         .factory_shadow
         .enqueue(owner_id, category, type_id, 0, 1, cost);
     assert!(started, "test fixture arms one fresh factory head");
-    super::production_queue::construct_and_link_active_factory_object(
-        sim, rules, owner_id, category, type_id,
-    )
-    .expect("ready-building fixture constructs at StartProduction");
+    super::construct_active_factory_fixture(sim, rules, owner_id, category, type_id)
+        .expect("ready-building fixture constructs at StartProduction");
     assert!(
         sim.production
             .factory_shadow
@@ -569,6 +569,8 @@ fn completed_building_moves_into_ready_placement_pool() {
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 10, 10);
     let americans = sim.interner.intern("Americans");
     let gacnst = sim.interner.intern("GACNST");
+    *super::credits_entry_for_owner(&mut sim, "Americans") = 50_000;
+    let built_before = sim.houses[&americans].stats.built;
     // P5d: arm the Building build directly in the registry (queue-of-record), then force it
     // to the completed-held state so `tick_production` moves it into the ready-placement pool.
     super::tests::arm_build_via(
@@ -602,6 +604,27 @@ fn completed_building_moves_into_ready_placement_pool() {
             .collect::<Vec<_>>(),
         vec![gacnst]
     );
+    let held_id = held.object.unwrap().entity_id.unwrap();
+    let built = sim.houses[&americans].stats.built;
+    assert_eq!(built, built_before + 1);
+    let rng = sim.scenario_rng.logical_state();
+    for _ in 0..3 {
+        assert!(!tick_production(&mut sim, &rules, &height_map, None));
+    }
+    assert_eq!(sim.houses[&americans].stats.built, built);
+    assert_eq!(
+        super::lifecycle_tests::held_id(&sim, americans, ProductionCategory::Building),
+        held_id
+    );
+    assert_eq!(
+        sim.production.ready_by_owner[&americans]
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![gacnst]
+    );
+    assert_eq!(sim.sound_events.iter().filter(|event| matches!(event, crate::sim::world::SimSoundEvent::BuildingComplete { owner } if *owner == americans)).count(), 1);
+    assert_eq!(sim.scenario_rng.logical_state(), rng);
 }
 
 #[test]
@@ -620,7 +643,17 @@ fn place_ready_building_spawns_and_consumes_ready_item() {
         .view(americans, ProductionCategory::Building)
         .and_then(|view| view.object.and_then(|object| object.entity_id))
         .expect("Factory+0x58 identity exists before placement");
-    let rng_before_placement = sim.scenario_rng.logical_state();
+    super::tests::arm_build_via(
+        &mut sim,
+        &rules,
+        "Americans",
+        "GACNST",
+        ProductionCategory::Building,
+        100,
+        50,
+    );
+    let mut expected = sim.scenario_rng.clone();
+    let successor_word = (expected.next_u32() & 0xffff) as u16;
 
     assert!(place_ready_building_without_overlays(
         &mut sim,
@@ -632,7 +665,7 @@ fn place_ready_building_spawns_and_consumes_ready_item() {
         Some(&grid),
         &height_map,
     ));
-    assert_eq!(sim.scenario_rng.logical_state(), rng_before_placement);
+    assert_eq!(sim.scenario_rng.logical_state(), expected.logical_state());
     assert!(ready_buildings_for_owner(&sim, &rules, "Americans").is_empty());
 
     let structures = sim
@@ -660,6 +693,32 @@ fn place_ready_building_spawns_and_consumes_ready_item() {
         .expect("same held identity placed");
     assert_eq!((placed.position.rx, placed.position.ry), (20, 20));
     assert!(!placed.lifecycle.in_limbo);
+    let successor = super::lifecycle_tests::held_id(&sim, americans, ProductionCategory::Building);
+    assert!(successor > held_id);
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(successor)
+            .unwrap()
+            .techno_ctor_random_word,
+        successor_word
+    );
+    assert!(
+        sim.substrate
+            .entities
+            .get(successor)
+            .unwrap()
+            .lifecycle
+            .in_limbo
+    );
+    assert_eq!(
+        sim.production
+            .factory_shadow
+            .view(americans, ProductionCategory::Building)
+            .unwrap()
+            .progress,
+        0
+    );
 }
 
 #[test]
@@ -1908,12 +1967,28 @@ fn gsi_04_07_command_places_authoritative_owned_wall_without_entity() {
     let height_map = BTreeMap::new();
     let path_grid = PathGrid::new(64, 64);
     let mut sim = Simulation::new();
+    *super::credits_entry_for_owner(&mut sim, "Americans") = 50_000;
     spawn_structure(&mut sim, 1, "Americans", "GACNST", 10, 10);
     sim.overlay_grid = Some(OverlayGrid::new(64, 64));
     sim.resolved_terrain = Some(resolved_clear_grid_with_override(64, 64, |_| {}));
     ready_building(&mut sim, &rules, "Americans", "GAWALL");
     let owner = sim.interner.get("Americans").expect("owner");
     let type_id = sim.interner.get("GAWALL").expect("wall type");
+    let category =
+        super::production_tech::production_category_for_object(rules.object("GAWALL").unwrap());
+    let held = super::lifecycle_tests::held_id(&sim, owner, category);
+    assert!(super::enqueue_by_type(
+        &mut sim,
+        &rules,
+        "Americans",
+        "GAWALL"
+    ));
+    assert!(matches!(
+        super::production_tech::revalidate_eligibility(&sim, &rules, "Americans", "GAWALL"),
+        super::factory::BuildEligibility::Buildable
+    ));
+    let mut expected = sim.scenario_rng.clone();
+    let successor_word = (expected.next_u32() & 0xffff) as u16;
     let entities_before = sim.substrate.entities.len();
 
     let tick = sim.advance_tick(
@@ -1941,8 +2016,8 @@ fn gsi_04_07_command_places_authoritative_owned_wall_without_entity() {
     );
     assert_eq!(
         sim.substrate.entities.len(),
-        entities_before - 1,
-        "wall placement consumes the limbo Factory+0x58 BuildingClass into overlay state"
+        entities_before,
+        "wall consumes one held identity and constructs exactly one successor"
     );
     assert!(ready_buildings_for_owner(&sim, &rules, "Americans").is_empty());
     let cell = sim.overlay_grid.as_ref().unwrap().cell(12, 10);
@@ -1953,6 +2028,26 @@ fn gsi_04_07_command_places_authoritative_owned_wall_without_entity() {
         entity.type_ref == type_id && (entity.position.rx, entity.position.ry) == (12, 10)
     }));
     assert_eq!(tick.state_hash, sim.state_hash());
+    assert!(!sim.substrate.entities.contains(held));
+    let successor = super::lifecycle_tests::held_id(&sim, owner, category);
+    assert!(successor > held);
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(successor)
+            .unwrap()
+            .techno_ctor_random_word,
+        successor_word
+    );
+    assert_eq!(sim.scenario_rng.logical_state(), expected.logical_state());
+    assert_eq!(
+        sim.production
+            .factory_shadow
+            .view(owner, category)
+            .unwrap()
+            .progress,
+        0
+    );
 }
 
 #[test]
@@ -1985,6 +2080,9 @@ fn gsi_04_07_regular_wall_autofill_is_cardinal_ordered_bounded_and_consumes_once
         1,
         "fixture must begin with one authoritative completed wall"
     );
+    super::tests::arm_build_via(&mut sim, &rules, "Americans", "GAWALL", category, 100, 50);
+    let mut expected_rng = sim.scenario_rng.clone();
+    let successor_word = (expected_rng.next_u32() & 0xffff) as u16;
     let overlay_id = registry.id_for_name("GAWALL").expect("wall overlay");
     let origin = (18, 18);
     let endpoints = [(18, 13), (23, 18), (18, 23), (13, 18)];
@@ -2047,12 +2145,27 @@ fn gsi_04_07_regular_wall_autofill_is_cardinal_ordered_bounded_and_consumes_once
         ready_buildings_for_owner(&sim, &rules, "Americans").is_empty(),
         "the primary plus all fillers consume the one ready product"
     );
-    assert!(
+    let successor = super::lifecycle_tests::held_id(&sim, owner, category);
+    assert!(successor > held_id);
+    assert_eq!(
         sim.production
             .factory_shadow
             .view(owner, category)
-            .is_none_or(|view| view.object.is_none() && view.queue.is_empty()),
-        "wall placement must clear the authoritative completed factory object"
+            .unwrap()
+            .progress,
+        0
+    );
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(successor)
+            .unwrap()
+            .techno_ctor_random_word,
+        successor_word
+    );
+    assert_eq!(
+        sim.scenario_rng.logical_state(),
+        expected_rng.logical_state()
     );
     assert!(
         sim.substrate.entities.get(held_id).is_none(),

--- a/src/sim/production/production_queue.rs
+++ b/src/sim/production/production_queue.rs
@@ -1,7 +1,7 @@
-//! Production queue management: enqueue items, advance timers, spawn completed units.
+//! Production views, economy queries and completed mobile delivery.
 //!
-//! Core queue loop driven by `tick_production()`. Handles credit deduction,
-//! timer advancement with dynamic rate scaling, and completed-item dispatch.
+//! `tick_production()` dispatches completed factory output after the frame's
+//! charge sweep. Factory-held identity and accounting settle in factory_lifecycle.
 
 use std::collections::BTreeMap;
 #[cfg(test)]
@@ -13,18 +13,18 @@ use crate::sim::intern::InternedId;
 use crate::sim::miner::{ResourceNode, ResourceType};
 use crate::sim::world::Simulation;
 
+use super::PRODUCTION_STEPS;
+use super::factory_lifecycle::{self, enqueue_by_type};
 use super::production_economy::tick_resource_economy;
 use super::production_spawn::{
     ProductionDeliveryKind, find_helipad_for_aircraft, find_spawn_selection_for_owner_with_type,
     mark_war_factory_spawn_contact, unlimbo_held_naval_unit,
 };
 use super::production_tech::{
-    build_option_for_owner, build_time_base_frames, effective_time_to_build_frames_for_type,
-    estimated_real_time_ms, owner_matches_build_identity, production_category_for_object,
-    should_use_relaxed_build_mode, supports_live_production,
+    effective_time_to_build_frames_for_type, estimated_real_time_ms, owner_matches_build_identity,
+    production_category_for_object, should_use_relaxed_build_mode,
 };
 use super::production_types::*;
-use super::{CancelOutcome, PRODUCTION_STEPS};
 
 /// Set rally point for an owner's production output.
 pub fn set_rally_point_for_owner(sim: &mut Simulation, owner: &InternedId, rx: u16, ry: u16) {
@@ -93,12 +93,6 @@ pub(in crate::sim) fn credits_entry_for_owner<'a>(
     &mut sim.houses.get_mut(&key).unwrap().credits
 }
 
-pub(super) fn next_enqueue_order(sim: &mut Simulation) -> u64 {
-    let order = sim.production.next_enqueue_order;
-    sim.production.next_enqueue_order = sim.production.next_enqueue_order.saturating_add(1);
-    order
-}
-
 /// Legacy fixture adapter for tests that do not construct `OverlayGrid` and
 /// the parsed type registries. Production map load must never call this.
 ///
@@ -160,94 +154,6 @@ pub fn enqueue_default_unit_for_owner(
     let type_id: InternedId = pick_default_buildable_unit(sim, rules, owner)?;
     let type_str = sim.interner.resolve(type_id).to_string();
     enqueue_by_type(sim, rules, owner, &type_str).then_some(type_id)
-}
-
-/// Enqueue a specific unit type.
-pub fn enqueue_by_type(sim: &mut Simulation, rules: &RuleSet, owner: &str, type_id: &str) -> bool {
-    let relaxed: bool = should_use_relaxed_build_mode(sim, rules, owner);
-    let mode = if relaxed {
-        BuildMode::PrototypeRelaxed
-    } else {
-        BuildMode::Strict
-    };
-    if let Some(opt) = build_option_for_owner(sim, rules, owner, type_id, mode) {
-        if !opt.enabled {
-            return false;
-        }
-    } else {
-        return false;
-    }
-    let Some(obj) = rules.object(type_id) else {
-        return false;
-    };
-    if !supports_live_production(obj) {
-        return false;
-    }
-    let queue_category = production_category_for_object(obj);
-    let owner_credits = credits_for_owner(sim, owner);
-    if obj.cost <= 0 || owner_credits < obj.cost {
-        return false;
-    }
-    let total_base_frames: u32 = build_time_base_frames(rules, obj);
-    // The upfront debit is RETIRED at the authority flip: the per-step `advance_one_step`
-    // (driven by `step_all` at the Phase-7 head) charges the cost down over the build
-    // against the one wallet (`house.credits`). Enqueue only checks affordability (the
-    // can-afford-to-START gate above) and appends the queue item.
-    let owner_id = sim.interner.intern(owner);
-    let type_interned = sim.interner.intern(type_id);
-    let enqueue_order = next_enqueue_order(sim);
-    let cost = obj.cost.max(0);
-    // P5d: append directly to the registry queue-of-record (create-or-append). With no
-    // active build the registry arms it inline (the retired reconcile SEED); otherwise it
-    // joins the FIFO tail. No upfront debit (the per-step charge owns the cost).
-    let started = sim.production.factory_shadow.enqueue(
-        owner_id,
-        queue_category,
-        type_interned,
-        enqueue_order,
-        total_base_frames,
-        cost,
-    );
-    if started {
-        construct_and_link_active_factory_object(
-            sim,
-            rules,
-            owner_id,
-            queue_category,
-            type_interned,
-        )
-        .expect("validated StartProduction type must construct one Techno");
-    }
-    true
-}
-
-/// Materialize the exact Techno retained by an active factory head. Active
-/// retail `FactoryClass::StartProduction @ 0x004C9C70` calls
-/// `type->CreateInstance(owner)` at start and stores the result at
-/// `Factory+0x58`; queued tail entries do not construct until promoted by
-/// `FactoryClass::StartNextQueued @ 0x004CA5A0`.
-pub(in crate::sim) fn construct_and_link_active_factory_object(
-    sim: &mut Simulation,
-    rules: &RuleSet,
-    owner_id: InternedId,
-    category: ProductionCategory,
-    type_id: InternedId,
-) -> Option<u64> {
-    let owner = sim.interner.resolve(owner_id).to_string();
-    let type_name = sim.interner.resolve(type_id).to_string();
-    // A factory-held object is still in limbo and has no cell authority. Zero
-    // is only inert storage here; the result-bearing Unlimbo later installs the
-    // selected delivery/placement coordinate on this same stable identity.
-    let stable_id = sim.construct_object_limbo_at_height(&type_name, &owner, 0, 0, 0, 0, rules)?;
-    let linked = sim
-        .production
-        .factory_shadow
-        .link_active_entity(owner_id, category, stable_id);
-    if linked != Some(stable_id) {
-        let _ = sim.discard_constructed_limbo(stable_id);
-        return None;
-    }
-    Some(stable_id)
 }
 
 /// Build a production list across supported sidebar categories for an owner.
@@ -486,32 +392,8 @@ fn tick_production_impl(
         };
         let done_type_str = sim.interner.resolve(done_type).to_string();
         let produced_category = rules.object(&done_type_str).map(|o| o.category);
-        // Score-screen "Built" column. gamemd increments once when this factory
-        // item completes, before delivery. A refused Unlimbo retains the same
-        // completed object, so the serialized object-owned latch prevents each
-        // delivery retry from replaying the completion edge.
-        let first_completion = sim
-            .production
-            .factory_shadow
-            .account_completed_object_once(owner_id, queue_category);
-        if first_completion {
-            if let Some(house) = sim.houses.get_mut(&owner_id) {
-                house.stats.built = house.stats.built.saturating_add(1);
-            }
-        }
+        factory_lifecycle::publish_completion(sim, rules, owner_id, queue_category);
         if produced_category == Some(crate::rules::object_type::ObjectCategory::Building) {
-            // HouseClass keeps the completed Factory object until placement.
-            // The ready queue is only a UI/type projection; repeated delivery
-            // sweeps must neither duplicate it nor clear/promote the factory.
-            if first_completion {
-                sim.production
-                    .ready_by_owner
-                    .entry(owner_id)
-                    .or_default()
-                    .push_back(done_type);
-                sim.sound_events
-                    .push(crate::sim::world::SimSoundEvent::BuildingComplete { owner: owner_id });
-            }
             continue;
         }
         let is_vehicle =
@@ -532,11 +414,7 @@ fn tick_production_impl(
                 helipad_airfield = Some(af_id);
             } else {
                 // No free helipad — refund.
-                if let Some(obj) = rules.object(&done_type_str) {
-                    *credits_entry_for_owner(sim, &owner_str) += obj.cost.max(0);
-                }
-                discard_active_factory_entity(sim, owner_id, queue_category);
-                advance_after_delivery(sim, rules, owner_id, queue_category);
+                factory_lifecycle::refund_failed_delivery(sim, rules, owner_id, queue_category);
                 continue;
             }
         } else {
@@ -562,17 +440,14 @@ fn tick_production_impl(
                 if is_vehicle {
                     continue;
                 }
-                if let Some(obj) = rules.object(&done_type_str) {
-                    *credits_entry_for_owner(sim, &owner_str) += obj.cost.max(0);
-                }
-                discard_active_factory_entity(sim, owner_id, queue_category);
-                advance_after_delivery(sim, rules, owner_id, queue_category);
+                factory_lifecycle::refund_failed_delivery(sim, rules, owner_id, queue_category);
                 continue;
             }
         }
         let (rx, ry) = spawn_cell.unwrap();
 
-        let Some(stable_id) = active_factory_entity_id(sim, owner_id, queue_category) else {
+        let Some(stable_id) = factory_lifecycle::active_entity_id(sim, owner_id, queue_category)
+        else {
             debug_assert!(
                 false,
                 "active Factory object must own its StartProduction entity before delivery"
@@ -773,16 +648,12 @@ fn tick_production_impl(
                 }
             }
             spawned_any = true;
-            advance_after_delivery(sim, rules, owner_id, queue_category);
+            factory_lifecycle::release_delivered_mobile(sim, rules, owner_id, queue_category);
         } else {
             if is_vehicle {
                 continue;
             }
-            if let Some(obj) = rules.object(&done_type_str) {
-                *credits_entry_for_owner(sim, &owner_str) += obj.cost.max(0);
-            }
-            discard_active_factory_entity(sim, owner_id, queue_category);
-            advance_after_delivery(sim, rules, owner_id, queue_category);
+            factory_lifecycle::refund_failed_delivery(sim, rules, owner_id, queue_category);
         }
     }
 
@@ -790,59 +661,6 @@ fn tick_production_impl(
     // `queues_by_owner.retain` prune.
     sim.production.factory_shadow.prune_all_idle();
     spawned_any
-}
-
-fn active_factory_entity_id(
-    sim: &Simulation,
-    owner_id: InternedId,
-    category: ProductionCategory,
-) -> Option<u64> {
-    sim.production
-        .factory_shadow
-        .view(owner_id, category)
-        .and_then(|view| view.object.and_then(|object| object.entity_id))
-        .filter(|&stable_id| sim.substrate.entities.contains(stable_id))
-}
-
-fn discard_active_factory_entity(
-    sim: &mut Simulation,
-    owner_id: InternedId,
-    category: ProductionCategory,
-) {
-    if let Some(stable_id) = active_factory_entity_id(sim, owner_id, category) {
-        let discarded = sim.discard_constructed_limbo(stable_id);
-        debug_assert!(
-            discarded,
-            "factory-held object must remain in limbo until delivery"
-        );
-    }
-}
-
-/// C7 StartNextQueued after a successful delivery (or a completed-but-undeliverable refund):
-/// clear the delivered active object and promote the next queued entry into the active slot,
-/// cost-seeded from `rules`. Runs in `tick_production` (Phase 7, AFTER `step_all`), so the
-/// promoted build's cadence (`step_delay = 0`) starts on the NEXT tick's sweep — never the
-/// same tick it is promoted.
-pub(super) fn advance_after_delivery(
-    sim: &mut Simulation,
-    rules: &RuleSet,
-    owner_id: InternedId,
-    category: ProductionCategory,
-) {
-    let next_cost = sim
-        .production
-        .factory_shadow
-        .peek_next_queued(owner_id, category)
-        .map(|t| sim.object_type(t, rules).map_or(0, |o| o.cost.max(0)))
-        .unwrap_or(0);
-    let promoted = sim
-        .production
-        .factory_shadow
-        .clear_active_and_advance(owner_id, category, next_cost, 0);
-    if let Some(type_id) = promoted {
-        construct_and_link_active_factory_object(sim, rules, owner_id, category, type_id)
-            .expect("validated promoted production type must construct one Techno");
-    }
 }
 
 /// Build a queue snapshot for one owner, including progress metadata for UI.
@@ -970,184 +788,6 @@ pub fn ready_buildings_for_owner(
                 .collect()
         })
         .unwrap_or_default()
-}
-
-/// Cancel the most recently queued item for this owner.
-///
-/// Post-flip refund rule: a queued (tail) item was never charged, so removing it
-/// refunds NOTHING; only the active build (a single-item queue, where the most-recent
-/// item IS the front) is abandoned with the C8 PARTIAL refund (`original_balance -
-/// balance`) routed through the registry against the one wallet (`house.credits`).
-pub fn cancel_last_for_owner(sim: &mut Simulation, _rules: &RuleSet, owner: &str) -> bool {
-    let owner_id = sim.interner.intern(owner);
-    // P5d: the registry owns the queue-of-record. `cancel_last` finds the global-max stamp
-    // across the owner's factories (tail-back, else the active build) and removes it — a
-    // tail item uncharged (QueuedRemoved), the active build with the C8 PARTIAL refund. The
-    // abandon arm only fires for an empty tail, so no StartNextQueued advance is needed.
-    let mut registry = std::mem::take(&mut sim.production.factory_shadow);
-    let outcome = if let Some(house) = sim.houses.get_mut(&owner_id) {
-        let mut wallet = std::mem::take(&mut house.economy);
-        wallet.credits = house.credits;
-        let outcome = registry.cancel_last(owner_id, &mut wallet);
-        house.credits = wallet.credits;
-        house.economy = wallet;
-        outcome
-    } else {
-        let mut throwaway = crate::sim::economy::Economy::default();
-        registry.cancel_last(owner_id, &mut throwaway)
-    };
-    registry.prune_all_idle();
-    sim.production.factory_shadow = registry;
-    if let CancelOutcome::AbandonedActive {
-        entity_id: Some(entity_id),
-        ..
-    } = outcome
-    {
-        let discarded = sim.discard_constructed_limbo(entity_id);
-        debug_assert!(
-            discarded,
-            "AbandonProduction destroys the held limbo object"
-        );
-    }
-    matches!(
-        outcome,
-        CancelOutcome::QueuedRemoved | CancelOutcome::AbandonedActive { .. }
-    )
-}
-
-/// Route a cancel of `type_id` for (owner, category) through the registry `cancel_one`
-/// (the single precedence source: queued-tail FIRST, else active-abandon), charging the
-/// C8 partial refund (or none, for a queued copy) against the ONE wallet
-/// (`house.credits`) via a per-sweep `Economy` shim. The caller mirrors the resulting
-/// queue change into `queues_by_owner`.
-fn registry_cancel_active(
-    sim: &mut Simulation,
-    owner_id: InternedId,
-    category: ProductionCategory,
-    type_id: InternedId,
-) -> CancelOutcome {
-    let mut registry = std::mem::take(&mut sim.production.factory_shadow);
-    let outcome = if let Some(house) = sim.houses.get_mut(&owner_id) {
-        let mut wallet = std::mem::take(&mut house.economy);
-        wallet.credits = house.credits; // load the authoritative balance into the shim
-        let outcome = registry.cancel_one(owner_id, category, type_id, &mut wallet);
-        house.credits = wallet.credits; // store the (possibly refunded) balance back
-        house.economy = wallet;
-        outcome
-    } else {
-        // No house to refund into; the cancel still resolves the registry deterministically.
-        let mut throwaway = crate::sim::economy::Economy::default();
-        registry.cancel_one(owner_id, category, type_id, &mut throwaway)
-    };
-    sim.production.factory_shadow = registry;
-    outcome
-}
-
-/// Cancel one queued/active production of `type_id` for this owner (right-click cameo).
-///
-/// Routed through the registry `cancel_one` (the single precedence source): a QUEUED
-/// tail copy is removed FIRST (FIRST front-to-back match, NO refund — a queued item was
-/// never charged), else the ACTIVE build is abandoned with the C8 PARTIAL refund
-/// (`original_balance - balance`) into the one wallet (`house.credits`). This replaces
-/// the legacy `.rev()` last-match + full-cost refund (a DRIFT under the per-step charge).
-/// When neither matches (or the build is complete-but-held), falls back to the
-/// completed-building ready queue.
-pub fn cancel_by_type_for_owner(
-    sim: &mut Simulation,
-    rules: &RuleSet,
-    owner: &str,
-    type_id: &str,
-) -> bool {
-    let owner_id = sim.interner.intern(owner);
-    let type_interned = sim.interner.intern(type_id);
-    // The registry is keyed by ProductionCategory; resolve it from the type (the same
-    // routing `enqueue_by_type` used, so the item is in this category's queue).
-    let category = match rules.object(type_id) {
-        Some(obj) => production_category_for_object(obj),
-        None => return cancel_ready_by_type_for_owner(sim, rules, owner, type_id),
-    };
-
-    match registry_cancel_active(sim, owner_id, category, type_interned) {
-        CancelOutcome::QueuedRemoved => {
-            // A queued (tail) copy was removed in the registry; the active build keeps
-            // running. Sweep any now-idle factory (none here, but keep it uniform).
-            sim.production.factory_shadow.prune_all_idle();
-            true
-        }
-        CancelOutcome::AbandonedActive { entity_id, .. } => {
-            if let Some(entity_id) = entity_id {
-                let discarded = sim.discard_constructed_limbo(entity_id);
-                debug_assert!(
-                    discarded,
-                    "AbandonProduction destroys the held limbo object"
-                );
-            }
-            // C7: the active build was abandoned (object cleared, tail intact). Promote the
-            // next queued entry into the active slot, cost-seeded. EventClass
-            // dispatch is after this tick's `step_all`, so step_delay = 0
-            // charges the promoted build on the next gameplay frame.
-            advance_after_delivery(sim, rules, owner_id, category);
-            sim.production.factory_shadow.prune_all_idle();
-            true
-        }
-        CancelOutcome::NoMatch => {
-            // Not an active/queued build (or a complete-but-held one) -> the ready queue.
-            cancel_ready_by_type_for_owner(sim, rules, owner, type_id)
-        }
-    }
-}
-
-/// Cancel a completed building from the ready_by_owner queue (awaiting placement).
-/// Used as fallback when `cancel_by_type_for_owner` finds nothing in the build queue.
-fn cancel_ready_by_type_for_owner(
-    sim: &mut Simulation,
-    rules: &RuleSet,
-    owner: &str,
-    type_id: &str,
-) -> bool {
-    let owner_id = sim.interner.intern(owner);
-    let type_interned = sim.interner.intern(type_id);
-    let Some(ready_queue) = sim.production.ready_by_owner.get_mut(&owner_id) else {
-        return false;
-    };
-    // Remove last instance of this type (consistent with queue cancel using .rev()).
-    let ready_idx = ready_queue
-        .iter()
-        .enumerate()
-        .rev()
-        .find(|(_, tid)| **tid == type_interned)
-        .map(|(i, _)| i);
-    let Some(idx) = ready_idx else {
-        return false;
-    };
-    ready_queue.remove(idx);
-    if ready_queue.is_empty() {
-        sim.production.ready_by_owner.remove(&owner_id);
-    }
-    let category = rules
-        .object(type_id)
-        .map(production_category_for_object)
-        .unwrap_or(ProductionCategory::Building);
-    let held_entity_id = sim
-        .production
-        .factory_shadow
-        .view(owner_id, category)
-        .and_then(|view| view.object)
-        .filter(|object| object.type_id == type_interned)
-        .and_then(|object| object.entity_id);
-    // Refund full cost.
-    if let Some(obj) = rules.object(type_id) {
-        *credits_entry_for_owner(sim, owner) += obj.cost.max(0);
-    }
-    if let Some(entity_id) = held_entity_id {
-        let discarded = sim.discard_constructed_limbo(entity_id);
-        debug_assert!(
-            discarded,
-            "ready-building cancel destroys Factory+0x58 object"
-        );
-    }
-    advance_after_delivery(sim, rules, owner_id, category);
-    true
 }
 
 fn pick_default_buildable_unit(

--- a/src/sim/production/production_queue_tests.rs
+++ b/src/sim/production/production_queue_tests.rs
@@ -812,7 +812,7 @@ fn tick_production_advances_multiple_queue_categories_for_same_owner() {
 #[test]
 fn blocked_vehicle_delivery_keeps_completed_item_and_holds_next_queue_item() {
     let mut sim = Simulation::new();
-    let rules = basic_multi_queue_rules();
+    let rules = super::lifecycle_tests::manager_rules();
     let height_map: BTreeMap<(u16, u16), u8> = BTreeMap::new();
     let terrain = water_terrain(32, 32);
     let grid = PathGrid::from_resolved_terrain(&terrain);
@@ -850,6 +850,13 @@ fn blocked_vehicle_delivery_keeps_completed_item_and_holds_next_queue_item() {
             .test_arm_ready(americans_id, ProductionCategory::Vehicle)
     );
 
+    let held_id_before =
+        super::lifecycle_tests::held_id(&sim, americans_id, ProductionCategory::Vehicle);
+    let children_before = super::lifecycle_tests::children(&sim, held_id_before);
+    assert_eq!(children_before.len(), 3);
+    let owned_before = sim.houses[&americans_id].owned_unit_count;
+    let rng_before = sim.scenario_rng.clone();
+    let allocated_before = sim.substrate.next_stable_object_id;
     let spawned = tick_production(&mut sim, &rules, &height_map, Some(&grid));
     assert!(
         !spawned,
@@ -898,12 +905,26 @@ fn blocked_vehicle_delivery_keeps_completed_item_and_holds_next_queue_item() {
     let held = sim.substrate.entities.get(held_id).unwrap();
     assert!(held.lifecycle.in_limbo && !held.lifecycle.cell_marked);
     assert_eq!(sim.interner.resolve(held.type_ref), "MTNK");
+    for _ in 0..3 {
+        assert!(!tick_production(&mut sim, &rules, &height_map, Some(&grid)));
+    }
+    assert_eq!(
+        super::lifecycle_tests::held_id(&sim, americans_id, ProductionCategory::Vehicle),
+        held_id_before
+    );
+    assert_eq!(
+        super::lifecycle_tests::children(&sim, held_id_before),
+        children_before
+    );
+    assert_eq!(sim.scenario_rng.logical_state(), rng_before.logical_state());
+    assert_eq!(sim.substrate.next_stable_object_id, allocated_before);
+    assert_eq!(sim.houses[&americans_id].owned_unit_count, owned_before + 0);
 }
 
 #[test]
 fn pending_vehicle_delivery_success_consumes_completed_item_and_starts_next_item() {
     let mut sim = Simulation::new();
-    let rules = basic_multi_queue_rules();
+    let rules = super::lifecycle_tests::manager_rules();
     let height_map: BTreeMap<(u16, u16), u8> = BTreeMap::new();
     let mut terrain = water_terrain(32, 32);
     let blocked_grid = PathGrid::from_resolved_terrain(&terrain);
@@ -919,6 +940,7 @@ fn pending_vehicle_delivery_success_consumes_completed_item_and_starts_next_item
     spawn_structure(&mut sim, 1, "Americans", "GAWEAP", 10, 10);
 
     let americans_id = sim.interner.intern("Americans");
+    *super::credits_entry_for_owner(&mut sim, "Americans") = 50_000;
     // P5d: arm the front MTNK (active) then a second MTNK at a higher stamp (FIFO tail).
     arm_build_via(
         &mut sim,
@@ -947,9 +969,22 @@ fn pending_vehicle_delivery_success_consumes_completed_item_and_starts_next_item
             .test_arm_ready(americans_id, ProductionCategory::Vehicle)
     );
 
+    let held_id_before =
+        super::lifecycle_tests::held_id(&sim, americans_id, ProductionCategory::Vehicle);
+    let children_before = super::lifecycle_tests::children(&sim, held_id_before);
+    assert_eq!(children_before.len(), 3);
+    let owned_before = sim.houses[&americans_id].owned_unit_count;
+    let rng_before = sim.scenario_rng.clone();
+    let allocated_before = sim.substrate.next_stable_object_id;
     let blocked = tick_production(&mut sim, &rules, &height_map, Some(&blocked_grid));
     assert!(!blocked, "first delivery attempt should remain pending");
 
+    assert_eq!(
+        super::lifecycle_tests::children(&sim, held_id_before),
+        children_before
+    );
+    assert_eq!(sim.scenario_rng.logical_state(), rng_before.logical_state());
+    assert_eq!(sim.substrate.next_stable_object_id, allocated_before);
     for cell in &mut terrain.cells {
         cell.is_water = false;
         cell.land_type = crate::rules::terrain_rules::LandType::Clear.as_index();
@@ -1026,14 +1061,42 @@ fn pending_vehicle_delivery_success_consumes_completed_item_and_starts_next_item
     let projected = queue_view_for_owner(&sim, &rules, "Americans");
     assert_eq!(projected.len(), 1);
     assert_eq!(projected[0].state, BuildQueueState::Building);
+    assert!(
+        !sim.substrate
+            .entities
+            .get(held_id_before)
+            .unwrap()
+            .lifecycle
+            .in_limbo
+    );
+    assert_eq!(
+        super::lifecycle_tests::children(&sim, held_id_before),
+        children_before
+    );
+    let promoted_children = super::lifecycle_tests::children(&sim, promoted_id);
+    assert_eq!(promoted_children.len(), 3);
+    assert!(
+        promoted_children
+            .iter()
+            .all(|id| !children_before.contains(id))
+    );
+    let mut expected = rng_before;
+    for id in std::iter::once(promoted_id).chain(promoted_children) {
+        assert_eq!(
+            sim.substrate
+                .entities
+                .get(id)
+                .unwrap()
+                .techno_ctor_random_word,
+            (expected.next_u32() & 0xffff) as u16
+        );
+    }
+    assert_eq!(sim.scenario_rng.logical_state(), expected.logical_state());
+    assert_eq!(sim.houses[&americans_id].owned_unit_count, owned_before + 4);
 }
 
 #[test]
-#[ignore = "retired (P5b): tick_production no longer advances a frames timer, so the \
-            paused-vs-active frame delta this asserted is gone. Pause behaviour (a Paused front \
-            maps to a `manual` registry factory that never charges) is pinned by the \
-            registry-driven pause guard test."]
-fn paused_queue_category_does_not_advance_while_other_category_does() {
+fn paused_category_projection_and_factory_charge_remain_independent() {
     let mut sim = Simulation::new();
     let rules = basic_multi_queue_rules();
     let height_map: BTreeMap<(u16, u16), u8> = BTreeMap::new();
@@ -1042,6 +1105,7 @@ fn paused_queue_category_does_not_advance_while_other_category_does() {
     spawn_structure(&mut sim, 2, "Americans", "GAWEAP", 14, 10);
 
     let americans_id = sim.interner.intern("Americans");
+    *super::credits_entry_for_owner(&mut sim, "Americans") = 50_000;
     // P5d: arm both category factories directly in the registry.
     arm_build_via(
         &mut sim,
@@ -1066,7 +1130,14 @@ fn paused_queue_category_does_not_advance_while_other_category_does() {
         toggle_pause_for_owner_category(&mut sim, "Americans", ProductionCategory::Infantry);
     assert!(paused);
 
-    let _ = tick_production(&mut sim, &rules, &height_map, None);
+    // Run the actual frame owner, which now performs revalidation and charging.
+    sim.houses
+        .get_mut(&americans_id)
+        .unwrap()
+        .owned_building_count = 2;
+    for _ in 0..40 {
+        sim.advance_tick(&[], Some(&rules), &height_map, None, None, 67);
+    }
 
     // Project the registry to the sidebar view for state assertions (the per-item
     // `state`/`remaining_base_frames` mirror is retired).
@@ -1082,35 +1153,18 @@ fn paused_queue_category_does_not_advance_while_other_category_does() {
 
     assert_eq!(infantry.state, BuildQueueState::Paused);
     assert_eq!(vehicle.state, BuildQueueState::Building);
-    // P5D-REVIEW: ignored/retired test. The paused-vs-active per-frame delta (infantry 1000,
-    // vehicle 999) is gone: `tick_production` no longer advances a frames timer, so neither
-    // factory's `progress` moves here and both keep their full base-frame remainder. The
-    // remaining-frame value assertions are documented as no longer applicable; the live
-    // surviving assertion is that the paused category stays Paused while the other is Building.
-    let infantry_remaining = sim
+    let infantry = sim
         .production
         .factory_shadow
         .view(americans_id, ProductionCategory::Infantry)
-        .map(|v| {
-            let steps_left = super::factory::PRODUCTION_STEPS
-                .saturating_sub(v.progress.min(super::factory::PRODUCTION_STEPS))
-                as u64;
-            ((1000u64 * steps_left) / super::factory::PRODUCTION_STEPS as u64) as u32
-        })
-        .expect("infantry factory");
-    let vehicle_remaining = sim
+        .unwrap();
+    let vehicle = sim
         .production
         .factory_shadow
         .view(americans_id, ProductionCategory::Vehicle)
-        .map(|v| {
-            let steps_left = super::factory::PRODUCTION_STEPS
-                .saturating_sub(v.progress.min(super::factory::PRODUCTION_STEPS))
-                as u64;
-            ((1000u64 * steps_left) / super::factory::PRODUCTION_STEPS as u64) as u32
-        })
-        .expect("vehicle factory");
-    assert_eq!(infantry_remaining, 1000);
-    assert_eq!(vehicle_remaining, 1000);
+        .unwrap();
+    assert_eq!(infantry.progress, 0);
+    assert!(vehicle.progress > 0);
 }
 
 #[test]

--- a/src/sim/production/production_tests.rs
+++ b/src/sim/production/production_tests.rs
@@ -606,7 +606,7 @@ pub(super) fn arm_build_via(
         cost,
     );
     if started {
-        super::production_queue::construct_and_link_active_factory_object(
+        super::construct_active_factory_fixture(
             sim,
             rules,
             oid,

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -7167,33 +7167,7 @@ impl Simulation {
             // Frequency: only while a player is nearly broke with both a
             // factory and a repair running. Downstream risk: credit trajectory
             // and stall cadence, no lifecycle or RNG effect.
-            {
-                let mut registry = std::mem::take(&mut self.production.factory_shadow);
-                // P6: prereq/factory-loss revalidation BEFORE the charge sweep. Builds whose
-                // prerequisites or producing factory were lost are abandoned (partial refund)
-                // + now-unbuildable queued items dropped, so a freshly-abandoned factory is not
-                // charged this tick and a freshly-promoted one starts charging next tick.
-                let reval_plan = registry.plan_revalidation(self, rules);
-                let lifecycle = registry.apply_revalidation(&reval_plan, &mut self.houses);
-                for entity_id in lifecycle.discarded_entity_ids {
-                    let discarded = self.discard_constructed_limbo(entity_id);
-                    debug_assert!(
-                        discarded,
-                        "prerequisite AbandonProduction destroys its held limbo object"
-                    );
-                }
-                self.production.factory_shadow = registry;
-                for (owner, category, type_id) in lifecycle.promoted {
-                    production::construct_and_link_active_factory_object(
-                        self, rules, owner, category, type_id,
-                    )
-                    .expect("validated revalidation promotion must construct one Techno");
-                }
-                let mut registry = std::mem::take(&mut self.production.factory_shadow);
-                let prepared = registry.prepare_step_inputs(self, rules);
-                registry.step_all(&mut self.houses, &prepared);
-                self.production.factory_shadow = registry;
-            }
+            production::revalidate_and_step_factories(self, rules);
             spawned_entities |= production::tick_production_with_overlay_registry(
                 self,
                 rules,

--- a/src/sim/world/production_shadow_tests.rs
+++ b/src/sim/world/production_shadow_tests.rs
@@ -80,7 +80,7 @@ fn arm(
     let cost = sim.object_type(ty, rules).map_or(0, |o| o.cost.max(0));
     sim.production
         .factory_shadow
-        .enqueue(owner, cat, ty, order, total, cost);
+        .test_enqueue_kernel(owner, cat, ty, order, total, cost);
 }
 
 // ===== P1 — Economy shadow =====
@@ -707,7 +707,7 @@ fn factory_cancel_one_does_not_change_state_hash() {
     // fires (AbandonedActive).
     let mut reg = sim.production.factory_shadow.clone();
     let mut oracle = sim.houses[&owner].economy.clone();
-    let outcome = reg.cancel_one(owner, ProductionCategory::Vehicle, ty, &mut oracle);
+    let outcome = reg.test_cancel_one_kernel(owner, ProductionCategory::Vehicle, ty, &mut oracle);
     assert!(
         matches!(outcome, CancelOutcome::AbandonedActive { .. }),
         "the active build (no queued copy) is abandoned on the clone"
@@ -853,7 +853,8 @@ fn production_shadow_with_cancel_is_deterministic() {
                     .get(&owner)
                     .map(|h| h.economy.clone())
                     .unwrap_or_default();
-                let _ = reg.cancel_one(owner, ProductionCategory::Vehicle, ty, &mut oracle);
+                let _ =
+                    reg.test_cancel_one_kernel(owner, ProductionCategory::Vehicle, ty, &mut oracle);
                 sim.state_hash()
             })
             .collect()


### PR DESCRIPTION
Factory queue decisions previously left callers responsible for constructing or destroying held entities, refunding credits, removing ready projections and promoting successors. The frame driver also coordinated revalidation disposal and construction directly. These operations now finish in one production lifecycle owner, including once-only completion publication and manager-child cleanup. Delivery and placement retain their existing world effects and timing, then settle the matched held identity through that owner.

The registry retains queue/charge algorithms. Constructor, discard and promotion helpers are private; external fixture construction is explicitly test-only. Three terminal-delivery refund/discard/promotion chains share one operation. Wall placement consumes the held object after overlay/autofill effects; ordinary placement preserves the revealed object. Revalidation still disposes every abandoned graph before constructing any successor.

Validation covers real enqueue/cancel/delivery and frame-command/revalidation paths, parent/SpawnManager/SlaveManager identities and counts, partial/full refunds, blocked retry, once-only completion, promotion timing and exact Rust RNG continuation. The obsolete paused-queue timing test now exercises the current frame charge path. Existing behavioral coverage is retained. These are behavior-preservation checks, not a new claim of full native parity. Native lifecycle evidence: FACTORY_CREDIT_SYSTEM_GHIDRA_REPORT.md (StartProduction 0x004C9C70, AbandonProduction 0x004CA0E0, StartNextQueued 0x004CA5A0).

Independent read-only source and validation critics reviewed the actual diff and production consumers. A preexisting malformed-save ready/factory correspondence gap remains explicitly open for restore admission work; this change preserves cancellation fallback behavior.

Final candidate validation: cargo check -p vera20k --lib passed (22.25s). Focused production tests: test result: ok. 211 passed; 0 failed; 5 ignored; 0 measured; 8318 filtered out; finished in 0.27s. Final cargo test -p vera20k --lib: test result: ok. 8454 passed; 0 failed; 80 ignored; 0 measured; 0 filtered out; finished in 25.72s. System-map check retains the same 43 baseline issues (no new severity/code/message/record/path or count; inserted array entries shift diagnostic indices). Final source matches tested 73b82957; origin/main refreshed and remains 05bf664d.

