### PR TITLE
Own Infantry terminal lifetimes through death, cleanup and restore

### DIFF
--- a/docs/system-map/topology.v2.json
+++ b/docs/system-map/topology.v2.json
@@ -560,10 +560,23 @@
           "symbol": "drop_in_bridge_member",
           "coverage": "representative",
           "observed_at_commit": "67127d0231341dc1613faab1a5ea804a9a96832d"
+        },
+        {
+          "path": "src/sim/world/infantry_terminal.rs",
+          "symbol": "Simulation::visit_infantry_terminal",
+          "coverage": "representative",
+          "observed_at_commit": "7b6ab348a3f42ae23e1c73b3571c7812f69107a9"
+        },
+        {
+          "path": "src/sim/world/lifecycle.rs",
+          "symbol": "Simulation::uninit_with_context",
+          "coverage": "representative",
+          "observed_at_commit": "7b6ab348a3f42ae23e1c73b3571c7812f69107a9"
         }
       ],
       "notes": [
-        "One world operation owns the represented deck member relayer, complete footprint removal/re-entry, one fresh serialized order and derived vehicle projection reconciliation. It preserves existing ground snap/movement reset, raw bytes, Drive reservations and clearing state; it does not run full Mark/Unmark teardown or placement effects. Full native DropIn, hidden-building entry and falling remain open."
+        "One world operation owns the represented deck member relayer, complete footprint removal/re-entry, one fresh serialized order and derived vehicle projection reconciliation. It preserves existing ground snap/movement reset, raw bytes, Drive reservations and clearing state; it does not run full Mark/Unmark teardown or placement effects. Full native DropIn, hidden-building entry and falling remain open.",
+        "Infantry terminal visits own finite Die1/Die2 waits or raw next-visit retirement. Common UnInit clears terminal policy before pointer-expiry callbacks and retains deferred physical deletion. Raw writers cannot rearm an already-UnInit object. Held limbo policies wait for their release owner rather than a global terminal sweep."
       ]
     },
     "GSI-08.10": {
@@ -609,11 +622,32 @@
           "symbol": "commit_direct_damage_receiver",
           "coverage": "representative",
           "observed_at_commit": "30237eb526137c935976acefac88c0036f821020"
+        },
+        {
+          "path": "src/sim/world/infantry_terminal.rs",
+          "symbol": "Simulation::begin_infantry_receiver_death / InfantryDeathPostlude::commit",
+          "coverage": "representative",
+          "observed_at_commit": "7b6ab348a3f42ae23e1c73b3571c7812f69107a9"
         }
       ],
       "notes": [
         "Combat, Bullet, Wave and direct area-damage ingress execute against resident Simulation authority. ReceiverRun owns recursion guards and ordered navigation receipts; the local health borrow ends before synchronous world lifecycle stages. This ownership refactor does not establish whole-loop native parity or close scheduler differences.",
-        "Ordinary combat and immediate Bullet/Wave/direct ingress now share one consuming world consequence owner. Weapon emission and recursive fatalities accumulate DeathEffects once. Ordinary radiation and death sounds retain their earlier receiver barriers; other settlement preserves constructor, navigation and notification ordering. Fatal garrison ejection remains synchronous, and wall mutation/expiry traces are test-only, never replayed. This is Rust ownership and regression evidence, not native postlude parity."
+        "Ordinary combat and immediate Bullet/Wave/direct ingress now share one consuming world consequence owner. Weapon emission and recursive fatalities accumulate DeathEffects once. Ordinary radiation and death sounds retain their earlier receiver barriers; other settlement preserves constructor, navigation and notification ordering. Fatal garrison ejection remains synchronous, and wall mutation/expiry traces are test-only, never replayed. This is Rust ownership and regression evidence, not native postlude parity.",
+        "A consuming Infantry postlude binds the represented effect recipe to explicit terminal lifetime. Selection stays before recursive DeathWeapon damage; effect and smudge delivery stay after recursion. Effect-only cleanup uses DamageConsequences; no-art parent cleanup retains its earlier ordering. This corrects looping corpse retention without claiming native selector or particle parity."
+      ]
+    },
+    "GSI-08.11": {
+      "native_anchors": [],
+      "rust_surfaces": [
+        {
+          "path": "src/sim/world/infantry_terminal.rs",
+          "symbol": "InfantryTerminal / Simulation::visit_infantry_terminal",
+          "coverage": "representative",
+          "observed_at_commit": "7b6ab348a3f42ae23e1c73b3571c7812f69107a9"
+        }
+      ],
+      "notes": [
+        "Represented Infantry terminal authority distinguishes finite sequence progress, raw retirement on the next own visit and receiver-owned consequence cleanup. Sprite animation presence still gates the legacy effect recipe; it no longer creates an indefinite lifetime wait. Full native DeathAnims, NotHuman, Cyborg, InfDeath9 placement and particle semantics remain unimplemented or unchecked."
       ]
     },
     "GSI-09.01": {
@@ -779,12 +813,18 @@
           "symbol": "Genetic LaunchSuperWeapon command regressions",
           "coverage": "representative",
           "observed_at_commit": "bb479d3b6231084bff81687b4f340ca96664e2fd"
+        },
+        {
+          "path": "src/sim/world/infantry_terminal.rs",
+          "symbol": "Simulation::mark_raw_mutation_victim",
+          "coverage": "representative",
+          "observed_at_commit": "7b6ab348a3f42ae23e1c73b3571c7812f69107a9"
         }
       ],
       "notes": [
         "One private mutation operation owns selection, completion of the original receiver batch, killed-position observation and all replacement attempts. Launch receives only the completed count. Per-cell recipients come from canonical marked cell membership and selected bridge/ground lists; held/unmarked coordinates no longer confer eligibility.",
         "Retains current stable-ID per-cell snapshot order, AoE receiver order, collateral-only exclusion from replacements and immediate BRUTE owner/facing/Z/failure policy. Production commands cover held factory state, bridge membership, original victims, aliases, dummy lookup, missing replacement type and recursive damage before admission. The unused saturating iterator and its four tests were removed.",
-        "Infantry terminal disposition remains open: represented raw mutation and animated shared InfDeath9 can retain looping Stand. Native receiver policy, deferred AnimToInfantry and full airborne Crash parity are not established by this bounded membership/admission change."
+        "Represented raw mutation now retires on the victim's next Logic visit; effect-only shared fatalities retire through consuming consequences. AoE replacement uses the receiver's fatal receipt after victim cleanup. The original looping-Stand regressions are covered through production commands. Native receiver selectors, deferred AnimToInfantry and full airborne Crash parity remain open."
       ]
     },
     "GSI-11.04": {
@@ -818,11 +858,17 @@
           "symbol": "actual LaunchSuperWeapon command regressions",
           "coverage": "representative",
           "observed_at_commit": "30237eb526137c935976acefac88c0036f821020"
+        },
+        {
+          "path": "src/sim/superweapon/cell_receiver_tests.rs",
+          "symbol": "infantry_terminal receiver and recursive-death command regressions",
+          "coverage": "representative",
+          "observed_at_commit": "7b6ab348a3f42ae23e1c73b3571c7812f69107a9"
         }
       ],
       "notes": [
         "Iron Curtain selects canonical cell membership and the native bridge/ground list, then reads the live successor after each callback. Infantry dispatches forced authored-Strength C4 damage through the resident world receiver. This removes the independent coordinate/HP/death-announcement path.",
-        "Production command regressions cover factory-held and unmarked immunity, authored Strength, forced damage and source House, retained Die2, layer/foundation selection, aliases/dummy stamping, nested DeathWeapon order and existing bridge DropIn integration. Manual UnInit proves the attributed receipt, not automatic sequence completion. Shared Infantry terminal cleanup, Genetic conversion and external chrono-warp interaction remain open; no whole-loop or rendered parity claim."
+        "Production command regressions cover factory-held and unmarked immunity, authored Strength, forced damage and source House, retained Die2, layer/foundation selection, aliases/dummy stamping, nested DeathWeapon order and existing bridge DropIn integration. Frame-driven terminal tests cover finite Die1/Die2 retirement and effect-only cleanup. External chrono-warp interaction and native selector semantics remain open; no whole-loop or rendered parity claim."
       ]
     },
     "GSI-11.02": {
@@ -971,9 +1017,24 @@
           "symbol": "rebuild_caches_after_load",
           "coverage": "representative",
           "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"
+        },
+        {
+          "path": "src/sim/snapshot.rs",
+          "symbol": "Simulation::restore_after_snapshot_load",
+          "coverage": "representative",
+          "observed_at_commit": "7b6ab348a3f42ae23e1c73b3571c7812f69107a9"
+        },
+        {
+          "path": "src/app/persistence/tests/infantry_terminal_restore_tests.rs",
+          "symbol": "Infantry terminal PreparedLoad and continued-frame regressions",
+          "coverage": "representative",
+          "observed_at_commit": "7b6ab348a3f42ae23e1c73b3571c7812f69107a9"
         }
       ],
