### PR TITLE
Fit the voxel light to the retail Iron Gull capture (azimuth 285, elevation 0)

### DIFF
--- a/src/render/vxl_normals.rs
+++ b/src/render/vxl_normals.rs
@@ -243,7 +243,14 @@ pub fn diffuse_shade(normal: Vec3, light_dir: Vec3, ambient: f32, diffuse: f32) 
 /// pitch/screen-Y conventions cancel for geometry but not for a model-space
 /// light); VERA-internal, gamemd equivalent UNCHECKED until that frame map is
 /// derived from the view-matrix bodies rather than fitted from a capture.
-const YR_WORLD_LIGHT: Vec3 = Vec3::new(-0.5, -0.707_107, -0.5);
+/// Fitted, not derived: per-pixel comparison of the retail Iron Gull fixture
+/// capture against CPU renders at every facing (2026-09-07) ranks this
+/// vector first at every tint assumption (mean abs error 47 vs 57 for
+/// (-0.5,-0.707,-0.5) and 66 for the binary-derived (-0.5,-0.707,+0.5)).
+/// It puts camera-facing hull sides on VPL pages 17-19 and flat tops on
+/// page 7, which is where the retail hull greys (index 55/56) and container
+/// tops (index 106, identity page 8) sit. Azimuth 285 deg, elevation 0.
+const YR_WORLD_LIGHT: Vec3 = Vec3::new(0.258_819, -0.965_926, 0.0);
 
 /// Viewer direction the original feeds Blinn-Phong: `VXL_Init_BlinnPhong`
 /// (0x00753D00) transforms (0, 0, 1) through the inverse of the matrix at
@@ -393,7 +400,7 @@ mod tests {
     }
 
     #[test]
-    fn top_faces_sit_on_the_dark_pages_like_retail_container_tops() {
+    fn top_and_side_pages_match_the_retail_capture() {
         // Retail renders the Iron Gull's flat container tops around VPL page
         // 3-4 (voxels.vpl page 8 is identity). In this frame that needs the
         // light's Z to be negative: a +Z normal then gets no diffuse term and
@@ -401,8 +408,15 @@ mod tests {
         // page 18 (near-white decks), which the capture rules out.
         let page: u8 = native_page(Vec3::Z, YR_WORLD_LIGHT);
         assert!(
-            (3..=5).contains(&page),
-            "top-face page must match retail: {page}"
+            (6..=8).contains(&page),
+            "top-face page must sit next to the identity page 8 like retail container tops: {page}"
+        );
+        // Camera-facing hull side (horizontal, toward the viewer) lands on the
+        // bright pages the retail hull greys occupy.
+        let side: u8 = native_page(Vec3::new(0.707_107, -0.707_107, 0.0), YR_WORLD_LIGHT);
+        assert!(
+            (17..=20).contains(&side),
+            "side page must match retail hull: {side}"
         );
         let table_top: u8 = blinn_phong_pages(4, Mat3::IDENTITY)[240];
         assert_eq!(


### PR DESCRIPTION
Player-visible problem: after #295 hull sides facing the camera rendered on
VPL pages 0-5 (near black) while retail has them on pages 17-19; the live
VERA fixture read (31,31,31)/(40,40,40) where retail reads (123,121,123).

Method: retail gamemd.exe -win capture of the asset-pipeline ocean fixture
versus CPU renders of irongull.vxl at every facing, per-pixel mean absolute
error after bbox alignment, at effective tints 1.0, 1.086 and 1.24:
  (0.259,-0.966, 0.0)  47   <- this commit
  (0.683,-0.683, 0.26) 50
  (-0.5,-0.707,-0.5)   57   (#295)
  (-0.5,-0.707,+0.5)   66   (#293, binary-derived in gamemd's frame)
The ordering holds at every tint. Analytically the chosen vector puts the
camera-facing horizontal side on page 19 and flat tops on page 7; retail
hull greys (unittem 55/56) invert to pages 17-19 and container tops
(index 106) to the identity page 8. The test now pins both.

Status: fitted, VERA-internal; the frame map between this renderer's model
space and gamemd's remains UNCHECKED (the binary's (-0.5,-0.707,+0.5) is
correct in its own frame). Also recorded from the same captures: VERA
applies ExtraUnitLight 0.2 as a linear-space multiply (effective ~1.09 in
8-bit terms) while gamemd scales palette bytes (retail units read ~1.24x);
that is a separate colour-conversion DRIFT, not touched here.

cargo test -p vera20k --lib: 8468 passed; 0 failed; 81 ignored.
