### PR TITLE
Document Capstone availability for native analysis

### DIFF
--- a/tools/native_oracle.md
+++ b/tools/native_oracle.md
@@ -8,6 +8,11 @@ executable identity, bounded execution, fresh function-call state, diagnostics, 
 reference-file checks. It does not establish that a chosen function or fixture
 represents the game's active path.
 
+### Capstone
+
+Python `capstone` is also installed in this development environment. Use it when
+helpful for native binary analysis; consult its documentation as needed.
+
 ## Run an existing comparison
 
 From the repository root, with Python 3.10+ and Unicorn **2.1.4** installed:


### PR DESCRIPTION
Adds the agreed short discovery note to `tools/native_oracle.md`, telling agents that Python Capstone is available for native binary analysis and to consult its documentation as needed.

Validation: confirmed Capstone 5.0.7 imports successfully; reviewed the five-line documentation diff; `git diff --check` passed. No runtime code changed.
