### PR TITLE
Retire active System Map maintenance

### DIFF
--- a/ENGINE.md
+++ b/ENGINE.md
@@ -120,8 +120,14 @@ documentation and CPU-only tests alone do not establish rendered gamemd parity.
 Use source and `research-index`; ranked results are not exhaustive. Verify index
 worktree provenance. Tracked research/plans belong in the task checkout; requested
 research documents need no accompanying code. Avoid unsolicited reports or permanent
-completion ledgers. Update [System Map](docs/system-map/) only for touched, verified
-connections, then `python -m tools.system_map check`.
+completion ledgers.
+
+The [System Map](docs/system-map/) is a navigation aid. Its descriptions, status fields
+and cited research may be stale, contradictory or incorrect. Recheck consequential
+claims against current Rust, native bodies/callers and retail data; an existing
+citation or past review does not establish current accuracy or parity. Update only
+touched, verified connections, then `python -m tools.system_map check`. This checker
+checks paths and IDs, not claim accuracy, freshness or evidence coverage.
 
 Resolve `<main-checkout>` with `git worktree list`; its `ini/`, config, index cache
 and `LOCAL.md` are machine-local. Read retail data before selecting constants.

--- a/ENGINE.md
+++ b/ENGINE.md
@@ -122,12 +122,12 @@ worktree provenance. Tracked research/plans belong in the task checkout; request
 research documents need no accompanying code. Avoid unsolicited reports or permanent
 completion ledgers.
 
-The [System Map](docs/system-map/) is a navigation aid. Its descriptions, status fields
-and cited research may be stale, contradictory or incorrect. Recheck consequential
-claims against current Rust, native bodies/callers and retail data; an existing
-citation or past review does not establish current accuracy or parity. Update only
-touched, verified connections, then `python -m tools.system_map check`. This checker
-checks paths and IDs, not claim accuracy, freshness or evidence coverage.
+The [System Map](docs/system-map/) is retired historical reference. Do not maintain
+its data or run its checker as a delivery requirement. Existing GSI IDs remain valid
+for phase scope. Derive current behavior and coverage from Rust and its nearby native
+references, focused research and reproducible comparisons; recheck consequential
+claims against native bodies/callers and retail data. Archived map claims may be stale,
+contradictory or incorrect and do not establish current status or parity.
 
 Resolve `<main-checkout>` with `git worktree list`; its `ini/`, config, index cache
 and `LOCAL.md` are machine-local. Read retail data before selecting constants.

--- a/docs/plans/2026-07-30-clean-slate-system-implementation-order.md
+++ b/docs/plans/2026-07-30-clean-slate-system-implementation-order.md
@@ -1,8 +1,8 @@
 # Clean-Slate System Implementation Order
 
 > **Repository execution note:** this is the dependency order and the row
-> enumeration, nothing more. Row status lives in the System Map registry and
-> per-phase working state lives in [`phase-briefs/`](phase-briefs/README.md);
+> enumeration, nothing more. Evidence-backed per-phase working state lives in
+> [`phase-briefs/`](phase-briefs/README.md); the System Map is retired historical reference;
 > a goal session reads its phase brief first. For a clean-slate rebuild,
 > follow the phases and rows in order. In the existing repository, never
 > reimplement rows 1–336 blindly.
@@ -16,8 +16,8 @@
 ## Purpose
 
 This document proposes a dependency-aware implementation order for rebuilding
-VERA20k from a clean slate. It covers all **336 canonical systems** in System
-Map v2 exactly once.
+VERA20k from a clean slate. It covers the **336 canonical systems** originally
+enumerated in System Map v2 exactly once. Their GSI IDs remain valid.
 
 The phase order is the dependency backbone. It also gives the existing
 repository one stable place to answer:
@@ -27,8 +27,8 @@ repository one stable place to answer:
 - how much production implementation currently exists;
 - where the per-phase working state lives (the phase briefs).
 
-This is still an evaluated planning overlay on the System Map, not a claim
-that missing map fields determine priority. Player-visible production loops,
+This is an evaluated planning order, not evidence of implementation or parity.
+The retired System Map does not determine priority. Player-visible production loops,
 current Rust, and active `gamemd.exe` evidence decide the actual task.
 
 ## Working briefs
@@ -36,7 +36,7 @@ current Rust, and active `gamemd.exe` evidence decide the actual task.
 This document does not prescribe a working mode. Each targeted phase has a
 brief under [`phase-briefs/`](phase-briefs/README.md) that carries what a
 session needs and this list cannot: current Rust owners per row, native
-anchors, registry status, loop membership, prior PRs, corrections to research
+anchors, evidence and coverage, production loops, prior PRs, corrections to research
 the rows depend on, inherited residuals, harness coverage and the open
 mechanism queue. The two goal modes (exhaustive phase close, bounded slice)
 are defined there, and the goal prompt names which one applies.
