### PR TITLE
Apply map light to palette colours in gamma space like LightConvert

### DIFF
--- a/src/render/batch_shader.wgsl
+++ b/src/render/batch_shader.wgsl
@@ -88,7 +88,37 @@ fn apply_fx(color: vec4f, _flags: u32, params: vec4f, effect_tint: vec4f) -> vec
     // branch mirrors the voxel shader so SHP and VXL share one DrawState ABI.
     // YR resolves selector opacity and invulnerability brightness before either
     // SHP or VXL submission. EMP and mirror deliberately remain no-op residuals.
-    return vec4f(color.rgb * effect_tint.rgb, color.a * params.x);
+    // Invulnerability/temporal brightness is folded into the gamma-space
+    // light multiply by the caller (natively 0x0070E380 scales the brightness
+    // argument itself, which selects the same LightConvert row); only opacity
+    // is applied here.
+    return vec4f(color.rgb, color.a * params.x);
+}
+
+
+// --- Map-light tint in the original's colour space -------------------------
+// gamemd lights a palette entry by scaling its 8-bit RGB bytes: LightConvert's
+// palette pass (FUN_00556090 -> FUN_007DE200 for RGB565) computes
+// (byte * scale16) >> 16 with scale16 = light_milli * 65536 / 1000 (three LEA x5
+// and a SHL 3 then the double 0.065536 at 0x007ED0B0) and clamps the product to
+// 255 before packing. That multiply happens on the palette bytes, i.e. in
+// sRGB-encoded space. These textures are sRGB-typed, so the sampled value is
+// already linear; multiplying it by the tint here would apply the light in
+// linear space, which reads as tint^(1/2.2) on screen (a 1.2 unit light became
+// ~1.09). Re-encode, scale, clamp, decode. The RGB565 quantisation that
+// follows natively is not modelled (DRIFT, sub-pixel colour).
+fn srgb_encode(c: vec3f) -> vec3f {
+    let lo = c * 12.92;
+    let hi = 1.055 * pow(max(c, vec3f(0.0)), vec3f(1.0 / 2.4)) - 0.055;
+    return select(hi, lo, c <= vec3f(0.0031308));
+}
+fn srgb_decode(c: vec3f) -> vec3f {
+    let lo = c / 12.92;
+    let hi = pow((c + 0.055) / 1.055, vec3f(2.4));
+    return select(hi, lo, c <= vec3f(0.04045));
+}
+fn palette_light(rgb_linear: vec3f, tint: vec3f) -> vec3f {
+    return srgb_decode(clamp(srgb_encode(rgb_linear) * tint, vec3f(0.0), vec3f(1.0)));
 }
 
 @fragment
