### PR TITLE
Give damage consequence delivery one world owner

### DIFF
--- a/docs/system-map/topology.v2.json
+++ b/docs/system-map/topology.v2.json
@@ -44,10 +44,11 @@
           "path": "src/sim/world/mod.rs",
           "symbol": "Simulation::advance_tick",
           "coverage": "representative",
-          "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"
+          "observed_at_commit": "0534b96535edf4b29d3c5d15dff36723c4aebd0d"
         }
       ],
-      "notes": ["Global scheduler and active-object order are load-bearing consumers of almost every gameplay loop."]
+      "notes": ["Global scheduler and active-object order are load-bearing consumers of almost every gameplay loop.",
+        "The frame retains bullet admission, appended-wave visits, turret/facing updates and SpawnManager before consuming ordinary damage consequences once. The shared world owner returns structure/bridge change flags and the post-callback navigation snapshot for subsequent phases."]
     },
     "GSI-02.01": {
       "native_anchors": [
@@ -531,6 +532,12 @@
       ],
       "rust_surfaces": [
         {
+          "path": "src/sim/world/damage_consequences.rs",
+          "symbol": "DamageConsequences::commit",
+          "coverage": "representative",
+          "observed_at_commit": "0534b96535edf4b29d3c5d15dff36723c4aebd0d"
+        },
+        {
           "path": "src/sim/combat/damage",
           "symbol": "damage kernel",
           "coverage": "representative",
@@ -556,7 +563,8 @@
         }
       ],
       "notes": [
-        "Combat, Bullet, Wave and direct area-damage ingress execute against resident Simulation authority. ReceiverRun owns recursion guards and ordered navigation receipts; the local health borrow ends before synchronous world lifecycle stages. This ownership refactor does not establish whole-loop native parity or close scheduler differences."
+        "Combat, Bullet, Wave and direct area-damage ingress execute against resident Simulation authority. ReceiverRun owns recursion guards and ordered navigation receipts; the local health borrow ends before synchronous world lifecycle stages. This ownership refactor does not establish whole-loop native parity or close scheduler differences.",
+        "Ordinary combat and immediate Bullet/Wave/direct ingress now share one consuming world consequence owner. Weapon emission and recursive fatalities accumulate DeathEffects once. Ordinary radiation and death sounds retain their earlier receiver barriers; other settlement preserves constructor, navigation and notification ordering. Fatal garrison ejection remains synchronous, and wall mutation/expiry traces are test-only, never replayed. This is Rust ownership and regression evidence, not native postlude parity."
       ]
     },
     "GSI-09.01": {

--- a/src/sim/combat/combat_aoe.rs
+++ b/src/sim/combat/combat_aoe.rs
@@ -30,8 +30,10 @@ use crate::sim::movement::locomotor::MovementLayer;
 use crate::sim::occupancy::{
     OccupancyGrid, air_spatial_query_bucket_order, air_spatial_tracks_entity,
 };
+#[cfg(test)]
+use crate::sim::overlay_grid::WallMutation;
 use crate::sim::overlay_grid::{
-    OverlayGrid, WallDamageTransactionHost, WallDirtyStep, WallMutation, WallPointerTarget,
+    OverlayGrid, WallDamageTransactionHost, WallDirtyStep, WallPointerTarget,
     WallZoneRepairKind, damage_wall_overlay_with_runtime_host,
 };
 use crate::sim::rng::SimRng;
@@ -102,6 +104,7 @@ pub(crate) trait AoECellPrelude {
 
 struct AoEWallDamageHost<'borrow, 'prelude> {
     entities: &'borrow mut EntityStore,
+    #[cfg(test)]
     trace: &'borrow mut Vec<CellTargetDetach>,
     prelude: &'borrow mut Option<&'prelude mut dyn AoECellPrelude>,
 }
@@ -127,7 +130,7 @@ impl WallDamageTransactionHost for AoEWallDamageHost<'_, '_> {
 
     fn pointer_expired(&mut self, target: WallPointerTarget) {
         if let WallPointerTarget::Real(rx, ry) = target {
-            expire_cell_target_references(self.entities, rx, ry, self.trace);
+            expire_cell_target_references(self.entities, rx, ry, #[cfg(test)] self.trace);
         }
     }
 }
@@ -242,6 +245,7 @@ pub(crate) fn air_impact_from_entity(
     })
 }
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct CellTargetDetach {
     pub listener_id: u64,
@@ -256,9 +260,9 @@ pub(crate) struct AoEDamageResult {
     /// callers consume `receivers`, which is the sole ordered authority.
     #[cfg(test)]
     pub hits: Vec<EntityDamageEvent>,
+    #[cfg(test)]
     pub wall_mutations: Vec<WallMutation>,
-    /// Diagnostic trace only; a production prelude publishes radar inline.
-    pub wall_radar_dirty_cells: Vec<(u16, u16)>,
+    #[cfg(test)]
     pub cell_target_detaches: Vec<CellTargetDetach>,
 }
 
@@ -691,7 +695,7 @@ fn route_wall_before_cell_objects(
     warhead: &WarheadType,
     context: &mut AoELayerContext<'_>,
     cell_prelude: &mut Option<&mut dyn AoECellPrelude>,
-    result: &mut AoEDamageResult,
+    _result: &mut AoEDamageResult,
 ) {
     let (Some(grid), Some(registry), Some(rng)) = (
         context.overlay_grid.as_deref_mut(),
@@ -720,10 +724,11 @@ fn route_wall_before_cell_objects(
         return;
     };
 
-    let wall_result = {
+    let _wall_result = {
         let mut host = AoEWallDamageHost {
             entities,
-            trace: &mut result.cell_target_detaches,
+            #[cfg(test)]
+            trace: &mut _result.cell_target_detaches,
             prelude: cell_prelude,
         };
         damage_wall_overlay_with_runtime_host(
@@ -737,10 +742,8 @@ fn route_wall_before_cell_objects(
             Some(&mut host),
         )
     };
-    result.wall_mutations.extend(wall_result.mutations);
-    result
-        .wall_radar_dirty_cells
-        .extend(wall_result.radar_dirty_cells);
+    #[cfg(test)]
+    _result.wall_mutations.extend(_wall_result.mutations);
 }
 
 /// Broadcast one CellClass pointer-expiry notification to represented Techno
@@ -750,7 +753,7 @@ pub(crate) fn expire_cell_target_references(
     entities: &mut EntityStore,
     rx: u16,
     ry: u16,
-    trace: &mut Vec<CellTargetDetach>,
+    #[cfg(test)] trace: &mut Vec<CellTargetDetach>,
 ) {
     let listener_ids = entities.keys_sorted();
     for listener_id in listener_ids {
@@ -767,10 +770,11 @@ pub(crate) fn expire_cell_target_references(
         let mission_was_suspended =
             entity.mission.suspended() != crate::sim::mission::MissionId::NONE;
         represented_assign_target(entity, None);
-        let restored = mission_was_suspended && restore_entity_after_target_expiry(entity);
+        let _restored = mission_was_suspended && restore_entity_after_target_expiry(entity);
+        #[cfg(test)]
         trace.push(CellTargetDetach {
             listener_id,
-            restored,
+            restored: _restored,
             cleared: true,
         });
     }

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -909,10 +909,10 @@ fn gsi_04_10_projectile_inert_suppresses_bridge_ore_and_collector_rng() {
     );
 
     assert!(emit.damage_events.is_empty());
-    assert!(emit.wall_mutations.is_empty());
-    assert!(emit.cell_target_detaches.is_empty());
-    assert!(emit.bridge_damage_events.is_empty());
-    assert!(emit.tiberium_reduction_requests.is_empty());
+    assert!(emit.effects.wall_mutations.is_empty());
+    assert!(emit.effects.cell_target_detaches.is_empty());
+    assert!(emit.effects.bridge_damage_events.is_empty());
+    assert!(emit.effects.tiberium_reduction_requests.is_empty());
     assert_eq!(scenario_rng.state(), before_rng);
 }
 
@@ -992,7 +992,6 @@ fn lifecycle_authority_combat_leaves_transport_cargo_for_carrier_uninit() {
     let result = run_combat_death_handoff(&mut store, &rules, &mut interner, &[1]);
 
     assert_eq!(result.immediate_uninit_ids, vec![1]);
-    assert!(result.destroyed_garrison_buildings.is_empty());
     let carrier = store.get(1).unwrap();
     assert_eq!(carrier.passenger_role.cargo().unwrap().passengers, vec![2]);
     let passenger = store.get(2).unwrap();
@@ -1218,12 +1217,12 @@ fn considered_aircraft_infantry_is_air_only_while_high_flying() {
             0,
             &mut main_rng,
         );
-        assert_eq!(result.fire_events.len(), 1);
+        assert_eq!(result.consequences.fire_events().len(), 1);
         (
             sim.interner
-                .resolve(result.fire_events[0].weapon_id)
+                .resolve(result.consequences.fire_events()[0].weapon_id)
                 .to_string(),
-            result.fire_events[0].weapon_slot,
+            result.consequences.fire_events()[0].weapon_slot,
         )
     }
 
@@ -1284,12 +1283,12 @@ fn ordinary_infantry_remains_ground_for_projectile_legality() {
         &mut main_rng,
     );
 
-    assert_eq!(result.fire_events.len(), 1);
+    assert_eq!(result.consequences.fire_events().len(), 1);
     assert_eq!(
-        sim.interner.resolve(result.fire_events[0].weapon_id),
+        sim.interner.resolve(result.consequences.fire_events()[0].weapon_id),
         "GroundGun"
     );
-    assert_eq!(result.fire_events[0].weapon_slot, WeaponSlot::Primary);
+    assert_eq!(result.consequences.fire_events()[0].weapon_slot, WeaponSlot::Primary);
 }
 
 #[test]
@@ -1550,11 +1549,11 @@ fn test_tick_combat_only_emits_bridge_damage_for_wall_warheads() {
         &mut main_rng,
     );
     assert!(
-        result.bridge_damage_events.is_empty(),
+        result.consequences.effects().bridge_damage_events.is_empty(),
         "non-wall warheads must not emit bridge damage"
     );
     assert!(
-        result.wall_mutations.is_empty(),
+        result.consequences.effects().wall_mutations.is_empty(),
         "non-wall warheads must not emit wall damage"
     );
 
@@ -1597,7 +1596,7 @@ fn test_tick_combat_only_emits_bridge_damage_for_wall_warheads() {
         &mut main_rng,
     );
     assert_eq!(
-        wall_result.bridge_damage_events,
+        wall_result.consequences.effects().bridge_damage_events,
         vec![BridgeDamageEvent {
             rx: 8,
             ry: 5,
@@ -1612,7 +1611,7 @@ fn test_tick_combat_only_emits_bridge_damage_for_wall_warheads() {
     // Without an overlay grid+registry, the discriminator can't identify a wall
     // cell — events fall through to bridge_damage_events. Immediate wall
     // mutation requires both a grid lookup and Wall=yes in the registry.
-    assert!(wall_result.wall_mutations.is_empty());
+    assert!(wall_result.consequences.effects().wall_mutations.is_empty());
 }
 
 #[test]
@@ -1667,7 +1666,7 @@ fn gsi_04_07_damage_wad_precedes_wall_and_wood_armor_routing() {
 
     let (absolute, absolute_grid) = fire("WallAbsoluteDestroyer=yes\nWall=yes", "concrete");
     assert_eq!(
-        absolute.wall_mutations,
+        absolute.consequences.effects().wall_mutations,
         vec![crate::sim::overlay_grid::WallMutation {
             rx: 8,
             ry: 5,
@@ -1676,13 +1675,13 @@ fn gsi_04_07_damage_wad_precedes_wall_and_wood_armor_routing() {
         "WallAbsoluteDestroyer wins and commits forced removal inline"
     );
     assert_eq!(absolute_grid.cell(8, 5).overlay_id, None);
-    assert!(absolute.bridge_damage_events.is_empty());
+    assert!(absolute.consequences.effects().bridge_damage_events.is_empty());
 
     let (wood, wood_grid) = fire("Wood=yes", "wood");
-    assert!(!wood.wall_mutations.is_empty());
+    assert!(!wood.consequences.effects().wall_mutations.is_empty());
     assert_eq!(wood_grid.cell(8, 5).overlay_id, None);
     let (concrete, concrete_grid) = fire("Wood=yes", "concrete");
-    assert!(concrete.wall_mutations.is_empty());
+    assert!(concrete.consequences.effects().wall_mutations.is_empty());
     assert_eq!(concrete_grid.cell(8, 5).overlay_id, Some(0));
 }
 
@@ -1781,7 +1780,7 @@ fn gsi_04_07_damage_live_order_second_attacker_reads_restored_target() {
     );
     assert_eq!(
         result
-            .fire_events
+            .consequences.fire_events()
             .iter()
             .map(|event| (event.attacker_id, event.target))
             .collect::<Vec<_>>(),
@@ -1790,7 +1789,7 @@ fn gsi_04_07_damage_live_order_second_attacker_reads_restored_target() {
     );
     assert_eq!(
         result
-            .cell_target_detaches
+            .consequences.effects().cell_target_detaches
             .iter()
             .map(|event| (event.listener_id, event.restored, event.cleared))
             .collect::<Vec<_>>(),
@@ -1918,11 +1917,11 @@ fn gsi_04_07_damage_prior_projectile_fatal_death_weapon_is_inline() {
 
     let (fatal, fatal_grid, fatal_entities, fatal_rng) = run(10, true);
     assert_eq!(fatal_entities.get(10).unwrap().health.current, 0);
-    assert_eq!(fatal.immediate_uninit_ids, vec![10]);
+    assert_eq!(fatal.consequences.effects().immediate_uninit_ids, vec![10]);
     assert_eq!(fatal_grid.cell(8, 5).overlay_id, None);
     assert_eq!(
         fatal
-            .fire_events
+            .consequences.fire_events()
             .iter()
             .map(|event| (event.attacker_id, event.target))
             .collect::<Vec<_>>(),
@@ -1931,7 +1930,7 @@ fn gsi_04_07_damage_prior_projectile_fatal_death_weapon_is_inline() {
     );
     assert!(
         fatal
-            .cell_target_detaches
+            .consequences.effects().cell_target_detaches
             .iter()
             .any(|detach| { detach.listener_id == 20 && detach.restored && detach.cleared })
     );
@@ -1961,13 +1960,13 @@ fn gsi_04_07_damage_prior_projectile_fatal_death_weapon_is_inline() {
         expected.state()
     });
     assert_eq!(surviving_grid.cell(8, 5).overlay_id, Some(0));
-    assert!(survives.wall_mutations.is_empty());
-    assert!(survives.cell_target_detaches.is_empty());
-    assert!(survives.immediate_uninit_ids.is_empty());
+    assert!(survives.consequences.effects().wall_mutations.is_empty());
+    assert!(survives.consequences.effects().cell_target_detaches.is_empty());
+    assert!(survives.consequences.effects().immediate_uninit_ids.is_empty());
     assert_eq!(surviving_entities.get(10).unwrap().health.current, 1);
     assert_eq!(
         survives
-            .fire_events
+            .consequences.fire_events()
             .iter()
             .map(|event| (event.attacker_id, event.target))
             .collect::<Vec<_>>(),
@@ -1983,8 +1982,8 @@ fn gsi_04_07_damage_prior_projectile_fatal_death_weapon_is_inline() {
         expected.next_range_u32_inclusive(0, 2);
         expected.state()
     });
-    assert!(ungated.wall_mutations.is_empty());
-    assert!(ungated.cell_target_detaches.is_empty());
+    assert!(ungated.consequences.effects().wall_mutations.is_empty());
+    assert!(ungated.consequences.effects().cell_target_detaches.is_empty());
 }
 
 #[test]
@@ -2151,11 +2150,11 @@ fn gsi_04_07_damage_retaliation_is_receiver_synchronous_and_uses_mission_overrid
             has_movement: victim.movement_target.is_some(),
             last_attacker: victim.last_attacker_id,
             fired: result
-                .fire_events
+                .consequences.fire_events()
                 .iter()
                 .map(|event| (event.attacker_id, event.target))
                 .collect(),
-            immediate_uninit: result.immediate_uninit_ids,
+            immediate_uninit: result.consequences.effects().immediate_uninit_ids.clone(),
         }
     }
 
@@ -4673,8 +4672,8 @@ fn undeployed_guardian_gi_vs_infantry_uses_m60() {
         &mut main_rng,
     );
 
-    assert_eq!(result.fire_events.len(), 1);
-    let ev = &result.fire_events[0];
+    assert_eq!(result.consequences.fire_events().len(), 1);
+    let ev = &result.consequences.fire_events()[0];
     assert_eq!(interner.resolve(ev.weapon_id), "M60");
     assert_eq!(ev.weapon_slot, WeaponSlot::Primary);
     assert_eq!(store.get(2).unwrap().health.current, 110);
@@ -4705,8 +4704,8 @@ fn deployed_guardian_gi_vs_rhino_at_six_cells_uses_missilelauncher() {
         &mut main_rng,
     );
 
-    assert_eq!(result.fire_events.len(), 1);
-    let ev = &result.fire_events[0];
+    assert_eq!(result.consequences.fire_events().len(), 1);
+    let ev = &result.consequences.fire_events()[0];
     assert_eq!(interner.resolve(ev.weapon_id), "MissileLauncher");
     assert_eq!(ev.weapon_slot, WeaponSlot::Secondary);
     assert_eq!(store.get(2).unwrap().health.current, 400);
@@ -4738,8 +4737,8 @@ fn deployed_guardian_gi_vs_rocketeer_uses_missilelauncher() {
         &mut main_rng,
     );
 
-    assert_eq!(result.fire_events.len(), 1);
-    let ev = &result.fire_events[0];
+    assert_eq!(result.consequences.fire_events().len(), 1);
+    let ev = &result.consequences.fire_events()[0];
     assert_eq!(interner.resolve(ev.weapon_id), "MissileLauncher");
     assert_eq!(ev.weapon_slot, WeaponSlot::Secondary);
 }
@@ -4801,7 +4800,7 @@ fn infantry_standing_fire_waits_for_fire_frame() {
     );
 
     assert_eq!(store.get(2).unwrap().health.current, 125);
-    assert!(result.fire_events.is_empty());
+    assert!(result.consequences.fire_events().is_empty());
     let attack = store.get(1).unwrap().attack_target.as_ref().unwrap();
     assert_eq!(
         attack.pending_infantry_fire.unwrap(),
@@ -4828,7 +4827,7 @@ fn infantry_standing_fire_waits_for_fire_frame() {
         &mut main_rng,
     );
     assert_eq!(store.get(2).unwrap().health.current, 125);
-    assert!(result.fire_events.is_empty());
+    assert!(result.consequences.fire_events().is_empty());
 
     set_anim_frame(&mut store, 1, 2);
     let result = tick_combat(
@@ -4843,8 +4842,8 @@ fn infantry_standing_fire_waits_for_fire_frame() {
         &mut main_rng,
     );
     assert_eq!(store.get(2).unwrap().health.current, 100);
-    assert_eq!(result.fire_events.len(), 1);
-    let ev = &result.fire_events[0];
+    assert_eq!(result.consequences.fire_events().len(), 1);
+    let ev = &result.consequences.fire_events()[0];
     assert_eq!(interner.resolve(ev.weapon_id), "M60");
     assert_eq!(ev.weapon_slot, WeaponSlot::Primary);
     assert_eq!(
@@ -4890,7 +4889,7 @@ fn prone_infantry_uses_prone_fire_sequence_and_frame() {
         &mut main_rng,
     );
     let attack = store.get(1).unwrap().attack_target.as_ref().unwrap();
-    assert!(result.fire_events.is_empty());
+    assert!(result.consequences.fire_events().is_empty());
     assert_eq!(
         attack.pending_infantry_fire.unwrap(),
         PendingInfantryFire {
@@ -4913,7 +4912,7 @@ fn prone_infantry_uses_prone_fire_sequence_and_frame() {
         &mut main_rng,
     );
     assert_eq!(store.get(2).unwrap().health.current, 125);
-    assert!(result.fire_events.is_empty());
+    assert!(result.consequences.fire_events().is_empty());
 
     set_anim_frame(&mut store, 1, 3);
     let result = tick_combat(
@@ -4928,8 +4927,8 @@ fn prone_infantry_uses_prone_fire_sequence_and_frame() {
         &mut main_rng,
     );
     assert_eq!(store.get(2).unwrap().health.current, 100);
-    assert_eq!(result.fire_events.len(), 1);
-    let ev = &result.fire_events[0];
+    assert_eq!(result.consequences.fire_events().len(), 1);
+    let ev = &result.consequences.fire_events()[0];
     assert_eq!(interner.resolve(ev.weapon_id), "M60");
     assert_eq!(ev.weapon_slot, WeaponSlot::Primary);
     assert_eq!(
@@ -4963,7 +4962,7 @@ fn deployed_gi_uses_deployed_fire_visual_with_deploy_fire_weapon() {
         &mut main_rng,
     );
     let attack = store.get(1).unwrap().attack_target.as_ref().unwrap();
-    assert!(result.fire_events.is_empty());
+    assert!(result.consequences.fire_events().is_empty());
     assert_eq!(
         attack.pending_infantry_fire.unwrap(),
         PendingInfantryFire {
@@ -4990,8 +4989,8 @@ fn deployed_gi_uses_deployed_fire_visual_with_deploy_fire_weapon() {
         260,
         "deployed-fire should use the DeployFireWeapon secondary slot"
     );
-    assert_eq!(result.fire_events.len(), 1);
-    let ev = &result.fire_events[0];
+    assert_eq!(result.consequences.fire_events().len(), 1);
+    let ev = &result.consequences.fire_events()[0];
     assert_eq!(interner.resolve(ev.weapon_id), "Para");
     assert_eq!(ev.weapon_slot, WeaponSlot::Secondary);
     assert_eq!(
@@ -5051,8 +5050,8 @@ fn garrison_fire_keeps_occupant_anim_and_sound_path() {
         &mut main_rng,
     );
 
-    assert_eq!(result.fire_events.len(), 1);
-    let ev = &result.fire_events[0];
+    assert_eq!(result.consequences.fire_events().len(), 1);
+    let ev = &result.consequences.fire_events()[0];
     assert_eq!(ev.garrison_muzzle_index, Some(0));
     assert_eq!(
         ev.occupant_anim.map(|id| interner.resolve(id)),
@@ -5102,7 +5101,7 @@ fn delayed_infantry_fire_cancels_when_target_dies_before_fire_frame() {
     );
 
     assert_eq!(store.get(2).unwrap().health.current, 0);
-    assert!(result.fire_events.is_empty());
+    assert!(result.consequences.fire_events().is_empty());
     assert!(
         store.get(1).unwrap().attack_target.is_none(),
         "dead target should cancel delayed shot instead of spawning stale damage"
@@ -5619,7 +5618,7 @@ fn test_weapon_fire_destroys_ore_in_spread() {
     // CellSpread=2. Both ore cells (8,5) and (9,5) get a reduction request.
     let req_amount = |rx: u16, ry: u16| {
         result
-            .tiberium_reduction_requests
+            .consequences.effects().tiberium_reduction_requests
             .iter()
             .find(|r| r.rx == rx && r.ry == ry)
             .map(|r| r.amount)
@@ -5695,7 +5694,7 @@ fn test_direct_hit_weapon_destroys_center_ore() {
     // damage=65 → ore_damage = 65/10 = 6 density levels. CellSpread=0 → only the
     // impact cell (8,5) gets a request; the adjacent cell (9,5) gets none.
     let center = result
-        .tiberium_reduction_requests
+        .consequences.effects().tiberium_reduction_requests
         .iter()
         .find(|r| r.rx == 8 && r.ry == 5);
     assert_eq!(
@@ -5705,7 +5704,7 @@ fn test_direct_hit_weapon_destroys_center_ore() {
     );
     assert!(
         !result
-            .tiberium_reduction_requests
+            .consequences.effects().tiberium_reduction_requests
             .iter()
             .any(|r| r.rx == 9 && r.ry == 5),
         "adjacent cell should get no request with CellSpread=0"
@@ -5763,7 +5762,7 @@ fn test_weak_weapon_partial_ore_reduction() {
     // Combat emits a TiberiumReductionRequest (applied later by World). M60
     // damage=25 → ore_damage = 25/10 = 2 density levels at the impact cell.
     let req = result
-        .tiberium_reduction_requests
+        .consequences.effects().tiberium_reduction_requests
         .iter()
         .find(|r| r.rx == 8 && r.ry == 5);
     assert_eq!(
@@ -6256,7 +6255,7 @@ fn v3_non_killing_aoe_emits_one_smudge_request() {
         "target must survive (test setup invariant)"
     );
     let anim_count = result
-        .smudge_spawn_requests
+        .consequences.effects().smudge_spawn_requests
         .iter()
         .filter(|r| matches!(r, SmudgeSpawnRequest::Anim { .. }))
         .count();
@@ -6266,7 +6265,7 @@ fn v3_non_killing_aoe_emits_one_smudge_request() {
     );
     let v3exp = interner.intern("V3EXP");
     assert!(
-        result.smudge_spawn_requests.iter().any(
+        result.consequences.effects().smudge_spawn_requests.iter().any(
             |r| matches!(r, SmudgeSpawnRequest::Anim { anim_name, .. } if *anim_name == v3exp)
         ),
         "Anim smudge must reference the V3 warhead's AnimList entry"
@@ -6312,12 +6311,12 @@ fn v3_killing_aoe_emits_exactly_one_smudge_request() {
     );
 
     assert_eq!(
-        result.despawned_ids.len(),
+        result.consequences.effects().despawned_ids.len(),
         1,
         "target must die (test setup invariant)"
     );
     let anim_count = result
-        .smudge_spawn_requests
+        .consequences.effects().smudge_spawn_requests
         .iter()
         .filter(|r| matches!(r, SmudgeSpawnRequest::Anim { .. }))
         .count();
@@ -6372,7 +6371,7 @@ fn gsi_04_11_death_weapon_anim_precedes_outer_detonation_anim() {
     let tankexp = interner.intern("TANKEXP");
     let ucexplod = interner.intern("UCEXPLOD");
     let ordered_anim_names: Vec<_> = result
-        .smudge_spawn_requests
+        .consequences.effects().smudge_spawn_requests
         .iter()
         .filter_map(|request| match request {
             SmudgeSpawnRequest::Anim { anim_name, .. } => Some(*anim_name),
@@ -6382,14 +6381,14 @@ fn gsi_04_11_death_weapon_anim_precedes_outer_detonation_anim() {
     assert_eq!(ordered_anim_names, vec![ucexplod, tankexp]);
     assert_eq!(
         result
-            .explosion_effects
+            .consequences.effects().explosion_effects
             .iter()
             .map(|effect| effect.shp_name)
             .collect::<Vec<_>>(),
         vec![ucexplod, tankexp]
     );
     let unique_anim_names: std::collections::BTreeSet<_> = result
-        .smudge_spawn_requests
+        .consequences.effects().smudge_spawn_requests
         .iter()
         .filter_map(|r| match r {
             SmudgeSpawnRequest::Anim { anim_name, .. } => Some(*anim_name),
@@ -6631,17 +6630,17 @@ fn inviso_scatter_uses_scenario_rng_only_for_effect_and_paired_smudge() {
 
     assert_eq!(scenario_rng.logical_state(), expected_rng.logical_state());
     assert_eq!(store.get(2).unwrap().health.current, 490);
-    assert_eq!(result.explosion_effects.len(), 1);
+    assert_eq!(result.consequences.effects().explosion_effects.len(), 1);
     assert_eq!(
-        explosion_coord(&result.explosion_effects[0]),
+        explosion_coord(&result.consequences.effects().explosion_effects[0]),
         expected_effect
     );
     assert_ne!(expected_effect, target_coord);
     assert!(
-        result.tiberium_reduction_requests.is_empty(),
+        result.consequences.effects().tiberium_reduction_requests.is_empty(),
         "a non-Tiberium warhead without authoritative overlay context must not reduce ore"
     );
-    match &result.smudge_spawn_requests[0] {
+    match &result.consequences.effects().smudge_spawn_requests[0] {
         SmudgeSpawnRequest::Anim {
             rx,
             ry,
@@ -6681,8 +6680,8 @@ fn inviso_empty_animlist_still_consumes_one_draw() {
     );
 
     assert_eq!(scenario_rng.logical_state(), expected_rng.logical_state());
-    assert!(result.explosion_effects.is_empty());
-    assert!(result.smudge_spawn_requests.is_empty());
+    assert!(result.consequences.effects().explosion_effects.is_empty());
+    assert!(result.consequences.effects().smudge_spawn_requests.is_empty());
 }
 
 #[test]
@@ -6721,7 +6720,7 @@ fn gsi_08_05_non_inviso_projectile_advances_scenario_rng_by_the_reload_jitter() 
 
     assert_eq!(scenario_rng.logical_state(), expected_rng.logical_state());
     assert!(
-        result.explosion_effects.is_empty(),
+        result.consequences.effects().explosion_effects.is_empty(),
         "non-Inviso Speed=0 still creates a persistent native shot"
     );
     assert_eq!(result.projectile_spawns.len(), 1);
@@ -6795,16 +6794,16 @@ fn two_inviso_attackers_consume_consecutive_draws_in_live_order() {
 
     assert_eq!(
         result
-            .fire_events
+            .consequences.fire_events()
             .iter()
             .map(|event| event.attacker_id)
             .collect::<Vec<_>>(),
         vec![2, 1]
     );
     assert_eq!(scenario_rng.logical_state(), expected_rng.logical_state());
-    assert_eq!(result.explosion_effects.len(), 2);
-    assert_eq!(explosion_coord(&result.explosion_effects[0]), expected[0]);
-    assert_eq!(explosion_coord(&result.explosion_effects[1]), expected[1]);
+    assert_eq!(result.consequences.effects().explosion_effects.len(), 2);
+    assert_eq!(explosion_coord(&result.consequences.effects().explosion_effects[0]), expected[0]);
+    assert_eq!(explosion_coord(&result.consequences.effects().explosion_effects[1]), expected[1]);
 }
 
 // --- emit_warhead_detonation_effects helper tests ---------------------------
@@ -7000,11 +6999,11 @@ fn combat_resolves_in_live_object_order_not_stable_id() {
             &mut main_rng,
         );
         assert_eq!(
-            result.fire_events[0].attacker_id, 2,
+            result.consequences.fire_events()[0].attacker_id, 2,
             "live order [2,1]: B (live-order-first) must fire first"
         );
         assert!(
-            result.despawned_ids.contains(&3),
+            result.consequences.effects().despawned_ids.contains(&3),
             "target must die this tick"
         );
     }
@@ -7035,11 +7034,11 @@ fn combat_resolves_in_live_object_order_not_stable_id() {
             &mut main_rng,
         );
         assert_eq!(
-            result.fire_events[0].attacker_id, 1,
+            result.consequences.fire_events()[0].attacker_id, 1,
             "empty live order: stable-id fallback fires A first"
         );
         assert!(
-            result.despawned_ids.contains(&3),
+            result.consequences.effects().despawned_ids.contains(&3),
             "target must die this tick"
         );
     }
@@ -7297,7 +7296,7 @@ fn gsi_04_07_damage_periodic_radiation_enters_direct_receiver_once() {
         "periodic radiation cannot arm retaliation"
     );
     assert!(
-        result.under_attack_events.is_empty(),
+        result.consequences.effects().under_attack_events.is_empty(),
         "null source house cannot emit an enemy under-attack event"
     );
 }
@@ -7550,12 +7549,12 @@ fn deployed_desolator_self_irradiates_and_refires_below_third() {
 
     // Tick 1: gate open (no site) → self-targeted deploy-weapon shot.
     let result = rad_combat_tick(&mut sim, &rules, 1);
-    assert_eq!(result.fire_events.len(), 1, "deployed self-irradiate fires");
+    assert_eq!(result.consequences.fire_events().len(), 1, "deployed self-irradiate fires");
     assert_eq!(
-        sim.interner.resolve(result.fire_events[0].weapon_id),
+        sim.interner.resolve(result.consequences.fire_events()[0].weapon_id),
         "RadEruptionWeapon"
     );
-    assert_eq!(result.fire_events[0].target, TargetKind::Cell(10, 10));
+    assert_eq!(result.consequences.fire_events()[0].target, TargetKind::Cell(10, 10));
     let site = sim
         .radiation
         .site_at((10, 10))
@@ -7566,7 +7565,7 @@ fn deployed_desolator_self_irradiates_and_refires_below_third() {
     // Tick 2: gate closed (effective 500 ≥ 500/3) → no fire, self-target
     // cleared.
     let result = rad_combat_tick(&mut sim, &rules, 2);
-    assert_eq!(result.fire_events.len(), 0, "gate closed after re-arm");
+    assert_eq!(result.consequences.fire_events().len(), 0, "gate closed after re-arm");
     assert!(
         sim.substrate
             .entities
@@ -7587,7 +7586,7 @@ fn deployed_desolator_self_irradiates_and_refires_below_third() {
 
     // Gate reopens → fires again and merges the site back up.
     let result = rad_combat_tick(&mut sim, &rules, 341);
-    assert_eq!(result.fire_events.len(), 1, "gate reopens below one third");
+    assert_eq!(result.consequences.fire_events().len(), 1, "gate reopens below one third");
     let site = sim.radiation.site_at((10, 10)).expect("merged site");
     assert!(site.level > 500, "re-detonation merged effective + added");
 }
@@ -7640,8 +7639,8 @@ fn under_attack_events_fire_for_sourced_structures_and_harvester_types() {
     let mut building = make_entity_owned(10, "CAGAS", 8, 5, 800, "Defender");
     building.category = EntityCategory::Structure;
     let result = run_attack(building);
-    assert_eq!(result.under_attack_events.len(), 1, "structure hit pings");
-    let ev = &result.under_attack_events[0];
+    assert_eq!(result.consequences.effects().under_attack_events.len(), 1, "structure hit pings");
+    let ev = &result.consequences.effects().under_attack_events[0];
     assert!(!ev.miner);
     assert!(ev.structure);
     assert_eq!(ev.owner, test_intern("Defender"));
@@ -7651,9 +7650,9 @@ fn under_attack_events_fire_for_sourced_structures_and_harvester_types() {
     // not the Rust miner component).
     let harv = make_entity_owned(10, "HARV", 8, 5, 1000, "Defender");
     let result = run_attack(harv);
-    assert_eq!(result.under_attack_events.len(), 1, "harvester hit pings");
-    assert!(result.under_attack_events[0].miner);
-    assert!(!result.under_attack_events[0].structure);
+    assert_eq!(result.consequences.effects().under_attack_events.len(), 1, "harvester hit pings");
+    assert!(result.consequences.effects().under_attack_events[0].miner);
+    assert!(!result.consequences.effects().under_attack_events[0].structure);
 
     // SAME-owner structure damage → still pings: `BuildingClass::
     // ReceiveDamage` never compares the source's house before
@@ -7661,15 +7660,15 @@ fn under_attack_events_fire_for_sourced_structures_and_harvester_types() {
     let mut friendly = make_entity_owned(10, "CAGAS", 8, 5, 800, "Attacker");
     friendly.category = EntityCategory::Structure;
     let result = run_attack(friendly);
-    assert_eq!(result.under_attack_events.len(), 1, "own-fire pings");
-    assert_eq!(result.under_attack_events[0].owner, test_intern("Attacker"));
+    assert_eq!(result.consequences.effects().under_attack_events.len(), 1, "own-fire pings");
+    assert_eq!(result.consequences.effects().under_attack_events[0].owner, test_intern("Attacker"));
 
     // `Insignificant=yes` building → `BuildingType+0x232` skip.
     let mut prop = make_entity_owned(10, "CATREE", 8, 5, 800, "Defender");
     prop.category = EntityCategory::Structure;
     let result = run_attack(prop);
     assert!(
-        result.under_attack_events.is_empty(),
+        result.consequences.effects().under_attack_events.is_empty(),
         "insignificant buildings never ping"
     );
 
@@ -7678,15 +7677,15 @@ fn under_attack_events_fire_for_sourced_structures_and_harvester_types() {
     let mut slave = make_entity_owned(10, "YAREFN", 8, 5, 800, "Defender");
     slave.category = EntityCategory::Structure;
     let result = run_attack(slave);
-    assert_eq!(result.under_attack_events.len(), 1);
-    assert!(result.under_attack_events[0].miner);
-    assert!(result.under_attack_events[0].structure);
+    assert_eq!(result.consequences.effects().under_attack_events.len(), 1);
+    assert!(result.consequences.effects().under_attack_events[0].miner);
+    assert!(result.consequences.effects().under_attack_events[0].structure);
 
     // Plain vehicle (not `Harvester=`, not a structure) → no ping.
     let plain = make_entity_owned(10, "MTNK", 8, 5, 1000, "Defender");
     let result = run_attack(plain);
     assert!(
-        result.under_attack_events.is_empty(),
+        result.consequences.effects().under_attack_events.is_empty(),
         "plain unit hits do not ping"
     );
 }
@@ -7734,10 +7733,10 @@ fn unit_lost_events_come_from_damage_kills_of_unspawned_non_buildings() {
 
     let tank = make_entity_owned(10, "MTNK", 8, 5, 10, "Defender");
     let result = run_kill(tank);
-    assert_eq!(result.unit_lost_events.len(), 1, "vehicle kill announces");
-    assert_eq!(result.unit_lost_events[0].owner, test_intern("Defender"));
+    assert_eq!(result.consequences.effects().unit_lost_events.len(), 1, "vehicle kill announces");
+    assert_eq!(result.consequences.effects().unit_lost_events[0].owner, test_intern("Defender"));
     assert_eq!(
-        (result.unit_lost_events[0].rx, result.unit_lost_events[0].ry),
+        (result.consequences.effects().unit_lost_events[0].rx, result.consequences.effects().unit_lost_events[0].ry),
         (8, 5)
     );
 
@@ -7745,7 +7744,7 @@ fn unit_lost_events_come_from_damage_kills_of_unspawned_non_buildings() {
     hornet.category = EntityCategory::Aircraft;
     let result = run_kill(hornet);
     assert!(
-        result.unit_lost_events.is_empty(),
+        result.consequences.effects().unit_lost_events.is_empty(),
         "Spawned= types are silent"
     );
 
@@ -7753,7 +7752,7 @@ fn unit_lost_events_come_from_damage_kills_of_unspawned_non_buildings() {
     shack.category = EntityCategory::Structure;
     let result = run_kill(shack);
     assert!(
-        result.unit_lost_events.is_empty(),
+        result.consequences.effects().unit_lost_events.is_empty(),
         "buildings have no Death_Announcement caller"
     );
 }
@@ -7801,18 +7800,18 @@ fn harvester_killing_blow_announces_unit_lost_without_the_miner_ping() {
 
     // Non-lethal hit: the `result != 4` arm pings and nothing dies.
     let result = run_attack(make_entity_owned(10, "HARV", 8, 5, 1000, "Defender"));
-    assert_eq!(result.under_attack_events.len(), 1, "survivor hit pings");
-    assert!(result.under_attack_events[0].miner);
-    assert!(result.unit_lost_events.is_empty(), "nothing died");
+    assert_eq!(result.consequences.effects().under_attack_events.len(), 1, "survivor hit pings");
+    assert!(result.consequences.effects().under_attack_events[0].miner);
+    assert!(result.consequences.effects().unit_lost_events.is_empty(), "nothing died");
 
     // One-shot kill: result 4 skips the ping; only the death arm speaks.
     let result = run_attack(make_entity_owned(10, "HARV", 8, 5, 10, "Defender"));
     assert!(
-        result.under_attack_events.is_empty(),
+        result.consequences.effects().under_attack_events.is_empty(),
         "a killing blow never reaches the miner ping"
     );
-    assert_eq!(result.unit_lost_events.len(), 1, "the kill announces once");
-    assert_eq!(result.unit_lost_events[0].owner, test_intern("Defender"));
+    assert_eq!(result.consequences.effects().unit_lost_events.len(), 1, "the kill announces once");
+    assert_eq!(result.consequences.effects().unit_lost_events[0].owner, test_intern("Defender"));
 }
 
 /// Build one ObjectType straight from an INI body, so the `Cost=` parse feeding
@@ -8433,7 +8432,7 @@ fn gsi_08_11_unit_death_plays_type_explosion_then_destroy_anim() {
     );
 
     let names: Vec<&str> = result
-        .explosion_effects
+        .consequences.effects().explosion_effects
         .iter()
         .map(|effect| interner.resolve(effect.shp_name))
         .collect();
@@ -8952,7 +8951,7 @@ fn gsi_05_14_a_dying_vehicle_scatters_metallic_debris() {
     );
 
     let names: Vec<&str> = result
-        .explosion_effects
+        .consequences.effects().explosion_effects
         .iter()
         .map(|effect| interner.resolve(effect.shp_name))
         .collect();
@@ -8961,7 +8960,7 @@ fn gsi_05_14_a_dying_vehicle_scatters_metallic_debris() {
         "the death should scatter MetallicDebris chunks, got {names:?}"
     );
     assert!(
-        result.voxel_debris.is_empty(),
+        result.consequences.effects().voxel_debris.is_empty(),
         "a type with no DebrisTypes= throws no VoxelAnims"
     );
 }
@@ -9010,7 +9009,7 @@ fn gsi_05_14_a_dying_building_uses_its_own_debris_anims() {
     );
 
     let names: Vec<&str> = result
-        .explosion_effects
+        .consequences.effects().explosion_effects
         .iter()
         .map(|effect| interner.resolve(effect.shp_name))
         .collect();
@@ -9073,9 +9072,9 @@ fn gsi_05_14_a_dying_harvester_throws_voxel_tires_and_no_shp_debris() {
 
     // MinDebris == MaxDebris - 1 pins the budget at 5 with no draw, and the
     // loop drains exactly that many.
-    assert_eq!(result.voxel_debris.len(), 5);
+    assert_eq!(result.consequences.effects().voxel_debris.len(), 5);
     let names: Vec<&str> = result
-        .explosion_effects
+        .consequences.effects().explosion_effects
         .iter()
         .map(|effect| interner.resolve(effect.shp_name))
         .collect();
@@ -9084,7 +9083,7 @@ fn gsi_05_14_a_dying_harvester_throws_voxel_tires_and_no_shp_debris() {
         "the voxel loop spends the whole budget: {names:?}"
     );
     // Every piece launches from the wreck's own coordinate, lifted 10 leptons.
-    for piece in &result.voxel_debris {
+    for piece in &result.consequences.effects().voxel_debris {
         assert_eq!(piece.object.duration, 150);
         assert_eq!(piece.object.world_coord().z, 10);
     }
@@ -9126,9 +9125,9 @@ fn gsi_05_14_a_type_without_maxdebris_takes_no_draw() {
         0,
         &mut rng,
     );
-    assert!(result.voxel_debris.is_empty());
+    assert!(result.consequences.effects().voxel_debris.is_empty());
     let names: Vec<&str> = result
-        .explosion_effects
+        .consequences.effects().explosion_effects
         .iter()
         .map(|effect| interner.resolve(effect.shp_name))
         .collect();
@@ -9216,7 +9215,7 @@ fn gsi_08_08_special_arm_suppresses_damage_but_keeps_the_detonation_tail() {
             &mut emitted,
         );
         let anims: Vec<(String, u16, u16, u8)> = emitted
-            .explosion_effects
+            .effects.explosion_effects
             .iter()
             .map(|effect| {
                 (
@@ -9230,7 +9229,7 @@ fn gsi_08_08_special_arm_suppresses_damage_but_keeps_the_detonation_tail() {
         TailOutcome {
             damage_events: emitted.damage_events.len(),
             anims,
-            smudges: emitted.smudge_spawn_requests.len(),
+            smudges: emitted.effects.smudge_spawn_requests.len(),
         }
     }
 
@@ -9335,7 +9334,7 @@ fn gsi_08_33_direct_rocker_only_claims_a_vehicle_target() {
             &mut emitted,
         );
         assert_eq!(
-            emitted.explosion_effects.len(),
+            emitted.effects.explosion_effects.len(),
             1,
             "both branches reach LAB_00469AA4"
         );

--- a/src/sim/combat/combat_turret_facing_tests.rs
+++ b/src/sim/combat/combat_turret_facing_tests.rs
@@ -1175,7 +1175,7 @@ fn gsi_08_03_homing_projectile_widens_the_fire_tolerance_to_0x1000() {
             facing_from_5_5_to_5_9().wrapping_add(offset),
             5,
         ));
-        !run_combat_direct(&mut sim, rules).fire_events.is_empty()
+        !run_combat_direct(&mut sim, rules).consequences.fire_events().is_empty()
     }
 
     let straight = rules_with_homing_projectile(0);
@@ -1286,7 +1286,7 @@ TurretAnimIsVoxel={}\n\n\
         sim.reveal(1);
         sim.reveal(2);
         use_test_interner(&mut sim);
-        !run_combat_direct(&mut sim, &rules).fire_events.is_empty()
+        !run_combat_direct(&mut sim, &rules).consequences.fire_events().is_empty()
     }
 
     // ROT=1 means one step is 0x0100.
@@ -1332,7 +1332,7 @@ fn gsi_08_04_rotation_latch_refuses_the_shot_until_the_arc_finishes() {
             5,
         ));
         attacker.turret_rotation_latch = latch;
-        !run_combat_direct(&mut sim, &rules).fire_events.is_empty()
+        !run_combat_direct(&mut sim, &rules).consequences.fire_events().is_empty()
     }
 
     // Exactly on target, so nothing but the latch can be doing the refusing.
@@ -1373,7 +1373,7 @@ fn gsi_08_04_rotation_latch_refuses_the_shot_until_the_arc_finishes() {
             5,
         ));
         attacker.turret_rotation_latch = latch;
-        !run_combat_direct(&mut sim, &rules).fire_events.is_empty()
+        !run_combat_direct(&mut sim, &rules).consequences.fire_events().is_empty()
     }
     assert!(
         fires_with_latch_omni(false),

--- a/src/sim/combat/delayed_building_fire_tests.rs
+++ b/src/sim/combat/delayed_building_fire_tests.rs
@@ -96,7 +96,7 @@ fn gsi_05_10_tesla_arms_without_emission_and_fires_on_visit_28() {
     let mut main_rng = SimRng::new(1);
 
     let first = combat_visit(&mut sim, &rules, &mut resources, &mut main_rng, 1);
-    assert!(first.fire_events.is_empty());
+    assert!(first.consequences.fire_events().is_empty());
     assert_eq!(
         sim.substrate.entities.get(target).unwrap().health.current,
         100
@@ -115,7 +115,7 @@ fn gsi_05_10_tesla_arms_without_emission_and_fires_on_visit_28() {
 
     for visit in 2..=27 {
         let result = combat_visit(&mut sim, &rules, &mut resources, &mut main_rng, visit);
-        assert!(result.fire_events.is_empty(), "early fire on visit {visit}");
+        assert!(result.consequences.fire_events().is_empty(), "early fire on visit {visit}");
     }
     assert_eq!(
         sim.substrate.entities.get(target).unwrap().health.current,
@@ -123,8 +123,8 @@ fn gsi_05_10_tesla_arms_without_emission_and_fires_on_visit_28() {
     );
 
     let expiry = combat_visit(&mut sim, &rules, &mut resources, &mut main_rng, 28);
-    assert_eq!(expiry.fire_events.len(), 1);
-    assert_eq!(expiry.fire_events[0].weapon_slot, WeaponSlot::Primary);
+    assert_eq!(expiry.consequences.fire_events().len(), 1);
+    assert_eq!(expiry.consequences.fire_events()[0].weapon_slot, WeaponSlot::Primary);
     assert_eq!(
         sim.substrate.entities.get(target).unwrap().health.current,
         90
@@ -169,7 +169,7 @@ fn gsi_05_10_expiry_reads_live_target_but_keeps_saved_weapon_slot() {
     let mut resources = BTreeMap::new();
     let mut main_rng = SimRng::new(2);
     let arm = combat_visit(&mut sim, &rules, &mut resources, &mut main_rng, 1);
-    assert!(arm.fire_events.is_empty());
+    assert!(arm.consequences.fire_events().is_empty());
     assert_eq!(
         sim.substrate
             .entities
@@ -190,8 +190,8 @@ fn gsi_05_10_expiry_reads_live_target_but_keeps_saved_weapon_slot() {
         .remaining_ticks = 1;
     let expiry = combat_visit(&mut sim, &rules, &mut resources, &mut main_rng, 2);
 
-    assert_eq!(expiry.fire_events.len(), 1);
-    assert_eq!(expiry.fire_events[0].weapon_slot, WeaponSlot::Secondary);
+    assert_eq!(expiry.consequences.fire_events().len(), 1);
+    assert_eq!(expiry.consequences.fire_events()[0].weapon_slot, WeaponSlot::Secondary);
     assert_eq!(sim.substrate.entities.get(air).unwrap().health.current, 100);
     assert_eq!(
         sim.substrate.entities.get(ground).unwrap().health.current,
@@ -226,7 +226,7 @@ fn gsi_05_10_expiry_error_clears_without_retarget_or_shot() {
         .remaining_ticks = 1;
     let expiry = combat_visit(&mut sim, &rules, &mut resources, &mut main_rng, 2);
 
-    assert!(expiry.fire_events.is_empty());
+    assert!(expiry.consequences.fire_events().is_empty());
     let building = sim.substrate.entities.get(tower).unwrap();
     assert!(building.pending_building_fire.is_none());
     assert_eq!(
@@ -283,7 +283,7 @@ fn gsi_05_10_non_delayed_and_prism_type_bypass_fire_immediately() {
         1,
     );
 
-    assert_eq!(result.fire_events.len(), 2);
+    assert_eq!(result.consequences.fire_events().len(), 2);
     assert!(
         sim.substrate
             .entities
@@ -324,7 +324,7 @@ fn gsi_05_10_delays_at_or_below_one_expire_on_the_arming_visit() {
             &mut SimRng::new(5),
             1,
         );
-        assert_eq!(result.fire_events.len(), 1, "delay {delay}");
+        assert_eq!(result.consequences.fire_events().len(), 1, "delay {delay}");
         assert!(
             sim.substrate
                 .entities

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -104,7 +104,9 @@ use crate::sim::mission::authority::{
 };
 use crate::sim::mission::concrete_effects::represented_assign_target;
 use crate::sim::mission::{MissionId, MissionType};
-use crate::sim::overlay_grid::{OverlayGrid, WallMutation};
+#[cfg(test)]
+use crate::sim::overlay_grid::WallMutation;
+use crate::sim::overlay_grid::OverlayGrid;
 #[cfg(test)]
 use crate::sim::power_system::PowerState;
 use crate::sim::projectile::{
@@ -1336,8 +1338,8 @@ pub struct DestroyedCrewedBuilding {
 
 /// A `CanBeOccupied` building destroyed in combat with live occupants —
 /// gamemd routes this through `BuildingClass::SellBuilding @ 0x00457DE0`, the
-/// same occupant-eject helper used by sell. The world layer owns the deferred
-/// repositioning because it has access to `Simulation` and the occupancy grid.
+/// same occupant-eject helper used by sell. The world fatal prelude consumes
+/// this plan synchronously, before the nested death weapon and carrier UnInit.
 pub struct DestroyedGarrisonBuilding {
     pub building_id: u64,
     pub type_id: InternedId,
@@ -1567,69 +1569,16 @@ pub struct TiberiumReductionRequest {
     pub amount: i32,
 }
 
-/// Result of a combat tick: reveal events + stable IDs of despawned entities.
+/// Ordinary fire prelude plus one consuming deferred-consequence packet.
+/// The frame admits bullets and applies facing before committing the packet at
+/// its existing post-SpawnManager boundary.
 pub struct CombatTickResult {
-    /// Ordinary projectiles created by fire this frame, to admit after the
-    /// current BulletClass pass. New bullets never advance recursively.
+    /// Bullets admitted after the current BulletClass pass; no recursive advance.
     pub projectile_spawns: Vec<ProjectileSpawn>,
-    pub reveal_events: Vec<RevealEvent>,
-    pub despawned_ids: Vec<u64>,
-    /// IDs that should enter world-owned UnInit immediately this tick.
-    /// `despawned_ids` also includes SHP deaths that remain in-store for their
-    /// death animation; this list is the immediate structure/voxel handoff only.
-    pub immediate_uninit_ids: Vec<u64>,
-    /// A structure was destroyed — PathGrid needs footprint unblock.
-    pub structure_destroyed: bool,
-    /// Bridge impact cells that should apply terrain damage after combat resolution.
-    pub bridge_damage_events: Vec<BridgeDamageEvent>,
-    /// Wall writes committed inline in exact cell/recursive cleanup order.
-    pub wall_mutations: Vec<WallMutation>,
-    /// Diagnostic first-unique trace of packed wall radar coordinates. Live
-    /// production publication already occurred through the world receiver.
-    pub wall_radar_dirty_cells: Vec<(u16, u16)>,
-    /// Scanned-cell pointer-expiry visits committed inline in forward stable-ID
-    /// order, clearing before conditional Restore.
-    /// Runtime applies them in-place; tests retain the ledger as an order audit.
-    #[cfg_attr(not(test), allow(dead_code))]
-    pub(crate) cell_target_detaches: Vec<combat_aoe::CellTargetDetach>,
-    /// Terrain cells whose inline receiver removed live spatial authority.
-    /// World rebuilds cost/path/zone caches from the already-mutated resolved
-    /// terrain before later same-frame consumers.
-    pub terrain_navigation_changed_cells: Vec<(u16, u16)>,
-    /// Tiberium cells that should be reduced through the shared cell reducer.
-    pub tiberium_reduction_requests: Vec<TiberiumReductionRequest>,
-    /// Fire events for render-side muzzle flash / projectile origin computation.
-    pub fire_events: Vec<SimFireEvent>,
-    /// Crewed buildings destroyed this tick — survivors should be ejected by the caller.
-    pub destroyed_crewed_buildings: Vec<DestroyedCrewedBuilding>,
-    /// Garrisoned buildings destroyed this tick — occupants should be ejected
-    /// by the caller via `production::eject_destruction_garrison`.
-    pub destroyed_garrison_buildings: Vec<DestroyedGarrisonBuilding>,
-    /// Explosion animations to spawn at death/impact locations.
-    pub explosion_effects: Vec<ExplosionEffect>,
-    /// `VoxelAnimClass` debris a death threw. Built inside the combat
-    /// transaction, which does not hold the shared object-id allocator, so the
-    /// world stamps ids and reveals in this order.
-    pub voxel_debris: Vec<crate::sim::voxel_anim::VoxelDebrisSpawn>,
-    /// Receiver-ordered IC/ForceShield transient combat-light requests.
-    pub invulnerability_impact_effects: Vec<InvulnerabilityImpactEffect>,
-    /// Hookless-test adapter for smudge requests. Empty on the production world
-    /// path because each producer commits before returning.
-    pub smudge_spawn_requests: Vec<SmudgeSpawnRequest>,
-    /// Per-Unit post-Foot Facing slot output — captured at Phase-2 entry before
-    /// current-frame attacker damage; that Unit's own explicit retarget/remove
-    /// may replace it, and its `Fire_At_Target` case-2 hull turn is appended
-    /// during the fire pass. Applied post-batch by
-    /// `unit_post::apply_unit_facing`. Transient — never stored, serialized, or
-    /// hashed.
+    /// Phase-2 entry facing slots, amended by explicit retarget/removal and
+    /// Fire_At_Target hull turns, applied by unit_post before SpawnManager.
     pub unit_facing: Vec<UnitFacingUpdate>,
-    /// Base-structure / harvester enemy-damage pings produced at the damage
-    /// apply site. Drained by the world into BaseUnderAttack/MinerUnderAttack
-    /// radar events + the local player's EVA dispatch.
-    pub under_attack_events: Vec<UnderAttackEvent>,
-    /// `Death_Announcement` inputs from this tick's damage kills; the world
-    /// applies the human-owner gate and the radar type-7 dedupe.
-    pub unit_lost_events: Vec<UnitLostEvent>,
+    pub(crate) consequences: crate::sim::world::damage_consequences::DamageConsequences,
 }
 
 /// A "your asset is being shot" ping: a Structure or harvester took damage
@@ -1979,24 +1928,26 @@ fn death_weapon_aoe(
     ))
 }
 
-/// Collected side-effects from processing entity deaths in a single tick.
+/// One ordered accumulator for weapon emission and recursive receiver effects.
+/// DamageConsequences consumes its deferred work at the world delivery boundary.
 #[derive(Default)]
 pub(crate) struct DeathEffects {
+    /// Fatal receivers, including SHP deaths that remain represented for animation.
     pub(crate) despawned_ids: Vec<u64>,
+    /// Remaining world UnInit requests; distinct from all fatal receiver IDs.
     pub(crate) immediate_uninit_ids: Vec<u64>,
     pub(crate) structure_destroyed: bool,
     pub(crate) destroyed_crewed_buildings: Vec<DestroyedCrewedBuilding>,
-    pub(crate) destroyed_garrison_buildings: Vec<DestroyedGarrisonBuilding>,
     pub(crate) explosion_effects: Vec<ExplosionEffect>,
-    /// `VoxelAnimClass` debris the death block built but could not admit: the
-    /// combat transaction borrows the entity store out of the world, so it does
-    /// not hold the shared object-id allocator. The world stamps ids and
-    /// reveals in this order.
+    /// `VoxelAnimClass` debris planned by the death block for admission at the
+    /// world consequence boundary. The live receiver has allocator access;
+    /// deferred admission preserves the existing allocation and Logic order.
     pub(crate) voxel_debris: Vec<crate::sim::voxel_anim::VoxelDebrisSpawn>,
     pub(crate) invulnerability_impact_effects: Vec<InvulnerabilityImpactEffect>,
     pub(crate) bridge_damage_events: Vec<BridgeDamageEvent>,
+    #[cfg(test)]
     pub(crate) wall_mutations: Vec<WallMutation>,
-    pub(crate) wall_radar_dirty_cells: Vec<(u16, u16)>,
+    #[cfg(test)]
     pub(crate) cell_target_detaches: Vec<combat_aoe::CellTargetDetach>,
     pub(crate) tiberium_reduction_requests: Vec<TiberiumReductionRequest>,
     pub(crate) death_sounds: Vec<(InternedId, u16, u16)>,
@@ -2077,17 +2028,16 @@ impl DeathEffects {
         self.structure_destroyed |= other.structure_destroyed;
         self.destroyed_crewed_buildings
             .append(&mut other.destroyed_crewed_buildings);
-        self.destroyed_garrison_buildings
-            .append(&mut other.destroyed_garrison_buildings);
         self.explosion_effects.append(&mut other.explosion_effects);
         self.voxel_debris.append(&mut other.voxel_debris);
         self.invulnerability_impact_effects
             .append(&mut other.invulnerability_impact_effects);
         self.bridge_damage_events
             .append(&mut other.bridge_damage_events);
+        #[cfg(test)]
         self.wall_mutations.append(&mut other.wall_mutations);
-        self.wall_radar_dirty_cells
-            .append(&mut other.wall_radar_dirty_cells);
+
+        #[cfg(test)]
         self.cell_target_detaches
             .append(&mut other.cell_target_detaches);
         self.tiberium_reduction_requests
@@ -2705,58 +2655,25 @@ fn area_near_center_ic_isolation_armed(
 
 
 
-/// Keep physical death consequences in the emission trace at the exact source
-/// boundary while retaining lifecycle requests for the tick's deferred handoff.
-fn absorb_inline_death_effects(
-    out: &mut CombatEmit,
-    lifecycle: &mut DeathEffects,
-    mut death: DeathEffects,
-) {
-    out.bridge_damage_events
-        .append(&mut death.bridge_damage_events);
-    out.wall_mutations.append(&mut death.wall_mutations);
-    out.wall_radar_dirty_cells
-        .append(&mut death.wall_radar_dirty_cells);
-    out.cell_target_detaches
-        .append(&mut death.cell_target_detaches);
-    out.tiberium_reduction_requests
-        .append(&mut death.tiberium_reduction_requests);
-    out.explosion_effects.append(&mut death.explosion_effects);
-    out.voxel_debris.append(&mut death.voxel_debris);
-    out.smudge_spawn_requests
-        .append(&mut death.smudge_spawn_requests);
-    out.rad_detonations.append(&mut death.rad_detonations);
-    lifecycle.append(death);
-}
-
 /// Transient per-tick bag of the Phase-2 fire-emission outputs. Bundles the
 /// emit vectors so the per-attacker fire body (`resolve_attacker_fire`) can push
 /// through one `&mut` handle. Never stored on `Simulation`, never serialized,
 /// never hashed — destructured back into the named locals after the Phase-2 loop.
 #[derive(Default)]
 pub(crate) struct CombatEmit {
+    /// One receiver-ordered consequence accumulator shared by weapon emission
+    /// and fatal damage. Radiation is drained at its earlier ordinary phase.
+    pub(crate) effects: DeathEffects,
     /// Persistent ordinary bullets admitted by accepted weapon fire. The world
     /// inserts them only after this frame's BulletClass pass has completed.
     pub(crate) projectile_spawns: Vec<ProjectileSpawn>,
     /// Native-order ReceiveDamage calls, including raw area records.
     pub(crate) damage_events: Vec<combat_aoe::AreaDamageReceiver>,
-    /// Radiation-emitting detonations (weapon RadLevel > 0), folded into
-    /// `RadiationState` before the damage-application phase.
-    pub(crate) rad_detonations: Vec<crate::sim::radiation::RadDetonation>,
     pub(crate) remove_attack: Vec<u64>,
     /// (attacker_id, new_target_id)
     pub(crate) retarget_events: Vec<(u64, u64)>,
     pub(crate) fire_events: Vec<SimFireEvent>,
     pub(crate) reveal_events: Vec<RevealEvent>,
-    pub(crate) bridge_damage_events: Vec<BridgeDamageEvent>,
-    pub(crate) wall_mutations: Vec<WallMutation>,
-    pub(crate) wall_radar_dirty_cells: Vec<(u16, u16)>,
-    pub(crate) cell_target_detaches: Vec<combat_aoe::CellTargetDetach>,
-    pub(crate) tiberium_reduction_requests: Vec<TiberiumReductionRequest>,
-    pub(crate) explosion_effects: Vec<ExplosionEffect>,
-    /// Death-thrown `VoxelAnimClass` debris awaiting an object id.
-    pub(crate) voxel_debris: Vec<crate::sim::voxel_anim::VoxelDebrisSpawn>,
-    pub(crate) smudge_spawn_requests: Vec<SmudgeSpawnRequest>,
     /// (id, burst_rem, burst_delay, rof_cd)
     pub(crate) burst_updates: Vec<(u64, u8, u8, u16)>,
     /// aircraft that fired this tick
@@ -3899,7 +3816,7 @@ mod impact_height_tests {
         );
 
         let effect = result
-            .explosion_effects
+            .consequences.effects().explosion_effects
             .first()
             .expect("force-fire should emit the warhead's impact animation");
         assert_eq!((effect.rx, effect.ry), (5, 6));

--- a/src/sim/combat/world_receiver.rs
+++ b/src/sim/combat/world_receiver.rs
@@ -258,10 +258,10 @@ pub(crate) fn commit_area(
                         append_fixture_tiberium(world, &mut effects.tiberium_reduction_requests);
                         collected
                     };
+                    #[cfg(test)]
                     effects.wall_mutations.extend(aoe.wall_mutations);
-                    effects
-                        .wall_radar_dirty_cells
-                        .extend(aoe.wall_radar_dirty_cells);
+
+                    #[cfg(test)]
                     effects
                         .cell_target_detaches
                         .extend(aoe.cell_target_detaches);
@@ -888,13 +888,13 @@ pub(crate) fn handle_death(
     let mut despawned_ids: Vec<u64> = Vec::new();
     let mut immediate_uninit_ids: Vec<u64> = Vec::new();
     let mut destroyed_crewed_buildings: Vec<DestroyedCrewedBuilding> = Vec::new();
-    let mut destroyed_garrison_buildings: Vec<DestroyedGarrisonBuilding> = Vec::new();
     let mut explosion_effects: Vec<ExplosionEffect> = Vec::new();
     let mut voxel_debris: Vec<crate::sim::voxel_anim::VoxelDebrisSpawn> = Vec::new();
     let mut invulnerability_impact_effects: Vec<InvulnerabilityImpactEffect> = Vec::new();
     let mut bridge_damage_events: Vec<BridgeDamageEvent> = Vec::new();
+    #[cfg(test)]
     let mut wall_mutations: Vec<WallMutation> = Vec::new();
-    let mut wall_radar_dirty_cells: Vec<(u16, u16)> = Vec::new();
+    #[cfg(test)]
     let mut cell_target_detaches: Vec<combat_aoe::CellTargetDetach> = Vec::new();
     let mut smudge_spawn_requests: Vec<SmudgeSpawnRequest> = Vec::new();
     let mut concrete_smudge_plans: Vec<ConcreteDeathSmudgePlan> = Vec::new();
@@ -1031,49 +1031,9 @@ pub(crate) fn handle_death(
                 }
             }
 
-            // Generic transport cargo remains attached and untouched here so
-            // the carrier's world-owned UnInit can recurse in cargo order. The
-            // snapshot is only exported for the distinct garrison-eject path.
-            let passenger_ids: Vec<u64> = world
-                .substrate
-                .entities
-                .get(dead_id)
-                .and_then(|e| e.passenger_role.cargo())
-                .map(|c| c.passengers.clone())
-                .unwrap_or_default();
-
-            // Garrisoned CanBeOccupied buildings use the same gamemd
-            // SellBuilding occupant-eject contract as sell. Generic transports
-            // deliberately emit no passenger-side mutations from combat.
-            //
-            // Re-resolve the type string here because earlier mutable borrows
-            // of `interner` (death_weapon_aoe, intern calls) ended its prior
-            // immutable borrow.
-            let type_id_str_for_branch = world.interner.resolve(type_id);
-            let is_garrison_building = rules
-                .object(type_id_str_for_branch)
-                .map(|obj| obj.can_be_occupied)
-                .unwrap_or(false)
-                && category == EntityCategory::Structure
-                && !passenger_ids.is_empty();
-
-            if is_garrison_building {
-                let (foundation_w, foundation_h) = rules
-                    .object(type_id_str_for_branch)
-                    .map(|obj| crate::sim::production::foundation_dimensions(&obj.foundation))
-                    .unwrap_or((1, 1));
-                destroyed_garrison_buildings.push(DestroyedGarrisonBuilding {
-                    building_id: dead_id,
-                    type_id,
-                    owner,
-                    rx,
-                    ry,
-                    z,
-                    foundation_w,
-                    foundation_h,
-                    passenger_ids,
-                });
-            }
+            // The world fatal prelude already owns garrison ejection before
+            // the nested death weapon. Generic cargo remains attached only in
+            // callback-disabled receiver fixtures, for their UnInit assertions.
 
             // Look up the warhead that dealt the killing blow for InfDeath
             // selection below. The AnimList anim + smudge are emitted at
@@ -1247,8 +1207,10 @@ pub(crate) fn handle_death(
                 append_fixture_tiberium(world, &mut tiberium_reduction_requests);
                 collected
             };
+            #[cfg(test)]
             wall_mutations.extend(aoe.wall_mutations);
-            wall_radar_dirty_cells.extend(aoe.wall_radar_dirty_cells);
+
+            #[cfg(test)]
             cell_target_detaches.extend(aoe.cell_target_detaches);
             if !scenario_no_damage && !routed_wall && warhead.wall && *dmg > 0 {
                 let wh_iid = *wh_id;
@@ -1283,13 +1245,14 @@ pub(crate) fn handle_death(
             immediate_uninit_ids.append(&mut nested.immediate_uninit_ids);
             structure_destroyed |= nested.structure_destroyed;
             destroyed_crewed_buildings.append(&mut nested.destroyed_crewed_buildings);
-            destroyed_garrison_buildings.append(&mut nested.destroyed_garrison_buildings);
             explosion_effects.append(&mut nested.explosion_effects);
             voxel_debris.append(&mut nested.voxel_debris);
             invulnerability_impact_effects.append(&mut nested.invulnerability_impact_effects);
             bridge_damage_events.append(&mut nested.bridge_damage_events);
+            #[cfg(test)]
             wall_mutations.append(&mut nested.wall_mutations);
-            wall_radar_dirty_cells.append(&mut nested.wall_radar_dirty_cells);
+
+            #[cfg(test)]
             cell_target_detaches.append(&mut nested.cell_target_detaches);
             tiberium_reduction_requests.append(&mut nested.tiberium_reduction_requests);
             death_sounds.append(&mut nested.death_sounds);
@@ -1372,13 +1335,13 @@ pub(crate) fn handle_death(
         immediate_uninit_ids,
         structure_destroyed,
         destroyed_crewed_buildings,
-        destroyed_garrison_buildings,
         explosion_effects,
         voxel_debris,
         invulnerability_impact_effects,
         bridge_damage_events,
+        #[cfg(test)]
         wall_mutations,
-        wall_radar_dirty_cells,
+        #[cfg(test)]
         cell_target_detaches,
         tiberium_reduction_requests,
         death_sounds,
@@ -1423,7 +1386,8 @@ fn emit_one_projectile_detonation(
     if let Some(weapon) = rules.weapon(world.interner.resolve(detonation.payload.weapon))
         && weapon.rad_level > 0
     {
-        out.rad_detonations
+        out.effects
+            .rad_detonations
             .push(crate::sim::radiation::RadDetonation {
                 rx: impact_rx,
                 ry: impact_ry,
@@ -1511,19 +1475,22 @@ fn emit_one_projectile_detonation(
                     air_impact,
                     impact_z,
                 );
-                append_fixture_tiberium(world, &mut out.tiberium_reduction_requests);
+                append_fixture_tiberium(world, &mut out.effects.tiberium_reduction_requests);
                 collected
             };
-            out.wall_mutations.extend(aoe.wall_mutations);
-            out.wall_radar_dirty_cells
-                .extend(aoe.wall_radar_dirty_cells);
-            out.cell_target_detaches.extend(aoe.cell_target_detaches);
+            #[cfg(test)]
+            out.effects.wall_mutations.extend(aoe.wall_mutations);
+
+            #[cfg(test)]
+            out.effects
+                .cell_target_detaches
+                .extend(aoe.cell_target_detaches);
             out.damage_events.extend(aoe.receivers);
 
             if !scenario_no_damage && detonation.payload.base_damage > 0 {
                 let damage = detonation.payload.base_damage.min(i32::from(u16::MAX)) as u16;
                 if !routed_wall && warhead.wall {
-                    out.bridge_damage_events.push(BridgeDamageEvent {
+                    out.effects.bridge_damage_events.push(BridgeDamageEvent {
                         rx: impact_rx,
                         ry: impact_ry,
                         damage,
@@ -1558,8 +1525,8 @@ fn emit_one_projectile_detonation(
         impact_z_byte(impact_z),
         world_z_leptons,
         &mut world.interner,
-        &mut out.explosion_effects,
-        &mut out.smudge_spawn_requests,
+        &mut out.effects.explosion_effects,
+        &mut out.effects.smudge_spawn_requests,
     );
 }
 
@@ -1604,13 +1571,12 @@ pub(crate) fn commit_projectile_detonations_inline(
     overlay_registry: Option<&OverlayTypeRegistry>,
     projectile_detonations: &[ProjectileDetonation],
     emit: &mut CombatEmit,
-    death: &mut DeathEffects,
     under_attack_events: &mut Vec<UnderAttackEvent>,
 ) {
     for detonation in projectile_detonations {
         let damage_start = emit.damage_events.len();
-        let explosion_start = emit.explosion_effects.len();
-        let smudge_start = emit.smudge_spawn_requests.len();
+        let explosion_start = emit.effects.explosion_effects.len();
+        let smudge_start = emit.effects.smudge_spawn_requests.len();
         emit_projectile_detonations(
             world,
             rules,
@@ -1618,8 +1584,8 @@ pub(crate) fn commit_projectile_detonations_inline(
             std::slice::from_ref(detonation),
             emit,
         );
-        let outer_explosion_effects = emit.explosion_effects.split_off(explosion_start);
-        let outer_anim_requests = emit.smudge_spawn_requests.split_off(smudge_start);
+        let outer_explosion_effects = emit.effects.explosion_effects.split_off(explosion_start);
+        let outer_anim_requests = emit.effects.smudge_spawn_requests.split_off(smudge_start);
         let (inline_death, mut pings) = commit_area(
             world,
             run,
@@ -1627,14 +1593,16 @@ pub(crate) fn commit_projectile_detonations_inline(
             rules,
             overlay_registry,
         );
-        absorb_inline_death_effects(emit, death, inline_death);
-        emit.explosion_effects.extend(outer_explosion_effects);
+        emit.effects.append(inline_death);
+        emit.effects
+            .explosion_effects
+            .extend(outer_explosion_effects);
         commit_smudges(
             world,
             rules,
             overlay_registry,
             outer_anim_requests,
-            &mut emit.smudge_spawn_requests,
+            &mut emit.effects.smudge_spawn_requests,
         );
         under_attack_events.append(&mut pings);
     }
@@ -1648,7 +1616,6 @@ pub(crate) fn commit_projectiles(
     overlay_registry: Option<&OverlayTypeRegistry>,
 ) -> LogicProjectileCommit {
     let mut emit = CombatEmit::default();
-    let mut effects = DeathEffects::default();
     let mut under_attack_events = Vec::new();
     commit_projectile_detonations_inline(
         world,
@@ -1657,34 +1624,9 @@ pub(crate) fn commit_projectiles(
         overlay_registry,
         detonations,
         &mut emit,
-        &mut effects,
         &mut under_attack_events,
     );
 
-    // Physical warhead/death outputs share the world's existing synchronous
-    // non-combat handoff. The remaining CombatEmit fields belong exclusively
-    // to Techno fire and therefore cannot be produced by this bounded path.
-    effects
-        .bridge_damage_events
-        .append(&mut emit.bridge_damage_events);
-    effects.wall_mutations.append(&mut emit.wall_mutations);
-    effects
-        .wall_radar_dirty_cells
-        .append(&mut emit.wall_radar_dirty_cells);
-    effects
-        .cell_target_detaches
-        .append(&mut emit.cell_target_detaches);
-    effects
-        .tiberium_reduction_requests
-        .append(&mut emit.tiberium_reduction_requests);
-    effects
-        .explosion_effects
-        .append(&mut emit.explosion_effects);
-    effects.voxel_debris.append(&mut emit.voxel_debris);
-    effects
-        .smudge_spawn_requests
-        .append(&mut emit.smudge_spawn_requests);
-    effects.rad_detonations.append(&mut emit.rad_detonations);
     debug_assert!(emit.remove_attack.is_empty());
     debug_assert!(emit.retarget_events.is_empty());
     debug_assert!(emit.fire_events.is_empty());
@@ -1700,7 +1642,7 @@ pub(crate) fn commit_projectiles(
 
     LogicProjectileCommit {
         projectile_spawns: emit.projectile_spawns,
-        effects,
+        effects: emit.effects,
         under_attack_events,
     }
 }
@@ -1746,13 +1688,13 @@ fn emit_missile_detonations(
             &mut outer_explosions,
             &mut outer_smudges,
         );
-        out.explosion_effects.extend(outer_explosions);
+        out.effects.explosion_effects.extend(outer_explosions);
         commit_smudges(
             world,
             rules,
             overlay_registry,
             outer_smudges,
-            &mut out.smudge_spawn_requests,
+            &mut out.effects.smudge_spawn_requests,
         );
         let aoe = {
             let collected = collect_area(
@@ -1766,13 +1708,16 @@ fn emit_missile_detonations(
                 air_impact,
                 impact_z,
             );
-            append_fixture_tiberium(world, &mut out.tiberium_reduction_requests);
+            append_fixture_tiberium(world, &mut out.effects.tiberium_reduction_requests);
             collected
         };
-        out.wall_mutations.extend(aoe.wall_mutations);
-        out.wall_radar_dirty_cells
-            .extend(aoe.wall_radar_dirty_cells);
-        out.cell_target_detaches.extend(aoe.cell_target_detaches);
+        #[cfg(test)]
+        out.effects.wall_mutations.extend(aoe.wall_mutations);
+
+        #[cfg(test)]
+        out.effects
+            .cell_target_detaches
+            .extend(aoe.cell_target_detaches);
         out.damage_events.extend(aoe.receivers);
     }
 }
@@ -3079,18 +3024,21 @@ pub(super) fn resolve_attacker_fire(
                 air_impact,
                 impact_z,
             );
-            append_fixture_tiberium(world, &mut out.tiberium_reduction_requests);
+            append_fixture_tiberium(world, &mut out.effects.tiberium_reduction_requests);
             collected
         };
-        out.wall_mutations.extend(aoe.wall_mutations);
-        out.wall_radar_dirty_cells
-            .extend(aoe.wall_radar_dirty_cells);
-        out.cell_target_detaches.extend(aoe.cell_target_detaches);
+        #[cfg(test)]
+        out.effects.wall_mutations.extend(aoe.wall_mutations);
+
+        #[cfg(test)]
+        out.effects
+            .cell_target_detaches
+            .extend(aoe.cell_target_detaches);
 
         out.damage_events.extend(aoe.receivers);
         if !scenario_no_damage && base_damage > 0 && !routed_wall && warhead.wall {
             let wh_iid = world.interner.intern(&warhead.id);
-            out.bridge_damage_events.push(BridgeDamageEvent {
+            out.effects.bridge_damage_events.push(BridgeDamageEvent {
                 rx: target_rx,
                 ry: target_ry,
                 damage: base_damage.min(i32::from(u16::MAX)) as u16,
@@ -3105,7 +3053,8 @@ pub(super) fn resolve_attacker_fire(
         // Radiation-emitting detonation: one site request per shot at the impact
         // cell. Spread is the warhead's CellSpread truncated to whole cells.
         if weapon.rad_level > 0 {
-            out.rad_detonations
+            out.effects
+                .rad_detonations
                 .push(crate::sim::radiation::RadDetonation {
                     rx: target_rx,
                     ry: target_ry,
@@ -3150,8 +3099,8 @@ pub(super) fn resolve_attacker_fire(
             effect_z,
             world_z_leptons,
             &mut world.interner,
-            &mut out.explosion_effects,
-            &mut out.smudge_spawn_requests,
+            &mut out.effects.explosion_effects,
+            &mut out.effects.smudge_spawn_requests,
         );
     }
 
@@ -3298,26 +3247,14 @@ pub(crate) fn tick_combat(
     if tick_ms == 0 {
         return CombatTickResult {
             projectile_spawns: Vec::new(),
-            reveal_events: Vec::new(),
-            despawned_ids: Vec::new(),
-            immediate_uninit_ids: Vec::new(),
-            structure_destroyed: false,
-            bridge_damage_events: Vec::new(),
-            wall_mutations: Vec::new(),
-            wall_radar_dirty_cells: Vec::new(),
-            cell_target_detaches: Vec::new(),
-            terrain_navigation_changed_cells: Vec::new(),
-            tiberium_reduction_requests: Vec::new(),
-            fire_events: Vec::new(),
-            destroyed_crewed_buildings: Vec::new(),
-            destroyed_garrison_buildings: Vec::new(),
-            explosion_effects: Vec::new(),
-            voxel_debris: Vec::new(),
-            invulnerability_impact_effects: Vec::new(),
-            smudge_spawn_requests: Vec::new(),
             unit_facing: Vec::new(),
-            under_attack_events: Vec::new(),
-            unit_lost_events: Vec::new(),
+            consequences: crate::sim::world::damage_consequences::DamageConsequences::ordinary(
+                DeathEffects::default(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+                Vec::new(),
+            ),
         };
     }
 
@@ -3326,7 +3263,6 @@ pub(crate) fn tick_combat(
     // recursive death weapon before the next detonation or attacker reads
     // wall, target, health, or RNG state.
     let mut emit = CombatEmit::default();
-    let mut death = DeathEffects::default();
     let mut under_attack_events = Vec::new();
     commit_projectile_detonations_inline(
         world,
@@ -3335,7 +3271,6 @@ pub(crate) fn tick_combat(
         overlay_registry,
         projectile_detonations,
         &mut emit,
-        &mut death,
         &mut under_attack_events,
     );
     for detonation in &missile_detonations {
@@ -3354,7 +3289,7 @@ pub(crate) fn tick_combat(
             rules,
             overlay_registry,
         );
-        absorb_inline_death_effects(&mut emit, &mut death, inline_death);
+        emit.effects.append(inline_death);
         under_attack_events.append(&mut pings);
     }
 
@@ -3814,8 +3749,8 @@ pub(crate) fn tick_combat(
         let n_retarget = emit.retarget_events.len();
         let n_remove = emit.remove_attack.len();
         let damage_start = emit.damage_events.len();
-        let explosion_start = emit.explosion_effects.len();
-        let smudge_start = emit.smudge_spawn_requests.len();
+        let explosion_start = emit.effects.explosion_effects.len();
+        let smudge_start = emit.effects.smudge_spawn_requests.len();
         let current_weapon_start = emit.current_weapon_updates.len();
         let fire_event_start = emit.fire_events.len();
         resolve_attacker_fire(
@@ -3830,8 +3765,8 @@ pub(crate) fn tick_combat(
             active_wave_owners.contains(&live_snap.stable_id),
             &mut emit,
         );
-        let outer_explosion_effects = emit.explosion_effects.split_off(explosion_start);
-        let outer_anim_requests = emit.smudge_spawn_requests.split_off(smudge_start);
+        let outer_explosion_effects = emit.effects.explosion_effects.split_off(explosion_start);
+        let outer_anim_requests = emit.effects.smudge_spawn_requests.split_off(smudge_start);
         for &(entity_id, weapon_index, weapon_ref) in
             &emit.current_weapon_updates[current_weapon_start..]
         {
@@ -3847,14 +3782,16 @@ pub(crate) fn tick_combat(
             rules,
             overlay_registry,
         );
-        absorb_inline_death_effects(&mut emit, &mut death, inline_death);
-        emit.explosion_effects.extend(outer_explosion_effects);
+        emit.effects.append(inline_death);
+        emit.effects
+            .explosion_effects
+            .extend(outer_explosion_effects);
         commit_smudges(
             world,
             rules,
             overlay_registry,
             outer_anim_requests,
-            &mut emit.smudge_spawn_requests,
+            &mut emit.effects.smudge_spawn_requests,
         );
         under_attack_events.append(&mut pings);
         let wave_fire_events = emit.fire_events[fire_event_start..].to_vec();
@@ -3964,21 +3901,13 @@ pub(crate) fn tick_combat(
     }
     // Destructure back into the named locals for post-fire state updates.
     let CombatEmit {
+        mut effects,
         projectile_spawns,
         mut damage_events,
-        rad_detonations,
         mut remove_attack,
         retarget_events,
         fire_events,
         reveal_events,
-        mut bridge_damage_events,
-        mut wall_mutations,
-        mut wall_radar_dirty_cells,
-        mut cell_target_detaches,
-        mut tiberium_reduction_requests,
-        mut explosion_effects,
-        mut voxel_debris,
-        mut smudge_spawn_requests,
         burst_updates,
         ammo_deduct,
         garrison_advance,
@@ -4120,7 +4049,7 @@ pub(crate) fn tick_combat(
     // death pipeline as weapon damage (death anim selection via the
     // RadSiteWarhead, owned-count bookkeeping, survivor ejection).
     if let Some(rad) = radiation_enabled.then_some(&mut world.radiation) {
-        for &det in &rad_detonations {
+        for det in effects.rad_detonations.drain(..) {
             rad.apply_detonation(
                 det,
                 binary_frame,
@@ -4210,21 +4139,9 @@ pub(crate) fn tick_combat(
             );
         }
     }
-    bridge_damage_events.append(&mut late_death.bridge_damage_events);
-    wall_mutations.append(&mut late_death.wall_mutations);
-    wall_radar_dirty_cells.append(&mut late_death.wall_radar_dirty_cells);
-    cell_target_detaches.append(&mut late_death.cell_target_detaches);
-    tiberium_reduction_requests.append(&mut late_death.tiberium_reduction_requests);
-    explosion_effects.append(&mut late_death.explosion_effects);
-    // `death` collects the deaths committed before the late radiation pass, so
-    // its debris is stamped first. It is empty in every path today —
-    // `absorb_inline_death_effects` drains `death.voxel_debris` into
-    // `CombatEmit` before the lifecycle append — but taking it in the wrong
-    // order here would invert the spawn ids the moment it stopped being empty.
-    voxel_debris.append(&mut death.voxel_debris);
-    voxel_debris.append(&mut late_death.voxel_debris);
-    smudge_spawn_requests.append(&mut late_death.smudge_spawn_requests);
-    death.append(late_death);
+    // Earlier emission and recursive death already share this accumulator;
+    // append the late radiation slice without rebuilding parallel vectors.
+    effects.append(late_death);
     under_attack_events.append(&mut late_pings);
 
     // Phase 5: remove AttackTarget from finished attackers.
@@ -4242,7 +4159,7 @@ pub(crate) fn tick_combat(
     // entity UnInit itself remains the world-owned deferred handoff.
     if sound_enabled {
         let sink = &mut world.sound_events;
-        for (die_id, rx, ry) in death.death_sounds {
+        for (die_id, rx, ry) in effects.death_sounds.drain(..) {
             sink.push(SimSoundEvent::EntityDied {
                 die_sound_id: die_id,
                 rx,
@@ -4261,26 +4178,14 @@ pub(crate) fn tick_combat(
 
     CombatTickResult {
         projectile_spawns,
-        reveal_events,
-        despawned_ids: death.despawned_ids,
-        immediate_uninit_ids: death.immediate_uninit_ids,
-        structure_destroyed: death.structure_destroyed,
-        bridge_damage_events,
-        wall_mutations,
-        wall_radar_dirty_cells,
-        cell_target_detaches,
-        terrain_navigation_changed_cells: run.navigation_changed_cells.clone(),
-        tiberium_reduction_requests,
-        fire_events,
-        destroyed_crewed_buildings: death.destroyed_crewed_buildings,
-        destroyed_garrison_buildings: death.destroyed_garrison_buildings,
-        explosion_effects,
-        voxel_debris,
-        invulnerability_impact_effects: death.invulnerability_impact_effects,
-        smudge_spawn_requests,
         unit_facing,
-        under_attack_events,
-        unit_lost_events: death.unit_lost_events,
+        consequences: crate::sim::world::damage_consequences::DamageConsequences::ordinary(
+            effects,
+            under_attack_events,
+            run.navigation_changed_cells.clone(),
+            reveal_events,
+            fire_events,
+        ),
     }
 }
 

--- a/src/sim/overlay_grid.rs
+++ b/src/sim/overlay_grid.rs
@@ -1203,14 +1203,17 @@ pub struct WallDamageResult {
     pub destroyed_cells: Vec<(u16, u16)>,
     /// Exact mutation order. This is deliberately a wall-local trace, not a
     /// generalized gameplay event system.
+    #[cfg(test)]
     pub mutations: Vec<WallMutation>,
     /// Diagnostic trace of packed CellStruct values submitted to
     /// MarkTerrainDirty, deduplicated in first-call order. Production mutation
     /// authority is the synchronous host callback, never replay of this list.
     /// True-dummy coordinates retain their raw signed-word bit patterns.
+    #[cfg(test)]
     pub radar_dirty_cells: Vec<(u16, u16)>,
 }
 
+#[cfg(test)]
 fn push_wall_radar_dirty(result: &mut WallDamageResult, coord: (u16, u16)) {
     if !result.radar_dirty_cells.contains(&coord) {
         result.radar_dirty_cells.push(coord);
@@ -1219,15 +1222,16 @@ fn push_wall_radar_dirty(result: &mut WallDamageResult, coord: (u16, u16)) {
 
 fn publish_wall_dirty_step(
     host: &mut Option<&mut dyn WallDamageTransactionHost>,
-    result: &mut WallDamageResult,
+    _result: &mut WallDamageResult,
     step: WallDirtyStep,
     packed_coord: (u16, u16),
 ) {
     if let Some(host) = host.as_deref_mut() {
         host.dirty_step(step, packed_coord);
     }
+    #[cfg(test)]
     if step == WallDirtyStep::Radar {
-        push_wall_radar_dirty(result, packed_coord);
+        push_wall_radar_dirty(_result, packed_coord);
     }
 }
 
@@ -1422,6 +1426,7 @@ fn damage_wall_recursive(
         if let NativeRuntimeOverlayCell::Real(rx, ry) = target {
             grid.dirty_cells.push((rx, ry));
             result.changed_cells.push((rx, ry));
+            #[cfg(test)]
             result.mutations.push(WallMutation {
                 rx,
                 ry,
@@ -1435,6 +1440,7 @@ fn damage_wall_recursive(
     clear_native_runtime_overlay_target(grid, resolved_terrain.as_deref(), target, false);
     if let NativeRuntimeOverlayCell::Real(rx, ry) = target {
         result.destroyed_cells.push((rx, ry));
+        #[cfg(test)]
         result.mutations.push(WallMutation {
             rx,
             ry,
@@ -1971,6 +1977,7 @@ fn cleanup_wall_neighbors_into(
                 RecomputeResult::NoChange => {}
                 RecomputeResult::Updated => {
                     result.changed_cells.push((nx, ny));
+                    #[cfg(test)]
                     result.mutations.push(WallMutation {
                         rx: nx,
                         ry: ny,
@@ -1979,6 +1986,7 @@ fn cleanup_wall_neighbors_into(
                 }
                 RecomputeResult::Destroyed => {
                     result.destroyed_cells.push((nx, ny));
+                    #[cfg(test)]
                     result.mutations.push(WallMutation {
                         rx: nx,
                         ry: ny,

--- a/src/sim/production/mod.rs
+++ b/src/sim/production/mod.rs
@@ -49,9 +49,10 @@ pub(crate) use self::production_refinery::spawn_completed_refinery_free_units;
 pub(crate) use self::production_sell::{
     eject_destruction_garrison_with_context, eject_red_hp_garrison,
 };
+#[cfg(test)]
+pub(crate) use self::production_sell::eject_destruction_garrison;
 pub use self::production_sell::{
-    eject_destruction_garrison, eject_destruction_survivors, sell_building, tick_repairs,
-    toggle_repair,
+    eject_destruction_survivors, sell_building, tick_repairs, toggle_repair,
 };
 pub use self::production_spawn::find_spawn_cell_for_owner;
 pub use self::production_tech::{

--- a/src/sim/production/production_sell.rs
+++ b/src/sim/production/production_sell.rs
@@ -622,7 +622,8 @@ fn eject_garrison_occupants(sim: &mut Simulation, rules: &RuleSet, building_id: 
 ///
 /// Returns the count of occupants successfully ejected (excludes those killed
 /// when no edge cell can be used).
-pub fn eject_destruction_garrison(
+#[cfg(test)]
+pub(crate) fn eject_destruction_garrison(
     sim: &mut Simulation,
     rules: &RuleSet,
     event: &DestroyedGarrisonBuilding,

--- a/src/sim/production/wall_placement.rs
+++ b/src/sim/production/wall_placement.rs
@@ -137,9 +137,11 @@ pub(super) fn stamp_wall(
         return false;
     }
 
+    #[cfg(test)]
     let mut detach_trace = Vec::new();
     let mut host = SimulationWallRuntimeHost {
         entities: &mut sim.substrate.entities,
+        #[cfg(test)]
         detach_trace: &mut detach_trace,
         radar_dirty_cells: &mut sim.radar_terrain_dirty_cells,
         radar_dirty_generation: &mut sim.radar_terrain_dirty_generation,

--- a/src/sim/world/damage_consequence_tests.rs
+++ b/src/sim/world/damage_consequence_tests.rs
@@ -1,0 +1,267 @@
+//! Regression coverage of the existing Rust consequence schedules, not native parity.
+
+use super::*;
+use crate::rules::{art_data::ArtRegistry, ini_parser::IniFile};
+use crate::sim::game_entity::GameEntity;
+use crate::sim::projectile::{ProjectileCoord, ProjectilePayload, ProjectileTarget};
+
+fn consequence_rules() -> RuleSet {
+    let mut rules = RuleSet::from_ini(&IniFile::from_str(
+        "[VehicleTypes]\n0=TESLA\n1=TARGET\n\
+         [TESLA]\nStrength=300\nArmor=heavy\nSpeed=6\nPrimary=CoilBolt\n\
+         [TARGET]\nStrength=10\nArmor=heavy\nSpeed=6\nDieSound=DieA\n\
+         MinDebris=1\nMaxDebris=2\nDebrisTypes=TIRE\nDebrisMaximums=1\n\
+         Explosion=DEATHFX\nDestroyAnim=DESTROYFX\n\
+         [VoxelAnims]\n0=TIRE\n\
+         [TIRE]\nElasticity=0.8\nMinAngularVelocity=12\nMaxAngularVelocity=24\n\
+         MinZVel=28\nMaxZVel=32\nMaxXYVel=10\nDuration=150\n\
+         [CoilBolt]\nDamage=40\nROF=50\nRange=6\nWarhead=AP\nIsElectricBolt=yes\n\
+         [Warheads]\n0=AP\n\
+         [AP]\nCellSpread=0\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+         [CombatDamage]\nDefaultSparkSystem=SparkSys\n\
+         [ParticleSystems]\n0=SparkSys\n\
+         [SparkSys]\nBehavesLike=Spark\nHoldsWhat=Spark\nParticleCap=6\n\
+         SparkSpawnFrames=1\nSpawnSparkPercentage=1\nLifetime=200\n\
+         [Particles]\n0=Spark\n\
+         [Spark]\nBehavesLike=Spark\nMaxEC=500\nXVelocity=10\nYVelocity=10\n\
+         MinZVelocity=40\nZVelocityRange=15\n",
+    ))
+    .unwrap();
+    let mut art = ArtRegistry::from_ini(&IniFile::from_str(
+        "[DEATHFX]\nReport=DeathReport\nEnd=80\n\
+         [DESTROYFX]\nReport=DestroyReport\nEnd=80\n",
+    ));
+    for name in ["DEATHFX", "DESTROYFX"] {
+        art.bind_anim_frame_count_for_test(name, 80);
+    }
+    rules.art_registry = art;
+    rules
+}
+
+fn consequence_world() -> (Simulation, u64, u64) {
+    let mut sim = Simulation::with_seed(17);
+    sim.input_delay_ticks = 0;
+    let attacker = sim.allocate_stable_id();
+    let victim = sim.allocate_stable_id();
+    for (id, kind, owner, rx, hp) in [
+        (attacker, "TESLA", "Americans", 5, 300),
+        (victim, "TARGET", "Soviet", 8, 10),
+    ] {
+        let mut entity = GameEntity::test_default(id, kind, owner, rx, 5);
+        entity.health.current = hp;
+        entity.health.max = hp;
+        sim.substrate.entities.insert(entity);
+    }
+    sim.interner = crate::sim::intern::test_interner();
+    for id in [attacker, victim] {
+        assert!(matches!(sim.reveal(id), RevealOutcome::Revealed { .. }));
+    }
+    (sim, attacker, victim)
+}
+
+fn debris_fingerprint(sim: &Simulation, id: u64) -> u64 {
+    bincode::serialize(sim.substrate.voxel_anims.get(id).unwrap())
+        .unwrap()
+        .into_iter()
+        .fold(0xcbf29ce484222325_u64, |hash, byte| {
+            (hash ^ u64::from(byte)).wrapping_mul(0x100000001b3)
+        })
+}
+
+fn delivered_ids(sim: &Simulation) -> Vec<u64> {
+    let debris = sim.substrate.voxel_anims.ids();
+    assert_eq!(debris.len(), 1);
+    let mut ids = debris;
+    for name in ["DEATHFX", "DESTROYFX"] {
+        ids.push(
+            sim.anims()
+                .find(|(_, anim)| sim.interner.resolve(anim.type_id) == name)
+                .unwrap_or_else(|| panic!("missing {name}"))
+                .0
+                .to_owned(),
+        );
+    }
+    assert!(ids.windows(2).all(|pair| pair[0] + 1 == pair[1]));
+    let live = sim.live_object_order_snapshot();
+    let selected: Vec<_> = live.into_iter().filter(|id| ids.contains(id)).collect();
+    assert_eq!(selected, ids);
+    sim.debug_assert_logic_membership_consistent();
+    ids
+}
+
+fn delivery_sounds(sim: &Simulation) -> Vec<String> {
+    sim.sound_events
+        .iter()
+        .filter_map(|event| match event {
+            SimSoundEvent::EntityDied { die_sound_id, .. } => {
+                Some(sim.interner.resolve(*die_sound_id).to_owned())
+            }
+            SimSoundEvent::AnimationStarted { sound_id, .. } => {
+                Some(sim.interner.resolve(*sound_id).to_owned())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn advance_lethal_shot(sim: &mut Simulation, rules: &RuleSet, attacker: u64, victim: u64) {
+    let owner = sim.interner.intern("Americans");
+    let grid = PathGrid::test_all_passable(64, 64);
+    sim.queue_command(CommandEnvelope::new(
+        owner,
+        sim.session.tick + 1,
+        Command::Attack {
+            attacker_id: attacker,
+            target_id: victim,
+        },
+    ));
+    for _ in 0..60 {
+        let commands = sim.take_due_commands();
+        sim.advance_tick(
+            &commands,
+            Some(rules),
+            &BTreeMap::new(),
+            Some(&grid),
+            None,
+            100,
+        );
+        if !sim.substrate.voxel_anims.is_empty() {
+            return;
+        }
+    }
+    panic!("the command must produce a lethal shot");
+}
+
+#[test]
+fn ordinary_lethal_fire_commits_debris_animations_and_sparks_once() {
+    let rules = consequence_rules();
+    let (mut sim, attacker, victim) = consequence_world();
+    let grid = PathGrid::test_all_passable(64, 64);
+    advance_lethal_shot(&mut sim, &rules, attacker, victim);
+    let mut ids = delivered_ids(&sim);
+    let spark = *sim
+        .particle_systems()
+        .iter()
+        .next()
+        .expect("late target lookup constructs spark")
+        .0;
+    assert_eq!(spark, ids[2] + 1);
+    ids.push(spark);
+    assert_eq!(
+        sim.live_object_order_snapshot(),
+        [vec![attacker], ids.clone()].concat()
+    );
+    assert_eq!(
+        delivery_sounds(&sim),
+        ["DieA", "DEATHREPORT", "DESTROYREPORT"]
+    );
+    assert!(sim.substrate.entities.get(victim).is_none());
+    // Captured from the real frame on pre-refactor 8a27b871; Rust regression,
+    // not a gamemd-derived golden. Fingerprint includes the complete debris body.
+    assert_eq!(sim.scenario_rng.state(), 13042760425816376097);
+    assert_eq!(sim.main_rng.state(), 2066545679410230777);
+    assert_eq!(debris_fingerprint(&sim, ids[0]), 14700842514585490858);
+    let next_id = sim.allocate_stable_id();
+    assert_eq!(next_id, spark + 1);
+    sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), Some(&grid), None, 100);
+    assert_eq!(delivered_ids(&sim), ids[..3]);
+    assert_eq!(
+        delivery_sounds(&sim),
+        ["DieA", "DEATHREPORT", "DESTROYREPORT"]
+    );
+    assert_eq!(sim.particle_systems().len(), 1);
+}
+
+#[test]
+fn ordinary_fatal_transport_finishes_cargo_lifecycle_before_consequence_admission() {
+    use crate::sim::passenger::{PassengerCargo, PassengerRole};
+    let rules = consequence_rules();
+    let (mut sim, attacker, carrier) = consequence_world();
+    let passenger = sim.allocate_stable_id();
+    let mut entity = GameEntity::test_default(passenger, "TARGET", "Soviet", 8, 5);
+    entity.passenger_role = PassengerRole::Inside {
+        transport_id: carrier,
+    };
+    sim.substrate.entities.insert(entity);
+    let mut cargo = PassengerCargo::new(1, 1);
+    assert!(cargo.board(passenger, 1));
+    sim.substrate
+        .entities
+        .get_mut(carrier)
+        .unwrap()
+        .passenger_role = PassengerRole::Transport { cargo };
+    sim.lifecycle_test_events.clear();
+    advance_lethal_shot(&mut sim, &rules, attacker, carrier);
+    assert!(sim.substrate.entities.get(passenger).is_none());
+    assert!(sim.substrate.entities.get(carrier).is_none());
+    assert!(sim.substrate.pending_delete.is_empty());
+    let cleared: Vec<_> = sim
+        .lifecycle_test_events
+        .iter()
+        .filter_map(|event| match event {
+            LifecycleTestEvent::UninitAliveCleared { stable_id } => Some(*stable_id),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(cleared, vec![passenger, carrier]);
+    assert_eq!(
+        delivered_ids(&sim),
+        vec![passenger + 1, passenger + 2, passenger + 3]
+    );
+    assert_eq!(
+        delivery_sounds(&sim),
+        ["DieA", "DEATHREPORT", "DESTROYREPORT"]
+    );
+}
+
+#[test]
+fn immediate_bullet_commits_before_return_with_its_original_sound_order() {
+    let rules = consequence_rules();
+    let (mut sim, attacker, victim) = consequence_world();
+    let projectile = sim.allocate_stable_id();
+    let impact = ProjectileCoord::new(8 * 256 + 128, 5 * 256 + 128, 0);
+    let mut spawn = super::lifecycle_tests::gsi_05_02_projectile(attacker, Some(0));
+    spawn.origin = impact;
+    spawn.target = ProjectileTarget::Entity(victim);
+    spawn.initial_target_position = impact;
+    spawn.payload = ProjectilePayload {
+        base_damage: 40,
+        warhead: sim.interner.intern("AP"),
+        weapon: sim.interner.intern("CoilBolt"),
+        owner: sim.interner.intern("Americans"),
+    };
+    sim.admit_projectile(projectile, spawn);
+    assert!(sim.object_ai_visit_one(projectile, Some(&rules), ObjectAiCtx::default()));
+    let ids = delivered_ids(&sim);
+    assert_eq!(ids, vec![projectile + 1, projectile + 2, projectile + 3]);
+    assert_eq!(
+        sim.live_object_order_snapshot(),
+        [vec![attacker], ids.clone()].concat()
+    );
+    assert_eq!(sim.substrate.pending_delete, vec![victim, projectile]);
+    assert!(
+        !sim.substrate
+            .entities
+            .get(victim)
+            .unwrap()
+            .lifecycle
+            .object_alive
+    );
+    assert_eq!(
+        delivery_sounds(&sim),
+        ["DEATHREPORT", "DESTROYREPORT", "DieA"]
+    );
+    assert!(sim.particle_systems().is_empty());
+    // Captured from the real Bullet AI on pre-refactor 8a27b871.
+    assert_eq!(sim.scenario_rng.state(), 3542812114296063344);
+    assert_eq!(sim.main_rng.state(), 2066545679410230777);
+    assert_eq!(debris_fingerprint(&sim, ids[0]), 8120097345519581533);
+    // Retired objects remain physically resolvable until the shared drain.
+    // Visiting again must not deliver another death transaction.
+    let _ = sim.object_ai_visit_one(projectile, Some(&rules), ObjectAiCtx::default());
+    assert_eq!(
+        delivery_sounds(&sim),
+        ["DEATHREPORT", "DESTROYREPORT", "DieA"]
+    );
+    assert_eq!(delivered_ids(&sim), ids);
+}

--- a/src/sim/world/damage_consequences.rs
+++ b/src/sim/world/damage_consequences.rs
@@ -1,0 +1,338 @@
+//! Consuming delivery of receiver consequences at explicit world boundaries.
+//!
+//! VERA-internal ownership protocol, gamemd equivalent UNCHECKED. This preserves
+//! the existing ordinary/immediate schedules; it does not relocate native damage
+//! callbacks, radiation selection, death-sound selection, or the shared ID allocator.
+
+use super::{SimFireEvent, SimSoundEvent, Simulation};
+use crate::map::entities::EntityCategory;
+use crate::map::overlay_types::OverlayTypeRegistry;
+use crate::rules::ruleset::RuleSet;
+use crate::sim::combat::{DeathEffects, RevealEvent, UnderAttackEvent};
+use crate::sim::intern::InternedId;
+use crate::sim::pathfinding::PathGrid;
+use crate::sim::production;
+use crate::sim::radar::RadarEventType;
+use std::sync::Arc;
+
+enum DamageDelivery {
+    Immediate,
+    Ordinary {
+        reveal_events: Vec<RevealEvent>,
+        fire_events: Vec<SimFireEvent>,
+    },
+}
+
+/// Pending work has one owner and is consumed once by its world commit.
+#[must_use]
+pub(crate) struct DamageConsequences {
+    effects: DeathEffects,
+    terrain_navigation_changed_cells: Vec<(u16, u16)>,
+    delivery: DamageDelivery,
+}
+
+pub(super) struct DamageCommitReceipt {
+    pub(super) structure_destroyed: bool,
+    pub(super) bridge_state_changed: bool,
+    pub(super) path_grid: Option<Arc<PathGrid>>,
+}
+
+impl DamageConsequences {
+    pub(super) fn finish_navigation(&mut self, cells: Vec<(u16, u16)>) {
+        self.terrain_navigation_changed_cells = cells;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn effects(&self) -> &DeathEffects {
+        &self.effects
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fire_events(&self) -> &[SimFireEvent] {
+        match &self.delivery {
+            DamageDelivery::Ordinary { fire_events, .. } => fire_events,
+            DamageDelivery::Immediate => &[],
+        }
+    }
+
+    pub(super) fn immediate(
+        mut effects: DeathEffects,
+        under_attack_events: Vec<UnderAttackEvent>,
+        terrain_navigation_changed_cells: Vec<(u16, u16)>,
+    ) -> Self {
+        // The caller's ordered receiver pings are the existing delivery source.
+        effects.under_attack_events = under_attack_events;
+        Self {
+            effects,
+            terrain_navigation_changed_cells,
+            delivery: DamageDelivery::Immediate,
+        }
+    }
+
+    pub(crate) fn ordinary(
+        mut effects: DeathEffects,
+        under_attack_events: Vec<UnderAttackEvent>,
+        terrain_navigation_changed_cells: Vec<(u16, u16)>,
+        reveal_events: Vec<RevealEvent>,
+        fire_events: Vec<SimFireEvent>,
+    ) -> Self {
+        // Ordinary radiation and death sounds already crossed their earlier
+        // receiver barriers. Disabled fixture sinks formerly discarded them;
+        // carrying the accumulator whole must not replay those leftovers here.
+        effects.rad_detonations.clear();
+        effects.death_sounds.clear();
+        effects.under_attack_events = under_attack_events;
+        Self {
+            effects,
+            terrain_navigation_changed_cells,
+            delivery: DamageDelivery::Ordinary {
+                reveal_events,
+                fire_events,
+            },
+        }
+    }
+
+    pub(super) fn commit(
+        self,
+        world: &mut Simulation,
+        rules: &RuleSet,
+        overlay_registry: Option<&OverlayTypeRegistry>,
+        fallback_path_grid: Option<&PathGrid>,
+    ) -> DamageCommitReceipt {
+        let Self {
+            mut effects,
+            terrain_navigation_changed_cells,
+            delivery,
+        } = self;
+        let ordinary = matches!(&delivery, DamageDelivery::Ordinary { .. });
+        // Capture owner/category now: ordinary delivery follows SpawnManager,
+        // while immediate delivery finishes before its caller's next live cursor.
+        let dead_infos: Vec<(InternedId, EntityCategory)> = effects
+            .despawned_ids
+            .iter()
+            .filter_map(|&dead_id| {
+                world
+                    .substrate
+                    .entities
+                    .get(dead_id)
+                    .map(|entity| (entity.owner(), entity.category))
+            })
+            .collect();
+
+        for &dead_id in &effects.immediate_uninit_ids {
+            world.undock_refinery_unit_on_death(rules, dead_id);
+            if world
+                .substrate
+                .entities
+                .get(dead_id)
+                .and_then(|building| building.bunker_occupant)
+                .is_some()
+            {
+                crate::sim::docking::bunker_link::release_sell_destroy(world, dead_id);
+            }
+            world.release_move_sound(dead_id);
+            world.uninit_with_rules(dead_id, rules);
+        }
+
+        let bridge_state_changed = crate::sim::world::bridge_orchestrator::apply_bridge_damage_events_with_overlay_registry(
+            world,
+            rules,
+            &effects.bridge_damage_events,
+            overlay_registry,
+        );
+        debug_assert!(effects.tiberium_reduction_requests.is_empty());
+        for request in &effects.tiberium_reduction_requests {
+            world.reduce_tiberium_at_with_native_context(
+                (request.rx, request.ry),
+                request.amount,
+                Some(rules),
+                overlay_registry,
+            );
+        }
+        for detonation in effects.rad_detonations.drain(..) {
+            world.radiation.apply_detonation(
+                detonation,
+                world.session.binary_frame,
+                &rules.radiation,
+                world.resolved_terrain.as_ref(),
+            );
+        }
+
+        let path_grid = world.finish_terrain_navigation_changes(
+            fallback_path_grid,
+            &terrain_navigation_changed_cells,
+        );
+        if let DamageDelivery::Ordinary { reveal_events, .. } = &delivery {
+            for event in reveal_events {
+                crate::sim::vision::reveal_radius(
+                    &mut world.fog,
+                    event.owner,
+                    event.rx,
+                    event.ry,
+                    event.radius,
+                );
+            }
+        }
+
+        for building in &effects.destroyed_crewed_buildings {
+            production::eject_destruction_survivors(
+                world,
+                rules,
+                building.type_id,
+                building.owner,
+                building.rx,
+                building.ry,
+                building.z,
+            );
+        }
+        if world.session.game_options.super_weapons && effects.structure_destroyed {
+            let mut refreshed = Vec::new();
+            for &(owner, category) in &dead_infos {
+                if category == EntityCategory::Structure && !refreshed.contains(&owner) {
+                    refreshed.push(owner);
+                    crate::sim::superweapon::refresh_super_weapons_for_owner(world, rules, owner);
+                }
+            }
+        }
+
+        world.admit_death_debris(std::mem::take(&mut effects.voxel_debris));
+        // Explosion animations from the completed receiver transaction.
+        // `AnimClass` instances, not legacy world effects: only the real
+        // constructor reaches `AnimClass::Start @ 0x00424CE0`, which is what
+        // plays the art type's `Report=`/`StartSound=`, and only the real
+        // AnimType carries its `Translucent=` and `Rate=`.
+        for fx in std::mem::take(&mut effects.explosion_effects) {
+            world.spawn_combat_explosion_anim(
+                rules,
+                fx.shp_name,
+                fx.rx,
+                fx.ry,
+                fx.sub_x,
+                fx.sub_y,
+                fx.z,
+            );
+        }
+        if let DamageDelivery::Ordinary { fire_events, .. } = &delivery {
+            admit_electric_sparks(world, rules, fire_events);
+        }
+        world
+            .invulnerability_impact_effects
+            .append(&mut effects.invulnerability_impact_effects);
+        if let DamageDelivery::Ordinary {
+            fire_events,
+            reveal_events,
+        } = delivery
+        {
+            world.fire_events.extend(fire_events);
+            for event in reveal_events {
+                world
+                    .radar_events
+                    .push(RadarEventType::Combat, event.rx, event.ry);
+            }
+        }
+        for (die_sound_id, rx, ry) in effects.death_sounds.drain(..) {
+            world.sound_events.push(SimSoundEvent::EntityDied {
+                die_sound_id,
+                rx,
+                ry,
+            });
+        }
+        world.dispatch_under_attack_events(&effects.under_attack_events);
+        world.dispatch_unit_lost_events(&effects.unit_lost_events);
+        debug_assert!(effects.smudge_spawn_requests.is_empty());
+        if ordinary {
+            debug_assert!(world.pending_smudge_requests.is_empty());
+            world.flush_smudge_dirty();
+            world.pending_smudge_requests.clear();
+        } else {
+            world
+                .pending_smudge_requests
+                .append(&mut effects.smudge_spawn_requests);
+        }
+        DamageCommitReceipt {
+            structure_destroyed: effects.structure_destroyed,
+            bridge_state_changed,
+            path_grid,
+        }
+    }
+}
+
+fn admit_electric_sparks(world: &mut Simulation, rules: &RuleSet, fire_events: &[SimFireEvent]) {
+    // gamemd-derived: `EBolt::Init @ 0x004C2A60` creates one spark
+    // system per electric bolt at `0x004C2B30`, passing
+    // `Rules+0x1020` (`[CombatDamage] DefaultSparkSystem`) and the
+    // bolt's TARGET endpoint — `EBolt+0x0C..0x14`, which
+    // `TechnoClass::CreateElectricBolt @ 0x006FD516` fills from the
+    // target object's coordinate virtual, and which `EBolt::Init`
+    // then hands the constructor by address. Owner house,
+    // attachment object and target object are all NULL; the
+    // fallback aim coordinate is `0x008A0E50`, a static all-zero
+    // triple, and `AI_Spark` never reads it. The handle is
+    // discarded: the system lives on the global particle list and
+    // expires on its own `Lifetime`.
+    //
+    // The path consumes no `ScenarioClass::Random` draws.
+    // `EBolt::Init` does take one `RandomRanged(0, 0x100)` at
+    // `0x004C2AA3`, but on the cosmetic `RandomClass` at
+    // `0x00886B88` — the one `LaserDrawClass::Draw` and
+    // `ThemeClass::Next_Song` also use — not the lockstep scenario
+    // stream, so it is not modelled here.
+    //
+    // VERA-internal ordering, gamemd equivalent UNCHECKED: native
+    // constructs the system inside `Fire_At`, i.e. during the
+    // firer's own AI. Whether that means it is visited by the SAME
+    // frame's object walk is UNCHECKED — the constructor's two
+    // appends (`0x0062DD7A` into the ParticleSystemClass instance
+    // registry at `0x00A80208`, and `0x0062DEF6` into the abstracts
+    // registry at `0x00B0F730`) are neither of them the per-frame
+    // walker, and the walker itself was not identified. This engine
+    // creates it in the post-combat walk that already admits Sonic
+    // and Magnetron waves from the same event list — after the
+    // logic walk — so its first burst lands no earlier than
+    // native's, and one frame later if native does visit
+    // same-frame. Bolt rendering itself is not implemented; the
+    // sparks are the part of the discharge that is a simulation
+    // object.
+    if let Some(spark_system_name) = rules.combat_damage.default_spark_system.as_deref() {
+        for event in fire_events {
+            let Some(weapon) = rules.weapon(world.interner.resolve(event.weapon_id)) else {
+                continue;
+            };
+            if !weapon.is_electric_bolt {
+                continue;
+            }
+            let Some(system_type) = rules.ps_type_id_by_name(spark_system_name) else {
+                continue;
+            };
+            let coords = match event.target {
+                crate::sim::combat::TargetKind::Entity(id) => {
+                    let Some(entity) = world.substrate.entities.get(id) else {
+                        continue;
+                    };
+                    glam::IVec3::new(
+                        i32::from(entity.position.rx) * 256 + entity.position.sub_x.to_num::<i32>(),
+                        i32::from(entity.position.ry) * 256 + entity.position.sub_y.to_num::<i32>(),
+                        i32::from(entity.position.z)
+                            * crate::util::lepton::GROUND_LEVEL_HEIGHT_LEPTONS,
+                    )
+                }
+                // VERA-internal, gamemd equivalent UNCHECKED: native
+                // takes the bolt endpoint from the TARGET OBJECT's
+                // coordinate virtual, and a cell target has no object
+                // to ask, so ground height is not folded in here.
+                crate::sim::combat::TargetKind::Cell(rx, ry) => {
+                    glam::IVec3::new(i32::from(rx) * 256 + 128, i32::from(ry) * 256 + 128, 0)
+                }
+            };
+            world.spawn_particle_system(
+                system_type,
+                coords,
+                None,
+                None,
+                glam::IVec3::ZERO,
+                None,
+                rules,
+            );
+        }
+    }
+}

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -22,6 +22,7 @@ mod lifecycle;
 mod load_object_lifecycle;
 mod logic_vector;
 mod navigation;
+pub(crate) mod damage_consequences;
 mod object_turn;
 #[cfg(test)]
 use object_turn::shp_vehicle_counter_admitted;
@@ -46,6 +47,8 @@ mod house_ai_activation_tests;
 mod eva_dispatch_tests;
 #[cfg(test)]
 mod lifecycle_tests;
+#[cfg(test)]
+mod damage_consequence_tests;
 #[cfg(test)]
 mod team_script_vm_tests;
 
@@ -1349,6 +1352,7 @@ pub(crate) fn repair_wall_damage_navigation_authorities(
 /// already available as disjoint Simulation fields.
 pub(crate) struct SimulationWallRuntimeHost<'a> {
     pub(crate) entities: &'a mut EntityStore,
+    #[cfg(test)]
     pub(crate) detach_trace: &'a mut Vec<crate::sim::combat::combat_aoe::CellTargetDetach>,
     pub(crate) radar_dirty_cells: &'a mut Vec<(u16, u16)>,
     pub(crate) radar_dirty_generation: &'a mut u64,
@@ -1396,6 +1400,7 @@ impl WallDamageTransactionHost for SimulationWallRuntimeHost<'_> {
                 self.entities,
                 rx,
                 ry,
+                #[cfg(test)]
                 self.detach_trace,
             );
         }
@@ -1604,7 +1609,7 @@ impl Simulation {
             self, &mut run, rules, overlay_registry, tick_ms, logic_order,
             fire_suppressed, projectile_detonations, wave_damage_events,
         );
-        result.terrain_navigation_changed_cells = run.finish(self);
+        result.consequences.finish_navigation(run.finish(self));
         result
     }
 
@@ -2008,9 +2013,10 @@ impl Simulation {
                 {
                     let _chain_reaction_no_op = flags.chain_reaction;
                     if flags.wall {
-                        let wall = {
+                        let _wall = {
                             let mut host = SimulationWallRuntimeHost {
                                 entities: &mut self.substrate.entities,
+                                #[cfg(test)]
                                 detach_trace: &mut effects.cell_target_detaches,
                                 radar_dirty_cells: &mut self.radar_terrain_dirty_cells,
                                 radar_dirty_generation: &mut self.radar_terrain_dirty_generation,
@@ -2031,10 +2037,8 @@ impl Simulation {
                                 Some(&mut host),
                             )
                         };
-                        effects.wall_mutations.extend(wall.mutations);
-                        effects
-                            .wall_radar_dirty_cells
-                            .extend(wall.radar_dirty_cells);
+                        #[cfg(test)]
+                        effects.wall_mutations.extend(_wall.mutations);
                     }
                 }
 
@@ -2076,6 +2080,7 @@ impl Simulation {
                                 &mut self.substrate.entities,
                                 coord.0,
                                 coord.1,
+                                #[cfg(test)]
                                 &mut effects.cell_target_detaches,
                             );
                             self.mark_radar_terrain_dirty_cells([coord]);
@@ -2282,121 +2287,15 @@ impl Simulation {
     /// same lifecycle/presentation/terrain outputs without leaving an alternate
     /// zero-HP object registered for the next LogicClass visit.
     fn absorb_noncombat_damage_effects(
-        &mut self,
-        rules: &RuleSet,
+        &mut self, rules: &RuleSet,
         overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
-        mut effects: crate::sim::combat::DeathEffects,
+        effects: crate::sim::combat::DeathEffects,
         under_attack_events: Vec<crate::sim::combat::UnderAttackEvent>,
         terrain_navigation_changed_cells: Vec<(u16, u16)>,
     ) {
-        // Wall tactical/radar state was published inside DestroyOverlay before
-        // combat restored these moved-out authorities. The retained result
-        // list is diagnostic only and must never be replayed here.
-
-        let dead_infos: Vec<(InternedId, EntityCategory)> = effects
-            .despawned_ids
-            .iter()
-            .filter_map(|&dead_id| {
-                self.substrate
-                    .entities
-                    .get(dead_id)
-                    .map(|entity| (entity.owner(), entity.category))
-            })
-            .collect();
-
-        for event in &effects.destroyed_garrison_buildings {
-            production::eject_destruction_garrison(self, rules, event);
-        }
-        for &dead_id in &effects.immediate_uninit_ids {
-            self.undock_refinery_unit_on_death(rules, dead_id);
-            if self
-                .substrate
-                .entities
-                .get(dead_id)
-                .and_then(|building| building.bunker_occupant)
-                .is_some()
-            {
-                crate::sim::docking::bunker_link::release_sell_destroy(self, dead_id);
-            }
-            self.release_move_sound(dead_id);
-            self.uninit_with_rules(dead_id, rules);
-        }
-
-        let _ = crate::sim::world::bridge_orchestrator::apply_bridge_damage_events_with_overlay_registry(
-            self,
-            rules,
-            &effects.bridge_damage_events,
-            overlay_registry,
-        );
-        debug_assert!(effects.tiberium_reduction_requests.is_empty());
-        for request in &effects.tiberium_reduction_requests {
-            self.reduce_tiberium_at_with_native_context(
-                (request.rx, request.ry),
-                request.amount,
-                Some(rules),
-                overlay_registry,
-            );
-        }
-        for detonation in effects.rad_detonations.drain(..) {
-            self.radiation.apply_detonation(
-                detonation,
-                self.session.binary_frame,
-                &rules.radiation,
-                self.resolved_terrain.as_ref(),
-            );
-        }
-
-        let _ = self.finish_terrain_navigation_changes(
-            None,
-            &terrain_navigation_changed_cells,
-        );
-
-        for building in &effects.destroyed_crewed_buildings {
-            production::eject_destruction_survivors(
-                self,
-                rules,
-                building.type_id,
-                building.owner,
-                building.rx,
-                building.ry,
-                building.z,
-            );
-        }
-        if self.session.game_options.super_weapons && effects.structure_destroyed {
-            let mut refreshed = Vec::new();
-            for &(owner, category) in &dead_infos {
-                if category == EntityCategory::Structure && !refreshed.contains(&owner) {
-                    refreshed.push(owner);
-                    crate::sim::superweapon::refresh_super_weapons_for_owner(self, rules, owner);
-                }
-            }
-        }
-
-        self.admit_death_debris(std::mem::take(&mut effects.voxel_debris));
-        // Explosion animations from a non-combat area-damage transaction.
-        // `AnimClass` instances, not legacy world effects: only the real
-        // constructor reaches `AnimClass::Start @ 0x00424CE0`, which is what
-        // plays the art type's `Report=`/`StartSound=`, and only the real
-        // AnimType carries its `Translucent=` and `Rate=`.
-        for fx in std::mem::take(&mut effects.explosion_effects) {
-            self.spawn_combat_explosion_anim(
-                rules, fx.shp_name, fx.rx, fx.ry, fx.sub_x, fx.sub_y, fx.z,
-            );
-        }
-        self.invulnerability_impact_effects
-            .append(&mut effects.invulnerability_impact_effects);
-        for (die_sound_id, rx, ry) in effects.death_sounds.drain(..) {
-            self.sound_events.push(SimSoundEvent::EntityDied {
-                die_sound_id,
-                rx,
-                ry,
-            });
-        }
-        self.dispatch_under_attack_events(&under_attack_events);
-        self.dispatch_unit_lost_events(&effects.unit_lost_events);
-        debug_assert!(effects.smudge_spawn_requests.is_empty());
-        self.pending_smudge_requests
-            .append(&mut effects.smudge_spawn_requests);
+        let _ = damage_consequences::DamageConsequences::immediate(
+            effects, under_attack_events, terrain_navigation_changed_cells,
+        ).commit(self, rules, overlay_registry, None);
     }
 
     /// `HouseClass::NotifyUnderAttack @ 0x004F93E0` for one damaged asset,
@@ -5143,9 +5042,11 @@ impl Simulation {
             return;
         }
         let Some(grid) = self.overlay_grid.as_mut() else { return; };
+        #[cfg(test)]
         let mut cell_target_detaches = Vec::new();
         let mut host = SimulationWallRuntimeHost {
             entities: &mut self.substrate.entities,
+            #[cfg(test)]
             detach_trace: &mut cell_target_detaches,
             radar_dirty_cells: &mut self.radar_terrain_dirty_cells,
             radar_dirty_generation: &mut self.radar_terrain_dirty_generation,
@@ -6817,7 +6718,7 @@ impl Simulation {
                 .map(|(&stable_id, _)| stable_id)
                 .collect::<BTreeSet<_>>();
             let fire_suppressed = tube_turn_owned_ids.clone();
-            let mut combat_result = self.tick_combat_with_fatal_lifecycle(
+            let combat_result = self.tick_combat_with_fatal_lifecycle(
                 rules,
                 overlay_registry,
                 tick_ms,
@@ -6870,218 +6771,13 @@ impl Simulation {
                 &ordinary_logic_order,
                 overlay_registry,
             );
-            destroyed_structure |= combat_result.structure_destroyed;
-            let combat_dead_infos: Vec<(InternedId, EntityCategory)> = combat_result
-                .despawned_ids
-                .iter()
-                .filter_map(|&dead_id| {
-                    self.substrate
-                        .entities
-                        .get(dead_id)
-                        .map(|entity| (entity.owner(), entity.category))
-                })
-                .collect();
-            // Animated infantry remain represented and live until their death
-            // sequence itself reaches UnInit. Immediate classes enter the
-            // common lifecycle below.
-            let mut sw_refresh_owners: Vec<InternedId> = Vec::new();
-            if self.session.game_options.super_weapons && combat_result.structure_destroyed {
-                for &(owner_id, category) in &combat_dead_infos {
-                    if category == EntityCategory::Structure
-                        && !sw_refresh_owners.contains(&owner_id)
-                    {
-                        sw_refresh_owners.push(owner_id);
-                    }
-                }
-            }
-            // Destroyed garrisons detach/eject their cargo while the building is
-            // still alive and represented. Generic carrier recursion must not
-            // consume those occupants first.
-            for event in &combat_result.destroyed_garrison_buildings {
-                production::eject_destruction_garrison(self, rules, event);
-            }
-            for &dead_id in &combat_result.immediate_uninit_ids {
-                self.undock_refinery_unit_on_death(rules, dead_id);
-                // Eject a bunkered unit before the bunker is removed (UndockUnit).
-                if self
-                    .substrate
-                    .entities
-                    .get(dead_id)
-                    .and_then(|b| b.bunker_occupant)
-                    .is_some()
-                {
-                    crate::sim::docking::bunker_link::release_sell_destroy(self, dead_id);
-                }
-                self.release_move_sound(dead_id);
-                self.uninit_with_rules(dead_id, rules);
-            }
-            // Bridge damage: 4-path dispatcher + cascade
-            // (kill ground occupants → DropIn deck → debris → rim refresh
-            // → TriggerEvent 31 → zone rebuild). Replaces the legacy
-            // 2-call pipeline.
-            bridge_state_changed |=
-                crate::sim::world::bridge_orchestrator::apply_bridge_damage_events_with_overlay_registry(
-                    self,
-                    rules,
-                    &combat_result.bridge_damage_events,
-                    overlay_registry,
-                );
-            debug_assert!(combat_result.tiberium_reduction_requests.is_empty());
-            for req in &combat_result.tiberium_reduction_requests {
-                self.reduce_tiberium_at_with_native_context(
-                    (req.rx, req.ry),
-                    req.amount,
-                    Some(rules),
-                    overlay_registry,
-                );
-            }
-            tail_path_grid = self.finish_terrain_navigation_changes(
-                active_post_combat_path_grid,
-                &combat_result.terrain_navigation_changed_cells,
+            let receipt = combat_result.consequences.commit(
+                self, rules, overlay_registry, active_post_combat_path_grid,
             );
-            let post_terrain_path_grid = tail_path_grid
-                .as_deref()
-                .or(active_post_combat_path_grid);
-            // Apply RevealOnFire events from combat.
-            for ev in &combat_result.reveal_events {
-                vision::reveal_radius(&mut self.fog, ev.owner, ev.rx, ev.ry, ev.radius);
-            }
-            // Eject survivors from crewed buildings destroyed in combat.
-            for bldg in &combat_result.destroyed_crewed_buildings {
-                production::eject_destruction_survivors(
-                    self,
-                    rules,
-                    bldg.type_id,
-                    bldg.owner,
-                    bldg.rx,
-                    bldg.ry,
-                    bldg.z,
-                );
-            }
-            // Refresh superweapon grants for owners who lost structures in combat.
-            if self.session.game_options.super_weapons && combat_result.structure_destroyed {
-                for owner_id in sw_refresh_owners {
-                    crate::sim::superweapon::refresh_super_weapons_for_owner(self, rules, owner_id);
-                }
-            }
-            self.admit_death_debris(std::mem::take(&mut combat_result.voxel_debris));
-            // Spawn explosion animations from combat deaths. `AnimClass`
-            // instances, not legacy world effects: only the real constructor
-            // reaches `AnimClass::Start @ 0x00424CE0`, which is what plays the
-            // art type's `Report=`/`StartSound=`.
-            let explosion_spawns = combat_result
-                .explosion_effects
-                .iter()
-                .map(|fx| (fx.shp_name, fx.rx, fx.ry, fx.sub_x, fx.sub_y, fx.z))
-                .collect::<Vec<_>>();
-            for (shp_name, rx, ry, sub_x, sub_y, z) in explosion_spawns {
-                self.spawn_combat_explosion_anim(rules, shp_name, rx, ry, sub_x, sub_y, z);
-            }
-            // gamemd-derived: `EBolt::Init @ 0x004C2A60` creates one spark
-            // system per electric bolt at `0x004C2B30`, passing
-            // `Rules+0x1020` (`[CombatDamage] DefaultSparkSystem`) and the
-            // bolt's TARGET endpoint — `EBolt+0x0C..0x14`, which
-            // `TechnoClass::CreateElectricBolt @ 0x006FD516` fills from the
-            // target object's coordinate virtual, and which `EBolt::Init`
-            // then hands the constructor by address. Owner house,
-            // attachment object and target object are all NULL; the
-            // fallback aim coordinate is `0x008A0E50`, a static all-zero
-            // triple, and `AI_Spark` never reads it. The handle is
-            // discarded: the system lives on the global particle list and
-            // expires on its own `Lifetime`.
-            //
-            // The path consumes no `ScenarioClass::Random` draws.
-            // `EBolt::Init` does take one `RandomRanged(0, 0x100)` at
-            // `0x004C2AA3`, but on the cosmetic `RandomClass` at
-            // `0x00886B88` — the one `LaserDrawClass::Draw` and
-            // `ThemeClass::Next_Song` also use — not the lockstep scenario
-            // stream, so it is not modelled here.
-            //
-            // VERA-internal ordering, gamemd equivalent UNCHECKED: native
-            // constructs the system inside `Fire_At`, i.e. during the
-            // firer's own AI. Whether that means it is visited by the SAME
-            // frame's object walk is UNCHECKED — the constructor's two
-            // appends (`0x0062DD7A` into the ParticleSystemClass instance
-            // registry at `0x00A80208`, and `0x0062DEF6` into the abstracts
-            // registry at `0x00B0F730`) are neither of them the per-frame
-            // walker, and the walker itself was not identified. This engine
-            // creates it in the post-combat walk that already admits Sonic
-            // and Magnetron waves from the same event list — after the
-            // logic walk — so its first burst lands no earlier than
-            // native's, and one frame later if native does visit
-            // same-frame. Bolt rendering itself is not implemented; the
-            // sparks are the part of the discharge that is a simulation
-            // object.
-            if let Some(spark_system_name) = rules.combat_damage.default_spark_system.as_deref()
-            {
-                for event in &combat_result.fire_events {
-                    let Some(weapon) = rules.weapon(self.interner.resolve(event.weapon_id))
-                    else {
-                        continue;
-                    };
-                    if !weapon.is_electric_bolt {
-                        continue;
-                    }
-                    let Some(system_type) = rules.ps_type_id_by_name(spark_system_name) else {
-                        continue;
-                    };
-                    let coords = match event.target {
-                        crate::sim::combat::TargetKind::Entity(id) => {
-                            let Some(entity) = self.substrate.entities.get(id) else {
-                                continue;
-                            };
-                            glam::IVec3::new(
-                                i32::from(entity.position.rx) * 256
-                                    + entity.position.sub_x.to_num::<i32>(),
-                                i32::from(entity.position.ry) * 256
-                                    + entity.position.sub_y.to_num::<i32>(),
-                                i32::from(entity.position.z)
-                                    * crate::util::lepton::GROUND_LEVEL_HEIGHT_LEPTONS,
-                            )
-                        }
-                        // VERA-internal, gamemd equivalent UNCHECKED: native
-                        // takes the bolt endpoint from the TARGET OBJECT's
-                        // coordinate virtual, and a cell target has no object
-                        // to ask, so ground height is not folded in here.
-                        crate::sim::combat::TargetKind::Cell(rx, ry) => glam::IVec3::new(
-                            i32::from(rx) * 256 + 128,
-                            i32::from(ry) * 256 + 128,
-                            0,
-                        ),
-                    };
-                    self.spawn_particle_system(
-                        system_type,
-                        coords,
-                        None,
-                        None,
-                        glam::IVec3::ZERO,
-                        None,
-                        rules,
-                    );
-                }
-            }
-            // Collect fire events for render-side muzzle flash / projectile origin.
-            self.invulnerability_impact_effects
-                .extend(combat_result.invulnerability_impact_effects.iter().copied());
-            self.fire_events.extend(combat_result.fire_events);
-            // Emit radar events for combat occurrences.
-            for ev in &combat_result.reveal_events {
-                self.radar_events.push(RadarEventType::Combat, ev.rx, ev.ry);
-            }
-            // Player-asset damage pings: owner-scoped radar diamond + EVA
-            // dispatch (voice gated app-side to the local player; the queue's
-            // dedup result rides along as `eva_allowed`, BridgeRepaired-style).
-            self.dispatch_under_attack_events(&combat_result.under_attack_events);
-            self.dispatch_unit_lost_events(&combat_result.unit_lost_events);
-            // Production commits every request at its native producer. The
-            // vectors remain only on hookless combat fixtures; a live world
-            // request here would be an ordering regression.
-            debug_assert!(self.pending_smudge_requests.is_empty());
-            debug_assert!(combat_result.smudge_spawn_requests.is_empty());
-            self.flush_smudge_dirty();
-            // Always clear pending — even if grids were unbound (headless
-            // tests). The vec is per-tick ephemeral state.
-            self.pending_smudge_requests.clear();
+            destroyed_structure |= receipt.structure_destroyed;
+            bridge_state_changed |= receipt.bridge_state_changed;
+            tail_path_grid = receipt.path_grid;
+            let post_terrain_path_grid = tail_path_grid.as_deref().or(active_post_combat_path_grid);
 
             // No end-of-Phase-5 drain: combat-killed structures/voxels stay in
             // the Dying window through the Phase 5.5-8.5 consumers and are freed

--- a/src/sim/world/world_commands.rs
+++ b/src/sim/world/world_commands.rs
@@ -16,7 +16,9 @@ use crate::rules::object_type::ObjectCategory;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::cell_rect::canonical_cell_coord;
 use crate::sim::combat;
-use crate::sim::combat::combat_aoe::{CellTargetDetach, expire_cell_target_references};
+use crate::sim::combat::combat_aoe::expire_cell_target_references;
+#[cfg(test)]
+use crate::sim::combat::combat_aoe::CellTargetDetach;
 use crate::sim::command::{
     COMMAND_RECORD_LEN, Command, CommandEnvelope, CommandRecord, ExitRecord, MegaMissionMoveRecord,
     SellWallAtCellRecord,
@@ -434,11 +436,13 @@ impl Simulation {
         // Selling invokes exactly one PostDestructionWallCleanup at the sold
         // cell: N, E, S, W, self. It is not damage's four-cardinal fan-out.
         const CROSS: [(i32, i32); 5] = [(0, -1), (1, 0), (0, 1), (-1, 0), (0, 0)];
+        #[cfg(test)]
         let mut detach_trace: Vec<CellTargetDetach> = Vec::new();
         for (dx, dy) in CROSS {
             let visit = {
                 let mut host = SimulationWallRuntimeHost {
                     entities: &mut self.substrate.entities,
+                    #[cfg(test)]
                     detach_trace: &mut detach_trace,
                     radar_dirty_cells: &mut self.radar_terrain_dirty_cells,
                     radar_dirty_generation: &mut self.radar_terrain_dirty_generation,
@@ -527,7 +531,7 @@ impl Simulation {
         }
         self.mark_radar_terrain_dirty_cells([(rx, ry)]);
 
-        expire_cell_target_references(&mut self.substrate.entities, rx, ry, &mut detach_trace);
+        expire_cell_target_references(&mut self.substrate.entities, rx, ry, #[cfg(test)] &mut detach_trace);
 
         if let Some(tail_grid) = tail_grid {
             if self.zone_grid.is_some() {

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -1727,20 +1727,20 @@ fn gsi_04_07_damage_fatal_transport_lifecycle_brackets_nested_death_weapon() {
     // takes `BuildingClass::ReceiveDamage` case 4, whose stock 8-frame timer
     // runs `ObjectClass::UnInit` (`0x005F6625` clears `IsAlive +0x90`) before
     // the `0x00442905` re-test, so `NotifyUnderAttack` never runs for it.
-    assert_eq!(result.under_attack_events.len(), 1);
+    assert_eq!(result.consequences.effects().under_attack_events.len(), 1);
     assert_eq!(
         (
-            result.under_attack_events[0].rx,
-            result.under_attack_events[0].ry
+            result.consequences.effects().under_attack_events[0].rx,
+            result.consequences.effects().under_attack_events[0].ry
         ),
         (8, 5)
     );
-    assert!(result.under_attack_events[0].structure);
+    assert!(result.consequences.effects().under_attack_events[0].structure);
     assert!(!fatal.substrate.occupancy.contains_entity(8, 5, 10));
     let attacker = fatal.substrate.entities.get(20).unwrap();
     assert!(!attacker.radio_contacts.contains(10));
     assert!(attacker.attack_target.is_none());
-    assert!(result.immediate_uninit_ids.is_empty());
+    assert!(result.consequences.effects().immediate_uninit_ids.is_empty());
     assert_eq!(
         fatal.overlay_grid.as_ref().unwrap().cell(8, 5).overlay_id,
         None
@@ -1777,7 +1777,7 @@ fn gsi_04_07_damage_fatal_transport_lifecycle_brackets_nested_death_weapon() {
         assert_eq!(listener.health.current, listener.health.max);
         assert_eq!(listener.last_attacker_id, None);
     }
-    assert!(boundary_result.under_attack_events.is_empty());
+    assert!(boundary_result.consequences.effects().under_attack_events.is_empty());
     assert_eq!(
         boundary
             .substrate
@@ -1889,8 +1889,8 @@ fn gsi_04_11_bullet_ore_reduction_precedes_outer_crater_anim_start() {
             .is_some(),
         "the outer crater must observe the already-cleared overlay cell"
     );
-    assert!(result.tiberium_reduction_requests.is_empty());
-    assert!(result.smudge_spawn_requests.is_empty());
+    assert!(result.consequences.effects().tiberium_reduction_requests.is_empty());
+    assert!(result.consequences.effects().smudge_spawn_requests.is_empty());
     let mut expected_rng = crate::sim::rng::SimRng::new(1);
     let _ = expected_rng.next_range_u32(1);
     assert_eq!(sim.scenario_rng.state(), expected_rng.state());
@@ -1964,8 +1964,8 @@ fn gsi_04_11_missile_outer_anim_precedes_per_cell_ore_reduction() {
         "RocketLocomotion starts its crater Anim before the later ore sweep"
     );
     assert_eq!(sim.scenario_rng.state(), before_rng);
-    assert!(result.tiberium_reduction_requests.is_empty());
-    assert!(result.smudge_spawn_requests.is_empty());
+    assert!(result.consequences.effects().tiberium_reduction_requests.is_empty());
+    assert!(result.consequences.effects().smudge_spawn_requests.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Ordinary combat and immediate Bullet/Wave/direct damage maintained separate delivery tails, while weapon emission duplicated the receiver consequence fields. A private consuming world owner now settles both paths from one `DeathEffects` accumulator. The frame keeps its bullet, facing and SpawnManager prelude and receives the resulting navigation snapshot and change flags.

Preserves the distinct ordinary/immediate radiation, sound, reveal and effect-construction schedules. Removes the obsolete deferred garrison replay, its redundant empty assertion, unused wall radar forwarding, and production allocations for test-only wall/target-expiry traces. Synchronous lifecycle and wall mutations stay at their existing boundaries.

Validation:
- Real full-frame lethal fire, immediate Bullet AI and fatal transport tests pass on both pre-refactor `8a27b871` and the candidate. They pin allocation/Logic/deletion order, sound order, no duplicate delivery, both RNG streams and the debris body.
- `cargo test -p vera20k --lib`: **8466 passed; 0 failed; 81 ignored** (29.77s), including nested death, wall, bridge and navigation regressions.
- `cargo check -p vera20k`: passed (24.89s, 90 existing warnings).
- System Map check: 0 errors across 3 files.
- Independent read-only reviews approved producer/consumer ordering, diagnostic gating, production-path coverage and map claims.

Validation provenance: shared-target freshness initially reused the baseline test executable. That run is excluded; the reported candidate result follows a forced rebuild whose log identifies the candidate checkout. The grouping is a Rust ownership improvement, not a native postlude parity claim. Genetic mutation targeting/replacement ownership remains a separately tracked part of the active goal.