@@ -47,20 +47,18 @@ prelude to rebuild in isolation.
 
 ## Status
 
-Row status is not kept in this document. It lives in the System Map registry
-(`docs/system-map/registry.v2.json`, one `baseline_status` per GSI row with
-`native_evidence`, `rust_implementation`, `parity` and `basis`) and is updated
-only for touched, verified connections, then checked with
-`python -m tools.system_map check`.
-Read a row there before selecting work; `parity` stays `UNCHECKED`/`DRIFT`
-until a gamemd-derived executable comparison demonstrates equivalence.
+Row status is not kept in this document. Consult the phase brief and verify
+its claims against current Rust, native evidence and actual validation.
+The System Map registry is historical and no longer maintained; its status
+fields and checker are not delivery gates. Parity requires gamemd-derived
+executable comparisons or exhaustive proof with explicit coverage limits.
 
 Each closed phase links a closure record under `docs/gap-scans/` from its
 phase heading below: the disparity scans that enumerated the phase's
 mechanisms, the reverse audits, the merged PR list and the remaining
 residuals. A new session starts from the phase brief, which links that
 record; it does not re-enumerate. The 2026-07-30 four-way audit that once
-filled this section is superseded by the registry; its counts are no longer
+filled this section and the later registry are historical; their counts are no longer
 reproduced here.
 
 ## Legend
@@ -268,7 +266,7 @@ reproduced here.
     `+0x234` holds the base stub `0x005B2ED0` (`return 450`) in all eight
     vtables and no code path assigns mission 12; rulesmd.ini marks `[Return]`
     `; <unused>`. Harvester return-to-refinery runs *inside* the Harvest
-    mission's states — see item 157. Keep the enum slot; System Map records
+    mission's states — see item 157. Keep the enum slot; the archived System Map records
     `COMPILED_INACTIVE` / `ABSENT`.)
 159. **GSI-07.37** — Radio contact and link protocol
 160. **GSI-07.38** — Docking reservations, queues and authority handoff
@@ -518,9 +516,9 @@ A six-lane evidence review (INI + research corpus + spot Ghidra checks)
 verified the 336-row taxonomy is complete for missions (32/32), locomotors
 (8 stock + 3 correctly skipped), attached managers (one exception below), and
 superweapons (12/12 active `[SuperWeaponTypes]` entries). It found **seven
-stock-skirmish-visible mechanisms no row title reaches**. These are candidates
-for System Map v2 registration when verified work touches them (the surface is
-frozen; extend only with verified work). They do NOT get row numbers here —
+stock-skirmish-visible mechanisms no row title reaches**. Track verified work
+and remaining coverage in the owning phase brief, without updating the retired
+System Map. These do NOT get row numbers here —
 row numbering 1–336 stays stable.
 
 Genuine gaps, all player-visible in ordinary stock skirmish:
@@ -577,8 +575,8 @@ Phase 14 work; no SKIP flag is justified today.
 
 The phase order is the load-bearing part of this document. Exact ordering inside
 the large faction-breadth and superweapon phases is a recommended build sequence,
-not a binary-proven dependency chain, because System Map v2 does not encode
-complete causal edges for all 336 rows.
+not a binary-proven dependency chain. Establish causal dependencies from current
+source and native evidence; the archived map never encoded all such edges.
 
-Source registry:
+Historical source registry (retired; IDs retained):
 [`docs/system-map/registry.v2.json`](../system-map/registry.v2.json).

--- a/docs/plans/phase-briefs/README.md
+++ b/docs/plans/phase-briefs/README.md
@@ -2,8 +2,8 @@
 
 One brief per phase of
 [`2026-07-30-clean-slate-system-implementation-order.md`](../2026-07-30-clean-slate-system-implementation-order.md).
-A goal session reads the brief for its phase **before** the plan, the registry
-or the research index. The brief is the handover between sessions working the
+A goal session reads the brief for its phase **before** the plan or the
+research index. The brief is the handover between sessions working the
 same phase; the plan is only the dependency order.
 
 Briefs are written when a phase is first targeted and updated by the session
@@ -24,16 +24,18 @@ Rows <first>–<last> of the plan. State: OPEN | IN PROGRESS | CLOSED <date>.
 
 ## Rows
 
-| Row | GSI | Rust owner(s) | Native anchor(s) | Registry | Notes |
+| Row | GSI | Rust owner(s) | Native anchor(s) | Evidence and coverage | Notes |
 
 One line per row. Owners are current file paths (check they exist). Anchors are
-symbol + address with the research doc that established them. Registry is
-`native_evidence / rust_implementation / parity` from `registry.v2.json`.
+symbol + address with the research doc that established them. Evidence and
+coverage cite the inspected code revision and actual native comparisons or
+Rust checks, with their limits. Do not copy status from the retired System Map.
 
 ## Loops
 
