### PR TITLE
Add proportionate validation reminder to ENGINE.md

### DIFF
--- a/ENGINE.md
+++ b/ENGINE.md
@@ -94,6 +94,9 @@ directly to `main`. Publication requires user/goal authority; PRs target `main`.
 Integrate promptly when authorized. Owners resolve conflicts and revalidate.
 Preserve unique/local data; use `sync` for complex cleanup.
 
+Choose validation appropriate to the change, considering native fidelity, connected
+production behavior and protection against regressions.
+
 - Working Rust: `cargo check -p vera20k` as needed; focused
   `cargo test -p vera20k --lib <module_path>::`.
 - Rust PR readiness: one full `cargo test -p vera20k --lib` plus


### PR DESCRIPTION
Add a brief reminder before the test commands in ENGINE.md to choose validation appropriate to the change, considering native fidelity, connected production behavior and protection against regressions. Leave the choice of methods and depth to engineering judgment.

Validation: exact wording and single-file diff reviewed; git diff --check passed; branch includes current origin/main. Documentation only; no Cargo tests needed.
