### PR TITLE
Own bridge deck membership and restoration order

### DIFF
--- a/docs/research/bridges/05-damage-collapse-repair-cabhut/BRIDGE_COLLAPSE_FALLOUT_ORDERING_GHIDRA_REPORT.md
+++ b/docs/research/bridges/05-damage-collapse-repair-cabhut/BRIDGE_COLLAPSE_FALLOUT_ORDERING_GHIDRA_REPORT.md
@@ -17,6 +17,44 @@ Evidence needed to mark COMPLETE: decompile plus assembly context for `BlowUpBri
 
 Stop conditions: stop once ground kill vs deck drop-in order, anim spawn timing, zone/radar/full-redraw side effects, event `0x1F` separation, Rust deltas, and do-not-do notes are covered with no open ordering questions inside this slice.
 
+## Bounded list-ownership update (2026-09-06)
+
+Read-only inspection of the active retail `/gamemd.exe` confirms that
+`0047DD96` saves the ground successor before ReceiveDamage, and
+`0047DDBA..0047DDC9` reads the deck head after ground callbacks and saves each
+successor before DropIn. Native mobile insertion prepends, so a deck list
+`[newer, older]` becomes ground `[older, newer]`. This order can affect an
+already-running Iron Curtain walk, which reads its current receiver's successor
+**after** the nested collapse returns.
+
+Rust now selects the live Bridge list and invokes one world-owned represented
+relayer. It removes the complete foundation footprint from Bridge, preserves the
+existing ground snap and movement reset, records one new serialized entry order,
+reconciles the derived vehicle occupation projection, and re-adds the footprint
+to Ground. Full snapshot restoration uses those entry orders to reproduce the
+same list. The actual hut dispatcher and an Iron Curtain command with a nested
+DeathWeapon exercise both production callers. Unmarked coordinate twins are
+excluded; raw bytes, serialized Drive reservations and building smudges are
+preserved. This is bounded list authority and restoration coverage, not complete
+DropIn or falling parity.
+
+The new native inspection also corrects overly broad callback assumptions:
+CellClass AddContent `0047E8A0` and RemoveContent `0047EA90` explicitly skip their
+raw occupation virtual calls for Infantry (`WhatAmI == 0xF`). DropIn `005F4160`
+sets the falling bytes, removes/re-adds membership around clearing OnBridge,
+then has a locomotor-dependent occupation clear. It does not itself snap XYZ
+or reset the Rust movement state. Reusing the full Rust Mark/Unmark transaction
+would add Infantry callbacks, hard-removal reservation disposal, building smudge
+removal and air-spatial policies that are not established for this call.
+
+Remaining **DRIFT**: exact falling/landing progression and original-Z callback
+inputs, concrete raw occupation writes and the later occupation clear, hidden
+occupation entry for supported building profiles, and the ground ReceiveDamage
+health-alias transaction. The latter distinguishes immunity writes to aliased HP
+from Object kill callbacks and Techno fatal admission; copying current HP into an
+ordinary damage event does not establish equivalence for authored C4 warheads.
+These remain required follow-up mechanisms in the broader ownership goal.
+
 ## 1. Overview
 
 `CellClass::BlowUpBridge` is the per-cell fallout primitive. Its order is: kill ground-list occupants, drop bridge-list occupants via `ObjectClass::DropIn`, enqueue the collapsed cell in a global cell queue, then maybe spawn metallic debris and one bridge-explosion anim.
@@ -49,7 +87,7 @@ Verified order:
 1. Early-out if map editor flag is set.
 2. Walk `CellClass+0xE4` ground list. For each object:
    - snapshot `object+0x30` before mutation;
-   - call vtable `+0x16C` with `RulesClass+C4Warhead`, damage `0`, and force-kill flags.
+   - call vtable `+0x16C` with `&Object.Health` (`+0x6C`), distance `0`, `RulesClass+C4Warhead`, null attacker, `ignoreDefenses=1`, `arg6=1`, and null source House. This is an aliased in/out damage pointer, not damage zero.
 3. Walk `CellClass+0xE8` deck list. For each object:
    - snapshot `object+0x30` before mutation;
    - call vtable `+0xEC`, which is `ObjectClass::DropIn` for normal objects.
@@ -74,9 +112,9 @@ Verified order:
 6. Submit to display layer.
 7. Call vtable `+0x124` with arg `1`.
 
-For normal Techno objects, vtable `+0x124` is `TechnoClass::DoCloak @ 0x004D3780`; mode `0` calls `TechnoClass__ExitCell_RemoveFromMultiCells`, and mode `1` calls `TechnoClass__EnterCell_AddToMultiCells`. The enter/exit helpers read `ObjectClass+0x8C` immediately before `CellClass::RemoveContent`/`AddContent`, so removal observes `OnBridge==1` and insertion observes `OnBridge==0`.
+For normal Techno objects, vtable `+0x124` is `TechnoClass::MarkCellLists @ 0x004D3780`. After MarkAndNotify succeeds and virtual `+0x78` reports display layer 2, mode `0` calls `TechnoClass__ExitCell_RemoveFromMultiCells @ 0x005687F0`; modes `1/3` call `TechnoClass__EnterCell_AddToMultiCells @ 0x005683C0`. The enter/exit helpers read `ObjectClass+0x8C` immediately before `CellClass::RemoveContent`/`AddContent`, so removal observes `OnBridge==1` and insertion observes `OnBridge==0`.
 
-Evidence: decompile `0x005F4160`, `0x004D3780`, `0x005683C0`, `0x005687F0`; assembly `0x005F416A..0x005F41A1`, `0x005684B1`, `0x005688E1`.
+Evidence: decompile `0x005F4160`, `0x004D3780`, `0x005683C0` (enter/add), `0x005687F0` (exit/remove); assembly `0x005F416A..0x005F41A1`, `0x005684B1`, `0x005688E1`.
 
 Active in YR: Yes for ordinary bridge-deck units/infantry; conditional only for exotic non-Techno objects that might occupy the bridge list.
 
@@ -130,7 +168,7 @@ Active in YR: Yes.
 
 ### Occupants
 
-Ground-list occupants die before deck-list occupants are processed. Deck occupants survive via `DropIn` and are relayered into the ground list after `OnBridge` is cleared.
+Ground-list occupants receive forced aliased-HP damage before the deck pass. Deck occupants receive `DropIn` and are relayered into the ground list after `OnBridge` is cleared; this establishes call ordering, not universal survival through later falling or nested effects.
 
 Active in YR: Yes. Evidence: `0x0047DD84..0x0047DDC9`, `0x005F4160`.
 
@@ -171,9 +209,11 @@ Active in YR: Conditional. The bridge call is live, but trigger effects require 
 
 Evidence: decompile `0x00575EE0`, assembly call sites `0x00575F95`, `0x00576007`, `0x0057606C`, `0x005760CC`, `0x00576137`, `0x0057619C`, `0x005761DE`; decompile `0x006E53A0` and `0x0071F680`.
 
-## 6. Current Rust Implementation Status
+## 6. Historical Rust Implementation Scan
 
-Current Rust file scanned: `src/sim/world/bridge_orchestrator.rs`.
+This original scan predates subsequent implementation changes, including the bounded update above. Its deltas are historical observations, not current validation.
+
+Original Rust file scanned: `src/sim/world/bridge_orchestrator.rs`.
 
 Observed cascade order in `apply_bridge_damage_events`:
 
@@ -202,7 +242,7 @@ No Rust was modified by this investigation.
 | `CellClass::BlowUpBridge` ground kill order | verified | decompile `0x0047DD70`; assembly `0x0047DD84..0x0047DDAE` | none |
 | `CellClass::BlowUpBridge` deck `DropIn` order | verified | decompile `0x0047DD70`; assembly `0x0047DDBA..0x0047DDC9` | none |
 | `ObjectClass::DropIn` relayer | verified | decompile `0x005F4160`; assembly `0x005F416A..0x005F41A1` | exotic non-Techno deck occupants not exhaustively classified |
-| Techno list helpers read `OnBridge` at call time | verified | decompile `0x004D3780`, `0x005683C0`, `0x005687F0`; assembly `0x005684B1`, `0x005688E1` | none for normal units |
+| Techno list helpers read `OnBridge` at call time | verified | decompile `0x004D3780`, `0x005683C0` (enter/add), `0x005687F0` (exit/remove); assembly `0x005684B1`, `0x005688E1` | none for normal units |
 | `CollapseBridge_*` anim-before-destroy order | verified | decompile `0x00575BA0`, `0x00575870`, `0x00575540`, `0x00575220` | none |
 | `CollapseBridge_*` tail zone/full-redraw order | verified | decompile same four walkers; tail write `0x00575B91` pattern | none |
 | Damage state-machine zone invalidation tail | verified | decompile `0x00576BA0`; assembly `0x005778CC..0x005778D9` | low-state twin not re-decompiled in this slot |
@@ -211,7 +251,7 @@ No Rust was modified by this investigation.
 | Shroud-edge helper internals | touched-not-exhausted | `0x006D3D10` calls `Tactical_layer_shroud_edges`; prior high-bridge docs | exact helper timing not re-drained here |
 | Event `0x1F` trigger-only path | verified | decompile `0x00575EE0`, `0x006E53A0`; assembly call sites | none for bridge-side hook |
 | Event `0x18` separation | verified | decompile `0x0071F680` | full public trigger enum labels out of scope |
-| Current Rust cascade | verified | `src/sim/world/bridge_orchestrator.rs` scan | exact test coverage not exhaustively audited |
+| Original Rust cascade scan | historical | `src/sim/world/bridge_orchestrator.rs` scan | exact test coverage not exhaustively audited |
 
 ## 8. Open Questions - Final State of the Investigation Log
 
@@ -225,17 +265,19 @@ No Rust was modified by this investigation.
 - `[RESOLVED] OQ-8 - Does `BlowUpBridge` play collapse sound directly? -> No; sounds come from spawned anims' `AnimClass::Middle` path.` (evidence: `0x0047DD70`, `0x00424CE0`)
 - `[RESOLVED] OQ-9 - Does event `0x1F` mutate bridge state? -> No; dispatcher evaluates/queues trigger actions only.` (evidence: `0x00575EE0`, `0x006E53A0`)
 - `[RESOLVED] OQ-10 - Is event `0x1F` the same as destroyed-registry event `0x18`? -> No.` (evidence: `0x0071F680`)
