### PR TITLE
Match native LocalSize clipping order and preserve spatial comparisons

### DIFF
--- a/docs/plans/phase-briefs/phase-03-map-spatial-world.md
+++ b/docs/plans/phase-briefs/phase-03-map-spatial-world.md
@@ -46,6 +46,13 @@ owning system a Phase 3 prerequisite.
 
 ## Prior work
 
+The 2026-09-10 increment at `258a59ce` repairs LocalSize clipping operand order
+and adds original-executable spatial comparisons. Its [evidence report](../../research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md)
+records the failing pre-fix result, corrected production path, independent
+review, four passing focused tests, full library results (8,587 passed, zero
+failed, 119 ignored), and Clippy exit zero with 1,144 warnings. This is bounded
+mechanism evidence; it does not close a row.
+
 The archived **Phase 3 integration goal** task
 `01a0529b-815e-7e31-be6d-90511e997891` reports recovery through PRs #166/#167 and
 #173–#193 at `5062bcea`. That completed recovery of eligible slices, not Phase 3.
@@ -95,25 +102,29 @@ outcome of the first map-lookup comparison.
 
 No phase-wide native differential or completed reverse audit is recorded by this
 goal. Existing Rust regression tests and older scoped critic passes do not imply
-whole-row equivalence. The [first comparison increment](../../research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md) records 2,144 original-executable calls/prefixes for lookup, playfield predicates, normalization and retained dummy identity. Its report records the executable, fixtures, endpoint limits and production test consumers. Rust and critic results must pass before publication; this bounded corpus does not close GSI-04.01.
+whole-row equivalence. The [first comparison increment](../../research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md)
+records 2,144 original-executable calls/prefixes for lookup, playfield predicates,
+normalization and retained dummy identity. Its report records the executable,
+fixtures, endpoint limits, production test consumers and passing validation.
+This bounded corpus does not close GSI-04.01. Ignored library tests remain
+unexecuted; they are not passing parity evidence.
 
 ## Open queue
 
-1. Deliver and independently review reproducible native comparisons for current
-   GSI-04.01 lookup/playfield helpers; fix any demonstrated mismatch.
-2. Recheck the remaining constructor identity, shared-dummy field,
+1. Recheck the remaining constructor identity, shared-dummy field,
    Resize/restore, iterator and consumer-order hypotheses. Implement only proven
    observable differences; retain unresolved candidates explicitly.
-3. Reconcile each other row with current production source and active retail
+2. Reconcile each other row with current production source and active retail
    evidence. Reuse bridge and earlier Phase 3 research without importing their
    historical scope expansions automatically.
-4. Run the phase-wide reverse audit only after every in-scope mechanism and
+3. Run the phase-wide reverse audit only after every in-scope mechanism and
    evidence-backed exclusion is accounted for. Any omission reopens its row.
 
 ## Start here
 
-Read the current task checkpoint, verify Git/process state, finish the first
-mechanism and its independent critic gate, then required full library tests and
-Clippy. Push, open/update its PR, merge and verify refreshed `origin/main` before
-starting another mechanism. Preserve a blocked mechanism and continue independent
-work when necessary. No phase or row is closed by this brief.
+Read the current task checkpoint and verify Git/process state, including whether
+the validated clipping increment has merged. Verify refreshed `origin/main`
+before selecting the next open mechanism. Each mechanism needs independent
+review, the required library tests and Clippy, then PR publication, merge and
+verification before another mechanism starts. Preserve a blocked mechanism and
+continue independent work when necessary. No phase or row is closed by this brief.