@@ -102,7 +132,7 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4f {
     // Map lighting happens before the shared DrawState effect branch, matching
     // the voxel fragment path. Alpha 1.0 = opaque; no draw state changes order.
     return apply_fx(
-        vec4f(color.rgb * input.tint, color.a * input.alpha),
+        vec4f(palette_light(color.rgb, input.tint * input.effect_tint.rgb), color.a * input.alpha),
         input.fx_flags,
         input.fx_params,
         input.effect_tint,

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -47,6 +47,7 @@ pub mod native_surface_format;
 pub mod overlay_assets;
 pub mod terrain_instances;
 pub mod overlay_atlas;
+pub mod palette_light;
 pub mod palette_textures;
 pub mod pixel_fx_sparkles;
 pub mod radar_anim;

--- a/src/render/palette_light.rs
+++ b/src/render/palette_light.rs
@@ -1,0 +1,85 @@
+//! Reference for how the original lights a palette entry, kept next to the
+//! shaders that emulate it (`palette_light` in `batch_shader.wgsl`,
+//! `sprite_voxel_shader.wgsl`, `zdepth_shader.wgsl`).
+//!
+//! `LightConvertClass::Constructor` (0x00555DA0) -> `FUN_00556090` builds the
+//! per-format table through `FUN_007DE200` (RGB565) and siblings: for every
+//! palette entry, each 8-bit channel is multiplied by a 16.16 scale
+//! `scale16 = ftol(light_milli * 1000 * 0.065536)` (three `LEA x5` and a `SHL 3`
+//! at 0x00556192..0x0055619B, then the double 0.065536 at 0x007ED0B0), i.e.
+//! `light_milli * 65536 / 1000` so neutral 1000 is exactly 0x10000. It is
+//! shifted right by 16, clamped to 255 when the product overflows a byte, then
+//! packed to the display format. The multiply is on the palette bytes, so it
+//! is a gamma-space scale.
+//!
+//! How a brightness such as Ambient 1.0 + ExtraUnitLight 0.2 reaches that
+//! multiply is by row selection, not by passing 1200: the constructor builds
+//! N rows (0x35 = 53, or 0x1B = 27 when r+g+b < 2000, per 0x00544E70) with
+//! `scale_k = k * 2 * scale16 / (N - 1)`, the colour key itself is clamped to
+//! 0..1000 by 0x00555AC0, and the draw picks a row for its brightness. So 1.2
+//! quantises to row 31 (1.192) or 32 (1.231) of a 53-row table; the row pick
+//! is UNCHECKED here. The shaders apply the exact product instead of a row
+//! (DRIFT: 3.85% brightness steps, 7.7% on 27-row tables) and do not model
+//! the RGB565 packing that follows (DRIFT: up to 3 bits per channel).
+
+/// Native 16.16 scale for a light value in milliunits (1000 = neutral).
+pub fn native_scale16(light_milli: i32) -> i64 {
+    // ftol truncates toward zero under gamemd's chop control word.
+    ((light_milli as f64) * 1000.0 * 0.065536) as i64
+}
+
+/// One palette byte lit the native way: `(byte * scale16) >> 16`, clamped to 255.
+pub fn native_lit_byte(byte: u8, light_milli: i32) -> u8 {
+    let product = byte as i64 * native_scale16(light_milli);
+    if product > 0x00FF_FFFF {
+        255
+    } else {
+        (product >> 16) as u8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn neutral_light_is_identity() {
+        for b in [0u8, 1, 52, 116, 200, 255] {
+            assert_eq!(native_lit_byte(b, 1000), b);
+        }
+    }
+
+    #[test]
+    fn table_scale_is_a_byte_multiply() {
+        // Native table arithmetic for a 1.2 scale (what the shader now applies;
+        // the native row pick would land on 1.192 or 1.231, see the module doc).
+        // Retail Iron Gull container top: unittem index 106 red byte 116 reads
+        // ~139-144 in a gamemd capture at Ambient 1.0 + ExtraUnitLight 0.2.
+        assert_eq!(native_lit_byte(116, 1200), 139);
+        // Hull grey 52 (index 56) -> 62.
+        assert_eq!(native_lit_byte(52, 1200), 62);
+        // A linear-space multiply would give only ~1.09x on these bytes.
+    }
+
+    #[test]
+    fn overflow_clamps_to_white() {
+        assert_eq!(native_lit_byte(255, 1200), 255);
+        assert_eq!(native_lit_byte(220, 2000), 255);
+    }
+
+    #[test]
+    fn shaders_declare_the_same_helper() {
+        for src in [
+            include_str!("batch_shader.wgsl"),
+            include_str!("sprite_voxel_shader.wgsl"),
+            include_str!("zdepth_shader.wgsl"),
+        ] {
+            assert!(src.contains("fn palette_light(rgb_linear: vec3f, tint: vec3f)"));
+            assert!(
+                src.contains("palette_light(")
+                    && !src.contains("rgb * in.tint")
+                    && !src.contains("color.rgb * input.tint")
+            );
+        }
+    }
+}

--- a/src/render/sprite_voxel_shader.wgsl
+++ b/src/render/sprite_voxel_shader.wgsl
@@ -7,14 +7,14 @@
 //   if (16 <= byte < 32) → rgb = house_ramp[house_idx][byte - 16]
 //   else                 → rgb = palette[byte]
 //   color = apply_fx(color, fx_flags, fx_params, effect_tint);
-//   return rgb * tint, alpha;
+//   return palette_light(rgb, tint), alpha;  (tint applied in sRGB byte space)
 //
 // Bind groups:
 //   group 0: camera uniform
 //   group 1: atlas (R8Uint)
 //   group 2: palette (Rgba8UnormSrgb) + house_ramp (Rgba8UnormSrgb) + sampler
-//   (sRGB format → sampler returns linear RGB; tint multiply runs in
-//   linear space; sRGB surface re-encodes on output → round-trip identity)
+//   (sRGB format → sampler returns linear RGB; the tint is applied after
+//   re-encoding to sRGB, the space gamemd's LightConvert scales in)
 
 struct Camera {
     screen_size: vec2f,
@@ -101,7 +101,37 @@ fn apply_fx(color: vec4f, _flags: u32, params: vec4f, effect_tint: vec4f) -> vec
     // SHP shader so representation does not affect active visual state.
     // Match the SHP path exactly: selector opacity plus independent YR
     // invulnerability brightness, with no inferred EMP or mirror styling.
-    return vec4f(color.rgb * effect_tint.rgb, color.a * params.x);
+    // Invulnerability/temporal brightness is folded into the gamma-space
+    // light multiply by the caller (natively 0x0070E380 scales the brightness
+    // argument itself, which selects the same LightConvert row); only opacity
+    // is applied here.
+    return vec4f(color.rgb, color.a * params.x);
+}
+
+
+// --- Map-light tint in the original's colour space -------------------------
+// gamemd lights a palette entry by scaling its 8-bit RGB bytes: LightConvert's
+// palette pass (FUN_00556090 -> FUN_007DE200 for RGB565) computes
+// (byte * scale16) >> 16 with scale16 = light_milli * 65536 / 1000 (three LEA x5
+// and a SHL 3 then the double 0.065536 at 0x007ED0B0) and clamps the product to
+// 255 before packing. That multiply happens on the palette bytes, i.e. in
+// sRGB-encoded space. These textures are sRGB-typed, so the sampled value is
+// already linear; multiplying it by the tint here would apply the light in
+// linear space, which reads as tint^(1/2.2) on screen (a 1.2 unit light became
+// ~1.09). Re-encode, scale, clamp, decode. The RGB565 quantisation that
+// follows natively is not modelled (DRIFT, sub-pixel colour).
+fn srgb_encode(c: vec3f) -> vec3f {
+    let lo = c * 12.92;
+    let hi = 1.055 * pow(max(c, vec3f(0.0)), vec3f(1.0 / 2.4)) - 0.055;
+    return select(hi, lo, c <= vec3f(0.0031308));
+}
+fn srgb_decode(c: vec3f) -> vec3f {
+    let lo = c / 12.92;
+    let hi = pow((c + 0.055) / 1.055, vec3f(2.4));
+    return select(hi, lo, c <= vec3f(0.04045));
+}
+fn palette_light(rgb_linear: vec3f, tint: vec3f) -> vec3f {
+    return srgb_decode(clamp(srgb_encode(rgb_linear) * tint, vec3f(0.0), vec3f(1.0)));
 }
 
 @fragment
@@ -126,7 +156,7 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
         rgb = textureLoad(palette, palette_coord, 0).rgb;
     }
 
-    var color: vec4f = vec4f(rgb * in.tint, in.alpha);
+    var color: vec4f = vec4f(palette_light(rgb, in.tint * in.effect_tint.rgb), in.alpha);
     color = apply_fx(color, in.fx_flags, in.fx_params, in.effect_tint);
     return color;
 }

--- a/src/render/zdepth_shader.wgsl
+++ b/src/render/zdepth_shader.wgsl
@@ -77,6 +77,32 @@ struct FragOutput {
     @builtin(frag_depth) depth: f32,
 };
 
+
+// --- Map-light tint in the original's colour space -------------------------
+// gamemd lights a palette entry by scaling its 8-bit RGB bytes: LightConvert's
+// palette pass (FUN_00556090 -> FUN_007DE200 for RGB565) computes
+// (byte * scale16) >> 16 with scale16 = light_milli * 65536 / 1000 (three LEA x5
+// and a SHL 3 then the double 0.065536 at 0x007ED0B0) and clamps the product to
+// 255 before packing. That multiply happens on the palette bytes, i.e. in
+// sRGB-encoded space. These textures are sRGB-typed, so the sampled value is
+// already linear; multiplying it by the tint here would apply the light in
+// linear space, which reads as tint^(1/2.2) on screen (a 1.2 unit light became
+// ~1.09). Re-encode, scale, clamp, decode. The RGB565 quantisation that
+// follows natively is not modelled (DRIFT, sub-pixel colour).
+fn srgb_encode(c: vec3f) -> vec3f {
+    let lo = c * 12.92;
+    let hi = 1.055 * pow(max(c, vec3f(0.0)), vec3f(1.0 / 2.4)) - 0.055;
+    return select(hi, lo, c <= vec3f(0.0031308));
+}
+fn srgb_decode(c: vec3f) -> vec3f {
+    let lo = c / 12.92;
+    let hi = pow((c + 0.055) / 1.055, vec3f(2.4));
+    return select(hi, lo, c <= vec3f(0.04045));
+}
+fn palette_light(rgb_linear: vec3f, tint: vec3f) -> vec3f {
+    return srgb_decode(clamp(srgb_encode(rgb_linear) * tint, vec3f(0.0), vec3f(1.0)));
+}
+
 @fragment
 fn fs_main(input: VertexOutput) -> FragOutput {
     let color: vec4f = textureSample(t_sprite, s_sprite, input.uv);
@@ -97,7 +123,7 @@ fn fs_main(input: VertexOutput) -> FragOutput {
     let frag_depth: f32 = clamp(input.base_depth - z_sample * depth_scale, 0.001, 0.999);
 
     var output: FragOutput;
-    output.color = vec4f(color.rgb * input.tint, color.a);
+    output.color = vec4f(palette_light(color.rgb, input.tint), color.a);
     output.depth = frag_depth;
     return output;
 }


### PR DESCRIPTION
Player-visible problem: units and terrain under any non-neutral light read
too close to the unlit palette. With Ambient 1.0 + ExtraUnitLight 0.2 the
retail Iron Gull fixture reads 1.24x the palette bytes (container top
byte 116 -> ~140); VERA read ~1.09x, because the shaders multiplied the
tint against a linear-RGB sample from an sRGB texture.

Native behaviour established: LightConvertClass::Constructor (0x00555DA0)
-> FUN_00556090 -> per-format table builders (FUN_007DE200 for RGB565 and
siblings) multiply each 8-bit palette byte (palettes are shifted <<2 on
load, 0x005454E0) by a 16.16 scale, shift >>16, clamp to 255, then pack.
The scale is light_milli * 1000 * 0.065536 (three LEA x5 and a SHL 3 at
0x00556192..0x0055619B, double at 0x007ED0B0) = light_milli * 65536/1000,
so neutral is exactly 0x10000, under the chop ftol (CW 0x0E7F). The
multiply is on palette bytes, i.e. gamma space. Invulnerability/temporal
brightness (0x0070E380) scales the same brightness argument.

Rust: batch_shader, zdepth_shader and sprite_voxel_shader gain a shared
palette_light helper: re-encode the sampled linear colour to sRGB, multiply
by the tint (map light x effect tint), clamp, decode. apply_fx keeps only
opacity. src/render/palette_light.rs pins the native table arithmetic
(116 x 1.2 -> 139, 52 -> 62, overflow -> 255) and a test checks all three
shaders carry the helper and no linear tint multiply remains.

Recorded DRIFT (not modelled): the native draw selects a table row, so a
brightness quantises to k*2/(N-1) of 53 or 27 rows (1.2 -> 1.192 or
1.231); RGB565 packing (up to 3 bits per channel); the MMX branch's 4-bit
scale truncation. Which row a given brightness selects is UNCHECKED.

Review: an independent read-only critic verified the constant bytes, the
byte range, the clamp, the ftol control word and the row structure, and
asked for the effect-tint fold and the row-selection wording, both applied.
cargo test -p vera20k --lib: 8472 passed; 0 failed; 81 ignored.
