### PR TITLE
Apply bridge ground damage through live object receivers

### DIFF
--- a/docs/research/HIGH_BRIDGE_RIM_REFRESH_ALGORITHM_GHIDRA_REPORT.md
+++ b/docs/research/HIGH_BRIDGE_RIM_REFRESH_ALGORITHM_GHIDRA_REPORT.md
@@ -1,5 +1,116 @@
 # High Bridge Rim Refresh Algorithm - Ghidra Research Report
 
+## 2026-09-11 ground receiver production increment
+
+This increment replaces the bridge ground pass's sorted-ID, anchor-coordinate
+HP writes with synchronous direct receivers over live cell membership. It also
+visits nonanchor building foundation cells. Native `CellClass::BlowUpBridge`
+`47DD70` supplies current Health, distance0, C4, null source/house and
+`ignore_defenses=true,arg6=true`. It captures `NextObject` at `47DD96` before
+calling the receiver at `47DDAE`. A removed captured successor is still visited;
+its cleared next pointer ends the walk. Ground receivers finish before that
+cell's deck-drop pass and debris. The surrounding bridge batch/field/rim
+sequencing is unchanged and remains open.
+
+The shared forced receiver bypasses both bunker protection arms, matching
+`701900`'s branch to `701BF6`. This corrects collapse damage to an occupied stock
+Tank Bunker with `Super.PenetratesBunker=yes`. The direct Terrain adapter retains
+`71B920`'s Wood/Immune gate before Object `5F5390`; forced Object damage bypasses
+verses, falloff, NoDamage and MaxDamage, but not the earlier Health<=0 or
+requested-damage0 rejection. Nested effects and Terrain removal use the existing
+world transaction and finish before the direct receiver returns.
+
+### Repeated zero-Health receivers
+
+An earlier ground object's DeathWeapon can kill and unlink the captured next
+object. `Object5F5390` returns0 at Health0 without repeating its kill callbacks,
+but Techno's `70202E..702035` join still selects its fatal tail. Rust now keeps
+that receiver entry separate from a fresh HP-to-zero transition. Repeatable
+death sounds and DeathWeapon work execute again without granting fresh kill
+credit. Concrete class work follows the nested DeathWeapon and reads the
+retained object's current state. Building `442230` returns before Techno when
+already at Health0; its concrete death helper also skips an object whose Alive
+flag was cleared. Infantry Do_Action `51D6F0` preserves progress for the same
+action; changing a retired object's action does not restore Logic membership
+or cancel pending deletion.
+
+The [receiver corpus](../../tools/spatial_oracle/bridge_zero_health_receiver.py)
+executes original Infantry `517FA0`, Foot `4D7330`, Techno `701900` and Object
+`5F5390` with stock-Super InfDeath2/forced/null-source arguments. Alive0 and
+Alive1 cases reach original Death_Announcement `4D98C0`. One-entry DieSound
+cases execute original `Random__Next65C780` and reach sound request `7509E0`:
+main-RNG indices change from `[0,103]` to `[1,104]` with one draw and the supplied
+sound ID. Original `65C6D0` seeds the fixture with1. Sound playback,
+announcement owner/UI effects and the remaining class postlude are excluded.
+The [companion corpus](../../tools/spatial_oracle/bridge_zero_health_deathweapon.py)
+executes Infantry `517FA0`, Unit `737C90` and Aircraft `4165C0`, both Alive values,
+through their zero-Health joins to death-weapon producer `70D690`. It stops at producer entry;
+it does not execute its detonation body. Both metadata files disclose supplied
+state and substituted virtual results. The ten cases were independently
+regenerated without differences against active retail gamemd SHA-256
+`1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c`.
+
+Rust production regressions in `world/bridge_ground.rs` exercise a stock
+TERROR-to-E1 cascade: TerrorBomb kills the captured GI, whose later direct
+Super receiver repeats GIDie while its loss/kill credit remains single. A second
+cascade requires the captured Terrorist's repeated TerrorBomb to kill an MTNK.
+These use retail damage definitions in minimal fixtures, not a complete native
+explosion comparison. Additional checks cover live registration order, unlinked
+objects, nonanchor foundations, occupied Tank Bunkers, Terrain gates, retired
+Infantry action state and a nested DeathWeapon crater before the caller returns.
+The extracted candidate passes `cargo test -p vera20k --lib`: 8,668 passed,
+0 failed, 121 ignored. `cargo clippy -p vera20k --lib` exits0 with warnings
+(1,147 reported); this is not a zero-warning claim. The fresh independent critic
+reviewed the scoped production changes and the corrected recursive-cleanup test
+expectations, and independently regenerated all sixteen native cases. These
+results do not constitute a phase-wide pass.
+
+### Health input scope and remaining coverage
+
+Native `47DDA8..47DDAE` passes **&object.Health**. The
+[Health-input corpus](../../tools/spatial_oracle/bridge_health_alias.py) executes
+the original ground loop/Techno receiver for three synthetic immunity cases,
+with copied-packet controls. Radiation, PsychicDamage and Poison write zero
+through the packet at `701C1C`, `701C4F`, `701C82`: aliased Health becomes0 while
+a copied packet leaves Health100, without Object death callbacks. Type/predicate
+virtuals are supplied and concrete class wrappers are excluded.
+
+The helper currently copies Health. A fresh independent scope review found no
+stock bridge witness requiring a global signed-Health migration: RULESMD selects
+C4Warhead=Super (line818), whose section (27093) has InfDeath2, 100% Verses and
+none of those immunity flags or Psychedelic. The 184 extracted named retail
+maps have no C4Warhead/Super/Psychedelic overrides; three unidentified map entries
+and mode coverage are not certified. In the ordinary forced-Super fatal path,
+Object writes initial HP through the packet at `5F54C2`, then Health0 at
+`5F550D` before callbacks. Techno's later anger read requires the absent source;
+its `702016` timer read excludes fatal result4. Forced Infantry skips prone
+writes and InfDeath2 skips `518010`; after Foot the pointer register is replaced
+at `5180E8`/`518BB2`. Foot, Unit and Building do not consume that packet after
+their shared receiver returns. This is bounded ordinary-retail equivalence.
+
+The following remain open for the phase-wide audit:
+
+- Accepted custom C4 immunity/InfDeath9/Psychedelic inputs require receiver-owned
+  writes through a Value/TargetHealth input; negative Psychedelic additionally
+  needs coherent signed Health and persistence. The saved alias corpus proves
+  the current custom-input difference. Unusual callback-driven survival and
+  every FirstObject category are not certified by the ordinary-stock argument.
+- Mixed membership preserves terrain-first scenario registration. Late Terrain
+  insertion has no unified native AddContent order in the existing substrate.
+- Wood-capable C4 with destructible SpawnsTiberium Terrain reaches an explosion
+  animation at `71BA7B..71BA85` before nested damage at `71BABF`; that animation
+  is still absent. Stock Super omits Wood, so ordinary stock trees survive.
+- Building BeforeDeathEffects/AfterDeathEffects hooks are still outside the
+  newly placed concrete Alive guard. No stock bridge witness clearing an
+  initially live Building's Alive during that nested interval was established;
+  complete Building postlude coverage is not claimed.
+- Ordered bridge setter publication, body/head/hut caller sequencing, rim
+  integration and phase-wide reverse audit remain separate unfinished work.
+
+The larger rim-core work is preserved on
+`feature/phase3-bridge-rim-publication-20260911`; it is excluded from this ground
+receiver PR. None of these changes closes a Phase 3 row.
+
 **Address(es):** `0x00576770` (`MapClass__UpdateAdjacentBridges_High`), `0x00576200` (`MapClass__UpdateBridgeEdgeTiles_High`), `0x0047E040` (`CellClass__SetBridgeDirection_NESW`)
 **Investigation Mode:** exhaustive-slice, downgraded to PARTIAL only for runtime-populated tile-table values
 **Claimed Scope:** HIGH rim refresh chain after bridge damage/collapse: entry, edge-tile scan, direct per-cell writes, `0x1E` walk cap, and group clear side effects

--- a/src/sim/combat/combat_aoe.rs
+++ b/src/sim/combat/combat_aoe.rs
@@ -2109,8 +2109,12 @@ mod tests {
         );
         assert_eq!(
             fatal.immediate_uninit_ids,
-            vec![40, 30, 5, 20, 10],
-            "center-air DeathWeapon recursively reaches the second air record before the perimeter record"
+            vec![30, 40, 30, 5, 20, 10],
+            // Aircraft4165C0 calls Foot at4165EC before its concrete cleanup.
+            // Nested30 therefore finishes before40, then the captured outer30
+            // record repeats its zero-HP receiver (no Aircraft Alive guard).
+            // Native producer-entry proof: bridge_zero_health_deathweapon.json.
+            "nested aircraft cleanup precedes its parent; the captured outer record still repeats"
         );
         let direct_cells: Vec<_> = fatal
             .wall_mutations

