### PR TITLE
Preserve canonical navigation across bridge and terrain updates

### DIFF
--- a/docs/system-map/topology.v2.json
+++ b/docs/system-map/topology.v2.json
@@ -381,6 +381,64 @@
       ],
       "notes": ["Static evidence records concrete load/unload ordering drift; no native executable loop oracle exists."]
     },
+    "GSI-04.14": {
+      "native_anchors": [
+        {
+          "symbol": "MapClass::UpdateBridgeZonesHelper",
+          "address": "0x0056C510",
+          "evidence": "docs/research/bridges/02-cell-state-layering-zones/LOW_BRIDGE_ZONE_PRECHECK_LANDTYPE10_CONNECTIVITY_GHIDRA_REPORT.md"
+        }
+      ],
+      "rust_surfaces": [
+        {
+          "path": "src/sim/world/bridge_orchestrator.rs",
+          "symbol": "refresh_bridge_zones_if_dirty; collapse and hut callers",
+          "coverage": "representative",
+          "observed_at_commit": "d13e84d449c5cbcc58b75af7326db68325d5d044"
+        },
+        {
+          "path": "src/sim/world/world_orders.rs",
+          "symbol": "tick_bridge_repair_orders_with_overlay_registry",
+          "coverage": "representative",
+          "observed_at_commit": "d13e84d449c5cbcc58b75af7326db68325d5d044"
+        }
+      ],
+      "notes": [
+        "Bridge collapse and repair retain their endpoint-first zone-tail timing and use the shared dynamic navigation owner. The former terrain-only canonical publication lost unrelated building foundations immediately; actual collapse and engineer-arrival regressions cover that loss. This is a VERA-internal projection correction, not whole bridge/native parity closure."
+      ]
+    },
+    "GSI-04.06": {
+      "rust_surfaces": [
+        {
+          "path": "src/sim/world/navigation.rs",
+          "symbol": "NavigationCaches::rebuild_dynamic / rebuild_zones / rebuild_zones_full",
+          "coverage": "representative",
+          "observed_at_commit": "d13e84d449c5cbcc58b75af7326db68325d5d044"
+        },
+        {
+          "path": "src/sim/world/mod.rs",
+          "symbol": "rebuild_dynamic_navigation; finish_terrain_navigation_changes; combat/noncombat and later phase consumers",
+          "coverage": "representative",
+          "observed_at_commit": "d13e84d449c5cbcc58b75af7326db68325d5d044"
+        },
+        {
+          "path": "src/sim/world/world_tests.rs",
+          "symbol": "test_bridge_orchestrator_state_machine_path_collapses_anchor_and_deactivates_endpoint",
+          "coverage": "representative",
+          "observed_at_commit": "d13e84d449c5cbcc58b75af7326db68325d5d044"
+        },
+        {
+          "path": "src/sim/world/world_orders_bridge_repair_tests.rs",
+          "symbol": "bridge_repair_preserves_unrelated_foundation_before_next_reader",
+          "coverage": "representative",
+          "observed_at_commit": "d13e84d449c5cbcc58b75af7326db68325d5d044"
+        }
+      ],
+      "notes": [
+        "One world operation consumes synchronous overlay and receiver terrain receipts, starting from navigation published after callbacks. Earlier pinned snapshots remain immutable; subsequent phases receive current canonical navigation, including when there are no receipts. The empty-receipt path reuses its Arc rather than copying the map.",
+        "Regressions cover immediate foundation preservation, stale pre-collapse snapshots with empty/nonempty receipts, actual engineer arrival and RNG, and snapshot/cache reconstruction. A postcombat movement route exercises the consumer but is only a smoke check, not native traversal parity. Existing shared structure-selection policy is unchanged."
+      ]
+    },
     "GSI-04.05": {
       "native_anchors": [
         {
@@ -1728,6 +1786,23 @@
         "docs/research/LOADING_FIRST_RENDERER_CORRECTED_COMPOSITION_DATA_READINESS_GHIDRA_REPORT.md",
         "docs/research/skirmish-ui/SKIRMISH_START_TO_FULL_INIT_SPAWN_TRACE.md"
       ]
+    },
+    {
+      "id": "EDGE-0062-BRIDGE-CANONICAL-NAVIGATION",
+      "plane": "rust",
+      "kind": "emits_to",
+      "from": "GSI-04.14",
+      "to": "GSI-04.06",
+      "context": "Collapse, hut fallout and engineer repair",
+      "detail": "After endpoint updates, bridge mutations publish the shared structure-aware navigation projection. Terrain completion retains that current authority for subsequent world readers.",
+      "evidence": [
+        "docs/research/bridges/05-damage-collapse-repair-cabhut/BRIDGE_COLLAPSE_FALLOUT_ORDERING_GHIDRA_REPORT.md",
+        "src/sim/world/bridge_orchestrator.rs",
+        "src/sim/world/world_orders.rs",
+        "src/sim/world/mod.rs",
+        "src/sim/world/navigation.rs"
+      ],
+      "observed_at_commit": "d13e84d449c5cbcc58b75af7326db68325d5d044"
     }
   ],
   "loops": {

--- a/src/sim/world/bridge_orchestrator.rs
+++ b/src/sim/world/bridge_orchestrator.rs
@@ -155,7 +155,7 @@ pub(crate) fn apply_bridge_damage_events_with_overlay_registry(
     // Cascade Step 6: zone graph rebuild (HIGH §12.8). Triggered when
     // any final-stage walker cell flagged the bridge endpoint records
     // dirty.
-    refresh_bridge_zones_if_dirty(sim, any_zones_dirty);
+    refresh_bridge_zones_if_dirty(sim, rules, any_zones_dirty);
 
     // BR-16: feed the minimap radar-dirty channel — the collapsed triple plus
     // every cascade-leaf cell touched (carried in each outcome's `radar_cells`),
@@ -552,7 +552,7 @@ fn apply_hut_bridge_execution(
     update_adjacent_bridges(sim, &rim_cells);
     project_pending_low_bridge_overlay_writes(sim, overlay_registry);
     notify_bridge_span_collapse(sim, &destroyed_set);
-    refresh_bridge_zones_if_dirty(sim, any_zones_dirty);
+    refresh_bridge_zones_if_dirty(sim, rules, any_zones_dirty);
 
     // BR-16: feed the minimap radar-dirty channel (see apply_bridge_damage_events).
     radar_dirty.extend(destroyed_set.iter().copied());
@@ -1576,24 +1576,27 @@ pub(crate) fn reconcile_low_bridge_surface_after_cache_load(
 ///      cell damage state — first destroyed cell in a group flips its
 ///      endpoint pair to `active = false`. Replaces the side-effect of
 ///      the legacy single-shot `apply_damage`.
-///   2. Rebuild the path grid from the post-collapse bridge state.
-///   3. Rerun `Simulation::rebuild_zone_grid` so cross-bridge
-///      passability reflects the new connectivity.
-pub(crate) fn refresh_bridge_zones_if_dirty(sim: &mut Simulation, any_zones_dirty: bool) {
+///   2. Ask the world navigation owner to publish current terrain costs,
+///      structure blockers, bridge passability and zone connectivity together.
+pub(crate) fn refresh_bridge_zones_if_dirty(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    any_zones_dirty: bool,
+) {
     if !any_zones_dirty {
         return;
     }
     if let Some(bs) = sim.bridge_state.as_mut() {
         bs.refresh_endpoint_active_flags();
     }
-    let Some(terrain) = sim.resolved_terrain.as_ref() else {
-        return;
-    };
-    let path_grid = crate::sim::pathfinding::PathGrid::from_resolved_terrain_with_bridges(
-        terrain,
-        sim.bridge_state.as_ref(),
-    );
-    sim.rebuild_zone_grid(&path_grid);
+    // VERA-internal projection ownership, gamemd equivalent UNCHECKED.
+    // This publishes the canonical path as well as zones. Use the shared
+    // structure/terrain projection so unrelated foundations survive bridge
+    // changes before the next reader; endpoint refresh must stay first.
+    // Native zone-tail ordering: BRIDGE_COLLAPSE_FALLOUT_ORDERING_GHIDRA_REPORT.md
+    // in docs/research/bridges/05-damage-collapse-repair-cabhut/, section
+    // "Zone/path invalidation" (UpdateBridgeZonesHelper @ 0x0056C510).
+    let _ = sim.rebuild_dynamic_navigation(rules);
 }
 
 /// Per-cell debris spawn. Mirror of binary `BlowUpBridge` step 4. RNG draw
@@ -2181,6 +2184,7 @@ mod tests {
         use crate::rules::terrain_rules::LandType;
 
         let registry = gsi_04_13_stock_low_registry();
+        let rules = RuleSet::from_ini(&crate::rules::ini_parser::IniFile::from_str("")).unwrap();
         let road_speed = registry
             .flags(0x4A)
             .and_then(|flags| flags.land_speed_costs)
@@ -2243,7 +2247,7 @@ mod tests {
         };
         assert!(zones_dirty);
         project_pending_low_bridge_overlay_writes(&mut sim, Some(&registry));
-        refresh_bridge_zones_if_dirty(&mut sim, zones_dirty);
+        refresh_bridge_zones_if_dirty(&mut sim, &rules, zones_dirty);
         gsi_04_13_assert_ground_surface(&sim, LandType::Rough.as_index());
         assert_eq!(
             sim.terrain_costs
@@ -2294,7 +2298,7 @@ mod tests {
         };
         assert!(repair.zones_dirty);
         project_pending_low_bridge_overlay_writes(&mut sim, Some(&registry));
-        refresh_bridge_zones_if_dirty(&mut sim, repair.zones_dirty);
+        refresh_bridge_zones_if_dirty(&mut sim, &rules, repair.zones_dirty);
         gsi_04_13_assert_ground_surface(&sim, LandType::Road.as_index());
         for ry in 0..3 {
             let overlay = sim.overlay_grid.as_ref().expect("overlay grid").cell(0, ry);

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -159,9 +159,9 @@ pub struct TickResult {
     /// An entity's owner changed (garrison reconciliation, engineer capture) — sprite
     /// atlas needs rebuild for the new house color.
     pub ownership_changed: bool,
-    /// A bridge cell transitioned to `DamageState::Destroyed` this tick; the
-    /// frame finalizer publishes the collapsed navigation snapshot for the next
-    /// tick. Matches gamemd's one-tick-delayed visibility.
+    /// Bridge state changed this tick. Mutation owners publish navigation at
+    /// their synchronous reader boundary; the frame finalizer also rebuilds
+    /// the projection before committing the frame for subsequent ticks.
     pub bridge_state_changed: bool,
     pub movement: movement::MovementTickStats,
 }
@@ -2346,23 +2346,10 @@ impl Simulation {
             );
         }
 
-        let mut navigation_changed_cells = self
-            .overlay_grid
-            .as_mut()
-            .map(|grid| grid.take_synchronous_navigation_cells())
-            .unwrap_or_default();
-        for cell in terrain_navigation_changed_cells {
-            if !navigation_changed_cells.contains(&cell) {
-                navigation_changed_cells.push(cell);
-            }
-        }
-        if !navigation_changed_cells.is_empty() {
-            let prior_path_grid = self.path_grid.as_deref().cloned();
-            let _ = self.refresh_navigation_after_terrain_changes(
-                prior_path_grid.as_ref(),
-                &navigation_changed_cells,
-            );
-        }
+        let _ = self.finish_terrain_navigation_changes(
+            None,
+            &terrain_navigation_changed_cells,
+        );
 
         for building in &effects.destroyed_crewed_buildings {
             production::eject_destruction_survivors(
@@ -5034,6 +5021,35 @@ impl Simulation {
         .rebuild_zones_full(path_grid, terrain, self.bridge_state.as_ref());
     }
 
+    /// Consume terrain/overlay receipts at their existing world-reader boundary.
+    /// VERA-internal projection protocol, gamemd equivalent UNCHECKED. A pinned
+    /// pre-callback grid is only a fallback: bridge and wall callbacks may have
+    /// already published newer canonical navigation. Never rebuild over it from
+    /// a stale reader snapshot. The returned projection serves subsequent phases.
+    fn finish_terrain_navigation_changes(
+        &mut self,
+        fallback_path_grid: Option<&PathGrid>,
+        terrain_changed_cells: &[(u16, u16)],
+    ) -> Option<Arc<PathGrid>> {
+        let mut changed_cells = self
+            .overlay_grid
+            .as_mut()
+            .map(|grid| grid.take_synchronous_navigation_cells())
+            .unwrap_or_default();
+        for &cell in terrain_changed_cells {
+            if !changed_cells.contains(&cell) {
+                changed_cells.push(cell);
+            }
+        }
+        let canonical = self.path_grid_snapshot();
+        if changed_cells.is_empty() {
+            return canonical.or_else(|| fallback_path_grid.cloned().map(Arc::new));
+        }
+        let current = canonical.as_deref().or(fallback_path_grid);
+        self.refresh_navigation_after_terrain_changes(current, &changed_cells)?;
+        self.path_grid_snapshot()
+    }
+
     /// Refresh navigation authority after inline overlay mutation or terrain
     /// object destruction. The incoming grid carries dynamic structure and
     /// wall blockers, so only synchronously changed cells are replaced from the
@@ -6489,7 +6505,7 @@ impl Simulation {
         let mut spawned_entities = false;
         let mut destroyed_structure = false;
         let mut placed_building_owners = Vec::new();
-        let mut tail_path_grid: Option<PathGrid> = None;
+        let mut tail_path_grid: Option<Arc<PathGrid>> = None;
         // No command-boundary drain: command-applied deaths (sell, MCV/slave
         // deploy-undeploy, engineer capture) now stay in the Dying window like
         // combat deaths, freed only by the single end-of-tick drain — matching
@@ -6919,28 +6935,12 @@ impl Simulation {
                     overlay_registry,
                 );
             }
-            let mut navigation_changed_cells = self
-                .overlay_grid
-                .as_mut()
-                .map(|grid| grid.take_synchronous_navigation_cells())
-                .unwrap_or_default();
-            for cell in combat_result
-                .terrain_navigation_changed_cells
-                .iter()
-                .copied()
-            {
-                if !navigation_changed_cells.contains(&cell) {
-                    navigation_changed_cells.push(cell);
-                }
-            }
-            if !navigation_changed_cells.is_empty() {
-                tail_path_grid = self.refresh_navigation_after_terrain_changes(
-                    active_post_combat_path_grid,
-                    &navigation_changed_cells,
-                );
-            }
+            tail_path_grid = self.finish_terrain_navigation_changes(
+                active_post_combat_path_grid,
+                &combat_result.terrain_navigation_changed_cells,
+            );
             let post_terrain_path_grid = tail_path_grid
-                .as_ref()
+                .as_deref()
                 .or(active_post_combat_path_grid);
             // Apply RevealOnFire events from combat.
             for ev in &combat_result.reveal_events {
@@ -7217,7 +7217,7 @@ impl Simulation {
         // behavior-preserving.) Native-spine note: gamemd runs HouseClass updates
         // (incl. defeat) in the tail and commits the frame counter late; AI
         // placement is project-deferred and kept in its current slot.
-        let late_path_grid = tail_path_grid.as_ref().or(path_grid);
+        let late_path_grid = tail_path_grid.as_deref().or(path_grid);
         let frame_committed = self.run_late_region(
             if lane == TickLane::Ordinary {
                 commands

--- a/src/sim/world/world_orders.rs
+++ b/src/sim/world/world_orders.rs
@@ -565,6 +565,7 @@ impl Simulation {
             // the collapse cascade's `refresh_bridge_zones_if_dirty` call.
             crate::sim::world::bridge_orchestrator::refresh_bridge_zones_if_dirty(
                 self,
+                rules,
                 outcome.zones_dirty,
             );
 

--- a/src/sim/world/world_orders_bridge_repair_tests.rs
+++ b/src/sim/world/world_orders_bridge_repair_tests.rs
@@ -586,6 +586,54 @@ fn engineer_at_intact_cabhut_emits_sound_no_mutation() {
     );
 }
 
+/// Exercise the arrival owner directly: a later frame rebuild must not mask
+/// an incomplete path projection published by the repair's zone refresh.
+#[test]
+fn bridge_repair_preserves_unrelated_foundation_before_next_reader() {
+    let (mut sim, rules, _) = build_sim();
+    let unrelated = spawn_cabhut(&mut sim, 1, 1);
+    let target = spawn_cabhut(&mut sim, 9, 10);
+    let engineer = spawn_engineer(&mut sim, 9, 10);
+    sim.substrate
+        .entities
+        .get_mut(engineer)
+        .unwrap()
+        .capture_target = Some(target);
+    seed_destroyed_bridge(&mut sim);
+    assert!(sim.rebuild_dynamic_navigation(&rules));
+    let pinned = sim.path_grid_snapshot().unwrap();
+    assert!(!pinned.is_walkable(1, 1));
+    assert!(sim.substrate.occupancy.contains_entity(1, 1, unrelated));
+    let gameplay_rng = (sim.scenario_rng.state(), sim.main_rng.state());
+    let mut expected_mapgen = sim.mapgen_rng.clone();
+    let _ = expected_mapgen.next_range_u32_inclusive_scaled(0, 3);
+
+    assert!(
+        sim.tick_bridge_repair_orders_with_overlay_registry(&rules, None, &Default::default(),)
+    );
+
+    assert!(sim.substrate.entities.get(engineer).unwrap().dying);
+    assert!(sim.substrate.occupancy.contains_entity(1, 1, unrelated));
+    assert!(
+        !sim.path_grid().unwrap().is_walkable(1, 1),
+        "engineer repair lost an unrelated foundation before the next reader"
+    );
+    assert!(!pinned.is_walkable(1, 1));
+    assert_eq!(
+        gameplay_rng,
+        (sim.scenario_rng.state(), sim.main_rng.state())
+    );
+    assert_eq!(sim.mapgen_rng.state(), expected_mapgen.state());
+    for &(rx, ry) in ENGINEER_REPAIR_STRIP_CELLS {
+        assert!(
+            sim.bridge_state
+                .as_ref()
+                .unwrap()
+                .is_bridge_walkable(rx, ry)
+        );
+    }
+}
+
 #[test]
 fn consecutive_engineers_second_bridge_repair_waits_for_next_tick() {
     let (mut sim, rules, heights) = build_sim();
@@ -1973,8 +2021,7 @@ fn generated_map_bridge_repair_continues_post_rmg_mapgen_stream() {
             usize::try_from(generated.index_b).expect("test MapGen cursor B is non-negative"),
         )
     };
-    let mut expected =
-        crate::sim::rng::SimRng::from_mapgen_continuation(continuation());
+    let mut expected = crate::sim::rng::SimRng::from_mapgen_continuation(continuation());
     let expected_variant = expected.next_range_u32_inclusive_scaled(0, 3) as u8;
 
     let (mut sim, _rules, _heights) = build_sim();
@@ -1982,8 +2029,7 @@ fn generated_map_bridge_repair_continues_post_rmg_mapgen_stream() {
     sim.mapgen_rng = crate::sim::rng::SimRng::from_mapgen_continuation(continuation());
     let scenario_before = sim.scenario_rng.state();
     let main_before = sim.main_rng.state();
-    let scan: Vec<(u16, u16)> =
-        crate::sim::bridge_state::cells_in_5x5_scan((9, 10)).collect();
+    let scan: Vec<(u16, u16)> = crate::sim::bridge_state::cells_in_5x5_scan((9, 10)).collect();
     let outcome = if let (Some(bridges), Some(terrain)) =
         (sim.bridge_state.as_mut(), sim.resolved_terrain.as_ref())
     {

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -2875,9 +2875,15 @@ fn sonic_tail_order_test_rules() -> RuleSet {
 }
 
 fn admit_test_wave(sim: &mut Simulation, rules: &RuleSet, event: &SimFireEvent) {
-    let wave = sim.prepare_fired_wave(
-        rules, event, &sim.substrate.entities, &sim.interner, sim.resolved_terrain.as_ref(),
-    ).expect("wave prepared");
+    let wave = sim
+        .prepare_fired_wave(
+            rules,
+            event,
+            &sim.substrate.entities,
+            &sim.interner,
+            sim.resolved_terrain.as_ref(),
+        )
+        .expect("wave prepared");
     let terrain = sim.resolved_terrain.take();
     sim.admit_fired_wave(event.attacker_id, wave, terrain.as_ref());
     sim.resolved_terrain = terrain;
@@ -4740,7 +4746,25 @@ fn test_bridge_orchestrator_state_machine_path_collapses_anchor_and_deactivates_
         .collect();
 
     let mut rules = combat_test_rules();
+    let mut building = make_test_entity("GACNST", EntityCategory::Structure);
+    building.cell_x = 0;
+    building.cell_y = 0;
+    let mut mover = make_test_entity("E1", EntityCategory::Infantry);
+    mover.cell_x = 6;
+    mover.cell_y = 0;
+    assert_eq!(
+        sim.spawn_from_map(&[building, mover], Some(&rules), &empty_heights()),
+        2
+    );
     sim.resolve_type_handles(&rules);
+    assert!(sim.rebuild_dynamic_navigation(&rules));
+    let before_path = sim.path_grid_snapshot().unwrap();
+    for ry in 0..3 {
+        for rx in 0..4 {
+            assert!(sim.substrate.occupancy.contains_entity(rx, ry, 1));
+            assert!(!before_path.is_walkable(rx, ry));
+        }
+    }
     let _ = crate::sim::world::bridge_orchestrator::apply_bridge_damage_events(
         &mut sim,
         &rules,
@@ -4754,6 +4778,18 @@ fn test_bridge_orchestrator_state_machine_path_collapses_anchor_and_deactivates_
         }],
     );
 
+    // A bridge refresh must publish the complete world projection before the
+    // next reader, including unrelated foundations. No end-frame repair here.
+    for ry in 0..3 {
+        for rx in 0..4 {
+            assert!(sim.substrate.occupancy.contains_entity(rx, ry, 1));
+            assert!(
+                !sim.path_grid().unwrap().is_walkable(rx, ry),
+                "bridge collapse lost unrelated foundation blocker at {rx},{ry}"
+            );
+            assert!(!before_path.is_walkable(rx, ry), "pinned reader changed");
+        }
+    }
     let bs = sim.bridge_state.as_ref().unwrap();
     assert_eq!(
         bs.cell(5, 5).unwrap().damage_state,
@@ -4770,6 +4806,63 @@ fn test_bridge_orchestrator_state_machine_path_collapses_anchor_and_deactivates_
              (pre={pre_active:?}, post={post_active:?})"
         );
     }
+    let collapsed = sim.path_grid_snapshot().unwrap();
+    assert_ne!(before_path.cell(5, 5), collapsed.cell(5, 5));
+    // The combat frame's fallback predates bridge fallout. Both receipt paths
+    // must return and publish the current projection without mutating that Arc.
+    for changed_cells in [&[][..], &[(6, 0)][..]] {
+        let tail = sim
+            .finish_terrain_navigation_changes(Some(&before_path), changed_cells)
+            .unwrap();
+        assert_eq!(tail.as_ref(), collapsed.as_ref());
+        if changed_cells.is_empty() {
+            assert!(
+                Arc::ptr_eq(&tail, &collapsed),
+                "no-change readers reuse the immutable projection"
+            );
+        }
+        assert_eq!(sim.path_grid(), Some(collapsed.as_ref()));
+        assert_ne!(before_path.cell(5, 5), tail.cell(5, 5));
+
+        // Real Phase-6 order resumption consumes the returned grid alongside
+        // the live zone owner, before any frame-final projection rebuild.
+        let unit = sim.substrate.entities.get_mut(2).unwrap();
+        unit.movement_target = None;
+        unit.order_intent = Some(crate::sim::components::OrderIntent::AttackMove {
+            goal_rx: 6,
+            goal_ry: 3,
+        });
+        sim.tick_order_intents_post_combat(Some(&tail), Some(&rules));
+        let target = sim
+            .substrate
+            .entities
+            .get(2)
+            .unwrap()
+            .movement_target
+            .as_ref()
+            .unwrap();
+        assert_eq!(target.path.last(), Some(&(6, 3)));
+        assert!(target.path.iter().all(|&(rx, ry)| !(rx < 4 && ry < 3)));
+    }
+
+    // The persisted bridge/entity owners must reconstruct the same navigation
+    // projection; a save/load must not be what repairs a lost foundation.
+    let expected_path = sim.path_grid_snapshot().unwrap();
+    let terrain_cache = sim.resolved_terrain.as_ref().unwrap().clone();
+    let bytes = crate::sim::snapshot::GameSnapshot::save(&sim, 0, 0, "bridge-nav", 0);
+    let mut restored = crate::sim::snapshot::GameSnapshot::load(&bytes)
+        .unwrap()
+        .sim;
+    restored.restore_after_snapshot_load().unwrap();
+    restored.rebuild_caches_after_load(
+        terrain_cache,
+        Default::default(),
+        Vec::new(),
+        Vec::new(),
+        BTreeMap::new(),
+    );
+    assert!(restored.rebuild_dynamic_navigation(&rules));
+    assert_eq!(restored.path_grid(), Some(expected_path.as_ref()));
 }
 
 /// Determinism: two independent simulations with identical seeds, identical


### PR DESCRIPTION
Bridge collapse and engineer repair published a terrain-only path grid, immediately losing unrelated building foundations. Combat terrain processing could then overwrite bridge changes using its pre-fallout snapshot. Bridge updates now use the shared dynamic navigation owner, and one world operation consumes overlay/receiver terrain updates using the current canonical projection. Later phases receive that projection; earlier snapshots remain immutable. Empty updates reuse the existing Arc.

The actual collapse and engineer-arrival regressions both fail on the previous implementation at the immediate foundation checks. The candidate preserves foundations, bridge changes across empty/nonempty terrain updates, pinned readers, RNG and snapshot/cache reconstruction. A real postcombat movement call is included as a consumer smoke check; it does not establish native obstacle traversal parity. The existing shared structure-selection policy remains unchanged.

Validation:
- Focused bridge suite: `test result: ok. 574 passed; 0 failed; 40 ignored; 0 measured; 7930 filtered out; finished in 0.37s`
- Full `cargo test -p vera20k --lib`: `test result: ok. 8463 passed; 0 failed; 81 ignored; 0 measured; 0 filtered out; finished in 24.05s`
- Production `cargo check -p vera20k`: passed, 50.89s, 90 existing warnings.
- System Map: `OK: 0 error(s) across 3 files`.

Independent read-only review confirmed the publication defect, challenged downstream reader timing and found an unnecessary deep copy; all substantiated findings were addressed. Native zone-tail ordering is anchored in the bridge fallout/connectivity research. This is a bounded Rust ownership and consistency correction, not whole bridge/native parity certification.
