### PR TITLE
Route Iron Curtain through live cell membership and the world receiver

### DIFF
--- a/docs/research/IRONCURTAIN_FORCESHIELD_GHIDRA_REPORT.md
+++ b/docs/research/IRONCURTAIN_FORCESHIELD_GHIDRA_REPORT.md
@@ -153,10 +153,46 @@ operate independently via different fields at +0x280 range.)
 5. Iterate all cells in the standard 3x3 area (table at 0x00B0C038):
    - For each cell, get the object linked list (CellClass+0xE4 or +0xE8 for bridges)
    - For each object in cell:
-     - Skip if not a valid techno (`(flags >> 2) & 1 == 0`) or if `field_0x27C != 0`
-     - Skip if object is a building with `NoForceShield` or similar immunity flag
+     - Skip only when `Object+0x14 & 4` is nonzero AND byte `Techno+0x27C` is nonzero
+       (`006CCFF8..006CD006`). A non-Techno object reaches its virtual method;
+       the former non-Techno/NoForceShield exclusion here was incorrect.
      - Call `object->IronCurtain(Rules->IronCurtainDuration, super->Owner, 0)`
        - The 3rd argument is 0 = NOT ForceShield
+
+### Live cell and receiver verification (2026-09-06)
+
+Read-only inspection of the active retail `/gamemd.exe`, x86 Windows, image base
+`00400000`, confirmed the active House Fire_SW -> `006CB920` -> Super launch path.
+The nine packed offsets at `00B0C038..00B0C05C` are initialized by
+`006CAE00..006CAEBF` in this order:
+`(0,0), (1,0), (1,-1), (0,-1), (-1,-1), (-1,0), (-1,1), (0,1), (1,1)`.
+`006CCF41/006CCF44` add the two components as independent 16-bit words.
+`GetCell 005657A0` owns signed fixed-stride aliasing and shared dummy stamping;
+per-axis saturation is not equivalent.
+
+`006CCF6A` looks up the cell and `006CCF75` tests flag `0x100`; a second lookup
+reads deck head `+E8` at `006CCFB0` or ground head `+E4` at `006CCFEE`.
+After virtual `+154` returns, `006CD025` reads the current object's `+30`.
+Successful `CellClass::RemoveContent 0047EA90` repairs the list and clears the
+removed object's next at `0047EAF0`; a failed selected-list search does not clear
+it. A later re-add can repopulate that pointer from another cell/layer. Thus an
+IC walk must observe receiver mutations, including relayering, before advancing.
+
+Ordinary Infantry `InfDeath=1/2` retains cell membership during the death action:
+`005185D5` selects action `0xB`, `00518635` selects `0xC`, and the ordinary path
+joins `005185E5 -> 00518BA0` without UnInit. `Do_Action 0051D6F0`, action reset
+`0051DAF0`, and stock Walk stop `0075ADA0` do not unlink this ordinary case.
+Local retail `ini/rulesmd.ini:818` selects `C4Warhead=Super`; `[Super]` at
+`27093..27098` has `InfDeath=2`. This retention does not extend to every authored
+death mode: forced Cyborg damage sets the immediate-cleanup flag at `0051815B`,
+and external-animation/no-sequence branches can enter cleanup at `005185F1`.
+InfDeath 9 has success and fallback branches, so it requires its own traversal
+and lifecycle treatment.
+
+Genetic per-cell mutation deliberately differs: `006CD9E0` captures next BEFORE
+calling ReceiveDamage at `006CDA29`. Its saved successor can still be dispatched
+after nested work unlinks it. These observations establish native mechanics;
+they do not certify all Rust superweapon behavior or presentation parity.
 
 ### IronCurtain call parameters (verified from assembly at 0x006cd008-0x006cd01f):
 ```
@@ -430,10 +466,9 @@ void __thiscall InfantryClass::IronCurtain(int duration, int source_house, int i
 
 ### Key details:
 - **Warhead used:** C4Warhead (Rules+0xFA8) -- the same warhead used for C4/demolition
-- **Damage amount:** The infantry unit's full Strength (instant kill)
-- **force_damage parameter:** `true` (1) -- this bypasses ALL damage reduction checks,
-  including any invulnerability that might already be on the unit
-- The infantry is **not** made invulnerable -- it is simply killed outright
+- **Damage amount:** Authored InfantryType Strength, not remaining HP or a raw zero-HP write. An over-strength object can survive this call.
+- **Receiver flags:** `ignoreDefenses=1`, `arg6=0`; the concrete receiver owns their consequences, including the existing-invulnerability bypass. The wrapper does not itself implement damage gates.
+- The Infantry override invokes ReceiveDamage instead of applying an invulnerability timer.
 - This applies to ALL infantry, regardless of type. There is no INI key to opt out.
 - The source_house parameter is passed through for kill attribution
 
@@ -619,8 +654,8 @@ Decoded from the string pointer table at 0x008425C0:
 2. **Timer is passive/implicit**: no per-tick decrement. `IsIronCurtainActive()` checks
    `CurrentFrame - StartFrame < Duration` on demand.
 
-3. **Iron Curtain kills all infantry** via InfantryClass::IronCurtain override at
-   0x00522600. Uses C4Warhead (Rules+0xFA8) with force_damage=true for instant kill.
+3. **Iron Curtain applies forced authored-Strength damage to infantry** via InfantryClass::IronCurtain override at
+   0x00522600. Uses C4Warhead (Rules+0xFA8) with ignoreDefenses=1 and authored Strength as damage.
 
 4. **Iron Curtain blocks**: normal damage, temporal warping, mind control, crushing.
 

--- a/docs/system-map/topology.v2.json
+++ b/docs/system-map/topology.v2.json
@@ -322,9 +322,17 @@
           "symbol": "commit_receiver_health",
           "coverage": "representative",
           "observed_at_commit": "e3d53e1c9f92a3c74fc4b84d4a43f4aa2b4ef2ac"
+        },
+        {
+          "path": "src/sim/world/mod.rs",
+          "symbol": "commit_direct_damage_receiver",
+          "coverage": "representative",
+          "observed_at_commit": "30237eb526137c935976acefac88c0036f821020"
         }
       ],
-      "notes": ["Combat, Bullet, Wave and direct area-damage ingress execute against resident Simulation authority. ReceiverRun owns recursion guards and ordered navigation receipts; the local health borrow ends before synchronous world lifecycle stages. This ownership refactor does not establish whole-loop native parity or close scheduler differences."]
+      "notes": [
+        "Combat, Bullet, Wave and direct area-damage ingress execute against resident Simulation authority. ReceiverRun owns recursion guards and ordered navigation receipts; the local health borrow ends before synchronous world lifecycle stages. This ownership refactor does not establish whole-loop native parity or close scheduler differences."
+      ]
     },
     "GSI-09.01": {
       "native_anchors": [
@@ -461,6 +469,44 @@
         "Owner of build-ready, placement legality, rejection, and committed foundation handoff.",
         "Feature 12948d89 closes ordinary marked Ground-mobile and live nonempty-overlay rejection in the shared preview/commit predicate, with a sealed-retail Dustbowl GAPOWR oracle through lifecycle, four-cell occupancy, buildup, and power.",
         "Special damaged-wall/ToTile/LaserFence/gate exceptions, delayed-command rejection UI/EVA, and active-retail input/pixel comparison remain explicit residuals."
+      ]
+    },
+    "GSI-11.04": {
+      "native_anchors": [
+        {
+          "symbol": "SuperClass::Launch Iron Curtain case",
+          "address": "0x006CCF39",
+          "evidence": "docs/research/IRONCURTAIN_FORCESHIELD_GHIDRA_REPORT.md"
+        },
+        {
+          "symbol": "InfantryClass::IronCurtain",
+          "address": "0x00522600",
+          "evidence": "docs/research/IRONCURTAIN_FORCESHIELD_GHIDRA_REPORT.md"
+        }
+      ],
+      "rust_surfaces": [
+        {
+          "path": "src/sim/superweapon/iron_curtain.rs",
+          "symbol": "launch",
+          "coverage": "representative",
+          "observed_at_commit": "30237eb526137c935976acefac88c0036f821020"
+        },
+        {
+          "path": "src/sim/superweapon/cell_grid.rs",
+          "symbol": "selected_cell_list / live_successor",
+          "coverage": "representative",
+          "observed_at_commit": "30237eb526137c935976acefac88c0036f821020"
+        },
+        {
+          "path": "src/sim/superweapon/cell_receiver_tests.rs",
+          "symbol": "actual LaunchSuperWeapon command regressions",
+          "coverage": "representative",
+          "observed_at_commit": "30237eb526137c935976acefac88c0036f821020"
+        }
+      ],
+      "notes": [
+        "Iron Curtain selects canonical cell membership and the native bridge/ground list, then reads the live successor after each callback. Infantry dispatches forced authored-Strength C4 damage through the resident world receiver. This removes the independent coordinate/HP/death-announcement path.",
+        "Production command regressions cover factory-held and unmarked immunity, authored Strength, forced damage and source House, retained Die2, layer/foundation selection, aliases/dummy stamping, nested DeathWeapon order and existing bridge DropIn integration. Manual UnInit proves the attributed receipt, not automatic sequence completion. Shared Infantry terminal cleanup, Genetic conversion and external chrono-warp interaction remain open; no whole-loop or rendered parity claim."
       ]
     },
     "GSI-11.02": {
@@ -1441,6 +1487,30 @@
         "src/render/sidebar_chrome_tests.rs"
       ],
       "observed_at_commit": "7448a5a55d8ee9a7c9daf7b45254d250f4acc69e"
+    },
+    {
+      "id": "EDGE-0056-IRON-CURTAIN-CELL-MEMBERSHIP",
+      "plane": "routing",
+      "kind": "requires",
+      "from": "GSI-11.04",
+      "to": "GSI-04.05",
+      "context": "Iron Curtain command",
+      "detail": "Canonical selected cell membership owns ground/deck recipients and the then-live successor after each object callback, including an existing nested DropIn relayer.",
+      "evidence": [
+        "docs/research/IRONCURTAIN_FORCESHIELD_GHIDRA_REPORT.md"
+      ]
+    },
+    {
+      "id": "EDGE-0057-IRON-CURTAIN-DIRECT-RECEIVER",
+      "plane": "routing",
+      "kind": "requires",
+      "from": "GSI-11.04",
+      "to": "GSI-08.10",
+      "context": "Iron Curtain command",
+      "detail": "The Infantry override invokes forced authored-Strength C4 damage through the shared world receiver, completing current nested world receipts before reading the next recipient.",
+      "evidence": [
+        "docs/research/IRONCURTAIN_FORCESHIELD_GHIDRA_REPORT.md"
+      ]
     }
   ],
   "loops": {

--- a/src/sim/occupancy.rs
+++ b/src/sim/occupancy.rs
@@ -1133,6 +1133,21 @@ impl CellOccupancy {
         self.occupants.iter().filter(move |o| o.layer == layer)
     }
 
+    /// Read the selected CellClass object-list head at the time of the call.
+    pub(crate) fn first_on_layer(&self, layer: MovementLayer) -> Option<u64> {
+        self.iter_layer(layer).next().map(|object| object.entity_id)
+    }
+
+    /// Read the live successor after an object callback. Removal splices the
+    /// list and clears the removed object's next pointer (CellClass::RemoveContent
+    /// 0x0047EA90, clear at 0x0047EAF0), so an absent current member has no successor.
+    /// Callers that require a pre-callback successor must read it before dispatch.
+    pub(crate) fn next_on_layer(&self, layer: MovementLayer, current: u64) -> Option<u64> {
+        let mut objects = self.iter_layer(layer);
+        objects.find(|object| object.entity_id == current)?;
+        objects.next().map(|object| object.entity_id)
+    }
+
     /// Non-infantry occupants on a given layer, preserving layer-list order.
     pub fn blockers(&self, layer: MovementLayer) -> impl Iterator<Item = u64> + '_ {
         self.occupants

--- a/src/sim/superweapon/cell_grid.rs
+++ b/src/sim/superweapon/cell_grid.rs
@@ -1,12 +1,93 @@
 //! 3×3 cell grid iteration helper for area-of-effect superweapons.
 //!
-//! Matches the binary's fixed grid offset table DAT_00B0C038 (9 packed
-//! (dx:i16, dy:i16) entries) used by IronCurtain and GeneticConverter.
+//! Exact native iteration and the remaining legacy GeneticConverter collector.
+//! The two remain separate until GeneticConverter migrates its receiver traversal.
 //!
 //! ## Dependency rules
-//! - Pure utility — no sim dependencies.
+//! - Reads the map-owned CellClass lookup and world-owned cell membership.
 
-/// 9 cell offsets for a 3×3 grid centered on (0,0), in binary order.
+use crate::sim::cell_rect::{CellRef, get_cellclass_fallback};
+use crate::sim::movement::locomotor::MovementLayer;
+use crate::sim::world::Simulation;
+
+/// Runtime-initialized table at 0x00B0C038..0x00B0C05C. Native initializer
+/// 0x006CAE00..0x006CAEBF; SuperClass::Launch adds each component as a word at
+/// 0x006CCF39..0x006CCF44 (IC) and uses the same table for per-cell mutation.
+/// Wrap each 16-bit component independently; never clamp an edge onto cell zero.
+pub(super) fn native_cells_3x3(rx: u16, ry: u16) -> impl Iterator<Item = (i16, i16)> {
+    const OFFSETS: [(i16, i16); 9] = [
+        (0, 0),
+        (1, 0),
+        (1, -1),
+        (0, -1),
+        (-1, -1),
+        (-1, 0),
+        (-1, 1),
+        (0, 1),
+        (1, 1),
+    ];
+    OFFSETS
+        .into_iter()
+        .map(move |(dx, dy)| ((rx as i16).wrapping_add(dx), (ry as i16).wrapping_add(dy)))
+}
+
+/// Select the canonical real cell and one live native object-list layer.
+/// SuperClass::Launch tests CellClass+0x140 & 0x100, then reads +0xE8 or +0xE4
+/// (IC 0x006CCF6A..0x006CCFEE). The existing GetCell facade owns fixed-stride
+/// aliases, allocation and dummy stamping; requested coordinates are not keys.
+/// The shared dummy has no represented object-list members in the Rust substrate.
+pub(super) fn selected_cell_list(
+    sim: &Simulation,
+    x: i16,
+    y: i16,
+) -> Option<((u16, u16), MovementLayer)> {
+    match get_cellclass_fallback(sim.resolved_terrain.as_ref(), i32::from(x), i32::from(y)) {
+        CellRef::Real(cell) => Some((
+            (cell.rx, cell.ry),
+            if cell.bridge_facts.raw_flags & crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL != 0 {
+                MovementLayer::Bridge
+            } else {
+                MovementLayer::Ground
+            },
+        )),
+        CellRef::Dummy { .. } => {
+            if sim.resolved_terrain.is_none() {
+                sim.effective_shared_cell_dummy()
+                    .stamp_coord(i32::from(x), i32::from(y));
+            }
+            None
+        }
+    }
+}
+
+/// Read an IC receiver's then-live link, including a callback that relayered
+/// or relocated it. Retain the selected footprint cell while the object remains
+/// on that list; after remove/re-add, its new membership owns the successor.
+/// Native IC reads Object+0x30 after the call (0x006CD025); RemoveContent clears
+/// it (0x0047EAF0), while PutContent may populate it from a different list.
+pub(super) fn live_successor(
+    sim: &Simulation,
+    current: u64,
+    visited_cell: (u16, u16),
+    visited_layer: MovementLayer,
+) -> Option<u64> {
+    if let Some(cell) = sim.substrate.occupancy.get(visited_cell.0, visited_cell.1)
+        && cell
+            .iter_layer(visited_layer)
+            .any(|member| member.entity_id == current)
+    {
+        return cell.next_on_layer(visited_layer, current);
+    }
+    let object = sim.substrate.entities.get(current)?;
+    let layer = crate::sim::occupancy::cell_list_layer_for_entity(object)?;
+    sim.substrate
+        .occupancy
+        .get(object.position.rx, object.position.ry)?
+        .next_on_layer(layer, current)
+}
+
+/// Legacy row-major offsets. Not native visit order; retained only for the
+/// unmigrated GeneticConverter coordinate collector.
 pub const GRID_3X3_OFFSETS: [(i16, i16); 9] = [
     (-1, -1),
     (0, -1),

--- a/src/sim/superweapon/cell_receiver_tests.rs
+++ b/src/sim/superweapon/cell_receiver_tests.rs
@@ -1,0 +1,587 @@
+//! Production command regressions for native CellClass membership authority.
+use super::SuperWeaponInstance;
+use crate::map::bridge_facts::BridgeCellFacts;
+use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid};
+use crate::rules::terrain_rules::{SpeedCostProfile, TerrainClass};
+use crate::rules::{ini_parser::IniFile, ruleset::RuleSet};
+use crate::sim::{command::Command, house_state::HouseState, production, world::Simulation};
+use std::collections::BTreeMap;
+
+fn fixture() -> (Simulation, RuleSet) {
+    fixture_with_extra("")
+}
+
+fn fixture_with_extra(extra: &str) -> (Simulation, RuleSet) {
+    let base = "[InfantryTypes]\n0=E1\n1=BRUTE\n2=BOOM\n[VehicleTypes]\n0=MTNK\n\
+         [AircraftTypes]\n[BuildingTypes]\n0=GAPILE\n1=BIG\n\
+         [SuperWeaponTypes]\n0=IC\n1=GM\n\
+         [IC]\nType=IronCurtain\nRechargeTime=1\n\
+         [GM]\nType=GeneticConverter\nRechargeTime=1\n\
+         [General]\nMutateExplosion=no\n\
+         [CombatDamage]\nC4Warhead=Super\n[SpecialWeapons]\nMutateWarhead=Mutate\n\
+         [Warheads]\n0=Super\n1=Mutate\n2=DeathWH\n\
+         [Super]\nInfDeath=2\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+         [Mutate]\nInfDeath=9\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+         [BOOM]\nStrength=100\nSpeed=4\nExplodes=yes\nDeathWeapon=DeathBoom\n\
+         [DeathBoom]\nDamage=400\nWarhead=DeathWH\n\
+         [DeathWH]\nCellSpread=1\nPercentAtMax=1\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+         [BIG]\nStrength=1000\nFoundation=3x1\n\
+         [E1]\nStrength=100\nSpeed=4\nCost=200\nTechLevel=1\nOwner=Americans\n\
+         [BRUTE]\nStrength=200\nSpeed=4\n\
+         [MTNK]\nStrength=300\nSpeed=6\n\
+         [GAPILE]\nStrength=1000\nFoundation=1x1\nFactory=InfantryType\n";
+    let mut ini = IniFile::from_str(base);
+    ini.merge(&IniFile::from_str(extra));
+    let rules = RuleSet::from_ini(&ini).unwrap();
+    assert!(!rules.general.mutate_explosion);
+    assert_eq!(rules.general.mutate_warhead, "Mutate");
+    let mut sim = Simulation::with_seed(23);
+    sim.intern_rule_type_ids(&rules);
+    sim.resolve_type_handles(&rules);
+    let owner = sim.interner.intern("Americans");
+    sim.houses
+        .insert(owner, HouseState::new(owner, 0, None, true, 50_000, 10));
+    sim.session.house_order.push(owner);
+    sim.session.game_options.super_weapons = true;
+    let cells = (0..16)
+        .flat_map(|y| (0..16).map(move |x| test_terrain_cell(x, y)))
+        .collect();
+    sim.resolved_terrain = Some(ResolvedTerrainGrid::from_cells(16, 16, cells));
+    sim.playfield_bounds = Some(test_playfield_bounds());
+    sim.spawn_object_at_height("GAPILE", "Americans", 10, 10, 0, 0, &rules)
+        .unwrap();
+    (sim, rules)
+}
+
+fn launch_command(sim: &mut Simulation, rules: &RuleSet, name: &str, rx: u16, ry: u16) {
+    let owner = sim.interner.intern("Americans");
+    let sw_type_id = sim.interner.intern(name);
+    let mut instance = SuperWeaponInstance::new(sw_type_id, owner);
+    instance.is_active = true;
+    instance.is_ready = true;
+    sim.super_weapons
+        .entry(owner)
+        .or_default()
+        .insert(sw_type_id, instance);
+    assert!(sim.apply_command_with_overlays(
+        "Americans",
+        &Command::LaunchSuperWeapon {
+            sw_type_id,
+            target_rx: rx,
+            target_ry: ry,
+        },
+        Some(rules),
+        None,
+        &BTreeMap::new(),
+        None
+    ));
+    assert!(
+        !sim.super_weapons[&owner][&sw_type_id].is_ready,
+        "actual command consumes readiness"
+    );
+}
+
+fn held_infantry_survives_launch(name: &str) {
+    let (mut sim, rules) = fixture();
+    let owner = sim.interner.intern("Americans");
+    assert!(production::enqueue_by_type(
+        &mut sim,
+        &rules,
+        "Americans",
+        "E1"
+    ));
+    let held = sim
+        .production
+        .factory_shadow
+        .view(owner, production::ProductionCategory::Infantry)
+        .unwrap()
+        .object
+        .unwrap()
+        .entity_id
+        .unwrap();
+    let twin = sim
+        .construct_object_limbo_at_height("E1", "Americans", 0, 0, 0, 0, &rules)
+        .unwrap();
+    let marked = sim
+        .spawn_object_at_height("E1", "Americans", 1, 1, 0, 0, &rules)
+        .unwrap();
+    assert!(
+        sim.substrate
+            .entities
+            .get(marked)
+            .unwrap()
+            .lifecycle
+            .cell_marked
+    );
+    assert!(sim.substrate.entities.get(held).unwrap().lifecycle.in_limbo);
+    assert!(!sim.substrate.occupancy.contains_entity(0, 0, held));
+    assert!(!sim.substrate.occupancy.contains_entity(0, 0, twin));
+    assert!(
+        sim.substrate
+            .occupancy
+            .get(1, 1)
+            .unwrap()
+            .iter_layer(crate::sim::movement::locomotor::MovementLayer::Ground)
+            .any(|member| member.entity_id == marked)
+    );
+    let before_factory = sim
+        .production
+        .factory_shadow
+        .iter_insertion_ordered()
+        .into_iter()
+        .cloned()
+        .collect::<Vec<_>>();
+    launch_command(&mut sim, &rules, name, 0, 0);
+    for id in [held, twin] {
+        let object = sim
+            .substrate
+            .entities
+            .get(id)
+            .expect("unmarked object retained");
+        assert_eq!(
+            object.health.current, 100,
+            "{name} must use marked cell membership: {id}"
+        );
+        assert!(!object.dying);
+        assert!(
+            object.lifecycle.in_limbo && !object.lifecycle.cell_marked && !object.in_logic_vector
+        );
+    }
+    assert!(
+        sim.substrate
+            .entities
+            .get(marked)
+            .is_none_or(|object| object.health.current == 0),
+        "marked control receives the launch"
+    );
+    assert_eq!(
+        sim.production
+            .factory_shadow
+            .iter_insertion_ordered()
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>(),
+        before_factory
+    );
+    production::validate_restored_factory_state(&sim, &rules).unwrap();
+}
+
+#[test]
+fn iron_curtain_command_does_not_damage_factory_held_or_unmarked_infantry() {
+    held_infantry_survives_launch("IC");
+}
+
+// Retail rulesmd.ini:818 selects C4Warhead=Super; [Super] uses InfDeath=2.
+// Native ordinary death retains membership during action 0xC (0x00518635).
+#[test]
+fn iron_curtain_command_forces_authored_strength_and_attributes_retained_deaths() {
+    use crate::sim::animation::SequenceKind;
+    use crate::sim::superweapon::invulnerability::{InvulnKind, apply_invulnerability};
+    let (mut sim, rules) = fixture();
+    let owner = sim.interner.intern("Americans");
+    let enemy = sim.interner.intern("Soviet");
+    sim.houses
+        .insert(enemy, HouseState::new(enemy, 1, None, true, 10_000, 10));
+    sim.session.house_order.push(enemy);
+    let tank = sim
+        .spawn_object_at_height("MTNK", "Americans", 5, 5, 0, 0, &rules)
+        .unwrap();
+    let over_strength = sim
+        .spawn_object_at_height("E1", "Soviet", 5, 5, 0, 0, &rules)
+        .unwrap();
+    let wounded = sim
+        .spawn_object_at_height("E1", "Soviet", 5, 5, 0, 0, &rules)
+        .unwrap();
+
+    let frame = sim.session.binary_frame;
+    {
+        let object = sim.substrate.entities.get_mut(over_strength).unwrap();
+        object.health.current = 150;
+        object.health.max = 150;
+    }
+    {
+        let object = sim.substrate.entities.get_mut(wounded).unwrap();
+        object.health.current = 40;
+        apply_invulnerability(object, frame, 100, InvulnKind::IronCurtain);
+    }
+    launch_command(&mut sim, &rules, "IC", 5, 5);
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(over_strength)
+            .unwrap()
+            .health
+            .current,
+        50,
+        "receiver damage is authored Strength=100, not a raw kill or health.max"
+    );
+    let dead = sim.substrate.entities.get(wounded).unwrap();
+    assert_eq!(
+        dead.health.current, 0,
+        "forced C4 bypasses prior invulnerability"
+    );
+    assert!(dead.dying && dead.lifecycle.cell_marked && dead.in_logic_vector);
+    assert_eq!(
+        dead.animation.as_ref().unwrap().sequence,
+        SequenceKind::Die2
+    );
+    assert_eq!(dead.killed_by, Some(owner));
+    // The ordinary sequence still owns the object; the existing shared UnInit
+    // terminal owns score publication. Verify the attributed receipt survives it.
+    sim.uninit_with_rules(wounded, &rules);
+    assert_eq!(sim.houses[&owner].stats.units_killed, 1);
+    assert_eq!(sim.houses[&enemy].stats.units_lost, 1);
+    assert!(
+        sim.substrate
+            .entities
+            .get(tank)
+            .unwrap()
+            .invulnerability
+            .is_some()
+    );
+}
+
+#[test]
+fn iron_curtain_command_selects_deck_members_and_overlapping_foundation() {
+    use crate::sim::movement::locomotor::MovementLayer;
+    let (mut sim, rules) = fixture();
+    let ground = sim
+        .spawn_object_at_height("MTNK", "Americans", 5, 5, 0, 0, &rules)
+        .unwrap();
+    {
+        let cell = sim
+            .resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(5, 5)
+            .unwrap();
+        cell.bridge_facts.raw_flags = crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL;
+        cell.has_bridge_deck = true;
+        cell.bridge_walkable = true;
+        cell.bridge_deck_level = 4;
+    }
+    let deck = sim
+        .construct_object_limbo_at_height("MTNK", "Americans", 5, 5, 0, 4, &rules)
+        .unwrap();
+    sim.substrate.entities.get_mut(deck).unwrap().on_bridge = true;
+    sim.reveal(deck);
+    let big = sim
+        .spawn_object_at_height("BIG", "Americans", 2, 4, 0, 0, &rules)
+        .unwrap();
+    let outside = sim
+        .spawn_object_at_height("MTNK", "Americans", 7, 7, 0, 0, &rules)
+        .unwrap();
+    let twin = sim
+        .construct_object_limbo_at_height("MTNK", "Americans", 4, 4, 0, 0, &rules)
+        .unwrap();
+    assert!(
+        sim.substrate
+            .occupancy
+            .get(5, 5)
+            .unwrap()
+            .iter_layer(MovementLayer::Bridge)
+            .any(|member| member.entity_id == deck)
+    );
+    assert!(sim.substrate.occupancy.contains_entity(4, 4, big));
+    assert_eq!(sim.substrate.entities.get(big).unwrap().position.rx, 2);
+    launch_command(&mut sim, &rules, "IC", 5, 5);
+    for id in [deck, big] {
+        assert!(
+            sim.substrate
+                .entities
+                .get(id)
+                .unwrap()
+                .invulnerability
+                .is_some(),
+            "selected member {id}"
+        );
+    }
+    for id in [ground, outside, twin] {
+        assert!(
+            sim.substrate
+                .entities
+                .get(id)
+                .unwrap()
+                .invulnerability
+                .is_none(),
+            "excluded member {id}"
+        );
+    }
+}
+
+#[test]
+fn iron_curtain_command_runs_nested_death_before_the_next_native_cell() {
+    // Native table visits the center before east. Swapping the two objects
+    // changes whether the tank was protected before the synchronous DeathWeapon.
+    for (boomer_x, tank_x, survives) in [(5, 6, false), (6, 5, true)] {
+        let (mut sim, rules) = fixture();
+        sim.spawn_object_at_height("BOOM", "Americans", boomer_x, 5, 0, 0, &rules)
+            .unwrap();
+        let tank = sim
+            .spawn_object_at_height("MTNK", "Americans", tank_x, 5, 0, 0, &rules)
+            .unwrap();
+        launch_command(&mut sim, &rules, "IC", 5, 5);
+        let object = sim.substrate.entities.get(tank).unwrap();
+        assert_eq!(
+            object.health.current > 0,
+            survives,
+            "center/east receiver ordering"
+        );
+        assert_eq!(object.invulnerability.is_some(), survives);
+    }
+}
+
+#[test]
+fn iron_curtain_command_uses_packed_aliases_and_stamps_missing_cells() {
+    for (x, y) in [(512, 1), (u16::MAX, 2)] {
+        let (mut sim, rules) = fixture();
+        let tank = sim
+            .spawn_object_at_height("MTNK", "Americans", 0, 2, 0, 0, &rules)
+            .unwrap();
+        launch_command(&mut sim, &rules, "IC", x, y);
+        assert!(
+            sim.substrate
+                .entities
+                .get(tank)
+                .unwrap()
+                .invulnerability
+                .is_some(),
+            "fixed-stride alias / independent word wrap reaches actual cell (0,2)"
+        );
+    }
+    let (mut sim, rules) = fixture();
+    let tank = sim
+        .spawn_object_at_height("MTNK", "Americans", 5, 5, 0, 0, &rules)
+        .unwrap();
+    let allocated: Vec<_> = (0..16)
+        .flat_map(|y| (0..16).map(move |x| (x, y)))
+        .filter(|&cell| cell != (5, 5))
+        .collect();
+    sim.resolved_terrain
+        .as_mut()
+        .unwrap()
+        .test_set_native_allocated_cells(&allocated);
+    launch_command(&mut sim, &rules, "IC", 5, 5);
+    assert!(
+        sim.substrate
+            .entities
+            .get(tank)
+            .unwrap()
+            .invulnerability
+            .is_none()
+    );
+    assert_eq!(sim.effective_shared_cell_dummy().snapshot().coord, (5, 5));
+    sim.resolved_terrain = None;
+    launch_command(&mut sim, &rules, "IC", 5, 5);
+    assert!(
+        sim.substrate
+            .entities
+            .get(tank)
+            .unwrap()
+            .invulnerability
+            .is_none()
+    );
+    assert_eq!(
+        sim.effective_shared_cell_dummy().snapshot().coord,
+        (6, 6),
+        "mapless command updates the retained process dummy through the final native visit"
+    );
+}
+
+#[test]
+fn iron_curtain_command_follows_current_infantry_after_nested_bridge_drop_in() {
+    use crate::sim::bridge_state::{
+        AnchorSpan, Axis, BridgeCellRole, BridgeRuntimeCell, BridgeRuntimeState,
+        BridgeheadAnchorClass, DamageState, Direction,
+    };
+    use crate::sim::movement::locomotor::MovementLayer;
+    let (mut sim, rules) = fixture_with_extra("[DeathWH]\nWall=yes\n[DeathBoom]\nDamage=2000\n");
+    assert!(rules.warhead("DeathWH").unwrap().wall);
+    // The selected damaged anchor takes one hit to collapse. Seed the existing
+    // runtime map/record boundary; launch, nested death and fallout are real.
+    let span = [(5, 5), (6, 5), (7, 5), (8, 5), (4, 5)];
+    for &(x, y) in &span {
+        let cell = sim
+            .resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(x, y)
+            .unwrap();
+        cell.bridge_facts.raw_flags = crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL;
+        // Current bridge dispatcher admits impacts within one terrain level.
+        // Deck Z=4 and ground Z=3 exercise its actual collapse/DropIn path.
+        cell.level = 3;
+        cell.has_bridge_deck = true;
+        cell.bridge_walkable = true;
+        cell.bridge_deck_level = 4;
+    }
+    sim.resolved_terrain
+        .as_mut()
+        .unwrap()
+        .cell_mut(5, 5)
+        .unwrap()
+        .bridge_facts
+        .raw_flags |= crate::map::bridge_facts::BRIDGE_FLAG_ANCHOR_SELF;
+    let mut state =
+        BridgeRuntimeState::from_resolved_terrain(sim.resolved_terrain.as_ref().unwrap(), true, 1);
+    state.test_seed_cell(
+        5,
+        5,
+        BridgeRuntimeCell {
+            deck_present: true,
+            destroyable: true,
+            deck_level: 4,
+            bridge_group_id: Some(1),
+            damage_state: DamageState::Damaged,
+            axis: Some(Axis::NS),
+            role: BridgeCellRole::Anchor,
+            anchor_span_id: Some(1),
+            overlay_byte: 0,
+            damaged_variant: true,
+            bridgehead_anchor_class: BridgeheadAnchorClass::Variant0,
+        },
+    );
+    state.test_seed_anchor_span(AnchorSpan {
+        id: 1,
+        anchor: (5, 5),
+        cells: [
+            Some(span[0]),
+            Some(span[1]),
+            Some(span[2]),
+            Some(span[3]),
+            Some(span[4]),
+            None,
+        ],
+        axis: Axis::NS,
+        direction: Direction::E,
+        damage_state: DamageState::Damaged,
+        bridge_group_id: 1,
+    });
+    sim.bridge_state = Some(state);
+    // Older deck recipient is visited only after the newer Infantry's callback.
+    let tank = sim
+        .construct_object_limbo_at_height("MTNK", "Americans", 5, 5, 0, 4, &rules)
+        .unwrap();
+    sim.substrate.entities.get_mut(tank).unwrap().on_bridge = true;
+    sim.reveal(tank);
+    // Keep it alive through the nested DeathWeapon without setting IC first.
+    sim.substrate.entities.get_mut(tank).unwrap().health.current = 10_000;
+    sim.substrate.entities.get_mut(tank).unwrap().health.max = 10_000;
+    let boomer = sim
+        .construct_object_limbo_at_height("BOOM", "Americans", 5, 5, 0, 4, &rules)
+        .unwrap();
+    sim.substrate.entities.get_mut(boomer).unwrap().on_bridge = true;
+    sim.reveal(boomer);
+    assert_eq!(
+        sim.substrate
+            .occupancy
+            .get(5, 5)
+            .unwrap()
+            .snapshot_layer(MovementLayer::Bridge),
+        vec![boomer, tank]
+    );
+    launch_command(&mut sim, &rules, "IC", 5, 5);
+    let current = sim.substrate.entities.get(boomer).unwrap();
+    assert!(
+        current.dying && !current.on_bridge,
+        "nested fallout relayers the retained current receiver"
+    );
+    let recipient = sim.substrate.entities.get(tank).unwrap();
+    assert!(!recipient.on_bridge && recipient.health.current > 0);
+    assert!(
+        recipient.invulnerability.is_some(),
+        "successor comes from current Ground membership after DropIn"
+    );
+    assert_eq!(
+        sim.substrate
+            .occupancy
+            .get(5, 5)
+            .unwrap()
+            .snapshot_layer(MovementLayer::Bridge),
+        Vec::<u64>::new()
+    );
+}
+
+// Wide native diamond used by the existing production admission fixtures;
+// explicitly supplies the mandatory mode-one bounds, including edge-cell tests.
+pub(super) fn test_playfield_bounds() -> crate::sim::cell_rect::PlayfieldBounds {
+    crate::sim::cell_rect::PlayfieldBounds {
+        base: 0,
+        off_fc: -100,
+        off_100: -100,
+        off_104: 200,
+        off_108: 200,
+    }
+}
+
+pub(super) fn test_terrain_cell(rx: u16, ry: u16) -> ResolvedTerrainCell {
+    ResolvedTerrainCell {
+        rx,
+        ry,
+        source_tile_index: 0,
+        source_sub_tile: 0,
+        final_tile_index: 0,
+        final_sub_tile: 0,
+        is_wood_bridge_repair_tile: false,
+        level: 0,
+        filled_clear: false,
+        tileset_index: Some(0),
+        land_type: 0,
+        yr_cell_land_type: 0,
+        slope_type: 0,
+        template_height: 0,
+        render_offset_x: 0,
+        render_offset_y: 0,
+        terrain_class: TerrainClass::Clear,
+        speed_costs: SpeedCostProfile {
+            foot: Some(100),
+            track: Some(100),
+            wheel: Some(100),
+            hover: Some(100),
+            amphibious: Some(100),
+            ..SpeedCostProfile::default()
+        },
+        is_water: false,
+        is_cliff_like: false,
+        is_rough: false,
+        is_road: false,
+        accepts_smudge: false,
+        allows_tiberium: false,
+        height_in_pixels: 0,
+        variant: 0,
+        has_ramp: false,
+        canonical_ramp: None,
+        ground_walk_blocked: false,
+        terrain_object_blocks: false,
+        terrain_object_occupation: None,
+        overlay_blocks: false,
+        overlay_zone_type: None,
+        outside_playfield: false,
+        zone_type: 0,
+        base_ground_walk_blocked: false,
+        base_build_blocked: false,
+        base_land_type: 0,
+        base_yr_cell_land_type: 0,
+        base_terrain_class: Default::default(),
+        base_speed_costs: SpeedCostProfile {
+            foot: Some(100),
+            track: Some(100),
+            wheel: Some(100),
+            hover: Some(100),
+            amphibious: Some(100),
+            ..SpeedCostProfile::default()
+        },
+        build_blocked: false,
+        has_bridge_deck: false,
+        bridge_walkable: false,
+        bridge_transition: false,
+        bridge_deck_level: 0,
+        bridge_layer: None,
+        bridge_facts: BridgeCellFacts::default(),
+        tube_index: None,
+        radar_left: [0, 0, 0],
+        radar_right: [0, 0, 0],
+        has_damaged_data: false,
+        bridgehead_anchor_class_at_load: None,
+    }
+}

--- a/src/sim/superweapon/iron_curtain.rs
+++ b/src/sim/superweapon/iron_curtain.rs
@@ -1,8 +1,8 @@
 //! IronCurtain superweapon launch handler.
 //!
 //! Applies timed invulnerability to all techno entities in a 3×3 cell grid
-//! centered on the target cell. Infantry are killed instead of protected
-//! (matches InfantryClass::IronCurtain override).
+//! centered on the target cell. Infantry receive forced authored-Strength damage
+//! through the InfantryClass::IronCurtain override.
 //!
 //! ## Dependency rules
 //! - Part of sim/ — depends on rules/, sim/superweapon/{invulnerability,cell_grid},
@@ -13,12 +13,12 @@ use crate::map::entities::EntityCategory;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::components::WorldEffect;
 use crate::sim::intern::InternedId;
-use crate::sim::superweapon::cell_grid::iter_cells_3x3;
+use crate::sim::superweapon::cell_grid::{live_successor, native_cells_3x3, selected_cell_list};
 use crate::sim::superweapon::invulnerability::{InvulnKind, apply_invulnerability};
 use crate::sim::world::{SimSoundEvent, Simulation};
 
 /// Launch IronCurtain at (target_rx, target_ry). Applies invulnerability or
-/// kills infantry in the 3×3 cell grid centered on the target.
+/// forced authored-Strength damage to infantry in the target’s 3×3 cell grid.
 pub fn launch(
     sim: &mut Simulation,
     rules: &RuleSet,
@@ -26,6 +26,7 @@ pub fn launch(
     target_rx: u16,
     target_ry: u16,
     sw_type: InternedId,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
 ) -> bool {
     let duration = rules.general.iron_curtain_duration;
     let anim_name = rules.general.iron_curtain_invoke_anim.clone();
@@ -34,39 +35,53 @@ pub fn launch(
     // 1. Spawn invoke animation at target.
     spawn_invoke_anim(sim, rules, &anim_name, target_rx, target_ry);
 
-    // 2. Collect entity IDs in the 3×3 grid (snapshot to avoid borrow conflict).
-    let cells: Vec<(u16, u16)> = iter_cells_3x3(target_rx, target_ry).collect();
-    let target_ids: Vec<u64> = sim
-        .substrate
-        .entities
-        .values()
-        .filter(|e| {
-            cells
-                .iter()
-                .any(|(rx, ry)| e.position.rx == *rx && e.position.ry == *ry)
-        })
-        .filter(|e| e.health.current > 0 && !e.dying)
-        .map(|e| e.stable_id())
-        .collect();
-
-    // 3. Apply effect per entity.
-    for id in &target_ids {
-        let mut killed = false;
-        if let Some(entity) = sim.substrate.entities.get_mut(*id) {
-            if entity.category == EntityCategory::Infantry {
-                // `InfantryClass::IronCurtain @ 0x00522632`: `ReceiveDamage`
-                // (`+0x16C`) with the type's full `Strength=` and `C4Warhead=`,
-                // so the kill runs the normal death branch including
-                // `Death_Announcement` (`+0x3B8`, "Unit lost").
-                entity.health.current = 0;
-                entity.dying = true;
-                killed = true;
-            } else {
-                apply_invulnerability(entity, current_frame, duration, InvulnKind::IronCurtain);
+    // SuperClass::Launch case 1 (0x006CCF39..0x006CD035) selects a live
+    // CellClass list, invokes +0x154, then reads that object's +0x30 AFTER the
+    // call. Never snapshot recipients or infer membership from coordinates.
+    // Native also skips external chrono-warp latch +0x27C on Technos. Its
+    // ChronoWarp/action-128 producers have no current Rust implementation; do
+    // not substitute ordinary teleport_state, whose native path leaves it clear.
+    let mut target_count = 0;
+    for (x, y) in native_cells_3x3(target_rx, target_ry) {
+        let Some(((rx, ry), layer)) = selected_cell_list(sim, x, y) else {
+            continue;
+        };
+        let mut next = sim
+            .substrate
+            .occupancy
+            .get(rx, ry)
+            .and_then(|cell| cell.first_on_layer(layer));
+        while let Some(id) = next {
+            if let Some(entity) = sim.substrate.entities.get(id) {
+                let category = entity.category;
+                let type_ref = entity.type_ref();
+                if category == EntityCategory::Infantry {
+                    // InfantryClass::IronCurtain 0x00522600..0x0052263B:
+                    // full authored Strength, distance 0, C4Warhead, null
+                    // attacker, ignoreDefenses=1, arg6=0, launching sourceHouse.
+                    // The shared receiver owns fatal effects and announcements.
+                    if let Some(object) = rules.object(sim.interner.resolve(type_ref)) {
+                        let event = crate::sim::combat::EntityDamageEvent::direct_receiver(
+                            id,
+                            object.strength,
+                            0,
+                            crate::sim::combat::RAD_NO_ATTACKER,
+                            Some(owner),
+                            sim.interner.intern(&rules.bridge_warheads.c4_name),
+                            crate::sim::combat::ReceiverCallFlags {
+                                ignore_defenses: true,
+                                arg6: false,
+                            },
+                        );
+                        sim.commit_direct_damage_receiver(rules, overlay_registry, event);
+                    }
+                } else if let Some(entity) = sim.substrate.entities.get_mut(id) {
+                    // TechnoClass::IronCurtain 0x0070E2B0 has no health gate.
+                    apply_invulnerability(entity, current_frame, duration, InvulnKind::IronCurtain);
+                }
+                target_count += 1;
             }
-        }
-        if killed {
-            sim.announce_unit_lost_at_death_site(rules, *id);
+            next = live_successor(sim, id, (rx, ry), layer);
         }
     }
 
@@ -83,7 +98,7 @@ pub fn launch(
         target_rx,
         target_ry,
         sim.interner.resolve(owner),
-        target_ids.len()
+        target_count
     );
 
     true
@@ -94,40 +109,39 @@ pub fn launch(
 mod tests {
     use super::*;
     use crate::rules::ini_parser::IniFile;
-    use crate::sim::components::Health;
-    use crate::sim::game_entity::GameEntity;
     use crate::sim::superweapon::invulnerability::is_invulnerable;
 
     fn test_rules() -> RuleSet {
         let ini = IniFile::from_str(
             "[InfantryTypes]\n0=E1\n[VehicleTypes]\n0=MTNK\n[AircraftTypes]\n[BuildingTypes]\n\
              [E1]\nStrength=125\nArmor=flak\nSpeed=4\n\
-             [MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\n",
+             [MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\n\
+             [CombatDamage]\nC4Warhead=C4\n[Warheads]\n0=C4\n\
+             [C4]\nInfDeath=1\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
         );
         RuleSet::from_ini(&ini).expect("test rules")
     }
 
     fn spawn(sim: &mut Simulation, id: u64, type_ref: &str, rx: u16, ry: u16, cat: EntityCategory) {
-        let owner = sim.interner.intern("Americans");
-        let tref = sim.interner.intern(type_ref);
-        let e = GameEntity::new_at_frame_zero_for_test(
-            id,
-            rx,
-            ry,
-            0,
-            0,
-            owner,
-            Health {
-                current: 300,
-                max: 300,
-            },
-            tref,
-            cat,
-            0,
-            5,
-            matches!(cat, EntityCategory::Unit),
-        );
-        sim.substrate.entities.insert(e);
+        let rules = test_rules();
+        sim.intern_rule_type_ids(&rules);
+        sim.resolve_type_handles(&rules);
+        sim.playfield_bounds = Some(super::super::cell_receiver_tests::test_playfield_bounds());
+        if sim.resolved_terrain.is_none() {
+            let cells = (0..20)
+                .flat_map(|y| {
+                    (0..20).map(move |x| super::super::cell_receiver_tests::test_terrain_cell(x, y))
+                })
+                .collect();
+            sim.resolved_terrain =
+                Some(crate::map::resolved_terrain::ResolvedTerrainGrid::from_cells(20, 20, cells));
+        }
+        let actual = sim
+            .spawn_object_at_height(type_ref, "Americans", rx, ry, 0, 0, &rules)
+            .expect("production constructor and Mark");
+        assert_eq!(actual, id);
+        assert_eq!(sim.substrate.entities.get(id).unwrap().category, cat);
+        assert!(sim.substrate.occupancy.contains_entity(rx, ry, id));
     }
 
     #[test]
@@ -137,7 +151,7 @@ mod tests {
         let owner = sim.interner.intern("Americans");
         spawn(&mut sim, 1, "MTNK", 10, 10, EntityCategory::Unit);
         let sw_test = sim.interner.intern("SWTEST");
-        assert!(launch(&mut sim, &rules, owner, 10, 10, sw_test));
+        assert!(launch(&mut sim, &rules, owner, 10, 10, sw_test, None));
         let e = sim.substrate.entities.get(1).expect("tank exists");
         assert!(e.invulnerability.is_some());
         assert!(is_invulnerable(
@@ -153,7 +167,7 @@ mod tests {
         let owner = sim.interner.intern("Americans");
         spawn(&mut sim, 1, "E1", 10, 10, EntityCategory::Infantry);
         let sw_test = sim.interner.intern("SWTEST");
-        assert!(launch(&mut sim, &rules, owner, 10, 10, sw_test));
+        assert!(launch(&mut sim, &rules, owner, 10, 10, sw_test, None));
         let e = sim.substrate.entities.get(1).expect("infantry exists");
         assert_eq!(e.health.current, 0);
         assert!(e.dying);
@@ -180,7 +194,7 @@ mod tests {
         spawn(&mut sim, 2, "E1", 11, 11, EntityCategory::Infantry);
         spawn(&mut sim, 3, "MTNK", 9, 9, EntityCategory::Unit);
         let sw_test = sim.interner.intern("SWTEST");
-        assert!(launch(&mut sim, &rules, owner, 10, 10, sw_test));
+        assert!(launch(&mut sim, &rules, owner, 10, 10, sw_test, None));
 
         let lost: Vec<InternedId> = sim
             .sound_events
@@ -201,7 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn ic_affects_all_3x3_cells() {
+    fn ic_affects_both_diagonals_and_center() {
         let rules = test_rules();
         let mut sim = Simulation::new();
         let owner = sim.interner.intern("Americans");
@@ -209,7 +223,7 @@ mod tests {
         spawn(&mut sim, 2, "MTNK", 10, 10, EntityCategory::Unit);
         spawn(&mut sim, 3, "MTNK", 11, 11, EntityCategory::Unit);
         let sw_test = sim.interner.intern("SWTEST");
-        launch(&mut sim, &rules, owner, 10, 10, sw_test);
+        launch(&mut sim, &rules, owner, 10, 10, sw_test, None);
         assert!(
             sim.substrate
                 .entities
@@ -243,7 +257,7 @@ mod tests {
         let owner = sim.interner.intern("Americans");
         spawn(&mut sim, 1, "MTNK", 15, 15, EntityCategory::Unit);
         let sw_test = sim.interner.intern("SWTEST");
-        launch(&mut sim, &rules, owner, 10, 10, sw_test);
+        launch(&mut sim, &rules, owner, 10, 10, sw_test, None);
         assert!(
             sim.substrate
                 .entities

--- a/src/sim/superweapon/mod.rs
+++ b/src/sim/superweapon/mod.rs
@@ -8,6 +8,8 @@
 //! - Part of sim/ — depends on rules/, sim/power_system, sim/components.
 //! - sim/ NEVER depends on render/, ui/, sidebar/, audio/, net/.
 
+#[cfg(test)]
+mod cell_receiver_tests;
 pub mod cell_grid;
 pub mod force_shield;
 pub mod genetic_converter;

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -2176,6 +2176,26 @@ impl Simulation {
         );
     }
 
+    /// Complete one direct object ReceiveDamage call before its caller resumes.
+    /// Unlike Apply_area_damage, a direct call has no collected area or area-wide
+    /// Iron Curtain isolation decision. Nested deaths, world mutations and their
+    /// publication finish before a live cell-list caller reads its successor.
+    pub(crate) fn commit_direct_damage_receiver(
+        &mut self,
+        rules: &RuleSet,
+        overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+        event: crate::sim::combat::EntityDamageEvent,
+    ) {
+        let mut run = crate::sim::combat::world_receiver::ReceiverRun::default();
+        let (effects, under_attack_events) = crate::sim::combat::world_receiver::commit_entities(
+            self, &mut run, std::slice::from_ref(&event), Some(false), rules, overlay_registry,
+        );
+        let terrain_navigation_changed_cells = run.finish(self);
+        self.absorb_noncombat_damage_effects(
+            rules, overlay_registry, effects, under_attack_events, terrain_navigation_changed_cells,
+        );
+    }
+
     /// Commit one non-combat Apply_area_damage hit list through the ordinary
     /// ReceiveDamage -> death transaction, then hand its deferred outputs back
     /// to the world owner. `hits` remains in CellClass/object-list order; the

--- a/src/sim/world/world_commands.rs
+++ b/src/sim/world/world_commands.rs
@@ -2203,6 +2203,7 @@ impl Simulation {
                             *target_rx,
                             *target_ry,
                             *sw_type_id,
+                            overlay_registry,
                         )
                     }
                     crate::rules::superweapon_type::SuperWeaponKind::ForceShield => {


### PR DESCRIPTION
Iron Curtain used a global coordinate scan and wrote infantry HP/death state directly, allowing a launch near (0,0) to damage factory-held and other unmarked infantry. The command now follows the selected live CellClass ground/deck list and routes infantry through the existing world damage receiver. Authored Strength, C4 flags/source House and callback ordering have one owner; nested death/bridge effects finish before the caller reads the current object's successor.

Native evidence is recorded in IRONCURTAIN_FORCESHIELD_GHIDRA_REPORT.md: SuperClass launch 0x006CCF39..0x006CD035 and Infantry override 0x00522600. Command regressions cover held/unmarked exclusion, over-strength survival, forced prior-invulnerability bypass, attribution, retained Die2, bridge selection, non-anchor foundations, fixed-stride aliases/dummy stamping, and nested death/DropIn ordering.

Validation:
- cargo check -p vera20k passed (90 existing warnings).
- Focused: test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 8525 filtered out; finished in 0.01s
- Full: test result: ok. 8463 passed; 0 failed; 80 ignored; 0 measured; 0 filtered out; finished in 13.08s
- System Map has the same 43 existing diagnostics and multiplicities; no new issues. Its normal checker remains nonpassing.
- Independent read-only source, scope, test and map reviews found no remaining blocker for this increment.

This increment does not close shared Infantry terminal cleanup, Genetic conversion, external chrono-warp interaction, automatic death-sequence completion, or native DropIn/presentation parity. Those remain in the active ownership scope. Existing meaningful tests are retained.