-      "notes": ["Rust bincode snapshots are regression infrastructure, not native SAV parity."]
+      "notes": [
+        "Rust bincode snapshots are regression infrastructure, not native SAV parity.",
+        "Version 136 persists Infantry terminal policy and sequence progress. Admission rejects transient AwaitingConsequences, native-dead policies and live dying Infantry without a policy; retained policies require serialized Logic membership or limbo. PreparedLoad tests cover finite progress, held factory release, and delivered fatal consequences surviving an aborted deletion frame before resumed cleanup. Older snapshot versions are rejected by the version gate."
+      ]
     }
   },
   "services": {
@@ -1998,6 +2059,7 @@
         "ObjectClass::ReceiveDamage 0x005F5390"
       ],
       "rust_touchpoints": [
+        {"path": "src/sim/world/infantry_terminal.rs", "coverage": "representative", "observed_at_commit": "7b6ab348a3f42ae23e1c73b3571c7812f69107a9"},
         {"path": "src/sim/world/world_commands.rs", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},
         {"path": "src/sim/combat/world_receiver.rs", "coverage": "representative", "observed_at_commit": "e3d53e1c9f92a3c74fc4b84d4a43f4aa2b4ef2ac"},
         {"path": "src/sim/combat/damage", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},

--- a/src/app/initialize.rs
+++ b/src/app/initialize.rs
@@ -559,7 +559,6 @@ impl App {
                     pending_fire_effects: Vec::new(),
                     garrison_muzzle_flashes: Vec::new(),
                     weapon_muzzle_flashes: Vec::new(),
-                    projectile_visuals: Vec::new(),
                     parachute_anims: Vec::new(),
                     idle_anim_elapsed_ms: 0,
                     building_anim_phase_base: std::collections::BTreeMap::new(),

--- a/src/app/persistence/mod.rs
+++ b/src/app/persistence/mod.rs
@@ -654,6 +654,7 @@ mod tests {
     }
 
     mod factory_restore_tests;
+    mod infantry_terminal_restore_tests;
 
     fn load_fixture_rules() -> RuleSet {
         let ini = IniFile::from_str(

--- a/src/app/persistence/tests/factory_restore_tests.rs
+++ b/src/app/persistence/tests/factory_restore_tests.rs
@@ -119,7 +119,6 @@ fn factory_restore_preserves_supported_held_states_and_constructor_graphs() {
         ("mobile-retry", "MTNK", ProductionCategory::Vehicle),
         ("absent-house", "E1", ProductionCategory::Infantry),
         ("retained-playfield", "E1", ProductionCategory::Infantry),
-        ("damaged-held", "E1", ProductionCategory::Infantry),
         ("unrelated-limbo", "PARENT", ProductionCategory::Building),
         ("empty-registry", "PARENT", ProductionCategory::Building),
     ] {
@@ -171,13 +170,6 @@ fn factory_restore_preserves_supported_held_states_and_constructor_graphs() {
             }
             "absent-house" => {
                 saved.houses.remove(&owner);
-            }
-            "damaged-held" => {
-                // Current coordinate-based superweapon ingress can create this
-                // live state; admission must not reclassify it as save corruption.
-                let entity = saved.substrate.entities.get_mut(parent).unwrap();
-                entity.health.current = 0;
-                entity.dying = true;
             }
             "unrelated-limbo" => {
                 saved

--- a/src/app/persistence/tests/infantry_terminal_restore_tests.rs
+++ b/src/app/persistence/tests/infantry_terminal_restore_tests.rs
@@ -1,0 +1,389 @@
+//! Terminal policy and progress through the production load preparation route.
+use super::*;
+use crate::sim::animation::{LoopMode, SequenceKind};
+use crate::sim::world::{InfantryDeathSequence, InfantryTerminal};
+use std::collections::BTreeMap;
+
+#[test]
+fn infantry_terminal_held_factory_restore_waits_for_release_before_retiring() {
+    use crate::sim::house_state::HouseState;
+    use crate::sim::production::{
+        ProductionCategory, enqueue_by_type, tick_production_with_overlay_registry,
+    };
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=E1\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n0=BARR\n\
+         [E1]\nStrength=100\nSpeed=4\nCost=200\nTechLevel=1\nOwner=Americans\n\
+         [BARR]\nStrength=1000\nFoundation=1x1\nFactory=InfantryType\nExitCoord=256,0,0\n",
+    ))
+    .unwrap();
+    let (mut saved, terrain) = terminal_load_world(&rules);
+    let owner = saved.interner.intern("Americans");
+    saved
+        .houses
+        .insert(owner, HouseState::new(owner, 0, None, true, 50_000, 10));
+    saved.session.house_order.push(owner);
+    saved
+        .spawn_object_at_height("BARR", "Americans", 1, 1, 0, 0, &rules)
+        .unwrap();
+    assert!(enqueue_by_type(&mut saved, &rules, "Americans", "E1"));
+    let held = saved
+        .production
+        .factory_shadow
+        .view(owner, ProductionCategory::Infantry)
+        .unwrap()
+        .object
+        .unwrap()
+        .entity_id
+        .unwrap();
+    // Characterize retained-limbo raw policy and its release owner. This uses
+    // the raw handoff directly, not a bridge-dispatch reachability fixture.
+    assert!(saved.begin_raw_infantry_death(held, None));
+    let object = saved.substrate.entities.get(held).unwrap();
+    assert!(object.lifecycle.in_limbo && !object.in_logic_vector);
+    saved.scenario_rng = crate::sim::rng::SimRng::new(0);
+    let bytes = snapshot_bytes(&saved, &rules);
+    let registry = OverlayTypeRegistry::empty();
+    let (mut restored, _) = PreparedLoad::prepare_candidate(
+        &bytes,
+        Some(&saved),
+        Some(LOAD_FIXTURE_MAP_HASH),
+        Some(&rules),
+        Some(&terrain),
+        Some(&registry),
+    )
+    .expect("retained terminal policy has a factory release owner");
+    let object = restored.substrate.entities.get(held).unwrap();
+    assert!(object.lifecycle.in_limbo && !object.in_logic_vector);
+    assert_eq!(
+        object.infantry_terminal,
+        Some(InfantryTerminal::RetireNextVisit)
+    );
+    restored.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+    let object = restored
+        .substrate
+        .entities
+        .get(held)
+        .expect("held lifetime waits for release");
+    assert!(object.lifecycle.in_limbo && !object.in_logic_vector);
+    assert_eq!(
+        object.infantry_terminal,
+        Some(InfantryTerminal::RetireNextVisit)
+    );
+    assert_eq!(
+        restored
+            .production
+            .factory_shadow
+            .view(owner, ProductionCategory::Infantry)
+            .unwrap()
+            .object
+            .unwrap()
+            .entity_id,
+        Some(held)
+    );
+    assert!(
+        restored
+            .production
+            .factory_shadow
+            .test_arm_ready(owner, ProductionCategory::Infantry)
+    );
+    tick_production_with_overlay_registry(
+        &mut restored,
+        &rules,
+        &BTreeMap::new(),
+        None,
+        Some(&registry),
+    );
+    let object = restored
+        .substrate
+        .entities
+        .get(held)
+        .expect("release retains the identity");
+    assert!(!object.lifecycle.in_limbo && object.in_logic_vector);
+    assert_eq!(
+        object.infantry_terminal,
+        Some(InfantryTerminal::RetireNextVisit)
+    );
+    assert!(
+        restored
+            .production
+            .factory_shadow
+            .view(owner, ProductionCategory::Infantry)
+            .is_none_or(|view| view.object.is_none())
+    );
+    restored.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+    assert!(!restored.substrate.entities.contains(held));
+    assert!(!restored.live_object_order_snapshot().contains(&held));
+}
+
+#[test]
+fn infantry_terminal_fatal_frame_exit_preserves_delivered_cleanup_through_load() {
+    use crate::sim::command::{Command, CommandEnvelope};
+    use crate::sim::house_state::HouseState;
+    use crate::sim::world::{LifecycleTestEvent, SimSoundEvent, TickLane};
+    let mut rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=E1\n[VehicleTypes]\n0=SHOOTER\n[AircraftTypes]\n[BuildingTypes]\n\
+         [E1]\nStrength=100\nSpeed=4\n\
+         [SHOOTER]\nStrength=300\nSpeed=6\nSight=8\nPrimary=Gun\n\
+         [Gun]\nDamage=1000\nROF=50\nRange=10\nProjectile=INVIS\nWarhead=KILL\n\
+         [INVIS]\nInviso=yes\n[Warheads]\n0=KILL\n\
+         [KILL]\nInfDeath=3\nCellSpread=0\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+         [General]\nInfantryExplode=DEATHTEST\n",
+    )).unwrap();
+    let mut art = crate::rules::art_data::ArtRegistry::from_ini(&IniFile::from_str(
+        "[DEATHTEST]\nReport=DeathReport\nEnd=80\n",
+    ));
+    art.bind_anim_frame_count_for_test("DEATHTEST", 80);
+    rules.art_registry = art;
+    let (mut saved, terrain) = terminal_load_world(&rules);
+    saved.input_delay_ticks = 0;
+    let owner = saved.interner.intern("Americans");
+    saved
+        .houses
+        .insert(owner, HouseState::new(owner, 0, None, true, 1000, 10));
+    saved.session.house_order.push(owner);
+    let shooter = saved
+        .spawn_object_at_height(
+            "SHOOTER",
+            "Americans",
+            1,
+            1,
+            crate::sim::movement::facing_from_delta(1, 0),
+            0,
+            &rules,
+        )
+        .unwrap();
+    let victim = saved
+        .spawn_object_at_height("E1", "Russians", 2, 1, 0, 0, &rules)
+        .unwrap();
+    assert!(crate::sim::combat::issue_attack_command(
+        &mut saved.substrate.entities,
+        shooter,
+        victim,
+        Some(&rules),
+        &saved.interner
+    ));
+    saved.clear_lifecycle_test_events_for_test();
+    let registry = OverlayTypeRegistry::empty();
+    let output = saved.advance_app_frame(
+        &[CommandEnvelope::new(owner, 1, Command::ExitMatch)],
+        Some(&rules),
+        &BTreeMap::new(),
+        Some(&registry),
+        67,
+        TickLane::Ordinary,
+        None,
+    );
+    assert!(!output.tick.frame_committed);
+    let object = saved.substrate.entities.get(victim).unwrap();
+    assert!(object.dying && object.lifecycle.in_limbo && !object.lifecycle.object_alive);
+    assert!(object.infantry_terminal.is_none() && !object.in_logic_vector);
+    assert!(!saved.substrate.occupancy.contains_entity(2, 1, victim));
+    assert_eq!(
+        saved
+            .substrate
+            .pending_delete
+            .iter()
+            .filter(|&&id| id == victim)
+            .count(),
+        1
+    );
+    assert_eq!(saved.lifecycle_test_events_for_test().iter().filter(|event|
+        matches!(event, LifecycleTestEvent::UninitAliveCleared { stable_id } if *stable_id == victim)).count(), 1);
+    assert!(
+        !saved
+            .lifecycle_test_events_for_test()
+            .contains(&LifecycleTestEvent::PendingDeleteDrainStarted)
+    );
+    let death_ids = |sim: &Simulation| {
+        sim.anims()
+            .filter(|(_, anim)| sim.interner.resolve(anim.type_id) == "DEATHTEST")
+            .map(|(id, _)| *id)
+            .collect::<Vec<_>>()
+    };
+    let effects = death_ids(&saved);
+    assert_eq!(
+        effects.len(),
+        1,
+        "ordinary consequence delivered before exit"
+    );
+    assert_eq!(output.sound_events.iter().filter(|event| matches!(event,
+        SimSoundEvent::AnimationStarted { sound_id, .. } if saved.interner.resolve(*sound_id) == "DEATHREPORT")).count(), 1);
+    saved.scenario_rng = crate::sim::rng::SimRng::new(0);
+    let bytes = snapshot_bytes(&saved, &rules);
+    let (mut restored, _) = PreparedLoad::prepare_candidate(
+        &bytes,
+        Some(&saved),
+        Some(LOAD_FIXTURE_MAP_HASH),
+        Some(&rules),
+        Some(&terrain),
+        Some(&registry),
+    )
+    .unwrap();
+    assert_eq!(
+        restored.substrate.pending_delete,
+        saved.substrate.pending_delete
+    );
+    assert_eq!(death_ids(&restored), effects);
+    assert_eq!(restored.state_hash(), saved.state_hash());
+    let next = restored.advance_app_frame(
+        &[],
+        Some(&rules),
+        &BTreeMap::new(),
+        Some(&registry),
+        67,
+        TickLane::Ordinary,
+        None,
+    );
+    // Exit requests are transient: production load resumes the match and the
+    // first committed frame drains the already-delivered victim normally.
+    assert!(next.tick.frame_committed);
+    assert!(!restored.substrate.entities.contains(victim));
+    assert!(!restored.substrate.pending_delete.contains(&victim));
+    assert_eq!(death_ids(&restored), effects);
+    assert!(!next.sound_events.iter().any(|event| matches!(event,
+        SimSoundEvent::AnimationStarted { sound_id, .. } if restored.interner.resolve(*sound_id) == "DEATHREPORT")));
+}
+
+#[test]
+fn infantry_terminal_prepared_load_preserves_policy_progress_and_cleanup_visit() {
+    for terminal in [
+        InfantryTerminal::RetireNextVisit,
+        InfantryTerminal::Sequence(InfantryDeathSequence::Die1),
+        InfantryTerminal::Sequence(InfantryDeathSequence::Die2),
+    ] {
+        let mut rules = RuleSet::from_ini(&IniFile::from_str(
+            "[InfantryTypes]\n0=E1\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
+             [E1]\nStrength=100\nSpeed=4\n",
+        ))
+        .unwrap();
+        let mut sequences = rules.animation_sequence("E1").unwrap().clone();
+        for sequence in [SequenceKind::Die1, SequenceKind::Die2] {
+            let mut def = sequences.get(&sequence).unwrap().clone();
+            def.frame_count = 3;
+            def.frame_delay = 1;
+            def.normalized = false;
+            def.loop_mode = LoopMode::HoldLast;
+            sequences.insert(sequence, def);
+        }
+        rules.replace_animation_sequences_for_test(BTreeMap::from([("E1".into(), sequences)]));
+        let (mut saved, terrain) = terminal_load_world(&rules);
+        let victim = saved
+            .spawn_object_at_height("E1", "Americans", 1, 1, 0, 0, &rules)
+            .unwrap();
+        let remaining_visits = match terminal {
+            InfantryTerminal::AwaitingConsequences => unreachable!("not a save boundary"),
+            InfantryTerminal::RetireNextVisit => {
+                assert!(saved.mark_raw_mutation_victim(victim));
+                1
+            }
+            InfantryTerminal::Sequence(sequence) => {
+                saved
+                    .substrate
+                    .entities
+                    .get_mut(victim)
+                    .unwrap()
+                    .health
+                    .current = 0;
+                saved.begin_infantry_death_sequence(victim, sequence);
+                saved.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+                assert_eq!(
+                    saved
+                        .substrate
+                        .entities
+                        .get(victim)
+                        .unwrap()
+                        .animation
+                        .as_ref()
+                        .unwrap()
+                        .frame_index,
+                    1
+                );
+                2
+            }
+        };
+        // Native in-scenario load restarts Scenario RNG at zero. Compare the
+        // terminal continuation from that same cursor rather than hide reset.
+        saved.scenario_rng = crate::sim::rng::SimRng::new(0);
+        let bytes = snapshot_bytes(&saved, &rules);
+        let registry = OverlayTypeRegistry::empty();
+        let (mut restored, _) = PreparedLoad::prepare_candidate(
+            &bytes,
+            Some(&saved),
+            Some(LOAD_FIXTURE_MAP_HASH),
+            Some(&rules),
+            Some(&terrain),
+            Some(&registry),
+        )
+        .expect("actual validate/deserialize/restore/rebuild preparation");
+        assert_eq!(
+            restored
+                .substrate
+                .entities
+                .get(victim)
+                .unwrap()
+                .infantry_terminal,
+            Some(terminal)
+        );
+        for visit in 1..=remaining_visits {
+            saved.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+            restored.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+            assert_eq!(
+                restored.substrate.entities.contains(victim),
+                visit < remaining_visits,
+                "{terminal:?}, visit {visit}"
+            );
+            assert_eq!(
+                saved.substrate.entities.contains(victim),
+                restored.substrate.entities.contains(victim)
+            );
+            assert_eq!(saved.scenario_rng.state(), restored.scenario_rng.state());
+            assert_eq!(
+                saved.state_hash(),
+                restored.state_hash(),
+                "{terminal:?}, visit {visit}"
+            );
+        }
+        assert!(!restored.substrate.occupancy.contains_entity(1, 1, victim));
+        assert!(!restored.live_object_order_snapshot().contains(&victim));
+    }
+}
+
+fn terminal_load_world(rules: &RuleSet) -> (Simulation, ResolvedTerrainGrid) {
+    let terrain = ResolvedTerrainGrid::from_cells(
+        4,
+        4,
+        (0..4)
+            .flat_map(|ry| {
+                (0..4).map(move |rx| {
+                    let mut cell = compatibility_snapshot_cell(0);
+                    cell.rx = rx;
+                    cell.ry = ry;
+                    let clear = SpeedCostProfile {
+                        foot: Some(100),
+                        track: Some(100),
+                        wheel: Some(100),
+                        hover: Some(100),
+                        amphibious: Some(100),
+                        ..SpeedCostProfile::default()
+                    };
+                    cell.speed_costs = clear;
+                    cell.base_speed_costs = clear;
+                    cell
+                })
+            })
+            .collect(),
+    );
+    let mut saved = load_fixture_simulation(true);
+    saved.overlay_grid = Some(OverlayGrid::new_with_retained_wall_plane(4, 4));
+    saved.install_resolved_terrain_for_new_map(terrain.clone());
+    saved.playfield_bounds = Some(crate::sim::cell_rect::PlayfieldBounds {
+        base: 0,
+        off_fc: -100,
+        off_100: -100,
+        off_104: 200,
+        off_108: 200,
+    });
+    saved.intern_rule_type_ids(rules);
+    saved.resolve_type_handles(rules);
+    (saved, terrain)
+}

--- a/src/app/presentation/fire_effects.rs
+++ b/src/app/presentation/fire_effects.rs
@@ -11,6 +11,7 @@ use crate::audio::events::{GameSoundEvent, SoundSource};
 use crate::map::entities::EntityCategory;
 use crate::rules::art_data::{ArtEntry, ArtRegistry};
 use crate::rules::ruleset::RuleSet;
+#[cfg(test)]
 use crate::sim::combat::TargetKind;
 use crate::sim::combat::combat_weapon::WeaponSlot;
 #[cfg(test)]
@@ -20,8 +21,6 @@ use crate::sim::world::{SimFireEvent, Simulation};
 use crate::util::fixed_math::SimFixed;
 
 const MUZZLE_FLASH_RATE_MS: u32 = 67;
-const MIN_PROJECTILE_VISUAL_MS: u32 = 160;
-const MAX_PROJECTILE_VISUAL_MS: u32 = 900;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FireOriginBranch {
@@ -49,33 +48,11 @@ pub(crate) struct FireOrigin {
     pub branch: FireOriginBranch,
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct ProjectileVisual {
-    pub shp_name: String,
-    pub start_screen_x: f32,
-    pub start_screen_y: f32,
-    pub end_screen_x: f32,
-    pub end_screen_y: f32,
-    pub z: u8,
-    pub frame: u16,
-    pub duration_ms: u32,
-    pub elapsed_ms: u32,
-}
-
 /// One persistent WaveClass draw resolved from simulation-owned registration state.
 #[derive(Debug, Clone)]
 pub(crate) struct WeaponWaveVisual {
     pub geometry: crate::render::wave_geometry::WaveGeometryInput,
     pub tint: [f32; 3],
-}
-
-impl ProjectileVisual {
-    pub(crate) fn progress(&self) -> f32 {
-        if self.duration_ms == 0 {
-            return 1.0;
-        }
-        (self.elapsed_ms as f32 / self.duration_ms as f32).clamp(0.0, 1.0)
-    }
 }
 
 pub(crate) fn select_weapon_muzzle_anim<'a>(anims: &'a [String], facing: u8) -> Option<&'a str> {
@@ -341,153 +318,6 @@ fn build_non_garrison_fire_effects(
     (flashes, sounds)
 }
 
-/// Height a shot aimed at a bare ground cell lands on, in **height levels**
-/// (signed, the unit `lepton_to_screen` and `FireOrigin::z` speak).
-///
-/// This derives nothing. It reads `sim::combat::attack_impact_z` — the same
-/// single value the detonation damaged at and the same value the impact
-/// animation is placed on — and narrows it with the sim's own
-/// `impact_z_byte`. The original engine forms one impact coordinate per
-/// detonation and hands that one coordinate to both area damage and animation
-/// placement, so a second derivation on the presentation side could only agree
-/// with the sim by coincidence; when this file derived its own, tracer and
-/// explosion sat 60 px apart on structural-bridge cells.
-///
-/// Two consequences, both deliberate: a level-0 cell still resolves to 0, so
-/// flat maps are unchanged; and the structural-bridge deck offset is absent
-/// here because it is absent in the sim — that shared residual, and the step
-/// that would settle it, are recorded on `attack_impact_z`.
-///
-/// Missing terrain (no map resolved yet) yields the same zero the sim helper
-/// returns; presentation has no better answer before load.
-fn cell_target_height_level(sim: &Simulation, rx: u16, ry: u16) -> u8 {
-    crate::sim::combat::impact_z_byte(crate::sim::combat::attack_impact_z(
-        TargetKind::Cell(rx, ry),
-        sim.entities(),
-        sim.resolved_terrain.as_ref(),
-    ))
-}
-
-fn target_fire_destination(sim: &Simulation, target: TargetKind) -> Option<FireOrigin> {
-    match target {
-        TargetKind::Entity(id) => {
-            let entity = sim.entities().get(id)?;
-            let (screen_x, screen_y) = crate::render::locomotor_visual::screen_position(entity);
-            Some(FireOrigin {
-                screen_x,
-                screen_y,
-                rx: entity.position.rx,
-                ry: entity.position.ry,
-                sub_x: entity.position.sub_x,
-                sub_y: entity.position.sub_y,
-                z: entity.position.z,
-                branch: FireOriginBranch::Flh,
-            })
-        }
-        TargetKind::Cell(rx, ry) => {
-            // The entity arm above reads the target's own height; a bare cell has
-            // no object to ask, so the terrain answers for it. Height enters
-            // screen Y alone, so getting it wrong drops the impact straight down
-            // by a half tile per level with no sideways drift.
-            let z = cell_target_height_level(sim, rx, ry);
-            let (screen_x, screen_y) = crate::util::lepton::lepton_to_screen(
-                rx,
-                ry,
-                crate::util::lepton::CELL_CENTER_LEPTON,
-                crate::util::lepton::CELL_CENTER_LEPTON,
-                z,
-            );
-            Some(FireOrigin {
-                screen_x,
-                screen_y,
-                rx,
-                ry,
-                sub_x: crate::util::lepton::CELL_CENTER_LEPTON,
-                sub_y: crate::util::lepton::CELL_CENTER_LEPTON,
-                z,
-                branch: FireOriginBranch::Flh,
-            })
-        }
-    }
-}
-
-fn projectile_direction_frame(origin: &FireOrigin, dest: &FireOrigin, frame_count: u16) -> u16 {
-    if frame_count == 0 {
-        return 0;
-    }
-    let dx = (dest.rx as i32 * 256 + dest.sub_x.to_num::<i32>())
-        - (origin.rx as i32 * 256 + origin.sub_x.to_num::<i32>());
-    let dy = (dest.ry as i32 * 256 + dest.sub_y.to_num::<i32>())
-        - (origin.ry as i32 * 256 + origin.sub_y.to_num::<i32>());
-    let facing = crate::sim::movement::facing_from_delta(dx, dy);
-    (((facing as u32 * frame_count as u32) / 256) as u16).min(frame_count.saturating_sub(1))
-}
-
-fn projectile_duration_ms(origin: &FireOrigin, dest: &FireOrigin, weapon_speed: i32) -> u32 {
-    let dx = (dest.rx as f32 * 256.0 + dest.sub_x.to_num::<f32>())
-        - (origin.rx as f32 * 256.0 + origin.sub_x.to_num::<f32>());
-    let dy = (dest.ry as f32 * 256.0 + dest.sub_y.to_num::<f32>())
-        - (origin.ry as f32 * 256.0 + origin.sub_y.to_num::<f32>());
-    let distance_cells = ((dx * dx + dy * dy).sqrt() / 256.0).max(1.0);
-    let speed = weapon_speed.max(1) as f32;
-    ((distance_cells / speed) * 1000.0) as u32
-}
-
-fn build_projectile_visuals(
-    sim: &Simulation,
-    rules: &RuleSet,
-    art_reg: &ArtRegistry,
-    frame_counts: Option<&HashMap<String, u16>>,
-    events: &[SimFireEvent],
-) -> Vec<ProjectileVisual> {
-    let mut visuals = Vec::new();
-
-    for ev in events {
-        let Some(weapon) = rules.weapon(sim.interner.resolve(ev.weapon_id)) else {
-            continue;
-        };
-        let Some(projectile_id) = weapon.projectile.as_deref() else {
-            continue;
-        };
-        let Some(projectile) = rules.projectile(projectile_id) else {
-            continue;
-        };
-        if crate::sim::combat::projectile_uses_authoritative_flight(weapon, rules) {
-            // YR BulletClass::AI linkage: persistent shots render from the
-            // simulation store, never a parallel app-local interpolation.
-            continue;
-        }
-        if projectile.inviso {
-            continue;
-        }
-        let Some(image) = projectile.image.as_deref() else {
-            continue;
-        };
-        let Ok(origin) = resolve_fire_origin_from_sim(sim, rules, art_reg, ev) else {
-            continue;
-        };
-        let Some(dest) = target_fire_destination(sim, ev.target) else {
-            continue;
-        };
-        let frame_count = presentation_effect_frame_count(frame_counts, image).unwrap_or(32);
-        let duration_ms = projectile_duration_ms(&origin, &dest, weapon.speed)
-            .clamp(MIN_PROJECTILE_VISUAL_MS, MAX_PROJECTILE_VISUAL_MS);
-        visuals.push(ProjectileVisual {
-            shp_name: image.to_string(),
-            start_screen_x: origin.screen_x,
-            start_screen_y: origin.screen_y,
-            end_screen_x: dest.screen_x,
-            end_screen_y: dest.screen_y,
-            z: origin.z.max(dest.z),
-            frame: projectile_direction_frame(&origin, &dest, frame_count),
-            duration_ms,
-            elapsed_ms: 0,
-        });
-    }
-
-    visuals
-}
-
 pub(crate) fn build_weapon_wave_visuals(
     sim: &Simulation,
     observer: Option<crate::sim::intern::InternedId>,
@@ -548,7 +378,7 @@ pub(crate) fn build_weapon_wave_visuals(
 }
 
 pub(crate) fn spawn_non_garrison_fire_effects(state: &mut AppState, events: &[SimFireEvent]) {
-    let (flashes, sounds, projectiles) = {
+    let (flashes, sounds) = {
         let Some(sim) = state
             .match_state
             .sim_runtime
@@ -569,10 +399,7 @@ pub(crate) fn spawn_non_garrison_fire_effects(state: &mut AppState, events: &[Si
             .sprite_atlas
             .as_ref()
             .map(|atlas| &atlas.active_anim_frame_counts);
-        let (flashes, sounds) =
-            build_non_garrison_fire_effects(sim, rules, art_reg, frame_counts, events);
-        let projectiles = build_projectile_visuals(sim, rules, art_reg, frame_counts, events);
-        (flashes, sounds, projectiles)
+        build_non_garrison_fire_effects(sim, rules, art_reg, frame_counts, events)
     };
 
     state
@@ -580,11 +407,6 @@ pub(crate) fn spawn_non_garrison_fire_effects(state: &mut AppState, events: &[Si
         .match_presentation
         .weapon_muzzle_flashes
         .extend(flashes);
-    state
-        .match_state
-        .match_presentation
-        .projectile_visuals
-        .extend(projectiles);
     for sound in sounds {
         state.match_state.match_audio.sound_events.push(sound);
     }
@@ -606,10 +428,6 @@ pub(crate) fn tick_weapon_muzzle_flashes(state: &mut AppState, dt_ms: u32) {
         &mut state.match_state.match_presentation.weapon_muzzle_flashes,
         dt_ms,
     );
-    tick_projectile_visuals(
-        &mut state.match_state.match_presentation.projectile_visuals,
-        dt_ms,
-    );
 }
 
 fn tick_weapon_muzzle_flash_list(flashes: &mut Vec<WeaponMuzzleFlash>, dt_ms: u32) {
@@ -623,21 +441,11 @@ fn tick_weapon_muzzle_flash_list(flashes: &mut Vec<WeaponMuzzleFlash>, dt_ms: u3
     });
 }
 
-fn tick_projectile_visuals(projectiles: &mut Vec<ProjectileVisual>, dt_ms: u32) {
-    projectiles.retain_mut(|projectile| {
-        projectile.elapsed_ms = projectile.elapsed_ms.saturating_add(dt_ms);
-        projectile.elapsed_ms < projectile.duration_ms
-    });
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::map::bridge_facts::{BRIDGE_FLAG_STRUCTURAL, BridgeCellFacts};
     use crate::map::entities::EntityCategory;
-    use crate::map::resolved_terrain::{ResolvedTerrainCell, ResolvedTerrainGrid};
     use crate::rules::ini_parser::IniFile;
-    use crate::rules::terrain_rules::{SpeedCostProfile, TerrainClass};
     use crate::sim::components::Health;
     use crate::sim::game_entity::GameEntity;
 
@@ -928,291 +736,5 @@ mod tests {
         }];
         tick_weapon_muzzle_flash_list(&mut flashes, MUZZLE_FLASH_RATE_MS);
         assert!(flashes.is_empty());
-    }
-
-    /// Regression for the reported projectile/impact one-cell visual
-    /// discrepancy. Exercise both production projectors with the exact same
-    /// native cell-center CoordStruct.
-    #[test]
-    fn coordinate_runtime_trace_world_effect_anchor_matches_projectile_endpoint() {
-        let sim = Simulation::new();
-
-        for (rx, ry) in [(10_u16, 10_u16), (23_u16, 20_u16), (41_u16, 17_u16)] {
-            let projectile =
-                target_fire_destination(&sim, TargetKind::Cell(rx, ry)).expect("cell target");
-            let world_effect = crate::app::presentation::instances::world_effect_screen_position(
-                rx,
-                ry,
-                crate::util::lepton::CELL_CENTER_LEPTON,
-                crate::util::lepton::CELL_CENTER_LEPTON,
-                0,
-            );
-
-            eprintln!(
-                "FIRE_TRACE cell=({rx},{ry}) projectile=({:.1},{:.1}) \
-                 world_effect=({:.1},{:.1}) delta=({:.1},{:.1})",
-                projectile.screen_x,
-                projectile.screen_y,
-                world_effect.0,
-                world_effect.1,
-                world_effect.0 - projectile.screen_x,
-                world_effect.1 - projectile.screen_y,
-            );
-
-            assert_eq!(world_effect.0, projectile.screen_x);
-            assert_eq!(
-                world_effect.1, projectile.screen_y,
-                "WorldEffect must land on its projectile endpoint"
-            );
-        }
-    }
-
-    // -----------------------------------------------------------------------
-    // Ground-impact height
-    // -----------------------------------------------------------------------
-
-    fn flat_terrain_cell(rx: u16, ry: u16, level: u8) -> ResolvedTerrainCell {
-        ResolvedTerrainCell {
-            rx,
-            ry,
-            source_tile_index: 0,
-            source_sub_tile: 0,
-            final_tile_index: 0,
-            final_sub_tile: 0,
-            is_wood_bridge_repair_tile: false,
-            level,
-            filled_clear: false,
-            tileset_index: Some(0),
-            land_type: 0,
-            yr_cell_land_type: 0,
-            slope_type: 0,
-            template_height: 0,
-            render_offset_x: 0,
-            render_offset_y: 0,
-            terrain_class: TerrainClass::Clear,
-            speed_costs: SpeedCostProfile::default(),
-            is_water: false,
-            is_cliff_like: false,
-            is_rough: false,
-            is_road: false,
-            accepts_smudge: false,
-            allows_tiberium: false,
-            height_in_pixels: 0,
-            variant: 0,
-            has_ramp: false,
-            canonical_ramp: None,
-            ground_walk_blocked: false,
-            terrain_object_blocks: false,
-            terrain_object_occupation: None,
-            overlay_blocks: false,
-            overlay_zone_type: None,
-            outside_playfield: false,
-            zone_type: 0,
-            base_ground_walk_blocked: false,
-            base_build_blocked: false,
-            base_land_type: 0,
-            base_yr_cell_land_type: 0,
-            base_terrain_class: Default::default(),
-            base_speed_costs: Default::default(),
-            build_blocked: false,
-            has_bridge_deck: false,
-            bridge_walkable: false,
-            bridge_transition: false,
-            bridge_deck_level: 0,
-            bridge_layer: None,
-            bridge_facts: BridgeCellFacts::default(),
-            tube_index: None,
-            radar_left: [0, 0, 0],
-            radar_right: [0, 0, 0],
-            has_damaged_data: false,
-            bridgehead_anchor_class_at_load: None,
-        }
-    }
-
-    /// A square map whose every cell sits at `level`.
-    fn sim_on_ground_at_level(level: u8) -> Simulation {
-        const SIZE: u16 = 32;
-        let mut cells = Vec::new();
-        for ry in 0..SIZE {
-            for rx in 0..SIZE {
-                cells.push(flat_terrain_cell(rx, ry, level));
-            }
-        }
-        let mut sim = Simulation::new();
-        sim.resolved_terrain = Some(ResolvedTerrainGrid::from_cells(SIZE, SIZE, cells));
-        sim
-    }
-
-    /// The same flat map with one structural-bridge span crossing `(rx, ry)`.
-    /// This is the cell the two halves disagreed on.
-    fn sim_with_structural_bridge_at(level: u8, rx: u16, ry: u16) -> Simulation {
-        let mut sim = sim_on_ground_at_level(level);
-        sim.resolved_terrain
-            .as_mut()
-            .and_then(|grid| grid.cell_mut(rx, ry))
-            .expect("bridge cell must be inside the fixture grid")
-            .bridge_facts = BridgeCellFacts {
-            raw_flags: BRIDGE_FLAG_STRUCTURAL,
-            ..BridgeCellFacts::default()
-        };
-        sim
-    }
-
-    /// The impact height the sim resolved for this cell, narrowed exactly as
-    /// production narrows it. Tests anchor on this, never on the render half's
-    /// own output — an assertion that feeds a projection its own result proves
-    /// nothing.
-    fn sim_impact_z_byte(sim: &Simulation, rx: u16, ry: u16) -> u8 {
-        crate::sim::combat::impact_z_byte(crate::sim::combat::attack_impact_z(
-            TargetKind::Cell(rx, ry),
-            sim.entities(),
-            sim.resolved_terrain.as_ref(),
-        ))
-    }
-
-    /// Level-0 ground is the case the old hardcoded zero got right, and it must
-    /// stay right: resolving the terrain must not shift a flat-map impact.
-    ///
-    /// Catches a fix that lifts every impact by a constant instead of by the
-    /// cell's own height.
-    #[test]
-    fn ground_impact_on_level_zero_terrain_is_unshifted() {
-        let sim = sim_on_ground_at_level(0);
-
-        for (rx, ry) in [(10_u16, 10_u16), (23_u16, 20_u16), (5_u16, 30_u16)] {
-            let dest =
-                target_fire_destination(&sim, TargetKind::Cell(rx, ry)).expect("cell target");
-            let flat = crate::util::lepton::lepton_to_screen(
-                rx,
-                ry,
-                crate::util::lepton::CELL_CENTER_LEPTON,
-                crate::util::lepton::CELL_CENTER_LEPTON,
-                0,
-            );
-            assert_eq!(dest.z, 0, "level-0 cell ({rx},{ry}) must resolve height 0");
-            assert_eq!((dest.screen_x, dest.screen_y), flat);
-        }
-    }
-
-    /// The reported bug: a shot landing on raised ground drew a whole tile low,
-    /// straight down with no sideways drift, because the cell arm answered 0 for
-    /// every terrain height.
-    ///
-    /// Height enters screen Y alone, one half tile (15 px) per level — so this
-    /// pins the exact per-level cadence and pins screen X as untouched, which is
-    /// the asymmetry that identified the fault as a height fault rather than a
-    /// planar one. Catches both a reintroduced constant height and a wrong
-    /// per-level step (e.g. a whole tile, or leptons fed in where levels belong).
-    #[test]
-    fn ground_impact_lifts_one_half_tile_per_terrain_height_level() {
-        const HALF_TILE_PX: f32 = crate::map::terrain::TILE_HEIGHT / 2.0;
-        let (rx, ry) = (23_u16, 20_u16);
-        let ground_row =
-            target_fire_destination(&sim_on_ground_at_level(0), TargetKind::Cell(rx, ry))
-                .expect("cell target");
-
-        for level in 0..=6_u8 {
-            let dest =
-                target_fire_destination(&sim_on_ground_at_level(level), TargetKind::Cell(rx, ry))
-                    .expect("cell target");
-            assert_eq!(dest.z, level, "cell height must reach the impact point");
-            assert_eq!(
-                dest.screen_x, ground_row.screen_x,
-                "height must not drift the impact sideways at level {level}",
-            );
-            assert_eq!(
-                dest.screen_y,
-                ground_row.screen_y - HALF_TILE_PX * f32::from(level),
-                "level {level} must lift the impact by {level} half-tiles",
-            );
-        }
-    }
-
-    /// A structural bridge span must not move the tracer endpoint on its own.
-    ///
-    /// The impact coordinate is the projectile's location clamped to the cell's
-    /// ground height; the deck-adding accessor is the *aim* point for a live
-    /// object target, a different quantity. Presentation therefore takes the
-    /// sim's impact height unchanged, deck or no deck.
-    ///
-    /// Catches the split this test replaced: the render half calling the
-    /// deck-adjusted helper while the sim half returns the bare floor, which
-    /// ends the tracer four levels — 60 px, two full tiles — above its own
-    /// explosion.
-    #[test]
-    fn ground_impact_on_structural_bridge_cell_takes_the_sim_impact_height() {
-        let (rx, ry) = (12_u16, 9_u16);
-        let open_water = sim_on_ground_at_level(0);
-        let spanned = sim_with_structural_bridge_at(0, rx, ry);
-
-        let deck =
-            target_fire_destination(&spanned, TargetKind::Cell(rx, ry)).expect("cell target");
-        let surface =
-            target_fire_destination(&open_water, TargetKind::Cell(rx, ry)).expect("cell target");
-
-        assert_eq!(
-            deck.z,
-            sim_impact_z_byte(&spanned, rx, ry),
-            "presentation must carry the sim's impact height, not one of its own",
-        );
-        assert_eq!(
-            (deck.screen_x, deck.screen_y),
-            (surface.screen_x, surface.screen_y),
-            "a span alone moves neither axis while the deck term is unmodelled \
-             on both halves",
-        );
-        assert_ne!(
-            i32::from(deck.z as i8),
-            crate::sim::combat::combat_aoe::bridge_adjusted_impact_z(
-                spanned.resolved_terrain.as_ref(),
-                rx,
-                ry,
-            ),
-            "the aim-point helper is a different quantity; if presentation ever \
-             matches it, the deck residual was closed on one half only",
-        );
-    }
-
-    /// The impact animation and the projectile that produced it must land on the
-    /// same pixel — the two projectors are reached by different call paths and
-    /// drifted apart before.
-    ///
-    /// The expected pixel is projected from the **sim's** impact height, so this
-    /// is an agreement check between the two halves rather than a projection fed
-    /// its own output. The structural-bridge row is the case that fails when
-    /// either half derives its own height.
-    #[test]
-    fn world_effect_anchor_matches_the_sim_impact_height() {
-        let cases: [(&str, Simulation); 5] = [
-            ("flat", sim_on_ground_at_level(0)),
-            ("level 1", sim_on_ground_at_level(1)),
-            ("level 2", sim_on_ground_at_level(2)),
-            ("level 5", sim_on_ground_at_level(5)),
-            (
-                "structural bridge over level-0 ground",
-                sim_with_structural_bridge_at(0, 10, 10),
-            ),
-        ];
-
-        for (label, sim) in cases {
-            for (rx, ry) in [(10_u16, 10_u16), (23_u16, 20_u16)] {
-                let projectile =
-                    target_fire_destination(&sim, TargetKind::Cell(rx, ry)).expect("cell target");
-                let world_effect =
-                    crate::app::presentation::instances::world_effect_screen_position(
-                        rx,
-                        ry,
-                        crate::util::lepton::CELL_CENTER_LEPTON,
-                        crate::util::lepton::CELL_CENTER_LEPTON,
-                        sim_impact_z_byte(&sim, rx, ry),
-                    );
-                assert_eq!(
-                    (world_effect.0, world_effect.1),
-                    (projectile.screen_x, projectile.screen_y),
-                    "{label}: cell ({rx},{ry}) — the explosion the sim places and \
-                     the tracer endpoint the app draws must be one point",
-                );
-            }
-        }
     }
 }

--- a/src/app/presentation/instances/overlays.rs
+++ b/src/app/presentation/instances/overlays.rs
@@ -10,7 +10,6 @@
 use std::collections::HashMap;
 
 use crate::app::AppState;
-use crate::app::presentation::fire_effects::ProjectileVisual;
 use crate::map::lighting::DEFAULT_TINT;
 use crate::map::overlay_types::is_bridge_overlay_index;
 use crate::map::terrain::{self, TILE_HEIGHT, TILE_WIDTH};
@@ -1055,15 +1054,6 @@ pub(crate) fn build_weapon_muzzle_flash_instances(
     }
 }
 
-fn projectile_visual_key(projectile: &ProjectileVisual) -> ShpSpriteKey {
-    ShpSpriteKey {
-        type_id: projectile.shp_name.clone(),
-        facing: 0,
-        frame: projectile.frame,
-        house_color: HouseColorIndex(0),
-    }
-}
-
 fn projectile_authoritative_screen_position(
     coordinate: ProjectileCoord,
 ) -> Option<(f32, f32, u16, u16, u8)> {
@@ -1080,7 +1070,7 @@ fn projectile_authoritative_screen_position(
 ///
 /// YR `BulletClass::AI` linkage: rendering reads the same committed CoordStruct
 /// that the next authoritative flight pass will advance.
-fn build_authoritative_projectile_instances(state: &AppState, paged: &mut [Vec<SpriteInstance>]) {
+pub(crate) fn build_projectile_visual_instances(state: &AppState, paged: &mut [Vec<SpriteInstance>]) {
     let (sim, rules, atlas) = match (
         state
             .match_state
@@ -1151,64 +1141,6 @@ fn build_authoritative_projectile_instances(state: &AppState, paged: &mut [Vec<S
         // do not re-lit projectiles.)
         let tint = DEFAULT_TINT;
         let depth = compute_sprite_depth_params(origin_y, world_height, screen_y, projectile_z);
-        paged[entry.page as usize].push(SpriteInstance {
-            position: [screen_x + entry.offset_x, screen_y + entry.offset_y],
-            size: entry.pixel_size,
-            uv_origin: entry.uv_origin,
-            uv_size: entry.uv_size,
-            depth,
-            tint,
-            alpha: 1.0,
-            ..Default::default()
-        });
-    }
-}
-
-/// Build SpriteInstances for render-only in-flight projectile visuals.
-pub(crate) fn build_projectile_visual_instances(
-    state: &AppState,
-    paged: &mut [Vec<SpriteInstance>],
-) {
-    build_authoritative_projectile_instances(state, paged);
-    let atlas = match &state.match_state.match_presentation.sprite_atlas {
-        Some(a) => a,
-        None => return,
-    };
-    let z = state.match_state.input.zoom_level;
-    let (cam_x, cam_y, sw, sh) = (
-        state.match_state.input.camera_x,
-        state.match_state.input.camera_y,
-        state.render_width() as f32 / z,
-        state.render_height() as f32 / z,
-    );
-    let (origin_y, world_height) = state
-        .match_state
-        .match_presentation
-        .terrain_grid
-        .as_ref()
-        .map(|g| (g.origin_y, g.world_height))
-        .unwrap_or((0.0, 1.0));
-
-    for projectile in &state.match_state.match_presentation.projectile_visuals {
-        let t = projectile.progress();
-        let screen_x =
-            projectile.start_screen_x + (projectile.end_screen_x - projectile.start_screen_x) * t;
-        let screen_y =
-            projectile.start_screen_y + (projectile.end_screen_y - projectile.start_screen_y) * t;
-        if !in_view(screen_x, screen_y, 96.0, 96.0, cam_x, cam_y, sw, sh, 96.0) {
-            continue;
-        }
-        let key = projectile_visual_key(projectile);
-        let Some(entry) = atlas.get(&key) else {
-            continue;
-        };
-        // In-flight projectile shapes are not cell-lit at all. gamemd's bullet
-        // draw passes the literal full-brightness value in the same argument
-        // slot that the animation and techno draws fill from the cell, for both
-        // the shadow and the body pass, and the only cell it looks up is for a
-        // bridge-height flag bit. No interpolated cell is needed here.
-        let tint = DEFAULT_TINT;
-        let depth = compute_sprite_depth_params(origin_y, world_height, screen_y, projectile.z);
         paged[entry.page as usize].push(SpriteInstance {
             position: [screen_x + entry.offset_x, screen_y + entry.offset_y],
             size: entry.pixel_size,

--- a/src/app/presentation/state.rs
+++ b/src/app/presentation/state.rs
@@ -102,8 +102,6 @@ pub(crate) struct MatchPresentationState {
     /// Active non-garrison weapon muzzle flash animations spawned from weapon `Anim=`.
     /// App-owned presentation state; combat only emits the fire facts.
     pub(crate) weapon_muzzle_flashes: Vec<crate::sim::components::WeaponMuzzleFlash>,
-    /// Active render-only projectile sprites spawned from non-instant weapon fire.
-    pub(crate) projectile_visuals: Vec<crate::app::presentation::fire_effects::ProjectileVisual>,
     /// Active parachute animations, one per descending paradropped infantry.
     /// Polling-based lifecycle: spawned when an entity gains parachute_state
     /// in the sim, removed on landing or death. Render-only; not snapshotted.

--- a/src/map/rmg/phases/meander.rs
+++ b/src/map/rmg/phases/meander.rs
@@ -46,7 +46,7 @@ const STEP_HALF: f64 = 0.5;
 const STEP_LOG_FLOOR: f64 = 1.0;
 
 /// Heading drift per step, as a multiple of the Gaussian.
-const HEADING_DRIFT: f64 = 0.785_398_163_397_448_3; // π/4
+const HEADING_DRIFT: f64 = std::f64::consts::FRAC_PI_4;
 
 const PI: f64 = std::f64::consts::PI;
 const TAU: f64 = std::f64::consts::TAU;

--- a/src/map/rmg/phases/river.rs
+++ b/src/map/rmg/phases/river.rs
@@ -46,8 +46,8 @@ use super::water::WaterArgs;
 /// Edge count, and the heading each edge aims at: `7π/4 − edge·π/2`.
 const EDGES: i32 = 4;
 const EDGE_BASE_HEADING: f64 = 5.497_787_143_782_138; // 7π/4
-const QUARTER_TURN: f64 = 1.570_796_326_794_896_6; // π/2
-const EIGHTH_TURN: f64 = 0.785_398_163_397_448_3; // π/4
+const QUARTER_TURN: f64 = std::f64::consts::FRAC_PI_2;
+const EIGHTH_TURN: f64 = std::f64::consts::FRAC_PI_4;
 /// Spread of the initial heading around its edge's mean.
 const START_SIGMA: f64 = 0.523_598_775_598_298_8; // π/6
 

--- a/src/render/vxl_raster.rs
+++ b/src/render/vxl_raster.rs
@@ -400,6 +400,7 @@ pub struct SpriteBounds {
 ///
 /// Returns `Mat4::IDENTITY` for slope_type 0 (flat) and as a defensive
 /// fallback for any value ≥ 17 that bypasses the consumer-side clamp.
+#[allow(clippy::approx_constant)] // Preserve the existing f32 slope matrices; 0.7854 is not FRAC_PI_4.
 fn compute_slope_rotation(slope_type: u8) -> Mat4 {
     let (compass_rad, tilt_rad): (f32, f32) = match slope_type {
         0 => return Mat4::IDENTITY,

--- a/src/sim/aircraft/mod.rs
+++ b/src/sim/aircraft/mod.rs
@@ -723,9 +723,12 @@ pub fn tick_aircraft_missions(
         // ReceiveDamage 0x004165C0`, result 4 → `+0x3B8` at `0x00416613`)
         // announces, and that runs through the combat kill loop.
         if m.self_destruct {
+            let infantry_terminal = sim.begin_raw_infantry_death(m.id, None);
             if let Some(entity) = sim.substrate.entities.get_mut(m.id) {
-                entity.health.current = 0;
-                entity.dying = true;
+                if !infantry_terminal {
+                    entity.health.current = 0;
+                    entity.dying = true;
+                }
                 entity.aircraft_mission = None;
             }
             continue;
@@ -884,9 +887,12 @@ pub fn tick_aircraft_missions(
     // (`+0xF8`) with no `Death_Announcement` (`+0x3B8`).
     for m in &mutations {
         if m.paradrop_silent_despawn {
+            let infantry_terminal = sim.begin_raw_infantry_death(m.id, None);
             if let Some(entity) = sim.substrate.entities.get_mut(m.id) {
-                entity.health.current = 0;
-                entity.dying = true;
+                if !infantry_terminal {
+                    entity.health.current = 0;
+                    entity.dying = true;
+                }
                 entity.aircraft_mission = None;
             }
         }

--- a/src/sim/combat/combat_tests.rs
+++ b/src/sim/combat/combat_tests.rs
@@ -4577,44 +4577,6 @@ fn fatal_sound_empty_lists_skip_draws_but_single_choices_still_draw() {
 }
 
 #[test]
-#[ignore = "WIP: combat-death entity removal not yet landed"]
-fn test_tick_combat_kills_target() {
-    let rules: RuleSet = test_rules();
-    let mut store = EntityStore::new();
-    let mut attacker = make_entity(1, "MTNK", 5, 5, 300);
-    let mut target = make_entity(2, "MTNK", 8, 5, 10);
-    attacker.mark_live_contact_with(2);
-    target.mark_live_contact_with(1);
-    store.insert(attacker);
-    store.insert(target);
-    let mut interner = test_interner();
-    issue_attack_command(&mut store, 1, 2, None, &interner);
-    let mut main_rng = SimRng::new(1);
-
-    tick_combat(
-        &mut store,
-        &mut OccupancyGrid::new(),
-        &rules,
-        &mut interner,
-        &mut BTreeMap::new(),
-        0u64,
-        100,
-        0u32,
-        &mut main_rng,
-    );
-
-    assert!(store.get(2).is_none(), "Dead entity should be removed");
-    assert!(
-        store.get(1).unwrap().attack_target.is_none(),
-        "AttackTarget removed after target dies"
-    );
-    assert!(
-        !store.get(1).unwrap().has_live_contact_with(2),
-        "immediate combat removal should clear stale radio contact"
-    );
-}
-
-#[test]
 fn test_tick_combat_out_of_range() {
     let rules: RuleSet = test_rules();
     let mut store = EntityStore::new();

--- a/src/sim/combat/combat_turret_facing_tests.rs
+++ b/src/sim/combat/combat_turret_facing_tests.rs
@@ -303,6 +303,8 @@ fn unit_authoritative_fire_kills_target_via_advance_tick() {
     let rules = rules_with_mtnk_rot(100);
     sim.substrate.entities.get_mut(1).unwrap().attack_target = Some(AttackTarget::new(2));
 
+    sim.substrate.entities.get_mut(1).unwrap().mark_live_contact_with(2);
+    sim.substrate.entities.get_mut(2).unwrap().mark_live_contact_with(1);
     let start_hp = sim.substrate.entities.get(2).unwrap().health.current;
     let mut fired = false;
     let mut target_gone = false;
@@ -325,6 +327,9 @@ fn unit_authoritative_fire_kills_target_via_advance_tick() {
         target_gone,
         "repeated fire should have killed and despawned the target"
     );
+    let survivor = sim.substrate.entities.get(1).unwrap();
+    assert!(survivor.attack_target.is_none());
+    assert!(!survivor.has_live_contact_with(2));
 }
 
 // --- S3 per-object facing-destination tests (read in the P2 window) ---

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -379,18 +379,6 @@ fn classify_projectile_delivery(
     }
 }
 
-/// Whether a fire event's visible projectile is represented by the serialized
-/// world `ProjectileStore`, rather than the legacy app-local interpolation.
-pub(crate) fn projectile_uses_authoritative_flight(
-    weapon: &crate::rules::weapon_type::WeaponType,
-    rules: &RuleSet,
-) -> bool {
-    matches!(
-        classify_projectile_delivery(weapon, rules),
-        ProjectileDelivery::Persistent { .. }
-    )
-}
-
 #[cfg(test)]
 mod projectile_delivery_tests {
     use super::*;
@@ -1443,7 +1431,7 @@ fn append_building_smudge_requests(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn emit_infantry_death_anim(
+pub(crate) fn emit_infantry_death_anim(
     general: &crate::rules::ruleset::GeneralRules,
     inf_death: u8,
     rx: u16,
@@ -2234,15 +2222,7 @@ fn append_selected_death_sounds(
 /// death-weapon transaction has returned. Keeping the plan data-only avoids
 /// consuming smudge RNG (or interning the InfDeath AnimType) too early.
 enum ConcreteDeathSmudgePlan {
-    Infantry {
-        inf_death: u8,
-        rx: u16,
-        ry: u16,
-        sub_x: SimFixed,
-        sub_y: SimFixed,
-        z: u8,
-        world_z_leptons: i32,
-    },
+    Infantry(crate::sim::world::InfantryDeathPostlude),
     Building {
         rx: u16,
         ry: u16,

--- a/src/sim/combat/world_receiver.rs
+++ b/src/sim/combat/world_receiver.rs
@@ -1121,53 +1121,30 @@ pub(crate) fn handle_death(
                 }
             }
 
-            if has_animation {
-                // Transitional Infantry/SHP handoff: health was already reduced
-                // to zero by damage processing. Combat owns only the Rust death
-                // gate and sequence selection until Mission/Foot owns cadence.
-                // Select InfDeath variant from the killing warhead (default Die1).
-                let inf_death: u8 = killing_warhead
-                    .as_ref()
-                    .map(|(wh, _)| wh.inf_death)
-                    .unwrap_or(1);
-                // The two arms are mutually exclusive in native: the jump
-                // table at 0x00518D58 either runs `Do_Action(Die1|Die2)` with
-                // no anim (InfDeath 1, 2) or spawns an anim with no sequence
-                // (InfDeath 3..10), and InfDeath 0 or > 10 does neither.
-                if category == EntityCategory::Infantry
-                    && crate::sim::animation::inf_death_spawns_anim(inf_death)
-                {
-                    concrete_smudge_plans.push(ConcreteDeathSmudgePlan::Infantry {
-                        inf_death,
-                        rx,
-                        ry,
-                        sub_x,
-                        sub_y,
-                        z,
-                        world_z_leptons,
-                    });
-                }
+            let inf_death = killing_warhead.as_ref().map_or(1, |(wh, _)| wh.inf_death);
+            if category == EntityCategory::Infantry {
+                let postlude = world.begin_infantry_receiver_death(
+                    dead_id,
+                    inf_death,
+                    &mut immediate_uninit_ids,
+                );
+                concrete_smudge_plans.push(ConcreteDeathSmudgePlan::Infantry(postlude));
+                despawned_ids.push(dead_id);
+            } else if has_animation {
+                // Non-Infantry SHP lifetime remains on its existing path.
                 if let Some(entity) = world.substrate.entities.get_mut(dead_id) {
                     entity.dying = true;
-                    if let Some(sequence) =
-                        crate::sim::animation::death_sequence_for_inf_death(inf_death)
-                    {
-                        if let Some(ref mut anim) = entity.animation {
-                            anim.switch_to(sequence);
-                        }
+                    if let (Some(sequence), Some(anim)) = (
+                        crate::sim::animation::death_sequence_for_inf_death(inf_death),
+                        entity.animation.as_mut(),
+                    ) {
+                        anim.switch_to(sequence);
                     }
                 }
-                // Still report as "despawned" for fog/path updates — entity is
-                // functionally dead even though the sprite lingers for the animation.
                 despawned_ids.push(dead_id);
-                log::trace!("Entity {} dying (death animation)", dead_id);
             } else {
-                // Structures and voxel vehicles remain otherwise intact. The
-                // world consumes this request through ordered UnInit, which owns
-                // deselection, targets, radio, cell/logic state, and passengers.
                 immediate_uninit_ids.push(dead_id);
                 despawned_ids.push(dead_id);
-                log::trace!("Entity {} destroyed", dead_id);
             }
         }
     }
@@ -1286,51 +1263,7 @@ pub(crate) fn handle_death(
             );
         }
     }
-
-    // Concrete InfDeath AnimClass and building destruction smudges are the
-    // receiver postlude. The structure is intentionally still represented and
-    // its raw occupation bytes remain live in the world during dispatch.
-    for plan in concrete_smudge_plans {
-        let mut requests = Vec::new();
-        match plan {
-            ConcreteDeathSmudgePlan::Infantry {
-                inf_death,
-                rx,
-                ry,
-                sub_x,
-                sub_y,
-                z,
-                world_z_leptons,
-            } => emit_infantry_death_anim(
-                &rules.general,
-                inf_death,
-                rx,
-                ry,
-                sub_x,
-                sub_y,
-                z,
-                world_z_leptons,
-                &mut world.interner,
-                &mut explosion_effects,
-                &mut requests,
-            ),
-            ConcreteDeathSmudgePlan::Building {
-                rx,
-                ry,
-                z,
-                foundation,
-            } => append_building_smudge_requests(&mut requests, rx, ry, z, &foundation),
-        }
-        commit_smudges(
-            world,
-            rules,
-            overlay_registry,
-            requests,
-            &mut smudge_spawn_requests,
-        );
-    }
-
-    DeathEffects {
+    let mut effects = DeathEffects {
         despawned_ids,
         immediate_uninit_ids,
         structure_destroyed,
@@ -1351,7 +1284,31 @@ pub(crate) fn handle_death(
         unit_lost_events,
         #[cfg(test)]
         receiver_stage_trace,
+    };
+
+    // The receiver owns the recursion boundary; each concrete owner consumes
+    // its captured postlude here without moving constructor/smudge RNG earlier.
+    for plan in concrete_smudge_plans {
+        match plan {
+            ConcreteDeathSmudgePlan::Infantry(postlude) => {
+                postlude.commit(world, rules, overlay_registry, &mut effects);
+            }
+            ConcreteDeathSmudgePlan::Building {
+                rx, ry, z, foundation,
+            } => {
+                let mut requests = Vec::new();
+                append_building_smudge_requests(&mut requests, rx, ry, z, &foundation);
+                commit_smudges(
+                    world,
+                    rules,
+                    overlay_registry,
+                    requests,
+                    &mut effects.smudge_spawn_requests,
+                );
+            }
+        }
     }
+    effects
 }
 
 fn emit_one_projectile_detonation(
@@ -3967,6 +3924,9 @@ pub(crate) fn tick_combat(
     }
     for &(attacker_id, sequence) in &animation_switches {
         if let Some(entity) = world.substrate.entities.get_mut(attacker_id) {
+            if entity.infantry_terminal.is_some() {
+                continue;
+            }
             if let Some(ref mut anim) = entity.animation {
                 anim.switch_to(sequence);
             }

--- a/src/sim/game_entity.rs
+++ b/src/sim/game_entity.rs
@@ -791,6 +791,8 @@ pub struct GameEntity {
     /// Whether this entity is playing its death animation (health=0, not yet despawned).
     /// Dying entities are excluded from combat targeting, pathfinding, and selection.
     pub dying: bool,
+    /// Retained Infantry lifetime policy; sprite animation stores progress only.
+    pub(crate) infantry_terminal: Option<crate::sim::world::InfantryTerminal>,
     /// Ticks remaining before a permanently blocked infantry scatters sideways.
     /// Set when movement is stuck on a non-temporary obstacle; counts down each tick.
     /// When it reaches 0, the unit scatters to a random adjacent cell instead of
@@ -1293,6 +1295,7 @@ impl GameEntity {
             zfudge_bridge: 7,
             too_big_to_fit_under_bridge: false,
             dying: false,
+            infantry_terminal: None,
             blocked_scatter_timer: 0,
             move_sound_active: false,
             move_sound_countdown: 0,

--- a/src/sim/production/factory_lifecycle.rs
+++ b/src/sim/production/factory_lifecycle.rs
@@ -647,9 +647,9 @@ pub(crate) fn validate_restored_factory_state(
         if entity.spawn_owner_id.is_some() || entity.slave_harvester.is_some() {
             return Err(fail(owner, "factory root is itself a manager child"));
         }
-        // Do not infer health or death flags from factory membership. Current
-        // coordinate-based superweapon ingress can damage an unmarked held
-        // Infantry; rejecting its save here would hide that separate live bug.
+        // Factory admission validates retained identity and membership, without
+        // inferring health or death flags. Terminal-state admission separately
+        // validates the object's lifecycle handoff.
         if !entity.lifecycle.in_limbo || entity.lifecycle.cell_marked || entity.in_logic_vector {
             return Err(fail(
                 owner,

--- a/src/sim/snapshot.rs
+++ b/src/sim/snapshot.rs
@@ -429,7 +429,9 @@ use crate::sim::world::Simulation;
 // sit ahead of the `#[serde(skip)]` debug log, so a v134 record is short by
 // their bytes and bincode would read the next entity's bytes as them; the hash
 // schema also folds all three (`include_credit_income_v135`).
-const SNAPSHOT_VERSION: u32 = 135;
+// v136 adds the retained Infantry terminal policy, independently of sprite
+// animation progress. The entity layout and current deterministic hash change.
+const SNAPSHOT_VERSION: u32 = 136;
 
 const SNAPSHOT_PRODUCT_MAGIC: [u8; 8] = *b"VERA20K\0";
 const SNAPSHOT_ENVELOPE_VERSION: u32 = 1;
@@ -519,6 +521,8 @@ pub enum SnapshotError {
 /// Structural failures found before a deserialized simulation is admitted.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum SnapshotRestoreError {
+    #[error("entity {object_id} has an invalid or incomplete Infantry terminal handoff")]
+    InvalidInfantryTerminalState { object_id: u64 },
     #[error("house {owner} has invalid serialized outcome state: {reason}")]
     InvalidHouseOutcomeState {
         owner: crate::sim::intern::InternedId,
@@ -1525,6 +1529,31 @@ impl Simulation {
     /// weak/derived identities, and reconstructs skipped indexes in dependency
     /// order.
     pub(crate) fn restore_after_snapshot_load(&mut self) -> Result<(), SnapshotRestoreError> {
+        // VERA-internal terminal admission invariant. UnInit clears the policy
+        // before marking the object dead; pending deletion needs no new visit.
+        // A borrowed consequence packet cannot survive a save boundary.
+        // Logic membership is rebuilt later. A retained limbo object may carry
+        // a terminal policy until its owner releases it back into Logic.
+        let terminal_logic_members: std::collections::BTreeSet<_> =
+            self.substrate.logic.snapshot().into_iter().collect();
+        for (object_id, entity) in self.substrate.entities.iter_sorted() {
+            let infantry = entity.category == crate::map::entities::EntityCategory::Infantry;
+            if (entity.infantry_terminal.is_some()
+                && (!infantry
+                    || !entity.dying
+                    || !entity.lifecycle.object_alive
+                    || (!entity.lifecycle.in_limbo
+                        && !terminal_logic_members.contains(&object_id))))
+                || entity.infantry_terminal
+                    == Some(crate::sim::world::InfantryTerminal::AwaitingConsequences)
+                || (infantry
+                    && entity.dying
+                    && entity.lifecycle.object_alive
+                    && entity.infantry_terminal.is_none())
+            {
+                return Err(SnapshotRestoreError::InvalidInfantryTerminalState { object_id });
+            }
+        }
         for (&owner, house) in &self.houses {
             let Some(outcome) = house.outcome_state else {
                 if house.is_defeated || house.has_won || house.has_lost {
@@ -3195,7 +3224,68 @@ mod tests {
     fn house_eva_advice_snapshot_version_is_133() {
         // 133 -> 134: repair-depot docking layout (see the constant's comment).
         // 134 -> 135: GameEntity ProduceCash timer + drain link pair (GSI-09.01).
-        assert_eq!(super::SNAPSHOT_VERSION, 135);
+        // 135 -> 136: explicit retained Infantry terminal lifetime policy.
+        assert_eq!(super::SNAPSHOT_VERSION, 136);
+    }
+
+    #[test]
+    fn infantry_terminal_restore_rejects_state_outside_its_admission() {
+        use crate::map::entities::EntityCategory;
+        use crate::sim::game_entity::GameEntity;
+        use crate::sim::world::InfantryTerminal;
+        for (category, dying, object_alive, in_limbo, terminal) in [
+            (
+                EntityCategory::Unit,
+                true,
+                true,
+                true,
+                Some(InfantryTerminal::RetireNextVisit),
+            ),
+            (
+                EntityCategory::Infantry,
+                false,
+                true,
+                true,
+                Some(InfantryTerminal::RetireNextVisit),
+            ),
+            (
+                EntityCategory::Infantry,
+                true,
+                true,
+                true,
+                Some(InfantryTerminal::AwaitingConsequences),
+            ),
+            (EntityCategory::Infantry, true, true, true, None),
+            (
+                EntityCategory::Infantry,
+                true,
+                false,
+                true,
+                Some(InfantryTerminal::RetireNextVisit),
+            ),
+            (
+                EntityCategory::Infantry,
+                true,
+                true,
+                false,
+                Some(InfantryTerminal::RetireNextVisit),
+            ),
+        ] {
+            let mut sim = Simulation::new();
+            let mut entity = GameEntity::test_default(1, "E1", "Americans", 5, 5);
+            entity.category = category;
+            entity.dying = dying;
+            entity.lifecycle.object_alive = object_alive;
+            entity.lifecycle.in_limbo = in_limbo;
+            entity.infantry_terminal = terminal;
+            sim.substrate.entities.insert(entity);
+            let bytes = GameSnapshot::save(&sim, 0, 0, "test_map", 0);
+            let mut restored = GameSnapshot::load(&bytes).unwrap().sim;
+            assert_eq!(
+                restored.restore_after_snapshot_load(),
+                Err(SnapshotRestoreError::InvalidInfantryTerminalState { object_id: 1 })
+            );
+        }
     }
 
     #[test]

--- a/src/sim/superweapon/cell_receiver_tests.rs
+++ b/src/sim/superweapon/cell_receiver_tests.rs
@@ -176,6 +176,47 @@ fn genetic_converter_command_does_not_damage_factory_held_or_unmarked_infantry()
     held_infantry_survives_launch("GM");
 }
 
+#[test]
+fn genetic_converter_per_cell_retires_animated_victim_through_production_frames() {
+    animated_mutation_victim_retires(false);
+}
+
+#[test]
+fn genetic_converter_explosion_retires_animated_victim_through_production_frames() {
+    animated_mutation_victim_retires(true);
+}
+
+fn animated_mutation_victim_retires(explosion: bool) {
+    let (mut sim, mut rules) = fixture_with_extra(
+        "[Warheads]\n3=MutationAoE\n[SpecialWeapons]\nMutateExplosionWarhead=MutationAoE\n\
+         [MutationAoE]\nCellSpread=1\nPercentAtMax=1\nInfDeath=9\n\
+         Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    );
+    rules.general.mutate_explosion = explosion;
+    let victim = sim
+        .spawn_object_at_height("E1", "Americans", 5, 5, 0, 0, &rules)
+        .unwrap();
+    let object = sim.substrate.entities.get(victim).unwrap();
+    assert_eq!(
+        object.animation.as_ref().unwrap().sequence,
+        crate::sim::animation::SequenceKind::Stand
+    );
+    assert!(object.lifecycle.cell_marked && object.in_logic_vector);
+    launch_command(&mut sim, &rules, "GM", 5, 5);
+    let replacements = marked_brutes(&sim);
+    assert_eq!(replacements.len(), 1);
+    for _ in 0..120 {
+        sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+    }
+    assert!(
+        sim.substrate.entities.get(victim).is_none(),
+        "mutation must establish a terminal disposition before the normal dying scheduler takes over"
+    );
+    assert!(!sim.substrate.occupancy.contains_entity(5, 5, victim));
+    assert!(!sim.live_object_order_snapshot().contains(&victim));
+    assert_eq!(marked_brutes(&sim), replacements);
+}
+
 fn marked_brutes(sim: &Simulation) -> Vec<u64> {
     sim.substrate
         .entities
@@ -185,6 +226,309 @@ fn marked_brutes(sim: &Simulation) -> Vec<u64> {
         })
         .map(|entity| entity.stable_id())
         .collect()
+}
+
+#[test]
+fn infantry_terminal_raw_mutation_retires_on_next_visit_with_or_without_animation() {
+    for animated in [false, true] {
+        let (mut sim, rules) = fixture();
+        let victim = sim
+            .spawn_object_at_height("E1", "Americans", 5, 5, 0, 0, &rules)
+            .unwrap();
+        if !animated {
+            sim.substrate.entities.get_mut(victim).unwrap().animation = None;
+        }
+        launch_command(&mut sim, &rules, "GM", 5, 5);
+        let object = sim.substrate.entities.get(victim).unwrap();
+        assert!(object.lifecycle.cell_marked && object.in_logic_vector);
+        assert_eq!(
+            object.infantry_terminal,
+            Some(crate::sim::world::InfantryTerminal::RetireNextVisit)
+        );
+        let replacements = marked_brutes(&sim);
+        assert_eq!(
+            replacements.len(),
+            1,
+            "whole replacement batch precedes retirement"
+        );
+        sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+        assert!(sim.substrate.entities.get(victim).is_none());
+        assert!(!sim.substrate.occupancy.contains_entity(5, 5, victim));
+        assert!(!sim.live_object_order_snapshot().contains(&victim));
+        assert_eq!(marked_brutes(&sim), replacements);
+    }
+}
+
+#[test]
+fn infantry_terminal_no_art_cleanup_preserves_parent_before_recursive_deaths() {
+    use crate::sim::world::LifecycleTestEvent;
+    let (mut sim, rules) = fixture_with_extra("[DeathWH]\nCellSpread=2\n");
+    let parent = sim
+        .spawn_object_at_height("BOOM", "Americans", 5, 5, 0, 0, &rules)
+        .unwrap();
+    let child = sim
+        .spawn_object_at_height("E1", "Americans", 7, 5, 0, 0, &rules)
+        .unwrap();
+    for id in [parent, child] {
+        sim.substrate.entities.get_mut(id).unwrap().animation = None;
+    }
+    launch_command(&mut sim, &rules, "IC", 5, 5);
+    let uninit_order: Vec<_> = sim
+        .lifecycle_test_events_for_test()
+        .iter()
+        .filter_map(|event| match event {
+            LifecycleTestEvent::UninitClassPre { stable_id }
+                if [parent, child].contains(stable_id) =>
+            {
+                Some(*stable_id)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(uninit_order, [parent, child]);
+    for id in [parent, child] {
+        let entity = sim.substrate.entities.get(id).unwrap();
+        assert!(entity.lifecycle.in_limbo && !entity.in_logic_vector);
+        assert!(entity.infantry_terminal.is_none());
+    }
+    sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+    assert!(!sim.substrate.entities.contains(parent));
+    assert!(!sim.substrate.entities.contains(child));
+}
+
+#[test]
+fn infantry_terminal_custom_fly_missions_retire_without_death_announcement() {
+    use crate::sim::aircraft::{AircraftMission, tick_aircraft_missions};
+    use crate::sim::world::InfantryTerminal;
+    for silent_exit in [false, true] {
+        let (mut sim, rules) = fixture_with_extra(
+            "[E1]\nLocomotor={4A582746-9839-11D1-B709-00A024DDAFD1}\nAirportBound=yes\n",
+        );
+        let victim = sim
+            .spawn_object_at_height("E1", "Americans", 5, 5, 0, 0, &rules)
+            .unwrap();
+        let entity = sim.substrate.entities.get_mut(victim).unwrap();
+        assert!(entity.aircraft_mission.is_some(), "authored Fly admission");
+        assert!(
+            entity.aircraft_ammo.is_none(),
+            "Infantry has no Aircraft ammo"
+        );
+        entity.locomotor.as_mut().unwrap().altitude =
+            crate::util::fixed_math::SimFixed::from_num(100);
+        entity.aircraft_mission = Some(if silent_exit {
+            AircraftMission::ParaDropOverfly {
+                exit_rx: 5,
+                exit_ry: 5,
+                drop_cooldown: 0,
+                landing_state: 0,
+                payload_count: 0,
+            }
+        } else {
+            AircraftMission::Idle
+        });
+        tick_aircraft_missions(&mut sim, &rules, None);
+        let entity = sim.substrate.entities.get(victim).unwrap();
+        assert_eq!(
+            entity.infantry_terminal,
+            Some(InfantryTerminal::RetireNextVisit)
+        );
+        assert!(entity.dying && entity.aircraft_mission.is_none());
+        assert!(
+            !sim.sound_events
+                .iter()
+                .any(|event| matches!(event, crate::sim::world::SimSoundEvent::UnitLost { .. }))
+        );
+        sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+        assert!(!sim.substrate.entities.contains(victim));
+        assert!(!sim.substrate.occupancy.contains_entity(5, 5, victim));
+        assert!(!sim.live_object_order_snapshot().contains(&victim));
+    }
+}
+
+#[test]
+fn infantry_terminal_same_frame_firer_death_keeps_electric_consequences() {
+    for inf_death in [2, 3] {
+        let (mut sim, mut rules) = fixture_with_extra(&format!(
+            "[VehicleTypes]\n1=TESLA\n[E1]\nPrimary=Rifle\nSight=8\n\
+         [TESLA]\nStrength=300\nSpeed=6\nSight=8\nPrimary=Coil\n\
+         [Rifle]\nDamage=1\nROF=50\nRange=10\nWarhead=KILL\n\
+         [Coil]\nDamage=1000\nROF=50\nRange=10\nWarhead=KILL\nIsElectricBolt=yes\n\
+         [Warheads]\n3=KILL\n[KILL]\nInfDeath={inf_death}\nCellSpread=0\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+         [CombatDamage]\nDefaultSparkSystem=SparkSys\n[ParticleSystems]\n0=SparkSys\n\
+         [SparkSys]\nBehavesLike=Spark\nHoldsWhat=Spark\nParticleCap=6\nSparkSpawnFrames=1\nLifetime=200\n\
+         [Particles]\n0=Spark\n[Spark]\nBehavesLike=Spark\nMaxEC=500\n",
+        ));
+        let mut set = rules.animation_sequence("E1").unwrap().clone();
+        let mut def = set
+            .get(&crate::sim::animation::SequenceKind::Die2)
+            .unwrap()
+            .clone();
+        def.frame_count = 3;
+        def.frame_delay = 1;
+        def.normalized = false;
+        def.loop_mode = crate::sim::animation::LoopMode::HoldLast;
+        set.insert(crate::sim::animation::SequenceKind::Die2, def);
+        rules.replace_animation_sequences_for_test(BTreeMap::from([("E1".into(), set)]));
+        let infantry = sim
+            .spawn_object_at_height(
+                "E1",
+                "Americans",
+                5,
+                5,
+                crate::sim::movement::facing_from_delta(1, 0),
+                0,
+                &rules,
+            )
+            .unwrap();
+        // Infantry construction selects a real subcell. Aim the Unit at that
+        // exact coordinate so its first own visit passes the facing gate.
+        let target_position = &sim.substrate.entities.get(infantry).unwrap().position;
+        let tesla_facing = (crate::sim::movement::turret::facing_toward_lepton(
+            6,
+            5,
+            crate::util::lepton::CELL_CENTER_LEPTON,
+            crate::util::lepton::CELL_CENTER_LEPTON,
+            target_position.rx,
+            target_position.ry,
+            target_position.sub_x,
+            target_position.sub_y,
+        ) >> 8) as u8;
+        let tesla = sim
+            .spawn_object_at_height("TESLA", "Russians", 6, 5, tesla_facing, 0, &rules)
+            .unwrap();
+        for (source, target) in [(infantry, tesla), (tesla, infantry)] {
+            assert!(crate::sim::combat::issue_attack_command(
+                &mut sim.substrate.entities,
+                source,
+                target,
+                Some(&rules),
+                &sim.interner
+            ));
+        }
+        let frame = sim.advance_app_frame(
+            &[],
+            Some(&rules),
+            &BTreeMap::new(),
+            None,
+            67,
+            crate::sim::world::TickLane::Ordinary,
+            None,
+        );
+        assert_eq!(
+            frame
+                .fire_events
+                .iter()
+                .map(|event| event.attacker_id)
+                .collect::<Vec<_>>(),
+            [infantry, tesla],
+            "Infantry fires before its fatal receiver in the same frame"
+        );
+        if inf_death == 2 {
+            let object = sim.substrate.entities.get(infantry).unwrap();
+            assert_eq!(
+                object.animation.as_ref().unwrap().sequence,
+                crate::sim::animation::SequenceKind::Die2,
+                "queued FireUp must not overwrite the terminal sequence"
+            );
+        } else {
+            assert!(!sim.substrate.entities.contains(infantry));
+        }
+        assert_eq!(
+            sim.particle_systems().len(),
+            1,
+            "fatal target resolves until spark delivery"
+        );
+        let spark_id = *sim.particle_systems().iter().next().unwrap().0;
+        assert!(sim.live_object_order_snapshot().contains(&spark_id));
+        for visit in 1..=3 {
+            sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+            assert_eq!(
+                sim.substrate.entities.contains(infantry),
+                inf_death == 2 && visit < 3
+            );
+        }
+        assert_eq!(
+            sim.particle_systems().len(),
+            1,
+            "no repeated death discharge"
+        );
+    }
+}
+
+#[test]
+fn infantry_terminal_receiver_sequences_finish_through_production_frames() {
+    use crate::sim::animation::{LoopMode, SequenceKind};
+    for (inf_death, sequence) in [(1, SequenceKind::Die1), (2, SequenceKind::Die2)] {
+        let (mut sim, mut rules) = fixture_with_extra(&format!("[Super]\nInfDeath={inf_death}\n"));
+        let mut set = rules.animation_sequence("E1").unwrap().clone();
+        let mut def = set.get(&sequence).unwrap().clone();
+        def.frame_count = 3;
+        def.frame_delay = 1;
+        def.normalized = false;
+        def.loop_mode = LoopMode::HoldLast;
+        set.insert(sequence, def);
+        rules.replace_animation_sequences_for_test(BTreeMap::from([("E1".to_string(), set)]));
+        let victim = sim
+            .spawn_object_at_height("E1", "Americans", 5, 5, 0, 0, &rules)
+            .unwrap();
+        launch_command(&mut sim, &rules, "IC", 5, 5);
+        let object = sim.substrate.entities.get(victim).unwrap();
+        assert!(object.dying && object.infantry_terminal.is_some());
+        assert_eq!(object.animation.as_ref().unwrap().sequence, sequence);
+        for frame in 1..=3 {
+            sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+            assert_eq!(
+                sim.substrate.entities.contains(victim),
+                frame < 3,
+                "InfDeath={inf_death}, frame={frame}"
+            );
+        }
+        assert!(!sim.substrate.occupancy.contains_entity(5, 5, victim));
+        assert!(!sim.live_object_order_snapshot().contains(&victim));
+    }
+}
+
+#[test]
+fn infantry_terminal_invalid_death_art_cannot_retain_a_live_logic_member() {
+    use crate::sim::animation::{LoopMode, SequenceKind, SequenceSet};
+    for invalid in 0..6 {
+        let (mut sim, mut rules) = fixture();
+        let mut set = rules.animation_sequence("E1").unwrap().clone();
+        let mut def = set.get(&SequenceKind::Die2).unwrap().clone();
+        match invalid {
+            0 => def.frame_count = 0,
+            1 => def.frame_delay = 0,
+            2 => def.loop_mode = LoopMode::Loop,
+            3 => def.loop_mode = LoopMode::TransitionTo(SequenceKind::Stand),
+            5 => {
+                def.frame_delay = 8192;
+                def.normalized = true;
+                sim.session.game_options.game_speed = 0;
+                assert_eq!(
+                    sim.session
+                        .game_options
+                        .normalized_anim_delay(def.frame_delay),
+                    0
+                );
+            }
+            _ => (),
+        }
+        set.insert(SequenceKind::Die2, def);
+        if invalid == 4 {
+            set = SequenceSet::new();
+        }
+        rules.replace_animation_sequences_for_test(BTreeMap::from([("E1".to_string(), set)]));
+        let victim = sim
+            .spawn_object_at_height("E1", "Americans", 5, 5, 0, 0, &rules)
+            .unwrap();
+        launch_command(&mut sim, &rules, "IC", 5, 5);
+        sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+        assert!(
+            sim.substrate.entities.get(victim).is_none(),
+            "invalid definition case {invalid}"
+        );
+        assert!(!sim.live_object_order_snapshot().contains(&victim));
+    }
 }
 
 #[test]

--- a/src/sim/superweapon/genetic_converter/mutation.rs
+++ b/src/sim/superweapon/genetic_converter/mutation.rs
@@ -129,17 +129,14 @@ fn apply_mutate_explosion(
                 })
         })
         .collect();
-    sim.commit_noncombat_aoe_receivers(rules, overlay_registry, &receivers);
+    let fatal_ids: BTreeSet<_> = sim
+        .commit_noncombat_aoe_receivers(rules, overlay_registry, &receivers)
+        .into_iter()
+        .collect();
 
     let killed: Vec<(u16, u16)> = candidates
         .into_iter()
-        .filter_map(|(id, rx, ry)| {
-            sim.substrate
-                .entities
-                .get(id)
-                .is_some_and(|entity| entity.health.current == 0 && entity.dying)
-                .then_some((rx, ry))
-        })
+        .filter_map(|(id, rx, ry)| fatal_ids.contains(&id).then_some((rx, ry)))
         .collect();
     killed
 }
@@ -180,9 +177,7 @@ fn apply_mutate_per_cell(sim: &mut Simulation, target_rx: u16, target_ry: u16) -
 
     let mut killed: Vec<(u16, u16)> = Vec::new();
     for (id, rx, ry) in &victims {
-        if let Some(e) = sim.substrate.entities.get_mut(*id) {
-            e.health.current = 0;
-            e.dying = true;
+        if sim.mark_raw_mutation_victim(*id) {
             killed.push((*rx, *ry));
         }
     }

--- a/src/sim/superweapon/paradrop.rs
+++ b/src/sim/superweapon/paradrop.rs
@@ -273,7 +273,10 @@ fn spawn_pdplane(
 
     if loaded == 0 {
         // No passengers loaded — kill the empty carrier rather than fly empty.
-        if let Some(entity) = sim.substrate.entities.get_mut(pdplane_id) {
+        let infantry_terminal = sim.begin_raw_infantry_death(pdplane_id, None);
+        if !infantry_terminal
+            && let Some(entity) = sim.substrate.entities.get_mut(pdplane_id)
+        {
             entity.health.current = 0;
             entity.dying = true;
         }

--- a/src/sim/superweapon/paradrop_tests.rs
+++ b/src/sim/superweapon/paradrop_tests.rs
@@ -14,9 +14,9 @@ use crate::rules::ini_parser::IniFile;
 use crate::rules::ruleset::RuleSet;
 use crate::sim::aircraft::AircraftMission;
 use crate::sim::pathfinding::PathGrid;
-use crate::sim::superweapon::paradrop::{launch, ParaDropKind};
-use crate::sim::world::edge_cell::{find_paradrop_edge_cell, Edge};
+use crate::sim::superweapon::paradrop::{ParaDropKind, launch};
 use crate::sim::world::Simulation;
+use crate::sim::world::edge_cell::{Edge, find_paradrop_edge_cell};
 
 /// Minimal ruleset with PDPLANE + ParaDropWeapon + E1 + AMRADR cargo plane setup.
 /// AmerParaDropNum trimmed to 4 for faster test cycles vs the vanilla 8.
@@ -228,6 +228,50 @@ fn count_alive_infantry(sim: &Simulation, type_str: &str) -> usize {
                 && e.health.current > 0
         })
         .count()
+}
+
+#[test]
+fn infantry_terminal_empty_custom_carrier_retires_after_failed_launch() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=PDPLANE\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
+         [PDPLANE]\nStrength=400\nSpeed=15\nLocomotor={4A582746-9839-11D1-B709-00A024DDAFD1}\n\
+         [General]\nAmerParaDropInf=PDPLANE\nAmerParaDropNum=0\nFlightLevel=1500\n",
+    ))
+    .unwrap();
+    let (mut sim, path_grid) = build_sim(&rules);
+    sim.intern_rule_type_ids(&rules);
+    sim.resolve_type_handles(&rules);
+    let owner = sim.interner.intern("Americans");
+    let sw = sim.interner.intern("SWTEST");
+    assert!(!launch(
+        &mut sim,
+        &rules,
+        owner,
+        50,
+        20,
+        ParaDropKind::American,
+        sw,
+        Some(&path_grid)
+    ));
+    let carrier = sim
+        .substrate
+        .entities
+        .values()
+        .find(|entity| sim.interner.resolve(entity.type_ref()) == "PDPLANE")
+        .unwrap();
+    let id = carrier.stable_id();
+    assert_eq!(
+        carrier.category,
+        crate::map::entities::EntityCategory::Infantry
+    );
+    assert!(carrier.dying && carrier.animation.is_some() && carrier.in_logic_vector);
+    assert_eq!(
+        carrier.infantry_terminal,
+        Some(crate::sim::world::InfantryTerminal::RetireNextVisit)
+    );
+    tick_n(&mut sim, &rules, &path_grid, 1);
+    assert!(!sim.substrate.entities.contains(id));
+    assert!(!sim.live_object_order_snapshot().contains(&id));
 }
 
 #[test]

--- a/src/sim/world/bridge_deck_tests.rs
+++ b/src/sim/world/bridge_deck_tests.rs
@@ -11,6 +11,69 @@ use crate::sim::{
 };
 
 #[test]
+fn infantry_terminal_hut_collapse_retires_effect_only_ground_victim() {
+    use crate::sim::house_state::HouseState;
+    use crate::sim::world::{InfantryTerminal, LifecycleTestEvent, SimSoundEvent};
+    use std::collections::BTreeMap;
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=E1\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
+         [E1]\nStrength=100\nSpeed=4\n[CombatDamage]\nC4Warhead=KILL\n\
+         [Warheads]\n0=KILL\n[KILL]\nInfDeath=3\n",
+    ))
+    .unwrap();
+    let mut sim = Simulation::with_seed(31);
+    sim.intern_rule_type_ids(&rules);
+    sim.resolve_type_handles(&rules);
+    sim.resolved_terrain = Some(water_below_bridge_terrain(4));
+    let mut bridge = BridgeRuntimeState::default();
+    for y in [3, 4, 5] {
+        bridge.test_seed_cell(4, y, seed_bridge_cell(0xD4));
+    }
+    sim.bridge_state = Some(bridge);
+    let owner = sim.interner.intern("Americans");
+    sim.houses
+        .insert(owner, HouseState::new(owner, 0, None, true, 1000, 10));
+    sim.session.house_order.push(owner);
+    let victim = sim
+        .spawn_object_at_height("E1", "Americans", 4, 4, 0, 0, &rules)
+        .unwrap();
+    assert!(!sim.substrate.entities.get(victim).unwrap().on_bridge);
+    sim.substrate.entities.get_mut(victim).unwrap().selected = true;
+    assert!(dispatch_bridge_collapse_from_hut_with_overlay_registry(
+        &mut sim,
+        &rules,
+        (4, 4),
+        None
+    ));
+    let object = sim.substrate.entities.get(victim).unwrap();
+    assert_eq!(
+        object.infantry_terminal,
+        Some(InfantryTerminal::RetireNextVisit)
+    );
+    assert!(object.dying && !object.selected);
+    assert_eq!(
+        sim.sound_events
+            .iter()
+            .filter(|event| matches!(event,
+        SimSoundEvent::UnitLost { owner: lost } if *lost == owner))
+            .count(),
+        1
+    );
+    sim.advance_tick(&[], Some(&rules), &BTreeMap::new(), None, None, 100);
+    assert!(!sim.substrate.entities.contains(victim));
+    assert!(!sim.substrate.occupancy.contains_entity(4, 4, victim));
+    assert!(!sim.live_object_order_snapshot().contains(&victim));
+    assert_eq!(
+        sim.lifecycle_test_events_for_test()
+            .iter()
+            .filter(|event| matches!(event,
+        LifecycleTestEvent::FinalizedCommon { stable_id } if *stable_id == victim))
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn hut_drop_in_owns_order_footprints_and_restore_without_teardown_side_effects() {
     let rules = RuleSet::from_ini(&IniFile::from_str(
         "[InfantryTypes]\n[VehicleTypes]\n0=MTNK\n[AircraftTypes]\n[BuildingTypes]\n0=BIG\n\

--- a/src/sim/world/bridge_orchestrator.rs
+++ b/src/sim/world/bridge_orchestrator.rs
@@ -1337,16 +1337,21 @@ fn kill_ground_occupants_at(
         .map(|(id, _)| id)
         .collect();
     for id in victims {
+        let infantry_terminal = sim.begin_raw_infantry_death(id, Some(c4_inf_death));
         if let Some(entity) = sim.substrate.entities.get_mut(id) {
-            entity.health.current = 0;
-            entity.dying = true;
+            if !infantry_terminal {
+                entity.health.current = 0;
+                entity.dying = true;
+            }
             entity.attack_target = None;
             entity.movement_target = None;
             entity.selected = false;
             // `death_seq` is `None` whenever the warhead's `InfDeath=` picks
             // an animation arm instead of a sequence — see the jump table at
             // 0x00518D58.
-            if let (Some(seq), Some(anim)) = (death_seq, entity.animation.as_mut()) {
+            if let (false, Some(seq), Some(anim)) =
+                (infantry_terminal, death_seq, entity.animation.as_mut())
+            {
                 anim.switch_to(seq);
             }
         }
@@ -3545,7 +3550,25 @@ mod tests {
         air.on_bridge = false;
         sim.substrate.entities.insert(air);
 
+        // Consumed Engineers can retain positive HP after UnInit until the
+        // deferred drain. The legacy coordinate scan must not restart their
+        // Infantry terminal lifetime when it visits this stored identity.
+        let retired = GameEntity::new_at_frame_zero_for_test(
+            3, 5, 5, 0, 0, sim.interner.intern("Americans"),
+            Health { current: 100, max: 100 }, sim.interner.intern("E1"),
+            crate::map::entities::EntityCategory::Infantry, 0, 5, false,
+        );
+        sim.substrate.entities.insert(retired);
+        sim.uninit(3);
+        assert!(sim.substrate.entities.get(3).unwrap().health.current > 0);
+
         kill_ground_occupants_at(&mut sim, &rules_with_voxel_max(0), 5, 5, 1);
+
+        let retired = sim.substrate.entities.get(3).unwrap();
+        assert_eq!(retired.health.current, 0, "raw HP write is preserved");
+        assert!(!retired.lifecycle.object_alive);
+        assert!(retired.infantry_terminal.is_none());
+        assert_eq!(sim.substrate.pending_delete, vec![3]);
 
         let g = sim.substrate.entities.get(1).expect("ground unit present");
         assert_eq!(g.health.current, 0, "ground occupant is force-killed");

--- a/src/sim/world/bridge_parity_harness_tests.rs
+++ b/src/sim/world/bridge_parity_harness_tests.rs
@@ -143,7 +143,11 @@ const BRIDGE_HARNESS_PRE_DISGUISE_DETECT_V117_HASH: u64 = 0x1422_9DF5_DB39_C07B;
 // and every older probe plus the three RNG streams are unchanged, so this is
 // composition-only (no derrick, DrainWeapon or capture in this fixture).
 const BRIDGE_HARNESS_PRE_CREDIT_INCOME_V135_HASH: u64 = 0x7D6C_E7BF_2564_FD19;
-const BRIDGE_HARNESS_FINAL_HASH: u64 = 0x88D0_BF2F_F9AC_A02B;
+const BRIDGE_HARNESS_PRE_INFANTRY_TERMINAL_V136_HASH: u64 = 0x88D0_BF2F_F9AC_A02B;
+// v136 adds the Infantry terminal-policy fold. The pre-v136 assertion below
+// reproduces the prior current baseline exactly; older probes and RNG pins
+// are unchanged. This is Rust hash-composition provenance, not native parity.
+const BRIDGE_HARNESS_FINAL_HASH: u64 = 0x81A1_308C_05B6_ECBD;
 
 fn bridge_ini() -> IniFile {
     // One armed ground vehicle and one distant infantryman on a second house, so
@@ -541,6 +545,11 @@ fn bridge_crossing_replay_is_deterministic_and_baseline_stable() {
     let pre_wall_runtime_hash = rep.state_hash_without_wall_runtime_v115();
     let pre_disguise_detect_hash = rep.state_hash_without_disguise_detect_v117();
     let pre_credit_income_hash = rep.state_hash_without_credit_income_v135();
+    assert_eq!(
+        rep.state_hash_without_infantry_terminal_v136(),
+        BRIDGE_HARNESS_PRE_INFANTRY_TERMINAL_V136_HASH,
+        "pre-v136 composition must reproduce the prior bridge baseline"
+    );
     assert_eq!(
         pre_credit_income_hash, BRIDGE_HARNESS_PRE_CREDIT_INCOME_V135_HASH,
         "the dedicated pre-v135 probe must reproduce the prior bridge current baseline"

--- a/src/sim/world/global_parity_harness_tests.rs
+++ b/src/sim/world/global_parity_harness_tests.rs
@@ -593,7 +593,11 @@ const GLOBAL_HARNESS_PRE_CREDIT_INCOME_V135_HASH: u64 = 0xCDD5_6F8D_8B28_E750;
 // Re-baselined 2026-09-06 for the v135 credit-income folds (GSI-09.01),
 // composition-only: `GLOBAL_HARNESS_PRE_CREDIT_INCOME_V135_HASH` holds the
 // prior value and every historical probe and stream pin is unchanged.
-const GLOBAL_HARNESS_FINAL_HASH: u64 = 0x9C72_8D95_EBB4_D7D7;
+const GLOBAL_HARNESS_PRE_INFANTRY_TERMINAL_V136_HASH: u64 = 0x9C72_8D95_EBB4_D7D7;
+// v136 adds the Infantry terminal-policy fold. The pre-v136 assertion below
+// reproduces the prior current baseline exactly; older probes and RNG pins
+// are unchanged. This is Rust hash-composition provenance, not native parity.
+const GLOBAL_HARNESS_FINAL_HASH: u64 = 0xDFD3_59DA_AFD5_CCFD;
 
 fn harness_ini() -> IniFile {
     // Multi-faction vehicles + infantry + buildings (war factory, refinery) plus a
@@ -918,6 +922,11 @@ fn global_skirmish_replay_is_deterministic_and_baseline_stable() {
     let pre_wall_runtime_hash = rep.state_hash_without_wall_runtime_v115();
     let pre_disguise_detect_hash = rep.state_hash_without_disguise_detect_v117();
     let pre_credit_income_hash = rep.state_hash_without_credit_income_v135();
+    assert_eq!(
+        rep.state_hash_without_infantry_terminal_v136(),
+        GLOBAL_HARNESS_PRE_INFANTRY_TERMINAL_V136_HASH,
+        "pre-v136 composition must reproduce the prior global baseline"
+    );
     println!(
         "[global parity] probes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},pre-v110:{pre_base_plan_hash:016X},pre-v114:{pre_crate_authority_hash:016X},pre-v115:{pre_wall_runtime_hash:016X},pre-v117:{pre_disguise_detect_hash:016X},pre-v135:{pre_credit_income_hash:016X}"
     );

--- a/src/sim/world/hash_schema.rs
+++ b/src/sim/world/hash_schema.rs
@@ -40,6 +40,7 @@ pub(super) enum HashFeature {
     HouseHarvesterNoOre = 132,
     HouseEva = 133,
     CreditIncome = 135,
+    InfantryTerminal = 136,
 }
 
 impl HashSchema {

--- a/src/sim/world/infantry_terminal.rs
+++ b/src/sim/world/infantry_terminal.rs
@@ -1,0 +1,266 @@
+//! Infantry terminal lifetime, separate from sprite animation progress.
+//!
+//! VERA-internal compatibility policy, gamemd equivalent UNCHECKED. Preserve
+//! the existing effect recipe and delivery order while correcting indefinite
+//! retention of effect-only corpses. Native InfantryClass::ReceiveDamage
+//! (0x00517FA0) has additional selectors/particle operations not implemented here.
+
+use super::Simulation;
+use crate::map::entities::EntityCategory;
+use crate::rules::ruleset::RuleSet;
+use crate::sim::animation::{Animation, LoopMode, SequenceKind, advance_animation};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub(crate) enum InfantryDeathSequence {
+    Die1,
+    Die2,
+}
+
+impl InfantryDeathSequence {
+    fn for_inf_death(inf_death: u8) -> Option<Self> {
+        match inf_death {
+            1 => Some(Self::Die1),
+            2 => Some(Self::Die2),
+            _ => None,
+        }
+    }
+    fn animation(self) -> SequenceKind {
+        match self {
+            Self::Die1 => SequenceKind::Die1,
+            Self::Die2 => SequenceKind::Die2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub(crate) enum InfantryTerminal {
+    RetireNextVisit,
+    Sequence(InfantryDeathSequence),
+    /// The receiver's consuming DamageConsequences owns the cleanup boundary.
+    AwaitingConsequences,
+}
+
+enum ReceiverDeathRecipe {
+    Sequence,
+    ExternalAnim(u8),
+    Cleanup,
+}
+
+/// Captured pre-recursion inputs; consuming this postlude cannot forget the
+/// matching lifetime decision or split effect/smudge selection between callers.
+#[must_use]
+pub(crate) struct InfantryDeathPostlude {
+    id: u64,
+    position: crate::sim::components::Position,
+    world_z_leptons: i32,
+    recipe: ReceiverDeathRecipe,
+}
+
+impl InfantryDeathPostlude {
+    pub(crate) fn commit(
+        self,
+        world: &mut Simulation,
+        rules: &RuleSet,
+        overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+        effects: &mut crate::sim::combat::DeathEffects,
+    ) {
+        if let ReceiverDeathRecipe::ExternalAnim(inf_death) = self.recipe {
+            let mut smudges = Vec::new();
+            crate::sim::combat::emit_infantry_death_anim(
+                &rules.general,
+                inf_death,
+                self.position.rx,
+                self.position.ry,
+                self.position.sub_x,
+                self.position.sub_y,
+                self.position.z,
+                self.world_z_leptons,
+                &mut world.interner,
+                &mut effects.explosion_effects,
+                &mut smudges,
+            );
+            for request in smudges {
+                #[cfg(test)]
+                if world.receiver_fixture.is_some() {
+                    effects.smudge_spawn_requests.push(request);
+                    continue;
+                }
+                world.commit_smudge_request_inline(rules, overlay_registry, request);
+            }
+        }
+        if matches!(self.recipe, ReceiverDeathRecipe::ExternalAnim(_)) {
+            effects.immediate_uninit_ids.push(self.id);
+        }
+    }
+}
+
+impl Simulation {
+    /// Select the represented recipe before recursive DeathWeapon damage, in
+    /// the same slot as the old sequence switch. Effects remain in the later
+    /// consuming postlude. Animation presence gates legacy effects, never an
+    /// indefinite lifetime wait.
+    pub(crate) fn begin_infantry_receiver_death(
+        &mut self,
+        id: u64,
+        inf_death: u8,
+        immediate_uninit_ids: &mut Vec<u64>,
+    ) -> InfantryDeathPostlude {
+        let entity = self
+            .substrate
+            .entities
+            .get(id)
+            .expect("fatal Infantry retained for postlude");
+        debug_assert_eq!(entity.category, EntityCategory::Infantry);
+        let position = entity.position.clone();
+        let world_z_leptons =
+            crate::sim::combat::object_world_z_leptons(entity, self.resolved_terrain.as_ref());
+        let recipe = if entity.animation.is_none() {
+            // Preserve the established no-art cleanup position before nested
+            // DeathWeapon receivers append their own cleanup IDs.
+            immediate_uninit_ids.push(id);
+            ReceiverDeathRecipe::Cleanup
+        } else if let Some(sequence) = InfantryDeathSequence::for_inf_death(inf_death) {
+            self.begin_infantry_death_sequence(id, sequence);
+            ReceiverDeathRecipe::Sequence
+        } else if crate::sim::animation::inf_death_spawns_anim(inf_death) {
+            ReceiverDeathRecipe::ExternalAnim(inf_death)
+        } else {
+            immediate_uninit_ids.push(id);
+            ReceiverDeathRecipe::Cleanup
+        };
+        if !matches!(recipe, ReceiverDeathRecipe::Sequence) {
+            let entity = self.substrate.entities.get_mut(id).unwrap();
+            entity.dying = true;
+            entity.infantry_terminal = Some(InfantryTerminal::AwaitingConsequences);
+        }
+        InfantryDeathPostlude {
+            id,
+            position,
+            world_z_leptons,
+            recipe,
+        }
+    }
+
+    /// VERA-internal compatibility, gamemd equivalent UNCHECKED: raw Genetic
+    /// mutation keeps its whole-batch immediate replacement policy and bypasses
+    /// ReceiveDamage effects. Retire on the victim's next Logic visit, as the
+    /// former non-animated path did; a looping Stand must not retain a corpse.
+    pub(crate) fn mark_raw_mutation_victim(&mut self, id: u64) -> bool {
+        let Some(entity) = self.substrate.entities.get(id) else {
+            return false;
+        };
+        if entity.category != EntityCategory::Infantry || entity.dying || entity.health.current == 0
+        {
+            return false;
+        }
+        self.begin_raw_infantry_death(id, None)
+    }
+
+    /// Complete the represented raw-kill handoff. Bridge fallout supplies its
+    /// C4 sequence selector; mutation and aircraft retirement supply no action.
+    /// No ReceiveDamage effects are introduced on these compatibility paths.
+    /// Returns false for other categories, whose existing lifetime stays local.
+    pub(crate) fn begin_raw_infantry_death(&mut self, id: u64, inf_death: Option<u8>) -> bool {
+        let Some(entity) = self.substrate.entities.get_mut(id) else {
+            return false;
+        };
+        if entity.category != EntityCategory::Infantry {
+            return false;
+        }
+        entity.health.current = 0;
+        entity.dying = true;
+        // Legacy raw coordinate scans can revisit an UnInit'd object before
+        // pending deletion drains it. Preserve their HP write, but never give
+        // a completed lifetime another scheduled terminal action.
+        if !entity.lifecycle.object_alive {
+            return true;
+        }
+        let sequence = entity
+            .animation
+            .as_ref()
+            .and_then(|_| inf_death.and_then(InfantryDeathSequence::for_inf_death));
+        if let Some(sequence) = sequence {
+            self.begin_infantry_death_sequence(id, sequence);
+        } else {
+            entity.infantry_terminal = Some(InfantryTerminal::RetireNextVisit);
+        }
+        true
+    }
+
+    /// Admit a selected death action atomically, including fresh progress even
+    /// if an earlier ordinary animation happened to use the same sequence.
+    pub(crate) fn begin_infantry_death_sequence(
+        &mut self,
+        id: u64,
+        sequence: InfantryDeathSequence,
+    ) {
+        let Some(entity) = self.substrate.entities.get_mut(id) else {
+            return;
+        };
+        debug_assert_eq!(entity.category, EntityCategory::Infantry);
+        debug_assert!(entity.lifecycle.object_alive);
+        entity.dying = true;
+        entity.infantry_terminal = Some(InfantryTerminal::Sequence(sequence));
+        entity.animation = Some(Animation::new(sequence.animation()));
+    }
+
+    /// Consume this object's terminal Logic visit, including eventual UnInit.
+    /// Returns false only when the object is outside this lifetime mechanism.
+    pub(super) fn visit_infantry_terminal(&mut self, id: u64, rules: Option<&RuleSet>) -> bool {
+        let Some(entity) = self.substrate.entities.get(id) else {
+            return false;
+        };
+        let Some(terminal) = entity.infantry_terminal else {
+            return false;
+        };
+        debug_assert!(entity.dying && entity.category == EntityCategory::Infantry);
+        let finished = match terminal {
+            InfantryTerminal::RetireNextVisit => true,
+            InfantryTerminal::AwaitingConsequences => return true,
+            InfantryTerminal::Sequence(sequence) => {
+                let Some(rules) = rules else {
+                    return true;
+                };
+                let def = rules
+                    .animation_sequence(self.interner.resolve(entity.type_ref()))
+                    .and_then(|set| set.get(&sequence.animation()));
+                let animation = self
+                    .substrate
+                    .entities
+                    .get_mut(id)
+                    .unwrap()
+                    .animation
+                    .as_mut();
+                match (animation, def) {
+                    (Some(animation), Some(def))
+                        if animation.sequence == sequence.animation()
+                            && def.frame_count > 0
+                            && def.frame_delay > 0
+                            && (!def.normalized
+                                || self
+                                    .session
+                                    .game_options
+                                    .normalized_anim_delay(def.frame_delay)
+                                    > 0)
+                            && matches!(def.loop_mode, LoopMode::HoldLast) =>
+                    {
+                        advance_animation(animation, def, &self.session.game_options);
+                        animation.finished
+                    }
+                    // VERA-internal malformed/missing art fallback: never wait
+                    // indefinitely on a looping or non-progressing definition.
+                    _ => true,
+                }
+            }
+        };
+        if finished {
+            self.release_move_sound(id);
+            if let Some(rules) = rules {
+                self.uninit_with_rules(id, rules);
+            } else {
+                self.uninit(id);
+            }
+        }
+        true
+    }
+}

--- a/src/sim/world/lifecycle.rs
+++ b/src/sim/world/lifecycle.rs
@@ -2940,9 +2940,12 @@ impl Simulation {
     }
 
     pub(crate) fn uninit_with_context(&mut self, stable_id: u64, context: UninitContext<'_>) {
-        if !self.substrate.entities.contains(stable_id) {
+        let Some(entity) = self.substrate.entities.get_mut(stable_id) else {
             return;
-        }
+        };
+        // Consume deferred/retained Infantry lifetime before pointer-expiry
+        // callbacks, including an UnInit that overtakes receiver delivery.
+        entity.infantry_terminal = None;
 
         self.run_represented_uninit_pre_hook(stable_id);
         self.uninit_carried_passengers(stable_id, context);

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -19,6 +19,10 @@ pub(crate) mod bridge_orchestrator;
 pub(crate) mod building_anim;
 pub mod edge_cell;
 mod hash_schema;
+mod infantry_terminal;
+pub(crate) use infantry_terminal::{InfantryDeathPostlude, InfantryTerminal};
+#[cfg(test)]
+pub(crate) use infantry_terminal::InfantryDeathSequence;
 mod lifecycle;
 mod load_object_lifecycle;
 mod logic_vector;
@@ -2228,12 +2232,15 @@ impl Simulation {
         rules: &RuleSet,
         overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
         receivers: &[crate::sim::combat::combat_aoe::AreaDamageReceiver],
-    ) {
+    ) -> Vec<u64> {
         let mut run = crate::sim::combat::world_receiver::ReceiverRun::default();
         let (effects, under_attack_events) = crate::sim::combat::world_receiver::commit_area(
             self, &mut run, receivers, rules, overlay_registry,
         );
         let terrain_navigation_changed_cells = run.finish(self);
+        // Fatal transitions are facts of this receiver transaction. Retain
+        // them before consequence delivery can retire their objects.
+        let fatal_ids = effects.despawned_ids.clone();
 
         self.absorb_noncombat_damage_effects(
             rules,
@@ -2242,6 +2249,7 @@ impl Simulation {
             under_attack_events,
             terrain_navigation_changed_cells,
         );
+        fatal_ids
     }
 
     /// `BuildingClass::ReceiveDamage @ 0x00442230`, result-4 (destroyed) arm

--- a/src/sim/world/slice6_retask_tests.rs
+++ b/src/sim/world/slice6_retask_tests.rs
@@ -362,7 +362,11 @@ const SLICE6_PRE_DISGUISE_DETECT_V117_HASH: u64 = 0x8A0C_1481_C5DC_F2F9;
 // this script has no derrick, DrainWeapon or capture, so only composition
 // moved (each object folds its dead constructor timer and two `None`s).
 const SLICE6_PRE_CREDIT_INCOME_V135_HASH: u64 = 0xF26E_75C0_F0E0_4633;
-const SLICE6_BASELINE_HASH: u64 = 0xB9AD_9B95_BF3D_1130;
+const SLICE6_PRE_INFANTRY_TERMINAL_V136_HASH: u64 = 0xB9AD_9B95_BF3D_1130;
+// v136 adds the Infantry terminal-policy fold. The pre-v136 assertion below
+// reproduces the prior current baseline exactly; older probes and RNG pins
+// are unchanged. This is Rust hash-composition provenance, not native parity.
+const SLICE6_BASELINE_HASH: u64 = 0x75EB_010D_E026_0566;
 
 #[test]
 fn replay_hash_stable_through_slice6() {
@@ -444,6 +448,11 @@ fn replay_hash_stable_through_slice6() {
     let pre_wall_runtime_hash = sim.state_hash_without_wall_runtime_v115();
     let pre_disguise_detect_hash = sim.state_hash_without_disguise_detect_v117();
     let pre_credit_income_hash = sim.state_hash_without_credit_income_v135();
+    assert_eq!(
+        sim.state_hash_without_infantry_terminal_v136(),
+        SLICE6_PRE_INFANTRY_TERMINAL_V136_HASH,
+        "pre-v136 composition must reproduce the prior Slice 6 baseline"
+    );
     let hash = sim.state_hash();
     println!(
         "[slice6] hashes=pre-v28:{pre_lifecycle_hash:016X},pre-v29:{pre_mission_hash:016X},pre-v110:{pre_base_plan_hash:016X},pre-v114:{pre_crate_authority_hash:016X},pre-v115:{pre_wall_runtime_hash:016X},pre-v117:{pre_disguise_detect_hash:016X},pre-v135:{pre_credit_income_hash:016X},current:{hash:016X}"

--- a/src/sim/world/techno_ai.rs
+++ b/src/sim/world/techno_ai.rs
@@ -368,6 +368,9 @@ impl Simulation {
         let Some(entity) = self.substrate.entities.get(id) else {
             return false;
         };
+        if entity.infantry_terminal.is_some() {
+            return self.visit_infantry_terminal(id, rules);
+        }
         if entity.dying {
             let Some(rules) = rules else {
                 return true;

--- a/src/sim/world/world_hash.rs
+++ b/src/sim/world/world_hash.rs
@@ -540,6 +540,12 @@ impl Simulation {
         self.state_hash_with_schema(HashSchema::Before(135))
     }
 
+    /// Reconstruct the v135 composition before the Infantry terminal-policy fold.
+    #[cfg(test)]
+    pub(crate) fn state_hash_without_infantry_terminal_v136(&self) -> u64 {
+        self.state_hash_with_schema(HashSchema::Before(136))
+    }
+
     /// Test-only provenance probe for the schema-v115 retained wall-count and
     /// shared-dummy overlay folds.
     #[cfg(test)]
@@ -1322,6 +1328,9 @@ impl Simulation {
                 entity.dying.hash(hasher);
                 entity.dirty_rect_eligible.hash(hasher);
                 entity.owned_count_released.hash(hasher);
+            }
+            if schema.includes(HashFeature::InfantryTerminal) {
+                entity.infantry_terminal.hash(hasher);
             }
             if schema.includes(HashFeature::TechnoPlayfield) {
                 // TechnoClass+0x3D5 is mutable admission state, not a derived


### PR DESCRIPTION
Animated Infantry fatalities could remain indefinitely in a looping Stand animation. A private world owner now binds terminal policy to receiver effects, raw deaths, Logic visits and UnInit: finite Die1/Die2 progress, retirement on the next own visit, or cleanup through consuming DamageConsequences. Recursive DeathWeapon effect/smudge ordering and the represented effect recipe remain intact. Genetic replacement consumes the fatal receipt after cleanup, and queued firing animations cannot overwrite a terminal action.

Snapshot v136 preserves policy/progress and rejects incomplete handoffs. Production load tests cover retained factory objects waiting for release and already-delivered death surviving an aborted deletion frame. Raw bridge reselection cannot restart an UnInit-completed lifetime. This intentionally fixes corpse retention; full native DeathAnims/NotHuman/Cyborg/InfDeath9 placement and particle parity remain outside this increment.

Remove the unreachable app projectile interpolation pipeline: its producer rejected every resolved projectile classification. The authoritative projectile renderer is unchanged. Remove five helper-only presentation tests, one obsolete ignored deletion test, and one fabricated invalid factory-positive case; retain their meaningful contracts through real firing, cleanup and load paths. Three hash baselines retain exact pre-v136 provenance assertions and unchanged RNG pins.

Validation: `cargo test -p vera20k --lib`: **8483 passed, 0 failed, 80 ignored** (32.88s). `cargo clippy -p vera20k --lib`, `cargo check -p vera20k`, and `python -m tools.system_map check` pass. Actual command/frame tests cover IC/Genetic, nested DeathWeapon ordering, same-frame firing/fatality, hut collapse, custom Fly/PDPlane, factory release and PreparedLoad continuation.

Independent read-only critics reviewed ownership, ordering, exclusions, test removals and production-path evidence. Small Clippy gate repairs preserve exact numeric behavior: equivalent f64 RMG constants and a function-scoped allowance for existing distinct f32 voxel slope values.
