### PR TITLE
Validate factory relationships before restoring a match

### DIFF
--- a/docs/system-map/topology.v2.json
+++ b/docs/system-map/topology.v2.json
@@ -433,9 +433,9 @@
       "rust_surfaces": [
         {
           "path": "src/sim/production/factory_lifecycle.rs",
-          "symbol": "enqueue_by_type / publish_completion / ReadyFactoryObject / revalidate_and_step_factories",
+          "symbol": "enqueue_by_type / publish_completion / ReadyFactoryObject / revalidate_and_step_factories / validate_restored_factory_state",
           "coverage": "representative",
-          "observed_at_commit": "73b82957923a824bd4a8a1fddd966b063a497d9f"
+          "observed_at_commit": "923731fb3fc9f5599ff2e29ffc85a1de678daace"
         },
         {
           "path": "src/sim/production/production_placement.rs",
@@ -457,7 +457,7 @@
         }
       ],
       "notes": [
-        "Factory-held construction, cancellation, completion publication and release now finish in factory_lifecycle. Registry lifecycle kernels are production-private; placement settles the matched identity after its world effects. This preserves phase order and does not close malformed-save admission or whole-loop parity.",
+        "Factory-held construction, cancellation, completion publication and release now finish in factory_lifecycle. Registry lifecycle kernels are production-private; placement settles the matched identity after its world effects. This preserves phase order. Before match commit, the same production owner validates loaded factory roots, ready publication and queued type relationships; universal snapshot validation and whole-loop parity remain unclaimed.",
         "Owner of build-ready, placement legality, rejection, and committed foundation handoff.",
         "Feature 12948d89 closes ordinary marked Ground-mobile and live nonempty-overlay rejection in the shared preview/commit predicate, with a sealed-retail Dustbowl GAPOWR oracle through lifecycle, four-cell occupancy, buildup, and power.",
         "Special damaged-wall/ToTile/LaserFence/gate exceptions, delayed-command rejection UI/EVA, and active-retail input/pixel comparison remain explicit residuals."
@@ -1924,6 +1924,10 @@
         "swizzle registrar 0x006CF240"
       ],
       "rust_touchpoints": [
+        {"path": "src/app/persistence/mod.rs", "coverage": "representative", "observed_at_commit": "923731fb3fc9f5599ff2e29ffc85a1de678daace"},
+        {"path": "src/app/persistence/commands.rs", "coverage": "representative", "observed_at_commit": "923731fb3fc9f5599ff2e29ffc85a1de678daace"},
+        {"path": "src/sim/production/factory_lifecycle.rs", "coverage": "representative", "observed_at_commit": "923731fb3fc9f5599ff2e29ffc85a1de678daace"},
+        {"path": "src/app/persistence/tests/factory_restore_tests.rs", "coverage": "representative", "observed_at_commit": "923731fb3fc9f5599ff2e29ffc85a1de678daace"},
         {"path": "src/app_save_load_panel.rs", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},
         {"path": "src/sim/snapshot.rs", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},
         {"path": "src/sim/world/mod.rs", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},
@@ -1933,7 +1937,7 @@
         {"order": 1, "system": "GSI-14.12", "action": "Invoke in-game save/load flow."},
         {"order": 2, "system": "GSI-03.08", "action": "Select slot and metadata."},
         {"order": 3, "system": "GSI-17.02", "action": "Serialize object/class state."},
-        {"order": 4, "system": "GSI-17.03", "action": "Persist/fix references and identity."},
+        {"order": 4, "system": "GSI-17.03", "action": "Persist/fix references and identity; after generic reference restoration, the production owner validates factory root, ready and queued type relationships before match commit."},
         {"order": 5, "system": "GSI-17.04", "action": "Restore globals, caches, and registrations."},
         {"order": 6, "system": "GSI-05.02", "action": "Restore active-object order."},
         {"order": 7, "system": "GSI-05.03", "action": "Restore lifecycle membership."},
@@ -1942,7 +1946,7 @@
       ],
       "oracle": {
         "status": "UNVERIFIED",
-        "gate": "Rust bincode snapshot regression is not native SAV parity; membership-byte restoration remains unresolved."
+        "gate": "Factory relationship admission is Rust regression-tested through PreparedLoad, including preservation of the running match on rejection. Rust bincode snapshot regression is not native SAV parity; membership-byte restoration remains unresolved."
       },
       "evidence": [
         "docs/research/SAVELOAD_LOGIC_ACTIVE_VECTOR_RECONSTRUCTION_GHIDRA_REPORT.md",

--- a/src/app/persistence/commands.rs
+++ b/src/app/persistence/commands.rs
@@ -197,5 +197,8 @@ fn log_prepared_load_error(
         PreparedLoadError::Restore(source) => {
             log::error!("Load: restoration validation failed: {source}")
         }
+        PreparedLoadError::FactoryState(source) => {
+            log::error!("Load: restoration validation failed: {source}")
+        }
     }
 }

