### PR TITLE
Own accepted movement cell-arrival invariants

### DIFF
--- a/docs/system-map/topology.v2.json
+++ b/docs/system-map/topology.v2.json
@@ -240,6 +240,7 @@
         }
       ],
       "rust_surfaces": [
+        {"path": "src/sim/movement/cell_arrival.rs", "symbol": "CellArrival::ordinary / track_jump", "coverage": "representative", "observed_at_commit": "32033c1882927fb4d6635b8bad1e857b55b7b2bb"},
         {
           "path": "src/sim/movement/drive_locomotion.rs",
           "symbol": "drive locomotion",
@@ -253,7 +254,7 @@
           "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"
         }
       ],
-      "notes": ["Owner of the bootstrap ground-move loop; native executable preflight remains blocked."]
+      "notes": ["Owner of the bootstrap ground-move loop; native executable preflight remains blocked.", "Accepted ordinary and track-jump arrivals share one private owner for entry order, layered cell lists, Drive occupation, claims, Infantry list repair and movement counts. Geometry, path consumption and differing path-layer phase positions remain with their callers; Rust regression evidence does not establish native parity."]
     },
     "GSI-07.13": {
       "native_anchors": [
@@ -1548,7 +1549,7 @@
       "from": "GSI-06.13",
       "to": "GSI-06.07",
       "context": "Ground-movement loop",
-      "detail": "Each accepted step must commit occupancy and layer transitions in native order.",
+      "detail": "Accepted ordinary and Drive track-jump crossings commit entry order, cell-list relinking, current Drive occupation and arrival claim/list correction through CellArrival. Existing distinct path-layer phase positions are preserved; native equivalence remains unchecked.",
       "evidence": ["docs/research/DRIVE_PROCESS_MOVEMENT_TICK_ORDER_GHIDRA_REPORT.md"]
     },
     {
@@ -2012,6 +2013,7 @@
         "Process_Drive_Track 0x004B0F20"
       ],
       "rust_touchpoints": [
+        {"path": "src/sim/movement/cell_arrival.rs", "coverage": "representative", "observed_at_commit": "32033c1882927fb4d6635b8bad1e857b55b7b2bb"},
         {"path": "src/sim/world/world_commands.rs", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},
         {"path": "src/sim/pathfinding", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},
         {"path": "src/sim/movement/movement_tick.rs", "coverage": "representative", "observed_at_commit": "5130d139db4db4ba0246744fbd8058df9853d005"},

--- a/src/sim/movement/bump_crush.rs
+++ b/src/sim/movement/bump_crush.rs
@@ -2857,27 +2857,15 @@ mod tests {
 
     // -- arrival-side claim: the zero-draw half of the sub-cell handshake --
 
-    /// GSI-06.14 G3. The retail arrival branch hands its sub-cell chooser a null
-    /// coordinate, which returns before the placement function runs — so arrival
-    /// consumes **no** random draw, whatever the mover's sub-position. A mover
-    /// standing at the cell centre is the case that would draw on the look-ahead
-    /// path, so it is the load-bearing fixture here.
-    #[test]
-    fn gsi_06_14_arrival_claim_consumes_no_rng() {
-        let rng = SimRng::new(42);
-        let before = rng.state();
-        // Centre sub-position: the look-ahead allocator draws here, the arrival
-        // claim must not. `claim_reserved_sub_cell` takes no RNG at all, so the
-        // guarantee is structural — this pins that it stays that way.
-        let claimed = claim_reserved_sub_cell(None, MovementLayer::Ground, 1, None);
-        assert_eq!(claimed, Some(2), "empty cell falls to the first free slot");
-        assert_eq!(rng.state(), before, "arrival must not advance the stream");
-    }
-
     /// The slot reserved by the look-ahead one cell earlier is the slot the man
     /// stands in on arrival — retail never re-selects.
     #[test]
     fn gsi_06_14_arrival_claims_the_pre_reserved_slot() {
+        assert_eq!(
+            claim_reserved_sub_cell(None, MovementLayer::Ground, 1, None),
+            Some(2),
+            "empty cell falls to the first free slot",
+        );
         let grid = make_occ(&[(5, 5, 2, MovementLayer::Ground, Some(2))]);
         let occ = grid.get(5, 5);
         assert_eq!(

--- a/src/sim/movement/cell_arrival.rs
+++ b/src/sim/movement/cell_arrival.rs
@@ -1,28 +1,117 @@
-//! Destination commitment — commits the infantry sub-cell or the vehicle
-//! cell-center dest after a successful cell transition. Previously also wrote to
-//! local reservation sets; now the live OccupancyGrid is the single source of
-//! truth.
+//! Complete accepted cell arrivals for ordinary crossings and Drive track jumps.
 //!
-//! **This is the arrival side and it consumes no RNG.** The original engine's
-//! arrival branch hands its sub-cell chooser a null coordinate, which returns
-//! before any placement runs, so no preference table is consulted and no random
-//! draw is taken. The slot was chosen one cell earlier by the look-ahead
-//! placement; here it is only claimed. Adding a draw here would double the
-//! scenario-stream consumption of the highest-rate consumer in movement.
+//! VERA-internal ownership boundary, gamemd equivalent UNCHECKED. Preserve the
+//! represented crossing order: fresh serialized list stamp, list relink,
+//! Drive current occupation, arrival claim and matching Infantry list repair.
+//! Geometry, path advancement, bridge rendering and look-ahead placement remain
+//! in their existing caller phases. Arrival consumes no RNG: WalkLocomotion
+//! ProcessMovement @ 0x0075BE0A reaches the NullCoord FindSubCellDest branch
+//! @ 0x0075C240; see the detailed arrival evidence beside the private claim.
 
 use crate::map::entities::EntityCategory;
-use crate::sim::components::Position;
+use crate::sim::components::{DriveLocomotionRuntime, Position};
 use crate::sim::movement::bump_crush;
 use crate::sim::movement::locomotor::{LocomotorState, MovementLayer};
-use crate::sim::occupancy::OccupancyGrid;
+use crate::sim::occupancy::{CellListInsertion, CellOccupationGrid, OccupancyGrid};
+use crate::sim::world::EnterOrderCounter;
+
+use super::MovementTickStats;
+
+/// Borrow only the projections an accepted arrival must update together.
+/// Position and old/new list layers have already been resolved by the caller;
+/// the path layer is separate because bridge predicates need not agree with it.
+pub(super) struct CellArrival<'a> {
+    pub entity_id: u64,
+    pub category: EntityCategory,
+    pub from: (u16, u16),
+    pub to: (u16, u16),
+    pub old_list_layer: MovementLayer,
+    pub new_list_layer: MovementLayer,
+    pub position: &'a Position,
+    pub locomotor: &'a mut Option<LocomotorState>,
+    pub drive_locomotion: &'a mut Option<DriveLocomotionRuntime>,
+    pub sub_cell: &'a mut Option<u8>,
+    pub occupancy_enter_order: &'a mut u64,
+    pub next_occupancy_enter_order: &'a mut EnterOrderCounter,
+    pub occupancy: &'a mut OccupancyGrid,
+    pub cell_occupation: &'a mut CellOccupationGrid,
+    pub stats: &'a mut MovementTickStats,
+    pub priority: bool,
+}
+
+impl CellArrival<'_> {
+    /// Ordinary crossings commit their path layer after current occupation.
+    pub(super) fn ordinary(mut self, next_layer: MovementLayer) {
+        self.relink();
+        if let Some(loco) = self.locomotor.as_mut() {
+            loco.layer = next_layer;
+        }
+        self.finish(next_layer);
+    }
+
+    /// Track jumps have already committed the path layer during bridge
+    /// resolution, before publishing the cell-list transition.
+    pub(super) fn track_jump(mut self, active_layer: MovementLayer) {
+        self.relink();
+        self.finish(active_layer);
+    }
+
+    fn relink(&mut self) {
+        *self.occupancy_enter_order = self.next_occupancy_enter_order.next();
+        self.occupancy.move_entity_layered(
+            self.from.0,
+            self.from.1,
+            self.to.0,
+            self.to.1,
+            self.entity_id,
+            self.old_list_layer,
+            self.new_list_layer,
+            *self.sub_cell,
+            CellListInsertion::from_category(self.category),
+        );
+        if self.category == EntityCategory::Unit
+            && let Some(drive) = self.drive_locomotion.as_mut()
+        {
+            crate::sim::occupancy::mark_current_drive_occupation_after_crossing(
+                drive,
+                self.cell_occupation,
+                self.entity_id,
+                self.to,
+                self.new_list_layer,
+            );
+        }
+    }
+
+    fn finish(self, path_layer: MovementLayer) {
+        reserve_destination_after_transition(
+            self.category,
+            self.entity_id,
+            self.locomotor,
+            self.position,
+            self.sub_cell,
+            path_layer,
+            self.to.0,
+            self.to.1,
+            self.occupancy,
+            self.priority,
+        );
+        // Claim and list correction are one operation: callers cannot publish
+        // a new Infantry sub_cell while leaving its cell-list entry stale.
+        if self.category == EntityCategory::Infantry {
+            self.occupancy
+                .update_sub_cell(self.to.0, self.to.1, self.entity_id, *self.sub_cell);
+        }
+        self.stats.moved_steps = self.stats.moved_steps.saturating_add(1);
+    }
+}
 
 /// Commit the arrival slot. Infallible, like the native arrival branch — the
 /// old `bool` return existed only for the failure path removed below.
-pub(super) fn reserve_destination_after_transition(
+fn reserve_destination_after_transition(
     category: EntityCategory,
     entity_id: u64,
     locomotor: &mut Option<LocomotorState>,
-    position: &mut Position,
+    position: &Position,
     sub_cell: &mut Option<u8>,
     next_layer: MovementLayer,
     nx: u16,

--- a/src/sim/movement/mod.rs
+++ b/src/sim/movement/mod.rs
@@ -52,6 +52,7 @@ use crate::util::fixed_math::{SIM_ONE, SimFixed, facing_from_delta_int};
 use crate::util::fixed_math::SIM_ZERO;
 
 // --- Internal submodules ---
+mod cell_arrival;
 mod drive_locomotion;
 pub(crate) mod locomotor_ready;
 mod movement_blocked;
@@ -59,7 +60,6 @@ pub(crate) mod movement_bridge;
 mod movement_commands;
 mod movement_occupancy;
 mod movement_path;
-mod movement_reservation;
 mod movement_step;
 mod movement_tick;
 mod navcom;

--- a/src/sim/movement/movement_step.rs
+++ b/src/sim/movement/movement_step.rs
@@ -7,6 +7,7 @@
 
 use std::collections::BTreeSet;
 
+use super::cell_arrival::CellArrival;
 use crate::map::entities::EntityCategory;
 use crate::map::resolved_terrain::ResolvedTerrainGrid;
 use crate::rules::locomotor_type::LocomotorKind;
@@ -26,8 +27,7 @@ use crate::sim::movement::movement_occupancy::{
     evaluate_runtime_can_enter_cell_with_transition, naval_terrain_diag,
     runtime_can_enter_cell_args,
 };
-use crate::sim::movement::movement_reservation::reserve_destination_after_transition;
-use crate::sim::occupancy::{CellListInsertion, CellOccupationGrid, OccupancyGrid};
+use crate::sim::occupancy::{CellOccupationGrid, OccupancyGrid};
 use crate::sim::pathfinding::LayeredEntityBlockMap;
 use crate::sim::pathfinding::PathGrid;
 use crate::sim::pathfinding::terrain_cost::TerrainCostGrid;
@@ -2179,57 +2179,26 @@ pub(super) fn process_cell_crossings(
         } else {
             MovementLayer::Ground
         };
-        // Update occupancy grid: move entity from old cell to new cell, removing
-        // on the OLD layer and inserting on the NEW layer (verified two-layer
-        // order). Uses current sub_cell (from old cell). For infantry,
-        // reserve_destination below may allocate a new sub-cell and correct it
-        // via update_sub_cell.
-        let insertion = CellListInsertion::from_category(category);
-        let order = next_occupancy_enter_order.next();
-        *occupancy_enter_order = order;
-        occupancy.move_entity_layered(
-            old_rx,
-            old_ry,
-            nx,
-            ny,
+        CellArrival {
             entity_id,
-            old_occupancy_layer,
-            new_occupancy_layer,
-            *sub_cell,
-            insertion,
-        );
-        if category == EntityCategory::Unit
-            && let Some(drive) = drive_locomotion.as_mut()
-        {
-            crate::sim::occupancy::mark_current_drive_occupation_after_crossing(
-                drive,
-                cell_occupation,
-                entity_id,
-                (nx, ny),
-                new_occupancy_layer,
-            );
-        }
-        active_layer = next_layer;
-        if let Some(loco) = locomotor {
-            loco.layer = next_layer;
-        }
-        reserve_destination_after_transition(
             category,
-            entity_id,
-            locomotor,
+            from: (old_rx, old_ry),
+            to: (nx, ny),
+            old_list_layer: old_occupancy_layer,
+            new_list_layer: new_occupancy_layer,
             position,
+            locomotor,
+            drive_locomotion,
             sub_cell,
-            next_layer,
-            nx,
-            ny,
+            occupancy_enter_order,
+            next_occupancy_enter_order,
             occupancy,
-            snap.sub_cell_priority_mission && snap.nav_com_cell == Some((nx, ny)),
-        );
-        // After reservation, infantry sub_cell may have changed.
-        if category == EntityCategory::Infantry {
-            occupancy.update_sub_cell(nx, ny, entity_id, *sub_cell);
+            cell_occupation,
+            stats,
+            priority: snap.sub_cell_priority_mission && snap.nav_com_cell == Some((nx, ny)),
         }
-        stats.moved_steps = stats.moved_steps.saturating_add(1);
+        .ordinary(next_layer);
+        active_layer = next_layer;
 
         configure_motion_after_transition(
             target,

--- a/src/sim/movement/movement_tests.rs
+++ b/src/sim/movement/movement_tests.rs
@@ -462,14 +462,8 @@ fn drive_slope_boundary_is_detected_on_process_after_forced_track_crossing() {
         .active_slope_transition_mut()
         .unwrap()
         .snap(4, 0);
-    let forced = drive_track::begin_forced_turn_track(
-        0x47,
-        0,
-        256,
-        SimFixed::from_num(128),
-        false,
-    )
-    .expect("retail southbound force track");
+    let forced = drive_track::begin_forced_turn_track(0x47, 0, 256, SimFixed::from_num(128), false)
+        .expect("retail southbound force track");
     {
         let (entities, cell_occupation) = (
             &mut sim.substrate.entities,
@@ -547,11 +541,8 @@ fn drive_ship_slope_process_uses_foot_class_boundary_not_object_speed_or_art() {
 
 #[test]
 fn entry_active_tube_excludes_drive_slope_process_for_the_whole_turn() {
-    let terrain = crate::map::resolved_terrain::ResolvedTerrainGrid::from_cells(
-        1,
-        1,
-        vec![slope_cell(0, 9)],
-    );
+    let terrain =
+        crate::map::resolved_terrain::ResolvedTerrainGrid::from_cells(1, 1, vec![slope_cell(0, 9)]);
     let mut sim = Simulation::new();
     let mut entity = GameEntity::test_default(1, "DRIVE", "Americans", 0, 0);
     entity.owner = sim.intern("Americans");
@@ -649,6 +640,8 @@ fn gsi_04_05_production_drive_observes_premark_clear_cross_and_finish() {
         "accepted Drive track must premark its head before moving the list"
     );
 
+    let arrival_order = sim.substrate.next_occupancy_enter_order.current();
+    let initial_order = sim.substrate.entities.get(1).unwrap().occupancy_enter_order;
     let initial_point_index = sim
         .substrate
         .entities
@@ -695,6 +688,14 @@ fn gsi_04_05_production_drive_observes_premark_clear_cross_and_finish() {
         crate::sim::occupancy::VEHICLE_OCCUPATION_BIT
     );
 
+    assert_eq!(
+        sim.substrate.next_occupancy_enter_order.current(),
+        arrival_order
+    );
+    assert_eq!(
+        sim.substrate.entities.get(1).unwrap().occupancy_enter_order,
+        initial_order
+    );
     let mut crossed = false;
     for frame in first_unpaid_frame..96 {
         gsi_04_05_tick_production_movement(&mut sim, Some(&grid), frame);
@@ -718,6 +719,14 @@ fn gsi_04_05_production_drive_observes_premark_clear_cross_and_finish() {
         "AddContent crossing must re-mark the new current cell"
     );
 
+    assert_eq!(
+        sim.substrate.entities.get(1).unwrap().occupancy_enter_order,
+        arrival_order
+    );
+    assert_eq!(
+        sim.substrate.next_occupancy_enter_order.current(),
+        arrival_order + 1
+    );
     let mut finished = sim
         .substrate
         .entities
@@ -761,6 +770,191 @@ fn gsi_04_05_production_drive_observes_premark_clear_cross_and_finish() {
         crate::sim::occupancy::VEHICLE_OCCUPATION_BIT,
         "completion promotes the head mark instead of clearing the endpoint"
     );
+}
+
+#[test]
+fn cell_arrival_infantry_keeps_detour_order_and_snapshot_continuation() {
+    use crate::map::resolved_terrain::ResolvedTerrainGrid;
+    use crate::rules::terrain_rules::SpeedCostProfile;
+    use crate::rules::{ini_parser::IniFile, ruleset::RuleSet};
+    use crate::sim::snapshot::GameSnapshot;
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[InfantryTypes]\n0=E1\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
+         [E1]\nStrength=100\nSpeed=4\n\
+         Locomotor={4A582744-9839-11d1-B709-00A024DDAFD1}\nSpeedType=Foot\n",
+    ))
+    .unwrap();
+    let terrain = ResolvedTerrainGrid::from_cells(
+        6,
+        3,
+        (0..3)
+            .flat_map(|ry| {
+                (0..6).map(move |rx| {
+                    let costs = SpeedCostProfile {
+                        foot: Some(100),
+                        ..Default::default()
+                    };
+                    let mut cell = drive_speed_test_cell(rx, ry, costs);
+                    cell.base_speed_costs = costs;
+                    cell
+                })
+            })
+            .collect(),
+    );
+    let grid = PathGrid::from_resolved_terrain(&terrain);
+    let mut sim = Simulation::with_seed(0xc311_a771);
+    sim.install_resolved_terrain_for_new_map(terrain.clone());
+    sim.intern_rule_type_ids(&rules);
+    sim.resolve_type_handles(&rules);
+    let walker = sim
+        .spawn_object_at_height("E1", "Americans", 1, 1, 0, 0, &rules)
+        .unwrap();
+    assert_eq!(
+        walker, 1,
+        "the production movement fixture visits this object"
+    );
+    let resident = sim
+        .spawn_object_at_height("E1", "Americans", 2, 1, 0, 0, &rules)
+        .unwrap();
+    assert_eq!(
+        sim.substrate
+            .entities
+            .get(walker)
+            .unwrap()
+            .locomotor
+            .as_ref()
+            .unwrap()
+            .kind,
+        LocomotorKind::Walk,
+    );
+    assert!(issue_move_command(
+        &mut sim.substrate.entities,
+        &grid,
+        walker,
+        (4, 1),
+        SimFixed::from_num(1024),
+        false,
+        None,
+        None,
+        None,
+        false
+    ));
+    let initial_cell = (1, 1);
+    let mut previous_cell = initial_cell;
+    // The represented Walk admission defers occupied cells and routes around
+    // this stationary resident. Exercise its actual accepted arrivals; the
+    // occupied-slot claim cases remain covered in bump_crush's leaf tests.
+    let mut crossed_detour_cell = false;
+    let mut restored: Option<Simulation> = None;
+    let mut trace = Vec::new();
+    for frame in 0..160 {
+        let next_order = sim.substrate.next_occupancy_enter_order.current();
+        gsi_04_05_tick_production_movement(&mut sim, Some(&grid), frame);
+        if let Some(loaded) = restored.as_mut() {
+            gsi_04_05_tick_production_movement(loaded, Some(&grid), frame);
+            assert_eq!(
+                loaded.state_hash(),
+                sim.state_hash(),
+                "restored frame {frame}"
+            );
+            assert_eq!(
+                loaded.scenario_rng.logical_state(),
+                sim.scenario_rng.logical_state()
+            );
+        }
+        let entity = sim.substrate.entities.get(walker).unwrap();
+        let cell = (entity.position.rx, entity.position.ry);
+        assert_ne!(cell, (2, 1), "the stationary resident remains a blocker");
+        assert!(sim.substrate.occupancy.contains_entity(2, 1, resident));
+        if cell != previous_cell {
+            assert!(!sim.substrate.occupancy.contains_entity(
+                previous_cell.0,
+                previous_cell.1,
+                walker
+            ));
+            let occupants = sim.substrate.occupancy.get(cell.0, cell.1).unwrap();
+            let own_entry = occupants
+                .iter_layer(MovementLayer::Ground)
+                .find(|entry| entry.entity_id == walker)
+                .unwrap();
+            assert_eq!(own_entry.sub_cell, entity.sub_cell);
+            assert_eq!(
+                occupants.first_on_layer(MovementLayer::Ground),
+                Some(walker)
+            );
+            assert_eq!(entity.occupancy_enter_order, next_order);
+            assert_eq!(
+                sim.substrate.next_occupancy_enter_order.current(),
+                next_order + 1
+            );
+            if cell == (2, 0) {
+                crossed_detour_cell = true;
+                let bytes = GameSnapshot::save(&sim, 0, 0, "arrival", 0);
+                let mut loaded = GameSnapshot::load(&bytes).unwrap().sim;
+                loaded.restore_after_snapshot_load().unwrap();
+                loaded.resolve_type_handles(&rules);
+                loaded.resolved_terrain = Some(terrain.clone());
+                let loaded_entries: Vec<_> = loaded
+                    .substrate
+                    .occupancy
+                    .get(cell.0, cell.1)
+                    .unwrap()
+                    .iter_layer(MovementLayer::Ground)
+                    .map(|entry| (entry.entity_id, entry.sub_cell))
+                    .collect();
+                let entries: Vec<_> = occupants
+                    .iter_layer(MovementLayer::Ground)
+                    .map(|entry| (entry.entity_id, entry.sub_cell))
+                    .collect();
+                assert_eq!(
+                    loaded_entries, entries,
+                    "serialized entry order rebuilds the live list"
+                );
+                // Full Scenario deserialization intentionally applies Seed(0)
+                // (see GameSnapshot::load_unchecked). Compare reconstructed
+                // movement with the retained state under that same reload
+                // rule, rather than asserting uninterrupted RNG continuity.
+                assert_eq!(
+                    loaded.scenario_rng.logical_state(),
+                    SimRng::new(0).logical_state()
+                );
+                sim.scenario_rng = SimRng::new(0);
+                assert_eq!(loaded.state_hash(), sim.state_hash());
+                assert!(loaded.substrate.occupancy.contains_entity(2, 1, resident));
+                restored = Some(loaded);
+            }
+            previous_cell = cell;
+        } else {
+            assert_eq!(
+                sim.substrate.next_occupancy_enter_order.current(),
+                next_order
+            );
+        }
+        trace.push((
+            frame,
+            cell,
+            entity.sub_cell,
+            entity.occupancy_enter_order,
+            sim.scenario_rng.state(),
+        ));
+        if entity.movement_target.is_none() {
+            break;
+        }
+    }
+    assert!(
+        crossed_detour_cell,
+        "production Walk path must take the same detour; trace={trace:?}"
+    );
+    assert_eq!(previous_cell, (4, 1));
+    assert!(
+        sim.substrate
+            .entities
+            .get(walker)
+            .unwrap()
+            .movement_target
+            .is_none()
+    );
+    println!("cell-arrival Infantry frames: {trace:?}");
 }
 
 #[test]
@@ -5580,9 +5774,23 @@ fn drive_track_ne_diagonal_costs_the_same_ticks_per_cell_as_se() {
         let mut occupancy = OccupancyGrid::new();
         let mut rng = SimRng::new(0);
         let mut lifecycle_requests = Vec::new();
+        occupancy.add(
+            start.0,
+            start.1,
+            1,
+            MovementLayer::Ground,
+            None,
+            CellListInsertion::PrependNonBuilding,
+        );
         let mut visited: Vec<(u16, u16)> = vec![start];
+        let mut intermediate_crossings = 0;
         let mut ticks = 0u64;
         for tick in 0..400u64 {
+            let before = entities.get(1).unwrap();
+            let prior_cell = (before.position.rx, before.position.ry);
+            let prior_target = before.movement_target.as_ref().unwrap();
+            let prior_index = prior_target.next_index;
+            let queued_cell = prior_target.path.get(prior_index).copied();
             tick_movement_with_grid(
                 &mut entities,
                 Some(&grid),
@@ -5597,12 +5805,35 @@ fn drive_track_ne_diagonal_costs_the_same_ticks_per_cell_as_se() {
             let Some(entity) = entities.get(1) else { break };
             let cell = (entity.position.rx, entity.position.ry);
             if visited.last() != Some(&cell) {
+                assert!(!occupancy.contains_entity(prior_cell.0, prior_cell.1, 1));
+                assert!(occupancy.contains_entity(cell.0, cell.1, 1));
+                if let Some(target) = entity.movement_target.as_ref() {
+                    if Some(cell) == queued_cell {
+                        assert_eq!(
+                            target.next_index,
+                            prior_index + 1,
+                            "reaching the queued cell consumes it once"
+                        );
+                    } else {
+                        intermediate_crossings += 1;
+                        assert_eq!(
+                            target.next_index, prior_index,
+                            "an intermediate track cell must not consume the queued destination"
+                        );
+                    }
+                }
                 visited.push(cell);
             }
             ticks = tick + 1;
             if cell == goal {
                 break;
             }
+        }
+        if dir == 1 {
+            assert!(
+                intermediate_crossings > 0,
+                "NE fixture must exercise an intermediate corner crossing"
+            );
         }
         (ticks, visited)
     }

--- a/src/sim/movement/movement_tick.rs
+++ b/src/sim/movement/movement_tick.rs
@@ -9,7 +9,7 @@
 //! ground movement is irreducibly complex — the borrow checker constrains how
 //! the per-entity loop can be decomposed, and the function already delegates to
 //! 6 private submodules (movement_path, movement_blocked, movement_bridge,
-//! movement_step, movement_reservation, movement_occupancy).
+//! movement_step, cell_arrival, movement_occupancy).
 //!
 //! ## Dependency rules
 //! - Internal to sim/movement — called via re-export in mod.rs.
@@ -2334,51 +2334,26 @@ fn tick_movement_with_grids_scoped(
                                 loco.layer = next_layer;
                             }
                         }
-                        // Update occupancy grid: move entity from old cell to new
-                        // cell, removing on the OLD layer and inserting on the NEW
-                        // layer (verified two-layer order).
-                        let order = next_occupancy_enter_order.next();
-                        entity.occupancy_enter_order = order;
-                        occupancy.move_entity_layered(
-                            old_rx,
-                            old_ry,
-                            nx,
-                            ny,
+                        super::cell_arrival::CellArrival {
                             entity_id,
-                            old_occupancy_layer,
-                            new_occupancy_layer,
-                            entity.sub_cell,
-                            CellListInsertion::from_category(entity.category),
-                        );
-                        if entity.category == EntityCategory::Unit
-                            && let Some(drive) = entity.drive_locomotion.as_mut()
-                        {
-                            crate::sim::occupancy::mark_current_drive_occupation_after_crossing(
-                                drive,
-                                cell_occupation,
-                                entity_id,
-                                (nx, ny),
-                                new_occupancy_layer,
-                            );
-                        }
-                        // Reserve destination cell.
-                        super::movement_reservation::reserve_destination_after_transition(
-                            entity.category,
-                            entity_id,
-                            &mut entity.locomotor,
-                            &mut entity.position,
-                            &mut entity.sub_cell,
-                            active_layer,
-                            nx,
-                            ny,
+                            category: entity.category,
+                            from: (old_rx, old_ry),
+                            to: (nx, ny),
+                            old_list_layer: old_occupancy_layer,
+                            new_list_layer: new_occupancy_layer,
+                            position: &entity.position,
+                            locomotor: &mut entity.locomotor,
+                            drive_locomotion: &mut entity.drive_locomotion,
+                            sub_cell: &mut entity.sub_cell,
+                            occupancy_enter_order: &mut entity.occupancy_enter_order,
+                            next_occupancy_enter_order,
                             occupancy,
-                            snap.sub_cell_priority_mission && snap.nav_com_cell == Some((nx, ny)),
-                        );
-                        // After reservation, infantry sub_cell may have changed.
-                        if entity.category == EntityCategory::Infantry {
-                            occupancy.update_sub_cell(nx, ny, entity_id, entity.sub_cell);
+                            cell_occupation,
+                            stats: &mut stats,
+                            priority: snap.sub_cell_priority_mission
+                                && snap.nav_com_cell == Some((nx, ny)),
                         }
-                        stats.moved_steps = stats.moved_steps.saturating_add(1);
+                        .track_jump(active_layer);
                         // Consume the queued path node only when the mover's own
                         // cell has actually reached it. A curve that crosses one
                         // axis at a time passes through an intermediate cell that


### PR DESCRIPTION
Ordinary movement crossings and Drive track jumps separately coordinated entry stamps, cell lists, Drive occupation, destination claims, Infantry subcell repair, and movement statistics. A private consuming CellArrival operation now owns that transaction for both callers, preserving their distinct path-layer timing and existing geometry, path, and RNG phases. Future arrival invariant changes have one production owner.

Extended Drive premark/crossing and intermediate-node checks, added actual Walk detour/snapshot reconstruction and continuation coverage, and removed an untouched-RNG tautology while retaining its fallback assertion. Updated the touched System Map connections; independent read-only critics reviewed the boundary, ordering, test changes, and final evidence.

Validation on source 32033c18 (map-only follow-up 96dd158e), based on refreshed origin/main a162fd67:

- `cargo test -p vera20k --lib`: `test result: ok. 8483 passed; 0 failed; 80 ignored; 0 measured; 0 filtered out; finished in 27.58s`
- Focused movement tests: 85 passed, 0 failed.
- Retail Hills bridge crossings: MTNK, ROBO, and E1 all passed with actual assets and destination arrival.
- `cargo clippy -p vera20k --lib` and `cargo check -p vera20k`: passed; existing warnings remain.
- `python -m tools.system_map check`: 0 errors.

Existing deterministic replay baselines are unchanged. These are Rust regression and real-asset crossing checks; native executable parity remains unproven.
