### PR TITLE
Own complete cargo departure and retry restoration

### DIFF
--- a/docs/system-map/topology.v2.json
+++ b/docs/system-map/topology.v2.json
@@ -397,18 +397,39 @@
       "rust_surfaces": [
         {
           "path": "src/sim/passenger.rs",
-          "symbol": "passenger cargo and unload",
+          "symbol": "cargo state, boarding and garrison departure",
           "coverage": "representative",
-          "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"
+          "observed_at_commit": "a8d49528a7f3b31e55bf7a2b8df52409d889d491"
         },
         {
           "path": "src/sim/radio",
           "symbol": "transport radio protocol",
           "coverage": "representative",
           "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"
+        },
+        {
+          "path": "src/sim/passenger/departure.rs",
+          "symbol": "depart_cargo_head / restore_departure",
+          "coverage": "representative",
+          "observed_at_commit": "a8d49528a7f3b31e55bf7a2b8df52409d889d491"
+        },
+        {
+          "path": "src/sim/transport_unload.rs",
+          "symbol": "eject_head_passenger / eject_from_aircraft",
+          "coverage": "representative",
+          "observed_at_commit": "a8d49528a7f3b31e55bf7a2b8df52409d889d491"
+        },
+        {
+          "path": "src/sim/aircraft/drop_payload.rs",
+          "symbol": "try_drop",
+          "coverage": "representative",
+          "observed_at_commit": "a8d49528a7f3b31e55bf7a2b8df52409d889d491"
         }
       ],