-- `[RESOLVED] OQ-11 - Does current Rust have a direct bridge-collapse sound event? -> No; scan found repair sound only and visual `WorldEffect` bridge explosions.` (evidence: `src/sim/world/mod.rs`, `src/sim/world/bridge_orchestrator.rs`)
-- `[RESOLVED] OQ-12 - Does current Rust run event 31? -> No, `notify_bridge_span_collapse` is an intentional no-op.` (evidence: `src/sim/world/bridge_orchestrator.rs`)
+- `[RESOLVED] OQ-11 - Did the original Rust scan have a direct bridge-collapse sound event? -> No; scan found repair sound only and visual `WorldEffect` bridge explosions.` (evidence: `src/sim/world/mod.rs`, `src/sim/world/bridge_orchestrator.rs`)
+- `[RESOLVED] OQ-12 - Did the original Rust scan run event 31? -> No, `notify_bridge_span_collapse` is an intentional no-op.` (evidence: `src/sim/world/bridge_orchestrator.rs`)
 - `[DEFERRED] OQ-13 - Exact shroud-edge helper internals after bridge collapse.` (category: `bounded-cost-too-high`; reason: this slot verified draw integration and prior docs cover active shroud-edge behavior, but did not re-drain the helper body; next-step-if-pursued: targeted `/re-investigate Tactical_layer_shroud_edges bridge dirty bits`.)
 - `[DEFERRED] OQ-14 - Exotic non-Techno objects in `CellClass+0xE8`.` (category: `out-of-scope`; reason: normal player-visible deck occupants are Techno-derived; next-step-if-pursued: classify all possible `AltObject` occupants and vtable `+0xEC` bindings.)
 
