### PR TITLE
docs: suggest production-path validation

### DIFF
--- a/ENGINE.md
+++ b/ENGINE.md
@@ -90,6 +90,8 @@ directly to `main`. Publication requires user/goal authority; PRs target `main`.
 Integrate promptly when authorized. Owners resolve conflicts and revalidate.
 Preserve unique/local data; use `sync` for complex cleanup.
 
+Consider validating changed behavior through production paths with appropriate checks.
+
 - Working Rust: `cargo check -p vera20k` as needed; focused
   `cargo test -p vera20k --lib <module_path>::`.
 - Rust PR readiness: one full `cargo test -p vera20k --lib` plus


### PR DESCRIPTION
Adds a brief suggestion in ENGINE.md to consider validating changed behavior through production paths with appropriate checks. The wording leaves agents room to choose suitable validation.

Validation: reviewed the exact sentence and its placement; git diff --check passed. Documentation only.