-      "notes": ["Static evidence records concrete load/unload ordering drift; no native executable loop oracle exists."]
+      "notes": [
+        "Static evidence records concrete load/unload ordering drift; no native executable loop oracle exists.",
+        "Retryable garrison, vehicle, landed-aircraft and paradrop departure now shares one synchronous owner for stored cargo size, head removal and phase-specific restoration. Geometry, cadence and ordered success effects remain in their production callers. Bulk sell/destruction ejection has distinct lifetime ordering and remains separate. Rust baseline/candidate regression traces match; this does not establish native loop parity."
+      ]
     },
     "GSI-04.14": {
       "native_anchors": [
@@ -2262,27 +2283,118 @@
         "cargo head pop 0x00473430"
       ],
       "rust_touchpoints": [
-        {"path": "src/sim/passenger.rs", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},
-        {"path": "src/sim/radio", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},
-        {"path": "src/sim/movement", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},
-        {"path": "src/sim/pathfinding", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"}
+        {
+          "path": "src/sim/passenger.rs",
+          "coverage": "representative",
+          "observed_at_commit": "a8d49528a7f3b31e55bf7a2b8df52409d889d491"
+        },
+        {
+          "path": "src/sim/radio",
+          "coverage": "representative",
+          "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"
+        },
+        {
+          "path": "src/sim/movement",
+          "coverage": "representative",
+          "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"
+        },
+        {
+          "path": "src/sim/pathfinding",
+          "coverage": "representative",
+          "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"
+        },
+        {
+          "path": "src/sim/passenger/departure.rs",
+          "coverage": "representative",
+          "observed_at_commit": "a8d49528a7f3b31e55bf7a2b8df52409d889d491"
+        },
+        {
+          "path": "src/sim/transport_unload.rs",
+          "coverage": "representative",
+          "observed_at_commit": "a8d49528a7f3b31e55bf7a2b8df52409d889d491"
+        },
+        {
+          "path": "src/sim/aircraft/drop_payload.rs",
+          "coverage": "representative",
+          "observed_at_commit": "a8d49528a7f3b31e55bf7a2b8df52409d889d491"
+        }
       ],
       "stages": [
-        {"order": 1, "system": "GSI-14.03", "action": "Resolve enter action."},
-        {"order": 2, "system": "GSI-14.07", "action": "Build board order."},
-        {"order": 3, "system": "GSI-07.01", "action": "Admit owned order."},
-        {"order": 4, "system": "GSI-07.12", "action": "Run Mission Enter."},
-        {"order": 5, "system": "GSI-06.01", "action": "Admit approach movement."},
-        {"order": 6, "system": "GSI-06.03", "action": "Path to transport."},
-        {"order": 7, "system": "GSI-06.07", "action": "Commit boarding cell transition."},
-        {"order": 8, "system": "GSI-07.37", "action": "Negotiate boarding radio."},
-        {"order": 9, "system": "GSI-07.42", "action": "Insert passenger/cargo order."},
-        {"order": 10, "system": "GSI-14.08", "action": "Issue deploy/unload input."},
-        {"order": 11, "system": "GSI-07.21", "action": "Run unload mission."},
-        {"order": 12, "system": "GSI-07.42", "action": "Pop passenger and select destination."},
-        {"order": 13, "system": "GSI-06.01", "action": "Admit unload destination."},
-        {"order": 14, "system": "GSI-06.07", "action": "Commit passenger exit occupancy."},
-        {"order": 15, "system": "GSI-13.06", "action": "Render unloaded infantry sequence."}
+        {
+          "order": 1,
+          "system": "GSI-14.03",
+          "action": "Resolve enter action."
+        },
+        {
+          "order": 2,
+          "system": "GSI-14.07",
+          "action": "Build board order."
+        },
+        {
+          "order": 3,
+          "system": "GSI-07.01",
+          "action": "Admit owned order."
+        },
+        {
+          "order": 4,
+          "system": "GSI-07.12",
+          "action": "Run Mission Enter."
+        },
+        {
+          "order": 5,
+          "system": "GSI-06.01",
+          "action": "Admit approach movement."
+        },
+        {
+          "order": 6,
+          "system": "GSI-06.03",
+          "action": "Path to transport."
+        },
+        {
+          "order": 7,
+          "system": "GSI-06.07",
+          "action": "Commit boarding cell transition."
+        },
+        {
+          "order": 8,
+          "system": "GSI-07.37",
+          "action": "Negotiate boarding radio."
+        },
+        {
+          "order": 9,
+          "system": "GSI-07.42",
+          "action": "Insert passenger/cargo order."
+        },
+        {
+          "order": 10,
+          "system": "GSI-14.08",
+          "action": "Issue deploy/unload input."
+        },
+        {
+          "order": 11,
+          "system": "GSI-07.21",
+          "action": "Run unload mission."
+        },
+        {
+          "order": 12,
+          "system": "GSI-07.42",
+          "action": "Run cargo-head departure through placement and complete any route-specific retry before returning."
+        },
+        {
+          "order": 13,
+          "system": "GSI-06.01",
+          "action": "Admit unload destination."
+        },
+        {
+          "order": 14,
+          "system": "GSI-06.07",
+          "action": "Commit passenger exit occupancy."
+        },
+        {
+          "order": 15,
+          "system": "GSI-13.06",
+          "action": "Render unloaded infantry sequence."
+        }
       ],
       "oracle": {
         "status": "UNVERIFIED",

--- a/src/sim/aircraft/drop_payload.rs
+++ b/src/sim/aircraft/drop_payload.rs
@@ -22,7 +22,7 @@ use crate::sim::cell_rect::{
 use crate::sim::movement::bump_crush;
 use crate::sim::movement::locomotor::MovementLayer;
 use crate::sim::movement::parachute_descent::begin_parachute_descent;
-use crate::sim::passenger::PassengerRole;
+use crate::sim::passenger::{DepartureFailure, DepartureRoute, PassengerRole, depart_cargo_head};
 use crate::sim::pathfinding::PathGrid;
 use crate::sim::world::{
     PlacementEvidence, RevealOutcome, RevealPosition, RevealRequest, SimSoundEvent, Simulation,
@@ -87,22 +87,6 @@ pub enum DropResult {
     NoCargo,
 }
 
-fn restore_passenger_to_cargo_head(
-    sim: &mut Simulation,
-    aircraft_id: u64,
-    passenger_id: u64,
-    passenger_size: u32,
-) {
-    if let Some(cargo) = sim
-        .substrate
-        .entities
-        .get_mut(aircraft_id)
-        .and_then(|a| a.passenger_role.cargo_mut())
-    {
-        cargo.restore_front(passenger_id, passenger_size);
-    }
-}
-
 /// Attempt to drop one passenger from the carrier aircraft's cargo.
 ///
 /// Pre-conditions (caller-enforced):
@@ -133,224 +117,204 @@ pub fn try_drop(
             None => return DropResult::NoCargo,
         };
 
-    // 2. Pop FIFO passenger from cargo.
-    let (passenger_id, passenger_size) = match sim
-        .substrate
-        .entities
-        .get_mut(aircraft_id)
-        .and_then(|a| a.passenger_role.cargo_mut())
-        .and_then(|c| c.unload_first())
-    {
-        Some(entry) => entry,
-        None => return DropResult::NoCargo,
-    };
-
-    let (
-        passenger_category,
-        passenger_ready_for_reveal,
-        passenger_speed_type,
-        passenger_movement_zone,
-        prior_movement_layer,
-    ) = match sim.substrate.entities.get(passenger_id) {
-        Some(passenger) => {
-            let object_type = sim.object_type(passenger.type_ref(), rules);
-            (
-                passenger.category,
-                passenger.lifecycle.object_alive && passenger.lifecycle.in_limbo,
-                passenger
-                    .locomotor
-                    .as_ref()
-                    .map(|locomotor| locomotor.speed_type)
-                    .or_else(|| object_type.map(|object_type| object_type.speed_type))
-                    .unwrap_or(crate::rules::locomotor_type::SpeedType::Foot),
-                passenger
-                    .locomotor
-                    .as_ref()
-                    .map(|locomotor| locomotor.movement_zone)
-                    .or_else(|| object_type.map(|object_type| object_type.movement_zone))
-                    .unwrap_or(crate::rules::locomotor_type::MovementZone::Normal),
-                passenger
-                    .locomotor
-                    .as_ref()
-                    .map(|locomotor| locomotor.layer)
-                    .unwrap_or(MovementLayer::Ground),
-            )
-        }
-        None => {
-            sim.clear_radio_contacts_for(passenger_id);
-            restore_passenger_to_cargo_head(sim, aircraft_id, passenger_id, passenger_size);
-            return DropResult::AttachFailedRetry;
-        }
-    };
-    if !passenger_ready_for_reveal {
-        restore_passenger_to_cargo_head(sim, aircraft_id, passenger_id, passenger_size);
-        return DropResult::AttachFailedRetry;
-    }
-
-    // 3. Compute V-offset in leptons, then split into (cell, sub-cell).
-    // Using `div_euclid`/`rem_euclid` so negative offsets cross cell
-    // boundaries correctly (left-side drops walk one cell west when the
-    // aircraft is in the western half of its cell).
-    let payload_count_post = payload_count_pre_dec.saturating_sub(1);
-    let (dx, dy) = v_offset(facing, payload_count_post);
-    let drop_x_lep = aircraft_x_lep + dx;
-    let drop_y_lep = aircraft_y_lep + dy;
-    let drop_rx = drop_x_lep.div_euclid(256).clamp(0, u16::MAX as i32) as u16;
-    let drop_ry = drop_y_lep.div_euclid(256).clamp(0, u16::MAX as i32) as u16;
-    let drop_sub_x = SimFixed::from_num(drop_x_lep.rem_euclid(256));
-    let drop_sub_y = SimFixed::from_num(drop_y_lep.rem_euclid(256));
-
-    // Native: ObjectClass::SpawnParachuted computes the landing plane and then
-    // calls CellClass::IsClearToMove before virtual Unlimbo. Zone identity is
-    // not threaded into this Rust caller, so only that unavailable comparison
-    // remains omitted; terrain, bridge plane, and raw occupation are live.
-    let land_passable = sim
-        .resolved_terrain
-        .as_ref()
-        .and_then(|terrain| terrain.cell(drop_rx, drop_ry))
-        .map(|cell| {
-            cell.speed_costs
-                .cost_for_speed_type(passenger_speed_type)
-                .is_none_or(|cost| cost > 0)
-        })
-        .unwrap_or_else(|| path_grid.is_none_or(|grid| grid.is_walkable(drop_rx, drop_ry)));
-    let passability = if path_grid.is_none() && sim.resolved_terrain.is_none() {
-        // Headless construction tests have no Cell substrate. Keep their
-        // established admission explicit; live calls always thread map data.
-        IsClearToMoveResult::Clear {
-            selected_layer: MovementLayer::Ground,
-        }
-    } else {
-        evaluate_live_cell_passability(LiveCellPassabilityQuery {
-            target: (drop_rx, drop_ry),
-            speed_type: passenger_speed_type,
-            movement_zone: passenger_movement_zone,
-            requested_zone: None,
-            actual_zone: 0,
-            requested_layer: None,
-            ignore_infantry: false,
-            ignore_vehicles: false,
-            land_passable,
-            path_grid,
-            resolved_terrain: sim.resolved_terrain.as_ref(),
-            raw_occupation: Some(&sim.substrate.raw_cell_occupation),
-        })
-    };
-    let landing_layer = match passability {
-        IsClearToMoveResult::Clear { selected_layer } => selected_layer,
-        IsClearToMoveResult::ClearWinged => MovementLayer::Ground,
-        _ => {
-            restore_passenger_to_cargo_head(sim, aircraft_id, passenger_id, passenger_size);
-            return DropResult::ImpassableRetry;
-        }
-    };
-    if !matches!(landing_layer, MovementLayer::Ground | MovementLayer::Bridge) {
-        restore_passenger_to_cargo_head(sim, aircraft_id, passenger_id, passenger_size);
-        return DropResult::ImpassableRetry;
-    }
-
-    let selected_sub_cell = if passenger_category == EntityCategory::Infantry {
-        let occ = sim.substrate.occupancy.get(drop_rx, drop_ry);
-        match bump_crush::allocate_sub_cell_with_preference(
-            occ,
-            landing_layer,
-            None,
-            drop_sub_x,
-            drop_sub_y,
-            // sub-cell placement — scenario stream. Direct field: `occ` may borrow
-            // &sim.substrate.occupancy, so the subcell_rng() accessor could conflict.
-            &mut sim.scenario_rng,
-        ) {
-            Some(sub_cell) => Some(sub_cell),
-            None => {
-                restore_passenger_to_cargo_head(sim, aircraft_id, passenger_id, passenger_size);
-                return DropResult::ImpassableRetry;
-            }
-        }
-    } else {
-        None
-    };
-    let (final_sub_x, final_sub_y) = selected_sub_cell
-        .map(|sub_cell| lepton::subcell_lepton_offset(Some(sub_cell)))
-        .unwrap_or((drop_sub_x, drop_sub_y));
-
-    // 5. Supply caller-owned subcell/role state while the passenger is still
-    // limbo. Parachute attachment follows; Reveal is the success boundary.
-    // Do NOT touch
-    // `loco.altitude` here: normal paradropped infantry keep their base
-    // locomotor identity, while descent altitude lives in ParachuteDescentState.
-    if let Some(passenger) = sim.substrate.entities.get_mut(passenger_id) {
-        passenger.sub_cell = selected_sub_cell;
-        passenger.passenger_role = PassengerRole::None;
-        if let Some(locomotor) = passenger.locomotor.as_mut() {
-            locomotor.layer = landing_layer;
-        }
-    }
-    // 6. Attach parachute descent while the passenger is still limbo. Reveal
-    // is the local success boundary; an attach retry is not Techno Limbo.
-    if !begin_parachute_descent(&mut sim.substrate.entities, passenger_id, altitude) {
-        // Preserve the separately classified legacy retry scrub. No common
-        // Reveal state has been committed yet.
-        sim.clear_radio_contacts_for(passenger_id);
-        if let Some(passenger) = sim.substrate.entities.get_mut(passenger_id) {
-            passenger.passenger_role = PassengerRole::Inside {
-                transport_id: aircraft_id,
+    // Remove the native cargo HEAD (last boarded), and complete any retry here.
+    let result = depart_cargo_head(
+        sim,
+        rules,
+        aircraft_id,
+        DepartureRoute::Paradrop,
+        |sim, passenger_id| {
+            let (
+                passenger_category,
+                passenger_ready_for_reveal,
+                passenger_speed_type,
+                passenger_movement_zone,
+                prior_movement_layer,
+            ) = match sim.substrate.entities.get(passenger_id) {
+                Some(passenger) => {
+                    let object_type = sim.object_type(passenger.type_ref(), rules);
+                    (
+                        passenger.category,
+                        passenger.lifecycle.object_alive && passenger.lifecycle.in_limbo,
+                        passenger
+                            .locomotor
+                            .as_ref()
+                            .map(|locomotor| locomotor.speed_type)
+                            .or_else(|| object_type.map(|object_type| object_type.speed_type))
+                            .unwrap_or(crate::rules::locomotor_type::SpeedType::Foot),
+                        passenger
+                            .locomotor
+                            .as_ref()
+                            .map(|locomotor| locomotor.movement_zone)
+                            .or_else(|| object_type.map(|object_type| object_type.movement_zone))
+                            .unwrap_or(crate::rules::locomotor_type::MovementZone::Normal),
+                        passenger
+                            .locomotor
+                            .as_ref()
+                            .map(|locomotor| locomotor.layer)
+                            .unwrap_or(MovementLayer::Ground),
+                    )
+                }
+                None => {
+                    return Err(DepartureFailure::MissingPassenger);
+                }
             };
-            if let Some(locomotor) = passenger.locomotor.as_mut() {
-                locomotor.layer = prior_movement_layer;
+            if !passenger_ready_for_reveal {
+                return Err(DepartureFailure::NotReady);
             }
-        }
-        restore_passenger_to_cargo_head(sim, aircraft_id, passenger_id, passenger_size);
-        return DropResult::AttachFailedRetry;
-    }
 
-    let landing_z = sim
-        .resolved_terrain
-        .as_ref()
-        .and_then(|terrain| terrain.cell(drop_rx, drop_ry))
-        .map_or(0, |cell| {
-            cell.level
-                .wrapping_add(u8::from(landing_layer == MovementLayer::Bridge) * 4)
-        });
-    let reveal_outcome = sim.try_reveal_entity(
-        passenger_id,
-        RevealRequest {
-            position: RevealPosition {
+            // 3. Compute V-offset in leptons, then split into (cell, sub-cell).
+            // Using `div_euclid`/`rem_euclid` so negative offsets cross cell
+            // boundaries correctly (left-side drops walk one cell west when the
+            // aircraft is in the western half of its cell).
+            let payload_count_post = payload_count_pre_dec.saturating_sub(1);
+            let (dx, dy) = v_offset(facing, payload_count_post);
+            let drop_x_lep = aircraft_x_lep + dx;
+            let drop_y_lep = aircraft_y_lep + dy;
+            let drop_rx = drop_x_lep.div_euclid(256).clamp(0, u16::MAX as i32) as u16;
+            let drop_ry = drop_y_lep.div_euclid(256).clamp(0, u16::MAX as i32) as u16;
+            let drop_sub_x = SimFixed::from_num(drop_x_lep.rem_euclid(256));
+            let drop_sub_y = SimFixed::from_num(drop_y_lep.rem_euclid(256));
+
+            // Native: ObjectClass::SpawnParachuted computes the landing plane and then
+            // calls CellClass::IsClearToMove before virtual Unlimbo. Zone identity is
+            // not threaded into this Rust caller, so only that unavailable comparison
+            // remains omitted; terrain, bridge plane, and raw occupation are live.
+            let land_passable = sim
+                .resolved_terrain
+                .as_ref()
+                .and_then(|terrain| terrain.cell(drop_rx, drop_ry))
+                .map(|cell| {
+                    cell.speed_costs
+                        .cost_for_speed_type(passenger_speed_type)
+                        .is_none_or(|cost| cost > 0)
+                })
+                .unwrap_or_else(|| path_grid.is_none_or(|grid| grid.is_walkable(drop_rx, drop_ry)));
+            let passability = if path_grid.is_none() && sim.resolved_terrain.is_none() {
+                // Headless construction tests have no Cell substrate. Keep their
+                // established admission explicit; live calls always thread map data.
+                IsClearToMoveResult::Clear {
+                    selected_layer: MovementLayer::Ground,
+                }
+            } else {
+                evaluate_live_cell_passability(LiveCellPassabilityQuery {
+                    target: (drop_rx, drop_ry),
+                    speed_type: passenger_speed_type,
+                    movement_zone: passenger_movement_zone,
+                    requested_zone: None,
+                    actual_zone: 0,
+                    requested_layer: None,
+                    ignore_infantry: false,
+                    ignore_vehicles: false,
+                    land_passable,
+                    path_grid,
+                    resolved_terrain: sim.resolved_terrain.as_ref(),
+                    raw_occupation: Some(&sim.substrate.raw_cell_occupation),
+                })
+            };
+            let landing_layer = match passability {
+                IsClearToMoveResult::Clear { selected_layer } => selected_layer,
+                IsClearToMoveResult::ClearWinged => MovementLayer::Ground,
+                _ => {
+                    return Err(DepartureFailure::Placement);
+                }
+            };
+            if !matches!(landing_layer, MovementLayer::Ground | MovementLayer::Bridge) {
+                return Err(DepartureFailure::Placement);
+            }
+
+            let selected_sub_cell = if passenger_category == EntityCategory::Infantry {
+                let occ = sim.substrate.occupancy.get(drop_rx, drop_ry);
+                match bump_crush::allocate_sub_cell_with_preference(
+                    occ,
+                    landing_layer,
+                    None,
+                    drop_sub_x,
+                    drop_sub_y,
+                    // sub-cell placement — scenario stream. Direct field: `occ` may borrow
+                    // &sim.substrate.occupancy, so the subcell_rng() accessor could conflict.
+                    &mut sim.scenario_rng,
+                ) {
+                    Some(sub_cell) => Some(sub_cell),
+                    None => {
+                        return Err(DepartureFailure::Placement);
+                    }
+                }
+            } else {
+                None
+            };
+            let (final_sub_x, final_sub_y) = selected_sub_cell
+                .map(|sub_cell| lepton::subcell_lepton_offset(Some(sub_cell)))
+                .unwrap_or((drop_sub_x, drop_sub_y));
+
+            // 5. Supply caller-owned subcell/role state while the passenger is still
+            // limbo. Parachute attachment follows; Reveal is the success boundary.
+            // Do NOT touch
+            // `loco.altitude` here: normal paradropped infantry keep their base
+            // locomotor identity, while descent altitude lives in ParachuteDescentState.
+            if let Some(passenger) = sim.substrate.entities.get_mut(passenger_id) {
+                passenger.sub_cell = selected_sub_cell;
+                passenger.passenger_role = PassengerRole::None;
+                if let Some(locomotor) = passenger.locomotor.as_mut() {
+                    locomotor.layer = landing_layer;
+                }
+            }
+            // 6. Attach parachute descent while the passenger is still limbo. Reveal
+            // is the local success boundary; an attach retry is not Techno Limbo.
+            if !begin_parachute_descent(&mut sim.substrate.entities, passenger_id, altitude) {
+                return Err(DepartureFailure::ParachuteAttach(prior_movement_layer));
+            }
+
+            let landing_z = sim
+                .resolved_terrain
+                .as_ref()
+                .and_then(|terrain| terrain.cell(drop_rx, drop_ry))
+                .map_or(0, |cell| {
+                    cell.level
+                        .wrapping_add(u8::from(landing_layer == MovementLayer::Bridge) * 4)
+                });
+            let reveal_outcome = sim.try_reveal_entity(
+                passenger_id,
+                RevealRequest {
+                    position: RevealPosition {
+                        rx: drop_rx,
+                        ry: drop_ry,
+                        z: landing_z,
+                        sub_x: final_sub_x,
+                        sub_y: final_sub_y,
+                    },
+                    placement: PlacementEvidence::MarkSucceeded,
+                    logic_eligible: true,
+                },
+            );
+            if !matches!(reveal_outcome, RevealOutcome::Revealed { .. }) {
+                return Err(DepartureFailure::ParachuteReveal(
+                    reveal_outcome,
+                    prior_movement_layer,
+                ));
+            }
+
+            // 7. ChuteSound at drop cell.
+            sim.sound_events.push(SimSoundEvent::ChuteSound {
                 rx: drop_rx,
                 ry: drop_ry,
-                z: landing_z,
-                sub_x: final_sub_x,
-                sub_y: final_sub_y,
-            },
-            placement: PlacementEvidence::MarkSucceeded,
-            logic_eligible: true,
+            });
+
+            Ok(())
         },
     );
-    if !matches!(reveal_outcome, RevealOutcome::Revealed { .. }) {
-        if reveal_outcome == RevealOutcome::AlreadyRevealed {
-            let _ = sim.techno_limbo_with_rules(passenger_id, rules);
-        }
-        sim.clear_radio_contacts_for(passenger_id);
-        if let Some(passenger) = sim.substrate.entities.get_mut(passenger_id) {
-            passenger.parachute_state = None;
-            passenger.passenger_role = PassengerRole::Inside {
-                transport_id: aircraft_id,
-            };
-            if let Some(locomotor) = passenger.locomotor.as_mut() {
-                locomotor.layer = prior_movement_layer;
-            }
-        }
-        restore_passenger_to_cargo_head(sim, aircraft_id, passenger_id, passenger_size);
-        return DropResult::AttachFailedRetry;
+    match result {
+        Ok(()) => DropResult::Success,
+        Err(DepartureFailure::NoCargo) => DropResult::NoCargo,
+        Err(DepartureFailure::Placement) => DropResult::ImpassableRetry,
+        Err(
+            DepartureFailure::MissingPassenger
+            | DepartureFailure::NotReady
+            | DepartureFailure::ParachuteAttach(_)
+            | DepartureFailure::ParachuteReveal(..),
+        ) => DropResult::AttachFailedRetry,
+        Err(DepartureFailure::GroundReveal(_)) => unreachable!("ground reveal in paradrop"),
     }
-
-    // 7. ChuteSound at drop cell.
-    sim.sound_events.push(SimSoundEvent::ChuteSound {
-        rx: drop_rx,
-        ry: drop_ry,
-    });
-
-    DropResult::Success
 }
 
 #[cfg(test)]
@@ -667,5 +631,116 @@ mod tests {
                 .has_live_contact_with(missing_passenger_id),
             "attach-failed retry should clear stale peer radio contacts"
         );
+    }
+    #[test]
+    fn cargo_departure_paradrop_preserves_early_state_and_unwinds_reveal_failure() {
+        use crate::sim::combat::combat_weapon::WeaponOverride;
+        use crate::sim::movement::locomotor::LocomotorState;
+        for post_attach in [false, true] {
+            let mut sim = Simulation::new();
+            let rules = drop_test_rules();
+            insert_loaded_paradrop_pair(&mut sim, 1, 2);
+            let mut loco = LocomotorState::from_object_type(rules.object("E1").unwrap(), 0, 0);
+            loco.layer = MovementLayer::Bridge;
+            {
+                let passenger = sim.substrate.entities.get_mut(2).unwrap();
+                passenger.locomotor = Some(loco);
+                passenger.lifecycle.object_alive = post_attach;
+                passenger.lifecycle.cell_marked = post_attach;
+            }
+            let mut peer = GameEntity::test_default(9, "E1", "Americans", 30, 30);
+            peer.mark_live_contact_with(2);
+            sim.substrate.entities.insert(peer);
+            {
+                let aircraft = sim.substrate.entities.get_mut(1).unwrap();
+                aircraft.weapon_override = Some(WeaponOverride::IfvSlot(99));
+                let cargo = aircraft.passenger_role.cargo_mut().unwrap();
+                cargo.passenger_sizes[0] = 7;
+                cargo.total_size = 7;
+                cargo.board_forced(1234, 3);
+                // Put the real passenger back at the head, preserving mixed sizes.
+                cargo.passengers.swap(0, 1);
+                cargo.passenger_sizes.swap(0, 1);
+            }
+            let held = serde_json::to_value(
+                sim.substrate
+                    .entities
+                    .get(1)
+                    .unwrap()
+                    .passenger_role
+                    .cargo(),
+            )
+            .unwrap();
+            let rng_before = sim.scenario_rng.state();
+            assert_eq!(
+                try_drop(&mut sim, &rules, 1, 4, None),
+                DropResult::AttachFailedRetry
+            );
+            let aircraft = sim.substrate.entities.get(1).unwrap();
+            assert_eq!(
+                serde_json::to_value(aircraft.passenger_role.cargo()).unwrap(),
+                held
+            );
+            assert_eq!(aircraft.weapon_override, Some(WeaponOverride::IfvSlot(99)));
+            let passenger = sim.substrate.entities.get(2).unwrap();
+            assert_eq!(passenger.passenger_role.inside_transport_id(), Some(1));
+            assert!(passenger.lifecycle.in_limbo);
+            assert_eq!(passenger.lifecycle.cell_marked, post_attach);
+            assert!(!passenger.in_logic_vector);
+            assert!(passenger.parachute_state.is_none());
+            assert_eq!(
+                passenger.locomotor.as_ref().unwrap().layer,
+                MovementLayer::Bridge
+            );
+            assert_eq!(
+                sim.substrate
+                    .entities
+                    .get(9)
+                    .unwrap()
+                    .has_live_contact_with(2),
+                !post_attach
+            );
+            assert!(sim.sound_events.is_empty());
+            if !post_attach {
+                assert_eq!(sim.scenario_rng.state(), rng_before);
+            }
+            println!(
+                "CARGO_TRACE paradrop {post_attach} {:?} {:?} {:?}",
+                sim.scenario_rng.state(),
+                held,
+                passenger.position
+            );
+            if post_attach {
+                sim.substrate
+                    .entities
+                    .get_mut(2)
+                    .unwrap()
+                    .lifecycle
+                    .cell_marked = false;
+                assert_eq!(try_drop(&mut sim, &rules, 1, 4, None), DropResult::Success);
+                let cargo = sim
+                    .substrate
+                    .entities
+                    .get(1)
+                    .unwrap()
+                    .passenger_role
+                    .cargo()
+                    .unwrap();
+                assert_eq!(cargo.passengers, vec![1234]);
+                assert_eq!(cargo.passenger_sizes, vec![3]);
+                assert_eq!(cargo.total_size, 3);
+                let passenger = sim.substrate.entities.get(2).unwrap();
+                assert!(passenger.parachute_state.is_some());
+                assert!(passenger.lifecycle.cell_marked && passenger.in_logic_vector);
+                assert!(!passenger.passenger_role.is_inside_transport());
+                assert_eq!(
+                    sim.sound_events
+                        .iter()
+                        .filter(|event| matches!(event, SimSoundEvent::ChuteSound { .. }))
+                        .count(),
+                    1
+                );
+            }
+        }
     }
 }

--- a/src/sim/passenger.rs
+++ b/src/sim/passenger.rs
@@ -4,7 +4,9 @@
 //! (CanBeOccupied=yes), IFV weapon swapping (Gunner=yes), and passenger
 //! death on transport destruction. Vehicle/aircraft unloading is the Unload
 //! mission handler in `crate::sim::transport_unload`; only garrison eviction
-//! stays on the per-tick `OrderIntent::Unloading` path here.
+//! stays on the per-tick `OrderIntent::Unloading` path here. The private
+//! departure module owns cargo-head removal and complete retry restoration for
+//! garrisons, vehicles, landed aircraft and paradrops.
 //!
 //! ## Original engine reference
 //! The original engine uses a linked-list at offsets +0x1D0/+0x1CC for passenger
@@ -13,6 +15,11 @@
 //! ## Dependency rules
 //! - Part of sim/ — depends on rules/ (ObjectType), sim/game_entity, sim/entity_store.
 //! - sim/ NEVER depends on render/, ui/, sidebar/, audio/, net/.
+
+mod departure;
+pub(crate) use departure::{
+    DepartureFailure, DepartureRoute, depart_cargo_head, reveal_unloaded_passenger,
+};
 
 use std::collections::BTreeMap;
 
@@ -24,12 +31,8 @@ use crate::sim::house_state::HouseState;
 use crate::sim::intern::{InternedId, StringInterner};
 use crate::sim::movement;
 use crate::sim::pathfinding::PathGrid;
-use crate::sim::world::{
-    ConcealOutcome, PlacementEvidence, RevealOutcome, RevealPosition, RevealRequest, SimSoundEvent,
-    Simulation,
-};
+use crate::sim::world::{ConcealOutcome, SimSoundEvent, Simulation};
 use crate::util::fixed_math::ra2_speed_to_leptons_per_second;
-use crate::util::lepton;
 
 /// Passenger cargo state, attached as `Option<PassengerCargo>` on transport entities.
 ///
@@ -124,7 +127,7 @@ impl PassengerCargo {
 
     /// Remove and return the list HEAD (the most recently boarded passenger)
     /// and its recorded size — `CargoClass::RemoveFirstPassenger @ 0x00473430`.
-    pub fn unload_first(&mut self) -> Option<(u64, u32)> {
+    fn unload_first(&mut self) -> Option<(u64, u32)> {
         if self.passengers.is_empty() {
             None
         } else {
@@ -137,7 +140,7 @@ impl PassengerCargo {
 
     /// Restore a failed head-pop at the cargo head (the native failure path
     /// re-runs `AddPassenger`, which prepends).
-    pub fn restore_front(&mut self, stable_id: u64, passenger_size: u32) {
+    fn restore_front(&mut self, stable_id: u64, passenger_size: u32) {
         self.passengers.insert(0, stable_id);
         self.passenger_sizes.insert(0, passenger_size);
         self.total_size += passenger_size;
@@ -713,187 +716,25 @@ fn reconcile_civilian_garrison_owner_for_building(
     false
 }
 
-/// Snapshot-then-mutate: process entities that are trying to board a transport.
-/// Returns `true` if any entity ownership changed. Boarding itself does not
-/// transfer civilian garrison ownership.
+/// Test driver for the production boarding operation. Snapshot admission IDs
+/// without running the separate building ownership reconciliation phase.
 #[cfg(test)]
 fn tick_boarding(sim: &mut Simulation, rules: &RuleSet) -> bool {
-    let ownership_changed = false;
-    // Snapshot entities with Boarding role — must collect fully before mutating.
-    let keys: Vec<u64> = sim.substrate.entities.keys_sorted();
-    let boarding_snapshot: Vec<(u64, u64)> = keys
-        .iter()
-        .filter_map(|&id| {
-            let e = sim.substrate.entities.get(id)?;
-            if let PassengerRole::Boarding {
-                target_transport_id,
-                ..
-            } = &e.passenger_role
-            {
-                Some((id, *target_transport_id))
-            } else {
-                Option::None
-            }
+    let boarding_ids: Vec<u64> = sim
+        .substrate
+        .entities
+        .keys_sorted()
+        .into_iter()
+        .filter(|&id| {
+            sim.substrate.entities.get(id).is_some_and(|entity| {
+                matches!(entity.passenger_role, PassengerRole::Boarding { .. })
+            })
         })
         .collect();
-
-    for (pax_id, transport_id) in boarding_snapshot {
-        // Check transport still exists and is alive.
-        let transport_alive = sim
-            .substrate
-            .entities
-            .get(transport_id)
-            .is_some_and(|t| t.is_alive() && !t.dying);
-        if !transport_alive {
-            // Transport gone — cancel boarding.
-            if let Some(e) = sim.substrate.entities.get_mut(pax_id) {
-                e.passenger_role = PassengerRole::None;
-            }
-            continue;
-        }
-
-        // Get positions to check distance.
-        let (pax_rx, pax_ry) = match sim.substrate.entities.get(pax_id) {
-            Some(e) => (e.position.rx, e.position.ry),
-            None => continue,
-        };
-        let (trx, try_) = match sim.substrate.entities.get(transport_id) {
-            Some(e) => (e.position.rx, e.position.ry),
-            None => continue,
-        };
-
-        // Chebyshev distance between passenger and transport.
-        let dx = (pax_rx as i32 - trx as i32).unsigned_abs();
-        let dy = (pax_ry as i32 - try_ as i32).unsigned_abs();
-        let dist = dx.max(dy);
-
-        if dist <= BOARD_DISTANCE {
-            // Passenger has arrived — attempt boarding.
-            let pax_type_str = sim
-                .substrate
-                .entities
-                .get(pax_id)
-                .map(|e| sim.interner.resolve(e.type_ref).to_string())
-                .unwrap_or_default();
-            let transport_type_str = sim
-                .substrate
-                .entities
-                .get(transport_id)
-                .map(|e| sim.interner.resolve(e.type_ref).to_string())
-                .unwrap_or_default();
-
-            let pax_size = rules.object(&pax_type_str).map(|obj| obj.size).unwrap_or(1);
-
-            let transport_obj = rules.object(&transport_type_str);
-            let transport_gunner = transport_obj.map(|obj| obj.gunner).unwrap_or(false);
-            let transport_open_topped = transport_obj.map(|obj| obj.open_topped).unwrap_or(false);
-
-            let pax_obj = rules.object(&pax_type_str);
-            let pax_ifv_mode = pax_obj.map(|obj| obj.ifv_mode).unwrap_or(0);
-            let pax_open_transport_weapon =
-                pax_obj.map(|obj| obj.open_transport_weapon).unwrap_or(-1);
-            let entering_owner = sim.substrate.entities.get(pax_id).map(|pax| pax.owner);
-
-            // Try to board.
-            let can_board = sim
-                .substrate
-                .entities
-                .get(transport_id)
-                .and_then(|t| t.passenger_role.cargo())
-                .is_some_and(|cargo| cargo.can_accept(pax_size));
-
-            if can_board {
-                if sim.techno_limbo_with_rules(pax_id, rules) != ConcealOutcome::Concealed {
-                    continue;
-                }
-                let boarded = sim
-                    .substrate
-                    .entities
-                    .get_mut(transport_id)
-                    .and_then(|t| t.passenger_role.cargo_mut())
-                    .is_some_and(|cargo| cargo.board(pax_id, pax_size));
-                debug_assert!(boarded, "boarding admission changed during one transaction");
-                if !boarded {
-                    let _ = sim.reveal(pax_id);
-                    continue;
-                }
-
-                // Garrison sound/EVA: emit on first occupant entry only.
-                // gamemd AddGarrisonOccupant fires EVA + BuildingGarrisonedSound
-                // when count transitions 0→1; subsequent occupants are silent.
-                let first_occupant = sim
-                    .substrate
-                    .entities
-                    .get(transport_id)
-                    .and_then(|t| t.passenger_role.cargo())
-                    .map_or(false, |c| c.count() == 1);
-                if first_occupant
-                    && rules
-                        .object(&transport_type_str)
-                        .map_or(false, |o| o.can_be_occupied)
-                {
-                    if let (Some(owner), Some(t)) =
-                        (entering_owner, sim.substrate.entities.get(transport_id))
-                    {
-                        let rx = t.position.rx;
-                        let ry = t.position.ry;
-                        sim.sound_events
-                            .push(SimSoundEvent::StructureGarrisoned { owner });
-                        sim.sound_events.push(SimSoundEvent::BuildingGarrisonedSfx {
-                            owner,
-                            rx,
-                            ry,
-                        });
-                    }
-                }
-
-                if let Some(pax) = sim.substrate.entities.get_mut(pax_id) {
-                    pax.passenger_role = PassengerRole::Inside { transport_id };
-                    pax.movement_target = None;
-                    pax.attack_target = None;
-                    pax.passively_acquired_target = false;
-                    pax.order_intent = None;
-                }
-                if transport_open_topped {
-                    let registered = sim.register_open_topped_passenger(pax_id);
-                    debug_assert!(
-                        registered,
-                        "accepted open-topped passenger must remain active"
-                    );
-                }
-                // Transport weapon override: Gunner=yes transports swap their
-                // own weapon to weapon_list[IFVMode]; open-topped non-Gunner
-                // transports fire the passenger's own Primary/Secondary based
-                // on the passenger's OpenTransportWeapon slot.
-                let new_override = if transport_gunner {
-                    Some(crate::sim::combat::combat_weapon::WeaponOverride::IfvSlot(
-                        pax_ifv_mode,
-                    ))
-                } else if transport_open_topped && pax_open_transport_weapon >= 0 {
-                    Some(
-                        crate::sim::combat::combat_weapon::WeaponOverride::OpenTransport(
-                            pax_open_transport_weapon as u32,
-                        ),
-                    )
-                } else {
-                    None
-                };
-                if new_override.is_some() {
-                    if let Some(t) = sim.substrate.entities.get_mut(transport_id) {
-                        t.weapon_override = new_override;
-                    }
-                }
-            } else {
-                // Transport full — cancel boarding.
-                if let Some(pax) = sim.substrate.entities.get_mut(pax_id) {
-                    pax.passenger_role = PassengerRole::None;
-                }
-            }
-        }
-        // If still approaching (movement_target present), let movement continue.
-        // If movement finished but not close enough, the unit just stops.
+    for id in boarding_ids {
+        process_boarding_passenger(sim, rules, id);
     }
-    ownership_changed
+    false
 }
 
 /// Process transports with `OrderIntent::Unloading` — eject one passenger per tick.
@@ -910,76 +751,6 @@ fn is_can_be_occupied_unloading_transport(
     }
     sim.object_type(entity.type_ref(), rules)
         .is_some_and(|obj| obj.can_be_occupied)
-}
-
-/// Reveal a cargo passenger at an exit cell. The passenger's `sub_cell` and
-/// `facing` must already be written by the caller; its role is cleared here.
-pub(crate) fn reveal_unloaded_passenger(
-    sim: &mut Simulation,
-    transport_id: u64,
-    passenger_id: u64,
-    rx: u16,
-    ry: u16,
-    z: u8,
-) -> RevealOutcome {
-    let sub_cell = sim
-        .substrate
-        .entities
-        .get(passenger_id)
-        .and_then(|passenger| passenger.sub_cell);
-    let (sub_x, sub_y) = lepton::subcell_lepton_offset(sub_cell);
-    if let Some(passenger) = sim.substrate.entities.get_mut(passenger_id) {
-        debug_assert!(matches!(
-            passenger.passenger_role,
-            PassengerRole::Inside {
-                transport_id: current_transport
-            } if current_transport == transport_id
-        ));
-        passenger.passenger_role = PassengerRole::None;
-    }
-    sim.try_reveal_entity(
-        passenger_id,
-        RevealRequest {
-            position: RevealPosition {
-                rx,
-                ry,
-                z,
-                sub_x,
-                sub_y,
-            },
-            // The caller already selected an unoccupied exit cell. The
-            // still-blocked native admission oracle is not fabricated here.
-            placement: PlacementEvidence::MarkSucceeded,
-            logic_eligible: true,
-        },
-    )
-}
-
-pub(crate) fn restore_unloaded_passenger_after_reveal_failure(
-    sim: &mut Simulation,
-    rules: &RuleSet,
-    transport_id: u64,
-    passenger_id: u64,
-    passenger_size: u32,
-    outcome: RevealOutcome,
-) {
-    if outcome == RevealOutcome::AlreadyRevealed {
-        // Defensive only: a cargo passenger should be limbo. Re-establish a
-        // coherent cargo state through lifecycle authority if that invariant
-        // was already broken before this call.
-        let _ = sim.techno_limbo_with_rules(passenger_id, rules);
-    }
-    if let Some(passenger) = sim.substrate.entities.get_mut(passenger_id) {
-        passenger.passenger_role = PassengerRole::Inside { transport_id };
-    }
-    if let Some(cargo) = sim
-        .substrate
-        .entities
-        .get_mut(transport_id)
-        .and_then(|transport| transport.passenger_role.cargo_mut())
-    {
-        cargo.restore_front(passenger_id, passenger_size);
-    }
 }
 
 /// `FootClass::GetCurrentSpeed @ 0x004DB1A0` for an ejected passenger.
@@ -1042,74 +813,63 @@ fn process_unloading_transport(sim: &mut Simulation, rules: &RuleSet, transport_
         return;
     };
 
-    let passenger = sim
-        .substrate
-        .entities
-        .get_mut(transport_id)
-        .and_then(|t| t.passenger_role.cargo_mut())
-        .and_then(|cargo| cargo.unload_first());
+    let result = depart_cargo_head(
+        sim,
+        rules,
+        transport_id,
+        DepartureRoute::Garrison,
+        |sim, pax_id| {
+            let pax_type_str = sim
+                .substrate
+                .entities
+                .get(pax_id)
+                .map(|e| sim.interner.resolve(e.type_ref()).to_string())
+                .unwrap_or_default();
+            reveal_unloaded_passenger(sim, transport_id, pax_id, exit_rx, exit_ry, tz)?;
 
-    let Some((pax_id, pax_size)) = passenger else {
-        if let Some(t) = sim.substrate.entities.get_mut(transport_id) {
-            t.order_intent = None;
-        }
-        return;
-    };
-
-    let pax_type_str = sim
-        .substrate
-        .entities
-        .get(pax_id)
-        .map(|e| sim.interner.resolve(e.type_ref()).to_string())
-        .unwrap_or_default();
-    let reveal_outcome = reveal_unloaded_passenger(sim, transport_id, pax_id, exit_rx, exit_ry, tz);
-    if !matches!(reveal_outcome, RevealOutcome::Revealed { .. }) {
-        restore_unloaded_passenger_after_reveal_failure(
-            sim,
-            rules,
-            transport_id,
-            pax_id,
-            pax_size,
-            reveal_outcome,
-        );
-        return;
-    }
-
-    // `FootClass::GetCurrentSpeed @ 0x004DB1A0`: a veteran passenger scatters at
-    // its FASTER speed like any other ordered move.
-    let scatter_speed = scatter_speed_for_passenger(sim, rules, pax_id, &pax_type_str);
-    let start_dir = sim.scatter_rng().next_u32() as usize % 8;
-    for i in 0..8 {
-        let (dx, dy) = NEIGHBORS[(start_dir + i) % 8];
-        let sx = exit_rx as i32 + dx as i32;
-        let sy = exit_ry as i32 + dy as i32;
-        if sx >= 0 && sy >= 0 {
-            let dest = (sx as u16, sy as u16);
-            let occupied = occupied_cells
-                .iter()
-                .any(|&(ox, oy)| ox == dest.0 && oy == dest.1);
-            if !occupied {
-                movement::issue_direct_move(
-                    &mut sim.substrate.entities,
-                    pax_id,
-                    dest,
-                    scatter_speed,
-                );
-                break;
+            // `FootClass::GetCurrentSpeed @ 0x004DB1A0`: a veteran passenger scatters at
+            // its FASTER speed like any other ordered move.
+            let scatter_speed = scatter_speed_for_passenger(sim, rules, pax_id, &pax_type_str);
+            let start_dir = sim.scatter_rng().next_u32() as usize % 8;
+            for i in 0..8 {
+                let (dx, dy) = NEIGHBORS[(start_dir + i) % 8];
+                let sx = exit_rx as i32 + dx as i32;
+                let sy = exit_ry as i32 + dy as i32;
+                if sx >= 0 && sy >= 0 {
+                    let dest = (sx as u16, sy as u16);
+                    let occupied = occupied_cells
+                        .iter()
+                        .any(|&(ox, oy)| ox == dest.0 && oy == dest.1);
+                    if !occupied {
+                        movement::issue_direct_move(
+                            &mut sim.substrate.entities,
+                            pax_id,
+                            dest,
+                            scatter_speed,
+                        );
+                        break;
+                    }
+                }
             }
-        }
-    }
 
-    let cargo_empty = sim
-        .substrate
-        .entities
-        .get(transport_id)
-        .and_then(|t| t.passenger_role.cargo())
-        .is_some_and(|c| c.is_empty());
-    if cargo_empty {
-        if let Some(t) = sim.substrate.entities.get_mut(transport_id) {
-            t.weapon_override = None;
-            t.order_intent = None;
+            let cargo_empty = sim
+                .substrate
+                .entities
+                .get(transport_id)
+                .and_then(|t| t.passenger_role.cargo())
+                .is_some_and(|c| c.is_empty());
+            if cargo_empty {
+                if let Some(t) = sim.substrate.entities.get_mut(transport_id) {
+                    t.weapon_override = None;
+                    t.order_intent = None;
+                }
+            }
+            Ok(())
+        },
+    );
+    if result == Err(DepartureFailure::NoCargo) {
+        if let Some(transport) = sim.substrate.entities.get_mut(transport_id) {
+            transport.order_intent = None;
         }
     }
 }
@@ -1120,6 +880,8 @@ mod tests {
     use crate::map::entities::EntityCategory;
     use crate::rules::ini_parser::IniFile;
     use crate::rules::ruleset::RuleSet;
+    use crate::sim::world::RevealOutcome;
+    use crate::util::lepton;
 
     fn garrison_test_rules() -> RuleSet {
         let ini_str = "\
@@ -1417,20 +1179,6 @@ ConditionYellow=50%
         assert_eq!(cargo.unload_first(), None);
         assert!(cargo.is_empty());
         assert!(cargo.passenger_sizes.is_empty());
-    }
-
-    #[test]
-    fn failed_unload_restores_id_size_and_total_at_head() {
-        let mut cargo = PassengerCargo::new(5, 0);
-        cargo.board(100, 3);
-        cargo.board(101, 1);
-
-        let entry = cargo.unload_first().expect("head passenger");
-        cargo.restore_front(entry.0, entry.1);
-
-        assert_eq!(cargo.passengers, vec![101, 100]);
-        assert_eq!(cargo.passenger_sizes, vec![1, 3]);
-        assert_eq!(cargo.total_size, 4);
     }
 
     #[test]
@@ -2472,5 +2220,72 @@ ConditionYellow=50%
             "blocked occupant must reach UnInit and the shared test drain"
         );
         assert!(!sim.substrate.pending_delete.contains(&pax));
+    }
+    #[test]
+    fn cargo_departure_garrison_reveal_failure_retains_order_and_recorded_size() {
+        use crate::sim::combat::combat_weapon::WeaponOverride;
+        let mut sim = Simulation::new();
+        let rules = garrison_test_rules();
+        let building = spawn_garrison_building(&mut sim, &rules, "CAGAS01", "Americans", 10, 10);
+        let passenger = spawn_boarding_occupier(&mut sim, "E1", "Americans", building, 10, 11);
+        process_boarding_passenger(&mut sim, &rules, passenger);
+        {
+            let carrier = sim.substrate.entities.get_mut(building).unwrap();
+            carrier.weapon_override = Some(WeaponOverride::IfvSlot(99));
+            carrier.order_intent = Some(OrderIntent::Unloading);
+            let cargo = carrier.passenger_role.cargo_mut().unwrap();
+            cargo.passenger_sizes[0] = 7;
+            cargo.total_size = 7;
+        }
+        sim.substrate
+            .entities
+            .get_mut(passenger)
+            .unwrap()
+            .lifecycle
+            .cell_marked = true;
+        let held = serde_json::to_value(
+            sim.substrate
+                .entities
+                .get(building)
+                .unwrap()
+                .passenger_role
+                .cargo(),
+        )
+        .unwrap();
+        let rng_before = sim.scenario_rng.state();
+        sim.sound_events.clear();
+        process_unloading_transport(&mut sim, &rules, building);
+        let carrier = sim.substrate.entities.get(building).unwrap();
+        assert_eq!(
+            serde_json::to_value(carrier.passenger_role.cargo()).unwrap(),
+            held
+        );
+        assert_eq!(carrier.weapon_override, Some(WeaponOverride::IfvSlot(99)));
+        assert!(matches!(carrier.order_intent, Some(OrderIntent::Unloading)));
+        let pax = sim.substrate.entities.get(passenger).unwrap();
+        assert_eq!(pax.passenger_role.inside_transport_id(), Some(building));
+        assert!(pax.lifecycle.in_limbo && pax.lifecycle.cell_marked);
+        assert!(!pax.in_logic_vector);
+        assert_eq!(sim.scenario_rng.state(), rng_before);
+        assert!(sim.sound_events.is_empty());
+        println!(
+            "CARGO_TRACE garrison {:?} {:?}",
+            sim.scenario_rng.state(),
+            held
+        );
+        sim.substrate
+            .entities
+            .get_mut(passenger)
+            .unwrap()
+            .lifecycle
+            .cell_marked = false;
+        process_unloading_transport(&mut sim, &rules, building);
+        let carrier = sim.substrate.entities.get(building).unwrap();
+        assert!(carrier.passenger_role.cargo().unwrap().is_empty());
+        assert_eq!(carrier.passenger_role.cargo().unwrap().total_size, 0);
+        assert!(carrier.weapon_override.is_none() && carrier.order_intent.is_none());
+        let pax = sim.substrate.entities.get(passenger).unwrap();
+        assert!(!pax.passenger_role.is_inside_transport());
+        assert!(pax.lifecycle.cell_marked && pax.in_logic_vector);
     }
 }

--- a/src/sim/passenger/departure.rs
+++ b/src/sim/passenger/departure.rs
@@ -1,0 +1,232 @@
+//! Cargo-head departure owns admission-time size and the complete retry transition.
+//!
+//! Geometry and mission cadence remain with each production caller. No removed
+//! entry escapes this operation: an unsuccessful attempt restores the same head
+//! and recorded size before returning. Serialized CargoClass state is unchanged.
+//! Native removal: CargoClass::RemoveFirstPassenger @ 0x00473430; retry:
+//! AddPassenger @ 0x004733A0. Route-specific compatibility policies below preserve
+//! the existing Rust branches; they do not claim uniform native retry semantics.
+
+use super::PassengerRole;
+use crate::rules::ruleset::RuleSet;
+use crate::sim::movement::locomotor::MovementLayer;
+use crate::sim::world::{
+    PlacementEvidence, RevealOutcome, RevealPosition, RevealRequest, Simulation,
+};
+use crate::util::lepton;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DepartureRoute {
+    Garrison,
+    Vehicle,
+    LandedAircraft,
+    Paradrop,
+}
+
+/// The phase which refused departure, rather than a caller-owned rollback plan.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum DepartureFailure {
+    NoCargo,
+    MissingPassenger,
+    NotReady,
+    Placement,
+    GroundReveal(RevealOutcome),
+    ParachuteAttach(MovementLayer),
+    ParachuteReveal(RevealOutcome, MovementLayer),
+}
+
+/// Run one complete cargo-head attempt. Only the passenger ID is exposed to the
+/// placement operation; admission-time size and head restoration stay here.
+pub(crate) fn depart_cargo_head(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    transport_id: u64,
+    route: DepartureRoute,
+    attempt: impl FnOnce(&mut Simulation, u64) -> Result<(), DepartureFailure>,
+) -> Result<(), DepartureFailure> {
+    let transport = sim
+        .substrate
+        .entities
+        .get_mut(transport_id)
+        .ok_or(DepartureFailure::NoCargo)?;
+    let cargo = transport
+        .passenger_role
+        .cargo_mut()
+        .ok_or(DepartureFailure::NoCargo)?;
+    let (passenger_id, passenger_size) = cargo.unload_first().ok_or(DepartureFailure::NoCargo)?;
+    // FUN_004DE710's empty-hold weapon reset occurs before placement for these
+    // two callers. Garrison resets only after successful scatter; paradrop does
+    // not reset the carrier override at all.
+    if matches!(
+        route,
+        DepartureRoute::Vehicle | DepartureRoute::LandedAircraft
+    ) && cargo.is_empty()
+    {
+        transport.weapon_override = None;
+    }
+    let result = attempt(sim, passenger_id);
+    if let Err(failure) = result.as_ref() {
+        restore_departure(
+            sim,
+            rules,
+            transport_id,
+            passenger_id,
+            passenger_size,
+            route,
+            *failure,
+        );
+    }
+    result
+}
+
+fn restore_departure(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    transport_id: u64,
+    passenger_id: u64,
+    passenger_size: u32,
+    route: DepartureRoute,
+    failure: DepartureFailure,
+) {
+    let reveal_outcome = match failure {
+        DepartureFailure::GroundReveal(outcome) | DepartureFailure::ParachuteReveal(outcome, _) => {
+            Some(outcome)
+        }
+        _ => None,
+    };
+    if reveal_outcome == Some(RevealOutcome::AlreadyRevealed) {
+        // Defensive legacy repair of an already-broken cargo/limbo invariant.
+        let _ = sim.techno_limbo_with_rules(passenger_id, rules);
+    }
+    match route {
+        DepartureRoute::Paradrop => match failure {
+            DepartureFailure::MissingPassenger => sim.clear_radio_contacts_for(passenger_id),
+            DepartureFailure::NotReady | DepartureFailure::Placement => {}
+            DepartureFailure::ParachuteAttach(prior_layer)
+            | DepartureFailure::ParachuteReveal(_, prior_layer) => {
+                sim.clear_radio_contacts_for(passenger_id);
+                if let Some(passenger) = sim.substrate.entities.get_mut(passenger_id) {
+                    if matches!(failure, DepartureFailure::ParachuteReveal(..)) {
+                        passenger.parachute_state = None;
+                    }
+                    passenger.passenger_role = PassengerRole::Inside { transport_id };
+                    if let Some(locomotor) = passenger.locomotor.as_mut() {
+                        locomotor.layer = prior_layer;
+                    }
+                }
+            }
+            DepartureFailure::NoCargo | DepartureFailure::GroundReveal(_) => {
+                unreachable!("invalid paradrop departure phase")
+            }
+        },
+        DepartureRoute::Garrison | DepartureRoute::Vehicle | DepartureRoute::LandedAircraft => {
+            assert!(
+                matches!(
+                    failure,
+                    DepartureFailure::MissingPassenger
+                        | DepartureFailure::Placement
+                        | DepartureFailure::GroundReveal(_)
+                ),
+                "invalid ground departure phase"
+            );
+            if let Some(passenger) = sim.substrate.entities.get_mut(passenger_id) {
+                passenger.passenger_role = PassengerRole::Inside { transport_id };
+            }
+        }
+    }
+    if let Some(cargo) = sim
+        .substrate
+        .entities
+        .get_mut(transport_id)
+        .and_then(|transport| transport.passenger_role.cargo_mut())
+    {
+        cargo.restore_front(passenger_id, passenger_size);
+    }
+    // Vehicle failures always re-adopt the current passenger's IFVMode. The
+    // landed-aircraft compatibility path did so only before Reveal; retain that
+    // distinction instead of restoring a saved override or unifying failure tails.
+    if route == DepartureRoute::Vehicle
+        || (route == DepartureRoute::LandedAircraft
+            && !matches!(failure, DepartureFailure::GroundReveal(_)))
+    {
+        reapply_gunner_weapon(sim, rules, transport_id, passenger_id);
+    }
+}
+
+/// Reveal a cargo passenger at an exit cell. The passenger's `sub_cell` and
+/// `facing` must already be written by the caller; its role is cleared here.
+pub(crate) fn reveal_unloaded_passenger(
+    sim: &mut Simulation,
+    transport_id: u64,
+    passenger_id: u64,
+    rx: u16,
+    ry: u16,
+    z: u8,
+) -> Result<(), DepartureFailure> {
+    let sub_cell = sim
+        .substrate
+        .entities
+        .get(passenger_id)
+        .and_then(|passenger| passenger.sub_cell);
+    let (sub_x, sub_y) = lepton::subcell_lepton_offset(sub_cell);
+    if let Some(passenger) = sim.substrate.entities.get_mut(passenger_id) {
+        debug_assert!(matches!(
+            passenger.passenger_role,
+            PassengerRole::Inside {
+                transport_id: current_transport
+            } if current_transport == transport_id
+        ));
+        passenger.passenger_role = PassengerRole::None;
+    }
+    let outcome = sim.try_reveal_entity(
+        passenger_id,
+        RevealRequest {
+            position: RevealPosition {
+                rx,
+                ry,
+                z,
+                sub_x,
+                sub_y,
+            },
+            // The caller already selected an unoccupied exit cell. The
+            // still-blocked native admission oracle is not fabricated here.
+            placement: PlacementEvidence::MarkSucceeded,
+            logic_eligible: true,
+        },
+    );
+    match outcome {
+        RevealOutcome::Revealed { .. } => Ok(()),
+        other => Err(DepartureFailure::GroundReveal(other)),
+    }
+}
+
+/// Vehicle failure tail `0x0073DC71`..`0x0073DCA6`: AddPassenger precedes
+/// UnitClass `+0x4D4` (`0x00746420`), which re-adopts the passenger's attachment
+/// and applies InfantryType+0x688 (IFVMode) through `FUN_0070DC70`. It reverses
+/// the empty-pop `+0x4D8` (`0x007464E0`). Aircraft/Techno bind those slots to
+/// stubs `0x004DE750`/`0x004DE760`; preserve the represented Rust Gunner gate.
+/// UnitClass `+0x4D4` (`0x00746420`) for a `Gunner=yes` transport: the
+/// re-added head passenger's `IFVMode=` becomes the transport's weapon slot
+/// again. VERA's representation of that swap is `weapon_override`.
+fn reapply_gunner_weapon(sim: &mut Simulation, rules: &RuleSet, transport_id: u64, pax_id: u64) {
+    let Some(transport) = sim.substrate.entities.get(transport_id) else {
+        return;
+    };
+    if !sim
+        .object_type(transport.type_ref(), rules)
+        .is_some_and(|obj| obj.gunner)
+    {
+        return;
+    }
+    let Some(passenger) = sim.substrate.entities.get(pax_id) else {
+        return;
+    };
+    let ifv_mode = sim
+        .object_type(passenger.type_ref(), rules)
+        .map_or(0, |obj| obj.ifv_mode);
+    if let Some(transport) = sim.substrate.entities.get_mut(transport_id) {
+        transport.weapon_override = Some(
+            crate::sim::combat::combat_weapon::WeaponOverride::IfvSlot(ifv_mode),
+        );
+    }
+}

--- a/src/sim/transport_unload.rs
+++ b/src/sim/transport_unload.rs
@@ -32,11 +32,11 @@ use crate::sim::movement::bump_crush;
 use crate::sim::movement::locomotor::MovementLayer;
 use crate::sim::movement::ready_producer::is_moving_now_for;
 use crate::sim::passenger::{
-    PassengerRole, restore_unloaded_passenger_after_reveal_failure, reveal_unloaded_passenger,
+    DepartureFailure, DepartureRoute, depart_cargo_head, reveal_unloaded_passenger,
 };
 use crate::sim::pathfinding::PathGrid;
 use crate::sim::pathfinding::passability::LandType;
-use crate::sim::world::{RevealOutcome, SimSoundEvent, Simulation};
+use crate::sim::world::{SimSoundEvent, Simulation};
 use crate::util::fixed_math::SIM_ZERO;
 use crate::util::lepton::CELL_CENTER_LEPTON;
 
@@ -493,23 +493,6 @@ fn queue_guard(sim: &mut Simulation, id: u64) {
     );
 }
 
-/// Pop the cargo head (`FUN_004DE710` → `CargoClass::RemoveFirstPassenger @
-/// 0x00473430`). The wrapper's `Type+0x805 && count == 0 → vtable+0x4D8`
-/// tail is the Gunner weapon reset once the hold is empty; VERA's
-/// representation of that swap is the transport's `weapon_override`.
-fn pop_cargo_head(sim: &mut Simulation, transport_id: u64) -> Option<(u64, u32)> {
-    let transport = sim.substrate.entities.get_mut(transport_id)?;
-    let popped = transport.passenger_role.cargo_mut()?.unload_first()?;
-    if transport
-        .passenger_role
-        .cargo()
-        .is_some_and(|cargo| cargo.is_empty())
-    {
-        transport.weapon_override = None;
-    }
-    Some(popped)
-}
-
 /// Outcome of one state-3 ejection attempt.
 enum EjectOutcome {
     /// Placed at the exit cell; the passenger was given `dest`.
@@ -561,213 +544,150 @@ fn eject_head_passenger(
     overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
     transport_id: u64,
 ) -> EjectOutcome {
-    let Some((pax_id, pax_size)) = pop_cargo_head(sim, transport_id) else {
-        return EjectOutcome::Failed;
-    };
-    let (base, facing, transport_z, leave_sound) = {
-        let transport = sim
-            .substrate
-            .entities
-            .get(transport_id)
-            .expect("transport resolved before the head pop");
-        let obj = sim.object_type(transport.type_ref(), rules);
-        (
-            (transport.position.rx, transport.position.ry),
-            transport.facing,
-            transport.position.z,
-            obj.and_then(|o| o.leave_transport_sound.clone()),
-        )
-    };
-    let Some(passenger_snapshot) = sim.substrate.entities.get(pax_id) else {
-        // A cargo id that no longer resolves cannot be placed; keep the
-        // native failure shape (re-insert) so the count stays coherent.
-        restore_head(sim, rules, transport_id, pax_id, pax_size);
-        return EjectOutcome::Failed;
-    };
-    let passenger_is_infantry = passenger_snapshot.category == EntityCategory::Infantry;
+    match depart_cargo_head(
+        sim,
+        rules,
+        transport_id,
+        DepartureRoute::Vehicle,
+        |sim, pax_id| {
+            let (base, facing, transport_z, leave_sound) = {
+                let transport = sim
+                    .substrate
+                    .entities
+                    .get(transport_id)
+                    .expect("transport resolved before the head pop");
+                let obj = sim.object_type(transport.type_ref(), rules);
+                (
+                    (transport.position.rx, transport.position.ry),
+                    transport.facing,
+                    transport.position.z,
+                    obj.and_then(|o| o.leave_transport_sound.clone()),
+                )
+            };
+            let Some(passenger_snapshot) = sim.substrate.entities.get(pax_id) else {
+                // A cargo id that no longer resolves cannot be placed; keep the
+                // native failure shape (re-insert) so the count stays coherent.
+                return Err(DepartureFailure::MissingPassenger);
+            };
+            let passenger_is_infantry = passenger_snapshot.category == EntityCategory::Infantry;
 
-    let facing16 = u16::from(facing) << 8;
-    let start = ((((u32::from(facing16.wrapping_add(0x7FFF))) >> 12) + 1) >> 1) as usize & 7;
-    let mut strict_pass = true;
-    let mut i: usize = 0;
-    // `(exit cell, beyond cell on the strict pass, octant)`.
-    let mut placement: Option<((u16, u16), Option<(u16, u16)>, usize)> = None;
-    while i < 8 {
-        let octant = (start + i) & 7;
-        let exit_cell = cell_from(base, OCTANT_OFFSETS[octant]);
-        let beyond_cell = exit_cell.and_then(|cell| cell_from(cell, OCTANT_OFFSETS[octant]));
-        let (adjacent_ok, beyond_ok) = match (exit_cell, beyond_cell) {
-            (Some(exit), Some(beyond)) => {
+            let facing16 = u16::from(facing) << 8;
+            let start =
+                ((((u32::from(facing16.wrapping_add(0x7FFF))) >> 12) + 1) >> 1) as usize & 7;
+            let mut strict_pass = true;
+            let mut i: usize = 0;
+            // `(exit cell, beyond cell on the strict pass, octant)`.
+            let mut placement: Option<((u16, u16), Option<(u16, u16)>, usize)> = None;
+            while i < 8 {
+                let octant = (start + i) & 7;
+                let exit_cell = cell_from(base, OCTANT_OFFSETS[octant]);
+                let beyond_cell =
+                    exit_cell.and_then(|cell| cell_from(cell, OCTANT_OFFSETS[octant]));
+                let (adjacent_ok, beyond_ok) = match (exit_cell, beyond_cell) {
+                    (Some(exit), Some(beyond)) => {
+                        let passenger = sim
+                            .substrate
+                            .entities
+                            .get(pax_id)
+                            .expect("passenger resolved above");
+                        (
+                            passenger_can_enter(sim, rules, path_grid, passenger, exit),
+                            passenger_can_enter(sim, rules, path_grid, passenger, beyond),
+                        )
+                    }
+                    _ => (false, false),
+                };
+                let accept = adjacent_ok && (beyond_ok || !strict_pass);
+                if !accept {
+                    if strict_pass && i == 7 {
+                        strict_pass = false;
+                        i = 1;
+                    } else {
+                        i += 1;
+                    }
+                    continue;
+                }
+                let (exit, beyond) = (
+                    exit_cell.expect("accepted cell exists"),
+                    beyond_cell.expect("accepted cell exists"),
+                );
+                if cell_has_structural_bridge(sim, path_grid, exit) {
+                    i += 1;
+                    continue;
+                }
+                placement = Some((exit, strict_pass.then_some(beyond), octant));
+                break;
+            }
+
+            let Some((exit, strict_beyond, octant)) = placement else {
+                return Err(DepartureFailure::Placement);
+            };
+
+            // Placement coordinate: the exit cell centre (`x * 256 + 0x80`).
+            let (place_cell, sub_cell) = if passenger_is_infantry {
+                // `PlaceInfantryInCell` from the cell centre: quadrant 0, so the
+                // centre-row `RandomRanged(0, 3)` draw is made on the Scenario stream.
+                let occupancy = sim.substrate.occupancy.get(exit.0, exit.1);
+                let spot = bump_crush::allocate_sub_cell_with_preference(
+                    occupancy,
+                    MovementLayer::Ground,
+                    None,
+                    CELL_CENTER_LEPTON,
+                    CELL_CENTER_LEPTON,
+                    &mut sim.scenario_rng,
+                );
+                (exit, spot)
+            } else {
                 let passenger = sim
                     .substrate
                     .entities
                     .get(pax_id)
                     .expect("passenger resolved above");
-                (
-                    passenger_can_enter(sim, rules, path_grid, passenger, exit),
-                    passenger_can_enter(sim, rules, path_grid, passenger, beyond),
-                )
+                let cell = find_nearby_passable_for(sim, rules, path_grid, passenger, exit, None)
+                    .unwrap_or(exit);
+                (cell, None)
+            };
+            if passenger_is_infantry && sub_cell.is_none() {
+                return Err(DepartureFailure::Placement);
             }
-            _ => (false, false),
-        };
-        let accept = adjacent_ok && (beyond_ok || !strict_pass);
-        if !accept {
-            if strict_pass && i == 7 {
-                strict_pass = false;
-                i = 1;
-            } else {
-                i += 1;
+            // Relaxed pass: `[ESP+0x14]` — the exit cell for infantry, the FNPC
+            // placement cell for a vehicle (`0x0073DAE8` overwrote the slot).
+            let dest = strict_beyond.unwrap_or(place_cell);
+
+            if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
+                passenger.sub_cell = sub_cell;
+                passenger.facing = ((octant as u32) << 5) as u8;
+                if let Some(loco) = passenger.locomotor.as_mut() {
+                    loco.layer = MovementLayer::Ground;
+                }
             }
-            continue;
-        }
-        let (exit, beyond) = (
-            exit_cell.expect("accepted cell exists"),
-            beyond_cell.expect("accepted cell exists"),
-        );
-        if cell_has_structural_bridge(sim, path_grid, exit) {
-            i += 1;
-            continue;
-        }
-        placement = Some((exit, strict_pass.then_some(beyond), octant));
-        break;
-    }
+            let z = cell_level_or(sim, place_cell, transport_z);
+            reveal_unloaded_passenger(sim, transport_id, pax_id, place_cell.0, place_cell.1, z)?;
 
-    let Some((exit, strict_beyond, octant)) = placement else {
-        restore_head(sim, rules, transport_id, pax_id, pax_size);
-        return EjectOutcome::Failed;
-    };
+            // OpenTopped: `TechnoClass::ClearInOpenTransport` (`0x007104A0`) drops the
+            // passenger's in-transport firing membership; VERA's open-topped registry
+            // is the logic-object registration the Reveal above re-establishes.
+            if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
+                passenger.attack_target = None;
+                passenger.passively_acquired_target = false;
+                passenger.order_intent = None;
+            }
+            sim.queue_megamission_with_teardown(pax_id, MissionType::Move, DockTeardown::None);
+            issue_pathed_move(sim, rules, path_grid, overlay_registry, pax_id, dest);
 
-    // Placement coordinate: the exit cell centre (`x * 256 + 0x80`).
-    let (place_cell, sub_cell) = if passenger_is_infantry {
-        // `PlaceInfantryInCell` from the cell centre: quadrant 0, so the
-        // centre-row `RandomRanged(0, 3)` draw is made on the Scenario stream.
-        let occupancy = sim.substrate.occupancy.get(exit.0, exit.1);
-        let spot = bump_crush::allocate_sub_cell_with_preference(
-            occupancy,
-            MovementLayer::Ground,
-            None,
-            CELL_CENTER_LEPTON,
-            CELL_CENTER_LEPTON,
-            &mut sim.scenario_rng,
-        );
-        (exit, spot)
-    } else {
-        let passenger = sim
-            .substrate
-            .entities
-            .get(pax_id)
-            .expect("passenger resolved above");
-        let cell =
-            find_nearby_passable_for(sim, rules, path_grid, passenger, exit, None).unwrap_or(exit);
-        (cell, None)
-    };
-    if passenger_is_infantry && sub_cell.is_none() {
-        restore_head(sim, rules, transport_id, pax_id, pax_size);
-        return EjectOutcome::Failed;
-    }
-    // Relaxed pass: `[ESP+0x14]` — the exit cell for infantry, the FNPC
-    // placement cell for a vehicle (`0x0073DAE8` overwrote the slot).
-    let dest = strict_beyond.unwrap_or(place_cell);
-
-    if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
-        passenger.sub_cell = sub_cell;
-        passenger.facing = ((octant as u32) << 5) as u8;
-        if let Some(loco) = passenger.locomotor.as_mut() {
-            loco.layer = MovementLayer::Ground;
-        }
-    }
-    let z = cell_level_or(sim, place_cell, transport_z);
-    let outcome =
-        reveal_unloaded_passenger(sim, transport_id, pax_id, place_cell.0, place_cell.1, z);
-    if !matches!(outcome, RevealOutcome::Revealed { .. }) {
-        restore_unloaded_passenger_after_reveal_failure(
-            sim,
-            rules,
-            transport_id,
-            pax_id,
-            pax_size,
-            outcome,
-        );
-        reapply_gunner_weapon(sim, rules, transport_id, pax_id);
-        return EjectOutcome::Failed;
-    }
-
-    // OpenTopped: `TechnoClass::ClearInOpenTransport` (`0x007104A0`) drops the
-    // passenger's in-transport firing membership; VERA's open-topped registry
-    // is the logic-object registration the Reveal above re-establishes.
-    if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
-        passenger.passenger_role = PassengerRole::None;
-        passenger.attack_target = None;
-        passenger.passively_acquired_target = false;
-        passenger.order_intent = None;
-    }
-    sim.queue_megamission_with_teardown(pax_id, MissionType::Move, DockTeardown::None);
-    issue_pathed_move(sim, rules, path_grid, overlay_registry, pax_id, dest);
-
-    if let Some(sound) = leave_sound {
-        let sound_id = sim.interner.intern(&sound);
-        sim.sound_events.push(SimSoundEvent::LeaveTransport {
-            sound_id,
-            rx: base.0,
-            ry: base.1,
-        });
-    }
-    EjectOutcome::Placed
-}
-
-/// The failure tail of the vehicle handler (`0x0073DC71`..`0x0073DCA6`):
-/// `CargoClass::AddPassenger @ 0x004733A0` re-inserts the passenger at the
-/// head, then `Type+0x805 (Gunner=)` calls UnitClass vtable `+0x4D4`
-/// (`0x00746420`, undefined as a Ghidra function; decoded from bytes) with
-/// the passenger: it re-adopts the passenger's `+0x274` attachment and
-/// applies `InfantryType+0x688 (IFVMode=)` through `FUN_0070DC70`, i.e. the
-/// gunner weapon swap that the pop's `+0x4D8` (`0x007464E0`, the inverse)
-/// undid when the hold emptied. Aircraft/Techno bind those slots to the
-/// three-byte stubs `0x004DE750`/`0x004DE760`, so only a Gunner unit swaps.
-fn restore_head(
-    sim: &mut Simulation,
-    rules: &RuleSet,
-    transport_id: u64,
-    pax_id: u64,
-    pax_size: u32,
-) {
-    if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
-        passenger.passenger_role = PassengerRole::Inside { transport_id };
-    }
-    if let Some(cargo) = sim
-        .substrate
-        .entities
-        .get_mut(transport_id)
-        .and_then(|transport| transport.passenger_role.cargo_mut())
-    {
-        cargo.restore_front(pax_id, pax_size);
-    }
-    reapply_gunner_weapon(sim, rules, transport_id, pax_id);
-}
-
-/// UnitClass `+0x4D4` (`0x00746420`) for a `Gunner=yes` transport: the
-/// re-added head passenger's `IFVMode=` becomes the transport's weapon slot
-/// again. VERA's representation of that swap is `weapon_override`.
-fn reapply_gunner_weapon(sim: &mut Simulation, rules: &RuleSet, transport_id: u64, pax_id: u64) {
-    let Some(transport) = sim.substrate.entities.get(transport_id) else {
-        return;
-    };
-    if !sim
-        .object_type(transport.type_ref(), rules)
-        .is_some_and(|obj| obj.gunner)
-    {
-        return;
-    }
-    let Some(passenger) = sim.substrate.entities.get(pax_id) else {
-        return;
-    };
-    let ifv_mode = sim
-        .object_type(passenger.type_ref(), rules)
-        .map_or(0, |obj| obj.ifv_mode);
-    if let Some(transport) = sim.substrate.entities.get_mut(transport_id) {
-        transport.weapon_override = Some(
-            crate::sim::combat::combat_weapon::WeaponOverride::IfvSlot(ifv_mode),
-        );
+            if let Some(sound) = leave_sound {
+                let sound_id = sim.interner.intern(&sound);
+                sim.sound_events.push(SimSoundEvent::LeaveTransport {
+                    sound_id,
+                    rx: base.0,
+                    ry: base.1,
+                });
+            }
+            Ok(())
+        },
+    ) {
+        Ok(()) => EjectOutcome::Placed,
+        Err(_) => EjectOutcome::Failed,
     }
 }
 
@@ -1057,7 +977,7 @@ const AIRCRAFT_EXIT_SCAN: [usize; 9] = [4, 5, 3, 7, 1, 0, 6, 2, 4];
 /// dispatch ejects the next passenger. VERA-internal bounded escape instead
 /// (trigger: three infantry already standing in the aircraft cell, rare;
 /// DRIFT — native loses the unit): the passenger goes back to the cargo head
-/// ([`restore_head`]), this returns `false`, and the caller leaves Unload for
+/// (cargo departure restoration), this returns `false`, and the caller leaves Unload for
 /// Guard through the empty-hold exit, so nothing retries and no further
 /// epilogue draws happen. Returns `true` when the passenger left the hold. On
 /// success: `Queue_Mission(Move)` (`0x00415C05`), `Set_Destination(scan
@@ -1070,89 +990,83 @@ fn eject_from_aircraft(
     overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
     aircraft_id: u64,
 ) -> bool {
-    let Some((pax_id, pax_size)) = pop_cargo_head(sim, aircraft_id) else {
-        return false;
-    };
-    let (cell, z, sub_x, sub_y) = match sim.substrate.entities.get(aircraft_id) {
-        Some(aircraft) => (
-            (aircraft.position.rx, aircraft.position.ry),
-            aircraft.position.z,
-            aircraft.position.sub_x,
-            aircraft.position.sub_y,
-        ),
-        None => return false,
-    };
-    let Some(passenger_snapshot) = sim.substrate.entities.get(pax_id) else {
-        restore_head(sim, rules, aircraft_id, pax_id, pax_size);
-        return false;
-    };
-    let is_infantry = passenger_snapshot.category == EntityCategory::Infantry;
+    depart_cargo_head(
+        sim,
+        rules,
+        aircraft_id,
+        DepartureRoute::LandedAircraft,
+        |sim, pax_id| {
+            let (cell, z, sub_x, sub_y) = match sim.substrate.entities.get(aircraft_id) {
+                Some(aircraft) => (
+                    (aircraft.position.rx, aircraft.position.ry),
+                    aircraft.position.z,
+                    aircraft.position.sub_x,
+                    aircraft.position.sub_y,
+                ),
+                None => unreachable!("aircraft resolved before cargo departure"),
+            };
+            let Some(passenger_snapshot) = sim.substrate.entities.get(pax_id) else {
+                return Err(DepartureFailure::MissingPassenger);
+            };
+            let is_infantry = passenger_snapshot.category == EntityCategory::Infantry;
 
-    let mut index = 8usize;
-    let mut scan_cell: Option<(u16, u16)> = None;
-    for (i, &octant) in AIRCRAFT_EXIT_SCAN[..8].iter().enumerate() {
-        let candidate = cell_from(cell, OCTANT_OFFSETS[octant & 7]);
-        scan_cell = candidate;
-        let passenger = sim
-            .substrate
-            .entities
-            .get(pax_id)
-            .expect("passenger resolved above");
-        if candidate.is_some_and(|c| passenger_can_enter(sim, rules, path_grid, passenger, c)) {
-            index = i;
-            break;
-        }
-    }
-    let facing = ((AIRCRAFT_EXIT_SCAN[index] & 7) as u32 * 32) as u8;
+            let mut index = 8usize;
+            let mut scan_cell: Option<(u16, u16)> = None;
+            for (i, &octant) in AIRCRAFT_EXIT_SCAN[..8].iter().enumerate() {
+                let candidate = cell_from(cell, OCTANT_OFFSETS[octant & 7]);
+                scan_cell = candidate;
+                let passenger = sim
+                    .substrate
+                    .entities
+                    .get(pax_id)
+                    .expect("passenger resolved above");
+                if candidate
+                    .is_some_and(|c| passenger_can_enter(sim, rules, path_grid, passenger, c))
+                {
+                    index = i;
+                    break;
+                }
+            }
+            let facing = ((AIRCRAFT_EXIT_SCAN[index] & 7) as u32 * 32) as u8;
 
-    let sub_cell = if is_infantry {
-        let occupancy = sim.substrate.occupancy.get(cell.0, cell.1);
-        let spot = bump_crush::allocate_sub_cell_with_preference(
-            occupancy,
-            MovementLayer::Ground,
-            None,
-            sub_x,
-            sub_y,
-            &mut sim.scenario_rng,
-        );
-        if spot.is_none() {
-            restore_head(sim, rules, aircraft_id, pax_id, pax_size);
-            return false;
-        }
-        spot
-    } else {
-        None
-    };
-    if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
-        passenger.sub_cell = sub_cell;
-        passenger.facing = facing;
-        if let Some(loco) = passenger.locomotor.as_mut() {
-            loco.layer = MovementLayer::Ground;
-        }
-    }
-    let outcome = reveal_unloaded_passenger(sim, aircraft_id, pax_id, cell.0, cell.1, z);
-    if !matches!(outcome, RevealOutcome::Revealed { .. }) {
-        restore_unloaded_passenger_after_reveal_failure(
-            sim,
-            rules,
-            aircraft_id,
-            pax_id,
-            pax_size,
-            outcome,
-        );
-        return false;
-    }
-    if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
-        passenger.passenger_role = PassengerRole::None;
-        passenger.attack_target = None;
-        passenger.passively_acquired_target = false;
-        passenger.order_intent = None;
-    }
-    sim.queue_megamission_with_teardown(pax_id, MissionType::Move, DockTeardown::None);
-    if let Some(dest) = scan_cell {
-        issue_pathed_move(sim, rules, path_grid, overlay_registry, pax_id, dest);
-    }
-    true
+            let sub_cell = if is_infantry {
+                let occupancy = sim.substrate.occupancy.get(cell.0, cell.1);
+                let spot = bump_crush::allocate_sub_cell_with_preference(
+                    occupancy,
+                    MovementLayer::Ground,
+                    None,
+                    sub_x,
+                    sub_y,
+                    &mut sim.scenario_rng,
+                );
+                if spot.is_none() {
+                    return Err(DepartureFailure::Placement);
+                }
+                spot
+            } else {
+                None
+            };
+            if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
+                passenger.sub_cell = sub_cell;
+                passenger.facing = facing;
+                if let Some(loco) = passenger.locomotor.as_mut() {
+                    loco.layer = MovementLayer::Ground;
+                }
+            }
+            reveal_unloaded_passenger(sim, aircraft_id, pax_id, cell.0, cell.1, z)?;
+            if let Some(passenger) = sim.substrate.entities.get_mut(pax_id) {
+                passenger.attack_target = None;
+                passenger.passively_acquired_target = false;
+                passenger.order_intent = None;
+            }
+            sim.queue_megamission_with_teardown(pax_id, MissionType::Move, DockTeardown::None);
+            if let Some(dest) = scan_cell {
+                issue_pathed_move(sim, rules, path_grid, overlay_registry, pax_id, dest);
+            }
+            Ok(())
+        },
+    )
+    .is_ok()
 }
 
 #[cfg(test)]

--- a/src/sim/transport_unload/tests.rs
+++ b/src/sim/transport_unload/tests.rs
@@ -942,3 +942,120 @@ fn nighthawk_failed_ejection_keeps_cargo_and_leaves_for_guard() {
     );
     assert_eq!(fx.cargo_ids(shad), held, "cargo still retained");
 }
+
+#[test]
+fn cargo_departure_ground_reveal_rejection_preserves_route_retry_state() {
+    use crate::sim::combat::combat_weapon::WeaponOverride;
+    use crate::sim::movement::locomotor::MovementLayer;
+    for aircraft in [false, true] {
+        for already_revealed in [false, true] {
+            let mut fx = Fixture::new(|_, _| false);
+            let transport = fx.spawn(if aircraft { "SHAD" } else { "FV" }, 20, 20, 0);
+            let passenger = fx.board(transport, 1)[0];
+            let peer = fx.spawn("E1", 30, 30, 0);
+            if already_revealed {
+                assert!(matches!(
+                    fx.sim.reveal(passenger),
+                    crate::sim::world::RevealOutcome::Revealed { .. }
+                ));
+            } else {
+                // Deliberately inconsistent cargo fixture: reach actual Reveal's
+                // early marked-object rejection after the caller clears Inside.
+                fx.sim
+                    .substrate
+                    .entities
+                    .get_mut(passenger)
+                    .unwrap()
+                    .lifecycle
+                    .cell_marked = true;
+            }
+            fx.sim
+                .substrate
+                .entities
+                .get_mut(peer)
+                .unwrap()
+                .mark_live_contact_with(passenger);
+            {
+                let carrier = fx.sim.substrate.entities.get_mut(transport).unwrap();
+                carrier.weapon_override = Some(WeaponOverride::IfvSlot(99));
+                let cargo = carrier.passenger_role.cargo_mut().unwrap();
+                // Admission-time size differs from current E1 Size=1.
+                cargo.passenger_sizes[0] = 7;
+                cargo.total_size = 7;
+            }
+            let held = serde_json::to_value(
+                fx.sim
+                    .substrate
+                    .entities
+                    .get(transport)
+                    .unwrap()
+                    .passenger_role
+                    .cargo(),
+            )
+            .unwrap();
+            let rng_before = fx.sim.scenario_rng.state();
+            if aircraft {
+                assert!(!super::eject_from_aircraft(
+                    &mut fx.sim,
+                    &fx.rules,
+                    Some(&fx.grid),
+                    None,
+                    transport
+                ));
+            } else {
+                assert!(matches!(
+                    super::eject_head_passenger(
+                        &mut fx.sim,
+                        &fx.rules,
+                        Some(&fx.grid),
+                        None,
+                        transport
+                    ),
+                    super::EjectOutcome::Failed
+                ));
+            }
+            let carrier = fx.sim.substrate.entities.get(transport).unwrap();
+            assert_eq!(
+                serde_json::to_value(carrier.passenger_role.cargo()).unwrap(),
+                held
+            );
+            assert_eq!(
+                carrier.weapon_override,
+                if aircraft {
+                    None
+                } else {
+                    Some(WeaponOverride::IfvSlot(1))
+                }
+            );
+            let pax = fx.sim.substrate.entities.get(passenger).unwrap();
+            assert_eq!(pax.passenger_role.inside_transport_id(), Some(transport));
+            assert!(pax.lifecycle.in_limbo);
+            assert_eq!(pax.lifecycle.cell_marked, !already_revealed);
+            assert!(!pax.in_logic_vector);
+            assert_eq!(pax.locomotor.as_ref().unwrap().layer, MovementLayer::Ground);
+            assert_eq!(
+                fx.sim
+                    .substrate
+                    .entities
+                    .get(peer)
+                    .unwrap()
+                    .has_live_contact_with(passenger),
+                !already_revealed
+            );
+            assert!(
+                fx.sim
+                    .sound_events
+                    .iter()
+                    .all(|event| !matches!(event, SimSoundEvent::LeaveTransport { .. }))
+            );
+            // Real placement still consumed its draw before Reveal rejected.
+            assert_ne!(fx.sim.scenario_rng.state(), rng_before);
+            println!(
+                "CARGO_TRACE ground {aircraft} {already_revealed} {:?} {:?} {:?}",
+                fx.sim.scenario_rng.state(),
+                held,
+                pax.position
+            );
+        }
+    }
+}


### PR DESCRIPTION
Cargo departure previously required four production paths to coordinate head removal, recorded passenger size and failure restoration. A private passenger departure operation now owns that complete transition for garrisons, vehicles, landed aircraft and paradrops. Callers retain placement geometry, mission cadence and ordered success effects. Raw head-pop and restore APIs are private; existing route-specific weapon, radio, layer and parachute policies are preserved.

The boarding tests now use the production boarding operation. Three production-path regression tests cover seven failure cases and successful retries with recorded cargo sizes differing from current rules; these replace one obsolete manual pop/restore test.

Validation:
- Unchanged main and candidate: all three new tests pass, with seven identical recorded cargo/RNG/coordinate traces.
- `cargo test -p vera20k --lib`: 8463 passed, 0 failed, 81 ignored. Retained tests exercise commands, mission dispatch and frame execution.
- `cargo check -p vera20k` and System Map validation pass. Independent read-only source and validation reviews accepted publication.

This demonstrates Rust behavior preservation. The defensive AlreadyRevealed fixture covers lifecycle/Logic/radio state; custom Gunner aircraft behavior is preserved by source comparison. No native parity claim or change to bulk sell/destruction ejection.