-Which `topology.v2.json` loops the rows sit in, and which stage each row owns.
-The loop is what a session traces; rows alone do not order the work.
+The production loops the rows participate in and which stage each row owns,
+established from current code and native evidence. Historical loop IDs may be
+retained as references, but archived topology does not establish ordering.
 
 ## Prior work
 
@@ -77,8 +79,8 @@ with a builder and an independent read-only critic, merge one coherent
 mechanism (or its prerequisite foundation) per PR,
 run a phase-wide reverse audit, and close only when no omission or regression
 remains and `cargo test -p vera20k --lib` passes. Parity stays
-`UNCHECKED`/`DRIFT` in the registry until a gamemd-derived executable
-comparison demonstrates it; closure is by evidence, not by claim.
+undemonstrated until a gamemd-derived executable comparison or exhaustive
+proof establishes it within stated coverage; closure is by evidence, not by claim.
 
 **Bounded slice.** Select one ordinary-stock end-to-end loop from the brief's
 loop list, trace it in runtime stage order, find the first player-visible or
@@ -88,5 +90,7 @@ first with its own evidence, validation and review. Rerun the parent loop;
 close it only if its end-to-end check passes, otherwise record residuals in
 the brief and stop after the handoff.
 
-Both modes update the brief and the System Map registry for touched, verified
-rows (`python -m tools.system_map check`).
+Both modes update the brief for touched, verified work. The System Map is
+retired: no registry/topology/mechanism updates or map checker are required.
+Existing briefs may retain explicitly historical map citations and status
+columns; revalidate them before using them to select work or claim completion.

--- a/docs/plans/phase-briefs/phase-03-map-spatial-world.md
+++ b/docs/plans/phase-briefs/phase-03-map-spatial-world.md
@@ -7,9 +7,10 @@ This is the current investigation frontier, not a completed mechanism census.
 
 ## Rows
 
-Registry values below are native evidence / Rust implementation / parity from
+Historical registry values below are native evidence / Rust implementation / parity from
 [registry.v2.json](../../system-map/registry.v2.json). They are inherited status,
-not newly established equivalence. Paths are current representative owners;
+not newly established equivalence. The System Map was retired on 2026-09-10;
+do not maintain these inherited values as current status. Paths are representative owners;
 references are starting evidence whose applicability must be checked per mechanism.
 
 | Row | GSI | Rust owner(s) | Native anchor or research starting point | Registry | Notes |
@@ -33,7 +34,7 @@ references are starting evidence whose applicability must be checked per mechani
 
 ## Loops
 
-The current [topology](../../system-map/topology.v2.json) records representative
+The archived [topology](../../system-map/topology.v2.json) records representative
 connections, not an exhaustive Phase 3 loop inventory:
 
 - `LOOP-005-BUILD-PLACE`: cell passability and occupancy, stages 10–11.

--- a/docs/plans/phase-briefs/phase-08-production-power-radar.md
+++ b/docs/plans/phase-briefs/phase-08-production-power-radar.md
@@ -7,6 +7,9 @@ work).
 
 ## Rows
 
+The System Map was retired on 2026-09-10. Its citations and Registry column
+below are historical; revalidate claims rather than maintaining map status.
+
 Registry column is `native_evidence / rust_implementation / parity` from
 `docs/system-map/registry.v2.json` at `cca05d50`. Owners were checked to exist
 at that commit. `topology.v2.json` still lists ten `src/app_*.rs` paths that
