### PR TITLE
Insert scheduler anims outside debug_assert so release builds keep them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,11 @@ rodio = "0.22"
 # instances, sorts them, and iterates over thousands of cells every frame —
 # unoptimized Rust is 10-50x slower than opt-level 1. Incremental recompiles
 # stay fast because opt-level 1 is lightweight (no heavy inlining/LTO).
+[lints.clippy]
+# A side effect inside `debug_assert!` vanishes from release builds. This
+# hid every scheduler anim (wakes, explosions) in shipped binaries for weeks.
+debug_assert_with_mut_call = "deny"
+
 [profile.dev]
 opt-level = 1
 # Emit line-table debuginfo only (keeps panic/backtrace line numbers) instead of

--- a/src/sim/anim_class.rs
+++ b/src/sim/anim_class.rs
@@ -753,7 +753,11 @@ impl Simulation {
             start_sound_active: false,
             stop_sound_id,
         };
-        debug_assert!(self.substrate.anims.insert(object).is_none());
+        // The insert must run in every build profile: wrapped in
+        // `debug_assert!` it was compiled out of release binaries and no
+        // scheduler anim ever existed in a shipped build.
+        let previous = self.substrate.anims.insert(object);
+        debug_assert!(previous.is_none());
         // Native registry insertion precedes Reveal, and Reveal precedes the
         // delay-zero constructor-time Middle call.
         self.reveal_anim(stable_id);
@@ -826,7 +830,11 @@ impl Simulation {
             start_sound_active: false,
             stop_sound_id,
         };
-        debug_assert!(self.substrate.anims.insert(object).is_none());
+        // The insert must run in every build profile: wrapped in
+        // `debug_assert!` it was compiled out of release binaries and no
+        // scheduler anim ever existed in a shipped build.
+        let previous = self.substrate.anims.insert(object);
+        debug_assert!(previous.is_none());
 
         let rate_reload = self.choose_anim_rate(&config);
         let frame_timer =

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -3718,7 +3718,8 @@ impl Simulation {
         let order = self.substrate.logic.as_slice();
         let mut seen = std::collections::BTreeSet::new();
         for &id in order {
-            debug_assert!(seen.insert(id), "logic order has duplicate id {id}");
+            let first_occurrence = seen.insert(id);
+            debug_assert!(first_occurrence, "logic order has duplicate id {id}");
             debug_assert!(
                 self.substrate
                     .entities


### PR DESCRIPTION
Insert scheduler anims outside debug_assert so release builds keep them

Player-visible problem: in release builds no scheduler-owned AnimClass
object ever existed. Ship wakes (Rules->Wake), combat explosion anims and
load anims were constructed and discarded on the same call, so the wake
stayed invisible through PRs #298, #301 and #302 while every lib test
passed in the dev profile.

Cause: `spawn_anim_at_world` and `spawn_load_anim_at_world` inserted the
new object with `debug_assert!(self.substrate.anims.insert(object).is_none())`.
`debug_assert!` is compiled out of release builds, so the insert never ran.
Diagnosed with in-build logging: the anim store held zero objects and the
logic vector did not contain the new id immediately after construction.

Fix: perform the insert unconditionally and assert on the returned value.
The same shape in `debug_assert_logic_membership_consistent` (a local
duplicate-check set inside a debug-only function) is rewritten too, and
`clippy::debug_assert_with_mut_call` is denied crate-wide so the pattern
cannot return.

Verified by the user in the release preview build: the wake now draws
under the sailing ship. `cargo test -p vera20k --lib`:
test result: ok. 8474 passed; 0 failed; 81 ignored.