-## 9. Implementation Handoff
+## 9. Historical Implementation Handoff
+
+Original proposed work is retained for context; it is not a current backlog or validation result. The explicitly dated relayer row reflects this update.
 
 | Verified behavior | Evidence | Current Rust delta | Affected Rust surface | Required implementation effect | Acceptance scenario | Risk / do-not-do |
 |---|---|---|---|---|---|---|
 | `BlowUpBridge` applies ground kill, deck `DropIn`, collapsed-cell queue, and its debris block per `BlowUpBridge` cell, in that order. | `0x0047DD84..0x0047E02C` | partial: Rust splits kill over `blow_up_cells` but DropIn/debris over all `destroyed_set` | `src/sim/world/bridge_orchestrator.rs` | Keep fallout scoped to the cells that actually receive `BlowUpBridge`, unless a sibling state-machine report proves additional destroyed cells should get separate visual-only effects. | Collapse a state-machine bridge segment where `destroyed_cells` includes cells without `SetBridgeDirection::BlowUpBridge`; only `BlowUpBridge` cells force-kill/drop/spawn `BlowUpBridge` debris. Proposed test: `bridge_collapse_fallout_runs_only_on_blowupbridge_cells` | Do not treat every destroyed overlay cell as a `BlowUpBridge` cell. |
-| Deck occupants survive by selected-layer relayering: remove while `OnBridge==1`, clear, add while `OnBridge==0`. | `0x005F4178..0x005F41A1`, `0x005684B1`, `0x005688E1` | partial: Rust clears state then uses generic occupancy movement; exact selected-old-layer invariant needs tests | `src/sim/world/bridge_orchestrator.rs`, `src/sim/occupancy.rs` | Preserve old-layer removal before state mutation and ground-layer insertion after state mutation; validate stale duplicate layers rather than silently repairing them. | A tank on a bridge deck over water survives collapse, ends on ground layer in the same cell, and is not present in the bridge layer afterward. Proposed test: `bridge_dropin_relayers_from_bridge_list_to_ground_list_in_order` | Do not kill, drown, despawn, or leave deck units floating on the bridge layer. |
+| [2026-09-06] Deck list traversal captures next before each selected-layer relayer. | `0x0047DDBA..0x0047DDC9`, `0x005F4160` | Bounded Rust list authority now resides in one world operation; full falling/raw/hidden callbacks remain DRIFT. | `src/sim/world/bridge_orchestrator.rs`, `src/sim/world/lifecycle.rs` | Complete footprint removal/re-entry and fresh serialized order; preserve existing raw and reservation state. | Actual hut and nested IC command tests cover order, unmarked exclusion, non-anchor foundation and snapshot restoration. | Do not substitute full Mark/Unmark or claim complete DropIn parity. |
 | `CollapseBridge_*` walker-spawned `BridgeExplosions` occur before `DestroyBridge_*` per axial iteration; `BlowUpBridge` anims are a separate per-cell fallout block. | `0x00575BA0`, `0x00575870`, `0x00575540`, `0x00575220`; `0x0047DFBA`, `0x0047E02C` | partial/unchecked: Rust has one `spawn_bridge_debris` after aggregation | `src/sim/world/bridge_orchestrator.rs`, `src/sim/bridge_state/mod.rs` | If exact visual/RNG parity is pursued, represent walker-spawned three-perpendicular `BridgeExplosions` separately from `BlowUpBridge` metallic/explosion spawns. | Deterministic bounded hut collapse consumes walker anim RNG before each per-cell destruction and consumes `BlowUpBridge` RNG only for cells where `BlowUpBridge` is called. Proposed test: `collapsebridge_spawns_walker_anims_before_destroybridge_rng` | Do not merge all bridge collapse visuals into one post-hoc destroyed-set loop when validating RNG lockstep. |
 | Bridge collapse sound is an anim-start `Report`/`StartSound` consequence, not a direct bridge sound and not `RepairBridgeSound`. | `0x00421EA0`, `0x00424CE0`, `0x0047E02C`; `ini/rulesmd.ini:721` | missing: bridge explosion `WorldEffect` has no anim-start sound routing | `src/sim/world/bridge_orchestrator.rs`, app/audio animation sound routing | Emit selected anim's resolved start/report sound when the delayed bridge explosion begins. | A collapse selecting `TWLT036` emits `Explosion06` after the chosen 1-5 frame delay, not immediately. Proposed test: `bridge_explosion_report_sound_plays_when_delayed_anim_starts` | Do not add a hardcoded `BridgeCollapseSound`; do not reuse `BridgeRepaired`. |
 | Event `0x1F` is trigger-only, cell-tag-gated, and separate from event `0x18`. | `0x00575EE0`, assembly `0x00575F95..0x005761DE`, `0x006E53A0`, `0x0071F680` | acceptable no-op for skirmish; missing campaign trigger runtime | `src/sim/world/bridge_orchestrator.rs`, `src/sim/trigger_runtime.rs` | Keep no-op for skirmish, but future campaign support should deliver numeric event 31 only to tagged span-footprint cells. | A map with event-31 cell tags queues trigger action on collapse; skirmish without tags has no side effects. Proposed test: `bridge_span_event31_is_trigger_only_and_distinct_from_event18` | Do not use event 31 for damage, audio, zone rebuild, or global bridge destroyed notification. |

--- a/docs/system-map/topology.v2.json
+++ b/docs/system-map/topology.v2.json
@@ -291,6 +291,83 @@
       ],
       "notes": ["Static evidence records concrete load/unload ordering drift; no native executable loop oracle exists."]
     },