--- a/src/app/persistence/mod.rs
+++ b/src/app/persistence/mod.rs
@@ -102,6 +102,8 @@ pub(crate) enum PreparedLoadError {
     Snapshot(#[from] SnapshotError),
     #[error(transparent)]
     Restore(#[from] SnapshotRestoreError),
+    #[error(transparent)]
+    FactoryState(#[from] crate::sim::production::FactoryRestoreError),
 }
 
 /// Fully validated, cache-rebuilt replacement state ready for one infallible commit.
@@ -225,6 +227,7 @@ impl PreparedLoad {
         // seed and Main/MapGen cursors retain their live values.
         simulation.retain_in_scenario_process_state_from(current_simulation);
         simulation.restore_after_snapshot_load()?;
+        crate::sim::production::validate_restored_factory_state(&simulation, rules)?;
         simulation.rebuild_caches_after_load(
             terrain_template,
             terrain_speed_config,
@@ -649,6 +652,8 @@ mod tests {
         last_loaded_save_path: Option<PathBuf>,
         save_list_dirty: bool,
     }
+
+    mod factory_restore_tests;
 
     fn load_fixture_rules() -> RuleSet {
         let ini = IniFile::from_str(

--- a/src/app/persistence/tests/factory_restore_tests.rs
+++ b/src/app/persistence/tests/factory_restore_tests.rs
@@ -1,0 +1,600 @@
+use super::*;
+use crate::sim::intern::InternedId;
+use crate::sim::production::{Factory, PRODUCTION_STEPS, ProductionCategory};
+
+fn factory_fixture(
+    type_name: &str,
+    category: ProductionCategory,
+) -> (Simulation, RuleSet, InternedId, u64) {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=SLAV\n1=E1\n\
+         [VehicleTypes]\n0=MTNK\n[AircraftTypes]\n0=HORN\n\
+         [BuildingTypes]\n0=PARENT\n1=OTHER\n2=DEFENSE\n\
+         [PARENT]\nCost=1000\nStrength=2000\nFoundation=1x1\nTechLevel=1\n\
+         Enslaves=SLAV\nSlavesNumber=2\nSlaveRegenRate=500\nSlaveReloadRate=25\n\
+         [OTHER]\nCost=500\nStrength=1000\nFoundation=1x1\nTechLevel=1\n\
+         [DEFENSE]\nCost=500\nStrength=1000\nFoundation=1x1\nBuildCat=Combat\nTechLevel=1\n\
+         [SLAV]\nStrength=125\nSpeed=4\nStorage=4\n\
+         [E1]\nCost=200\nStrength=125\nSpeed=4\nTechLevel=1\n\
+         [MTNK]\nCost=700\nStrength=300\nSpeed=6\nTechLevel=1\nSpawns=HORN\nSpawnsNumber=2\n\
+         [HORN]\nStrength=75\nSpeed=14\n",
+    ))
+    .expect("factory restore fixture rules");
+    let mut saved = load_fixture_simulation(true);
+    saved.intern_rule_type_ids(&rules);
+    saved.resolve_type_handles(&rules);
+    let owner = saved.interner.intern("Americans");
+    saved.houses.insert(
+        owner,
+        crate::sim::house_state::HouseState::new(owner, 0, None, true, 50_000, 10),
+    );
+    let parent = saved
+        .construct_object_limbo_at_height(type_name, "Americans", 0, 0, 0, 0, &rules)
+        .expect("construct actual held graph");
+    let type_id = saved.interner.get(type_name).unwrap();
+    let cost = rules.object(type_name).unwrap().cost;
+    assert!(
+        saved
+            .production
+            .factory_shadow
+            .test_enqueue_kernel(owner, category, type_id, 1, 100, cost,)
+    );
+    saved
+        .production
+        .factory_shadow
+        .test_factory_mut(owner, category)
+        .unwrap()
+        .object
+        .as_mut()
+        .unwrap()
+        .entity_id = Some(parent);
+    saved.production.next_enqueue_order = 2;
+    (saved, rules, owner, parent)
+}
+
+fn prepare_saved(
+    saved: &Simulation,
+    rules: RuleSet,
+    label: &str,
+) -> Result<PreparedLoad, PreparedLoadError> {
+    let mut state = RunningMatchTestState::running(&rules);
+    let directory = isolated_directory(label);
+    let repository = SaveRepository::at(&directory);
+    let path = repository
+        .write_named("factory.bin", &snapshot_bytes(saved, &rules))
+        .expect("write matching-header snapshot");
+    state.runtime.resources.rules = rules;
+    state.runtime.resources.overlay_registry = OverlayTypeRegistry::empty();
+    state.runtime.resources.terrain_template = Some(load_fixture_terrain());
+    let before = state.baseline();
+    let result = PreparedLoad::from_repository(
+        LoadPreparationView::from_runtime(
+            &repository,
+            Some(&state.runtime),
+            Some(LOAD_FIXTURE_MAP_HASH),
+        ),
+        &path,
+    );
+    assert_eq!(
+        state.baseline(),
+        before,
+        "preparation mutated running match: {label}"
+    );
+    std::fs::remove_file(&path).unwrap();
+    std::fs::remove_dir(&directory).unwrap();
+    result
+}
+
+#[test]
+fn factory_restore_rejects_unrelated_ready_projection_before_match_commit() {
+    let (mut saved, rules, owner, parent) = factory_fixture("PARENT", ProductionCategory::Building);
+    assert_eq!(saved.production.slave_bindings[&parent].len(), 2);
+    let missing = saved.interner.intern("REMOVED_TYPE");
+    saved
+        .production
+        .ready_by_owner
+        .insert(owner, [missing].into());
+    let error = match prepare_saved(&saved, rules, "factory-invalid-ready") {
+        Ok(_) => panic!("malformed ready projection was admitted"),
+        Err(error) => error,
+    };
+    assert!(
+        matches!(error, PreparedLoadError::FactoryState(ref error)
+        if error.owner == owner && error.reason == "ready type is absent from bound rules"),
+        "{error}"
+    );
+}
+
+#[test]
+fn factory_restore_preserves_supported_held_states_and_constructor_graphs() {
+    for (label, type_name, category) in [
+        ("active-tail", "PARENT", ProductionCategory::Building),
+        (
+            "unpublished-complete",
+            "PARENT",
+            ProductionCategory::Building,
+        ),
+        ("ready-building", "PARENT", ProductionCategory::Building),
+        ("ready-defense", "DEFENSE", ProductionCategory::Defense),
+        ("mobile-retry", "MTNK", ProductionCategory::Vehicle),
+        ("absent-house", "E1", ProductionCategory::Infantry),
+        ("retained-playfield", "E1", ProductionCategory::Infantry),
+        ("damaged-held", "E1", ProductionCategory::Infantry),
+        ("unrelated-limbo", "PARENT", ProductionCategory::Building),
+        ("empty-registry", "PARENT", ProductionCategory::Building),
+    ] {
+        let (mut saved, rules, owner, parent) = factory_fixture(type_name, category);
+        match label {
+            "active-tail" => {
+                let type_id = saved.interner.get(type_name).unwrap();
+                assert!(
+                    !saved
+                        .production
+                        .factory_shadow
+                        .test_enqueue_kernel(owner, category, type_id, 2, 100, 1000)
+                );
+                saved.production.next_enqueue_order = 3;
+            }
+            "unpublished-complete" | "ready-building" | "ready-defense" | "mobile-retry" => {
+                assert!(
+                    saved
+                        .production
+                        .factory_shadow
+                        .test_arm_ready(owner, category)
+                );
+                if label != "unpublished-complete" {
+                    assert!(!crate::sim::production::tick_production(
+                        &mut saved,
+                        &rules,
+                        &Default::default(),
+                        None
+                    ));
+                    assert!(
+                        saved
+                            .production
+                            .factory_shadow
+                            .view(owner, category)
+                            .unwrap()
+                            .object
+                            .unwrap()
+                            .completion_accounted
+                    );
+                }
+            }
+            "retained-playfield" => {
+                saved
+                    .substrate
+                    .entities
+                    .get_mut(parent)
+                    .unwrap()
+                    .in_playfield = true;
+            }
+            "absent-house" => {
+                saved.houses.remove(&owner);
+            }
+            "damaged-held" => {
+                // Current coordinate-based superweapon ingress can create this
+                // live state; admission must not reclassify it as save corruption.
+                let entity = saved.substrate.entities.get_mut(parent).unwrap();
+                entity.health.current = 0;
+                entity.dying = true;
+            }
+            "unrelated-limbo" => {
+                saved
+                    .construct_object_limbo_at_height("MTNK", "Americans", 0, 0, 0, 0, &rules)
+                    .unwrap();
+            }
+            "empty-registry" => {
+                saved.production.factory_shadow = Default::default();
+            }
+            _ => unreachable!(),
+        }
+        let factories: Vec<Factory> = saved
+            .production
+            .factory_shadow
+            .iter_insertion_ordered()
+            .into_iter()
+            .cloned()
+            .collect();
+        let ready = saved.production.ready_by_owner.clone();
+        // MatchStatistics is skipped by the existing snapshot format; this
+        // admission change preserves the serialized counts and wallet only.
+        let counts = saved.houses.get(&owner).map(|house| {
+            (
+                house.owned_building_count,
+                house.owned_unit_count,
+                house.credits,
+            )
+        });
+        let identities: Vec<_> = saved
+            .substrate
+            .entities
+            .values()
+            .map(|entity| {
+                (
+                    entity.stable_id(),
+                    entity.type_ref,
+                    entity.owner(),
+                    entity.health.current,
+                    entity.dying,
+                    entity.lifecycle,
+                    entity.in_playfield,
+                    entity.techno_ctor_random_word,
+                    entity.spawn_owner_id,
+                    entity.spawn_manager.as_ref().map(|manager| {
+                        manager
+                            .slots
+                            .iter()
+                            .map(|slot| slot.spawn)
+                            .collect::<Vec<_>>()
+                    }),
+                    entity.slave_harvester.as_ref().map(|slave| slave.master_id),
+                )
+            })
+            .collect();
+        let prepared =
+            prepare_saved(&saved, rules, label).unwrap_or_else(|error| panic!("{label}: {error}"));
+        let restored = &prepared.simulation;
+        assert_eq!(
+            restored
+                .production
+                .factory_shadow
+                .iter_insertion_ordered()
+                .into_iter()
+                .cloned()
+                .collect::<Vec<_>>(),
+            factories,
+            "{label}"
+        );
+        assert_eq!(restored.production.ready_by_owner, ready, "{label}");
+        assert_eq!(
+            restored.houses.get(&owner).map(|house| (
+                house.owned_building_count,
+                house.owned_unit_count,
+                house.credits,
+            )),
+            counts,
+            "{label}"
+        );
+        assert_eq!(
+            restored
+                .substrate
+                .entities
+                .values()
+                .map(|entity| (
+                    entity.stable_id(),
+                    entity.type_ref,
+                    entity.owner(),
+                    entity.health.current,
+                    entity.dying,
+                    entity.lifecycle,
+                    entity.in_playfield,
+                    entity.techno_ctor_random_word,
+                    entity.spawn_owner_id,
+                    entity.spawn_manager.as_ref().map(|manager| manager
+                        .slots
+                        .iter()
+                        .map(|slot| slot.spawn)
+                        .collect::<Vec<_>>()),
+                    entity.slave_harvester.as_ref().map(|slave| slave.master_id),
+                ))
+                .collect::<Vec<_>>(),
+            identities,
+            "{label}"
+        );
+        assert_eq!(
+            restored.production.slave_bindings, saved.production.slave_bindings,
+            "{label}"
+        );
+    }
+}
+
+#[test]
+fn factory_restore_rejects_inconsistent_roots_and_ready_relationships() {
+    for label in [
+        "key-owner",
+        "idle-owner-index",
+        "ready-owner-index",
+        "tail-unknown-type",
+        "tail-type-index",
+        "tail-category",
+        "active-category",
+        "duplicate-roots",
+        "revealed-root",
+        "marked-root",
+        "logic-root",
+        "missing-entity",
+        "key-category",
+        "no-identity",
+        "unknown-active-type",
+        "wrong-type",
+        "wrong-owner",
+        "concrete-category",
+        "manager-owned-root",
+        "child-root-alias",
+        "tail-without-head",
+        "ready-no-factory",
+        "ready-no-head",
+        "ready-mismatch",
+        "ready-nonbuilding",
+        "duplicate-ready",
+        "early-ready",
+        "unaccounted-ready",
+        "missing-ready",
+        "early-accounting",
+    ] {
+        let (mut saved, rules, owner, parent) =
+            factory_fixture("PARENT", ProductionCategory::Building);
+        let category = ProductionCategory::Building;
+        let parent_type = saved.interner.get("PARENT").unwrap();
+        let other = saved.interner.get("OTHER").unwrap();
+        let foreign = saved.interner.intern("Russians");
+        let missing = saved.interner.intern("REMOVED_TYPE");
+        if (label.starts_with("ready-") && label != "ready-owner-index")
+            || matches!(
+                label,
+                "duplicate-ready" | "early-ready" | "unaccounted-ready"
+            )
+        {
+            assert!(
+                saved
+                    .production
+                    .factory_shadow
+                    .test_arm_ready(owner, category)
+            );
+            assert!(!crate::sim::production::tick_production(
+                &mut saved,
+                &rules,
+                &Default::default(),
+                None
+            ));
+        }
+        match label {
+            "idle-owner-index" => {
+                let invalid_owner = InternedId::from_index(u32::MAX);
+                saved.production.factory_shadow.test_enqueue_kernel(
+                    invalid_owner,
+                    category,
+                    parent_type,
+                    3,
+                    100,
+                    1000,
+                );
+                saved
+                    .production
+                    .factory_shadow
+                    .test_factory_mut(invalid_owner, category)
+                    .unwrap()
+                    .object = None;
+            }
+            "ready-owner-index" => {
+                saved.production.ready_by_owner.clear();
+                saved
+                    .production
+                    .ready_by_owner
+                    .insert(InternedId::from_index(u32::MAX), Default::default());
+            }
+            "tail-unknown-type" | "tail-type-index" | "tail-category" => {
+                let queued_type = match label {
+                    "tail-unknown-type" => missing,
+                    "tail-type-index" => InternedId::from_index(u32::MAX),
+                    _ => saved.interner.get("E1").unwrap(),
+                };
+                assert!(!saved.production.factory_shadow.test_enqueue_kernel(
+                    owner,
+                    category,
+                    queued_type,
+                    2,
+                    100,
+                    200
+                ));
+            }
+            "active-category" => {
+                saved
+                    .production
+                    .factory_shadow
+                    .test_first_mut()
+                    .unwrap()
+                    .object
+                    .as_mut()
+                    .unwrap()
+                    .type_id = saved.interner.get("E1").unwrap()
+            }
+            "duplicate-roots" => {
+                saved.production.factory_shadow.test_enqueue_kernel(
+                    foreign,
+                    category,
+                    parent_type,
+                    3,
+                    100,
+                    1000,
+                );
+                saved
+                    .production
+                    .factory_shadow
+                    .test_factory_mut(foreign, category)
+                    .unwrap()
+                    .object
+                    .as_mut()
+                    .unwrap()
+                    .entity_id = Some(parent);
+            }
+            "revealed-root" => {
+                saved
+                    .substrate
+                    .entities
+                    .get_mut(parent)
+                    .unwrap()
+                    .lifecycle
+                    .in_limbo = false
+            }
+            "marked-root" => {
+                let order = saved.substrate.next_occupancy_enter_order.next();
+                let entity = saved.substrate.entities.get_mut(parent).unwrap();
+                entity.occupancy_enter_order = order;
+                entity.lifecycle.cell_marked = true;
+            }
+            "logic-root" => saved.set_logic_order_for_test(vec![parent]),
+            "missing-entity" => {
+                saved
+                    .production
+                    .factory_shadow
+                    .test_first_mut()
+                    .unwrap()
+                    .object
+                    .as_mut()
+                    .unwrap()
+                    .entity_id = Some(u64::MAX)
+            }
+            "key-owner" => {
+                saved
+                    .production
+                    .factory_shadow
+                    .test_first_mut()
+                    .unwrap()
+                    .owner = foreign
+            }
+            "key-category" => {
+                saved
+                    .production
+                    .factory_shadow
+                    .test_first_mut()
+                    .unwrap()
+                    .category = ProductionCategory::Infantry
+            }
+            "no-identity" => {
+                saved
+                    .production
+                    .factory_shadow
+                    .test_first_mut()
+                    .unwrap()
+                    .object
+                    .as_mut()
+                    .unwrap()
+                    .entity_id = None
+            }
+            "unknown-active-type" => {
+                saved
+                    .production
+                    .factory_shadow
+                    .test_first_mut()
+                    .unwrap()
+                    .object
+                    .as_mut()
+                    .unwrap()
+                    .type_id = missing
+            }
+            "wrong-type" => saved.substrate.entities.get_mut(parent).unwrap().type_ref = other,
+            "wrong-owner" => saved.substrate.entities.get_mut(parent).unwrap().owner = foreign,
+            "concrete-category" => {
+                saved.substrate.entities.get_mut(parent).unwrap().category =
+                    crate::map::entities::EntityCategory::Infantry
+            }
+            "manager-owned-root" => {
+                saved
+                    .substrate
+                    .entities
+                    .get_mut(parent)
+                    .unwrap()
+                    .spawn_owner_id = Some(parent)
+            }
+            "child-root-alias" => {
+                saved.production.slave_bindings.get_mut(&parent).unwrap()[0] = parent
+            }
+            "tail-without-head" => {
+                saved.production.factory_shadow.test_enqueue_kernel(
+                    owner,
+                    category,
+                    parent_type,
+                    2,
+                    100,
+                    1000,
+                );
+                saved
+                    .production
+                    .factory_shadow
+                    .test_first_mut()
+                    .unwrap()
+                    .object = None;
+            }
+            "ready-no-factory" => saved.production.factory_shadow = Default::default(),
+            "ready-no-head" => {
+                saved
+                    .production
+                    .factory_shadow
+                    .test_first_mut()
+                    .unwrap()
+                    .object = None
+            }
+            "ready-mismatch" => {
+                *saved
+                    .production
+                    .ready_by_owner
+                    .get_mut(&owner)
+                    .unwrap()
+                    .front_mut()
+                    .unwrap() = other
+            }
+            "ready-nonbuilding" => {
+                *saved
+                    .production
+                    .ready_by_owner
+                    .get_mut(&owner)
+                    .unwrap()
+                    .front_mut()
+                    .unwrap() = saved.interner.get("E1").unwrap()
+            }
+            "duplicate-ready" => saved
+                .production
+                .ready_by_owner
+                .get_mut(&owner)
+                .unwrap()
+                .push_back(parent_type),
+            "early-ready" => {
+                saved
+                    .production
+                    .factory_shadow
+                    .test_first_mut()
+                    .unwrap()
+                    .progress = 1
+            }
+            "unaccounted-ready" => {
+                saved
+                    .production
+                    .factory_shadow
+                    .test_first_mut()
+                    .unwrap()
+                    .object
+                    .as_mut()
+                    .unwrap()
+                    .completion_accounted = false
+            }
+            "missing-ready" => {
+                let factory = saved.production.factory_shadow.test_first_mut().unwrap();
+                factory.progress = PRODUCTION_STEPS;
+                factory.object.as_mut().unwrap().completion_accounted = true;
+            }
+            "early-accounting" => {
+                saved
+                    .production
+                    .factory_shadow
+                    .test_first_mut()
+                    .unwrap()
+                    .object
+                    .as_mut()
+                    .unwrap()
+                    .completion_accounted = true
+            }
+            _ => unreachable!(),
+        }
+        match prepare_saved(&saved, rules, label) {
+            Err(PreparedLoadError::FactoryState(_)) => {}
+            Err(PreparedLoadError::Restore(SnapshotRestoreError::UnresolvedObjectReference {
+                source_registry: "FactoryRegistry",
+                ..
+            })) if label == "missing-entity" => {}
+            Err(error) => panic!("{label}: unexpected earlier failure {error}"),
+            Ok(_) => panic!("{label}: inconsistent factory was admitted"),
+        }
+    }
+}

--- a/src/sim/production/factory.rs
+++ b/src/sim/production/factory.rs
@@ -538,6 +538,14 @@ pub(crate) struct RevalAction {
 }
 
 impl FactoryRegistry {
+    /// Saved keys participate in factory identity; restoration must validate
+    /// them against the embedded values before accepting world relationships.
+    pub(super) fn keyed_factories(
+        &self,
+    ) -> impl Iterator<Item = (&(InternedId, ProductionCategory), &Factory)> {
+        self.factories.iter()
+    }
+
     /// Seed the queue kernel without constructing a world object. External
     /// fixtures explicitly finish construction when their scenario requires it.
     #[cfg(test)]

--- a/src/sim/production/factory_lifecycle.rs
+++ b/src/sim/production/factory_lifecycle.rs
@@ -520,3 +520,182 @@ pub(in crate::sim) fn revalidate_and_step_factories(sim: &mut Simulation, rules:
     registry.step_all(&mut sim.houses, &prepared);
     sim.production.factory_shadow = registry;
 }
+
+/// A saved relationship that the live factory operations cannot publish.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("factory state for owner {owner}: {reason}")]
+pub(crate) struct FactoryRestoreError {
+    pub(crate) owner: InternedId,
+    pub(crate) reason: &'static str,
+}
+
+/// Validate factory relationships before a loaded candidate becomes a match.
+///
+/// VERA-internal snapshot admission; gamemd equivalent UNCHECKED. These checks
+/// follow the synchronous constructor/publication/settlement operations above,
+/// not a new queue, refund or gameplay policy. Generic snapshot reference and
+/// LogicVector validation precede this operation. Missing Houses and unrelated
+/// limbo objects remain supported; manager pointers are not globally reciprocal.
+pub(crate) fn validate_restored_factory_state(
+    sim: &Simulation,
+    rules: &RuleSet,
+) -> Result<(), FactoryRestoreError> {
+    use crate::map::entities::EntityCategory;
+    use std::collections::{BTreeMap, BTreeSet};
+
+    let fail = |owner, reason| FactoryRestoreError { owner, reason };
+    let mut ready = BTreeMap::new();
+    for (&owner, entries) in &sim.production.ready_by_owner {
+        if sim.interner.try_resolve(owner).is_none() {
+            return Err(fail(owner, "ready owner is absent from the interner"));
+        }
+        for &type_id in entries {
+            let object = sim
+                .interner
+                .try_resolve(type_id)
+                .and_then(|name| rules.object(name))
+                .ok_or_else(|| fail(owner, "ready type is absent from bound rules"))?;
+            if object.category != ObjectCategory::Building {
+                return Err(fail(owner, "ready entry is not a building"));
+            }
+            let category = production_category_for_object(object);
+            if ready.insert((owner, category), type_id).is_some() {
+                return Err(fail(owner, "multiple ready entries claim one factory"));
+            }
+            let factory = sim
+                .production
+                .factory_shadow
+                .view(owner, category)
+                .ok_or_else(|| fail(owner, "ready entry has no factory"))?;
+            let held = factory
+                .object
+                .ok_or_else(|| fail(owner, "ready entry has no active object"))?;
+            if held.type_id != type_id {
+                return Err(fail(owner, "ready type disagrees with active object"));
+            }
+            if !factory.ready || !held.completion_accounted {
+                return Err(fail(owner, "ready entry precedes completion publication"));
+            }
+        }
+    }
+
+    let mut roots = BTreeSet::new();
+    for (&(owner, category), factory) in sim.production.factory_shadow.keyed_factories() {
+        if factory.owner != owner || factory.category != category {
+            return Err(fail(owner, "registry key disagrees with factory identity"));
+        }
+        if sim.interner.try_resolve(owner).is_none() {
+            return Err(fail(owner, "factory owner is absent from the interner"));
+        }
+        for queued in &factory.queue {
+            let object = sim
+                .interner
+                .try_resolve(queued.type_id)
+                .and_then(|name| rules.object(name))
+                .ok_or_else(|| fail(owner, "queued type is absent from bound rules"))?;
+            if production_category_for_object(object) != category {
+                return Err(fail(owner, "queued type disagrees with factory category"));
+            }
+        }
+        let Some(held) = &factory.object else {
+            if !factory.queue.is_empty() {
+                return Err(fail(owner, "queued tail has no active object"));
+            }
+            continue;
+        };
+        let object = sim
+            .interner
+            .try_resolve(held.type_id)
+            .and_then(|name| rules.object(name))
+            .ok_or_else(|| fail(owner, "active type is absent from bound rules"))?;
+        if production_category_for_object(object) != category {
+            return Err(fail(owner, "active type disagrees with factory category"));
+        }
+        let entity_id = held
+            .entity_id
+            .ok_or_else(|| fail(owner, "active object has no constructed identity"))?;
+        if !roots.insert(entity_id) {
+            return Err(fail(
+                owner,
+                "constructed identity belongs to multiple factories",
+            ));
+        }
+        let entity = sim.substrate.entities.get(entity_id).ok_or_else(|| {
+            fail(
+                owner,
+                "constructed identity is absent from the entity store",
+            )
+        })?;
+        if entity.owner() != owner || entity.type_ref() != held.type_id {
+            return Err(fail(
+                owner,
+                "constructed identity disagrees with factory owner or type",
+            ));
+        }
+        let expected_category = match object.category {
+            ObjectCategory::Infantry => EntityCategory::Infantry,
+            ObjectCategory::Vehicle => EntityCategory::Unit,
+            ObjectCategory::Aircraft => EntityCategory::Aircraft,
+            ObjectCategory::Building => EntityCategory::Structure,
+        };
+        if entity.category != expected_category {
+            return Err(fail(
+                owner,
+                "constructed identity has the wrong concrete category",
+            ));
+        }
+        if entity.spawn_owner_id.is_some() || entity.slave_harvester.is_some() {
+            return Err(fail(owner, "factory root is itself a manager child"));
+        }
+        // Do not infer health or death flags from factory membership. Current
+        // coordinate-based superweapon ingress can damage an unmarked held
+        // Infantry; rejecting its save here would hide that separate live bug.
+        if !entity.lifecycle.in_limbo || entity.lifecycle.cell_marked || entity.in_logic_vector {
+            return Err(fail(
+                owner,
+                "factory object is already admitted to the world",
+            ));
+        }
+        if held.completion_accounted && factory.progress < super::PRODUCTION_STEPS {
+            return Err(fail(
+                owner,
+                "completion accounting precedes completed progress",
+            ));
+        }
+        if held.completion_accounted
+            && object.category == ObjectCategory::Building
+            && ready.get(&(owner, category)) != Some(&held.type_id)
+        {
+            return Err(fail(owner, "accounted building has no ready entry"));
+        }
+    }
+
+    // Restrict only factory roots: native manager pointers elsewhere can alias
+    // without implying reciprocal ownership, and ordinary limbo is not a root.
+    for (&(owner, _), factory) in sim.production.factory_shadow.keyed_factories() {
+        let Some(parent) = factory.object.as_ref().and_then(|object| object.entity_id) else {
+            continue;
+        };
+        let entity = sim
+            .substrate
+            .entities
+            .get(parent)
+            .expect("validated factory root");
+        let spawn_alias = entity.spawn_manager.as_ref().is_some_and(|manager| {
+            manager
+                .slots
+                .iter()
+                .filter_map(|slot| slot.spawn)
+                .any(|id| roots.contains(&id))
+        });
+        let slave_alias = sim
+            .production
+            .slave_bindings
+            .get(&parent)
+            .is_some_and(|children| children.iter().any(|id| roots.contains(id)));
+        if spawn_alias || slave_alias {
+            return Err(fail(owner, "factory root aliases a held constructor child"));
+        }
+    }
+    Ok(())
+}

--- a/src/sim/production/mod.rs
+++ b/src/sim/production/mod.rs
@@ -29,6 +29,7 @@ pub use self::factory::{
     build_step_time, category_for_object,
 };
 pub use self::factory_lifecycle::{cancel_by_type_for_owner, cancel_last_for_owner, enqueue_by_type};
+pub(crate) use self::factory_lifecycle::{FactoryRestoreError, validate_restored_factory_state};
 pub use self::production_economy::is_harvester_type;
 pub use self::production_placement::{
     active_producer_for_owner_category, cycle_active_producer_for_owner_category,


### PR DESCRIPTION
A matching-content save could contain a ready building entry unrelated to its factory-held object. Loading succeeded, then cancellation cleared the factory link while leaving the constructed parent and children orphaned. Other malformed relationships could leave completed buildings permanently stuck or make the next factory update panic on an invalid interned identity.

The production lifecycle owner now validates factory roots, ready entries and queued types after generic reference and membership restoration, before PreparedLoad rebuilds the remaining load caches or commits the candidate. It checks keyed owner/category identity, bound rules and constructed entity relationships, completion/ready correspondence in both directions, and factory-root versus constructor-child separation. The app consumes one domain validation result. Valid construction, queued tails, unpublished completions, mobile retries, absent Houses, retained playfield flags and unrelated limbo objects remain supported.

The original production-path regression saved a real held parent and two slave children, read it through PreparedLoad, and demonstrated orphaning after cancellation before the fix. The final matrix uses the same file/repository/runtime preparation path and verifies the running match's hash, RNG, shared dummy and represented presentation remain unchanged. Positive cases compare factory records, constructor identities/words, parent manager slots, child back-references, serialized counts and credits. Existing skipped MatchStatistics behavior is preserved; this is not a change to that snapshot policy.

Independent read-only critics challenged initial exclusions and found the queued-identity and idle-owner holes; those findings were implemented. This validates the named factory relationships, not every serialized scalar or all native SAV behavior. Native equivalence of the Rust-only admission contract remains unchecked. A separate live Iron Curtain/Genetic Mutator cell-membership defect remains open; damaged held objects currently produced by that path are not rejected here.

Validation on source 923731fb (only System Map documentation changed afterward):

- Production `cargo check -p vera20k` passed (90 existing warnings).
- Focused file/repository/runtime restore scenarios:
  `test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 8534 filtered out; finished in 0.60s`
- Full `cargo test -p vera20k --lib`:
  `test result: ok. 8457 passed; 0 failed; 80 ignored; 0 measured; 0 filtered out; finished in 25.92s`
- System Map checker still reports 43 existing baseline diagnostics. Comparison confirms the same issues and multiplicity; added entries shift array positions. This is not a passing map check.
- Independent source, fixture and bounded documentation reviews completed; substantiated findings addressed.
