### PR TITLE
Spawn the ship wake like the drive locomotor: moving now, every 10 frames, at the hull

### DIFF
--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -5686,6 +5686,58 @@ impl Simulation {
     /// tooling advance exclusively through `SimRuntime::advance_frame`, whose
     /// resources are bound at construction and cannot be substituted per call.
     #[cfg(test)]
+    /// `DriveLocomotionClass::Process` (0x004B0823 region; ships share the
+    /// drive locomotor's process, hover runs the same test in its `Move` at
+    /// 0x00514AC3) spawns `Rules->Wake` (Rules+0x94) when `Is_Moving_Now`
+    /// (vtable +0x80) holds, `g_CurrentFrameCounter % 10 == 0`, the unit is
+    /// not on a bridge (`+0x8C`), and its cell's `CellClass+0xEC` land type is
+    /// 2 (Water). The anim goes at the unit's exact `PositionCoord`
+    /// (+0xA0/+0xA4), not the cell centre, so each wake stays where the hull
+    /// was and the trail forms behind it as the unit advances. The earlier
+    /// form here spawned every 8 frames at the cell centre for any unit with
+    /// a movement target, which put the foam mid-hull and under stationary
+    /// ships.
+    pub(crate) fn spawn_wakes_for_frame(&mut self, rules: &RuleSet) {
+        if self.session.binary_frame % 10 != 0 {
+            return;
+        }
+        let binary_frame = self.session.binary_frame;
+        let terrain = self.resolved_terrain.as_ref();
+        let wake_positions: Vec<(u16, u16, SimFixed, SimFixed, u8)> = self
+            .substrate
+            .entities
+            .keys_sorted()
+            .iter()
+            .filter_map(|id| wake_anchor_for(self.substrate.entities.get(*id)?, terrain, binary_frame))
+            .collect();
+        if wake_positions.is_empty() {
+            return;
+        }
+        let wake_name_str = &rules.general.wake.name;
+        let wake_rate = rules.general.wake.frame_delay;
+        let wake_frames = rules.effect_frame_count(wake_name_str).unwrap_or(8);
+        let wake_id = self.interner.intern(wake_name_str);
+        for (rx, ry, sub_x, sub_y, z) in wake_positions {
+            self.world_effects.push(WorldEffect {
+                anim_spawn: None,
+                shp_name: wake_id,
+                rx,
+                ry,
+                sub_x,
+                sub_y,
+                z,
+                frame: 0,
+                total_frames: wake_frames,
+                frame_delay: wake_rate,
+                elapsed_frames: 0,
+                translucent: true,
+                delay_frames: 0,
+                start_sound_id: None,
+                start_sound_emitted: false,
+            });
+        }
+    }
+
     pub(crate) fn advance_tick(
         &mut self,
         commands: &[CommandEnvelope],
@@ -5925,54 +5977,10 @@ impl Simulation {
             crate::sim::aircraft::tick_aircraft_missions(self, rules, active_path_grid);
         }
 
-        // Spawn wake effects behind moving ships on water (every 8 native frames).
-        if self.session.binary_frame & 7 == 0 {
-            if let Some(rules) = rules {
-                let wake_name_str = &rules.general.wake.name;
-                let wake_rate = rules.general.wake.frame_delay;
-                let wake_frames = rules.effect_frame_count(wake_name_str).unwrap_or(8);
-                // Collect positions to avoid borrow conflict (read entities, write world_effects).
-                let wake_positions: Vec<(u16, u16, u8)> = self
-                    .substrate
-                    .entities
-                    .keys_sorted()
-                    .iter()
-                    .filter_map(|id| {
-                        let e = self.substrate.entities.get(*id)?;
-                        if e.movement_target.is_none() {
-                            return None;
-                        }
-                        let loco = e.locomotor.as_ref()?;
-                        let is_water_mover = loco.movement_zone.is_water_mover();
-                        if !is_water_mover {
-                            return None;
-                        }
-                        Some((e.position.rx, e.position.ry, e.position.z))
-                    })
-                    .collect();
-                if !wake_positions.is_empty() {
-                    let wake_id = self.interner.intern(wake_name_str);
-                    for (rx, ry, z) in wake_positions {
-                        self.world_effects.push(WorldEffect {
-                            anim_spawn: None,
-                            shp_name: wake_id,
-                            rx,
-                            ry,
-                            sub_x: crate::util::lepton::CELL_CENTER_LEPTON,
-                            sub_y: crate::util::lepton::CELL_CENTER_LEPTON,
-                            z,
-                            frame: 0,
-                            total_frames: wake_frames,
-                            frame_delay: wake_rate,
-                            elapsed_frames: 0,
-                            translucent: true,
-                            delay_frames: 0,
-                            start_sound_id: None,
-                            start_sound_emitted: false,
-                        });
-                    }
-                }
-            }
+        // Wake anims under moving units on water (native gate and cadence in
+        // `spawn_wakes_for_frame`).
+        if let Some(rules) = rules {
+            self.spawn_wakes_for_frame(rules);
         }
 
         // --- Phase 3: Vision refresh ---
@@ -6707,3 +6715,29 @@ mod radar_dirty_ack_tests;
 #[cfg(test)]
 #[path = "bridge_parity_harness_tests.rs"]
 mod bridge_parity_harness_tests;
+
+/// The wake gate for one unit this frame: moving now, not on a bridge, on a
+/// cell whose `CellClass+0xEC` mirror is Water, anchored at its exact leptons.
+pub(crate) fn wake_anchor_for(
+    entity: &crate::sim::game_entity::GameEntity,
+    terrain: Option<&ResolvedTerrainGrid>,
+    binary_frame: u32,
+) -> Option<(u16, u16, SimFixed, SimFixed, u8)> {
+    if !crate::sim::movement::ready_producer::is_moving_now_for(entity, binary_frame) {
+        return None;
+    }
+    if entity.is_on_bridge_layer() {
+        return None;
+    }
+    let cell = terrain?.cell(entity.position.rx, entity.position.ry)?;
+    if cell.yr_cell_land_type != crate::rules::terrain_rules::LandType::Water.as_index() {
+        return None;
+    }
+    Some((
+        entity.position.rx,
+        entity.position.ry,
+        entity.position.sub_x,
+        entity.position.sub_y,
+        entity.position.z,
+    ))
+}

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -465,13 +465,42 @@ fn app_and_headless_frames_hash_identically_for_particle_frame_timing() {
 
 #[test]
 fn moving_water_unit_spawns_rules_bound_wake_without_preinterned_effect_name() {
-    let mut rules = naval_bridge_test_rules();
+    // A drive-family boat: the native wake gate is the drive locomotor's
+    // `Is_Moving_Now` slot, so the fixture names the Drive locomotor.
+    let ini: IniFile = IniFile::from_str(
+        "[InfantryTypes]
+
+         [VehicleTypes]
+0=BOAT
+
+         [AircraftTypes]
+
+         [BuildingTypes]
+
+         [BOAT]
+Strength=300
+Armor=heavy
+Speed=6
+MovementZone=Water
+SpeedType=Float
+Naval=yes
+         Locomotor={4A582741-9839-11d1-B709-00A024DDAFD1}
+",
+    );
+    let mut rules = RuleSet::from_ini(&ini).expect("drive boat rules should parse");
     rules.set_effect_frame_count_for_test("WAKE1", 5, 5);
     let mut sim = Simulation::new();
     let boat_id = sim
         .spawn_object("BOAT", "Americans", 0, 0, 64, &rules, &empty_heights())
         .expect("spawn boat");
     assert!(sim.interner.get("WAKE1").is_none());
+    // The native gate reads CellClass+0xEC == 2 (Water); the fixture's water
+    // grid carries land type 4 for movement, so stamp the binary's mirror.
+    let mut terrain = water_terrain(2, 1);
+    for cell in &mut terrain.cells {
+        cell.yr_cell_land_type = crate::rules::terrain_rules::LandType::Water.as_index();
+    }
+    sim.resolved_terrain = Some(terrain);
     let boat = sim
         .substrate
         .entities
@@ -488,18 +517,62 @@ fn moving_water_unit_spawns_rules_bound_wake_without_preinterned_effect_name() {
         move_dir_len: SimFixed::from_num(256),
         ..Default::default()
     });
+    // The native gate is the locomotor's `Is_Moving_Now` slot: a live
+    // destination/head-to coordinate and a positive owner speed.
+    {
+        let ahead = crate::sim::components::DriveCoord {
+            x: 256 + 128,
+            y: 128,
+            z: 0,
+        };
+        // BOAT carries no Locomotor= key, so it runs the drive family; its
+        // runtime is created lazily by the first movement step, so seed it.
+        let drive = boat
+            .drive_locomotion
+            .get_or_insert_with(crate::sim::components::DriveLocomotionRuntime::default);
+        drive.destination = Some(ahead);
+        drive.head_to = Some(ahead);
+        drive.owner_current_speed = 256;
+    }
 
-    let result = sim.advance_tick(
-        &[],
-        Some(&rules),
-        &empty_heights(),
-        Some(&PathGrid::new(2, 1)),
-        None,
-        67,
+    // The movement step of a full tick would rewrite the drive runtime from
+    // the fixture's (non-)motion, so exercise the spawn owner directly at a
+    // frame the native cadence accepts.
+    assert_eq!(sim.session.binary_frame % 10, 0);
+    sim.spawn_wakes_for_frame(&rules);
+    let wake = sim.world_effects.first().expect("wake effect").clone();
+    // Exact lepton position, not the cell centre (native `PositionCoord`).
+    let boat_after = sim.substrate.entities.get(boat_id).expect("boat");
+    assert_eq!(
+        (wake.rx, wake.ry),
+        (boat_after.position.rx, boat_after.position.ry)
     );
-
-    assert!(result.frame_committed);
-    let wake = sim.world_effects.first().expect("wake effect");
+    assert_eq!(
+        (wake.sub_x, wake.sub_y),
+        (boat_after.position.sub_x, boat_after.position.sub_y)
+    );
+    // Stationary (owner speed 0) or off-cadence frames spawn nothing.
+    sim.world_effects.clear();
+    sim.session.binary_frame = 5;
+    sim.spawn_wakes_for_frame(&rules);
+    assert!(
+        sim.world_effects.is_empty(),
+        "off-cadence frame must not spawn"
+    );
+    sim.session.binary_frame = 10;
+    sim.substrate
+        .entities
+        .get_mut(boat_id)
+        .expect("boat")
+        .drive_locomotion
+        .as_mut()
+        .expect("drive runtime")
+        .owner_current_speed = 0;
+    sim.spawn_wakes_for_frame(&rules);
+    assert!(
+        sim.world_effects.is_empty(),
+        "a unit that is not moving now casts no wake"
+    );
     assert_eq!(sim.interner.resolve(wake.shp_name), "WAKE1");
     assert_eq!(wake.total_frames, 5);
 }
@@ -1740,7 +1813,13 @@ fn gsi_04_07_damage_fatal_transport_lifecycle_brackets_nested_death_weapon() {
     let attacker = fatal.substrate.entities.get(20).unwrap();
     assert!(!attacker.radio_contacts.contains(10));
     assert!(attacker.attack_target.is_none());
-    assert!(result.consequences.effects().immediate_uninit_ids.is_empty());
+    assert!(
+        result
+            .consequences
+            .effects()
+            .immediate_uninit_ids
+            .is_empty()
+    );
     assert_eq!(
         fatal.overlay_grid.as_ref().unwrap().cell(8, 5).overlay_id,
         None
@@ -1777,7 +1856,13 @@ fn gsi_04_07_damage_fatal_transport_lifecycle_brackets_nested_death_weapon() {
         assert_eq!(listener.health.current, listener.health.max);
         assert_eq!(listener.last_attacker_id, None);
     }
-    assert!(boundary_result.consequences.effects().under_attack_events.is_empty());
+    assert!(
+        boundary_result
+            .consequences
+            .effects()
+            .under_attack_events
+            .is_empty()
+    );
     assert_eq!(
         boundary
             .substrate
@@ -1889,8 +1974,20 @@ fn gsi_04_11_bullet_ore_reduction_precedes_outer_crater_anim_start() {
             .is_some(),
         "the outer crater must observe the already-cleared overlay cell"
     );
-    assert!(result.consequences.effects().tiberium_reduction_requests.is_empty());
-    assert!(result.consequences.effects().smudge_spawn_requests.is_empty());
+    assert!(
+        result
+            .consequences
+            .effects()
+            .tiberium_reduction_requests
+            .is_empty()
+    );
+    assert!(
+        result
+            .consequences
+            .effects()
+            .smudge_spawn_requests
+            .is_empty()
+    );
     let mut expected_rng = crate::sim::rng::SimRng::new(1);
     let _ = expected_rng.next_range_u32(1);
     assert_eq!(sim.scenario_rng.state(), expected_rng.state());
@@ -1964,8 +2061,20 @@ fn gsi_04_11_missile_outer_anim_precedes_per_cell_ore_reduction() {
         "RocketLocomotion starts its crater Anim before the later ore sweep"
     );
     assert_eq!(sim.scenario_rng.state(), before_rng);
-    assert!(result.consequences.effects().tiberium_reduction_requests.is_empty());
-    assert!(result.consequences.effects().smudge_spawn_requests.is_empty());
+    assert!(
+        result
+            .consequences
+            .effects()
+            .tiberium_reduction_requests
+            .is_empty()
+    );
+    assert!(
+        result
+            .consequences
+            .effects()
+            .smudge_spawn_requests
+            .is_empty()
+    );
 }
 
 #[test]


### PR DESCRIPTION
Player-visible problem: the wake foam appeared mid-hull and under
stationary ships, at the wrong rhythm.

Native behaviour established: DriveLocomotionClass::Process (0x004B0823
region; ships run the drive locomotor's process, Hover repeats the test in
its Move at 0x00514AC3) spawns Rules->Wake (Rules+0x94) when Is_Moving_Now
(vtable +0x80) holds, g_CurrentFrameCounter % 10 == 0, the unit is not on
a bridge (+0x8C), and its cell's CellClass+0xEC land type is 2 (Water).
The anim is placed at the unit's exact PositionCoord (+0xA0/+0xA4).

Rust: the spawn moves into Simulation::spawn_wakes_for_frame with the
gate in wake_anchor_for: locomotor Is_Moving_Now producer, bridge layer,
resolved cell yr_cell_land_type == Water, cadence % 10, anchored at the
entity's sub-cell leptons instead of the cell centre. The old form fired
every 8 frames at the cell centre for any water-zone unit holding a
movement target.

Test: a drive boat with a live head-to and positive owner speed on a
Water-mirror cell spawns the rules-bound wake at its exact position;
off-cadence frames and owner speed 0 spawn nothing. The moving-now state
is seeded directly because the fixture's movement step does not move the
boat.
