### PR TITLE
Cast ground shadows for voxel vehicles and ships

### DIFF
--- a/src/app/presentation/instances/units.rs
+++ b/src/app/presentation/instances/units.rs
@@ -18,7 +18,7 @@ use crate::map::entities::EntityCategory;
 use crate::map::lighting;
 use crate::map::terrain::{TILE_HEIGHT, TILE_WIDTH};
 use crate::render::batch::SpriteInstance;
-use crate::render::draw_state::{DrawState, ObserverDrawContext};
+use crate::render::draw_state::{DrawState, FX_SHADOW, ObserverDrawContext};
 use crate::render::sprite_atlas::ShpSpriteKey;
 use crate::render::unit_atlas::{
     UnitSpriteEntry, UnitSpriteKey, VxlLayer, canonical_turret_facing, canonical_unit_facing,
@@ -260,15 +260,21 @@ pub(crate) fn build_unit_instances(
     ground_objects: &mut Vec<PlannedGroundObjectInstance>,
     ground_order: &NativeGroundOrder,
 ) {
-    let (sim, atlas) = match (state.match_state.sim_runtime.as_ref().map(|rt| &rt.simulation), &state.match_state.match_presentation.unit_atlas) {
+    let (sim, atlas) = match (
+        state
+            .match_state
+            .sim_runtime
+            .as_ref()
+            .map(|rt| &rt.simulation),
+        &state.match_state.match_presentation.unit_atlas,
+    ) {
         (Some(s), Some(a)) => (s, a),
         _ => return,
     };
     let z = state.match_state.input.zoom_level;
     // Presentation runs after the just-completed simulation frame; snapshot
     // the one binary frame used by every Drive/Ship Draw_Matrix in this pass.
-    let display_binary_frame =
-        display_binary_frame_for_committed_session(sim.session.binary_frame);
+    let display_binary_frame = display_binary_frame_for_committed_session(sim.session.binary_frame);
     let (cam_x, cam_y, sw, sh) = (
         state.match_state.input.camera_x,
         state.match_state.input.camera_y,
@@ -278,10 +284,10 @@ pub(crate) fn build_unit_instances(
     let local_owner = crate::app::input::commands::preferred_local_owner_name(state);
     let local_owner_id = local_owner.as_deref().and_then(|o| sim.interner.get(o));
     let ignore_visibility = state.match_state.sandbox_full_visibility;
-    let art_reg: Option<&crate::rules::art_data::ArtRegistry> = state.rules().map(|rules| &rules.art_registry);
+    let art_reg: Option<&crate::rules::art_data::ArtRegistry> =
+        state.rules().map(|rules| &rules.art_registry);
 
-    let encounter_order =
-        super::helpers::tactical_entity_encounter_order(sim, state.rules());
+    let encounter_order = super::helpers::tactical_entity_encounter_order(sim, state.rules());
     for stable_id in encounter_order {
         let Some(entity) = sim.entities().get(stable_id) else {
             continue;
@@ -298,7 +304,8 @@ pub(crate) fn build_unit_instances(
         // miner dock sub-FSM's UnloadingClass (HORV/CMON) hint.
         let active_disguise = entity.disguise.as_ref().filter(|state| state.disguised);
         let base_type = sim.interner.resolve(entity.type_ref());
-        let no_spawn_alt = state.rules()
+        let no_spawn_alt = state
+            .rules()
             .and_then(|rules| rules.object(base_type))
             .is_some_and(|object| object.no_spawn_alt);
         let no_spawn_alt_type =
@@ -325,7 +332,9 @@ pub(crate) fn build_unit_instances(
             .map(|id| sim.interner.resolve(id))
             .unwrap_or(owner_str);
         let hc: HouseColorIndex = state
-            .match_state.match_presentation.house_color_map
+            .match_state
+            .match_presentation
+            .house_color_map
             .get(remap_owner)
             .copied()
             .unwrap_or_default();
@@ -362,9 +371,11 @@ pub(crate) fn build_unit_instances(
             state.match_state.match_presentation.lighting.grid(),
             (pos.rx, pos.ry),
             entity.category,
-            state.rules()
+            state
+                .rules()
                 .map_or(0, |rules| rules.general.extra_unit_light),
-            state.rules()
+            state
+                .rules()
                 .map_or(0, |rules| rules.general.extra_aircraft_light),
         );
         let center_x: f32 = sx;
@@ -453,6 +464,24 @@ pub(crate) fn build_unit_instances(
             {
                 let depth_y: f32 = sy + entry.offset_y + entry.pixel_size[1] + dock_depth_y_offset;
                 let depth: f32 = body_sort_depth(state, entity, band, depth_y, interp_z);
+                emit_unit_shadow_sprite(
+                    target_instances,
+                    target_instance_pages,
+                    atlas,
+                    entity,
+                    type_str,
+                    center_x,
+                    center_y,
+                    depth,
+                    draw_state,
+                    slope_state,
+                    transition_instances,
+                    bridge_transition_instances,
+                    is_bridge_unit,
+                    band,
+                    collect_ground,
+                    &mut ground_pieces,
+                );
                 let sprite = SpriteInstance {
                     position: [center_x + entry.offset_x, center_y + entry.offset_y],
                     size: entry.pixel_size,
@@ -513,7 +542,8 @@ pub(crate) fn build_unit_instances(
                 z: i32::from(pos.z),
             };
             let parent = if entity.category == EntityCategory::Structure {
-                state.rules()
+                state
+                    .rules()
                     .and_then(|rules| rules.object(sim.interner.resolve(entity.type_ref())))
                     .and_then(|object_type| {
                         ground_order.building_object_draw(
@@ -673,8 +703,11 @@ fn unit_entry_for_slope_state(
 ) -> Option<(UnitSpriteEntry, UnitTextureSource)> {
     if let Some(transition_key) = transition_key_for_unit(key, slope_state) {
         if let Some(asset_manager) = state.process_assets.manager() {
-            if let Some(TransitionUnitSpriteEntry { page, entry }) =
-                state.renderer.vxl_slope_transition_cache.borrow_mut().get_or_render(
+            if let Some(TransitionUnitSpriteEntry { page, entry }) = state
+                .renderer
+                .vxl_slope_transition_cache
+                .borrow_mut()
+                .get_or_render(
                     &state.renderer.gpu,
                     &state.renderer.batch_renderer,
                     asset_manager,
@@ -702,6 +735,86 @@ fn push_transition_sprite(
         transition_instances.resize_with(page + 1, Vec::new);
     }
     transition_instances[page].push(sprite);
+}
+
+/// The hull's ground shadow as one more piece of the unit's draw.
+///
+/// Natively the shadow is the *last* call of `UnitClass::DrawVoxelBody`
+/// (0x0073C5C4, after every `Draw_Voxel` and the composite blit) and its
+/// blitter is Z-tested against the body's depth, so the hull is never darkened
+/// by its own shadow. This pipeline writes no depth for sprites, so the same
+/// result is had by emitting the shadow first and letting the body paint over
+/// it. `Techno_Draw_Voxel_Shadow` (0x00706BD0) returns for any cloak state,
+/// so cloaking, cloaked and uncloaking units cast none. Ground-band vehicles
+/// and ships only: aircraft shadows follow FlyLocomotion's own matrix and drop
+/// point, which are not modelled yet, and structures' voxel turrets cast none.
+/// The stencil lives in the unit atlas under `VxlLayer::Shadow` (frame 0, same
+/// facing and slope as the body) and is drawn through the voxel pipeline with
+/// `FX_SHADOW`, untinted.
+///
+/// Residual (VERA-internal, gamemd equivalent UNCHECKED): with no depth
+/// writes, a later unit's shadow darkens any earlier unit's body it overlaps;
+/// whether the native Z-tested shadow blit would also darken a farther body
+/// depends on the body blit's Z writes, which were not read.
+#[allow(clippy::too_many_arguments)]
+fn emit_unit_shadow_sprite(
+    stable_instances: &mut Vec<SpriteInstance>,
+    stable_instance_pages: &mut Vec<usize>,
+    atlas: &crate::render::unit_atlas::UnitAtlas,
+    entity: &crate::sim::game_entity::GameEntity,
+    type_id: &str,
+    center_x: f32,
+    center_y: f32,
+    depth: f32,
+    draw_state: DrawState,
+    slope_state: UnitRenderSlopeState,
+    transition_instances: &mut Vec<Vec<SpriteInstance>>,
+    bridge_transition_instances: &mut Vec<Vec<SpriteInstance>>,
+    is_bridge_unit: bool,
+    band: EntityDrawBand,
+    collect_ground: bool,
+    ground_pieces: &mut Vec<GroundPieceInstance>,
+) {
+    if entity.category != EntityCategory::Unit || band != EntityDrawBand::Ground {
+        return;
+    }
+    if draw_state.fx_flags & crate::render::draw_state::FX_CLOAK != 0 {
+        return;
+    }
+    let key = UnitSpriteKey {
+        type_id: type_id.to_string(),
+        facing: canonical_unit_facing(entity.facing),
+        layer: VxlLayer::Shadow,
+        frame: 0,
+        slope_type: stable_slope_for_key(slope_state),
+    };
+    let Some(entry) = atlas.get(&key).copied() else {
+        return;
+    };
+    let mut shadow_state: DrawState = draw_state;
+    shadow_state.fx_flags |= FX_SHADOW;
+    let sprite = SpriteInstance {
+        position: [center_x + entry.offset_x, center_y + entry.offset_y],
+        size: entry.pixel_size,
+        uv_origin: entry.uv_origin,
+        uv_size: entry.uv_size,
+        depth,
+        tint: lighting::DEFAULT_TINT,
+        alpha: 1.0,
+        draw_state: shadow_state,
+        ..Default::default()
+    };
+    push_unit_sprite(
+        stable_instances,
+        stable_instance_pages,
+        transition_instances,
+        bridge_transition_instances,
+        is_bridge_unit,
+        UnitTextureSource::Stable(entry.page),
+        sprite,
+        collect_ground,
+        ground_pieces,
+    );
 }
 
 fn push_unit_sprite(
@@ -814,6 +927,27 @@ fn emit_turret_unit_sprites(
         None => center_y + dock_depth_y_offset,
     };
     let entity_depth: f32 = body_sort_depth(state, entity, band, entity_depth_y, z);
+
+    // The hull's ground shadow goes down first, then body, turret, barrel (see
+    // `emit_unit_shadow_sprite` for why first rather than the native last).
+    emit_unit_shadow_sprite(
+        instances,
+        instance_pages,
+        atlas,
+        entity,
+        type_id,
+        center_x,
+        center_y,
+        entity_depth,
+        draw_state,
+        slope_state,
+        transition_instances,
+        bridge_transition_instances,
+        is_bridge_unit,
+        band,
+        collect_ground,
+        ground_pieces,
+    );
 
     // Emit body first (always). Uses frame fallback for mismatched HVA counts.
     if let Some((entry, texture_source)) = body_entry_opt {
@@ -1117,7 +1251,9 @@ mod tests {
         sim.substrate.entities.insert(entity);
 
         let bytes = GameSnapshot::save(&sim, 1, 2, "slope display selector", 3);
-        let restored = GameSnapshot::load(&bytes).expect("current slope snapshot").sim;
+        let restored = GameSnapshot::load(&bytes)
+            .expect("current slope snapshot")
+            .sim;
         let display_binary_frame =
             display_binary_frame_for_committed_session(restored.session.binary_frame);
         assert_eq!(display_binary_frame, 50);

--- a/src/app/presentation/render/draw_passes.rs
+++ b/src/app/presentation/render/draw_passes.rs
@@ -139,14 +139,14 @@ pub(super) fn dispatch_draw_passes(
 
     // --- Step 3.5: Overlay shadows — bridge decks ---
     //
-    // **This is the only shadow pass in the renderer.** GSI-13.11 covers three
-    // — ground, object and voxel — and the other two do not exist: a
-    // repo-wide search finds no shadow instance emission for infantry,
-    // vehicles, buildings or aircraft, and no voxel shadow in any shader. So
-    // every tank, soldier, structure and plane in an ordinary skirmish is
-    // missing its ground shadow. Recorded, not closed. Trigger: every frame
-    // with any unit or building on screen. Player effect: the scene reads flat
-    // against retail, which shadows every object. Frequency: continuous.
+    // **This is the only separate shadow pass in the renderer.** GSI-13.11
+    // covers three — ground, object and voxel. Voxel ground vehicles and ships
+    // now cast their shadow as the first piece of their own draw (see
+    // `instances::units::emit_unit_shadow_sprite`, `VxlLayer::Shadow`).
+    // Still missing: infantry and SHP vehicle shadow halves, building shadows,
+    // and aircraft (FlyLocomotion shadow matrix/point). Recorded, not closed.
+    // Trigger: every frame with such an object on screen. Player effect: those
+    // objects read flat against retail. Frequency: continuous.
     // Downstream risk: the SHP-blitter contract the bridge path already honours
     // (1-bit stencil half, composited darken) is the shape the object pass has
     // to reuse, and `BRIDGE_SHADOW_DARKEN_ALPHA` already carries its own

--- a/src/render/draw_state.rs
+++ b/src/render/draw_state.rs
@@ -23,6 +23,10 @@ pub const FX_WARP: u32 = 1 << 3;
 /// Explicit residual: no dedicated YR mirror material mutation is proven.
 pub const FX_MIRROR: u32 = 1 << 4;
 pub const FX_DISGUISE: u32 = 1 << 5;
+/// The instance is a ground shadow stencil (`VxlLayer::Shadow`): the voxel
+/// sprite shader ignores the palette and darkens whatever is beneath, the way
+/// the native shadow blitter (`Blitter_selector(0x2001)`) does.
+pub const FX_SHADOW: u32 = 1 << 6;
 
 /// Native cloak state values consumed by YR draw selection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/render/sprite_voxel_shader.wgsl
+++ b/src/render/sprite_voxel_shader.wgsl
@@ -145,6 +145,16 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4f {
         discard;
     }
 
+    // Ground shadow stencil (FX_SHADOW = 1 << 6): every non-zero atlas byte
+    // darkens the destination. The native darken blitter halves the encoded
+    // 16-bit word; this pass alpha-blends black in linear space against an
+    // sRGB target, so the alpha that halves an encoded value is
+    // 1 - 0.5^2.2 = 0.782 rather than 0.5 (the bridge shadow's 128/255 is a
+    // recorded lighter drift; this path takes the closer value).
+    if ((in.fx_flags & 64u) != 0u) {
+        return vec4f(0.0, 0.0, 0.0, 0.782 * in.alpha);
+    }
+
     // RGB substitution: bytes in [16, 32) sample the per-house ramp; all
     // others sample the theater palette directly.
     var rgb: vec3f;

--- a/src/render/unit_atlas.rs
+++ b/src/render/unit_atlas.rs
@@ -258,6 +258,12 @@ fn seed_unit_variant_keys(
             is_ground_vehicle,
         );
     }
+    // Ground vehicles and ships cast a voxel shadow (one frame, every facing
+    // and slope). Aircraft use FlyLocomotion's own shadow matrix and point,
+    // which are not modelled yet, so they get none (recorded residual).
+    if is_ground_vehicle {
+        insert_unit_layer_keys(needed, &variant.type_id, VxlLayer::Shadow, 1, true);
+    }
 }
 
 /// Collect the set of unit sprite keys needed by the current ECS world.
@@ -736,6 +742,7 @@ pub(crate) fn render_unit_sprite_with_slope_blend(
             VxlLayer::Composite => {
                 composite_unit_vxl_cpu(asset_manager, &vxl, hva.as_ref(), &image, &params, vpl)
             }
+            VxlLayer::Shadow => vxl_raster::render_vxl_shadow(&vxl, hva.as_ref(), &params),
             VxlLayer::Body | VxlLayer::Turret | VxlLayer::Barrel => {
                 let body_sprite: VxlSprite =
                     vxl_raster::render_vxl(&vxl, hva.as_ref(), &params, vpl);
@@ -1006,7 +1013,9 @@ pub fn canonical_turret_facing(facing_u16: u16) -> u8 {
 /// Get the facing quantization step and bucket count for a given VxlLayer.
 fn facing_config_for_layer(layer: VxlLayer) -> (u8, u16) {
     match layer {
-        VxlLayer::Body | VxlLayer::Composite => (UNIT_FACING_STEP, UNIT_FACING_BUCKETS),
+        VxlLayer::Body | VxlLayer::Composite | VxlLayer::Shadow => {
+            (UNIT_FACING_STEP, UNIT_FACING_BUCKETS)
+        }
         VxlLayer::Turret | VxlLayer::Barrel => (TURRET_FACING_STEP, TURRET_FACING_BUCKETS),
     }
 }

--- a/src/render/unit_atlas_tests.rs
+++ b/src/render/unit_atlas_tests.rs
@@ -339,6 +339,7 @@ fn test_facing_config_for_layer() {
         VxlLayer::Composite,
         VxlLayer::Turret,
         VxlLayer::Barrel,
+        VxlLayer::Shadow,
     ] {
         let (step, buckets) = super::facing_config_for_layer(layer);
         assert_eq!(step, 8, "{layer:?} facing step");

--- a/src/render/vxl_raster.rs
+++ b/src/render/vxl_raster.rs
@@ -366,6 +366,9 @@ fn axis_order(size: u8, depth_contribution: f32) -> AxisIter {
 pub struct LimbRenderData {
     pub grid: Vec<PackedVoxel>,
     pub combined: Mat4,
+    /// `slope × body facing × section` — the draw matrix before the camera,
+    /// kept so the shadow bake can flatten in world space.
+    pub model_to_world: Mat4,
     pub vpl_pages: [u8; 256],
     pub normals_mode: u8,
     pub size_x: u8,
@@ -545,6 +548,7 @@ pub fn prepare_limb_data(
         limb_data.push(LimbRenderData {
             grid,
             combined,
+            model_to_world: slope_mat * body_facing * section_transform,
             vpl_pages,
             normals_mode: limb.normals_mode,
             size_x: limb.size_x,
@@ -554,6 +558,137 @@ pub fn prepare_limb_data(
     }
 
     (limb_data, max_footprint)
+}
+
+/// Stencil value written for shadow pixels; the voxel sprite shader only tests
+/// non-zero when `FX_SHADOW` is set, so the value itself is not a palette index.
+pub const SHADOW_STENCIL_INDEX: u8 = 1;
+
+/// Screen-space shift of the shadow footprint, in pixels.
+///
+/// `VXL_LightDirection_Setup` (0x00754C00) stores, next to the light vector,
+/// `(-6 × light.x, 0, 0)` at 0x00887420 (constant -6.0 at 0x007F6950): the
+/// voxel shadow light vector. With the binary's light.x = -0.5 that is
+/// (3, 0, 0), added to every flattened corner after the camera transform and
+/// before the Y flip in `VXL_Submit_Billboard` (0x00753F90), i.e. three pixels
+/// to the right. Kept as the binary's constant rather than derived from this
+/// renderer's fitted light, whose frame differs (see `vxl_normals`).
+const SHADOW_LIGHT_OFFSET_PX: f32 = 3.0;
+
+/// Ground shadow of a voxel model, the way gamemd draws it.
+///
+/// Native chain: `UnitClass::DrawVoxelBody` (0x0073B470) ends with the shadow
+/// call at 0x0073C5C4 -> `Techno_Draw_Voxel_Shadow` (0x00706BD0; returns for
+/// any cloak state at +0x220 or `NoShadow` at Type+0xD98) ->
+/// `Techno_Render_Voxel_Shadow` (0x00707280), which submits only the hull
+/// voxel (`Type+0xB0`, layer `Type+0x7FC`) with matrix
+/// `IsoView x Shadow_Matrix x HVA(layer, frame 0)`. `Shadow_Matrix`
+/// (Drive 0x004B0410 / Ship, both through `Build_Shadow_Matrix` 0x0055A7D0)
+/// is `VXL_GetFacingMatrix(cell slope byte) x RotateZ(facing quantised to
+/// 32)`: the ordinary draw matrix, no interpolation. `VXL_Submit_Billboard`
+/// (0x00753F90) pushes the section's four z-min bounding-box corners
+/// (tailer +0x40..+0x64) through that matrix, zeroes Z (a no-op for the
+/// screen x/y once the iso view is inside the matrix), transforms by
+/// 0x00887430 (identity), adds the shadow light vector and negates Y;
+/// `VXL_Quad_Rasterizer` (0x00756860) then walks the section's (x, y)
+/// columns (tailer +0xA0/+0xA1, never Z), writing a stencil for every column
+/// whose span table is not -1, mapped by the parallelogram of those corners.
+/// No lighting. The blit halves the encoded 16-bit destination word
+/// (`Blitter_selector(0x2001)` -> 0x00492D20 / cached 0x00496820,
+/// `dst = (dst >> 1) & mask`, Z-tested).
+///
+/// So the native shadow is the hull's bottom face projected through the full
+/// draw matrix: on flat ground a flat footprint, on a ramp a parallelogram
+/// lying on the ramp. This renderer does the same: `camera x model_to_world`
+/// applied to each occupied column's `(x, y, 0)` grid point (grid z = 0 is the
+/// z-min face), shifted by `SHADOW_LIGHT_OFFSET_PX`, plotted with the body's
+/// fill rectangle. Turret and barrel are not part of it; neither is any
+/// `ConsideredAircraft` half-scale (0x00707319, unmodelled) or `NoShadow`
+/// (no stock ground-band user).
+pub fn render_vxl_shadow(
+    vxl: &VxlFile,
+    hva: Option<&HvaFile>,
+    params: &VxlRenderParams,
+) -> VxlSprite {
+    let (limbs, _) = prepare_limb_data(vxl, hva, params);
+    if limbs.is_empty() {
+        return VxlSprite {
+            palette_indices: vec![0u8; 4],
+            depth: Vec::new(),
+            width: 2,
+            height: 2,
+            offset_x: 0.0,
+            offset_y: 0.0,
+        };
+    }
+    let scale: f32 = params.scale;
+    let shift: Mat4 = Mat4::from_translation(Vec3::new(SHADOW_LIGHT_OFFSET_PX, 0.0, 0.0));
+    let camera: Mat4 = voxel_camera_view();
+
+    // Bottom-face limbs: same grids, the full draw matrix, one voxel of height
+    // so the shared bounds routine measures the z-min face's parallelogram.
+    let flat: Vec<LimbRenderData> = limbs
+        .iter()
+        .map(|ld| LimbRenderData {
+            grid: Vec::new(),
+            combined: shift * camera * ld.model_to_world,
+            model_to_world: ld.model_to_world,
+            vpl_pages: ld.vpl_pages,
+            normals_mode: ld.normals_mode,
+            size_x: ld.size_x,
+            size_y: ld.size_y,
+            size_z: 1,
+        })
+        .collect();
+    let mut max_footprint: f32 = 1.0;
+    for ld in &flat {
+        max_footprint = max_footprint.max(compute_voxel_footprint(&ld.combined, scale));
+    }
+    let bounds: SpriteBounds = compute_sprite_bounds(&flat, scale, max_footprint);
+    let width: u32 = bounds.width;
+    let height: u32 = bounds.height;
+    let mut stencil: Vec<u8> = vec![0u8; (width * height) as usize];
+    let fill_size: i32 = bounds.fill_size;
+    let half_fill: i32 = bounds.half_fill;
+
+    for (src, ld) in limbs.iter().zip(flat.iter()) {
+        let sy: usize = src.size_y as usize;
+        let sz: usize = src.size_z as usize;
+        for ix in 0..src.size_x {
+            for iy in 0..src.size_y {
+                let base: usize = ix as usize * sy * sz + iy as usize * sz;
+                if !src.grid[base..base + sz].iter().any(|&v| v != 0) {
+                    continue;
+                }
+                let world: Vec3 = ld
+                    .combined
+                    .transform_point3(Vec3::new(ix as f32, iy as f32, 0.0));
+                let sx_fp: i32 = (world.x * scale * FP_SCALE) as i32;
+                let sy_fp: i32 = (-world.y * scale * FP_SCALE) as i32;
+                let px: i32 = (sx_fp + bounds.buf_off_x_fp) >> FP_SHIFT;
+                let py: i32 = (sy_fp + bounds.buf_off_y_fp) >> FP_SHIFT;
+                for dy in -half_fill..=(fill_size - 1 - half_fill) {
+                    for dx in -half_fill..=(fill_size - 1 - half_fill) {
+                        let fx: i32 = px + dx;
+                        let fy: i32 = py + dy;
+                        if fx < 0 || fy < 0 || fx >= width as i32 || fy >= height as i32 {
+                            continue;
+                        }
+                        stencil[fy as usize * width as usize + fx as usize] = SHADOW_STENCIL_INDEX;
+                    }
+                }
+            }
+        }
+    }
+
+    VxlSprite {
+        palette_indices: stencil,
+        depth: Vec::new(),
+        width,
+        height,
+        offset_x: bounds.offset_x,
+        offset_y: bounds.offset_y,
+    }
 }
 
 /// Compute the sprite bounding box from precomputed limb transforms.
@@ -947,6 +1082,88 @@ mod tests {
         let truly_empty: PackedVoxel = 0;
         assert_eq!(unpack_color(truly_empty), 0);
         assert_eq!(unpack_normal(truly_empty), 0);
+    }
+
+    #[test]
+    fn shadow_marks_every_occupied_column_and_nothing_else() {
+        // The fixture has voxels in columns (1,1) and (0,0) only; the shadow is
+        // those two columns flattened, shifted right, and nothing more.
+        let vxl: VxlFile = make_test_vxl();
+        let params: VxlRenderParams = VxlRenderParams::default();
+        let shadow: VxlSprite = render_vxl_shadow(&vxl, None, &params);
+        let lit: usize = shadow.palette_indices.iter().filter(|&&b| b != 0).count();
+        assert!(lit > 0, "shadow must have pixels");
+        assert!(
+            shadow
+                .palette_indices
+                .iter()
+                .all(|&b| b == 0 || b == SHADOW_STENCIL_INDEX),
+            "shadow bytes are a stencil, not palette indices"
+        );
+        assert!(shadow.depth.is_empty());
+
+        // A model with an empty column casts nothing there: on a wider grid
+        // (8x8x2, columns (0,0) and (7,7) far apart on screen) removing the
+        // (0,0) voxel must shrink the shadow.
+        let mut wide: VxlFile = make_test_vxl();
+        {
+            let limb = &mut wide.limbs[0];
+            limb.size_x = 8;
+            limb.size_y = 8;
+            limb.bounds = [-4.0, -4.0, -1.0, 4.0, 4.0, 1.0];
+            limb.voxels[0].x = 7;
+            limb.voxels[0].y = 7;
+        }
+        let shadow_wide: VxlSprite = render_vxl_shadow(&wide, None, &params);
+        let lit: usize = shadow_wide
+            .palette_indices
+            .iter()
+            .filter(|&&b| b != 0)
+            .count();
+        let mut one: VxlFile = make_test_vxl();
+        {
+            let limb = &mut one.limbs[0];
+            limb.size_x = 8;
+            limb.size_y = 8;
+            limb.bounds = [-4.0, -4.0, -1.0, 4.0, 4.0, 1.0];
+            limb.voxels[0].x = 7;
+            limb.voxels[0].y = 7;
+            limb.voxels.retain(|v| !(v.x == 0 && v.y == 0));
+        }
+        let shadow_one: VxlSprite = render_vxl_shadow(&one, None, &params);
+        let lit_one: usize = shadow_one
+            .palette_indices
+            .iter()
+            .filter(|&&b| b != 0)
+            .count();
+        assert!(lit_one < lit, "{lit_one} vs {lit}");
+    }
+
+    #[test]
+    fn shadow_is_the_bottom_face_through_the_draw_matrix_shifted_right() {
+        // Each occupied column's shadow point is its (x, y, 0) grid point through
+        // camera x model_to_world, plus 3 px right: on a slope the footprint
+        // follows the ramp because the slope matrix is inside model_to_world.
+        let vxl: VxlFile = make_test_vxl();
+        let flat_params: VxlRenderParams = VxlRenderParams::default();
+        let ramp_params: VxlRenderParams = VxlRenderParams {
+            slope_type: 4,
+            ..VxlRenderParams::default()
+        };
+        let (flat_limbs, _) = prepare_limb_data(&vxl, None, &flat_params);
+        let (ramp_limbs, _) = prepare_limb_data(&vxl, None, &ramp_params);
+        let m_flat: Mat4 = voxel_camera_view() * flat_limbs[0].model_to_world;
+        let m_ramp: Mat4 = voxel_camera_view() * ramp_limbs[0].model_to_world;
+        let p_flat: Vec3 = m_flat.transform_point3(Vec3::new(1.0, 1.0, 0.0));
+        let p_ramp: Vec3 = m_ramp.transform_point3(Vec3::new(1.0, 1.0, 0.0));
+        assert!(
+            (p_flat.y - p_ramp.y).abs() > 1e-4,
+            "the ramp must move the bottom face on screen"
+        );
+        let shifted: Mat4 =
+            Mat4::from_translation(Vec3::new(SHADOW_LIGHT_OFFSET_PX, 0.0, 0.0)) * m_flat;
+        let sp: Vec3 = shifted.transform_point3(Vec3::new(1.0, 1.0, 0.0));
+        assert!((sp.x - p_flat.x - 3.0).abs() < 1e-5 && (sp.y - p_flat.y).abs() < 1e-5);
     }
 
     #[test]

--- a/src/sim/components.rs
+++ b/src/sim/components.rs
@@ -588,6 +588,10 @@ pub enum VxlLayer {
     Turret,
     /// Barrel only ({IMAGE}BARL.VXL).
     Barrel,
+    /// Ground shadow of the main voxel: each section's occupied (x, y) columns
+    /// flattened onto z = 0 and shifted by the shadow light vector, always at
+    /// motion frame 0. See `render::vxl_raster::render_vxl_shadow`.
+    Shadow,
 }
 
 /// Per-entity voxel HVA animation state.

--- a/src/sim/voxel_frame_catalog.rs
+++ b/src/sim/voxel_frame_catalog.rs
@@ -139,6 +139,10 @@ pub(crate) fn detect_hva_frame_count(
         VxlLayer::Composite | VxlLayer::Body => art_data::voxel_asset_names(&image).1,
         VxlLayer::Turret => format!("{}TUR.HVA", image),
         VxlLayer::Barrel => format!("{}BARL.HVA", image),
+        // The shadow is rendered from motion frame 0 regardless of the body's
+        // HVA length (`Get_Layer_Matrix(layer, 0)` in the TS shadow path, and
+        // the RA2 shadow key folds only slope and facing: 0x0055A7D0).
+        VxlLayer::Shadow => return 1,
     };
 
     let frame_count: u32 = asset_manager


### PR DESCRIPTION
Player-visible problem: no unit in VERA cast a shadow; only bridge decks
did. Every tank and ship read flat against retail.

Native behaviour established (gamemd.exe): UnitClass::DrawVoxelBody
(0x0073B470) ends at 0x0073C5C4 with the shadow call into
Techno_Draw_Voxel_Shadow (0x00706BD0; returns for any cloak state at
+0x220 and for NoShadow), then Techno_Render_Voxel_Shadow (0x00707280),
which submits the hull voxel only with IsoView x Shadow_Matrix x HVA
frame 0. Shadow_Matrix (Drive 0x004B0410 / Ship, via Build_Shadow_Matrix
0x0055A7D0) is VXL_GetFacingMatrix(cell slope) x RotateZ(facing/32): the
ordinary draw matrix. VXL_Submit_Billboard (0x00753F90) pushes each
section's z-min box corners (tailer +0x40..+0x64) through it, zeroes Z,
transforms by 0x00887430 (identity), adds the shadow light vector at
0x00887420 = (-6 x light.x, 0, 0) = (+3, 0, 0) (constant -6.0 at
0x007F6950), negates Y. VXL_Quad_Rasterizer (0x00756860) walks the
section's (x, y) columns (never Z) and writes a stencil for every column
whose span table is not -1. The blit halves the encoded 16-bit word
(Blitter_selector(0x2001) -> 0x00492D20 / cached 0x00496820), Z-tested.

Rust: VxlLayer::Shadow entries in the unit atlas (frame 0, every facing
and slope, ground vehicles only) baked by vxl_raster::render_vxl_shadow:
each occupied column's (x, y, 0) grid point through camera x
model_to_world, shifted 3 px right, plotted with the body's fill; so on a
ramp the footprint lies on the ramp like the native z-min face. Emitted as
the first piece of the unit's own draw with FX_SHADOW; the voxel sprite
shader then outputs black at alpha 0.782 (= 1 - 0.5^2.2, a halve in
encoded space on the sRGB target). Emitted before the body because this
pipeline writes no sprite depth; natively the shadow is drawn last and its
blitter is Z-tested against the hull. Cloaking/cloaked units cast none.

Recorded residuals: aircraft (FlyLocomotion shadow matrix/point),
infantry/SHP vehicle shadow halves and buildings still cast nothing;
ConsideredAircraft half-scale (0x00707319) and NoShadow unmodelled; a
later unit's shadow darkens an earlier unit's body (native Z behaviour
UNCHECKED); the third Build_Shadow_Matrix caller at 0x005142EB is
unlabelled (Hover plausible, unproven).

Review: an independent read-only critic verified the corner source, the
+3 vector, the column walk, the 16-bit halve blitter and the matrix chain,
and corrected three things applied here: the z-min face is projected
through the full draw matrix (no world-space flatten), cloaked units are
skipped, and the draw-order provenance. Tests: shadow marks every
occupied column and nothing else; bottom-face projection and 3 px shift;
facing config covers the new layer.
cargo test -p vera20k --lib: 8474 passed; 0 failed; 81 ignored.
