### PR TITLE
docs: clarify native comparison guide flexibility

### DIFF
--- a/tools/native_oracle.md
+++ b/tools/native_oracle.md
@@ -1,5 +1,7 @@
 # Native comparison workflow
 
+Native comparison guidance; adapt as useful and distinguish findings from hypotheses.
+
 Use original `gamemd.exe` instructions to produce reference outputs, then compare
 the Rust function used by the engine against them. The shared Python runner handles
 executable identity, bounded execution, fresh function-call state, diagnostics, and


### PR DESCRIPTION
Clarifies that the native comparison guide can be adapted to the task, while distinguishing findings from hypotheses.

Adds one introductory sentence to `tools/native_oracle.md`. No other files change.

Validation: reviewed the exact diff and passed `git diff --check`. Existing links and examples are unchanged; no code tests are needed for this wording change.