### PR TITLE
Fix unplaced structures blocking rebuilt navigation

### DIFF
--- a/docs/system-map/topology.v2.json
+++ b/docs/system-map/topology.v2.json
@@ -488,7 +488,13 @@
           "path": "src/sim/world/navigation.rs",
           "symbol": "NavigationCaches::rebuild_dynamic / rebuild_zones / rebuild_zones_full",
           "coverage": "representative",
-          "observed_at_commit": "d13e84d449c5cbcc58b75af7326db68325d5d044"
+          "observed_at_commit": "258ddea596b3b11550a9c58718bd1b45d4de20c5"
+        },
+        {
+          "path": "src/sim/world/navigation_tests.rs",
+          "symbol": "held_factory_and_attached_upgrade_stay_off_navigation_through_frame_and_restore",
+          "coverage": "representative",
+          "observed_at_commit": "258ddea596b3b11550a9c58718bd1b45d4de20c5"
         },
         {
           "path": "src/sim/world/mod.rs",
@@ -513,7 +519,8 @@
         "OverlayGrid now owns synchronous overlay projection and its publication receipts in one operation across eight crate, tiberium, placement, damage and sale sites. The first changed projection survives later no-op recalculations; ordered next-reader coordinates and the frame-tail change flag remain independent obligations. Hosted wall callbacks retain their original order.",
         "Receipt-free map admission, terrain spawning, snapshot reconstruction, frame-tail replay and bridge inline publication retain their separate lifecycle owners. The full library suite and real-asset Lostlake MTNK/E1/ROBO movement regressions preserve represented behavior; this is not native differential or universal terrain parity. Obsolete standalone Mark replication and five tests were removed; unique wall-count and fixed-stride alias checks now enter production wall placement.",
         "One world operation consumes synchronous overlay and receiver terrain receipts, starting from navigation published after callbacks. Earlier pinned snapshots remain immutable; subsequent phases receive current canonical navigation, including when there are no receipts. The empty-receipt path reuses its Arc rather than copying the map.",
-        "Regressions cover immediate foundation preservation, stale pre-collapse snapshots with empty/nonempty receipts, actual engineer arrival and RNG, and snapshot/cache reconstruction. A postcombat movement route exercises the consumer but is only a smoke check, not native traversal parity. Existing shared structure-selection policy is unchanged."
+        "Regressions cover immediate foundation preservation, stale pre-collapse snapshots with empty/nonempty receipts, actual engineer arrival and RNG, and snapshot/cache reconstruction. A postcombat movement route exercises the consumer but is only a smoke check, not native traversal parity.",
+        "Canonical structure projection now reads the existing cell_marked authority. Factory-held buildings and retained attached upgrades contribute no independent footprint; dying structures retain their footprint until actual UnInit unmarks them. The regression uses real factory enqueue, map admission, a dirty-overlay frame and snapshot reconstruction. The older bridge/bib composition fixture now admits its building through map spawning. The full library suite and three real-asset Lostlake movement checks passed. This is a bounded Rust projection correction, not native upgrade-lifetime or universal navigation parity; foundation, HasBib, sorting and bridge-layer policies remain unchanged."
       ]
     },
     "GSI-04.05": {

--- a/src/sim/world/navigation.rs
+++ b/src/sim/world/navigation.rs
@@ -35,14 +35,22 @@ impl NavigationCaches<'_> {
         let mut grid = PathGrid::from_resolved_terrain_with_bridges(terrain, bridges);
         *self.terrain_costs = build_canonical_terrain_cost_grids(terrain);
 
+        // Cell membership owns footprint presence, not EntityStore residency.
+        // Native: Techno enter/exit (0x005683C0 / 0x005687F0) call CellClass
+        // AddContent/RemoveContent (0x0047E8A0 / 0x0047EA90), which mark/clear
+        // occupation; see docs/research/bridges/02-cell-state-layering-zones/
+        // BRIDGE_OCCUPANCY_OBJECT_LISTS_GHIDRA_REPORT.md. Held factory objects
+        // and retained attached upgrades have no independent marked footprint.
+        // A dying structure still blocks until the lifecycle owner unmarks it.
         let mut structures: Vec<(u16, u16, String)> = entities
             .values()
             .filter_map(|entity| {
-                (entity.category == EntityCategory::Structure).then_some((
-                    entity.position.rx,
-                    entity.position.ry,
-                    interner.resolve(entity.type_ref()).to_string(),
-                ))
+                (entity.category == EntityCategory::Structure && entity.lifecycle.cell_marked)
+                    .then_some((
+                        entity.position.rx,
+                        entity.position.ry,
+                        interner.resolve(entity.type_ref()).to_string(),
+                    ))
             })
             .collect();
         structures.sort_by(|a, b| {

--- a/src/sim/world/navigation_tests.rs
+++ b/src/sim/world/navigation_tests.rs
@@ -1,0 +1,223 @@
+//! Production navigation reconstruction must respect Mark-owned cell presence.
+
+use super::{empty_heights, gsi_04_10_clear_terrain, make_test_entity};
+use crate::map::entities::EntityCategory;
+use crate::map::overlay_types::OverlayTypeRegistry;
+use crate::rules::ini_parser::IniFile;
+use crate::rules::ruleset::RuleSet;
+use crate::sim::overlay_grid::OverlayGrid;
+use crate::sim::production::{ProductionCategory, enqueue_by_type};
+use crate::sim::snapshot::GameSnapshot;
+use crate::sim::world::{Simulation, TickLane};
+use std::collections::BTreeMap;
+
+fn rules_and_overlays() -> (RuleSet, OverlayTypeRegistry) {
+    let ini = IniFile::from_str(
+        "[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n\
+         [BuildingTypes]\n0=YARD\n1=HELD\n2=UPGRADE\n\
+         [YARD]\nStrength=500\nFoundation=2x2\nBib=yes\nFactory=BuildingType\n\
+         [HELD]\nStrength=300\nCost=100\nTechLevel=1\nOwner=Americans\nFoundation=3x3\n\
+         [UPGRADE]\nStrength=100\nFoundation=4x4\n\
+         [OverlayTypes]\n0=ROAD\n[ROAD]\nLand=Road\n\
+         [Road]\nFoot=37%\nTrack=100%\n",
+    );
+    (
+        RuleSet::from_ini(&ini).unwrap(),
+        OverlayTypeRegistry::from_ini(&ini, None),
+    )
+}
+
+fn assert_only_marked_foundation(sim: &Simulation) {
+    let path = sim.path_grid_snapshot().unwrap();
+    for ry in 0..3 {
+        for rx in 0..3 {
+            assert!(
+                path.is_walkable(rx, ry),
+                "held factory coordinate has no footprint"
+            );
+        }
+    }
+    assert!(!path.is_walkable(6, 6), "marked parent remains a blocker");
+    assert!(!path.is_walkable(6, 7));
+    assert!(
+        path.is_walkable(7, 6),
+        "the parent's HasBib relaxation is preserved"
+    );
+    assert!(path.is_walkable(7, 7));
+    for (rx, ry) in [(8, 6), (9, 6), (6, 8), (6, 9), (9, 9)] {
+        assert!(
+            path.is_walkable(rx, ry),
+            "unmarked upgrade adds no foundation at {rx},{ry}"
+        );
+    }
+}
+
+fn assert_retained_roles(sim: &Simulation, parent_id: u64, upgrade_id: u64, held_id: u64) {
+    assert!(
+        sim.substrate
+            .entities
+            .get(parent_id)
+            .unwrap()
+            .lifecycle
+            .cell_marked
+    );
+    let upgrade = sim.substrate.entities.get(upgrade_id).unwrap();
+    assert!(!upgrade.lifecycle.in_limbo && !upgrade.lifecycle.cell_marked);
+    assert!(
+        upgrade
+            .structure_upgrade_link
+            .is_some_and(|link| link.parent_stable_id == parent_id)
+    );
+    let held = sim.substrate.entities.get(held_id).unwrap();
+    assert!(held.lifecycle.in_limbo && !held.lifecycle.cell_marked);
+    assert_eq!(
+        sim.production
+            .factory_shadow
+            .view(held.owner(), ProductionCategory::Building)
+            .unwrap()
+            .object
+            .as_ref()
+            .unwrap()
+            .entity_id,
+        Some(held_id)
+    );
+}
+
+#[test]
+fn held_factory_and_attached_upgrade_stay_off_navigation_through_frame_and_restore() {
+    let (rules, overlays) = rules_and_overlays();
+    let mut sim = Simulation::with_seed(0x4D41_524B);
+    sim.session.map_width = 16;
+    sim.session.map_height = 16;
+    sim.session.game_options.crates = false;
+    sim.production.ore_growth_config.grows = false;
+    sim.production.ore_growth_config.spreads = false;
+    let terrain = gsi_04_10_clear_terrain(16, 16);
+    sim.install_resolved_terrain_for_new_map(terrain.clone());
+    let mut overlay_grid = OverlayGrid::from_overlay_entries(&[], 16, 16);
+    overlay_grid.retain_zero_wall_plane_for_tests();
+    sim.overlay_grid = Some(overlay_grid);
+    sim.intern_rule_type_ids(&rules);
+    let owner = sim.interner.intern("Americans");
+    sim.houses.insert(
+        owner,
+        crate::sim::house_state::HouseState::new(owner, 0, None, true, 50_000, 10),
+    );
+    let mut yard = make_test_entity("YARD", EntityCategory::Structure);
+    yard.cell_x = 6;
+    yard.cell_y = 6;
+    yard.structure_upgrades = [Some("UPGRADE".to_owned()), None, None];
+    assert_eq!(
+        sim.spawn_from_map(&[yard], Some(&rules), &empty_heights()),
+        2
+    );
+    sim.resolve_type_handles(&rules);
+    let parent_id = sim
+        .substrate
+        .entities
+        .values()
+        .find(|entity| entity.structure_upgrade_link.is_none())
+        .unwrap()
+        .stable_id();
+    let upgrade = sim
+        .substrate
+        .entities
+        .values()
+        .find(|entity| entity.structure_upgrade_link.is_some())
+        .unwrap();
+    assert!(!upgrade.lifecycle.in_limbo && !upgrade.lifecycle.cell_marked);
+    let upgrade_id = upgrade.stable_id();
+    assert!(enqueue_by_type(&mut sim, &rules, "Americans", "HELD"));
+    let held_id = sim
+        .production
+        .factory_shadow
+        .view(owner, ProductionCategory::Building)
+        .unwrap()
+        .object
+        .as_ref()
+        .unwrap()
+        .entity_id
+        .unwrap();
+    let held = sim.substrate.entities.get(held_id).unwrap();
+    assert!(held.lifecycle.in_limbo && !held.lifecycle.cell_marked);
+    assert_eq!((held.position.rx, held.position.ry), (0, 0));
+
+    assert!(sim.rebuild_dynamic_navigation(&rules));
+    assert_only_marked_foundation(&sim);
+    assert_retained_roles(&sim, parent_id, upgrade_id, held_id);
+    let before = sim.path_grid_snapshot().unwrap();
+    // A real dirty-overlay frame triggers the same canonical rebuild used by
+    // ordinary terrain mutation, independent of the held building's location.
+    sim.overlay_grid
+        .as_mut()
+        .unwrap()
+        .place_overlay(12, 12, 0, 0);
+    let output = sim.advance_app_frame(
+        &[],
+        Some(&rules),
+        &BTreeMap::new(),
+        Some(&overlays),
+        67,
+        TickLane::Ordinary,
+        None,
+    );
+    assert_eq!(output.overlay_updates.len(), 1);
+    assert_eq!(
+        (output.overlay_updates[0].rx, output.overlay_updates[0].ry),
+        (12, 12)
+    );
+    assert!(!std::sync::Arc::ptr_eq(
+        &before,
+        &sim.path_grid_snapshot().unwrap()
+    ));
+    assert_only_marked_foundation(&sim);
+    assert_retained_roles(&sim, parent_id, upgrade_id, held_id);
+
+    let bytes = GameSnapshot::save(&sim, 0, 0, "marked-navigation.map", 0);
+    let mut restored = GameSnapshot::load(&bytes).unwrap().sim;
+    restored.restore_after_snapshot_load().unwrap();
+    restored.rebuild_caches_after_load(
+        terrain,
+        Default::default(),
+        Vec::new(),
+        Vec::new(),
+        BTreeMap::new(),
+    );
+    restored
+        .restore_map_authority_after_snapshot_load(&rules, &overlays)
+        .unwrap();
+    assert!(
+        restored
+            .substrate
+            .entities
+            .get(held_id)
+            .unwrap()
+            .lifecycle
+            .in_limbo
+    );
+    assert_only_marked_foundation(&restored);
+    assert_retained_roles(&restored, parent_id, upgrade_id, held_id);
+
+    // Death is distinct from cell unlinking. Static navigation keeps a marked
+    // footprint until the real lifecycle owner removes it.
+    restored
+        .substrate
+        .entities
+        .get_mut(parent_id)
+        .unwrap()
+        .dying = true;
+    assert!(restored.rebuild_dynamic_navigation(&rules));
+    assert_only_marked_foundation(&restored);
+    restored.uninit_with_rules(parent_id, &rules);
+    assert!(
+        !restored
+            .substrate
+            .entities
+            .get(parent_id)
+            .unwrap()
+            .lifecycle
+            .cell_marked
+    );
+    assert!(restored.rebuild_dynamic_navigation(&rules));
+    assert!(restored.path_grid_snapshot().unwrap().is_walkable(6, 6));
+}

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -4,6 +4,9 @@
 
 use std::collections::BTreeMap;
 
+#[path = "navigation_tests.rs"]
+mod navigation_tests;
+
 use super::*;
 use crate::map::entities::{EntityCategory, MapEntity};
 use crate::map::houses::HouseAllianceMap;
@@ -1484,27 +1487,20 @@ fn dynamic_navigation_publication_composes_structures_bibs_and_bridges() {
         &terrain, true, 10,
     ));
     sim.resolved_terrain = Some(terrain);
-    let owner = sim.interner.intern("Americans");
-    let type_ref = sim.interner.intern("GAREFN");
-    sim.substrate
-        .entities
-        .insert(GameEntity::new_at_frame_zero_for_test(
-            1,
-            8,
-            8,
-            0,
-            0,
-            owner,
-            crate::sim::components::Health {
-                current: 100,
-                max: 100,
-            },
-            type_ref,
-            EntityCategory::Structure,
-            0,
-            0,
-            false,
-        ));
+    let mut building = make_test_entity("GAREFN", EntityCategory::Structure);
+    building.cell_x = 8;
+    building.cell_y = 8;
+    assert_eq!(
+        sim.spawn_from_map(&[building], Some(&rules), &empty_heights()),
+        1
+    );
+    let placed = sim.substrate.entities.values().next().unwrap();
+    assert!(placed.lifecycle.cell_marked);
+    assert!(
+        sim.substrate
+            .occupancy
+            .contains_entity(8, 9, placed.stable_id())
+    );
 
     assert!(sim.rebuild_dynamic_navigation(&rules));
     let grid = sim.path_grid().expect("published navigation");


### PR DESCRIPTION
Rebuilding navigation treated every stored structure as a placed building. A real factory enqueue therefore introduced a phantom foundation at `(0,0)`, and retained attached upgrades could project an additional foundation around their parent.

The canonical rebuild now requires the existing `cell_marked` state. Map admission, terrain frames and snapshot restoration share that decision without another owner or caller protocol. Foundation geometry, HasBib, sorting, bridge layers and dying-but-marked behavior remain unchanged. Native cell add/remove research supports the membership boundary; this change preserves Rust's retained upgrade lifetime and does not claim native lifetime parity.

The new regression enters real map spawning and factory enqueue, then checks dirty-overlay frame processing, snapshot reconstruction, dying-but-marked retention and actual UnInit. The existing bridge/bib test now uses real map admission instead of inserting an unmarked raw object. Independent read-only review found no redundant tests to remove; those tests cover distinct contracts.

Validation:

- Unchanged baseline reproduced phantom factory blocking: 0 passed, 1 failed at the held-building footprint assertion.
- Corrected focused regression: 1 passed, 0 failed.
- Final `cargo test -p vera20k --lib`: 8481 passed, 0 failed, 80 ignored.
- Explicit retail Lostlake MTNK, E1 and ROBO movement checks: 3 passed, all loaded real assets and reached the destination. These are bounded Rust production regressions, not native differential validation.
- `cargo clippy -p vera20k --lib` and `cargo check -p vera20k`: exit 0, existing warnings remain.
- `python -m tools.system_map check`: 0 errors.

Based on refreshed `origin/main` at `4b28c654`. The first full run found the old unmarked raw fixture; its repair retained every original geometry, layer and zone assertion, and the final full run passed.