--- a/src/sim/combat/mod.rs
+++ b/src/sim/combat/mod.rs
@@ -2316,6 +2316,12 @@ fn resolve_receive_damage(
     let distance_leptons = event.distance_leptons?;
     let receiver_flags = event.receiver_flags?;
     let target = entities.get(event.target_id)?;
+    // Building442230 returns before Techno for Health0, after its wrapper
+    // response (already executed by commit_entities). Infantry/Unit instead
+    // delegate and can re-enter Techno's fatal tail at zero Health.
+    if target.category == EntityCategory::Structure && target.health.current == 0 {
+        return None;
+    }
     let warhead = rules.warhead(interner.resolve(event.warhead_ref))?;
     let target_type = rules.object(interner.resolve(target.type_ref()));
     let source = (event.attacker_id != RAD_NO_ATTACKER)
@@ -2366,13 +2372,16 @@ fn resolve_receive_damage(
         && source.is_some_and(|source| {
             source.type_ref() == target.type_ref() && source.owner() == target.owner()
         });
-    let bunker_blocked = if target_is_building && target.bunker_occupant.is_some() {
-        // Linked Building branch is intentionally the inverse of the installed
-        // non-Building branch in TechnoClass::ReceiveDamage.
-        warhead.penetrates_bunker
-    } else {
-        target.bunker_link.installed_in().is_some() && !warhead.penetrates_bunker
-    };
+    // 701900 jumps to701BF6 when ignoreDefenses is set, before either linked
+    // bunker branch. BlowUpBridge's forced C4 receiver must bypass both arms.
+    let bunker_blocked = !receiver_flags.ignore_defenses
+        && if target_is_building && target.bunker_occupant.is_some() {
+            // Linked Building branch is intentionally the inverse of the installed
+            // non-Building branch in TechnoClass::ReceiveDamage.
+            warhead.penetrates_bunker
+        } else {
+            target.bunker_link.installed_in().is_some() && !warhead.penetrates_bunker
+        };
     let active_invulnerability = target.invulnerability.as_ref().filter(|_| {
         crate::sim::superweapon::invulnerability::is_invulnerable(
             target.invulnerability.as_ref(),

--- a/src/sim/combat/receiver_health.rs
+++ b/src/sim/combat/receiver_health.rs
@@ -8,6 +8,7 @@ use super::*;
 
 pub(super) struct ReceiverHealthCommit {
     pub(super) became_fatal: bool,
+    pub(super) entered_techno_death: bool,
     pub(super) reached_exact_zero: bool,
     pub(super) postmortem_candidate: Option<i32>,
     pub(super) fatal_category: EntityCategory,
@@ -41,6 +42,7 @@ pub(super) fn commit_receiver_health(
         postmortem_duration_for_event(event, target, rules, interner, resolved.outcome)
     });
     let mut became_fatal = false;
+    let mut entered_techno_death = false;
     let mut reached_exact_zero = false;
     let mut postmortem_candidate = None;
     let mut fatal_category = EntityCategory::Unit;
@@ -228,6 +230,16 @@ pub(super) fn commit_receiver_health(
             }
         }
 
+        // 70202E..702035 selects Techno's fatal branch on post-Object Health0,
+        // including a captured successor killed by a prior nested receiver.
+        // This does not repeat Object's fresh exact-zero kill/score callbacks.
+        // Native comparison: tools/spatial_oracle/bridge_zero_health_receiver.
+        entered_techno_death =
+            became_fatal || (reached_survivor_postlude && target.health.current == 0);
+        if entered_techno_death {
+            fatal_category = target.category;
+        }
+
         // gamemd-derived: `BuildingClass::ReceiveDamage @ 0x00442230`'s
         // damage-state dispatch, latched here and emitted below so it
         // lands after the shared Techno receiver's own consequences —
@@ -316,6 +328,7 @@ pub(super) fn commit_receiver_health(
 
     Some(ReceiverHealthCommit {
         became_fatal,
+        entered_techno_death,
         reached_exact_zero,
         postmortem_candidate,
         fatal_category,

--- a/src/sim/combat/world_receiver.rs
+++ b/src/sim/combat/world_receiver.rs
@@ -186,7 +186,6 @@ pub(crate) fn commit_area(
     overlay_registry: Option<&OverlayTypeRegistry>,
 ) -> (DeathEffects, Vec<UnderAttackEvent>) {
     let current_tick = receiver_tick(world);
-    let scenario_no_damage = world.session.no_damage;
 
     let isolation_armed =
         area_near_center_ic_isolation_armed(receivers, &mut world.substrate.entities, current_tick);
@@ -211,80 +210,100 @@ pub(crate) fn commit_area(
                 if isolation_armed && event.near_center_ic_isolation_eligible {
                     continue;
                 }
-                let Some(warhead) = rules
-                    .warhead(world.interner.resolve(event.warhead_ref))
-                    .cloned()
-                else {
-                    continue;
-                };
-                let receive = crate::sim::terrain_object::receive_terrain_area_damage_with_scenario(
-                    &mut world.production.terrain_objects,
-                    &world.production.terrain_object_cells,
-                    &mut run.finalizing_terrain,
-                    event.stable_id,
-                    (event.rx, event.ry),
-                    event.damage,
-                    event.distance_leptons,
-                    &warhead,
-                    rules,
-                    &mut world.interner,
-                    scenario_no_damage,
-                );
-                let TerrainAreaReceiveResult::Lethal(lethal) = receive else {
-                    continue;
-                };
-
-                if lethal.spawns_tiberium
-                    && let Some(c4_warhead) = rules.warhead(&rules.bridge_warheads.c4_name).cloned()
-                {
-                    let c4_id = world.interner.intern(&c4_warhead.id);
-                    let impact_z = world
-                        .resolved_terrain
-                        .as_ref()
-                        .and_then(|grid| grid.cell(lethal.cell.0, lethal.cell.1))
-                        .map_or(0, |cell| i32::from(cell.level));
-                    let aoe = {
-                        let collected = collect_area(
-                            world,
-                            rules,
-                            overlay_registry,
-                            lethal.cell,
-                            100,
-                            &c4_warhead,
-                            (RAD_NO_ATTACKER, None, c4_id),
-                            None,
-                            impact_z,
-                        );
-                        append_fixture_tiberium(world, &mut effects.tiberium_reduction_requests);
-                        collected
-                    };
-                    #[cfg(test)]
-                    effects.wall_mutations.extend(aoe.wall_mutations);
-
-                    #[cfg(test)]
-                    effects
-                        .cell_target_detaches
-                        .extend(aoe.cell_target_detaches);
-                    let (nested, mut pings) =
-                        commit_area(world, run, &aoe.receivers, rules, overlay_registry);
-                    effects.append(nested);
-                    under_attack_events.append(&mut pings);
-                }
-
-                let _ = crate::sim::terrain_object::finalize_terrain_lethal(
-                    crate::sim::terrain_object::production_authority_parts(
-                        &mut world.production,
-                        &mut world.substrate.raw_cell_occupation,
-                    ),
-                    &mut run.finalizing_terrain,
-                    &mut run.navigation_changed_cells,
-                    lethal,
-                    world.resolved_terrain.as_mut(),
-                );
+                let (nested, mut pings) =
+                    commit_terrain(world, run, event, false, rules, overlay_registry);
+                effects.append(nested);
+                under_attack_events.append(&mut pings);
             }
         }
     }
 
+    (effects, under_attack_events)
+}
+
+/// Complete one TerrainClass receiver, including its nested C4 and removal.
+/// Direct bridge calls use ignore_defenses=true; ordinary area calls retain
+/// their damage kernel and perform the area-wide IC gate before entering here.
+pub(crate) fn commit_terrain(
+    world: &mut Simulation,
+    run: &mut ReceiverRun,
+    event: TerrainDamageEvent,
+    ignore_defenses: bool,
+    rules: &RuleSet,
+    overlay_registry: Option<&OverlayTypeRegistry>,
+) -> (DeathEffects, Vec<UnderAttackEvent>) {
+    let mut effects = DeathEffects::default();
+    let mut under_attack_events = Vec::new();
+    let Some(warhead) = rules
+        .warhead(world.interner.resolve(event.warhead_ref))
+        .cloned()
+    else {
+        return (effects, under_attack_events);
+    };
+    let receive = crate::sim::terrain_object::receive_terrain_damage_with_scenario(
+        &mut world.production.terrain_objects,
+        &world.production.terrain_object_cells,
+        &mut run.finalizing_terrain,
+        event.stable_id,
+        (event.rx, event.ry),
+        event.damage,
+        event.distance_leptons,
+        &warhead,
+        rules,
+        &mut world.interner,
+        world.session.no_damage,
+        ignore_defenses,
+    );
+    let TerrainAreaReceiveResult::Lethal(lethal) = receive else {
+        return (effects, under_attack_events);
+    };
+
+    if lethal.spawns_tiberium
+        && let Some(c4_warhead) = rules.warhead(&rules.bridge_warheads.c4_name).cloned()
+    {
+        let c4_id = world.interner.intern(&c4_warhead.id);
+        let impact_z = world
+            .resolved_terrain
+            .as_ref()
+            .and_then(|grid| grid.cell(lethal.cell.0, lethal.cell.1))
+            .map_or(0, |cell| i32::from(cell.level));
+        let aoe = {
+            let collected = collect_area(
+                world,
+                rules,
+                overlay_registry,
+                lethal.cell,
+                100,
+                &c4_warhead,
+                (RAD_NO_ATTACKER, None, c4_id),
+                None,
+                impact_z,
+            );
+            append_fixture_tiberium(world, &mut effects.tiberium_reduction_requests);
+            collected
+        };
+        #[cfg(test)]
+        effects.wall_mutations.extend(aoe.wall_mutations);
+
+        #[cfg(test)]
+        effects
+            .cell_target_detaches
+            .extend(aoe.cell_target_detaches);
+        let (nested, mut pings) = commit_area(world, run, &aoe.receivers, rules, overlay_registry);
+        effects.append(nested);
+        under_attack_events.append(&mut pings);
+    }
+
+    let _ = crate::sim::terrain_object::finalize_terrain_lethal(
+        crate::sim::terrain_object::production_authority_parts(
+            &mut world.production,
+            &mut world.substrate.raw_cell_occupation,
+        ),
+        &mut run.finalizing_terrain,
+        &mut run.navigation_changed_cells,
+        lethal,
+        world.resolved_terrain.as_mut(),
+    );
     (effects, under_attack_events)
 }
 
@@ -418,6 +437,7 @@ pub(crate) fn commit_entities(
         }
         let Some(receiver_health::ReceiverHealthCommit {
             became_fatal,
+            entered_techno_death,
             reached_exact_zero,
             postmortem_candidate,
             fatal_category,
@@ -801,7 +821,7 @@ pub(crate) fn commit_entities(
             }
         }
 
-        if became_fatal {
+        if entered_techno_death {
             {
                 if callbacks_enabled(world) {
                     world.apply_fatal_lifecycle_stage(
@@ -898,19 +918,16 @@ pub(crate) fn handle_death(
     #[cfg(test)]
     let mut cell_target_detaches: Vec<combat_aoe::CellTargetDetach> = Vec::new();
     let mut smudge_spawn_requests: Vec<SmudgeSpawnRequest> = Vec::new();
-    let mut concrete_smudge_plans: Vec<ConcreteDeathSmudgePlan> = Vec::new();
     let mut rad_detonations: Vec<crate::sim::radiation::RadDetonation> = Vec::new();
     let mut under_attack_events: Vec<UnderAttackEvent> = Vec::new();
     let mut unit_lost_events: Vec<UnitLostEvent> = Vec::new();
     let mut structure_destroyed: bool = false;
     for &dead_id in dead_entities {
-        // ReceiveDamage enters the death helper exactly once at the fatal
-        // transition. Non-animated objects remain in the store until the
-        // world-owned UnInit handoff, so keep this tick-local guard explicit.
-        if run.handled_deaths.contains(&dead_id) {
-            continue;
+        // Native702035 re-enters this branch for an already-zero receiver.
+        // Keep unique diagnostic IDs, without suppressing receiver effects.
+        if !run.handled_deaths.contains(&dead_id) {
+            run.handled_deaths.push(dead_id);
         }
-        run.handled_deaths.push(dead_id);
         let dead_info = world.substrate.entities.get(dead_id).map(|e| {
             if e.category == EntityCategory::Structure {
                 structure_destroyed = true;
@@ -927,7 +944,6 @@ pub(crate) fn handle_death(
                 world_z_leptons,
                 air_impact,
                 e.owner(),
-                e.animation.is_some(),
                 e.category,
                 e.veterancy,
                 e.current_weapon_index,
@@ -945,7 +961,6 @@ pub(crate) fn handle_death(
             world_z_leptons,
             air_impact,
             owner,
-            has_animation,
             category,
             veterancy,
             current_weapon_index,
@@ -965,15 +980,6 @@ pub(crate) fn handle_death(
                     ry,
                     &mut death_sounds,
                 );
-                // `TechnoClass::Death_Announcement @ 0x004D98C0` runs at the
-                // Aircraft/Infantry/Unit `ReceiveDamage` kill sites (vtable
-                // `+0x3B8`; `BuildingClass` has none) and skips `Spawned=`
-                // types at `0x004D98DD`. Its owner gate (`0x0050B6F0`) and
-                // the `CreateRadarEvent(7)` dedupe (`0x004D98FE`) need the
-                // house table and radar queue, which the world owns.
-                if let Some(event) = death_announcement_event(obj, category, rx, ry, owner) {
-                    unit_lost_events.push(event);
-                }
                 // gamemd-derived: the debris block of
                 // `TechnoClass::ReceiveDamage @ 0x00701900`
                 // (`0x00702281`..`0x0070256C`). It sits BELOW the two death
@@ -1020,133 +1026,11 @@ pub(crate) fn handle_death(
                         owner,
                     ));
                 }
-                // Crewed structures eject infantry survivors on destruction.
-                if obj.crewed && category == EntityCategory::Structure {
-                    destroyed_crewed_buildings.push(DestroyedCrewedBuilding {
-                        type_id: type_id,
-                        owner: owner,
-                        rx,
-                        ry,
-                        z,
-                    });
-                }
             }
 
             // The world fatal prelude already owns garrison ejection before
             // the nested death weapon. Generic cargo remains attached only in
             // callback-disabled receiver fixtures, for their UnInit assertions.
-
-            // Look up the warhead that dealt the killing blow for InfDeath
-            // selection below. The AnimList anim + smudge are emitted at
-            // the per-shot fire site (and at the death-AoE loop), not here.
-            let killing_warhead = damage_events
-                .iter()
-                .rfind(|event| event.target_id == dead_id)
-                .and_then(|event| {
-                    rules
-                        .warhead(world.interner.resolve(event.warhead_ref))
-                        .map(|wh| (wh, event.damage))
-                });
-
-            // BuildingClass runs DestructionEffects/SpawnSurvivors only after
-            // TechnoClass's synchronous death weapon has returned. Capture the
-            // immutable plan now; placement and all RNG stay at that postlude.
-            if category == EntityCategory::Structure {
-                let foundation = rules
-                    .object(world.interner.resolve(type_id))
-                    .map(|obj| obj.foundation.as_str())
-                    .unwrap_or("1x1");
-                concrete_smudge_plans.push(ConcreteDeathSmudgePlan::Building {
-                    rx,
-                    ry,
-                    z: i32::from(z),
-                    foundation: foundation.to_owned(),
-                });
-            }
-
-            // `UnitClass::Death_Explosion @ 0x00738680` for vehicles and
-            // `AircraftClass::ReceiveDamage @ 0x0041661F` for aircraft: after
-            // the killing warhead's own `AnimList=` anim, the dying object plays
-            // ONE anim drawn from its type's `Explosion=` list and then one from
-            // `DestroyAnim=`, both at its own coordinate, one `Random__Next()`
-            // draw each. Without this a Grizzly and an Apocalypse died with the
-            // same warhead-derived puff.
-            //
-            // INFANTRY are excluded deliberately: `get_xrefs_to 0x00738680`
-            // returns four callers, all `UnitClass`, and an operand scan for the
-            // `Explosion=` count (`type+0x73C`) finds readers only in
-            // `AircraftClass::ReceiveDamage` and
-            // `BuildingClass::DestructionEffects @ 0x0044194D`. Infantry death
-            // spawns from the `InfDeath`/`DeathAnims` table alone. No stock
-            // `[InfantryTypes]` section authors `Explosion=` either, so this is
-            // a contract correction rather than a visible one.
-            //
-            // RESIDUAL (GSI-08.11) — the BUILDING arm is not modelled. Native
-            // runs `BuildingClass::DestructionEffects @ 0x004415F0`, which plays
-            // the `Explosion=` list once PER FOUNDATION CELL at cell centre with
-            // a scatter helper and a `RandomRanged(0, 3)` anim delay, then one
-            // `DestroyAnim=` at the building coordinate; the sub-order of the
-            // scatter, delay and index draws is UNCHECKED, and getting it wrong
-            // would misroute the stream for every structure death. `Explodes=`
-            // (forcing the last `Explosion=` entry for a loaded miner) is
-            // likewise unread. Trigger: every building death, and every loaded
-            // miner death. Frequency: continuous.
-            //
-            // Landing that arm also un-latents a second gap: four of the
-            // buildings it would newly reach — the base power plant of every
-            // faction (`GAPOWR`, `NAPOWR`, `YAPOWR`) plus `YAROCK` — author an
-            // `Explosion=` list whose sixth entry (`gtpowexp`/`tstlexp`) has no
-            // art section, so one draw in six per foundation cell resolves to
-            // nothing VERA can construct. That is correct against gamemd, which
-            // also draws nothing there, but VERA skips the object entirely
-            // where native still constructs and discards one. Read the residual
-            // on `ArtRegistry::bind_combat_explosion_anim_assets` before
-            // treating a missing power-plant explosion as a bug.
-            if matches!(category, EntityCategory::Unit | EntityCategory::Aircraft)
-                && let Some(obj) = rules.object(world.interner.resolve(type_id))
-            {
-                for list in [&obj.explosion_anims, &obj.destroy_anims] {
-                    if list.is_empty() {
-                        continue;
-                    }
-                    let index = (world.main_rng.next_u32() % list.len() as u32) as usize;
-                    let shp_name = world.interner.intern(&list[index]);
-                    explosion_effects.push(ExplosionEffect {
-                        shp_name,
-                        rx,
-                        ry,
-                        sub_x,
-                        sub_y,
-                        z,
-                    });
-                }
-            }
-
-            let inf_death = killing_warhead.as_ref().map_or(1, |(wh, _)| wh.inf_death);
-            if category == EntityCategory::Infantry {
-                let postlude = world.begin_infantry_receiver_death(
-                    dead_id,
-                    inf_death,
-                    &mut immediate_uninit_ids,
-                );
-                concrete_smudge_plans.push(ConcreteDeathSmudgePlan::Infantry(postlude));
-                despawned_ids.push(dead_id);
-            } else if has_animation {
-                // Non-Infantry SHP lifetime remains on its existing path.
-                if let Some(entity) = world.substrate.entities.get_mut(dead_id) {
-                    entity.dying = true;
-                    if let (Some(sequence), Some(anim)) = (
-                        crate::sim::animation::death_sequence_for_inf_death(inf_death),
-                        entity.animation.as_mut(),
-                    ) {
-                        anim.switch_to(sequence);
-                    }
-                }
-                despawned_ids.push(dead_id);
-            } else {
-                immediate_uninit_ids.push(dead_id);
-                despawned_ids.push(dead_id);
-            }
         }
     }
 
@@ -1287,15 +1171,197 @@ pub(crate) fn handle_death(
         receiver_stage_trace,
     };
 
+    // Concrete receivers resume after Techno's nested DeathWeapon. Read the
+    // retained entity's current state at that boundary.
+    for &dead_id in dead_entities {
+        finish_concrete_death(
+            world,
+            dead_id,
+            damage_events,
+            rules,
+            overlay_registry,
+            &mut effects,
+        );
+    }
+
+    effects
+}
+
+/// Concrete receiver work after shared Techno death effects return.
+/// Evidence: Infantry517FA0, Unit737C90 and Building442230 base-call order.
+fn finish_concrete_death(
+    world: &mut Simulation,
+    dead_id: u64,
+    damage_events: &[EntityDamageEvent],
+    rules: &RuleSet,
+    overlay_registry: Option<&OverlayTypeRegistry>,
+    effects: &mut DeathEffects,
+) {
+    let Some(entity) = world.substrate.entities.get(dead_id) else {
+        return;
+    };
+    let category = entity.category;
+    // Building442230 returns before its result dispatch when Alive is clear.
+    if category == EntityCategory::Structure && !entity.lifecycle.object_alive {
+        return;
+    }
+    let (type_id, owner, rx, ry, sub_x, sub_y, z, has_animation) = (
+        entity.type_ref(),
+        entity.owner(),
+        entity.position.rx,
+        entity.position.ry,
+        entity.position.sub_x,
+        entity.position.sub_y,
+        entity.position.z,
+        entity.animation.is_some(),
+    );
+    let mut concrete_smudge_plans = Vec::new();
+    if let Some(obj) = rules.object(world.interner.resolve(type_id)) {
+        // `TechnoClass::Death_Announcement @ 0x004D98C0` runs at the
+        // Aircraft/Infantry/Unit `ReceiveDamage` kill sites (vtable
+        // `+0x3B8`; `BuildingClass` has none) and skips `Spawned=`
+        // types at `0x004D98DD`. Its owner gate (`0x0050B6F0`) and
+        // the `CreateRadarEvent(7)` dedupe (`0x004D98FE`) need the
+        // house table and radar queue, which the world owns.
+        if let Some(event) = death_announcement_event(obj, category, rx, ry, owner) {
+            effects.unit_lost_events.push(event);
+        }
+        // Crewed structures eject infantry survivors on destruction.
+        if obj.crewed && category == EntityCategory::Structure {
+            effects
+                .destroyed_crewed_buildings
+                .push(DestroyedCrewedBuilding {
+                    type_id: type_id,
+                    owner: owner,
+                    rx,
+                    ry,
+                    z,
+                });
+        }
+    }
+    // Look up the warhead that dealt the killing blow for InfDeath
+    // selection below. The AnimList anim + smudge are emitted at
+    // the per-shot fire site (and at the death-AoE loop), not here.
+    let killing_warhead = damage_events
+        .iter()
+        .rfind(|event| event.target_id == dead_id)
+        .and_then(|event| {
+            rules
+                .warhead(world.interner.resolve(event.warhead_ref))
+                .map(|wh| (wh, event.damage))
+        });
+
+    // BuildingClass runs DestructionEffects/SpawnSurvivors only after
+    // TechnoClass's synchronous death weapon has returned. Capture the
+    // immutable plan now; placement and all RNG stay at that postlude.
+    if category == EntityCategory::Structure {
+        let foundation = rules
+            .object(world.interner.resolve(type_id))
+            .map(|obj| obj.foundation.as_str())
+            .unwrap_or("1x1");
+        concrete_smudge_plans.push(ConcreteDeathSmudgePlan::Building {
+            rx,
+            ry,
+            z: i32::from(z),
+            foundation: foundation.to_owned(),
+        });
+    }
+
+    // `UnitClass::Death_Explosion @ 0x00738680` for vehicles and
+    // `AircraftClass::ReceiveDamage @ 0x0041661F` for aircraft: after
+    // the killing warhead's own `AnimList=` anim, the dying object plays
+    // ONE anim drawn from its type's `Explosion=` list and then one from
+    // `DestroyAnim=`, both at its own coordinate, one `Random__Next()`
+    // draw each. Without this a Grizzly and an Apocalypse died with the
+    // same warhead-derived puff.
+    //
+    // INFANTRY are excluded deliberately: `get_xrefs_to 0x00738680`
+    // returns four callers, all `UnitClass`, and an operand scan for the
+    // `Explosion=` count (`type+0x73C`) finds readers only in
+    // `AircraftClass::ReceiveDamage` and
+    // `BuildingClass::DestructionEffects @ 0x0044194D`. Infantry death
+    // spawns from the `InfDeath`/`DeathAnims` table alone. No stock
+    // `[InfantryTypes]` section authors `Explosion=` either, so this is
+    // a contract correction rather than a visible one.
+    //
+    // RESIDUAL (GSI-08.11) — the BUILDING arm is not modelled. Native
+    // runs `BuildingClass::DestructionEffects @ 0x004415F0`, which plays
+    // the `Explosion=` list once PER FOUNDATION CELL at cell centre with
+    // a scatter helper and a `RandomRanged(0, 3)` anim delay, then one
+    // `DestroyAnim=` at the building coordinate; the sub-order of the
+    // scatter, delay and index draws is UNCHECKED, and getting it wrong
+    // would misroute the stream for every structure death. `Explodes=`
+    // (forcing the last `Explosion=` entry for a loaded miner) is
+    // likewise unread. Trigger: every building death, and every loaded
+    // miner death. Frequency: continuous.
+    //
+    // Landing that arm also un-latents a second gap: four of the
+    // buildings it would newly reach — the base power plant of every
+    // faction (`GAPOWR`, `NAPOWR`, `YAPOWR`) plus `YAROCK` — author an
+    // `Explosion=` list whose sixth entry (`gtpowexp`/`tstlexp`) has no
+    // art section, so one draw in six per foundation cell resolves to
+    // nothing VERA can construct. That is correct against gamemd, which
+    // also draws nothing there, but VERA skips the object entirely
+    // where native still constructs and discards one. Read the residual
+    // on `ArtRegistry::bind_combat_explosion_anim_assets` before
+    // treating a missing power-plant explosion as a bug.
+    if matches!(category, EntityCategory::Unit | EntityCategory::Aircraft)
+        && let Some(obj) = rules.object(world.interner.resolve(type_id))
+    {
+        for list in [&obj.explosion_anims, &obj.destroy_anims] {
+            if list.is_empty() {
+                continue;
+            }
+            let index = (world.main_rng.next_u32() % list.len() as u32) as usize;
+            let shp_name = world.interner.intern(&list[index]);
+            effects.explosion_effects.push(ExplosionEffect {
+                shp_name,
+                rx,
+                ry,
+                sub_x,
+                sub_y,
+                z,
+            });
+        }
+    }
+
+    let inf_death = killing_warhead.as_ref().map_or(1, |(wh, _)| wh.inf_death);
+    if category == EntityCategory::Infantry {
+        let postlude = world.begin_infantry_receiver_death(
+            dead_id,
+            inf_death,
+            &mut effects.immediate_uninit_ids,
+        );
+        concrete_smudge_plans.push(ConcreteDeathSmudgePlan::Infantry(postlude));
+        effects.despawned_ids.push(dead_id);
+    } else if has_animation {
+        // Non-Infantry SHP lifetime remains on its existing path.
+        if let Some(entity) = world.substrate.entities.get_mut(dead_id) {
+            entity.dying = true;
+            if let (Some(sequence), Some(anim)) = (
+                crate::sim::animation::death_sequence_for_inf_death(inf_death),
+                entity.animation.as_mut(),
+            ) {
+                anim.switch_to(sequence);
+            }
+        }
+        effects.despawned_ids.push(dead_id);
+    } else {
+        effects.immediate_uninit_ids.push(dead_id);
+        effects.despawned_ids.push(dead_id);
+    }
     // The receiver owns the recursion boundary; each concrete owner consumes
     // its captured postlude here without moving constructor/smudge RNG earlier.
     for plan in concrete_smudge_plans {
         match plan {
             ConcreteDeathSmudgePlan::Infantry(postlude) => {
-                postlude.commit(world, rules, overlay_registry, &mut effects);
+                postlude.commit(world, rules, overlay_registry, effects);
             }
             ConcreteDeathSmudgePlan::Building {
-                rx, ry, z, foundation,
+                rx,
+                ry,
+                z,
+                foundation,
             } => {
                 let mut requests = Vec::new();
                 append_building_smudge_requests(&mut requests, rx, ry, z, &foundation);
@@ -1309,7 +1375,6 @@ pub(crate) fn handle_death(
             }
         }
     }
-    effects
 }
 
 fn emit_one_projectile_detonation(

--- a/src/sim/occupancy.rs
+++ b/src/sim/occupancy.rs
@@ -25,6 +25,15 @@ pub(crate) const VEHICLE_OCCUPATION_BIT: u8 = 0x20;
 pub(crate) const OBJECT_OCCUPATION_BIT: u8 = 0x40;
 pub(crate) const BUILDING_OCCUPATION_BIT: u8 = 0x80;
 
+/// Object identities on a CellClass ground/deck list. Terrain remains owned
+/// by ProductionState; this view inserts its member between mobile objects
+/// and the building tail, as the native AddContent registration paths do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CellObjectMember {
+    Entity(u64),
+    Terrain(u64),
+}
+
 /// Side length of gamemd's global airborne-object spatial bucket grid.
 /// `FUN_00412870` constructs exactly 400 vectors as a 20 x 20 grid.
 pub(crate) const AIR_SPATIAL_BUCKET_SIDE: u16 = 20;
@@ -280,12 +289,7 @@ impl RawCellOccupationGrid {
 
     /// Infantry owner identity paired with the selected native occupation byte.
     /// Ground (`+0x124`) and deck (`+0x128`) are independent planes.
-    pub(crate) fn infantry_owner(
-        &self,
-        rx: u16,
-        ry: u16,
-        layer: MovementLayer,
-    ) -> Option<u64> {
+    pub(crate) fn infantry_owner(&self, rx: u16, ry: u16, layer: MovementLayer) -> Option<u64> {
         self.cells.get(&(rx, ry)).and_then(|cell| match layer {
             MovementLayer::Ground => cell.ground_infantry_owner,
             MovementLayer::Bridge => cell.deck_infantry_owner,
@@ -1436,6 +1440,35 @@ impl OccupancyGrid {
     /// Get occupancy for a cell (all layers).
     pub fn get(&self, rx: u16, ry: u16) -> Option<&CellOccupancy> {
         self.cells.get(&(rx, ry))
+    }
+
+    /// Borrow the live mixed list without allocating a replacement member
+    /// vector. Callers decide whether to capture the next member before or
+    /// after a receiver callback; those two native traversals are different.
+    /// Terrain precedes buildings and follows mobile objects for the current
+    /// terrain-first scenario registration. Generic native AddContent prepends
+    /// every nonbuilding; this projection does not model later Terrain insertion.
+    pub(crate) fn cell_objects(
+        &self,
+        rx: u16,
+        ry: u16,
+        layer: MovementLayer,
+        terrain_id: Option<u64>,
+    ) -> impl Iterator<Item = CellObjectMember> + '_ {
+        let mut terrain = terrain_id.filter(|_| layer == MovementLayer::Ground);
+        let mut entities = self
+            .get(rx, ry)
+            .into_iter()
+            .flat_map(move |cell| cell.iter_layer(layer))
+            .peekable();
+        std::iter::from_fn(move || {
+            if terrain.is_some() && entities.peek().is_none_or(|member| member.is_building) {
+                return terrain.take().map(CellObjectMember::Terrain);
+            }
+            entities
+                .next()
+                .map(|member| CellObjectMember::Entity(member.entity_id))
+        })
     }
 
     /// First BuildingClass identity on a selected native list, preserving

--- a/src/sim/superweapon/cell_receiver_tests.rs
+++ b/src/sim/superweapon/cell_receiver_tests.rs
@@ -260,7 +260,7 @@ fn infantry_terminal_raw_mutation_retires_on_next_visit_with_or_without_animatio
 }
 
 #[test]
-fn infantry_terminal_no_art_cleanup_preserves_parent_before_recursive_deaths() {
+fn infantry_terminal_no_art_cleanup_follows_recursive_deaths() {
     use crate::sim::world::LifecycleTestEvent;
     let (mut sim, rules) = fixture_with_extra("[DeathWH]\nCellSpread=2\n");
     let parent = sim
@@ -285,7 +285,9 @@ fn infantry_terminal_no_art_cleanup_preserves_parent_before_recursive_deaths() {
             _ => None,
         })
         .collect();
-    assert_eq!(uninit_order, [parent, child]);
+    // Infantry517FA0 resumes its concrete cleanup only after the shared
+    // Techno701900 receiver's recursive DeathWeapon has completed.
+    assert_eq!(uninit_order, [child, parent]);
     for id in [parent, child] {
         let entity = sim.substrate.entities.get(id).unwrap();
         assert!(entity.lifecycle.in_limbo && !entity.in_logic_vector);

--- a/src/sim/terrain_object.rs
+++ b/src/sim/terrain_object.rs
@@ -233,7 +233,7 @@ impl TerrainAreaState {
         rules: &RuleSet,
         interner: &StringInterner,
     ) -> TerrainAreaReceiveResult {
-        receive_terrain_area_damage_with_scenario(
+        receive_terrain_damage_with_scenario(
             &mut self.terrain_objects,
             &self.terrain_object_cells,
             &mut self.finalizing_terrain,
@@ -244,6 +244,7 @@ impl TerrainAreaState {
             warhead,
             rules,
             interner,
+            false,
             false,
         )
     }
@@ -519,6 +520,103 @@ mod tests {
             max_damage, warhead_section
         ));
         RuleSet::from_ini(&ini).expect("kernel rules")
+    }
+
+    #[test]
+    fn bridge_direct_terrain_damage_bypasses_kernel_and_finishes_removal() {
+        let rules = terrain_kernel_rules(
+            "Verses=0%,0%,0%,0%,0%,0%,0%,0%,0%,0%,0%\nCellSpread=1\nPercentAtMax=0",
+            1,
+        );
+        let mut sim = Simulation::new();
+        sim.session.no_damage = true;
+        seed_one_at(&mut sim, &rules, "TREE01", (0, 0));
+        let stable_id = sim.production.terrain_object_cells[&(0, 0)];
+        let health = sim.production.terrain_objects[&stable_id].health;
+        let warhead_ref = sim.interner.intern("WH");
+        sim.commit_direct_terrain_damage_receiver(
+            &rules,
+            None,
+            crate::sim::combat::TerrainDamageEvent {
+                stable_id,
+                rx: 0,
+                ry: 0,
+                damage: health,
+                distance_leptons: 512,
+                warhead_ref,
+                near_center_ic_isolation_eligible: false,
+            },
+        );
+        let terrain = &sim.production.terrain_objects[&stable_id];
+        assert_eq!(terrain.health, 0);
+        assert_eq!(terrain.lifecycle, TerrainObjectLifecycle::Destroyed);
+        assert!(
+            !terrain.in_logic_vector,
+            "direct receiver finishes retirement before returning"
+        );
+        assert!(!sim.production.terrain_object_cells.contains_key(&(0, 0)));
+        assert_eq!(sim.substrate.raw_cell_occupation.ground_bits(0, 0), 0);
+    }
+
+    #[test]
+    fn bridge_direct_terrain_damage_keeps_wood_and_immune_gates() {
+        for (wood, section) in [(false, ""), (true, "Immune=yes\n")] {
+            let rules = terrain_rules("TREE01", wood, section);
+            let mut sim = Simulation::new();
+            seed_one_at(&mut sim, &rules, "TREE01", (0, 0));
+            let stable_id = sim.production.terrain_object_cells[&(0, 0)];
+            let health = sim.production.terrain_objects[&stable_id].health;
+            let warhead_ref = sim.interner.intern("WH");
+            sim.commit_direct_terrain_damage_receiver(
+                &rules,
+                None,
+                crate::sim::combat::TerrainDamageEvent {
+                    stable_id,
+                    rx: 0,
+                    ry: 0,
+                    damage: health,
+                    distance_leptons: 0,
+                    warhead_ref,
+                    near_center_ic_isolation_eligible: false,
+                },
+            );
+            assert_eq!(sim.production.terrain_objects[&stable_id].health, health);
+            assert!(sim.production.terrain_objects[&stable_id].is_live());
+            assert_eq!(sim.production.terrain_object_cells[&(0, 0)], stable_id);
+        }
+    }
+
+    #[test]
+    fn bridge_direct_terrain_receiver_rejects_zero_health_during_nested_death() {
+        let rules = terrain_rules("TREE01", true, "");
+        let mut sim = Simulation::new();
+        seed_one_at(&mut sim, &rules, "TREE01", (0, 0));
+        let stable_id = sim.production.terrain_object_cells[&(0, 0)];
+        // During a nested death callback, Health is zero before outer Limbo.
+        sim.production
+            .terrain_objects
+            .get_mut(&stable_id)
+            .unwrap()
+            .health = 0;
+        let warhead_ref = sim.interner.intern("WH");
+        sim.commit_direct_terrain_damage_receiver(
+            &rules,
+            None,
+            crate::sim::combat::TerrainDamageEvent {
+                stable_id,
+                rx: 0,
+                ry: 0,
+                damage: -10,
+                distance_leptons: 0,
+                warhead_ref,
+                near_center_ic_isolation_eligible: false,
+            },
+        );
+        assert_eq!(sim.production.terrain_objects[&stable_id].health, 0);
+        assert!(
+            sim.production.terrain_objects[&stable_id].is_live(),
+            "outer receiver still owns finalization"
+        );
     }
 
     fn rules(tib_section: &str) -> RuleSet {
@@ -1183,7 +1281,7 @@ mod tests {
 /// Receive against live Terrain maps. The recursion guard belongs to the
 /// outer damage operation; no persisted authority leaves ProductionState.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn receive_terrain_area_damage_with_scenario(
+pub(crate) fn receive_terrain_damage_with_scenario(
     terrain_objects: &mut BTreeMap<u64, TerrainObjectState>,
     terrain_object_cells: &BTreeMap<(u16, u16), u64>,
     finalizing_terrain: &mut BTreeSet<u64>,
@@ -1195,6 +1293,7 @@ pub(crate) fn receive_terrain_area_damage_with_scenario(
     rules: &RuleSet,
     interner: &StringInterner,
     scenario_no_damage: bool,
+    ignore_defenses: bool,
 ) -> TerrainAreaReceiveResult {
     if finalizing_terrain.contains(&stable_id)
         || terrain_object_cells.get(&cell) != Some(&stable_id)
@@ -1205,7 +1304,9 @@ pub(crate) fn receive_terrain_area_damage_with_scenario(
     let Some(snapshot) = terrain_objects.get(&stable_id) else {
         return TerrainAreaReceiveResult::Ignored;
     };
-    if !snapshot.is_live() || snapshot.cell() != cell {
+    // ObjectClass::ReceiveDamage 005F53A1..005F53B7 rejects these before
+    // either ordinary armor calculation or the forced direct-damage path.
+    if !snapshot.is_live() || snapshot.cell() != cell || snapshot.health <= 0 || raw_damage == 0 {
         return TerrainAreaReceiveResult::Ignored;
     }
     let Some(terrain_type) =
@@ -1217,16 +1318,23 @@ pub(crate) fn receive_terrain_area_damage_with_scenario(
         return TerrainAreaReceiveResult::Ignored;
     }
 
-    let resolved_damage = damage::kernel::apply_warhead_damage(
-        raw_damage,
-        warhead.cell_spread_f64,
-        warhead.percent_at_max_f64,
-        &warhead.verses_f64,
-        damage::ArmorClass(armor_index(&terrain_type.armor) as u8),
-        distance_leptons,
-        scenario_no_damage,
-        rules.combat_damage.max_damage,
-    );
+    // TerrainClass 0071B920 always checks Wood/Immune above, then forwards
+    // ignore_defenses to ObjectClass 005F5390. BlowUpBridge 0047DD70 passes
+    // true: current Health bypasses verses, falloff, NoDamage and MaxDamage.
+    let resolved_damage = if ignore_defenses {
+        raw_damage
+    } else {
+        damage::kernel::apply_warhead_damage(
+            raw_damage,
+            warhead.cell_spread_f64,
+            warhead.percent_at_max_f64,
+            &warhead.verses_f64,
+            damage::ArmorClass(armor_index(&terrain_type.armor) as u8),
+            distance_leptons,
+            scenario_no_damage,
+            rules.combat_damage.max_damage,
+        )
+    };
     if resolved_damage == 0 {
         return TerrainAreaReceiveResult::Ignored;
     }

--- a/src/sim/world/bridge_deck_tests.rs
+++ b/src/sim/world/bridge_deck_tests.rs
@@ -13,7 +13,7 @@ use crate::sim::{
 #[test]
 fn infantry_terminal_hut_collapse_retires_effect_only_ground_victim() {
     use crate::sim::house_state::HouseState;
-    use crate::sim::world::{InfantryTerminal, LifecycleTestEvent, SimSoundEvent};
+    use crate::sim::world::{LifecycleTestEvent, SimSoundEvent};
     use std::collections::BTreeMap;
     let rules = RuleSet::from_ini(&IniFile::from_str(
         "[InfantryTypes]\n0=E1\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
@@ -46,11 +46,11 @@ fn infantry_terminal_hut_collapse_retires_effect_only_ground_victim() {
         None
     ));
     let object = sim.substrate.entities.get(victim).unwrap();
-    assert_eq!(
-        object.infantry_terminal,
-        Some(InfantryTerminal::RetireNextVisit)
-    );
+    assert!(object.infantry_terminal.is_none());
+    assert!(!object.lifecycle.object_alive);
     assert!(object.dying && !object.selected);
+    assert!(!sim.substrate.occupancy.contains_entity(4, 4, victim));
+    assert!(!sim.live_object_order_snapshot().contains(&victim));
     assert_eq!(
         sim.sound_events
             .iter()

--- a/src/sim/world/bridge_ground.rs
+++ b/src/sim/world/bridge_ground.rs
@@ -1,0 +1,492 @@
+//! Ground receivers of CellClass::BlowUpBridge 0047DD70.
+//!
+//! Each live member supplies its current Health to the ordinary direct damage
+//! receiver; death/lifecycle consequences finish before traversal resumes.
+//! Evidence: HIGH_BRIDGE_RIM_REFRESH_ALGORITHM_GHIDRA_REPORT.md.
+
+use crate::map::overlay_types::OverlayTypeRegistry;
+use crate::rules::ruleset::RuleSet;
+use crate::sim::combat::{
+    EntityDamageEvent, RAD_NO_ATTACKER, ReceiverCallFlags, TerrainDamageEvent,
+};
+use crate::sim::movement::locomotor::MovementLayer;
+use crate::sim::occupancy::CellObjectMember;
+use crate::sim::world::Simulation;
+
+fn members(sim: &Simulation, rx: u16, ry: u16) -> impl Iterator<Item = CellObjectMember> + '_ {
+    sim.substrate.occupancy.cell_objects(
+        rx,
+        ry,
+        MovementLayer::Ground,
+        sim.production.terrain_object_cells.get(&(rx, ry)).copied(),
+    )
+}
+
+pub(super) fn apply(
+    sim: &mut Simulation,
+    rules: &RuleSet,
+    registry: Option<&OverlayTypeRegistry>,
+    rx: u16,
+    ry: u16,
+) {
+    let warhead_ref = sim.interner.intern(&rules.bridge_warheads.c4_name);
+    let mut current = members(sim, rx, ry).next();
+    while let Some(member) = current {
+        // 0047DD96 captures NextObject BEFORE the virtual ReceiveDamage. A
+        // captured successor removed by nested effects has no next link when
+        // its own iteration begins; do not resume from a precollected vector.
+        let next = {
+            let mut live = members(sim, rx, ry);
+            live.find(|candidate| *candidate == member)
+                .and_then(|_| live.next())
+        };
+        match member {
+            CellObjectMember::Entity(stable_id) => {
+                if let Some(entity) = sim.substrate.entities.get(stable_id) {
+                    // Native passes &Health. For retail C4Warhead=Super, forced
+                    // damage reaches the ordinary fatal Object path, which
+                    // writes HP0 before callbacks with either input location.
+                    // Override-only early packet writes are NOT equivalent:
+                    // see bridge_health_alias.py and the report's open residual.
+                    let event = EntityDamageEvent::direct_receiver(
+                        stable_id,
+                        i32::from(entity.health.current),
+                        0,
+                        RAD_NO_ATTACKER,
+                        None,
+                        warhead_ref,
+                        ReceiverCallFlags {
+                            ignore_defenses: true,
+                            arg6: true,
+                        },
+                    );
+                    sim.commit_direct_damage_receiver(rules, registry, event);
+                }
+            }
+            CellObjectMember::Terrain(stable_id) => {
+                if let Some(terrain) = sim.production.terrain_objects.get(&stable_id) {
+                    let event = TerrainDamageEvent {
+                        stable_id,
+                        rx,
+                        ry,
+                        damage: terrain.health,
+                        distance_leptons: 0,
+                        warhead_ref,
+                        near_center_ic_isolation_eligible: false,
+                    };
+                    sim.commit_direct_terrain_damage_receiver(rules, registry, event);
+                }
+            }
+        }
+        current = next;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rules::ini_parser::IniFile;
+    use crate::sim::world::LifecycleTestEvent;
+
+    fn world(rules: &RuleSet) -> Simulation {
+        let mut sim = Simulation::with_seed(31);
+        sim.intern_rule_type_ids(rules);
+        sim.resolve_type_handles(rules);
+        let cells = (0..8)
+            .flat_map(|y| {
+                (0..8).map(move |x| {
+                    crate::sim::world::lifecycle_tests::common_raw_terrain_cell(x, y, 0, false)
+                })
+            })
+            .collect();
+        sim.resolved_terrain =
+            Some(crate::map::resolved_terrain::ResolvedTerrainGrid::from_cells(8, 8, cells));
+        sim
+    }
+
+    fn place(sim: &mut Simulation, rules: &RuleSet, name: &str, x: u16) -> u64 {
+        let id = sim
+            .construct_object_limbo_at_height(name, "Americans", x, 4, 0, 0, rules)
+            .unwrap();
+        sim.reveal(id);
+        id
+    }
+
+    fn stock_cascade_rules() -> RuleSet {
+        // Retail RULESMD TERROR/TerrorBomb/TerrorBombWH, E1 and MTNK damage
+        // inputs; unrelated art/voice/debris definitions are omitted.
+        RuleSet::from_ini(&IniFile::from_str(
+            "[InfantryTypes]\n0=E1\n1=TERROR\n[VehicleTypes]\n0=MTNK\n\
+             [AircraftTypes]\n[BuildingTypes]\n0=BUNK\n[CombatDamage]\nC4Warhead=Super\n\
+             [E1]\nStrength=125\nArmor=none\nSpeed=4\nDieSound=GIDie\n\
+             [TERROR]\nStrength=75\nArmor=flak\nSpeed=6\nExplodes=yes\nDeathWeapon=TerrorBomb\n\
+             [MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\n\
+             [BUNK]\nStrength=1000\nFoundation=1x1\nDieSound=BuildingDie\n\
+             [TerrorBomb]\nDamage=225\nWarhead=TerrorBombWH\nSuicide=yes\n\
+             [Warheads]\n0=Super\n1=TerrorBombWH\n\
+             [Super]\nInfDeath=2\nPenetratesBunker=yes\n\
+             Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+             [TerrorBombWH]\nInfDeath=4\nCellSpread=2\nPercentAtMax=.5\n\
+             Verses=150%,100%,100%,90%,50%,50%,100%,150%,30%,100%,100%\n",
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn bridge_ground_revisits_zero_health_gi_and_repeats_die_sound_without_double_score() {
+        use crate::sim::world::SimSoundEvent;
+        let rules = stock_cascade_rules();
+        let mut sim = world(&rules);
+        let owner = sim.interner.intern("Americans");
+        sim.houses.insert(
+            owner,
+            crate::sim::house_state::HouseState::new(owner, 0, None, false, 1000, 10),
+        );
+        let gi = place(&mut sim, &rules, "E1", 4);
+        let terror = place(&mut sim, &rules, "TERROR", 4);
+        assert_eq!(
+            members(&sim, 4, 4).collect::<Vec<_>>(),
+            vec![
+                CellObjectMember::Entity(terror),
+                CellObjectMember::Entity(gi),
+            ]
+        );
+        apply(&mut sim, &rules, None, 4, 4);
+        let native: serde_json::Value = serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tools/spatial_oracle/bridge_zero_health_receiver.json"
+        )))
+        .unwrap();
+        let repeat = native["cases"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|case| case["initial_alive"] == false && case["die_sound_count"] == 1)
+            .unwrap();
+        assert_eq!(repeat["endpoint"], "007509E0");
+        let sounds = sim.sound_events.iter().filter(|event| matches!(event,
+            SimSoundEvent::EntityDied { die_sound_id, .. } if sim.interner.resolve(*die_sound_id) == "GIDie"
+        )).count();
+        assert_eq!(
+            sounds,
+            1 + repeat["rng_draws"].as_u64().unwrap() as usize,
+            "initial fatal receiver plus the native zero-HP successor revisit"
+        );
+        assert_eq!(
+            sim.houses[&owner].stats.units_lost, 1,
+            "the retired GI is counted once; Terrorist still has its death sequence"
+        );
+        assert_eq!(
+            sim.houses[&owner].stats.units_killed, 1,
+            "only TerrorBomb's first GI kill is credited"
+        );
+        assert!(sim.substrate.entities.get(gi).unwrap().owned_count_released);
+        assert!(!sim.live_object_order_snapshot().contains(&gi));
+        let head = sim.substrate.entities.get(terror).unwrap();
+        assert!(head.infantry_terminal.is_some());
+        assert!(!head.owned_count_released);
+        // The rules catalog supplies a default Die2 even without art input.
+        // Drive its normal terminal visits through retirement before checking
+        // the eventual total; this test does not assert animation duration.
+        for _ in 0..120 {
+            if sim
+                .substrate
+                .entities
+                .get(terror)
+                .unwrap()
+                .owned_count_released
+            {
+                break;
+            }
+            assert!(sim.visit_infantry_terminal(terror, Some(&rules)));
+        }
+        assert!(
+            sim.substrate
+                .entities
+                .get(terror)
+                .unwrap()
+                .owned_count_released
+        );
+        assert_eq!(sim.houses[&owner].stats.units_lost, 2);
+        assert_eq!(sim.houses[&owner].stats.units_killed, 1);
+    }
+
+    #[test]
+    fn bridge_ground_revisited_terrorist_executes_its_death_weapon_again() {
+        let rules = stock_cascade_rules();
+        let mut sim = world(&rules);
+        let tank = place(&mut sim, &rules, "MTNK", 4);
+        let next = place(&mut sim, &rules, "TERROR", 4);
+        let head = place(&mut sim, &rules, "TERROR", 4);
+        assert_eq!(
+            members(&sim, 4, 4).collect::<Vec<_>>(),
+            vec![
+                CellObjectMember::Entity(head),
+                CellObjectMember::Entity(next),
+                CellObjectMember::Entity(tank),
+            ]
+        );
+        apply(&mut sim, &rules, None, 4, 4);
+        // Two original deaths leave the heavy tank alive. The captured
+        // successor's repeated DeathWeapon kills it; its unlinked NextObject
+        // cannot pass it a later direct C4 receiver.
+        assert_eq!(sim.substrate.entities.get(tank).unwrap().health.current, 0);
+    }
+
+    #[test]
+    fn bridge_ground_zero_health_building_skips_the_techno_death_tail() {
+        use crate::sim::world::SimSoundEvent;
+        let rules = stock_cascade_rules();
+        let mut sim = world(&rules);
+        let building = place(&mut sim, &rules, "BUNK", 4);
+        sim.substrate
+            .entities
+            .get_mut(building)
+            .unwrap()
+            .health
+            .current = 0;
+        apply(&mut sim, &rules, None, 4, 4);
+        assert!(
+            !sim.sound_events
+                .iter()
+                .any(|event| matches!(event, SimSoundEvent::EntityDied { .. }))
+        );
+        assert!(
+            sim.substrate
+                .entities
+                .get(building)
+                .unwrap()
+                .lifecycle
+                .object_alive
+        );
+        assert!(sim.substrate.pending_delete.is_empty());
+    }
+
+    #[test]
+    fn bridge_ground_infantry_action_preserves_same_sequence_and_retired_membership() {
+        use crate::sim::animation::{Animation, SequenceKind};
+        use crate::sim::world::InfantryDeathSequence;
+        let rules = stock_cascade_rules();
+        let mut sim = world(&rules);
+        let gi = place(&mut sim, &rules, "E1", 4);
+        let mut animation = Animation::new(SequenceKind::Die2);
+        animation.frame_index = 7;
+        sim.substrate.entities.get_mut(gi).unwrap().animation = Some(animation);
+        sim.begin_infantry_death_sequence(gi, InfantryDeathSequence::Die2);
+        assert_eq!(
+            sim.substrate
+                .entities
+                .get(gi)
+                .unwrap()
+                .animation
+                .as_ref()
+                .unwrap()
+                .frame_index,
+            7
+        );
+        sim.uninit_with_rules(gi, &rules);
+        let pending = sim.substrate.pending_delete.clone();
+        sim.begin_infantry_death_sequence(gi, InfantryDeathSequence::Die1);
+        let object = sim.substrate.entities.get(gi).unwrap();
+        assert_eq!(
+            object.animation.as_ref().unwrap().sequence,
+            SequenceKind::Die1
+        );
+        assert_eq!(object.animation.as_ref().unwrap().frame_index, 0);
+        assert!(object.infantry_terminal.is_none());
+        assert!(!object.lifecycle.object_alive);
+        assert!(!sim.live_object_order_snapshot().contains(&gi));
+        assert_eq!(sim.substrate.pending_delete, pending);
+    }
+
+    #[test]
+    fn bridge_ground_forced_super_damages_an_occupied_tank_bunker() {
+        // Stock Super has PenetratesBunker=yes. Without the ignoreDefenses
+        // bypass, the linked Building arm incorrectly nullifies its damage.
+        let rules = RuleSet::from_ini(&IniFile::from_str(
+            "[InfantryTypes]\n[VehicleTypes]\n0=TANK\n[AircraftTypes]\n\
+             [BuildingTypes]\n0=NATBNK\n[TANK]\nStrength=100\nSpeed=4\n\
+             [NATBNK]\nStrength=1000\nFoundation=2x2\nTankBunker=yes\n\
+             [CombatDamage]\nC4Warhead=Super\n[Warheads]\n0=Super\n\
+             [Super]\nInfDeath=2\nPenetratesBunker=yes\n\
+             Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+        ))
+        .unwrap();
+        let mut sim = world(&rules);
+        let bunker = place(&mut sim, &rules, "NATBNK", 3);
+        let occupant = place(&mut sim, &rules, "TANK", 6);
+        crate::sim::docking::bunker_link::install_bunker_link(&mut sim, bunker, occupant, &rules);
+        assert_eq!(
+            sim.substrate.entities.get(bunker).unwrap().bunker_occupant,
+            Some(occupant)
+        );
+        assert_eq!(
+            members(&sim, 4, 4).collect::<Vec<_>>(),
+            vec![CellObjectMember::Entity(bunker)]
+        );
+        apply(&mut sim, &rules, None, 4, 4);
+        assert_eq!(
+            sim.substrate.entities.get(bunker).unwrap().health.current,
+            0
+        );
+    }
+
+    #[test]
+    fn bridge_ground_dispatches_terrain_and_keeps_stock_wood_gate() {
+        use crate::map::overlay::TerrainObject;
+        use crate::sim::terrain_object::TerrainObjectLifecycle;
+        for wood in [false, true] {
+            let rules = RuleSet::from_ini(&IniFile::from_str(&format!(
+                "[InfantryTypes]\n[VehicleTypes]\n[AircraftTypes]\n[BuildingTypes]\n\
+                 [TerrainTypes]\n0=TREE\n[TREE]\nStrength=100\nTemperateOccupationBits=7\n\
+                 [CombatDamage]\nC4Warhead=C4\n[Warheads]\n0=C4\n\
+                 [C4]\nWood={}\nVerses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+                if wood { "yes" } else { "no" },
+            )))
+            .unwrap();
+            let mut sim = world(&rules);
+            crate::sim::terrain_spawn::seed_terrain_spawners(
+                &mut sim,
+                &[TerrainObject {
+                    rx: 4,
+                    ry: 4,
+                    name: "TREE".into(),
+                }],
+                &rules,
+                &OverlayTypeRegistry::empty(),
+                false,
+            );
+            let id = sim.production.terrain_object_cells[&(4, 4)];
+            assert_eq!(
+                members(&sim, 4, 4).collect::<Vec<_>>(),
+                vec![CellObjectMember::Terrain(id)]
+            );
+            apply(&mut sim, &rules, None, 4, 4);
+            let tree = &sim.production.terrain_objects[&id];
+            if wood {
+                assert_eq!(tree.health, 0);
+                assert_eq!(tree.lifecycle, TerrainObjectLifecycle::Destroyed);
+                assert!(!tree.in_logic_vector);
+                assert!(members(&sim, 4, 4).next().is_none());
+                assert_eq!(sim.substrate.raw_cell_occupation.ground_bits(4, 4), 0);
+            } else {
+                assert_eq!(tree.health, 100);
+                assert!(tree.is_live());
+                assert_eq!(sim.production.terrain_object_cells[&(4, 4)], id);
+            }
+        }
+    }
+
+    #[test]
+    fn bridge_ground_stops_after_nested_death_removes_captured_successor() {
+        // Head's synchronous DeathWeapon removes the captured next member.
+        // The tail survives that warhead and must not receive a later C4 call
+        // through a stale precollected member vector.
+        let rules = RuleSet::from_ini(&IniFile::from_str(
+            "[InfantryTypes]\n0=NEXT\n1=TAIL\n[VehicleTypes]\n0=HEAD\n\
+             [AircraftTypes]\n[BuildingTypes]\n[CombatDamage]\nC4Warhead=Super\n\
+             [HEAD]\nStrength=100\nArmor=light\nSpeed=4\nExplodes=yes\nDeathWeapon=Boom\n\
+             [NEXT]\nStrength=1\nArmor=none\nSpeed=4\n\
+             [TAIL]\nStrength=100\nArmor=heavy\nSpeed=4\n\
+             [Boom]\nDamage=100\nWarhead=EXP\n[Warheads]\n0=Super\n1=EXP\n\
+             [Super]\nInfDeath=2\nPenetratesBunker=yes\n\
+             Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n\
+             [EXP]\nCellSpread=0.5\nPercentAtMax=1\nInfDeath=3\n\
+             Verses=100%,100%,100%,100%,100%,0%,100%,100%,100%,100%,100%\n",
+        ))
+        .unwrap();
+        let mut sim = world(&rules);
+        let tail = place(&mut sim, &rules, "TAIL", 4);
+        let next = place(&mut sim, &rules, "NEXT", 4);
+        let head = place(&mut sim, &rules, "HEAD", 4);
+        assert_eq!(
+            members(&sim, 4, 4).collect::<Vec<_>>(),
+            vec![
+                CellObjectMember::Entity(head),
+                CellObjectMember::Entity(next),
+                CellObjectMember::Entity(tail),
+            ]
+        );
+        apply(&mut sim, &rules, None, 4, 4);
+        assert_eq!(sim.substrate.entities.get(head).unwrap().health.current, 0);
+        assert_eq!(sim.substrate.entities.get(next).unwrap().health.current, 0);
+        assert_eq!(
+            sim.substrate.entities.get(tail).unwrap().health.current,
+            100
+        );
+        assert_eq!(
+            members(&sim, 4, 4).collect::<Vec<_>>(),
+            vec![CellObjectMember::Entity(tail)]
+        );
+    }
+
+    #[test]
+    fn bridge_ground_uses_membership_order_and_nonanchor_building_foundation() {
+        let rules = RuleSet::from_ini(&IniFile::from_str(
+            "[InfantryTypes]\n0=E1\n[VehicleTypes]\n[AircraftTypes]\n\
+             [BuildingTypes]\n0=BIG\n[E1]\nStrength=100\nSpeed=4\n\
+             [BIG]\nStrength=1000\nFoundation=2x1\n\
+             [CombatDamage]\nC4Warhead=KILL\n[Warheads]\n0=KILL\n\
+             [KILL]\nInfDeath=3\nVerses=0%,0%,0%,0%,0%,0%,0%,0%,0%,0%,0%\n",
+        ))
+        .unwrap();
+        let mut sim = Simulation::with_seed(31);
+        sim.intern_rule_type_ids(&rules);
+        sim.resolve_type_handles(&rules);
+        let cells = (0..8)
+            .flat_map(|y| {
+                (0..8).map(move |x| {
+                    crate::sim::world::lifecycle_tests::common_raw_terrain_cell(x, y, 0, false)
+                })
+            })
+            .collect();
+        sim.resolved_terrain =
+            Some(crate::map::resolved_terrain::ResolvedTerrainGrid::from_cells(8, 8, cells));
+        let mut create = |name, x, marked| {
+            let id = sim
+                .construct_object_limbo_at_height(name, "Americans", x, 4, 0, 0, &rules)
+                .unwrap();
+            if marked {
+                sim.reveal(id);
+            }
+            id
+        };
+        let older = create("E1", 4, true);
+        let newer = create("E1", 4, true);
+        let building = create("BIG", 3, true);
+        let unmarked = create("E1", 4, false);
+        assert_eq!(
+            members(&sim, 4, 4).collect::<Vec<_>>(),
+            vec![
+                CellObjectMember::Entity(newer),
+                CellObjectMember::Entity(older),
+                CellObjectMember::Entity(building),
+            ]
+        );
+        apply(&mut sim, &rules, None, 4, 4);
+        for id in [older, newer, building] {
+            assert_eq!(
+                sim.substrate.entities.get(id).unwrap().health.current,
+                0,
+                "receiver {id}"
+            );
+        }
+        assert!(sim.substrate.entities.get(unmarked).unwrap().health.current > 0);
+        let order: Vec<_> = sim
+            .lifecycle_test_events_for_test()
+            .iter()
+            .filter_map(|event| {
+                if let LifecycleTestEvent::UninitClassPre { stable_id } = event {
+                    [older, newer].contains(stable_id).then_some(*stable_id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(
+            order,
+            vec![newer, older],
+            "native cell-list order, not ascending stable IDs"
+        );
+    }
+}

--- a/src/sim/world/bridge_orchestrator.rs
+++ b/src/sim/world/bridge_orchestrator.rs
@@ -15,6 +15,9 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
+#[path = "bridge_ground.rs"]
+mod ground_fallout;
+
 use crate::map::bridge_facts::{
     BRIDGE_FLAG_ANCHOR_SELF, BRIDGE_FLAG_DESTROYED_OR_RAMP, BRIDGE_FLAG_DIRECTION_ZERO,
     BRIDGE_FLAG_STRUCTURAL,
@@ -123,9 +126,8 @@ pub(crate) fn apply_bridge_damage_events_with_overlay_registry(
     // C4Warhead semantics, bridge-deck occupants DropIn, then that cell emits
     // debris. Keeping the effects inside this helper preserves the binary's
     // per-cell fallout order instead of batching kills, drops, and debris.
-    let c4_inf_death = c4_inf_death(rules, sim);
     for &(rx, ry) in &blow_up_cells {
-        blow_up_bridge_cell_fallout(sim, rules, rx, ry, c4_inf_death);
+        blow_up_bridge_cell_fallout(sim, rules, rx, ry, overlay_registry);
     }
 
     // Aggregate rim cells + zones-dirty flag from the dispatcher's
@@ -545,9 +547,8 @@ fn apply_hut_bridge_execution(
     any_zones_dirty |= extra_zones_dirty;
 
     project_pending_low_bridge_overlay_writes(sim, overlay_registry);
-    let c4_inf_death = c4_inf_death(rules, sim);
     for &(rx, ry) in &blow_up_cells {
-        blow_up_bridge_cell_fallout(sim, rules, rx, ry, c4_inf_death);
+        blow_up_bridge_cell_fallout(sim, rules, rx, ry, overlay_registry);
     }
     update_adjacent_bridges(sim, &rim_cells);
     project_pending_low_bridge_overlay_writes(sim, overlay_registry);
@@ -1272,35 +1273,15 @@ fn hut_cell_is_low_bridge(
         })
 }
 
-/// Kill ground-layer entities at `(rx, ry)`. Mirrors the binary's
-/// `BlowUpBridge` ground-occupant pass: walk every entity at the cell
-/// that is NOT on the bridge layer and force-kill via C4Warhead semantics
-/// (`damage = 0, force_kill = 1` in the binary; we set health = 0 and
-/// flag `dying` for the next combat tick to handle death effects).
-///
-/// Bridge-deck entities go through `drop_in_bridge_deck_entities`
-/// (Task 11) and survive — vanilla never drowns or kills them on
-/// collapse (HIGH §12.7, §12.9).
-///
-/// `c4_inf_death` is the C4Warhead's `InfDeath=` byte; for entities with
-/// an animation, the kill loop switches the death sequence to match (so
-/// infantry play the C4-selected explosive death anim rather than the
-/// default Die1). Mirrors the combat-side path in
-/// `compute_dying_entities_combat_effects`.
-fn c4_inf_death(rules: &RuleSet, sim: &Simulation) -> u8 {
-    let c4_id = sim.rule_handles().c4;
-    let name = sim.interner.resolve(c4_id);
-    rules.warhead(name).map(|wh| wh.inf_death).unwrap_or(1)
-}
-
+/// Complete ground receivers before the deck pass and debris RNG.
 fn blow_up_bridge_cell_fallout(
     sim: &mut Simulation,
     rules: &RuleSet,
     rx: u16,
     ry: u16,
-    c4_inf_death: u8,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
 ) {
-    kill_ground_occupants_at(sim, rules, rx, ry, c4_inf_death);
+    kill_ground_occupants_at(sim, rules, rx, ry, overlay_registry);
     drop_in_bridge_deck_entities(sim, rx, ry);
     let mut one_cell = BTreeSet::new();
     one_cell.insert((rx, ry));
@@ -1310,53 +1291,14 @@ fn blow_up_bridge_cell_fallout(
 /// `CellClass::BlowUpBridge @ 0x0047DDAE`: every ground occupant takes
 /// `ReceiveDamage` (`+0x16C`) with its own HP and `C4Warhead=`, so the kill
 /// runs the normal death branch including `Death_Announcement` (`+0x3B8`).
-fn kill_ground_occupants_at(
+pub(super) fn kill_ground_occupants_at(
     sim: &mut Simulation,
     rules: &RuleSet,
     rx: u16,
     ry: u16,
-    c4_inf_death: u8,
+    overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
 ) {
-    use crate::sim::animation::death_sequence_for_inf_death;
-    let death_seq = death_sequence_for_inf_death(c4_inf_death);
-    let victims: Vec<u64> = sim
-        .substrate
-        .entities
-        .iter_sorted()
-        .filter(|(_, e)| {
-            e.position.rx == rx
-                && e.position.ry == ry
-                && !e.is_on_bridge_layer()
-                // BlowUpBridge force-kills only the cell's GROUND object-list
-                // occupants. Air units (and TS-legacy underground) are never on
-                // that list, so an aircraft overflying the collapse cell must
-                // survive — `occupancy_list_layer()` is `None` for those layers.
-                && e.occupancy_list_layer().is_some()
-                && e.health.current > 0
-        })
-        .map(|(id, _)| id)
-        .collect();
-    for id in victims {
-        let infantry_terminal = sim.begin_raw_infantry_death(id, Some(c4_inf_death));
-        if let Some(entity) = sim.substrate.entities.get_mut(id) {
-            if !infantry_terminal {
-                entity.health.current = 0;
-                entity.dying = true;
-            }
-            entity.attack_target = None;
-            entity.movement_target = None;
-            entity.selected = false;
-            // `death_seq` is `None` whenever the warhead's `InfDeath=` picks
-            // an animation arm instead of a sequence — see the jump table at
-            // 0x00518D58.
-            if let (false, Some(seq), Some(anim)) =
-                (infantry_terminal, death_seq, entity.animation.as_mut())
-            {
-                anim.switch_to(seq);
-            }
-        }
-        sim.announce_unit_lost_at_death_site(rules, id);
-    }
+    ground_fallout::apply(sim, rules, overlay_registry, rx, ry);
 }
 
 /// Rim refresh. For each just-collapsed rim cell, walk along the bridge
@@ -3554,21 +3496,50 @@ mod tests {
         // deferred drain. The legacy coordinate scan must not restart their
         // Infantry terminal lifetime when it visits this stored identity.
         let retired = GameEntity::new_at_frame_zero_for_test(
-            3, 5, 5, 0, 0, sim.interner.intern("Americans"),
-            Health { current: 100, max: 100 }, sim.interner.intern("E1"),
-            crate::map::entities::EntityCategory::Infantry, 0, 5, false,
+            3,
+            5,
+            5,
+            0,
+            0,
+            sim.interner.intern("Americans"),
+            Health {
+                current: 100,
+                max: 100,
+            },
+            sim.interner.intern("E1"),
+            crate::map::entities::EntityCategory::Infantry,
+            0,
+            5,
+            false,
         );
         sim.substrate.entities.insert(retired);
         sim.uninit(3);
         assert!(sim.substrate.entities.get(3).unwrap().health.current > 0);
 
-        kill_ground_occupants_at(&mut sim, &rules_with_voxel_max(0), 5, 5, 1);
+        let rules = RuleSet::from_ini(&crate::rules::ini_parser::IniFile::from_str(
+            "[VehicleTypes]\n0=MTNK\n[MTNK]\nStrength=256\nArmor=heavy\n[Warheads]\n0=Super\n[Super]\nInfDeath=1\n",
+        )).unwrap();
+        let ground = sim.substrate.entities.get_mut(1).unwrap();
+        ground.lifecycle.in_limbo = false;
+        ground.lifecycle.cell_marked = true;
+        sim.substrate.occupancy.add(
+            5,
+            5,
+            1,
+            MovementLayer::Ground,
+            None,
+            crate::sim::occupancy::CellListInsertion::PrependNonBuilding,
+        );
+        kill_ground_occupants_at(&mut sim, &rules, 5, 5, None);
 
         let retired = sim.substrate.entities.get(3).unwrap();
-        assert_eq!(retired.health.current, 0, "raw HP write is preserved");
+        assert_eq!(
+            retired.health.current, 100,
+            "unlinked retired object is not a ground receiver"
+        );
         assert!(!retired.lifecycle.object_alive);
         assert!(retired.infantry_terminal.is_none());
-        assert_eq!(sim.substrate.pending_delete, vec![3]);
+        assert_eq!(sim.substrate.pending_delete, vec![3, 1]);
 
         let g = sim.substrate.entities.get(1).expect("ground unit present");
         assert_eq!(g.health.current, 0, "ground occupant is force-killed");
@@ -3592,7 +3563,7 @@ mod tests {
         use crate::sim::world::SimSoundEvent;
 
         let rules = RuleSet::from_ini(&crate::rules::ini_parser::IniFile::from_str(
-            "[VehicleTypes]\n0=MTNK\n[MTNK]\nStrength=300\nArmor=heavy\n",
+            "[VehicleTypes]\n0=MTNK\n[MTNK]\nStrength=300\nArmor=heavy\n[Warheads]\n0=Super\n[Super]\nInfDeath=1\n",
         ))
         .expect("rules parse");
         let mut sim = Simulation::new();
@@ -3629,7 +3600,20 @@ mod tests {
             sim.substrate.entities.insert(unit);
         }
 
-        kill_ground_occupants_at(&mut sim, &rules, 5, 5, 1);
+        for id in 1..=3 {
+            let unit = sim.substrate.entities.get_mut(id).unwrap();
+            unit.lifecycle.in_limbo = false;
+            unit.lifecycle.cell_marked = true;
+            sim.substrate.occupancy.add(
+                5,
+                5,
+                id,
+                MovementLayer::Ground,
+                None,
+                crate::sim::occupancy::CellListInsertion::PrependNonBuilding,
+            );
+        }
+        kill_ground_occupants_at(&mut sim, &rules, 5, 5, None);
 
         let lost: Vec<_> = sim
             .sound_events

--- a/src/sim/world/infantry_terminal.rs
+++ b/src/sim/world/infantry_terminal.rs
@@ -46,7 +46,8 @@ enum ReceiverDeathRecipe {
     Cleanup,
 }
 
-/// Captured pre-recursion inputs; consuming this postlude cannot forget the
+/// Captured concrete-receiver inputs after recursive DeathWeapon damage;
+/// consuming this postlude cannot forget the
 /// matching lifetime decision or split effect/smudge selection between callers.
 #[must_use]
 pub(crate) struct InfantryDeathPostlude {
@@ -95,10 +96,9 @@ impl InfantryDeathPostlude {
 }
 
 impl Simulation {
-    /// Select the represented recipe before recursive DeathWeapon damage, in
-    /// the same slot as the old sequence switch. Effects remain in the later
-    /// consuming postlude. Animation presence gates legacy effects, never an
-    /// indefinite lifetime wait.
+    /// Select the represented concrete recipe after recursive DeathWeapon
+    /// damage. Effects remain in the consuming postlude. Animation presence
+    /// gates legacy effects, never an indefinite lifetime wait.
     pub(crate) fn begin_infantry_receiver_death(
         &mut self,
         id: u64,
@@ -115,8 +115,8 @@ impl Simulation {
         let world_z_leptons =
             crate::sim::combat::object_world_z_leptons(entity, self.resolved_terrain.as_ref());
         let recipe = if entity.animation.is_none() {
-            // Preserve the established no-art cleanup position before nested
-            // DeathWeapon receivers append their own cleanup IDs.
+            // The no-art cleanup belongs to this concrete receiver's postlude,
+            // after any nested DeathWeapon receivers have finished.
             immediate_uninit_ids.push(id);
             ReceiverDeathRecipe::Cleanup
         } else if let Some(sequence) = InfantryDeathSequence::for_inf_death(inf_death) {
@@ -187,8 +187,9 @@ impl Simulation {
         true
     }
 
-    /// Admit a selected death action atomically, including fresh progress even
-    /// if an earlier ordinary animation happened to use the same sequence.
+    /// Native Do_Action51D6F0 retains progress for an unchanged action. A
+    /// captured receiver can write a different action after UnInit, without
+    /// restoring Logic membership or canceling its pending deletion.
     pub(crate) fn begin_infantry_death_sequence(
         &mut self,
         id: u64,
@@ -198,10 +199,17 @@ impl Simulation {
             return;
         };
         debug_assert_eq!(entity.category, EntityCategory::Infantry);
-        debug_assert!(entity.lifecycle.object_alive);
         entity.dying = true;
-        entity.infantry_terminal = Some(InfantryTerminal::Sequence(sequence));
-        entity.animation = Some(Animation::new(sequence.animation()));
+        if entity.lifecycle.object_alive {
+            entity.infantry_terminal = Some(InfantryTerminal::Sequence(sequence));
+        }
+        if entity
+            .animation
+            .as_ref()
+            .is_none_or(|animation| animation.sequence != sequence.animation())
+        {
+            entity.animation = Some(Animation::new(sequence.animation()));
+        }
     }
 
     /// Consume this object's terminal Logic visit, including eventual UnInit.

--- a/src/sim/world/lifecycle_tests.rs
+++ b/src/sim/world/lifecycle_tests.rs
@@ -6450,10 +6450,19 @@ fn wave_tail_consumes_wall_roll_before_mandatory_cliff_chance_roll() {
 
 #[test]
 fn wave_fatal_death_weapon_starts_crater_with_live_smudge_authority() {
+    assert_direct_fatal_death_weapon_starts_crater(false);
+}
+
+#[test]
+fn bridge_ground_fatal_death_weapon_starts_crater_before_receiver_returns() {
+    assert_direct_fatal_death_weapon_starts_crater(true);
+}
+
+fn assert_direct_fatal_death_weapon_starts_crater(bridge: bool) {
     use crate::rules::ini_parser::IniFile;
 
     let ini = IniFile::from_str(
-        "[InfantryTypes]\n[VehicleTypes]\n0=VICTIM\n1=FIRER\n\
+        "[CombatDamage]\nC4Warhead=KILLWH\n[InfantryTypes]\n[VehicleTypes]\n0=VICTIM\n1=FIRER\n\
          [AircraftTypes]\n[BuildingTypes]\n[OverlayTypes]\n\
          [Warheads]\n0=KILLWH\n1=CRATERWH\n[SmudgeTypes]\n0=CR1\n\
          [VICTIM]\nStrength=1\nArmor=light\nExplodes=yes\nDeathWeapon=DeathBoom\n\
@@ -6495,44 +6504,50 @@ fn wave_fatal_death_weapon_starts_crater_with_live_smudge_authority() {
         sim.try_reveal_entity(victim_id, common_raw_request(4, 5, 0, 128, 128)),
         RevealOutcome::Revealed { .. }
     ));
-    let firer_id = sim.allocate_stable_id();
-    insert_entity(&mut sim, firer_id, EntityCategory::Unit);
-    let firer = sim.substrate.entities.get_mut(firer_id).unwrap();
-    firer.type_ref = sim.interner.intern("FIRER");
-    firer.attack_target = Some(AttackTarget::new(victim_id));
-    let wave_id = sim.allocate_stable_id();
-    let mut wave = Wave::new_owned(
-        0,
-        firer_id,
-        TargetKind::Entity(victim_id),
-        ProjectileCoord::new(4 * 256, 5 * 256, 0),
-        ProjectileCoord::new(5 * 256, 5 * 256, 0),
-    );
-    wave.active_geometry = false;
-    wave.decaying = true;
-    wave.fade_in = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
-    wave.fade_out = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
-    wave.replace_recorded_cells(vec![WaveRecordedCell::real(4, 5)]);
-    sim.admit_wave(wave_id, wave);
+    if bridge {
+        super::bridge_orchestrator::kill_ground_occupants_at(
+            &mut sim, &rules, 4, 5, Some(&registry),
+        );
+    } else {
+        let firer_id = sim.allocate_stable_id();
+        insert_entity(&mut sim, firer_id, EntityCategory::Unit);
+        let firer = sim.substrate.entities.get_mut(firer_id).unwrap();
+        firer.type_ref = sim.interner.intern("FIRER");
+        firer.attack_target = Some(AttackTarget::new(victim_id));
+        let wave_id = sim.allocate_stable_id();
+        let mut wave = Wave::new_owned(
+            0,
+            firer_id,
+            TargetKind::Entity(victim_id),
+            ProjectileCoord::new(4 * 256, 5 * 256, 0),
+            ProjectileCoord::new(5 * 256, 5 * 256, 0),
+        );
+        wave.active_geometry = false;
+        wave.decaying = true;
+        wave.fade_in = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+        wave.fade_out = NativeF64Bits::from_bits(0x3fa9_9999_a000_0000);
+        wave.replace_recorded_cells(vec![WaveRecordedCell::real(4, 5)]);
+        sim.admit_wave(wave_id, wave);
 
-    // Wave vslot call 0x0075F42C -> DeathWeapon Detonate 0x0070D782 ->
-    // zero-delay Anim constructor 0x00469C93 -> 0x00422702/0x00424D5A.
-    // Default Start=0 crater work is synchronous, including Reduce_Tiberium
-    // at 0x004250E7. Evidence: active gamemd.exe bodies/call instructions.
-    assert!(sim.object_ai_visit_one(
-        wave_id,
-        Some(&rules),
-        ObjectAiCtx {
-            overlay_registry: Some(&registry),
-            ..ObjectAiCtx::default()
-        },
-    ));
+        // Wave vslot call 0x0075F42C -> DeathWeapon Detonate 0x0070D782 ->
+        // zero-delay Anim constructor 0x00469C93 -> 0x00422702/0x00424D5A.
+        // Default Start=0 crater work is synchronous, including Reduce_Tiberium
+        // at 0x004250E7. Evidence: active gamemd.exe bodies/call instructions.
+        assert!(sim.object_ai_visit_one(
+            wave_id,
+            Some(&rules),
+            ObjectAiCtx {
+                overlay_registry: Some(&registry),
+                ..ObjectAiCtx::default()
+            },
+        ));
+    }
     assert!(!sim.substrate.entities.get(victim_id).unwrap().is_alive());
     let crater = rules.smudge_types.find_by_name("CR1").unwrap();
     assert_eq!(
         sim.smudge_grid.as_ref().unwrap().cell(4, 5).type_id,
         Some(crater),
-        "nested DeathWeapon starts its crater before Wave AI returns, without a later effects drain",
+        "nested DeathWeapon starts its crater before direct caller returns, without a later effects drain",
     );
 }
 

--- a/src/sim/world/mod.rs
+++ b/src/sim/world/mod.rs
@@ -1834,11 +1834,7 @@ impl Simulation {
             return;
         }
 
-        #[derive(Clone, Copy, PartialEq, Eq)]
-        enum CellObject {
-            Entity(u64),
-            Terrain(u64),
-        }
+        use crate::sim::occupancy::CellObjectMember as CellObject;
 
         fn current_order(
             occupancy: &crate::sim::occupancy::OccupancyGrid,
@@ -1847,24 +1843,7 @@ impl Simulation {
             ry: u16,
             layer: MovementLayer,
         ) -> Vec<CellObject> {
-            let terrain_id = (layer == MovementLayer::Ground)
-                .then(|| terrain_cells.get(&(rx, ry)).copied())
-                .flatten();
-            let mut order = Vec::new();
-            let mut terrain_inserted = terrain_id.is_none();
-            if let Some(occupancy) = occupancy.get(rx, ry) {
-                for occupant in occupancy.iter_layer(layer) {
-                    if !terrain_inserted && occupant.is_building {
-                        order.push(CellObject::Terrain(terrain_id.expect("present")));
-                        terrain_inserted = true;
-                    }
-                    order.push(CellObject::Entity(occupant.entity_id));
-                }
-            }
-            if !terrain_inserted {
-                order.push(CellObject::Terrain(terrain_id.expect("present")));
-            }
-            order
+            occupancy.cell_objects(rx, ry, layer, terrain_cells.get(&(rx, ry)).copied()).collect()
         }
 
         let mut run = crate::sim::combat::world_receiver::ReceiverRun::default();
@@ -2235,6 +2214,24 @@ impl Simulation {
         let mut run = crate::sim::combat::world_receiver::ReceiverRun::default();
         let (effects, under_attack_events) = crate::sim::combat::world_receiver::commit_entities(
             self, &mut run, std::slice::from_ref(&event), Some(false), rules, overlay_registry,
+        );
+        let terrain_navigation_changed_cells = run.finish(self);
+        self.absorb_noncombat_damage_effects(
+            rules, overlay_registry, effects, under_attack_events, terrain_navigation_changed_cells,
+        );
+    }
+
+    /// Terrain counterpart of a direct object receiver. Native bridge fallout
+    /// forces Object damage, while Terrain's Wood/Immune gate still applies.
+    pub(crate) fn commit_direct_terrain_damage_receiver(
+        &mut self,
+        rules: &RuleSet,
+        overlay_registry: Option<&crate::map::overlay_types::OverlayTypeRegistry>,
+        event: crate::sim::combat::TerrainDamageEvent,
+    ) {
+        let mut run = crate::sim::combat::world_receiver::ReceiverRun::default();
+        let (effects, under_attack_events) = crate::sim::combat::world_receiver::commit_terrain(
+            self, &mut run, event, true, rules, overlay_registry,
         );
         let terrain_navigation_changed_cells = run.finish(self);
         self.absorb_noncombat_damage_effects(

--- a/src/sim/world/world_tests.rs
+++ b/src/sim/world/world_tests.rs
@@ -4627,6 +4627,11 @@ fn test_destroyed_bridge_fallout_matches_rebuilt_ground_walkability() {
 /// covers the parallel ground-layer path.
 #[test]
 fn test_bridge_collapse_kills_ground_unit_under_destroyed_cell() {
+    let rules = RuleSet::from_ini(&IniFile::from_str(
+        "[VehicleTypes]\n0=MTNK\n[MTNK]\nStrength=300\nArmor=heavy\nSpeed=6\n\
+         [Warheads]\n0=Super\n[Super]\nInfDeath=2\nPenetratesBunker=yes\n\
+         Verses=100%,100%,100%,100%,100%,100%,100%,100%,100%,100%,100%\n",
+    )).unwrap();
     let mut sim = Simulation::new();
     let (resolved, bridge_state) = ew_high_bridge_strip_for_dispatch(5, 5, 3, false, 0);
     install_rectangular_test_playfield(&mut sim, resolved.width(), resolved.height());
@@ -4654,7 +4659,7 @@ fn test_bridge_collapse_kills_ground_unit_under_destroyed_cell() {
             recruitable_b: true,
             structure_upgrades: [None, None, None],
         }],
-        Some(&combat_test_rules()),
+        Some(&rules),
         &BTreeMap::new(),
         Some(&resolved),
     );
@@ -4666,14 +4671,17 @@ fn test_bridge_collapse_kills_ground_unit_under_destroyed_cell() {
         .map(|(id, _)| id)
         .expect("ground unit spawned");
     sim.remove_entity_occupancy(id);
-    sim.substrate.entities.get_mut(id).unwrap().on_bridge = false;
+    let unit = sim.substrate.entities.get_mut(id).unwrap();
+    unit.on_bridge = false;
+    if let Some(locomotor) = unit.locomotor.as_mut() {
+        locomotor.layer = MovementLayer::Ground;
+    }
     sim.add_entity_occupancy(id);
     assert!(
         !sim.substrate.entities.get(id).unwrap().on_bridge,
         "ground layer"
     );
 
-    let mut rules = combat_test_rules();
     sim.resolve_type_handles(&rules);
     let _ = crate::sim::world::bridge_orchestrator::apply_bridge_damage_events(
         &mut sim,
@@ -4692,9 +4700,9 @@ fn test_bridge_collapse_kills_ground_unit_under_destroyed_cell() {
         .substrate
         .entities
         .get(id)
-        .expect("ground unit still in EntityStore (kill is via dying flag)");
+        .expect("ground unit retained until pending deletion drains");
     assert_eq!(e.health.current, 0, "kill_ground_occupants_at zeroed HP");
-    assert!(e.dying, "dying flag set for next combat-tick death effects");
+    assert!(e.dying, "direct receiver completed death before returning");
     assert!(e.attack_target.is_none());
     assert!(e.movement_target.is_none());
 }

--- a/tools/spatial_oracle/bridge_health_alias.json
+++ b/tools/spatial_oracle/bridge_health_alias.json
@@ -1,0 +1,160 @@
+{
+  "cases": [
+    {
+      "calls": [
+        {
+          "arg6": 1,
+          "attacker": 0,
+          "damage_is_health": false,
+          "distance": 0,
+          "ignore_defenses": 1,
+          "source_house": 0,
+          "warhead_matches": true
+        }
+      ],
+      "damage": 0,
+      "health": 100,
+      "input_location": "value",
+      "name": "radiation_immune",
+      "result": 0,
+      "writes": [
+        {
+          "instruction": "00701C1C",
+          "location": "packet",
+          "size": 4,
+          "value": 0
+        }
+      ]
+    },
+    {
+      "calls": [
+        {
+          "arg6": 1,
+          "attacker": 0,
+          "damage_is_health": true,
+          "distance": 0,
+          "ignore_defenses": 1,
+          "source_house": 0,
+          "warhead_matches": true
+        }
+      ],
+      "damage": 0,
+      "health": 0,
+      "input_location": "health",
+      "name": "radiation_immune",
+      "result": 0,
+      "writes": [
+        {
+          "instruction": "00701C1C",
+          "location": "health",
+          "size": 4,
+          "value": 0
+        }
+      ]
+    },
+    {
+      "calls": [
+        {
+          "arg6": 1,
+          "attacker": 0,
+          "damage_is_health": false,
+          "distance": 0,
+          "ignore_defenses": 1,
+          "source_house": 0,
+          "warhead_matches": true
+        }
+      ],
+      "damage": 0,
+      "health": 100,
+      "input_location": "value",
+      "name": "psychic_damage_immune",
+      "result": 0,
+      "writes": [
+        {
+          "instruction": "00701C4F",
+          "location": "packet",
+          "size": 4,
+          "value": 0
+        }
+      ]
+    },
+    {
+      "calls": [
+        {
+          "arg6": 1,
+          "attacker": 0,
+          "damage_is_health": true,
+          "distance": 0,
+          "ignore_defenses": 1,
+          "source_house": 0,
+          "warhead_matches": true
+        }
+      ],
+      "damage": 0,
+      "health": 0,
+      "input_location": "health",
+      "name": "psychic_damage_immune",
+      "result": 0,
+      "writes": [
+        {
+          "instruction": "00701C4F",
+          "location": "health",
+          "size": 4,
+          "value": 0
+        }
+      ]
+    },
+    {
+      "calls": [
+        {
+          "arg6": 1,
+          "attacker": 0,
+          "damage_is_health": false,
+          "distance": 0,
+          "ignore_defenses": 1,
+          "source_house": 0,
+          "warhead_matches": true
+        }
+      ],
+      "damage": 0,
+      "health": 100,
+      "input_location": "value",
+      "name": "poison_immune",
+      "result": 0,
+      "writes": [
+        {
+          "instruction": "00701C82",
+          "location": "packet",
+          "size": 4,
+          "value": 0
+        }
+      ]
+    },
+    {
+      "calls": [
+        {
+          "arg6": 1,
+          "attacker": 0,
+          "damage_is_health": true,
+          "distance": 0,
+          "ignore_defenses": 1,
+          "source_house": 0,
+          "warhead_matches": true
+        }
+      ],
+      "damage": 0,
+      "health": 0,
+      "input_location": "health",
+      "name": "poison_immune",
+      "result": 0,
+      "writes": [
+        {
+          "instruction": "00701C82",
+          "location": "health",
+          "size": 4,
+          "value": 0
+        }
+      ]
+    }
+  ]
+}

--- a/tools/spatial_oracle/bridge_health_alias.meta.json
+++ b/tools/spatial_oracle/bridge_health_alias.meta.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "native_sha256": "1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c",
+  "unicorn_binding": "2.1.4",
+  "unicorn_core": [
+    2,
+    1,
+    33621247
+  ],
+  "scope": "Original47DD70 ground loop calling original701900 early immunity returns; copied packet controls",
+  "assumptions": [
+    "Synthetic single-member ground list, Health100, null next/source/house, forced flags true/true",
+    "Accepted C4 warhead flags; stock Super has none of these immunity flags",
+    "Zero supplied unused object/type fields; no ammo update, Object receiver, or death callbacks reached",
+    "Aliased cases stop at47DDBA before deck/debris work; controls return from701900"
+  ],
+  "substitutions": [
+    "Supplied Object vtable16C binds directly to Techno701900; concrete class wrappers excluded",
+    "Vtable160 and1D4 predicates return false; vtable84 returns supplied Type"
+  ],
+  "entry_points": {
+    "bridge_ground": "0x0047DD70",
+    "techno_receive": "0x00701900"
+  },
+  "payload_sha256": "ba33e41eec213875f0fbb3be90266fc7aeea108a4abef7b566a212f8b206a229"
+}

--- a/tools/spatial_oracle/bridge_health_alias.py
+++ b/tools/spatial_oracle/bridge_health_alias.py
@@ -1,0 +1,111 @@
+"""Original bridge ground Health-pointer ABI and early Techno immunity writes.
+
+Synthetic accepted warheads expose pointer aliasing; stock C4Warhead=Super does
+not enable these three gates. This corpus establishes neither a stock-map
+witness nor complete concrete Unit/Infantry/Building receiver semantics.
+"""
+from pathlib import Path
+import struct
+
+from unicorn import Uc, UC_ARCH_X86, UC_MODE_32, UC_HOOK_CODE, UC_HOOK_MEM_WRITE
+from unicorn.x86_const import UC_X86_REG_EAX, UC_X86_REG_ECX, UC_X86_REG_EIP, UC_X86_REG_ESP
+from tools.native_oracle import (
+    load_image, run_checked, STACK_BASE, STACK_SIZE, SCRATCH, SCRATCH_SIZE,
+    RET_MAGIC, finish_vectors, provenance,
+)
+
+
+OBJECT, TYPE, WARHEAD, VTABLE = (SCRATCH + n for n in (0, 0x2000, 0x4000, 0x6000))
+CELL, RULES, PACKET = (SCRATCH + n for n in (0x7000, 0x8000, 0xA000))
+FALSE_STUB, TYPE_STUB = SCRATCH + 0xB000, SCRATCH + 0xB010
+
+
+def words(*values):
+    return struct.pack('<' + 'I' * len(values), *(value & 0xFFFFFFFF for value in values))
+
+
+def original_case(name, warhead_flag, type_flag, write_address, alias):
+    u = Uc(UC_ARCH_X86, UC_MODE_32)
+    load_image(u)
+    u.mem_map(STACK_BASE, STACK_SIZE)
+    u.mem_map(SCRATCH, SCRATCH_SIZE)
+    u.mem_map(RET_MAGIC, 0x1000)
+    u.mem_write(OBJECT, words(VTABLE))
+    u.mem_write(OBJECT + 0x6C, words(100))
+    u.mem_write(PACKET, words(100))
+    u.mem_write(TYPE + type_flag, b'\x01')
+    u.mem_write(WARHEAD + warhead_flag, b'\x01')
+    for slot, entry in [(0x84, TYPE_STUB), (0x160, FALSE_STUB),
+                        (0x1D4, FALSE_STUB), (0x16C, 0x701900)]:
+        u.mem_write(VTABLE + slot, words(entry))
+    u.mem_write(CELL + 0xE4, words(OBJECT))
+    u.mem_write(0x8871E0, words(RULES))
+    u.mem_write(RULES + 0xFA8, words(WARHEAD))
+    # Explicit inactive bridge suppression byte and null Object.NextObject.
+    u.mem_write(0xA8ED6B, b'\x00')
+    u.mem_write(OBJECT + 0x30, words(0))
+    writes, calls = [], []
+
+    def code(uc, address, _size, _data):
+        if address == 0x701900:
+            sp = uc.reg_read(UC_X86_REG_ESP)
+            args = struct.unpack('<7I', uc.mem_read(sp + 4, 28))
+            calls.append(dict(damage_is_health=args[0] == OBJECT + 0x6C,
+                              distance=args[1], warhead_matches=args[2] == WARHEAD,
+                              attacker=args[3], ignore_defenses=args[4],
+                              arg6=args[5], source_house=args[6]))
+        if address not in (FALSE_STUB, TYPE_STUB):
+            return
+        sp = uc.reg_read(UC_X86_REG_ESP)
+        destination = struct.unpack('<I', uc.mem_read(sp, 4))[0]
+        uc.reg_write(UC_X86_REG_EAX, TYPE if address == TYPE_STUB else 0)
+        uc.reg_write(UC_X86_REG_ESP, sp + 4)
+        uc.reg_write(UC_X86_REG_EIP, destination)
+
+    def write(uc, _access, address, size, value, _data):
+        if address in (OBJECT + 0x6C, PACKET):
+            writes.append(dict(location='health' if address == OBJECT + 0x6C else 'packet',
+                               size=size, value=value,
+                               instruction=f'{uc.reg_read(UC_X86_REG_EIP):08X}'))
+
+    u.hook_add(UC_HOOK_CODE, code)
+    u.hook_add(UC_HOOK_MEM_WRITE, write)
+    sp = STACK_BASE + STACK_SIZE - 0x1000
+    u.reg_write(UC_X86_REG_ESP, sp)
+    if alias:
+        u.mem_write(sp, words(RET_MAGIC))
+        u.reg_write(UC_X86_REG_ECX, CELL)
+        # Stop after the complete ground list, before the deck/debris stages.
+        begin, end, required = 0x47DD70, 0x47DDBA, [0x47DDAE, write_address]
+    else:
+        u.mem_write(sp, words(RET_MAGIC, PACKET, 0, WARHEAD, 0, 1, 1, 0))
+        u.reg_write(UC_X86_REG_ECX, OBJECT)
+        begin, end, required = 0x701900, RET_MAGIC, [write_address]
+    run_checked(u, begin, end, count=2000, required_addresses=required)
+    read = lambda address: struct.unpack('<i', u.mem_read(address, 4))[0]
+    return dict(name=name, input_location='health' if alias else 'value',
+                result=u.reg_read(UC_X86_REG_EAX), health=read(OBJECT + 0x6C),
+                damage=read(OBJECT + 0x6C if alias else PACKET), calls=calls, writes=writes)
+
+
+def cases():
+    return dict(cases=[original_case(name, wh, typ, instruction, alias)
+                      for name, wh, typ, instruction in [
+                          ('radiation_immune', 0x177, 0xD37, 0x701C1C),
+                          ('psychic_damage_immune', 0x178, 0xD36, 0x701C4F),
+                          ('poison_immune', 0x156, 0xD3B, 0x701C82)]
+                      for alias in (False, True)])
+
+
+if __name__ == '__main__':
+    finish_vectors(cases, Path(__file__).with_suffix('.json'), provenance=lambda: provenance(
+        scope='Original47DD70 ground loop calling original701900 early immunity returns; copied packet controls',
+        assumptions=[
+            'Synthetic single-member ground list, Health100, null next/source/house, forced flags true/true',
+            'Accepted C4 warhead flags; stock Super has none of these immunity flags',
+            'Zero supplied unused object/type fields; no ammo update, Object receiver, or death callbacks reached',
+            'Aliased cases stop at47DDBA before deck/debris work; controls return from701900',
+        ], substitutions=[
+            'Supplied Object vtable16C binds directly to Techno701900; concrete class wrappers excluded',
+            'Vtable160 and1D4 predicates return false; vtable84 returns supplied Type',
+        ], entry_points={'bridge_ground':0x47DD70, 'techno_receive':0x701900}))

--- a/tools/spatial_oracle/bridge_zero_health_deathweapon.json
+++ b/tools/spatial_oracle/bridge_zero_health_deathweapon.json
@@ -1,0 +1,176 @@
+{
+  "cases": [
+    {
+      "death_weapon_receiver_matches": true,
+      "die_sound_count": 0,
+      "endpoint": "0070D690",
+      "entry": "00517FA0",
+      "final_alive": false,
+      "final_health": 0,
+      "initial_alive": false,
+      "initial_health": 0,
+      "rng_draws": 0,
+      "rng_indices_after": [
+        0,
+        103
+      ],
+      "rng_indices_before": [
+        0,
+        103
+      ],
+      "rng_state_changed": false,
+      "sound_id": null,
+      "visited": [
+        "00517FA0",
+        "004D7330",
+        "00701900",
+        "005F5390",
+        "00702035",
+        "00702603"
+      ]
+    },
+    {
+      "death_weapon_receiver_matches": true,
+      "die_sound_count": 0,
+      "endpoint": "0070D690",
+      "entry": "00517FA0",
+      "final_alive": true,
+      "final_health": 0,
+      "initial_alive": true,
+      "initial_health": 0,
+      "rng_draws": 0,
+      "rng_indices_after": [
+        0,
+        103
+      ],
+      "rng_indices_before": [
+        0,
+        103
+      ],
+      "rng_state_changed": false,
+      "sound_id": null,
+      "visited": [
+        "00517FA0",
+        "004D7330",
+        "00701900",
+        "005F5390",
+        "00702035",
+        "00702603"
+      ]
+    },
+    {
+      "death_weapon_receiver_matches": true,
+      "die_sound_count": 0,
+      "endpoint": "0070D690",
+      "entry": "00737C90",
+      "final_alive": false,
+      "final_health": 0,
+      "initial_alive": false,
+      "initial_health": 0,
+      "rng_draws": 0,
+      "rng_indices_after": [
+        0,
+        103
+      ],
+      "rng_indices_before": [
+        0,
+        103
+      ],
+      "rng_state_changed": false,
+      "sound_id": null,
+      "visited": [
+        "00737C90",
+        "004D7330",
+        "00701900",
+        "005F5390",
+        "00702035",
+        "00702603"
+      ]
+    },
+    {
+      "death_weapon_receiver_matches": true,
+      "die_sound_count": 0,
+      "endpoint": "0070D690",
+      "entry": "00737C90",
+      "final_alive": true,
+      "final_health": 0,
+      "initial_alive": true,
+      "initial_health": 0,
+      "rng_draws": 0,
+      "rng_indices_after": [
+        0,
+        103
+      ],
+      "rng_indices_before": [
+        0,
+        103
+      ],
+      "rng_state_changed": false,
+      "sound_id": null,
+      "visited": [
+        "00737C90",
+        "004D7330",
+        "00701900",
+        "005F5390",
+        "00702035",
+        "00702603"
+      ]
+    },
+    {
+      "death_weapon_receiver_matches": true,
+      "die_sound_count": 0,
+      "endpoint": "0070D690",
+      "entry": "004165C0",
+      "final_alive": false,
+      "final_health": 0,
+      "initial_alive": false,
+      "initial_health": 0,
+      "rng_draws": 0,
+      "rng_indices_after": [
+        0,
+        103
+      ],
+      "rng_indices_before": [
+        0,
+        103
+      ],
+      "rng_state_changed": false,
+      "sound_id": null,
+      "visited": [
+        "004D7330",
+        "00701900",
+        "005F5390",
+        "00702035",
+        "00702603"
+      ]
+    },
+    {
+      "death_weapon_receiver_matches": true,
+      "die_sound_count": 0,
+      "endpoint": "0070D690",
+      "entry": "004165C0",
+      "final_alive": true,
+      "final_health": 0,
+      "initial_alive": true,
+      "initial_health": 0,
+      "rng_draws": 0,
+      "rng_indices_after": [
+        0,
+        103
+      ],
+      "rng_indices_before": [
+        0,
+        103
+      ],
+      "rng_state_changed": false,
+      "sound_id": null,
+      "visited": [
+        "004D7330",
+        "00701900",
+        "005F5390",
+        "00702035",
+        "00702603"
+      ]
+    }
+  ]
+}

--- a/tools/spatial_oracle/bridge_zero_health_deathweapon.meta.json
+++ b/tools/spatial_oracle/bridge_zero_health_deathweapon.meta.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "native_sha256": "1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c",
+  "unicorn_binding": "2.1.4",
+  "unicorn_core": [
+    2,
+    1,
+    33621247
+  ],
+  "scope": "Original zero-Health Infantry517FA0, Unit737C90, Aircraft4165C0 -> Foot/Techno/Object -> death-weapon producer70D690 entry",
+  "assumptions": [
+    "Health0, Alive0/1, Type.Explodes1, stock-Super InfDeath2, nullsource/house, forcedtrue/true",
+    "Shared supplied state/virtual results from bridge_zero_health_receiver; no DieSound entries",
+    "Producer body and repeated detonation are excluded; no complete explosion parity claim"
+  ],
+  "substitutions": [
+    "Supplied predicate/Type/mission/height/emptyWeaponRecord virtual results as disclosed by bridge_zero_health_receiver",
+    "No original receiver instructions replaced; producer70D690 is a stop boundary, not a return-value substitution"
+  ],
+  "entry_points": {
+    "infantry_receive": "0x00517FA0",
+    "unit_receive": "0x00737C90",
+    "aircraft_receive": "0x004165C0",
+    "foot_receive": "0x004D7330",
+    "techno_receive": "0x00701900",
+    "object_receive": "0x005F5390"
+  },
+  "payload_sha256": "0f018e5a8a5b4cca71117276a6695868f6d10c6b5d5a3a7a1351ca54ec801ddd"
+}

--- a/tools/spatial_oracle/bridge_zero_health_deathweapon.py
+++ b/tools/spatial_oracle/bridge_zero_health_deathweapon.py
@@ -1,0 +1,29 @@
+"""Original zero-HP Infantry/Unit/Aircraft enter the death-weapon producer.
+
+Companion to bridge_zero_health_receiver; the producer body and detonation are
+excluded. Rust production tests separately exercise repeated TerrorBomb damage.
+"""
+from pathlib import Path
+from tools.native_oracle import finish_vectors, provenance
+from tools.spatial_oracle.bridge_zero_health_receiver import original_case
+
+
+def cases():
+    return dict(cases=[original_case(alive, False, entry=entry, death_weapon=True)
+                      for entry in (0x517FA0, 0x737C90, 0x4165C0) for alive in (0, 1)])
+
+
+if __name__ == '__main__':
+    finish_vectors(cases, Path(__file__).with_suffix('.json'), provenance=lambda: provenance(
+        scope='Original zero-Health Infantry517FA0, Unit737C90, Aircraft4165C0 -> Foot/Techno/Object -> death-weapon producer70D690 entry',
+        assumptions=[
+            'Health0, Alive0/1, Type.Explodes1, stock-Super InfDeath2, nullsource/house, forcedtrue/true',
+            'Shared supplied state/virtual results from bridge_zero_health_receiver; no DieSound entries',
+            'Producer body and repeated detonation are excluded; no complete explosion parity claim',
+        ], substitutions=[
+            'Supplied predicate/Type/mission/height/emptyWeaponRecord virtual results as disclosed by bridge_zero_health_receiver',
+            'No original receiver instructions replaced; producer70D690 is a stop boundary, not a return-value substitution',
+        ], entry_points={'infantry_receive':0x517FA0, 'unit_receive':0x737C90,
+                         'aircraft_receive':0x4165C0,
+                         'foot_receive':0x4D7330, 'techno_receive':0x701900,
+                         'object_receive':0x5F5390}))

--- a/tools/spatial_oracle/bridge_zero_health_receiver.json
+++ b/tools/spatial_oracle/bridge_zero_health_receiver.json
@@ -1,0 +1,116 @@
+{
+  "cases": [
+    {
+      "announcement_receiver_matches": true,
+      "die_sound_count": 0,
+      "endpoint": "004D98C0",
+      "final_alive": false,
+      "final_health": 0,
+      "initial_alive": false,
+      "initial_health": 0,
+      "rng_draws": 0,
+      "rng_indices_after": [
+        0,
+        103
+      ],
+      "rng_indices_before": [
+        0,
+        103
+      ],
+      "rng_state_changed": false,
+      "sound_id": null,
+      "visited": [
+        "00517FA0",
+        "004D7330",
+        "00701900",
+        "005F5390",
+        "00702035",
+        "00518077"
+      ]
+    },
+    {
+      "announcement_receiver_matches": true,
+      "die_sound_count": 0,
+      "endpoint": "004D98C0",
+      "final_alive": true,
+      "final_health": 0,
+      "initial_alive": true,
+      "initial_health": 0,
+      "rng_draws": 0,
+      "rng_indices_after": [
+        0,
+        103
+      ],
+      "rng_indices_before": [
+        0,
+        103
+      ],
+      "rng_state_changed": false,
+      "sound_id": null,
+      "visited": [
+        "00517FA0",
+        "004D7330",
+        "00701900",
+        "005F5390",
+        "00702035",
+        "00518077"
+      ]
+    },
+    {
+      "announcement_receiver_matches": null,
+      "die_sound_count": 1,
+      "endpoint": "007509E0",
+      "final_alive": false,
+      "final_health": 0,
+      "initial_alive": false,
+      "initial_health": 0,
+      "rng_draws": 1,
+      "rng_indices_after": [
+        1,
+        104
+      ],
+      "rng_indices_before": [
+        0,
+        103
+      ],
+      "rng_state_changed": true,
+      "sound_id": 291,
+      "visited": [
+        "00517FA0",
+        "004D7330",
+        "00701900",
+        "005F5390",
+        "00702035",
+        "0065C780"
+      ]
+    },
+    {
+      "announcement_receiver_matches": null,
+      "die_sound_count": 1,
+      "endpoint": "007509E0",
+      "final_alive": true,
+      "final_health": 0,
+      "initial_alive": true,
+      "initial_health": 0,
+      "rng_draws": 1,
+      "rng_indices_after": [
+        1,
+        104
+      ],
+      "rng_indices_before": [
+        0,
+        103
+      ],
+      "rng_state_changed": true,
+      "sound_id": 291,
+      "visited": [
+        "00517FA0",
+        "004D7330",
+        "00701900",
+        "005F5390",
+        "00702035",
+        "0065C780"
+      ]
+    }
+  ]
+}

--- a/tools/spatial_oracle/bridge_zero_health_receiver.meta.json
+++ b/tools/spatial_oracle/bridge_zero_health_receiver.meta.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "native_sha256": "1cdd1180e49024fbda8ad568caac2e86e856063ff67ab38f62b7d2c7bb84298c",
+  "unicorn_binding": "2.1.4",
+  "unicorn_core": [
+    2,
+    1,
+    33621247
+  ],
+  "scope": "Original Infantry517FA0 -> Foot4D7330 -> Techno701900 -> Object5F5390; stop at Death_Announcement4D98C0 or DieSound PlayAt7509E0",
+  "assumptions": [
+    "Health0 and Alive0/1 variants, damage aliases Health, distance0, null source/house, forced flags true/true",
+    "Stock Super InfDeath2; zero other supplied object/type/warhead/rules state except optional one-entry DieSound vector",
+    "Synthetic DieSound ID123hex; actual Random65C6D0 seeds main RNG886B88 with1; original65C780 draw has no substitution",
+    "No original Object exact-zero callbacks run: its entry Health gate returns before them",
+    "Sound playback, Death_Announcement body and remaining Infantry postlude are excluded"
+  ],
+  "substitutions": [
+    "Seven supplied vtable results:84=Type,160=false,1D4=false,280=false,3A0=false,1C8=height0,3F8=emptyWeaponRecord",
+    "Vtable3B8 binds original Death_Announcement; no executable instructions replaced"
+  ],
+  "entry_points": {
+    "infantry_receive": "0x00517FA0",
+    "foot_receive": "0x004D7330",
+    "techno_receive": "0x00701900",
+    "object_receive": "0x005F5390",
+    "random_seed": "0x0065C6D0",
+    "random_next": "0x0065C780"
+  },
+  "payload_sha256": "a0540f93dc44596b89045ccb6e9241b1fc5d1f8124fedbc0e31a9ef19914a932"
+}

--- a/tools/spatial_oracle/bridge_zero_health_receiver.py
+++ b/tools/spatial_oracle/bridge_zero_health_receiver.py
@@ -1,0 +1,112 @@
+"""Original Infantry receiver reaches its death tail after a zero-HP join.
+
+Uses the stock-Super selector/forced/null-source ABI. Cases establish entry
+into Death_Announcement and a separate one-entry DieSound draw/PlayAt request.
+Sound playback, announcement owner/UI effects and the remaining Infantry action
+are excluded. Object callbacks must not be replayed merely because Techno
+re-enters its own fatal postlude.
+"""
+from pathlib import Path
+import struct
+
+from unicorn import Uc, UC_ARCH_X86, UC_MODE_32, UC_HOOK_CODE
+from unicorn.x86_const import UC_X86_REG_EAX, UC_X86_REG_ECX, UC_X86_REG_EIP, UC_X86_REG_ESP
+from tools.native_oracle import (
+    load_image, run_checked, STACK_BASE, STACK_SIZE, SCRATCH, SCRATCH_SIZE,
+    RET_MAGIC, finish_vectors, provenance,
+)
+from tools.rmg_oracle.gen_rng_vectors import seeded_struct, STRUCT_LEN
+
+
+def words(*values):
+    return struct.pack('<' + 'I' * len(values), *(value & 0xFFFFFFFF for value in values))
+
+
+def original_case(alive, die_sound, *, entry=0x517FA0, death_weapon=False):
+    u = Uc(UC_ARCH_X86, UC_MODE_32)
+    load_image(u)
+    for base, size in [(STACK_BASE, STACK_SIZE), (SCRATCH, SCRATCH_SIZE), (RET_MAGIC, 0x1000)]:
+        u.mem_map(base, size)
+    obj, typ, vtable, warhead, rules, weapon = (SCRATCH + n for n in (0, 0x2000, 0x4000, 0x5000, 0x6000, 0x8000))
+    u.mem_write(obj, words(vtable))
+    u.mem_write(obj + 0x6C, words(0))
+    u.mem_write(obj + 0x90, bytes((alive,)))
+    u.mem_write(warhead + 0x120, words(2))
+    if death_weapon:
+        u.mem_write(typ + 0xD15, b'\x01')  # Explodes=yes.
+    u.mem_write(0x8871E0, words(rules))
+    u.mem_write(vtable + 0x3B8, words(0x4D98C0))
+    rng = 0x886B88
+    u.mem_write(rng, seeded_struct(1))
+    rng_before = bytes(u.mem_read(rng, STRUCT_LEN))
+    if die_sound:
+        # The pointer is the vector's items at Type+514; +520 is count.
+        u.mem_write(typ + 0x514, words(SCRATCH + 0x8100))
+        u.mem_write(typ + 0x520, words(1))
+        u.mem_write(SCRATCH + 0x8100, words(0x123))
+    stubs = {}
+    for slot, argc, value in [
+        (0x84, 0, typ), (0x160, 0, 0), (0x1D4, 0, 0), (0x280, 1, 0),
+        (0x3A0, 0, 0), (0x1C8, 0, 0), (0x3F8, 1, weapon),
+    ]:
+        address = SCRATCH + 0x9000 + slot
+        u.mem_write(vtable + slot, words(address))
+        stubs[address] = (argc, value)
+    visited = []
+
+    def code(uc, address, _size, _data):
+        if address in (0x517FA0, 0x737C90, 0x4D7330, 0x701900, 0x5F5390, 0x702035, 0x518077, 0x65C780, 0x702603):
+            visited.append(f'{address:08X}')
+        if address not in stubs:
+            return
+        argc, value = stubs[address]
+        sp = uc.reg_read(UC_X86_REG_ESP)
+        destination = struct.unpack('<I', uc.mem_read(sp, 4))[0]
+        uc.reg_write(UC_X86_REG_EAX, value)
+        uc.reg_write(UC_X86_REG_ESP, sp + 4 + argc * 4)
+        uc.reg_write(UC_X86_REG_EIP, destination)
+
+    u.hook_add(UC_HOOK_CODE, code)
+    sp = STACK_BASE + STACK_SIZE - 0x1000
+    u.mem_write(sp, words(RET_MAGIC, obj + 0x6C, 0, warhead, 0, 1, 1, 0))
+    u.reg_write(UC_X86_REG_ESP, sp)
+    u.reg_write(UC_X86_REG_ECX, obj)
+    endpoint = 0x70D690 if death_weapon else (0x7509E0 if die_sound else 0x4D98C0)
+    required = [0x5F5390, 0x702035, 0x702603 if death_weapon else (0x65C780 if die_sound else 0x518077)]
+    run_checked(u, entry, endpoint, count=3000, required_addresses=required)
+    rng_after = bytes(u.mem_read(rng, STRUCT_LEN))
+    result = dict(initial_alive=bool(alive), initial_health=0, die_sound_count=int(die_sound),
+                final_health=struct.unpack('<i', u.mem_read(obj + 0x6C, 4))[0],
+                final_alive=bool(u.mem_read(obj + 0x90, 1)[0]),
+                endpoint=f'{u.reg_read(UC_X86_REG_EIP):08X}',
+                sound_id=u.reg_read(UC_X86_REG_ECX) if die_sound else None,
+                announcement_receiver_matches=None if die_sound else u.reg_read(UC_X86_REG_ECX) == obj,
+                rng_draws=visited.count('0065C780'), rng_state_changed=rng_after != rng_before,
+                rng_indices_before=list(struct.unpack_from('<II', rng_before, 4)),
+                rng_indices_after=list(struct.unpack_from('<II', rng_after, 4)),
+                visited=visited)
+    if death_weapon:
+        result['entry'] = f'{entry:08X}'
+        result['death_weapon_receiver_matches'] = result.pop('announcement_receiver_matches')
+    return result
+
+
+def cases():
+    return dict(cases=[original_case(alive, sound) for sound in (False, True) for alive in (0, 1)])
+
+
+if __name__ == '__main__':
+    finish_vectors(cases, Path(__file__).with_suffix('.json'), provenance=lambda: provenance(
+        scope='Original Infantry517FA0 -> Foot4D7330 -> Techno701900 -> Object5F5390; stop at Death_Announcement4D98C0 or DieSound PlayAt7509E0',
+        assumptions=[
+            'Health0 and Alive0/1 variants, damage aliases Health, distance0, null source/house, forced flags true/true',
+            'Stock Super InfDeath2; zero other supplied object/type/warhead/rules state except optional one-entry DieSound vector',
+            'Synthetic DieSound ID123hex; actual Random65C6D0 seeds main RNG886B88 with1; original65C780 draw has no substitution',
+            'No original Object exact-zero callbacks run: its entry Health gate returns before them',
+            'Sound playback, Death_Announcement body and remaining Infantry postlude are excluded',
+        ], substitutions=[
+            'Seven supplied vtable results:84=Type,160=false,1D4=false,280=false,3A0=false,1C8=height0,3F8=emptyWeaponRecord',
+            'Vtable3B8 binds original Death_Announcement; no executable instructions replaced',
+        ], entry_points={'infantry_receive':0x517FA0, 'foot_receive':0x4D7330,
+                         'techno_receive':0x701900, 'object_receive':0x5F5390,
+                         'random_seed':0x65C6D0, 'random_next':0x65C780}))


### PR DESCRIPTION
Bridge collapse currently zeroes ground objects' HP through a sorted coordinate scan, skipping normal death effects and missing nonanchor building foundation cells. Deliver ground damage through live cell membership and synchronous object/Terrain receivers so nested explosions and removals finish before traversal resumes and before the cell's deck-drop/debris pass.

The required receiver corrections preserve forced bunker bypass, repeat zero-Health Infantry/Unit death effects when a captured successor was killed by an earlier explosion, retain single kill credit, and run concrete death actions after nested DeathWeapon effects. The direct Terrain path preserves its Wood/Immune gates. Existing Wave traversal uses the same extracted membership iterator without changing its order.

Validation: full `cargo test -p vera20k --lib` passes with 8,668 passed, 0 failed and 121 ignored. `cargo clippy -p vera20k --lib` exits successfully with warnings. All 16 saved native comparison cases reproduce exactly, including independent regeneration. Fresh independent read-only review passes for the declared PR scope. Rust regressions cover stock Terrorist/GI/tank cascades, occupied Tank Bunkers, nonanchor foundations, Terrain gates, and synchronous nested crater delivery.

Remaining bridge setter/rim sequencing, custom C4 Health-alias cases and other bounded coverage limits stay open in the updated research report. The unfinished rim rewrite is preserved outside this PR; no Phase 3 row is closed.
