### PR TITLE
Clarify architecture and integration guidance in ENGINE.md

### DIFF
--- a/ENGINE.md
+++ b/ENGINE.md
@@ -66,8 +66,9 @@ and `advance_tick` phases describe the architecture. Name coordinate frames/unit
 consult the [coordinate reference](docs/research/coordinate-reference-frames.md).
 
 One owner follows a complete mechanism through evidence, implementation, production
-integration and review. Inspect the surrounding loop/consumers; validate the actual
-production path, using runtime reproduction when needed. Reassess worsening fixes.
+integration and review. Consider the surrounding architecture and affected consumers,
+and use integration evidence appropriate to the change, including runtime reproduction
+when needed. Reassess worsening fixes.
 Design/plan artifacts are optional; implementation authority includes design choices.
 
 Promote coherent prerequisites when a smaller patch creates broken behavior, duplicate


### PR DESCRIPTION
Clarify the existing Architecture and delivery paragraph with a brief reminder to consider the surrounding architecture and affected consumers, and use integration evidence appropriate to the change, including runtime reproduction when needed. Preserve engineering judgment without adding a checklist or separate procedure.

Only one sentence in ENGINE.md changes. Validation: reviewed the exact diff against the agreed wording; git diff --check passed; branch includes current origin/main. Documentation only; no Cargo tests needed.
