### PR TITLE
Light voxels from the native direction and draw the wake with anim.pal

### DIFF
--- a/src/render/sprite_atlas.rs
+++ b/src/render/sprite_atlas.rs
@@ -840,6 +840,11 @@ pub fn build_sprite_atlas(
             effect_names.push(r.general.warp_in.name.clone());
             effect_names.push(r.general.warp_out.name.clone());
             effect_names.push(r.general.warp_away.name.clone());
+            // [General] Wake= (WAKE1): spawned as a WorldEffect behind ships.
+            // Stock art sets no AltPalette= and its Theater= line is commented
+            // out, so it is an anim.pal draw like every other AnimType; left
+            // out of this set it fell through to unit.pal and drew green.
+            effect_names.push(r.general.wake.name.clone());
             // Add damage fire types (FIRE01, FIRE02, FIRE03 by default).
             for fire_ref in &r.general.damage_fire_types {
                 if !effect_names

--- a/src/render/vxl_normals.rs
+++ b/src/render/vxl_normals.rs
@@ -10,7 +10,7 @@
 //! ## Dependency rules
 //! - Part of render/ — depends only on glam.
 
-use glam::Vec3;
+use glam::{Mat3, Vec3};
 
 /// Number of normals in RA2 mode (normals_mode = 4).
 const RA2_NORMAL_COUNT: usize = 245;
@@ -218,44 +218,58 @@ pub fn diffuse_shade(normal: Vec3, light_dir: Vec3, ambient: f32, diffuse: f32) 
     (ambient + diffuse * n_dot_l).clamp(0.0, 1.0)
 }
 
-/// Light direction for YR: -X rotated 45 degrees around Z.
-/// Transform(-UnitX, RotationZ(45°)) = (-cos45, -sin45, 0) = (-0.707, -0.707, 0)
-const YR_LIGHT_BASE: [f32; 3] = [-0.707_107, -0.707_107, 0.0];
+/// The original engine's world-space light direction.
+///
+/// `Init_Game` (call at 0x0052BDF5) runs `VXL_LightDirection_Setup` (0x00754C00)
+/// with the angle constant at 0x007E1E68 = 0x3F490E56 = pi/4. That routine builds
+/// an identity, post-multiplies `Matrix_rotate_y_axis` (0x005AF080) -- which mixes
+/// matrix columns 0 and 2, i.e. a rotation about **Y**, not Z -- and transforms
+/// the literal (0xBF3504E6, 0xBF3504E6, 0) = (-0.707107, -0.707107, 0) through
+/// it: x' = x*cos45 + z*sin45 = -0.5, y' = -0.707107, z' = -x*sin45 + z*cos45 =
+/// +0.5. The result is stored at `g_VXL_LightDirection` (0x00887470) and never
+/// rewritten. The +Z half is what lights every top face; the earlier Rust
+/// constant (-0.707, -0.707, 0) had no Z term and left tops and far sides on the
+/// darkest VPL page.
+const YR_WORLD_LIGHT: Vec3 = Vec3::new(-0.5, -0.707_107, 0.5);
 
-/// Build the 256-slot VPL page lookup table for a given facing.
+/// Viewer direction the original feeds Blinn-Phong: `VXL_Init_BlinnPhong`
+/// (0x00753D00) transforms (0, 0, 1) through the inverse of the matrix at
+/// 0x00887430, which `Init_Game` sets to identity (`Matrix3x4_SetIdentity`
+/// 0x005AE860 at 0x0052BDDD) and nothing rewrites, so the viewer stays +Z.
+const YR_VIEWER: Vec3 = Vec3::Z;
+
+/// Normal-index -> VPL page table for one draw, the way `VXL_Init_BlinnPhong`
+/// (0x00753D00) + `VXL_BlinnPhongLighting` (0x007586F0) build `g_VXL_NormalLUT`.
 ///
-/// Uses the Blinn-Phong reflection model matching the original engine's lighting calculation.
-/// Returns a 256-element array mapping normal_index → VPL page (brightness level).
-/// The VPL page is then used with `VplFile::get_palette_index(page, color)` to get
-/// the final shaded palette color.
+/// `model_rotation` is the rotation part of the locomotor draw matrix the
+/// original hands `TechnoClass::Render` (0x00706ED0) -- `slope_matrix x
+/// facing_rotation` on the simple path -- **without** the camera. The native
+/// init inverts that matrix (`FUN_005AFC20`, a rigid inverse) and transforms
+/// `g_VXL_LightDirection` through its 3x3 (`FUN_005AF4D0`), so the light lands
+/// in model space and is dotted with the model-space normal table. The viewer
+/// stays world +Z (see `YR_VIEWER`); the original does not bring it into model
+/// space, and neither does this.
 ///
-/// `facing_rad`: the model's facing rotation in radians (0–2PI).
-/// `normals_mode`: 2 (TS, 36 normals) or 4 (RA2, 245 normals).
-pub fn blinn_phong_pages(normals_mode: u8, facing_rad: f32) -> [u8; 256] {
+/// Residual (VERA-internal, gamemd equivalent UNCHECKED): the original
+/// normalises the halfway vector with `Sqrt_Approx` (0x004CAC40) on an x87
+/// double and skips the divide when the length is exactly 0; this uses glam's
+/// exact `normalize`. A page can differ by one only where 16 x brightness
+/// lands within the approximation error of an integer boundary.
+pub fn blinn_phong_pages(normals_mode: u8, model_rotation: Mat3) -> [u8; 256] {
     // Native leaves shared-LUT slots 245–252 stale. Rust deliberately starts
     // them at a deterministic safe default; retail VXLs never reference them.
     let mut result: [u8; 256] = [0u8; 256];
 
-    // Rotate the base YR light direction by the model's facing.
-    // Transform(YRLight, RotZ(rotation - 45°)).
-    // The base YR light is already at 45°, so rotating by (facing - 45°) = net facing.
-    let rot_angle: f32 = facing_rad - std::f32::consts::FRAC_PI_4;
-    let cos_a: f32 = rot_angle.cos();
-    let sin_a: f32 = rot_angle.sin();
-    let light: Vec3 = Vec3::new(
-        YR_LIGHT_BASE[0] * cos_a - YR_LIGHT_BASE[1] * sin_a,
-        YR_LIGHT_BASE[0] * sin_a + YR_LIGHT_BASE[1] * cos_a,
-        YR_LIGHT_BASE[2],
-    );
-
-    // Viewer direction (looking down Z axis from above).
-    let viewer: Vec3 = Vec3::Z;
+    // Rigid inverse of the draw rotation applied to the world light.
+    let light: Vec3 = model_rotation.transpose() * YR_WORLD_LIGHT;
+    let viewer: Vec3 = YR_VIEWER;
 
     // Blinn-Phong halfway vector between light and viewer.
     let halfway: Vec3 = (light + viewer).normalize();
 
-    // YR specular strength constant. Schlick exponent in the original
-    // Blinn-Phong approximation; verified against the binary's call site.
+    // Specular constant: `TechnoClass::Render` pushes 0x40400000 = 3.0 at
+    // 0x00706F23 and it reaches `VXL_BlinnPhongLighting` as the Schlick
+    // denominator term.
     const SPECULAR_STRENGTH: f32 = 3.0;
 
     let table: &[[f32; 3]] = match normals_mode {
@@ -281,7 +295,8 @@ pub fn blinn_phong_pages(normals_mode: u8, facing_rad: f32) -> [u8; 256] {
         };
 
         let brightness: f32 = diffuse + specular;
-        // Map brightness to VPL page (0–255): brightness * 16.
+        // `FMUL [0x007F6960]` = 16.0, then `Math__ftol` (0x007C5F00, chop):
+        // page = trunc(16 x (diffuse + specular)).
         let page: u8 = (brightness * 16.0).clamp(0.0, 255.0) as u8;
         result[i] = page;
     }
@@ -315,7 +330,7 @@ mod tests {
         assert_eq!(get_normal(4, 244), final_native);
         assert_eq!(get_normal(4, 245), Vec3::Z);
 
-        let pages = blinn_phong_pages(4, 0.0);
+        let pages = blinn_phong_pages(4, Mat3::IDENTITY);
         assert_eq!(pages[244], pages[240]);
         assert_ne!(pages[244], 0, "the final native entry must be processed");
         assert_eq!(&pages[245..253], &[0; 8]);
@@ -346,12 +361,56 @@ mod tests {
         // page regardless of mode or facing.
         for facing in [0.0_f32, 1.3, 4.2] {
             for mode in [2u8, 4u8] {
-                let pages = blinn_phong_pages(mode, facing);
+                let pages = blinn_phong_pages(mode, Mat3::from_rotation_z(facing));
                 assert_eq!(pages[253], AMBIENT_PAGE, "mode {mode} facing {facing}");
                 assert_eq!(pages[254], AMBIENT_PAGE, "mode {mode} facing {facing}");
                 assert_eq!(pages[255], AMBIENT_PAGE, "mode {mode} facing {facing}");
             }
         }
+    }
+
+    /// Page for one normal under the native formula, so tests can state the
+    /// expected value from the established chain rather than from prior Rust.
+    fn native_page(normal: Vec3, light: Vec3) -> u8 {
+        let halfway: Vec3 = (light + Vec3::Z).normalize();
+        let diffuse: f32 = normal.dot(light).max(0.0);
+        let h: f32 = normal.dot(halfway);
+        let specular: f32 = (h / (3.0 - h * 3.0 + h)).max(0.0);
+        ((diffuse + specular) * 16.0) as u8
+    }
+
+    #[test]
+    fn world_light_lights_top_faces_at_identity() {
+        // A +Z normal sees diffuse 0.5 from the native (-0.5, -0.707, +0.5)
+        // light; the old Z-less light gave it 0 and only specular remained.
+        let page: u8 = native_page(Vec3::Z, YR_WORLD_LIGHT);
+        assert!(
+            page >= 8,
+            "top faces must not sit on the dark pages: {page}"
+        );
+        let table_top: u8 = blinn_phong_pages(4, Mat3::IDENTITY)[240];
+        assert_eq!(
+            table_top,
+            native_page(Vec3::from_array(RA2_NORMALS[240]), YR_WORLD_LIGHT)
+        );
+    }
+
+    #[test]
+    fn model_rotation_moves_the_light_by_its_inverse() {
+        // The light is carried into model space by the transpose (rigid
+        // inverse) of the draw rotation, as FUN_005AFC20 + FUN_005AF4D0 do.
+        let rot: Mat3 = Mat3::from_rotation_z(std::f32::consts::FRAC_PI_2);
+        let pages: [u8; 256] = blinn_phong_pages(4, rot);
+        let expected_light: Vec3 = rot.transpose() * YR_WORLD_LIGHT;
+        for (i, n) in RA2_NORMALS.iter().enumerate().take(245) {
+            assert_eq!(
+                pages[i],
+                native_page(Vec3::from_array(*n), expected_light),
+                "normal {i}"
+            );
+        }
+        let identity_pages: [u8; 256] = blinn_phong_pages(4, Mat3::IDENTITY);
+        assert!(pages[..245] != identity_pages[..245]);
     }
 
     #[test]

--- a/src/render/vxl_raster.rs
+++ b/src/render/vxl_raster.rs
@@ -15,7 +15,7 @@
 //! - Part of render/ — depends on assets/ (VxlFile, HvaFile, VplFile).
 //! - Uses glam for vector/matrix math.
 
-use glam::{Mat4, Quat, Vec3, Vec4};
+use glam::{Mat3, Mat4, Quat, Vec3, Vec4};
 
 use crate::assets::hva_file::HvaFile;
 use crate::assets::vpl_file::VplFile;
@@ -458,9 +458,6 @@ pub fn prepare_limb_data(
     // Facing is quantized to 32 steps before the rotation matrix is built, so
     // every voxel body, turret and barrel renders at exactly 1 of 32 orientations.
     let facing_step: u8 = voxel_facing_step(params.facing);
-    // Equivalent continuous facing for the lighting LUT, quantized in lockstep
-    // with the body so a sprite's shading cannot disagree with its geometry.
-    let facing_rad: f32 = (facing_step as f32) * VOXEL_FACING_STEP_RAD;
     let scale: f32 = params.scale;
 
     // The simple (no-rock) draw path builds `slope_matrix * facing_rotation`, then
@@ -476,6 +473,12 @@ pub fn prepare_limb_data(
     let camera_view: Mat4 = voxel_camera_view();
     let body_facing: Mat4 = Mat4::from_rotation_z(voxel_facing_angle(facing_step));
 
+    // Terrain slope is a property of the cell, not the limb: one matrix per draw.
+    let slope_mat: Mat4 = params
+        .slope_blend
+        .map(compute_slope_blend_rotation)
+        .unwrap_or_else(|| compute_slope_rotation(params.slope_type));
+
     let mut limb_data: Vec<LimbRenderData> = Vec::new();
     let mut max_footprint: f32 = 1.0;
 
@@ -484,7 +487,21 @@ pub fn prepare_limb_data(
             continue;
         }
 
-        let vpl_pages: [u8; 256] = vxl_normals::blinn_phong_pages(limb.normals_mode, facing_rad);
+        // Lighting sees the same draw rotation the geometry uses (slope x body
+        // facing, camera excluded): `TechnoClass::Render` (0x00706ED0) passes
+        // the locomotor draw matrix to `VXL_Init_BlinnPhong` (0x00753D00), which
+        // inverts it and carries `g_VXL_LightDirection` into model space.
+        //
+        // DRIFT (recorded): that init runs once per hull `Render`; the turret
+        // and barrel draws (`VXL_turret_draw` 0x00706BD0 via `FUN_00707280`)
+        // never re-run it and rasterise with the hull's `g_VXL_NormalLUT`, so
+        // natively a turret's normals are dotted with the light in *hull*
+        // model space. This path lights each layer with its own facing, as
+        // it always has. Trigger: every turreted voxel unit whose turret is
+        // not aligned with the hull; effect: per-page shading differences on
+        // the turret only; frequency: constant.
+        let draw_rotation: Mat3 = Mat3::from_mat4(slope_mat * body_facing);
+        let vpl_pages: [u8; 256] = vxl_normals::blinn_phong_pages(limb.normals_mode, draw_rotation);
 
         // Section scale: maps grid coordinates to model-space units.
         let sx: f32 = if limb.size_x > 0 {
@@ -516,10 +533,6 @@ pub fn prepare_limb_data(
         };
 
         let section_transform: Mat4 = section_translate * bone_mat * section_scale;
-        let slope_mat: Mat4 = params
-            .slope_blend
-            .map(compute_slope_blend_rotation)
-            .unwrap_or_else(|| compute_slope_rotation(params.slope_type));
         let combined: Mat4 = camera_view * slope_mat * body_facing * section_transform;
 
         let footprint: f32 = compute_voxel_footprint(&combined, scale);


### PR DESCRIPTION
Player-visible problem: voxel units seen from behind or from the side
rendered on the darkest VPL pages (the Amphibious Transport's hull was
near black from its stern), and the water wake behind ships drew as green
blobs instead of white foam.

Native behaviour established (gamemd.exe):
- Init_Game (0x0052BDF5) calls VXL_LightDirection_Setup (0x00754C00) with
  [0x007E1E68] = pi/4. That routine post-multiplies an identity by
  Matrix_rotate_y_axis (0x005AF080), a rotation about Y (it mixes matrix
  columns 0 and 2), then transforms (-0.707107, -0.707107, 0), giving the
  world light (-0.5, -0.707107, +0.5) at g_VXL_LightDirection (0x00887470).
  The Rust constant was (-0.707, -0.707, 0), rotated about Z: no Z term, so
  every top face and far side sat on page 0.
- TechnoClass::Render (0x00706ED0, call at 0x00706F4D) passes the locomotor
  draw matrix (slope x facing, camera excluded), 0x00887430 (identity: set
  once by Init_Game at 0x0052BDDD, never rewritten), the light pointer and
  3.0 to VXL_Init_BlinnPhong (0x00753D00). It rigid-inverts the draw
  matrix (FUN_005AFC20) and carries the light through the 3x3
  (FUN_005AF4D0); the viewer is (0,0,1) through the identity.
- VXL_BlinnPhongLighting (0x007586F0): page = ftol(16 x (max(0, n.L) +
  max(0, schlick(n.H)))) with [0x007F6960] = 16.0 and the pushed 3.0.

Rust: blinn_phong_pages takes the draw rotation (Mat3) and applies its
transpose to the native world light; vxl_raster hands it
slope_mat * body_facing, hoisted above the limb loop. Two tests pin the
page formula from the established chain rather than from prior output.

Wake: [General] Wake= (WAKE1) is spawned as a WorldEffect but was never
registered as an effect anim, so sprite_palette_choice fell through to
unit.pal. Stock art has no AltPalette= and Theater= commented out; it now
joins the anim.pal set with WarpIn/WarpOut/WarpAway.

Parity: not demonstrated. CPU contact-sheet renders of lcrf.vxl before and
after show the deck and near sides moving onto brighter pages; no gamemd
capture was diffed. cargo test -p vera20k --lib: 8470 passed; 0 failed;
81 ignored.

Review: an independent read-only critic re-derived the light vector from the sin/cos table, confirmed the argument roles, the identity-only 0x00887430, the 16.0 and 3.0 constants, and the anim.pal draw in AnimClass::DrawIt (0x00422CA0). Recorded from its findings: turrets/barrels natively reuse the hull's LUT (DRIFT note in vxl_raster.rs) and Sqrt_Approx vs exact halfway normalisation (residual note in vxl_normals.rs).