--- a/docs/plans/phase-briefs/phase-03-map-spatial-world.md
+++ b/docs/plans/phase-briefs/phase-03-map-spatial-world.md
@@ -1,0 +1,115 @@
+# Phase 3 brief — Map and spatial world
+
+Rows 37–52 of the [implementation order](../2026-07-30-clean-slate-system-implementation-order.md).
+State: **IN PROGRESS; every row remains open**. Baseline: fetched `origin/main`
+`8f988ab256b3b38c30bdd3db67fee215c54e25ac`, inspected 2026-09-10.
+This is the current investigation frontier, not a completed mechanism census.
+
+## Rows
+
+Registry values below are native evidence / Rust implementation / parity from
+[registry.v2.json](../../system-map/registry.v2.json). They are inherited status,
+not newly established equivalence. Paths are current representative owners;
+references are starting evidence whose applicability must be checked per mechanism.
+
+| Row | GSI | Rust owner(s) | Native anchor or research starting point | Registry | Notes |
+|---|---|---|---|---|---|
+| 37 | GSI-04.01 | `src/map/cell_index.rs`, `playfield.rs`, `resolved_terrain.rs`; `src/sim/cell_rect.rs` | Get_CellClass `0x005657A0`, world lookup `0x00565730`, IsCellInPlayfield `0x00578460`; [dummy contract](../../research/MAPCLASS_GET_CELLCLASS_FALLBACK_DUMMY_CELL_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Current lookup/boundary executable comparison is the first increment. Constructor/iterator and unmodeled-state candidates require separate proof. |
+| 38 | GSI-04.02 | `src/map/theater.rs`, `resolved_terrain.rs` | CalculateLegacyMapTileIndex `0x00544E30`; [translation](../../research/PHASE3_LAST_TILES_IN_SET_COMPATIBILITY_TRANSLATION_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Load, Fill, map-pack and generated-map paths must be checked separately. |
+| 39 | GSI-04.03 | `src/util/lepton.rs`; `src/sim/cell_kernel.rs`; `src/map/resolved_terrain.rs` | ComputeGroundHeightAtCoord `0x0047B3A0`; [domain census](../../research/PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | The CellClass 90-lepton and object/VXL 104-lepton domains are distinct. |
+| 40 | GSI-04.04 | `src/sim/cell_kernel.rs`, `overlay_grid.rs`, `pathfinding/terrain_cost.rs` | [RecalcZoneType](../../research/CELLCLASS_RECALCZONE_TYPE_00483C80_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Preserve synchronous publication before the next reader. |
+| 41 | GSI-04.06 | `src/sim/pathfinding/zone_map.rs`, `zone_build.rs`; `src/sim/world/navigation.rs` | FloodFillReachableZones `0x005840C0`; [flood fill](../../research/MAPCLASS_FLOODFILLREACHABLEZONES_005840C0_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Tube hierarchy registration is explicitly unimplemented in current source; verify its active callers before choosing the repair. |
+| 42 | GSI-04.05 | `src/sim/occupancy.rs`, `cell_rect.rs`; `src/sim/world/lifecycle.rs` | AddContent `0x0047E8A0`, RemoveContent `0x0047EA90`; [live list writers](../../research/CELLCLASS_SUBSTRATE_LIVE_OBJECT_LIST_WRITERS_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Cell lists, layer transitions and reservations are distinct authorities. Do not import all AI behavior merely because it reads occupancy. |
+| 43 | GSI-04.07 | `src/map/authored_overlay.rs`; `src/sim/overlay_grid.rs` | OverlayClass::Mark `0x005FC570`, DestroyOverlay `0x00480CB0`; [authored boundary](../../research/bridges/01-assets-map-load-overlay/AUTHORED_OVERLAYPACK_INLINE_TRANSACTION_REINVESTIGATION_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Includes mutation order, ownership, shared dummy effects and projection to consumers. |
+| 44 | GSI-04.09 | `src/sim/tiberium/mod.rs`, `overlay_grid.rs`; `src/map/authored_overlay.rs` | Reduce_Tiberium `0x00480A80`; [quantity mutation](../../research/CELLCLASS_REDUCE_TIBERIUM_FUN_00480A80_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Identity and quantity are this row; growth/harvesting policy enters only as a proved prerequisite or consumer. |
+| 45 | GSI-04.10 | `src/sim/terrain_object.rs`, `terrain_spawn.rs` | [TerrainClass timing](../../research/TIBTRE_TERRAINCLASS_AI_TIMING_AND_RNG_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Verify ordinary trees/rocks as well as TIBTRE; spawning is not full destruction/fire coverage. |
+| 46 | GSI-04.12 | `src/sim/bridge_state/mod.rs`, `map/bridge_topology.rs`, `world/bridge_orchestrator.rs` | [bridge coverage](../../research/bridges/00-system-models/ACTIVE_RETAIL_BRIDGE_COVERAGE_REINVESTIGATION_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Existing bridge work is substantial but explicitly incomplete. |
+| 47 | GSI-04.13 | `src/map/bridge_facts.rs`; `src/sim/movement/movement_bridge.rs` | [bridge coverage](../../research/bridges/00-system-models/ACTIVE_RETAIL_BRIDGE_COVERAGE_REINVESTIGATION_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Distinguish high bridge decks, wood bridges and low bridge tubes. |
+| 48 | GSI-04.15 | `src/map/tubes.rs`, `tube_facts.rs`; `src/sim/movement/tube_movement.rs` | ReadTubesINI `0x007283C0`; [bridge coverage](../../research/bridges/00-system-models/ACTIVE_RETAIL_BRIDGE_COVERAGE_REINVESTIGATION_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Active low-bridge tubes cannot be excluded as TS-only based on their name. |
+| 49 | GSI-04.16 | `src/map/waypoints.rs`; `src/map/map_file.rs` | Read_Waypoints `0x0068BDC0`; [map substrate](../../research/CELLCLASS_MAPCLASS_ENGINE_SUBSTRATE_SERVICE_STUDY.md) | CONTRACTED / PARTIAL / DRIFT | Signed values and canonical key recovery already landed; audit starts/regions and downstream use separately. |
+| 50 | GSI-04.18 | `src/sim/vision/mod.rs`; `src/sim/snapshot.rs` | [shroud reveal](../../research/SHROUD_REVEAL_SYSTEM_GHIDRA_REPORT.md) | ANCHORED / PARTIAL / UNCHECKED | Persisted knowledge, reveal counters and present visibility are distinct. Historical SHROUD_DISPARITIES is not a current gap list. |
+| 51 | GSI-04.11 | `src/sim/smudge_grid.rs`, `combat/smudge_dispatch.rs` | [smudge class](../../research/SMUDGE_CLASS_GHIDRA_REPORT.md), [spawn callers](../../research/SMUDGE_SPAWN_TRIGGERS_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / UNCHECKED | Placement, caller-specific ore mutation, RNG order and restore require evidence. |
+| 52 | GSI-04.20 | `src/map/lighting.rs`; `src/app/presentation/lighting.rs` | ApplyAreaLightConvert `0x00554AF0`; [light source lifecycle](../../research/LIGHTSOURCE_LIFECYCLE_POWER_DAMAGE_SAVELOAD_GHIDRA_REPORT.md) | N/A / N/A / N/A (group) | Group status is not exclusion or closure. Separate active ambience, lamp lifecycle and global tint from dormant TS behavior. |
+
+## Loops
+
+The current [topology](../../system-map/topology.v2.json) records representative
+connections, not an exhaustive Phase 3 loop inventory:
+
+- `LOOP-005-BUILD-PLACE`: cell passability and occupancy, stages 10–11.
+- `LOOP-006-FACTORY-EXIT`: exit occupancy, stage 7.
+- `LOOP-008-REVEAL-RADAR`: persisted per-cell knowledge, stage 5.
+
+Trace unlisted map-load, overlay, terrain, bridge and lighting transactions from
+their actual entrypoints. A downstream reader alone does not make its entire
+owning system a Phase 3 prerequisite.
+
+## Prior work
+
+The archived **Phase 3 integration goal** task
+`01a0529b-815e-7e31-be6d-90511e997891` reports recovery through PRs #166/#167 and
+#173–#193 at `5062bcea`. That completed recovery of eligible slices, not Phase 3.
+Current source has subsequently changed; use Git and the actual consumers.
+
+[PR #172](https://github.com/Yrvera/vera20k/pull/172) remains an open, conflicting
+mixed-history archive at `49f7707f`. Recover individual evidence and coherent
+changes only. Its rejected animation shadow/layer and lowercase atlas work,
+partial Railgun/AI/trigger/crate/capture work, and Explodes/Temporal research are
+not preapproved implementations or automatically required Phase 3 scope.
+
+Current bridge work and remaining transactions are described in the
+[bridge plan](../2026-08-28-active-retail-bridge-parity-design.md). The plan's
+status is historical; reconcile it against current source before selecting work.
+
+## Corrections
+
+- Old GSI-04.01 gaps G1 dummy reservation reset and G2 IsoMapPack miss stamping
+  have production implementations. The old reservation-writer candidate is also
+  stale: current lifecycle code implements the Mark/Clear perimeter paths.
+- The old copied-dummy target-Z claim is a [documented false positive](../../gap-scans/2026-08-25-disparity-scan-gsi-04-01-dummy-cell-target-z.md).
+- CellClass constructor order and anti-diagonal Fill/RNG order are different;
+  never fix a hypothetical identity gap by reordering Fill.
+- TS-only exclusions require active-binary/data evidence. Neither inherited TS
+  code nor a generic registry group is enough to establish applicability.
+
+## Inherited residuals
+
+`src/sim/pathfinding/zone_build.rs::tube_hierarchy_pairs_are_unregistered` records
+an ignored test for the tube arm of `0x00582D70`. Its hypothesized trigger is a
+long route across a low bridge; the consequence is a detour or no hierarchy route.
+Retail incidence and the active caller chain need rechecking; the source marker
+is an investigation lead, not a fresh native finding.
+
+The bridge plan retains unresolved construction, restamp, topology and consumer
+transactions. Current shroud, smudge, terrain and lighting code has not received
+this goal's exhaustive reverse audit. These rows remain open regardless of the
+outcome of the first map-lookup comparison.
+
+## Coverage
+
+No phase-wide native differential or completed reverse audit is recorded by this
+goal. Existing Rust regression tests and older scoped critic passes do not imply
+whole-row equivalence. The first comparison increment targets only map lookup,
+playfield predicates and normalization; its final evidence must name executable
+identity, fixtures, substitutions, covered branches and production test consumers.
+
+## Open queue
+
+1. Deliver and independently review reproducible native comparisons for current
+   GSI-04.01 lookup/playfield helpers; fix any demonstrated mismatch.
+2. Recheck the remaining constructor identity, shared-dummy field,
+   Resize/restore, iterator and consumer-order hypotheses. Implement only proven
+   observable differences; retain unresolved candidates explicitly.
+3. Reconcile each other row with current production source and active retail
+   evidence. Reuse bridge and earlier Phase 3 research without importing their
+   historical scope expansions automatically.
+4. Run the phase-wide reverse audit only after every in-scope mechanism and
+   evidence-backed exclusion is accounted for. Any omission reopens its row.
+
+## Start here
+
+Read the current task checkpoint, verify Git/process state, finish the first
+mechanism and its independent critic gate, then required full library tests and
+Clippy. Push, open/update its PR, merge and verify refreshed `origin/main` before
+starting another mechanism. Preserve a blocked mechanism and continue independent
+work when necessary. No phase or row is closed by this brief.

--- a/docs/plans/phase-briefs/phase-03-map-spatial-world.md
+++ b/docs/plans/phase-briefs/phase-03-map-spatial-world.md
@@ -14,7 +14,7 @@ references are starting evidence whose applicability must be checked per mechani
 
 | Row | GSI | Rust owner(s) | Native anchor or research starting point | Registry | Notes |
 |---|---|---|---|---|---|
-| 37 | GSI-04.01 | `src/map/cell_index.rs`, `playfield.rs`, `resolved_terrain.rs`; `src/sim/cell_rect.rs` | Get_CellClass `0x005657A0`, world lookup `0x00565730`, IsCellInPlayfield `0x00578460`; [dummy contract](../../research/MAPCLASS_GET_CELLCLASS_FALLBACK_DUMMY_CELL_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Current lookup/boundary executable comparison is the first increment. Constructor/iterator and unmodeled-state candidates require separate proof. |
+| 37 | GSI-04.01 | `src/map/cell_index.rs`, `playfield.rs`, `resolved_terrain.rs`; `src/sim/cell_rect.rs` | Get_CellClass `0x005657A0`, world lookup `0x00565730`, IsCellInPlayfield `0x00578460`; [dummy contract](../../research/MAPCLASS_GET_CELLCLASS_FALLBACK_DUMMY_CELL_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Current native comparison exposed reversed ClipRect operands under signed overflow; its repair is the first increment. Constructor/iterator and unmodeled-state candidates require separate proof. |
 | 38 | GSI-04.02 | `src/map/theater.rs`, `resolved_terrain.rs` | CalculateLegacyMapTileIndex `0x00544E30`; [translation](../../research/PHASE3_LAST_TILES_IN_SET_COMPATIBILITY_TRANSLATION_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Load, Fill, map-pack and generated-map paths must be checked separately. |
 | 39 | GSI-04.03 | `src/util/lepton.rs`; `src/sim/cell_kernel.rs`; `src/map/resolved_terrain.rs` | ComputeGroundHeightAtCoord `0x0047B3A0`; [domain census](../../research/PHASE3_CELL_GROUND_HEIGHT_104_DOMAIN_CONSUMER_CENSUS_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | The CellClass 90-lepton and object/VXL 104-lepton domains are distinct. |
 | 40 | GSI-04.04 | `src/sim/cell_kernel.rs`, `overlay_grid.rs`, `pathfinding/terrain_cost.rs` | [RecalcZoneType](../../research/CELLCLASS_RECALCZONE_TYPE_00483C80_GHIDRA_REPORT.md) | CONTRACTED / PARTIAL / DRIFT | Preserve synchronous publication before the next reader. |
@@ -63,6 +63,12 @@ status is historical; reconcile it against current source before selecting work.
 
 ## Corrections
 
+- The new original-instruction corpus exposed reversed ClipRect operands in
+  `src/map/playfield.rs`: native clips candidate Size against LocalSize. Ordinary
+  intersection symmetry hides the difference; accepted signed-overflow input
+  does not. The pre-fix Rust comparison failed, and the first increment repairs
+  the production order. See the [comparison report](../../research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md).
+
 - Old GSI-04.01 gaps G1 dummy reservation reset and G2 IsoMapPack miss stamping
   have production implementations. The old reservation-writer candidate is also
   stale: current lifecycle code implements the Mark/Clear perimeter paths.
@@ -89,9 +95,7 @@ outcome of the first map-lookup comparison.
 
 No phase-wide native differential or completed reverse audit is recorded by this
 goal. Existing Rust regression tests and older scoped critic passes do not imply
-whole-row equivalence. The first comparison increment targets only map lookup,
-playfield predicates and normalization; its final evidence must name executable
-identity, fixtures, substitutions, covered branches and production test consumers.
+whole-row equivalence. The [first comparison increment](../../research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md) records 2,144 original-executable calls/prefixes for lookup, playfield predicates, normalization and retained dummy identity. Its report records the executable, fixtures, endpoint limits and production test consumers. Rust and critic results must pass before publication; this bounded corpus does not close GSI-04.01.
 
 ## Open queue
 

--- a/docs/research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md
+++ b/docs/research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md
@@ -1,0 +1,145 @@
+# Phase 3 map lookup and playfield native comparison
+
+Date: 2026-09-10. Source baseline: `origin/main` `8f988ab2`.
+Scope: bounded GSI-04.01 lookup and playfield evidence. No Phase 3 row is closed
+by this comparison. The comparison exposed and corrects one production
+LocalSize clipping operand-order mismatch for signed-overflow inputs.
+
+## Native behavior established
+
+The current Ghidra `testProsjekt` program `gamemd.exe` was read explicitly,
+including the following bodies, assembly, and active callers. The original
+retail executable has image base `0x00400000` and SHA-256
+`1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c`.
+
+| Native entry | Established behavior and active consumer |
+| --- | --- |
+| `0x005657A0` | Packed signed-i16 `y*512+x`; only the linear index is checked against `0x40000`. A nonnull slot returns its pointer without touching the dummy. Misses return `0x00ABDC50` and overwrite only its packed coordinate at `+0x24`. Ordinary map, movement and projectile callers use this shared lookup. |
+| `0x00565730` | Signed world/lepton X/Y divide by 256 toward zero. Full i32 quotients feed wrapping linear-index arithmetic; only the miss path narrows to packed words. Its upper bound reads `MapClass+0x140`; normal retail table capacity is `0x40000`. Active calls include Map Logic at `0x004D245E`, Foot cell-action selection at `0x004DDE45`, Techno fire at `0x006FE1D0`, and Bullet detonation at `0x004695D6`. |
+| `0x00578460` | Only the low byte of mode selects lookup. Mode zero performs no lookup or stamp. Nonzero mode reads the global table pointer `0x0087F924`, applies shared fallback, reads signed level `+0x11B` and unsigned slope `+0x11C`, and uses the strict upper-half slope correction and four signed wrapping inequalities. Active callers include `CellClass::RecalcZoneType` at `0x00483C90`, `CrateSlot::ValidateCellAndCreateOverlay` at `0x004A1915`, and aircraft landing at `0x00419B18`. |
+| `0x005785F0` | Signed world division, then packed narrowing, then forced mode one at `0x0057862B`; Z is ignored. Active callers include aircraft Unlimbo at `0x00414352`, Building CanDock at `0x00457D31`, and Object Paradrop at `0x005F5952`. |
+| `0x00567230` through `0x005672D3` | Calls the original ClipRect `0x00421B60`, writes normalized LocalSize, floors left/top at two and caps width/height against Size margins. The endpoint is **before** the redraw call; Techno membership updates are also outside this comparison. Radar map-bounds setup invokes the full owner at `0x0065449D`. |
+
+The lookup code is shared active YR code. No TS-only activation is asserted.
+Native constructors, input selection in every caller, allocation failure, and
+the full Resize lifecycle are not executed here.
+
+### Confirmed LocalSize correction
+
+The pre-fix Rust test failed on `Size=0,0,80,80` and
+`LocalSize=2147483647,2,2,20`: Rust produced
+`[2147483647,2,-2147483569,20]`, while native execution produced `[2,2,0,0]`.
+The other three comparison tests passed. Independent review identified the
+operand-order error; a fresh builder disassembly read confirmed it.
+
+At `0x00567233`, EDX receives raw LocalSize. The caller pushes Size at
+`0x00567240..0x00567251`. ClipRect initializes its candidate from that stack
+argument at `0x00421B6F..0x00421B7E`, while EDX supplies its clipping bounds.
+Rust had reversed the rectangles. Ordinary positive intersections are
+equivalent, but the intermediate signed wrapping branches are not. The
+production helper now initializes its candidate as normalized Size and applies
+the LocalSize bounds in the original order, retaining all native empty checks,
+wrapping operations and the subsequent margins.
+
+This input reaches active retail code: `ScenarioClass::Full_Init` calls map
+loading at `0x006879FF`; `Read_Map_Section_And_IsoMapPacks @ 0x004ACE70`
+reads LocalSize at `0x004AD77A` through `INIClass::ReadRect @ 0x00527CC0`,
+stores its signed dwords, then invokes `RadarClass::ComputeRadarMapBounds`,
+which calls normalization at `0x0065449D`. ReadRect copies into its 64-byte
+buffer and scans `%d,%d,%d,%d`; INT_MAX is representable and this text fits.
+No shipped-retail occurrence is established. The verified retail nearoref
+header is unaffected. The trigger action integer-input boundary is not needed
+to establish this physical-map-input path and is not newly certified here.
+
+The original map supplied by default-active asset lookup is `nearoref.map`
+from `multimd.mix`, entry `0x5E33E585`, 97,641 bytes, SHA-256
+`d35a49d858e49bb31f63bbfe5d17e3cfcc2734fbfa4d4708c1b355ab6270d424`.
+Its `[Map]` section has `Theater=TEMPERATE`, `Size=0,0,80,58`, and
+`LocalSize=2,4,76,48`. A different `Size` in its Preview section is not the map
+shape. The executable fixture uses these map dimensions in one case family;
+the sparse cell allocation and level/slope cases are explicitly synthetic.
+
+## Executable evidence and Rust production delivery
+
+[The generator](../../tools/spatial_oracle/map_queries.py) executes original
+instructions with the shared checked runner. It provides both table owners,
+retail capacity, seven real slots, the full zeroed remainder of the pointer
+table, and retained dummy bytes. Real pointers encode distinct fixture cells;
+unexpected returned pointers fail generation. Input and dummy-height writes
+are checked. No native call results or instruction bodies are substituted.
+
+[The reference](../../tools/spatial_oracle/map_queries.json) and
+[provenance sidecar](../../tools/spatial_oracle/map_queries.meta.json) preserve:
+
+- 114 packed/world lookup cases: allocated/null/out-of-range slots, fixed-stride
+  aliases, negative division boundaries, i16 narrowing and i32 index wrap.
+- 15 LocalSize normalization prefixes, including the retail header, clipping,
+  empty and small rectangles, signed limits and arithmetic wrap.
+- 2,010 playfield cases: five final field sets; low-byte modes zero, one, 255
+  and 256; signed level limits; slope zero/nonzero; both sides and equality at
+  bounds and slope thresholds; packed aliases; 92 world-wrapper cases.
+- Five sequential calls in one emulator retaining the first dummy pointer,
+  showing later real hits preserve its coordinate and later misses mutate
+  that same retained object without clearing its height/slope.
+
+These are 2,144 bounded calls/prefixes, not an exhaustive proof of all signed
+inputs, map lifecycle, or complete gameplay loops. Extreme signed field sets
+exercise the arithmetic contract; they are not claimed as shipped map data.
+
+[Rust comparison tests](../../src/sim/cell_rect_native_tests.rs) call the actual
+owners in [cell_rect.rs](../../src/sim/cell_rect.rs) and
+[playfield.rs](../../src/map/playfield.rs), using the same seven-slot allocation
+and level/slope inputs. They compare native pointer-selected cell coordinates,
+verdicts, dummy stamps, preserved fields, and retained shared identity.
+The current production connections include:
+
+- `ProjectileCollisionWorld::cell` uses the world lookup; its packed collision
+  helpers use the packed lookup.
+- `find_nearby_cell` and Simulation playfield membership use the same
+  height-aware predicate.
+- `Simulation::install_playfield_from_map_header` uses the same normalization
+  owner for loaded map headers. Trigger LocalSize changes share that owner.
+
+The normalization test also parses each physical signed header through
+`MapFile::from_bytes` and installs it through the production Simulation seam,
+comparing the resulting authority to the same native reference.
+
+The tests do not substitute a second Rust algorithm. They demonstrate only the
+bounded mechanism exposed by these production owners,
+not equivalence of every caller's input or scheduling.
+
+## Validation
+
+Run from the repository root with the original retail executable configured:
+
+```powershell
+$env:VERA20K_GAMEMD_EXE = 'C:/your-retail-install/gamemd.exe'
+python -m tools.spatial_oracle.map_queries --check
+cargo test -p vera20k --lib sim::cell_rect::tests::map_
+```
+
+Generation and a separate read-only `--check` passed under Unicorn 2.1.4:
+`native outputs match; no files written`. The sidecar records native identity,
+binding/core versions, entry points and fixture assumptions. Pre-fix focused
+Rust result: **3 passed, 1 failed**, the exact LocalSize drift above.
+Post-fix focused result: **4 passed, 0 failed, 8,702 filtered out**, including
+the physical-map-input production seam (0.04 seconds; initial recompile
+4 minutes 15 seconds). The library emitted 58 existing warnings. Native
+reference values were retained unchanged for the fix. A fresh independent
+read-only critic passed the bounded code/evidence revision without findings.
+Final-candidate full-library and Clippy results are pending at this checkpoint.
+
+## Residual scope
+
+GSI-04.01 remains open for the phase-wide audit of CellClass constructor/ID
+observability, Resize caller multiplicity and surrounding lifecycle, all
+remaining shared-dummy writer/reader chains, and generic CellIterator consumer
+ordering. The older local GSI-04.01 census was used only as a search lead:
+its reservation-writer unknowns predate current production Mark/Clear and
+perimeter work, so they cannot be copied as current gaps. The live projectile
+world owner already has Size-diamond bounds; the unused `coord_is_on_grid`
+helper is not evidence of a production divergence.
+
+Bridge-zone routing, shroud, terrain mutations, and other Phase 3 mechanisms
+have separate closure obligations. This evidence increment does not certify
+or exclude them.

--- a/docs/research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md
+++ b/docs/research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md
@@ -116,6 +116,8 @@ Run from the repository root with the original retail executable configured:
 $env:VERA20K_GAMEMD_EXE = 'C:/your-retail-install/gamemd.exe'
 python -m tools.spatial_oracle.map_queries --check
 cargo test -p vera20k --lib sim::cell_rect::tests::map_
+cargo test -p vera20k --lib
+cargo clippy -p vera20k --lib
 ```
 
 Generation and a separate read-only `--check` passed under Unicorn 2.1.4:
@@ -127,7 +129,14 @@ the physical-map-input production seam (0.04 seconds; initial recompile
 4 minutes 15 seconds). The library emitted 58 existing warnings. Native
 reference values were retained unchanged for the fix. A fresh independent
 read-only critic passed the bounded code/evidence revision without findings.
-Final-candidate full-library and Clippy results are pending at this checkpoint.
+Final-candidate full-library validation exited **0**: **8,587 passed, 0 failed,
+119 ignored**, in 26.29 seconds. Clippy exited **0** in 3 minutes 20 seconds
+with **1,144 warnings**; this increment does not resolve the repository warning
+backlog. No Rust changes followed the validated implementation commit
+`258a59ce`. Full local receipts are preserved in
+`.local/spatial-full-lib.log` and `.local/spatial-clippy.log`; focused and native
+check receipts are `.local/spatial-focused-fixed.log` and
+`.local/spatial-native-check.log`. These local logs are not tracked artifacts.
 
 ## Residual scope
 

--- a/docs/system-map/topology.v2.json
+++ b/docs/system-map/topology.v2.json
@@ -31,6 +31,23 @@
     }
   ],
   "systems": {
+    "GSI-04.01": {
+      "native_anchors": [
+        {"symbol": "MapClass::Set_Clipped_LocalSize / ClipRect", "address": "0x00567230", "evidence": "docs/research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md"},
+        {"symbol": "MapClass::Get_CellClass", "address": "0x005657A0", "evidence": "docs/research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md"},
+        {"symbol": "MapClass::IsCellInPlayfield", "address": "0x00578460", "evidence": "docs/research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md"}
+      ],
+      "rust_surfaces": [
+        {"path": "src/map/playfield.rs", "symbol": "PlayfieldBounds::from_map_header; clip_local_size_to_map", "coverage": "representative", "observed_at_commit": "258a59ce2023d5c73be035ff8c6a613f9958b48a"},
+        {"path": "src/sim/cell_rect.rs", "symbol": "get_cellclass_fallback; get_cellclass_fallback_leptons; cell_is_in_playfield_height_aware", "coverage": "representative", "observed_at_commit": "258a59ce2023d5c73be035ff8c6a613f9958b48a"},
+        {"path": "src/sim/cell_rect_native_tests.rs", "symbol": "map_localsize_normalization_matches_native_executed_prefix; map_lookup_matches_native_executable_pointer_and_dummy_effects; map_playfield_matches_native_executable_modes_heights_and_stamps; map_retained_dummy_alias_matches_native_query_sequence", "coverage": "representative", "observed_at_commit": "258a59ce2023d5c73be035ff8c6a613f9958b48a"}
+      ],
+      "notes": [
+        "Original retail instruction comparisons exposed reversed clipping operands for accepted signed-overflow LocalSize input. Production normalization now clips candidate Size against LocalSize in the native operation order. A physical MapFile input is installed through the Simulation playfield owner in the regression.",
+        "The saved 2,144-call/prefix corpus covers bounded packed/world lookups, dummy writes and retained identity, playfield modes/heights and the LocalSize normalization prefix. The native prefix stops before redraw and Techno membership effects. No substituted native instructions or call results are used.",
+        "This representative evidence does not close GSI-04.01: constructor/ID observability, Resize/restore lifecycle, remaining dummy writer/reader chains and iterator consumer ordering still need the wider audit. Registry PARTIAL/DRIFT status remains unchanged."
+      ]
+    },
     "GSI-12.10": {
       "native_anchors": [
         {"symbol": "Scenario Basic FreeRadar parser", "address": "0x0068A5E3", "evidence": "docs/research/FREE_RADAR_SCENARIO_AUTHORITY_2026_09_09.md"},

--- a/src/map/playfield.rs
+++ b/src/map/playfield.rs
@@ -190,40 +190,46 @@ pub(crate) const fn lepton_to_packed_cell_component(value: i32) -> i32 {
 
 /// Signed intersection of raw LocalSize with normalized Size, matching active
 /// `ClipRect @ 0x00421B60` inside `0x00567230`.
+/// Native passes LocalSize in EDX as the clipping bounds and Size on the stack
+/// as the initial candidate (`0x00567233..0x00567251`). Reversing those roles
+/// preserves ordinary intersections but changes signed-overflow branches.
+/// Executable comparison: `tools/spatial_oracle/map_queries.py`.
 fn clip_local_size_to_map(
     size_width: i32,
     size_height: i32,
-    [mut left, mut top, mut width, mut height]: [i32; 4],
+    [clip_left, clip_top, clip_width, clip_height]: [i32; 4],
 ) -> [i32; 4] {
-    if size_width <= 0 || size_height <= 0 || width <= 0 || height <= 0 {
+    if clip_width <= 0 || clip_height <= 0 || size_width <= 0 || size_height <= 0 {
         return [0; 4];
     }
 
-    if left < 0 {
-        width = width.wrapping_add(left);
-        left = 0;
+    let (mut left, mut top, mut width, mut height) = (0i32, 0i32, size_width, size_height);
+    if left < clip_left {
+        width = width.wrapping_add(left.wrapping_sub(clip_left));
+        left = clip_left;
     }
     if width <= 0 {
         return [0; 4];
     }
 
-    if top < 0 {
-        height = height.wrapping_add(top);
-        top = 0;
+    if top < clip_top {
+        height = height.wrapping_add(top.wrapping_sub(clip_top));
+        top = clip_top;
     }
     if height <= 0 {
         return [0; 4];
     }
 
-    if size_width < left.wrapping_add(width) {
-        width = size_width.wrapping_sub(left);
+    if clip_left.wrapping_add(clip_width) < left.wrapping_add(width) {
+        width = clip_left.wrapping_sub(left).wrapping_add(clip_width);
     }
     if width <= 0 {
         return [0; 4];
     }
 
-    if size_height < top.wrapping_add(height) {
-        height = size_height.wrapping_sub(top);
+    let clip_bottom = clip_top.wrapping_add(clip_height);
+    if clip_bottom < top.wrapping_add(height) {
+        height = clip_bottom.wrapping_sub(top);
     }
     if height <= 0 {
         return [0; 4];

--- a/src/sim/cell_rect.rs
+++ b/src/sim/cell_rect.rs
@@ -1075,6 +1075,8 @@ mod tests {
     use crate::sim::occupancy::CellListInsertion;
     use crate::sim::pathfinding::zone_map::ZoneGrid;
 
+    include!("cell_rect_native_tests.rs");
+
     fn map_header_with_rects(size: (i32, i32), local: [i32; 4]) -> MapHeader {
         MapHeader {
             theater: "TEMPERATE".to_string(),

--- a/src/sim/cell_rect_native_tests.rs
+++ b/src/sim/cell_rect_native_tests.rs
@@ -1,0 +1,206 @@
+// Native executable comparison of the production lookup/playfield owners.
+// Entries/fixture limits: tools/spatial_oracle/map_queries.py and
+// docs/research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md.
+// Included within cell_rect::tests to share its plain terrain fixture.
+
+fn spatial_native_vectors() -> serde_json::Value {
+    serde_json::from_str(include_str!("../../tools/spatial_oracle/map_queries.json")).unwrap()
+}
+
+fn native_pair(value: &serde_json::Value) -> (i32, i32) {
+    (
+        value[0].as_i64().unwrap() as i32,
+        value[1].as_i64().unwrap() as i32,
+    )
+}
+
+fn native_fixture_terrain(vectors: &serde_json::Value) -> ResolvedTerrainGrid {
+    let mut terrain = flat_terrain(512, 82);
+    let allocated = vectors["allocated"].as_array().unwrap();
+    assert_eq!(allocated.len(), 7);
+    let coords: Vec<_> = allocated
+        .iter()
+        .map(|row| {
+            let (x, y) = native_pair(row);
+            let cell = terrain.cell_mut(x as u16, y as u16).unwrap();
+            cell.level = row[2].as_i64().unwrap() as u8;
+            cell.slope_type = row[3].as_u64().unwrap() as u8;
+            (x as u16, y as u16)
+        })
+        .collect();
+    terrain.test_set_native_allocated_cells(&coords);
+    terrain
+}
+
+#[test]
+fn map_lookup_matches_native_executable_pointer_and_dummy_effects() {
+    let vectors = spatial_native_vectors();
+    let terrain = native_fixture_terrain(&vectors);
+    let seed = native_pair(&vectors["dummy_seed"]);
+    let rows = vectors["lookups"].as_array().unwrap();
+    assert_eq!(rows.len(), 114);
+    let mut packed_count = 0;
+    let mut real_count = 0;
+    for row in rows {
+        terrain.stamp_dummy_cell_requested_coord(seed.0, seed.1);
+        terrain.test_set_dummy_cell_level_slope(-7, 1);
+        let (x, y) = native_pair(&row["xy"]);
+        let cell = match row["kind"].as_str().unwrap() {
+            "packed_lookup" => {
+                packed_count += 1;
+                get_cellclass_fallback(Some(&terrain), x, y)
+            }
+            "world_lookup" => get_cellclass_fallback_leptons(Some(&terrain), x, y),
+            unexpected => panic!("unexpected native query {unexpected}"),
+        };
+        let real = match cell {
+            CellRef::Real(cell) => {
+                real_count += 1;
+                Some((i32::from(cell.rx), i32::from(cell.ry)))
+            }
+            CellRef::Dummy { cell } => {
+                assert!(cell.same_identity(&terrain.shared_cell_dummy()));
+                None
+            }
+        };
+        let expected = (!row["real"].is_null()).then(|| native_pair(&row["real"]));
+        assert_eq!(real, expected, "native pointer selection: {row}");
+        assert_eq!(
+            terrain.dummy_cell_requested_coord(),
+            native_pair(&row["dummy_coord"]),
+            "native miss-only stamp: {row}"
+        );
+        assert_eq!(terrain.dummy_cell_level_slope(), (-7, 1));
+    }
+    assert_eq!(packed_count, 16);
+    assert!(
+        real_count > 10,
+        "corpus must exercise real and dummy branches"
+    );
+}
+
+#[test]
+fn map_playfield_matches_native_executable_modes_heights_and_stamps() {
+    let vectors = spatial_native_vectors();
+    let terrain = native_fixture_terrain(&vectors);
+    let seed = native_pair(&vectors["dummy_seed"]);
+    let rows = vectors["predicates"].as_array().unwrap();
+    assert_eq!(rows.len(), 2010);
+    let mut inside_count = 0;
+    let mut geometry_count = 0;
+    let mut wrapper_count = 0;
+    for row in rows {
+        let fields = row["bounds"].as_array().unwrap();
+        let field = |index: usize| fields[index].as_i64().unwrap() as i32;
+        let bounds = PlayfieldBounds::from_normalized_local_size(
+            field(0),
+            field(1),
+            field(2),
+            field(3),
+            field(4),
+        );
+        let dummy = native_pair(&row["dummy"]);
+        terrain.stamp_dummy_cell_requested_coord(seed.0, seed.1);
+        terrain.test_set_dummy_cell_level_slope(dummy.0 as i8, dummy.1 as u8);
+        let xy = native_pair(&row["xy"]);
+        let inside = match row["kind"].as_str().unwrap() {
+            "world_playfield" => {
+                wrapper_count += 1;
+                cell_is_in_playfield_leptons((xy.0, xy.1, -559038737), Some(bounds), Some(&terrain))
+            }
+            "playfield" if row["mode"].as_u64().unwrap() as u8 == 0 => {
+                geometry_count += 1;
+                cell_is_in_playfield_geometry_only(xy, bounds)
+            }
+            "playfield" => cell_is_in_playfield_height_aware(xy, Some(bounds), Some(&terrain)),
+            unexpected => panic!("unexpected native query {unexpected}"),
+        };
+        inside_count += usize::from(inside);
+        assert_eq!(
+            inside,
+            row["inside"].as_bool().unwrap(),
+            "native verdict: {row}"
+        );
+        assert_eq!(
+            terrain.dummy_cell_requested_coord(),
+            native_pair(&row["dummy_coord"]),
+            "native mode/lookup side effects: {row}"
+        );
+        assert_eq!(
+            terrain.dummy_cell_level_slope(),
+            (dummy.0 as i8, dummy.1 as u8)
+        );
+    }
+    assert_eq!(wrapper_count, 92);
+    assert!(geometry_count > 100);
+    assert!(inside_count > 100 && inside_count < rows.len());
+}
+
+#[test]
+fn map_localsize_normalization_matches_native_executed_prefix() {
+    let vectors = spatial_native_vectors();
+    let rows = vectors["normalizations"].as_array().unwrap();
+    assert_eq!(rows.len(), 15);
+    for row in rows {
+        let local = std::array::from_fn(|i| row["local"][i].as_i64().unwrap() as i32);
+        let actual = PlayfieldBounds::from_map_header(&map_header_with_rects(
+            native_pair(&row["size"]),
+            local,
+        ));
+        let expected: [i32; 4] =
+            std::array::from_fn(|i| row["normalized"][i].as_i64().unwrap() as i32);
+        assert_eq!(
+            [
+                actual.off_fc,
+                actual.off_100,
+                actual.off_104,
+                actual.off_108
+            ],
+            expected,
+            "native 567230 through 5672D3, before redraw/Techno effects: {row}"
+        );
+        // Physical signed INI input through the parser and initial sim seam.
+        let size = native_pair(&row["size"]);
+        let text = format!(
+            "[Map]\nTheater=TEMPERATE\nSize=0,0,{},{}\nLocalSize={},{},{},{}\n\
+             [IsoMapPack5]\n1=DwALABwBAAIA/////wAAABEAAA==\n",
+            size.0, size.1, local[0], local[1], local[2], local[3],
+        );
+        let map = crate::map::map_file::MapFile::from_bytes(text.as_bytes()).unwrap();
+        let mut sim = crate::sim::world::Simulation::new();
+        sim.install_playfield_from_map_header(&map.header);
+        assert_eq!(
+            sim.playfield_bounds,
+            Some(actual),
+            "physical map input: {row}"
+        );
+    }
+}
+
+#[test]
+fn map_retained_dummy_alias_matches_native_query_sequence() {
+    let vectors = spatial_native_vectors();
+    let terrain = native_fixture_terrain(&vectors);
+    let seed = native_pair(&vectors["dummy_seed"]);
+    terrain.stamp_dummy_cell_requested_coord(seed.0, seed.1);
+    terrain.test_set_dummy_cell_level_slope(-7, 1);
+    let rows = vectors["retained_sequence"].as_array().unwrap();
+    assert_eq!(rows.len(), 5);
+    let mut retained = None;
+    for row in rows {
+        let (x, y) = native_pair(&row["xy"]);
+        let selected = get_cellclass_fallback(Some(&terrain), x, y);
+        if retained.is_none() {
+            retained = Some(selected.clone());
+        }
+        let old = retained.as_ref().unwrap();
+        assert_eq!(old == &selected, row["returns_retained"].as_bool().unwrap());
+        let snapshot = old.dummy_snapshot().unwrap();
+        assert_eq!(snapshot.coord, native_pair(&row["retained_coord"]));
+        let height = native_pair(&row["retained_height"]);
+        assert_eq!(
+            (snapshot.level as u8, snapshot.slope_type),
+            (height.0 as u8, height.1 as u8)
+        );
+    }
+}

--- a/tools/native_oracle.md
+++ b/tools/native_oracle.md
@@ -39,6 +39,7 @@ These generators now default to **read-only checks**, also spelled `--check`:
 | `tools.projectile_oracle.ordinary_motion` | 120 cases, eight gravity/candidate blocks each | `src/sim/projectile.rs`, `src/sim/world/projectile_collision.rs` |
 | `tools.projectile_oracle.vertical_motion` | 110 cases, eight velocity/candidate blocks each | Same projectile consumers |
 | `tools.color_oracle.hsv_to_rgb` | All 256 hues at nine saturation/value pairs | `src/rules/color_scheme.rs` |
+| `tools.spatial_oracle.map_queries` | 114 lookup cases, 15 LocalSize prefixes, 2,010 playfield queries and five retained-dummy calls | `src/sim/cell_rect_native_tests.rs`, production `cell_rect.rs` / `map/playfield.rs` |
 
 Run them as modules (`python -m ...`). Imports do not emulate or write files;
 `--help` works without retail configuration. `--output <path>` selects another
@@ -109,7 +110,7 @@ zero, and native bit dumps remain preferable where precise representation matter
 `tools/rmg_oracle/harness.py` keeps legacy imports working through the verified loader
 and checked `call`. Other scripts that directly invoke `emu_start` have **not** all
 been migrated. In particular, do not infer completion checking or read-only CLI
-behavior for the entire oracle directory from these five examples.
+behavior for the entire oracle directory from the listed examples.
 
 Run the runner's synthetic failure checks with:
 

--- a/tools/spatial_oracle/__init__.py
+++ b/tools/spatial_oracle/__init__.py
@@ -1,0 +1,1 @@
+"""Bounded active-retail map spatial comparisons."""

--- a/tools/spatial_oracle/map_queries.json
+++ b/tools/spatial_oracle/map_queries.json
@@ -1,0 +1,50090 @@
+{
+  "allocated": [
+    [
+      0,
+      0,
+      -128,
+      1
+    ],
+    [
+      511,
+      0,
+      127,
+      255
+    ],
+    [
+      0,
+      1,
+      -1,
+      0
+    ],
+    [
+      10,
+      10,
+      0,
+      0
+    ],
+    [
+      40,
+      48,
+      2,
+      1
+    ],
+    [
+      50,
+      40,
+      7,
+      4
+    ],
+    [
+      80,
+      50,
+      0,
+      0
+    ]
+  ],
+  "dummy_seed": [
+    1234,
+    -2345
+  ],
+  "lookups": [
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "packed_lookup",
+      "real": [
+        0,
+        0
+      ],
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "packed_lookup",
+      "real": [
+        511,
+        0
+      ],
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "packed_lookup",
+      "real": [
+        0,
+        1
+      ],
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "packed_lookup",
+      "real": [
+        0,
+        1
+      ],
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "packed_lookup",
+      "real": [
+        511,
+        0
+      ],
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "packed_lookup",
+      "real": [
+        10,
+        10
+      ],
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "kind": "packed_lookup",
+      "real": null,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "kind": "packed_lookup",
+      "real": null,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "packed_lookup",
+      "real": null,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "kind": "packed_lookup",
+      "real": null,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "kind": "packed_lookup",
+      "real": null,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "kind": "packed_lookup",
+      "real": null,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "kind": "packed_lookup",
+      "real": null,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "kind": "packed_lookup",
+      "real": null,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "packed_lookup",
+      "real": [
+        0,
+        0
+      ],
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "packed_lookup",
+      "real": [
+        511,
+        0
+      ],
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -2147483648,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -2147483648,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -2147483648,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -2147483648,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -8388609,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -8388609,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -8388609,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -8388609,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -8388608,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -8388608,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -8388608,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -8388608,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        -256,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -65537,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -256,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -65537,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        -256,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -65537,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -256,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -65537,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        -2,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -513,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -2,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -513,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        -2,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -513,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -2,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -513,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        -2,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -512,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -2,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -512,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        -2,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -512,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -2,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -512,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -511,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -511,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        511,
+        0
+      ],
+      "xy": [
+        -511,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -511,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -257,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -257,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        511,
+        0
+      ],
+      "xy": [
+        -257,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -257,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -256,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -256,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        511,
+        0
+      ],
+      "xy": [
+        -256,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -256,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -255,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        0
+      ],
+      "xy": [
+        -255,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        1
+      ],
+      "xy": [
+        -255,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -255,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -1,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        0
+      ],
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        1
+      ],
+      "xy": [
+        -1,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        -1,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        0,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        0
+      ],
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        1
+      ],
+      "xy": [
+        0,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        0,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        1,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        0
+      ],
+      "xy": [
+        1,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        1
+      ],
+      "xy": [
+        1,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        1,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        255,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        0
+      ],
+      "xy": [
+        255,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        1
+      ],
+      "xy": [
+        255,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        255,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        256,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        1,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        256,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        256,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        256,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        257,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        1,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        257,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        257,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        257,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        511,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        1,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        511,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        511,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        2,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        512,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        2,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        2,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        512,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        2,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        512,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        255,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        65535,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        255,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        65535,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        255,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        65535,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        255,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        65535,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        256,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        65536,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        256,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        65536,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        256,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        65536,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        256,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        65536,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        32767,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        8388607,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        32767,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        8388607,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        32767,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        8388607,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        32767,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        8388607,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        8388608,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        8388608,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        8388608,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -32768,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        8388608,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        2147483647,
+        -256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        2147483647,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        2147483647,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        2147483647,
+        2147483647
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        10,
+        10
+      ],
+      "xy": [
+        2560,
+        2560
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        511,
+        0
+      ],
+      "xy": [
+        -256,
+        256
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        1
+      ],
+      "xy": [
+        131072,
+        0
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        0
+      ],
+      "xy": [
+        16777216,
+        -32768
+      ]
+    },
+    {
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "kind": "world_lookup",
+      "real": [
+        0,
+        0
+      ],
+      "xy": [
+        0,
+        -2147483648
+      ]
+    },
+    {
+      "dummy_coord": [
+        -1,
+        -1
+      ],
+      "kind": "world_lookup",
+      "real": null,
+      "xy": [
+        2147483647,
+        2147483647
+      ]
+    }
+  ],
+  "normalizations": [
+    {
+      "local": [
+        2,
+        4,
+        76,
+        48
+      ],
+      "normalized": [
+        2,
+        4,
+        76,
+        48
+      ],
+      "size": [
+        80,
+        58
+      ]
+    },
+    {
+      "local": [
+        -5,
+        -6,
+        100,
+        100
+      ],
+      "normalized": [
+        2,
+        2,
+        76,
+        72
+      ],
+      "size": [
+        80,
+        80
+      ]
+    },
+    {
+      "local": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "normalized": [
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "size": [
+        0,
+        0
+      ]
+    },
+    {
+      "local": [
+        0,
+        0,
+        1,
+        1
+      ],
+      "normalized": [
+        2,
+        2,
+        -3,
+        -7
+      ],
+      "size": [
+        1,
+        1
+      ]
+    },
+    {
+      "local": [
+        5,
+        6,
+        40,
+        50
+      ],
+      "normalized": [
+        5,
+        6,
+        33,
+        38
+      ],
+      "size": [
+        40,
+        50
+      ]
+    },
+    {
+      "local": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "normalized": [
+        2,
+        2,
+        0,
+        0
+      ],
+      "size": [
+        40,
+        50
+      ]
+    },
+    {
+      "local": [
+        -1,
+        3,
+        1,
+        5
+      ],
+      "normalized": [
+        2,
+        2,
+        0,
+        0
+      ],
+      "size": [
+        80,
+        80
+      ]
+    },
+    {
+      "local": [
+        3,
+        -1,
+        5,
+        1
+      ],
+      "normalized": [
+        2,
+        2,
+        0,
+        0
+      ],
+      "size": [
+        80,
+        80
+      ]
+    },
+    {
+      "local": [
+        81,
+        4,
+        5,
+        5
+      ],
+      "normalized": [
+        2,
+        2,
+        0,
+        0
+      ],
+      "size": [
+        80,
+        80
+      ]
+    },
+    {
+      "local": [
+        4,
+        81,
+        5,
+        5
+      ],
+      "normalized": [
+        2,
+        2,
+        0,
+        0
+      ],
+      "size": [
+        80,
+        80
+      ]
+    },
+    {
+      "local": [
+        3,
+        4,
+        -1,
+        5
+      ],
+      "normalized": [
+        2,
+        2,
+        0,
+        0
+      ],
+      "size": [
+        80,
+        80
+      ]
+    },
+    {
+      "local": [
+        3,
+        4,
+        5,
+        -1
+      ],
+      "normalized": [
+        2,
+        2,
+        0,
+        0
+      ],
+      "size": [
+        80,
+        80
+      ]
+    },
+    {
+      "local": [
+        2147483647,
+        2,
+        2,
+        20
+      ],
+      "normalized": [
+        2,
+        2,
+        0,
+        0
+      ],
+      "size": [
+        80,
+        80
+      ]
+    },
+    {
+      "local": [
+        -2147483648,
+        2,
+        2147483647,
+        20
+      ],
+      "normalized": [
+        2,
+        2,
+        0,
+        0
+      ],
+      "size": [
+        80,
+        80
+      ]
+    },
+    {
+      "local": [
+        2,
+        2147483647,
+        20,
+        2
+      ],
+      "normalized": [
+        2,
+        2,
+        0,
+        0
+      ],
+      "size": [
+        80,
+        80
+      ]
+    }
+  ],
+  "predicates": [
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -27,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -27,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -27,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -27,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -27,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -26,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -26,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -26,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -26,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -26,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -25,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -25,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -25,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -25,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -25,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -81
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -81
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -81
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -81
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -81
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -80
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -80
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -80
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -80
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -80
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -79
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -79
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -79
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -79
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -79
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -77
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -77
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -77
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -77
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -77
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -77
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -77
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -77
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -77
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -77
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -77
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -77
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -76
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -76
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -76
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -76
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -76
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -76
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -76
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -76
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -76
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -76
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -76
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -76
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -75
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -75
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -75
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -75
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -75
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -75
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -75
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -75
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -75
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -75
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -75
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -75
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        17
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        17
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        17
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        17
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        17
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        17
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        17
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        17
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        17
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        17
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        17
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        17
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        18
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        18
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        18
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        18
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        18
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        18
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        18
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        18
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        18
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        18
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        18
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        18
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        19
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        19
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        19
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        19
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        19
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        19
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        19
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        19
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        19
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        19
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        19
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        19
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        46
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        46
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        46
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        46
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        46
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        47
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        47
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        47
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        47
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        47
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        49
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        49
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        49
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        49
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        49
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        51
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        51
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        51
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        51
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        51
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        51
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        51
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        51
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        51
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        51
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        51
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        51
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        52
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        52
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        52
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        52
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        52
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        52
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        52
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        52
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        52
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        52
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        52
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        52
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        53
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        53
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        53
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        53
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        53
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        53
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        53
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        53
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        53
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        53
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        53
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        53
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        54
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        54
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        54
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        54
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        54
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        54
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        54
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        54
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        54
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        54
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        54
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        54
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        144
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        144
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        144
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        144
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        144
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        144
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        144
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        144
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        144
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        144
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        144
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        144
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        145
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        145
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        145
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        145
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        145
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        145
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        145
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        145
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        145
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        145
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        145
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        145
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        146
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        146
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        146
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        146
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        146
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        146
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        146
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        146
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        146
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        146
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        146
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        146
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        147
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        147
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        147
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        147
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        147
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        147
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        147
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        147
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        147
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        147
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        147
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        147
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        148
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        148
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        148
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        148
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        148
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        148
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        148
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        148
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        148
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        148
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        148
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        148
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        174
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        174
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        174
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        174
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        174
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        175
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        175
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        175
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        175
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        175
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        176
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        176
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        176
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        176
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        176
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        178
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        178
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        178
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        178
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        178
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        178
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        178
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        178
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        178
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        178
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        178
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        178
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        179
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        179
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        179
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        179
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        179
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        179
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        179
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        179
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        179
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        179
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        179
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        179
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        180
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        180
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        180
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        180
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        180
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        180
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        180
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        180
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        180
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        180
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        180
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        180
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        272
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        272
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        272
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        272
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        272
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        272
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        272
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        272
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        272
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        272
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        272
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        272
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        273
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        273
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        273
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        273
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        273
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        273
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        273
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        273
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        273
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        273
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        273
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        273
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        274
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        274
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        274
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        274
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        274
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        274
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        274
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        274
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        274
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        274
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        274
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        274
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        125,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        125,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        125,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        125,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        125,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        126,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        126,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        126,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        126,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        126,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        127,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        127,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        127,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        127,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        127,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -157
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -157
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -157
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -157
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -157
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -157
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -157
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -157
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -157
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -157
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -157
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -157
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -156
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -156
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -156
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -156
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -156
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -156
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -156
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -156
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -156
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -156
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -156
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -156
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -155
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -155
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -155
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -155
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -155
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -155
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -155
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -155
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -155
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -155
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -155
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -155
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -154
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -154
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -154
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -154
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -154
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -154
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -154
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -154
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -154
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -154
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -154
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -154
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -153
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -153
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -153
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -153
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -153
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -153
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -153
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -153
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -153
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -153
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -153
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -153
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -152
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -152
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -152
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -152
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -152
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -152
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -152
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -152
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -152
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -152
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -152
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -152
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -151
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -151
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -151
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -151
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -151
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -151
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -151
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -151
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -151
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -151
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -151
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -151
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -30
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -30
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -30
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -30
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -30
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -29
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -29
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -29
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -29
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -29
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -29
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -29
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -29
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -29
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -29
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -29
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -29
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -28
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -28
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -28
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -28
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -28
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -28
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -28
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -28
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -28
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -28
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -28
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -28
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -27
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -27
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -27
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -27
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -27
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -27
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -27
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -27
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -27
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -27
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -27
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -27
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -26
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -26
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -26
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -26
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -26
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -26
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -26
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -26
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -26
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -26
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -26
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -26
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -25
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -25
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -25
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -25
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -25
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -25
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -25
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -25
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -25
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -25
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -25
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -25
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -24
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -24
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -24
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -24
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -24
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -24
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -24
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -24
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -24
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -24
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -24
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -24
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -23
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -23
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -23
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -23
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -23
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -23
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -23
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -23
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -23
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -23
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -23
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -23
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -22
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -22
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -22
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -22
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -22
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -22
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -22
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -22
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -22
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -22
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -22
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -22
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        98
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        98
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        98
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        98
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        98
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        98
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        98
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        98
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        98
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        98
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        98
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        98
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        99
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        99
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        99
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        99
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        99
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        99
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        99
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        99
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        99
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        99
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        99
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        99
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        100
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        100
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        100
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        100
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        100
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        100
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        100
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        100
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        100
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        100
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        100
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        100
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        101
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        101
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        101
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        101
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        101
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        101
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        101
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        101
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        101
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        101
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        101
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        101
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        102
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        102
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        102
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        102
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        102
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        102
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        102
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        102
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        102
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        102
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        102
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        102
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        103
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        103
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        103
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        103
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        103
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        103
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        103
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        103
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        103
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        103
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        103
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        103
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        104
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        104
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        104
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        104
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        104
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        104
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        104
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        104
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        104
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        104
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        104
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        104
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        45,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        45,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        45,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        45,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        45,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        46,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        46,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        46,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        46,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        46,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        47,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        47,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        47,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        47,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        47,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        54,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        54,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        54,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        54,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        54,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        55,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        55,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        55,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        55,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        55,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        8,
+        2,
+        2,
+        4,
+        0
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -27,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -27,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -27,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -27,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -27,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -27,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -26,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -26,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -26,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -26,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -26,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -26,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -25,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -25,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -25,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -25,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -25,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -25,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -85
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -85
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -85
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -85
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -85
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -85
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -85
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -85
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -85
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -85
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -85
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -85
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -84
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -84
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -84
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -84
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -84
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -84
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -84
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -84
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -84
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -84
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -84
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -84
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -83
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -83
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -83
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -83
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -83
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -83
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -83
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -83
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -83
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -83
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -83
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -83
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -81
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -81
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -81
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -81
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -81
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -81
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -80
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -80
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -80
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -80
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -80
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -80
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -79
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -79
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -79
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -79
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -79
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -79
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        42
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        42
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        42
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        42
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        42
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        42
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        42
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        42
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        42
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        42
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        42
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        42
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        43
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        43
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        43
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        43
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        43
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        43
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        43
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        43
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        43
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        43
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        43
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        43
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        44
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        44
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        44
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        44
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        44
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        44
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        44
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        44
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        44
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        44
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        44
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        44
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        45
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        45
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        45
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        45
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        45
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        45
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        45
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        45
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        45
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        45
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        45
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        45
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        46
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        46
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        46
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        46
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        46
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        46
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        47
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        47
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        47
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        47
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        47
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        47
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        49
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        49
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        49
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        49
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        49
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        49
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        61
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        61
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        61
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        61
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        61
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        61
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        61
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        61
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        61
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        61
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        61
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        61
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        62
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        62
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        62
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        62
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        62
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        62
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        62
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        62
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        62
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        62
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        62
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        62
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        63
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        63
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        63
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        63
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        63
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        63
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        63
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        63
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        63
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        63
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        63
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        63
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        170
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        170
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        170
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        170
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        170
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        170
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        170
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        170
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        170
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        170
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        170
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        170
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        171
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        171
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        171
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        171
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        171
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        171
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        171
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        171
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        171
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        171
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        171
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        171
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        172
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        172
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        172
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        172
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        172
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        172
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        172
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        172
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        172
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        172
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        172
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        172
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        174
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        174
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        174
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        174
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        174
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        174
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        175
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        175
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        175
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        175
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        175
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        175
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        176
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        176
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        176
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        176
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        176
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        176
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        188
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        188
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        188
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        188
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        188
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        188
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        188
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        188
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        188
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        188
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        188
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        188
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        189
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        189
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        189
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        189
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        189
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        189
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        189
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        189
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        189
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        189
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        189
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        189
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        190
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        190
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        190
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        190
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        190
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        190
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        190
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        190
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        190
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        190
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        190
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        190
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        191
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        191
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        191
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        191
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        191
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        191
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        191
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        191
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        191
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        191
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        191
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        191
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        192
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        192
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        192
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        192
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        192
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        192
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        192
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        192
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        192
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        192
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        192
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        192
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        316
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        316
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        316
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        316
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        316
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        316
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        316
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        316
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        316
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        316
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        316
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        316
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        317
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        317
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        317
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        317
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        317
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        317
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        317
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        317
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        317
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        317
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        317
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        317
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        318
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        318
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        318
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        318
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        318
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        318
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        318
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        318
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        318
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        318
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        318
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        318
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        125,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        125,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        125,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        125,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        125,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        125,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        126,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        126,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        126,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        126,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        126,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        126,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        127,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        127,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        127,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        127,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        127,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        127,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        2,
+        76,
+        72
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -179
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -179
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -179
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -179
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -179
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -179
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -179
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -179
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -179
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -179
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -179
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -179
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -178
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -178
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -178
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -178
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -178
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -178
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -178
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -178
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -178
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -178
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -178
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -178
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -177
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -177
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -177
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -177
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -177
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -177
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -177
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -177
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -177
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -177
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -177
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -177
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -165
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -165
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -165
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -165
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -165
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -165
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -165
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -164
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -164
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -164
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -164
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -164
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -164
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -164
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -164
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -164
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -164
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -164
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -164
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -163
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -163
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -163
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -163
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -163
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -163
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -163
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -163
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -163
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -163
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -163
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -163
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -161
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -161
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -161
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -161
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -161
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -161
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -161
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -161
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -161
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -161
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -161
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -161
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -160
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -160
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -160
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -160
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -160
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -160
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -160
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -160
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -160
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -160
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -160
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -160
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -159
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -159
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -159
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -159
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -159
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -159
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -159
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -159
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -159
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -159
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -159
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -159
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -52
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -52
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -52
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -52
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -52
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -52
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -52
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -52
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -52
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -52
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -52
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -52
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -51
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -51
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -51
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -51
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -51
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -51
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -51
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -51
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -51
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -51
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -51
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -51
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -49
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -49
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -49
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -49
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -49
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -49
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -49
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -49
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -49
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -49
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -49
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -49
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -48
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -48
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -48
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -48
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -48
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -38
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -38
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -38
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -38
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -38
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -38
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -38
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -37
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -37
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -37
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -37
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -37
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -37
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -37
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -36
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -36
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -36
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -36
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -36
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -36
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -36
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -35
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -35
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -35
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -35
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -35
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -35
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -35
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -35
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -35
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -35
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -35
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -35
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -34
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -34
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -34
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -34
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -34
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -34
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -34
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -34
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -34
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -34
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -34
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -34
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -33
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -33
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -33
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -33
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -33
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -33
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -33
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -33
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -33
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -33
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -33
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -33
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -32
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -32
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -32
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -32
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -32
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -32
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -32
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -32
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -32
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -32
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -32
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -32
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -31
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -31
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -31
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -31
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -31
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -31
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -31
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -31
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -31
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -31
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -31
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -31
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -30
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -30
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -30
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -30
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -30
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -30
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        76
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        76
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        76
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        76
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        76
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        76
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        76
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        76
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        76
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        76
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        76
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        76
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        77
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        77
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        77
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        77
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        77
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        77
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        77
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        77
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        77
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        77
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        77
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        77
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        78
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        78
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        78
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        78
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        78
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        78
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        78
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        78
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        78
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        78
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        78
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        78
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        90
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        90
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        90
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        90
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        90
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        90
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        90
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        91
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        91
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        91
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        91
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        91
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        91
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        91
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        91
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        91
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        91
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        91
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        91
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        92
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        92
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        92
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        92
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        92
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        92
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        92
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        92
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        92
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        92
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        92
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        92
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        94
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        94
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        94
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        94
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        94
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        94
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        94
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        94
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        94
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        94
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        94
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        94
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        95
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        95
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        95
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        95
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        95
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        95
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        95
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        95
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        95
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        95
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        95
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        95
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        96
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        96
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        96
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        96
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        96
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        96
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        96
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        96
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        96
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        96
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        96
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        96
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        45,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        45,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        45,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        45,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        45,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        45,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        46,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        46,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        46,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        46,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        46,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        46,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        47,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        47,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        47,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        47,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        47,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        47,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        53,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        54,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        54,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        54,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        54,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        54,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        54,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        55,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        55,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        55,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        55,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        55,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        55,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        0,
+        2,
+        2,
+        -4,
+        -8
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -2147483597,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -2147483597,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        51,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -2147483597,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        51,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -2147483597,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        51,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -2147483597,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        51,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -2147483597,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        51,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -2147483597,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -2147483596,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -2147483596,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        52,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -2147483596,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        52,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -2147483596,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        52,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -2147483596,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        52,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -2147483596,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        52,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -2147483596,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -2147483595,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -2147483595,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -2147483595,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -2147483595,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -2147483595,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -2147483595,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -2147483595,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        -32768
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -32768,
+        -32768
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        512
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        -1,
+        512
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        -1
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        -1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        0,
+        1
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        11,
+        10
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        11,
+        10
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -2147483562
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -2147483562
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        86
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483562
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        86
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483562
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        86
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483562
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        86
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483562
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        86
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -2147483562
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -2147483561
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -2147483561
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        87
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483561
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        87
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483561
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        87
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483561
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        87
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483561
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        87
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -2147483561
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -2147483560
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -2147483560
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        88
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483560
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        88
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483560
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        88
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483560
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        88
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483560
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        88
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -2147483560
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -2147483558
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -2147483558
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483558
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483558
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483558
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483558
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -2147483558
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -2147483557
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -2147483557
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        91
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483557
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        91
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483557
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        91
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483557
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        91
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483557
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        91
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -2147483557
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        -2147483556
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        -2147483556
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        92
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483556
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        92
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483556
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        92
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483556
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        92
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        -2147483556
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        92
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        -2147483556
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        48
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147417945
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147417945
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -167
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147417945
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -167
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147417945
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -167
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147417945
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -167
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147417945
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -167
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147417945
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147417946
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147417946
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -166
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147417946
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -166
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147417946
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -166
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147417946
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -166
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147417946
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -166
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147417946
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147417947
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147417947
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147417947
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147417947
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147417947
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147417947
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147417947
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147418072
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147418072
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -40
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418072
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -40
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418072
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -40
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418072
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -40
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418072
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -40
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147418072
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147418073
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147418073
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -39
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418073
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -39
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418073
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -39
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418073
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -39
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418073
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -39
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147418073
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147418074
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147418074
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418074
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418074
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418074
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418074
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147418074
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147418075
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147418075
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418075
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418075
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418075
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418075
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147418075
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147418076
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147418076
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418076
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418076
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418076
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418076
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147418076
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147418200
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147418200
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        88
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418200
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        88
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418200
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        88
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418200
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        88
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418200
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        88
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147418200
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147418201
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147418201
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        89
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418201
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        89
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418201
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        89
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418201
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        89
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418201
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        89
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147418201
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147418202
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147418202
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418202
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418202
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418202
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147418202
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        90
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147418202
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483479
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483479
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -169
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483479
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -169
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483479
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -169
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483479
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -169
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483479
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -169
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483479
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483480
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483480
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -168
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483480
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -168
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483480
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -168
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483480
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -168
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483480
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -168
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483480
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483481
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483481
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -167
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483481
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -167
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483481
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -167
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483481
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -167
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483481
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -167
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483481
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483483
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483483
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483483
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483483
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483483
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483483
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -165
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483483
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483484
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483484
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -164
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483484
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -164
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483484
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -164
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483484
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -164
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483484
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -164
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483484
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483485
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483485
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -163
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483485
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -163
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483485
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -163
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483485
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -163
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483485
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -163
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483485
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483606
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483606
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -42
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483606
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -42
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483606
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -42
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483606
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -42
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483606
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -42
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483606
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483607
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483607
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -41
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483607
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -41
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483607
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -41
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483607
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -41
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483607
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -41
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483607
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483608
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483608
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -40
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483608
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -40
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483608
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -40
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483608
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -40
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483608
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -40
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483608
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483609
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483609
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -39
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483609
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -39
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483609
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -39
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483609
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -39
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483609
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -39
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483609
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483610
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483610
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483610
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483610
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483610
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483610
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -38
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483610
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483611
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483611
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483611
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483611
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483611
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483611
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -37
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483611
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483612
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483612
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483612
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483612
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483612
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483612
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -36
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483612
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483613
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483613
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -35
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483613
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -35
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483613
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -35
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483613
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -35
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483613
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -35
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483613
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        40,
+        2147483614
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        40,
+        2147483614
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -34
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483614
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -34
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483614
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        40,
+        -34
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483614
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        40,
+        -34
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        40,
+        2147483614
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        40,
+        -34
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        40,
+        2147483614
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        50,
+        40
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        80,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        511,
+        511
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        511,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        512,
+        511
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        512,
+        511
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        32767
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        32767,
+        32767
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        65535,
+        65537
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        65536,
+        65536
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        2147418163,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        2147418163,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        51,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        2147418163,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        51,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        2147418163,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        51,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        2147418163,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        51,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        2147418163,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        51,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        2147418163,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        2147418164,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        2147418164,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        52,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        2147418164,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        52,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        2147418164,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        52,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        2147418164,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        52,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        2147418164,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        52,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        2147418164,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 0,
+      "xy": [
+        2147418165,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        255
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 256,
+      "xy": [
+        2147418165,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -128,
+        0
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        2147418165,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        -1,
+        1
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": false,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        2147418165,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        0,
+        0
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        2147418165,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        1,
+        255
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 1,
+      "xy": [
+        2147418165,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        -2147483648,
+        -2147483647,
+        -2147483648,
+        -32768,
+        -32768
+      ],
+      "dummy": [
+        127,
+        1
+      ],
+      "dummy_coord": [
+        53,
+        50
+      ],
+      "inside": true,
+      "kind": "playfield",
+      "mode": 255,
+      "xy": [
+        2147418165,
+        50
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -2147483648,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -2147483648,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -2147483648,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -2147483648,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -8388609,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -8388609,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -8388609,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -8388609,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -8388608,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -8388608,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -8388608,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -8388608,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -256,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -65537,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -256,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -65537,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -256,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -65537,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -256,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -65537,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -2,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -513,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -2,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -513,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -2,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -513,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -2,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -513,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -2,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -512,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -2,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -2,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -512,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -2,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -512,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -511,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -511,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -511,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -257,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -257,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -257,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -257,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -256,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -256,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -256,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -256,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -255,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -255,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -255,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -255,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        -1,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        0,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        1,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        1,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        1,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        1,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        255,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": true,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        255,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        255,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        0,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        255,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        256,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        256,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        256,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        256,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        257,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        257,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        257,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        257,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        511,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        2,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        2,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        2,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        2,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        512,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        255,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        255,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        255,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        255,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        65535,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        256,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        256,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        256,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        256,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        65536,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        8388607,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        8388607,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        8388607,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        32767,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        8388607,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        8388608,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        8388608,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        1
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        8388608,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -32768,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        8388608,
+        12543
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        2147483647,
+        -255
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        0
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        2147483647,
+        0
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        1234,
+        -2345
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        2147483647,
+        256
+      ]
+    },
+    {
+      "bounds": [
+        80,
+        2,
+        4,
+        76,
+        48
+      ],
+      "dummy": [
+        -7,
+        1
+      ],
+      "dummy_coord": [
+        -1,
+        48
+      ],
+      "inside": false,
+      "kind": "world_playfield",
+      "mode": 1,
+      "xy": [
+        2147483647,
+        12543
+      ]
+    }
+  ],
+  "retained_sequence": [
+    {
+      "retained_coord": [
+        -1,
+        0
+      ],
+      "retained_height": [
+        249,
+        1
+      ],
+      "returns_retained": true,
+      "xy": [
+        -1,
+        0
+      ]
+    },
+    {
+      "retained_coord": [
+        -1,
+        0
+      ],
+      "retained_height": [
+        249,
+        1
+      ],
+      "returns_retained": false,
+      "xy": [
+        10,
+        10
+      ]
+    },
+    {
+      "retained_coord": [
+        12,
+        11
+      ],
+      "retained_height": [
+        249,
+        1
+      ],
+      "returns_retained": true,
+      "xy": [
+        12,
+        11
+      ]
+    },
+    {
+      "retained_coord": [
+        12,
+        11
+      ],
+      "retained_height": [
+        249,
+        1
+      ],
+      "returns_retained": false,
+      "xy": [
+        -1,
+        1
+      ]
+    },
+    {
+      "retained_coord": [
+        32767,
+        -32768
+      ],
+      "retained_height": [
+        249,
+        1
+      ],
+      "returns_retained": true,
+      "xy": [
+        32767,
+        -32768
+      ]
+    }
+  ],
+  "source": "unicorn/gamemd.exe"
+}

--- a/tools/spatial_oracle/map_queries.meta.json
+++ b/tools/spatial_oracle/map_queries.meta.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "native_sha256": "1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c",
+  "unicorn_binding": "2.1.4",
+  "unicorn_core": [
+    2,
+    1,
+    33621247
+  ],
+  "scope": "Bounded packed/world lookup, LocalSize normalization prefix, and playfield predicates; not phase-wide parity",
+  "assumptions": [
+    "Fresh emulator per query with seven explicit allocated slots and all remaining pointer slots zero",
+    "MapClass+13C and global 87F924 select the same table; capacity is retail 0x40000",
+    "Dummy coordinate seed and level/slope are supplied; queries must preserve level/slope and source input",
+    "Five packed lookups also execute consecutively in one emulator, retaining the first dummy pointer",
+    "Real-cell level/slope inputs and signed/overflow cases are synthetic; nearoref.map supplies the 80x58/2,4,76,48 header",
+    "567230 executes original ClipRect and stops at 5672D3 before redraw and Techno membership effects",
+    "No map constructors, lifecycle, final presentation, complete callers or exhaustive i32 domain are claimed"
+  ],
+  "substitutions": [],
+  "entry_points": {
+    "packed_lookup": "0x005657A0",
+    "world_lookup": "0x00565730",
+    "playfield": "0x00578460",
+    "world_playfield": "0x005785F0",
+    "normalize": "0x00567230",
+    "clip_rect": "0x00421B60"
+  },
+  "payload_sha256": "14cd022a1b472d4ac3331e800b5213a2612c35f103acac79a2beb63f99a7bbfb"
+}

--- a/tools/spatial_oracle/map_queries.py
+++ b/tools/spatial_oracle/map_queries.py
@@ -1,0 +1,200 @@
+"""Execute original map lookup, normalization, and playfield instructions.
+
+Run: python -m tools.spatial_oracle.map_queries [--check | --write]
+See docs/research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md.
+This supplies sparse cell-table state; it does not emulate map construction.
+"""
+
+import struct
+from pathlib import Path
+
+from unicorn import Uc, UC_ARCH_X86, UC_MODE_32
+from unicorn.x86_const import UC_X86_REG_EAX, UC_X86_REG_ECX, UC_X86_REG_ESP
+
+from tools.native_oracle import (
+    RET_MAGIC, SCRATCH, STACK_BASE, STACK_SIZE, call, finish_vectors, load_image,
+    provenance, run_checked,
+)
+
+MAP, INPUT, CELLS = SCRATCH, SCRATCH + 0x200, SCRATCH + 0x1000
+# Fixture table in the runner's broad non-executable image mapping. Explicitly
+# clear the entire table: mapped image data is not initialized runtime state.
+TABLE, DUMMY, GLOBAL_TABLE = 0x00C00000, 0x00ABDC50, 0x0087F924
+EMPTY_TABLE = bytes(0x40000 * 4)
+SENTINEL = (1234, -2345)
+ALLOCATED = [(0, 0, -128, 1), (511, 0, 127, 255), (0, 1, -1, 0),
+             (10, 10, 0, 0), (40, 48, 2, 1), (50, 40, 7, 4), (80, 50, 0, 0)]
+ENTRIES = {"packed_lookup": 0x005657A0, "world_lookup": 0x00565730,
+           "playfield": 0x00578460, "world_playfield": 0x005785F0,
+           "normalize": 0x00567230, "clip_rect": 0x00421B60}
+
+
+def dwords(*values):
+    return struct.pack("<" + "I" * len(values), *(x & 0xFFFFFFFF for x in values))
+
+
+def packed(x, y):
+    return struct.pack("<HH", x & 0xFFFF, y & 0xFFFF)
+
+
+def state(bounds=(80, 2, 4, 76, 48), dummy=(-7, 1)):
+    table = bytearray(EMPTY_TABLE)
+    writes = {MAP + 0xF4: dwords(bounds[0]), MAP + 0xFC: dwords(*bounds[1:]),
+              MAP + 0x13C: dwords(TABLE, 0x40000), GLOBAL_TABLE: dwords(TABLE),
+              DUMMY + 0x24: packed(*SENTINEL),
+              DUMMY + 0x11B: bytes((dummy[0] & 255, dummy[1]))}
+    for n, (x, y, level, slope) in enumerate(ALLOCATED):
+        ptr = CELLS + n * 0x200
+        struct.pack_into("<I", table, (y * 512 + x) * 4, ptr)
+        writes[ptr + 0x24] = packed(x, y)
+        writes[ptr + 0x11B] = bytes((level & 255, slope))
+    writes[TABLE] = bytes(table)
+    return writes
+
+
+def query(kind, xy, bounds=(80, 2, 4, 76, 48), dummy=(-7, 1), mode=1):
+    writes = state(bounds, dummy)
+    writes[INPUT] = dwords(*xy, 0xDEADBEEF) if kind.startswith("world") else packed(*xy)
+    args = [INPUT, mode] if kind == "playfield" else [INPUT]
+    result = call(ENTRIES[kind], ecx=MAP, stack_args=args, writes=writes,
+                  dumps={"dummy_coord": (DUMMY + 0x24, 4),
+                         "dummy_height": (DUMMY + 0x11B, 2),
+                         "input": (INPUT, len(writes[INPUT]))}, timeout_instr=500)
+    if result["dumps"]["input"] != writes[INPUT].hex():
+        raise RuntimeError("native query changed its caller input")
+    if result["dumps"]["dummy_height"] != writes[DUMMY + 0x11B].hex():
+        raise RuntimeError("native query changed retained dummy level/slope")
+    row = {"kind": kind, "xy": xy,
+           "dummy_coord": struct.unpack("<hh", bytes.fromhex(result["dumps"]["dummy_coord"]))}
+    if "lookup" in kind:
+        pointer = result["eax"]
+        valid = {CELLS + n * 0x200: [x, y] for n, (x, y, _, _) in enumerate(ALLOCATED)}
+        if pointer != DUMMY and pointer not in valid:
+            raise RuntimeError(f"unexpected native CellClass pointer {pointer:#x}: {kind} {xy}")
+        row["real"] = valid.get(pointer)
+    else:
+        row.update(bounds=bounds, dummy=dummy, mode=mode, inside=bool(result["eax"] & 255))
+    return row
+
+
+def normalize(size, local):
+    # Enter the full function with its real stack ABI; execute ClipRect and every
+    # field write, stopping BEFORE the redraw call/Techno traversal. No hooks or
+    # substituted calls. The result is only the normalization portion.
+    uc = Uc(UC_ARCH_X86, UC_MODE_32)
+    load_image(uc)
+    uc.mem_map(SCRATCH, 0x10000)
+    uc.mem_map(STACK_BASE, STACK_SIZE)
+    sp = STACK_BASE + STACK_SIZE - 0x1000
+    uc.mem_write(sp, dwords(0, INPUT))
+    uc.mem_write(INPUT, dwords(*local))
+    uc.mem_write(MAP + 0xEC, dwords(0, 0, *size))
+    uc.reg_write(UC_X86_REG_ESP, sp)
+    uc.reg_write(UC_X86_REG_ECX, MAP)
+    run_checked(uc, ENTRIES["normalize"], 0x005672D3, count=1000,
+                required_addresses=[ENTRIES["clip_rect"], 0x005672CD])
+    if bytes(uc.mem_read(INPUT, 16)) != dwords(*local):
+        raise RuntimeError("normalizer changed input rectangle")
+    return {"size": size, "local": local,
+            "normalized": struct.unpack("<iiii", uc.mem_read(MAP + 0xFC, 16))}
+
+
+def retained_dummy_sequence():
+    """Retain the first returned native pointer across later real/miss queries."""
+    uc = Uc(UC_ARCH_X86, UC_MODE_32)
+    load_image(uc)
+    uc.mem_map(SCRATCH, 0x10000)
+    uc.mem_map(STACK_BASE, STACK_SIZE)
+    uc.mem_map(RET_MAGIC, 0x1000)
+    for address, value in state().items():
+        uc.mem_write(address, value)
+    rows, retained = [], None
+    for xy in [(-1, 0), (10, 10), (12, 11), (-1, 1), (32767, -32768)]:
+        sp = STACK_BASE + STACK_SIZE - 0x1000
+        uc.mem_write(INPUT, packed(*xy))
+        uc.mem_write(sp, dwords(RET_MAGIC, INPUT))
+        uc.reg_write(UC_X86_REG_ECX, MAP)
+        uc.reg_write(UC_X86_REG_ESP, sp)
+        run_checked(uc, ENTRIES["packed_lookup"], RET_MAGIC, count=500)
+        pointer = uc.reg_read(UC_X86_REG_EAX)
+        if retained is None:
+            retained = pointer
+            if retained != DUMMY:
+                raise RuntimeError("first sequence query must select the shared dummy")
+        rows.append({"xy": xy, "returns_retained": pointer == retained,
+                     "retained_coord": struct.unpack("<hh", uc.mem_read(retained + 0x24, 4)),
+                     "retained_height": list(uc.mem_read(retained + 0x11B, 2))})
+    return rows
+
+
+def generate():
+    lookups = []
+    pairs = [(0, 0), (-1, 1), (512, 0), (0, 1), (511, 0), (10, 10), (11, 10),
+             (-1, 0), (0, -1), (511, 511), (512, 511), (-1, 512),
+             (-32768, -32768), (32767, 32767), (65536, 65536), (65535, 65537)]
+    for xy in pairs:
+        lookups.append(query("packed_lookup", xy))
+    components = [-2147483648, -8388609, -8388608, -65537, -513, -512, -511,
+                  -257, -256, -255, -1, 0, 1, 255, 256, 257, 511, 512,
+                  65535, 65536, 8388607, 8388608, 2147483647]
+    for x in components:
+        for y in [-256, 0, 256, 2147483647]:
+            lookups.append(query("world_lookup", (x, y)))
+    for xy in [(2560, 2560), (-256, 256), (131072, 0), (16777216, -32768),
+               (0, -2147483648), (2147483647, 2147483647)]:
+        lookups.append(query("world_lookup", xy))
+
+    local_inputs = [(80, 58, [2, 4, 76, 48]), (80, 80, [-5, -6, 100, 100]),
+                    (0, 0, [0, 0, 0, 0]), (1, 1, [0, 0, 1, 1]),
+                    (40, 50, [5, 6, 40, 50]), (40, 50, [0, 0, 0, 0])]
+    for local in [[-1, 3, 1, 5], [3, -1, 5, 1], [81, 4, 5, 5], [4, 81, 5, 5],
+                  [3, 4, -1, 5], [3, 4, 5, -1], [2147483647, 2, 2, 20],
+                  [-2147483648, 2, 2147483647, 20], [2, 2147483647, 20, 2]]:
+        local_inputs.append((80, 80, local))
+    normalizations = [normalize((w, h), local) for w, h, local in local_inputs]
+    fields = [(80, 2, 4, 76, 48), (8, 2, 2, 4, 0),
+              (80, 2, 2, 76, 72), (0, 2, 2, -4, -8),
+              (-2147483648, -2147483647, -2147483648, -32768, -32768)]
+    predicates = []
+    for bounds in fields:
+        points = set(pairs + [(40, 48), (50, 40), (80, 50)])
+        # Sample either side and exactly on every geometric bound and on the
+        # slope correction threshold. Expected verdicts always come from x86.
+        w, left, top, width, height = bounds
+        for level in [-128, -1, 0, 1, 127]:
+            for edge in [w + 2 * top + level, w + 4 + 2 * top + level,
+                         w + 2 + 2 * (height + top) + level]:
+                for delta in [-1, 0, 1]:
+                    points.add((40, edge - 40 + delta))
+        for difference in [2 * (width + left) - w, -(w - 2 * left)]:
+            for delta in [-1, 0, 1]:
+                points.add((difference + 50 + delta, 50))
+        # Keep input API i32-shaped; native packs these words at the seam.
+        points = sorted((int((x + 2**31) % 2**32 - 2**31),
+                         int((y + 2**31) % 2**32 - 2**31)) for x, y in points)
+        for xy in points:
+            for mode, dummy in [(0, (-7, 1)), (256, (127, 255)), (1, (-128, 0)),
+                                (1, (-1, 1)), (1, (0, 0)), (1, (1, 255)), (255, (127, 1))]:
+                predicates.append(query("playfield", xy, bounds, dummy, mode))
+    for x in components:
+        for y in [-255, 0, 256, 48 * 256 + 255]:
+            predicates.append(query("world_playfield", (x, y)))
+    return {"source": "unicorn/gamemd.exe", "allocated": ALLOCATED,
+            "dummy_seed": SENTINEL, "lookups": lookups,
+            "normalizations": normalizations, "predicates": predicates,
+            "retained_sequence": retained_dummy_sequence()}
+
+
+if __name__ == "__main__":
+    finish_vectors(generate, Path(__file__).with_suffix(".json"),
+        provenance=lambda: provenance(
+            scope="Bounded packed/world lookup, LocalSize normalization prefix, and playfield predicates; not phase-wide parity",
+            assumptions=[
+                "Fresh emulator per query with seven explicit allocated slots and all remaining pointer slots zero",
+                "MapClass+13C and global 87F924 select the same table; capacity is retail 0x40000",
+                "Dummy coordinate seed and level/slope are supplied; queries must preserve level/slope and source input",
+                "Five packed lookups also execute consecutively in one emulator, retaining the first dummy pointer",
+                "Real-cell level/slope inputs and signed/overflow cases are synthetic; nearoref.map supplies the 80x58/2,4,76,48 header",
+                "567230 executes original ClipRect and stops at 5672D3 before redraw and Techno membership effects",
+                "No map constructors, lifecycle, final presentation, complete callers or exhaustive i32 domain are claimed",
+            ], substitutions=[], entry_points=ENTRIES))


### PR DESCRIPTION
Authored maps can supply signed LocalSize fields that overflow rectangle arithmetic. Rust clipped LocalSize against Size in the reverse operand order from gamemd.exe; ordinary intersections matched, but `Size=0,0,80,80` with `LocalSize=2147483647,2,2,20` produced different bounds. This change preserves native operand and operation order through the production map parser and playfield authority.

Adds reproducible comparisons of original retail instructions for packed/world cell lookup, shared dummy identity and writes, playfield predicates, and the LocalSize normalization prefix. The 2,144-call corpus records executable identity, runtime versions, fixture assumptions and retail nearoref.map header provenance. No native code or call results are substituted. The Phase 3 brief and System Map keep all rows open; this is bounded mechanism evidence, not phase-wide certification. The signed-overflow input is accepted by the active native loader; no shipped-map incidence is claimed.

Validation:
- Original native reference check: PASS; reference values unchanged by the fix.
- Pre-fix focused comparison: 3 passed, 1 failed, exposing the clipping mismatch.
- Post-fix focused comparison: 4 passed, including physical MapFile input through Simulation installation.
- `cargo test -p vera20k --lib`: 8,587 passed, 0 failed, 119 ignored.
- `cargo clippy -p vera20k --lib`: exit 0, 1,144 warnings.
- System Map and diff checks: PASS.
- A fresh independent read-only critic passed the repaired code and native evidence; the original critic's sole confirmed finding was the corrected clipping operand order.

Evidence and coverage limits: docs/research/PHASE3_MAP_SPATIAL_NATIVE_COMPARISON_20260910.md. PR #172 is preserved and was not merged wholesale.