+    "GSI-04.05": {
+      "native_anchors": [
+        {
+          "symbol": "CellClass::AddContent",
+          "address": "0x0047E8A0",
+          "evidence": "docs/research/bridges/05-damage-collapse-repair-cabhut/BRIDGE_COLLAPSE_FALLOUT_ORDERING_GHIDRA_REPORT.md"
+        },
+        {
+          "symbol": "CellClass::RemoveContent",
+          "address": "0x0047EA90",
+          "evidence": "docs/research/bridges/05-damage-collapse-repair-cabhut/BRIDGE_COLLAPSE_FALLOUT_ORDERING_GHIDRA_REPORT.md"
+        }
+      ],
+      "rust_surfaces": [
+        {
+          "path": "src/sim/occupancy.rs",
+          "symbol": "CellOccupancy::first_on_layer / next_on_layer; OccupancyGrid::add / remove_on_layer / rebuild",
+          "coverage": "representative",
+          "observed_at_commit": "67127d0231341dc1613faab1a5ea804a9a96832d"
+        }
+      ],
+      "notes": [
+        "Bridge deck dispatch reads live selected membership. The represented world relayer updates every footprint cell and its serialized entry order so cache restoration reproduces the live list. This representative connection does not establish all raw occupation or movement callback semantics."
+      ]
+    },
+    "GSI-04.12": {
+      "native_anchors": [
+        {
+          "symbol": "CellClass::BlowUpBridge deck pass",
+          "address": "0x0047DDBA",
+          "evidence": "docs/research/bridges/05-damage-collapse-repair-cabhut/BRIDGE_COLLAPSE_FALLOUT_ORDERING_GHIDRA_REPORT.md"
+        }
+      ],
+      "rust_surfaces": [
+        {
+          "path": "src/sim/world/bridge_orchestrator.rs",
+          "symbol": "drop_in_bridge_deck_entities",
+          "coverage": "representative",
+          "observed_at_commit": "67127d0231341dc1613faab1a5ea804a9a96832d"
+        },
+        {
+          "path": "src/sim/world/bridge_deck_tests.rs",
+          "symbol": "hut_drop_in_owns_order_footprints_and_restore_without_teardown_side_effects",
+          "coverage": "representative",
+          "observed_at_commit": "67127d0231341dc1613faab1a5ea804a9a96832d"
+        },
+        {
+          "path": "src/sim/superweapon/cell_receiver_tests.rs",
+          "symbol": "iron_curtain_command_observes_native_deck_order_after_nested_bridge_drop_in",
+          "coverage": "representative",
+          "observed_at_commit": "67127d0231341dc1613faab1a5ea804a9a96832d"
+        }
+      ],
+      "notes": [
+        "The deck pass selects Bridge membership after the existing ground pass and captures next before each world relayer. Actual high-bridge hut and nested Iron Curtain command tests cover order, non-anchor footprint, unmarked exclusion and snapshot restoration. Full ground damage aliasing, raw/hidden callbacks and falling remain DRIFT; no whole bridge or rendered parity claim."
+      ]
+    },
+    "GSI-05.03": {
+      "native_anchors": [
+        {
+          "symbol": "ObjectClass::DropIn",
+          "address": "0x005F4160",
+          "evidence": "docs/research/bridges/05-damage-collapse-repair-cabhut/BRIDGE_COLLAPSE_FALLOUT_ORDERING_GHIDRA_REPORT.md"
+        }
+      ],
+      "rust_surfaces": [
+        {
+          "path": "src/sim/world/lifecycle.rs",
+          "symbol": "drop_in_bridge_member",
+          "coverage": "representative",
+          "observed_at_commit": "67127d0231341dc1613faab1a5ea804a9a96832d"
+        }
+      ],
+      "notes": [
+        "One world operation owns the represented deck member relayer, complete footprint removal/re-entry, one fresh serialized order and derived vehicle projection reconciliation. It preserves existing ground snap/movement reset, raw bytes, Drive reservations and clearing state; it does not run full Mark/Unmark teardown or placement effects. Full native DropIn, hidden-building entry and falling remain open."
+      ]
+    },
     "GSI-08.10": {
       "native_anchors": [
         {
@@ -1510,6 +1587,30 @@
       "detail": "The Infantry override invokes forced authored-Strength C4 damage through the shared world receiver, completing current nested world receipts before reading the next recipient.",
       "evidence": [
         "docs/research/IRONCURTAIN_FORCESHIELD_GHIDRA_REPORT.md"
+      ]
+    },
+    {
+      "id": "EDGE-0058-BRIDGE-DECK-CELL-MEMBERSHIP",
+      "plane": "routing",
+      "kind": "requires",
+      "from": "GSI-04.12",
+      "to": "GSI-04.05",
+      "context": "Bridge deck fallout",
+      "detail": "Read the selected Bridge list after ground callbacks and capture each successor before invoking the relayer that removes current membership.",
+      "evidence": [
+        "docs/research/bridges/05-damage-collapse-repair-cabhut/BRIDGE_COLLAPSE_FALLOUT_ORDERING_GHIDRA_REPORT.md"
+      ]
+    },
+    {
+      "id": "EDGE-0059-BRIDGE-DECK-WORLD-RELAYER",
+      "plane": "routing",
+      "kind": "requires",
+      "from": "GSI-04.12",
+      "to": "GSI-05.03",
+      "context": "Bridge deck fallout",
+      "detail": "One world-owned represented relayer maintains complete footprint membership, serialized re-entry order and the derived vehicle projection while preserving existing raw bytes and reservations.",
+      "evidence": [
+        "docs/research/bridges/05-damage-collapse-repair-cabhut/BRIDGE_COLLAPSE_FALLOUT_ORDERING_GHIDRA_REPORT.md"
       ]
     }
   ],

--- a/src/sim/superweapon/cell_receiver_tests.rs
+++ b/src/sim/superweapon/cell_receiver_tests.rs
@@ -389,7 +389,7 @@ fn iron_curtain_command_uses_packed_aliases_and_stamps_missing_cells() {
 }
 
 #[test]
-fn iron_curtain_command_follows_current_infantry_after_nested_bridge_drop_in() {
+fn iron_curtain_command_observes_native_deck_order_after_nested_bridge_drop_in() {
     use crate::sim::bridge_state::{
         AnchorSpan, Axis, BridgeCellRole, BridgeRuntimeCell, BridgeRuntimeState,
         BridgeheadAnchorClass, DamageState, Direction,
@@ -480,6 +480,10 @@ fn iron_curtain_command_follows_current_infantry_after_nested_bridge_drop_in() {
             .snapshot_layer(MovementLayer::Bridge),
         vec![boomer, tank]
     );
+    let unmarked = sim
+        .construct_object_limbo_at_height("MTNK", "Americans", 5, 5, 0, 4, &rules)
+        .unwrap();
+    sim.substrate.entities.get_mut(unmarked).unwrap().on_bridge = true;
     launch_command(&mut sim, &rules, "IC", 5, 5);
     let current = sim.substrate.entities.get(boomer).unwrap();
     assert!(
@@ -489,8 +493,30 @@ fn iron_curtain_command_follows_current_infantry_after_nested_bridge_drop_in() {
     let recipient = sim.substrate.entities.get(tank).unwrap();
     assert!(!recipient.on_bridge && recipient.health.current > 0);
     assert!(
-        recipient.invulnerability.is_some(),
-        "successor comes from current Ground membership after DropIn"
+        recipient.invulnerability.is_none(),
+        "native deck traversal prepends tank after boomer; current boomer then has no successor"
+    );
+    let ground = sim
+        .substrate
+        .occupancy
+        .get(5, 5)
+        .unwrap()
+        .snapshot_layer(MovementLayer::Ground);
+    assert_eq!(ground, vec![tank, boomer]);
+    let rebuilt = crate::sim::occupancy::OccupancyGrid::rebuild(&sim.substrate.entities);
+    assert_eq!(
+        rebuilt
+            .get(5, 5)
+            .unwrap()
+            .snapshot_layer(MovementLayer::Ground),
+        ground,
+        "serialized re-entry order preserves the live list during restore"
+    );
+    let twin = sim.substrate.entities.get(unmarked).unwrap();
+    assert!(twin.on_bridge && twin.lifecycle.in_limbo && !twin.lifecycle.cell_marked);
+    assert_eq!(
+        twin.position.z, 4,
+        "unmarked deck coordinate is not a DropIn recipient"
     );
     assert_eq!(
         sim.substrate

--- a/src/sim/world/bridge_deck_tests.rs
+++ b/src/sim/world/bridge_deck_tests.rs
@@ -1,0 +1,267 @@
+//! Production hut-collapse membership and restoration regressions.
+use super::{
+    dispatch_bridge_collapse_from_hut_with_overlay_registry,
+    tests::{seed_bridge_cell, water_below_bridge_terrain},
+};
+use crate::rules::{ini_parser::IniFile, ruleset::RuleSet};
+use crate::sim::{
+    bridge_state::{BridgeRuntimeState, DamageState},
+    movement::locomotor::MovementLayer,
+    world::Simulation,
+};
+
+#[test]
+fn hut_drop_in_owns_order_footprints_and_restore_without_teardown_side_effects() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n[VehicleTypes]\n0=MTNK\n[AircraftTypes]\n[BuildingTypes]\n0=BIG\n\
+         [MTNK]\nStrength=300\nSpeed=6\n[BIG]\nStrength=1000\nFoundation=2x1\n",
+    ))
+    .unwrap();
+    let mut sim = Simulation::with_seed(31);
+    sim.intern_rule_type_ids(&rules);
+    sim.resolve_type_handles(&rules);
+    sim.resolved_terrain = Some(water_below_bridge_terrain(4));
+    for (x, y) in [(4, 3), (4, 4), (4, 5), (3, 4)] {
+        let cell = sim
+            .resolved_terrain
+            .as_mut()
+            .unwrap()
+            .cell_mut(x, y)
+            .unwrap();
+        cell.level = 0;
+        cell.bridge_facts.raw_flags = crate::map::bridge_facts::BRIDGE_FLAG_STRUCTURAL;
+        cell.has_bridge_deck = true;
+        cell.bridge_walkable = true;
+        cell.bridge_deck_level = 4;
+    }
+    let mut bridge = BridgeRuntimeState::default();
+    for y in [3, 4, 5] {
+        bridge.test_seed_cell(4, y, seed_bridge_cell(0xD4));
+    }
+    sim.bridge_state = Some(bridge);
+    let mut construct = |name: &str, x: u16, marked: bool| {
+        let id = sim
+            .construct_object_limbo_at_height(name, "Americans", x, 4, 0, 4, &rules)
+            .unwrap();
+        sim.substrate.entities.get_mut(id).unwrap().on_bridge = true;
+        if marked {
+            sim.reveal(id);
+        }
+        id
+    };
+    let older = construct("MTNK", 4, true);
+    let newer = construct("MTNK", 4, true);
+    let building = construct("BIG", 3, true);
+    let unmarked = construct("MTNK", 4, false);
+    assert!(
+        sim.substrate
+            .entities
+            .get(building)
+            .unwrap()
+            .lifecycle
+            .cell_marked
+    );
+    assert_eq!(
+        sim.substrate
+            .occupancy
+            .get(4, 4)
+            .unwrap()
+            .snapshot_layer(MovementLayer::Bridge),
+        vec![newer, older, building]
+    );
+    assert_eq!(
+        sim.substrate
+            .occupancy
+            .get(3, 4)
+            .unwrap()
+            .snapshot_layer(MovementLayer::Bridge),
+        vec![building]
+    );
+    let drive = sim
+        .substrate
+        .entities
+        .get_mut(older)
+        .unwrap()
+        .drive_locomotion
+        .get_or_insert_with(Default::default);
+    drive.occupation_head_to = Some(crate::sim::components::DriveOccupationFootprint {
+        rx: 8,
+        ry: 8,
+        layer: MovementLayer::Ground,
+    });
+    drive.occupation_handoff = Some(crate::sim::components::DriveOccupationFootprint {
+        rx: 9,
+        ry: 8,
+        layer: MovementLayer::Bridge,
+    });
+    drive.current_occupation_cleared = false;
+    let drive_before = bincode::serialize(drive).unwrap();
+    sim.substrate
+        .cell_occupation
+        .reconcile_entity(sim.substrate.entities.get(older).unwrap());
+    sim.substrate
+        .entities
+        .get_mut(newer)
+        .unwrap()
+        .drive_locomotion
+        .get_or_insert_with(Default::default)
+        .current_occupation_cleared = true;
+    sim.substrate
+        .cell_occupation
+        .reconcile_entity(sim.substrate.entities.get(newer).unwrap());
+    let next_order = sim.substrate.next_occupancy_enter_order.current();
+    let raw_before = sim.substrate.raw_cell_occupation.clone();
+    let mut smudge = crate::sim::smudge_grid::SmudgeGrid::new(10, 10);
+    let decal = crate::sim::smudge_grid::SmudgeCell {
+        type_id: Some(1),
+        footprint_origin: Some((3, 4)),
+        frame_offset: 0,
+    };
+    smudge.test_force_set(3, 4, decal);
+    sim.smudge_grid = Some(smudge);
+
+    assert!(dispatch_bridge_collapse_from_hut_with_overlay_registry(
+        &mut sim,
+        &rules,
+        (4, 4),
+        None
+    ));
+    for y in [3, 4, 5] {
+        let cell = sim.bridge_state.as_ref().unwrap().cell(4, y).unwrap();
+        assert_eq!(cell.overlay_byte, 0xE7);
+        assert_eq!(cell.damage_state, DamageState::Destroyed);
+    }
+    let ground = vec![older, newer, building];
+    for (x, expected) in [(4, ground.clone()), (3, vec![building])] {
+        let cell = sim.substrate.occupancy.get(x, 4).unwrap();
+        assert!(cell.snapshot_layer(MovementLayer::Bridge).is_empty());
+        assert_eq!(cell.snapshot_layer(MovementLayer::Ground), expected);
+    }
+    for (offset, id) in [newer, older, building].into_iter().enumerate() {
+        let object = sim.substrate.entities.get(id).unwrap();
+        assert!(!object.on_bridge && object.lifecycle.cell_marked);
+        assert_eq!(
+            object.position.z, 0,
+            "existing represented ground snap retained"
+        );
+        assert_eq!(object.occupancy_enter_order, next_order + offset as u64);
+    }
+    assert_eq!(
+        sim.substrate.next_occupancy_enter_order.current(),
+        next_order + 3
+    );
+    let twin = sim.substrate.entities.get(unmarked).unwrap();
+    assert!(twin.on_bridge && twin.lifecycle.in_limbo && !twin.lifecycle.cell_marked);
+    assert_eq!(twin.position.z, 4);
+    assert_eq!(
+        sim.substrate.raw_cell_occupation, raw_before,
+        "raw callback/falling drift is not rewritten from the legacy snapped Z"
+    );
+    assert_eq!(
+        bincode::serialize(
+            sim.substrate
+                .entities
+                .get(older)
+                .unwrap()
+                .drive_locomotion
+                .as_ref()
+                .unwrap()
+        )
+        .unwrap(),
+        drive_before
+    );
+    for (x, y, layer) in [
+        (4, 4, MovementLayer::Ground),
+        (8, 8, MovementLayer::Ground),
+        (9, 8, MovementLayer::Bridge),
+    ] {
+        assert_ne!(sim.substrate.cell_occupation.vehicle_bits(x, y, layer), 0);
+    }
+    assert_eq!(
+        sim.substrate
+            .cell_occupation
+            .vehicle_bits(4, 4, MovementLayer::Bridge),
+        0
+    );
+    assert_eq!(
+        *sim.smudge_grid.as_ref().unwrap().cell(3, 4),
+        decal,
+        "relayer is not a building placement"
+    );
+
+    assert!(
+        sim.substrate
+            .entities
+            .get(newer)
+            .unwrap()
+            .drive_locomotion
+            .as_ref()
+            .unwrap()
+            .current_occupation_cleared
+    );
+    assert_eq!(
+        sim.substrate
+            .cell_occupation
+            .vehicle_bits_ignoring(4, 4, MovementLayer::Ground, older),
+        0,
+        "a cleared current footprint stays cleared while list membership relayers"
+    );
+    let bytes = crate::sim::snapshot::GameSnapshot::save(&sim, 0, 0, "bridge-deck", 0);
+    let mut restored = crate::sim::snapshot::GameSnapshot::load(&bytes)
+        .unwrap()
+        .sim;
+    restored.restore_after_snapshot_load().unwrap();
+    assert_eq!(
+        restored
+            .substrate
+            .occupancy
+            .get(4, 4)
+            .unwrap()
+            .snapshot_layer(MovementLayer::Ground),
+        ground
+    );
+    assert_eq!(
+        restored
+            .substrate
+            .occupancy
+            .get(3, 4)
+            .unwrap()
+            .snapshot_layer(MovementLayer::Ground),
+        vec![building]
+    );
+    assert!(
+        restored
+            .substrate
+            .entities
+            .get(newer)
+            .unwrap()
+            .drive_locomotion
+            .as_ref()
+            .unwrap()
+            .current_occupation_cleared
+    );
+    assert_eq!(
+        restored.substrate.cell_occupation.vehicle_bits_ignoring(
+            4,
+            4,
+            MovementLayer::Ground,
+            older
+        ),
+        0
+    );
+    assert_eq!(restored.substrate.raw_cell_occupation, raw_before);
+    assert_eq!(
+        restored.substrate.next_occupancy_enter_order.current(),
+        next_order + 3
+    );
+    for (x, y, layer) in [
+        (4, 4, MovementLayer::Ground),
+        (8, 8, MovementLayer::Ground),
+        (9, 8, MovementLayer::Bridge),
+    ] {
+        assert_eq!(
+            restored.substrate.cell_occupation.vehicle_bits(x, y, layer),
+            sim.substrate.cell_occupation.vehicle_bits(x, y, layer)
+        );
+    }
+}

--- a/src/sim/world/bridge_orchestrator.rs
+++ b/src/sim/world/bridge_orchestrator.rs
@@ -1756,71 +1756,23 @@ fn bridge_jittered_subcell(draw: u32) -> SimFixed {
     CELL_CENTER_LEPTON + SimFixed::from_num(offset)
 }
 
-/// Snap bridge-deck entities at `(rx, ry)` to ground level. Mirror of
-/// the binary's `BlowUpBridge` step 2 (HIGH §11.4 + §12.7): walks the
-/// deck entity list and calls `DropIn` on each.
-///
-/// Per HIGH §12.7 / §12.9: NO damage, NO despawn — units survive
-/// stranded even when the destination is unwalkable (water below).
-/// Vanilla has no drown mechanism. This is the parity correction
-/// against the legacy `resolve_bridge_state_changes`, which despawned
-/// deck entities over unwalkable ground.
+/// BlowUpBridge's deck pass (0x0047DDBA..0x0047DDC9): read the selected
+/// head after ground callbacks, capture next BEFORE DropIn removes current.
+/// Membership owns selection, including retained corpses and non-anchor cells.
 fn drop_in_bridge_deck_entities(sim: &mut Simulation, rx: u16, ry: u16) {
-    use crate::sim::movement::locomotor::{GroundMovePhase, MovementLayer};
-    use crate::sim::occupancy::CellListInsertion;
-
-    let ground_level = sim
-        .resolved_terrain
-        .as_ref()
-        .and_then(|t| t.cell(rx, ry))
-        .map(|c| c.level)
-        .unwrap_or(0);
-
-    let to_snap: Vec<u64> = sim
+    use crate::sim::movement::locomotor::MovementLayer;
+    let mut next = sim
         .substrate
-        .entities
-        .iter_sorted()
-        .filter(|(_, e)| e.position.rx == rx && e.position.ry == ry && e.is_on_bridge_layer())
-        .map(|(id, _)| id)
-        .collect();
-
-    for id in to_snap {
-        let mut relayer = None;
-        if let Some(entity) = sim.substrate.entities.get_mut(id) {
-            entity.bridge_occupancy = None;
-            entity.on_bridge = false;
-            entity.position.z = ground_level;
-            entity.position.exact_z_leptons = None;
-            entity.movement_target = None;
-            if let Some(ref mut loco) = entity.locomotor {
-                loco.layer = MovementLayer::Ground;
-                loco.phase = GroundMovePhase::Idle;
-            }
-            relayer = Some((
-                entity.position.rx,
-                entity.position.ry,
-                entity.sub_cell,
-                CellListInsertion::from_category(entity.category),
-            ));
-        }
-        if let Some((rx, ry, sub_cell, insertion)) = relayer {
-            // DropIn relayer (GATE A2 / P6): the deck object list is relayered DOWN
-            // — remove the occupant from the BRIDGE object-list layer (its layer
-            // before the collapse) and re-add it on the GROUND layer in the same
-            // cell. Authoritative two-layer move: the old half observes the deck
-            // layer, the new half the ground layer.
-            sim.substrate.occupancy.move_entity_layered(
-                rx,
-                ry,
-                rx,
-                ry,
-                id,
-                MovementLayer::Bridge,
-                MovementLayer::Ground,
-                sub_cell,
-                insertion,
-            );
-        }
+        .occupancy
+        .get(rx, ry)
+        .and_then(|cell| cell.first_on_layer(MovementLayer::Bridge));
+    while let Some(id) = next {
+        next = sim
+            .substrate
+            .occupancy
+            .get(rx, ry)
+            .and_then(|cell| cell.next_on_layer(MovementLayer::Bridge, id));
+        sim.drop_in_bridge_member(id);
     }
 }
 
@@ -1972,7 +1924,9 @@ mod tests {
     use crate::sim::occupancy::CellListInsertion;
     use crate::util::fixed_math::{SIM_ZERO, SimFixed};
 
-    fn seed_bridge_cell(overlay_byte: u8) -> crate::sim::bridge_state::BridgeRuntimeCell {
+    pub(super) fn seed_bridge_cell(
+        overlay_byte: u8,
+    ) -> crate::sim::bridge_state::BridgeRuntimeCell {
         crate::sim::bridge_state::BridgeRuntimeCell {
             deck_present: true,
             destroyable: true,
@@ -1992,7 +1946,7 @@ mod tests {
     /// `deck_level`, ground level=0, water below (`is_water=true`,
     /// `ground_walk_blocked=true`). Used to verify DropIn lets deck units
     /// survive even with no walkable ground.
-    fn water_below_bridge_terrain(deck_level: u8) -> ResolvedTerrainGrid {
+    pub(super) fn water_below_bridge_terrain(deck_level: u8) -> ResolvedTerrainGrid {
         let mut cells = Vec::new();
         for y in 0..=5u16 {
             for x in 0..=5u16 {
@@ -2465,55 +2419,8 @@ mod tests {
         assert_eq!(cell.count_on(MovementLayer::Bridge), 0);
     }
 
-    /// P6 / GATE A2: collapse DropIn relayers the persistent occupancy entry from
-    /// the BRIDGE object-list layer to the GROUND layer (not merely clearing the
-    /// entity's `on_bridge` byte). The deck list is relayered DOWN — a verified
-    /// authoritative two-layer move (remove on Bridge, add on Ground in-place).
-    #[test]
-    fn collapse_dropin_relayers_occupancy_to_ground() {
-        let mut sim = Simulation::new();
-        sim.resolved_terrain = Some(water_below_bridge_terrain(3));
-        let id = spawn_deck_unit(&mut sim);
-        // Occupant starts on the BRIDGE object-list layer at (5,5).
-        sim.substrate.occupancy.add(
-            5,
-            5,
-            id,
-            MovementLayer::Bridge,
-            None,
-            CellListInsertion::PrependNonBuilding,
-        );
-        assert_eq!(
-            sim.substrate
-                .occupancy
-                .count_on_layer(5, 5, MovementLayer::Bridge),
-            1,
-            "precondition: occupant on the bridge layer"
-        );
-
-        drop_in_bridge_deck_entities(&mut sim, 5, 5);
-
-        // After DropIn: the occupant is gone from the bridge layer and present on
-        // the ground layer of the SAME cell.
-        assert_eq!(
-            sim.substrate
-                .occupancy
-                .count_on_layer(5, 5, MovementLayer::Bridge),
-            0,
-            "deck-layer occupancy relayered away"
-        );
-        assert_eq!(
-            sim.substrate
-                .occupancy
-                .count_on_layer(5, 5, MovementLayer::Ground),
-            1,
-            "occupancy dropped in onto the ground layer"
-        );
-        assert!(sim.substrate.occupancy.contains_entity(5, 5, id));
-    }
-
-    /// Build a minimal RuleSet whose `bridge_rules.voxel_max` matches the
-    /// argument. Used by Task 12 debris tests to toggle the voxel-max gate.
+    /// Build a minimal RuleSet whose bridge voxel maximum matches the argument.
+    /// Used by debris tests to toggle the voxel-max gate.
     fn rules_with_voxel_max(voxel_max: u32) -> crate::rules::ruleset::RuleSet {
         let body = format!(
             "[InfantryTypes]\n\
@@ -3715,3 +3622,7 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "bridge_deck_tests.rs"]
+mod deck_tests;

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -1475,6 +1475,65 @@ impl Simulation {
         }
     }
 
+    /// Own the represented bridge DropIn's complete cell-list relayer.
+    /// Native ObjectClass::DropIn 0x005F4160 removes membership while OnBridge
+    /// is set, then clears it and re-enters through the multi-cell hooks.
+    /// The fresh entry order also owns reconstruction after snapshot restore.
+    ///
+    /// This preserves the existing Rust ground snap and locomotor reset.
+    /// Native falling/unchanged-Z, concrete raw occupation callbacks, and
+    /// hidden-building occupation entry remain DRIFT. Add/RemoveContent skip Infantry raw callbacks;
+    /// full Mark/Unmark would also discard reservations and building smudges.
+    pub(super) fn drop_in_bridge_member(&mut self, stable_id: u64) {
+        use crate::sim::movement::locomotor::{GroundMovePhase, MovementLayer};
+        let Some(entity) = self.substrate.entities.get(stable_id) else {
+            return;
+        };
+        let cells = entity_occupancy_cells(entity);
+        let current_cell = (entity.position.rx, entity.position.ry);
+        let sub_cell = entity.sub_cell;
+        let insertion = CellListInsertion::from_category(entity.category);
+        let ground_level = self
+            .resolved_terrain
+            .as_ref()
+            .and_then(|terrain| terrain.cell(current_cell.0, current_cell.1))
+            .map_or(0, |cell| cell.level);
+        for &(rx, ry) in &cells {
+            self.substrate
+                .occupancy
+                .remove_on_layer(rx, ry, stable_id, MovementLayer::Bridge);
+        }
+        let order = self.substrate.next_occupancy_enter_order.next();
+        let entity = self
+            .substrate
+            .entities
+            .get_mut(stable_id)
+            .expect("member remains represented");
+        entity.bridge_occupancy = None;
+        entity.on_bridge = false;
+        entity.position.z = ground_level;
+        entity.position.exact_z_leptons = None;
+        entity.movement_target = None;
+        entity.occupancy_enter_order = order;
+        if let Some(loco) = entity.locomotor.as_mut() {
+            loco.layer = MovementLayer::Ground;
+            loco.phase = GroundMovePhase::Idle;
+        }
+        // Rebuild only the derived vehicle projection: serialized head-to,
+        // handoff and current-cleared facts retain their existing owners.
+        self.substrate.cell_occupation.reconcile_entity(entity);
+        for &(rx, ry) in &cells {
+            self.substrate.occupancy.add(
+                rx,
+                ry,
+                stable_id,
+                MovementLayer::Ground,
+                sub_cell,
+                insertion,
+            );
+        }
+    }
+
     /// Test/fixture helper retained at the transaction boundary.  It is
     /// idempotent and updates the authoritative `cell_marked` fact.
     pub(crate) fn add_entity_occupancy(&mut self, stable_id: u64) {


### PR DESCRIPTION
Bridge collapse previously collected deck receivers globally by coordinates and stable ID. It now traverses the selected Bridge membership list, captures the next receiver before each callback, and delegates footprint removal, ground insertion, serialized entry order and vehicle projection reconciliation to one world-owned operation. Snapshot restoration reproduces the resulting order.

Native evidence: BlowUpBridge0047DDBA..0047DDC9 and DropIn005F4160, documented in the updated collapse report. The represented physical drop behavior is preserved; native falling, concrete raw callbacks, hidden-building entry and ground aliased damage remain open. The changed nested Iron Curtain receiver order is an evidence-backed native correction.

Validation:
- Actual hut-dispatch integration covers non-anchor building footprints, receiver order, unmarked exclusion, preserved reservations/raw occupation/smudges, and save/load cache reconstruction.
- Nested Iron Curtain/DeathWeapon dispatch covers downstream receiver continuation. The old implementation fails this order regression.
- Removed one weaker redundant single-object helper test; retained complementary water and ground exclusion checks.
- cargo check -p vera20k passed (90 existing warnings).
- cargo test -p vera20k --lib: test result: ok. 8463 passed; 0 failed; 80 ignored; 0 measured; 0 filtered out; finished in 14.91s
- Independent read-only source, native evidence, test and documentation reviews found no blocker.
- System Map checker still reports the same43 baseline diagnostics; comparison found no new issues. Normal checker is not passing.

Started from refreshed origin/main a86a1fff. Final tested Rust source67127d02; subsequent commit changes only System Map documentation.
