### PR TITLE
Restate goal 2 in plain words

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ VERA20K operates after contributor-owned cooperative principles. Contributors ea
 Engine true to the original Westwood game: visuals, atmosphere, gameplay.
 
 **2.**
-Constructed from the ground up for large multiplayer — targeting support for up to **30 players** and **20,000 units** on significantly bigger maps.
+Built for big multiplayer: targeting support for 30 players, 20,000 units, larger maps.
 
 **3.**
 Offer known old and new rts feautures never seen before to enhance the cnc ra2 experience.


### PR DESCRIPTION
Goal 2 now reads: Built for big multiplayer: targeting support for 30 players, 20,000 units, larger maps.