### PR TITLE
Preserve reproducible native comparison evidence

### DIFF
--- a/ENGINE.md
+++ b/ENGINE.md
@@ -43,6 +43,10 @@ not hand calculations or prior Rust. Avoid unqualified “VERIFIED”/“complet
 
 [Unicorn](tools/native_oracle.md) can help with native comparisons; use when useful.
 
+Preserve native comparisons as reproducible harnesses and results, recording binary
+identity and coverage limits. Link them to Rust tests where practical; parity claims
+must cite saved evidence and actual validation results.
+
 Each cohesive gamemd-derived Rust behavior carries nearby native identity/address
 and source; sim-behavior commits cite their evidence.
 Consult the [Ghidra reference](docs/research/ghidra-workflow.md) for access,


### PR DESCRIPTION
Make preserving reproducible native comparisons an explicit expectation in ENGINE.md, directly below the Unicorn guidance. Require binary identity and coverage limits, links to Rust tests where practical, and saved evidence plus actual validation results for parity claims.

Validation: checked the exact two-sentence addition, confirmed tools/native_oracle.md exists, and passed git diff --check. Documentation only; no Rust behavior changed.