@@ -38,7 +41,7 @@ under `src/app/` (`presentation/`, `loading/`, `input/commands.rs`,
 
 ## Loops
 
-From `topology.v2.json`:
+Historical references from the archived `topology.v2.json`:
 
 - **LOOP-005-BUILD-PLACE**: 14.10 (1) → 09.08 (2) → 09.09 (3) → 09.10 (4) → 13.24 (6) → 14.08 (7) → 09.11 (9, 12) → 09.12 (14) → 09.07 (15).
 - **LOOP-006-FACTORY-EXIT**: 14.10 → 09.08 → 09.09 → 09.10 → 07.41 (6).

--- a/docs/system-map/README.md
+++ b/docs/system-map/README.md
@@ -1,19 +1,25 @@
-# VERA20k System Map
+# VERA20k System Map — retired
 
-Three hand-maintained JSON files that name the engine's systems and record
-what has been established about them. They are a navigation aid for parity
-work, not a completion ledger, and nothing in them certifies parity.
+**Retired from active maintenance on 2026-09-10.** The files remain in place
+to preserve existing GSI, loop and mechanism references and historical evidence.
+Do not update them for new engine work or require their checker for delivery.
 
-## Files
+Descriptions, status fields and cited research may be stale, contradictory or
+incorrect. An archived citation or review is not proof of current accuracy.
+Use current Rust and its nearby native references, focused research, and
+reproducible native comparisons. Per-phase handoffs live in
+[`docs/plans/phase-briefs/`](../plans/phase-briefs/README.md).
+
+## Preserved files
 
 - `registry.v2.json` — the 336 canonical systems (`GSI-NN.NN`), grouped by
   family, each with a `baseline_status` (`native_evidence`,
   `rust_implementation`, `parity`, `basis`). Originally imported from
   `docs/research/GAMEMD_SYSTEM_INVENTORY_COVERAGE_MAP_GHIDRA_REPORT.md` and
-  `GAMEMD_SYSTEM_STATUS_MATRIX_SYSTEM_MODEL_SYNTHESIS.md`; since 2026-09-06 it
-  is edited directly.
+  `GAMEMD_SYSTEM_STATUS_MATRIX_SYSTEM_MODEL_SYNTHESIS.md`; edited directly from
+  2026-09-06 until retirement. Status values are historical snapshots.
 - `topology.v2.json` — reviewed annotations on load-bearing systems (native
-  anchors with addresses, current Rust surfaces, notes), typed edges between
+  anchors with addresses, then-observed Rust surfaces, notes), typed edges between
   systems, the ordered stock player-visible loops (`LOOP-NNN-*`), coupled
   sets, and legacy slice aliases.
 - `mechanisms.v1.json` — reviewed mechanism blocks (`MBLK-NNN-*`): one
@@ -22,24 +28,23 @@ work, not a completion ledger, and nothing in them certifies parity.
 - `schemas/*.schema.json` — the shapes of the three files, kept as
   documentation. Nothing validates against them any more.
 
-## Checking
+## Optional archive check
 
 ```powershell
 python -m tools.system_map check
 ```
 
-Reports every cited repository path that does not exist and every
-GSI/loop/block id that is not defined. That is the whole tool. The previous
+The retained compatibility tool reports missing cited repository paths and
+undefined GSI/loop/block IDs. It does not check accuracy or freshness. The previous
 importer, freshness model, renderer, source lock and query commands were
 removed on 2026-09-06 (about 11,600 lines of Python) after an audit found the
 data useful and the machinery unused; see the git history of
 `tools/system_map/` if a piece is wanted back.
 
-## Reading the data
+## Reading historical data
 
-- `parity` stays `UNCHECKED` or `DRIFT` until a gamemd-derived executable
-  comparison demonstrates equivalence. `ANCHORED` native evidence means the
-  bodies were read, not that Rust matches them.
+- `parity` and other statuses record past assessments, not current coverage.
+  `ANCHORED` native evidence meant the bodies were read, not that Rust matched them.
 - Native anchors, Rust surfaces and edges sit on separate planes. A native
   edge never implies Rust implements or orders the connection; a Rust surface
   marked `representative` names one place the mechanism lives, not all of
@@ -59,12 +64,12 @@ data useful and the machinery unused; see the git history of
 - Loops are `LOOP-NNN-SLUG`, edges `EDGE-NNNN-SLUG`, mechanism blocks
   `MBLK-NNN-SLUG`, mechanism edges `MBEDGE-NNNN-SLUG`.
 
-## Maintenance
+## Retirement boundary
 
-Update only the rows, surfaces, edges and blocks your change touched and
-verified, then run the checker. Do not pause parity work to annotate the
-whole registry, and do not pick work from missing fields: unannotated systems
-are unmapped, not unimportant. Per-phase working state (owners per row,
-corrections, residuals, open queue) belongs in
-[`docs/plans/phase-briefs/`](../plans/phase-briefs/README.md), which cites
-this map rather than duplicating it.
+The inventory IDs and existing links remain valid identifiers, not current
+status claims. Neither missing annotations nor old status fields select the
+next implementation task. Record current evidence beside the implementation
+and in focused research; use a phase brief for the current working handoff.
+
+The research-index `research_map` tool is separate: it searches and groups
+research documents and is not retired with these hand-maintained JSON files.


### PR DESCRIPTION
Retire the hand-maintained System Map from active delivery requirements. ENGINE.md and the phase plan/brief guidance now direct agents to current Rust, nearby native references, focused research and reproducible comparisons instead of maintaining registry, topology and mechanism status.

Preserve all existing map data, schemas, GSI numbering and links as historical references. Mark inherited Phase 3/8 map citations as historical. Keep the separate research-index search tool and optional legacy path checker unchanged.

Validation: checked local Markdown links in all six changed documents, verified numbered GSI rows are unchanged, confirmed map data and tooling are unchanged, and passed git diff --check. Documentation-only change; no Cargo suite required.
